### PR TITLE
Fix SVD convergence error in 7-day dampening computation

### DIFF
--- a/_bmad-output/implementation-artifacts/bug-Github-#130-svd-dampening-convergence.md
+++ b/_bmad-output/implementation-artifacts/bug-Github-#130-svd-dampening-convergence.md
@@ -3,7 +3,7 @@
 issue: 130
 branch: "QS_130"
 
-Status: ready-for-dev
+Status: dev-complete
 
 ## Story
 As a Quiet Solar user,
@@ -28,28 +28,28 @@ so that pressing the "Compute Dampening (7 Day)" button never crashes with an SV
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Add near-identical forecast handling in `compute_dampening` (AC: #1, #5)
-  - [ ] 1.1: In `ha_model/solar.py`, in `compute_dampening()` inside the 7-day branch (after the `len(points) < 3` check), add a near-identical forecast check using `np.ptp(forecasts) < threshold`. When triggered, compute `a_k = np.mean(actuals_vals) / np.mean(forecasts)` with `b_k = 0.0`, clamp `a_k` to [0.1, 3.0]. Guard against `mean(forecasts) < 10` (use identity).
-  - [ ] 1.2: Add tests: identical forecasts (all 1000.0), near-identical forecasts (1000.0 ± 0.001), and verify `a_k` is the mean ratio with `b_k = 0`.
+- [x] Task 1: Add near-identical forecast handling in `compute_dampening` (AC: #1, #5)
+  - [x] 1.1: In `ha_model/solar.py`, in `compute_dampening()` inside the 7-day branch (after the `len(points) < 3` check), add a near-identical forecast check using `np.ptp(forecasts) < threshold`. When triggered, compute `a_k = np.mean(actuals_vals) / np.mean(forecasts)` with `b_k = 0.0`, clamp `a_k` to [0.1, 3.0]. Guard against `mean(forecasts) < 10` (use identity).
+  - [x] 1.2: Add tests: identical forecasts (all 1000.0), near-identical forecasts (1000.0 ± 0.001), and verify `a_k` is the mean ratio with `b_k = 0`.
 
-- [ ] Task 2: Wrap `np.polyfit` in try/except (AC: #2, #3, #6)
-  - [ ] 2.1: In `ha_model/solar.py`, in `compute_dampening()`, wrap the `np.polyfit()` call in `try/except (np.linalg.LinAlgError, ValueError)`. On exception, log warning with `%s` formatting including slot number and point count, fall back to (1.0, 0.0).
-  - [ ] 2.2: After polyfit returns, validate output with `np.isfinite(a_k) and np.isfinite(b_k)`. If not finite, log warning and fall back to identity.
-  - [ ] 2.3: Add tests: mock `np.polyfit` to raise `LinAlgError`, verify identity fallback and warning logged. Test near-degenerate data producing non-finite output.
+- [x] Task 2: Wrap `np.polyfit` in try/except (AC: #2, #3, #6)
+  - [x] 2.1: In `ha_model/solar.py`, in `compute_dampening()`, wrap the `np.polyfit()` call in `try/except (np.linalg.LinAlgError, ValueError)`. On exception, log warning with `%s` formatting including slot number and point count, fall back to (1.0, 0.0).
+  - [x] 2.2: After polyfit returns, validate output with `np.isfinite(a_k) and np.isfinite(b_k)`. If not finite, log warning and fall back to identity.
+  - [x] 2.3: Add tests: mock `np.polyfit` to raise `LinAlgError`, verify identity fallback and warning logged. Test near-degenerate data producing non-finite output.
 
-- [ ] Task 3: Add NaN/Inf defense-in-depth at slot assembly (AC: #4, #5)
-  - [ ] 3.1: In `ha_model/solar.py`, in `compute_dampening()`, in the loop where `(forecast_val, actual_val)` pairs are appended to `slots[slot]`, add `if np.isfinite(forecast_val) and np.isfinite(actual_val)` guard. Document in comment: defense-in-depth for future storage changes (current ring buffer is int32, cannot contain NaN).
-  - [ ] 3.2: Add tests: inject NaN/Inf into forecast and actual data via test helpers, verify they are excluded from slot points.
+- [x] Task 3: Add NaN/Inf defense-in-depth at slot assembly (AC: #4, #5)
+  - [x] 3.1: In `ha_model/solar.py`, in `compute_dampening()`, in the loop where `(forecast_val, actual_val)` pairs are appended to `slots[slot]`, add `if np.isfinite(forecast_val) and np.isfinite(actual_val)` guard. Document in comment: defense-in-depth for future storage changes (current ring buffer is int32, cannot contain NaN).
+  - [x] 3.2: Add tests: inject NaN/Inf into forecast and actual data via test helpers, verify they are excluded from slot points.
 
-- [ ] Task 4: Add exception safety net in `compute_dampening_all_providers` (AC: #7)
-  - [ ] 4.1: In `ha_model/solar.py`, in `compute_dampening_all_providers()`, wrap the `provider.compute_dampening(time, num_days)` call in try/except to catch any unexpected exception. Log error with provider name, continue to next provider.
-  - [ ] 4.2: Add test: mock `compute_dampening` to raise an unexpected exception, verify other providers still get processed.
+- [x] Task 4: Add exception safety net in `compute_dampening_all_providers` (AC: #7)
+  - [x] 4.1: In `ha_model/solar.py`, in `compute_dampening_all_providers()`, wrap the `provider.compute_dampening(time, num_days)` call in try/except to catch any unexpected exception. Log error with provider name, continue to next provider.
+  - [x] 4.2: Add test: mock `compute_dampening` to raise an unexpected exception, verify other providers still get processed.
 
-- [ ] Task 5: Verify 1-day mode resilience (AC: #4)
-  - [ ] 5.1: Verify that the 1-day ratio correction path (the `num_days == 1` branch) is protected by Task 3's NaN/Inf filter at slot assembly. The `f_val < 10` guard at line 700 already prevents division by near-zero. Add test for 1-day mode with NaN data injected via test helper.
+- [x] Task 5: Verify 1-day mode resilience (AC: #4)
+  - [x] 5.1: Verify that the 1-day ratio correction path (the `num_days == 1` branch) is protected by Task 3's NaN/Inf filter at slot assembly. The `f_val < 10` guard at line 700 already prevents division by near-zero. Add test for 1-day mode with NaN data injected via test helper.
 
-- [ ] Task 6: Run quality gates
-  - [ ] 6.1: Run `python scripts/qs/quality_gate.py` — pytest 100% coverage + ruff + mypy + translations all pass.
+- [x] Task 6: Run quality gates
+  - [x] 6.1: Run `python scripts/qs/quality_gate.py` — pytest 100% coverage + ruff + mypy + translations all pass.
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/bug-Github-#130-svd-dampening-convergence.md
+++ b/_bmad-output/implementation-artifacts/bug-Github-#130-svd-dampening-convergence.md
@@ -124,3 +124,22 @@ When `np.ptp(forecasts) < threshold` (e.g., 1.0 W):
 ### Known risks acknowledged:
 - Test data path (floats) differs from production data path (int32) — NaN/Inf tests exercise code that can't fire in production
 - Near-identical threshold choice (e.g., 1.0 W) is somewhat arbitrary — may need tuning based on real-world data
+
+## Code Review — PR #133 (2026-04-14)
+
+### Decisions
+| # | File | Finding | Decision | Notes |
+|---|------|---------|----------|-------|
+| 1 | solar.py:736 | PEP 758 except syntax | reject | Project targets py314 |
+| 2 | solar.py:316-318 | Stale dampening on exception | fix | Call reset_dampening() |
+| 3 | test_solar_dampening.py:993 | Near-identical test uses identical data | fix | Add test with varying forecasts |
+| 4 | story artifact | PEP 758 not documented | skip | |
+| 5 | solar.py:755 | b_k intercept unbounded | fix | Add b_k clamping |
+| 6 | solar.py:726 | mean_fc division safety | skip | Already guarded |
+| 7 | solar.py:721 | np.ptp on list | skip | Works correctly |
+
+### Deferred items
+(none)
+
+### Doc updates planned
+(none)

--- a/_bmad-output/implementation-artifacts/bug-Github-#130-svd-dampening-convergence.md
+++ b/_bmad-output/implementation-artifacts/bug-Github-#130-svd-dampening-convergence.md
@@ -1,0 +1,126 @@
+# Story bug-Github-#130-svd-dampening-convergence: Fix SVD convergence error in 7-day dampening computation
+
+issue: 130
+branch: "QS_130"
+
+Status: ready-for-dev
+
+## Story
+As a Quiet Solar user,
+I want the solar dampening computation to gracefully handle degenerate or identical forecast data,
+so that pressing the "Compute Dampening (7 Day)" button never crashes with an SVD error.
+
+## Acceptance Criteria
+
+1. Given all forecast values in a slot are identical or near-identical (`np.ptp(forecasts) < threshold`), When `compute_dampening` runs in 7-day mode, Then it computes `a_k = mean(actuals) / mean(forecasts)` with `b_k = 0`, clamped to [0.1, 3.0].
+
+2. Given `np.polyfit` raises `LinAlgError` or `ValueError` for any reason, When `compute_dampening` processes a slot, Then the exception is caught, a warning is logged with slot number and point count, and identity coefficients (1.0, 0.0) are used for that slot.
+
+3. Given `np.polyfit` returns non-finite coefficients (NaN/Inf in `a_k` or `b_k`), When `compute_dampening` processes a slot, Then identity coefficients (1.0, 0.0) are used and a warning is logged.
+
+4. Given `compute_dampening` receives data with NaN/Inf forecast or actual values for a slot, When building per-slot point lists, Then NaN/Inf pairs are filtered out before any computation (defense-in-depth for future storage changes).
+
+5. Given a slot has fewer than 3 valid data points after filtering, When `compute_dampening` runs in 7-day mode, Then identity coefficients (1.0, 0.0) are used for that slot.
+
+6. Given some slots fail and others succeed, When `compute_dampening` returns, Then it returns `True` with computed coefficients for successful slots and identity for failed slots.
+
+7. Given `compute_dampening` raises an unexpected exception for a provider, When `compute_dampening_all_providers` iterates providers, Then the exception is caught and logged, and remaining providers are still processed.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add near-identical forecast handling in `compute_dampening` (AC: #1, #5)
+  - [ ] 1.1: In `ha_model/solar.py`, in `compute_dampening()` inside the 7-day branch (after the `len(points) < 3` check), add a near-identical forecast check using `np.ptp(forecasts) < threshold`. When triggered, compute `a_k = np.mean(actuals_vals) / np.mean(forecasts)` with `b_k = 0.0`, clamp `a_k` to [0.1, 3.0]. Guard against `mean(forecasts) < 10` (use identity).
+  - [ ] 1.2: Add tests: identical forecasts (all 1000.0), near-identical forecasts (1000.0 ± 0.001), and verify `a_k` is the mean ratio with `b_k = 0`.
+
+- [ ] Task 2: Wrap `np.polyfit` in try/except (AC: #2, #3, #6)
+  - [ ] 2.1: In `ha_model/solar.py`, in `compute_dampening()`, wrap the `np.polyfit()` call in `try/except (np.linalg.LinAlgError, ValueError)`. On exception, log warning with `%s` formatting including slot number and point count, fall back to (1.0, 0.0).
+  - [ ] 2.2: After polyfit returns, validate output with `np.isfinite(a_k) and np.isfinite(b_k)`. If not finite, log warning and fall back to identity.
+  - [ ] 2.3: Add tests: mock `np.polyfit` to raise `LinAlgError`, verify identity fallback and warning logged. Test near-degenerate data producing non-finite output.
+
+- [ ] Task 3: Add NaN/Inf defense-in-depth at slot assembly (AC: #4, #5)
+  - [ ] 3.1: In `ha_model/solar.py`, in `compute_dampening()`, in the loop where `(forecast_val, actual_val)` pairs are appended to `slots[slot]`, add `if np.isfinite(forecast_val) and np.isfinite(actual_val)` guard. Document in comment: defense-in-depth for future storage changes (current ring buffer is int32, cannot contain NaN).
+  - [ ] 3.2: Add tests: inject NaN/Inf into forecast and actual data via test helpers, verify they are excluded from slot points.
+
+- [ ] Task 4: Add exception safety net in `compute_dampening_all_providers` (AC: #7)
+  - [ ] 4.1: In `ha_model/solar.py`, in `compute_dampening_all_providers()`, wrap the `provider.compute_dampening(time, num_days)` call in try/except to catch any unexpected exception. Log error with provider name, continue to next provider.
+  - [ ] 4.2: Add test: mock `compute_dampening` to raise an unexpected exception, verify other providers still get processed.
+
+- [ ] Task 5: Verify 1-day mode resilience (AC: #4)
+  - [ ] 5.1: Verify that the 1-day ratio correction path (the `num_days == 1` branch) is protected by Task 3's NaN/Inf filter at slot assembly. The `f_val < 10` guard at line 700 already prevents division by near-zero. Add test for 1-day mode with NaN data injected via test helper.
+
+- [ ] Task 6: Run quality gates
+  - [ ] 6.1: Run `python scripts/qs/quality_gate.py` — pytest 100% coverage + ruff + mypy + translations all pass.
+
+## Dev Notes
+
+### Root Cause
+The primary failure mode is **identical int32-quantized forecast values** across 7 days for the same slot, creating a singular Vandermonde matrix in `np.polyfit`. The ring buffer stores `np.int32` values which cannot contain NaN/Inf. When all forecasts for a slot are the same (e.g., all 1000), polyfit's SVD fails to converge because the system is underdetermined.
+
+### Architecture Constraints
+- `compute_dampening()` and `compute_dampening_all_providers()` live in `ha_model/solar.py` — both in the HA model layer
+- Ring buffer accessors in `ha_model/home.py` return int32 values — NaN/Inf impossible at this layer
+- Two-layer boundary: all changes are in `ha_model/`, no boundary crossing
+- Per project rule: "Domain-level numerical errors must be caught at ha_model layer, never bubble into HA event loop"
+- Per project rule: "Button press handlers must catch exceptions and log appropriately"
+
+### Error Handling Pattern
+- Catch `np.linalg.LinAlgError` and `ValueError` specifically around polyfit
+- Use lazy `%s` logging, no f-strings, no trailing periods
+- Identity coefficients (1.0, 0.0) are the safe fallback — equivalent to "no dampening adjustment"
+- For the near-identical case, compute meaningful `a_k` rather than falling back to identity
+
+### Near-Identical Forecast Logic
+When `np.ptp(forecasts) < threshold` (e.g., 1.0 W):
+- All forecasts are effectively the same value
+- Linear regression is meaningless (slope undefined)
+- Instead compute `a_k = mean(actuals) / mean(forecasts)`, `b_k = 0.0`
+- This is the multi-day ratio correction: "on average, actual production is a_k times the forecast"
+- Clamp `a_k` to [0.1, 3.0] as with polyfit results
+- If `mean(forecasts) < 10`, use identity (nighttime or near-zero production)
+
+### Test Patterns
+- Tests in `tests/test_solar_dampening.py` — follow existing patterns with `_make_provider_with_histories` helper
+- Test helper injects Python floats (not int32), so NaN/Inf tests ARE possible even though production data is int32
+- Document this discrepancy in test comments
+- Key test scenarios:
+  - Identical forecasts → ratio-based `a_k`, `b_k = 0`
+  - Near-identical forecasts (within threshold) → same behavior
+  - Polyfit `LinAlgError` (mocked) → identity fallback
+  - Non-finite polyfit output → identity fallback
+  - NaN/Inf in input data → filtered at slot assembly
+  - Mixed success/failure across slots → partial coefficients
+  - Provider exception in `compute_dampening_all_providers` → other providers continue
+  - 1-day mode with NaN data → protected by slot filter
+
+### Key Files
+- `custom_components/quiet_solar/ha_model/solar.py` — `compute_dampening()`, `compute_dampening_all_providers()`
+- `tests/test_solar_dampening.py` — existing dampening tests
+
+### References
+- Issue #130: SVD did not converge in Linear Least Squares
+- Feature #124 (PR #125): introduced dampening buttons
+- Story 3.14: scoring infrastructure (in-progress)
+- numpy.polyfit docs: raises LinAlgError when SVD fails to converge
+
+## Adversarial Review Notes
+
+**Reviewers:** Critic, Concrete Planner, Dev Proxy
+**Rounds:** 1
+
+### Key findings incorporated:
+- Ring buffer uses int32 — upstream NaN/Inf filter (original Task 1) was dead code → removed
+- Button handler `async_press` has no try/except for dampening call → added safety net in `compute_dampening_all_providers` (Task 4)
+- Pre-check `len(set(forecasts)) == 1` is fragile for floats → replaced with `np.ptp(forecasts) < threshold` and user-requested ratio computation for near-identical data (Task 1)
+- Polyfit output should be validated for finiteness → added `np.isfinite` check (Task 2.2)
+- Line numbers are fragile → switched to function-signature-based task descriptions
+- Test helpers inject floats not int32 → documented discrepancy
+
+### Decisions made:
+- Drop upstream NaN/Inf filter in `get_historical_data` — Rationale: int32 ring buffer cannot contain NaN/Inf, filter would be dead code
+- For identical/near-identical forecasts: compute `a_k = mean(actuals)/mean(forecasts)` with `b_k = 0` instead of identity fallback — Rationale: user wants meaningful dampening even with constant forecast data
+- Always return True from `compute_dampening` — Rationale: identity coefficients are safe, simpler logic, consistent with current behavior
+- Keep NaN/Inf slot filter as defense-in-depth — Rationale: protects against future storage changes
+
+### Known risks acknowledged:
+- Test data path (floats) differs from production data path (int32) — NaN/Inf tests exercise code that can't fire in production
+- Near-identical threshold choice (e.g., 1.0 W) is somewhat arbitrary — may need tuning based on real-world data

--- a/custom_components/quiet_solar/ha_model/solar.py
+++ b/custom_components/quiet_solar/ha_model/solar.py
@@ -311,7 +311,11 @@ class QSSolar(HADeviceMixin, AbstractDevice):
         if time is None:
             time = dt_util.utcnow()
         for name, provider in self.solar_forecast_providers.items():
-            success = provider.compute_dampening(time, num_days)
+            try:
+                success = provider.compute_dampening(time, num_days)
+            except Exception:
+                _LOGGER.exception("Unexpected error computing dampening for provider %s", name)
+                continue
             if success:
                 _LOGGER.info("Computed %d-day dampening for provider %s", num_days, name)
             else:
@@ -673,6 +677,10 @@ class QSSolarProvider:
         for t, actual_val in actuals:
             if t in forecast_dict:
                 forecast_val = forecast_dict[t]
+                # Defense-in-depth: filter NaN/Inf (ring buffer is int32 so
+                # cannot contain NaN today, but protects against future changes)
+                if not (np.isfinite(forecast_val) and np.isfinite(actual_val)):
+                    continue
                 slot = self._time_to_slot_index(t)
                 if slot not in slots:
                     slots[slot] = []
@@ -708,10 +716,41 @@ class QSSolarProvider:
                 if len(points) < 3:
                     coefficients[slot] = (1.0, 0.0)
                     continue
+
+                # Near-identical forecasts: singular Vandermonde matrix
+                if np.ptp(forecasts) < 1.0:
+                    mean_fc = float(np.mean(forecasts))
+                    if mean_fc < 10:
+                        coefficients[slot] = (1.0, 0.0)
+                    else:
+                        a_k = float(np.mean(actuals_vals)) / mean_fc
+                        a_k = max(0.1, min(3.0, a_k))
+                        coefficients[slot] = (a_k, 0.0)
+                    continue
+
                 # numpy.polyfit(forecasts, actuals, 1) → [a_k, b_k]
-                fit = np.polyfit(forecasts, actuals_vals, 1)
-                a_k = float(fit[0])
-                b_k = float(fit[1])
+                try:
+                    fit = np.polyfit(forecasts, actuals_vals, 1)
+                    a_k = float(fit[0])
+                    b_k = float(fit[1])
+                except np.linalg.LinAlgError, ValueError:
+                    _LOGGER.warning(
+                        "Polyfit failed for slot %d (%d points), using identity",
+                        slot,
+                        len(points),
+                    )
+                    coefficients[slot] = (1.0, 0.0)
+                    continue
+
+                if not (np.isfinite(a_k) and np.isfinite(b_k)):
+                    _LOGGER.warning(
+                        "Non-finite polyfit output for slot %d (%d points), using identity",
+                        slot,
+                        len(points),
+                    )
+                    coefficients[slot] = (1.0, 0.0)
+                    continue
+
                 a_k = max(0.1, min(3.0, a_k))
                 coefficients[slot] = (a_k, b_k)
 

--- a/custom_components/quiet_solar/ha_model/solar.py
+++ b/custom_components/quiet_solar/ha_model/solar.py
@@ -753,6 +753,7 @@ class QSSolarProvider:
                     continue
 
                 a_k = max(0.1, min(3.0, a_k))
+                b_k = max(-5000.0, min(5000.0, b_k))
                 coefficients[slot] = (a_k, b_k)
 
         self._dampening_coefficients = coefficients

--- a/custom_components/quiet_solar/ha_model/solar.py
+++ b/custom_components/quiet_solar/ha_model/solar.py
@@ -314,6 +314,7 @@ class QSSolar(HADeviceMixin, AbstractDevice):
             try:
                 success = provider.compute_dampening(time, num_days)
             except Exception:
+                provider.reset_dampening()
                 _LOGGER.exception("Unexpected error computing dampening for provider %s", name)
                 continue
             if success:

--- a/tests/test_solar_dampening.py
+++ b/tests/test_solar_dampening.py
@@ -991,27 +991,32 @@ class TestIdenticalForecastHandling:
 
     @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
     def test_near_identical_forecasts_use_ratio(self, mock_dt_util):
-        """Near-identical forecasts (ptp < 1.0) also use ratio path."""
+        """Near-identical forecasts (0 < ptp < 1.0) use ratio path, not polyfit."""
         tz = pytz.timezone("Europe/Paris")
         mock_dt_util.get_default_time_zone.return_value = tz
 
-        t0 = datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
-        # Forecasts with tiny variation (all map to same h → same value)
-        provider = _make_provider_with_histories(
-            actuals_fn=lambda h: 900.0 if 8 <= h <= 16 else 0.0,
-            forecast_fn=lambda h: 1000.0 if 8 <= h <= 16 else 0.0,
-            t0=t0,
-            num_days=7,
+        # Inject per-day varying forecasts at slot 48 (12:00 CEST) with ptp=0.6
+        actuals_data = []
+        forecast_data = []
+        for day in range(7):
+            t = datetime.datetime(2024, 6, 8 + day, 10, 0, tzinfo=pytz.UTC)
+            fc = 1000.0 + day * 0.1  # ptp = 0.6 < 1.0 but not identical
+            forecast_data.append((t, fc))
+            actuals_data.append((t, 900.0))
+
+        provider = _TestProvider(solar=None, domain="test", provider_name="prov")
+        provider._get_historical_data_for_dampening = MagicMock(
+            return_value=(actuals_data, forecast_data)
         )
+        t0 = datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
 
         result = provider.compute_dampening(t0, num_days=7)
         assert result is True
 
-        # Verify b_k = 0 for all non-identity slots (ratio path, not regression)
-        for slot in range(NUM_INTERVALS_PER_DAY):
-            a_k, b_k = provider._dampening_coefficients.get(slot, (1.0, 0.0))
-            if a_k != 1.0:
-                assert b_k == 0.0
+        # Slot 48 should use ratio path: a_k ~0.9, b_k = 0
+        a_k, b_k = provider._dampening_coefficients[48]
+        assert abs(a_k - 0.9) < 0.01
+        assert b_k == 0.0
 
     @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
     def test_near_identical_low_forecast_identity(self, mock_dt_util):

--- a/tests/test_solar_dampening.py
+++ b/tests/test_solar_dampening.py
@@ -957,6 +957,347 @@ class TestDampenedScoreSensorCreation:
 
 
 # ============================================================================
+# SVD convergence fix tests (Issue #130)
+# ============================================================================
+
+
+class TestIdenticalForecastHandling:
+    """Test near-identical forecast handling in 7-day mode (AC #1, #5)."""
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_identical_forecasts_use_ratio(self, mock_dt_util):
+        """Identical forecasts across 7 days compute a_k = mean(actuals)/mean(forecasts)."""
+        tz = pytz.timezone("Europe/Paris")
+        mock_dt_util.get_default_time_zone.return_value = tz
+
+        t0 = datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
+        # All forecasts 1000W, actuals 800W → a_k = 0.8, b_k = 0
+        provider = _make_provider_with_histories(
+            actuals_fn=lambda h: 800.0 if 8 <= h <= 16 else 0.0,
+            forecast_fn=lambda h: 1000.0 if 8 <= h <= 16 else 0.0,
+            t0=t0,
+            num_days=7,
+        )
+
+        result = provider.compute_dampening(t0, num_days=7)
+        assert result is True
+
+        # Daytime slots should have a_k ~0.8, b_k = 0
+        for slot in range(32, 64):  # 8:00 to 16:00
+            a_k, b_k = provider._dampening_coefficients.get(slot, (1.0, 0.0))
+            if a_k != 1.0:  # Skip identity slots
+                assert abs(a_k - 0.8) < 0.01
+                assert b_k == 0.0
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_near_identical_forecasts_use_ratio(self, mock_dt_util):
+        """Near-identical forecasts (ptp < 1.0) also use ratio path."""
+        tz = pytz.timezone("Europe/Paris")
+        mock_dt_util.get_default_time_zone.return_value = tz
+
+        t0 = datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
+        # Forecasts with tiny variation (all map to same h → same value)
+        provider = _make_provider_with_histories(
+            actuals_fn=lambda h: 900.0 if 8 <= h <= 16 else 0.0,
+            forecast_fn=lambda h: 1000.0 if 8 <= h <= 16 else 0.0,
+            t0=t0,
+            num_days=7,
+        )
+
+        result = provider.compute_dampening(t0, num_days=7)
+        assert result is True
+
+        # Verify b_k = 0 for all non-identity slots (ratio path, not regression)
+        for slot in range(NUM_INTERVALS_PER_DAY):
+            a_k, b_k = provider._dampening_coefficients.get(slot, (1.0, 0.0))
+            if a_k != 1.0:
+                assert b_k == 0.0
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_near_identical_low_forecast_identity(self, mock_dt_util):
+        """Near-identical forecasts with mean < 10 use identity coefficients."""
+        tz = pytz.timezone("Europe/Paris")
+        mock_dt_util.get_default_time_zone.return_value = tz
+
+        t0 = datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
+        # Low forecasts (5W) that are identical → mean_fc < 10 → identity
+        provider = _make_provider_with_histories(
+            actuals_fn=lambda h: 5.0 if 8 <= h <= 16 else 0.0,
+            forecast_fn=lambda h: 5.0 if 8 <= h <= 16 else 0.0,
+            t0=t0,
+            num_days=7,
+        )
+
+        provider.compute_dampening(t0, num_days=7)
+
+        # All slots should be identity
+        for slot in range(NUM_INTERVALS_PER_DAY):
+            assert provider._dampening_coefficients[slot] == (1.0, 0.0)
+
+
+class TestPolyfitSuccessWithVaryingForecasts:
+    """Test normal polyfit success path with varying forecasts across days."""
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_varying_forecasts_use_polyfit(self, mock_dt_util):
+        """Varying forecasts (ptp >= 1.0) use polyfit regression path."""
+        tz = pytz.timezone("Europe/Paris")
+        mock_dt_util.get_default_time_zone.return_value = tz
+
+        # 7 data points at 12:00 CEST (slot 48) with varying forecasts
+        actuals_data = []
+        forecast_data = []
+        for day in range(7):
+            t = datetime.datetime(2024, 6, 8 + day, 10, 0, tzinfo=pytz.UTC)
+            fc = 800.0 + day * 50.0  # 800, 850, ..., 1100 → ptp=300
+            actuals_data.append((t, fc * 0.9 + 50.0))
+            forecast_data.append((t, fc))
+
+        provider = _TestProvider(solar=None, domain="test", provider_name="prov")
+        provider._get_historical_data_for_dampening = MagicMock(
+            return_value=(actuals_data, forecast_data)
+        )
+
+        t0 = datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
+        result = provider.compute_dampening(t0, num_days=7)
+        assert result is True
+
+        # Slot 48 should have non-identity coefficients from regression
+        a_k, b_k = provider._dampening_coefficients[48]
+        assert abs(a_k - 0.9) < 0.05  # slope ~0.9
+        assert abs(b_k - 50.0) < 5.0  # intercept ~50
+
+
+class TestPolyfitExceptionHandling:
+    """Test polyfit exception handling in 7-day mode (AC #2, #3, #6).
+
+    Uses direct data injection with varying forecasts per slot across days
+    to ensure ptp >= 1.0 and the polyfit path is actually reached.
+    """
+
+    @staticmethod
+    def _make_provider_with_varying_data(mock_dt_util):
+        """Create provider with 7 days of varying forecasts at slot 48 (12:00 CEST)."""
+        tz = pytz.timezone("Europe/Paris")
+        mock_dt_util.get_default_time_zone.return_value = tz
+
+        # 7 data points at 12:00 CEST across 7 days — forecasts vary by 50W/day
+        # ptp = 300, well above the 1.0 threshold
+        actuals_data = []
+        forecast_data = []
+        for day in range(7):
+            t = datetime.datetime(2024, 6, 8 + day, 10, 0, tzinfo=pytz.UTC)  # 12:00 CEST
+            fc = 800.0 + day * 50.0
+            actuals_data.append((t, fc * 0.8 + 20.0))
+            forecast_data.append((t, fc))
+
+        provider = _TestProvider(solar=None, domain="test", provider_name="prov")
+        provider._get_historical_data_for_dampening = MagicMock(
+            return_value=(actuals_data, forecast_data)
+        )
+        return provider, datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_linalg_error_falls_back_to_identity(self, mock_dt_util):
+        """LinAlgError from polyfit results in identity coefficients."""
+        provider, t0 = self._make_provider_with_varying_data(mock_dt_util)
+
+        with patch("custom_components.quiet_solar.ha_model.solar.np.polyfit") as mock_polyfit:
+            mock_polyfit.side_effect = np.linalg.LinAlgError("SVD did not converge")
+            result = provider.compute_dampening(t0, num_days=7)
+
+        assert result is True
+        assert provider._dampening_coefficients[48] == (1.0, 0.0)
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_value_error_falls_back_to_identity(self, mock_dt_util):
+        """ValueError from polyfit results in identity coefficients."""
+        provider, t0 = self._make_provider_with_varying_data(mock_dt_util)
+
+        with patch("custom_components.quiet_solar.ha_model.solar.np.polyfit") as mock_polyfit:
+            mock_polyfit.side_effect = ValueError("bad input")
+            result = provider.compute_dampening(t0, num_days=7)
+
+        assert result is True
+        assert provider._dampening_coefficients[48] == (1.0, 0.0)
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_non_finite_output_falls_back_to_identity(self, mock_dt_util):
+        """Non-finite polyfit output (NaN/Inf) results in identity coefficients."""
+        provider, t0 = self._make_provider_with_varying_data(mock_dt_util)
+
+        with patch("custom_components.quiet_solar.ha_model.solar.np.polyfit") as mock_polyfit:
+            mock_polyfit.return_value = np.array([np.inf, np.nan])
+            result = provider.compute_dampening(t0, num_days=7)
+
+        assert result is True
+        assert provider._dampening_coefficients[48] == (1.0, 0.0)
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_polyfit_warning_logged_on_exception(self, mock_dt_util, caplog):
+        """Warning is logged when polyfit raises an exception."""
+        import logging
+
+        provider, t0 = self._make_provider_with_varying_data(mock_dt_util)
+
+        with (
+            patch("custom_components.quiet_solar.ha_model.solar.np.polyfit") as mock_polyfit,
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_polyfit.side_effect = np.linalg.LinAlgError("SVD did not converge")
+            provider.compute_dampening(t0, num_days=7)
+
+        assert "Polyfit failed for slot" in caplog.text
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_non_finite_warning_logged(self, mock_dt_util, caplog):
+        """Warning is logged when polyfit returns non-finite values."""
+        import logging
+
+        provider, t0 = self._make_provider_with_varying_data(mock_dt_util)
+
+        with (
+            patch("custom_components.quiet_solar.ha_model.solar.np.polyfit") as mock_polyfit,
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_polyfit.return_value = np.array([np.nan, 0.0])
+            provider.compute_dampening(t0, num_days=7)
+
+        assert "Non-finite polyfit output for slot" in caplog.text
+
+
+class TestNanInfFiltering:
+    """Test NaN/Inf defense-in-depth at slot assembly (AC #4).
+
+    Note: production ring buffer stores int32 which cannot contain NaN/Inf.
+    Test helpers inject Python floats, so these tests exercise code that
+    protects against future storage changes.
+    """
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_nan_forecast_filtered_7day(self, mock_dt_util):
+        """NaN forecast values are excluded from slot data in 7-day mode."""
+        tz = pytz.timezone("Europe/Paris")
+        mock_dt_util.get_default_time_zone.return_value = tz
+
+        t0 = datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
+        # Inject NaN at local hour 10.0 (slot 40)
+        provider = _make_provider_with_histories(
+            actuals_fn=lambda h: 800.0 if 8 <= h <= 16 else 0.0,
+            forecast_fn=lambda h: float("nan") if abs(h - 10.0) < 0.01 else (1000.0 if 8 <= h <= 16 else 0.0),
+            t0=t0,
+            num_days=7,
+        )
+
+        result = provider.compute_dampening(t0, num_days=7)
+        assert result is True
+        # Slot 40 should have no valid points → identity
+        assert provider._dampening_coefficients[40] == (1.0, 0.0)
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_inf_actual_filtered_7day(self, mock_dt_util):
+        """Inf actual values are excluded from slot data in 7-day mode."""
+        tz = pytz.timezone("Europe/Paris")
+        mock_dt_util.get_default_time_zone.return_value = tz
+
+        t0 = datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
+        # Inject Inf at local hour 12.0 (slot 48)
+        provider = _make_provider_with_histories(
+            actuals_fn=lambda h: float("inf") if abs(h - 12.0) < 0.01 else (800.0 if 8 <= h <= 16 else 0.0),
+            forecast_fn=lambda h: 1000.0 if 8 <= h <= 16 else 0.0,
+            t0=t0,
+            num_days=7,
+        )
+
+        result = provider.compute_dampening(t0, num_days=7)
+        assert result is True
+        # Slot 48 should have no valid points → identity
+        assert provider._dampening_coefficients[48] == (1.0, 0.0)
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_nan_forecast_filtered_1day(self, mock_dt_util):
+        """NaN forecast values are excluded in 1-day mode (Task 5: AC #4)."""
+        tz = pytz.timezone("Europe/Paris")
+        mock_dt_util.get_default_time_zone.return_value = tz
+
+        t0 = datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
+        # Inject NaN forecast at local hour 10.0
+        provider = _make_provider_with_histories(
+            actuals_fn=lambda h: 800.0 if 8 <= h <= 16 else 0.0,
+            forecast_fn=lambda h: float("nan") if abs(h - 10.0) < 0.01 else (1000.0 if 8 <= h <= 16 else 0.0),
+            t0=t0,
+            num_days=1,
+        )
+
+        result = provider.compute_dampening(t0, num_days=1)
+        assert result is True
+        # Slot 40 should have no points → identity
+        assert provider._dampening_coefficients[40] == (1.0, 0.0)
+
+    @patch("custom_components.quiet_solar.ha_model.solar.dt_util")
+    def test_neg_inf_both_filtered(self, mock_dt_util):
+        """Negative infinity in both forecast and actual are filtered."""
+        tz = pytz.timezone("Europe/Paris")
+        mock_dt_util.get_default_time_zone.return_value = tz
+
+        t0 = datetime.datetime(2024, 6, 15, 23, 0, tzinfo=pytz.UTC)
+        provider = _make_provider_with_histories(
+            actuals_fn=lambda h: float("-inf") if abs(h - 11.0) < 0.01 else (800.0 if 8 <= h <= 16 else 0.0),
+            forecast_fn=lambda h: float("-inf") if abs(h - 11.0) < 0.01 else (1000.0 if 8 <= h <= 16 else 0.0),
+            t0=t0,
+            num_days=7,
+        )
+
+        result = provider.compute_dampening(t0, num_days=7)
+        assert result is True
+        # Slot 44 (11:00) should have no valid points → identity
+        assert provider._dampening_coefficients[44] == (1.0, 0.0)
+
+
+class TestProviderExceptionSafety:
+    """Test exception safety in compute_dampening_all_providers (AC #7)."""
+
+    async def test_provider_exception_continues_others(self, fake_hass):
+        """Exception in one provider does not block remaining providers."""
+        solar = _make_solar(
+            fake_hass,
+            providers_config=[
+                {CONF_SOLAR_PROVIDER_DOMAIN: SOLCAST_SOLAR_DOMAIN, CONF_SOLAR_PROVIDER_NAME: "Failing"},
+                {CONF_SOLAR_PROVIDER_DOMAIN: SOLCAST_SOLAR_DOMAIN, CONF_SOLAR_PROVIDER_NAME: "Working"},
+            ],
+        )
+
+        providers = list(solar.solar_forecast_providers.values())
+        providers[0].compute_dampening = MagicMock(side_effect=RuntimeError("boom"))
+        providers[1].compute_dampening = MagicMock(return_value=True)
+
+        await solar.compute_dampening_all_providers(num_days=7)
+
+        # Both providers were called despite the first raising
+        providers[0].compute_dampening.assert_called_once()
+        providers[1].compute_dampening.assert_called_once()
+
+    async def test_provider_exception_logged(self, fake_hass, caplog):
+        """Exception in provider is logged with provider name."""
+        import logging
+
+        solar = _make_solar(
+            fake_hass,
+            providers_config=[
+                {CONF_SOLAR_PROVIDER_DOMAIN: SOLCAST_SOLAR_DOMAIN, CONF_SOLAR_PROVIDER_NAME: "BadProvider"},
+            ],
+        )
+
+        provider = list(solar.solar_forecast_providers.values())[0]
+        provider.compute_dampening = MagicMock(side_effect=RuntimeError("unexpected"))
+
+        with caplog.at_level(logging.ERROR):
+            await solar.compute_dampening_all_providers(num_days=7)
+
+        assert "Unexpected error computing dampening for provider" in caplog.text
+
+
+# ============================================================================
 # Coverage: edge cases for _get_historical_data_for_dampening
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- Add near-identical forecast detection with ratio-based a_k fallback (np.ptp < 1.0)
- Wrap np.polyfit in try/except for LinAlgError/ValueError with identity fallback
- Validate polyfit output for non-finite values (NaN/Inf)
- Add NaN/Inf defense-in-depth filter at slot assembly
- Add per-provider exception safety net in compute_dampening_all_providers
- 16 new tests covering all convergence edge cases

Fixes #130

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved convergence failures in solar forecast dampening computation for 7-day analysis, improving stability with edge case data.
  * Enhanced exception handling across solar forecast providers to prevent cascading failures when individual providers encounter errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->