### PR TITLE
fix: pass directory context to OpenCode session API for correct sandbox association

### DIFF
--- a/_qsprocess_opencode/agent_templates/qs-create-plan.md.tmpl
+++ b/_qsprocess_opencode/agent_templates/qs-create-plan.md.tmpl
@@ -237,7 +237,8 @@ the parallel-review design):
       python scripts/qs_opencode/spawn_session.py \
           --agent qs-{{IMPLEMENT_PHASE}}-QS-{{ISSUE}} \
           --prompt "<spawn_prompt from handoff JSON>" \
-          --title "QS-{{ISSUE}}: {{IMPLEMENT_PHASE}}"
+          --title "QS-{{ISSUE}}: {{IMPLEMENT_PHASE}}" \
+          --directory "{{WORK_DIR}}"
       ```
       This creates a new session visible in the OpenCode sidebar.
       Your work is DONE after this — do NOT continue in this session.

--- a/_qsprocess_opencode/agent_templates/qs-implement-setup-task.md.tmpl
+++ b/_qsprocess_opencode/agent_templates/qs-implement-setup-task.md.tmpl
@@ -145,7 +145,8 @@ Follow these steps:
    python scripts/qs_opencode/spawn_session.py \
        --agent qs-review-task-QS-{{ISSUE}} \
        --prompt "<spawn_prompt from handoff JSON>" \
-       --title "QS-{{ISSUE}}: review-task"
+       --title "QS-{{ISSUE}}: review-task" \
+       --directory "{{WORK_DIR}}"
    ```
    This creates a new session visible in the OpenCode sidebar.
    The review orchestrator will Task-spawn the 4 reviewer sub-roles

--- a/_qsprocess_opencode/agent_templates/qs-implement-task.md.tmpl
+++ b/_qsprocess_opencode/agent_templates/qs-implement-task.md.tmpl
@@ -145,7 +145,8 @@ Follow these steps:
    python scripts/qs_opencode/spawn_session.py \
        --agent qs-review-task-QS-{{ISSUE}} \
        --prompt "<spawn_prompt from handoff JSON>" \
-       --title "QS-{{ISSUE}}: review-task"
+       --title "QS-{{ISSUE}}: review-task" \
+       --directory "{{WORK_DIR}}"
    ```
    This creates a new session visible in the OpenCode sidebar.
    The review orchestrator will Task-spawn the 4 reviewer sub-roles

--- a/_qsprocess_opencode/agent_templates/qs-review-task.md.tmpl
+++ b/_qsprocess_opencode/agent_templates/qs-review-task.md.tmpl
@@ -265,7 +265,8 @@ Follow these steps:
    python scripts/qs_opencode/spawn_session.py \
        --agent qs-finish-task-QS-{{ISSUE}} \
        --prompt "<spawn_prompt from handoff JSON>" \
-       --title "QS-{{ISSUE}}: finish-task"
+       --title "QS-{{ISSUE}}: finish-task" \
+       --directory "{{WORK_DIR}}"
    ```
    This creates a new session visible in the OpenCode sidebar.
    Your work is DONE after this — do NOT continue in this session.

--- a/scripts/qs_opencode/next_step.py
+++ b/scripts/qs_opencode/next_step.py
@@ -253,6 +253,7 @@ def main() -> None:
         f" --agent {shlex.quote(next_agent)}"
         f" --prompt {shlex.quote(prompt)}"
         f" --title {shlex.quote(session_title)}"
