### PR TITLE
feat: streamline finish-task phase (#157)

### DIFF
--- a/_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl
+++ b/_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl
@@ -37,7 +37,7 @@ permission:
 Read `_qsprocess/skills/finish-task.md` (or `finish-story.md`) for the
 merge checklist and cleanup sequence.
 
-Note: the phase protocol below supersedes the instructions in finish-story.md. Follow the steps below, not the older skill file.
+> **Note**: the phase protocol below supersedes the instructions in finish-story.md. Follow the steps below, not the older skill file.
 
 ## Phase protocol
 
@@ -57,6 +57,9 @@ gh pr checks {{PR_NUMBER}}
 
 If checks are failing, report to the user and STOP. Do not attempt merge.
 
+If `gh pr checks` exits non-zero but reports no checks found (empty
+output or "no required checks"), treat this as passing.
+
 If checks pass (or no required checks are configured), ask the user
 for explicit **"merge"** authorization before proceeding.
 
@@ -67,7 +70,9 @@ gh pr merge {{PR_NUMBER}} --merge
 ```
 
 If merge fails, report the error to the user and proceed to step 3
-with non-force cleanup.
+with non-force cleanup. However, if `gh pr merge` reports the PR is
+already merged, treat this as a successful merge for cleanup purposes
+(use `--force`).
 
 ### 3. Clean up
 
@@ -105,7 +110,13 @@ Parse the JSON output:
   with chosen flag.
 - `"status": "error"` — report error to user.
 
+If `worktree_remove_error` is present in the JSON output, report it as
+a warning (cleanup succeeded via fallback but git worktree state may be
+stale).
+
 #### 3c. Final message
+
+If merge **succeeded** (including already-merged):
 
 ```
 Task #{{ISSUE}} is merged; worktree removed.
@@ -113,10 +124,17 @@ Task #{{ISSUE}} is merged; worktree removed.
 If you want to cut a release, run `/release` from the main checkout.
 ```
 
+If merge **failed or was not attempted**:
+
+```
+PR #{{PR_NUMBER}} was NOT merged. Worktree removed — branch may still exist on remote.
+```
+
 ## Hard rules
 
 - No merge without explicit user authorization.
-- Auto-force worktree cleanup after successful merge (code is safely on main). Only consult the user about cleanup if merge failed.
+- Auto-force worktree cleanup after successful merge.
+- Only consult the user about cleanup if merge failed.
 - Do NOT auto-chain to release — always ask.
 - Do NOT edit source code or tests in this phase. Your edit scope is
   denied for all paths.

--- a/_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl
+++ b/_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl
@@ -1,9 +1,9 @@
 ---
 description: >-
-  Per-task finish-task agent for QS-{{ISSUE}} / PR #{{PR_NUMBER}}. Runs
-  the final quality gate, merges the PR with explicit user authorization,
-  cleans up the worktree (agents + unregister + delete). Tells the user
-  to run `/release` separately if a release is warranted.
+  Per-task finish-task agent for QS-{{ISSUE}} / PR #{{PR_NUMBER}}. Verifies
+  CI status, merges the PR with explicit user authorization, cleans up
+  the remote branch and worktree. Tells the user to run `/release`
+  separately if a release is warranted.
 mode: primary
 color: "#EC4899"
 # model: github-copilot/claude-sonnet-4.5  # uncomment to override project default
@@ -16,10 +16,6 @@ permission:
     "gh pr view *": allow
     "gh pr checks *": allow
     "gh pr merge *": ask
-    "python scripts/qs/quality_gate.py*": allow
-    "source venv/bin/activate*": allow
-    "pytest*": allow
-    "ruff *": allow
     "python scripts/qs_opencode/cleanup_worktree.py *": allow
   webfetch: deny
 ---
@@ -41,41 +37,61 @@ permission:
 Read `_qsprocess/skills/finish-task.md` (or `finish-story.md`) for the
 merge checklist and cleanup sequence.
 
+Note: the phase protocol below supersedes the instructions in finish-story.md. Follow the steps below, not the older skill file.
+
 ## Phase protocol
 
-### 1. Final quality gate on PR head
+### 1. Pre-merge check
+
+Show the PR summary:
 
 ```bash
-git fetch origin
-git checkout {{BRANCH}}
-git pull
-{{QUALITY_GATE_CMD}}
+gh pr view {{PR_NUMBER}}
 ```
 
-Must be green. Also check:
+Verify CI status:
 
 ```bash
 gh pr checks {{PR_NUMBER}}
 ```
 
-All required checks must be passing on the PR.
+If checks are failing, report to the user and STOP. Do not attempt merge.
 
-### 2. Merge authorization
+If checks pass (or no required checks are configured), ask the user
+for explicit **"merge"** authorization before proceeding.
 
-Show the PR summary and final quality-gate result. Wait for explicit
-**"merge"** from the user before running:
+### 2. Merge
 
 ```bash
-gh pr merge {{PR_NUMBER}} --merge --delete-branch
+gh pr merge {{PR_NUMBER}} --merge
 ```
 
-(Or `--squash` / `--rebase` per the project's convention — confirm with
-the user if the story file doesn't specify.)
+If merge fails, report the error to the user and proceed to step 3
+with non-force cleanup.
 
-### 3. Clean up worktree
+### 3. Clean up
 
-Run the cleanup script which handles agent file removal, git worktree
-un-registration, and physical directory deletion in one step:
+#### 3a. Delete remote branch
+
+```bash
+git push origin --delete {{BRANCH}}
+```
+
+Ignore errors (branch may already be deleted by GitHub).
+
+#### 3b. Remove worktree
+
+If merge **succeeded**, force-cleanup (code is safely on main):
+
+```bash
+python scripts/qs_opencode/cleanup_worktree.py \
+    --work-dir "{{WORK_DIR}}" \
+    --issue {{ISSUE}} \
+    --force
+```
+
+If merge **failed or was not attempted**, run without `--force` and
+present the user with options from the JSON output:
 
 ```bash
 python scripts/qs_opencode/cleanup_worktree.py \
@@ -84,16 +100,12 @@ python scripts/qs_opencode/cleanup_worktree.py \
 ```
 
 Parse the JSON output:
-- If `"status": "removed"` — cleanup succeeded, proceed to step 4.
-- If `"status": "action_required"` — present the options to the user:
-  - `--force`: delete everything, lose uncommitted/unpushed changes
-  - `--push-first`: push current branch first, then delete
-  Re-invoke with the chosen flag.
-- If `"status": "error"` — report the error to the user.
+- `"status": "removed"` — cleanup succeeded.
+- `"status": "action_required"` — present options to user and re-invoke
+  with chosen flag.
+- `"status": "error"` — report error to user.
 
-### 4. Final message
-
-Tell the user:
+#### 3c. Final message
 
 ```
 Task #{{ISSUE}} is merged; worktree removed.
@@ -101,13 +113,10 @@ Task #{{ISSUE}} is merged; worktree removed.
 If you want to cut a release, run `/release` from the main checkout.
 ```
 
-Then stop. Release is a separate static agent (`qs-release`) invoked via
-`/release` — it is not part of the per-task pipeline.
-
 ## Hard rules
 
 - No merge without explicit user authorization.
-- No force-remove of worktree without explicit user authorization.
+- Auto-force worktree cleanup after successful merge (code is safely on main). Only consult the user about cleanup if merge failed.
 - Do NOT auto-chain to release — always ask.
 - Do NOT edit source code or tests in this phase. Your edit scope is
   denied for all paths.

--- a/_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl
+++ b/_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl
@@ -49,16 +49,23 @@ Show the PR summary:
 gh pr view {{PR_NUMBER}}
 ```
 
+If `gh pr view` shows the PR is already merged, skip the merge
+authorization and `gh pr merge` step — proceed directly to step 3 with
+force cleanup.
+
 Verify CI status:
 
 ```bash
 gh pr checks {{PR_NUMBER}}
 ```
 
-If checks are failing, report to the user and STOP. Do not attempt merge.
-
-If `gh pr checks` exits non-zero but reports no checks found (empty
-output or "no required checks"), treat this as passing.
+Parse the output of `gh pr checks`:
+- If **all checks pass** → proceed.
+- If any check is **pending** (still in progress) → advise the user to
+  wait and re-run rather than reporting failure.
+- If any check **failed** → report to the user and STOP. Do not attempt
+  merge.
+- If **no checks are listed** (empty output) → treat as passing.
 
 If checks pass (or no required checks are configured), ask the user
 for explicit **"merge"** authorization before proceeding.
@@ -72,11 +79,17 @@ gh pr merge {{PR_NUMBER}} --merge
 If merge fails, report the error to the user and proceed to step 3
 with non-force cleanup. However, if `gh pr merge` reports the PR is
 already merged, treat this as a successful merge for cleanup purposes
-(use `--force`).
+(i.e., use `--force` with the cleanup script in step 3b).
 
 ### 3. Clean up
 
 #### 3a. Delete remote branch
+
+**Safety check**: if `{{BRANCH}}` is `main` or `master`, do NOT delete
+it — report an error and STOP.
+
+Only delete the remote branch if merge **succeeded** (including
+already-merged). If merge **failed**, skip this step.
 
 ```bash
 git push origin --delete {{BRANCH}}
@@ -110,9 +123,9 @@ Parse the JSON output:
   with chosen flag.
 - `"status": "error"` — report error to user.
 
-If `worktree_remove_error` is present in the JSON output, report it as
-a warning (cleanup succeeded via fallback but git worktree state may be
-stale).
+For **both** force and non-force paths: if `worktree_remove_error` is
+present in the JSON output, report it as a warning (cleanup succeeded
+via fallback but git worktree state may be stale).
 
 #### 3c. Final message
 

--- a/_qsprocess_opencode/stories/QS-157.story.md
+++ b/_qsprocess_opencode/stories/QS-157.story.md
@@ -212,4 +212,4 @@ so that finishing a task is fast, reliable, and doesn't require unnecessary user
 
 ### Known risks accepted:
 - If review-task phase regresses and stops verifying CI, finish-task's `gh pr checks` is the last safety net (but not a full quality gate)
-- `{{QUALITY_GATE_CMD}}` placeholder will be passed but unused by renderer — confirmed safe (renderer only fails on undefined, not unused)
+- `{{QUALITY_GATE_CMD}}` placeholder is no longer referenced in the template. Render calls that pass it via `--extra` will succeed (renderer ignores extra variables).

--- a/_qsprocess_opencode/stories/QS-157.story.md
+++ b/_qsprocess_opencode/stories/QS-157.story.md
@@ -1,0 +1,215 @@
+# Story QS-157: Streamline finish-task phase
+
+Status: ready-for-dev
+Issue: 157
+Branch: QS_157
+
+## Story
+
+As a developer using the OpenCode workflow,
+I want the finish-task phase to only perform essential steps (merge + branch cleanup + worktree cleanup),
+so that finishing a task is fast, reliable, and doesn't require unnecessary user interaction.
+
+## Acceptance Criteria
+
+1. Given the finish-task agent template is rendered for a task,
+   When examining the phase protocol,
+   Then there is NO quality gate step (quality gate already ran in implement-task and was verified in review-task).
+
+2. Given the finish-task agent template is rendered for a task,
+   When examining the merge command,
+   Then `gh pr merge` does NOT include `--delete-branch` (local branch cleanup is handled by worktree removal; remote branch is deleted explicitly in a separate step).
+
+3. Given the finish-task agent template is rendered for a task,
+   When examining the phase protocol,
+   Then there is NO `git fetch/checkout/pull` dance (the agent is already on the correct branch in the worktree).
+
+4. Given the finish-task agent template is rendered for a task,
+   When examining the phase protocol,
+   Then there is a lightweight `gh pr checks {{PR_NUMBER}}` verification before merge (fast sanity check, not a full quality gate re-run).
+
+5. Given a PR has been successfully merged,
+   When the remote branch cleanup runs,
+   Then the remote branch is explicitly deleted via `git push origin --delete {{BRANCH}}` (not relying on GitHub auto-delete setting or `--delete-branch` flag).
+
+6. Given a PR has been successfully merged,
+   When the worktree cleanup step runs,
+   Then the cleanup script is called with `--force` directly (no safety check dance — the code is already on main).
+
+7. Given a PR merge fails or was not attempted,
+   When the cleanup step runs,
+   Then the cleanup script is called WITHOUT `--force` and the user is consulted about options.
+
+8. Given the finish-task template frontmatter permissions,
+   When examining the permission block,
+   Then quality-gate-related permissions (`python scripts/qs/quality_gate.py*`, `source venv/bin/activate*`, `pytest*`, `ruff *`) are removed since they're no longer needed.
+
+9. Given the finish-task template frontmatter description,
+   When examining the description,
+   Then it no longer mentions "final quality gate" since that step was removed.
+
+10. Given the Authoritative protocol section,
+    When the agent reads it,
+    Then it contains a note that the phase protocol below supersedes `finish-story.md` instructions.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Update template frontmatter (AC: #8, #9)
+  - [ ] Remove these permission entries:
+    - `"python scripts/qs/quality_gate.py*": allow`
+    - `"source venv/bin/activate*": allow`
+    - `"pytest*": allow`
+    - `"ruff *": allow`
+  - [ ] Keep these permission entries:
+    - `"gh pr checks *": allow` (still used for pre-merge sanity check)
+    - `"gh pr view *": allow`
+    - `"gh pr merge *": ask`
+    - `"git *": allow`
+    - `"python scripts/qs_opencode/cleanup_worktree.py *": allow`
+  - [ ] Update description from:
+    `Per-task finish-task agent for QS-{{ISSUE}} / PR #{{PR_NUMBER}}. Runs the final quality gate, merges the PR with explicit user authorization, cleans up the worktree (agents + unregister + delete). Tells the user to run /release separately if a release is warranted.`
+    to:
+    `Per-task finish-task agent for QS-{{ISSUE}} / PR #{{PR_NUMBER}}. Verifies CI status, merges the PR with explicit user authorization, cleans up the remote branch and worktree. Tells the user to run /release separately if a release is warranted.`
+
+- [ ] Task 2: Update Authoritative protocol section (AC: #10)
+  - [ ] Add after the existing text: `Note: the phase protocol below supersedes the instructions in finish-story.md. Follow the steps below, not the older skill file.`
+
+- [ ] Task 3: Replace the entire Phase protocol section (AC: #1, #2, #3, #4, #5, #6, #7)
+  - [ ] Remove Step 1 "Final quality gate on PR head" entirely (the `git fetch/checkout/pull` + `{{QUALITY_GATE_CMD}}` block)
+  - [ ] New Step 1 "Pre-merge check" — show PR summary and run `gh pr checks {{PR_NUMBER}}`:
+    ```markdown
+    ### 1. Pre-merge check
+
+    Show the PR summary:
+
+    ```bash
+    gh pr view {{PR_NUMBER}}
+    ```
+
+    Verify CI status:
+
+    ```bash
+    gh pr checks {{PR_NUMBER}}
+    ```
+
+    If checks are failing, report to the user and STOP. Do not attempt merge.
+
+    If checks pass (or no required checks are configured), ask the user
+    for explicit **"merge"** authorization before proceeding.
+    ```
+  - [ ] New Step 2 "Merge" — `gh pr merge {{PR_NUMBER}} --merge` (no `--delete-branch`, no squash/rebase parenthetical):
+    ```markdown
+    ### 2. Merge
+
+    ```bash
+    gh pr merge {{PR_NUMBER}} --merge
+    ```
+
+    If merge fails, report the error to the user and proceed to step 3
+    with non-force cleanup.
+    ```
+  - [ ] New Step 3 "Clean up" — three sub-steps: delete remote branch, force-cleanup worktree (or non-force on merge failure), final message:
+    ```markdown
+    ### 3. Clean up
+
+    #### 3a. Delete remote branch
+
+    ```bash
+    git push origin --delete {{BRANCH}}
+    ```
+
+    Ignore errors (branch may already be deleted by GitHub).
+
+    #### 3b. Remove worktree
+
+    If merge **succeeded**, force-cleanup (code is safely on main):
+
+    ```bash
+    python scripts/qs_opencode/cleanup_worktree.py \
+        --work-dir "{{WORK_DIR}}" \
+        --issue {{ISSUE}} \
+        --force
+    ```
+
+    If merge **failed or was not attempted**, run without `--force` and
+    present the user with options from the JSON output:
+
+    ```bash
+    python scripts/qs_opencode/cleanup_worktree.py \
+        --work-dir "{{WORK_DIR}}" \
+        --issue {{ISSUE}}
+    ```
+
+    Parse the JSON output:
+    - `"status": "removed"` — cleanup succeeded.
+    - `"status": "action_required"` — present options to user and re-invoke
+      with chosen flag.
+    - `"status": "error"` — report error to user.
+
+    #### 3c. Final message
+
+    ```
+    Task #{{ISSUE}} is merged; worktree removed.
+
+    If you want to cut a release, run `/release` from the main checkout.
+    ```
+    ```
+
+- [ ] Task 4: Update hard rules section
+  - [ ] Remove: `- No force-remove of worktree without explicit user authorization.`
+  - [ ] Add: `- Auto-force worktree cleanup after successful merge (code is safely on main). Only consult the user about cleanup if merge failed.`
+  - [ ] Keep all other hard rules unchanged.
+
+## Dev Notes
+
+### Architecture constraints
+- ONLY modify `_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl`
+- Do NOT touch `scripts/qs_opencode/cleanup_worktree.py` — script is correct, just called differently
+- Do NOT touch anything under `_qsprocess/`, `scripts/qs/`, `.claude/`, `CLAUDE.md`
+- The Claude Code `finish_story.py` already uses this pattern: merge without `--delete-branch`, then explicit `git push origin --delete branch`
+
+### Key observations from real usage (QS-155 finish)
+- `gh pr merge --delete-branch` fails with `fatal: 'main' is already used by worktree` because git tries to checkout main locally to delete the feature branch, but main is used by another worktree
+- Quality gate re-run is pure overhead — implement-task and review-task already verified it
+- Cleanup script correctly detects untracked files but template makes the agent ask about them even after successful merge, when they're irrelevant
+
+### Remote branch deletion
+- The repo does NOT have "Automatically delete head branches" enabled (`delete_branch_on_merge: NOT SET`)
+- Therefore remote branch deletion MUST be explicit — cannot rely on GitHub auto-delete
+- `git push origin --delete {{BRANCH}}` after merge handles this
+- Errors should be ignored (branch may already be gone if GitHub setting changes later)
+
+### Cleanup failure handling
+- If `cleanup_worktree.py --force` fails (e.g., permission errors, NFS locks), report the error to the user
+- The `"status": "error"` JSON response handles this case — agent should present the error message
+
+### Test requirements
+- No automated tests needed (template-only change)
+- Manual verification: render the template with `render_agent.py` and inspect output
+- Verify: no `{{QUALITY_GATE_CMD}}` reference, no `--delete-branch`, `--force` in correct conditional position
+
+### References
+- Screenshot of QS-155 finish-task showing all three failure modes
+- `scripts/qs/finish_story.py` lines 50-85 — Claude Code version pattern
+- `scripts/qs_opencode/cleanup_worktree.py` — cleanup script (unchanged)
+
+## Adversarial Review Notes
+
+**Reviewers:** Critic, Concrete Planner, Dev Proxy, Scope Guardian
+**Rounds:** 1
+
+### Key findings incorporated:
+- Remote branch deletion must be explicit (`git push origin --delete`) — repo has no auto-delete setting (Critic, Dev Proxy, Scope Guardian)
+- Keep `gh pr checks` as lightweight pre-merge sanity check — removing it was unjustified (Critic, Scope Guardian)
+- Add "supersedes finish-story.md" note to avoid contradictory instructions (Dev Proxy)
+- Provide explicit replacement template text for all tasks (Concrete Planner)
+- Add cleanup failure handling path via `"status": "error"` JSON (Critic)
+
+### Decisions made:
+- Keep `gh pr checks` permission and step — Rationale: fast, provides meaningful safety net, and its removal wasn't motivated by the issue
+- Auto-force cleanup after merge without user confirmation — Rationale: merge authorization implicitly covers cleanup; code is safely on main
+- Ignore `git push origin --delete` errors — Rationale: branch may already be deleted; this is a best-effort cleanup
+
+### Known risks accepted:
+- If review-task phase regresses and stops verifying CI, finish-task's `gh pr checks` is the last safety net (but not a full quality gate)
+- `{{QUALITY_GATE_CMD}}` placeholder will be passed but unused by renderer — confirmed safe (renderer only fails on undefined, not unused)


### PR DESCRIPTION
## Summary

Closes #157

- Remove redundant quality gate re-run from finish-task (already verified in implement-task + review-task)
- Fix `--delete-branch` causing worktree conflicts by using explicit `git push origin --delete` instead
- Auto-force worktree cleanup after successful merge (code is safely on main)
- Add lightweight `gh pr checks` as pre-merge sanity check

## Quality Checklist

- [x] Tests pass: `pytest _qsprocess_opencode/tests/ -v` — 65 passed
- [x] Ruff check: clean
- [x] Ruff format: clean
- [x] All 10 acceptance criteria verified via automated grep checks

## Risk Assessment

- **Surfaces touched**: `_qsprocess_opencode/agent_templates/qs-finish-task.md.tmpl` only
- **Blast radius**: Only affects future finish-task agent renders — no runtime code changed
- **Rollback plan**: Revert single commit