### PR TITLE
fix: solar provider select not persisted after reboot

### DIFF
--- a/_bmad-output/implementation-artifacts/bug-Github-#90-solar-provider-select-not-persisted.md
+++ b/_bmad-output/implementation-artifacts/bug-Github-#90-solar-provider-select-not-persisted.md
@@ -1,6 +1,6 @@
 # Bug Fix: Solar provider select not persisted after reboot
 
-Status: ready-for-dev
+Status: done
 issue: 90
 branch: "QS_90"
 
@@ -12,132 +12,29 @@ so that I do not have to re-select my preferred provider every time the system r
 
 ## Bug Description
 
-The select entity for choosing the solar forecast provider (or "auto") reverts to the default value after a Home Assistant reboot. Users who explicitly select a specific provider find the entity has switched back to "auto" on restart.
+The select entity for choosing the solar forecast provider (or "auto") reverted to the default after a Home Assistant reboot.
 
-### Entity Involved
+### Root Cause
 
-- **Entity key:** `qs_solar_provider_mode` (`SELECT_SOLAR_PROVIDER_MODE` in `const.py:235`)
-- **Entity class:** `QSUserOverrideSelectRestore` (in `select.py:426-459`)
-- **Device callback:** `QSSolar.set_provider_mode()` (in `ha_model/solar.py:204-211`)
+The entity used `QSUserOverrideSelectRestore` with HA's `ExtraStoredData` mechanism, which was unnecessarily complex for this use case. The `device.provider_mode` is a stable user-set value that doesn't change dynamically — the simpler `QSSimpleSelectRestore` (basic HA state restoration via `async_get_last_state()`) is sufficient, and is what every other select entity in the codebase uses successfully.
 
-### Persistence Mechanism
+### Fix
 
-The entity uses `QSUserOverrideSelectRestore` which extends `QSBaseSelectRestore(QSBaseSelect, RestoreEntity)`. It stores the user's selection via HA's `ExtraStoredData` mechanism:
-
-- `extra_restore_state_data` property (line 430) returns `QSExtraStoredDataSelect(self.user_selected_option)`
-- `async_get_last_select_data()` (line 434) retrieves saved data on restore
-- `async_added_to_hass()` (line 440) calls `super()` first, then restores the extra data and calls `device.set_provider_mode()`
-
-### Root Cause Analysis
-
-**Primary suspect — `async_update_callback` overrides restored state (select.py:344-354):**
-
-```python
-@callback
-def async_update_callback(self, time: datetime) -> None:
-    self._set_availabiltiy()
-    self._attr_options = self.get_available_options()
-    self._attr_current_option = self.get_current_option()  # reads device.provider_mode
-    self.async_write_ha_state()
-```
-
-This callback is inherited from `QSBaseSelect` and `QSUserOverrideSelectRestore` does **not** override it. On every update tick (every ~4-7s), it:
-1. Reads `device.provider_mode` directly
-2. Overwrites `_attr_current_option`
-3. Writes HA state (which includes `extra_restore_state_data`)
-
-The `user_selected_option` attribute is only set by `async_select_option()` (user UI action or restore) but NOT by the periodic callback. If the callback fires after the device has been re-initialized (with default "auto") but **before** `async_added_to_hass()` restores the saved value, the extra data could be flushed with `user_selected_option = None`.
-
-**Secondary suspects:**
-
-1. **Initialization ordering (select.py:356-361):** `QSBaseSelect.async_added_to_hass()` sets `_attr_current_option = self.get_current_option()` (device default "auto") and calls `super().async_added_to_hass()` which registers the entity in HA's state machine. Between this registration and the extra data restore in `QSUserOverrideSelectRestore.async_added_to_hass()` (line 444), there is a window where state could be persisted with stale values.
-
-2. **Provider name validation (solar.py:207):** `set_provider_mode()` silently falls back to "auto" if the saved provider name doesn't match any entry in `self.solar_forecast_providers`. If provider names change between reboots (unlikely but possible), the restored selection would be discarded.
-
-3. **Missing `None` → default coercion (select.py:451-454):** When the restored `user_selected_option` is `None`, the code passes `None` to `async_select_option()` which then calls `device.set_provider_mode(None)` → falls back to "auto". But `_attr_current_option` remains `None` until the next `async_update_callback`, causing the entity state to briefly be `None`/unknown.
-
-### Comparison with Working Selects
-
-Other select entities (car stale mode, off-grid mode, bistate mode) use `QSSimpleSelectRestore` which restores via `async_get_last_state()` (basic HA state). This simpler mechanism avoids the `ExtraStoredData` complexity and may explain why those selects persist correctly while the solar provider does not.
+Switched from `QSUserOverrideSelectRestore` to `QSSimpleSelectRestore` in `create_ha_select_for_QSSolar()`. Removed the now-unused `QSUserOverrideSelectRestore` and `QSExtraStoredDataSelect` classes and their tests.
 
 ## Acceptance Criteria
 
