### PR TITLE
Fix dampened solar score unavailable after reboot

### DIFF
--- a/_bmad-output/implementation-artifacts/bug-Github-#131-dampened-score-unavailable-after-reboot.md
+++ b/_bmad-output/implementation-artifacts/bug-Github-#131-dampened-score-unavailable-after-reboot.md
@@ -1,0 +1,67 @@
+# Story bug-Github-#131: Fix dampened solar provider scores unavailable after HA reboot
+
+issue: 131
+branch: "QS_131"
+
+Status: ready-for-dev
+
+## Story
+As a Quiet Solar user with dampening enabled,
+I want my dampened solar forecast scores to survive HA reboots,
+so that my dashboard shows accurate values immediately after restart instead of "unavailable".
+
+## Acceptance Criteria
+1. Given a provider with dampening active and a valid `score_dampened` value persisted before reboot, When HA restarts and the first scoring cycle runs but `compute_dampened_score()` fails due to missing historical data, Then the previously restored `score_dampened` value is preserved (not cleared to None).
+2. Given a provider with dampening active and a valid `score_dampened` restored from state, When `_run_scoring_cycle()` is called and `compute_dampened_score()` returns False, Then the existing `score_dampened` value remains unchanged and the sensor remains available.
+3. Given a provider where dampening has never been computed (score_dampened is None), When `compute_dampened_score()` fails, Then `score_dampened` remains None (no regression -- no value to preserve).
+4. Given a provider where `compute_dampened_score()` succeeds, When the scoring cycle runs normally, Then `score_dampened` is updated to the newly computed value (no change in happy path behavior).
+
+## Tasks / Subtasks
+- [ ] Task 1: Remove aggressive score clearing in `_run_scoring_cycle()` (AC: #1, #2, #3)
+  - [ ] 1.1: In `ha_model/solar.py`, method `QSSolar._run_scoring_cycle()`, remove the `provider.score_dampened = None` assignment inside the `if not provider.compute_dampened_score(time):` block
+  - [ ] 1.2: Change the log from `_LOGGER.warning` to `_LOGGER.info` with message: `"Dampened score refresh failed for provider %s, keeping existing score %s", name, provider.score_dampened` (lazy `%s`, no period)
+  - [ ] 1.3: In the existing `_LOGGER.info` that follows the scoring block, add `provider.score_dampened` to the log output for visibility
+- [ ] Task 2: Update and add tests in `TestScoringCycleDampenedRefresh` (AC: #1, #2, #3, #4)
+  - [ ] 2.0: Modify existing `test_scoring_cycle_clears_stale_dampened_score` -- rename to `test_scoring_cycle_preserves_existing_dampened_score_on_failure`, change assertion from `assert provider.score_dampened is None` to `assert provider.score_dampened == 100.0` (preserved)
+  - [ ] 2.1: Add `test_scoring_cycle_preserves_none_dampened_score_on_failure` -- set `provider._dampening_coefficients = {0: (0.8, 0.0)}` (so `has_dampening` is True) but leave `score_dampened` as None, mock `compute_dampened_score` to return False, assert `score_dampened is None`
+  - [ ] 2.2: Enhance existing `test_scoring_cycle_refreshes_dampened_score` to verify actual value update (not just that the mock was called)
+- [ ] Task 3: Run quality gates (AC: all)
+  - [ ] 3.1: Run `python scripts/qs/quality_gate.py` -- ensure 100% coverage, ruff, mypy, translations pass
+
+## Dev Notes
+- **Root cause**: `QSSolar._run_scoring_cycle()` in `ha_model/solar.py` clears `provider.score_dampened = None` when `compute_dampened_score()` fails. After reboot, historical data isn't available yet, so the computation always fails on the first cycle, destroying the value that `QSBaseSensorSolarDampenedScoreRestore.async_added_to_hass()` (sensor.py) just restored.
+- **Asymmetry with raw score**: `compute_score()` returning False does NOT clear `provider.score` -- the raw score restore survives. Only the dampened score is aggressively cleared. `reset_dampening()` is a separate intentional clearing path (user action) -- unrelated to this bug.
+- **Fix approach**: Remove the `provider.score_dampened = None` assignment. Demote log to `info` since this is routine after reboot. This makes dampened score behavior match raw score behavior on failed computation.
+- **Files changed**: `ha_model/solar.py` (code fix) + `tests/test_solar_dampening.py` (update existing test + add new test)
+- **Layer boundary**: Fix is entirely within `ha_model/solar.py` -- no cross-layer changes needed.
+- **Test class**: All test changes go in `TestScoringCycleDampenedRefresh` in `tests/test_solar_dampening.py`. Helpers `_make_solar` and `FakeConfigEntry` are already available there.
+- **Logging rules**: lazy `%s`, no f-strings, no trailing periods.
+
+### Project Structure Notes
+- `ha_model/solar.py` -- `QSSolar._run_scoring_cycle()` method, target: `provider.score_dampened = None` inside the `if not provider.compute_dampened_score(time):` block
+- `ha_model/solar.py` -- `QSSolarProvider.compute_dampened_score()` method
+- `sensor.py` -- `QSBaseSensorSolarDampenedScoreRestore.async_added_to_hass()` (restore works correctly, no changes needed)
+- `tests/test_solar_dampening.py` -- `TestScoringCycleDampenedRefresh` class
+
+### References
+- Issue #131: https://github.com/tmenguy/quiet-solar/issues/131
+- Similar fix pattern: bug #84 (prober persistence), bug #113 (solar forecast score hydration)
+
+## Adversarial Review Notes
+
+**Reviewers:** Critic, Concrete Planner, Dev Proxy
+**Rounds:** 1
+
+### Key findings incorporated:
+- [All 3] Existing test `test_scoring_cycle_clears_stale_dampened_score` must be updated (not just new tests added) -> Added Task 2.0 with explicit rename and assertion change
+- [Critic + Concrete + Dev Proxy] Log should be demoted to `info` (routine post-reboot), include preserved score value -> Updated Task 1.2
+- [Concrete] Task 2.1 clarified as modification of existing test, Task 2.2 as enhancement -> Restructured Task 2
+- [Dev Proxy] Note both files that change -> Added to Dev Notes
+- [Concrete] Add dampened score to scoring info log -> Added Task 1.3
+
+### Decisions made:
+- Stale score concern dismissed -- Rationale: raw score has same staleness after reboot; fix makes behavior symmetric, not worse
+- Timing/ordering concern dismissed -- Rationale: analysis confirmed async_added_to_hass completes before first update_all_states
+
+### Known risks acknowledged:
+- After reboot, "dampened score refresh failed" will log at info level on every scoring cycle until historical data accumulates (~24h). This is expected and benign.

--- a/_bmad-output/implementation-artifacts/bug-Github-#131-dampened-score-unavailable-after-reboot.md
+++ b/_bmad-output/implementation-artifacts/bug-Github-#131-dampened-score-unavailable-after-reboot.md
@@ -3,7 +3,7 @@
 issue: 131
 branch: "QS_131"
 
-Status: ready-for-dev
+Status: dev-complete
 
 ## Story
 As a Quiet Solar user with dampening enabled,
@@ -17,16 +17,16 @@ so that my dashboard shows accurate values immediately after restart instead of 
 4. Given a provider where `compute_dampened_score()` succeeds, When the scoring cycle runs normally, Then `score_dampened` is updated to the newly computed value (no change in happy path behavior).
 
 ## Tasks / Subtasks
-- [ ] Task 1: Remove aggressive score clearing in `_run_scoring_cycle()` (AC: #1, #2, #3)
-  - [ ] 1.1: In `ha_model/solar.py`, method `QSSolar._run_scoring_cycle()`, remove the `provider.score_dampened = None` assignment inside the `if not provider.compute_dampened_score(time):` block
-  - [ ] 1.2: Change the log from `_LOGGER.warning` to `_LOGGER.info` with message: `"Dampened score refresh failed for provider %s, keeping existing score %s", name, provider.score_dampened` (lazy `%s`, no period)
-  - [ ] 1.3: In the existing `_LOGGER.info` that follows the scoring block, add `provider.score_dampened` to the log output for visibility
-- [ ] Task 2: Update and add tests in `TestScoringCycleDampenedRefresh` (AC: #1, #2, #3, #4)
-  - [ ] 2.0: Modify existing `test_scoring_cycle_clears_stale_dampened_score` -- rename to `test_scoring_cycle_preserves_existing_dampened_score_on_failure`, change assertion from `assert provider.score_dampened is None` to `assert provider.score_dampened == 100.0` (preserved)
-  - [ ] 2.1: Add `test_scoring_cycle_preserves_none_dampened_score_on_failure` -- set `provider._dampening_coefficients = {0: (0.8, 0.0)}` (so `has_dampening` is True) but leave `score_dampened` as None, mock `compute_dampened_score` to return False, assert `score_dampened is None`
-  - [ ] 2.2: Enhance existing `test_scoring_cycle_refreshes_dampened_score` to verify actual value update (not just that the mock was called)
-- [ ] Task 3: Run quality gates (AC: all)
-  - [ ] 3.1: Run `python scripts/qs/quality_gate.py` -- ensure 100% coverage, ruff, mypy, translations pass
+- [x] Task 1: Remove aggressive score clearing in `_run_scoring_cycle()` (AC: #1, #2, #3)
+  - [x] 1.1: In `ha_model/solar.py`, method `QSSolar._run_scoring_cycle()`, remove the `provider.score_dampened = None` assignment inside the `if not provider.compute_dampened_score(time):` block
+  - [x] 1.2: Change the log from `_LOGGER.warning` to `_LOGGER.info` with message: `"Dampened score refresh failed for provider %s, keeping existing score %s", name, provider.score_dampened` (lazy `%s`, no period)
+  - [x] 1.3: In the existing `_LOGGER.info` that follows the scoring block, add `provider.score_dampened` to the log output for visibility
+- [x] Task 2: Update and add tests in `TestScoringCycleDampenedRefresh` (AC: #1, #2, #3, #4)
+  - [x] 2.0: Modify existing `test_scoring_cycle_clears_stale_dampened_score` -- rename to `test_scoring_cycle_preserves_existing_dampened_score_on_failure`, change assertion from `assert provider.score_dampened is None` to `assert provider.score_dampened == 100.0` (preserved)
+  - [x] 2.1: Add `test_scoring_cycle_preserves_none_dampened_score_on_failure` -- set `provider._dampening_coefficients = {0: (0.8, 0.0)}` (so `has_dampening` is True) but leave `score_dampened` as None, mock `compute_dampened_score` to return False, assert `score_dampened is None`
+  - [x] 2.2: Enhance existing `test_scoring_cycle_refreshes_dampened_score` to verify actual value update (not just that the mock was called)
+- [x] Task 3: Run quality gates (AC: all)
+  - [x] 3.1: Run `python scripts/qs/quality_gate.py` -- ensure 100% coverage, ruff, mypy, translations pass
 
 ## Dev Notes
 - **Root cause**: `QSSolar._run_scoring_cycle()` in `ha_model/solar.py` clears `provider.score_dampened = None` when `compute_dampened_score()` fails. After reboot, historical data isn't available yet, so the computation always fails on the first cycle, destroying the value that `QSBaseSensorSolarDampenedScoreRestore.async_added_to_hass()` (sensor.py) just restored.

--- a/custom_components/quiet_solar/ha_model/solar.py
+++ b/custom_components/quiet_solar/ha_model/solar.py
@@ -353,17 +353,18 @@ class QSSolar(HADeviceMixin, AbstractDevice):
             # Keep dampened score in sync when dampening is active
             if provider.has_dampening:
                 if not provider.compute_dampened_score(time):
-                    _LOGGER.warning(
-                        "Dampened score refresh failed for provider %s, clearing stale score",
+                    _LOGGER.info(
+                        "Dampened score refresh failed for provider %s, keeping existing score %s",
                         name,
+                        provider.score_dampened,
                     )
-                    provider.score_dampened = None
 
             _LOGGER.info(
-                "Scoring cycle for provider %s: score=%.2f is_score_computed=%s",
+                "Scoring cycle for provider %s: score=%.2f is_score_computed=%s dampened_score=%s",
                 name,
                 provider.score if provider.score is not None else float("nan"),
                 is_score_computed,
+                provider.score_dampened,
             )
 
     def get_forecast(

--- a/tests/test_solar_dampening.py
+++ b/tests/test_solar_dampening.py
@@ -1400,7 +1400,7 @@ class TestScoringCycleDampenedRefresh:
     """Test that _run_scoring_cycle refreshes dampened scores."""
 
     def test_scoring_cycle_refreshes_dampened_score(self, fake_hass):
-        """When dampening is active, scoring cycle recomputes dampened score."""
+        """When dampening is active and computation succeeds, dampened score is updated."""
         solar = _make_solar(
             fake_hass,
             providers_config=[{CONF_SOLAR_PROVIDER_DOMAIN: SOLCAST_SOLAR_DOMAIN, CONF_SOLAR_PROVIDER_NAME: "Test"}],
@@ -1411,15 +1411,19 @@ class TestScoringCycleDampenedRefresh:
         provider._dampening_coefficients = {0: (0.8, 0.0)}
         provider.score_dampened = 100.0
 
-        # Mock compute methods
+        def _fake_compute_dampened(time):
+            provider.score_dampened = 95.0
+            return True
+
         provider.compute_score = MagicMock(return_value=True)
-        provider.compute_dampened_score = MagicMock(return_value=True)
+        provider.compute_dampened_score = MagicMock(side_effect=_fake_compute_dampened)
 
         t0 = datetime.datetime(2024, 6, 15, 12, 0, tzinfo=pytz.UTC)
         solar._run_scoring_cycle(t0)
 
         provider.compute_score.assert_called_once_with(t0)
         provider.compute_dampened_score.assert_called_once_with(t0)
+        assert provider.score_dampened == 95.0
 
     def test_scoring_cycle_skips_dampened_when_inactive(self, fake_hass):
         """When no dampening, scoring cycle does not compute dampened score."""
@@ -1437,8 +1441,8 @@ class TestScoringCycleDampenedRefresh:
         provider.compute_score.assert_called_once()
         provider.compute_dampened_score.assert_not_called()
 
-    def test_scoring_cycle_clears_stale_dampened_score(self, fake_hass):
-        """When dampened score computation fails, score_dampened is set to None."""
+    def test_scoring_cycle_preserves_existing_dampened_score_on_failure(self, fake_hass):
+        """When dampened score computation fails, existing score_dampened is preserved."""
         solar = _make_solar(
             fake_hass,
             providers_config=[{CONF_SOLAR_PROVIDER_DOMAIN: SOLCAST_SOLAR_DOMAIN, CONF_SOLAR_PROVIDER_NAME: "Test"}],
@@ -1446,6 +1450,22 @@ class TestScoringCycleDampenedRefresh:
         provider = list(solar.solar_forecast_providers.values())[0]
         provider._dampening_coefficients = {0: (0.8, 0.0)}
         provider.score_dampened = 100.0
+        provider.compute_score = MagicMock(return_value=True)
+        provider.compute_dampened_score = MagicMock(return_value=False)
+
+        t0 = datetime.datetime(2024, 6, 15, 12, 0, tzinfo=pytz.UTC)
+        solar._run_scoring_cycle(t0)
+
+        assert provider.score_dampened == 100.0
+
+    def test_scoring_cycle_preserves_none_dampened_score_on_failure(self, fake_hass):
+        """When dampened score was never computed and computation fails, score_dampened stays None."""
+        solar = _make_solar(
+            fake_hass,
+            providers_config=[{CONF_SOLAR_PROVIDER_DOMAIN: SOLCAST_SOLAR_DOMAIN, CONF_SOLAR_PROVIDER_NAME: "Test"}],
+        )
+        provider = list(solar.solar_forecast_providers.values())[0]
+        provider._dampening_coefficients = {0: (0.8, 0.0)}
         provider.compute_score = MagicMock(return_value=True)
         provider.compute_dampened_score = MagicMock(return_value=False)
 


### PR DESCRIPTION
## Summary
Remove aggressive score_dampened clearing in _run_scoring_cycle when compute_dampened_score fails;Preserve restored dampened score after reboot instead of clearing to None;Demote log from warning to info (routine post-reboot);Add dampened_score to scoring cycle info log for visibility

Fixes #131

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where dampened solar forecast provider scores would become unavailable after a Home Assistant reboot when historical data for re-computation was temporarily missing. Scores are now preserved during this state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->