### PR TITLE
Add confirmation popups for home and solar action buttons

### DIFF
--- a/_bmad-output/implementation-artifacts/feature-Github-#128-confirmation-popup-home-solar.md
+++ b/_bmad-output/implementation-artifacts/feature-Github-#128-confirmation-popup-home-solar.md
@@ -3,7 +3,7 @@
 issue: 128
 branch: "QS_128"
 
-Status: ready-for-dev
+Status: dev-complete
 
 ## Story
 As a Quiet Solar user,
@@ -17,19 +17,19 @@ so that I don't accidentally trigger destructive actions like history resets or 
 4. Given the rendered dashboard YAML, when parsed, then `confirmation:` text appears for all 9 action buttons in both templates.
 
 ## Tasks / Subtasks
-- [ ] Task 1: Add confirmation blocks to home buttons in BOTH templates (AC: #1, #3)
-  - [ ] qs_home_serialize_for_debug — standard_ha:395-399, custom:199-203
-  - [ ] qs_home_light_reset_history — standard_ha:400-404, custom:204-208
-  - [ ] qs_home_recompute_people_historical_data — standard_ha:405-409, custom:209-213
-  - [ ] qs_home_reset_history — standard_ha:410-414, custom:214-218
-  - [ ] qs_home_generate_yaml_dashboard — standard_ha:415-419, custom:219-223
-- [ ] Task 2: Add confirmation blocks to solar buttons in BOTH templates (AC: #2, #3)
-  - [ ] qs_solar_recompute_forecast_scores — standard_ha:465-469, custom:269-273
-  - [ ] qs_solar_compute_dampening_1day — standard_ha:470-474, custom:274-278
-  - [ ] qs_solar_compute_dampening_7day — standard_ha:475-479, custom:279-283
-  - [ ] qs_solar_reset_dampening — standard_ha:480-484, custom:284-288
-- [ ] Task 3: Add regression test for confirmation presence in rendered output (AC: #4)
-- [ ] Task 4: Run quality gates and verify all tests pass
+- [x] Task 1: Add confirmation blocks to home buttons in BOTH templates (AC: #1, #3)
+  - [x] qs_home_serialize_for_debug — standard_ha:395-399, custom:199-203
+  - [x] qs_home_light_reset_history — standard_ha:400-404, custom:204-208
+  - [x] qs_home_recompute_people_historical_data — standard_ha:405-409, custom:209-213
+  - [x] qs_home_reset_history — standard_ha:410-414, custom:214-218
+  - [x] qs_home_generate_yaml_dashboard — standard_ha:415-419, custom:219-223
+- [x] Task 2: Add confirmation blocks to solar buttons in BOTH templates (AC: #2, #3)
+  - [x] qs_solar_recompute_forecast_scores — standard_ha:465-469, custom:269-273
+  - [x] qs_solar_compute_dampening_1day — standard_ha:470-474, custom:274-278
+  - [x] qs_solar_compute_dampening_7day — standard_ha:475-479, custom:279-283
+  - [x] qs_solar_reset_dampening — standard_ha:480-484, custom:284-288
+- [x] Task 3: Add regression test for confirmation presence in rendered output (AC: #4)
+- [x] Task 4: Run quality gates and verify all tests pass
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/feature-Github-#128-confirmation-popup-home-solar.md
+++ b/_bmad-output/implementation-artifacts/feature-Github-#128-confirmation-popup-home-solar.md
@@ -1,0 +1,131 @@
+# Story feature-Github-#128-confirmation-popup-home-solar: Add confirmation popup for home and solar buttons in dashboard
+
+issue: 128
+branch: "QS_128"
+
+Status: ready-for-dev
+
+## Story
+As a Quiet Solar user,
+I want confirmation popups on home and solar action buttons in the dashboard,
+so that I don't accidentally trigger destructive actions like history resets or forecast recomputations.
+
+## Acceptance Criteria
+1. Given a user viewing the dashboard, when they tap any home action button (serialize_for_debug, light_reset_history, recompute_people_historical_data, reset_history, generate_yaml_dashboard), then a confirmation popup appears with action-specific text before the action executes.
+2. Given a user viewing the dashboard, when they tap any solar action button (recompute_forecast_scores, compute_dampening_1day, compute_dampening_7day, reset_dampening), then a confirmation popup appears with action-specific text before the action executes.
+3. Given both template files (quiet_solar_dashboard_template.yaml.j2 and quiet_solar_dashboard_template_standard_ha.yaml.j2), when rendered, then the confirmation blocks follow the same tap_action/confirmation pattern used in the car section.
+4. Given the rendered dashboard YAML, when parsed, then `confirmation:` text appears for all 9 action buttons in both templates.
+
+## Tasks / Subtasks
+- [ ] Task 1: Add confirmation blocks to home buttons in BOTH templates (AC: #1, #3)
+  - [ ] qs_home_serialize_for_debug — standard_ha:395-399, custom:199-203
+  - [ ] qs_home_light_reset_history — standard_ha:400-404, custom:204-208
+  - [ ] qs_home_recompute_people_historical_data — standard_ha:405-409, custom:209-213
+  - [ ] qs_home_reset_history — standard_ha:410-414, custom:214-218
+  - [ ] qs_home_generate_yaml_dashboard — standard_ha:415-419, custom:219-223
+- [ ] Task 2: Add confirmation blocks to solar buttons in BOTH templates (AC: #2, #3)
+  - [ ] qs_solar_recompute_forecast_scores — standard_ha:465-469, custom:269-273
+  - [ ] qs_solar_compute_dampening_1day — standard_ha:470-474, custom:274-278
+  - [ ] qs_solar_compute_dampening_7day — standard_ha:475-479, custom:279-283
+  - [ ] qs_solar_reset_dampening — standard_ha:480-484, custom:284-288
+- [ ] Task 3: Add regression test for confirmation presence in rendered output (AC: #4)
+- [ ] Task 4: Run quality gates and verify all tests pass
+
+## Dev Notes
+
+### Insertion pattern
+
+Insert 4 lines after the `name` line and before the `{%- endif %}` of each entity block. Example before/after for `qs_home_serialize_for_debug`:
+
+**Before:**
+```jinja2
+              {%- set ha_entity = device.ha_entities.get("qs_home_serialize_for_debug") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+```
+
+**After:**
+```jinja2
+              {%- set ha_entity = device.ha_entities.get("qs_home_serialize_for_debug") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will export home data to a debug file." }}
+              {%- endif %}
+```
+
+Apply the same 4-line insertion to all 9 entity blocks in both files, using the confirmation text from the table below.
+
+### Indentation
+
+The tap_action and confirmation blocks must be indented at the same level as the entity's `name` property:
+- `{{ "  tap_action:" }}` — 2-space indent (matches `name`)
+- `{{ "    action: toggle" }}` — 4-space indent
+- `{{ "  confirmation:" }}` — 2-space indent
+- `{{ "    text: ..." }}` — 4-space indent
+
+### No icon needed
+
+The car section entities include custom `icon:` lines (e.g., `mdi:rabbit`). Home/solar action buttons do not need custom icons — only the `tap_action` + `confirmation` block is required.
+
+### Template differences
+
+The custom template (`quiet_solar_dashboard_template.yaml.j2`) has no existing confirmation pattern to reference — car/pool/climate use custom JS cards there. However, the home and solar sections in both templates use the identical `{{ "- entity: ..." }}` / `{{ "  name: ..." }}` Jinja2 string rendering, so the same tap_action/confirmation block applies directly.
+
+### Confirmation Text per Button
+
+| Entity key | Confirmation text |
+|------------|-------------------|
+| qs_home_serialize_for_debug | This will export home data to a debug file. |
+| qs_home_light_reset_history | This will clear recent home history (keeps older data). |
+| qs_home_recompute_people_historical_data | This will recompute all people historical data. |
+| qs_home_reset_history | WARNING: This will permanently delete ALL home history data. |
+| qs_home_generate_yaml_dashboard | This will regenerate the YAML dashboard. |
+| qs_solar_recompute_forecast_scores | This will recompute all solar forecast scores. |
+| qs_solar_compute_dampening_1day | This will compute solar dampening from 1 day of data. |
+| qs_solar_compute_dampening_7day | This will compute solar dampening from 7 days of data. |
+| qs_solar_reset_dampening | WARNING: This will reset ALL solar dampening values. |
+
+### Scope note
+
+This story is intentionally scoped to home and solar buttons per issue #128. Other device sections (climate, pool, on_off_duration) also have action buttons (e.g., `qs_device_clean_and_reset`) without confirmations — those are out of scope for this change.
+
+### Test requirements
+
+Add a regression test in `tests/test_dashboard_rendering.py` that renders both templates and asserts `confirmation:` text appears for all 9 action buttons. This guards against silent removal of confirmation blocks.
+
+### Files to modify
+- `custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2` — home section (lines 395-419), solar section (lines 465-484)
+- `custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2` — home section (lines 199-223), solar section (lines 269-288)
+- `tests/test_dashboard_rendering.py` — add confirmation presence test
+
+### General notes
+- Template changes only affect NEW dashboard generation — existing users must regenerate dashboards
+- No Python source code changes needed — pure template + test modification
+
+## Adversarial Review Notes
+
+**Reviewers:** Critic, Concrete Planner, Dev Proxy
+**Rounds:** 1
+
+### Key findings incorporated:
+- Task structure: merged "mirror" Task 3 into Tasks 1+2 so both files are edited together per button group (Critic + Concrete Planner)
+- Added concrete before/after example to eliminate insertion ambiguity (Critic + Concrete Planner)
+- Added dev notes on exact indentation, insert position, icon exclusion, template differences (Dev Proxy + Concrete Planner)
+- Added regression test task for confirmation presence (all 3 reviewers)
+- Rewrote confirmation texts in plain language with severity hints for destructive actions (Critic)
+- Added scope note acknowledging other device sections are intentionally excluded (Critic)
+
+### Decisions made:
+- Plain language confirmation texts — Rationale: user chose user-friendly wording over technical descriptions
+- All 9 action buttons get confirmations — Rationale: user confirmed all action buttons, not just destructive ones
+- Scoped to home/solar only — Rationale: matches issue #128 scope; other sections can be a follow-up
+
+### Known risks acknowledged:
+- Template changes don't propagate to existing dashboards — users must regenerate
+- HA Lovelace parser validation is not tested at runtime level (only YAML structure is validated by tests)

--- a/_bmad-output/implementation-artifacts/feature-Github-#128-confirmation-popup-home-solar.md
+++ b/_bmad-output/implementation-artifacts/feature-Github-#128-confirmation-popup-home-solar.md
@@ -129,3 +129,22 @@ Add a regression test in `tests/test_dashboard_rendering.py` that renders both t
 ### Known risks acknowledged:
 - Template changes don't propagate to existing dashboards — users must regenerate
 - HA Lovelace parser validation is not tested at runtime level (only YAML structure is validated by tests)
+
+## Code Review — PR #129 (2026-04-09)
+
+### Decisions
+| # | File | Finding | Decision | Notes |
+|---|------|---------|----------|-------|
+| 1 | Both templates | Dashboard regeneration warning text could mention manual edits lost | reject | Current text is intentional |
+| 2 | Both templates | Pattern matches car section exactly | reject | Correct implementation |
+| 3 | Both templates | WARNING single-quote YAML quoting | reject | Working as designed |
+| 4 | Both templates | Both templates have identical blocks | reject | Expected |
+| 5 | Both templates | None guard skips missing entities | reject | Correct pattern |
+| 6 | test_dashboard_rendering.py | String search adequate as regression guard | reject | Existing tests cover YAML validity |
+| 7 | test_dashboard_rendering.py | Global text presence vs per-entity binding (CodeRabbit) | reject | Hypothetical edge case not worth test complexity |
+
+### Deferred items
+_None_
+
+### Doc updates planned
+_None_

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
@@ -200,26 +200,46 @@ views:
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will export home data to a debug file." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_home_light_reset_history") %}
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will clear recent home history (keeps older data)." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_home_recompute_people_historical_data") %}
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will recompute all people historical data." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_home_reset_history") %}
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: 'WARNING: This will permanently delete ALL home history data.'" }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_home_generate_yaml_dashboard") %}
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will regenerate the YAML dashboard." }}
               {%- endif %}
             {% elif device.device_type == "battery" -%}
               {%- set ha_entity = device.ha_entities.get("load_current_command") %}
@@ -270,21 +290,37 @@ views:
               {%- if ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will recompute all solar forecast scores." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_solar_compute_dampening_1day") %}
               {%- if ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will compute solar dampening from 1 day of data." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_solar_compute_dampening_7day") %}
               {%- if ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will compute solar dampening from 7 days of data." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_solar_reset_dampening") %}
               {%- if ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: 'WARNING: This will reset ALL solar dampening values.'" }}
               {%- endif %}
             {% endif %}
             {%- if device.device_type not in ["car", "pool", "climate", "on_off_duration"] %}

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2
@@ -396,26 +396,46 @@ views:
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will export home data to a debug file." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_home_light_reset_history") %}
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will clear recent home history (keeps older data)." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_home_recompute_people_historical_data") %}
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will recompute all people historical data." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_home_reset_history") %}
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: 'WARNING: This will permanently delete ALL home history data.'" }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_home_generate_yaml_dashboard") %}
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will regenerate the YAML dashboard." }}
               {%- endif %}
             {% elif device.device_type == "battery" -%}
               {%- set ha_entity = device.ha_entities.get("load_current_command") %}