-1. After HA reboot, the solar provider select entity retains the user's last explicit selection
+1. After HA reboot, the solar provider select entity retains the user's last selection
 2. Selecting a specific provider, rebooting, and checking the entity shows the same provider
 3. Selecting "auto", rebooting, and checking the entity shows "auto"
-4. The `user_selected_option` in `extra_restore_state_data` matches the displayed entity state at all times
-5. The `async_update_callback` does not overwrite restored or user-selected state with stale device defaults
-6. If a previously selected provider no longer exists after reboot, the entity falls back to "auto" gracefully and logs a warning
+4. All quality gates pass (100% coverage, ruff, mypy, translations)
 
-## Tasks / Subtasks
+## Changes
 
-- [ ] Task 1: Reproduce and confirm the bug (AC: 1, 2)
-  - [ ] 1.1 Add a test that creates a `QSUserOverrideSelectRestore` solar provider entity, sets a provider, simulates a reboot (save extra data, reinitialize, call `async_added_to_hass`), and checks the restored state
-  - [ ] 1.2 Verify the test fails with current code (confirms the bug)
-
-- [ ] Task 2: Fix persistence — ensure `async_update_callback` respects user override (AC: 4, 5)
-  - [ ] 2.1 Override `async_update_callback` in `QSUserOverrideSelectRestore` to read from `user_selected_option` instead of blindly from `device.provider_mode` — when `user_selected_option` is set, it takes precedence
-  - [ ] 2.2 Alternatively, ensure `device.provider_mode` is always in sync with `user_selected_option` so the callback reads the correct value
-
-- [ ] Task 3: Fix restore initialization (AC: 1, 2, 3)
-  - [ ] 3.1 In `async_added_to_hass`, handle `None` restored value by applying `qs_default_option` (same pattern as `QSSimpleSelectRestore` lines 393-397)
-  - [ ] 3.2 After restoring `user_selected_option`, ensure `device.set_provider_mode()` receives the correct value and the device state is in sync before `async_write_ha_state()` is called
-
-- [ ] Task 4: Add graceful fallback for missing providers (AC: 6)
-  - [ ] 4.1 In `async_added_to_hass`, after restoring `user_selected_option`, check if the value is still in the current `options` list. If not, log a warning and fall back to `qs_default_option` ("auto")
-
-- [ ] Task 5: Test coverage (AC: 1-6)
-  - [ ] 5.1 Test: select provider, save state, restore → restored value matches
-  - [ ] 5.2 Test: select "auto", save state, restore → "auto" is preserved
-  - [ ] 5.3 Test: `async_update_callback` does not overwrite user selection
-  - [ ] 5.4 Test: provider name no longer valid after restore → graceful fallback to "auto" with log warning
-  - [ ] 5.5 Test: first boot (no saved state) → defaults to "auto"
-
-## Dev Notes
-
-### Architecture Constraints
-
-- **Two-layer boundary:** `ha_model/solar.py` (HA bridge) and `select.py` (HA entity) are both in the HA layer. No domain boundary concerns for this fix.
-- **Logging:** Use lazy `%s` formatting, no f-strings in log calls, no trailing periods.
-- **Constants:** `SELECT_SOLAR_PROVIDER_MODE` and `SOLAR_PROVIDER_MODE_AUTO` are in `const.py` — use them, don't hardcode.
-- **Translations:** If adding new log messages visible to users, edit `strings.json` not `translations/en.json`.
-
-### Key Files
-
-| File | Lines | Role |
-|------|-------|------|
-| `select.py` | 191-212 | `create_ha_select_for_QSSolar()` — entity creation |
-| `select.py` | 271-364 | `QSBaseSelect` — base class with `async_update_callback` |
-| `select.py` | 366-399 | `QSSimpleSelectRestore` — working persistence pattern to reference |
-| `select.py` | 402-459 | `QSUserOverrideSelectRestore` + `QSExtraStoredDataSelect` — the bug area |
-| `ha_model/solar.py` | 82-211 | `QSSolar` — device-side `set_provider_mode()` and init |
-| `const.py` | 101, 235 | Constants for provider mode and select key |
-| `entity.py` | 128-134 | `QSDeviceEntity.async_added_to_hass()` — base entity setup |
-
-### Testing Patterns
-
-- Use test factories from `tests/factories.py` for creating domain objects
-- Use mock configs from `tests/ha_tests/const.py` for HA integration tests
-- For restore entity tests, mock `async_get_last_extra_data()` to return saved state
-- Reference `bug-Github-#84` (solar forecast scores/prober persistence) for a prior persistence fix pattern in the same codebase
-
-### Previous Story Intelligence
-
-`bug-Github-#84` fixed persistence for `QSforecastValueSensor` using `ExtraStoredData` — a very similar pattern. That fix successfully restored forecast prober data across reboots. The key difference: that fix created a new `QSBaseSensorForecastRestore` class. The solar provider select already has `QSUserOverrideSelectRestore` but the restore path may not correctly handle the interaction between `async_update_callback` and `extra_restore_state_data`.
-
-### Project Structure Notes
-
-- All code is within `custom_components/quiet_solar/` — HA integration layer
-- Select entity persistence uses HA's `RestoreEntity` + `ExtraStoredData` mechanism from `homeassistant.helpers.restore_state`
-- No domain layer changes needed — this is entirely an HA entity persistence bug
-
-### References
-
-- [Source: select.py:426-459] — `QSUserOverrideSelectRestore` persistence class
-- [Source: select.py:344-354] — `async_update_callback` that may overwrite state
-- [Source: select.py:379-399] — `QSSimpleSelectRestore` working pattern
-- [Source: ha_model/solar.py:204-211] — `set_provider_mode()` with fallback logic
-- [Source: _bmad-output/project-context.md] — project rules and testing standards
+- `select.py:208` — switched `QSUserOverrideSelectRestore` to `QSSimpleSelectRestore`
+- `select.py` — removed dead `QSUserOverrideSelectRestore` and `QSExtraStoredDataSelect` classes, cleaned up unused imports (`asdict`, `ExtraStoredData`)
+- `tests/test_platform_select.py` — removed tests for dead classes, cleaned up unused imports
+- `tests/test_solar_forecast_resilience.py` — added `test_set_provider_mode_none_falls_back_to_auto` to cover `set_provider_mode(None)` fallback path (previously covered by removed tests)
 
 ## Dev Agent Record
 
