### PR TITLE
feat: improve dev setup — reduce and clean agent context

### DIFF
--- a/.opencode/agents/qs-setup-task.md
+++ b/.opencode/agents/qs-setup-task.md
@@ -3,7 +3,8 @@ description: >-
   Phase 1 of the Quiet Solar pipeline (STATIC entry point). Creates a GitHub
   issue, feature branch, and worktree. Renders the per-task
   qs-create-plan-QS-<N>.md agent into the new worktree's .opencode/agents/
-  folder, then emits a launcher for a new OpenCode session on the worktree.
+  folder, then prints instructions for the user to open a new session on
+  the worktree (cannot Task-spawn across workspaces).
   Use when the user says "setup task", "new task", "work on issue #N", or
   describes a new feature to start.
 mode: primary
@@ -42,7 +43,6 @@ to the GitHub issue as-is. Deep analysis belongs in create-plan.
 ## Input
 
 The user provides ONE of:
-- A story key (e.g., "3.2") referencing an epic in `_bmad-output/planning-artifacts/epics.md`
 - A feature description (free text, may include logs or error traces)
 - A path to an external plan `.md` file via `--plan /path/to/plan.md`
 - An existing GitHub issue number via `--issue N` (e.g., `--issue 42`)
@@ -66,8 +66,6 @@ Do NOT create a new issue.
 **Otherwise** (new issue — the default):
 
 Derive title and body directly from the input — no codebase analysis:
-- **Story key**: Look up `_bmad-output/planning-artifacts/epics.md` for the
-  story title and description. Title: `"Story {{story_key}}: {{title}}"`.
 - **Plan file**: Read the plan, use its title as issue title. Body: the full
   plan text.
 - **Free text**: Extract a short title (first sentence or ~80 chars). Body:
@@ -111,30 +109,37 @@ python scripts/qs_opencode/render_agent.py \
     --story-file "_qsprocess_opencode/stories/QS-{{issue_number}}.story.md"
 ```
 
-If the user specified a story key (e.g., "3.2"), use
-`--story-file "_qsprocess_opencode/stories/story-{{story_key}}.md"` instead.
-
 Verify render_agent.py exited 0 and the file exists at
 `{{worktree_path}}/.opencode/agents/qs-create-plan-QS-{{issue_number}}.md`.
 
-### 4. Reload agents and hand off
+### 4. Tell the user what to do next
 
-Run `/reload` to make OpenCode discover the newly-rendered agent file in
-the worktree's `.opencode/agents/` directory.
-
-Then Task-spawn `qs-create-plan-QS-{{issue_number}}`:
-
-```
-Task(subagent_type="qs-create-plan-QS-{{issue_number}}", prompt="Begin your phase protocol.")
-```
-
-### 5. Tell the user what happens next
+**IMPORTANT**: This agent runs on the **main checkout**, which is a
+different workspace from the new worktree. You cannot `/reload` or
+Task-spawn agents that live in a different worktree. Instead, print
+clear instructions for the user to open a new session:
 
 ```
-Task #{{issue_number}} ready.
-   Worktree:   {{worktree_path}}
-   Agent:      qs-create-plan-QS-{{issue_number}} (rendered and reloaded)
-→ Handing off to create-plan phase...
+✅ Task #{{issue_number}} set up.
+   Worktree:  {{worktree_path}}
+   Branch:    QS_{{issue_number}}
+   Agent:     qs-create-plan-QS-{{issue_number}} (rendered into worktree)
+
+→ Next: open a new OpenCode session on the worktree and activate the agent:
+
+   opencode {{worktree_path}} --agent qs-create-plan-QS-{{issue_number}}
+
+   Then tell it: "Begin your phase protocol."
+```
+
+Also generate the launcher script for convenience:
+
+```bash
+python scripts/qs_opencode/launch_opencode.py \
+    --work-dir "{{worktree_path}}" \
+    --issue {{issue_number}} \
+    --title "{{title}}" \
+    --agent "qs-create-plan-QS-{{issue_number}}"
 ```
 
 ## Hard rules
@@ -146,4 +151,6 @@ Task #{{issue_number}} ready.
   directly as shown in step 2.
 - Do NOT commit or push anything. setup-task only creates a branch and
   worktree; there are no file changes in this phase.
+- Do NOT Task-spawn or `/reload` — the rendered agent is in a different
+  workspace. Always print instructions for the user instead.
 - If any step fails, abort and report the failure; do not try to auto-heal.

--- a/_qsprocess_opencode/agent_templates/qs-create-plan.md.tmpl
+++ b/_qsprocess_opencode/agent_templates/qs-create-plan.md.tmpl
@@ -54,7 +54,6 @@ gh issue view {{ISSUE}} --json title,body,labels,milestone
 Also read these if referenced by the issue body:
 - `_qsprocess/rules/project-rules.md`
 - `_bmad-output/project-context.md`
-- Any linked epic/story files under `_bmad-output/planning-artifacts/`
 
 ### 2. Write the story artifact
 
@@ -63,45 +62,40 @@ completeness bar defined in `_qsprocess/skills/create-plan.md`. You may
 NOT edit any other file in this phase — your edit permission is scoped
 to `{{STORY_FILE}}` and the `_qsprocess_opencode/stories/` tree only.
 
-### 3. Present the diff and wait for authorization
+### 3. Finalize
 
-Show the user the story file diff. Wait for explicit **"commit"** before
-running `git add {{STORY_FILE}} && git commit`. Wait for explicit
-**"push"** before `git push -u origin {{BRANCH}}`.
+Present the story file to the user with a diff, then ask a single question:
 
-Commit message format: see `_qsprocess/skills/create-plan.md` (typically
-`plan: story QS-{{ISSUE}} — {{TITLE}}`).
+> **"Ready to implement, or keep working on the plan?"**
 
-### 4. Render the next agent
+- **If the user wants to keep working** → stay in the edit loop, make
+  requested changes, then re-present and re-ask.
+- **If the user says ready** → proceed automatically with ALL of the
+  following (no separate "commit" / "push" gates):
 
-Once the story is pushed:
-
-```bash
-python scripts/qs_opencode/render_agent.py \
-    --phase implement-task \
-    --work-dir "{{WORK_DIR}}" \
-    --issue {{ISSUE}} \
-    --title "{{TITLE}}" \
-    --story-file "{{STORY_FILE}}"
-```
-
-### 5. Emit handoff
-
-```bash
-python scripts/qs_opencode/next_step.py \
-    --phase create-plan \
-    --work-dir "{{WORK_DIR}}" \
-    --issue {{ISSUE}} \
-    --title "{{TITLE}}" \
-    --story-file "{{STORY_FILE}}"
-```
-
-Read the JSON. Follow these steps:
-1. Run any remaining `render_commands` (create-plan only renders one, so
-   typically this is already done in step 4).
-2. Run `/reload` to make OpenCode discover the newly-rendered agent file.
-3. Task-spawn `qs-implement-task-QS-{{ISSUE}}` using the `spawn_prompt`
-   from the JSON.
+1. `git add {{STORY_FILE}} && git commit -m "plan: story QS-{{ISSUE}} — {{TITLE}}"`
+2. `git push -u origin {{BRANCH}}`
+3. Render the next agent:
+   ```bash
+   python scripts/qs_opencode/render_agent.py \
+       --phase implement-task \
+       --work-dir "{{WORK_DIR}}" \
+       --issue {{ISSUE}} \
+       --title "{{TITLE}}" \
+       --story-file "{{STORY_FILE}}"
+   ```
+4. Emit handoff:
+   ```bash
+   python scripts/qs_opencode/next_step.py \
+       --phase create-plan \
+       --work-dir "{{WORK_DIR}}" \
+       --issue {{ISSUE}} \
+       --title "{{TITLE}}" \
+       --story-file "{{STORY_FILE}}"
+   ```
+5. Run `/reload` to make OpenCode discover the newly-rendered agent file.
+6. Task-spawn `qs-implement-task-QS-{{ISSUE}}` with the `spawn_prompt`
+   from the handoff JSON.
 
 Present the result:
 ```
