### PR TITLE
fix: skip day-rollover lcc double-count in pool metrics (#101)

### DIFF
--- a/_bmad-output/implementation-artifacts/bug-Github-#101-pool-target-offset-slider-mid-run.md
+++ b/_bmad-output/implementation-artifacts/bug-Github-#101-pool-target-offset-slider-mid-run.md
@@ -1,6 +1,6 @@
 # Bug Fix: Pool target offset by already-run hours when slider is adjusted mid-run (regression)
 
-Status: in-progress
+Status: done
 issue: 101
 branch: "QS_101"
 
@@ -87,21 +87,21 @@ Keep the change localized to `update_current_metrics` (per project boundary: no 
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Implement rollover skip in `update_current_metrics` default path (AC: 1, 2, 3)
-  - [ ] 1.1: Next to the existing `already_absorbed` check (~line 142), add a `rollover_from_previous_day` guard: skip lcc when `lcc.end_of_constraint == today_utc` AND an active same-type constraint exists in the day window
-  - [ ] 1.2: Combine with existing `already_absorbed` as: `if not already_absorbed and not rollover_from_previous_day:`
+- [x] Task 1: Implement rollover skip in `update_current_metrics` default path (AC: 1, 2, 3)
+  - [x] 1.1: Next to the existing `already_absorbed` check (~line 142), add a `rollover_from_previous_day` guard: skip lcc when `lcc.end_of_constraint == today_utc` AND an active same-type constraint exists in the day window
+  - [x] 1.2: Combine with existing `already_absorbed` as: `if not already_absorbed and not rollover_from_previous_day:`
 
-- [ ] Task 2: Add regression test — lcc.end==today_utc + active.end==tomorrow_utc (AC: 1, 2, 3)
-  - [ ] 2.1: In `tests/test_ha_pool.py` (or `test_bug_78_daily_metrics.py`): lcc with `end_of_constraint = today_utc`, non-zero target/current (yesterday's completed cycle). Active constraint with `end_of_constraint = tomorrow_utc`, target = slider value, current = some runtime.
-  - [ ] 2.2: Assert `qs_bistate_current_duration_h == active.target / 3600` and `qs_bistate_current_on_h == active.current / 3600` (lcc NOT included)
+- [x] Task 2: Add regression test — lcc.end==today_utc + active.end==tomorrow_utc (AC: 1, 2, 3)
+  - [x] 2.1: In `tests/test_ha_pool.py`: lcc with `end_of_constraint = today_utc`, non-zero target/current (yesterday's completed cycle). Active constraint with `end_of_constraint = tomorrow_utc`, target = slider value, current = some runtime.
+  - [x] 2.2: Assert `qs_bistate_current_duration_h == active.target / 3600` and `qs_bistate_current_on_h == active.current / 3600` (lcc NOT included)
 
-- [ ] Task 3: Verify existing tests pass — no regression on intra-day cases (AC: 3, 4, 5)
-  - [ ] 3.1: `test_pool_update_current_metrics_completed_and_active_sums_both` — lcc at 08:00, active at 17:00, both counted (lcc.end ≠ today_utc)
-  - [ ] 3.2: `test_default_mode_exact_midnight_lcc_included` — lcc at exact midnight, no active → lcc counted
-  - [ ] 3.3: All 48 existing regression tests pass
+- [x] Task 3: Verify existing tests pass — no regression on intra-day cases (AC: 3, 4, 5)
+  - [x] 3.1: `test_pool_update_current_metrics_completed_and_active_sums_both` — lcc at 08:00, active at 17:00, both counted (lcc.end ≠ today_utc)
+  - [x] 3.2: `test_default_mode_exact_midnight_lcc_included` — lcc at exact midnight, no active → lcc counted
+  - [x] 3.3: All 49 tests pass (23 pool + 26 daily metrics)
 
-- [ ] Task 4: Run full quality gate (AC: 6)
-  - [ ] 4.1: `python scripts/qs/quality_gate.py`
+- [x] Task 4: Run full quality gate (AC: 6)
+  - [x] 4.1: `python scripts/qs/quality_gate.py` — all gates green, 100% coverage
 
 ## Dev Notes
 

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -145,8 +145,17 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                     for ct in self._constraints
                     if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc
                 )
+                # Bug #101: skip lcc when it ended exactly at local midnight
+                # (previous day's rollover) and a same-type active constraint
+                # represents today's cycle — avoids double-counting yesterday
+                rollover_from_previous_day = lcc.end_of_constraint == today_utc and any(
+                    type(ct) == type(lcc)
+                    for ct in self._constraints
+                    if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc
+                )
                 if (
                     not already_absorbed
+                    and not rollover_from_previous_day
                     and lcc.end_of_constraint != DATETIME_MAX_UTC
                     and lcc.end_of_constraint >= today_utc  # >= includes exact-midnight boundary (DST)
                     and lcc.end_of_constraint <= tomorrow_utc

--- a/tests/test_ha_pool.py
+++ b/tests/test_ha_pool.py
@@ -512,3 +512,50 @@ async def test_pool_update_current_metrics_extended_lcc_absorbed_via_initial_end
     # lcc absorbed via initial_end match — only active counted
     assert pool.qs_bistate_current_duration_h == 21600.0 / 3600.0  # 6h
     assert pool.qs_bistate_current_on_h == 14400.0 / 3600.0  # 4h
+
+
+async def test_pool_update_current_metrics_day_rollover_lcc_not_double_counted():
+    """Test that lcc from previous day rollover is not double-counted with today's active.
+
+    Bug #101: Pool with default_on_finish_time=00:00 has yesterday's completed
+    constraint ending at today_utc (midnight) and today's active constraint ending
+    at tomorrow_utc (next midnight). The lcc passes the day-window check but
+    represents yesterday's cycle — counting it inflates target by lcc.target and
+    actual by lcc.current.
+    """
+    from custom_components.quiet_solar.ha_model.bistate_duration import QSBiStateDuration
+    from custom_components.quiet_solar.home_model.constraints import TimeBasedSimplePowerLoadConstraint
+
+    now = datetime(2026, 3, 30, 14, 0, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+
+    # Yesterday's completed constraint ending exactly at today_utc (midnight rollover)
+    # This simulates a pool that ran yesterday with default_on_finish_time=00:00
+    lcc = TimeBasedSimplePowerLoadConstraint(
+        type=1, time=now, power=1500, initial_value=0,
+        target_value=28800.0,   # 8h target (yesterday)
+        current_value=28800.0,  # 8h actual (yesterday)
+        start_of_constraint=datetime(2026, 3, 29, 16, 0, 0, tzinfo=pytz.UTC),
+        end_of_constraint=today_utc,  # midnight — exact rollover boundary
+    )
+
+    # Today's active constraint ending at tomorrow_utc (next midnight)
+    # User set slider to 10h target, pool has run 3h so far today
+    active_ct = TimeBasedSimplePowerLoadConstraint(
+        type=1, time=now, power=1500, initial_value=0,
+        target_value=36000.0,   # 10h target (slider value)
+        current_value=10800.0,  # 3h actual (today's runtime)
+        start_of_constraint=datetime(2026, 3, 30, 8, 0, 0, tzinfo=pytz.UTC),
+        end_of_constraint=tomorrow_utc,  # next midnight
+    )
+
+    pool, _, _ = _make_pool_with_day_bounds(now, today_utc, tomorrow_utc)
+    pool._last_completed_constraint = lcc
+    pool._constraints = [active_ct]
+
+    await QSBiStateDuration.update_current_metrics(pool, now)
+
+    # Only today's active constraint should count — lcc is a previous-day rollover
+    assert pool.qs_bistate_current_duration_h == 36000.0 / 3600.0  # 10h (AC1)
+    assert pool.qs_bistate_current_on_h == 10800.0 / 3600.0  # 3h (AC2)


### PR DESCRIPTION
## Summary
- Add rollover_from_previous_day guard in update_current_metrics to skip lcc ending at today_utc when a same-type active constraint exists for today
- Fixes inflated target/actual hours when pool slider is adjusted mid-run with default_on_finish_time=00:00
- Regression test: lcc.end==today_utc + active.end==tomorrow_utc asserts only active constraint values
- All 49 pool/metrics tests pass, 100% coverage, all quality gates green

Fixes #101

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression where adjusting the Quiet Solar pool target-hour slider during operation would cause on-duration metrics to become inflated with already-run hours instead of reflecting the slider value as the new daily target.

* **Tests**
  * Added regression test ensuring day-rollover metrics are calculated correctly and constraints from previous days are not double-counted with active current constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->