@@ -147,14 +44,6 @@ Claude Opus 4.6
 
 ### Completion Notes List
 
-- Story created from user bug report: solar provider select not persisted after reboot
-- Thorough analysis of persistence chain: entity → ExtraStoredData → device → callback loop
-- Identified primary suspect: `async_update_callback` not respecting user override
-- Cross-referenced with working `QSSimpleSelectRestore` pattern
-
-### File List
-
-- `custom_components/quiet_solar/select.py`
-- `custom_components/quiet_solar/ha_model/solar.py`
-- `custom_components/quiet_solar/const.py`
-- `custom_components/quiet_solar/entity.py`
+- Root cause identified by user: unnecessary complexity using `QSUserOverrideSelectRestore` when `QSSimpleSelectRestore` suffices
+- One-line fix plus dead code cleanup
+- All quality gates pass

--- a/custom_components/quiet_solar/select.py
+++ b/custom_components/quiet_solar/select.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Callable
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
@@ -8,7 +8,7 @@ from homeassistant.components.select import SelectEntity, SelectEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     CAR_STALE_MODE_AUTO,
@@ -205,9 +205,7 @@ def create_ha_select_for_QSSolar(device: QSSolar):
         qs_default_option=SOLAR_PROVIDER_MODE_AUTO,
     )
     entities.append(
-        QSUserOverrideSelectRestore(
-            data_handler=device.data_handler, device=device, description=provider_mode_description
-        )
+        QSSimpleSelectRestore(data_handler=device.data_handler, device=device, description=provider_mode_description)
     )
     return entities
 
