### PR TITLE
Fix cumulus rapid cycling from filler-constraint loop (Github-#70)

### DIFF
--- a/_bmad-output/implementation-artifacts/bug-Github-#70-fix-cumulus-rapid-cycling.md
+++ b/_bmad-output/implementation-artifacts/bug-Github-#70-fix-cumulus-rapid-cycling.md
@@ -1,6 +1,6 @@
 # Story: Fix cumulus rapid cycling caused by filler-constraint infinite loop and bistate metrics reset
 
-Status: draft
+Status: done
 
 issue: 70
 branch: "QS_70"
@@ -49,20 +49,20 @@ The solver running every 7 seconds generates new plans each time. Under marginal
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Skip filler constraint when already met (AC: #1)
-  - [ ] 1.1 In `charger.py` at line ~3670, after `target_charge = max_target_charge`, add guard: `if realized_charge_target >= target_charge: type = None`
-  - [ ] 1.2 Add unit test: fully-charged car plugged in does not push filler constraint
-  - [ ] 1.3 Add unit test: partially-charged car still pushes filler constraint as before
+- [x] Task 1: Skip filler constraint when already met (AC: #1)
+  - [x] 1.1 In `charger.py` at line ~3670, after `target_charge = max_target_charge`, add guard: `if realized_charge_target >= target_charge: type = None`
+  - [x] 1.2 Add unit test: fully-charged car plugged in does not push filler constraint
+  - [x] 1.3 Add unit test: partially-charged car still pushes filler constraint as before
 
-- [ ] Task 2: Bistate metrics fallback to completed constraint (AC: #2)
-  - [ ] 2.1 In `bistate_duration.py` `update_current_metrics`, add `end_range` parameter handling matching pool.py pattern
-  - [ ] 2.2 Build `ct_to_probe` list: extend with `_constraints`, elif fallback to `_last_completed_constraint`
-  - [ ] 2.3 Filter by current day window (start_day to end_day) before accumulating metrics
-  - [ ] 2.4 Add unit test: metrics show completed hours after constraint removal (via _last_completed_constraint)
-  - [ ] 2.5 Add unit test: metrics show active constraint hours when constraint is still live
+- [x] Task 2: Bistate metrics fallback to completed constraint (AC: #2)
+  - [x] 2.1 In `bistate_duration.py` `update_current_metrics`, add `end_range` parameter handling matching pool.py pattern
+  - [x] 2.2 Build `ct_to_probe` list: extend with `_constraints`, elif fallback to `_last_completed_constraint`
+  - [x] 2.3 Filter by current day window (start_day to end_day) before accumulating metrics
+  - [x] 2.4 Add unit test: metrics show completed hours after constraint removal (via _last_completed_constraint)
+  - [x] 2.5 Add unit test: metrics show active constraint hours when constraint is still live
 
-- [ ] Task 3: Quality gates (AC: #3)
-  - [ ] 3.1 Run `python scripts/qs/quality_gate.py` -- all checks pass
+- [x] Task 3: Quality gates (AC: #3)
+  - [x] 3.1 Run `python scripts/qs/quality_gate.py` -- all checks pass
 
 ## Key Files
 

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -10,7 +10,7 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from ..const import CONSTRAINT_TYPE_FILLER_AUTO, CONSTRAINT_TYPE_MANDATORY_END_TIME
 from ..ha_model.device import HADeviceMixin
 from ..home_model.commands import CMD_IDLE, LoadCommand
-from ..home_model.constraints import DATETIME_MAX_UTC, TimeBasedSimplePowerLoadConstraint
+from ..home_model.constraints import DATETIME_MAX_UTC, DATETIME_MIN_UTC, TimeBasedSimplePowerLoadConstraint
 from ..home_model.load import AbstractLoad
 
 bistate_modes = [
@@ -54,14 +54,43 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         self.qs_bistate_current_on_h: float = 0.0
 
     def update_current_metrics(self, time: datetime, end_range: dt_time | None = None):
+        """Update bistate UI metrics from active or last-completed constraint.
 
-        self.qs_bistate_current_on_h = 0
-        self.qs_bistate_current_duration_h = 0
+        Follows pool.py pattern: falls back to _last_completed_constraint when
+        the active constraint has been removed, filtered by current day window.
+        """
+        if end_range is None:
+            end_range = self.default_on_finish_time or dt_time(hour=0, minute=0, second=0)
 
-        if self._constraints:
-            ct = self._constraints[0]
-            self.qs_bistate_current_on_h = ct.convert_target_value_to_time(ct.current_value) / 3600.0
-            self.qs_bistate_current_duration_h = ct.convert_target_value_to_time(ct.target_value) / 3600.0
+        end_day = self.get_next_time_from_hours(local_hours=end_range, time_utc_now=time, output_in_utc=True)
+        duration_s = 0.0
+        run_s = 0.0
+
+        if end_day is not None:
+            start_day = self.get_next_time_from_hours(
+                local_hours=end_range,
+                time_utc_now=end_day - timedelta(hours=26),
+                output_in_utc=True,
+            )
+
+            ct_to_probe = []
+            if self._constraints:
+                ct_to_probe.extend(self._constraints)
+            elif self._last_completed_constraint is not None:
+                ct_to_probe.append(self._last_completed_constraint)
+
+            for ct in ct_to_probe:
+                if ct.end_of_constraint <= end_day or (
+                    ct.start_of_constraint != DATETIME_MIN_UTC and ct.start_of_constraint <= end_day
+                ):
+                    if ct.end_of_constraint > start_day or (
+                        ct.start_of_constraint != DATETIME_MIN_UTC and ct.start_of_constraint > start_day
+                    ):
+                        duration_s += ct.target_value
+                        run_s += ct.current_value
+
+        self.qs_bistate_current_on_h = run_s / 3600.0
+        self.qs_bistate_current_duration_h = duration_s / 3600.0
 
     async def user_set_default_on_duration(self, float_value: float, for_init: bool = False):
         self.default_on_duration = float_value

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -3668,6 +3668,9 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                         # and be after battery, lowest priority
                         type = CONSTRAINT_TYPE_FILLER
                         target_charge = max_target_charge
+                        if realized_charge_target >= target_charge:
+                            # already fully charged — skip filler to avoid push-remove-push loop
+                            type = None
 
                 if type is not None:
                     car_charge_best_effort = ConstraintClass(

--- a/tests/test_bug_70_cumulus_rapid_cycling.py
+++ b/tests/test_bug_70_cumulus_rapid_cycling.py
@@ -1,0 +1,382 @@
+"""Tests for bug #70: cumulus rapid cycling caused by filler-constraint infinite loop.
+
+Verifies fixes for:
+- Task 1: Skip filler constraint when car is already fully charged (prevents push-remove-push loop)
+- Task 2: Bistate metrics fallback to _last_completed_constraint after removal
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, time as dt_time, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytz
+
+from custom_components.quiet_solar.const import (
+    CONF_CHARGER_CONSUMPTION,
+    CONF_CHARGER_MAX_CHARGE,
+    CONF_CHARGER_MAX_CHARGING_CURRENT_NUMBER,
+    CONF_CHARGER_MIN_CHARGE,
+    CONF_CHARGER_PLUGGED,
+    CONF_CHARGER_STATUS_SENSOR,
+    CONF_IS_3P,
+    CONF_MONO_PHASE,
+    CONF_SWITCH,
+    CONSTRAINT_TYPE_BEFORE_BATTERY_GREEN,
+    CONSTRAINT_TYPE_FILLER,
+    DATA_HANDLER,
+    DOMAIN,
+)
+from custom_components.quiet_solar.ha_model.charger import QSChargerGeneric
+from custom_components.quiet_solar.home_model.commands import LoadCommand
+from custom_components.quiet_solar.home_model.constraints import (
+    DATETIME_MIN_UTC,
+    TimeBasedSimplePowerLoadConstraint,
+)
+from tests.factories import create_minimal_home_model
+
+# =============================================================================
+# Test helpers (following test_bug_48 pattern)
+# =============================================================================
+
+
+def create_mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = MagicMock()
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=None)
+    hass.services = MagicMock()
+    hass.data = {DOMAIN: {DATA_HANDLER: MagicMock()}}
+    return hass
+
+
+def create_mock_home(hass):
+    """Create a mock QSHome instance."""
+    home = create_minimal_home_model()
+    home.hass = hass
+    home.battery = None
+    home.is_off_grid = MagicMock(return_value=False)
+    home.get_available_power_values = MagicMock(return_value=None)
+    home.get_grid_consumption_power_values = MagicMock(return_value=None)
+    home.battery_can_discharge = MagicMock(return_value=True)
+    home.get_tariff = MagicMock(return_value=0.15)
+    home.get_best_tariff = MagicMock(return_value=0.10)
+    home.force_next_solve = MagicMock()
+    home.get_car_by_name = MagicMock(return_value=None)
+    return home
+
+
+def create_charger_generic(hass, home, name="TestCharger", **extra_config):
+    """Create a QSChargerGeneric instance for testing."""
+    config_entry = MagicMock()
+    config_entry.entry_id = f"test_entry_{name}"
+    config_entry.data = {}
+
+    config = {
+        "name": name,
+        "hass": hass,
+        "home": home,
+        "config_entry": config_entry,
+        CONF_CHARGER_MIN_CHARGE: 6,
+        CONF_CHARGER_MAX_CHARGE: 32,
+        CONF_CHARGER_CONSUMPTION: 70,
+        CONF_IS_3P: True,
+        CONF_MONO_PHASE: 1,
+        CONF_CHARGER_STATUS_SENSOR: f"sensor.{name}_status",
+        CONF_CHARGER_PLUGGED: f"sensor.{name}_plugged",
+        CONF_CHARGER_MAX_CHARGING_CURRENT_NUMBER: f"number.{name}_max_current",
+    }
+    config.update(extra_config)
+
+    with patch("custom_components.quiet_solar.ha_model.charger.entity_registry"):
+        charger = QSChargerGeneric(**config)
+
+    return charger
+
+
+def create_mock_car(
+    name="TestCar",
+    target_charge=95.0,
+    car_default_charge=100.0,
+    car_battery_capacity=50000.0,
+    current_charge=100.0,
+    min_ok_soc=20.0,
+):
+    """Create a mock car with configurable charge parameters."""
+    mock_car = MagicMock()
+    mock_car.name = name
+    mock_car.car_battery_capacity = car_battery_capacity
+    mock_car.car_default_charge = car_default_charge
+    mock_car.efficiency_factor = 1.0
+    mock_car.do_force_next_charge = False
+    mock_car.do_next_charge_time = None
+    mock_car.can_use_charge_percent_constraints.return_value = True
+    mock_car.setup_car_charge_target_if_needed = AsyncMock(return_value=target_charge)
+    mock_car.get_car_charge_percent.return_value = current_charge
+    mock_car.get_car_target_SOC.return_value = target_charge
+    mock_car.get_car_minimum_ok_SOC.return_value = min_ok_soc
+    mock_car.get_next_scheduled_event = AsyncMock(return_value=(None, None))
+    mock_car.get_best_person_next_need = AsyncMock(return_value=(None, None, None, None))
+    mock_car.set_next_charge_target_percent = AsyncMock()
+
+    user_values: dict = {}
+
+    def has_user_originated(key):
+        return key in user_values
+
+    def get_user_originated(key):
+        return user_values.get(key)
+
+    def set_user_originated(key, value):
+        user_values[key] = value
+
+    def clear_user_originated(key):
+        user_values.pop(key, None)
+
+    def clear_all_user_originated():
+        user_values.clear()
+
+    mock_car.has_user_originated = MagicMock(side_effect=has_user_originated)
+    mock_car.get_user_originated = MagicMock(side_effect=get_user_originated)
+    mock_car.set_user_originated = MagicMock(side_effect=set_user_originated)
+    mock_car.clear_user_originated = MagicMock(side_effect=clear_user_originated)
+    mock_car.clear_all_user_originated = MagicMock(side_effect=clear_all_user_originated)
+
+    return mock_car
+
+
+def setup_charger_with_plugged_car(charger, mock_car, time):
+    """Set up charger to be plugged in with a car, past boot time."""
+    charger.car = mock_car
+    charger._boot_time = None
+    charger._boot_time_adjusted = None
+    charger._power_steps = [LoadCommand(command="on", power_consign=7000.0)]
+
+
+# =============================================================================
+# Task 1: Filler constraint skipped when car fully charged
+# =============================================================================
+
+
+class TestFillerConstraintSkippedWhenFullyCharged(unittest.IsolatedAsyncioTestCase):
+    """Test that no filler constraint is pushed when the car is already at max charge."""
+
+    def setUp(self):
+        self.hass = create_mock_hass()
+        self.home = create_mock_home(self.hass)
+        self.charger = create_charger_generic(self.hass, self.home)
+        self.time = datetime(2026, 3, 30, 10, 0, 0, tzinfo=pytz.UTC)
+
+    async def test_fully_charged_car_does_not_push_filler(self):
+        """Car at 100% with target 95% and max 100% should NOT push filler constraint.
+
+        This is the exact scenario from bug #70: realized >= max_target_charge,
+        so the filler would be immediately met, removed, force_solving=True,
+        and the cycle repeats every 7 seconds.
+        """
+        mock_car = create_mock_car(
+            target_charge=95.0,
+            car_default_charge=100.0,
+            current_charge=100.0,  # fully charged
+        )
+        setup_charger_with_plugged_car(self.charger, mock_car, self.time)
+
+        push_calls = []
+        original_push = self.charger.push_live_constraint
+
+        def tracking_push(time, constraint):
+            push_calls.append(constraint)
+            return original_push(time, constraint)
+
+        with (
+            patch.object(self.charger, "is_not_plugged", return_value=False),
+            patch.object(self.charger, "is_plugged", return_value=True),
+            patch.object(self.charger, "is_charger_unavailable", return_value=False),
+            patch.object(self.charger, "probe_for_possible_needed_reboot", return_value=False),
+            patch.object(self.charger, "get_best_car", return_value=mock_car),
+            patch.object(
+                self.charger, "clean_constraints_for_load_param_and_if_same_key_same_value_info", return_value=False
+            ),
+            patch.object(self.charger, "push_live_constraint", side_effect=tracking_push),
+        ):
+            await self.charger.check_load_activity_and_constraints(self.time)
+
+        filler_pushes = [
+            c for c in push_calls if c._type in (CONSTRAINT_TYPE_FILLER, CONSTRAINT_TYPE_BEFORE_BATTERY_GREEN)
+        ]
+        assert filler_pushes == [], (
+            f"Filler constraint should NOT be pushed for fully-charged car, "
+            f"but got {len(filler_pushes)} filler push(es)"
+        )
+
+    async def test_partially_charged_car_still_pushes_filler(self):
+        """Car at 96% with target 95% and max 100% SHOULD push filler (96 < 100).
+
+        The car passed its target but has room to charge to max_target_charge.
+        """
+        mock_car = create_mock_car(
+            target_charge=95.0,
+            car_default_charge=100.0,
+            current_charge=96.0,  # past target but not at max
+        )
+        setup_charger_with_plugged_car(self.charger, mock_car, self.time)
+
+        push_calls = []
+        original_push = self.charger.push_live_constraint
+
+        def tracking_push(time, constraint):
+            push_calls.append(constraint)
+            return original_push(time, constraint)
+
+        with (
+            patch.object(self.charger, "is_not_plugged", return_value=False),
+            patch.object(self.charger, "is_plugged", return_value=True),
+            patch.object(self.charger, "is_charger_unavailable", return_value=False),
+            patch.object(self.charger, "probe_for_possible_needed_reboot", return_value=False),
+            patch.object(self.charger, "get_best_car", return_value=mock_car),
+            patch.object(
+                self.charger, "clean_constraints_for_load_param_and_if_same_key_same_value_info", return_value=False
+            ),
+            patch.object(self.charger, "push_live_constraint", side_effect=tracking_push),
+        ):
+            await self.charger.check_load_activity_and_constraints(self.time)
+
+        filler_pushes = [
+            c for c in push_calls if c._type in (CONSTRAINT_TYPE_FILLER, CONSTRAINT_TYPE_BEFORE_BATTERY_GREEN)
+        ]
+        assert len(filler_pushes) > 0, (
+            "Filler constraint SHOULD be pushed for partially-charged car (96% < 100% max)"
+        )
+        # The filler should target max_target_charge (100%)
+        filler = filler_pushes[0]
+        assert filler.target_value == pytest.approx(100.0), (
+            f"Filler target should be max_target_charge (100%), got {filler.target_value}"
+        )
+
+
+# =============================================================================
+# Task 2: Bistate metrics fallback to _last_completed_constraint
+# =============================================================================
+
+
+class TestBistateMetricsFallback(unittest.TestCase):
+    """Test that bistate update_current_metrics falls back to _last_completed_constraint."""
+
+    def _create_bistate_device(self):
+        """Create a concrete bistate device for testing metrics."""
+        from custom_components.quiet_solar.ha_model.bistate_duration import QSBiStateDuration
+
+        hass = create_mock_hass()
+        home = create_mock_home(hass)
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_bistate_metrics"
+        config_entry.data = {}
+
+        class ConcreteBiState(QSBiStateDuration):
+            def __init__(self, **kwargs):
+                if "switch_entity" in kwargs:
+                    kwargs[CONF_SWITCH] = kwargs.pop("switch_entity")
+                elif CONF_SWITCH not in kwargs:
+                    kwargs[CONF_SWITCH] = "switch.test_device"
+                super().__init__(**kwargs)
+
+            async def execute_command_system(self, time, command, state):
+                return True
+
+            def get_virtual_current_constraint_translation_key(self):
+                return "test_key"
+
+            def get_select_translation_key(self):
+                return "test_select_key"
+
+        device = ConcreteBiState(
+            hass=hass,
+            config_entry=config_entry,
+            home=home,
+            name="Test Cumulus",
+        )
+        device.power_use = 2000.0
+        device.default_on_finish_time = dt_time(hour=0, minute=0, second=0)
+        return device
+
+    def _create_time_constraint(self, device, time, target_seconds, current_seconds, start_offset_h=0):
+        """Create a TimeBasedSimplePowerLoadConstraint for testing."""
+        start = time - timedelta(hours=start_offset_h) if start_offset_h else DATETIME_MIN_UTC
+        end = time + timedelta(hours=12)
+        return TimeBasedSimplePowerLoadConstraint(
+            type=1,
+            time=time,
+            load=device,
+            power=device.power_use,
+            initial_value=0,
+            target_value=target_seconds,
+            current_value=current_seconds,
+            start_of_constraint=start,
+            end_of_constraint=end,
+        )
+
+    def test_metrics_show_completed_hours_after_constraint_removal(self):
+        """After constraint removal, metrics should fall back to _last_completed_constraint.
+
+        This is bug #70 task 2: when the active constraint is removed,
+        qs_bistate_current_on_h was reset to 0 instead of showing the completed 3h.
+        """
+        device = self._create_bistate_device()
+        time = datetime(2026, 3, 30, 18, 0, 0, tzinfo=pytz.UTC)
+
+        completed_ct = self._create_time_constraint(
+            device, time, target_seconds=3 * 3600.0, current_seconds=3 * 3600.0, start_offset_h=6
+        )
+
+        # Constraint was removed (empty list) but we have a completed one
+        device._constraints = []
+        device._last_completed_constraint = completed_ct
+
+        device.update_current_metrics(time)
+
+        assert device.qs_bistate_current_on_h == pytest.approx(3.0), (
+            f"Should show 3h from completed constraint, got {device.qs_bistate_current_on_h}"
+        )
+        assert device.qs_bistate_current_duration_h == pytest.approx(3.0), (
+            f"Should show 3h duration from completed constraint, got {device.qs_bistate_current_duration_h}"
+        )
+
+    def test_metrics_show_active_constraint_hours_when_live(self):
+        """When an active constraint exists, metrics should show its current progress."""
+        device = self._create_bistate_device()
+        time = datetime(2026, 3, 30, 18, 0, 0, tzinfo=pytz.UTC)
+
+        active_ct = self._create_time_constraint(
+            device, time, target_seconds=3 * 3600.0, current_seconds=1.5 * 3600.0, start_offset_h=3
+        )
+
+        device._constraints = [active_ct]
+        device._last_completed_constraint = None
+
+        device.update_current_metrics(time)
+
+        assert device.qs_bistate_current_on_h == pytest.approx(1.5), (
+            f"Should show 1.5h from active constraint, got {device.qs_bistate_current_on_h}"
+        )
+        assert device.qs_bistate_current_duration_h == pytest.approx(3.0), (
+            f"Should show 3h target duration, got {device.qs_bistate_current_duration_h}"
+        )
+
+    def test_metrics_zero_when_no_constraints_at_all(self):
+        """When no constraints exist and no completed constraint, metrics should be zero."""
+        device = self._create_bistate_device()
+        time = datetime(2026, 3, 30, 18, 0, 0, tzinfo=pytz.UTC)
+
+        device._constraints = []
+        device._last_completed_constraint = None
+
+        device.update_current_metrics(time)
+
+        assert device.qs_bistate_current_on_h == 0.0
+        assert device.qs_bistate_current_duration_h == 0.0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ha_bistate_duration.py
+++ b/tests/test_ha_bistate_duration.py
@@ -179,7 +179,11 @@ def bistate_check_load_device(hass: HomeAssistant, bistate_setup) -> ConcreteBiS
     )
     device.load_is_auto_to_be_boosted = False
     device._constraints = []
-    device.constraint_reset_and_reset_commands_if_needed = MagicMock()
+
+    def _mock_constraint_reset(**kwargs):
+        device._constraints = []
+
+    device.constraint_reset_and_reset_commands_if_needed = MagicMock(side_effect=_mock_constraint_reset)
     device.power_use = 1000.0
     return device
 


### PR DESCRIPTION
## Summary
- Skip filler constraint when car already fully charged to prevent push-remove-push infinite loop
- Align bistate_duration metrics with pool.py fallback to _last_completed_constraint
- Fix existing test mock to clear constraints on reset (matching real behavior)

Fixes #70

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [x] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)