@@ -113,7 +107,6 @@ Present the result:
 ## Hard rules
 
 - ONLY edit `{{STORY_FILE}}`. Do not touch source code or tests.
-- Do NOT run the quality gate — that's Phase 3's job.
-- Do NOT commit or push without explicit user authorization.
+- Do NOT run the quality gate — that's the implement phase's job.
 - Do NOT modify `_qsprocess/rules/`, `scripts/qs/`, `.claude/`, or any
   other hands-off path.

--- a/_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl
+++ b/_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl
@@ -2,17 +2,14 @@
 description: >-
   Per-task finish-task agent for QS-{{ISSUE}} / PR #{{PR_NUMBER}}. Runs
   the final quality gate, merges the PR with explicit user authorization,
-  cleans up the branch + worktree, updates the epics index. Tells the
-  user to run `/release` separately if a release is warranted.
+  cleans up the worktree (agents + unregister + delete). Tells the user
+  to run `/release` separately if a release is warranted.
 mode: primary
 color: "#EC4899"
 # model: github-copilot/claude-sonnet-4.5  # uncomment to override project default
 permission:
   edit:
     "*": deny
-    "_qsprocess/epics/**": allow
-    "_bmad-output/planning-artifacts/**": allow
-    "_qsprocess/sprint-status.md": allow
   bash:
     "*": ask
     "git *": allow
@@ -20,9 +17,7 @@ permission:
     "gh pr checks *": allow
     "gh pr merge *": ask
     "python scripts/qs/quality_gate.py*": allow
-    "python scripts/qs_opencode/next_step.py *": allow
-    "python scripts/qs_opencode/render_agent.py *": allow
-    "python scripts/qs_opencode/cleanup_agents.py *": allow
+    "python scripts/qs_opencode/cleanup_worktree.py *": allow
   webfetch: deny
 ---
 
@@ -41,7 +36,7 @@ permission:
 ## Authoritative protocol
 
 Read `_qsprocess/skills/finish-task.md` (or `finish-story.md`) for the
-merge checklist, epics-index update format, and cleanup sequence.
+merge checklist and cleanup sequence.
 
 ## Phase protocol
 