@@ -397,63 +395,3 @@ class QSSimpleSelectRestore(QSBaseSelectRestore):
             new_option = self.options[0]
 
         await self.async_select_option(new_option, for_init=True)
-
-
-@dataclass
-class QSExtraStoredDataSelect(ExtraStoredData):
-    """Object to hold extra stored data."""
-
-    user_selected_option: str | None
-
-    def as_dict(self) -> dict[str, Any]:
-        """Return a dict representation of the text data."""
-        return asdict(self)
-
-    @classmethod
-    def from_dict(cls, restored: dict[str, Any]):
-        """Initialize a stored text state from a dict."""
-        try:
-            return cls(
-                restored["user_selected_option"],
-            )
-        except Exception as e:
-            _LOGGER.error(
-                "QSExtraStoredDataSelect.from_dict exception %s %s", restored, e, exc_info=True, stack_info=True
-            )
-            return None
-
-
-class QSUserOverrideSelectRestore(QSBaseSelectRestore):
-    user_selected_option: str | None = None
-
-    @property
-    def extra_restore_state_data(self) -> QSExtraStoredDataSelect:
-        """Return sensor specific state data to be restored."""
-        return QSExtraStoredDataSelect(self.user_selected_option)
-
-    async def async_get_last_select_data(self) -> QSExtraStoredDataSelect | None:
-        """Restore native_value and native_unit_of_measurement."""
-        if (restored_last_extra_data := await self.async_get_last_extra_data()) is None:
-            return None
-        return QSExtraStoredDataSelect.from_dict(restored_last_extra_data.as_dict())
-
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-
-        last_sensor_state = await self.async_get_last_select_data()
-
-        if not last_sensor_state:
-            user_option = None
-        else:
-            user_option = last_sensor_state.user_selected_option
-
-        self.user_selected_option = user_option
-        self._attr_current_option = self.user_selected_option
-
-        await self.async_select_option(self.user_selected_option, for_init=True)
-
-    async def async_select_option(self, option: str, for_init=False) -> None:
-        """Select an option."""
-        self.user_selected_option = option
-        await super().async_select_option(option, for_init=for_init)

--- a/tests/test_platform_select.py
+++ b/tests/test_platform_select.py
@@ -14,10 +14,8 @@ from homeassistant.helpers import entity_registry as er
 from custom_components.quiet_solar.const import DOMAIN
 from custom_components.quiet_solar.select import (
     QSBaseSelect,
-    QSExtraStoredDataSelect,
     QSSelectEntityDescription,
     QSSimpleSelectRestore,
-    QSUserOverrideSelectRestore,
     async_unload_entry,
 )
 
@@ -188,76 +186,6 @@ async def test_select_setter_handles_attribute_error():
 
     await entity.async_select_option("option_2")
     entity.async_write_ha_state.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_user_override_select_restore():
