### PR TITLE
Fix #8: Replace property shims with _user_originated API

### DIFF
--- a/custom_components/quiet_solar/const.py
+++ b/custom_components/quiet_solar/const.py
@@ -141,6 +141,7 @@ CONF_CHARGER_STATUS_SENSOR = "charger_status_sensor"
 CHARGER_NO_CAR_CONNECTED = "No car connected"
 FORCE_CAR_NO_CHARGER_CONNECTED = "Force Car not connected"
 FORCE_CAR_NO_PERSON_ATTACHED = "Force no person for car"
+CHARGE_TIME_CONSTRAINTS_CLEARED = "constraints_cleared"
 
 CONF_CAR_TRACKER = "car_tracker"
 CONF_CAR_PLUGGED = "car_plugged"

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -19,6 +19,7 @@ from ..const import (
     CAR_EFFICIENCY_KM_PER_KWH,
     CAR_HARD_WIRED_CHARGER,
     CAR_USE_PERCENT_MODE_SENSOR,
+    CHARGE_TIME_CONSTRAINTS_CLEARED,
     CONF_CAR_BATTERY_CAPACITY,
     CONF_CAR_CHARGE_PERCENT_MAX_NUMBER,
     CONF_CAR_CHARGE_PERCENT_MAX_NUMBER_STEPS,
@@ -184,8 +185,6 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         self._reset_charge_targets()
 
-        self.user_attached_charger_name: str | None = None
-
         self.default_charge_time: dt_time | None = None
 
         self._qs_bump_solar_priority = False
@@ -209,8 +208,6 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         self._use_percent_mode = True  # to have a default value, overriden by the call below if necessary
         self._use_percent_mode = self.can_use_charge_percent_constraints()
-
-        self.user_selected_person_name_for_car: str | None = None
 
         self.attach_ha_state_to_probe(self.car_charge_percent_sensor, is_numerical=True, reload_from_history=True)
 
@@ -242,10 +239,26 @@ class QSCar(HADeviceMixin, AbstractDevice):
     def _car_person_option(self, person_name: str):
         return person_name
 
+    def _on_user_originated_changed(self, key: str, value: Any) -> None:
+        """Auto-capture all current car state when any user-originated value changes."""
+        super()._on_user_originated_changed(key, value)
+        self.set_user_originated("charge_target_percent", self._next_charge_target)
+        self.set_user_originated("charge_target_energy", self._next_charge_target_energy)
+        self.set_user_originated("bump_solar", self._qs_bump_solar_priority)
+        self.set_user_originated("force_charge", self.do_force_next_charge)
+        # charge_time: real time supersedes sentinel; None preserves sentinel
+        if self.do_next_charge_time is not None:
+            self.set_user_originated("charge_time", self.do_next_charge_time.isoformat())
+        elif self.get_user_originated("charge_time") != CHARGE_TIME_CONSTRAINTS_CLEARED:
+            self.set_user_originated("charge_time", None)
+        # person_name: only snapshot forecast if no explicit user selection
+        if not self.has_user_originated("person_name"):
+            if self.current_forecasted_person is not None:
+                if self._is_person_authorized_for_car(self.current_forecasted_person.name):
+                    self.set_user_originated("person_name", self.current_forecasted_person.name)
+
     def update_to_be_saved_extra_device_info(self, data_to_update: dict):
         super().update_to_be_saved_extra_device_info(data_to_update)
-        # do not use the property, but teh underlying model
-        data_to_update["user_selected_person_name_for_car"] = self.user_selected_person_name_for_car
 
         forecasted_name = None
         if self.current_forecasted_person is not None:
@@ -254,8 +267,6 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
     def use_saved_extra_device_info(self, stored_load_info: dict):
         super().use_saved_extra_device_info(stored_load_info)
-        # do not use the property to not trigger an unnecessary compute of the people allocation
-        self.user_selected_person_name_for_car = stored_load_info.get("user_selected_person_name_for_car", None)
         self._current_forecasted_person_name_from_boot = stored_load_info.get(
             "current_forecasted_person_name_from_boot", None
         )
@@ -270,22 +281,22 @@ class QSCar(HADeviceMixin, AbstractDevice):
                 if person is not None:
                     self.current_forecasted_person = person
 
-        if self.user_selected_person_name_for_car is not None:
-            if self.user_selected_person_name_for_car == FORCE_CAR_NO_PERSON_ATTACHED:
+        if self.get_user_originated("person_name") is not None:
+            if self.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED:
                 self.current_forecasted_person = None
             else:
                 if self.home:
-                    person = self.home.get_person_by_name(self.user_selected_person_name_for_car)
+                    person = self.home.get_person_by_name(self.get_user_originated("person_name"))
                     if person is None:
-                        self.user_selected_person_name_for_car = None
+                        self.clear_all_user_originated()
                         self.current_forecasted_person = None
-                    elif not self._is_person_authorized_for_car(self.user_selected_person_name_for_car):
+                    elif not self._is_person_authorized_for_car(self.get_user_originated("person_name")):
                         _LOGGER.warning(
                             "device_post_home_init: Car:%s clearing stale Person:%s (not authorized)",
                             self.name,
-                            self.user_selected_person_name_for_car,
+                            self.get_user_originated("person_name"),
                         )
-                        self.user_selected_person_name_for_car = None
+                        self.clear_all_user_originated()
                         self.current_forecasted_person = None
                     else:
                         self.current_forecasted_person = person
@@ -313,11 +324,13 @@ class QSCar(HADeviceMixin, AbstractDevice):
         return self.name in person.authorized_cars
 
     def _fix_user_selected_person_from_forecast(self):
-        """Set user_selected_person_name_for_car from current_forecasted_person, with authorization check."""
+        """Set person_name from current_forecasted_person, with authorization check."""
+        if self.has_user_originated("person_name"):
+            return
         if self.current_forecasted_person is None:
             return
         if self._is_person_authorized_for_car(self.current_forecasted_person.name):
-            self.user_selected_person_name_for_car = self.current_forecasted_person.name
+            self.set_user_originated("person_name", self.current_forecasted_person.name)
         else:
             _LOGGER.warning(
                 "Car:%s skipping auto-assignment of Person:%s (not authorized)",
@@ -352,8 +365,8 @@ class QSCar(HADeviceMixin, AbstractDevice):
     def get_car_person_option(self) -> str | None:
 
         p_name = None
-        if self.user_selected_person_name_for_car is not None:
-            p_name = self.user_selected_person_name_for_car
+        if self.get_user_originated("person_name") is not None:
+            p_name = self.get_user_originated("person_name")
         elif self.current_forecasted_person is not None:
             p_name = self.current_forecasted_person.name
 
@@ -363,7 +376,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         return None
 
-    async def set_user_person_for_car(self, option: str):
+    async def user_set_person_for_car(self, option: str):
 
         if option is None:
             option = FORCE_CAR_NO_PERSON_ATTACHED
@@ -371,11 +384,11 @@ class QSCar(HADeviceMixin, AbstractDevice):
         if option != FORCE_CAR_NO_PERSON_ATTACHED and self.home:
             p_per = self.home.get_person_by_name(option)
             if p_per is None:
-                _LOGGER.error(f"set_user_person_for_car: WRONG PERSON OPTION PASSED {option}")
+                _LOGGER.error(f"user_set_person_for_car: WRONG PERSON OPTION PASSED {option}")
                 option = FORCE_CAR_NO_PERSON_ATTACHED
             elif not self._is_person_authorized_for_car(option):
                 _LOGGER.warning(
-                    "set_user_person_for_car: Car:%s Person:%s not authorized, ignoring",
+                    "user_set_person_for_car: Car:%s Person:%s not authorized, ignoring",
                     self.name,
                     option,
                 )
@@ -383,10 +396,10 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         new_value = option
 
-        if new_value == self.user_selected_person_name_for_car:
+        if new_value == self.get_user_originated("person_name"):
             return
 
-        self.user_selected_person_name_for_car = new_value
+        self.set_user_originated("person_name", new_value)
 
         # Check if the manual selection matches what is already forecasted;
         # if so, no reallocation is needed.
@@ -397,9 +410,11 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         if self.home:
             for car in self.home._cars:
-                if car.name != self.name and car.user_selected_person_name_for_car == new_value:
-                    # reset the user_selected_person_name_for_car for this car
-                    car.user_selected_person_name_for_car = None
+                if car.name != self.name and car.get_user_originated("person_name") == new_value:
+                    # the person is being reassigned to self; the other car's
+                    # entire snapshot (charge targets, times, etc.) was tied
+                    # to that person, so clear everything.
+                    car.clear_all_user_originated()
 
             await self.home.compute_and_set_best_persons_cars_allocations(force_update=True, do_notify=True)
 
@@ -493,7 +508,14 @@ class QSCar(HADeviceMixin, AbstractDevice):
     ) -> tuple[bool | None, datetime | None, float | None, Any | None]:
 
         if self.home:
-            person = self.current_forecasted_person
+            person = None
+            selected = self.get_user_originated("person_name")
+            if selected == FORCE_CAR_NO_PERSON_ATTACHED:
+                return (None, None, None, None)
+            if selected is not None:
+                person = self.home.get_person_by_name(selected)
+            if person is None:
+                person = self.current_forecasted_person
 
             if person is not None:
                 next_usage_time, p_mileage = person.update_person_forecast(time)
@@ -607,9 +629,6 @@ class QSCar(HADeviceMixin, AbstractDevice):
             return self.charger.get_charge_type()[0]
 
     async def convert_auto_constraint_to_manual_if_needed(self) -> bool:
-
-        # fix the person name ... for whom the car is charging
-        self._fix_user_selected_person_from_forecast()
 
         if self.charger is None:
             return False
@@ -834,7 +853,6 @@ class QSCar(HADeviceMixin, AbstractDevice):
         self.charger = None
         self.do_force_next_charge = False
         self.do_next_charge_time = None
-        self.user_attached_charger_name = None
         self._qs_bump_solar_priority = False
 
     def attach_charger(self, charger):
@@ -1576,10 +1594,8 @@ class QSCar(HADeviceMixin, AbstractDevice):
         if self.can_add_default_charge() is False:
             return False
 
-        # fix the person name ... for whom the car is charging
-        self._fix_user_selected_person_from_forecast()
-
         self.do_next_charge_time = end_charge
+        self.set_user_originated("charge_time", end_charge.isoformat())
         # start_time = end_charge
         # end_time = end_charge + timedelta(seconds=60*30)
         # time = datetime.now(pytz.UTC)
@@ -1601,14 +1617,12 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
     async def user_add_default_charge(self):
 
-        # fix the person name ... for whom the car is charging
-        self._fix_user_selected_person_from_forecast()
-
         if self.can_add_default_charge():
             res = await self.user_add_default_charge_at_dt_time(self.default_charge_time)
 
             if res and self.charger:
                 self.do_force_next_charge = False
+                self.set_user_originated("force_charge", False)
                 await self.charger.update_charger_for_user_change()
 
     def can_add_default_charge(self) -> bool:
@@ -1623,11 +1637,9 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
     async def user_force_charge_now(self):
         if self.can_force_a_charge_now():
-            # fix the person name ... for whom the car is charging
-            self._fix_user_selected_person_from_forecast()
-
             self.do_force_next_charge = True
             self.do_next_charge_time = None
+            self.set_user_originated("force_charge", True)
             if self.charger:
                 await self.charger.update_charger_for_user_change()
 
@@ -1676,15 +1688,17 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
     async def user_set_next_charge_target(self, value: int | float | str):
 
-        # fix the person name ... for whom the car is charging
-        self._fix_user_selected_person_from_forecast()
-
         do_update = await self.convert_auto_constraint_to_manual_if_needed()
 
         if self.can_use_charge_percent_constraints():
             do_update = await self.set_next_charge_target_percent(value) or do_update
         else:
             do_update = await self.set_next_charge_target_energy(value) or do_update
+
+        if self.can_use_charge_percent_constraints():
+            self.set_user_originated("charge_target_percent", self._next_charge_target)
+        else:
+            self.set_user_originated("charge_target_energy", self._next_charge_target_energy)
 
         if do_update and self.charger:
             await self.charger.update_charger_for_user_change()
@@ -1850,10 +1864,11 @@ class QSCar(HADeviceMixin, AbstractDevice):
         if value is False:
             self._qs_bump_solar_priority = False
         else:
-            # only one can have a bump of the entire chargers list
+            # only one can have a bump — clear others via direct attribute, not property
             for c in self.home._cars:
-                c.qs_bump_solar_charge_priority = False
+                c._qs_bump_solar_priority = False
             self._qs_bump_solar_priority = True
+        self.set_user_originated("bump_solar", self._qs_bump_solar_priority)
 
     def get_charger_options(self) -> list[str]:
 
@@ -1871,38 +1886,37 @@ class QSCar(HADeviceMixin, AbstractDevice):
         return options
 
     def get_current_selected_charger_option(self) -> str | None:
-        if self.user_attached_charger_name is not None:
-            return self.user_attached_charger_name
+        if self.get_user_originated("charger_name") is not None:
+            return self.get_user_originated("charger_name")
 
         if self.charger is None:
             return None
         else:
             return self.charger.name
 
-    async def set_user_selected_charger_by_name(self, charger_name: str | None):
+    async def user_set_selected_charger_by_name(self, charger_name: str | None):
 
         # if the car is already attached to a charger, we detach it
         orig_charger = self.charger
-        new_charger = None
 
         if self.charger is not None and self.charger.name != charger_name:
             self.detach_charger()
 
         if charger_name == FORCE_CAR_NO_CHARGER_CONNECTED:
-            self.user_attached_charger_name = FORCE_CAR_NO_CHARGER_CONNECTED
+            self.set_user_originated("charger_name", FORCE_CAR_NO_CHARGER_CONNECTED)
+        elif charger_name is not None:
+            charger = None
+            for c in self.home._chargers:
+                if c.name == charger_name:
+                    charger = c
+                    break
+            if charger is not None:
+                self.set_user_originated("charger_name", charger_name)
+                await charger.user_set_selected_car_by_name(car_name=self.name)
+            else:
+                self.clear_user_originated("charger_name")
         else:
-            self.user_attached_charger_name = None
-
-            if charger_name is not None:
-                charger = None
-                for c in self.home._chargers:
-                    if c.name == charger_name:
-                        charger = c
-                        break
-
-                if charger is not None:
-                    # this one will update the charger
-                    await charger.set_user_selected_car_by_name(car_name=self.name)
+            self.clear_user_originated("charger_name")
 
         if orig_charger is not None:
             await orig_charger.update_charger_for_user_change()
@@ -1911,8 +1925,6 @@ class QSCar(HADeviceMixin, AbstractDevice):
         charger = self.charger
         await super().user_clean_and_reset()
 
-        self.user_attached_charger_name = None
-        self.user_selected_person_name_for_car = None
         self.current_forecasted_person = None
 
         self.reset(keep_commands=True)  # will detach the car
@@ -1928,6 +1940,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
     async def user_clean_constraints(self):
         charger = self.charger
+        self.set_user_originated("charge_time", CHARGE_TIME_CONSTRAINTS_CLEARED)
         await super().user_clean_constraints()
         self._reset_charge_targets()
         await self.setup_car_charge_target_if_needed()

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -105,6 +105,7 @@ from ..const import (
     CAR_CHARGE_TYPE_SOLAR_PRIORITY_BEFORE_BATTERY,
     CAR_CHARGE_TYPE_TARGET_MET,
     CAR_HARD_WIRED_CHARGER,
+    CHARGE_TIME_CONSTRAINTS_CLEARED,
     CHARGER_NO_CAR_CONNECTED,
     CONF_CALENDAR,
     CONF_CAR_CHARGER_MAX_CHARGE,
@@ -1825,7 +1826,6 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
         self._internal_fake_is_plugged_id = "is_there_a_car_plugged"
 
         self.car: QSCar | None = None
-        self.user_attached_car_name: str | None = None
         self.car_attach_time: datetime | None = None
 
         self.charge_state = STATE_UNKNOWN
@@ -1884,30 +1884,11 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
 
         self._power_steps = []
 
-        self._auto_constraints_cleaned_at_user_reset: list[LoadConstraint] = []
-
     def update_to_be_saved_extra_device_info(self, data_to_update: dict):
         super().update_to_be_saved_extra_device_info(data_to_update)
-        data_to_update["user_attached_car_name"] = self.user_attached_car_name
-
-        serialized_constraints = [l.to_dict() for l in self._auto_constraints_cleaned_at_user_reset]
-
-        data_to_update["auto_constraints_cleaned_at_user_reset"] = serialized_constraints
 
     def use_saved_extra_device_info(self, stored_load_info: dict):
         super().use_saved_extra_device_info(stored_load_info)
-        self.user_attached_car_name = stored_load_info.get("user_attached_car_name", None)
-
-        constraints_dicts = stored_load_info.get("auto_constraints_cleaned_at_user_reset", [])
-
-        time = datetime.now(pytz.UTC)
-
-        self._auto_constraints_cleaned_at_user_reset = []
-
-        for c_dict in constraints_dicts:
-            cs_load = LoadConstraint.new_from_saved_dict(time, self, c_dict)
-            if cs_load is not None:
-                self._auto_constraints_cleaned_at_user_reset.append(cs_load)
 
     async def update_charger_for_user_change(self):
         time = datetime.now(pytz.UTC)
@@ -1916,27 +1897,11 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
 
     async def user_clean_and_reset(self):
         # manual reset the user selected car for charger
-        self.user_attached_car_name = None
         await super().user_clean_and_reset()
         await self.update_charger_for_user_change()
 
     async def user_clean_constraints(self):
-        # find any automated constraint
-        time = datetime.now(pytz.UTC)
-        auto_constraints = []
-        for ct in self._constraints:
-            if ct.is_constraint_active_for_time_period(time):
-                if (
-                    ct.type == CONSTRAINT_TYPE_MANDATORY_END_TIME
-                    and ct.load_param
-                    and ct.load_info is not None
-                    and "person" in ct.load_info
-                    and ct.from_user is False
-                ):
-                    auto_constraints.append(ct)
-
         await super().user_clean_constraints()
-        self._auto_constraints_cleaned_at_user_reset = auto_constraints
         await self.update_charger_for_user_change()
 
     @property
@@ -2434,7 +2399,6 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
         self._reset_state_machine()
         self._asked_for_reboot_at_time = None
         self.qs_bump_solar_priority = False
-        self._auto_constraints_cleaned_at_user_reset = []
         self.reset_boot_data()
         self.possible_charge_error_start_time = None
 
@@ -2501,9 +2465,9 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
             connected_time_delta = time - self.car_attach_time
             is_long_time_attached = connected_time_delta > timedelta(seconds=CAR_CHARGER_LONG_RELATIONSHIP_S)
 
-        if self.user_attached_car_name is not None:
-            if self.user_attached_car_name != CHARGER_NO_CAR_CONNECTED:
-                attached_car = self.home.get_car_by_name(self.user_attached_car_name)
+        if self.get_user_originated("car_name") is not None:
+            if self.get_user_originated("car_name") != CHARGER_NO_CAR_CONNECTED:
+                attached_car = self.home.get_car_by_name(self.get_user_originated("car_name"))
                 if attached_car is not None and car is not None:
                     if attached_car.name != car.name:
                         score = 0.0
@@ -2622,14 +2586,14 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
         # find the best car ...
 
         # cleanly handle the case where it has been user forced to a car
-        if self.user_attached_car_name is not None:
-            if self.user_attached_car_name != CHARGER_NO_CAR_CONNECTED:
-                if self.user_attached_car_name == self._default_generic_car.name:
+        if self.get_user_originated("car_name") is not None:
+            if self.get_user_originated("car_name") != CHARGER_NO_CAR_CONNECTED:
+                if self.get_user_originated("car_name") == self._default_generic_car.name:
                     car = self._default_generic_car
                 else:
-                    car = self.home.get_car_by_name(self.user_attached_car_name)
+                    car = self.home.get_car_by_name(self.get_user_originated("car_name"))
 
-                if car.user_attached_charger_name == FORCE_CAR_NO_CHARGER_CONNECTED:
+                if car.get_user_originated("charger_name") == FORCE_CAR_NO_CHARGER_CONNECTED:
                     car = None
 
                 if car is not None:
@@ -2641,13 +2605,13 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
 
                         if charger != self and charger.car is not None and charger.car.name == car.name:
                             if (
-                                charger.user_attached_car_name is not None
-                                and charger.user_attached_car_name == car.name
+                                charger.get_user_originated("car_name") is not None
+                                and charger.get_user_originated("car_name") == car.name
                             ):
                                 _LOGGER.error(
                                     f"get_best_car: {car.name} manually attached to multiple chargers: {self.name} and {charger.name}, detaching from {charger.name}"
                                 )
-                                charger.user_attached_car_name = None
+                                charger.clear_user_originated("car_name")
                             else:
                                 _LOGGER.info(
                                     f"get_best_car: {car.name} manually attached to charger {self.name}, detaching from {charger.name}"
@@ -2681,7 +2645,7 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
             chargers_scores[charger] = []
 
             for car in self.home._cars:
-                if car.user_attached_charger_name == FORCE_CAR_NO_CHARGER_CONNECTED:
+                if car.get_user_originated("charger_name") == FORCE_CAR_NO_CHARGER_CONNECTED:
                     _LOGGER.info(f"get_best_car: FORCE_CAR_NO_CHARGER_CONNECTED car: {car.name}")
                     continue
 
@@ -2738,7 +2702,7 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
         if best_car is None:
             if (
                 self._boot_car is not None
-                and self._boot_car.user_attached_charger_name != FORCE_CAR_NO_CHARGER_CONNECTED
+                and self._boot_car.get_user_originated("charger_name") != FORCE_CAR_NO_CHARGER_CONNECTED
             ):
                 best_car = self._boot_car
                 _LOGGER.info(f"get_best_car: Best Car from boot data: {best_car.name} for charger {self.name}")
@@ -2750,7 +2714,7 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
             if (
                 self._boot_car is not None
                 and self._boot_car.name != best_car.name
-                and self._boot_car.user_attached_charger_name != FORCE_CAR_NO_CHARGER_CONNECTED
+                and self._boot_car.get_user_originated("charger_name") != FORCE_CAR_NO_CHARGER_CONNECTED
             ):
                 # the best is not as good as the boot one ... we will use the boot one for now, whatever the score
                 _LOGGER.info(
@@ -2787,16 +2751,16 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
             return [CHARGER_NO_CAR_CONNECTED]
 
     def get_current_selected_car_option(self) -> str | None:
-        if self.user_attached_car_name is not None:
-            return self.user_attached_car_name
+        if self.get_user_originated("car_name") is not None:
+            return self.get_user_originated("car_name")
 
         if self.car is None:
             return None
         else:
             return self.car.name
 
-    async def set_user_selected_car_by_name(self, car_name: str | None):
-        self.user_attached_car_name = car_name
+    async def user_set_selected_car_by_name(self, car_name: str | None):
+        self.set_user_originated("car_name", car_name)
         if self.car is not None and self.car.name != car_name:
             self.detach_car()
 
@@ -2841,22 +2805,22 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
         self._boot_time_adjusted = None
 
         old_connected_car_name = None
-        if self.user_attached_car_name is not None:
-            if self.user_attached_car_name != CHARGER_NO_CAR_CONNECTED:
-                old_connected_car_name = self.user_attached_car_name
+        if self.get_user_originated("car_name") is not None:
+            if self.get_user_originated("car_name") != CHARGER_NO_CAR_CONNECTED:
+                old_connected_car_name = self.get_user_originated("car_name")
                 _LOGGER.info(
                     f"device_post_home_init: found a stored user attached car to be kept with {old_connected_car_name}"
                 )
                 self._boot_car = self.home.get_car_by_name(old_connected_car_name)
                 if self._boot_car is not None:
-                    self._boot_car.user_attached_charger_name = self.name
+                    self._boot_car._user_originated["charger_name"] = self.name
         elif self._constraints is not None and len(self._constraints) > 0:
             for ct in self._constraints:
                 old_connected_car_name = ct.load_param
                 self._boot_car = self.home.get_car_by_name(old_connected_car_name)
                 if (
                     self._boot_car is not None
-                    and self._boot_car.user_attached_charger_name == FORCE_CAR_NO_CHARGER_CONNECTED
+                    and self._boot_car.get_user_originated("charger_name") == FORCE_CAR_NO_CHARGER_CONNECTED
                 ):
                     self._boot_car = None
                     old_connected_car_name = None
@@ -2883,7 +2847,7 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                 self._boot_car = self.home.get_car_by_name(old_connected_car_name)
                 if (
                     self._boot_car is not None
-                    and self._boot_car.user_attached_charger_name == FORCE_CAR_NO_CHARGER_CONNECTED
+                    and self._boot_car.get_user_originated("charger_name") == FORCE_CAR_NO_CHARGER_CONNECTED
                 ):
                     _LOGGER.info(
                         f"device_post_home_init: found a stored car constraint to be kept with {old_connected_car_name} but it is not attached to a charger, so we will not use it"
@@ -2904,7 +2868,6 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
     async def check_load_activity_and_constraints(self, time: datetime) -> bool:
         # check that we have a connected car, and which one, or that it is completely disconnected
         #  if there is no more car ... just reset
-
         do_force_solve = False
         if not self._constraints:
             self._constraints = []
@@ -2945,13 +2908,11 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                     "clearing user_selected_person=%s and resetting charger",
                     self.car.name,
                     self.name,
-                    self.car.user_selected_person_name_for_car,
+                    self.car.get_user_originated("person_name"),
                 )
-                self.car.user_selected_person_name_for_car = (
-                    None  # in fact if a car is unplugged ... why changing any allocation?
-                )
+                self.car.clear_all_user_originated()
                 self.reset(keep_commands=True)  # will detach the car
-                self.user_attached_car_name = None  # physical unplug, reset the user selected car for charger
+                self.clear_user_originated("car_name")  # physical unplug, reset the user selected car for charger
                 do_force_solve = True
 
             # set_charging_num_phases will check that this switch is possible
@@ -3052,6 +3013,14 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
 
             common_additional_kwargs = {"total_capacity_wh": self.car.car_battery_capacity}
 
+            target_key = "charge_target_percent" if is_target_percent else "charge_target_energy"
+            if self.car.has_user_originated(target_key):
+                user_target = self.car.get_user_originated(target_key)
+                if user_target is not None and isinstance(user_target, (int, float)):
+                    target_charge = user_target
+                    if self.car.can_use_charge_percent_constraints():
+                        await self.car.setup_car_charge_target_if_needed(target_charge)
+
             # now check if the exiting constraint has the right class, ie the self.car.can_use_charge_percent_constraints() has changed or not
             has_changed_ct = False
             for i, ct in enumerate(self._constraints):
@@ -3089,16 +3058,32 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                 ) = await self.car.get_best_person_next_need(time)
                 person_to_notify = person
 
-            if self.car.do_force_next_charge is True and self.car.do_next_charge_time is not None:
+            if self.car.has_user_originated("force_charge"):
+                force_charge = self.car.get_user_originated("force_charge")
+            else:
+                force_charge = self.car.do_force_next_charge
+
+            has_charge_time = False
+            if self.car.has_user_originated("charge_time"):
+                ct_val = self.car.get_user_originated("charge_time")
+                has_charge_time = ct_val is not None and ct_val != CHARGE_TIME_CONSTRAINTS_CLEARED
+            if not has_charge_time:
+                has_charge_time = self.car.do_next_charge_time is not None
+
+            if force_charge is True and has_charge_time:
                 # both are set ... we will ignore the time based one
                 self.car.do_next_charge_time = None
+                self.car.clear_user_originated("charge_time")
 
-            degraded_type = CONSTRAINT_TYPE_FILLER
-            if self.qs_bump_solar_charge_priority:
-                degraded_type = CONSTRAINT_TYPE_BEFORE_BATTERY_GREEN
+            if self.car.has_user_originated("bump_solar"):
+                bump_solar = self.car.get_user_originated("bump_solar")
+            else:
+                bump_solar = self.qs_bump_solar_charge_priority
+
+            degraded_type = CONSTRAINT_TYPE_BEFORE_BATTERY_GREEN if bump_solar else CONSTRAINT_TYPE_FILLER
 
             # in case a user pressed the button ....clean everything and force the charge
-            if self.car.do_force_next_charge is True:
+            if force_charge is True:
                 do_force_solve = True
                 self.constraint_reset_and_reset_commands_if_needed(
                     keep_commands=True
@@ -3143,7 +3128,14 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                                 # update the constraints to follow the new as fast target
                                 self.set_live_constraints(time, self._constraints)
                             break
-                if force_constraint is not None and self.car.do_next_charge_time is not None:
+
+                if self.car.has_user_originated("charge_time"):
+                    ct_val = self.car.get_user_originated("charge_time")
+                    has_charge_time = ct_val is not None and ct_val != CHARGE_TIME_CONSTRAINTS_CLEARED
+                else:
+                    has_charge_time = self.car.do_next_charge_time is not None
+
+                if force_constraint is not None and has_charge_time:
                     # we should kill the force constraint and push a time based one...it will be done just below
                     # to be sure the time based one is pushed
                     force_constraint = None
@@ -3152,14 +3144,27 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                 # reset the next charge force state
                 self.car.do_force_next_charge = False
                 self.car.do_next_charge_time = None
+                self.car.clear_user_originated("force_charge")
+                self.car.clear_user_originated("charge_time")
                 realized_charge_target = target_charge
             else:
                 user_timed_constraint = None
-                # check for a possible user timed constraint
-                if self.car.do_next_charge_time is not None:
+                # check for a possible user timed constraint — _user_originated is the canonical source
+                charge_time = None
+                if self.car.has_user_originated("charge_time"):
+                    ct_val = self.car.get_user_originated("charge_time")
+                    if ct_val is not None and ct_val != CHARGE_TIME_CONSTRAINTS_CLEARED:
+                        if isinstance(ct_val, datetime):
+                            charge_time = ct_val
+                        elif isinstance(ct_val, str):
+                            charge_time = datetime.fromisoformat(ct_val)
+                else:
+                    charge_time = self.car.do_next_charge_time
+
+                if charge_time is not None:
                     # the constraint will be launched and the start time was the one pushed here : reset it
                     do_force_solve = True
-                    local_end_of_constraint = self.car.do_next_charge_time
+                    local_end_of_constraint = charge_time
                     self.constraint_reset_and_reset_commands_if_needed(
                         keep_commands=True
                     )  # cleanup any previous constraints to force this one!
@@ -3200,6 +3205,7 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
 
                 if user_timed_constraint:
                     self.car.do_next_charge_time = None
+                    self.car.clear_user_originated("charge_time")
                     realized_charge_target = target_charge
                 else:
                     # now see if we can have a schedule constraint from the agenda, not overridden by the time based user one above
@@ -3287,19 +3293,8 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                         ):
                             do_force_solve = True
 
-                        for old_ct in self._auto_constraints_cleaned_at_user_reset:
-                            if (
-                                old_ct.load_param == self.car.name
-                                and old_ct.load_info is not None
-                                and old_ct.load_info.get("person") == person.name
-                            ):
-                                if (
-                                    abs(old_ct.end_of_constraint - next_usage_time) < timedelta(minutes=15)
-                                    and abs(old_ct.target_value - person_min_target_charge) < 3.0
-                                ):
-                                    # ok found one ... that was reset by the user ... we should not add it back
-                                    person = None
-                                    break
+                        if self.car.get_user_originated("charge_time") == CHARGE_TIME_CONSTRAINTS_CLEARED:
+                            person = None
 
                     do_remove_all_person_constraints = True
 
@@ -3406,10 +3401,10 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
 
                 if is_target_percent is False:
                     type = CONSTRAINT_TYPE_FILLER
-                    if self.qs_bump_solar_charge_priority:
+                    if bump_solar:
                         type = CONSTRAINT_TYPE_BEFORE_BATTERY_GREEN
                 else:
-                    if self.qs_bump_solar_charge_priority:
+                    if bump_solar:
                         type = CONSTRAINT_TYPE_BEFORE_BATTERY_GREEN
                         default_type_for_low_battery = CONSTRAINT_TYPE_BEFORE_BATTERY_GREEN
                         intermediate_target_charge = 0

--- a/custom_components/quiet_solar/ha_model/home.py
+++ b/custom_components/quiet_solar/ha_model/home.py
@@ -2390,14 +2390,16 @@ class QSHome(QSDynamicGroup):
             for car in self._cars:
                 car.current_forecasted_person = None
 
-                if car.user_selected_person_name_for_car is None:
+                _person_name = car.get_user_originated("person_name")
+
+                if _person_name is None:
                     continue
 
-                if car.user_selected_person_name_for_car == FORCE_CAR_NO_PERSON_ATTACHED:
+                if _person_name == FORCE_CAR_NO_PERSON_ATTACHED:
                     covered_cars.add(car.name)
                     continue
 
-                p_per = self.get_person_by_name(car.user_selected_person_name_for_car)
+                p_per = self.get_person_by_name(_person_name)
                 if p_per is not None:
                     if car.name not in p_per.authorized_cars:
                         _LOGGER.warning(
@@ -2406,7 +2408,7 @@ class QSHome(QSDynamicGroup):
                             car.name,
                             p_per.name,
                         )
-                        car.user_selected_person_name_for_car = None
+                        car.clear_all_user_originated()
                         continue
                     self._last_persons_car_allocation[car.name] = p_per
                     covered_persons.add(p_per.name)

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -93,6 +93,8 @@ class AbstractDevice:
     def __init__(self, name: str, device_type: str | None = None, **kwargs):
         super().__init__()
         self._enabled = True
+        self._user_originated: dict[str, Any] = {}
+        self._in_user_originated_update: bool = False
         self._power_use_conf = kwargs.pop(CONF_POWER, None)
         self.efficiency = float(min(kwargs.pop(CONF_DEVICE_EFFICIENCY, 100.0), 100.0))
         self._device_is_3p_conf = kwargs.pop(CONF_IS_3P, False)
@@ -143,6 +145,30 @@ class AbstractDevice:
         self.father_device: QSDynamicGroup = self.home
 
         self._computed_dashboard_section = None
+
+    def set_user_originated(self, key: str, value: Any) -> None:
+        self._user_originated[key] = value
+        if not self._in_user_originated_update:
+            self._in_user_originated_update = True
+            try:
+                self._on_user_originated_changed(key, value)
+            finally:
+                self._in_user_originated_update = False
+
+    def _on_user_originated_changed(self, key: str, value: Any) -> None:
+        """Override in subclasses to react to user-originated state changes."""
+
+    def get_user_originated(self, key: str, default: Any = None) -> Any:
+        return self._user_originated.get(key, default)
+
+    def has_user_originated(self, key: str) -> bool:
+        return key in self._user_originated
+
+    def clear_user_originated(self, key: str) -> None:
+        self._user_originated.pop(key, None)
+
+    def clear_all_user_originated(self) -> None:
+        self._user_originated.clear()
 
     def is_device_light_on(self) -> bool:
         if self.current_command is None or self.current_command.is_off_or_idle():
@@ -278,6 +304,7 @@ class AbstractDevice:
 
     async def user_clean_and_reset(self):
         _LOGGER.info(f"user_clean_and_reset device {self.name}")
+        self.clear_all_user_originated()
         self.reset()
 
     async def user_clean_constraints(self):
@@ -391,8 +418,10 @@ class AbstractDevice:
         data_to_update["last_check_update"] = (
             self.last_check_update.isoformat() if self.last_check_update is not None else None
         )
+        data_to_update["_user_originated"] = self._user_originated
 
     def use_saved_extra_device_info(self, stored_load_info: dict):
+        self._user_originated = stored_load_info.get("_user_originated", {})
         self.num_on_off = stored_load_info.get("num_on_off", 0)
 
         if self.num_on_off > 0 and self.num_on_off % 2 == 1:

--- a/custom_components/quiet_solar/select.py
+++ b/custom_components/quiet_solar/select.py
@@ -44,7 +44,7 @@ def create_ha_select_for_QSCharger(device: QSChargerGeneric):
         translation_key="selected_car_for_charger",
         get_available_options_fn=lambda device, key: device.get_car_options(),
         get_current_option_fn=lambda device, key: device.get_current_selected_car_option(),
-        async_set_current_option_fn=lambda device, key, option, for_init: device.set_user_selected_car_by_name(option),
+        async_set_current_option_fn=lambda device, key, option, for_init: device.user_set_selected_car_by_name(option),
     )
     # use QSBaseSelect as it needs to be recomputed every time, the information is stored on the charger constraint load infos
     entities.append(QSBaseSelect(data_handler=device.data_handler, device=device, description=selected_car_description))
@@ -59,7 +59,7 @@ def create_ha_select_for_QSCar(device: QSCar):
         translation_key="selected_charger_for_car",
         get_available_options_fn=lambda device, key: device.get_charger_options(),
         get_current_option_fn=lambda device, key: device.get_current_selected_charger_option(),
-        async_set_current_option_fn=lambda device, key, option, for_init: device.set_user_selected_charger_by_name(
+        async_set_current_option_fn=lambda device, key, option, for_init: device.user_set_selected_charger_by_name(
             option
         ),
     )
@@ -84,7 +84,7 @@ def create_ha_select_for_QSCar(device: QSCar):
         translation_key="selected_person_for_car",
         get_available_options_fn=lambda device, key: device.get_car_persons_options(),
         get_current_option_fn=lambda device, key: device.get_car_person_option(),
-        async_set_current_option_fn=lambda device, key, option, for_init: device.set_user_person_for_car(option),
+        async_set_current_option_fn=lambda device, key, option, for_init: device.user_set_person_for_car(option),
     )
     # use QSBaseSelect as it needs to be recomputed every time, the information is stored on the car device infos
     entities.append(QSBaseSelect(data_handler=device.data_handler, device=device, description=selected_car_description))

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -687,10 +687,27 @@ class TestCarDouble:
         self.qs_bump_solar_charge_priority = qs_bump_solar_charge_priority
         self.charger = None
         self._current_charge_percent = kwargs.get("current_soc", 50.0)
+        self._user_originated: dict[str, Any] = {}
 
         # Apply any additional kwargs as attributes
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+    # Mirror AbstractDevice user_originated API
+    def set_user_originated(self, key: str, value: Any) -> None:
+        self._user_originated[key] = value
+
+    def get_user_originated(self, key: str, default: Any = None) -> Any:
+        return self._user_originated.get(key, default)
+
+    def has_user_originated(self, key: str) -> bool:
+        return key in self._user_originated
+
+    def clear_user_originated(self, key: str) -> None:
+        self._user_originated.pop(key, None)
+
+    def clear_all_user_originated(self) -> None:
+        self._user_originated.clear()
 
     def get_charge_power_per_phase_A(
         self,

--- a/tests/ha_tests/test_car.py
+++ b/tests/ha_tests/test_car.py
@@ -805,7 +805,7 @@ async def test_car_user_selected_person(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
-    """Test car user_selected_person_name_for_car property."""
+    """Test car get_user_originated('person_name') returns None initially."""
     from .const import MOCK_CAR_CONFIG
 
     await hass.config_entries.async_setup(home_config_entry.entry_id)
@@ -824,7 +824,7 @@ async def test_car_user_selected_person(
 
     car_device = hass.data[DOMAIN].get(car_entry.entry_id)
     # Initially should be None
-    assert car_device.user_selected_person_name_for_car is None
+    assert car_device.get_user_originated("person_name") is None
 
 
 async def test_car_is_invited(
@@ -912,7 +912,7 @@ async def test_car_person_options_filters_authorized_persons(
     assert FORCE_CAR_NO_PERSON_ATTACHED in options
 
 
-async def test_car_set_user_person_for_car_updates_other_cars(
+async def test_car_user_set_person_for_car_updates_other_cars(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
@@ -954,12 +954,12 @@ async def test_car_set_user_person_for_car_updates_other_cars(
     mock_person.name = "Person A"
     mock_person.authorized_cars = [car1_device.name, car2_device.name]
     data_handler.home.get_person_by_name = MagicMock(return_value=mock_person)
-    car2_device.user_selected_person_name_for_car = "Person A"
+    car2_device.set_user_originated("person_name", "Person A")
 
-    await car1_device.set_user_person_for_car("Person A")
+    await car1_device.user_set_person_for_car("Person A")
 
-    assert car1_device.user_selected_person_name_for_car == "Person A"
-    assert car2_device.user_selected_person_name_for_car is None
+    assert car1_device.get_user_originated("person_name") == "Person A"
+    assert car2_device.get_user_originated("person_name") is None
 
 
 async def test_car_device_post_home_init_restores_person(
@@ -997,7 +997,7 @@ async def test_car_device_post_home_init_restores_person(
     car_device = hass.data[DOMAIN].get(car_entry.entry_id)
     car_device.use_saved_extra_device_info(
         {
-            "user_selected_person_name_for_car": "Person Restore",
+            "_user_originated": {"person_name": "Person Restore"},
             "current_forecasted_person_name_from_boot": "Person Restore",
         }
     )
@@ -1078,7 +1078,10 @@ async def test_car_convert_auto_constraint_to_manual(
     result = await car_device.convert_auto_constraint_to_manual_if_needed()
 
     assert result is True
-    assert car_device.user_selected_person_name_for_car == MOCK_PERSON_CONFIG["name"]
+    # Person is now set via snapshot inside user_add_default_charge_at_datetime,
+    # but since we mocked that method, the snapshot didn't fire.
+    # Verify the mock was called (the real method would snapshot the person).
+    car_device.user_add_default_charge_at_datetime.assert_awaited_once()
 
 
 async def test_car_efficiency_from_soc_and_odometer(
@@ -1718,13 +1721,13 @@ async def test_car_user_selected_charger_by_name(
     charger_device.attach_car(car_device, datetime.now(tz=pytz.UTC))
 
     with patch.object(charger_device, "update_charger_for_user_change", new=AsyncMock()) as mock_update:
-        await car_device.set_user_selected_charger_by_name(charger_device.name)
-        assert charger_device.user_attached_car_name == car_device.name
-        assert car_device.user_attached_charger_name is None
+        await car_device.user_set_selected_charger_by_name(charger_device.name)
+        assert charger_device.get_user_originated("car_name") == car_device.name
+        assert car_device.get_user_originated("charger_name") == charger_device.name
         mock_update.assert_awaited()
 
-        await car_device.set_user_selected_charger_by_name(FORCE_CAR_NO_CHARGER_CONNECTED)
-        assert car_device.user_attached_charger_name == FORCE_CAR_NO_CHARGER_CONNECTED
+        await car_device.user_set_selected_charger_by_name(FORCE_CAR_NO_CHARGER_CONNECTED)
+        assert car_device.get_user_originated("charger_name") == FORCE_CAR_NO_CHARGER_CONNECTED
         assert car_device.charger is None
         assert charger_device.car is None
 
@@ -1768,8 +1771,8 @@ async def test_car_user_clean_and_reset(
 
     charger_device.attach_car(car_device, datetime.now(tz=pytz.UTC))
     car_device._constraints = [MagicMock()]
-    car_device.user_attached_charger_name = charger_device.name
-    car_device.user_selected_person_name_for_car = "Person A"
+    car_device.set_user_originated("charger_name", charger_device.name)
+    car_device.set_user_originated("person_name", "Person A")
     car_device._next_charge_target = 90
     car_device._next_charge_target_energy = 30000.0
     car_device.do_force_next_charge = True
@@ -1781,13 +1784,13 @@ async def test_car_user_clean_and_reset(
     with patch.object(charger_device, "update_charger_for_user_change", new=AsyncMock()):
         await car_device.user_clean_and_reset()
 
-    assert car_device.user_attached_charger_name is None
-    assert car_device.user_selected_person_name_for_car is None
+    assert car_device.get_user_originated("charger_name") is None
+    assert car_device.get_user_originated("person_name") is None
     assert car_device.charger is None
     assert car_device._constraints == []
     assert car_device._next_charge_target == car_device.car_default_charge
     assert car_device._next_charge_target_energy is None
-    assert charger_device.user_attached_car_name is None
+    assert charger_device.get_user_originated("car_name") is None
 
 
 async def test_car_user_clean_constraints(
@@ -1830,7 +1833,7 @@ async def test_car_user_clean_constraints(
     charger_device.attach_car(car_device, datetime.now(tz=pytz.UTC))
     car_device._constraints = [MagicMock()]
     car_device._next_charge_target = 95
-    car_device.user_attached_charger_name = charger_device.name
+    car_device.set_user_originated("charger_name", charger_device.name)
 
     with patch.object(charger_device, "update_charger_for_user_change", new=AsyncMock()):
         await car_device.user_clean_constraints()

--- a/tests/ha_tests/test_car_coverage.py
+++ b/tests/ha_tests/test_car_coverage.py
@@ -49,14 +49,14 @@ async def test_car_device_post_home_init_no_person_match(
     car_device = hass.data[DOMAIN].get(car_entry.entry_id)
 
     # Set an invalid person name that won't match any existing person
-    car_device.user_selected_person_name_for_car = "NonExistentPerson"
+    car_device.set_user_originated("person_name", "NonExistentPerson")
     car_device._current_forecasted_person_name_from_boot = None
 
     time = datetime.now(tz=pytz.UTC)
     car_device.device_post_home_init(time)
 
     # Should clear the invalid person selection
-    assert car_device.user_selected_person_name_for_car is None
+    assert car_device.get_user_originated("person_name") is None
     assert car_device.current_forecasted_person is None
 
 
@@ -82,7 +82,7 @@ async def test_car_device_post_home_init_force_no_person(
     await hass.async_block_till_done()
 
     car_device = hass.data[DOMAIN].get(car_entry.entry_id)
-    car_device.user_selected_person_name_for_car = FORCE_CAR_NO_PERSON_ATTACHED
+    car_device.set_user_originated("person_name", FORCE_CAR_NO_PERSON_ATTACHED)
 
     time = datetime.now(tz=pytz.UTC)
     car_device.device_post_home_init(time)
@@ -614,7 +614,7 @@ async def test_car_update_to_be_saved_extra_device_info(
     car_device = hass.data[DOMAIN].get(car_entry.entry_id)
 
     # Set some values to save
-    car_device.user_selected_person_name_for_car = "TestPerson"
+    car_device.set_user_originated("person_name", "TestPerson")
 
     mock_person = MagicMock()
     mock_person.name = "ForecastPerson"
@@ -623,8 +623,9 @@ async def test_car_update_to_be_saved_extra_device_info(
     data = {}
     car_device.update_to_be_saved_extra_device_info(data)
 
-    assert "user_selected_person_name_for_car" in data
-    assert data["user_selected_person_name_for_car"] == "TestPerson"
+    # person_name is now persisted via _user_originated, not as a separate key
+    assert "_user_originated" in data
+    assert data["_user_originated"]["person_name"] == "TestPerson"
     assert "current_forecasted_person_name_from_boot" in data
     assert data["current_forecasted_person_name_from_boot"] == "ForecastPerson"
 
@@ -653,11 +654,11 @@ async def test_car_use_saved_extra_device_info(
     car_device = hass.data[DOMAIN].get(car_entry.entry_id)
 
     stored_data = {
-        "user_selected_person_name_for_car": "RestoredPerson",
+        "_user_originated": {"person_name": "RestoredPerson"},
         "current_forecasted_person_name_from_boot": "RestoredForecast",
     }
 
     car_device.use_saved_extra_device_info(stored_data)
 
-    assert car_device.user_selected_person_name_for_car == "RestoredPerson"
+    assert car_device.get_user_originated("person_name") == "RestoredPerson"
     assert car_device._current_forecasted_person_name_from_boot == "RestoredForecast"

--- a/tests/ha_tests/test_car_extended_coverage.py
+++ b/tests/ha_tests/test_car_extended_coverage.py
@@ -18,7 +18,7 @@ Key targets:
  - Various other under-tested happy paths and corner cases
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, time as dt_time, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -271,10 +271,14 @@ async def test_user_set_next_charge_target_energy_mode(
     car._use_percent_mode = False
     car.car_is_invited = True  # force energy mode
     car.convert_auto_constraint_to_manual_if_needed = AsyncMock(return_value=False)
-    car.set_next_charge_target_energy = AsyncMock(return_value=True)
+    async def _mock_set_energy(value):
+        car._next_charge_target_energy = 30000
+        return True
+
+    car.set_next_charge_target_energy = _mock_set_energy
 
     await car.user_set_next_charge_target("30kWh")
-    car.set_next_charge_target_energy.assert_awaited_once_with("30kWh")
+    assert car.get_user_originated("charge_target_energy") == 30000
     car.charger.update_charger_for_user_change.assert_awaited_once()
 
 
@@ -290,7 +294,7 @@ async def test_user_set_next_charge_target_sets_person(
     car.current_forecasted_person = SimpleNamespace(name="MyPerson")
 
     await car.user_set_next_charge_target(80)
-    assert car.user_selected_person_name_for_car == "MyPerson"
+    assert car.get_user_originated("person_name") == "MyPerson"
 
 
 # ===========================================================================
@@ -1208,7 +1212,7 @@ async def test_get_car_person_option_with_user_selected(
 ) -> None:
     """Returns user selected person name when set."""
     car, _ = await _create_car(hass, home_config_entry, entry_id_suffix="popt_usr")
-    car.user_selected_person_name_for_car = "MyPerson"
+    car.set_user_originated("person_name", "MyPerson")
     result = car.get_car_person_option()
     assert result == "MyPerson"
 
@@ -1230,7 +1234,7 @@ async def test_get_car_person_option_none(
 ) -> None:
     """Returns None when no person is set."""
     car, _ = await _create_car(hass, home_config_entry, entry_id_suffix="popt_no")
-    car.user_selected_person_name_for_car = None
+    car.clear_user_originated("person_name")
     car.current_forecasted_person = None
     result = car.get_car_person_option()
     assert result is None
@@ -1322,7 +1326,7 @@ async def test_user_add_default_charge_at_datetime(
     result = await car.user_add_default_charge_at_datetime(end)
     assert result is True
     assert car.do_next_charge_time == end
-    assert car.user_selected_person_name_for_car == "P1"
+    assert car.get_user_originated("person_name") == "P1"
 
 
 async def test_user_add_default_charge_at_datetime_no_charger(
@@ -1522,11 +1526,11 @@ async def test_car_can_limit_soc(
 
 
 # ===========================================================================
-# set_user_person_for_car – None option
+# user_set_person_for_car – None option
 # ===========================================================================
 
 
-async def test_set_user_person_for_car_none(
+async def test_user_set_person_for_car_none(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
@@ -1534,11 +1538,11 @@ async def test_set_user_person_for_car_none(
     car, _ = await _create_car(hass, home_config_entry, entry_id_suffix="pers_none")
     car.home.compute_and_set_best_persons_cars_allocations = AsyncMock(return_value={})
 
-    await car.set_user_person_for_car(None)
-    assert car.user_selected_person_name_for_car == FORCE_CAR_NO_PERSON_ATTACHED
+    await car.user_set_person_for_car(None)
+    assert car.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
 
 
-async def test_set_user_person_for_car_force_no(
+async def test_user_set_person_for_car_force_no(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
@@ -1546,8 +1550,8 @@ async def test_set_user_person_for_car_force_no(
     car, _ = await _create_car(hass, home_config_entry, entry_id_suffix="pers_fno")
     car.home.compute_and_set_best_persons_cars_allocations = AsyncMock(return_value={})
 
-    await car.set_user_person_for_car(FORCE_CAR_NO_PERSON_ATTACHED)
-    assert car.user_selected_person_name_for_car == FORCE_CAR_NO_PERSON_ATTACHED
+    await car.user_set_person_for_car(FORCE_CAR_NO_PERSON_ATTACHED)
+    assert car.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
 
 
 # ===========================================================================
@@ -1559,9 +1563,9 @@ async def test_get_current_selected_charger_user_name(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
-    """Returns user_attached_charger_name when set."""
+    """Returns get_user_originated('charger_name') when set."""
     car, _ = await _create_car(hass, home_config_entry, entry_id_suffix="selchg_usr")
-    car.user_attached_charger_name = "My Charger"
+    car.set_user_originated("charger_name", "My Charger")
     assert car.get_current_selected_charger_option() == "My Charger"
 
 
@@ -1666,7 +1670,7 @@ async def test_add_soc_odo_full_segment_lifecycle(
 
 
 # ===========================================================================
-# user_selected_person_name_for_car setter – clearing other cars
+# set_user_originated("person_name") – clearing other cars
 # ===========================================================================
 
 
@@ -1705,16 +1709,16 @@ async def test_user_selected_person_setter_clears_others(
     car1 = hass.data[DOMAIN].get(car1_entry.entry_id)
     car2 = hass.data[DOMAIN].get(car2_entry.entry_id)
 
-    car2.user_selected_person_name_for_car = "Alice"
+    car2.set_user_originated("person_name", "Alice")
 
     data_handler = hass.data[DOMAIN][DATA_HANDLER]
     data_handler.home.compute_and_set_best_persons_cars_allocations = AsyncMock(return_value={})
 
-    car1.user_selected_person_name_for_car = "Alice"
-    assert car1.user_selected_person_name_for_car == "Alice"
-    # Plain attribute assignment no longer triggers cross-car clearing;
-    # that logic now lives exclusively in set_user_person_for_car.
-    assert car2.user_selected_person_name_for_car == "Alice"
+    car1.set_user_originated("person_name", "Alice")
+    assert car1.get_user_originated("person_name") == "Alice"
+    # Plain set_user_originated no longer triggers cross-car clearing;
+    # that logic now lives exclusively in user_set_person_for_car.
+    assert car2.get_user_originated("person_name") == "Alice"
 
 
 # ===========================================================================
@@ -2364,12 +2368,22 @@ async def test_user_add_default_charge_sets_person_name(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
-    """user_add_default_charge copies current_forecasted_person to
-    user_selected_person_name_for_car (car.py line 1472)."""
+    """user_add_default_charge snapshots forecast person when charger is connected."""
     car, _ = await _create_car(hass, home_config_entry, entry_id_suffix="defchg_pn")
-    car.charger = None
-    car.current_forecasted_person = SimpleNamespace(name="ForecastedUser")
+    # Attach a mock charger so can_add_default_charge() returns True
+    charger = MagicMock()
+    charger.update_charger_for_user_change = AsyncMock()
+    car.charger = charger
+    car.default_charge_time = dt_time(7, 0)
+
+    person = SimpleNamespace(name="ForecastedUser")
+    car.current_forecasted_person = person
+    # Make person authorized
+    person_obj = MagicMock()
+    person_obj.authorized_cars = [car.name]
+    car.home.get_person_by_name = MagicMock(return_value=person_obj)
+    car.home._persons = [person_obj]
 
     await car.user_add_default_charge()
 
-    assert car.user_selected_person_name_for_car == "ForecastedUser"
+    assert car.get_user_originated("person_name") == "ForecastedUser"

--- a/tests/ha_tests/test_car_missing_lines.py
+++ b/tests/ha_tests/test_car_missing_lines.py
@@ -20,7 +20,7 @@ Covers:
  - update_dampening_value graph add fail for amperage (line 1335)
  - update_dampening_value 3p cross-update to 1p (line 1351)
  - user_add_default_charge_at_dt_time can_add=False (line 1509)
- - set_user_person_for_car with charger update (line 379)
+ - user_set_person_for_car with charger update (line 379)
 """
 
 from datetime import datetime, timedelta
@@ -909,7 +909,7 @@ async def test_user_add_default_charge_at_dt_time_cannot_add(
 
 
 # ===========================================================================
-# set_user_person_for_car with charger update (line 379)
+# user_set_person_for_car with charger update (line 379)
 # ===========================================================================
 
 
@@ -917,7 +917,7 @@ async def test_set_user_person_triggers_charger_update(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
-    """set_user_person_for_car triggers charger update when car has charger (line 379)."""
+    """user_set_person_for_car triggers charger update when car has charger (line 379)."""
     from .const import MOCK_CAR_CONFIG
 
     await hass.config_entries.async_setup(home_config_entry.entry_id)
@@ -948,8 +948,8 @@ async def test_set_user_person_triggers_charger_update(
     data_handler.home._persons = [mock_person]
     data_handler.home.get_person_by_name = MagicMock(return_value=mock_person)
 
-    await car.set_user_person_for_car("NewPerson")
-    assert car.user_selected_person_name_for_car == "NewPerson"
+    await car.user_set_person_for_car("NewPerson")
+    assert car.get_user_originated("person_name") == "NewPerson"
     # Charger update now happens inside compute_and_set_best_persons_cars_allocations
     data_handler.home.compute_and_set_best_persons_cars_allocations.assert_awaited_once()
 
@@ -995,7 +995,7 @@ async def test_get_max_charge_limit_float_state(
 
 # ===========================================================================
 # Authorization check coverage: _is_person_authorized_for_car, _fix_user_selected_person_from_forecast,
-# device_post_home_init unauthorized branch, set_user_person_for_car unauthorized branch
+# device_post_home_init unauthorized branch, user_set_person_for_car unauthorized branch
 # ===========================================================================
 
 
@@ -1023,10 +1023,10 @@ async def test_fix_user_selected_person_from_forecast_unauthorized(
     data_handler.home._persons = [mock_person]
 
     car.current_forecasted_person = mock_person
-    car.user_selected_person_name_for_car = None
+    car.clear_user_originated("person_name")
 
     car._fix_user_selected_person_from_forecast()
-    assert car.user_selected_person_name_for_car is None
+    assert car.get_user_originated("person_name") is None
 
 
 async def test_device_post_home_init_clears_unauthorized_person(
@@ -1070,7 +1070,7 @@ async def test_device_post_home_init_clears_unauthorized_person(
     car_device = hass.data[DOMAIN].get(car_entry.entry_id)
     car_device.use_saved_extra_device_info(
         {
-            "user_selected_person_name_for_car": "Unauthorized Person",
+            "_user_originated": {"person_name": "Unauthorized Person"},
             "current_forecasted_person_name_from_boot": "Unauthorized Person",
         }
     )
@@ -1078,15 +1078,15 @@ async def test_device_post_home_init_clears_unauthorized_person(
     car_device.device_post_home_init(datetime.now(tz=pytz.UTC))
 
     # Person exists but is not authorized for this car -> cleared
-    assert car_device.user_selected_person_name_for_car is None
+    assert car_device.get_user_originated("person_name") is None
     assert car_device.current_forecasted_person is None
 
 
-async def test_set_user_person_for_car_rejects_unauthorized(
+async def test_user_set_person_for_car_rejects_unauthorized(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
-    """set_user_person_for_car rejects an unauthorized person (lines 347-351)."""
+    """user_set_person_for_car rejects an unauthorized person (lines 347-351)."""
     from .const import MOCK_CAR_CONFIG
 
     await hass.config_entries.async_setup(home_config_entry.entry_id)
@@ -1112,8 +1112,8 @@ async def test_set_user_person_for_car_rejects_unauthorized(
     mock_person.authorized_cars = []  # car not in authorized list
     data_handler.home.get_person_by_name = MagicMock(return_value=mock_person)
 
-    car.user_selected_person_name_for_car = None
-    await car.set_user_person_for_car("BadPerson")
+    car.clear_user_originated("person_name")
+    await car.user_set_person_for_car("BadPerson")
 
     # Should be rejected, value unchanged
-    assert car.user_selected_person_name_for_car is None
+    assert car.get_user_originated("person_name") is None

--- a/tests/ha_tests/test_charger.py
+++ b/tests/ha_tests/test_charger.py
@@ -1020,10 +1020,10 @@ async def test_charger_set_user_selected_car_detaches(
     charger_device.attach_car(car_device, datetime.now(tz=pytz.UTC))
     charger_device.update_charger_for_user_change = AsyncMock()
 
-    await charger_device.set_user_selected_car_by_name("Other Car")
+    await charger_device.user_set_selected_car_by_name("Other Car")
 
     assert charger_device.car is None
-    assert charger_device.user_attached_car_name == "Other Car"
+    assert charger_device.get_user_originated("car_name") == "Other Car"
     charger_device.update_charger_for_user_change.assert_awaited_once()
 
 
@@ -1221,7 +1221,7 @@ async def test_charger_check_load_activity_unplugged(
     charger_device = hass.data[DOMAIN].get(charger_entry.entry_id)
     car_device = hass.data[DOMAIN].get(car_entry.entry_id)
     charger_device.car = car_device
-    car_device.user_selected_person_name_for_car = "Person A"
+    car_device.set_user_originated("person_name", "Person A")
 
     charger_device.is_not_plugged = MagicMock(return_value=True)
     charger_device.is_plugged = MagicMock(return_value=False)
@@ -1233,8 +1233,8 @@ async def test_charger_check_load_activity_unplugged(
     do_force = await charger_device.check_load_activity_and_constraints(time)
 
     assert do_force is True
-    assert car_device.user_selected_person_name_for_car is None
-    assert charger_device.user_attached_car_name is None
+    assert car_device.get_user_originated("person_name") is None
+    assert charger_device.get_user_originated("car_name") is None
     charger_device.reset.assert_called_once()
 
 
@@ -2505,18 +2505,11 @@ async def test_charger_saved_info_and_user_updates(
     charger_device.do_run_check_load_activity_and_constraints = AsyncMock(return_value=True)
 
     data = {}
-    # Mock constraint with to_dict method
-    mock_constraint = MagicMock()
-    mock_constraint.to_dict = MagicMock(return_value={"key": "value"})
-    charger_device._auto_constraints_cleaned_at_user_reset = [mock_constraint]
     charger_device.update_to_be_saved_extra_device_info(data)
-    assert "auto_constraints_cleaned_at_user_reset" in data
+    assert "_user_originated" in data
 
-    with patch(
-        "custom_components.quiet_solar.ha_model.charger.LoadConstraint.new_from_saved_dict",
-        side_effect=[MagicMock(), None],
-    ):
-        charger_device.use_saved_extra_device_info({"auto_constraints_cleaned_at_user_reset": [{"a": 1}, {"b": 2}]})
+    charger_device.use_saved_extra_device_info({"_user_originated": {"car_name": "SomeCar"}})
+    assert charger_device.get_user_originated("car_name") == "SomeCar"
 
     await charger_device.update_charger_for_user_change()
     charger_device.home.force_next_solve.assert_called_once()
@@ -2547,22 +2540,22 @@ async def test_charger_user_clean_constraints_and_group_power(
     charger_device.home.force_next_solve = MagicMock()
     charger_device.update_charger_for_user_change = AsyncMock()
 
-    # Mock constraint for testing user_clean_constraints
-    ct = MagicMock()
-    ct.is_constraint_active_for_time_period = MagicMock(return_value=True)
-    ct.type = CONSTRAINT_TYPE_MANDATORY_END_TIME
-    ct.load_param = "car"
-    ct.load_info = {"person": "Person A"}
-    ct.from_user = False
-    charger_device._constraints = [ct]
+    # Attach a mock car so we can verify clean_constraints flow
+    from tests.factories import create_test_car_double
 
+    car = create_test_car_double(name="TestCar")
+    charger_device.car = car
+
+    # The sentinel is set by car.user_clean_constraints, not charger's.
+    # Test that charger's user_clean_constraints delegates properly.
     with patch(
         "custom_components.quiet_solar.ha_model.charger.AbstractLoad.user_clean_constraints",
         new=AsyncMock(),
     ):
         await charger_device.user_clean_constraints()
 
-    assert charger_device._auto_constraints_cleaned_at_user_reset
+    # Charger should have called update_charger_for_user_change
+    charger_device.update_charger_for_user_change.assert_called_once()
 
     charger_device.father_device.get_average_power = MagicMock(return_value=50.0)
     assert charger_device.is_charger_group_power_zero(datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC), for_duration=60)
@@ -3334,7 +3327,7 @@ async def test_charger_check_load_activity_unplugged(
         car_charger_min_charge=6,
         car_charger_max_charge=32,
     )
-    car.user_selected_person_name_for_car = "user"
+    car.set_user_originated("person_name", "user")
     charger_device.car = car
     charger_device.reset = MagicMock()
 
@@ -3735,7 +3728,7 @@ async def test_charger_get_car_score(
 
     charger_device = hass.data[DOMAIN].get(charger_entry.entry_id)
     charger_device.car = None
-    charger_device.user_attached_car_name = None
+    charger_device.clear_user_originated("car_name")
     charger_device.charger_latitude = 48.8566
     charger_device.charger_longitude = 2.3522
 
@@ -3765,7 +3758,7 @@ async def test_charger_get_car_score(
     assert score is not None
     assert score > 0
 
-    charger_device.user_attached_car_name = car.name
+    charger_device.set_user_originated("car_name", car.name)
     charger_device.home.get_car_by_name = MagicMock(return_value=car)
     score = charger_device.get_car_score(car, datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC), cache)
     assert score >= 0
@@ -3805,7 +3798,7 @@ async def test_charger_get_car_score_user_attached(
     car_a = DummyCar("Car A")
     car_b = DummyCar("Car B")
 
-    charger_device.user_attached_car_name = car_a.name
+    charger_device.set_user_originated("car_name", car_a.name)
     charger_device.home.get_car_by_name = MagicMock(return_value=car_a)
 
     cache: dict = {}
@@ -3849,7 +3842,7 @@ async def test_charger_get_car_score_long_attached(
     car = DummyCar("Car Long")
     charger_device.car = car
     charger_device.car_attach_time = datetime(2026, 1, 14, 0, 0, tzinfo=pytz.UTC)
-    charger_device.user_attached_car_name = None
+    charger_device.clear_user_originated("car_name")
 
     cache: dict = {}
     score = charger_device.get_car_score(car, datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC), cache)
@@ -3878,7 +3871,7 @@ async def test_charger_get_car_score_plug_time_edges(
     await hass.async_block_till_done()
 
     charger_device = hass.data[DOMAIN].get(charger_entry.entry_id)
-    charger_device.user_attached_car_name = None
+    charger_device.clear_user_originated("car_name")
     charger_device.charger_latitude = 48.8566
     charger_device.charger_longitude = 2.3522
     charger_device.get_continuous_plug_duration = MagicMock(return_value=None)
@@ -3931,7 +3924,7 @@ async def test_charger_get_best_car_boot_and_default(
     await hass.async_block_till_done()
 
     charger_device = hass.data[DOMAIN].get(charger_entry.entry_id)
-    charger_device.user_attached_car_name = None
+    charger_device.clear_user_originated("car_name")
     charger_device.home._cars = []
     charger_device.home._chargers = [charger_device]
     charger_device.is_plugged = MagicMock(return_value=False)
@@ -3939,14 +3932,14 @@ async def test_charger_get_best_car_boot_and_default(
     from tests.factories import create_test_car_double
 
     boot_car = create_test_car_double(name="Boot Car")
-    boot_car.user_attached_charger_name = "charger"
+    boot_car.set_user_originated("charger_name", "charger")
     boot_car.charger = None
     charger_device._boot_car = boot_car
     assert charger_device.get_best_car(datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC)) == boot_car
 
     charger_device._boot_car = None
     default_car = create_test_car_double(name="Default Car")
-    default_car.user_attached_charger_name = None
+    default_car.clear_user_originated("charger_name")
     default_car.charger = None
     charger_device._default_generic_car = default_car
     assert charger_device.get_best_car(datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC)) == default_car
@@ -3978,9 +3971,21 @@ async def test_charger_best_car_and_user_selection(
     class DummyCar:
         def __init__(self, name: str) -> None:
             self.name = name
-            self.user_attached_charger_name = None
+            self._user_originated: dict = {}
             self.charger = None
             self.default_charge_time = None
+
+        def get_user_originated(self, key, default=None):
+            return self._user_originated.get(key, default)
+
+        def set_user_originated(self, key, value):
+            self._user_originated[key] = value
+
+        def has_user_originated(self, key):
+            return key in self._user_originated
+
+        def clear_user_originated(self, key):
+            self._user_originated.pop(key, None)
 
         def __hash__(self) -> int:
             return id(self)
@@ -3997,22 +4002,26 @@ async def test_charger_best_car_and_user_selection(
     best = charger_device.get_best_car(datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC))
     assert best in [car_a, car_b]
 
-    charger_device.user_attached_car_name = car_a.name
+    charger_device.set_user_originated("car_name", car_a.name)
     from tests.factories import create_test_charger_double
 
     other_charger = create_test_charger_double(name="Other", car=car_a)
     other_charger.qs_enable_device = True
-    other_charger.user_attached_car_name = None
+    other_charger._user_originated = {}
+    other_charger.get_user_originated = lambda key, default=None: other_charger._user_originated.get(key, default)
+    other_charger.set_user_originated = lambda key, value: other_charger._user_originated.__setitem__(key, value)
+    other_charger.has_user_originated = lambda key: key in other_charger._user_originated
+    other_charger.clear_user_originated = lambda key: other_charger._user_originated.pop(key, None)
     other_charger.detach_car = MagicMock()
     charger_device.home._chargers = [charger_device, other_charger]
     best = charger_device.get_best_car(datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC))
     assert best == car_a
     other_charger.detach_car.assert_called_once()
 
-    charger_device.user_attached_car_name = CHARGER_NO_CAR_CONNECTED
+    charger_device.set_user_originated("car_name", CHARGER_NO_CAR_CONNECTED)
     assert charger_device.get_best_car(datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC)) is None
 
-    charger_device.user_attached_car_name = None
+    charger_device.clear_user_originated("car_name")
     charger_device.car = car_a
     car_a.default_charge_time = datetime(2026, 1, 15, 7, 0, tzinfo=pytz.UTC).time()
     assert charger_device.default_charge_time == car_a.default_charge_time
@@ -4023,7 +4032,7 @@ async def test_charger_best_car_and_user_selection(
 
     charger_device.update_charger_for_user_change = AsyncMock()
     charger_device.detach_car = MagicMock()
-    await charger_device.set_user_selected_car_by_name(car_b.name)
+    await charger_device.user_set_selected_car_by_name(car_b.name)
     charger_device.detach_car.assert_called_once()
     charger_device.update_charger_for_user_change.assert_awaited()
 
@@ -4054,8 +4063,20 @@ async def test_charger_user_helpers_and_boot_data(
     class DummyCar:
         def __init__(self, name: str) -> None:
             self.name = name
-            self.user_attached_charger_name = None
+            self._user_originated: dict = {}
             self.default_charge_time = None
+
+        def get_user_originated(self, key, default=None):
+            return self._user_originated.get(key, default)
+
+        def set_user_originated(self, key, value):
+            self._user_originated[key] = value
+
+        def has_user_originated(self, key):
+            return key in self._user_originated
+
+        def clear_user_originated(self, key):
+            self._user_originated.pop(key, None)
 
         def can_add_default_charge(self) -> bool:
             return True
@@ -4083,9 +4104,9 @@ async def test_charger_user_helpers_and_boot_data(
     options = charger_device.get_car_options()
     assert car.name in options
 
-    charger_device.user_attached_car_name = car.name
+    charger_device.set_user_originated("car_name", car.name)
     assert charger_device.get_current_selected_car_option() == car.name
-    charger_device.user_attached_car_name = None
+    charger_device.clear_user_originated("car_name")
     charger_device.car = car
     assert charger_device.get_current_selected_car_option() == car.name
     charger_device.car = None
@@ -4095,10 +4116,10 @@ async def test_charger_user_helpers_and_boot_data(
     await charger_device.user_add_default_charge()
     await charger_device.user_force_charge_now()
 
-    charger_device.user_attached_car_name = car.name
+    charger_device.set_user_originated("car_name", car.name)
     charger_device.device_post_home_init(datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC))
     assert charger_device._boot_car == car
-    assert car.user_attached_charger_name == charger_device.name
+    assert car.get_user_originated("charger_name") == charger_device.name
 
 
 async def test_charger_boot_constraints_restore(
@@ -4127,7 +4148,19 @@ async def test_charger_boot_constraints_restore(
     class DummyCar:
         def __init__(self, name: str) -> None:
             self.name = name
-            self.user_attached_charger_name = FORCE_CAR_NO_CHARGER_CONNECTED
+            self._user_originated: dict = {"charger_name": FORCE_CAR_NO_CHARGER_CONNECTED}
+
+        def get_user_originated(self, key, default=None):
+            return self._user_originated.get(key, default)
+
+        def set_user_originated(self, key, value):
+            self._user_originated[key] = value
+
+        def has_user_originated(self, key):
+            return key in self._user_originated
+
+        def clear_user_originated(self, key):
+            self._user_originated.pop(key, None)
 
         def __hash__(self) -> int:
             return id(self)
@@ -4140,7 +4173,7 @@ async def test_charger_boot_constraints_restore(
             self.name = name
             self.load_param = load_param
 
-    charger_device.user_attached_car_name = None
+    charger_device.clear_user_originated("car_name")
     charger_device._constraints = [DummyConstraint("ct1", "Car Boot")]
     charger_device._last_completed_constraint = DummyConstraint("ct_last", "Car Boot")
 
@@ -4171,13 +4204,25 @@ async def test_charger_best_car_assignment_loop(
     await hass.async_block_till_done()
 
     charger_device = hass.data[DOMAIN].get(charger_entry.entry_id)
-    charger_device.user_attached_car_name = None
+    charger_device.clear_user_originated("car_name")
 
     class DummyCar:
         def __init__(self, name: str) -> None:
             self.name = name
-            self.user_attached_charger_name = None
+            self._user_originated: dict = {}
             self.charger = None
+
+        def get_user_originated(self, key, default=None):
+            return self._user_originated.get(key, default)
+
+        def set_user_originated(self, key, value):
+            self._user_originated[key] = value
+
+        def has_user_originated(self, key):
+            return key in self._user_originated
+
+        def clear_user_originated(self, key):
+            self._user_originated.pop(key, None)
 
         def __hash__(self) -> int:
             return id(self)

--- a/tests/ha_tests/test_charger_coverage.py
+++ b/tests/ha_tests/test_charger_coverage.py
@@ -411,11 +411,11 @@ async def test_charger_get_current_selected_car_option(
     assert result is None or isinstance(result, str)
 
 
-async def test_charger_set_user_selected_car_by_name_none(
+async def test_charger_user_set_selected_car_by_name_none(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
-    """Test set_user_selected_car_by_name with None (lines 2504-2634)."""
+    """Test user_set_selected_car_by_name with None (lines 2504-2634)."""
     from .const import MOCK_CHARGER_CONFIG
 
     await hass.config_entries.async_setup(home_config_entry.entry_id)
@@ -434,7 +434,7 @@ async def test_charger_set_user_selected_car_by_name_none(
 
     charger_device = hass.data[DOMAIN].get(charger_entry.entry_id)
 
-    await charger_device.set_user_selected_car_by_name(None)
+    await charger_device.user_set_selected_car_by_name(None)
 
     assert charger_device.car is None
 

--- a/tests/ha_tests/test_home.py
+++ b/tests/ha_tests/test_home.py
@@ -697,21 +697,29 @@ async def test_home_best_persons_cars_allocations_basic(
     car_a = SimpleNamespace(
         name="Car A",
         current_forecasted_person=None,
-        user_selected_person_name_for_car=None,
+        _user_originated={},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
         get_adapt_target_percent_soc_to_reach_range_km=MagicMock(return_value=(False, 40.0, 80.0, 10.0)),
     )
+    car_a.get_user_originated = lambda key, default=None: car_a._user_originated.get(key, default)
+    car_a.set_user_originated = lambda key, value: car_a._user_originated.__setitem__(key, value)
+    car_a.has_user_originated = lambda key: key in car_a._user_originated
+    car_a.clear_user_originated = lambda key: car_a._user_originated.pop(key, None)
     car_b = SimpleNamespace(
         name="Car B",
         current_forecasted_person=None,
-        user_selected_person_name_for_car=None,
+        _user_originated={},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
         get_adapt_target_percent_soc_to_reach_range_km=MagicMock(return_value=(True, 90.0, 60.0, 0.0)),
     )
+    car_b.get_user_originated = lambda key, default=None: car_b._user_originated.get(key, default)
+    car_b.set_user_originated = lambda key, value: car_b._user_originated.__setitem__(key, value)
+    car_b.has_user_originated = lambda key: key in car_b._user_originated
+    car_b.clear_user_originated = lambda key: car_b._user_originated.pop(key, None)
 
     person_a = _HashableNS(
         name="Person A",
@@ -1612,35 +1620,51 @@ async def test_home_best_persons_cars_allocations_fallbacks_and_notify(
     car_selected = SimpleNamespace(
         name="Car Selected",
         current_forecasted_person=None,
-        user_selected_person_name_for_car="Person Selected",
+        _user_originated={"person_name": "Person Selected"},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
     )
+    car_selected.get_user_originated = lambda key, default=None: car_selected._user_originated.get(key, default)
+    car_selected.set_user_originated = lambda key, value: car_selected._user_originated.__setitem__(key, value)
+    car_selected.has_user_originated = lambda key: key in car_selected._user_originated
+    car_selected.clear_user_originated = lambda key: car_selected._user_originated.pop(key, None)
     car_force_none = SimpleNamespace(
         name="Car Force None",
         current_forecasted_person=person_preferred,
-        user_selected_person_name_for_car=FORCE_CAR_NO_PERSON_ATTACHED,
+        _user_originated={"person_name": FORCE_CAR_NO_PERSON_ATTACHED},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
     )
+    car_force_none.get_user_originated = lambda key, default=None: car_force_none._user_originated.get(key, default)
+    car_force_none.set_user_originated = lambda key, value: car_force_none._user_originated.__setitem__(key, value)
+    car_force_none.has_user_originated = lambda key: key in car_force_none._user_originated
+    car_force_none.clear_user_originated = lambda key: car_force_none._user_originated.pop(key, None)
     car_preferred = SimpleNamespace(
         name="Car Preferred",
         current_forecasted_person=person_selected,
-        user_selected_person_name_for_car=None,
+        _user_originated={},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
     )
+    car_preferred.get_user_originated = lambda key, default=None: car_preferred._user_originated.get(key, default)
+    car_preferred.set_user_originated = lambda key, value: car_preferred._user_originated.__setitem__(key, value)
+    car_preferred.has_user_originated = lambda key: key in car_preferred._user_originated
+    car_preferred.clear_user_originated = lambda key: car_preferred._user_originated.pop(key, None)
     car_authorized = SimpleNamespace(
         name="Car Authorized",
         current_forecasted_person=None,
-        user_selected_person_name_for_car=None,
+        _user_originated={},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
     )
+    car_authorized.get_user_originated = lambda key, default=None: car_authorized._user_originated.get(key, default)
+    car_authorized.set_user_originated = lambda key, value: car_authorized._user_originated.__setitem__(key, value)
+    car_authorized.has_user_originated = lambda key: key in car_authorized._user_originated
+    car_authorized.clear_user_originated = lambda key: car_authorized._user_originated.pop(key, None)
 
     home._cars = [car_selected, car_force_none, car_preferred, car_authorized]
     home._persons = [person_selected, person_preferred, person_authorized]
@@ -1826,21 +1850,29 @@ async def test_home_best_persons_cars_allocations_cost_matrix_branches(
     car_main = SimpleNamespace(
         name="Car Main",
         current_forecasted_person=None,
-        user_selected_person_name_for_car=None,
+        _user_originated={},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
         get_adapt_target_percent_soc_to_reach_range_km=MagicMock(return_value=(False, 40.0, 80.0, 10.0)),
     )
+    car_main.get_user_originated = lambda key, default=None: car_main._user_originated.get(key, default)
+    car_main.set_user_originated = lambda key, value: car_main._user_originated.__setitem__(key, value)
+    car_main.has_user_originated = lambda key: key in car_main._user_originated
+    car_main.clear_user_originated = lambda key: car_main._user_originated.pop(key, None)
     car_unused = SimpleNamespace(
         name="Car Unused",
         current_forecasted_person=None,
-        user_selected_person_name_for_car=None,
+        _user_originated={},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
         get_adapt_target_percent_soc_to_reach_range_km=MagicMock(return_value=(False, 40.0, 80.0, 10.0)),
     )
+    car_unused.get_user_originated = lambda key, default=None: car_unused._user_originated.get(key, default)
+    car_unused.set_user_originated = lambda key, value: car_unused._user_originated.__setitem__(key, value)
+    car_unused.has_user_originated = lambda key: key in car_unused._user_originated
+    car_unused.clear_user_originated = lambda key: car_unused._user_originated.pop(key, None)
 
     person = _HashableNS(
         name="Person A",
@@ -1944,19 +1976,27 @@ async def test_home_best_persons_cars_allocations_skip_cases(
     invited_car = SimpleNamespace(
         name="Invited",
         current_forecasted_person=None,
-        user_selected_person_name_for_car=None,
+        _user_originated={},
         car_is_invited=True,
         charger=_FakeCharger(),
         ha_entities={},
     )
+    invited_car.get_user_originated = lambda key, default=None: invited_car._user_originated.get(key, default)
+    invited_car.set_user_originated = lambda key, value: invited_car._user_originated.__setitem__(key, value)
+    invited_car.has_user_originated = lambda key: key in invited_car._user_originated
+    invited_car.clear_user_originated = lambda key: invited_car._user_originated.pop(key, None)
     preset_car = SimpleNamespace(
         name="Preset",
         current_forecasted_person=SimpleNamespace(name="PresetPerson"),
-        user_selected_person_name_for_car=None,
+        _user_originated={},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
     )
+    preset_car.get_user_originated = lambda key, default=None: preset_car._user_originated.get(key, default)
+    preset_car.set_user_originated = lambda key, value: preset_car._user_originated.__setitem__(key, value)
+    preset_car.has_user_originated = lambda key: key in preset_car._user_originated
+    preset_car.clear_user_originated = lambda key: preset_car._user_originated.pop(key, None)
     home._cars = [invited_car, preset_car]
     home._persons = []
 
@@ -2124,11 +2164,16 @@ async def test_home_allocation_clears_stale_unauthorized_manual_assignment(
     car_stale = SimpleNamespace(
         name="Stale Car",
         current_forecasted_person=None,
-        user_selected_person_name_for_car="Stale Person",
+        _user_originated={"person_name": "Stale Person"},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
     )
+    car_stale.get_user_originated = lambda key, default=None: car_stale._user_originated.get(key, default)
+    car_stale.set_user_originated = lambda key, value: car_stale._user_originated.__setitem__(key, value)
+    car_stale.has_user_originated = lambda key: key in car_stale._user_originated
+    car_stale.clear_user_originated = lambda key: car_stale._user_originated.pop(key, None)
+    car_stale.clear_all_user_originated = lambda: car_stale._user_originated.clear()
 
     home._cars = [car_stale]
     home._persons = [person_stale]
@@ -2140,7 +2185,7 @@ async def test_home_allocation_clears_stale_unauthorized_manual_assignment(
     )
 
     # The stale manual assignment should have been cleared
-    assert car_stale.user_selected_person_name_for_car is None
+    assert car_stale._user_originated.get("person_name") is None
 
 
 async def test_home_allocation_rejects_unauthorized_hungarian_assignment(
@@ -2169,11 +2214,15 @@ async def test_home_allocation_rejects_unauthorized_hungarian_assignment(
     car = SimpleNamespace(
         name="Car X",
         current_forecasted_person=None,
-        user_selected_person_name_for_car=None,
+        _user_originated={},
         car_is_invited=False,
         charger=_FakeCharger(),
         ha_entities={},
     )
+    car.get_user_originated = lambda key, default=None: car._user_originated.get(key, default)
+    car.set_user_originated = lambda key, value: car._user_originated.__setitem__(key, value)
+    car.has_user_originated = lambda key: key in car._user_originated
+    car.clear_user_originated = lambda key: car._user_originated.pop(key, None)
 
     home._cars = [car]
     home._persons = [person]

--- a/tests/ha_tests/test_home_coverage.py
+++ b/tests/ha_tests/test_home_coverage.py
@@ -1183,7 +1183,7 @@ async def test_home_persons_cars_no_person_attached(
     for car in home._cars:
         from custom_components.quiet_solar.const import FORCE_CAR_NO_PERSON_ATTACHED
 
-        car.user_selected_person_name_for_car = FORCE_CAR_NO_PERSON_ATTACHED
+        car.set_user_originated("person_name", FORCE_CAR_NO_PERSON_ATTACHED)
 
     result = await home.compute_and_set_best_persons_cars_allocations()
     assert isinstance(result, dict)
@@ -1227,7 +1227,7 @@ async def test_home_persons_cars_user_selected_person(
     home = data_handler.home
 
     for car in home._cars:
-        car.user_selected_person_name_for_car = MOCK_PERSON_CONFIG["name"]
+        car.set_user_originated("person_name", MOCK_PERSON_CONFIG["name"])
 
     result = await home.compute_and_set_best_persons_cars_allocations()
     assert isinstance(result, dict)
@@ -2352,7 +2352,7 @@ async def test_topology_load_in_different_group(
 
 
 # ---------------------------------------------------------------------------
-# Cluster: user_selected_person_name_for_car (lines 2354-2367)
+# Cluster: get_user_originated("person_name") (lines 2354-2367)
 # ---------------------------------------------------------------------------
 
 
@@ -2393,7 +2393,7 @@ async def test_persons_cars_user_selected_person_not_covered(
 
     # Set car to have user-selected person; this person is not in covered_persons
     for car in home._cars:
-        car.user_selected_person_name_for_car = MOCK_PERSON_CONFIG["name"]
+        car.set_user_originated("person_name", MOCK_PERSON_CONFIG["name"])
         car.current_forecasted_person = None
 
     result = await home.compute_and_set_best_persons_cars_allocations()
@@ -3087,7 +3087,7 @@ async def test_allocation_energy_optimal_over_preferred(
         charger_mock.update_charger_for_user_change = AsyncMock()
         car.charger = charger_mock
         car.car_is_invited = False
-        car.user_selected_person_name_for_car = None
+        car.clear_user_originated("person_name")
         car.ha_entities = {}
 
     for person in home._persons:
@@ -3651,7 +3651,7 @@ async def test_car_allocation_no_forecasted_person_skip(
     for c in home._cars:
         c.charger = None
         c.current_forecasted_person = None
-        c.user_selected_person_name_for_car = None
+        c.clear_user_originated("person_name")
 
     car_inv.car_is_invited = True
     car_assigned.car_is_invited = False
@@ -4312,7 +4312,7 @@ async def test_allocation_force_no_person_fallback(
 ) -> None:
     """Cover lines 2356-2357: fallback loop hits FORCE_CAR_NO_PERSON_ATTACHED.
 
-    The car starts with user_selected_person_name_for_car=None so the first
+    The car starts with get_user_originated("person_name")=None so the first
     loop skips it.  A logger side-effect injects FORCE between the two loops,
     so the second loop sets current_forecasted_person = None and continues.
     """
@@ -4340,14 +4340,14 @@ async def test_allocation_force_no_person_fallback(
     home = data_handler.home
     car = home._cars[0]
 
-    assert car.user_selected_person_name_for_car is None
+    assert car.get_user_originated("person_name") is None
 
     logger = logging.getLogger("custom_components.quiet_solar.ha_model.home")
     original_info = logger.info
 
     def inject_force(msg, *args, **kwargs):
         if "No persons or cars to allocate" in str(msg):
-            car.user_selected_person_name_for_car = FORCE_CAR_NO_PERSON_ATTACHED
+            car.set_user_originated("person_name", FORCE_CAR_NO_PERSON_ATTACHED)
         return original_info(msg, *args, **kwargs)
 
     with patch.object(logger, "info", side_effect=inject_force):
@@ -4397,7 +4397,7 @@ async def test_allocation_user_selected_person_fallback(
     person = home._persons[0]
     car_a = next(c for c in home._cars if c.name == "Car A")
 
-    assert car_a.user_selected_person_name_for_car is None
+    assert car_a.get_user_originated("person_name") is None
 
     with patch.object(person, "update_person_forecast", return_value=(None, None)):
         result = await home.compute_and_set_best_persons_cars_allocations(force_update=True)

--- a/tests/test_car_charger_person_integration.py
+++ b/tests/test_car_charger_person_integration.py
@@ -704,13 +704,13 @@ class TestCarPersonAllocation:
         car2 = env.cars[1]
 
         # Set person on car1
-        car1.user_selected_person_name_for_car = "Person_1"
+        car1.set_user_originated("person_name", "Person_1")
 
         # Now set same person on car2 - should clear from car1
-        car2.user_selected_person_name_for_car = "Person_1"
+        car2.set_user_originated("person_name", "Person_1")
 
-        # Direct attribute assignment no longer triggers cross-car clearing
-        assert car1.user_selected_person_name_for_car == "Person_1"
+        # Direct set_user_originated no longer triggers cross-car clearing
+        assert car1.get_user_originated("person_name") == "Person_1"
 
     @pytest.mark.asyncio
     async def test_current_forecasted_person_assignment(
@@ -1116,13 +1116,14 @@ class TestCarResetInit:
         car = env.cars[0]
         person = env.persons[0]
 
-        car.user_selected_person_name_for_car = "Person_1"
+        car.set_user_originated("person_name", "Person_1")
         car.current_forecasted_person = person
 
         data = {}
         car.update_to_be_saved_extra_device_info(data)
 
-        assert "user_selected_person_name_for_car" in data
+        assert "_user_originated" in data
+        assert data["_user_originated"]["person_name"] == "Person_1"
         assert "current_forecasted_person_name_from_boot" in data
 
     @pytest.mark.asyncio
@@ -1134,13 +1135,13 @@ class TestCarResetInit:
         car = env.cars[0]
 
         stored_data = {
-            "user_selected_person_name_for_car": "SomePerson",
+            "_user_originated": {"person_name": "SomePerson"},
             "current_forecasted_person_name_from_boot": "AnotherPerson",
         }
 
         car.use_saved_extra_device_info(stored_data)
 
-        assert car.user_selected_person_name_for_car == "SomePerson"
+        assert car.get_user_originated("person_name") == "SomePerson"
         assert car._current_forecasted_person_name_from_boot == "AnotherPerson"
 
 

--- a/tests/test_charger_additional_coverage.py
+++ b/tests/test_charger_additional_coverage.py
@@ -449,7 +449,7 @@ def test_get_car_score_plug_and_distance() -> None:
     car = MagicMock()
     car.name = "TestCar"
     car.car_is_invited = False
-    car.user_attached_charger_name = None
+    car.get_user_originated = MagicMock(return_value=None)
     car.is_car_plugged.return_value = True
     car.is_car_home.return_value = True
     car.get_continuous_plug_duration.return_value = 120.0
@@ -474,15 +474,15 @@ def test_get_best_car_user_selected_detaches_others() -> None:
 
     car = MagicMock()
     car.name = "PreferredCar"
-    car.user_attached_charger_name = None
+    car.get_user_originated = MagicMock(return_value=None)
 
-    charger.user_attached_car_name = car.name
+    charger.set_user_originated("car_name", car.name)
     home.get_car_by_name = MagicMock(return_value=car)
 
     other_charger = MagicMock()
     other_charger.qs_enable_device = True
     other_charger.car = car
-    other_charger.user_attached_car_name = None
+    other_charger.get_user_originated = MagicMock(return_value=None)
     other_charger.detach_car = MagicMock()
 
     home._chargers = [charger, other_charger]
@@ -501,7 +501,7 @@ def test_get_best_car_falls_back_to_default() -> None:
 
     car = MagicMock()
     car.name = "IgnoredCar"
-    car.user_attached_charger_name = FORCE_CAR_NO_CHARGER_CONNECTED
+    car.get_user_originated = MagicMock(return_value=FORCE_CAR_NO_CHARGER_CONNECTED)
     home._cars = [car]
     home._chargers = [charger]
 
@@ -525,7 +525,7 @@ def test_get_car_options_and_current_selection() -> None:
     assert car.name in options
     assert CHARGER_NO_CAR_CONNECTED in options
 
-    charger.user_attached_car_name = car.name
+    charger.set_user_originated("car_name", car.name)
     assert charger.get_current_selected_car_option() == car.name
 
     with patch.object(charger, "is_optimistic_plugged", return_value=False):
@@ -533,7 +533,7 @@ def test_get_car_options_and_current_selection() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_user_selected_car_by_name_detaches() -> None:
+async def test_user_set_selected_car_by_name_detaches() -> None:
     """Cover user selection changing and detaching current car."""
     hass = create_mock_hass()
     home = create_mock_home(hass)
@@ -546,7 +546,7 @@ async def test_set_user_selected_car_by_name_detaches() -> None:
     charger.detach_car = MagicMock()
     charger.update_charger_for_user_change = AsyncMock()
 
-    await charger.set_user_selected_car_by_name("NewCar")
+    await charger.user_set_selected_car_by_name("NewCar")
 
     charger.detach_car.assert_called_once()
     charger.update_charger_for_user_change.assert_called_once()
@@ -562,7 +562,7 @@ def test_device_post_home_init_uses_user_attached_car() -> None:
     car.name = "StoredCar"
     home.get_car_by_name = MagicMock(return_value=car)
 
-    charger.user_attached_car_name = car.name
+    charger.set_user_originated("car_name", car.name)
     charger.device_post_home_init(datetime.now(pytz.UTC))
 
     assert charger._boot_car == car

--- a/tests/test_charger_coverage_deep.py
+++ b/tests/test_charger_coverage_deep.py
@@ -1406,7 +1406,7 @@ class TestDevicePostHomeInit:
         ch = _create_charger(hass, home)
         car = _make_real_car(hass, home)
         _init_charger_states(ch)
-        ch.user_attached_car_name = "TestCar"
+        ch.set_user_originated("car_name", "TestCar")
         ch.device_post_home_init(datetime.now(pytz.UTC))
         assert ch._boot_car is not None and ch._boot_car.name == "TestCar"
 
@@ -1428,7 +1428,7 @@ class TestDevicePostHomeInit:
         home = _make_home()
         ch = _create_charger(hass, home)
         car = _make_real_car(hass, home)
-        car.user_attached_charger_name = FORCE_CAR_NO_CHARGER_CONNECTED
+        car.set_user_originated("charger_name", FORCE_CAR_NO_CHARGER_CONNECTED)
         _init_charger_states(ch)
         ct = MagicMock()
         ct.load_param = "TestCar"
@@ -2951,8 +2951,8 @@ class TestGetBestCarEdgeCases:
         ch = _create_charger(hass, home)
         car = _make_real_car(hass, home)
         _init_charger_states(ch)
-        car.user_attached_charger_name = FORCE_CAR_NO_CHARGER_CONNECTED
-        ch.user_attached_car_name = "TestCar"
+        car.set_user_originated("charger_name", FORCE_CAR_NO_CHARGER_CONNECTED)
+        ch.set_user_originated("car_name", "TestCar")
         result = ch.get_best_car(datetime.now(pytz.UTC))
         # car was set to None at line 2358 but code falls through to scoring
         # which returns the default generic car
@@ -2969,7 +2969,7 @@ class TestGetBestCarEdgeCases:
         car = _make_real_car(hass, home)
         _init_charger_states(ch)
         _init_charger_states(ch2)
-        ch.user_attached_car_name = "TestCar"
+        ch.set_user_originated("car_name", "TestCar")
         # ch2 is disabled, shouldn't interfere
         result = ch.get_best_car(datetime.now(pytz.UTC))
         assert result is not None
@@ -2984,13 +2984,13 @@ class TestGetBestCarEdgeCases:
         _init_charger_states(ch1)
         _init_charger_states(ch2)
         # Both chargers claim the same car
-        ch1.user_attached_car_name = "TestCar"
-        ch2.user_attached_car_name = "TestCar"
+        ch1.set_user_originated("car_name", "TestCar")
+        ch2.set_user_originated("car_name", "TestCar")
         _plug_car(ch2, car, datetime.now(pytz.UTC))
         result = ch1.get_best_car(datetime.now(pytz.UTC))
         assert result is not None
         # ch2 should have been detached
-        assert ch2.user_attached_car_name is None
+        assert ch2.get_user_originated("car_name") is None
         assert ch2.car is None
 
 
@@ -4246,7 +4246,7 @@ class TestGetCarScore:
     def test_charger_no_car_connected_returns_neg(self):
         """Line 2435: disabled charger skipped in get_best_car."""
         hass, home, ch, car, now = self._setup()
-        ch.user_attached_car_name = CHARGER_NO_CAR_CONNECTED
+        ch.set_user_originated("car_name", CHARGER_NO_CAR_CONNECTED)
         result = ch.get_best_car(now)
         assert result is None
 
@@ -4286,7 +4286,7 @@ class TestGetCarScore:
         _init_charger_states(ch2)
         _plug_car(ch2, car2, now)
         ch.is_plugged = MagicMock(return_value=True)
-        ch.user_attached_car_name = None
+        ch.clear_user_originated("car_name")
         ch._boot_car = None
         result = ch.get_best_car(now)
         assert result is not None
@@ -4296,7 +4296,7 @@ class TestGetCarScore:
         hass, home, ch, car, now = self._setup()
         car2 = _make_real_car(hass, home, name="BootCar")
         ch._boot_car = car2
-        ch.user_attached_car_name = None
+        ch.clear_user_originated("car_name")
         ch.is_plugged = MagicMock(return_value=True)
         result = ch.get_best_car(now)
         assert result.name == "BootCar"
@@ -4305,8 +4305,8 @@ class TestGetCarScore:
         """Line 2502: empty chargers_scores[charger] -> continue."""
         hass, home, ch, car, now = self._setup()
         ch.detach_car()
-        car.user_attached_charger_name = FORCE_CAR_NO_CHARGER_CONNECTED
-        ch.user_attached_car_name = None
+        car.set_user_originated("charger_name", FORCE_CAR_NO_CHARGER_CONNECTED)
+        ch.clear_user_originated("car_name")
         ch._boot_car = None
         ch.is_plugged = MagicMock(return_value=True)
         result = ch.get_best_car(now)
@@ -4823,9 +4823,9 @@ class TestGetBestCarBootCarOverride:
         _init_charger_states(ch)
         now = datetime.now(pytz.UTC)
 
-        ch.user_attached_car_name = None
+        ch.clear_user_originated("car_name")
         ch._boot_car = car_b
-        car_b.user_attached_charger_name = None
+        car_b.clear_user_originated("charger_name")
 
         def mock_score(car, time, cache):
             if car.name == "CarA":
@@ -4853,8 +4853,8 @@ class TestGetBestCarCleanupEmptyScores:
         _init_charger_states(ch1)
         _init_charger_states(ch2)
 
-        ch1.user_attached_car_name = None
-        ch2.user_attached_car_name = None
+        ch1.clear_user_originated("car_name")
+        ch2.clear_user_originated("car_name")
         ch1._boot_car = None
         ch2._boot_car = None
 
@@ -5101,7 +5101,7 @@ class TestAutoConstraintCleanedPreventsPersonReAdd:
             support_auto=True,
         )
         old_ct.load_info = {"person": "Alice"}
-        charger._auto_constraints_cleaned_at_user_reset = [old_ct]
+        car.set_user_originated("charge_time", "constraints_cleared")
 
         await charger.check_load_activity_and_constraints(now)
 
@@ -5675,7 +5675,7 @@ class TestPersonConstraintBlockedByAutoReset:
 
     @pytest.mark.asyncio
     async def test_auto_reset_blocks_person_constraint(self):
-        """A matching old_ct in _auto_constraints_cleaned_at_user_reset blocks person."""
+        """constraints_cleared override on car blocks person constraint re-add."""
         *_, charger, car, now = self._setup()
 
         car.do_force_next_charge = False
@@ -5691,20 +5691,7 @@ class TestPersonConstraintBlockedByAutoReset:
 
         car.get_best_person_next_need = AsyncMock(return_value=(False, next_usage_time, person_min_target, person_mock))
 
-        old_ct = MultiStepsPowerLoadConstraintChargePercent(
-            total_capacity_wh=60000,
-            type=CONSTRAINT_TYPE_MANDATORY_END_TIME,
-            time=now - timedelta(hours=2),
-            load=charger,
-            load_param=car.name,
-            from_user=False,
-            end_of_constraint=next_usage_time,
-            initial_value=30.0,
-            target_value=person_min_target,
-            power_steps=charger._power_steps,
-            load_info={"person": "Alice"},
-        )
-        charger._auto_constraints_cleaned_at_user_reset = [old_ct]
+        car.set_user_originated("charge_time", "constraints_cleared")
 
         await charger.check_load_activity_and_constraints(now)
 
@@ -6644,3 +6631,76 @@ class TestUpdateValueCallbackLines3967_3971:
         # result should be result_calculus (50 + int(6) = 56), not sensor_result (52)
         assert result == 56
         assert keep is True
+
+
+# =============================================================================
+# Coverage: charge_time user_originated fallback (string and datetime branches)
+# =============================================================================
+
+
+class TestChargeTimeUserOriginatedFallback:
+    """Lines 3145-3153: charge_time from user_originated (string and datetime)."""
+
+    def _setup(self):
+        hass = _make_hass()
+        home = _make_home()
+        charger = _create_charger(hass, home)
+        car = _make_real_car(hass, home, default_charge=80.0, minimum_ok_charge=20.0)
+        now = datetime.now(pytz.UTC)
+
+        _init_charger_states(charger)
+        charger.is_charger_unavailable = MagicMock(return_value=False)
+        charger.probe_for_possible_needed_reboot = MagicMock(return_value=False)
+        charger.is_not_plugged = MagicMock(return_value=False)
+        charger.is_plugged = MagicMock(return_value=True)
+        charger.set_charging_num_phases = AsyncMock(return_value=False)
+        charger.set_max_charging_current = AsyncMock(return_value=True)
+        charger.reboot = AsyncMock()
+
+        _plug_car(charger, car, now)
+        charger.get_best_car = MagicMock(return_value=car)
+        return hass, home, charger, car, now
+
+    @pytest.mark.asyncio
+    async def test_charge_time_from_user_originated_string(self):
+        """charge_time fallback reads ISO string from user_originated."""
+        *_, charger, car, now = self._setup()
+
+        car.do_force_next_charge = False
+        car.do_next_charge_time = None  # force the fallback path
+        car.get_next_scheduled_event = AsyncMock(return_value=(None, None))
+        car.set_next_charge_target_percent = AsyncMock()
+        car.get_car_charge_percent = lambda time=None, *a, **kw: 40.0
+        car.get_best_person_next_need = AsyncMock(return_value=(None, None, None, None))
+
+        # Set charge_time as ISO string directly (bypass auto-snapshot which would overwrite it)
+        target_time = now + timedelta(hours=6)
+        car._user_originated["charge_time"] = target_time.isoformat()
+
+        await charger.check_load_activity_and_constraints(now)
+
+        # A timed constraint should have been created
+        timed_cts = [c for c in charger._constraints if c is not None and c.from_user is True]
+        assert len(timed_cts) >= 1
+
+    @pytest.mark.asyncio
+    async def test_charge_time_from_user_originated_datetime(self):
+        """charge_time fallback reads datetime object from user_originated."""
+        *_, charger, car, now = self._setup()
+
+        car.do_force_next_charge = False
+        car.do_next_charge_time = None  # force the fallback path
+        car.get_next_scheduled_event = AsyncMock(return_value=(None, None))
+        car.set_next_charge_target_percent = AsyncMock()
+        car.get_car_charge_percent = lambda time=None, *a, **kw: 40.0
+        car.get_best_person_next_need = AsyncMock(return_value=(None, None, None, None))
+
+        # Set charge_time as datetime object directly in user_originated
+        target_time = now + timedelta(hours=6)
+        car._user_originated["charge_time"] = target_time  # direct, bypassing isoformat
+
+        await charger.check_load_activity_and_constraints(now)
+
+        # A timed constraint should have been created
+        timed_cts = [c for c in charger._constraints if c is not None and c.from_user is True]
+        assert len(timed_cts) >= 1

--- a/tests/test_charger_extended.py
+++ b/tests/test_charger_extended.py
@@ -617,14 +617,14 @@ class TestQSChargerGenericExtended(unittest.TestCase):
 
     def test_get_current_selected_car_option_user_attached(self):
         """Test get_current_selected_car_option with user attached car."""
-        self.charger.user_attached_car_name = "MyCar"
+        self.charger.set_user_originated("car_name", "MyCar")
 
         result = self.charger.get_current_selected_car_option()
         self.assertEqual(result, "MyCar")
 
     def test_get_current_selected_car_option_no_car(self):
         """Test get_current_selected_car_option with no car."""
-        self.charger.user_attached_car_name = None
+        self.charger.clear_user_originated("car_name")
         self.charger.car = None
 
         result = self.charger.get_current_selected_car_option()
@@ -632,7 +632,7 @@ class TestQSChargerGenericExtended(unittest.TestCase):
 
     def test_get_current_selected_car_option_attached_car(self):
         """Test get_current_selected_car_option with attached car."""
-        self.charger.user_attached_car_name = None
+        self.charger.clear_user_originated("car_name")
         mock_car = MagicMock()
         mock_car.name = "AttachedCar"
         self.charger.car = mock_car
@@ -902,10 +902,10 @@ class TestQSChargerGenericCarSelection(unittest.TestCase):
         """Test get_best_car with user attached car."""
         mock_car = MagicMock()
         mock_car.name = "UserCar"
-        mock_car.user_attached_charger_name = None
+        mock_car.get_user_originated = MagicMock(return_value=None)
 
         self.home.get_car_by_name = MagicMock(return_value=mock_car)
-        self.charger.user_attached_car_name = "UserCar"
+        self.charger.set_user_originated("car_name", "UserCar")
 
         time = datetime.now(pytz.UTC)
         result = self.charger.get_best_car(time)
@@ -914,7 +914,7 @@ class TestQSChargerGenericCarSelection(unittest.TestCase):
 
     def test_get_best_car_no_car_connected(self):
         """Test get_best_car when user set CHARGER_NO_CAR_CONNECTED."""
-        self.charger.user_attached_car_name = CHARGER_NO_CAR_CONNECTED
+        self.charger.set_user_originated("car_name", CHARGER_NO_CAR_CONNECTED)
 
         time = datetime.now(pytz.UTC)
         result = self.charger.get_best_car(time)
@@ -931,7 +931,7 @@ class TestQSChargerGenericCarSelection(unittest.TestCase):
         attached_car.name = "AttachedCar"
 
         self.home.get_car_by_name = MagicMock(return_value=attached_car)
-        self.charger.user_attached_car_name = "AttachedCar"
+        self.charger.set_user_originated("car_name", "AttachedCar")
 
         time = datetime.now(pytz.UTC)
         cache = {}

--- a/tests/test_charger_heavy_integration.py
+++ b/tests/test_charger_heavy_integration.py
@@ -78,8 +78,11 @@ def create_mock_car(name="TestCar", charge_percent=50.0, battery_capacity=60000)
     car.do_force_next_charge = False
     car.do_next_charge_time = None
     car.calendar = None
-    car.user_selected_person_name_for_car = None
-    car.user_attached_charger_name = None
+    car._user_originated = {}
+    car.get_user_originated = lambda key, default=None: car._user_originated.get(key, default)
+    car.has_user_originated = lambda key: key in car._user_originated
+    car.set_user_originated = lambda key, value: car._user_originated.__setitem__(key, value)
+    car.clear_user_originated = lambda key: car._user_originated.pop(key, None)
     car.charger = None
 
     # Mock methods
@@ -245,9 +248,9 @@ class TestCheckLoadActivityAndConstraints:
         time = datetime.now(pytz.UTC)
 
         mock_car = create_mock_car()
-        mock_car.user_selected_person_name_for_car = "TestPerson"
+        mock_car._user_originated["person_name"] = "TestPerson"
         charger.car = mock_car
-        charger.user_attached_car_name = "TestCar"
+        charger.set_user_originated("car_name", "TestCar")
 
         with (
             patch.object(charger, "is_charger_unavailable", return_value=False),
@@ -263,7 +266,7 @@ class TestCheckLoadActivityAndConstraints:
 
         # Should reset the charger
         mock_reset.assert_called_once()
-        assert charger.user_attached_car_name is None
+        assert charger.get_user_originated("car_name") is None
         assert result is True  # Force solve triggered
 
     @pytest.mark.asyncio

--- a/tests/test_charger_integration.py
+++ b/tests/test_charger_integration.py
@@ -119,7 +119,7 @@ class TestCheckLoadActivityAndConstraints(unittest.IsolatedAsyncioTestCase):
 
         mock_car = MagicMock()
         mock_car.name = "TestCar"
-        mock_car.user_selected_person_name_for_car = "TestPerson"
+        mock_car.get_user_originated = MagicMock(return_value="TestPerson")
         self.charger.car = mock_car
 
         with (
@@ -182,7 +182,7 @@ class TestCheckLoadActivityAndConstraints(unittest.IsolatedAsyncioTestCase):
         mock_car.can_use_charge_percent_constraints.return_value = False
         mock_car.get_car_target_charge_energy.return_value = 45000.0
         mock_car.get_next_scheduled_event = AsyncMock(return_value=(None, None))
-        mock_car.user_selected_person_name_for_car = None
+        mock_car.get_user_originated = MagicMock(return_value=None)
 
         self.charger.car = mock_car
         self.charger._power_steps = [LoadCommand(command="on", power_consign=7000.0)]
@@ -242,10 +242,10 @@ class TestDevicePostHomeInit(unittest.TestCase):
 
         mock_car = MagicMock()
         mock_car.name = "UserCar"
-        mock_car.user_attached_charger_name = None
+        mock_car.get_user_originated = MagicMock(return_value=None)
 
         self.home.get_car_by_name = MagicMock(return_value=mock_car)
-        self.charger.user_attached_car_name = "UserCar"
+        self.charger.set_user_originated("car_name", "UserCar")
 
         self.charger.device_post_home_init(time)
 
@@ -258,7 +258,7 @@ class TestDevicePostHomeInit(unittest.TestCase):
 
         mock_car = MagicMock()
         mock_car.name = "ConstraintCar"
-        mock_car.user_attached_charger_name = None
+        mock_car.get_user_originated = MagicMock(return_value=None)
 
         mock_constraint = MagicMock()
         mock_constraint.load_param = "ConstraintCar"
@@ -325,7 +325,7 @@ class TestGetBestCar(unittest.TestCase):
         """Test get_best_car when user attached the generic car."""
         time = datetime.now(pytz.UTC)
 
-        self.charger.user_attached_car_name = self.charger._default_generic_car.name
+        self.charger.set_user_originated("car_name", self.charger._default_generic_car.name)
 
         result = self.charger.get_best_car(time)
 
@@ -336,7 +336,7 @@ class TestGetBestCar(unittest.TestCase):
         time = datetime.now(pytz.UTC)
 
         # Set user attached car name to CHARGER_NO_CAR_CONNECTED
-        self.charger.user_attached_car_name = CHARGER_NO_CAR_CONNECTED
+        self.charger.set_user_originated("car_name", CHARGER_NO_CAR_CONNECTED)
 
         result = self.charger.get_best_car(time)
 
@@ -348,10 +348,10 @@ class TestGetBestCar(unittest.TestCase):
 
         mock_boot_car = MagicMock()
         mock_boot_car.name = "BootCar"
-        mock_boot_car.user_attached_charger_name = None
+        mock_boot_car.get_user_originated = MagicMock(return_value=None)
 
         self.charger._boot_car = mock_boot_car
-        self.charger.user_attached_car_name = None
+        self.charger.clear_user_originated("car_name")
         self.home._cars = []
 
         with patch.object(self.charger, "is_plugged", return_value=False):
@@ -542,7 +542,7 @@ class TestGetCarScore(unittest.TestCase):
         mock_car = MagicMock()
         mock_car.name = "InvitedCar"
         mock_car.car_is_invited = True
-        mock_car.user_attached_charger_name = None
+        mock_car.get_user_originated = MagicMock(return_value=None)
 
         cache = {}
         result = self.charger.get_car_score(mock_car, time, cache)
@@ -562,7 +562,7 @@ class TestGetCarScore(unittest.TestCase):
         attached_car.name = "AttachedCar"
 
         self.home.get_car_by_name = MagicMock(return_value=attached_car)
-        self.charger.user_attached_car_name = "AttachedCar"
+        self.charger.set_user_originated("car_name", "AttachedCar")
 
         cache = {}
         result = self.charger.get_car_score(mock_car, time, cache)

--- a/tests/test_charger_methods.py
+++ b/tests/test_charger_methods.py
@@ -754,22 +754,20 @@ class TestQSChargerGenericSavedInfo(unittest.TestCase):
 
     def test_update_to_be_saved_extra_device_info(self):
         """Test update_to_be_saved_extra_device_info method."""
-        self.charger.user_attached_car_name = "TestCar"
-        self.charger._auto_constraints_cleaned_at_user_reset = []
+        self.charger.set_user_originated("car_name", "TestCar")
 
         data = {}
         self.charger.update_to_be_saved_extra_device_info(data)
 
-        self.assertEqual(data["user_attached_car_name"], "TestCar")
-        self.assertEqual(data["auto_constraints_cleaned_at_user_reset"], [])
+        self.assertEqual(data["_user_originated"]["car_name"], "TestCar")
 
     def test_use_saved_extra_device_info(self):
         """Test use_saved_extra_device_info method."""
-        stored_info = {"user_attached_car_name": "SavedCar", "auto_constraints_cleaned_at_user_reset": []}
+        stored_info = {"_user_originated": {"car_name": "SavedCar"}}
 
         self.charger.use_saved_extra_device_info(stored_info)
 
-        self.assertEqual(self.charger.user_attached_car_name, "SavedCar")
+        self.assertEqual(self.charger.get_user_originated("car_name"), "SavedCar")
 
 
 if __name__ == "__main__":

--- a/tests/test_chargers_advanced.py
+++ b/tests/test_chargers_advanced.py
@@ -306,7 +306,7 @@ class TestQSChargerGenericAdvanced(unittest.IsolatedAsyncioTestCase):
         mock_car = MagicMock()
         mock_car.name = "UserSelectedCar"
         charger.home.get_car_by_name = MagicMock(return_value=mock_car)
-        charger.user_attached_car_name = "UserSelectedCar"
+        charger.set_user_originated("car_name", "UserSelectedCar")
         charger.home._chargers = [charger]
 
         time = datetime.now(pytz.UTC)
@@ -320,7 +320,7 @@ class TestQSChargerGenericAdvanced(unittest.IsolatedAsyncioTestCase):
         with patch("custom_components.quiet_solar.ha_model.charger.entity_registry"):
             charger = QSChargerGeneric(**self.charger_config)
 
-        charger.user_attached_car_name = CHARGER_NO_CAR_CONNECTED
+        charger.set_user_originated("car_name", CHARGER_NO_CAR_CONNECTED)
 
         time = datetime.now(pytz.UTC)
 
@@ -343,10 +343,10 @@ class TestQSChargerGenericAdvanced(unittest.IsolatedAsyncioTestCase):
         mock_charger2 = MagicMock()
         mock_charger2.qs_enable_device = True
         mock_charger2.car = mock_car2
-        mock_charger2.user_attached_car_name = None
+        mock_charger2.get_user_originated = MagicMock(return_value=None)
         charger.home._chargers = [charger, mock_charger2]
 
-        charger.user_attached_car_name = None
+        charger.clear_user_originated("car_name")
 
         time = datetime.now(pytz.UTC)
 

--- a/tests/test_chargers_comprehensive.py
+++ b/tests/test_chargers_comprehensive.py
@@ -559,7 +559,7 @@ class TestQSChargerGenericBasics(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(charger.charger_max_charge, 32)
         self.assertEqual(charger.charger_consumption_W, 70)
         self.assertIsNone(charger.car)
-        self.assertIsNone(charger.user_attached_car_name)
+        self.assertIsNone(charger.get_user_originated("car_name"))
         self.assertIsNone(charger.car_attach_time)
         self.assertEqual(charger.charge_state, STATE_UNKNOWN)
 
@@ -620,7 +620,7 @@ class TestQSChargerGenericBasics(unittest.IsolatedAsyncioTestCase):
         with patch("custom_components.quiet_solar.ha_model.charger.entity_registry"):
             charger = QSChargerGeneric(**self.charger_config)
 
-        charger.user_attached_car_name = "ManualCar"
+        charger.set_user_originated("car_name", "ManualCar")
         result = charger.get_current_selected_car_option()
         self.assertEqual(result, "ManualCar")
 
@@ -645,7 +645,7 @@ class TestQSChargerGenericBasics(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, "AttachedCar")
 
     @pytest.mark.asyncio
-    async def test_set_user_selected_car_by_name(self):
+    async def test_user_set_selected_car_by_name(self):
         """Test setting user selected car by name."""
         with patch("custom_components.quiet_solar.ha_model.charger.entity_registry"):
             charger = QSChargerGeneric(**self.charger_config)
@@ -659,14 +659,14 @@ class TestQSChargerGenericBasics(unittest.IsolatedAsyncioTestCase):
             patch.object(charger, "detach_car") as mock_detach,
             patch.object(charger, "update_charger_for_user_change", new_callable=AsyncMock) as mock_update,
         ):
-            await charger.set_user_selected_car_by_name("NewCar")
+            await charger.user_set_selected_car_by_name("NewCar")
 
-        self.assertEqual(charger.user_attached_car_name, "NewCar")
+        self.assertEqual(charger.get_user_originated("car_name"), "NewCar")
         mock_detach.assert_called_once()
         mock_update.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_set_user_selected_car_by_name_same_car(self):
+    async def test_user_set_selected_car_by_name_same_car(self):
         """Test setting user selected car to same car name."""
         with patch("custom_components.quiet_solar.ha_model.charger.entity_registry"):
             charger = QSChargerGeneric(**self.charger_config)
@@ -680,9 +680,9 @@ class TestQSChargerGenericBasics(unittest.IsolatedAsyncioTestCase):
             patch.object(charger, "detach_car") as mock_detach,
             patch.object(charger, "update_charger_for_user_change", new_callable=AsyncMock),
         ):
-            await charger.set_user_selected_car_by_name("SameCar")
+            await charger.user_set_selected_car_by_name("SameCar")
 
-        self.assertEqual(charger.user_attached_car_name, "SameCar")
+        self.assertEqual(charger.get_user_originated("car_name"), "SameCar")
         mock_detach.assert_not_called()  # Should not detach same car
 
     def test_attach_car(self):

--- a/tests/test_ha_car_comprehensive.py
+++ b/tests/test_ha_car_comprehensive.py
@@ -248,26 +248,26 @@ class TestQSCarRangeEstimation:
 class TestQSCarPersonInteraction:
     """Test car-person allocation and interaction."""
 
-    def test_user_selected_person_property_getter(self, create_car):
-        """Test user_selected_person_name_for_car getter."""
+    def test_user_selected_person_get_set(self, create_car):
+        """Test get/set_user_originated for person_name."""
         car = create_car()
-        car.user_selected_person_name_for_car = "John"
+        car.set_user_originated("person_name", "John")
 
-        assert car.user_selected_person_name_for_car == "John"
+        assert car.get_user_originated("person_name") == "John"
 
-    def test_user_selected_person_property_setter_triggers_update(self, create_car, hass, car_home):
-        """Verify direct attribute assignment works (property setter was removed)."""
+    def test_user_selected_person_set_triggers_update(self, create_car, hass, car_home):
+        """Verify set_user_originated for person_name works."""
         car = create_car()
-        car.user_selected_person_name_for_car = "Jane"
-        assert car.user_selected_person_name_for_car == "Jane"
+        car.set_user_originated("person_name", "Jane")
+        assert car.get_user_originated("person_name") == "Jane"
 
     def test_user_selected_person_no_person_attached(self, create_car):
         """Test setting FORCE_CAR_NO_PERSON_ATTACHED."""
         car = create_car()
 
-        car.user_selected_person_name_for_car = FORCE_CAR_NO_PERSON_ATTACHED
+        car.set_user_originated("person_name", FORCE_CAR_NO_PERSON_ATTACHED)
 
-        assert car.user_selected_person_name_for_car == FORCE_CAR_NO_PERSON_ATTACHED
+        assert car.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
 
     def test_car_person_option_format(self, create_car):
         """Test _car_person_option returns person name."""
@@ -318,11 +318,11 @@ class TestQSCarChargerIntegration:
         assert car.charger == mock_charger
 
     def test_user_attached_charger_name(self, create_car):
-        """Test user_attached_charger_name property."""
+        """Test get/set_user_originated for charger_name."""
         car = create_car()
-        car.user_attached_charger_name = "My Charger"
+        car.set_user_originated("charger_name", "My Charger")
 
-        assert car.user_attached_charger_name == "My Charger"
+        assert car.get_user_originated("charger_name") == "My Charger"
 
     def test_hard_wired_charger(self, create_car):
         """Test car with hard-wired charger."""
@@ -433,7 +433,7 @@ class TestQSCarSaveRestoreState:
     def test_update_to_be_saved_extra_device_info(self, create_car):
         """Test update_to_be_saved_extra_device_info saves person info."""
         car = create_car()
-        car.user_selected_person_name_for_car = "John"
+        car.set_user_originated("person_name", "John")
 
         mock_person = MagicMock()
         mock_person.name = "Jane"
@@ -442,18 +442,21 @@ class TestQSCarSaveRestoreState:
         data = {}
         car.update_to_be_saved_extra_device_info(data)
 
-        assert data["user_selected_person_name_for_car"] == "John"
+        assert data["_user_originated"]["person_name"] == "John"
         assert data["current_forecasted_person_name_from_boot"] == "Jane"
 
     def test_use_saved_extra_device_info(self, create_car):
         """Test use_saved_extra_device_info restores person info."""
         car = create_car()
 
-        stored_data = {"user_selected_person_name_for_car": "John", "current_forecasted_person_name_from_boot": "Jane"}
+        stored_data = {
+            "_user_originated": {"person_name": "John"},
+            "current_forecasted_person_name_from_boot": "Jane",
+        }
 
         car.use_saved_extra_device_info(stored_data)
 
-        assert car.user_selected_person_name_for_car == "John"
+        assert car.get_user_originated("person_name") == "John"
         assert car._current_forecasted_person_name_from_boot == "Jane"
 
 
@@ -505,7 +508,7 @@ class TestQSCarExtendedCoverage:
         from custom_components.quiet_solar.ha_model.car import FORCE_CAR_NO_PERSON_ATTACHED
 
         car = create_car()
-        car.user_selected_person_name_for_car = FORCE_CAR_NO_PERSON_ATTACHED
+        car.set_user_originated("person_name", FORCE_CAR_NO_PERSON_ATTACHED)
 
         time = datetime.datetime.now(pytz.UTC)
         car.device_post_home_init(time)
@@ -515,13 +518,13 @@ class TestQSCarExtendedCoverage:
     def test_device_post_home_init_user_selected_invalid_person(self, create_car, car_home):
         """Test device_post_home_init with invalid user selected person (lines 281-284)."""
         car = create_car()
-        car.user_selected_person_name_for_car = "NonExistentPerson"
+        car.set_user_originated("person_name", "NonExistentPerson")
         car_home.get_person_by_name = MagicMock(return_value=None)
 
         time = datetime.datetime.now(pytz.UTC)
         car.device_post_home_init(time)
 
-        assert car.user_selected_person_name_for_car is None
+        assert car.get_user_originated("person_name") is None
         assert car.current_forecasted_person is None
 
     def test_device_post_home_init_exception_handling(self, create_car, car_home):
@@ -559,7 +562,7 @@ class TestQSCarExtendedCoverage:
     def test_get_car_person_option_with_forecasted_person(self, create_car):
         """Test get_car_person_option returns forecasted person (lines 330-331)."""
         car = create_car()
-        car.user_selected_person_name_for_car = None
+        car.clear_user_originated("person_name")
 
         mock_person = MagicMock()
         mock_person.name = "John"
@@ -573,26 +576,26 @@ class TestQSCarExtendedCoverage:
         car._car_person_option.assert_called_with("John")
 
     @pytest.mark.asyncio
-    async def test_set_user_person_for_car_none(self, create_car):
-        """Test set_user_person_for_car with None (lines 346-348)."""
+    async def test_user_set_person_for_car_none(self, create_car):
+        """Test user_set_person_for_car with None (lines 346-348)."""
         from custom_components.quiet_solar.ha_model.car import FORCE_CAR_NO_PERSON_ATTACHED
 
         car = create_car()
 
-        await car.set_user_person_for_car(None)
+        await car.user_set_person_for_car(None)
 
-        assert car.user_selected_person_name_for_car == FORCE_CAR_NO_PERSON_ATTACHED
+        assert car.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
 
     @pytest.mark.asyncio
-    async def test_set_user_person_for_car_force_no_person(self, create_car):
-        """Test set_user_person_for_car with FORCE_CAR_NO_PERSON_ATTACHED (lines 349-351)."""
+    async def test_user_set_person_for_car_force_no_person(self, create_car):
+        """Test user_set_person_for_car with FORCE_CAR_NO_PERSON_ATTACHED (lines 349-351)."""
         from custom_components.quiet_solar.ha_model.car import FORCE_CAR_NO_PERSON_ATTACHED
 
         car = create_car()
 
-        await car.set_user_person_for_car(FORCE_CAR_NO_PERSON_ATTACHED)
+        await car.user_set_person_for_car(FORCE_CAR_NO_PERSON_ATTACHED)
 
-        assert car.user_selected_person_name_for_car == FORCE_CAR_NO_PERSON_ATTACHED
+        assert car.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
 
     def test_get_charge_power_per_phase_A_1p(self, create_car):
         """Test get_charge_power_per_phase_A method for 1-phase (lines 1491-1590)."""

--- a/tests/test_ha_charger_comprehensive.py
+++ b/tests/test_ha_charger_comprehensive.py
@@ -1156,9 +1156,9 @@ class TestQSChargerExtendedCoverage:
         assert result is None or isinstance(result, str)
 
     @pytest.mark.asyncio
-    async def test_set_user_selected_car_by_name_none(self, charger_generic):
-        """Test set_user_selected_car_by_name with None (lines 2504-2634)."""
-        await charger_generic.set_user_selected_car_by_name(None)
+    async def test_user_set_selected_car_by_name_none(self, charger_generic):
+        """Test user_set_selected_car_by_name with None (lines 2504-2634)."""
+        await charger_generic.user_set_selected_car_by_name(None)
 
         # Car should be None
         assert charger_generic.car is None

--- a/tests/test_person_car_allocation.py
+++ b/tests/test_person_car_allocation.py
@@ -1,7 +1,7 @@
 """End-to-end tests for the person-car allocation algorithm.
 
 These tests exercise the real allocation pipeline (Hungarian algorithm,
-pre-allocation of unplugged cars, manual overrides via set_user_person_for_car)
+pre-allocation of unplugged cars, manual overrides via user_set_person_for_car)
 with lightweight fakes instead of full HA integration.
 """
 
@@ -27,7 +27,7 @@ KWH_PER_KM = 0.15
 
 
 class _FakeCharger:
-    """Stub charger so car.charger is truthy and set_user_person_for_car works."""
+    """Stub charger so car.charger is truthy and user_set_person_for_car works."""
 
     async def update_charger_for_user_change(self):
         pass
@@ -41,10 +41,26 @@ class _FakeCar:
         self._remaining_km = remaining_km
         self.charger = _FakeCharger() if has_charger else None
         self.car_is_invited = is_invited
-        self.user_selected_person_name_for_car = None
+        self._user_originated: dict = {}
         self.current_forecasted_person = None
         self.home = None
         self.ha_entities = {}
+
+    # Mirror AbstractDevice user_originated API
+    def set_user_originated(self, key, value):
+        self._user_originated[key] = value
+
+    def get_user_originated(self, key, default=None):
+        return self._user_originated.get(key, default)
+
+    def has_user_originated(self, key):
+        return key in self._user_originated
+
+    def clear_user_originated(self, key):
+        self._user_originated.pop(key, None)
+
+    def clear_all_user_originated(self):
+        self._user_originated.clear()
 
     def get_adapt_target_percent_soc_to_reach_range_km(self, mileage, time):
         """Return (is_covered, current_soc, needed_soc, diff_energy)."""
@@ -57,7 +73,7 @@ class _FakeCar:
         return (False, 40.0, 80.0, deficit)
 
     # Bind real methods from QSCar so we exercise the actual logic.
-    set_user_person_for_car = QSCar.set_user_person_for_car
+    user_set_person_for_car = QSCar.user_set_person_for_car
     _is_person_authorized_for_car = QSCar._is_person_authorized_for_car
     _fix_user_selected_person_from_forecast = QSCar._fix_user_selected_person_from_forecast
 
@@ -187,7 +203,7 @@ def _build_scenario():
 
 
 class TestSetUserPersonEdgeCases:
-    """Cover edge-case branches in set_user_person_for_car."""
+    """Cover edge-case branches in user_set_person_for_car."""
 
     @pytest.mark.asyncio
     async def test_invalid_person_name_becomes_force_no_person(self):
@@ -196,23 +212,23 @@ class TestSetUserPersonEdgeCases:
         home, tesla, twingo, zoe, idbuzz, arthur, magali, thomas, brice = _build_scenario()
         await home.compute_and_set_best_persons_cars_allocations(force_update=True)
 
-        await twingo.set_user_person_for_car("GhostPerson")
+        await twingo.user_set_person_for_car("GhostPerson")
 
-        assert twingo.user_selected_person_name_for_car == FORCE_CAR_NO_PERSON_ATTACHED
+        assert twingo.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
 
     @pytest.mark.asyncio
     async def test_same_value_noop(self):
-        """Calling set_user_person_for_car with the already-set value should
+        """Calling user_set_person_for_car with the already-set value should
         return immediately without touching the allocation (car.py line 322)."""
         home, tesla, twingo, zoe, idbuzz, arthur, magali, thomas, brice = _build_scenario()
         await home.compute_and_set_best_persons_cars_allocations(force_update=True)
 
-        await twingo.set_user_person_for_car("Arthur")
-        assert twingo.user_selected_person_name_for_car == "Arthur"
+        await twingo.user_set_person_for_car("Arthur")
+        assert twingo.get_user_originated("person_name") == "Arthur"
 
         # Call again with the same value -- should be a no-op
-        await twingo.set_user_person_for_car("Arthur")
-        assert twingo.user_selected_person_name_for_car == "Arthur"
+        await twingo.user_set_person_for_car("Arthur")
+        assert twingo.get_user_originated("person_name") == "Arthur"
 
     @pytest.mark.asyncio
     async def test_forecasted_matches_skips_reallocation(self):
@@ -224,8 +240,8 @@ class TestSetUserPersonEdgeCases:
         # Arthur is auto-assigned to Twingo (his preferred car);
         # manually confirming should skip realloc
         assert _person_name(twingo) == "Arthur"
-        await twingo.set_user_person_for_car("Arthur")
-        assert twingo.user_selected_person_name_for_car == "Arthur"
+        await twingo.user_set_person_for_car("Arthur")
+        assert twingo.get_user_originated("person_name") == "Arthur"
         assert _person_name(twingo) == "Arthur"
 
 
@@ -357,10 +373,10 @@ class TestPersonCarAllocationScenario:
         await home.compute_and_set_best_persons_cars_allocations(force_update=True)
 
         # --- step 2: manually override Arthur → Twingo ---
-        await twingo.set_user_person_for_car("Arthur")
+        await twingo.user_set_person_for_car("Arthur")
 
         # --- verify the reassignment ---
-        assert twingo.user_selected_person_name_for_car == "Arthur"
+        assert twingo.get_user_originated("person_name") == "Arthur"
         assert _person_name(twingo) == "Arthur", f"Twingo should be Arthur (manual), got {_person_name(twingo)}"
         assert _person_name(zoe) == "Magali", f"Zoe should be Magali after reassignment, got {_person_name(zoe)}"
         assert _person_name(tesla) == "Thomas", f"Tesla should still be Thomas, got {_person_name(tesla)}"

--- a/tests/test_user_overrides.py
+++ b/tests/test_user_overrides.py
@@ -1,0 +1,490 @@
+"""Tests for the _user_originated system (fix #8).
+
+Tests cover:
+- AbstractDevice CRUD helpers
+- Persistence round-trip and backward-compat migration
+- user_clean_and_reset clears all user_originated
+- QSCar get/set/clear_user_originated for person_name and charger_name
+- _on_user_originated_changed auto-captures all values AFTER state changes
+- charge_time "constraints_cleared" sentinel logic
+- _fix_user_selected_person_from_forecast guarded by user_originated
+- get_best_person_next_need prefers user selection
+- user_clean_constraints sets charge_time sentinel + triggers snapshot
+- Car unplug clears charge_time sentinel
+- User-action methods trigger snapshot with correct (post-change) values
+- qs_bump_solar_charge_priority setter: value stored, no recursive snapshot
+"""
+
+from __future__ import annotations
+
+import datetime
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytz
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.quiet_solar.const import (
+    CHARGE_TIME_CONSTRAINTS_CLEARED,
+    DATA_HANDLER,
+    DOMAIN,
+    FORCE_CAR_NO_PERSON_ATTACHED,
+)
+from custom_components.quiet_solar.home_model.load import AbstractDevice
+from tests.factories import MinimalTestLoad, create_minimal_home_model
+
+
+# =============================================================================
+# AbstractDevice _user_originated CRUD
+# =============================================================================
+
+
+class TestUserOriginatedCRUD:
+    """Test _user_originated helpers at AbstractDevice level."""
+
+    def _make_device(self) -> MinimalTestLoad:
+        return MinimalTestLoad(name="TestLoad")
+
+    def test_set_and_get(self):
+        dev = self._make_device()
+        dev.set_user_originated("key1", "val1")
+        assert dev.get_user_originated("key1") == "val1"
+
+    def test_get_default(self):
+        dev = self._make_device()
+        assert dev.get_user_originated("missing") is None
+        assert dev.get_user_originated("missing", 42) == 42
+
+    def test_has(self):
+        dev = self._make_device()
+        assert dev.has_user_originated("x") is False
+        dev.set_user_originated("x", 1)
+        assert dev.has_user_originated("x") is True
+
+    def test_clear_single(self):
+        dev = self._make_device()
+        dev.set_user_originated("a", 1)
+        dev.set_user_originated("b", 2)
+        dev.clear_user_originated("a")
+        assert dev.has_user_originated("a") is False
+        assert dev.has_user_originated("b") is True
+
+    def test_clear_missing_key_is_noop(self):
+        dev = self._make_device()
+        dev.clear_user_originated("nonexistent")  # should not raise
+
+    def test_clear_all(self):
+        dev = self._make_device()
+        dev.set_user_originated("a", 1)
+        dev.set_user_originated("b", 2)
+        dev.clear_all_user_originated()
+        assert dev._user_originated == {}
+
+    @pytest.mark.asyncio
+    async def test_user_clean_and_reset_clears_user_originated(self):
+        dev = self._make_device()
+        dev.set_user_originated("x", 42)
+        await dev.user_clean_and_reset()
+        assert dev._user_originated == {}
+
+
+# =============================================================================
+# Persistence round-trip
+# =============================================================================
+
+
+class TestUserOriginatedPersistence:
+    """Test save/restore of _user_originated."""
+
+    def test_save_round_trip(self):
+        dev = MinimalTestLoad(name="TestLoad")
+        dev.set_user_originated("key", "value")
+        data = {}
+        dev.update_to_be_saved_extra_device_info(data)
+        assert data["_user_originated"] == {"key": "value"}
+
+        dev2 = MinimalTestLoad(name="TestLoad")
+        dev2.use_saved_extra_device_info(data)
+        assert dev2.get_user_originated("key") == "value"
+
+    def test_restore_empty(self):
+        dev = MinimalTestLoad(name="TestLoad")
+        dev.use_saved_extra_device_info({})
+        assert dev._user_originated == {}
+
+
+# =============================================================================
+# QSCar user_originated for person_name and charger_name
+# =============================================================================
+
+
+@pytest.fixture
+def car_home():
+    home = create_minimal_home_model()
+    home.is_off_grid = MagicMock(return_value=False)
+    home.latitude = 48.8566
+    home.longitude = 2.3522
+    return home
+
+
+@pytest.fixture
+def car_data_handler(car_home):
+    handler = MagicMock()
+    handler.home = car_home
+    return handler
+
+
+@pytest.fixture
+def car_hass_data(hass: HomeAssistant, car_data_handler):
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][DATA_HANDLER] = car_data_handler
+
+
+@pytest.fixture
+def create_car(hass, car_hass_data, car_home):
+    from custom_components.quiet_solar.ha_model.car import QSCar
+
+    def _factory(**extra_kwargs):
+        from custom_components.quiet_solar.const import (
+            CONF_CAR_BATTERY_CAPACITY,
+            CONF_CAR_CHARGE_PERCENT_SENSOR,
+            CONF_CAR_CHARGER_MAX_CHARGE,
+            CONF_CAR_CHARGER_MIN_CHARGE,
+            CONF_CAR_PLUGGED,
+            CONF_CAR_TRACKER,
+            CONF_DEFAULT_CAR_CHARGE,
+            CONF_MINIMUM_OK_CAR_CHARGE,
+        )
+
+        config = {
+            CONF_NAME: "Test Car",
+            CONF_CAR_TRACKER: "device_tracker.test_car",
+            CONF_CAR_PLUGGED: "binary_sensor.test_car_plugged",
+            CONF_CAR_CHARGE_PERCENT_SENSOR: "sensor.test_car_soc",
+            CONF_CAR_BATTERY_CAPACITY: 60000,
+            CONF_CAR_CHARGER_MIN_CHARGE: 6,
+            CONF_CAR_CHARGER_MAX_CHARGE: 32,
+            CONF_DEFAULT_CAR_CHARGE: 80,
+            CONF_MINIMUM_OK_CAR_CHARGE: 30,
+        }
+        config.update(extra_kwargs)
+        car = QSCar(hass=hass, config_entry=MockConfigEntry(domain=DOMAIN, data=config), **config)
+        car.home = car_home
+        return car
+
+    return _factory
+
+
+class TestUserOriginatedPersonAndCharger:
+    """Test get/set/clear_user_originated for person_name and charger_name on QSCar."""
+
+    def test_person_name_none_by_default(self, create_car):
+        car = create_car()
+        assert car.get_user_originated("person_name") is None
+
+    def test_set_person_name_stores_in_overrides(self, create_car):
+        car = create_car()
+        car.set_user_originated("person_name", "Alice")
+        assert car.get_user_originated("person_name") == "Alice"
+
+    def test_clear_person_name(self, create_car):
+        car = create_car()
+        car.set_user_originated("person_name", "Alice")
+        car.clear_user_originated("person_name")
+        assert car.has_user_originated("person_name") is False
+
+    def test_restore_person_from_user_originated(self, create_car):
+        """Saved _user_originated with person_name restores correctly."""
+        car = create_car()
+        stored = {
+            "_user_originated": {"person_name": "Bob"},
+            "current_forecasted_person_name_from_boot": None,
+        }
+        car.use_saved_extra_device_info(stored)
+        assert car.get_user_originated("person_name") == "Bob"
+
+
+# =============================================================================
+# _on_user_originated_changed tests (auto-snapshot hook)
+# =============================================================================
+
+
+class TestOnUserOriginatedChanged:
+    """Test _on_user_originated_changed auto-captures all values when triggered."""
+
+    def test_captures_all_fields_via_set(self, create_car):
+        """set_user_originated triggers _on_user_originated_changed which snapshots state."""
+        car = create_car()
+        car._next_charge_target = 80
+        car._next_charge_target_energy = 48000
+        car._qs_bump_solar_priority = True
+        car.do_force_next_charge = True
+        car.do_next_charge_time = datetime.datetime(2026, 3, 20, 7, 0, tzinfo=pytz.UTC)
+        car.set_user_originated("charger_name", "Charger1")
+
+        # Trigger the hook explicitly to snapshot all current state
+        car._on_user_originated_changed("test", None)
+
+        assert car.get_user_originated("charge_target_percent") == 80
+        assert car.get_user_originated("charge_target_energy") == 48000
+        assert car.get_user_originated("bump_solar") is True
+        assert car.get_user_originated("force_charge") is True
+        assert car.get_user_originated("charge_time") == "2026-03-20T07:00:00+00:00"
+        assert car.get_user_originated("charger_name") == "Charger1"
+
+    def test_preserves_existing_person(self, create_car):
+        """If person_name is already in overrides, snapshot doesn't overwrite it."""
+        car = create_car()
+        car.set_user_originated("person_name", "Explicit")
+        person = MagicMock()
+        person.name = "Forecast"
+        car.current_forecasted_person = person
+        car._on_user_originated_changed("test", None)
+        assert car.get_user_originated("person_name") == "Explicit"
+
+    def test_captures_forecast_person_when_no_explicit(self, create_car):
+        """Snapshot captures forecast person when no explicit selection exists."""
+        car = create_car()
+        person = MagicMock()
+        person.name = "Alice"
+        car.current_forecasted_person = person
+        # Make person authorized
+        person_obj = MagicMock()
+        person_obj.authorized_cars = [car.name]
+        car.home.get_person_by_name = MagicMock(return_value=person_obj)
+        car.home._persons = [person_obj]
+
+        car._on_user_originated_changed("test", None)
+        assert car.get_user_originated("person_name") == "Alice"
+
+    def test_null_charge_time(self, create_car):
+        car = create_car()
+        car.do_next_charge_time = None
+        car._on_user_originated_changed("test", None)
+        assert car.get_user_originated("charge_time") is None
+
+    def test_preserves_constraints_cleared_sentinel(self, create_car):
+        """When charge_time is 'constraints_cleared' and do_next_charge_time is None,
+        the sentinel is preserved."""
+        car = create_car()
+        car.set_user_originated("charge_time", CHARGE_TIME_CONSTRAINTS_CLEARED)
+        car.do_next_charge_time = None
+        car._on_user_originated_changed("test", None)
+        assert car.get_user_originated("charge_time") == CHARGE_TIME_CONSTRAINTS_CLEARED
+
+    def test_supersedes_constraints_cleared_when_time_set(self, create_car):
+        """When do_next_charge_time is set, it overwrites the constraints_cleared sentinel."""
+        car = create_car()
+        car.set_user_originated("charge_time", CHARGE_TIME_CONSTRAINTS_CLEARED)
+        car.do_next_charge_time = datetime.datetime(2026, 3, 20, 7, 0, tzinfo=pytz.UTC)
+        car._on_user_originated_changed("test", None)
+        assert car.get_user_originated("charge_time") == "2026-03-20T07:00:00+00:00"
+
+
+# =============================================================================
+# _fix_user_selected_person_from_forecast guarded by override
+# =============================================================================
+
+
+class TestFixPersonGuard:
+    """Test that _fix_user_selected_person_from_forecast is guarded by person_name override."""
+
+    def test_noop_when_no_forecasted_person(self, create_car):
+        """Early return when current_forecasted_person is None and no override."""
+        car = create_car()
+        car.current_forecasted_person = None
+        car._fix_user_selected_person_from_forecast()
+        assert car.get_user_originated("person_name") is None
+
+    def test_guard_blocks_when_override_exists(self, create_car):
+        car = create_car()
+        car.set_user_originated("person_name", "Explicit")
+        person = MagicMock()
+        person.name = "Forecast"
+        car.current_forecasted_person = person
+        car._fix_user_selected_person_from_forecast()
+        # Should NOT have been overwritten
+        assert car.get_user_originated("person_name") == "Explicit"
+
+    def test_guard_allows_when_no_override(self, create_car):
+        car = create_car()
+        person = MagicMock()
+        person.name = "Forecast"
+        car.current_forecasted_person = person
+        # Make person authorized
+        person_obj = MagicMock()
+        person_obj.authorized_cars = [car.name]
+        car.home.get_person_by_name = MagicMock(return_value=person_obj)
+        car.home._persons = [person_obj]
+
+        car._fix_user_selected_person_from_forecast()
+        assert car.get_user_originated("person_name") == "Forecast"
+
+
+# =============================================================================
+# get_best_person_next_need prefers user selection
+# =============================================================================
+
+
+class TestGetBestPersonNextNeed:
+    """Test get_best_person_next_need prefers user selection."""
+
+    @pytest.mark.asyncio
+    async def test_force_no_person(self, create_car):
+        car = create_car()
+        car.set_user_originated("person_name", FORCE_CAR_NO_PERSON_ATTACHED)
+        result = await car.get_best_person_next_need(datetime.datetime.now(pytz.UTC))
+        assert result == (None, None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_user_selected_person_used(self, create_car):
+        car = create_car()
+        person = MagicMock()
+        person.name = "Alice"
+        person.update_person_forecast = MagicMock(
+            return_value=(datetime.datetime(2026, 3, 20, 18, 0, tzinfo=pytz.UTC), 50.0)
+        )
+        car.home.get_person_by_name = MagicMock(return_value=person)
+        car.home._persons = [person]
+        car.set_user_originated("person_name", "Alice")
+
+        result = await car.get_best_person_next_need(datetime.datetime.now(pytz.UTC))
+        assert result[3] is person
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_forecast(self, create_car):
+        car = create_car()
+        person = MagicMock()
+        person.name = "Bob"
+        person.update_person_forecast = MagicMock(
+            return_value=(datetime.datetime(2026, 3, 20, 18, 0, tzinfo=pytz.UTC), 50.0)
+        )
+        car.current_forecasted_person = person
+        car.home._persons = [person]
+        # No user selection
+        result = await car.get_best_person_next_need(datetime.datetime.now(pytz.UTC))
+        assert result[3] is person
+
+
+# =============================================================================
+# User-action methods trigger snapshot with CORRECT (post-change) values
+# =============================================================================
+
+
+class TestUserActionTriggersSnapshot:
+    """Test that user-action methods snapshot AFTER state modifications."""
+
+    @pytest.mark.asyncio
+    async def test_user_force_charge_now_captures_new_state(self, create_car):
+        """force_charge=True and charge_time=None must appear in overrides."""
+        car = create_car()
+        charger = MagicMock()
+        charger.update_charger_for_user_change = AsyncMock()
+        car.charger = charger
+        car.do_force_next_charge = False  # initial
+        car.do_next_charge_time = datetime.datetime(2026, 3, 20, 7, 0, tzinfo=pytz.UTC)  # will be set to None
+
+        await car.user_force_charge_now()
+
+        # Snapshot should have captured the POST-change values
+        assert car.get_user_originated("force_charge") is True
+        assert car.get_user_originated("charge_time") is None
+
+    @pytest.mark.asyncio
+    async def test_user_add_default_charge_captures_charge_time(self, create_car):
+        """charge_time override should be an isoformat string, not None."""
+        car = create_car()
+        charger = MagicMock()
+        charger.update_charger_for_user_change = AsyncMock()
+        car.charger = charger
+        car.default_charge_time = datetime.time(7, 0)
+        await car.user_add_default_charge()
+        # charge_time should be a real isoformat string (from user_add_default_charge_at_datetime)
+        ct = car.get_user_originated("charge_time")
+        assert ct is not None
+        assert isinstance(ct, str) and ct != "constraints_cleared"
+
+    @pytest.mark.asyncio
+    async def test_user_set_next_charge_target_triggers_snapshot(self, create_car):
+        """Snapshot fires after the target value has been changed."""
+        car = create_car()
+        charger = MagicMock()
+        charger.update_charger_for_user_change = AsyncMock()
+        charger.get_charge_type = MagicMock(return_value=("not_plugged", None))
+        car.charger = charger
+
+        await car.user_set_next_charge_target(80)
+
+        # The snapshot captured whatever _next_charge_target was set to
+        # (set_next_charge_target_percent sets it before snapshot fires)
+        assert car.has_user_originated("charge_target_percent")
+        assert car.get_user_originated("charge_target_percent") == car._next_charge_target
+
+    def test_bump_solar_setter_captures_new_value(self, create_car):
+        """bump_solar override must be True after setting to True."""
+        car = create_car()
+        car.home._cars = [car]
+        car._qs_bump_solar_priority = False  # initial
+        car.qs_bump_solar_charge_priority = True
+        assert car.get_user_originated("bump_solar") is True
+
+    def test_bump_solar_setter_no_recursive_snapshot_on_other_cars(self, create_car):
+        """Setting bump on car1 should NOT trigger snapshot on car2."""
+        car1 = create_car()
+        car2 = create_car()
+        car1.home._cars = [car1, car2]
+        car2.home = car1.home
+
+        car1.qs_bump_solar_charge_priority = True
+
+        # car2 should NOT have any overrides (no snapshot was triggered on it)
+        assert car2._user_originated == {}
+        # car1 should have bump_solar=True
+        assert car1.get_user_originated("bump_solar") is True
+
+    @pytest.mark.asyncio
+    async def test_user_set_selected_charger_captures_new_charger(self, create_car):
+        """charger_name override should reflect the post-change state."""
+        car = create_car()
+        car.home._chargers = []
+        car.set_user_originated("charger_name", "OldCharger")  # initial
+        from custom_components.quiet_solar.const import FORCE_CAR_NO_CHARGER_CONNECTED
+
+        await car.user_set_selected_charger_by_name(FORCE_CAR_NO_CHARGER_CONNECTED)
+        # After setting to FORCE_CAR_NO_CHARGER_CONNECTED, the snapshot should capture it
+        assert car.get_user_originated("charger_name") == FORCE_CAR_NO_CHARGER_CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_user_add_default_charge_at_datetime_captures_time(self, create_car):
+        """Snapshot captures the new charge time, not the old one."""
+        car = create_car()
+        charger = MagicMock()
+        car.charger = charger
+        car.do_next_charge_time = None  # initial
+
+        end = datetime.datetime(2026, 6, 15, 8, 0, tzinfo=pytz.UTC)
+        result = await car.user_add_default_charge_at_datetime(end)
+
+        assert result is True
+        assert car.get_user_originated("charge_time") == end.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_user_set_selected_charger_none_clears(self, create_car):
+        """Passing None to user_set_selected_charger_by_name clears charger_name."""
+        car = create_car()
+        car.home._chargers = []
+        car.set_user_originated("charger_name", "SomeCharger")
+        await car.user_set_selected_charger_by_name(None)
+        assert car.get_user_originated("charger_name") is None
+
+    @pytest.mark.asyncio
+    async def test_user_set_selected_charger_unknown_name_clears(self, create_car):
+        """Passing an unknown charger name clears charger_name."""
+        car = create_car()
+        car.home._chargers = []
+        car.set_user_originated("charger_name", "SomeCharger")
+        await car.user_set_selected_charger_by_name("NonExistentCharger")
+        assert car.get_user_originated("charger_name") is None


### PR DESCRIPTION
## Summary
- Remove all user-state property shims (`user_selected_person_name_for_car`, `user_attached_charger_name`, `user_attached_car_name`) and `_snapshot_car_user_state` — all user state now flows through `set/get/has/clear_user_originated` exclusively
- Auto-snapshot via `_on_user_originated_changed` hook with recursion guard in `set_user_originated`
- `_user_originated` is the canonical source of truth in the charger constraint flow (force_charge, charge_time, bump_solar, charge_target), with runtime attributes as fallback

Fixes #8

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified (3842 tests, 13709 statements)
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [x] CRITICAL (solver, constraints, charger budgeting)
- [x] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific)
- [x] LOW (platforms, UI, docs)