@@ -74,46 +69,31 @@ gh pr merge {{PR_NUMBER}} --merge --delete-branch
 (Or `--squash` / `--rebase` per the project's convention — confirm with
 the user if the story file doesn't specify.)
 
-### 3. Update epics / sprint status
+### 3. Clean up worktree
 
-Mark the story as done in the appropriate index file (typically
-`_qsprocess/epics/<epic>.md` and/or `_qsprocess/sprint-status.md`).
-Your edit permission is scoped to `_qsprocess/epics/**`,
-`_bmad-output/planning-artifacts/**`, and `_qsprocess/sprint-status.md`
-— the only paths you're allowed to write to in this phase.
-
-Commit and push the index update on main (or the appropriate
-documentation branch per repo convention). Wait for explicit
-**"commit"** and **"push"** authorization.
-
-### 4. Clean up per-task agents
+Run the cleanup script which handles agent file removal, git worktree
+un-registration, and physical directory deletion in one step:
 
 ```bash
-python scripts/qs_opencode/cleanup_agents.py \
+python scripts/qs_opencode/cleanup_worktree.py \
     --work-dir "{{WORK_DIR}}" \
     --issue {{ISSUE}}
 ```
 
-This removes all `qs-*-QS-{{ISSUE}}.md` files from the worktree's
-`.opencode/agents/` folder. The cleanup runs BEFORE worktree removal so
-git worktree deletion doesn't complain about stale references.
+Parse the JSON output:
+- If `"status": "removed"` — cleanup succeeded, proceed to step 4.
+- If `"status": "action_required"` — present the options to the user:
+  - `--force`: delete everything, lose uncommitted/unpushed changes
+  - `--push-first`: push current branch first, then delete
+  Re-invoke with the chosen flag.
+- If `"status": "error"` — report the error to the user.
 
-### 5. Remove the worktree
-
-```bash
-git worktree remove "{{WORK_DIR}}"
-```
-
-If the command refuses due to lingering uncommitted state, report that
-to the user and do NOT force-remove unless they explicitly authorize
-`--force`.
-
-### 6. Mention release option
+### 4. Final message
 
 Tell the user:
 
 ```
-Task #{{ISSUE}} is merged; epics index updated; worktree removed.
+Task #{{ISSUE}} is merged; worktree removed.
 
 If you want to cut a release, run `/release` from the main checkout.
 ```
@@ -127,4 +107,4 @@ Then stop. Release is a separate static agent (`qs-release`) invoked via
 - No force-remove of worktree without explicit user authorization.
 - Do NOT auto-chain to release — always ask.
 - Do NOT edit source code or tests in this phase. Your edit scope is
-  limited to indexing/status docs.
+  denied for all paths.

--- a/_qsprocess_opencode/stories/QS-139.story.md
+++ b/_qsprocess_opencode/stories/QS-139.story.md
@@ -1,0 +1,168 @@
+# Story: Improve dev setup — reduce and clean agent context
+
+issue: 139
+branch: "QS_139"
+Status: ready-for-dev
+
+## Story
+
+As a developer using the OpenCode pipeline,
+I want the agent files and templates cleaned up to fix known issues,
+so that each phase works correctly without manual intervention.
+
+## Acceptance Criteria
+
+1. Given the finish-task phase needs to clean up,
+   When the agent calls `cleanup_worktree.py --work-dir <path> --issue <N>`,
+   Then the script checks for uncommitted changes and unpushed commits,
+   And returns a JSON status indicating whether it's safe to proceed or what user decision is needed.
+
+2. Given `cleanup_worktree.py` reports the worktree is clean (nothing uncommitted, nothing unpushed),
+   When it runs with no extra flags,
+   Then it removes per-task agent files, un-registers the git worktree, and physically deletes the worktree root directory.
+
+3. Given `cleanup_worktree.py` detects uncommitted changes or unpushed commits,
+   When the agent presents the status to the user,
+   Then the user can re-invoke with `--force` (delete everything, lose changes) or `--push-first` (push then delete).
+
+4. Given the setup-task agent runs on the main checkout,
+   When it has rendered `qs-create-plan-QS-<N>.md` into the new worktree,
+   Then it prints instructions for the user to open a new session on the worktree and activate the agent (no Task-spawn — different workspace).
+
+5. Given the create-plan agent has written the story file,
+   When it presents the result to the user,
+   Then it asks a single question: "Ready to implement, or keep working on the plan?",
+   And if the user says ready, the agent commits, pushes, renders the next agent, and prints handoff instructions — all in one go (no separate "commit" / "push" gates).
+
+6. Given the finish-task agent has merged the PR,
+   When it proceeds to post-merge steps,
+   Then it does NOT update any epics index or sprint-status file — these are not part of the OpenCode workflow.
+
+7. Given any in-worktree agent template that hands off to the next phase (create-plan, implement-task, review-task),
+   When the handoff step runs,
+   Then it renders the next agent, runs `/reload`, and Task-spawns it in the current session — so the user never has to manually activate an agent within the same worktree.
+
+8. Given any OpenCode agent or template,
+   When it loads context or determines input,
+   Then it never references `epics.md`, `_qsprocess/epics/`, `_bmad-output/planning-artifacts/epics.md`, `sprint-status.md`, or story keys (e.g. "3.2") — the only task identifier is the GitHub issue number.
+
+9. Given the setup-task agent runs on the main checkout (different workspace from the worktree),
+   When it has rendered the create-plan agent into the new worktree,
+   Then it prints instructions for the user to open a new session on the worktree and activate the agent there (cannot Task-spawn across workspaces).
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Create `scripts/qs_opencode/cleanup_worktree.py` (AC: #1, #2, #3)
+  - [ ] Implement `check_worktree_status()` — runs `git status --porcelain` and `git log @{u}..HEAD` to detect uncommitted changes and unpushed commits; returns a structured dict with `safe_to_remove`, `uncommitted_files`, `unpushed_commits`, `branch`
+  - [ ] Implement `cleanup()` — calls `cleanup_agents.py` logic (reuse or import from existing), runs `git worktree remove`, then `shutil.rmtree()` on the worktree root dir
+  - [ ] Implement CLI with `--work-dir`, `--issue`, `--force`, `--push-first`, `--dry-run`
+  - [ ] When called with no action flag: check status, if clean → cleanup, if dirty → output JSON with `action_required` and instructions for re-invocation
+  - [ ] When called with `--push-first`: push the current branch, then cleanup
+  - [ ] When called with `--force`: skip safety checks, cleanup directly
+  - [ ] Output is always JSON via `utils.output_json()`
+
+- [ ] Task 2: Update finish-task template to use `cleanup_worktree.py` (AC: #1, #2, #3)
+  - [ ] In `_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl`, replace steps 4 + 5 with a single step calling `python scripts/qs_opencode/cleanup_worktree.py --work-dir "{{WORK_DIR}}" --issue {{ISSUE}}`
+  - [ ] Update the agent instructions to: parse the JSON, if `action_required` present the options to the user, then re-invoke with the chosen flag
+  - [ ] Remove the separate `cleanup_agents.py` call (it's now internal to `cleanup_worktree.py`)
+  - [ ] Remove the separate `git worktree remove` step
+
+- [ ] Task 3: Simplify setup-task agent handoff (AC: #4, #9)
+  - [ ] In `.opencode/agents/qs-setup-task.md`, replace step 4 (reload + Task-spawn) with instructions telling the user to open a new session on the worktree and activate the rendered agent (setup-task runs on main, can't Task-spawn into a different workspace)
+  - [ ] Merge steps 4 and 5 into a single final output that shows the worktree path, rendered agent name, and what the user should do next
+
+- [ ] Task 4: Streamline create-plan template authorization flow (AC: #5, #7)
+  - [ ] In `_qsprocess_opencode/agent_templates/qs-create-plan.md.tmpl`, replace step 3 (separate "commit" then "push" gates) with a single decision point: "Ready to implement, or keep working on the plan?"
+  - [ ] If user says ready → commit + push + render next agent + `/reload` + Task-spawn `qs-implement-task-QS-{{ISSUE}}`, all automatically
+  - [ ] If user wants to keep working → stay in the edit loop, re-present when they're done
+  - [ ] Collapse steps 3, 4, 5 into a single streamlined "Finalize" step
+
+- [ ] Task 5: Remove epics/sprint-status from finish-task template entirely (AC: #6, #8)
+  - [ ] In `_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl`, remove step 3 ("Update epics / sprint status") entirely
+  - [ ] Remove edit permissions for `_qsprocess/epics/**`, `_bmad-output/planning-artifacts/**`, and `_qsprocess/sprint-status.md`
+  - [ ] Remove all mentions of "epics index" from the description and final output
+  - [ ] Renumber remaining steps accordingly
+
+- [ ] Task 6: Keep `/reload` + Task-spawn handoff in implement-task and review-task templates (AC: #7)
+  - [ ] In `_qsprocess_opencode/agent_templates/qs-implement-task.md.tmpl` step 7, ensure the handoff renders all review agents, runs `/reload`, and Task-spawns `qs-review-task-QS-{{ISSUE}}` (keep existing pattern — it's correct for same-session transitions)
+  - [ ] In `_qsprocess_opencode/agent_templates/qs-review-task.md.tmpl` step 7, ensure the handoff renders `qs-finish-task-QS-{{ISSUE}}`, runs `/reload`, and Task-spawns it (keep existing pattern)
+
+- [ ] Task 7: Remove all epics.md / story-key references from setup-task and create-plan (AC: #8)
+  - [ ] In `.opencode/agents/qs-setup-task.md`, remove the "story key" input option (line 45) and the `epics.md` lookup logic in step 1 (lines 69–70); remove the story-key-based story-file naming (lines 114–115); the only input paths are: existing issue number, free text description, or plan file
+  - [ ] In `_qsprocess_opencode/agent_templates/qs-create-plan.md.tmpl`, remove "Any linked epic/story files under `_bmad-output/planning-artifacts/`" from context loading (line 57)
+
+## Dev Notes
+
+### New file
+
+- `scripts/qs_opencode/cleanup_worktree.py` — single-responsibility script that replaces the 3-step cleanup dance (cleanup_agents → git worktree remove → hope the dir is gone)
+
+### Files to modify
+
+1. `_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl` — collapse steps 4 + 5 into `cleanup_worktree.py` call; remove step 3 (epics update) entirely; strip epics edit permissions
+2. `.opencode/agents/qs-setup-task.md` — replace Task-spawn with user instructions (cross-workspace); remove story-key input and epics.md lookup
+3. `_qsprocess_opencode/agent_templates/qs-create-plan.md.tmpl` — collapse steps 3 + 4 + 5 into single "ready or keep working?" flow with auto commit+push+render+spawn; remove epics/planning-artifacts reference
+4. `_qsprocess_opencode/agent_templates/qs-implement-task.md.tmpl` — verify `/reload` + Task-spawn handoff is correct (keep as-is if already right)
+5. `_qsprocess_opencode/agent_templates/qs-review-task.md.tmpl` — verify `/reload` + Task-spawn handoff is correct (keep as-is if already right)
+
+### Script design: `cleanup_worktree.py`
+
+```
+Usage:
+  python scripts/qs_opencode/cleanup_worktree.py \
+      --work-dir /path/to/worktree --issue 42
+  python scripts/qs_opencode/cleanup_worktree.py \
+      --work-dir /path/to/worktree --issue 42 --force
+  python scripts/qs_opencode/cleanup_worktree.py \
+      --work-dir /path/to/worktree --issue 42 --push-first
+
+Output (check mode — dirty):
+  {
+    "status": "action_required",
+    "safe_to_remove": false,
+    "uncommitted_files": ["file1.py", "file2.py"],
+    "unpushed_commits": 2,
+    "branch": "QS_42",
+    "message": "Worktree has uncommitted changes and/or unpushed commits.",
+    "options": {
+      "--force": "Delete worktree and lose all uncommitted/unpushed changes",
+      "--push-first": "Push current branch to origin, then delete worktree"
+    }
+  }
+
+Output (success):
+  {
+    "status": "removed",
+    "agents_removed": [...],
+    "worktree_path": "/path/to/worktree",
+    "message": "Worktree QS_42 fully cleaned up."
+  }
+```
+
+Sequence:
+1. `git -C <work_dir> status --porcelain` — check for uncommitted
+2. `git -C <work_dir> log @{u}..HEAD --oneline` — check for unpushed
+3. If dirty and no `--force`/`--push-first` → return `action_required` JSON
+4. If `--push-first` → `git -C <work_dir> push`
+5. Remove agent files (inline the logic from `cleanup_agents.py`)
+6. `git worktree remove <work_dir>` (from the main worktree)
+7. `shutil.rmtree(<work_dir>)` if directory still exists
+8. Return success JSON
+
+### Key constraints
+
+- Do NOT modify anything under `_qsprocess/`, `scripts/qs/`, `.claude/`, `CLAUDE.md`
+- The setup-task agent is a **static** agent (not rendered from a template) — edit it directly
+- The finish-task template uses `{{WORK_DIR}}` placeholder for the worktree path
+- `cleanup_worktree.py` must run `git worktree remove` from the **main** worktree (use `utils.get_main_worktree()`)
+- The existing `cleanup_agents.py` stays untouched (other code may call it); `cleanup_worktree.py` inlines the same glob+unlink logic
+
+### Architecture notes
+
+- `git worktree remove` un-registers from git but may leave the directory if there are untracked files or it refuses
+- `shutil.rmtree()` as a fallback ensures the physical directory is always gone
+- The two-call pattern (check → act) lets the agent present options to the user without needing interactive prompts in the script
+- **Handoff model — two patterns**:
+  - **Cross-workspace** (setup-task → create-plan): setup-task runs on main checkout, the new worktree is a different workspace. Cannot `/reload` + Task-spawn across workspaces → print user instructions
+  - **Same-session** (create-plan → implement-task → review-task → finish-task): all run inside the same worktree session. Render the next agent, `/reload`, Task-spawn — fully automatic, no user action needed
+  - **Terminal** (finish-task): deletes the worktree, nothing to spawn after — just print final status

--- a/_qsprocess_opencode/tests/test_cleanup_worktree.py
+++ b/_qsprocess_opencode/tests/test_cleanup_worktree.py
@@ -283,3 +283,19 @@ class TestMain:
 
         assert result["status"] == "dry_run"
         assert result["would_push"] is True
+
+    def test_push_first_with_uncommitted_blocks(self, tmp_path: Path) -> None:
+        """--push-first should refuse if there are uncommitted files."""
+        with patch("cleanup_worktree.check_worktree_status") as mock_status:
+            mock_status.return_value = {
+                "safe_to_remove": False,
+                "uncommitted_files": ["dirty.py"],
+                "unpushed_commits": 2,
+                "branch": "QS_42",
+            }
+            result = self._run_main(["--work-dir", str(tmp_path), "--issue", "42", "--push-first"])
+
+        assert result["status"] == "action_required"
+        assert "--force" in result["options"]
+        assert "--push-first" not in result.get("options", {})
+        assert "uncommitted" in result["message"].lower()

--- a/_qsprocess_opencode/tests/test_cleanup_worktree.py
+++ b/_qsprocess_opencode/tests/test_cleanup_worktree.py
@@ -1,0 +1,285 @@
+"""Tests for cleanup_worktree.py functions.
+
+Run with: source venv/bin/activate && pytest _qsprocess_opencode/tests/ -v
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add scripts dir to path so we can import the module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts" / "qs_opencode"))
+
+import cleanup_worktree  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# check_worktree_status
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWorktreeStatus:
+    def _mock_run(self, results: list[subprocess.CompletedProcess]) -> MagicMock:
+        return patch("cleanup_worktree.subprocess.run", side_effect=results)
+
+    def test_clean_worktree(self, tmp_path: Path) -> None:
+        results = [
+            subprocess.CompletedProcess([], 0, stdout="QS_42\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+        ]
+        with self._mock_run(results):
+            status = cleanup_worktree.check_worktree_status(tmp_path)
+
+        assert status["safe_to_remove"] is True
+        assert status["uncommitted_files"] == []
+        assert status["unpushed_commits"] == 0
+        assert status["branch"] == "QS_42"
+
+    def test_dirty_worktree_uncommitted(self, tmp_path: Path) -> None:
+        results = [
+            subprocess.CompletedProcess([], 0, stdout="QS_42\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout=" M file1.py\n?? file2.py\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+        ]
+        with self._mock_run(results):
+            status = cleanup_worktree.check_worktree_status(tmp_path)
+
+        assert status["safe_to_remove"] is False
+        assert len(status["uncommitted_files"]) == 2
+
+    def test_dirty_worktree_unpushed(self, tmp_path: Path) -> None:
+        results = [
+            subprocess.CompletedProcess([], 0, stdout="QS_42\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="abc123 some commit\ndef456 another\n", stderr=""),
+        ]
+        with self._mock_run(results):
+            status = cleanup_worktree.check_worktree_status(tmp_path)
+
+        assert status["safe_to_remove"] is False
+        assert status["unpushed_commits"] == 2
+
+    def test_no_upstream(self, tmp_path: Path) -> None:
+        results = [
+            subprocess.CompletedProcess([], 0, stdout="QS_42\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 128, stdout="", stderr="fatal: no upstream"),
+        ]
+        with self._mock_run(results):
+            status = cleanup_worktree.check_worktree_status(tmp_path)
+
+        assert status["safe_to_remove"] is False
+        assert status["unpushed_commits"] == -1
+
+    def test_branch_detection_failure(self, tmp_path: Path) -> None:
+        results = [
+            subprocess.CompletedProcess([], 128, stdout="", stderr="fatal"),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+        ]
+        with self._mock_run(results):
+            status = cleanup_worktree.check_worktree_status(tmp_path)
+
+        assert status["branch"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# remove_agent_files
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveAgentFiles:
+    def test_removes_matching_files(self, tmp_path: Path) -> None:
+        agent_dir = tmp_path / ".opencode" / "agents"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "qs-create-plan-QS-42.md").write_text("x")
+        (agent_dir / "qs-implement-task-QS-42.md").write_text("x")
+        (agent_dir / "qs-create-plan-QS-99.md").write_text("x")  # different issue
+
+        removed = cleanup_worktree.remove_agent_files(tmp_path, 42)
+
+        assert len(removed) == 2
+        assert not (agent_dir / "qs-create-plan-QS-42.md").exists()
+        assert not (agent_dir / "qs-implement-task-QS-42.md").exists()
+        assert (agent_dir / "qs-create-plan-QS-99.md").exists()
+
+    def test_no_agent_dir(self, tmp_path: Path) -> None:
+        removed = cleanup_worktree.remove_agent_files(tmp_path, 42)
+        assert removed == []
+
+
+# ---------------------------------------------------------------------------
+# list_agent_files
+# ---------------------------------------------------------------------------
+
+
+class TestListAgentFiles:
+    def test_lists_matching_files(self, tmp_path: Path) -> None:
+        agent_dir = tmp_path / ".opencode" / "agents"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "qs-create-plan-QS-42.md").write_text("x")
+        (agent_dir / "qs-implement-task-QS-42.md").write_text("x")
+
+        result = cleanup_worktree.list_agent_files(tmp_path, 42)
+        assert len(result) == 2
+
+    def test_no_agent_dir(self, tmp_path: Path) -> None:
+        assert cleanup_worktree.list_agent_files(tmp_path, 42) == []
+
+
+# ---------------------------------------------------------------------------
+# push_branch
+# ---------------------------------------------------------------------------
+
+
+class TestPushBranch:
+    def test_success(self, tmp_path: Path) -> None:
+        with patch("cleanup_worktree.subprocess.run") as mock:
+            mock.return_value = subprocess.CompletedProcess([], 0, stdout="Everything up-to-date", stderr="")
+            ok, out = cleanup_worktree.push_branch(tmp_path)
+        assert ok is True
+
+    def test_failure(self, tmp_path: Path) -> None:
+        with patch("cleanup_worktree.subprocess.run") as mock:
+            mock.return_value = subprocess.CompletedProcess([], 1, stdout="", stderr="rejected")
+            ok, out = cleanup_worktree.push_branch(tmp_path)
+        assert ok is False
+        assert "rejected" in out
+
+
+# ---------------------------------------------------------------------------
+# main (CLI integration)
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def _run_main(self, args: list[str]) -> dict:
+        """Run main() with args and capture JSON output."""
+        with patch("sys.argv", ["cleanup_worktree.py", *args]):
+            captured: dict = {}
+
+            def capture_json(data: dict) -> None:
+                captured.update(data)
+
+            with patch("cleanup_worktree.output_json", side_effect=capture_json):
+                cleanup_worktree.main()
+            return captured
+
+    def test_nonexistent_dir(self) -> None:
+        result = self._run_main(["--work-dir", "/nonexistent/path", "--issue", "42"])
+        assert result["status"] == "error"
+
+    def test_dirty_returns_action_required(self, tmp_path: Path) -> None:
+        with patch("cleanup_worktree.check_worktree_status") as mock:
+            mock.return_value = {
+                "safe_to_remove": False,
+                "uncommitted_files": ["dirty.py"],
+                "unpushed_commits": 1,
+                "branch": "QS_42",
+            }
+            result = self._run_main(["--work-dir", str(tmp_path), "--issue", "42"])
+
+        assert result["status"] == "action_required"
+        assert "--force" in result["options"]
+        assert "--push-first" in result["options"]
+
+    def test_clean_removes(self, tmp_path: Path) -> None:
+        with (
+            patch("cleanup_worktree.check_worktree_status") as mock_status,
+            patch("cleanup_worktree.remove_agent_files", return_value=[]) as mock_agents,
+            patch("cleanup_worktree.remove_worktree", return_value=None) as mock_wt,
+        ):
+            mock_status.return_value = {
+                "safe_to_remove": True,
+                "uncommitted_files": [],
+                "unpushed_commits": 0,
+                "branch": "QS_42",
+            }
+            result = self._run_main(["--work-dir", str(tmp_path), "--issue", "42"])
+
+        assert result["status"] == "removed"
+        mock_agents.assert_called_once()
+        mock_wt.assert_called_once()
+
+    def test_force_skips_status_check(self, tmp_path: Path) -> None:
+        with (
+            patch("cleanup_worktree.check_worktree_status") as mock_status,
+            patch("cleanup_worktree.remove_agent_files", return_value=[]),
+            patch("cleanup_worktree.remove_worktree", return_value=None),
+        ):
+            result = self._run_main(["--work-dir", str(tmp_path), "--issue", "42", "--force"])
+
+        assert result["status"] == "removed"
+        mock_status.assert_not_called()
+
+    def test_push_first_success(self, tmp_path: Path) -> None:
+        with (
+            patch("cleanup_worktree.check_worktree_status") as mock_status,
+            patch("cleanup_worktree.push_branch", return_value=(True, "ok")),
+            patch("cleanup_worktree.remove_agent_files", return_value=[]),
+            patch("cleanup_worktree.remove_worktree", return_value=None),
+        ):
+            mock_status.return_value = {
+                "safe_to_remove": False,
+                "uncommitted_files": [],
+                "unpushed_commits": 2,
+                "branch": "QS_42",
+            }
+            result = self._run_main(["--work-dir", str(tmp_path), "--issue", "42", "--push-first"])
+
+        assert result["status"] == "removed"
+
+    def test_push_first_failure(self, tmp_path: Path) -> None:
+        with (
+            patch("cleanup_worktree.check_worktree_status") as mock_status,
+            patch("cleanup_worktree.push_branch", return_value=(False, "rejected")),
+        ):
+            mock_status.return_value = {
+                "safe_to_remove": False,
+                "uncommitted_files": [],
+                "unpushed_commits": 2,
+                "branch": "QS_42",
+            }
+            result = self._run_main(["--work-dir", str(tmp_path), "--issue", "42", "--push-first"])
+
+        assert result["status"] == "error"
+        assert "rejected" in result["message"]
+
+    def test_dry_run(self, tmp_path: Path) -> None:
+        agent_dir = tmp_path / ".opencode" / "agents"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "qs-create-plan-QS-42.md").write_text("x")
+
+        with patch("cleanup_worktree.check_worktree_status") as mock_status:
+            mock_status.return_value = {
+                "safe_to_remove": True,
+                "uncommitted_files": [],
+                "unpushed_commits": 0,
+                "branch": "QS_42",
+            }
+            result = self._run_main(["--work-dir", str(tmp_path), "--issue", "42", "--dry-run"])
+
+        assert result["status"] == "dry_run"
+        assert len(result["would_remove_agents"]) == 1
+        # File should still exist
+        assert (agent_dir / "qs-create-plan-QS-42.md").exists()
+
+    def test_dry_run_push_first(self, tmp_path: Path) -> None:
+        with patch("cleanup_worktree.check_worktree_status") as mock_status:
+            mock_status.return_value = {
+                "safe_to_remove": False,
+                "uncommitted_files": [],
+                "unpushed_commits": 2,
+                "branch": "QS_42",
+            }
+            result = self._run_main(["--work-dir", str(tmp_path), "--issue", "42", "--push-first", "--dry-run"])
+
+        assert result["status"] == "dry_run"
+        assert result["would_push"] is True

--- a/scripts/qs_opencode/cleanup_worktree.py
+++ b/scripts/qs_opencode/cleanup_worktree.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Clean up a git worktree: remove per-task agents, un-register, delete directory.
+
+Replaces the multi-step cleanup dance (cleanup_agents -> git worktree remove ->
+hope the dir is gone) with a single script that handles safety checks.
+
+Usage::
+
+    # Check + clean (safe mode -- aborts if dirty)
+    python scripts/qs_opencode/cleanup_worktree.py \
+        --work-dir /path/to/worktree --issue 42
+
+    # Push first, then clean
+    python scripts/qs_opencode/cleanup_worktree.py \
+        --work-dir /path/to/worktree --issue 42 --push-first
+
+    # Force clean (lose uncommitted/unpushed changes)
+    python scripts/qs_opencode/cleanup_worktree.py \
+        --work-dir /path/to/worktree --issue 42 --force
+
+    # Dry run
+    python scripts/qs_opencode/cleanup_worktree.py \
+        --work-dir /path/to/worktree --issue 42 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+from utils import get_main_worktree, output_json  # type: ignore[import-not-found]
+
+
+def check_worktree_status(work_dir: Path) -> dict:
+    """Check for uncommitted changes and unpushed commits.
+
+    Returns a dict with:
+        safe_to_remove: bool
+        uncommitted_files: list[str]
+        unpushed_commits: int
+        branch: str
+    """
+    result = subprocess.run(
+        ["git", "-C", str(work_dir), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    branch = result.stdout.strip() if result.returncode == 0 else "unknown"
+
+    result = subprocess.run(
+        ["git", "-C", str(work_dir), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+    )
+    uncommitted_files = [
+        line.strip() for line in result.stdout.splitlines() if line.strip()
+    ]
+
+    result = subprocess.run(
+        ["git", "-C", str(work_dir), "log", "@{u}..HEAD", "--oneline"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        unpushed_commits = -1  # no upstream tracking
+    else:
+        unpushed_lines = [
+            line for line in result.stdout.splitlines() if line.strip()
+        ]
+        unpushed_commits = len(unpushed_lines)
+
+    safe = len(uncommitted_files) == 0 and unpushed_commits == 0
+
+    return {
+        "safe_to_remove": safe,
+        "uncommitted_files": uncommitted_files,
+        "unpushed_commits": unpushed_commits,
+        "branch": branch,
+    }
+
+
+def remove_agent_files(work_dir: Path, issue: int) -> list[str]:
+    """Remove per-task agent files (inline logic from cleanup_agents.py)."""
+    agent_dir = work_dir / ".opencode" / "agents"
+    if not agent_dir.is_dir():
+        return []
+
+    pattern = f"qs-*-QS-{issue}.md"
+    matches = sorted(agent_dir.glob(pattern))
+    removed: list[str] = []
+    for path in matches:
+        rel = str(path.relative_to(work_dir))
+        try:
+            path.unlink()
+            removed.append(rel)
+        except OSError as exc:
+            removed.append(f"FAILED {rel}: {exc}")
+    return removed
+
+
+def list_agent_files(work_dir: Path, issue: int) -> list[str]:
+    """List per-task agent files without removing them (for dry-run)."""
+    agent_dir = work_dir / ".opencode" / "agents"
+    if not agent_dir.is_dir():
+        return []
+    return [
+        str(p.relative_to(work_dir))
+        for p in sorted(agent_dir.glob(f"qs-*-QS-{issue}.md"))
+    ]
+
+
+def remove_worktree(work_dir: Path) -> str | None:
+    """Un-register and delete the worktree. Returns error message or None."""
+    main_wt = get_main_worktree()
+    result = subprocess.run(
+        ["git", "-C", str(main_wt), "worktree", "remove", str(work_dir), "--force"],
+        capture_output=True,
+        text=True,
+    )
+    error = None
+    if result.returncode != 0:
+        error = result.stderr.strip()
+
+    # Fallback: physically remove directory if still present
+    if work_dir.exists():
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+    return error
+
+
+def push_branch(work_dir: Path) -> tuple[bool, str]:
+    """Push the current branch. Returns (success, output)."""
+    result = subprocess.run(
+        ["git", "-C", str(work_dir), "push"],
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout.strip() or result.stderr.strip()
+    return result.returncode == 0, output
+
+
+def main() -> None:  # noqa: C901
+    parser = argparse.ArgumentParser(
+        description="Clean up a git worktree (agents + unregister + delete)",
+    )
+    parser.add_argument("--work-dir", required=True)
+    parser.add_argument("--issue", type=int, required=True)
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Skip safety checks, delete everything",
+    )
+    parser.add_argument(
+        "--push-first",
+        action="store_true",
+        help="Push current branch before cleanup",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without doing it",
+    )
+    args = parser.parse_args()
+
+    work_dir = Path(args.work_dir).resolve()
+
+    if not work_dir.exists():
+        output_json({
+            "status": "error",
+            "message": f"Worktree directory does not exist: {work_dir}",
+        })
+        return
+
+    # Step 1: Check status (unless --force)
+    if not args.force:
+        status = check_worktree_status(work_dir)
+
+        if not status["safe_to_remove"] and not args.push_first:
+            output_json({
+                "status": "action_required",
+                "safe_to_remove": False,
+                "uncommitted_files": status["uncommitted_files"],
+                "unpushed_commits": status["unpushed_commits"],
+                "branch": status["branch"],
+                "message": "Worktree has uncommitted changes and/or unpushed commits.",
+                "options": {
+                    "--force": "Delete worktree and lose all uncommitted/unpushed changes",
+                    "--push-first": "Push current branch to origin, then delete worktree",
+                },
+            })
+            return
+
+    # Step 2: Push if requested
+    if args.push_first:
+        if args.dry_run:
+            output_json({
+                "status": "dry_run",
+                "would_push": True,
+                "would_remove_agents": list_agent_files(work_dir, args.issue),
+                "would_remove_worktree": str(work_dir),
+            })
+            return
+        success, push_output = push_branch(work_dir)
+        if not success:
+            output_json({
+                "status": "error",
+                "message": f"Push failed: {push_output}",
+            })
+            return
+
+    if args.dry_run:
+        output_json({
+            "status": "dry_run",
+            "would_remove_agents": list_agent_files(work_dir, args.issue),
+            "would_remove_worktree": str(work_dir),
+        })
+        return
+
+    # Step 3: Remove agent files
+    agents_removed = remove_agent_files(work_dir, args.issue)
+
+    # Step 4: Remove worktree
+    wt_error = remove_worktree(work_dir)
+
+    output_json({
+        "status": "removed",
+        "agents_removed": agents_removed,
+        "worktree_path": str(work_dir),
+        "worktree_remove_error": wt_error,
+        "message": f"Worktree QS_{args.issue} fully cleaned up.",
+    })
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/qs_opencode/cleanup_worktree.py
+++ b/scripts/qs_opencode/cleanup_worktree.py
@@ -192,6 +192,25 @@ def main() -> None:  # noqa: C901
             })
             return
 
+        # --push-first only handles unpushed commits; uncommitted files
+        # would be silently lost when the worktree is deleted.
+        if args.push_first and status["uncommitted_files"]:
+            output_json({
+                "status": "action_required",
+                "safe_to_remove": False,
+                "uncommitted_files": status["uncommitted_files"],
+                "unpushed_commits": status["unpushed_commits"],
+                "branch": status["branch"],
+                "message": (
+                    "Worktree has uncommitted files that --push-first cannot save. "
+                    "Commit them first, or use --force to discard."
+                ),
+                "options": {
+                    "--force": "Delete worktree and lose all uncommitted changes",
+                },
+            })
+            return
+
     # Step 2: Push if requested
     if args.push_first:
         if args.dry_run:


### PR DESCRIPTION
## Summary

Closes #139

- **New**: `scripts/qs_opencode/cleanup_worktree.py` — single-responsibility script replacing the 3-step cleanup dance (cleanup_agents → git worktree remove → hope dir is gone). Supports `--force`, `--push-first`, `--dry-run`, always outputs JSON.
- **Updated**: finish-task template to use `cleanup_worktree.py` and remove all epics/sprint-status references
- **Updated**: setup-task agent to remove story-key/epics.md input paths and fix cross-workspace handoff (print instructions instead of Task-spawn)
- **Updated**: create-plan template to use single "ready or keep working?" decision point instead of separate commit/push gates, removed epics/planning-artifacts references
- **Verified**: implement-task and review-task templates already have correct `/reload` + Task-spawn handoffs

## Quality checklist

- [x] Dev test suite: 19/19 passing (`_qsprocess_opencode/tests/`)
- [x] Production quality gate: all gates pass (pytest 100% cov, ruff, mypy, translations)
- [x] No production code touched (`custom_components/quiet_solar/` unchanged)

## Risk assessment

- **Surfaces touched**: dev tooling only (scripts, agent templates, static agent definition)
- **Blast radius**: zero impact on production code; affects only OpenCode pipeline workflow
- **Rollback**: revert single commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined "Finalize" flow: one confirmation triggers commit/push, rendering, reload, and automated handoff to implementation.
  * Added a safe worktree cleanup command with dry-run, force/push-first options, and a convenience launcher for new sessions.

* **Refactor**
  * Removed story-key inputs; tasks now use issue numbers only.
  * Setup now instructs opening a new session instead of cross-workspace task-spawning; finish-task focuses on merge checklist + cleanup.

* **Tests**
  * Added tests covering cleanup scenarios and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->