### PR TITLE
fix: drop force=True from periodic amperage ping (#165)

### DIFF
--- a/_qsprocess_opencode/stories/QS-165.story.md
+++ b/_qsprocess_opencode/stories/QS-165.story.md
@@ -1,0 +1,95 @@
+# QS-165: Car charger goes to zero on off way too much, and is not respecting hysteresis
+
+## Story
+
+As a Quiet Solar user with an EV charger,
+I want the periodic amperage ping to respect the equality guard,
+So that my car doesn't pause charging every 42-84 seconds due to redundant SetChargingProfile commands.
+
+## Root Cause
+
+The periodic ping at `_ensure_correct_state` (method in `QSChargerGeneric`) calls `set_charging_current` with `force=True` every 42-84 seconds. This bypasses the equality guard at `set_charging_current` (signature: `async def set_charging_current(self, current, time, force=False, blocking=False)`), which checks `if force or self.get_charging_current() != current` before calling `low_level_set_charging_current`. The result is redundant OCPP `SetChargingProfile` commands even when the wallbox already has the correct value. For certain EV/wallbox combos (e.g., Twingo), each `SetChargingProfile` triggers a charge pause of 30s-2min, creating a positive feedback loop with dampening pollution.
+
+## Acceptance Criteria
+
+### AC-1: Periodic ping respects equality guard
+Given a charger in steady-state with reported amps matching the expected value
+When the periodic ping fires (duration_check_s elapsed since last_ping_time_success)
+Then `set_charging_current` is called WITHOUT `force=True`
+And `low_level_set_charging_current` is NOT invoked (equality guard skips it)
+
+### AC-2: Wallbox drift still corrected
+Given a charger where the wallbox drifted (reported amps != expected)
+When `_ensure_correct_state` runs
+Then `set_charging_current` fires normally via the mismatch branch
+And the drift is corrected
+(Existing test coverage: `test_amps_mismatch_not_ok_to_launch` and the mismatch launch test in `TestEnsureCorrectStateCharger`)
+
+### AC-3: Ping bookkeeping preserved
+Given a charger in steady-state
+When the periodic ping fires
+Then `last_ping_time_success` is still updated to current time
+(Line 4518: `self._expected_amperage.last_ping_time_success = time` is preserved unchanged)
+
+## Tasks
+
+### Task 1: Drop `force=True` from periodic ping (AC-1, AC-3)
+- File: `custom_components/quiet_solar/ha_model/charger.py`
+- Method: `_ensure_correct_state`, in the steady-state branch where `charging_current_amp == self._expected_amperage.value`
+- Change the `set_charging_current` call to remove `force=True` (defaults to `False`)
+- Update the debug log message to use lazy `%s` format:
+  ```python
+  _LOGGER.debug(
+      "Ensure State:%s amperage ping (no-op if %sA == %sA)",
+      self.name,
+      charging_current_amp,
+      self._expected_amperage.value,
+  )
+  await self.set_charging_current(
+      current=self._expected_amperage.value, time=time
+  )
+  ```
+- Line 4518 (`self._expected_amperage.last_ping_time_success = time`) is preserved unchanged
+
+### Task 2: Rename and enhance test (AC-1)
+- File: `tests/test_charger_coverage_deep.py`
+- Class: `TestEnsureCorrectStateCharger`
+- Rename `test_amps_match_but_reset_needed` → `test_amps_match_ping_called_but_no_low_level_resend`
+- The test currently mocks `set_charging_current` — to verify the equality guard works through the ping path, either:
+  - (a) Keep `set_charging_current` as real method, mock only `low_level_set_charging_current`, and assert it's NOT called, OR
+  - (b) Check `set_charging_current.call_args` to verify `force=True` is absent
+- The assertion `ch.set_charging_current.assert_called()` remains valid (the wrapper is still called)
+- Add complementary assertion that `low_level_set_charging_current` is NOT called
+
+### Task 3: Quality gate
+- Run `python scripts/qs/quality_gate.py` — pytest 100% coverage, ruff, mypy, translations
+- Verify zero failures
+
+## Dev Notes
+
+- **Equality guard location**: `set_charging_current` method — `if force or self.get_charging_current() != current:` — `force` defaults to `False`
+- **Why force=True existed**: Paranoia about wallboxes losing their ChargePointMaxProfile after idle. User confirmed no known firmware has this issue. The `update_data_request` call 3s earlier already refreshes `Current.Offered` via `TriggerMessage:MeterValues`, so drift is detected and corrected via the mismatch branch on the next tick.
+- **Why redundant SetChargingProfile causes car to pause**: Certain EV/wallbox combos (Twingo + OCPP wallbox) treat every `SetChargingProfile` as a new charging profile negotiation, causing the EV to pause charging for 30s-2min while it renegotiates. This is an EV-side behavior, not a protocol error.
+- **Deferred work**: P2 (bump `CHARGER_ADAPTATION_WINDOW_S` from 45s to ~60s) and P3 (dampening write guard) are deferred until field results from P1 are available. P2 would close the 49s ping-pong reversal cadence. P3 would prevent dampening table pollution during car pauses.
+- **Architecture**: No changes to constants, no new imports, no boundary violations. Pure behavioral fix in `ha_model/`.
+
+## Adversarial Review Notes
+
+**Reviewers:** Critic, Concrete Planner, Dev Proxy, Scope Guardian
+**Rounds:** 1
+
+### Key findings incorporated:
+- Log message updated to use lazy `%s` format instead of f-string (Concrete Planner, Dev Proxy)
+- Explicitly stated line 4518 (ping bookkeeping) is preserved (Critic, Concrete Planner)
+- Fixed test class name reference to `TestEnsureCorrectStateCharger` (Concrete Planner)
+- Clarified test implementation approach for asserting `low_level_set_charging_current` not called (Concrete Planner)
+- Added root cause context explaining why redundant SetChargingProfile causes car to pause (Critic)
+- Referenced existing mismatch tests for AC-2 coverage (Critic)
+- Documented original intent of `force=True` and why it's safe to remove (Critic)
+
+### Decisions made:
+- Test rename kept as requested by user despite Scope Guardian suggesting it's cosmetic
+- Single round of review sufficient — all findings were auto-incorporable improvements, no critical blockers
+
+### Known risks accepted:
+- P2/P3 deferred: the 49s ping-pong reversal cadence and dampening pollution may still occur with real budget changes, but at much lower frequency (8 real changes vs 18 total sends in the log sample)

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -4510,11 +4510,12 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                     if probe_only is False:
                         if (time - self._expected_amperage.last_ping_time_success).total_seconds() > duration_check_s:
                             _LOGGER.debug(
-                                f"Ensure State:{self.name} set amperage already set to {charging_current_amp}A ... but reset it"
+                                "Ensure State:%s amperage ping (no-op if %sA == %sA)",
+                                self.name,
+                                charging_current_amp,
+                                self._expected_amperage.value,
                             )
-                            await self.set_charging_current(
-                                current=self._expected_amperage.value, time=time, force=True
-                            )
+                            await self.set_charging_current(current=self._expected_amperage.value, time=time)
                             self._expected_amperage.last_ping_time_success = time
                 else:
                     one_bad = True

--- a/tests/test_charger_coverage_deep.py
+++ b/tests/test_charger_coverage_deep.py
@@ -3345,8 +3345,10 @@ class TestEnsureCorrectStateCharger:
         ch.update_data_request.assert_called()
 
     @pytest.mark.asyncio
-    async def test_amps_match_but_reset_needed(self):
-        """Lines 3709-3712: amps match but ping timeout -> re-sets charging current."""
+    async def test_amps_match_ping_called_but_no_low_level_resend(self):
+        """Amps match but ping timeout -> set_charging_current called WITHOUT force,
+        so low_level_set_charging_current is NOT invoked (equality guard skips it).
+        """
         _, _, ch, _, now = self._setup()
         ch.is_charge_enabled = MagicMock(return_value=True)
         ch.is_charge_disabled = MagicMock(return_value=False)
@@ -3355,8 +3357,13 @@ class TestEnsureCorrectStateCharger:
         very_long_ago = now - timedelta(seconds=2 * STATE_CMD_TIME_BETWEEN_RETRY_S + 10)
         ch._expected_amperage.first_time_success = very_long_ago
         ch._expected_amperage.last_ping_time_success = very_long_ago
+        # Use real set_charging_current so the equality guard runs
+        ch.set_charging_current = ch.__class__.set_charging_current.__get__(ch)
+        ch.low_level_set_charging_current = AsyncMock(return_value=False)
         await ch._ensure_correct_state(now)
-        ch.set_charging_current.assert_called()
+        # The wrapper is called (ping fires), but low-level is NOT called
+        # because amps match and force is not set
+        ch.low_level_set_charging_current.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_amps_mismatch_not_ok_to_launch(self):


### PR DESCRIPTION
## Summary

- Removes `force=True` from the periodic amperage ping in `_ensure_correct_state`, so the equality guard in `set_charging_current` prevents redundant `SetChargingProfile` OCPP commands when amps already match.
- Fixes EV charging pauses (30s-2min) on certain EV/wallbox combos (e.g. Twingo) caused by redundant profile renegotiations every 42-84s.
- Updates debug log to lazy `%s` format per project conventions.

Closes #165

## Quality Checklist

- [x] Coverage: 100% (4824 tests passed)
- [x] Ruff format: PASS
- [x] Ruff lint: PASS
- [x] mypy: PASS
- [x] Translations: PASS

## Risk Assessment

- **Surfaces touched**: `ha_model/charger.py` (1 line change + log format), `tests/test_charger_coverage_deep.py` (test rename + enhanced assertion)
- **Blast radius**: Minimal — only affects the periodic ping path when amps already match. Mismatch correction and all other charger logic unchanged.
- **Rollback plan**: Revert single commit, re-add `force=True`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed periodic amperage health checks that were unnecessarily triggering charging profile updates, which could pause EV charging. The system now skips low-level profile writes when reported current already matches expected values during these routine checks.

* **Tests**
  * Enhanced test coverage to verify that routine amperage pings do not trigger redundant charging profile writes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/169)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->