-    """Test QSUserOverrideSelectRestore restores user selection."""
-    handler = MagicMock()
-    handler.hass = MagicMock()
-    device = _make_device()
-    device.mode = "option_1"
-
-    description = QSSelectEntityDescription(
-        key="mode",
-        translation_key="mode",
-        options=["option_1", "option_2"],
-    )
-
-    entity = QSUserOverrideSelectRestore(handler, device, description)
-    entity.async_write_ha_state = MagicMock()
-
-    extra = QSExtraStoredDataSelect("option_2")
-    with patch.object(entity, "async_get_last_extra_data", return_value=extra):
-        await entity.async_added_to_hass()
-
-    assert entity.user_selected_option == "option_2"
-
-
-@pytest.mark.asyncio
-async def test_user_override_select_no_restore_data():
-    """Test user override select with no restore data."""
-    handler = MagicMock()
-    handler.hass = MagicMock()
-    device = _make_device()
-
-    description = QSSelectEntityDescription(
-        key="test_key",
-        translation_key="test_key",
-        options=["option_1", "option_2"],
-    )
-
-    entity = QSUserOverrideSelectRestore(handler, device, description)
-    entity.async_get_last_extra_data = AsyncMock(return_value=None)
-    entity.async_select_option = AsyncMock()
-
-    await entity.async_added_to_hass()
-
-    assert entity.user_selected_option is None
-    entity.async_select_option.assert_called_once()
-
-
-def test_user_override_select_extra_restore_data():
-    """Test user override select extra restore data."""
-    handler = MagicMock()
-    handler.hass = MagicMock()
-    device = _make_device()
-
-    description = QSSelectEntityDescription(
-        key="test_key",
-        translation_key="test_key",
-        options=["option_1", "option_2"],
-    )
-
-    entity = QSUserOverrideSelectRestore(handler, device, description)
-    extra = entity.extra_restore_state_data
-
-    assert isinstance(extra, QSExtraStoredDataSelect)
-
-
-def test_extra_stored_data_from_dict_error():
-    """Test QSExtraStoredDataSelect.from_dict handles errors."""
-    assert QSExtraStoredDataSelect.from_dict({}) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_solar_forecast_resilience.py
+++ b/tests/test_solar_forecast_resilience.py
@@ -203,6 +203,17 @@ class TestProviderSelection:
         solar.auto_select_best_provider()
         assert solar.active_provider_name == "B"
 
+    def test_set_provider_mode_none_falls_back_to_auto(self, fake_hass):
+        """Test that None or unknown provider name falls back to auto."""
+        providers_config = [
+            {CONF_SOLAR_PROVIDER_DOMAIN: SOLCAST_SOLAR_DOMAIN, CONF_SOLAR_PROVIDER_NAME: "A"},
+        ]
+        solar = _make_solar(fake_hass, providers_config=providers_config)
+        solar.set_provider_mode(None)
+        assert solar.provider_mode == SOLAR_PROVIDER_MODE_AUTO
+        solar.set_provider_mode("nonexistent")
+        assert solar.provider_mode == SOLAR_PROVIDER_MODE_AUTO
+
     def test_auto_tiebreak_by_freshness(self, fake_hass):
         """Test auto mode tie-breaking by freshest forecast."""
         providers_config = [


### PR DESCRIPTION
## Summary

- Switched solar provider select entity from `QSUserOverrideSelectRestore` (complex `ExtraStoredData` mechanism) to `QSSimpleSelectRestore` (standard HA state restoration), matching all other select entities in the codebase
- Removed dead `QSUserOverrideSelectRestore` and `QSExtraStoredDataSelect` classes and their tests (-200 lines)
- Added test for `set_provider_mode(None)` fallback to maintain 100% coverage

Fixes #90

## Test plan

- [ ] All quality gates pass (pytest 100% cov + ruff + mypy + translations)
- [ ] Select a specific solar provider, reboot HA, verify selection persists
- [ ] Select "auto", reboot HA, verify "auto" persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Solar provider selection now persists correctly after Home Assistant reboots.

* **Tests**
  * Enhanced test coverage for provider mode fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->