+        f" --directory {shlex.quote(args.work_dir)}"
     )
 
     instructions = [

--- a/scripts/qs_opencode/spawn_session.py
+++ b/scripts/qs_opencode/spawn_session.py
@@ -13,7 +13,13 @@ Usage::
     python scripts/qs_opencode/spawn_session.py \
         --agent qs-implement-task-QS-42 \
         --prompt "Begin your phase protocol." \
-        --title "QS-42: implement-task"
+        --title "QS-42: implement-task" \
+        --directory /path/to/worktree
+
+The ``--directory`` flag is **required** — it tells the OpenCode server
+which project/sandbox the session belongs to.  Without it the middleware
+falls back to ``process.cwd()`` which typically resolves to the global
+project, making the session invisible in the sandbox sidebar.
 
 The script outputs JSON with the created session ID so the calling agent
 can report success.
@@ -40,15 +46,31 @@ def _base_url() -> str:
     return f"http://127.0.0.1:{port}"
 
 
-def _api(method: str, path: str, body: dict | None = None) -> dict:
-    """Make a JSON request to the OpenCode server API."""
+def _api(
+    method: str,
+    path: str,
+    body: dict | None = None,
+    *,
+    directory: str | None = None,
+) -> dict:
+    """Make a JSON request to the OpenCode server API.
+
+    When *directory* is given it is sent via the ``x-opencode-directory``
+    header so the instance middleware resolves the correct project /
+    sandbox context for the request.
+    """
     url = f"{_base_url()}{path}"
     data = json.dumps(body).encode() if body else None
+    headers: dict[str, str] = {}
+    if data:
+        headers["Content-Type"] = "application/json"
+    if directory:
+        headers["x-opencode-directory"] = directory
     req = urllib.request.Request(
         url,
         data=data,
         method=method,
-        headers={"Content-Type": "application/json"} if data else {},
+        headers=headers,
     )
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
@@ -77,10 +99,20 @@ def spawn_session(
     agent: str,
     prompt: str,
     title: str | None = None,
+    directory: str | None = None,
 ) -> dict:
-    """Create a new interactive session and send the kickoff prompt."""
+    """Create a new interactive session and send the kickoff prompt.
+
+    *directory* must point to the worktree / sandbox so that the session
+    is created under the correct project and appears in the sidebar.
+    """
     # 1. Create a new session
-    session = _api("POST", "/session", {"title": title or agent})
+    session = _api(
+        "POST",
+        "/session",
+        {"title": title or agent},
+        directory=directory,
+    )
     session_id = session.get("id") or session.get("ID")
     if not session_id:
         print(f"ERROR: Unexpected session response: {session}", file=sys.stderr)
@@ -94,12 +126,14 @@ def spawn_session(
             "agent": agent,
             "parts": [{"type": "text", "text": prompt}],
         },
+        directory=directory,
     )
 
     return {
         "session_id": session_id,
         "agent": agent,
         "title": title or agent,
+        "directory": directory,
         "status": "spawned",
     }
 
@@ -123,12 +157,23 @@ def main() -> None:
         default=None,
         help="Session title (defaults to agent name)",
     )
+    parser.add_argument(
+        "--directory",
+        default=None,
+        help=(
+            "Worktree / sandbox directory for the session.  Sent via "
+            "x-opencode-directory header so the session is created under "
+            "the correct project.  Required for sessions to appear in "
+            "the sandbox sidebar."
+        ),
+    )
     args = parser.parse_args()
 
     result = spawn_session(
         agent=args.agent,
         prompt=args.prompt,
         title=args.title,
+        directory=args.directory,
     )
     output_json(result)
 


### PR DESCRIPTION
## Summary
- `spawn_session.py` was creating sessions under `projectID: "global"` because the OpenCode middleware falls back to `process.cwd()` when no directory is specified — making spawned sessions invisible in the sandbox sidebar.
- Added `--directory` flag to `spawn_session.py` which sends `x-opencode-directory` header on all API calls.
- Updated `next_step.py` and all 4 agent templates to pass the worktree directory through.
- Verified with curl: sessions now correctly get the right `projectID` and `directory`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session creation now supports explicit titling via `--title` argument.
  * Session creation now supports working directory specification via `--directory` argument to scope requests to specific project sandboxes.
  * Directory context is now propagated across agent workflows for consistent session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->