### PR TITLE
Round solar forecast scores to 2 decimal places

### DIFF
--- a/_qsprocess_opencode/stories/QS-137.story.md
+++ b/_qsprocess_opencode/stories/QS-137.story.md
@@ -2,7 +2,7 @@
 
 issue: 137
 branch: "QS_137"
-Status: ready-for-dev
+Status: done
 
 ## Story
 
@@ -30,13 +30,13 @@ so that the sensor values are clean and readable in the HA dashboard.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Add `suggested_display_precision=2` to score sensor descriptions (AC: #1, #2, #4)
-  - [ ] Add to `score_sensor` QSSensorEntityDescription in `sensor.py` (~line 393)
-  - [ ] Add to `dampened_score_sensor` QSSensorEntityDescription in `sensor.py` (~line 417)
-- [ ] Task 2: Add/update tests (AC: #1, #2, #3)
-  - [ ] Verify score sensor entity descriptions include `suggested_display_precision=2`
-  - [ ] Verify dampened score sensor entity descriptions include `suggested_display_precision=2`
-  - [ ] Verify None/unavailable behavior is unchanged
+- [x] Task 1: Add `suggested_display_precision=2` to score sensor descriptions (AC: #1, #2, #4)
+  - [x] Add to `score_sensor` QSSensorEntityDescription in `sensor.py` (~line 393)
+  - [x] Add to `dampened_score_sensor` QSSensorEntityDescription in `sensor.py` (~line 417)
+- [x] Task 2: Add/update tests (AC: #1, #2, #3)
+  - [x] Verify score sensor entity descriptions include `suggested_display_precision=2`
+  - [x] Verify dampened score sensor entity descriptions include `suggested_display_precision=2`
+  - [x] Verify None/unavailable behavior is unchanged
 
 ## Dev Notes
 

--- a/_qsprocess_opencode/stories/QS-137.story.md
+++ b/_qsprocess_opencode/stories/QS-137.story.md
@@ -1,0 +1,74 @@
+# Story: Round solar forecast scores to 2 decimal places
+
+issue: 137
+branch: "QS_137"
+Status: ready-for-dev
+
+## Story
+
+As a Quiet Solar user,
+I want the solar forecast scores (raw and dampened) displayed with only 2 decimal places,
+so that the sensor values are clean and readable in the HA dashboard.
+
+## Acceptance Criteria
+
+1. Given a solar forecast provider with a computed raw score,
+   When the score sensor value is displayed in Home Assistant,
+   Then it shows at most 2 decimal places.
+
+2. Given a solar forecast provider with a computed dampened score,
+   When the dampened score sensor value is displayed in Home Assistant,
+   Then it shows at most 2 decimal places.
+
+3. Given a solar forecast provider whose score is None (unavailable),
+   When the sensor is queried,
+   Then it remains unavailable (no change in behavior).
+
+4. Given the rounding is applied,
+   When the underlying score values are used internally for provider selection,
+   Then internal comparisons use the full-precision value (rounding is display-only).
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add `suggested_display_precision=2` to score sensor descriptions (AC: #1, #2, #4)
+  - [ ] Add to `score_sensor` QSSensorEntityDescription in `sensor.py` (~line 393)
+  - [ ] Add to `dampened_score_sensor` QSSensorEntityDescription in `sensor.py` (~line 417)
+- [ ] Task 2: Add/update tests (AC: #1, #2, #3)
+  - [ ] Verify score sensor entity descriptions include `suggested_display_precision=2`
+  - [ ] Verify dampened score sensor entity descriptions include `suggested_display_precision=2`
+  - [ ] Verify None/unavailable behavior is unchanged
+
+## Dev Notes
+
+### Approach: `suggested_display_precision` (display-only)
+
+Use Home Assistant's built-in `suggested_display_precision` on `SensorEntityDescription`. This controls how the frontend renders the value without altering the actual `native_value`. This means:
+
+- **Internal logic is unaffected** — `provider.score` stays full precision for provider selection in `ha_model/solar.py:_select_best_provider()`
+- **No domain layer changes** — respects the two-layer boundary (home_model never touched)
+- **HA-native solution** — no custom rounding code needed
+
+### Architecture Constraints
+
+- Two-layer boundary: only `ha_model/` and `sensor.py` are touched. `home_model/` is NOT modified.
+- `const.py` keys: no new keys needed, existing `SENSOR_SOLAR_FORECAST_SCORE_PREFIX` and `SENSOR_SOLAR_FORECAST_DAMPENED_SCORE_PREFIX` are reused.
+
+### Affected Files
+
+- `custom_components/quiet_solar/sensor.py` — add `suggested_display_precision=2` to two sensor descriptions
+- `tests/` — add assertions for the new attribute
+
+### Risk Assessment
+
+- **Level: LOW** — trivial, isolated change to sensor metadata
+- No new dependencies, no config migration, no breaking changes
+
+### Project Structure Notes
+
+- Score sensors are created dynamically per-provider in `_create_solar_sensors()` in `sensor.py`
+- `QSSensorEntityDescription` extends HA's `SensorEntityDescription` — `suggested_display_precision` is inherited
+
+### References
+
+- HA docs: `SensorEntityDescription.suggested_display_precision`
+- Issue #137 body: "float with way too many precision digits, I would like to only have 2 numbers in the decimal part"

--- a/custom_components/quiet_solar/sensor.py
+++ b/custom_components/quiet_solar/sensor.py
@@ -397,6 +397,7 @@ def create_ha_sensor_for_QSSolar(device: QSSolar):
             entity_category=EntityCategory.DIAGNOSTIC,
             value_fn=lambda device, key, prov=provider: prov.score,
             qs_is_none_unavailable=True,
+            suggested_display_precision=2,
         )
         entities.append(
             QSBaseSensorSolarScoreRestore(
@@ -421,6 +422,7 @@ def create_ha_sensor_for_QSSolar(device: QSSolar):
             entity_category=EntityCategory.DIAGNOSTIC,
             value_fn_and_attr=_dampened_score_and_attr,
             qs_is_none_unavailable=True,
+            suggested_display_precision=2,
         )
         entities.append(
             QSBaseSensorSolarDampenedScoreRestore(

--- a/tests/ha_tests/test_home_extended_coverage.py
+++ b/tests/ha_tests/test_home_extended_coverage.py
@@ -1733,6 +1733,32 @@ class TestQSSolarHistoryValsInit:
         result = await hv.init(datetime(2026, 2, 10, 14, 0, tzinfo=pytz.UTC))
         assert result == (None, None)
 
+    @pytest.mark.asyncio
+    async def test_init_resets_values_with_wrong_shape(self, tmp_path):
+        """Init resets values when read_values_async returns array with wrong shape. Covers lines 4310-4313."""
+        forecast = MagicMock()
+        forecast.home = None
+        forecast.storage_path = str(tmp_path)
+
+        hv = QSSolarHistoryVals(forecast=forecast, entity_id="sensor.test_shape")
+        hv._init_done = False
+        hv.values = None
+
+        # Return an array with wrong shape (3, 10) instead of (2, BUFFER_SIZE_IN_INTERVALS)
+        wrong_shape_array = np.ones((3, 10), dtype=np.int32)
+
+        with (
+            patch.object(hv, "read_values_async", new_callable=AsyncMock, return_value=wrong_shape_array),
+            patch("custom_components.quiet_solar.ha_model.home.load_from_history", new_callable=AsyncMock, return_value=[]),
+        ):
+            result = await hv.init(datetime(2026, 2, 10, 14, 0, tzinfo=pytz.UTC))
+
+        # values should have been reset to a fresh zeros array (wrong shape discarded)
+        assert hv.values is not None
+        assert hv.values.shape == (2, BUFFER_SIZE_IN_INTERVALS)
+        # result should be (None, None) since no history states were loaded
+        assert result == (None, None)
+
 
 # ========================================================================
 # QSHome map_location_path

--- a/tests/test_platform_sensor.py
+++ b/tests/test_platform_sensor.py
@@ -475,7 +475,9 @@ def test_solar_sensors_use_restore_class():
 
     assert isinstance(forecast_age[0], QSBaseSensorRestore), "Forecast age sensor must use QSBaseSensorRestore"
     assert isinstance(scores[0], QSBaseSensorSolarScoreRestore), "Score sensor must use QSBaseSensorSolarScoreRestore"
-    assert isinstance(active_provider[0], QSBaseSensorSolarActiveProviderRestore), "Active provider sensor must use QSBaseSensorSolarActiveProviderRestore"
+    assert isinstance(active_provider[0], QSBaseSensorSolarActiveProviderRestore), (
+        "Active provider sensor must use QSBaseSensorSolarActiveProviderRestore"
+    )
 
 
 def test_solar_score_sensors_have_display_precision():
@@ -488,7 +490,8 @@ def test_solar_score_sensors_have_display_precision():
     mock_provider = MagicMock()
     mock_provider.score = 123.456789
     mock_provider.score_dampened = 98.7654321
-    mock_provider.has_dampening = False
+    mock_provider.has_dampening = True
+    mock_provider.dampening_coefficients = {0: (1.0, 0.5), 1: (0.9, 0.3)}
 
     mock_device = create_mock_device("solar", name="Test Solar")
     mock_device.data_handler = MagicMock()
@@ -514,6 +517,102 @@ def test_solar_score_sensors_have_display_precision():
     assert dampened[0].entity_description.suggested_display_precision == 2, (
         "Dampened score sensor must have suggested_display_precision=2"
     )
+
+
+def test_solar_score_sensor_none_reports_unavailable():
+    """Test that score sensor reports unavailable when provider.score is None (AC #3)."""
+    from custom_components.quiet_solar.const import (
+        SENSOR_SOLAR_FORECAST_SCORE_PREFIX,
+    )
+
+    mock_provider = MagicMock()
+    mock_provider.score = None
+    mock_provider.score_dampened = None
+    mock_provider.has_dampening = False
+
+    mock_device = create_mock_device("solar", name="Test Solar")
+    mock_device.data_handler = MagicMock()
+    mock_device.solar_forecast_providers = {"TestProvider": mock_provider}
+    mock_device.get_forecast_age_hours = MagicMock(return_value=1.5)
+    mock_device.active_provider_name = "TestProvider"
+    mock_device.solar_forecast_sensor_values = {}
+    mock_device.solar_forecast_sensor_values_probers = {}
+    mock_device.solar_forecast_sensor_values_per_provider = {}
+    mock_device.solar_forecast_sensor_values_per_provider_probers = {}
+
+    entities = create_ha_sensor_for_QSSolar(mock_device)
+    scores = [e for e in entities if e.entity_description.key.startswith(SENSOR_SOLAR_FORECAST_SCORE_PREFIX)]
+    assert len(scores) == 1
+
+    sensor = scores[0]
+    sensor.async_write_ha_state = MagicMock()
+
+    test_time = datetime.now(pytz.UTC)
+    sensor.async_update_callback(test_time)
+
+    assert sensor._attr_available is False
+    assert sensor._attr_native_value == STATE_UNAVAILABLE
+
+
+def test_solar_score_sensor_native_value_full_precision():
+    """Test that native_value returns full-precision float, not rounded (AC #4)."""
+    from custom_components.quiet_solar.const import (
+        SENSOR_SOLAR_FORECAST_SCORE_PREFIX,
+    )
+
+    mock_provider = MagicMock()
+    mock_provider.score = 123.456789
+    mock_provider.score_dampened = 98.7654321
+    mock_provider.has_dampening = False
+
+    mock_device = create_mock_device("solar", name="Test Solar")
+    mock_device.data_handler = MagicMock()
+    mock_device.solar_forecast_providers = {"TestProvider": mock_provider}
+    mock_device.get_forecast_age_hours = MagicMock(return_value=1.5)
+    mock_device.active_provider_name = "TestProvider"
+    mock_device.solar_forecast_sensor_values = {}
+    mock_device.solar_forecast_sensor_values_probers = {}
+    mock_device.solar_forecast_sensor_values_per_provider = {}
+    mock_device.solar_forecast_sensor_values_per_provider_probers = {}
+
+    entities = create_ha_sensor_for_QSSolar(mock_device)
+    scores = [e for e in entities if e.entity_description.key.startswith(SENSOR_SOLAR_FORECAST_SCORE_PREFIX)]
+    assert len(scores) == 1
+
+    sensor = scores[0]
+    sensor.async_write_ha_state = MagicMock()
+
+    test_time = datetime.now(pytz.UTC)
+    sensor.async_update_callback(test_time)
+
+    # native_value must be the full-precision float, not rounded
+    assert sensor._attr_native_value == 123.456789
+
+
+def test_solar_no_providers_no_score_sensors():
+    """Test that empty solar_forecast_providers creates no score/dampened sensors."""
+    from custom_components.quiet_solar.const import (
+        SENSOR_SOLAR_FORECAST_DAMPENED_SCORE_PREFIX,
+        SENSOR_SOLAR_FORECAST_SCORE_PREFIX,
+    )
+
+    mock_device = create_mock_device("solar", name="Test Solar")
+    mock_device.data_handler = MagicMock()
+    mock_device.solar_forecast_providers = {}
+    mock_device.get_forecast_age_hours = MagicMock(return_value=1.5)
+    mock_device.active_provider_name = None
+    mock_device.solar_forecast_sensor_values = {}
+    mock_device.solar_forecast_sensor_values_probers = {}
+    mock_device.solar_forecast_sensor_values_per_provider = {}
+    mock_device.solar_forecast_sensor_values_per_provider_probers = {}
+
+    entities = create_ha_sensor_for_QSSolar(mock_device)
+
+    scores = [e for e in entities if e.entity_description.key.startswith(SENSOR_SOLAR_FORECAST_SCORE_PREFIX)]
+    dampened = [e for e in entities if e.entity_description.key.startswith(SENSOR_SOLAR_FORECAST_DAMPENED_SCORE_PREFIX)]
+
+    assert len(scores) == 0, "No score sensors should be created with empty providers"
+    assert len(dampened) == 0, "No dampened score sensors should be created with empty providers"
 
 
 # --- Tests for QSBaseSensorRestore filtering unavailable/unknown on restore ---
@@ -625,9 +724,7 @@ def _make_score_restore_sensor(provider=None):
         provider = MagicMock()
         provider.score = None
 
-    return QSBaseSensorSolarScoreRestore(
-        mock_handler, mock_device, description, provider=provider
-    )
+    return QSBaseSensorSolarScoreRestore(mock_handler, mock_device, description, provider=provider)
 
 
 async def _restore_score_with_value(native_value, provider=None):
@@ -746,9 +843,7 @@ def _make_active_provider_restore_sensor(providers=None):
         translation_key="test",
     )
 
-    return QSBaseSensorSolarActiveProviderRestore(
-        mock_handler, mock_device, description
-    )
+    return QSBaseSensorSolarActiveProviderRestore(mock_handler, mock_device, description)
 
 
 async def _restore_active_provider_with_value(native_value, providers=None):

--- a/tests/test_platform_sensor.py
+++ b/tests/test_platform_sensor.py
@@ -478,6 +478,44 @@ def test_solar_sensors_use_restore_class():
     assert isinstance(active_provider[0], QSBaseSensorSolarActiveProviderRestore), "Active provider sensor must use QSBaseSensorSolarActiveProviderRestore"
 
 
+def test_solar_score_sensors_have_display_precision():
+    """Test that score and dampened score sensors set suggested_display_precision=2."""
+    from custom_components.quiet_solar.const import (
+        SENSOR_SOLAR_FORECAST_DAMPENED_SCORE_PREFIX,
+        SENSOR_SOLAR_FORECAST_SCORE_PREFIX,
+    )
+
+    mock_provider = MagicMock()
+    mock_provider.score = 123.456789
+    mock_provider.score_dampened = 98.7654321
+    mock_provider.has_dampening = False
+
+    mock_device = create_mock_device("solar", name="Test Solar")
+    mock_device.data_handler = MagicMock()
+    mock_device.solar_forecast_providers = {"TestProvider": mock_provider}
+    mock_device.get_forecast_age_hours = MagicMock(return_value=1.5)
+    mock_device.active_provider_name = "TestProvider"
+    mock_device.solar_forecast_sensor_values = {}
+    mock_device.solar_forecast_sensor_values_probers = {}
+    mock_device.solar_forecast_sensor_values_per_provider = {}
+    mock_device.solar_forecast_sensor_values_per_provider_probers = {}
+
+    entities = create_ha_sensor_for_QSSolar(mock_device)
+
+    scores = [e for e in entities if e.entity_description.key.startswith(SENSOR_SOLAR_FORECAST_SCORE_PREFIX)]
+    dampened = [e for e in entities if e.entity_description.key.startswith(SENSOR_SOLAR_FORECAST_DAMPENED_SCORE_PREFIX)]
+
+    assert len(scores) == 1, "Expected exactly one score sensor"
+    assert len(dampened) == 1, "Expected exactly one dampened score sensor"
+
+    assert scores[0].entity_description.suggested_display_precision == 2, (
+        "Score sensor must have suggested_display_precision=2"
+    )
+    assert dampened[0].entity_description.suggested_display_precision == 2, (
+        "Dampened score sensor must have suggested_display_precision=2"
+    )
+
+
 # --- Tests for QSBaseSensorRestore filtering unavailable/unknown on restore ---
 
 


### PR DESCRIPTION
## Summary

- Add `suggested_display_precision=2` to score and dampened score sensor descriptions so HA displays values with 2 decimal places while preserving full precision internally for provider selection.
- Add test verifying both score sensors have the precision attribute set.
- Cover pre-existing coverage gap in `QSSolarHistoryVals.init` wrong-shape numpy array reset (`home.py:4310-4313`).

Closes #137

## Quality Checklist

- [x] Coverage: 100%
- [x] Ruff (lint + format): pass
- [x] Mypy: pass
- [x] Translations: pass

## Risk Assessment

- **Level: LOW** — display-only metadata change on two sensor descriptions
- **Surfaces touched**: `sensor.py` (2 lines), `test_platform_sensor.py`, `test_home_extended_coverage.py`
- **Blast radius**: frontend display only; no internal logic change
- **Rollback**: revert single commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Solar forecast raw and dampened scores now display with a maximum of 2 decimal places in Home Assistant.

* **Tests**
  * Added test coverage to verify score sensor display precision attributes.
  * Added test to validate handling of malformed historical data during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->