### PR TITLE
Fix docstrings to reference Quiet Solar

### DIFF
--- a/custom_components/quiet_solar/entity.py
+++ b/custom_components/quiet_solar/entity.py
@@ -107,7 +107,7 @@ class QSDeviceEntity(QSBaseEntity):
     device : AbstractDevice
 
     def __init__(self, data_handler, device: AbstractDevice, description) -> None:
-        """Set up Netatmo entity base."""
+        """Set up Quiet Solar entity base."""
         super().__init__(data_handler=data_handler, description=description)
         self.device = device
         self._attr_device_info = DeviceInfo(

--- a/custom_components/quiet_solar/select.py
+++ b/custom_components/quiet_solar/select.py
@@ -122,7 +122,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Netatmo switch platform."""
+    """Set up the Quiet Solar select platform."""
     device = hass.data[DOMAIN].get(entry.entry_id)
 
     if device:

--- a/custom_components/quiet_solar/sensor.py
+++ b/custom_components/quiet_solar/sensor.py
@@ -224,7 +224,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Netatmo switch platform."""
+    """Set up the Quiet Solar sensor platform."""
     device = hass.data[DOMAIN].get(entry.entry_id)
 
     if device:
@@ -251,13 +251,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 @dataclass(frozen=True, kw_only=True)
 class QSSensorEntityDescription(SensorEntityDescription):
-    """Describes Netatmo sensor entity."""
+    """Describes Quiet Solar sensor entity."""
     qs_is_none_unavailable: bool  = False
     value_fn: Callable[[AbstractDevice, str], Any] | None = None
 
 
 class QSBaseSensor(QSDeviceEntity, SensorEntity):
-    """Implementation of a Netatmo sensor."""
+    """Implementation of a Quiet Solar sensor."""
 
     entity_description: QSSensorEntityDescription
 

--- a/custom_components/quiet_solar/switch.py
+++ b/custom_components/quiet_solar/switch.py
@@ -118,7 +118,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Netatmo switch platform."""
+    """Set up the Quiet Solar switch platform."""
     device = hass.data[DOMAIN].get(entry.entry_id)
 
     if device:

--- a/custom_components/quiet_solar/time.py
+++ b/custom_components/quiet_solar/time.py
@@ -80,7 +80,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Netatmo switch platform."""
+    """Set up the Quiet Solar time platform."""
     device = hass.data[DOMAIN].get(entry.entry_id)
 
     if device:


### PR DESCRIPTION
## Summary
- correct docstrings that still referenced Netatmo
- mention Quiet Solar platforms and integration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'custom_components' and 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_68775e60db0c833081bc0ec3001204df