@@ -466,21 +486,37 @@ views:
               {%- if ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will recompute all solar forecast scores." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_solar_compute_dampening_1day") %}
               {%- if ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will compute solar dampening from 1 day of data." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_solar_compute_dampening_7day") %}
               {%- if ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: This will compute solar dampening from 7 days of data." }}
               {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_solar_reset_dampening") %}
               {%- if ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  tap_action:" }}
+              {{ "    action: toggle" }}
+              {{ "  confirmation:" }}
+              {{ "    text: 'WARNING: This will reset ALL solar dampening values.'" }}
               {%- endif %}
             {% endif -%}
             title: {{ device.name }}

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -318,6 +318,50 @@ class TestEntityTranslationKeys:
 # ============================================================================
 
 
+class TestConfirmationPopups:
+    """Verify confirmation popups appear for all home and solar action buttons."""
+
+    EXPECTED_CONFIRMATIONS = {
+        "qs_home_serialize_for_debug": "This will export home data to a debug file.",
+        "qs_home_light_reset_history": "This will clear recent home history (keeps older data).",
+        "qs_home_recompute_people_historical_data": "This will recompute all people historical data.",
+        "qs_home_reset_history": "'WARNING: This will permanently delete ALL home history data.'",
+        "qs_home_generate_yaml_dashboard": "This will regenerate the YAML dashboard.",
+        "qs_solar_recompute_forecast_scores": "This will recompute all solar forecast scores.",
+        "qs_solar_compute_dampening_1day": "This will compute solar dampening from 1 day of data.",
+        "qs_solar_compute_dampening_7day": "This will compute solar dampening from 7 days of data.",
+        "qs_solar_reset_dampening": "'WARNING: This will reset ALL solar dampening values.'",
+    }
+
+    @pytest.mark.parametrize(
+        "template_name",
+        [
+            "quiet_solar_dashboard_template.yaml.j2",
+            "quiet_solar_dashboard_template_standard_ha.yaml.j2",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_confirmation_text_present_for_all_action_buttons(
+        self, hass, full_dashboard_home, template_name
+    ):
+        """All 9 home/solar action buttons must have confirmation text in rendered output."""
+        home = full_dashboard_home
+        template_path = COMPONENT_ROOT / "ui" / template_name
+        template_content = template_path.read_text()
+
+        tpl = Template(template_content, hass)
+        rendered = tpl.async_render(variables={"home": home})
+
+        missing = []
+        for entity_key, expected_text in self.EXPECTED_CONFIRMATIONS.items():
+            if f"text: {expected_text}" not in rendered:
+                missing.append(entity_key)
+
+        assert missing == [], (
+            f"Template {template_name} missing confirmation text for: {', '.join(missing)}"
+        )
+
+
 class TestDashboardSectionMapping:
     """Verify LOAD_TYPE_DASHBOARD_DEFAULT_SECTION maps all device types correctly."""
 


### PR DESCRIPTION
## Summary
- Add tap_action/confirmation blocks to all 9 home and solar action buttons in both dashboard templates
- Quote WARNING texts for YAML validity (colon-space in text)
- Add parametrized regression test covering all 9 buttons in both templates

Fixes #128

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home and solar action buttons now require confirmation before toggling, with descriptive messages for nine specific actions to prevent accidental operations.

* **Tests**
  * Added regression test(s) to render dashboard templates and verify confirmation text is present for all affected action buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->