### PR TITLE
QS-175: launch phase agents as interactive claude --agent sessions

### DIFF
--- a/.claude/agents/qs-create-plan.md
+++ b/.claude/agents/qs-create-plan.md
@@ -60,7 +60,13 @@ noted, an additional artifact):
   project-context.md.
 - `qs-plan-scope-guardian` — plan + the issue body.
 
-See [docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md)
+This step is the orchestrator-vs-sub-agent split in action: **I'm an
+interactive orchestrator (the user is talking to me right now), but the
+4 plan reviewers below are non-interactive `Agent`-tool fan-out**. See
+[docs/workflow/overview.md](../../docs/workflow/overview.md) section
+"Orchestrators are interactive sessions; sub-agents are parallel
+fan-out" for the rationale and
+[docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md)
 for the lens of each reviewer. Each returns a structured findings list
 with categories `critical` / `redesign` / `improve` / `clarify`.
 
@@ -94,12 +100,31 @@ Inspect the file paths your task breakdown will touch:
 
 ### 8. Tell the user the next command
 
+Build the launcher payload for the next phase so the user has a copy/paste
+command to open a fresh interactive `claude --agent` session:
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "{{NEXT_PHASE}}" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}"
+```
+
+Parse the JSON; capture `new_context`. Then print both blocks:
+
 ```text
 ✅ Story written: docs/stories/QS-{{issue}}.story.md
 ✅ Committed and pushed to {{branch}}.
 
-Next: type the implement command in this session.
-  → /{{NEXT_PHASE}}
+Next phase: {{NEXT_PHASE}}.
+
+Preferred (opens a fresh interactive `claude --agent qs-{{NEXT_PHASE}}` session):
+  {{new_context}}
+
+Fallback (stay in this session, degraded one-shot UX via the Agent tool —
+kept for Claude Desktop and any chat without a CLI launcher):
+  /{{NEXT_PHASE}}
 ```
 
 ## Hard rules

--- a/.claude/agents/qs-finish-task.md
+++ b/.claude/agents/qs-finish-task.md
@@ -142,12 +142,18 @@ The standard merge flow.
    ✅ Remote branch {{branch}} deleted.
    ✅ Worktree removed.
 
-   Production code was touched → run /release from the main checkout
-   when you're ready to ship a release.
+   Production code was touched → from the main checkout, run /release
+   (or `claude --agent qs-release` for the interactive path) when
+   you're ready to ship a release.
    ```
    (Skip the release suggestion when no `custom_components/quiet_solar/`
    files were in the diff — check `gh pr diff {{pr_number}} --name-only`
    or just inspect the file list.)
+
+   **Why no launcher payload here**: `/release` runs on the main
+   checkout, not the worktree (which is now gone). We intentionally
+   don't build a launcher with `--next-cmd release` — see QS-175 OUT OF
+   SCOPE. The user invokes release manually after switching workspaces.
 
 ## Hard rules
 

--- a/.claude/agents/qs-implement-setup-task.md
+++ b/.claude/agents/qs-implement-setup-task.md
@@ -82,13 +82,32 @@ empty directories.)
 
 ### 6. Tell the user the next command
 
+Build the launcher payload for `/review-task` so the user has a copy/paste
+command to open a fresh interactive `claude --agent qs-review-task` session:
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "review-task" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}"
+```
+
+Parse the JSON; capture `new_context`. Then print both blocks:
+
 ```text
 ✅ Implementation complete — quality gate passed.
 ✅ Committed and pushed to {{branch}}.
 ✅ PR #{{pr_number}} opened: {{pr_url}}
 
-Next: type in this session.
-  → /review-task
+Next phase: review-task.
+
+Preferred (opens a fresh interactive `claude --agent qs-review-task` session):
+  {{new_context}}
+
+Fallback (stay in this session, degraded one-shot UX via the Agent tool —
+kept for Claude Desktop and any chat without a CLI launcher):
+  /review-task
 ```
 
 ## Hard rules

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -87,13 +87,32 @@ workflow — no user confirmation needed for any of these three.
 
 ### 6. Tell the user the next command
 
+Build the launcher payload for `/review-task` so the user has a copy/paste
+command to open a fresh interactive `claude --agent qs-review-task` session:
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "review-task" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}"
+```
+
+Parse the JSON; capture `new_context`. Then print both blocks:
+
 ```text
 ✅ Implementation complete — quality gate passed.
 ✅ Committed and pushed to {{branch}}.
 ✅ PR #{{pr_number}} opened: {{pr_url}}
 
-Next: type in this session.
-  → /review-task
+Next phase: review-task.
+
+Preferred (opens a fresh interactive `claude --agent qs-review-task` session):
+  {{new_context}}
+
+Fallback (stay in this session, degraded one-shot UX via the Agent tool —
+kept for Claude Desktop and any chat without a CLI launcher):
+  /review-task
 ```
 
 ## Hard rules

--- a/.claude/agents/qs-review-task.md
+++ b/.claude/agents/qs-review-task.md
@@ -50,7 +50,14 @@ Agent invocations**:
 - `qs-review-acceptance-auditor` — pass PR number + `{{story_file}}`.
 - `qs-review-coderabbit` — pass PR number.
 
-See [docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md).
+This step is the orchestrator-vs-sub-agent split in action: **I'm an
+interactive orchestrator (the user is talking to me right now), but the
+4 reviewers below are non-interactive `Agent`-tool fan-out**. See
+[docs/workflow/overview.md](../../docs/workflow/overview.md) section
+"Orchestrators are interactive sessions; sub-agents are parallel
+fan-out" for the rationale and
+[docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md)
+for each reviewer's lens.
 
 ### 3. Consolidate findings
 
@@ -64,12 +71,30 @@ Deduplicate across reviewers (`file:line` + similar text → one entry).
 
 ### 4. Zero-findings fast path
 
-If there are no must-fix or should-fix findings, present:
+If there are no must-fix or should-fix findings, build the launcher
+payload for `/finish-task`:
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "finish-task" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}"
+```
+
+Parse the JSON; capture `new_context`. Then present both blocks:
 
 ```text
 ✅ Adversarial review complete. No blocking findings.
-Next: type in this session.
-  → /finish-task
+
+Next phase: finish-task.
+
+Preferred (opens a fresh interactive `claude --agent qs-finish-task` session):
+  {{new_context}}
+
+Fallback (stay in this session, degraded one-shot UX via the Agent tool —
+kept for Claude Desktop and any chat without a CLI launcher):
+  /finish-task
 ```
 
 Stop here.
@@ -133,16 +158,33 @@ git commit -m "QS-{{issue}}: review fix plan #NN"
 git push origin {{branch}}
 ```
 
-Then present a ready-to-copy prompt for the user:
+Then build the launcher payload for `/implement-task`:
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "implement-task" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}"
+```
+
+Parse the JSON; capture `new_context`. Then present both blocks:
 
 ```text
 ✅ Fix plan written: {{fix_plan_path}}
 ✅ Committed and pushed.
 
-Next: type in this session.
-  → /implement-task
+Next phase: implement-task.
 
-Then come back to this session and re-run /review-task to verify.
+Preferred (opens a fresh interactive `claude --agent qs-implement-task` session):
+  {{new_context}}
+
+Fallback (stay in this session, degraded one-shot UX via the Agent tool —
+kept for Claude Desktop and any chat without a CLI launcher):
+  /implement-task
+
+Then re-run /review-task (or open a fresh `claude --agent qs-review-task`
+session) to verify.
 ```
 
 ### 7. Re-review loop

--- a/.claude/agents/qs-setup-task.md
+++ b/.claude/agents/qs-setup-task.md
@@ -72,35 +72,38 @@ Capture `worktree_path`, `branch`, and the launcher payload
 ### 3. Tell the user what to do next
 
 The worktree already has `HEAD` on `QS_{{issue_number}}` (verified by
-`scripts/worktree-setup.sh`). Surface BOTH a CLI flow and a Claude
-Desktop flow, because the friction is different in each.
+`scripts/worktree-setup.sh`). Surface the launcher (preferred path — an
+interactive `claude --agent qs-create-plan` session) and the slash-command
+fallback (degraded one-shot UX, kept for Claude Desktop).
 
 ```text
 Task #{{issue_number}} set up.
   Worktree:  {{worktree_path}}
   Branch:    QS_{{issue_number}}  (HEAD already checked out)
 
-Pick whichever opens a new session for you:
+Next phase: create-plan.
 
-[CLI / terminal] copy-paste this:
+Preferred (opens a fresh interactive `claude --agent qs-create-plan` session):
   {{new_context}}
 
-[Claude Desktop] manually:
+Fallback (stay in this session, degraded one-shot UX via the Agent tool —
+kept for Claude Desktop and any chat without a CLI launcher):
+  {{same_context}}
+
+[Claude Desktop] no `--agent` equivalent exists on Desktop. Manual route:
   • New session → open folder → pick
         {{worktree_path}}
   • The worktree is already on QS_{{issue_number}}. If Desktop's
     auto-isolation spawns a `claude/...` sub-worktree, that sub-tree
     inherits HEAD, so you still land on QS_{{issue_number}}.
-
-Then in the new session type:
-  /create-plan
+  • Then type `/create-plan` in the new chat (the degraded path).
 ```
 
-If PyCharm options are present in the payload, mention them as
-alternatives after the two flows above.
+If `pycharm_context` is present in the payload, mention it as a bridge
+for IDE-embedded terminals (clipboard / AppleScript helpers).
 
 Do NOT attempt to spawn the next agent in this session — the ergonomic
-flow is one session per workspace.
+flow is one session per phase.
 
 ## Hard rules
 

--- a/.claude/agents/qs-setup-task.md
+++ b/.claude/agents/qs-setup-task.md
@@ -88,7 +88,7 @@ Preferred (opens a fresh interactive `claude --agent qs-create-plan` session):
 
 Fallback (stay in this session, degraded one-shot UX via the Agent tool —
 kept for Claude Desktop and any chat without a CLI launcher):
-  {{same_context}}
+  /create-plan
 
 [Claude Desktop] no `--agent` equivalent exists on Desktop. Manual route:
   • New session → open folder → pick

--- a/.claude/commands/create-plan.md
+++ b/.claude/commands/create-plan.md
@@ -2,6 +2,17 @@
 description: Draft the story artifact with acceptance criteria, run adversarial review with 4 parallel sub-agents, commit and push.
 ---
 
+> **Preferred entry**: open a fresh terminal in the worktree and run
+> `claude --agent qs-create-plan` (interactive session — you can answer
+> the persona's clarifying questions in step 2 of its protocol).
+>
+> **This slash command is the degraded fallback** — kept for Claude
+> Desktop and any chat without a CLI launcher. It spawns a one-shot
+> non-interactive `Agent`-tool sub-process; the persona runs to
+> completion and returns a final summary, and you cannot interject. This
+> is the broken-by-design UX that QS-175 mitigates — we keep the slash
+> command **only as a fallback**, not as the primary flow.
+
 Use the **qs-create-plan** subagent to handle this. The subagent will
 discover the current task context from the branch name (`QS_<N>`) and
 the GitHub issue.
@@ -12,7 +23,9 @@ Expected outcome:
 - 4-reviewer adversarial review run in parallel; findings triaged
   interactively.
 - Story committed and pushed.
-- Next-phase command printed (`/implement-task` or
+- Next-phase command printed: launcher form (`claude --agent
+  qs-implement-task` or `claude --agent qs-implement-setup-task`)
+  plus slash-command fallback (`/implement-task` or
   `/implement-setup-task`).
 
 User request:

--- a/.claude/commands/finish-task.md
+++ b/.claude/commands/finish-task.md
@@ -2,6 +2,18 @@
 description: Callable any time. If a PR exists, merge it (with auth) then clean up. Otherwise just clean up the worktree + remote branch.
 ---
 
+> **Preferred entry**: open a fresh terminal in the worktree and run
+> `claude --agent qs-finish-task` (interactive session — you can answer
+> "Ready to merge PR #N?" and authorize the force-delete prompts
+> mid-flight).
+>
+> **This slash command is the degraded fallback** — kept for Claude
+> Desktop and any chat without a CLI launcher. It spawns a one-shot
+> non-interactive `Agent`-tool sub-process; the persona runs to
+> completion and returns a final summary, and you cannot interject. This
+> is the broken-by-design UX that QS-175 mitigates — we keep the slash
+> command **only as a fallback**, not as the primary flow.
+
 Use the **qs-finish-task** subagent to handle this. The subagent
 discovers PR + branch + worktree from the current branch name and
 branches behavior on whether a PR exists.

--- a/.claude/commands/implement-setup-task.md
+++ b/.claude/commands/implement-setup-task.md
@@ -2,6 +2,18 @@
 description: TDD implementation for dev-environment changes (scripts/, .claude/, .cursor/, .opencode/, _qsprocess_opencode/, docs/, .github/, top-level config). Quality gate runs in dev-only fast path.
 ---
 
+> **Preferred entry**: open a fresh terminal in the worktree and run
+> `claude --agent qs-implement-setup-task` (interactive session — you
+> can answer "Ready to run the quality gate?" and drive the
+> implementation mid-flight).
+>
+> **This slash command is the degraded fallback** — kept for Claude
+> Desktop and any chat without a CLI launcher. It spawns a one-shot
+> non-interactive `Agent`-tool sub-process; the persona runs to
+> completion and returns a final summary, and you cannot interject. This
+> is the broken-by-design UX that QS-175 mitigates — we keep the slash
+> command **only as a fallback**, not as the primary flow.
+
 Use the **qs-implement-setup-task** subagent to handle this. The
 subagent discovers task context from the branch name.
 
@@ -10,7 +22,8 @@ Expected outcome:
 - `python scripts/qs/quality_gate.py` passes (dev-only fast path:
   modified test files only; ruff/mypy/coverage skipped).
 - Auto-committed, pushed, PR opened.
-- Next-phase command printed (`/review-task`).
+- Next-phase command printed: launcher form (`claude --agent
+  qs-review-task`) plus slash-command fallback (`/review-task`).
 
 User request:
 $ARGUMENTS

--- a/.claude/commands/implement-task.md
+++ b/.claude/commands/implement-task.md
@@ -2,6 +2,18 @@
 description: TDD implementation of the story under custom_components/quiet_solar/, pass full quality gate, open PR.
 ---
 
+> **Preferred entry**: open a fresh terminal in the worktree and run
+> `claude --agent qs-implement-task` (interactive session — you can
+> answer "Ready to run the quality gate?" and drive the implementation
+> mid-flight).
+>
+> **This slash command is the degraded fallback** — kept for Claude
+> Desktop and any chat without a CLI launcher. It spawns a one-shot
+> non-interactive `Agent`-tool sub-process; the persona runs to
+> completion and returns a final summary, and you cannot interject. This
+> is the broken-by-design UX that QS-175 mitigates — we keep the slash
+> command **only as a fallback**, not as the primary flow.
+
 Use the **qs-implement-task** subagent to handle this. The subagent
 discovers task context from the branch name.
 
@@ -10,7 +22,8 @@ Expected outcome:
 - `python scripts/qs/quality_gate.py` passes (pytest 100% cov + ruff +
   mypy + translations).
 - Auto-committed, pushed, PR opened.
-- Next-phase command printed (`/review-task`).
+- Next-phase command printed: launcher form (`claude --agent
+  qs-review-task`) plus slash-command fallback (`/review-task`).
 
 User request:
 $ARGUMENTS

--- a/.claude/commands/review-task.md
+++ b/.claude/commands/review-task.md
@@ -2,6 +2,17 @@
 description: Run adversarial review on the PR with 4 parallel reviewer sub-agents, drive interactive triage, generate a fix plan if needed.
 ---
 
+> **Preferred entry**: open a fresh terminal in the worktree and run
+> `claude --agent qs-review-task` (interactive session — you can drive
+> "fix all / skip all / one by one?" triage mid-flight).
+>
+> **This slash command is the degraded fallback** — kept for Claude
+> Desktop and any chat without a CLI launcher. It spawns a one-shot
+> non-interactive `Agent`-tool sub-process; the persona runs to
+> completion and returns a final summary, and you cannot interject. This
+> is the broken-by-design UX that QS-175 mitigates — we keep the slash
+> command **only as a fallback**, not as the primary flow.
+
 Use the **qs-review-task** subagent to handle this. The subagent
 discovers PR + story file from the branch name.
 
@@ -10,9 +21,11 @@ Expected outcome:
   edge-case-hunter, acceptance-auditor, coderabbit).
 - Findings consolidated and triaged interactively with the user.
 - If findings remain, a fix plan written to
-  `docs/stories/QS-<N>.story_review_fix_#NN.md` with
-  a ready-to-copy `/implement-task` prompt.
-- If clean, next-phase command printed (`/finish-task`).
+  `docs/stories/QS-<N>.story_review_fix_#NN.md`, plus the launcher form
+  (`claude --agent qs-implement-task`) and slash-command fallback
+  (`/implement-task`) for the user to apply it.
+- If clean, next-phase command printed: launcher form (`claude --agent
+  qs-finish-task`) plus slash-command fallback (`/finish-task`).
 
 User request:
 $ARGUMENTS

--- a/.claude/commands/setup-task.md
+++ b/.claude/commands/setup-task.md
@@ -2,6 +2,17 @@
 description: Create GitHub issue + feature branch QS_<N> + worktree, then print the launcher for the new session.
 ---
 
+> **Preferred entry**: open a fresh terminal in the main checkout and run
+> `claude --agent qs-setup-task` (interactive session — you can converse
+> with the persona mid-flight).
+>
+> **This slash command is the degraded fallback** — kept for Claude
+> Desktop and any chat without a CLI launcher. It spawns a one-shot
+> non-interactive `Agent`-tool sub-process; the persona runs to
+> completion and returns a final summary, and you cannot interject. This
+> is the broken-by-design UX that QS-175 mitigates — we keep the slash
+> command **only as a fallback**, not as the primary flow.
+
 Use the **qs-setup-task** subagent to handle this. Pass the user's full
 request verbatim as the task description.
 
@@ -10,8 +21,9 @@ Expected outcome:
 - Branch `QS_<N>` created from `origin/main`.
 - Worktree created at `../<repo>-worktrees/QS_<N>/` (unless
   `--no-worktree`).
-- Launcher command printed for the user to open a new session on the
-  worktree. The next phase is `/create-plan`.
+- Launcher command printed for the user to open a fresh interactive
+  `claude --agent qs-create-plan` session on the worktree (preferred),
+  with `/create-plan` as the slash-command fallback for Claude Desktop.
 
 User request:
 $ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,15 +7,22 @@ before doing substantive work.
 
 ## Commands
 
-| Command                  | Phase            | Where                  |
-| ------------------------ | ---------------- | ---------------------- |
-| `/setup-task`            | Create issue + branch + worktree | main checkout |
-| `/create-plan`           | Story + adversarial review       | worktree      |
-| `/implement-task`        | TDD product code → PR            | worktree      |
-| `/implement-setup-task`  | TDD dev-env code → PR            | worktree      |
-| `/review-task`           | 4-reviewer adversarial review    | worktree      |
-| `/finish-task`           | Merge PR + cleanup worktree      | worktree      |
-| `/release`               | Tag and ship                     | main checkout |
+Each phase runs as an interactive `claude --agent qs-<phase>` session
+(preferred — fresh terminal) or as a `/<phase>` slash command
+(fallback — degraded one-shot UX kept for Claude Desktop). See
+[docs/workflow/overview.md](docs/workflow/overview.md) section
+"Orchestrators are interactive sessions; sub-agents are parallel
+fan-out" for the rationale.
+
+| Phase                | Preferred (interactive)                      | Fallback (degraded)      | Where         |
+| -------------------- | -------------------------------------------- | ------------------------ | ------------- |
+| Setup task           | `claude --agent qs-setup-task`               | `/setup-task`            | main checkout |
+| Create plan          | `claude --agent qs-create-plan`              | `/create-plan`           | worktree      |
+| Implement (product)  | `claude --agent qs-implement-task`           | `/implement-task`        | worktree      |
+| Implement (dev-env)  | `claude --agent qs-implement-setup-task`     | `/implement-setup-task`  | worktree      |
+| Review task          | `claude --agent qs-review-task`              | `/review-task`           | worktree      |
+| Finish task          | `claude --agent qs-finish-task`              | `/finish-task`           | worktree      |
+| Release              | `claude --agent qs-release`                  | `/release`               | main checkout |
 
 Static agents live in [.claude/agents/](.claude/agents/); slash commands
 in [.claude/commands/](.claude/commands/). Agents discover task context

--- a/docs/stories/QS-175.story.md
+++ b/docs/stories/QS-175.story.md
@@ -1,0 +1,630 @@
+# QS-175: Refactor pipeline so phase agents launch as interactive sessions (`claude --agent`)
+
+## Story
+
+**As a** developer using the Quiet Solar pipeline from the Claude Code CLI
+**I want** each phase agent (create-plan, implement-task, review-task, …) to run as an interactive `claude --agent <name>` session whose system prompt IS the agent body
+**So that** I can converse with the agent mid-flight (ask clarifying questions, course-correct, supply context) instead of getting a one-shot non-interactive `Agent`-tool sub-process that only returns a final summary.
+
+## Root Cause
+
+Today the slash commands (`/setup-task`, `/create-plan`, `/implement-task`,
+`/implement-setup-task`, `/review-task`, `/finish-task`, `/release`) all
+delegate to their `qs-X` agent via the `Agent` tool. The `Agent` tool
+spawns a **non-interactive sub-process**: it runs to completion and
+returns one final summary; the user cannot interject. For per-phase agent
+personas that *want* the user mid-flight (e.g. `qs-create-plan` asks for
+clarifying questions in step 2, `qs-implement-task` asks "Ready to run
+the quality gate?" in step 4), this defeats the persona.
+
+Claude Code provides a direct fix: `claude --agent <name>` launches a
+new interactive session whose **system prompt is the agent body**
+(tools, model, persona inherited). Confirmed against
+`claude-code-guide`:
+
+- `--agent` accepts a bare name and resolves it against `.claude/agents/`
+  then `~/.claude/agents/`.
+- The flag replaces the default Claude Code system prompt for the
+  lifetime of the session.
+- The system prompt is immutable mid-session, so each phase runs in its
+  own session — one phase = one session.
+
+The right architecture is: **orchestrators are interactive
+`claude --agent` sessions; sub-agents (the 4 parallel plan/code
+reviewers) remain `Agent`-tool fan-out**, because non-interactive
+parallel workers is exactly what the `Agent` tool is good at.
+
+### Claude Desktop is a degraded path — by design
+
+We confirmed Claude Desktop has **no equivalent to `claude --agent`**:
+no URL scheme, no `--args` pass-through, no UI gesture to pre-load an
+agent persona for a new chat, and nothing on Anthropic's roadmap. The
+correct decision for QS-175 is to ship the **launcher command** as the
+primary path (CLI-first) and keep the **slash-command form as a
+degraded fallback** for Desktop users. We do NOT try to automate
+Desktop with AppleScript / clipboard tricks for this refactor — the
+existing `pycharm_context` clipboard helpers in `launchers/claude.py`
+already cover the "I can't paste into my IDE" friction; Desktop users
+can use that path or just type the slash command.
+
+## Acceptance Criteria
+
+### AC-1: Launcher payload format includes the interactive-agent invocation
+
+```gherkin
+Given the Claude Code launcher (scripts/qs/launchers/claude.py) builds
+  a payload for the next phase
+When --next-cmd specifies a known phase name (e.g. "create-plan")
+Then payload["new_context"] is a shell command of the form
+  `sh /tmp/qs_launch_<issue>.sh`
+And the generated script invokes `claude --agent qs-<phase>` with the
+  existing CLAUDE_LAUNCH_OPTS, in the target worktree
+And payload["same_context"] is the slash-command equivalent
+  (e.g. "/create-plan") preserved verbatim
+And payload["agent"] is the resolved agent name (e.g. "qs-create-plan")
+```
+
+### AC-2: `--next-cmd` accepts a phase name and validates it strictly
+
+```gherkin
+Given scripts/qs/next_step.py is invoked with --next-cmd
+When the value is one of the known phases
+  (setup-task, create-plan, implement-task, implement-setup-task,
+   review-task, finish-task, release)
+Then the launcher payload is emitted with `agent = "qs-<phase>"`
+And the slash form is derived as `/<phase>` for backward compat
+
+Given the same invocation
+When the value is anything else (unknown phase name, free text,
+  empty string)
+Then next_step.py raises ValueError with a message naming the
+  invalid value and listing the known phases
+And exits with non-zero status
+(No silent fallback. Free-form prompts get the separate --next-prompt arg.)
+```
+
+### AC-3: Phase orchestrator agents print BOTH the launcher and the slash fallback
+
+```gherkin
+Given a phase orchestrator agent (qs-setup-task, qs-create-plan,
+  qs-implement-task, qs-implement-setup-task, qs-review-task,
+  qs-finish-task) finishes its phase
+When it surfaces the next-phase handoff to the user
+Then it prints a two-block message:
+  1. The launcher command (a single `sh /tmp/qs_launch_<N>.sh` line
+     or, when crossing workspaces, the full payload's new_context)
+     labelled as the preferred path that opens a fresh interactive
+     session.
+  2. The slash-command fallback (`/<next-phase>`) labelled as the
+     degraded same-session path for users (notably Claude Desktop)
+     who can't launch a fresh CLI session.
+And no Desktop-specific automation is attempted beyond the existing
+  pycharm_context clipboard/AppleScript helpers.
+```
+
+### AC-4: Cursor launcher gets parity
+
+```gherkin
+Given scripts/qs/launchers/cursor.py builds a payload for the next phase
+When `cursor-agent` is on PATH and supports `--agent <name>`
+Then cli_context invokes `cursor-agent --workspace <wd> --agent qs-<phase>`
+  (with the same slash command surfaced as the in-chat fallback)
+
+Given the same launcher
+When `cursor-agent` is NOT on PATH or does not support `--agent`
+Then cli_context falls back to the current behaviour
+  (`cursor-agent --workspace <wd> <prompt>`) with a clearly-labeled
+  comment in the source noting the manual equivalent
+  (open Cursor on the worktree → type `/<phase>` in chat)
+```
+
+### AC-5: Slash commands remain available as a fallback (degraded UX)
+
+```gherkin
+Given the slash command files under .claude/commands/*.md
+When the refactor ships
+Then each slash command file is REWORDED — not deleted — to:
+  1. Tell the reader the preferred entry is the launcher
+     (`claude --agent qs-<phase>` in the worktree).
+  2. State explicitly that running the slash command in the current
+     session is a degraded fallback (non-interactive one-shot via the
+     Agent tool — the very UX QS-175 mitigates) and is kept only for
+     environments without CLI launcher access (notably Claude Desktop).
+```
+
+### AC-6: Docs explain the new pattern and link the canonical paragraph
+
+```gherkin
+Given docs/workflow/overview.md and docs/workflow/phase-protocols.md
+When the refactor ships
+Then overview.md contains a NEW canonical paragraph titled
+  "Orchestrators are interactive sessions; sub-agents are parallel
+  fan-out" explaining the distinction between the two patterns,
+  immediately after the existing "Adversarial review" section.
+And phase-protocols.md mentions that each phase runs as
+  `claude --agent qs-<phase>` (with the slash form as fallback) without
+  duplicating the canonical paragraph from overview.md.
+And the orchestrator agent bodies that fan out (qs-create-plan and
+  qs-review-task) link to the canonical paragraph instead of inlining
+  the explanation; other phase agents do not need this paragraph.
+```
+
+### AC-7: No code in `custom_components/quiet_solar/` is touched
+
+```gherkin
+Given the implementation diff for QS-175
+When `git diff --name-only main...HEAD` is computed
+Then no file under `custom_components/quiet_solar/` appears.
+```
+
+### AC-8: Claude Desktop limitation is documented honestly
+
+```gherkin
+Given docs/workflow/overview.md (or phase-protocols.md)
+When the refactor ships
+Then a short subsection documents the Desktop limitation:
+  - no `--agent`-style launcher exists on Desktop
+  - Desktop users land on the slash-command fallback path
+  - the existing pycharm_context clipboard helper remains the suggested
+    bridge for users who want to copy/paste the CLI command into a
+    terminal embedded in their IDE
+```
+
+### AC-9: `next_step.py` resolves agent names from any CWD
+
+```gherkin
+Given scripts/qs/next_step.py is invoked
+When the calling shell's CWD is the main checkout, a worktree, the
+  scripts/ dir, or somewhere outside the repo (e.g. /tmp)
+Then phase-name → agent-name resolution succeeds (it uses a static
+  mapping, not a filesystem scan)
+And payload emission succeeds without requiring a particular CWD.
+```
+
+## OUT OF SCOPE
+
+The following are deliberately excluded:
+
+- **Product code under `custom_components/quiet_solar/`** — none of it
+  is touched; this is a dev-environment refactor only.
+- **Removing the slash commands.** They stay as a degraded fallback for
+  Claude Desktop and any environment where the CLI launcher cannot run
+  (decision Q1 = keep slash commands, just reword them).
+- **Refactoring agent tool allowlists, model choices, or system-prompt
+  bodies.** Confirmed: all six phase orchestrators already have `Bash`
+  in their `tools:` line, so they can already call `next_step.py`. No
+  tool-list edits are needed.
+- **Crossing into the main checkout for `qs-finish-task → qs-release`.**
+  `/release` stays a manually-typed command run on the main checkout
+  after merge; the finish-task agent prints the suggestion text but
+  does NOT attempt a `claude --add-dir <main-checkout>` handoff or a
+  launcher for a different worktree. (Decision: scope this out — adds
+  cross-workspace complexity for marginal benefit on a phase the user
+  invokes explicitly anyway.)
+- **The experimental `SendMessage` / `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+  feature.** Confirmed as the wrong pattern for this refactor.
+- **Mid-session persona swap.** Claude Code does not support it; the
+  refactor lives within the "one phase = one session" constraint.
+
+## Tasks
+
+### Task 1 — Extend Claude launcher to emit `claude --agent` invocations (AC-1)
+
+File: `scripts/qs/launchers/claude.py`
+
+- Add a module-level mapping `_PHASE_TO_AGENT` from phase name to agent
+  name (e.g. `"create-plan"` → `"qs-create-plan"`). Cover all 7 phases
+  (`setup-task`, `create-plan`, `implement-task`,
+  `implement-setup-task`, `review-task`, `finish-task`, `release`).
+- Add a private helper `_resolve_agent_for_next_cmd(next_cmd: str) -> str`
+  that:
+  - Accepts a leading `/` (so `"/create-plan"` works too — backward
+    compat for callers still passing slash form).
+  - Looks up the bare name in `_PHASE_TO_AGENT`.
+  - Raises `ValueError(f"Unknown phase {next_cmd!r}; known phases: {sorted(_PHASE_TO_AGENT)}")`
+    on miss. **No silent fallback.**
+- Rewrite `_claude_command(...)` so the generated `/tmp/qs_launch_<N>.sh`
+  invokes `claude {CLAUDE_LAUNCH_OPTS} --agent {agent_name} --name {safe_title}`
+  (the `--agent` flag is added; everything else preserved). The optional
+  `next_prompt` continues to be appended as a positional initial prompt.
+- Update `build_payload(...)` to:
+  - Call `_resolve_agent_for_next_cmd(next_cmd)` and let `ValueError`
+    propagate.
+  - Add `"agent": resolved_agent_name` to the returned dict.
+  - Keep `same_context = next_cmd` (the slash form, for the
+    fallback path).
+- **Repo-root resolution note for the implementer**: this file lives at
+  `scripts/qs/launchers/claude.py`. From here,
+  `Path(__file__).resolve().parents[3]` is the repo root (parents:
+  `[0]=launchers`, `[1]=qs`, `[2]=scripts`, `[3]=repo root`). Use this
+  if/when you need to reference repo-relative paths inside the helper
+  (e.g. `repo_root / ".claude" / "agents" / f"{agent}.md"` for a
+  sanity-existence check).
+
+### Task 2 — Validate `--next-cmd` in `next_step.py` (AC-2, AC-9)
+
+File: `scripts/qs/next_step.py`
+
+- Accept `--next-cmd` as either a slash form (`/create-plan`) or a bare
+  phase name (`create-plan`). Strip leading `/` before lookup. No
+  behavioural change for callers that already pass slash form.
+- Validate against the same `_PHASE_TO_AGENT` keys as `claude.py`
+  (import or duplicate the constant; if duplicating, mark the source as
+  a single owner and add a comment in both files). Suggested layout:
+  put the canonical mapping in `scripts/qs/launchers/__init__.py` (or a
+  new `scripts/qs/launchers/phases.py`) and import it from both
+  `claude.py` and `next_step.py` to keep one source of truth.
+- On unknown phase: raise `ValueError`, write a JSON error payload to
+  stdout (`{"error": "unknown phase", "value": "...", "known": [...]}`),
+  and `sys.exit(1)`.
+- Confirm `next_step.py` uses **stdlib only** (argparse, sys, plus the
+  in-repo helpers). It already does — no venv activation needed.
+- CWD-independence: the phase → agent mapping is a static dict in
+  Python source. No filesystem scan, no `Path.cwd()` calls. Resolution
+  works from any CWD (worktree, main, `/tmp`, etc.) by construction.
+
+### Task 3 — Rewrite handoff blocks in the 6 orchestrator agent bodies (AC-3)
+
+Files (exactly these 6, no glob):
+
+- `.claude/agents/qs-setup-task.md`
+- `.claude/agents/qs-create-plan.md`
+- `.claude/agents/qs-implement-task.md`
+- `.claude/agents/qs-implement-setup-task.md`
+- `.claude/agents/qs-review-task.md`
+- `.claude/agents/qs-finish-task.md`
+
+For each: locate the "Tell the user the next command" / "Report" section
+and rewrite it to print two clearly-labelled blocks. Template:
+
+```text
+Next phase: {{NEXT_PHASE_HUMAN}}
+
+Preferred (opens a fresh interactive session):
+    {{new_context}}        # from the launcher payload — copy/paste in a terminal
+
+Fallback (stay in this session, degraded one-shot UX):
+    /{{NEXT_PHASE}}        # works in Claude Desktop and any chat without a CLI launcher
+```
+
+Where `{{new_context}}` comes from
+`python scripts/qs/next_step.py --next-cmd <phase> --work-dir <wd> --issue <N> --title <title>`
+(orchestrators already have `Bash`, so they can call it).
+
+For `qs-finish-task` specifically: when production code was touched and
+the user should run `/release`, keep the **text** suggestion (current
+behaviour) but DO NOT call the launcher with `--next-cmd release` — see
+OUT OF SCOPE; release lives on the main checkout and is invoked
+manually.
+
+### Task 4 — Cursor launcher parity (AC-4)
+
+File: `scripts/qs/launchers/cursor.py`
+
+- Decide at runtime whether `cursor-agent` supports `--agent <name>`.
+  Pragmatic approach: try `shutil.which("cursor-agent")`; if present,
+  emit `cursor-agent --workspace <wd> --agent qs-<phase>` for
+  `cli_context`. We do NOT shell out to probe `--help` (avoid runtime
+  overhead and Cursor-version sniffing).
+- If `cursor-agent` is missing, leave `cli_context` as the current
+  prompt-positional form AND add a source-comment block above the
+  fallback explaining the manual equivalent for the user: "Open Cursor
+  on the worktree → in chat, type `/<phase>` (slash-command fallback,
+  same degraded UX as Claude Desktop)".
+- Keep `_cursor_ide_command(...)` as-is (no changes to the IDE
+  launcher — Cursor IDE supports interactive sessions natively once you
+  open it on the worktree; user types the slash command in chat).
+- The IDE-launcher path keeps its slash-form in the banner echo
+  (line 46: `echo '── In the chat, type: {next_cmd} ──'`) — that's
+  correct for Cursor since `cursor <path>` only opens the IDE; there's
+  no equivalent to `claude --agent` for the IDE path. Per Q3=(b), this
+  is the cleanest read.
+
+### Task 5 — Update `docs/workflow/overview.md` (AC-6, AC-8)
+
+File: `docs/workflow/overview.md`
+
+- After the existing "Adversarial review (parallel sub-agents)"
+  section, insert a NEW section titled **"Orchestrators are
+  interactive sessions; sub-agents are parallel fan-out"** that says,
+  in 2–3 paragraphs:
+  1. Each phase orchestrator (setup-task, create-plan, …) is meant to
+     run as an interactive `claude --agent qs-<phase>` session so the
+     user can converse with the persona mid-flight.
+  2. The 4 plan reviewers (in `qs-create-plan`) and 4 code reviewers
+     (in `qs-review-task`) stay as `Agent`-tool fan-out — they're
+     non-interactive parallel workers by design, which is what the
+     `Agent` tool is good at.
+  3. The slash commands (`/setup-task`, `/create-plan`, …) remain as a
+     **degraded fallback** for environments without CLI launcher access
+     (notably Claude Desktop). Running a slash command from the
+     default session spawns a one-shot non-interactive sub-process; the
+     persona is invoked, but the user is not in conversation with it.
+- Add a short subsection (or paragraph) titled **"Claude Desktop
+  limitation"** explicitly stating: Desktop has no equivalent to
+  `claude --agent`; Desktop users land on the slash-command fallback;
+  the `pycharm_context` clipboard helper remains the suggested bridge.
+
+### Task 6 — Update `docs/workflow/phase-protocols.md` (AC-6)
+
+File: `docs/workflow/phase-protocols.md`
+
+- Add a brief intro paragraph noting that each phase is invoked via
+  `claude --agent qs-<phase>` (preferred) or `/<phase>` (fallback), and
+  linking to the new canonical paragraph in `overview.md` for the
+  rationale. **Do not duplicate the rationale prose.**
+- Update each phase's "Next phase" line to use the launcher form
+  (e.g. "Next phase: `claude --agent qs-create-plan` in the worktree,
+  or `/create-plan` as fallback").
+
+### Task 7 — Reword the 6 slash-command bodies (AC-5)
+
+Files (exactly these 6, no glob):
+
+- `.claude/commands/setup-task.md`
+- `.claude/commands/create-plan.md`
+- `.claude/commands/implement-task.md`
+- `.claude/commands/implement-setup-task.md`
+- `.claude/commands/review-task.md`
+- `.claude/commands/finish-task.md`
+
+For each: prepend a short note (2–3 lines) at the top stating that the
+**preferred** entry to this phase is the launcher
+(`claude --agent qs-<phase>` in the worktree), and that this slash
+command is the **degraded fallback** path for environments without CLI
+access (notably Claude Desktop). Mention explicitly that the
+slash-command path is the broken-by-design one-shot UX that QS-175
+mitigates (the persona runs non-interactively; the user cannot
+interject mid-phase) — kept **only as a fallback**, not as the primary
+flow. The rest of each slash-command body (the "Expected outcome" and
+`$ARGUMENTS` placeholder) stays.
+
+`.claude/commands/release.md` is NOT in this list — `/release` runs on
+the main checkout and isn't an interactive-orchestrator concern for
+QS-175. Leave it untouched.
+
+### Task 8 — Audit slash → launcher migration in existing examples
+
+Scan `docs/workflow/*.md`, agent bodies, and `CLAUDE.md` for hardcoded
+"type `/<phase>` in this session" instructions. Update each to follow
+the new two-block pattern (launcher preferred, slash fallback), or
+delete if redundant with the canonical paragraph from Task 5.
+
+This is a **search-and-replace polish pass**, not a deep refactor. If
+an instance is clearly out-of-scope (e.g. a legacy `_qsprocess_opencode/`
+or `AGENTS.md` reference), leave it.
+
+### Task 9 — Tests for launcher + next_step.py (AC-1, AC-2, AC-4, AC-9)
+
+Test path: `tests/qs/launchers/` (top-level `tests/` is pytest's
+discovery root per `pytest.ini`'s `testpaths = tests`; the
+`tests/qs/launchers/` subdirectory keeps the suite organized by module
+without breaking discovery).
+
+Create `tests/qs/__init__.py` and `tests/qs/launchers/__init__.py` (if
+needed for import resolution).
+
+Test files and the cases each must cover:
+
+**`tests/qs/launchers/test_phase_mapping.py`**
+- 9a: every entry in `_PHASE_TO_AGENT` resolves via
+  `_resolve_agent_for_next_cmd("<phase>")` (bare form).
+- 9b: every entry resolves via `_resolve_agent_for_next_cmd("/<phase>")`
+  (slash form — back-compat).
+- 9c: invalid phase ("foo", "", "  ", "/nope") raises
+  `ValueError` whose message names the invalid value and the known
+  phases.
+
+**`tests/qs/launchers/test_claude_launcher.py`**
+- 9d: `build_payload(... next_cmd="create-plan" ...)` returns a dict
+  containing `agent == "qs-create-plan"`, `same_context == "create-plan"`,
+  and `new_context` whose generated script contains
+  `claude ... --agent qs-create-plan`.
+- 9e: `build_payload(... next_cmd="bogus" ...)` raises `ValueError`.
+- Both `--next-cmd "create-plan"` and `--next-cmd "/create-plan"` must
+  produce identical `agent` (back-compat assertion).
+- Confirms the script path lands in `tempfile.gettempdir()` and is
+  executable (mode `0o755`).
+
+**`tests/qs/launchers/test_cursor_launcher.py`**
+- 9f: when `cursor-agent` is on PATH (mocked via
+  `monkeypatch.setattr(shutil, "which", ...)`), `cli_context` contains
+  `--agent qs-<phase>`.
+- 9f': when `cursor-agent` is NOT on PATH, `cli_context` does NOT
+  contain `--agent` and falls back to the current prompt-positional
+  form.
+- Cursor launcher's `same_context` mirrors the slash form (parity with
+  `claude.py`).
+
+**`tests/qs/launchers/test_next_step_cli.py`**
+- 9g: invoking `next_step.py` via `subprocess.run` from a temp CWD
+  (`tmp_path`, not in the repo) with a valid phase emits a JSON payload
+  on stdout and exits 0.
+- 9g': invoking with `--next-cmd foo` emits a JSON error payload and
+  exits non-zero (covers the error/fallback branch of
+  `build_payload`).
+- 9g'': invoking with `--harness cursor --next-cmd create-plan` returns
+  a payload with `tool == "cursor"` (covers cursor branch through
+  `next_step.py`).
+
+**Coverage**: 100% line and branch coverage for the modified parts of
+`scripts/qs/launchers/claude.py`, `scripts/qs/launchers/cursor.py`, and
+`scripts/qs/next_step.py` is non-negotiable per project rules. The 9g'
+case is the key coverage trap — without it, the unknown-phase error
+branch in `next_step.py` would be uncovered.
+
+If pytest discovery refuses `tests/qs/launchers/` for some
+local-environment reason at implement time, fall back to flat naming
+(`tests/test_launcher_phase_mapping.py`, etc.) — same content, just
+moved. Verify the location with one `pytest --collect-only` run before
+committing.
+
+### Task 10 — Manual sanity check (AC-3, AC-5, AC-8)
+
+Two lines, manually executed by the implementer once everything else
+is green:
+
+1. Open one phase orchestrator via the new launcher
+   (`claude --agent qs-create-plan` in a worktree) and confirm it boots
+   and the agent works (no hard failure, the persona greets you and
+   discovers task context).
+2. Type `/create-plan` from a fresh default `claude` session in the
+   same worktree and confirm it still routes to `qs-create-plan` via
+   the `Agent` tool (degraded fallback path is intact).
+
+That's the entire manual checklist. No tool-allowlist assertions, no
+end-to-end pipeline walkthrough. The story spec (slash command stays
+as fallback, launcher is preferred) is enforced by tests in Task 9;
+this is just the "does it actually run on my machine" gut check.
+
+### Task 11 — Quality gate
+
+```bash
+python scripts/qs/quality_gate.py
+```
+
+Must exit 0. The dev-only fast path is fine (no
+`custom_components/quiet_solar/` files are touched), but the launcher
++ next_step tests must run as part of pytest.
+
+## Dev Notes
+
+- **Architecture invariant preserved**: orchestrators run as the
+  user-facing main session; sub-agents (the 4 plan reviewers in
+  `qs-create-plan` and the 4 code reviewers in `qs-review-task`) stay
+  as `Agent`-tool fan-out. This is the right shape — non-interactive
+  parallel workers is exactly what `Agent` is for.
+- **Why slash commands stay**: Claude Desktop has no `--agent`
+  equivalent. Slash commands are the only path for Desktop users. The
+  UX is degraded (one-shot, no mid-flight conversation) but functional.
+  Removing them would break Desktop entirely.
+- **`pycharm_context` helpers**: untouched. They already give Desktop
+  users a "copy this command to clipboard and paste into your IDE
+  terminal" path. That's the migration bridge for users who want the
+  CLI flow but live in Desktop today.
+- **Decision matrix (recap from the user's triage)**:
+  - Q1: keep slash commands as fallback (don't delete).
+  - Q2: `--next-cmd` accepts a phase name; launcher resolves it. Strict
+    validation, no silent fallback. Free-form prompts get `--next-prompt`.
+  - Q3: Cursor parity via `cursor-agent --agent <name>` when supported;
+    fall back to the current behaviour with a comment otherwise.
+  - Q4: print BOTH the launcher and the slash fallback in handoffs.
+  - Q5: 2-line manual sanity check, not a 5-step smoke checklist
+    (anti-gold-plating).
+- **Tool allowlists**: confirmed across all 6 phase orchestrators — they
+  all have `Bash` in `tools:` so they can call `next_step.py` from a
+  shell. No `tools:` edits needed.
+- **Stdlib-only deps**: `next_step.py` and all four launchers
+  (`claude.py`, `cursor.py`, `codex.py`, `opencode.py`) import only
+  stdlib (`argparse`, `sys`, `shlex`, `shutil`, `tempfile`, `platform`,
+  `pathlib`) plus in-repo helpers (`harness`, `launchers`, `utils`).
+  No third-party deps — no venv activation needed to run them.
+- **Repo-root resolution from `launchers/`**: `Path(__file__).resolve().parents[3]`
+  (parents: `[0]=launchers`, `[1]=qs`, `[2]=scripts`, `[3]=repo root`).
+- **Test-discovery location**: pytest's `testpaths = tests` in
+  `pytest.ini`, so `tests/qs/launchers/` is a valid subdirectory.
+  Verify with `pytest --collect-only tests/qs/launchers` once the
+  files exist; fall back to flat names under `tests/` if for any
+  reason discovery fails locally.
+- **CodeRabbit / mypy / ruff**: this refactor is pure
+  dev-infrastructure (Python scripts + markdown). The full quality
+  gate's smart scope detection should detect no
+  `custom_components/quiet_solar/` changes and run the fast path; if
+  not, the full gate is still fine — it just takes longer.
+
+## Adversarial Review Notes
+
+**Reviewers:** Critic, Concrete Planner, Dev Proxy, Scope Guardian
+**Rounds:** 1 (with user-driven triage as round 2)
+**Total findings:** 20 (6 critical, 4 redesign, 6 improve, 4 clarify)
+**Triage decision:** fix all.
+
+### Criticals (1–6)
+
+1. **T1 vs AC3 contradiction resolved**: launcher now raises
+   `ValueError` on unknown phase names (no silent fallback). Free-form
+   prompts get the separate `--next-prompt` argument. (T1, T2, AC-2)
+2. **AC1 / AC4 split**: AC-1 is the launcher payload format; AC-3 is
+   the agent's printed handoff output. They're now independent
+   criteria.
+3. **Test location**: tests live at `tests/qs/launchers/` (top-level
+   `tests/` is the pytest discovery root per `pytest.ini`'s
+   `testpaths = tests`). Verify location with `pytest --collect-only`
+   at implement time; fall back to flat names if needed. (T9)
+4. **Explicit `parents[N]` offset**: documented in T1 and in Dev Notes —
+   from `scripts/qs/launchers/*.py`, `Path(__file__).resolve().parents[3]`
+   is the repo root.
+5. **Coverage trap closed**: T9 now explicitly enumerates the
+   unknown-phase error branch in `next_step.py` (test 9g') and the
+   cursor.py changes (9f and 9f') so 100% coverage is achievable.
+6. **`qs-finish-task → qs-release` scope cut**: explicit OUT OF SCOPE
+   line. `/release` stays a manually-typed command run on the main
+   checkout after merge.
+
+### Redesigns (7–10)
+
+7. **Story clarifies the difference**: launcher command = "open a
+   fresh terminal/session"; slash-command fallback = "stay in your
+   current session, degraded ergonomics". Stated in the Root Cause
+   section and in Tasks 3 and 7.
+8. **T7 explicit framing**: the slash-command fallback is the
+   broken-by-design one-shot UX that QS-175 is **mitigating, not
+   replacing** — said out loud in Task 7's rewording template.
+9. **Doc duplication eliminated**: the canonical "orchestrators are
+   interactive sessions; sub-agents are parallel fan-out" paragraph
+   lives in `overview.md` (Task 5). `phase-protocols.md` and the
+   orchestrator agent bodies that fan out (`qs-create-plan`,
+   `qs-review-task`) link to it instead of inlining the rationale.
+10. **T10 shrunk to 2 lines**: launcher boots one agent + slash command
+    routes the fallback. Dropped the 5-step smoke checklist (anti-gold-
+    plating per the user's stated preference).
+
+### Improves (11–16)
+
+11. **AC-9 added**: phase-name resolution works from any CWD because
+    it uses a static dict, not a filesystem scan. T9 covers this with
+    test 9g (run from `tmp_path`).
+12. **T10 step 2 reframed**: "agent works" / "slash routes correctly"
+    rather than "assert tool allowlist". The allowlist is enforced by
+    Claude Code at session start.
+13. **Tool allowlist verified**: all 6 phase orchestrators have `Bash`
+    in `tools:`. No tool-list changes needed. Documented in Dev Notes.
+14. **T6 paragraph link scope narrowed**: only the two orchestrators
+    that fan out (`qs-create-plan`, `qs-review-task`) need to link the
+    canonical paragraph. Other phase agents don't fan out and don't
+    need the cross-reference.
+15. **`next_step.py` stdlib-only**: confirmed; documented in Dev
+    Notes. No venv activation needed to run it.
+16. **T7 / T4 file lists enumerated**: no `*.md` glob ambiguity. Exact
+    6 files for T7 (`.claude/commands/`); exact 6 files for T3
+    (`.claude/agents/qs-*-task.md` / `qs-create-plan.md` /
+    `qs-finish-task.md`); `release.md` slash-command and `qs-release.md`
+    agent body explicitly excluded.
+
+### Clarifies (17–20)
+
+17. **AC-5 rephrased**: "no-op behaviour preserved" was misleading.
+    The actual statement is "the slash command stays available as a
+    degraded fallback".
+18. **T4 cursor decision**: keep slash-form locally in the IDE-launcher
+    banner echo (line 46) with an explicit rationale comment — Cursor's
+    `cursor <path>` IDE launcher has no `--agent` equivalent; the user
+    types the slash form in chat once the IDE opens.
+19. **OUT OF SCOPE addition**: "Removing slash commands. They stay as
+    a degraded fallback." (Q1 = (a).)
+20. **Next-step block style confirmed**: follows the existing
+    "Preferred / Fallback" two-block pattern already used in
+    `qs-setup-task` and `setup_task.py` outputs (CLI flow + Desktop
+    flow).
+
+### Known risks accepted
+
+- Claude Desktop users land on a degraded path. Acknowledged and
+  documented. Mitigation: `pycharm_context` clipboard helper remains
+  available as a bridge.
+- `_PHASE_TO_AGENT` mapping lives in two places (launchers/__init__.py
+  or phases.py, imported by `claude.py` and `next_step.py`). Single
+  source of truth is required per Task 2.
+- The 2-line manual sanity check (Task 10) is intentionally light. If
+  it surfaces a regression at implement time, expand to a 5-step
+  checklist in the implement-phase fix loop — not in this plan.

--- a/docs/stories/QS-175.story_review_fix_#01.md
+++ b/docs/stories/QS-175.story_review_fix_#01.md
@@ -1,0 +1,251 @@
+# QS-175 — Review fix plan #01
+
+## Summary
+
+- Source PR: #176
+- Source story: `docs/stories/QS-175.story.md`
+- Findings to fix: 16 (6 should-fix, 10 nice-to-have)
+- Reviewers: qs-review-blind-hunter, qs-review-acceptance-auditor, qs-review-coderabbit
+- Note: `qs-review-edge-case-hunter` stalled (600s no-progress watchdog).
+  Consider re-running it separately before merge — it is the reviewer most
+  likely to catch shell-escaping and cwd-related bugs in this PR.
+
+## Findings to fix
+
+### [should-fix] codex/opencode launchers regressed by strict `--next-cmd` validation
+
+- File: `scripts/qs/next_step.py:80-92`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `next_step.py` now hard-rejects any `--next-cmd` not in
+  `_PHASE_TO_AGENT`. The mapping only covers the new claude/cursor
+  launchers; `codex_launcher` and `opencode_launcher` (legacy OpenCode
+  pipeline, still in use per `CLAUDE.md`) were not updated. Any
+  previously-valid free-form `--next-cmd` value going to those harnesses
+  now fails with exit 1 — a silent behavior regression.
+- Proposed fix: Gate the strict validation on the harness in use, or
+  only validate when the resolved launcher (claude/cursor) actually
+  consumes the agent name. Easiest implementation: in `next_step.py`,
+  let the launcher's `build_payload` raise if it needs a phase mapping
+  and `next_step.py` only catches and JSON-formats the error — do not
+  pre-validate. Codex/opencode launchers can keep their existing
+  free-form behavior. Add regression tests covering
+  `--next-cmd foo --harness opencode` exits 0 and produces a payload.
+
+### [should-fix] cursor fallback prompt uses bare phase instead of slash form
+
+- File: `scripts/qs/launchers/cursor.py:104-109` (also `159-170`)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: When `next_cmd` is passed as bare phase text (e.g.
+  `create-plan`), the Cursor fallback prompt / instructions render as
+  `create-plan` instead of `/create-plan`. The degraded Cursor path
+  cannot then invoke the phase as a slash command.
+- Proposed fix: Normalise `next_cmd` to slash form when composing the
+  fallback prompt — `slash = next_cmd if next_cmd.startswith("/") else
+  f"/{next_cmd}"` — and use `slash` in the prompt/instruction text.
+  Keep `same_context` verbatim so the back-compat invariant holds; only
+  the fallback prompt string changes. Add tests for both bare and slash
+  input shapes asserting the prompt contains the slash form.
+
+### [should-fix] qs-setup-task orchestrator fallback diverges from peers
+
+- File: `.claude/agents/qs-setup-task.md` (handoff section, around line
+  in the rewritten block; search for `{{same_context}}`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The fallback block in `qs-setup-task.md` prints
+  `{{same_context}}` (a verbatim template variable that becomes
+  whatever `next_cmd` is — possibly the bare phase). The five peer
+  orchestrators (`qs-create-plan`, `qs-implement-task`,
+  `qs-implement-setup-task`, `qs-review-task`, `qs-finish-task`) hard-
+  code `/<phase>` for the fallback line. Setup-task is the lone
+  divergence and risks rendering a non-slash fallback.
+- Proposed fix: Replace `{{same_context}}` in the fallback block with
+  the hardcoded `/<NEXT_PHASE>` form, matching the five peers. No code
+  change — agent body only.
+
+### [should-fix] phases.py exports use leading-underscore (private) names
+
+- File: `scripts/qs/launchers/phases.py:32, 40`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `_PHASE_TO_AGENT` and `_resolve_agent_for_next_cmd`
+  start with `_` (Python convention = private to module), yet they are
+  imported from `scripts/qs/launchers/claude.py`,
+  `scripts/qs/launchers/cursor.py`, `scripts/qs/next_step.py`, and four
+  test files. Ruff `PLC2701` (private-name import) flags this.
+- Proposed fix: Rename to public:
+  - `_PHASE_TO_AGENT` → `PHASE_TO_AGENT`
+  - `_resolve_agent_for_next_cmd` → `resolve_agent_for_next_cmd`
+
+  Update all importers (4 source files + 4 test files) in the same
+  change. Verify `ruff check` passes after rename.
+
+### [should-fix] phase resolution duplicated between next_step.py and build_payload
+
+- File: `scripts/qs/next_step.py:83-92` (and downstream `build_payload`
+  calls in `scripts/qs/launchers/claude.py` and `cursor.py`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `next_step.py` calls `_resolve_agent_for_next_cmd` to
+  validate, then discards the resolved agent. `build_payload` inside
+  `claude.py`/`cursor.py` re-resolves the same value. Minor DRY /
+  efficiency violation; two places to keep in sync.
+- Proposed fix: Either (a) drop the pre-resolution in `next_step.py`
+  and let `build_payload` raise (combined with the fix for finding #1
+  this is the cleanest path), or (b) pass the resolved agent name into
+  `build_payload` as an optional argument so the launchers reuse it
+  instead of re-resolving. Prefer (a) for symmetry with the codex/
+  opencode fix above.
+
+### [should-fix] brittle exact-mode assertion in test
+
+- File: `tests/qs/launchers/test_claude_launcher.py:1971`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `assert mode & 0o777 == 0o755` asserts the exact
+  filesystem mode. Depending on how `claude.py` sets the mode (chmod
+  0o755 vs open-with-umask), this may fail on a developer machine with
+  a non-default umask. The `mode & stat.S_IXUSR` check above already
+  asserts the executable-by-owner intent that matters.
+- Proposed fix: Remove the exact-mode assertion (keep the `S_IXUSR`
+  one), OR change it to `mode & 0o700 == 0o700` (owner-rwx) so it's
+  robust to umask. Pick whichever matches the actual intent in the
+  story (executable for the user).
+
+### [nice-to-have] lock two-block handoff pattern across orchestrators
+
+- File: new test, e.g. `tests/qs/agents/test_orchestrator_handoff.py`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: AC-3 is enforced only by manual review. A regex test
+  that scans the 6 orchestrator `.md` files for the two-block pattern
+  (`Preferred` and `Fallback` markers + `claude --agent qs-<phase>` and
+  `/<phase>`) would lock the contract against future drift.
+- Proposed fix: Add a parametrised test over the 6 orchestrator files
+  asserting each contains both markers and at least one
+  `claude --agent qs-` token plus one `/<phase>` token.
+
+### [nice-to-have] lock slash-command preamble across the 6 fallback files
+
+- File: new test, e.g. `tests/qs/agents/test_slash_command_preambles.py`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: AC-5 is enforced only by manual review. A test asserting
+  each of the 6 `.claude/commands/*.md` files contains the "Preferred
+  entry" / "degraded fallback" framing would harden against accidental
+  preamble deletion.
+- Proposed fix: Parametrised test over the 6 slash-command files
+  asserting each contains the canonical preamble markers.
+
+### [nice-to-have] doc-structure ordering test for overview.md
+
+- File: new test, e.g. `tests/qs/docs/test_overview_structure.py`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: AC-6 specifies the new section is placed "immediately
+  after the existing Adversarial review section" — verified manually
+  today. A structural test would lock the ordering.
+- Proposed fix: Test that parses `docs/workflow/overview.md` headings
+  and asserts the "Orchestrators are interactive sessions..." heading
+  immediately follows the "Adversarial review..." heading.
+
+### [nice-to-have] source-grep test for cursor fallback rationale comment
+
+- File: new test, e.g. `tests/qs/launchers/test_cursor_documentation.py`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The fallback path in `cursor.py` includes a comment
+  explaining why the legacy form is used when `cursor-agent` is missing;
+  no test currently locks the comment in place. Source-grep test would
+  prevent silent removal during refactor.
+- Proposed fix: Single test that opens `cursor.py` and asserts a
+  substring of the fallback rationale comment is present.
+
+### [nice-to-have] shlex.quote test for --agent flag
+
+- File: `tests/qs/launchers/test_claude_launcher.py` (new test)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: `_claude_command` quotes the agent name with
+  `shlex.quote` — currently the mapping never produces metacharacters,
+  so the quoting is theoretical. A direct test would lock the behaviour.
+- Proposed fix: Unit test calling `_claude_command` (or whatever the
+  helper is renamed to after the public-rename fix) with a synthetic
+  agent name containing a space/quote and asserting the produced
+  command is correctly quoted.
+
+### [nice-to-have] misleading comment in claude launcher test
+
+- File: `tests/qs/launchers/test_claude_launcher.py:1992`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Comment "The agent invocation must come AFTER the launch
+  opts so flags apply" overstates the case — CLI flag order is
+  independent in argparse-style parsers. The positional assertion is a
+  stable layout invariant; the rationale comment overclaims.
+- Proposed fix: Reword the comment to describe the actual invariant
+  ("stable layout — `--agent` appears after `CLAUDE_LAUNCH_OPTS`")
+  without claiming flag-order semantics.
+
+### [nice-to-have] guard module-purge loop against `__file__ is None`
+
+- File: `tests/qs/launchers/conftest.py:1857-1862`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The module-purge fixture iterates over a snapshot of
+  `sys.modules`, then accesses `mod.__file__`. The `getattr(..., None)
+  or ""` already handles `None`, but an early `continue` would be more
+  readable and slightly safer against frozen/namespace packages.
+- Proposed fix: Add `if not getattr(mod, "__file__", None): continue`
+  early in the loop body.
+
+### [nice-to-have] phase-protocols.md wording could clash with finish-task agent body
+
+- File: `docs/workflow/phase-protocols.md:170`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The note says `qs-finish-task` does **not** emit a
+  launcher payload for release, but the agent body (`qs-finish-task.md`)
+  does mention `claude --agent qs-release` as a follow-up — just not via
+  the launcher script. Easy to misread.
+- Proposed fix: Reword to "does not call `scripts/qs/next_step.py
+  --next-cmd release`", which is the precise invariant.
+
+### [nice-to-have] DRY the duplicated slash-command fallback notes
+
+- File: `.claude/commands/{setup-task,create-plan,implement-task,implement-setup-task,review-task,finish-task}.md`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: All six slash-command files contain the same 6-line
+  "Preferred entry / degraded fallback" preamble verbatim. Drift risk
+  on future edits.
+- Proposed fix: Two options:
+  - (a) Keep the duplication (intentional per AC-5) but add the
+    slash-command preamble test (see nice-to-have above) so drift is
+    detected.
+  - (b) Point each preamble to a single canonical paragraph in
+    `docs/workflow/overview.md` — shorter preamble, single source.
+  Prefer (a) since AC-5 explicitly mandates a preamble per slash command.
+
+### [nice-to-have] confirm phases.py single-slash-strip behaviour
+
+- File: `scripts/qs/launchers/phases.py:50`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The comment "``//create-plan`` is intentionally rejected"
+  is correct; the implementation strips one leading slash, so `/` →
+  empty string → "not in mapping" → raise. `test_resolve_unknown_phase_raises`
+  already parametrises `/`. No action needed — listing only for record.
+- Proposed fix: No change.
+
+## How to apply
+
+Run `/implement-task` (or open a fresh
+`claude --agent qs-implement-task` session) against this fix plan.
+When done, return and run `/review-task` again to re-verify.
+
+Consider also re-running the edge-case hunter separately
+(`Agent` invocation with `subagent_type: qs-review-edge-case-hunter`)
+before merge, since it failed on the first pass.

--- a/docs/stories/QS-175.story_review_fix_#02.md
+++ b/docs/stories/QS-175.story_review_fix_#02.md
@@ -1,0 +1,267 @@
+# QS-175 — Review fix plan #02
+
+## Summary
+
+- Source PR: #176 (HEAD `b1299ab` at time of review)
+- Source story: `docs/stories/QS-175.story.md`
+- Previous fix plan: `docs/stories/QS-175.story_review_fix_#01.md` (16/16 applied + tested per round-2 acceptance audit)
+- Findings to fix: 14 (3 should-fix, 11 nice-to-have)
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor, qs-review-coderabbit
+- One round-1 blind-hunter finding (missing `import shutil`) was
+  verified false (cursor.py line 28). Excluded.
+
+## Findings to fix
+
+### [should-fix] `next_step.py` broad `except ValueError` over-claims "unknown phase"
+
+- File: `scripts/qs/next_step.py:94-108`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: After the round-1 cleanup (option (a): no pre-validation;
+  let `build_payload` raise), the catch is `except ValueError:` which is
+  too broad. If `build_payload` — or any callee, present or future —
+  raises `ValueError` for a non-phase reason (bad int parse, malformed
+  argument, etc.), the emitted JSON misleadingly claims the phase is
+  unknown and lists the wrong recovery hint.
+- Proposed fix: Introduce a custom exception in
+  `scripts/qs/launchers/phases.py`:
+
+  ```python
+  class UnknownPhaseError(ValueError):
+      """Raised by resolve_agent_for_next_cmd for an unknown phase."""
+
+      def __init__(self, value: str, known: list[str]) -> None:
+          super().__init__(f"unknown phase {value!r}")
+          self.value = value
+          self.known = known
+  ```
+
+  Have `resolve_agent_for_next_cmd` raise `UnknownPhaseError` instead
+  of plain `ValueError` (keep `UnknownPhaseError` as a subclass so any
+  legacy `except ValueError` still works). Narrow `next_step.py` to
+  `except UnknownPhaseError as exc:` and read `.value` / `.known` from
+  the exception directly instead of re-parsing the message. Add a
+  regression test that injects a synthetic `ValueError` from a launcher
+  and asserts `next_step.py` propagates it as a non-"unknown phase"
+  error (or simply re-raises).
+
+### [should-fix] `next_step.py` accepts empty `--next-cmd` silently on codex/opencode
+
+- File: `scripts/qs/next_step.py` (argparse layer)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: When `--harness codex|opencode` is paired with
+  `--next-cmd ""`, the codex/opencode `build_payload` does NOT call
+  `resolve_agent_for_next_cmd`, so an empty `next_cmd` silently passes
+  through, producing a payload with `same_context: ""` and `new_context`
+  containing `"run ''"`. Exit code is 0 — the user gets a garbled
+  handoff message with no indication of failure.
+- Proposed fix: Reject empty/whitespace-only `--next-cmd` at the
+  argparse layer for ALL harnesses. Either use a custom `type=` callable
+  or validate after `parse_args` and write the same JSON error shape
+  used for unknown phases. Add tests for the four harnesses (claude,
+  cursor, codex, opencode) × empty / whitespace `--next-cmd`, each
+  asserting exit 1 with a clean error JSON.
+
+### [should-fix] `test_orchestrator_fallback_uses_concrete_slash_form` contradicts its stated intent
+
+- File: `tests/qs/agents/test_orchestrator_handoff.py:~52-66`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The test parametrises `qs-create-plan.md` with
+  `expected_slash="/{{NEXT_PHASE}}"`. The test's docstring claims it
+  catches the regression where `{{same_context}}` was emitted instead
+  of a hardcoded slash form — but asserting a literal template
+  placeholder (`/{{NEXT_PHASE}}`) is exactly the kind of "verbatim
+  template variable" the test purports to forbid. Internal contradiction.
+- Proposed fix: Option (a) — drop the `qs-create-plan` row from the
+  parametrise list. The create-plan orchestrator's `NEXT_PHASE` value
+  is dynamic (it picks implement-task vs implement-setup-task at
+  runtime based on the diff), so a hardcoded slash form isn't possible
+  there. Replace with a dedicated test asserting `qs-create-plan.md`
+  fallback uses a placeholder of the shape `/<NEXT_PHASE>` or `/<phase>`
+  — but explicitly NOT `{{same_context}}`.
+
+  Option (b) — rename the test/docstring to "fallback names a slash
+  form (literal OR placeholder)" and keep the parametrise list as-is.
+
+  Prefer (a): it lets the universal test stay strict and creates a
+  single-purpose test for the create-plan exception.
+
+### [nice-to-have] unused `expected_slash` parameter in handoff tests
+
+- File: `tests/qs/agents/test_orchestrator_handoff.py:~38-50`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `expected_slash` is unused in
+  `test_orchestrator_has_two_block_handoff` and
+  `test_orchestrator_handoff_mentions_claude_agent_invocation`. Ruff
+  `ARG001` would flag this unless test args are exempted.
+- Proposed fix: Split into two `pytest.mark.parametrize` lists — one
+  for the universal "has both markers" check (no `expected_slash`),
+  one for the per-orchestrator slash-form check. Alternatively prefix
+  the unused param with `_` (less idiomatic with pytest).
+
+### [nice-to-have] fragile `Fallback[^:]*:` regex in handoff test
+
+- File: `tests/qs/agents/test_orchestrator_handoff.py:~125-141`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The regex `r"Fallback[^:]*:[^\n]*\n([^\n]+)\n"` matches
+  "Fallback" then the FIRST `:` in the file body. Any future edit that
+  introduces a colon between "Fallback" and "launcher):" (e.g., a
+  parenthetical "Note: ...") would shift the captured "fallback line"
+  off-by-one and either pass spuriously or fail with a confusing
+  message.
+- Proposed fix: Anchor the regex to the code-block fence (look for the
+  surrounding triple-backtick) or switch to a line-by-line scan
+  iterating until a line starts with `/` for the fallback marker.
+
+### [nice-to-have] `[^\n\`]` exclusion regex misses fenced `next_step.py --next-cmd release` invocations
+
+- File: `tests/qs/agents/test_orchestrator_handoff.py:~155-176`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `test_finish_task_does_not_call_next_step_for_release`
+  excludes backticks via `[^\n\`]`, so a code-fence-wrapped invocation
+  like `` `python scripts/qs/next_step.py --next-cmd release` `` on a
+  single line still bypasses detection (the backticks live outside the
+  captured range).
+- Proposed fix: Strip code fences (single and triple) before regex
+  match, OR document the limitation in the test docstring. Stripping
+  fences is cleaner: `text = re.sub(r"`+([^`]*)`+", r"\1", text)` first,
+  then run the existing assertion.
+
+### [nice-to-have] claude.py module docstring quote style doesn't match `shlex.quote` output
+
+- File: `scripts/qs/launchers/claude.py` (module docstring, ~line 13)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Docstring example shows `--name "QS_<N>: <title>"`
+  (double quotes), but `shlex.quote` wraps with single quotes. Minor
+  doc/code drift — readers may copy the wrong form.
+- Proposed fix: Change the docstring example to use single quotes, OR
+  add a "(or equivalent shell-quoted form via shlex.quote)" note.
+
+### [nice-to-have] hardcoded "Cursor 2.4+" version in comment could go stale
+
+- File: `scripts/qs/launchers/cursor.py:~106`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Comment "Preferred path — Cursor 2.4+ supports
+  `--agent <name>`" embeds a version cutoff that may not be the actual
+  threshold and could become wrong as Cursor evolves. The runtime
+  `shutil.which("cursor-agent")` check is what actually gates the path.
+- Proposed fix: Drop the version number — "Preferred path — uses
+  `--agent <name>` when `cursor-agent` is on PATH" is sufficient.
+
+### [nice-to-have] `phases.py` docstring contradicts the `PHASE_TO_AGENT` value test
+
+- File: `scripts/qs/launchers/phases.py:~38`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Docstring says "we keep the mapping explicit so a typo
+  in either side is immediately visible" (implying values can diverge
+  from a derived `f"qs-{phase}"` form), but
+  `test_phase_to_agent_values_match_qs_prefix` strictly enforces the
+  convention. Comment & test in tension.
+- Proposed fix: Reword the docstring to "we keep the mapping explicit
+  so the canonical name set is grep-able, and pin the
+  `qs-<phase>` convention via a regression test in
+  `test_phase_mapping.py`". Alternatively, relax the test to allow
+  exceptions and document them — but the strict version is preferable
+  for a single-source-of-truth mapping.
+
+### [nice-to-have] test reaches into private `_claude_command`
+
+- File: `tests/qs/launchers/test_claude_launcher.py:~167-176`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `test_claude_command_quotes_agent_name_with_metacharacters`
+  calls the private helper `claude_launcher._claude_command(...)`
+  directly. Ruff `SLF001` flag; brittle to refactors.
+- Proposed fix: Reproduce the metacharacter case via the public
+  surface `build_payload`. Inject a synthetic agent name by
+  monkeypatching `resolve_agent_for_next_cmd` to return e.g.
+  `"qs-create-plan; echo pwned"`, then assert the produced
+  `new_context` script contains the shell-quoted form.
+
+### [nice-to-have] `_slash_form` defense-in-depth for unreachable inputs
+
+- File: `scripts/qs/launchers/cursor.py:73-81`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `_slash_form("")` returns `"/"`; `_slash_form("//create-plan")`
+  returns `"//create-plan"` unchanged. Currently unreachable from
+  `build_payload` because upstream `resolve_agent_for_next_cmd`
+  validates first. A future refactor could call `_slash_form` outside
+  that validation path.
+- Proposed fix: Add an `assert next_cmd` (or a `ValueError` raise for
+  empty input) at the top of `_slash_form`, plus a parametrised unit
+  test exercising the bare/slash/double-slash/empty cases against the
+  helper directly. Keeps the invariant local to the function.
+
+### [nice-to-have] `tempfile.gettempdir() / f"qs_cursor_{issue}.sh"` races on parallel runs
+
+- File: `scripts/qs/launchers/cursor.py:67` (also `claude.py:82`,
+  `_pycharm_*` paths)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The launcher script path is deterministic per issue, so
+  two simultaneous setup-task runs on the same issue would race on the
+  file. Pre-existing pattern, not introduced by this PR.
+- Proposed fix: Either accept the limitation (single-user dev pipeline)
+  and document it in the launcher modules' docstrings, or switch to
+  `tempfile.NamedTemporaryFile(prefix=f"qs_cursor_{issue}_", suffix=".sh",
+  delete=False)`. Recommend documenting since concurrent runs aren't a
+  real-world scenario.
+
+### [nice-to-have] no `pytest.raises` for `//create-plan` / empty at build_payload level
+
+- File: `tests/qs/launchers/test_cursor_launcher.py:112-145`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Tests parametrise `["create-plan", "/create-plan"]` but
+  don't exercise the `//create-plan` / empty-string failure mode at
+  `build_payload` layer. Upstream `resolve_agent_for_next_cmd` does
+  raise, but no launcher-level contract test pins the end-to-end
+  invariant.
+- Proposed fix: Add a parametrised test:
+
+  ```python
+  @pytest.mark.parametrize("bad_next_cmd", ["", "/", "//create-plan", "unknown"])
+  def test_build_payload_rejects_invalid_next_cmd(bad_next_cmd):
+      with pytest.raises(ValueError):
+          cursor_launcher.build_payload(
+              work_dir="/tmp", issue=1, title="t", next_cmd=bad_next_cmd
+          )
+  ```
+
+  Same pattern can be added to `test_claude_launcher.py` for symmetry.
+
+### [nice-to-have] DRY canonical heading literal in `test_overview_structure.py`
+
+- File: `tests/qs/docs/test_overview_structure.py:32-33, 50`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: The canonical title "Orchestrators are interactive
+  sessions; sub-agents are parallel fan-out" is asserted in multiple
+  places; extracting it once avoids accidental drift between tests.
+- Proposed fix: Add at module scope:
+
+  ```python
+  CANONICAL_QS175_HEADING = (
+      "Orchestrators are interactive sessions; sub-agents are parallel fan-out"
+  )
+  ```
+
+  Reference from both
+  `test_overview_has_canonical_qs175_section` and
+  `test_canonical_section_immediately_follows_adversarial_review`.
+
+## How to apply
+
+Run `/implement-task` or `/implement-setup-task` (this fix plan only
+touches dev-env files: `scripts/qs/`, `tests/qs/`) against this fix
+plan. When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-175.story_review_fix_#03.md
+++ b/docs/stories/QS-175.story_review_fix_#03.md
@@ -1,0 +1,334 @@
+# QS-175 — Review fix plan #03
+
+## Summary
+
+- Source PR: #176 (HEAD `53a0353` at time of review)
+- Source story: `docs/stories/QS-175.story.md`
+- Previous fix plans:
+  - `docs/stories/QS-175.story_review_fix_#01.md` (16/16 applied)
+  - `docs/stories/QS-175.story_review_fix_#02.md` (14/14 applied)
+- Findings to fix: 15 (1 must-fix, 4 should-fix, 10 nice-to-have)
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor, qs-review-coderabbit
+- One CodeRabbit finding (const.py rule for `next_step.py`) was rejected
+  as invalid (that rule scopes to `custom_components/quiet_solar/`, not
+  pipeline scripts).
+
+## Findings to fix
+
+### [must-fix] vacuous assertion when bogus is the empty string
+
+- File: `tests/qs/launchers/test_phase_mapping.py:74`
+- Severity: must-fix
+- Source: qs-review-coderabbit (verified by orchestrator)
+- Description: The assertion
+  `assert repr(bogus) in msg or bogus in msg`
+  is always True when `bogus == ""` because `"" in msg` is True for
+  any `msg`. The parametrise list includes `""`, so for that case the
+  test passes regardless of whether the error message actually names
+  the invalid value. This silently masks a regression in error message
+  formatting.
+- Proposed fix: Option (a) — drop `""` from the `bogus` parametrise
+  list (whitespace `"  "` already exercises the empty-after-strip case
+  at the resolver level). The empty-string invariant is already pinned
+  separately by `test_empty_or_whitespace_next_cmd_rejected_for_all_harnesses`
+  in `test_next_step_cli.py`.
+
+  Option (b) — special-case empty input:
+
+  ```python
+  if bogus:
+      assert repr(bogus) in msg or bogus in msg
+  else:
+      # repr("") is "''" — assert that explicit token rather than the
+      # vacuously-true "" substring.
+      assert "''" in msg
+  ```
+
+  Prefer (a) for simplicity — the empty-string case is contract-tested
+  at the CLI layer (next_step.py's `empty next-cmd` early reject), so
+  removing it from the resolver-level test doesn't lose coverage.
+
+### [should-fix] new in-process unit test monkeypatches private `_LAUNCHERS`
+
+- File: `tests/qs/launchers/test_next_step_unit.py:50, 65, 79`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: All three tests in the new file use
+  `monkeypatch.setitem(next_step._LAUNCHERS, ...)` — a private
+  (single-underscore) attribute. The PR itself called out exactly this
+  pattern as undesirable in round 1 (fix plan #02 NTH7) and refactored
+  `test_claude_launcher.py` to use the public surface. The new file
+  reintroduces the smell with no `# noqa: SLF001` justification.
+- Proposed fix: Option (a) — promote `_LAUNCHERS` to a public name
+  (`LAUNCHERS`) in `scripts/qs/next_step.py` since it is part of the
+  intended extension surface (every importer accessing it does so as
+  a configuration table). Update the 1 reference inside `next_step.py`
+  and the 3 references in the test file.
+
+  Option (b) — keep the private name and monkeypatch the public
+  function that consumes it (i.e., have the launchers route through a
+  `_get_launcher(name)` helper that the test can monkeypatch instead).
+
+  Option (c) — add a justified `# noqa: SLF001  # mapping is private but
+  the test is contract-locked to its shape` at each call site.
+
+  Prefer (a): the mapping is configuration data, not an implementation
+  detail. Promoting it matches the round-1 NTH4 pattern
+  (`_PHASE_TO_AGENT` → `PHASE_TO_AGENT`).
+
+### [should-fix] private `_slash_form` imported directly from test
+
+- File: `tests/qs/launchers/test_cursor_launcher.py:188, 196`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `from launchers.cursor import _slash_form` reaches into
+  a single-underscore private helper. Same `SLF001` concern as the
+  `_LAUNCHERS` case. The PR's own round-2 NTH7 fix explicitly refactored
+  away from such imports.
+- Proposed fix: Option (a) — drop the direct import. Exercise
+  `_slash_form` behaviour via the public `build_payload` surface; the
+  empty/whitespace cases can be tested by calling `build_payload` with
+  a phase that resolves but where you've monkeypatched
+  `resolve_agent_for_next_cmd` to return a value such that
+  `_slash_form` would be called with empty input. (This is awkward —
+  the resolver always guards the path.)
+
+  Option (b) — promote `_slash_form` to public `slash_form` since it is
+  a pure utility with no internal-only invariants. The defense-in-depth
+  contract is more useful as a public guarantee.
+
+  Option (c) — add `# noqa: SLF001` with a justification that the
+  helper is exposed for testing only.
+
+  Prefer (b): it matches the public-name promotion philosophy from
+  fix-#01 NTH4 (`_PHASE_TO_AGENT` → `PHASE_TO_AGENT`) and from this
+  plan's option (a) for `_LAUNCHERS`. The function is a pure helper
+  whose contract is worth pinning publicly.
+
+### [should-fix] harness.md doc claims `agent` is always emitted
+
+- File: `docs/workflow/harness.md:55-58`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The doc says "All launchers return a dict with at
+  minimum `tool`, `agent`, `same_context`, `new_context`". This is
+  wrong: `test_codex_passes_known_phase_through_unchanged` asserts
+  `"agent" not in payload` for codex (and by analogy opencode). Only
+  claude and cursor launchers emit `agent`.
+- Proposed fix: Rewrite the contract paragraph to reflect the true
+  surface:
+
+  ```markdown
+  All launchers return a dict with at minimum:
+  - `tool` (string, e.g. `"claude-code"`)
+  - `same_context` (string, slash-form fallback command)
+  - `new_context` (string, shell command to spawn a fresh session)
+
+  Claude and Cursor launchers additionally emit `agent` (the resolved
+  `qs-<phase>` name); Codex and OpenCode launchers do NOT emit `agent`
+  because they accept free-form `--next-cmd` values that may not map
+  to a static phase.
+  ```
+
+  Cross-reference the test `test_codex_passes_known_phase_through_unchanged`
+  in `docs/workflow/harness.md` so the contract is grep-able.
+
+### [should-fix] next_step.py docstring claims argparse-layer rejection
+
+- File: `scripts/qs/next_step.py:14-20`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: Docstring says "Empty / whitespace-only `--next-cmd` is
+  rejected at the argparse layer for ALL harnesses", but the
+  rejection happens after `parse_args()` returns (line ~96), not via
+  an argparse `type=` callable. A future reader looking for
+  `type=non_empty_str` will not find it.
+- Proposed fix: Either move the check to a `type=` callable on the
+  argparse argument:
+
+  ```python
+  def _non_empty_next_cmd(value: str) -> str:
+      if not value.strip():
+          raise argparse.ArgumentTypeError(
+              "--next-cmd must be non-empty"
+          )
+      return value
+
+  parser.add_argument("--next-cmd", required=True, type=_non_empty_next_cmd)
+  ```
+
+  …OR update the docstring to "Empty / whitespace-only `--next-cmd` is
+  rejected by the main() entrypoint before harness dispatch for all
+  harnesses." Prefer the docstring update — the post-parse check
+  preserves the unified JSON error contract (argparse would print a
+  human-readable usage message to stderr instead).
+
+### [nice-to-have] `""` missing from build_payload reject parametrise
+
+- File: `tests/qs/launchers/test_claude_launcher.py:195` +
+  `tests/qs/launchers/test_cursor_launcher.py:231`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: `test_*_build_payload_rejects_invalid_next_cmd`
+  parametrises `["/", "//create-plan", "unknown", "/nope"]` but not
+  `""`. Empty string is contract-tested at the CLI layer (SF2 from
+  fix #02), but a direct caller importing `build_payload` could pass
+  `""` and the resolver would raise `UnknownPhaseError` — worth
+  pinning at the launcher contract level for symmetry.
+- Proposed fix: Add `""` to the parametrise list in both files.
+
+### [nice-to-have] redundant empty-check in next_step.py
+
+- File: `scripts/qs/next_step.py:96`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `if not args.next_cmd or not args.next_cmd.strip():` —
+  the first half is redundant. `"".strip() == ""` is falsy, so
+  `not args.next_cmd.strip()` alone covers both empty and whitespace
+  cases.
+- Proposed fix: Simplify to `if not args.next_cmd.strip():`. (argparse
+  `required=True` ensures `args.next_cmd` is always a `str`, never
+  `None`.)
+
+### [nice-to-have] `_slash_form` defense asymmetric vs resolver
+
+- File: `scripts/qs/launchers/cursor.py:80-94`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+- Description: `_slash_form` raises for empty/whitespace input but
+  returns `"//create-plan"` unchanged when given a double-slash input
+  (because it `startswith("/")`). The upstream resolver rejects `//`,
+  so this asymmetry is unreachable in production — but the defense-
+  in-depth contract is incomplete and the asymmetry is not documented
+  in the function itself.
+- Proposed fix: Either reject `next_cmd.startswith("//")` in
+  `_slash_form` for symmetry with the resolver, OR add a one-line
+  comment explaining the asymmetry: "Double-slash inputs are rejected
+  upstream by `resolve_agent_for_next_cmd`; we intentionally do not
+  re-check here." Prefer the comment — adding a second guard creates
+  drift risk between the two checks.
+
+### [nice-to-have] unusual `_ = Path` "satisfy ruff" idiom
+
+- File: `tests/qs/launchers/test_next_step_unit.py:112-113`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The trailing `_ = Path` assignment plus an explanatory
+  comment is hard to grep for and confuses a future reader. If `Path`
+  is imported but unused, delete the import; if it is used inside a
+  monkeypatch closure, refactor to make the use direct.
+- Proposed fix: Identify why `Path` was imported in the first place
+  (likely a holdover from an earlier draft). If genuinely unused,
+  remove the import; pytest will pass without it.
+
+### [nice-to-have] UnknownPhaseError message format
+
+- File: `scripts/qs/launchers/phases.py:73-82`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The error message uses `repr(list)` for known phases,
+  e.g. `"Unknown phase '/'; known phases: ['setup-task', 'create-plan',
+  ...]"`. The leading-slash case `value == "/"` makes the error
+  visually ambiguous (looks like a path). A comma-separated rendering
+  reads better.
+- Proposed fix: Format as
+
+  ```python
+  f"unknown phase {value!r}; known phases: {', '.join(known)}"
+  ```
+
+  Update `test_resolve_unknown_phase_raises` accordingly if it asserts
+  the exact format.
+
+### [nice-to-have] conftest cleanup misses higher-conftest imports
+
+- File: `tests/qs/launchers/conftest.py:34-48`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `set(sys.modules) - before` only purges modules imported
+  AFTER this conftest's `before` snapshot. If a higher-level conftest
+  pre-imported `next_step` or `launchers.*`, they survive teardown.
+  Cross-test pollution is bounded by `monkeypatch`, but the limitation
+  is undocumented.
+- Proposed fix: Add a comment at the top of the cleanup loop:
+
+  ```python
+  # Note: this only purges modules imported BY OR AFTER our autouse
+  # fixture. Modules already in sys.modules at fixture entry are
+  # assumed safe (their state is reverted by monkeypatch teardown).
+  ```
+
+### [nice-to-have] trailing-space `--next-cmd` pass-through on codex/opencode
+
+- File: `scripts/qs/next_step.py` (SF2 region)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `--next-cmd "create-plan "` (trailing space) with
+  `--harness codex|opencode` passes through verbatim into the payload
+  (`same_context: "create-plan "`), and the rendered shell instruction
+  embeds the trailing space inside single quotes. SF2 from fix #02
+  only blocks the fully-empty / whitespace-only case, not edge
+  whitespace.
+- Proposed fix: Either normalize `args.next_cmd = args.next_cmd.strip()`
+  early (changes the contract — codex/opencode lose ability to pass
+  intentional whitespace), OR document explicitly in the docstring and
+  in `harness.md` that codex/opencode treat `--next-cmd` as a verbatim
+  free-form string. Prefer the doc clarification — explicit free-form
+  is a feature, not a bug.
+
+### [nice-to-have] `_slash_form` raises plain ValueError, breaking JSON contract
+
+- File: `scripts/qs/launchers/cursor.py:93-96`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `_slash_form` raises plain `ValueError` for empty input.
+  If this defense ever fires (currently unreachable), `next_step.main`'s
+  `except UnknownPhaseError` does NOT catch it, and the user gets a raw
+  Python traceback instead of the JSON `{"error": ...}` contract used
+  for every other failure mode.
+- Proposed fix: Wrap with `UnknownPhaseError` (or a sibling subclass of
+  `ValueError`) so the JSON-error contract is preserved if the
+  defense ever fires. Example:
+
+  ```python
+  if not next_cmd.strip():
+      raise UnknownPhaseError(
+          value=next_cmd, known=list(PHASE_TO_AGENT.keys())
+      )
+  ```
+
+  Alternatively, leave the plain `ValueError` and document that
+  `_slash_form` is an internal invariant whose failure indicates a
+  programmer error (not a user error), so a traceback is the correct
+  UX. Either is acceptable; pick based on whether you want a uniform
+  JSON contract or a clear distinction between user / programmer
+  errors.
+
+### [nice-to-have] non-phase ValueError bypasses JSON contract
+
+- File: `scripts/qs/next_step.py:111-125`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The SF1 narrowing intentionally lets non-phase
+  `ValueError` propagate uncaught (as verified by
+  `test_next_step_propagates_non_phase_value_error`). This is correct
+  vs the SF1 intent, but the user-facing UX is now bimodal: phase
+  errors return JSON, everything else returns a Python traceback. A
+  future reader auditing the JSON error contract will be surprised.
+- Proposed fix: Two options.
+  - (a) Accept the bimodal contract: a non-phase `ValueError` is a
+    programmer error, so a traceback is informative. Document the
+    bimodal contract explicitly in `next_step.py`'s docstring AND in
+    `harness.md`.
+  - (b) Add a broader `except Exception as exc:` that emits
+    `{"error": "internal", "detail": str(exc), "traceback": ...}` and
+    exits non-zero. Preserves a stable JSON contract at the cost of
+    losing the immediate traceback.
+  Prefer (a) — programmer errors should fail loudly.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan (all changes are
+dev-env-only: `scripts/qs/`, `tests/qs/`, `docs/workflow/`). When done,
+return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-175.story_review_fix_#03.md
+++ b/docs/stories/QS-175.story_review_fix_#03.md
@@ -7,7 +7,11 @@
 - Previous fix plans:
   - `docs/stories/QS-175.story_review_fix_#01.md` (16/16 applied)
   - `docs/stories/QS-175.story_review_fix_#02.md` (14/14 applied)
-- Findings to fix: 15 (1 must-fix, 4 should-fix, 10 nice-to-have)
+- Findings to fix: 14 (1 must-fix, 4 should-fix, 9 nice-to-have)
+  (corrected from "15 (… 10 nice-to-have)" per fix-plan #04 NTH13 —
+  the body lists 9 nice-to-have findings; the summary was off by one,
+  likely because acceptance-auditor's NTH8+NTH10 merge into a single
+  docblock during fix-plan #02 application drifted into the #03 count.)
 - Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
   qs-review-acceptance-auditor, qs-review-coderabbit
 - One CodeRabbit finding (const.py rule for `next_step.py`) was rejected
@@ -172,8 +176,9 @@
 - Source: qs-review-acceptance-auditor
 - Description: `test_*_build_payload_rejects_invalid_next_cmd`
   parametrises `["/", "//create-plan", "unknown", "/nope"]` but not
-  `""`. Empty string is contract-tested at the CLI layer (SF2 from
-  fix #02), but a direct caller importing `build_payload` could pass
+  `""`. Empty string is contract-tested at the CLI layer (SF2 —
+  should-fix #2 from fix plan #02 — argparse-time empty-cmd reject),
+  but a direct caller importing `build_payload` could pass
   `""` and the resolver would raise `UnknownPhaseError` — worth
   pinning at the launcher contract level for symmetry.
 - Proposed fix: Add `""` to the parametrise list in both files.
@@ -267,9 +272,9 @@
 - Description: `--next-cmd "create-plan "` (trailing space) with
   `--harness codex|opencode` passes through verbatim into the payload
   (`same_context: "create-plan "`), and the rendered shell instruction
-  embeds the trailing space inside single quotes. SF2 from fix #02
-  only blocks the fully-empty / whitespace-only case, not edge
-  whitespace.
+  embeds the trailing space inside single quotes. SF2 (should-fix #2
+  from fix plan #02) only blocks the fully-empty / whitespace-only
+  case, not edge whitespace.
 - Proposed fix: Either normalize `args.next_cmd = args.next_cmd.strip()`
   early (changes the contract — codex/opencode lose ability to pass
   intentional whitespace), OR document explicitly in the docstring and

--- a/docs/stories/QS-175.story_review_fix_#04.md
+++ b/docs/stories/QS-175.story_review_fix_#04.md
@@ -1,0 +1,310 @@
+# QS-175 — Review fix plan #04
+
+## Summary
+
+- Source PR: #176 (HEAD `dcab7bc` at time of review)
+- Source story: `docs/stories/QS-175.story.md`
+- Previous fix plans:
+  - `docs/stories/QS-175.story_review_fix_#01.md` (16/16 applied)
+  - `docs/stories/QS-175.story_review_fix_#02.md` (14/14 applied)
+  - `docs/stories/QS-175.story_review_fix_#03.md` (15/15 applied)
+- Findings to fix: 17 (3 should-fix, 14 nice-to-have)
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor, qs-review-coderabbit
+- Two findings rejected as invalid:
+  - blind-hunter "slash_form docstring contradicts itself" — verified
+    the docstring is internally consistent (the empty-input claim is
+    accurate; the asymmetry note explicitly covers the `//` case).
+  - CodeRabbit "move payload keys to const.py" — that rule scopes to
+    `custom_components/quiet_solar/`, not pipeline scripts.
+
+> **Note from the orchestrator**: we are 4 rounds in with 0 must-fix
+> bugs detected by the reviewers. Each round finds polish on the
+> previous round's polish. The PR is functionally sound. Consider
+> declaring "good enough" and routing to `/finish-task` after this
+> round.
+
+## Findings to fix
+
+### [should-fix] `setup_task.py` still uses private `_LAUNCHERS`
+
+- File: `scripts/qs/setup_task.py:34`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Round 3 (SF1) promoted `next_step.py`'s harness-dispatch
+  table from `_LAUNCHERS` to public `LAUNCHERS` to remove the SLF001
+  smell exposed by `test_next_step_unit.py`'s `monkeypatch.setitem`.
+  The parallel dispatcher in `setup_task.py:34` was missed. Test code
+  mirroring the new `monkeypatch.setitem(next_step.LAUNCHERS, ...)`
+  pattern on `setup_task` would `AttributeError`. The two dispatchers
+  are conceptually the same configuration table; they should share the
+  same naming convention.
+- Proposed fix: Promote `_LAUNCHERS` to `LAUNCHERS` in
+  `scripts/qs/setup_task.py:34`. Update the single internal reference
+  (likely line 96 per the edge-case-hunter report). Add a comment
+  pointing to the round-3 rationale.
+
+  Stretch goal: deduplicate the two dispatch tables by importing one
+  from the other (e.g. `from next_step import LAUNCHERS` in
+  `setup_task.py`). Skip this if it creates a circular-import risk;
+  the simple rename is sufficient.
+
+### [should-fix] forbidden-invocation regex misses multi-line shell continuations
+
+- File: `tests/qs/agents/test_orchestrator_handoff.py:183`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The regex
+  `r"scripts/qs/next_step\.py[^\n]{0,200}?--next-cmd\s+[\"']?release"`
+  uses `[^\n]` between the script path and the `--next-cmd` flag, so
+  a backslash-continued multi-line invocation slips through:
+
+  ```
+  python scripts/qs/next_step.py \
+      --next-cmd release
+  ```
+
+  A future qs-finish-task edit could re-introduce this exact form and
+  the regression test would silently pass.
+- Proposed fix: Replace `[^\n]` with `.` and add `re.DOTALL` to the
+  compile flags:
+
+  ```python
+  forbidden = re.compile(
+      r"scripts/qs/next_step\.py.{0,200}?--next-cmd\s+[\"']?release",
+      re.DOTALL,
+  )
+  ```
+
+  Add a regression test that constructs a fake markdown body containing
+  the multi-line form and asserts the regex matches. Keep the existing
+  single-line test as well.
+
+### [should-fix] Cursor IDE banner shows bare phase instead of slash form
+
+- File: `scripts/qs/launchers/cursor.py:55-58`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The IDE launcher script's user-facing instruction
+  interpolates the raw `next_cmd` into two f-strings. For bare phases
+  (e.g. `create-plan`), the chat banner reads `… type create-plan …`
+  instead of `/create-plan`. This is the same regression that round-2
+  SF2 fixed in the fallback prompt — only the IDE path was missed.
+- Proposed fix: Apply `slash_form(next_cmd)` once at the top of the
+  IDE-banner block and substitute the normalized form into both
+  f-strings. Add a test in `test_cursor_launcher.py` asserting the IDE
+  path's `new_context` script contains `/create-plan` (not `create-plan`
+  alone) — this dovetails with NTH13 below (CodeRabbit's request for
+  IDE-path coverage).
+
+### [nice-to-have] redundant empty-check in `slash_form`
+
+- File: `scripts/qs/launchers/cursor.py:115`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `if not next_cmd or not next_cmd.strip():` — the
+  `not next_cmd` clause is redundant (`not "".strip()` is also True).
+  Round 3 (NTH2) simplified the same pattern in `next_step.py:114`;
+  the parallel pattern here was missed.
+- Proposed fix: Simplify to `if not next_cmd.strip():`. The type hint
+  already enforces `next_cmd: str`, never `None`.
+
+### [nice-to-have] `_find_fallback_line` has a dead `continue` branch
+
+- File: `tests/qs/agents/test_orchestrator_handoff.py` (`_find_fallback_line`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: After the `if stripped.startswith(("/", "{{")):` returns,
+  the trailing `if stripped and not stripped.endswith(":"): continue`
+  branch is dead code — `continue` is what already happens at the
+  end of the loop body. The comment "Skip blank lines and the closing
+  `):` line" describes behavior that happens implicitly.
+- Proposed fix: Drop the trailing `if/continue` lines. Keep the comment
+  on the preceding `return line` to explain why we look for `/` or
+  `{{` prefixes.
+
+### [nice-to-have] `UnknownPhaseError` type hint too narrow
+
+- File: `scripts/qs/launchers/phases.py` `UnknownPhaseError.__init__`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `known: list[str]` matches the current caller (which
+  passes `sorted(PHASE_TO_AGENT)`), but a future tuple-based caller or
+  test-fixture caller (e.g. `UnknownPhaseError("bogus", ("a", "b"))`)
+  would trigger mypy noise.
+- Proposed fix: Change the annotation to `Sequence[str]`. Import
+  `Sequence` from `collections.abc`. The attribute can still be stored
+  as `tuple(known)` if you want an immutable internal representation.
+
+### [nice-to-have] `UnknownPhaseError` carries original input, not lookup key
+
+- File: `scripts/qs/launchers/phases.py` `resolve_agent_for_next_cmd`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: When the resolver fails, `UnknownPhaseError.value` is the
+  original `next_cmd` (e.g. `"/bogus"`). A caller debugging the error
+  has to re-derive the post-normalization lookup key (`"bogus"`) to
+  understand what was actually looked up in `PHASE_TO_AGENT`.
+- Proposed fix: Add a `.phase` attribute storing the post-normalization
+  lookup key. Keep `.value` as the original input for back-compat.
+  Update the message to include both:
+  `f"unknown phase {value!r} (lookup key {phase!r})"`.
+
+### [nice-to-have] bimodal-error docstring omits argparse SystemExit
+
+- File: `scripts/qs/next_step.py:40-46`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The "Bimodal error contract" paragraph describes two
+  paths (JSON for user errors, traceback for programmer errors) but
+  omits a third real path: `argparse` exit-2 with stderr banner when
+  required flags are missing or `--harness` is invalid. A reader
+  leaning on "bimodal" reasoning will be surprised.
+- Proposed fix: Add a third bullet:
+  > Argparse rejects malformed CLI invocations (missing required
+  > flag, unknown harness if `choices=` is used) by writing a usage
+  > banner to stderr and exiting with code 2. This is the standard
+  > argparse contract — we do not catch or reformat it.
+
+### [nice-to-have] bimodal-error docstring omits KeyboardInterrupt
+
+- File: `scripts/qs/next_step.py:40-46`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `KeyboardInterrupt` during a launcher's `build_payload`
+  (Ctrl-C while mid-IO in `claude.py`'s `script_path.write_text`, or
+  `shutil.which` on a hung PATH) propagates uncaught. Not handled, not
+  documented.
+- Proposed fix: Add a sentence to the bimodal paragraph:
+  > `KeyboardInterrupt` is not caught — Ctrl-C terminates the process
+  > with the standard Python traceback. This is intentional: a
+  > half-written launcher script in `/tmp` is acceptable because the
+  > user will re-run the phase anyway.
+
+### [nice-to-have] bimodal-error docstring omits `KeyError` from unknown `--harness`
+
+- File: `scripts/qs/next_step.py:40-46` (and `next_step.py:111-125`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: An unknown `--harness` value raises `KeyError` from
+  `LAUNCHERS[harness]`, which is neither caught (not an
+  `UnknownPhaseError`) nor an argparse `SystemExit`. The bimodal
+  contract omits this exit shape.
+- Proposed fix: Either constrain the argparse argument with
+  `choices=list(LAUNCHERS)` (preferred — argparse then handles the bad
+  case with exit-2 + stderr banner, matching the existing pattern), or
+  catch the `KeyError` and emit `{"error": "unknown harness", ...}` to
+  match the JSON contract for `UnknownPhaseError`.
+
+  Recommendation: use `choices=` since `LAUNCHERS` is now public and
+  enumerable. This collapses three error categories into two
+  (argparse-level vs. phase-level), simplifying the contract.
+
+### [nice-to-have] Cursor `build_payload` docstring overclaims `new_context`
+
+- File: `scripts/qs/launchers/cursor.py:172`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Docstring says "Always returns `new_context` (the IDE
+  launcher script)". When `cursor` is not on PATH, `new_context` is
+  free-text instructions, not a launcher script. The "Always returns"
+  is correct in terms of the key being present; the parenthetical is
+  what's misleading.
+- Proposed fix: Reword to:
+  > Always returns a `new_context` key. When the `cursor` CLI is on
+  > PATH, this is a shell command running the IDE launcher script;
+  > otherwise it is free-text fallback instructions for the user to
+  > follow manually.
+
+### [nice-to-have] `slash_form` ValueError vs JSON-contract clarification
+
+- File: `scripts/qs/launchers/cursor.py` (`slash_form` failure-mode docblock)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `slash_form` raises plain `ValueError`, not
+  `UnknownPhaseError`, so if the defense ever fires from inside
+  `build_payload` (unreachable today), the user gets a traceback —
+  not the JSON `{"error": ...}` shape. Already documented in the
+  docstring as a programmer-error signal, but the explanation could
+  cross-reference the bimodal contract docstring in `next_step.py`.
+- Proposed fix: Add a sentence to the failure-mode docblock:
+  > See `scripts/qs/next_step.py`'s "Bimodal error contract" paragraph
+  > for the philosophy: user errors get JSON, programmer errors get
+  > tracebacks. A `slash_form` ValueError fires only as a programmer
+  > error, so the traceback is the intended UX.
+
+### [nice-to-have] case-sensitive matching in overview structure test
+
+- File: `tests/qs/docs/test_overview_structure.py:105-111`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: The exception-clause matching uses case-sensitive
+  literals; a valid wording like `` Do not emit `agent` `` could fail
+  unexpectedly because of an uppercase "D". The rest of the test
+  family already normalizes to lowercase.
+- Proposed fix: Normalize `body` to lowercase before the substring
+  search, and lowercase the candidate phrases too.
+
+### [nice-to-have] no IDE-path coverage for slash-normalized chat instruction
+
+- File: `tests/qs/launchers/test_cursor_launcher.py:18-45` (also 129-146)
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: The fallback-path slash-form invariant is tested, but
+  the IDE-path equivalent (the IDE banner script) is not. Closes the
+  gap with should-fix #3.
+- Proposed fix: Add a parametrised test asserting the IDE-path
+  `new_context` script contains `/<phase>` (not bare `<phase>`) for
+  both bare and slash input shapes. Place it alongside the existing
+  IDE-path tests.
+
+### [nice-to-have] NTH8/NTH10 docblock lacks grep-able sub-heading
+
+- File: `scripts/qs/launchers/cursor.py:99-115`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The combined "Asymmetry note (NTH3) + Failure mode (NTH8)"
+  docblock covers what was originally listed as two findings (NTH8 +
+  NTH10) in fix plan #03. The merge is reasonable, but a future
+  finding-to-diff cross-reference run would benefit from a one-line
+  sub-heading per finding number.
+- Proposed fix: Insert `Failure mode (NTH10)` as a brief paragraph
+  heading above the relevant sentences. Trivial cosmetic change.
+
+### [nice-to-have] fix-plan #03 finding count mismatch
+
+- File: `docs/stories/QS-175.story_review_fix_#03.md:10`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: Summary claims "15 (1 must-fix, 4 should-fix, 10
+  nice-to-have)" but the document lists 14 findings with 9 nice-to-have
+  items (findings 6-14). One was either accidentally omitted in the
+  body or double-counted in the summary.
+- Proposed fix: Reconcile by amending the summary block in fix plan
+  #03. This is a docs-only fix on a historical artifact; either
+  update the summary to "14 (1 must-fix, 4 should-fix, 9 nice-to-have)"
+  AND adjust the round-3 acceptance audit references, or insert the
+  missing NTH item if it was lost. Audit suggests the merge of NTH8 +
+  NTH10 into one docblock (acceptance-auditor's note for this round)
+  caused the count drift.
+
+### [nice-to-have] SF1/SF2 abbreviations undefined on first use
+
+- File: `docs/stories/QS-175.story_review_fix_#03.md:175, 270-273`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: "SF1" and "SF2" appear without definition. Context
+  suggests "Story Finding" or "Should-Fix" numbers from previous fix
+  plans, but a brief parenthetical on first use would help reviewers
+  unfamiliar with the shorthand.
+- Proposed fix: On first occurrence, expand to "SF1 (should-fix #1
+  from fix plan #02)" or similar. Apply once at line 175 and once at
+  270; subsequent uses can stay abbreviated.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan (all changes are
+dev-env-only: `scripts/qs/`, `tests/qs/`, `docs/workflow/`,
+`docs/stories/`). When done, return and run `/review-task` again — OR
+declare the long-tail addressed and route to `/finish-task` per the
+orchestrator note above.

--- a/docs/workflow/harness.md
+++ b/docs/workflow/harness.md
@@ -27,25 +27,39 @@ mechanics** are isolated in Python.
 
 ## Launcher dispatch — `scripts/qs/launchers/`
 
-When a phase finishes and the next phase runs in a new session
-(e.g., `setup-task` → `create-plan` crosses workspaces), the agent
-calls `python scripts/qs/next_step.py --phase <p> --next-cmd
-"/create-plan"`. That delegates to the harness-specific launcher:
+When a phase finishes and the user is about to start the next phase
+(typically in a fresh interactive session), the agent calls
+`python scripts/qs/next_step.py --next-cmd <phase> --work-dir <wd>
+--issue <N> --title <t>`. The `--next-cmd` arg accepts either the bare
+phase name (`create-plan`) or the slash form (`/create-plan`) for
+back-compat; unknown phases raise `ValueError` and produce a JSON
+error payload (no silent fallback). The phase-name → agent-name
+mapping lives in `scripts/qs/launchers/phases.py` as a static dict —
+no filesystem scan, so this works from any CWD.
+
+`next_step.py` delegates to the harness-specific launcher:
 
 - **`launchers/claude.py`** — emits a `sh /tmp/qs_launch_<N>.sh` one-liner
-  that opens a terminal in the worktree and runs `claude` with launch
-  options.
-- **`launchers/cursor.py`** — emits instructions to open the worktree as
-  a new Cursor workspace and type the next slash command. Cursor doesn't
-  have a CLI launcher equivalent today.
+  whose generated script runs `claude --agent qs-<phase>` in the
+  worktree. The `--agent` flag is what makes the new session
+  interactive — Claude Code loads the agent body as the system prompt
+  and the user can converse with the phase persona mid-flight (QS-175).
+- **`launchers/cursor.py`** — emits a `cursor-agent --workspace <wd>
+  --agent qs-<phase>` invocation (the `cli_context`) when
+  `cursor-agent` is on PATH. When the binary is missing, falls back to
+  the legacy prompt-positional form (the user opens Cursor manually
+  and types `/<phase>` in chat). The IDE launcher (`new_context`)
+  invokes `cursor <wd>` directly — Cursor doesn't expose a `--agent`
+  flag for the IDE path, so the user types the slash command in chat
+  once the IDE opens.
 - **`launchers/opencode.py`** — emits the same OpenCode HTTP-API spawn
   approach as the legacy pipeline (delegates to `scripts/qs_opencode/`).
 - **`launchers/codex.py`** — stub.
 
-All launchers return a dict with at minimum `tool`, `same_context`,
-`new_context`. PyCharm convenience commands (`pycharm_context`,
-`pycharm_applescript_context`) are added when PyCharm is detected on
-macOS and the work dir is a worktree.
+All launchers return a dict with at minimum `tool`, `agent` (the
+`qs-<phase>` name), `same_context`, `new_context`. PyCharm convenience
+commands (`pycharm_context`, `pycharm_applescript_context`) are added
+when PyCharm is detected on macOS and the work dir is a worktree.
 
 ## Why not synchronize agent files via a script?
 

--- a/docs/workflow/harness.md
+++ b/docs/workflow/harness.md
@@ -56,10 +56,30 @@ no filesystem scan, so this works from any CWD.
   approach as the legacy pipeline (delegates to `scripts/qs_opencode/`).
 - **`launchers/codex.py`** — stub.
 
-All launchers return a dict with at minimum `tool`, `agent` (the
-`qs-<phase>` name), `same_context`, `new_context`. PyCharm convenience
-commands (`pycharm_context`, `pycharm_applescript_context`) are added
-when PyCharm is detected on macOS and the work dir is a worktree.
+All launchers return a dict with at minimum:
+
+- `tool` (string, e.g. `"claude-code"`)
+- `same_context` (string, slash-form fallback command)
+- `new_context` (string, shell command to spawn a fresh session)
+
+The **Claude** and **Cursor** launchers additionally emit `agent` (the
+resolved `qs-<phase>` name). The **Codex** and **OpenCode** launchers
+do NOT emit `agent` because they accept free-form `--next-cmd` values
+that may not map to a static phase — see
+`tests/qs/launchers/test_next_step_cli.py::test_codex_passes_known_phase_through_unchanged`
+for the grep-able contract pin.
+
+**Whitespace in `--next-cmd`** (review-fix #03 NTH7): codex/opencode
+treat `--next-cmd` as a free-form string, so trailing or leading
+whitespace inside an otherwise-non-empty value is preserved verbatim
+(`--next-cmd "create-plan "` → `same_context: "create-plan "`). This is
+intentional — explicit free-form is a feature, not a bug. The
+empty / whitespace-only case is rejected for all harnesses by
+`next_step.main()` after `parse_args()` returns.
+
+PyCharm convenience commands (`pycharm_context`,
+`pycharm_applescript_context`) are added when PyCharm is detected on
+macOS and the work dir is a worktree.
 
 ## Why not synchronize agent files via a script?
 

--- a/docs/workflow/overview.md
+++ b/docs/workflow/overview.md
@@ -55,6 +55,55 @@ invocations** — serial spawning defeats the design (later reviewers see
 earlier findings and conform to them). See
 [adversarial-review.md](adversarial-review.md) for the full pattern.
 
+## Orchestrators are interactive sessions; sub-agents are parallel fan-out
+
+The pipeline runs two fundamentally different kinds of agent, and the
+launcher distinction matters.
+
+**Phase orchestrators** (`qs-setup-task`, `qs-create-plan`,
+`qs-implement-task`, `qs-implement-setup-task`, `qs-review-task`,
+`qs-finish-task`, `qs-release`) are meant to run as **interactive
+`claude --agent qs-<phase>` sessions**. Claude Code launches a fresh
+session whose system prompt IS the agent body, and the user converses
+with the persona mid-flight — answering clarifying questions in
+`qs-create-plan` step 2, authorizing the quality gate in
+`qs-implement-task` step 4, driving "fix all / skip all" triage in
+`qs-review-task`, and so on. One phase = one session (the system prompt
+is immutable mid-session). The launcher (`scripts/qs/launchers/`) emits
+a `claude --agent qs-<phase>` invocation in the new_context for exactly
+this reason.
+
+**Sub-agents** are the 4 plan reviewers spawned by `qs-create-plan` and
+the 4 code reviewers spawned by `qs-review-task`. They **stay as
+`Agent`-tool fan-out** — non-interactive, parallel, returning a final
+findings report. That's the right shape for them: they're independent
+parallel workers, which is exactly what the `Agent` tool is good at.
+Making them interactive would defeat the design (later reviewers would
+see earlier findings and conform).
+
+**Slash commands stay as a degraded fallback.** Running `/create-plan`
+(or any `/qs-*` slash) from the default Claude Code session spawns the
+phase orchestrator via the `Agent` tool — non-interactive, one-shot,
+returning a final summary with no way for the user to interject. The
+persona body executes, but the per-phase "answer mid-flight" UX is
+gone. This is broken-by-design UX kept **only as a fallback path** for
+environments without the CLI launcher (notably Claude Desktop). The
+slash command files under `.claude/commands/` are reworded — not
+deleted — to flag this distinction.
+
+### Claude Desktop limitation
+
+Claude Desktop has no equivalent to `claude --agent`: no URL scheme, no
+CLI argument pass-through, no UI gesture to pre-load an agent persona
+into a new chat. Desktop users land on the slash-command fallback path
+by necessity. The existing `pycharm_context` (clipboard / AppleScript)
+helpers in `scripts/qs/launchers/claude.py` remain the suggested
+bridge: setup-task emits a `pycharm_context` shell command that copies
+the launcher invocation to the clipboard and opens PyCharm on the
+worktree — users then paste into PyCharm's embedded terminal to get
+the interactive path. This is honest about the limitation, not an
+attempt to automate Desktop with brittle clipboard tricks.
+
 ## Phase routing
 
 `create-plan` chooses between two implement-phase variants based on the

--- a/docs/workflow/phase-protocols.md
+++ b/docs/workflow/phase-protocols.md
@@ -168,9 +168,12 @@ When fixes are needed, re-run `claude --agent qs-implement-task` (or
 **Output**: confirmation; user is directed to `/release` if appropriate.
 **Next phase**: `/release` from the main checkout (independent), or
 `claude --agent qs-release` if the user prefers the interactive form.
-Note that `qs-finish-task` does **not** emit a launcher payload for
-release — it lives on the main checkout, which is a different
-workspace, and the user invokes it manually (see QS-175 OUT OF SCOPE).
+Note that `qs-finish-task` does **not** call
+`scripts/qs/next_step.py --next-cmd release` to build a launcher
+payload — release lives on the main checkout, which is a different
+workspace, and the user invokes it manually. The agent body still
+mentions both `/release` and `claude --agent qs-release` in plain prose
+as alternatives (see QS-175 OUT OF SCOPE).
 
 **Phase protocol**:
 1. Show PR summary.

--- a/docs/workflow/phase-protocols.md
+++ b/docs/workflow/phase-protocols.md
@@ -5,6 +5,14 @@ Each phase has a static agent under `.claude/agents/` (and
 `python scripts/qs/context.py`. This document captures the contract for
 each phase — inputs, outputs, hand-off, hard rules.
 
+Each phase is invoked **as an interactive session** via
+`claude --agent qs-<phase>` (the launcher form — preferred). The
+slash-command form (`/<phase>`) is kept as a **degraded fallback** for
+Claude Desktop and any chat without a CLI launcher. See
+[overview.md](overview.md) section "Orchestrators are interactive
+sessions; sub-agents are parallel fan-out" for the full rationale —
+this document does not duplicate it.
+
 ---
 
 ## `setup-task` (agent: `qs-setup-task`)
@@ -16,8 +24,8 @@ existing GitHub issue, OR `--plan /path/to/plan.md`.
 worktree at `<repo>-worktrees/QS_<N>/`.
 **Output**: launcher command (`scripts/qs/launchers/<harness>.py`-generated)
 the user runs to open a new session on the worktree.
-**Next phase**: user opens new session on the worktree, invokes
-`/create-plan`.
+**Next phase**: `claude --agent qs-create-plan` in the worktree
+(preferred — fresh interactive session), or `/create-plan` as fallback.
 
 **Hard rules**:
 - Do NOT analyze, diagnose, or interpret user input. Pass the text
@@ -36,8 +44,11 @@ the user runs to open a new session on the worktree.
 `docs/stories/QS-<N>.story.md`, commits and pushes.
 **Output**: story file with acceptance criteria + task breakdown +
 adversarial review notes appended.
-**Next phase**: `/implement-task` or `/implement-setup-task` (the agent
-decides based on the file paths in its task breakdown).
+**Next phase**: `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` in the worktree (preferred —
+fresh interactive session), or `/implement-task` /
+`/implement-setup-task` as fallback. The agent decides which based on
+the file paths in its task breakdown.
 
 **Phase protocol**:
 1. Read the issue (`gh issue view`). Read `docs/workflow/project-rules.md`
@@ -57,8 +68,10 @@ decides based on the file paths in its task breakdown).
    otherwise `implement-task`.
 7. Write the story file. Append "Adversarial Review Notes". Commit and
    push.
-8. Tell the user the next command (`/implement-task` or
-   `/implement-setup-task`).
+8. Tell the user the next command — emit the launcher payload (preferred,
+   `claude --agent qs-implement-task` or `claude --agent
+   qs-implement-setup-task`) plus the slash-command fallback
+   (`/implement-task` or `/implement-setup-task`).
 
 **Hard rules**:
 - Do not write code in this phase.
@@ -75,7 +88,8 @@ decides based on the file paths in its task breakdown).
 `tests/` (or `scripts/`, `.claude/`, etc. for `implement-setup-task`);
 auto-commits, pushes, opens PR after green quality gate.
 **Output**: PR opened with quality checklist and risk assessment.
-**Next phase**: `/review-task`.
+**Next phase**: `claude --agent qs-review-task` in the worktree
+(preferred — fresh interactive session), or `/review-task` as fallback.
 
 **Phase protocol**:
 1. Read story file. Confirm branch state.
@@ -111,8 +125,11 @@ auto-commits, pushes, opens PR after green quality gate.
 are needed).
 **Output**: triaged findings; either "ready for finish-task" or a fix
 plan + instructions for the user to apply fixes.
-**Next phase**: `/finish-task` (when clean) or re-run `/implement-task`
-followed by `/review-task` (when fixes are needed).
+**Next phase**: `claude --agent qs-finish-task` in the worktree
+(preferred — fresh interactive session), or `/finish-task` as fallback.
+When fixes are needed, re-run `claude --agent qs-implement-task` (or
+`/implement-task`) and then `claude --agent qs-review-task` (or
+`/review-task`).
 
 **Phase protocol**:
 1. Fetch PR diff.
@@ -124,14 +141,16 @@ followed by `/review-task` (when fixes are needed).
    - `qs-review-coderabbit` — wraps CodeRabbit's review
 3. Consolidate into must-fix / should-fix / nice-to-have / invalid.
 4. **Zero-findings fast path**: if no must-fix or should-fix findings,
-   tell the user to run `/finish-task`.
+   emit the launcher payload (preferred, `claude --agent
+   qs-finish-task`) plus the slash-command fallback (`/finish-task`).
 5. Interactive triage: present table → ask "fix all / skip all / one by
    one?" → collect decisions → confirm.
 6. If fixes needed, write fix-plan file (auto-incremented suffix
-   `#01`, `#02`, …) and emit a ready-to-paste prompt for the user to
-   invoke `/implement-task` against the fix plan.
-7. When fixes pushed, the user re-invokes `/review-task` — loop back to
-   step 1 until clean.
+   `#01`, `#02`, …) and emit the launcher payload (`claude --agent
+   qs-implement-task`) plus the slash-command fallback (`/implement-task`)
+   for the user to apply the fix plan.
+7. When fixes pushed, the user re-runs `claude --agent qs-review-task`
+   (or `/review-task` as fallback) — loop back to step 1 until clean.
 
 **Hard rules**:
 - This agent is an orchestrator — do not review code yourself. Always
@@ -147,7 +166,11 @@ followed by `/review-task` (when fixes are needed).
 **Inputs**: PR number.
 **Side effects**: merges PR, deletes branch on origin, removes worktree.
 **Output**: confirmation; user is directed to `/release` if appropriate.
-**Next phase**: `/release` (independent — runs from main checkout).
+**Next phase**: `/release` from the main checkout (independent), or
+`claude --agent qs-release` if the user prefers the interactive form.
+Note that `qs-finish-task` does **not** emit a launcher payload for
+release — it lives on the main checkout, which is a different
+workspace, and the user invokes it manually (see QS-175 OUT OF SCOPE).
 
 **Phase protocol**:
 1. Show PR summary.

--- a/docs/workflow/project-context.md
+++ b/docs/workflow/project-context.md
@@ -16,15 +16,21 @@ _This file contains critical rules and patterns that AI agents must follow when 
 
 ## Development Lifecycle
 
-The development pipeline uses slash commands that route to static phase
-agents + Python scripts:
-- **`/setup-task`** → **`/create-plan`** → **`/implement-task`** → **`/review-task`** → **`/finish-task`** → **`/release`**
+The development pipeline runs each phase as an interactive
+`claude --agent qs-<phase>` session (preferred) or via the
+slash-command fallback (`/<phase>`, kept for Claude Desktop):
+
+- **`qs-setup-task`** → **`qs-create-plan`** → **`qs-implement-task`** → **`qs-review-task`** → **`qs-finish-task`** → **`qs-release`**
 
 Agents are defined in `.claude/agents/` (and mirrored to `.cursor/agents/`).
 They delegate creative work to themselves and mechanical work to Python
 scripts in `scripts/qs/`. Stories live under
 `docs/stories/QS-<N>.story.md` — shared by the new pipeline and the
 legacy OpenCode pipeline (whose templates were updated to point here).
+
+See [overview.md](overview.md) section "Orchestrators are interactive
+sessions; sub-agents are parallel fan-out" for the rationale behind the
+launcher-vs-slash distinction.
 
 Quality gates: `python scripts/qs/quality_gate.py` (pytest 100% coverage
 + ruff + mypy + translations).

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -43,18 +43,23 @@ source venv/bin/activate && pytest tests/test_solver.py::test_function_name -v
 
 ## Workflow routing
 
-Use slash commands for all development work. Do NOT ask which to use —
-infer from context.
+Each phase runs as an interactive `claude --agent qs-<phase>` session
+(preferred — open a fresh terminal) or as a `/<phase>` slash command
+(fallback — degraded one-shot UX kept for Claude Desktop). Do NOT ask
+which phase to use — infer from context.
 
-| You say                                                      | Command            |
-| ------------------------------------------------------------ | ------------------ |
-| "Setup task 3.2" / describe feature / "work on issue #42"    | `/setup-task`      |
-| "Create plan" (inside worktree)                              | `/create-plan`     |
-| "Implement task" (inside worktree)                           | `/implement-task`  |
-| "Review PR #5" or "review task"                              | `/review-task`     |
-| "Merge PR #5" or "finish task"                               | `/finish-task`     |
-| "Create a release"                                           | `/release`         |
-| Bug fix / small fix                                          | `/setup-task`      |
+| You say                                                      | Preferred launcher                       | Fallback           |
+| ------------------------------------------------------------ | ---------------------------------------- | ------------------ |
+| "Setup task 3.2" / describe feature / "work on issue #42"    | `claude --agent qs-setup-task` on main   | `/setup-task`      |
+| "Create plan" (inside worktree)                              | `claude --agent qs-create-plan`          | `/create-plan`     |
+| "Implement task" (inside worktree)                           | `claude --agent qs-implement-task`       | `/implement-task`  |
+| "Review PR #5" or "review task"                              | `claude --agent qs-review-task`          | `/review-task`     |
+| "Merge PR #5" or "finish task"                               | `claude --agent qs-finish-task`          | `/finish-task`     |
+| "Create a release"                                           | `claude --agent qs-release` on main      | `/release`         |
+| Bug fix / small fix                                          | `claude --agent qs-setup-task` on main   | `/setup-task`      |
+
+See [overview.md](overview.md) section "Orchestrators are interactive
+sessions; sub-agents are parallel fan-out" for the rationale.
 
 Each command delegates to a static agent under `.claude/agents/` (or
 `.cursor/agents/`). Agents discover task context at runtime from

--- a/scripts/qs/launchers/claude.py
+++ b/scripts/qs/launchers/claude.py
@@ -3,13 +3,24 @@
 The Claude launcher emits a ``sh /tmp/qs_launch_<N>.sh`` one-liner whose
 generated script invokes::
 
-    claude {CLAUDE_LAUNCH_OPTS} --agent qs-<phase> --name "QS_<N>: <title>"
+    claude {CLAUDE_LAUNCH_OPTS} --agent qs-<phase> --name 'QS_<N>: <title>'
+
+(Single quotes — ``shlex.quote`` wraps the ``--name`` argument and the
+``--agent`` agent name in single-quote form; the docstring example
+mirrors the rendered shell line.)
 
 The ``--agent`` flag is what makes the new session interactive: Claude
 Code loads the matching ``.claude/agents/qs-<phase>.md`` body as the
 system prompt and the user can converse with the persona mid-flight.
 This is the QS-175 fix for the "non-interactive Agent-tool sub-process"
 UX of the older slash-command path.
+
+Concurrency note: the script path is deterministic per issue number
+(``/tmp/qs_launch_<N>.sh``), so two simultaneous setup-task runs on the
+SAME issue would race on the file. This is fine for the single-user
+dev pipeline this script is built for; switching to
+``NamedTemporaryFile`` would lose the predictable path that the
+``new_context`` consumers rely on.
 """
 
 from __future__ import annotations

--- a/scripts/qs/launchers/claude.py
+++ b/scripts/qs/launchers/claude.py
@@ -21,7 +21,7 @@ import tempfile
 from pathlib import Path
 
 from launchers.phases import (  # type: ignore[import-not-found]
-    _resolve_agent_for_next_cmd,
+    resolve_agent_for_next_cmd,
 )
 
 # Extra flags appended to ``claude`` invocations. Kept narrow on purpose
@@ -174,7 +174,7 @@ def build_payload(
         ValueError: if ``next_cmd`` is not a known phase. No silent
             fallback — free-form prompts go through ``--next-prompt``.
     """
-    agent = _resolve_agent_for_next_cmd(next_cmd)
+    agent = resolve_agent_for_next_cmd(next_cmd)
     new_context = _claude_command(
         work_dir, issue, title, agent=agent, next_prompt=next_prompt,
     )

--- a/scripts/qs/launchers/claude.py
+++ b/scripts/qs/launchers/claude.py
@@ -1,4 +1,16 @@
-"""Launcher payload for Claude Code (CLI + Desktop on macOS)."""
+"""Launcher payload for Claude Code (CLI + Desktop on macOS).
+
+The Claude launcher emits a ``sh /tmp/qs_launch_<N>.sh`` one-liner whose
+generated script invokes::
+
+    claude {CLAUDE_LAUNCH_OPTS} --agent qs-<phase> --name "QS_<N>: <title>"
+
+The ``--agent`` flag is what makes the new session interactive: Claude
+Code loads the matching ``.claude/agents/qs-<phase>.md`` body as the
+system prompt and the user can converse with the persona mid-flight.
+This is the QS-175 fix for the "non-interactive Agent-tool sub-process"
+UX of the older slash-command path.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +19,10 @@ import shlex
 import shutil
 import tempfile
 from pathlib import Path
+
+from launchers.phases import (  # type: ignore[import-not-found]
+    _resolve_agent_for_next_cmd,
+)
 
 # Extra flags appended to ``claude`` invocations. Kept narrow on purpose
 # — users can override via env or by editing this constant.
@@ -42,17 +58,23 @@ def _claude_command(
     issue: int | str,
     title: str,
     *,
+    agent: str,
     next_prompt: str | None,
 ) -> str:
-    """Build a short ``sh /tmp/qs_launch_<N>.sh`` one-liner to open Claude."""
+    """Build a short ``sh /tmp/qs_launch_<N>.sh`` one-liner to open Claude.
+
+    The generated script invokes ``claude --agent <agent>`` so the new
+    session boots straight into the phase orchestrator persona (QS-175).
+    """
     tab_title = f"QS_{issue}: {title}"
     safe_title = shlex.quote(tab_title)
     safe_dir = shlex.quote(work_dir)
+    safe_agent = shlex.quote(agent)
 
     full_cmd = (
         f"printf '\\033]0;%s\\007' {safe_title} && "
         f"cd {safe_dir} && "
-        f"claude {CLAUDE_LAUNCH_OPTS} --name {safe_title}"
+        f"claude {CLAUDE_LAUNCH_OPTS} --agent {safe_agent} --name {safe_title}"
     )
     if next_prompt is not None:
         full_cmd += f" {shlex.quote(next_prompt)}"
@@ -144,14 +166,22 @@ def build_payload(
         next_prompt: Optional preload prompt for the new session.
 
     Returns:
-        A dict with ``tool``, ``same_context``, ``new_context`` and
-        (on macOS with PyCharm installed) ``pycharm_context`` /
+        A dict with ``tool``, ``agent``, ``same_context``, ``new_context``
+        and (on macOS with PyCharm installed) ``pycharm_context`` /
         ``pycharm_applescript_context`` keys.
+
+    Raises:
+        ValueError: if ``next_cmd`` is not a known phase. No silent
+            fallback — free-form prompts go through ``--next-prompt``.
     """
-    new_context = _claude_command(work_dir, issue, title, next_prompt=next_prompt)
+    agent = _resolve_agent_for_next_cmd(next_cmd)
+    new_context = _claude_command(
+        work_dir, issue, title, agent=agent, next_prompt=next_prompt,
+    )
 
     payload: dict = {
         "tool": "claude-code",
+        "agent": agent,
         "same_context": next_cmd,
         "new_context": new_context,
     }

--- a/scripts/qs/launchers/cursor.py
+++ b/scripts/qs/launchers/cursor.py
@@ -30,7 +30,7 @@ import tempfile
 from pathlib import Path
 
 from launchers.phases import (  # type: ignore[import-not-found]
-    _resolve_agent_for_next_cmd,
+    resolve_agent_for_next_cmd,
 )
 
 
@@ -70,6 +70,17 @@ def _cursor_ide_command(
     return f"sh {script_path}"
 
 
+def _slash_form(next_cmd: str) -> str:
+    """Normalize a phase reference to its slash form (``"/create-plan"``).
+
+    Used in the Cursor fallback prompt so the user lands on a slash
+    command they can paste into Cursor's chat — review-fix #2 catches
+    the regression where a bare phase (``"create-plan"``) was embedded
+    in the fallback prompt with no leading slash.
+    """
+    return next_cmd if next_cmd.startswith("/") else f"/{next_cmd}"
+
+
 def _cursor_cli_command(
     work_dir: str,
     *,
@@ -98,10 +109,10 @@ def _cursor_cli_command(
             invocation += f" {shlex.quote(next_prompt)}"
         return invocation
     # Fallback — older cursor-agent binaries / no binary at all. Pre-fill
-    # the prompt with the slash command so the user lands on the right
-    # phase once the session opens. Manual equivalent: open Cursor on the
-    # worktree → in chat, type ``/<phase>``.
-    prompt_parts = [next_cmd]
+    # the prompt with the SLASH form of the command (review-fix #2) so the
+    # user lands on the right phase once the session opens. Manual
+    # equivalent: open Cursor on the worktree → in chat, type ``/<phase>``.
+    prompt_parts = [_slash_form(next_cmd)]
     if next_prompt:
         prompt_parts.append(next_prompt)
     prompt = "\n\n".join(prompt_parts)
@@ -131,7 +142,7 @@ def build_payload(
         ValueError: if ``next_cmd`` is not a known phase. No silent
             fallback — same contract as the Claude launcher.
     """
-    agent = _resolve_agent_for_next_cmd(next_cmd)
+    agent = resolve_agent_for_next_cmd(next_cmd)
     # Use ``--agent`` only when the cursor-agent binary is on PATH; older
     # versions don't understand it. We probe presence rather than
     # ``--help``-sniffing to keep this cheap and version-agnostic.
@@ -165,8 +176,11 @@ def build_payload(
             "",
             # Manual equivalent of the ``--agent`` path: the user opens
             # Cursor and types the slash command in chat. Same degraded
-            # one-shot UX as Claude Desktop, documented honestly.
-            f"Then in chat, type: {next_cmd}",
+            # one-shot UX as Claude Desktop, documented honestly. The
+            # slash form is what Cursor's chat expects, so we normalize
+            # here too (review-fix #2) — a bare phase name would not be
+            # recognized as a slash command.
+            f"Then in chat, type: {_slash_form(next_cmd)}",
         ]
         if next_prompt:
             instructions.extend(["", "Initial prompt:", next_prompt])

--- a/scripts/qs/launchers/cursor.py
+++ b/scripts/qs/launchers/cursor.py
@@ -75,7 +75,7 @@ def _cursor_ide_command(
     return f"sh {script_path}"
 
 
-def _slash_form(next_cmd: str) -> str:
+def slash_form(next_cmd: str) -> str:
     """Normalize a phase reference to its slash form (``"/create-plan"``).
 
     Used in the Cursor fallback prompt so the user lands on a slash
@@ -83,16 +83,38 @@ def _slash_form(next_cmd: str) -> str:
     the regression where a bare phase (``"create-plan"``) was embedded
     in the fallback prompt with no leading slash.
 
+    **Public surface** (review-fix #03 SF2): exposed without a leading
+    underscore so tests can pin its contract without reaching for a
+    "private" name. The function is a pure helper with no
+    module-internal invariants — making it public matches the
+    ``PHASE_TO_AGENT`` / ``LAUNCHERS`` promotion pattern.
+
     Defense-in-depth (review-fix #02 NTH8): the helper is currently
     upstream-protected by ``resolve_agent_for_next_cmd`` (called before
     we land here), but rejecting empty / whitespace-only input here too
     keeps the contract local — a future refactor that wires
-    ``_slash_form`` into a different call path can't silently produce
+    ``slash_form`` into a different call path can't silently produce
     ``"/"`` from ``""``.
+
+    Asymmetry note (review-fix #03 NTH3): we reject empty input but
+    accept ``"//create-plan"`` unchanged (pass-through). Double-slash
+    inputs are rejected upstream by ``resolve_agent_for_next_cmd``;
+    re-checking here would create drift risk between the two guards.
+    If the resolver's policy on ``//`` ever changes, this guard does
+    NOT need to follow — the resolver remains the single source of
+    truth for what counts as a valid phase form.
+
+    Failure mode (review-fix #03 NTH8): the ``ValueError`` raised here
+    is a programmer-error signal — ``slash_form`` is unreachable from
+    ``build_payload`` with empty input because the resolver guards
+    that path. If this defense ever fires in production, the user gets
+    a Python traceback rather than the JSON ``{"error": ...}``
+    contract used for user errors. This is intentional and matches the
+    bimodal contract documented in ``scripts/qs/next_step.py``.
     """
     if not next_cmd or not next_cmd.strip():
         raise ValueError(
-            f"_slash_form requires a non-empty next_cmd; got {next_cmd!r}",
+            f"slash_form requires a non-empty next_cmd; got {next_cmd!r}",
         )
     return next_cmd if next_cmd.startswith("/") else f"/{next_cmd}"
 
@@ -130,7 +152,7 @@ def _cursor_cli_command(
     # the prompt with the SLASH form of the command (review-fix #2) so the
     # user lands on the right phase once the session opens. Manual
     # equivalent: open Cursor on the worktree → in chat, type ``/<phase>``.
-    prompt_parts = [_slash_form(next_cmd)]
+    prompt_parts = [slash_form(next_cmd)]
     if next_prompt:
         prompt_parts.append(next_prompt)
     prompt = "\n\n".join(prompt_parts)
@@ -198,7 +220,7 @@ def build_payload(
             # slash form is what Cursor's chat expects, so we normalize
             # here too (review-fix #2) — a bare phase name would not be
             # recognized as a slash command.
-            f"Then in chat, type: {_slash_form(next_cmd)}",
+            f"Then in chat, type: {slash_form(next_cmd)}",
         ]
         if next_prompt:
             instructions.extend(["", "Initial prompt:", next_prompt])

--- a/scripts/qs/launchers/cursor.py
+++ b/scripts/qs/launchers/cursor.py
@@ -20,6 +20,11 @@ Cursor 2.4+ supports subagents in `.cursor/agents/` and slash-command
 invocation (`/<name>`). The same set of phase agents we ship for Claude
 Code is mirrored under `.cursor/agents/` with `readonly:` instead of
 `tools:` in the frontmatter.
+
+Concurrency note: the cursor IDE script path is deterministic per issue
+(``/tmp/qs_cursor_<N>.sh``), so two simultaneous setup-task runs on the
+SAME issue would race on the file. Fine for the single-user dev
+pipeline; same trade-off as the Claude launcher.
 """
 
 from __future__ import annotations
@@ -77,7 +82,18 @@ def _slash_form(next_cmd: str) -> str:
     command they can paste into Cursor's chat — review-fix #2 catches
     the regression where a bare phase (``"create-plan"``) was embedded
     in the fallback prompt with no leading slash.
+
+    Defense-in-depth (review-fix #02 NTH8): the helper is currently
+    upstream-protected by ``resolve_agent_for_next_cmd`` (called before
+    we land here), but rejecting empty / whitespace-only input here too
+    keeps the contract local — a future refactor that wires
+    ``_slash_form`` into a different call path can't silently produce
+    ``"/"`` from ``""``.
     """
+    if not next_cmd or not next_cmd.strip():
+        raise ValueError(
+            f"_slash_form requires a non-empty next_cmd; got {next_cmd!r}",
+        )
     return next_cmd if next_cmd.startswith("/") else f"/{next_cmd}"
 
 
@@ -101,9 +117,11 @@ def _cursor_cli_command(
     """
     safe_dir = shlex.quote(work_dir)
     if agent is not None:
-        # Preferred path — Cursor 2.4+ supports ``--agent <name>``. The
-        # next_prompt is appended as the initial chat message; the agent
-        # body is loaded as the system prompt.
+        # Preferred path — uses ``--agent <name>`` when ``cursor-agent``
+        # is on PATH. The next_prompt is appended as the initial chat
+        # message; the agent body is loaded as the system prompt. (We
+        # gate purely on PATH presence rather than a version cutoff — the
+        # runtime check is what actually decides.)
         invocation = f"cursor-agent --workspace {safe_dir} --agent {shlex.quote(agent)}"
         if next_prompt:
             invocation += f" {shlex.quote(next_prompt)}"

--- a/scripts/qs/launchers/cursor.py
+++ b/scripts/qs/launchers/cursor.py
@@ -51,10 +51,16 @@ def _cursor_ide_command(
     tab_title = f"QS_{issue}: {title}"
     safe_title = shlex.quote(tab_title)
     safe_dir = shlex.quote(work_dir)
+    # Normalize the user-facing "type this in chat" instruction to the
+    # slash form. Round-2 SF2 fixed the fallback path; this is the
+    # parallel fix for the IDE path (review-fix #04 SF3). The user types
+    # the result into Cursor's chat where ``/<phase>`` is the recognized
+    # slash-command form.
+    chat_slash = slash_form(next_cmd)
 
     banner_lines = [
         f"echo '── Cursor opening on {tab_title} ──'",
-        f"echo '── In the chat, type: {next_cmd} ──'",
+        f"echo '── In the chat, type: {chat_slash} ──'",
     ]
     if next_prompt:
         banner_lines.append(
@@ -104,15 +110,21 @@ def slash_form(next_cmd: str) -> str:
     NOT need to follow — the resolver remains the single source of
     truth for what counts as a valid phase form.
 
-    Failure mode (review-fix #03 NTH8): the ``ValueError`` raised here
-    is a programmer-error signal — ``slash_form`` is unreachable from
-    ``build_payload`` with empty input because the resolver guards
-    that path. If this defense ever fires in production, the user gets
-    a Python traceback rather than the JSON ``{"error": ...}``
-    contract used for user errors. This is intentional and matches the
-    bimodal contract documented in ``scripts/qs/next_step.py``.
+    Failure mode (review-fix #03 NTH8 / #04 NTH9): the ``ValueError``
+    raised here is a programmer-error signal — ``slash_form`` is
+    unreachable from ``build_payload`` with empty input because the
+    resolver guards that path. If this defense ever fires in
+    production, the user gets a Python traceback rather than the JSON
+    ``{"error": ...}`` contract used for user errors. This matches the
+    "Error contract" paragraph in ``scripts/qs/next_step.py``: user
+    errors get JSON, programmer errors get tracebacks. The cross-
+    reference is intentional so a future reader auditing the JSON
+    contract sees the same philosophy in both places.
     """
-    if not next_cmd or not next_cmd.strip():
+    # ``"".strip()`` is also falsy, so a single check covers both empty
+    # and whitespace cases (review-fix #04 NTH1; matches the round-3
+    # NTH2 simplification in next_step.py).
+    if not next_cmd.strip():
         raise ValueError(
             f"slash_form requires a non-empty next_cmd; got {next_cmd!r}",
         )
@@ -169,14 +181,24 @@ def build_payload(
 ) -> dict:
     """Return launcher payload for Cursor.
 
-    Always returns ``new_context`` (the IDE launcher script), ``agent``
-    (the resolved ``qs-<phase>`` name) and ``cli_context`` (the
-    ``cursor-agent`` invocation). When ``cursor-agent`` is on PATH the
-    ``cli_context`` includes ``--agent qs-<phase>`` so the new session
-    boots straight into the phase orchestrator (parity with Claude's
-    ``claude --agent``). When ``cursor-agent`` is missing, ``cli_context``
-    falls back to the legacy prompt-positional form and the user types
-    ``/<phase>`` manually in Cursor's chat after the IDE opens.
+    Always returns a ``new_context`` key (review-fix #04 NTH8: the
+    return shape is uniform, but the CONTENT depends on PATH state):
+
+    - When the ``cursor`` CLI is on PATH, ``new_context`` is a shell
+      command running the generated IDE launcher script
+      (``sh /tmp/qs_cursor_<N>.sh``).
+    - When ``cursor`` is missing, ``new_context`` is free-text
+      fallback instructions for the user to follow manually
+      (open the worktree, run ``cursor-agent``, etc.).
+
+    Also always returns ``agent`` (the resolved ``qs-<phase>`` name)
+    and ``cli_context`` (the ``cursor-agent`` invocation). When
+    ``cursor-agent`` is on PATH the ``cli_context`` includes
+    ``--agent qs-<phase>`` so the new session boots straight into the
+    phase orchestrator (parity with Claude's ``claude --agent``). When
+    ``cursor-agent`` is missing, ``cli_context`` falls back to the
+    legacy prompt-positional form and the user types ``/<phase>``
+    manually in Cursor's chat after the IDE opens.
 
     Raises:
         ValueError: if ``next_cmd`` is not a known phase. No silent

--- a/scripts/qs/launchers/cursor.py
+++ b/scripts/qs/launchers/cursor.py
@@ -5,7 +5,10 @@ Cursor exposes two launchers:
 - ``cursor <path>`` — opens the Cursor IDE on a folder. Best for an
   interactive workflow where the user wants the GUI.
 - ``cursor-agent --workspace <path> [prompt]`` — the headless Cursor CLI
-  agent. Best for scripted / terminal-only flows.
+  agent. Best for scripted / terminal-only flows. When the binary is on
+  PATH we add ``--agent qs-<phase>`` so the new session boots directly
+  into the phase orchestrator (parity with Claude's ``claude --agent``,
+  see QS-175).
 
 We emit a short ``sh /tmp/qs_cursor_<N>.sh`` one-liner that prefers
 ``cursor`` (the IDE launcher — most common dev experience) and falls
@@ -25,6 +28,10 @@ import shlex
 import shutil
 import tempfile
 from pathlib import Path
+
+from launchers.phases import (  # type: ignore[import-not-found]
+    _resolve_agent_for_next_cmd,
+)
 
 
 def _cursor_ide_command(
@@ -68,12 +75,32 @@ def _cursor_cli_command(
     *,
     next_cmd: str,
     next_prompt: str | None,
+    agent: str | None,
 ) -> str:
-    """Build the equivalent headless ``cursor-agent`` invocation."""
+    """Build the equivalent headless ``cursor-agent`` invocation.
+
+    When ``cursor-agent`` is on PATH we add ``--agent qs-<phase>`` so the
+    new session boots straight into the phase orchestrator (QS-175,
+    parity with Claude's ``claude --agent``).
+
+    When the binary is missing we fall back to the legacy prompt-positional
+    form — the user is expected to type ``/<phase>`` themselves in chat
+    once they open Cursor manually. The manual equivalent is documented
+    in ``build_payload``'s fallback ``instructions`` block.
+    """
     safe_dir = shlex.quote(work_dir)
-    # Cursor CLI passes the prompt as a positional arg.  We pre-fill it with
-    # the slash command (and optional preload prompt) so the agent kicks
-    # off on its own when the session opens.
+    if agent is not None:
+        # Preferred path — Cursor 2.4+ supports ``--agent <name>``. The
+        # next_prompt is appended as the initial chat message; the agent
+        # body is loaded as the system prompt.
+        invocation = f"cursor-agent --workspace {safe_dir} --agent {shlex.quote(agent)}"
+        if next_prompt:
+            invocation += f" {shlex.quote(next_prompt)}"
+        return invocation
+    # Fallback — older cursor-agent binaries / no binary at all. Pre-fill
+    # the prompt with the slash command so the user lands on the right
+    # phase once the session opens. Manual equivalent: open Cursor on the
+    # worktree → in chat, type ``/<phase>``.
     prompt_parts = [next_cmd]
     if next_prompt:
         prompt_parts.append(next_prompt)
@@ -91,16 +118,34 @@ def build_payload(
 ) -> dict:
     """Return launcher payload for Cursor.
 
-    Always returns ``new_context`` (the IDE launcher script) and
-    ``cli_context`` (the ``cursor-agent`` invocation).  When the
-    ``cursor`` CLI is not on PATH, ``new_context`` falls back to plain
-    instructions so the user can act manually.
+    Always returns ``new_context`` (the IDE launcher script), ``agent``
+    (the resolved ``qs-<phase>`` name) and ``cli_context`` (the
+    ``cursor-agent`` invocation). When ``cursor-agent`` is on PATH the
+    ``cli_context`` includes ``--agent qs-<phase>`` so the new session
+    boots straight into the phase orchestrator (parity with Claude's
+    ``claude --agent``). When ``cursor-agent`` is missing, ``cli_context``
+    falls back to the legacy prompt-positional form and the user types
+    ``/<phase>`` manually in Cursor's chat after the IDE opens.
+
+    Raises:
+        ValueError: if ``next_cmd`` is not a known phase. No silent
+            fallback — same contract as the Claude launcher.
     """
+    agent = _resolve_agent_for_next_cmd(next_cmd)
+    # Use ``--agent`` only when the cursor-agent binary is on PATH; older
+    # versions don't understand it. We probe presence rather than
+    # ``--help``-sniffing to keep this cheap and version-agnostic.
+    agent_for_cli = agent if shutil.which("cursor-agent") else None
+
     payload: dict = {
         "tool": "cursor",
+        "agent": agent,
         "same_context": next_cmd,
         "cli_context": _cursor_cli_command(
-            work_dir, next_cmd=next_cmd, next_prompt=next_prompt,
+            work_dir,
+            next_cmd=next_cmd,
+            next_prompt=next_prompt,
+            agent=agent_for_cli,
         ),
         "issue": issue,
         "work_dir": work_dir,
@@ -118,6 +163,9 @@ def build_payload(
             "Or use the headless Cursor agent CLI:",
             f"    {payload['cli_context']}",
             "",
+            # Manual equivalent of the ``--agent`` path: the user opens
+            # Cursor and types the slash command in chat. Same degraded
+            # one-shot UX as Claude Desktop, documented honestly.
             f"Then in chat, type: {next_cmd}",
         ]
         if next_prompt:

--- a/scripts/qs/launchers/phases.py
+++ b/scripts/qs/launchers/phases.py
@@ -8,6 +8,11 @@ resolve them to the ``qs-<phase>`` agent that lives under
 Keeping the mapping in one module avoids the drift bug where the launcher
 and the dispatcher disagree on what counts as a valid phase. Adding a new
 phase = add one entry here.
+
+Public names (``PHASE_TO_AGENT``, ``resolve_agent_for_next_cmd``) are
+intentional — they are imported across modules (``claude.py``,
+``cursor.py``, ``next_step.py``, tests). Ruff's ``PLC2701`` would flag
+underscore-prefixed names as private-import violations.
 """
 
 from __future__ import annotations
@@ -15,7 +20,7 @@ from __future__ import annotations
 # Static — phase name → agent file stem (without ``.md``). Every entry is
 # ``"<phase>": f"qs-<phase>"`` by convention, but we keep the mapping
 # explicit so a typo in either side is immediately visible.
-_PHASE_TO_AGENT: dict[str, str] = {
+PHASE_TO_AGENT: dict[str, str] = {
     "setup-task": "qs-setup-task",
     "create-plan": "qs-create-plan",
     "implement-task": "qs-implement-task",
@@ -26,7 +31,7 @@ _PHASE_TO_AGENT: dict[str, str] = {
 }
 
 
-def _resolve_agent_for_next_cmd(next_cmd: str) -> str:
+def resolve_agent_for_next_cmd(next_cmd: str) -> str:
     """Return the ``qs-<phase>`` agent name for a ``--next-cmd`` value.
 
     Accepts either the slash form (``"/create-plan"`` — what older
@@ -41,15 +46,15 @@ def _resolve_agent_for_next_cmd(next_cmd: str) -> str:
         The matching agent file stem (e.g. ``"qs-create-plan"``).
 
     Raises:
-        ValueError: if ``next_cmd`` is not in ``_PHASE_TO_AGENT``. The
+        ValueError: if ``next_cmd`` is not in ``PHASE_TO_AGENT``. The
             error message names the invalid value and lists the known
             phases so the user immediately sees what they meant to type.
     """
     # Strip exactly one leading slash. ``//create-plan`` is intentionally
     # rejected — it indicates a caller bug, not a phase name we should heal.
     phase = next_cmd[1:] if next_cmd.startswith("/") else next_cmd
-    if phase in _PHASE_TO_AGENT:
-        return _PHASE_TO_AGENT[phase]
+    if phase in PHASE_TO_AGENT:
+        return PHASE_TO_AGENT[phase]
     raise ValueError(
-        f"Unknown phase {next_cmd!r}; known phases: {sorted(_PHASE_TO_AGENT)}",
+        f"Unknown phase {next_cmd!r}; known phases: {sorted(PHASE_TO_AGENT)}",
     )

--- a/scripts/qs/launchers/phases.py
+++ b/scripts/qs/launchers/phases.py
@@ -21,26 +21,61 @@ violations.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 
 class UnknownPhaseError(ValueError):
     """Raised by ``resolve_agent_for_next_cmd`` for an unknown phase.
 
     Subclass of ``ValueError`` so legacy ``except ValueError`` blocks
-    keep working. Carrying the ``value`` and ``known`` attributes lets
-    callers (notably ``next_step.py``) format their JSON error payload
-    without re-parsing the exception message — review-fix #02 SF1.
+    keep working. Carrying the ``value``, ``phase``, and ``known``
+    attributes lets callers (notably ``next_step.py``) format their JSON
+    error payload without re-parsing the exception message — review-fix
+    #02 SF1.
+
+    Attributes:
+        value: The original ``next_cmd`` input that failed resolution
+            (e.g. ``"/bogus"`` if the caller passed the slash form).
+        phase: The post-normalization lookup key actually consulted in
+            ``PHASE_TO_AGENT`` (e.g. ``"bogus"`` for ``value="/bogus"``).
+            Surfaced separately so a debugger doesn't have to re-derive
+            it from ``value`` (review-fix #04 NTH4).
+        known: The list of known phase names — what the caller should
+            display as recovery hints. Accepts any ``Sequence[str]`` so
+            tuple-based callers (test fixtures) don't trigger mypy
+            noise (review-fix #04 NTH3).
     """
 
-    def __init__(self, value: str, known: list[str]) -> None:
+    def __init__(
+        self,
+        value: str,
+        known: Sequence[str],
+        *,
+        phase: str | None = None,
+    ) -> None:
+        # ``known`` is normalised to ``list`` so callers can rely on
+        # standard list operations (sorted, indexing) without surprise.
+        known_list = list(known)
+        # ``phase`` defaults to the post-normalization lookup key —
+        # which is what ``resolve_agent_for_next_cmd`` actually consulted.
+        # Callers that build the exception synthetically (e.g. tests)
+        # can pass it explicitly.
+        if phase is None:
+            phase = value[1:] if value.startswith("/") else value
         # Comma-separated rendering reads more cleanly than ``repr(list)``
         # — the latter mixes square brackets and single quotes that look
         # like noise when ``value`` is also a short string (review-fix
-        # #03 NTH5).
-        super().__init__(
-            f"Unknown phase {value!r}; known phases: {', '.join(known)}",
-        )
+        # #03 NTH5). Include the post-normalization lookup key when it
+        # differs from ``value`` so a debugger doesn't have to re-derive
+        # it (review-fix #04 NTH4).
+        if phase != value:
+            head = f"Unknown phase {value!r} (lookup key {phase!r})"
+        else:
+            head = f"Unknown phase {value!r}"
+        super().__init__(f"{head}; known phases: {', '.join(known_list)}")
         self.value = value
-        self.known = known
+        self.phase = phase
+        self.known = known_list
 
 
 # Static — phase name → agent file stem (without ``.md``). Every entry is
@@ -83,4 +118,6 @@ def resolve_agent_for_next_cmd(next_cmd: str) -> str:
     phase = next_cmd[1:] if next_cmd.startswith("/") else next_cmd
     if phase in PHASE_TO_AGENT:
         return PHASE_TO_AGENT[phase]
-    raise UnknownPhaseError(next_cmd, sorted(PHASE_TO_AGENT))
+    # Pass ``phase`` explicitly so the exception's ``.phase`` attribute
+    # records the post-normalization lookup key (review-fix #04 NTH4).
+    raise UnknownPhaseError(next_cmd, sorted(PHASE_TO_AGENT), phase=phase)

--- a/scripts/qs/launchers/phases.py
+++ b/scripts/qs/launchers/phases.py
@@ -5,21 +5,43 @@ Both ``launchers/claude.py`` (used by ``setup_task.py`` and friends) and
 resolve them to the ``qs-<phase>`` agent that lives under
 ``.claude/agents/``.
 
-Keeping the mapping in one module avoids the drift bug where the launcher
-and the dispatcher disagree on what counts as a valid phase. Adding a new
-phase = add one entry here.
+Keeping the mapping in one module makes the canonical name set
+grep-able. The ``qs-<phase>`` convention (every value is
+``f"qs-{key}"``) is enforced by
+``tests/qs/launchers/test_phase_mapping.py::test_phase_to_agent_values_match_qs_prefix``;
+the mapping stays as an explicit dict so that adding a new phase
+remains a single-line, reviewable change.
 
-Public names (``PHASE_TO_AGENT``, ``resolve_agent_for_next_cmd``) are
-intentional — they are imported across modules (``claude.py``,
-``cursor.py``, ``next_step.py``, tests). Ruff's ``PLC2701`` would flag
-underscore-prefixed names as private-import violations.
+Public names (``PHASE_TO_AGENT``, ``resolve_agent_for_next_cmd``,
+``UnknownPhaseError``) are intentional — they are imported across
+modules (``claude.py``, ``cursor.py``, ``next_step.py``, tests). Ruff's
+``PLC2701`` would flag underscore-prefixed names as private-import
+violations.
 """
 
 from __future__ import annotations
 
+
+class UnknownPhaseError(ValueError):
+    """Raised by ``resolve_agent_for_next_cmd`` for an unknown phase.
+
+    Subclass of ``ValueError`` so legacy ``except ValueError`` blocks
+    keep working. Carrying the ``value`` and ``known`` attributes lets
+    callers (notably ``next_step.py``) format their JSON error payload
+    without re-parsing the exception message — review-fix #02 SF1.
+    """
+
+    def __init__(self, value: str, known: list[str]) -> None:
+        super().__init__(
+            f"Unknown phase {value!r}; known phases: {known}",
+        )
+        self.value = value
+        self.known = known
+
+
 # Static — phase name → agent file stem (without ``.md``). Every entry is
-# ``"<phase>": f"qs-<phase>"`` by convention, but we keep the mapping
-# explicit so a typo in either side is immediately visible.
+# ``"<phase>": f"qs-<phase>"`` by convention (pinned by a regression test
+# in tests/qs/launchers/test_phase_mapping.py).
 PHASE_TO_AGENT: dict[str, str] = {
     "setup-task": "qs-setup-task",
     "create-plan": "qs-create-plan",
@@ -36,8 +58,9 @@ def resolve_agent_for_next_cmd(next_cmd: str) -> str:
 
     Accepts either the slash form (``"/create-plan"`` — what older
     callers pass) or the bare phase name (``"create-plan"``). Raises
-    ``ValueError`` on any unknown phase. There is **no** silent fallback:
-    free-form prompts get the separate ``--next-prompt`` arg.
+    ``UnknownPhaseError`` (a ``ValueError`` subclass) on any unknown
+    phase. There is **no** silent fallback: free-form prompts get the
+    separate ``--next-prompt`` arg.
 
     Args:
         next_cmd: ``"/create-plan"`` or ``"create-plan"`` etc.
@@ -46,15 +69,14 @@ def resolve_agent_for_next_cmd(next_cmd: str) -> str:
         The matching agent file stem (e.g. ``"qs-create-plan"``).
 
     Raises:
-        ValueError: if ``next_cmd`` is not in ``PHASE_TO_AGENT``. The
-            error message names the invalid value and lists the known
-            phases so the user immediately sees what they meant to type.
+        UnknownPhaseError: if ``next_cmd`` is not in ``PHASE_TO_AGENT``.
+            The exception's ``.value`` and ``.known`` attributes carry
+            the raw input and the list of accepted phases so callers
+            don't have to re-parse the message.
     """
     # Strip exactly one leading slash. ``//create-plan`` is intentionally
     # rejected — it indicates a caller bug, not a phase name we should heal.
     phase = next_cmd[1:] if next_cmd.startswith("/") else next_cmd
     if phase in PHASE_TO_AGENT:
         return PHASE_TO_AGENT[phase]
-    raise ValueError(
-        f"Unknown phase {next_cmd!r}; known phases: {sorted(PHASE_TO_AGENT)}",
-    )
+    raise UnknownPhaseError(next_cmd, sorted(PHASE_TO_AGENT))

--- a/scripts/qs/launchers/phases.py
+++ b/scripts/qs/launchers/phases.py
@@ -1,0 +1,55 @@
+"""Phase name → static-agent name mapping (single source of truth).
+
+Both ``launchers/claude.py`` (used by ``setup_task.py`` and friends) and
+``next_step.py`` import this module to validate ``--next-cmd`` values and
+resolve them to the ``qs-<phase>`` agent that lives under
+``.claude/agents/``.
+
+Keeping the mapping in one module avoids the drift bug where the launcher
+and the dispatcher disagree on what counts as a valid phase. Adding a new
+phase = add one entry here.
+"""
+
+from __future__ import annotations
+
+# Static — phase name → agent file stem (without ``.md``). Every entry is
+# ``"<phase>": f"qs-<phase>"`` by convention, but we keep the mapping
+# explicit so a typo in either side is immediately visible.
+_PHASE_TO_AGENT: dict[str, str] = {
+    "setup-task": "qs-setup-task",
+    "create-plan": "qs-create-plan",
+    "implement-task": "qs-implement-task",
+    "implement-setup-task": "qs-implement-setup-task",
+    "review-task": "qs-review-task",
+    "finish-task": "qs-finish-task",
+    "release": "qs-release",
+}
+
+
+def _resolve_agent_for_next_cmd(next_cmd: str) -> str:
+    """Return the ``qs-<phase>`` agent name for a ``--next-cmd`` value.
+
+    Accepts either the slash form (``"/create-plan"`` — what older
+    callers pass) or the bare phase name (``"create-plan"``). Raises
+    ``ValueError`` on any unknown phase. There is **no** silent fallback:
+    free-form prompts get the separate ``--next-prompt`` arg.
+
+    Args:
+        next_cmd: ``"/create-plan"`` or ``"create-plan"`` etc.
+
+    Returns:
+        The matching agent file stem (e.g. ``"qs-create-plan"``).
+
+    Raises:
+        ValueError: if ``next_cmd`` is not in ``_PHASE_TO_AGENT``. The
+            error message names the invalid value and lists the known
+            phases so the user immediately sees what they meant to type.
+    """
+    # Strip exactly one leading slash. ``//create-plan`` is intentionally
+    # rejected — it indicates a caller bug, not a phase name we should heal.
+    phase = next_cmd[1:] if next_cmd.startswith("/") else next_cmd
+    if phase in _PHASE_TO_AGENT:
+        return _PHASE_TO_AGENT[phase]
+    raise ValueError(
+        f"Unknown phase {next_cmd!r}; known phases: {sorted(_PHASE_TO_AGENT)}",
+    )

--- a/scripts/qs/launchers/phases.py
+++ b/scripts/qs/launchers/phases.py
@@ -32,8 +32,12 @@ class UnknownPhaseError(ValueError):
     """
 
     def __init__(self, value: str, known: list[str]) -> None:
+        # Comma-separated rendering reads more cleanly than ``repr(list)``
+        # — the latter mixes square brackets and single quotes that look
+        # like noise when ``value`` is also a short string (review-fix
+        # #03 NTH5).
         super().__init__(
-            f"Unknown phase {value!r}; known phases: {known}",
+            f"Unknown phase {value!r}; known phases: {', '.join(known)}",
         )
         self.value = value
         self.known = known

--- a/scripts/qs/next_step.py
+++ b/scripts/qs/next_step.py
@@ -14,6 +14,16 @@ Usage::
         --title "Story 3.2: foo bar" \\
         [--next-prompt "Begin your phase protocol."] \\
         [--harness HARNESS_OVERRIDE]
+
+``--next-cmd`` accepts both ``/create-plan`` (back-compat) and
+``create-plan`` (bare phase name). Anything else raises ``ValueError`` —
+the launcher writes a JSON error to stdout and exits non-zero. No silent
+fallback; free-form prompts get the separate ``--next-prompt`` arg.
+
+The phase-name → agent-name resolution is a static dict
+(``launchers/phases.py``) — no filesystem scan, no ``Path.cwd()`` call —
+so this script works from any CWD (worktree, main checkout, ``/tmp``,
+…). That's AC-9 of QS-175.
 """
 
 from __future__ import annotations
@@ -27,6 +37,10 @@ from launchers import claude as claude_launcher  # type: ignore[import-not-found
 from launchers import codex as codex_launcher  # type: ignore[import-not-found]
 from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
 from launchers import opencode as opencode_launcher  # type: ignore[import-not-found]
+from launchers.phases import (  # type: ignore[import-not-found]
+    _PHASE_TO_AGENT,
+    _resolve_agent_for_next_cmd,
+)
 
 from utils import output_json  # type: ignore[import-not-found]
 
@@ -40,7 +54,16 @@ _LAUNCHERS = {
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Emit a harness-aware handoff payload.")
-    parser.add_argument("--next-cmd", required=True, help="Slash command for the next phase (e.g. /create-plan)")
+    parser.add_argument(
+        "--next-cmd",
+        required=True,
+        help=(
+            "Phase name for the next step. Accepts either the bare form "
+            "('create-plan') or the slash form ('/create-plan') for "
+            "back-compat. Unknown values are rejected — see --next-prompt "
+            "for free-form initial prompts."
+        ),
+    )
     parser.add_argument("--work-dir", required=True, help="Worktree the new session should open in")
     parser.add_argument("--issue", type=int, required=True)
     parser.add_argument("--title", required=True)
@@ -56,6 +79,18 @@ def main() -> None:
         help="Override the detected harness.",
     )
     args = parser.parse_args()
+
+    # Validate the phase up front so a typo fails loudly with a JSON
+    # error payload instead of producing a junk launcher script downstream.
+    try:
+        _resolve_agent_for_next_cmd(args.next_cmd)
+    except ValueError:
+        output_json({
+            "error": "unknown phase",
+            "value": args.next_cmd,
+            "known": sorted(_PHASE_TO_AGENT),
+        })
+        sys.exit(1)
 
     harness = args.harness or detect_harness()
     launcher = _LAUNCHERS[harness]

--- a/scripts/qs/next_step.py
+++ b/scripts/qs/next_step.py
@@ -37,13 +37,27 @@ preserved verbatim under codex/opencode (review-fix #03 NTH7); those
 launchers treat ``--next-cmd`` as free-form, so an intentional space
 is the user's call.
 
-**Bimodal error contract** (review-fix #03 NTH9): expected failures
-(unknown phase, empty next-cmd) emit a JSON ``{"error": ...}`` payload
-and exit 1. Programmer errors (any other exception from a launcher,
-including non-phase ``ValueError`` from future launcher code) propagate
-uncaught — the user gets a Python traceback. This is intentional:
-programmer errors should fail loudly so the bug is visible in CI logs;
-user errors should emit a parseable JSON contract.
+**Error contract** (review-fix #03 NTH9, extended in review-fix #04
+NTH5/NTH6/NTH7). Four exit shapes, ordered by where they're caught:
+
+- **Argparse user errors** (exit 2, stderr banner) — missing required
+  flag, unknown ``--harness`` value (constrained by ``choices=`` so
+  the harness name is rejected before dispatch instead of
+  ``KeyError``-ing inside ``LAUNCHERS[harness]``). Standard argparse
+  contract; we do not catch or reformat.
+- **Expected user errors** (exit 1, JSON payload) — unknown phase
+  (caught as ``UnknownPhaseError``) and empty / whitespace-only
+  ``--next-cmd`` (rejected in main()). Both emit
+  ``{"error": ..., "value": ..., ...}`` so downstream scripts can
+  parse the failure mode programmatically.
+- **Programmer errors** (Python traceback, non-zero exit) — any other
+  exception from a launcher, including non-phase ``ValueError`` from
+  future launcher code. NOT caught: programmer errors should fail
+  loudly so the bug is visible in CI logs.
+- **KeyboardInterrupt** (Python traceback) — Ctrl-C during a
+  ``build_payload`` call propagates uncaught. Acceptable because a
+  half-written launcher script in ``/tmp`` doesn't break anything; the
+  user re-runs the phase and the script is overwritten.
 
 The phase-name → agent-name resolution is a static dict
 (``launchers/phases.py``) — no filesystem scan, no ``Path.cwd()`` call —
@@ -56,7 +70,6 @@ from __future__ import annotations
 import argparse
 import sys
 
-from harness import VALID_HARNESSES  # type: ignore[import-not-found]
 from harness import detect as detect_harness
 from launchers import claude as claude_launcher  # type: ignore[import-not-found]
 from launchers import codex as codex_launcher  # type: ignore[import-not-found]
@@ -103,7 +116,15 @@ def main() -> None:
     parser.add_argument(
         "--harness",
         default=None,
-        choices=list(VALID_HARNESSES),
+        # Use ``LAUNCHERS`` (this module's dispatch table) rather than
+        # ``VALID_HARNESSES`` (harness.py's enum) as the choices source.
+        # The two sets are identical today but ``LAUNCHERS`` is the
+        # actual source of truth for what this script can dispatch — if
+        # someone ever adds a harness to ``VALID_HARNESSES`` without a
+        # corresponding launcher, argparse rejects the bad value cleanly
+        # instead of letting it KeyError inside main(). Review-fix #04
+        # NTH7.
+        choices=list(LAUNCHERS),
         help="Override the detected harness.",
     )
     args = parser.parse_args()

--- a/scripts/qs/next_step.py
+++ b/scripts/qs/next_step.py
@@ -19,9 +19,16 @@ Usage::
 ``create-plan`` (bare phase name) for the claude/cursor launchers.
 Validation is delegated to the launcher's ``build_payload`` so the
 codex and opencode launchers — which have no agent mapping today —
-accept ANY ``--next-cmd`` string unchanged. On a known harness with an
-unknown phase, ``build_payload`` raises ``ValueError`` and this script
-writes a JSON error to stdout + exits non-zero.
+accept any non-empty ``--next-cmd`` string unchanged. On a known
+harness with an unknown phase, ``build_payload`` raises
+``UnknownPhaseError`` and this script writes a JSON error to stdout +
+exits non-zero. Other ``ValueError`` subclasses (from future launcher
+code) are deliberately NOT caught — review-fix #02 SF1.
+
+Empty / whitespace-only ``--next-cmd`` is rejected at the argparse
+layer for ALL harnesses (review-fix #02 SF2): without this guard,
+codex/opencode would silently accept the empty string and emit a
+garbled handoff payload.
 
 The phase-name → agent-name resolution is a static dict
 (``launchers/phases.py``) — no filesystem scan, no ``Path.cwd()`` call —
@@ -40,9 +47,7 @@ from launchers import claude as claude_launcher  # type: ignore[import-not-found
 from launchers import codex as codex_launcher  # type: ignore[import-not-found]
 from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
 from launchers import opencode as opencode_launcher  # type: ignore[import-not-found]
-from launchers.phases import (  # type: ignore[import-not-found]
-    PHASE_TO_AGENT,
-)
+from launchers.phases import UnknownPhaseError  # type: ignore[import-not-found]
 
 from utils import output_json  # type: ignore[import-not-found]
 
@@ -84,13 +89,25 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    # Reject empty / whitespace-only --next-cmd for every harness
+    # (review-fix #02 SF2). Without this, codex/opencode would silently
+    # pass the empty string through to ``build_payload`` and emit a
+    # garbled payload with ``same_context: ""``.
+    if not args.next_cmd or not args.next_cmd.strip():
+        output_json({
+            "error": "empty next-cmd",
+            "value": args.next_cmd,
+            "detail": "--next-cmd must be a non-empty, non-whitespace string",
+        })
+        sys.exit(1)
+
     harness = args.harness or detect_harness()
     launcher = _LAUNCHERS[harness]
     # Delegate validation to the launcher: claude/cursor enforce the
     # phase mapping inside ``build_payload``; codex/opencode accept any
-    # ``next_cmd`` string. This is the QS-175-review-fix-#1 contract —
-    # no top-level pre-validation that would regress the legacy
-    # free-form harnesses.
+    # ``next_cmd`` string. We catch only ``UnknownPhaseError`` here —
+    # other ``ValueError`` subclasses must propagate so a future failure
+    # mode isn't misreported as "unknown phase" (review-fix #02 SF1).
     try:
         payload = launcher.build_payload(
             args.work_dir,
@@ -99,11 +116,11 @@ def main() -> None:
             next_cmd=args.next_cmd,
             next_prompt=args.next_prompt,
         )
-    except ValueError:
+    except UnknownPhaseError as exc:
         output_json({
             "error": "unknown phase",
-            "value": args.next_cmd,
-            "known": sorted(PHASE_TO_AGENT),
+            "value": exc.value,
+            "known": exc.known,
         })
         sys.exit(1)
     payload["harness"] = harness

--- a/scripts/qs/next_step.py
+++ b/scripts/qs/next_step.py
@@ -25,10 +25,25 @@ harness with an unknown phase, ``build_payload`` raises
 exits non-zero. Other ``ValueError`` subclasses (from future launcher
 code) are deliberately NOT caught — review-fix #02 SF1.
 
-Empty / whitespace-only ``--next-cmd`` is rejected at the argparse
-layer for ALL harnesses (review-fix #02 SF2): without this guard,
-codex/opencode would silently accept the empty string and emit a
-garbled handoff payload.
+Empty / whitespace-only ``--next-cmd`` is rejected by ``main()`` after
+``parser.parse_args()`` returns, for ALL harnesses (review-fix #02
+SF2). The check sits after parse rather than inside an argparse
+``type=`` callable because argparse type errors print a usage banner
+to stderr, but the rest of this script speaks a JSON error contract
+(``{"error": ..., "value": ..., ...}``) — putting the check in main()
+keeps the contract uniform. Trailing/leading whitespace inside an
+otherwise-non-empty ``--next-cmd`` (e.g. ``"create-plan "``) IS
+preserved verbatim under codex/opencode (review-fix #03 NTH7); those
+launchers treat ``--next-cmd`` as free-form, so an intentional space
+is the user's call.
+
+**Bimodal error contract** (review-fix #03 NTH9): expected failures
+(unknown phase, empty next-cmd) emit a JSON ``{"error": ...}`` payload
+and exit 1. Programmer errors (any other exception from a launcher,
+including non-phase ``ValueError`` from future launcher code) propagate
+uncaught — the user gets a Python traceback. This is intentional:
+programmer errors should fail loudly so the bug is visible in CI logs;
+user errors should emit a parseable JSON contract.
 
 The phase-name → agent-name resolution is a static dict
 (``launchers/phases.py``) — no filesystem scan, no ``Path.cwd()`` call —
@@ -51,7 +66,11 @@ from launchers.phases import UnknownPhaseError  # type: ignore[import-not-found]
 
 from utils import output_json  # type: ignore[import-not-found]
 
-_LAUNCHERS = {
+# Public mapping (review-fix #03 SF1) — tests and future extension code
+# treat this as the harness-dispatch configuration table. Keeping it
+# under a public name avoids SLF001-style import smells in test code
+# that monkeypatches the dispatcher.
+LAUNCHERS = {
     "claude-code": claude_launcher,
     "cursor": cursor_launcher,
     "opencode": opencode_launcher,
@@ -92,8 +111,10 @@ def main() -> None:
     # Reject empty / whitespace-only --next-cmd for every harness
     # (review-fix #02 SF2). Without this, codex/opencode would silently
     # pass the empty string through to ``build_payload`` and emit a
-    # garbled payload with ``same_context: ""``.
-    if not args.next_cmd or not args.next_cmd.strip():
+    # garbled payload with ``same_context: ""``. The first ``not`` form
+    # is dropped (review-fix #03 NTH2) — ``"".strip()`` is also falsy,
+    # so a single check covers both empty and whitespace cases.
+    if not args.next_cmd.strip():
         output_json({
             "error": "empty next-cmd",
             "value": args.next_cmd,
@@ -102,7 +123,7 @@ def main() -> None:
         sys.exit(1)
 
     harness = args.harness or detect_harness()
-    launcher = _LAUNCHERS[harness]
+    launcher = LAUNCHERS[harness]
     # Delegate validation to the launcher: claude/cursor enforce the
     # phase mapping inside ``build_payload``; codex/opencode accept any
     # ``next_cmd`` string. We catch only ``UnknownPhaseError`` here —

--- a/scripts/qs/next_step.py
+++ b/scripts/qs/next_step.py
@@ -16,9 +16,12 @@ Usage::
         [--harness HARNESS_OVERRIDE]
 
 ``--next-cmd`` accepts both ``/create-plan`` (back-compat) and
-``create-plan`` (bare phase name). Anything else raises ``ValueError`` —
-the launcher writes a JSON error to stdout and exits non-zero. No silent
-fallback; free-form prompts get the separate ``--next-prompt`` arg.
+``create-plan`` (bare phase name) for the claude/cursor launchers.
+Validation is delegated to the launcher's ``build_payload`` so the
+codex and opencode launchers — which have no agent mapping today —
+accept ANY ``--next-cmd`` string unchanged. On a known harness with an
+unknown phase, ``build_payload`` raises ``ValueError`` and this script
+writes a JSON error to stdout + exits non-zero.
 
 The phase-name → agent-name resolution is a static dict
 (``launchers/phases.py``) — no filesystem scan, no ``Path.cwd()`` call —
@@ -38,8 +41,7 @@ from launchers import codex as codex_launcher  # type: ignore[import-not-found]
 from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
 from launchers import opencode as opencode_launcher  # type: ignore[import-not-found]
 from launchers.phases import (  # type: ignore[import-not-found]
-    _PHASE_TO_AGENT,
-    _resolve_agent_for_next_cmd,
+    PHASE_TO_AGENT,
 )
 
 from utils import output_json  # type: ignore[import-not-found]
@@ -60,8 +62,10 @@ def main() -> None:
         help=(
             "Phase name for the next step. Accepts either the bare form "
             "('create-plan') or the slash form ('/create-plan') for "
-            "back-compat. Unknown values are rejected — see --next-prompt "
-            "for free-form initial prompts."
+            "back-compat under the claude/cursor launchers. Free-form "
+            "strings are passed through unchanged under codex/opencode "
+            "(no agent mapping there). See --next-prompt for an initial "
+            "prompt that loads into the new session."
         ),
     )
     parser.add_argument("--work-dir", required=True, help="Worktree the new session should open in")
@@ -80,27 +84,28 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    # Validate the phase up front so a typo fails loudly with a JSON
-    # error payload instead of producing a junk launcher script downstream.
+    harness = args.harness or detect_harness()
+    launcher = _LAUNCHERS[harness]
+    # Delegate validation to the launcher: claude/cursor enforce the
+    # phase mapping inside ``build_payload``; codex/opencode accept any
+    # ``next_cmd`` string. This is the QS-175-review-fix-#1 contract —
+    # no top-level pre-validation that would regress the legacy
+    # free-form harnesses.
     try:
-        _resolve_agent_for_next_cmd(args.next_cmd)
+        payload = launcher.build_payload(
+            args.work_dir,
+            args.issue,
+            args.title,
+            next_cmd=args.next_cmd,
+            next_prompt=args.next_prompt,
+        )
     except ValueError:
         output_json({
             "error": "unknown phase",
             "value": args.next_cmd,
-            "known": sorted(_PHASE_TO_AGENT),
+            "known": sorted(PHASE_TO_AGENT),
         })
         sys.exit(1)
-
-    harness = args.harness or detect_harness()
-    launcher = _LAUNCHERS[harness]
-    payload = launcher.build_payload(
-        args.work_dir,
-        args.issue,
-        args.title,
-        next_cmd=args.next_cmd,
-        next_prompt=args.next_prompt,
-    )
     payload["harness"] = harness
     output_json(payload)
     sys.exit(0)

--- a/scripts/qs/setup_task.py
+++ b/scripts/qs/setup_task.py
@@ -31,7 +31,14 @@ from utils import (  # type: ignore[import-not-found]
     run_git,
 )
 
-_LAUNCHERS = {
+# Public mapping (review-fix #04 SF1) — promoted to match the
+# round-3 SF1 rename of next_step.LAUNCHERS. The two dispatch tables
+# are conceptually the same configuration; keeping the naming
+# convention aligned avoids drift and lets test code monkeypatch
+# either via the public attribute. Kept as a local copy (not imported
+# from ``next_step``) so ``setup_task`` stays independent of the
+# next-phase dispatcher.
+LAUNCHERS = {
     "claude-code": claude_launcher,
     "cursor": cursor_launcher,
     "opencode": opencode_launcher,
@@ -93,7 +100,7 @@ def main() -> None:
     title = args.title or f"Issue #{issue}"
 
     harness = args.harness or detect_harness()
-    launcher = _LAUNCHERS[harness]
+    launcher = LAUNCHERS[harness]
     launcher_payload = launcher.build_payload(
         work_dir,
         issue,

--- a/tests/qs/__init__.py
+++ b/tests/qs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for scripts/qs/ — the harness-agnostic QS pipeline scripts."""

--- a/tests/qs/agents/__init__.py
+++ b/tests/qs/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Tests that lock the QS-175 contracts in .claude/agents/ and .claude/commands/."""

--- a/tests/qs/agents/test_orchestrator_handoff.py
+++ b/tests/qs/agents/test_orchestrator_handoff.py
@@ -2,11 +2,22 @@
 BOTH a launcher block (``claude --agent qs-<phase>``) AND a slash-command
 fallback block (``/<phase>``).
 
-This is the regression catch for QS-175 review-fix #7 — without it the
-two-block pattern is enforced only by manual review. The test also catches
-review-fix #3 (qs-setup-task fallback drift): it asserts each fallback
-mentions ``/<phase>`` for a concrete known phase, not a verbatim template
-variable like ``{{same_context}}``.
+This is the regression catch for QS-175 review-fix #07 — without it the
+two-block pattern is enforced only by manual review.
+
+Round-2 review-fix #03 / #04 / #05 / #06 cleanups:
+- ``qs-create-plan`` is split out into a dedicated test because its
+  ``NEXT_PHASE`` is dynamic (the orchestrator picks
+  ``implement-task`` vs ``implement-setup-task`` at runtime) and a
+  hardcoded slash form isn't possible there.
+- The parametrise lists are split so unused ``expected_slash`` params
+  don't trigger ruff ``ARG001``.
+- The ``Fallback`` line scan is now a line-by-line walk rather than a
+  brittle ``re.search`` with a greedy ``[^:]*`` pattern that could match
+  past a future "Note:" parenthetical.
+- The ``does-not-call-next-step-for-release`` regex strips inline +
+  fenced backticks before scanning so a backtick-wrapped ``python ...
+  --next-cmd release`` invocation can't slip past.
 """
 
 from __future__ import annotations
@@ -19,24 +30,36 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 AGENTS_DIR = REPO_ROOT / ".claude" / "agents"
 
-# Each entry: (orchestrator file, the next-phase slash that MUST appear in
-# the handoff wording somewhere). The five "normal" orchestrators ship the
-# strict two-block ``Preferred`` / ``Fallback`` pattern; qs-finish-task is
-# the deliberate exception — see ``_FINISH_TASK_EXCEPTIONS`` below.
+
+# All 6 orchestrators that ship the strict two-block ``Preferred`` /
+# ``Fallback`` pattern. ``qs-finish-task`` is the deliberate exception
+# (release follow-up is text-only — see QS-175 OUT OF SCOPE) and gets
+# its own dedicated tests below.
 _TWO_BLOCK_ORCHESTRATORS = [
+    "qs-setup-task.md",
+    "qs-create-plan.md",
+    "qs-implement-task.md",
+    "qs-implement-setup-task.md",
+    "qs-review-task.md",
+]
+
+# Five of those orchestrators emit a hardcoded ``/<phase>`` in the
+# fallback block. ``qs-create-plan`` is dynamic (the NEXT_PHASE depends
+# on the diff) and gets its own dedicated test asserting it uses a
+# placeholder of the right SHAPE, but explicitly NOT
+# ``{{same_context}}``.
+_HARDCODED_FALLBACK = [
     ("qs-setup-task.md", "/create-plan"),
-    ("qs-create-plan.md", "/{{NEXT_PHASE}}"),
     ("qs-implement-task.md", "/review-task"),
     ("qs-implement-setup-task.md", "/review-task"),
     ("qs-review-task.md", "/finish-task"),
 ]
 
 
-@pytest.mark.parametrize(("filename", "expected_slash"), _TWO_BLOCK_ORCHESTRATORS)
-def test_orchestrator_has_two_block_handoff(filename: str, expected_slash: str) -> None:
+@pytest.mark.parametrize("filename", _TWO_BLOCK_ORCHESTRATORS)
+def test_orchestrator_has_two_block_handoff(filename: str) -> None:
     """Every orchestrator's handoff contains 'Preferred' AND 'Fallback' markers."""
-    path = AGENTS_DIR / filename
-    body = path.read_text()
+    body = (AGENTS_DIR / filename).read_text()
     assert "Preferred" in body, (
         f"{filename}: missing 'Preferred' marker — every orchestrator must "
         f"label the interactive launcher path."
@@ -47,13 +70,10 @@ def test_orchestrator_has_two_block_handoff(filename: str, expected_slash: str) 
     )
 
 
-@pytest.mark.parametrize(("filename", "expected_slash"), _TWO_BLOCK_ORCHESTRATORS)
-def test_orchestrator_handoff_mentions_claude_agent_invocation(
-    filename: str, expected_slash: str,
-) -> None:
+@pytest.mark.parametrize("filename", _TWO_BLOCK_ORCHESTRATORS)
+def test_orchestrator_handoff_mentions_claude_agent_invocation(filename: str) -> None:
     """Handoff text references ``claude --agent qs-<phase>`` — the preferred path."""
-    path = AGENTS_DIR / filename
-    body = path.read_text()
+    body = (AGENTS_DIR / filename).read_text()
     # The orchestrator may emit either a literal ``claude --agent qs-...``
     # string (qs-setup-task) or use the new_context variable that resolves
     # to one at runtime (qs-create-plan, qs-implement-task, etc.). Either
@@ -64,24 +84,75 @@ def test_orchestrator_handoff_mentions_claude_agent_invocation(
     )
 
 
-@pytest.mark.parametrize(("filename", "expected_slash"), _TWO_BLOCK_ORCHESTRATORS)
+@pytest.mark.parametrize(("filename", "expected_slash"), _HARDCODED_FALLBACK)
 def test_orchestrator_fallback_uses_concrete_slash_form(
     filename: str, expected_slash: str,
 ) -> None:
-    """Each fallback block names a real ``/<phase>`` slash, not ``{{same_context}}``."""
-    path = AGENTS_DIR / filename
-    body = path.read_text()
+    """Each fixed-next-phase fallback block names a real ``/<phase>``."""
+    body = (AGENTS_DIR / filename).read_text()
     assert expected_slash in body, (
         f"{filename}: expected fallback to mention {expected_slash!r}; "
-        f"this catches the qs-setup-task regression where {{{{same_context}}}} "
-        f"was emitted instead of a hardcoded slash form."
+        f"this catches the qs-setup-task-style regression where "
+        f"{{{{same_context}}}} or another verbatim template variable "
+        f"would be emitted instead of a hardcoded slash form."
     )
 
 
+# --------------------------------------------------------------------------- #
+# qs-create-plan is the dynamic-next-phase exception. The fallback line
+# can't be a single hardcoded ``/<phase>`` because the orchestrator picks
+# ``implement-task`` vs ``implement-setup-task`` based on its task
+# breakdown. The fallback uses a ``/{{NEXT_PHASE}}`` placeholder that
+# the persona substitutes at runtime — what we forbid is the
+# ``{{same_context}}`` shape that caused the qs-setup-task regression.
+# --------------------------------------------------------------------------- #
+
+
+def test_create_plan_fallback_uses_next_phase_placeholder_not_same_context() -> None:
+    """qs-create-plan fallback uses ``/<NEXT_PHASE>`` placeholder, not ``{{same_context}}``."""
+    body = (AGENTS_DIR / "qs-create-plan.md").read_text()
+    fallback_line = _find_fallback_line(body)
+    assert fallback_line is not None, "qs-create-plan: 'Fallback' block not found"
+    assert "{{same_context}}" not in fallback_line, (
+        f"qs-create-plan fallback uses {{{{same_context}}}} — that's the "
+        f"verbatim template variable that caused the qs-setup-task "
+        f"regression; use a slash-form placeholder like /{{{{NEXT_PHASE}}}} "
+        f"instead. Got: {fallback_line!r}"
+    )
+    assert fallback_line.lstrip().startswith("/"), (
+        f"qs-create-plan fallback should start with '/' (slash form). "
+        f"Got: {fallback_line!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# qs-setup-task: same dedicated assertion as before — hardcode /create-plan,
+# don't fall back to a {{same_context}} template. This is the case the
+# round-1 fix targeted.
+# --------------------------------------------------------------------------- #
+
+
+def test_setup_task_fallback_does_not_use_same_context_template() -> None:
+    """qs-setup-task's fallback block must hardcode ``/create-plan``, not template."""
+    body = (AGENTS_DIR / "qs-setup-task.md").read_text()
+    fallback_line = _find_fallback_line(body)
+    assert fallback_line is not None, "qs-setup-task: 'Fallback' block not found"
+    assert "{{same_context}}" not in fallback_line, (
+        "qs-setup-task fallback uses {{same_context}} template — must hardcode "
+        "/create-plan to match the four peer orchestrators (review-fix #03)."
+    )
+    assert "/create-plan" in fallback_line, (
+        f"qs-setup-task fallback should hardcode '/create-plan', got: "
+        f"{fallback_line!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
 # qs-finish-task is the deliberate exception — release runs on a different
 # workspace (main checkout), so the agent body shows both forms as
 # alternatives in plain prose rather than the strict two-block pattern.
 # Per QS-175 OUT OF SCOPE: "DO NOT call the launcher with --next-cmd release".
+# --------------------------------------------------------------------------- #
 
 
 def test_finish_task_mentions_both_release_forms() -> None:
@@ -101,17 +172,19 @@ def test_finish_task_does_not_call_next_step_for_release() -> None:
     don't build a launcher with `--next-cmd release`" — that's the OUT OF
     SCOPE explanation). What's forbidden is an ACTIVE invocation: a
     ``scripts/qs/next_step.py`` call followed by ``--next-cmd release``
-    in the same code block.
+    in real source, not inside backticks.
+
+    We strip both inline and fenced backticks before scanning so a stray
+    backtick-wrapped ``python scripts/qs/next_step.py --next-cmd release``
+    on a single line can't bypass the check.
     """
     body = (AGENTS_DIR / "qs-finish-task.md").read_text()
-    # Look for an active invocation: next_step.py + --next-cmd "release"
-    # within a window of ~200 chars (a single code block). This pattern
-    # would be the real OUT OF SCOPE violation.
+    stripped = _strip_backticks(body)
     forbidden = re.compile(
-        r"scripts/qs/next_step\.py[^\n`]{0,200}?--next-cmd\s+[\"']?release",
+        r"scripts/qs/next_step\.py[^\n]{0,200}?--next-cmd\s+[\"']?release",
         re.DOTALL,
     )
-    match = forbidden.search(body)
+    match = forbidden.search(stripped)
     assert not match, (
         f"qs-finish-task: active 'next_step.py --next-cmd release' invocation "
         f"found ({match.group()!r}). Release runs on the main checkout "
@@ -120,22 +193,57 @@ def test_finish_task_does_not_call_next_step_for_release() -> None:
     )
 
 
-def test_setup_task_fallback_does_not_use_same_context_template() -> None:
-    """qs-setup-task's fallback block must hardcode ``/create-plan``, not template."""
-    body = (AGENTS_DIR / "qs-setup-task.md").read_text()
-    # Find the fallback block content — between the literal ``Fallback``
-    # marker (capital F, distinguishing it from prose mentions of
-    # "fallback" earlier in the file) and its captured line.
-    fallback_match = re.search(
-        r"Fallback[^:]*:[^\n]*\n([^\n]+)\n", body,
-    )
-    assert fallback_match, "qs-setup-task: 'Fallback' block not found"
-    fallback_line = fallback_match.group(1)
-    assert "{{same_context}}" not in fallback_line, (
-        "qs-setup-task fallback uses {{same_context}} template — must hardcode "
-        "/create-plan to match the five peer orchestrators (review-fix #3)."
-    )
-    assert "/create-plan" in fallback_line, (
-        f"qs-setup-task fallback should hardcode '/create-plan', got: "
-        f"{fallback_line!r}"
-    )
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _find_fallback_line(body: str) -> str | None:
+    """Return the first non-empty line following the literal ``Fallback`` marker.
+
+    Replaces the brittle ``re.search(r"Fallback[^:]*:...")`` pattern (review-
+    fix #02 NTH2). Iterates lines: once a line starting with ``Fallback``
+    (capital F — the marker, not a prose mention) is found, walk forward
+    until a content line that starts with ``/`` is reached. That's the
+    slash-fallback line.
+    """
+    lines = body.splitlines()
+    in_fallback_block = False
+    for line in lines:
+        stripped = line.strip()
+        if not in_fallback_block:
+            # Match a ``Fallback`` marker — must start with that literal
+            # word (after any leading whitespace). Excludes prose
+            # mentions like "the fallback path" that appear earlier in
+            # the file body.
+            if stripped.startswith("Fallback"):
+                in_fallback_block = True
+            continue
+        # In the fallback block — find the first line whose stripped
+        # content begins with ``/`` (the slash-form fallback) or with
+        # ``{{`` (a placeholder, e.g. ``{{same_context}}``). Either is a
+        # candidate "fallback line" for downstream tests to inspect.
+        if stripped.startswith(("/", "{{")):
+            return line
+        # Skip blank lines and the closing ``):`` line of the
+        # "Fallback (stay in this session...)" preamble.
+        if stripped and not stripped.endswith(":"):
+            continue
+    return None
+
+
+def _strip_backticks(text: str) -> str:
+    """Remove single and triple backtick fences, keeping the inner content.
+
+    Review-fix #02 NTH3: without this, a fenced one-line invocation
+    like a backtick-wrapped ``python scripts/qs/next_step.py
+    --next-cmd release`` would slip past the
+    ``does-not-call-next-step-for-release`` regex.
+    """
+    # Strip triple-fence blocks first (they may span multiple lines), then
+    # single-tick inline code. Both forms are replaced with their inner
+    # text so the search can find an active invocation regardless of
+    # markdown formatting.
+    text = re.sub(r"```[a-zA-Z]*\n?([\s\S]*?)```", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    return text

--- a/tests/qs/agents/test_orchestrator_handoff.py
+++ b/tests/qs/agents/test_orchestrator_handoff.py
@@ -30,6 +30,17 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 AGENTS_DIR = REPO_ROOT / ".claude" / "agents"
 
+# Pattern for an ACTIVE ``next_step.py --next-cmd release`` invocation.
+# Uses ``.`` with ``re.DOTALL`` so backslash-continued multi-line shell
+# forms (``python ... \\\n    --next-cmd release``) are caught — the
+# previous ``[^\n]`` form silently let them through (review-fix #04
+# SF2). Compiled once at module load and shared between the
+# qs-finish-task assertion and the regex-shape regression tests.
+_FORBIDDEN_RELEASE_INVOCATION = re.compile(
+    r"scripts/qs/next_step\.py.{0,200}?--next-cmd\s+[\"']?release",
+    re.DOTALL,
+)
+
 
 # All 6 orchestrators that ship the strict two-block ``Preferred`` /
 # ``Fallback`` pattern. ``qs-finish-task`` is the deliberate exception
@@ -176,21 +187,56 @@ def test_finish_task_does_not_call_next_step_for_release() -> None:
 
     We strip both inline and fenced backticks before scanning so a stray
     backtick-wrapped ``python scripts/qs/next_step.py --next-cmd release``
-    on a single line can't bypass the check.
+    on a single line can't bypass the check. The regex uses ``.`` with
+    ``re.DOTALL`` (instead of ``[^\\n]``) so a backslash-continued
+    multi-line invocation also gets caught (review-fix #04 SF2).
     """
     body = (AGENTS_DIR / "qs-finish-task.md").read_text()
     stripped = _strip_backticks(body)
-    forbidden = re.compile(
-        r"scripts/qs/next_step\.py[^\n]{0,200}?--next-cmd\s+[\"']?release",
-        re.DOTALL,
-    )
-    match = forbidden.search(stripped)
+    match = _FORBIDDEN_RELEASE_INVOCATION.search(stripped)
     assert not match, (
         f"qs-finish-task: active 'next_step.py --next-cmd release' invocation "
         f"found ({match.group()!r}). Release runs on the main checkout "
         f"(different workspace); per QS-175 OUT OF SCOPE the agent surfaces "
         f"the text suggestion but does not emit a launcher payload."
     )
+
+
+# Regression patterns the forbidden-invocation regex MUST catch. Round-4
+# SF2: the round-2 implementation used ``[^\n]`` which silently let
+# backslash-continued multi-line invocations through.
+_MULTILINE_INVOCATION = (
+    "python scripts/qs/next_step.py \\\n"
+    "    --next-cmd release\n"
+)
+_SINGLE_LINE_INVOCATION = (
+    "python scripts/qs/next_step.py --next-cmd release\n"
+)
+_INVOCATION_QUOTED = (
+    'python scripts/qs/next_step.py --next-cmd "release"\n'
+)
+
+
+@pytest.mark.parametrize("snippet", [
+    _SINGLE_LINE_INVOCATION,
+    _MULTILINE_INVOCATION,
+    _INVOCATION_QUOTED,
+])
+def test_forbidden_release_regex_catches_invocation_forms(snippet: str) -> None:
+    """The regex catches every active invocation shape — single, multi, quoted."""
+    assert _FORBIDDEN_RELEASE_INVOCATION.search(snippet), (
+        f"Forbidden-invocation regex missed {snippet!r}. Without DOTALL + "
+        f"``.`` across newlines, a backslash-continued shell line slips "
+        f"through (review-fix #04 SF2)."
+    )
+
+
+def test_forbidden_release_regex_ignores_prose_mention() -> None:
+    """Bare prose mentioning ``--next-cmd release`` (without the script path) is fine."""
+    # The agent body uses this exact wording in its OUT OF SCOPE note —
+    # only an ACTIVE invocation paired with the script path is forbidden.
+    prose = "We don't build a launcher with --next-cmd release."
+    assert _FORBIDDEN_RELEASE_INVOCATION.search(prose) is None
 
 
 # --------------------------------------------------------------------------- #
@@ -204,8 +250,8 @@ def _find_fallback_line(body: str) -> str | None:
     Replaces the brittle ``re.search(r"Fallback[^:]*:...")`` pattern (review-
     fix #02 NTH2). Iterates lines: once a line starting with ``Fallback``
     (capital F — the marker, not a prose mention) is found, walk forward
-    until a content line that starts with ``/`` is reached. That's the
-    slash-fallback line.
+    until a content line that starts with ``/`` or ``{{`` is reached.
+    That's the slash-fallback (or placeholder) line.
     """
     lines = body.splitlines()
     in_fallback_block = False
@@ -223,12 +269,12 @@ def _find_fallback_line(body: str) -> str | None:
         # content begins with ``/`` (the slash-form fallback) or with
         # ``{{`` (a placeholder, e.g. ``{{same_context}}``). Either is a
         # candidate "fallback line" for downstream tests to inspect.
+        # Blank lines, the preamble's closing ``):`` line, and any
+        # other intermediate content are naturally skipped by the
+        # implicit loop continuation (review-fix #04 NTH2: the trailing
+        # explicit ``if/continue`` was dead code).
         if stripped.startswith(("/", "{{")):
             return line
-        # Skip blank lines and the closing ``):`` line of the
-        # "Fallback (stay in this session...)" preamble.
-        if stripped and not stripped.endswith(":"):
-            continue
     return None
 
 

--- a/tests/qs/agents/test_orchestrator_handoff.py
+++ b/tests/qs/agents/test_orchestrator_handoff.py
@@ -1,0 +1,141 @@
+"""Lock the AC-3 contract: every phase orchestrator's handoff section emits
+BOTH a launcher block (``claude --agent qs-<phase>``) AND a slash-command
+fallback block (``/<phase>``).
+
+This is the regression catch for QS-175 review-fix #7 — without it the
+two-block pattern is enforced only by manual review. The test also catches
+review-fix #3 (qs-setup-task fallback drift): it asserts each fallback
+mentions ``/<phase>`` for a concrete known phase, not a verbatim template
+variable like ``{{same_context}}``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+AGENTS_DIR = REPO_ROOT / ".claude" / "agents"
+
+# Each entry: (orchestrator file, the next-phase slash that MUST appear in
+# the handoff wording somewhere). The five "normal" orchestrators ship the
+# strict two-block ``Preferred`` / ``Fallback`` pattern; qs-finish-task is
+# the deliberate exception — see ``_FINISH_TASK_EXCEPTIONS`` below.
+_TWO_BLOCK_ORCHESTRATORS = [
+    ("qs-setup-task.md", "/create-plan"),
+    ("qs-create-plan.md", "/{{NEXT_PHASE}}"),
+    ("qs-implement-task.md", "/review-task"),
+    ("qs-implement-setup-task.md", "/review-task"),
+    ("qs-review-task.md", "/finish-task"),
+]
+
+
+@pytest.mark.parametrize(("filename", "expected_slash"), _TWO_BLOCK_ORCHESTRATORS)
+def test_orchestrator_has_two_block_handoff(filename: str, expected_slash: str) -> None:
+    """Every orchestrator's handoff contains 'Preferred' AND 'Fallback' markers."""
+    path = AGENTS_DIR / filename
+    body = path.read_text()
+    assert "Preferred" in body, (
+        f"{filename}: missing 'Preferred' marker — every orchestrator must "
+        f"label the interactive launcher path."
+    )
+    assert "Fallback" in body, (
+        f"{filename}: missing 'Fallback' marker — every orchestrator must "
+        f"label the degraded slash-command path."
+    )
+
+
+@pytest.mark.parametrize(("filename", "expected_slash"), _TWO_BLOCK_ORCHESTRATORS)
+def test_orchestrator_handoff_mentions_claude_agent_invocation(
+    filename: str, expected_slash: str,
+) -> None:
+    """Handoff text references ``claude --agent qs-<phase>`` — the preferred path."""
+    path = AGENTS_DIR / filename
+    body = path.read_text()
+    # The orchestrator may emit either a literal ``claude --agent qs-...``
+    # string (qs-setup-task) or use the new_context variable that resolves
+    # to one at runtime (qs-create-plan, qs-implement-task, etc.). Either
+    # way the launcher concept must be named in the file body.
+    assert "claude --agent" in body, (
+        f"{filename}: the orchestrator handoff must reference "
+        f"`claude --agent qs-<phase>` so the user knows the preferred path."
+    )
+
+
+@pytest.mark.parametrize(("filename", "expected_slash"), _TWO_BLOCK_ORCHESTRATORS)
+def test_orchestrator_fallback_uses_concrete_slash_form(
+    filename: str, expected_slash: str,
+) -> None:
+    """Each fallback block names a real ``/<phase>`` slash, not ``{{same_context}}``."""
+    path = AGENTS_DIR / filename
+    body = path.read_text()
+    assert expected_slash in body, (
+        f"{filename}: expected fallback to mention {expected_slash!r}; "
+        f"this catches the qs-setup-task regression where {{{{same_context}}}} "
+        f"was emitted instead of a hardcoded slash form."
+    )
+
+
+# qs-finish-task is the deliberate exception — release runs on a different
+# workspace (main checkout), so the agent body shows both forms as
+# alternatives in plain prose rather than the strict two-block pattern.
+# Per QS-175 OUT OF SCOPE: "DO NOT call the launcher with --next-cmd release".
+
+
+def test_finish_task_mentions_both_release_forms() -> None:
+    """qs-finish-task's release suggestion mentions both forms as alternatives."""
+    body = (AGENTS_DIR / "qs-finish-task.md").read_text()
+    assert "/release" in body, "qs-finish-task: missing '/release' fallback mention"
+    assert "claude --agent qs-release" in body, (
+        "qs-finish-task: missing 'claude --agent qs-release' — the interactive "
+        "form must also be named so users on CLI know the preferred path."
+    )
+
+
+def test_finish_task_does_not_call_next_step_for_release() -> None:
+    """qs-finish-task must NOT call ``next_step.py --next-cmd release`` (OUT OF SCOPE).
+
+    The agent body may *mention* the forbidden pattern in prose (e.g. "we
+    don't build a launcher with `--next-cmd release`" — that's the OUT OF
+    SCOPE explanation). What's forbidden is an ACTIVE invocation: a
+    ``scripts/qs/next_step.py`` call followed by ``--next-cmd release``
+    in the same code block.
+    """
+    body = (AGENTS_DIR / "qs-finish-task.md").read_text()
+    # Look for an active invocation: next_step.py + --next-cmd "release"
+    # within a window of ~200 chars (a single code block). This pattern
+    # would be the real OUT OF SCOPE violation.
+    forbidden = re.compile(
+        r"scripts/qs/next_step\.py[^\n`]{0,200}?--next-cmd\s+[\"']?release",
+        re.DOTALL,
+    )
+    match = forbidden.search(body)
+    assert not match, (
+        f"qs-finish-task: active 'next_step.py --next-cmd release' invocation "
+        f"found ({match.group()!r}). Release runs on the main checkout "
+        f"(different workspace); per QS-175 OUT OF SCOPE the agent surfaces "
+        f"the text suggestion but does not emit a launcher payload."
+    )
+
+
+def test_setup_task_fallback_does_not_use_same_context_template() -> None:
+    """qs-setup-task's fallback block must hardcode ``/create-plan``, not template."""
+    body = (AGENTS_DIR / "qs-setup-task.md").read_text()
+    # Find the fallback block content — between the literal ``Fallback``
+    # marker (capital F, distinguishing it from prose mentions of
+    # "fallback" earlier in the file) and its captured line.
+    fallback_match = re.search(
+        r"Fallback[^:]*:[^\n]*\n([^\n]+)\n", body,
+    )
+    assert fallback_match, "qs-setup-task: 'Fallback' block not found"
+    fallback_line = fallback_match.group(1)
+    assert "{{same_context}}" not in fallback_line, (
+        "qs-setup-task fallback uses {{same_context}} template — must hardcode "
+        "/create-plan to match the five peer orchestrators (review-fix #3)."
+    )
+    assert "/create-plan" in fallback_line, (
+        f"qs-setup-task fallback should hardcode '/create-plan', got: "
+        f"{fallback_line!r}"
+    )

--- a/tests/qs/agents/test_slash_command_preambles.py
+++ b/tests/qs/agents/test_slash_command_preambles.py
@@ -1,0 +1,89 @@
+"""Lock the AC-5 contract: every slash-command file in ``.claude/commands/``
+ships the "Preferred entry / degraded fallback" preamble.
+
+This is the regression catch for QS-175 review-fix #8 — AC-5 is enforced
+only by manual review without this test. Each of the 6 slash-command
+files (release.md is intentionally excluded — see QS-175 OUT OF SCOPE)
+must contain the canonical preamble markers explaining the fallback
+nature of the slash-command path.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _normalize_whitespace(body: str) -> str:
+    """Collapse newlines + markdown blockquote markers (``> ``) to single spaces.
+
+    Markdown wraps long lines, so a phrase like ``Claude Desktop`` may appear
+    as ``Claude\\n> Desktop`` in the source. We normalize before substring
+    checks so the tests are robust to line wrap.
+    """
+    # Strip ``> `` blockquote prefixes (at line start) and collapse all
+    # whitespace runs to a single space.
+    stripped = re.sub(r"(?m)^\s*>\s?", "", body)
+    return re.sub(r"\s+", " ", stripped)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMMANDS_DIR = REPO_ROOT / ".claude" / "commands"
+
+# Exactly the 6 slash-command files listed in QS-175 Task 7. release.md is
+# excluded — that's a manual command on the main checkout, not part of the
+# orchestrator chain.
+_SLASH_COMMAND_FILES = [
+    "setup-task.md",
+    "create-plan.md",
+    "implement-task.md",
+    "implement-setup-task.md",
+    "review-task.md",
+    "finish-task.md",
+]
+
+
+@pytest.mark.parametrize("filename", _SLASH_COMMAND_FILES)
+def test_slash_command_has_preferred_entry_marker(filename: str) -> None:
+    """The preamble names ``claude --agent qs-<phase>`` as the preferred entry."""
+    body = _normalize_whitespace((COMMANDS_DIR / filename).read_text())
+    assert "Preferred entry" in body, (
+        f"{filename}: missing 'Preferred entry' label — AC-5 requires every "
+        f"slash command to label the launcher path as preferred."
+    )
+    assert "claude --agent qs-" in body, (
+        f"{filename}: missing 'claude --agent qs-...' reference — the preamble "
+        f"must name the launcher invocation explicitly."
+    )
+
+
+@pytest.mark.parametrize("filename", _SLASH_COMMAND_FILES)
+def test_slash_command_has_degraded_fallback_marker(filename: str) -> None:
+    """The preamble explicitly labels itself as the degraded fallback."""
+    body = _normalize_whitespace((COMMANDS_DIR / filename).read_text())
+    assert "degraded fallback" in body, (
+        f"{filename}: missing 'degraded fallback' label — AC-5 requires every "
+        f"slash command to be flagged as the broken-by-design fallback UX."
+    )
+
+
+@pytest.mark.parametrize("filename", _SLASH_COMMAND_FILES)
+def test_slash_command_mentions_claude_desktop(filename: str) -> None:
+    """Each preamble names Claude Desktop as the reason to keep the fallback."""
+    body = _normalize_whitespace((COMMANDS_DIR / filename).read_text())
+    assert "Claude Desktop" in body, (
+        f"{filename}: missing 'Claude Desktop' rationale — AC-5 / AC-8 "
+        f"require honest naming of the environment that needs this fallback."
+    )
+
+
+@pytest.mark.parametrize("filename", _SLASH_COMMAND_FILES)
+def test_slash_command_mentions_qs_175(filename: str) -> None:
+    """Each preamble references the QS-175 mitigation framing."""
+    body = _normalize_whitespace((COMMANDS_DIR / filename).read_text())
+    assert "QS-175" in body, (
+        f"{filename}: missing 'QS-175' reference — the framing 'broken-by-"
+        f"design UX QS-175 mitigates' is what makes the preamble actionable; "
+        f"don't drop it on edit."
+    )

--- a/tests/qs/docs/__init__.py
+++ b/tests/qs/docs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests that lock structural contracts in docs/workflow/."""

--- a/tests/qs/docs/test_overview_structure.py
+++ b/tests/qs/docs/test_overview_structure.py
@@ -1,0 +1,73 @@
+"""Lock the AC-6 doc structure contract: the new ``Orchestrators are
+interactive sessions; sub-agents are parallel fan-out`` section is
+positioned immediately after the existing ``Adversarial review`` section
+in ``docs/workflow/overview.md``.
+
+This is the regression catch for QS-175 review-fix #9 — without it, the
+"immediately after" placement is enforced only by manual review.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OVERVIEW = REPO_ROOT / "docs" / "workflow" / "overview.md"
+
+
+def _section_headings() -> list[tuple[int, str]]:
+    """Return list of ``(line_index, heading_text)`` for every H2 heading."""
+    headings: list[tuple[int, str]] = []
+    for i, line in enumerate(OVERVIEW.read_text().splitlines()):
+        m = re.match(r"^##\s+(.*)$", line)
+        if m:
+            headings.append((i, m.group(1).strip()))
+    return headings
+
+
+def test_overview_has_canonical_qs175_section() -> None:
+    """The canonical paragraph section exists."""
+    headings = [h for _, h in _section_headings()]
+    target = "Orchestrators are interactive sessions; sub-agents are parallel fan-out"
+    assert target in headings, (
+        f"overview.md is missing the canonical QS-175 section. Headings: {headings}"
+    )
+
+
+def test_canonical_section_immediately_follows_adversarial_review() -> None:
+    """The new section is placed right after the 'Adversarial review' section."""
+    headings = [h for _, h in _section_headings()]
+    adversarial_idx = None
+    for i, h in enumerate(headings):
+        if h.lower().startswith("adversarial review"):
+            adversarial_idx = i
+            break
+    assert adversarial_idx is not None, (
+        f"overview.md: 'Adversarial review' section heading not found. "
+        f"Headings: {headings}"
+    )
+    target = "Orchestrators are interactive sessions; sub-agents are parallel fan-out"
+    assert adversarial_idx + 1 < len(headings), (
+        "overview.md: no heading after 'Adversarial review'"
+    )
+    next_heading = headings[adversarial_idx + 1]
+    assert next_heading == target, (
+        f"AC-6: '{target}' must immediately follow 'Adversarial review', "
+        f"got {next_heading!r} instead."
+    )
+
+
+def test_overview_documents_claude_desktop_limitation() -> None:
+    """AC-8: overview.md (or phase-protocols.md) calls out Desktop's limit."""
+    body = OVERVIEW.read_text()
+    assert "Claude Desktop" in body and "limitation" in body.lower(), (
+        "overview.md is missing the Claude Desktop limitation subsection "
+        "(AC-8). The doc must honestly state Desktop has no `--agent` "
+        "equivalent and direct users to the slash-command fallback."
+    )
+    # Must specifically mention pycharm_context as the bridge.
+    assert "pycharm_context" in body, (
+        "overview.md should mention pycharm_context as the suggested bridge "
+        "for users who can't use the CLI launcher directly."
+    )

--- a/tests/qs/docs/test_overview_structure.py
+++ b/tests/qs/docs/test_overview_structure.py
@@ -101,13 +101,18 @@ def test_harness_doc_documents_codex_opencode_agent_exception() -> None:
         "agent-contract paragraph."
     )
     # Either explicit "do not emit agent" wording or "without agent" form
-    # is acceptable; we look for the conceptual marker.
-    has_exception_clause = (
-        "do NOT emit" in body
-        or "do not emit `agent`" in body
-        or "without `agent`" in body
-        or "skip `agent`" in body
-        or "no `agent`" in body
+    # is acceptable; we look for the conceptual marker. Normalize to
+    # lowercase so case variations like "Do not emit `agent`" don't make
+    # the test brittle (review-fix #04 NTH10).
+    body_lower = body.lower()
+    has_exception_clause = any(
+        candidate in body_lower
+        for candidate in (
+            "do not emit",
+            "without `agent`",
+            "skip `agent`",
+            "no `agent`",
+        )
     )
     assert has_exception_clause, (
         "harness.md must explicitly state that Codex / OpenCode launchers "

--- a/tests/qs/docs/test_overview_structure.py
+++ b/tests/qs/docs/test_overview_structure.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 OVERVIEW = REPO_ROOT / "docs" / "workflow" / "overview.md"
+HARNESS_DOC = REPO_ROOT / "docs" / "workflow" / "harness.md"
 
 # Canonical title of the QS-175 paragraph section in overview.md. Centralised
 # here so a doc edit doesn't drift between the multiple assertions that
@@ -62,6 +63,55 @@ def test_canonical_section_immediately_follows_adversarial_review() -> None:
     assert next_heading == target, (
         f"AC-6: '{target}' must immediately follow 'Adversarial review', "
         f"got {next_heading!r} instead."
+    )
+
+
+def test_harness_doc_does_not_claim_agent_is_always_emitted() -> None:
+    """``harness.md`` must NOT claim every launcher emits ``agent`` (review-fix #03 SF3).
+
+    Codex and OpenCode launchers accept free-form ``--next-cmd`` values
+    that don't map to a static phase, so they don't emit an ``agent``
+    key in the payload. The contract paragraph must reflect this — a
+    blanket "all launchers return agent" claim contradicts
+    ``test_codex_passes_known_phase_through_unchanged``.
+    """
+    body = HARNESS_DOC.read_text()
+    # Forbid the over-broad claim. We accept any rewording that doesn't
+    # assert "agent" is part of the minimum surface for every launcher.
+    forbidden_phrasings = [
+        "at minimum `tool`, `agent`, `same_context`, `new_context`",
+        "minimum: tool, agent, same_context",
+    ]
+    for phrase in forbidden_phrasings:
+        assert phrase not in body, (
+            f"harness.md contains the wrong agent-is-universal claim "
+            f"({phrase!r}). Codex/opencode payloads don't include "
+            f"``agent`` — see test_codex_passes_known_phase_through_unchanged."
+        )
+
+
+def test_harness_doc_documents_codex_opencode_agent_exception() -> None:
+    """``harness.md`` must explicitly note that codex/opencode skip the ``agent`` key."""
+    body = HARNESS_DOC.read_text()
+    # The doc must say codex and opencode don't emit agent. Tolerant of
+    # markdown line wrap via simple whitespace collapse.
+    normalized = " ".join(body.split())
+    assert "codex" in normalized.lower() and "opencode" in normalized.lower(), (
+        "harness.md must name both codex and opencode launchers in the "
+        "agent-contract paragraph."
+    )
+    # Either explicit "do not emit agent" wording or "without agent" form
+    # is acceptable; we look for the conceptual marker.
+    has_exception_clause = (
+        "do NOT emit" in body
+        or "do not emit `agent`" in body
+        or "without `agent`" in body
+        or "skip `agent`" in body
+        or "no `agent`" in body
+    )
+    assert has_exception_clause, (
+        "harness.md must explicitly state that Codex / OpenCode launchers "
+        "don't emit the ``agent`` key (review-fix #03 SF3)."
     )
 
 

--- a/tests/qs/docs/test_overview_structure.py
+++ b/tests/qs/docs/test_overview_structure.py
@@ -15,6 +15,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 OVERVIEW = REPO_ROOT / "docs" / "workflow" / "overview.md"
 
+# Canonical title of the QS-175 paragraph section in overview.md. Centralised
+# here so a doc edit doesn't drift between the multiple assertions that
+# reference it (review-fix #02 NTH11).
+CANONICAL_QS175_HEADING = (
+    "Orchestrators are interactive sessions; sub-agents are parallel fan-out"
+)
+
 
 def _section_headings() -> list[tuple[int, str]]:
     """Return list of ``(line_index, heading_text)`` for every H2 heading."""
@@ -29,7 +36,7 @@ def _section_headings() -> list[tuple[int, str]]:
 def test_overview_has_canonical_qs175_section() -> None:
     """The canonical paragraph section exists."""
     headings = [h for _, h in _section_headings()]
-    target = "Orchestrators are interactive sessions; sub-agents are parallel fan-out"
+    target = CANONICAL_QS175_HEADING
     assert target in headings, (
         f"overview.md is missing the canonical QS-175 section. Headings: {headings}"
     )
@@ -47,7 +54,7 @@ def test_canonical_section_immediately_follows_adversarial_review() -> None:
         f"overview.md: 'Adversarial review' section heading not found. "
         f"Headings: {headings}"
     )
-    target = "Orchestrators are interactive sessions; sub-agents are parallel fan-out"
+    target = CANONICAL_QS175_HEADING
     assert adversarial_idx + 1 < len(headings), (
         "overview.md: no heading after 'Adversarial review'"
     )

--- a/tests/qs/launchers/__init__.py
+++ b/tests/qs/launchers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for scripts/qs/launchers/ and scripts/qs/next_step.py."""

--- a/tests/qs/launchers/conftest.py
+++ b/tests/qs/launchers/conftest.py
@@ -11,8 +11,8 @@ runs in its own interpreter and is unaffected).
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator
 
 import pytest
 
@@ -37,7 +37,12 @@ def _add_scripts_qs_to_syspath() -> Iterator[None]:
         new = set(sys.modules) - before
         for name in new:
             mod = sys.modules.get(name)
-            mod_file = getattr(mod, "__file__", None) or ""
+            # Namespace/frozen packages may carry ``__file__ is None``;
+            # skip them outright instead of falling through to the
+            # substring check on a bare empty string.
+            mod_file = getattr(mod, "__file__", None)
+            if not mod_file:
+                continue
             if path_str in mod_file:
                 sys.modules.pop(name, None)
         if added:

--- a/tests/qs/launchers/conftest.py
+++ b/tests/qs/launchers/conftest.py
@@ -30,6 +30,13 @@ def _add_scripts_qs_to_syspath() -> Iterator[None]:
 
     # Snapshot modules originating from scripts/qs/ so we can purge them after
     # the test and avoid cross-test pollution from module-level state.
+    #
+    # Limitation (review-fix #03 NTH6): this only purges modules imported
+    # BY OR AFTER our autouse fixture. If a higher-level conftest
+    # pre-imported ``next_step`` or ``launchers.*`` before we entered
+    # here, they survive teardown. The remaining cross-test pollution is
+    # bounded by ``monkeypatch`` (which reverts its own setattr/setitem
+    # changes on teardown), so the practical exposure is small.
     before = set(sys.modules)
     try:
         yield

--- a/tests/qs/launchers/conftest.py
+++ b/tests/qs/launchers/conftest.py
@@ -1,0 +1,44 @@
+"""Shared fixtures: put scripts/qs/ on sys.path so the launcher modules can
+be imported as top-level (``launchers.claude`` etc.), matching how
+``next_step.py`` and ``setup_task.py`` import them at runtime.
+
+We tear sys.path back down after each test and pop any modules that came in
+from the QS scripts dir, so a single pytest session can both import the
+launcher modules in-process AND subprocess-invoke ``next_step.py`` (which
+runs in its own interpreter and is unaffected).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+SCRIPTS_QS_DIR = Path(__file__).resolve().parents[3] / "scripts" / "qs"
+
+
+@pytest.fixture(autouse=True)
+def _add_scripts_qs_to_syspath() -> Iterator[None]:
+    """Make ``launchers.*`` and ``next_step`` importable as top-level."""
+    added = False
+    path_str = str(SCRIPTS_QS_DIR)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+        added = True
+
+    # Snapshot modules originating from scripts/qs/ so we can purge them after
+    # the test and avoid cross-test pollution from module-level state.
+    before = set(sys.modules)
+    try:
+        yield
+    finally:
+        new = set(sys.modules) - before
+        for name in new:
+            mod = sys.modules.get(name)
+            mod_file = getattr(mod, "__file__", None) or ""
+            if path_str in mod_file:
+                sys.modules.pop(name, None)
+        if added:
+            sys.path.remove(path_str)

--- a/tests/qs/launchers/test_claude_launcher.py
+++ b/tests/qs/launchers/test_claude_launcher.py
@@ -192,9 +192,16 @@ def test_build_payload_shlex_quotes_agent_name(monkeypatch: pytest.MonkeyPatch) 
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.parametrize("bad_next_cmd", ["/", "//create-plan", "unknown", "/nope"])
+@pytest.mark.parametrize(
+    "bad_next_cmd", ["", "/", "//create-plan", "unknown", "/nope"],
+)
 def test_claude_build_payload_rejects_invalid_next_cmd(bad_next_cmd: str) -> None:
-    """``build_payload`` raises for invalid next_cmd at the public boundary."""
+    """``build_payload`` raises for invalid next_cmd at the public boundary.
+
+    ``""`` is included for parity with the CLI-layer check
+    (review-fix #03 NTH1): a direct caller importing ``build_payload``
+    must hit the same contract as a user passing ``--next-cmd ""``.
+    """
     from launchers import claude as claude_launcher  # type: ignore[import-not-found]
 
     with pytest.raises(ValueError):

--- a/tests/qs/launchers/test_claude_launcher.py
+++ b/tests/qs/launchers/test_claude_launcher.py
@@ -1,0 +1,137 @@
+"""Tests for ``scripts/qs/launchers/claude.py`` ``build_payload``.
+
+The Claude launcher now invokes ``claude --agent qs-<phase>`` instead of a
+bare ``claude`` (the old non-interactive Agent-tool path). Both the slash
+form and the bare phase name must resolve to the same agent (back-compat
+with callers like ``setup_task.py`` that still pass slash form).
+"""
+
+from __future__ import annotations
+
+import stat
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+def _read_script(new_context: str) -> str:
+    """``new_context`` is a ``sh /tmp/qs_launch_<N>.sh`` one-liner; read the script."""
+    assert new_context.startswith("sh "), f"unexpected new_context: {new_context!r}"
+    script_path = new_context[len("sh "):]
+    return Path(script_path).read_text()
+
+
+def test_build_payload_emits_agent_flag_for_bare_phase() -> None:
+    """``next_cmd='create-plan'`` produces a script invoking ``claude --agent qs-create-plan``."""
+    from launchers import claude as claude_launcher  # type: ignore[import-not-found]
+
+    payload = claude_launcher.build_payload(
+        "/tmp/work",
+        42,
+        "Fix bug",
+        next_cmd="create-plan",
+    )
+
+    assert payload["tool"] == "claude-code"
+    assert payload["agent"] == "qs-create-plan"
+    assert payload["same_context"] == "create-plan"
+
+    script = _read_script(payload["new_context"])
+    assert "claude " in script
+    assert "--agent qs-create-plan" in script
+
+
+def test_build_payload_emits_agent_flag_for_slash_phase() -> None:
+    """Slash form maps to the same agent (back-compat for older callers)."""
+    from launchers import claude as claude_launcher  # type: ignore[import-not-found]
+
+    payload = claude_launcher.build_payload(
+        "/tmp/work",
+        42,
+        "Fix bug",
+        next_cmd="/create-plan",
+    )
+    assert payload["agent"] == "qs-create-plan"
+    # ``same_context`` is preserved verbatim so the fallback path the
+    # orchestrator prints stays intact.
+    assert payload["same_context"] == "/create-plan"
+    script = _read_script(payload["new_context"])
+    assert "--agent qs-create-plan" in script
+
+
+def test_build_payload_back_compat_bare_and_slash_agree_on_agent() -> None:
+    """Bare and slash forms resolve to the same agent."""
+    from launchers import claude as claude_launcher  # type: ignore[import-not-found]
+
+    bare = claude_launcher.build_payload(
+        "/tmp/work", 42, "Fix bug", next_cmd="create-plan",
+    )
+    slash = claude_launcher.build_payload(
+        "/tmp/work", 42, "Fix bug", next_cmd="/create-plan",
+    )
+    assert bare["agent"] == slash["agent"] == "qs-create-plan"
+
+
+def test_build_payload_unknown_phase_raises() -> None:
+    """Unknown phase propagates as ValueError (no silent fallback)."""
+    from launchers import claude as claude_launcher  # type: ignore[import-not-found]
+
+    with pytest.raises(ValueError):
+        claude_launcher.build_payload(
+            "/tmp/work", 42, "Fix bug", next_cmd="bogus",
+        )
+
+
+def test_build_payload_script_is_under_tempdir_and_executable() -> None:
+    """Generated script lives under tempfile.gettempdir() and has mode 0o755."""
+    from launchers import claude as claude_launcher  # type: ignore[import-not-found]
+
+    payload = claude_launcher.build_payload(
+        "/tmp/work", 99, "Some title", next_cmd="implement-task",
+    )
+    new_context = payload["new_context"]
+    assert new_context.startswith("sh ")
+    script_path = Path(new_context[len("sh "):])
+    # Path must be under the system tempdir
+    assert str(script_path).startswith(tempfile.gettempdir())
+    # Executable bit must be set
+    mode = script_path.stat().st_mode
+    assert mode & stat.S_IXUSR, f"script not executable: {oct(mode)}"
+    assert mode & 0o777 == 0o755, f"unexpected mode: {oct(mode)}"
+
+
+def test_build_payload_preserves_launch_opts_and_workdir() -> None:
+    """The legacy ``CLAUDE_LAUNCH_OPTS`` flags survive the rewrite."""
+    from launchers import claude as claude_launcher  # type: ignore[import-not-found]
+
+    payload = claude_launcher.build_payload(
+        "/tmp/work",
+        7,
+        "Title",
+        next_cmd="finish-task",
+    )
+    script = _read_script(payload["new_context"])
+    assert "/tmp/work" in script
+    # CLAUDE_LAUNCH_OPTS keeps these defaults — change here is intentional and
+    # caught by this assertion.
+    assert "--dangerously-skip-permissions" in script
+    assert "--model opus" in script
+    assert "--effort max" in script
+    # The agent invocation must come AFTER the launch opts so flags apply.
+    assert script.index("--dangerously-skip-permissions") < script.index("--agent")
+
+
+def test_build_payload_appends_next_prompt_when_provided() -> None:
+    """``next_prompt`` is appended as a positional initial prompt."""
+    from launchers import claude as claude_launcher  # type: ignore[import-not-found]
+
+    payload = claude_launcher.build_payload(
+        "/tmp/work",
+        7,
+        "Title",
+        next_cmd="finish-task",
+        next_prompt="please ship it",
+    )
+    script = _read_script(payload["new_context"])
+    assert "please ship it" in script

--- a/tests/qs/launchers/test_claude_launcher.py
+++ b/tests/qs/launchers/test_claude_launcher.py
@@ -84,7 +84,7 @@ def test_build_payload_unknown_phase_raises() -> None:
 
 
 def test_build_payload_script_is_under_tempdir_and_executable() -> None:
-    """Generated script lives under tempfile.gettempdir() and has mode 0o755."""
+    """Generated script lives under tempfile.gettempdir() and is owner-executable."""
     from launchers import claude as claude_launcher  # type: ignore[import-not-found]
 
     payload = claude_launcher.build_payload(
@@ -95,10 +95,13 @@ def test_build_payload_script_is_under_tempdir_and_executable() -> None:
     script_path = Path(new_context[len("sh "):])
     # Path must be under the system tempdir
     assert str(script_path).startswith(tempfile.gettempdir())
-    # Executable bit must be set
+    # Executable-by-owner is the contract that actually matters for
+    # ``sh /tmp/qs_launch_<N>.sh`` to run. We avoid asserting an exact mode
+    # (``0o755``) because a developer's umask can shift the group/other
+    # bits and break the test without breaking the launcher.
     mode = script_path.stat().st_mode
-    assert mode & stat.S_IXUSR, f"script not executable: {oct(mode)}"
-    assert mode & 0o777 == 0o755, f"unexpected mode: {oct(mode)}"
+    assert mode & stat.S_IXUSR, f"script not executable by owner: {oct(mode)}"
+    assert mode & 0o700 == 0o700, f"owner must have rwx; got: {oct(mode & 0o777)}"
 
 
 def test_build_payload_preserves_launch_opts_and_workdir() -> None:
@@ -118,7 +121,10 @@ def test_build_payload_preserves_launch_opts_and_workdir() -> None:
     assert "--dangerously-skip-permissions" in script
     assert "--model opus" in script
     assert "--effort max" in script
-    # The agent invocation must come AFTER the launch opts so flags apply.
+    # Stable layout invariant: ``--agent`` appears after CLAUDE_LAUNCH_OPTS
+    # in the rendered command line. (CLI flag ORDER is independent in
+    # argparse-style parsers — this is a layout/cosmetic check, not a
+    # semantic requirement.)
     assert script.index("--dangerously-skip-permissions") < script.index("--agent")
 
 
@@ -135,3 +141,39 @@ def test_build_payload_appends_next_prompt_when_provided() -> None:
     )
     script = _read_script(payload["new_context"])
     assert "please ship it" in script
+
+
+# --------------------------------------------------------------------------- #
+# Shell-escaping regression — lock that the agent name reaches the script via
+# ``shlex.quote`` so a hypothetical agent name with whitespace or quotes
+# cannot break the shell command. The current mapping never produces
+# metacharacters; this test guards the contract anyway. Review-fix #11.
+# --------------------------------------------------------------------------- #
+
+
+def test_claude_command_quotes_agent_name_with_metacharacters() -> None:
+    """``_claude_command`` must shlex.quote the agent name."""
+    from launchers import claude as claude_launcher  # type: ignore[import-not-found]
+
+    # Bypass build_payload (which goes through the validated mapping) and
+    # exercise the private helper directly with a synthetic name that has
+    # whitespace + a single quote — exactly the chars shlex.quote handles.
+    script_invocation = claude_launcher._claude_command(
+        "/tmp/work",
+        99,
+        "Title",
+        agent="qs-test agent's-name",
+        next_prompt=None,
+    )
+    script = _read_script(script_invocation)
+    # The dangerous chars must be quoted, not spliced raw into the shell line.
+    # shlex.quote wraps the whole token in single quotes and escapes inner
+    # single quotes — the literal substring is the safe form, not the raw.
+    import shlex
+    expected_safe = shlex.quote("qs-test agent's-name")
+    assert expected_safe in script, (
+        f"Expected shlex-quoted agent in script; got: {script!r}"
+    )
+    # And the raw form (with unescaped space + apostrophe) must NOT appear
+    # outside the quoted block.
+    assert "qs-test agent's-name " not in script.replace(expected_safe, "")

--- a/tests/qs/launchers/test_claude_launcher.py
+++ b/tests/qs/launchers/test_claude_launcher.py
@@ -148,28 +148,34 @@ def test_build_payload_appends_next_prompt_when_provided() -> None:
 # ``shlex.quote`` so a hypothetical agent name with whitespace or quotes
 # cannot break the shell command. The current mapping never produces
 # metacharacters; this test guards the contract anyway. Review-fix #11.
+#
+# Round-2 review-fix #02 NTH7: this used to reach into the private
+# ``_claude_command`` helper (ruff ``SLF001``). The refactored version
+# monkeypatches the resolver so the synthetic agent name flows through
+# the public ``build_payload`` API instead.
 # --------------------------------------------------------------------------- #
 
 
-def test_claude_command_quotes_agent_name_with_metacharacters() -> None:
-    """``_claude_command`` must shlex.quote the agent name."""
+def test_build_payload_shlex_quotes_agent_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``build_payload`` must shlex.quote whatever the resolver returns."""
+    import shlex
+
     from launchers import claude as claude_launcher  # type: ignore[import-not-found]
 
-    # Bypass build_payload (which goes through the validated mapping) and
-    # exercise the private helper directly with a synthetic name that has
-    # whitespace + a single quote — exactly the chars shlex.quote handles.
-    script_invocation = claude_launcher._claude_command(
-        "/tmp/work",
-        99,
-        "Title",
-        agent="qs-test agent's-name",
-        next_prompt=None,
+    # Inject a synthetic agent name via the public path — the resolver is
+    # what build_payload consults, so monkeypatching it puts a value with
+    # metacharacters into the shell command without reaching for any
+    # private helper.
+    monkeypatch.setattr(
+        claude_launcher,
+        "resolve_agent_for_next_cmd",
+        lambda _next_cmd: "qs-test agent's-name",
     )
-    script = _read_script(script_invocation)
-    # The dangerous chars must be quoted, not spliced raw into the shell line.
-    # shlex.quote wraps the whole token in single quotes and escapes inner
-    # single quotes — the literal substring is the safe form, not the raw.
-    import shlex
+    payload = claude_launcher.build_payload(
+        "/tmp/work", 99, "Title", next_cmd="create-plan",
+    )
+    script = _read_script(payload["new_context"])
+
     expected_safe = shlex.quote("qs-test agent's-name")
     assert expected_safe in script, (
         f"Expected shlex-quoted agent in script; got: {script!r}"
@@ -177,3 +183,21 @@ def test_claude_command_quotes_agent_name_with_metacharacters() -> None:
     # And the raw form (with unescaped space + apostrophe) must NOT appear
     # outside the quoted block.
     assert "qs-test agent's-name " not in script.replace(expected_safe, "")
+
+
+# --------------------------------------------------------------------------- #
+# build_payload-level rejection of invalid next_cmd values — review-fix #02
+# NTH10. Each input below should raise ``ValueError`` (or a subclass) so
+# the launcher contract stays end-to-end strict.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad_next_cmd", ["/", "//create-plan", "unknown", "/nope"])
+def test_claude_build_payload_rejects_invalid_next_cmd(bad_next_cmd: str) -> None:
+    """``build_payload`` raises for invalid next_cmd at the public boundary."""
+    from launchers import claude as claude_launcher  # type: ignore[import-not-found]
+
+    with pytest.raises(ValueError):
+        claude_launcher.build_payload(
+            "/tmp/work", 1, "Title", next_cmd=bad_next_cmd,
+        )

--- a/tests/qs/launchers/test_cursor_launcher.py
+++ b/tests/qs/launchers/test_cursor_launcher.py
@@ -1,0 +1,101 @@
+"""Tests for ``scripts/qs/launchers/cursor.py`` ``build_payload``.
+
+The Cursor launcher gets parity with Claude: when ``cursor-agent`` is on
+PATH, ``cli_context`` invokes ``cursor-agent --workspace <wd> --agent
+qs-<phase>``; otherwise it falls back to the legacy prompt-positional
+form.
+"""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+
+import pytest
+
+
+def test_cli_context_uses_agent_flag_when_cursor_agent_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``cursor-agent`` on PATH → cli_context invokes it with --agent."""
+    from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
+
+    def fake_which(name: str) -> str | None:
+        if name == "cursor-agent":
+            return "/usr/local/bin/cursor-agent"
+        return None
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+
+    payload = cursor_launcher.build_payload(
+        "/tmp/work",
+        42,
+        "Fix bug",
+        next_cmd="create-plan",
+    )
+
+    assert payload["tool"] == "cursor"
+    assert payload["agent"] == "qs-create-plan"
+    assert payload["same_context"] == "create-plan"
+    cli = payload["cli_context"]
+    assert "cursor-agent" in cli
+    assert "--workspace" in cli
+    assert "--agent qs-create-plan" in cli
+    # And the work dir is properly quoted.
+    assert shlex.quote("/tmp/work") in cli
+
+
+def test_cli_context_falls_back_when_cursor_agent_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No ``cursor-agent`` on PATH → cli_context uses legacy prompt-positional form."""
+    from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
+
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+    payload = cursor_launcher.build_payload(
+        "/tmp/work",
+        42,
+        "Fix bug",
+        next_cmd="create-plan",
+    )
+    cli = payload["cli_context"]
+    # Fallback path: no --agent flag, legacy prompt-positional form.
+    assert "--agent" not in cli
+    assert "cursor-agent --workspace" in cli
+    # Slash form gets injected into the prompt body for the fallback.
+    assert "create-plan" in cli
+
+
+def test_same_context_mirrors_slash_form(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``same_context`` is the next_cmd verbatim (parity with claude.py)."""
+    from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
+
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    payload = cursor_launcher.build_payload(
+        "/tmp/work", 1, "T", next_cmd="/review-task",
+    )
+    assert payload["same_context"] == "/review-task"
+    assert payload["agent"] == "qs-review-task"
+
+
+def test_unknown_phase_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unknown phase propagates as ValueError (matches claude.py behaviour)."""
+    from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
+
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    with pytest.raises(ValueError):
+        cursor_launcher.build_payload(
+            "/tmp/work", 1, "T", next_cmd="bogus",
+        )
+
+
+def test_next_prompt_appended_to_cli_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``next_prompt`` survives into the cli_context for the fallback path."""
+    from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
+
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    payload = cursor_launcher.build_payload(
+        "/tmp/work",
+        1,
+        "T",
+        next_cmd="create-plan",
+        next_prompt="hello world",
+    )
+    assert "hello world" in payload["cli_context"]

--- a/tests/qs/launchers/test_cursor_launcher.py
+++ b/tests/qs/launchers/test_cursor_launcher.py
@@ -185,3 +185,58 @@ def test_cursor_source_documents_fallback_rationale() -> None:
         "Fallback rationale should document the manual equivalent for the "
         "user (open Cursor → type the slash command in chat)."
     )
+
+
+# --------------------------------------------------------------------------- #
+# _slash_form defense-in-depth — review-fix #02 NTH8.
+#
+# The helper is upstream-protected by ``resolve_agent_for_next_cmd``, so
+# the empty / double-slash cases are currently unreachable from
+# ``build_payload``. But a future refactor could call ``_slash_form``
+# outside that validation path. The function should be a leaf with its
+# own preconditions encoded.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(("input_val", "expected"), [
+    ("create-plan", "/create-plan"),
+    ("/create-plan", "/create-plan"),
+    # ``//create-plan`` is a contract violation but the function's job is
+    # to NORMALIZE to slash form — passing through here is acceptable.
+    # The upstream resolver is what rejects ``//<anything>``.
+    ("//create-plan", "//create-plan"),
+])
+def test_slash_form_normalizes_to_slash_prefix(input_val: str, expected: str) -> None:
+    """``_slash_form`` adds a leading slash iff one is missing."""
+    from launchers.cursor import _slash_form  # type: ignore[import-not-found]
+
+    assert _slash_form(input_val) == expected
+
+
+@pytest.mark.parametrize("bad", ["", " ", "  ", "\t", "\n"])
+def test_slash_form_rejects_empty_or_whitespace(bad: str) -> None:
+    """Empty/whitespace input is a contract violation — ``_slash_form`` raises."""
+    from launchers.cursor import _slash_form  # type: ignore[import-not-found]
+
+    with pytest.raises(ValueError):
+        _slash_form(bad)
+
+
+# --------------------------------------------------------------------------- #
+# build_payload-level rejection of invalid next_cmd values — review-fix #02
+# NTH10. Symmetric with the claude.py contract.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad_next_cmd", ["/", "//create-plan", "unknown", "/nope"])
+def test_cursor_build_payload_rejects_invalid_next_cmd(
+    bad_next_cmd: str, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``build_payload`` raises for invalid next_cmd at the public boundary."""
+    from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
+
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    with pytest.raises(ValueError):
+        cursor_launcher.build_payload(
+            "/tmp/work", 1, "Title", next_cmd=bad_next_cmd,
+        )

--- a/tests/qs/launchers/test_cursor_launcher.py
+++ b/tests/qs/launchers/test_cursor_launcher.py
@@ -145,6 +145,43 @@ def test_cursor_fallback_new_context_uses_slash_form(
     )
 
 
+# --------------------------------------------------------------------------- #
+# IDE-path slash-form coverage — review-fix #04 SF3 + NTH11.
+#
+# Round 2 SF2 normalized the FALLBACK-path prompt to slash form, but the
+# IDE-path banner script kept interpolating the raw ``next_cmd`` — so a
+# bare phase was rendered as ``type create-plan`` in the user-facing
+# instruction. The IDE path is the more common one (cursor IDE on PATH),
+# so this gap was the more user-visible of the two.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("next_cmd", ["create-plan", "/create-plan"])
+def test_cursor_ide_banner_uses_slash_form(
+    next_cmd: str, monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """IDE launcher script's user-facing instruction shows ``/<phase>``."""
+    from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
+
+    # Pretend ``cursor`` is on PATH so the IDE path is selected (not the
+    # text-instructions fallback). The IDE script lands under
+    # tempfile.gettempdir() — read it back to inspect the rendered text.
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/cursor" if name == "cursor" else None)
+    payload = cursor_launcher.build_payload(
+        "/tmp/work", 42, "T", next_cmd=next_cmd,
+    )
+    assert payload["new_context"].startswith("sh "), payload["new_context"]
+    script_path = Path(payload["new_context"][len("sh "):])
+    script_body = script_path.read_text()
+
+    # The "In the chat, type: ..." banner is the user-facing instruction
+    # at the top of the IDE script. It must show ``/create-plan`` with a
+    # leading slash regardless of the input form.
+    assert "/create-plan" in script_body, (
+        f"IDE banner missed the slash form. Got script body:\n{script_body!r}"
+    )
+
+
 def test_cursor_same_context_preserves_input_verbatim(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/qs/launchers/test_cursor_launcher.py
+++ b/tests/qs/launchers/test_cursor_launcher.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import shlex
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -99,3 +100,88 @@ def test_next_prompt_appended_to_cli_context(monkeypatch: pytest.MonkeyPatch) ->
         next_prompt="hello world",
     )
     assert "hello world" in payload["cli_context"]
+
+
+# --------------------------------------------------------------------------- #
+# Fallback prompt must render the SLASH form regardless of input shape — so a
+# user landing on the degraded Cursor path can invoke the phase as a slash
+# command in chat. Regression catch for review-fix #2.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("next_cmd", ["create-plan", "/create-plan"])
+def test_cursor_fallback_cli_uses_slash_form(
+    next_cmd: str, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When cursor-agent is missing, the fallback prompt embeds ``/<phase>``."""
+    from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
+
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    payload = cursor_launcher.build_payload(
+        "/tmp/work", 1, "T", next_cmd=next_cmd,
+    )
+    cli = payload["cli_context"]
+    # Slash form must be present so the user can paste/type it as a slash
+    # command once they open Cursor manually.
+    assert "/create-plan" in cli, f"expected '/create-plan' in {cli!r}"
+
+
+@pytest.mark.parametrize("next_cmd", ["create-plan", "/create-plan"])
+def test_cursor_fallback_new_context_uses_slash_form(
+    next_cmd: str, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``new_context`` instructions point at the slash form when no IDE on PATH."""
+    from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
+
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    payload = cursor_launcher.build_payload(
+        "/tmp/work", 1, "T", next_cmd=next_cmd,
+    )
+    new_context = payload["new_context"]
+    # The "Then in chat, type:" instruction must surface ``/create-plan``
+    # (with leading slash) so the user reaches the slash-command fallback.
+    assert "/create-plan" in new_context, (
+        f"expected '/create-plan' in new_context, got: {new_context!r}"
+    )
+
+
+def test_cursor_same_context_preserves_input_verbatim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``same_context`` is the next_cmd verbatim — only the fallback prompt normalizes."""
+    from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
+
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    bare = cursor_launcher.build_payload("/tmp/w", 1, "T", next_cmd="create-plan")
+    slash = cursor_launcher.build_payload("/tmp/w", 1, "T", next_cmd="/create-plan")
+    # Verbatim preservation is the back-compat invariant.
+    assert bare["same_context"] == "create-plan"
+    assert slash["same_context"] == "/create-plan"
+
+
+# --------------------------------------------------------------------------- #
+# Source-grep regression — locks the cursor fallback rationale comment in
+# place so a future refactor cannot silently delete the "why we fall back to
+# the legacy prompt-positional form" explanation. Review-fix #10.
+# --------------------------------------------------------------------------- #
+
+
+def test_cursor_source_documents_fallback_rationale() -> None:
+    """cursor.py must explain why the legacy form is used when cursor-agent is missing."""
+    cursor_py = (
+        Path(__file__).resolve().parents[3]
+        / "scripts" / "qs" / "launchers" / "cursor.py"
+    )
+    source = cursor_py.read_text()
+    # The rationale block lives in _cursor_cli_command's fallback branch.
+    # Look for two stable substrings — keep this loose so wording can evolve.
+    assert "legacy prompt-positional form" in source, (
+        "Fallback rationale comment was removed from cursor.py — restore the "
+        "block explaining why older cursor-agent binaries (no --agent support) "
+        "fall back to the legacy form."
+    )
+    assert "manual equivalent" in source.lower() or "type ``/" in source.lower() \
+        or "type `/" in source.lower(), (
+        "Fallback rationale should document the manual equivalent for the "
+        "user (open Cursor → type the slash command in chat)."
+    )

--- a/tests/qs/launchers/test_cursor_launcher.py
+++ b/tests/qs/launchers/test_cursor_launcher.py
@@ -188,13 +188,17 @@ def test_cursor_source_documents_fallback_rationale() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# _slash_form defense-in-depth — review-fix #02 NTH8.
+# slash_form defense-in-depth — review-fix #02 NTH8.
 #
 # The helper is upstream-protected by ``resolve_agent_for_next_cmd``, so
 # the empty / double-slash cases are currently unreachable from
-# ``build_payload``. But a future refactor could call ``_slash_form``
+# ``build_payload``. But a future refactor could call ``slash_form``
 # outside that validation path. The function should be a leaf with its
 # own preconditions encoded.
+#
+# Round-3 review-fix #03 SF2: the helper was promoted to a public name
+# (``slash_form`` without leading underscore) so tests can pin its
+# contract directly without reaching for a "private" import.
 # --------------------------------------------------------------------------- #
 
 
@@ -207,19 +211,19 @@ def test_cursor_source_documents_fallback_rationale() -> None:
     ("//create-plan", "//create-plan"),
 ])
 def test_slash_form_normalizes_to_slash_prefix(input_val: str, expected: str) -> None:
-    """``_slash_form`` adds a leading slash iff one is missing."""
-    from launchers.cursor import _slash_form  # type: ignore[import-not-found]
+    """``slash_form`` adds a leading slash iff one is missing."""
+    from launchers.cursor import slash_form  # type: ignore[import-not-found]
 
-    assert _slash_form(input_val) == expected
+    assert slash_form(input_val) == expected
 
 
 @pytest.mark.parametrize("bad", ["", " ", "  ", "\t", "\n"])
 def test_slash_form_rejects_empty_or_whitespace(bad: str) -> None:
-    """Empty/whitespace input is a contract violation — ``_slash_form`` raises."""
-    from launchers.cursor import _slash_form  # type: ignore[import-not-found]
+    """Empty/whitespace input is a contract violation — ``slash_form`` raises."""
+    from launchers.cursor import slash_form  # type: ignore[import-not-found]
 
     with pytest.raises(ValueError):
-        _slash_form(bad)
+        slash_form(bad)
 
 
 # --------------------------------------------------------------------------- #
@@ -228,11 +232,17 @@ def test_slash_form_rejects_empty_or_whitespace(bad: str) -> None:
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.parametrize("bad_next_cmd", ["/", "//create-plan", "unknown", "/nope"])
+@pytest.mark.parametrize(
+    "bad_next_cmd", ["", "/", "//create-plan", "unknown", "/nope"],
+)
 def test_cursor_build_payload_rejects_invalid_next_cmd(
     bad_next_cmd: str, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``build_payload`` raises for invalid next_cmd at the public boundary."""
+    """``build_payload`` raises for invalid next_cmd at the public boundary.
+
+    ``""`` is included for parity with the CLI-layer check
+    (review-fix #03 NTH1).
+    """
     from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
 
     monkeypatch.setattr(shutil, "which", lambda _name: None)

--- a/tests/qs/launchers/test_next_step_cli.py
+++ b/tests/qs/launchers/test_next_step_cli.py
@@ -129,3 +129,66 @@ def test_every_known_phase_resolves(phase: str, tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     assert payload["agent"] == f"qs-{phase}"
+
+
+# --------------------------------------------------------------------------- #
+# Free-form harnesses (codex, opencode) must NOT be regressed by the strict
+# claude/cursor validation. These launchers carry no agent mapping today, so
+# next_step.py must let them pass any --next-cmd value through unchanged.
+# Regression catch for review-fix #1 + #5.
+# --------------------------------------------------------------------------- #
+
+
+def test_codex_accepts_free_form_next_cmd(tmp_path: Path) -> None:
+    """Codex launcher must accept any --next-cmd string (no agent mapping)."""
+    result = _run(
+        [
+            "--next-cmd", "anything-goes-here",
+            "--work-dir", "/tmp/work",
+            "--issue", "42",
+            "--title", "Title",
+            "--harness", "codex",
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["tool"] == "codex"
+    assert payload["same_context"] == "anything-goes-here"
+
+
+def test_opencode_accepts_free_form_next_cmd(tmp_path: Path) -> None:
+    """OpenCode launcher must accept any --next-cmd string (legacy pipeline)."""
+    result = _run(
+        [
+            "--next-cmd", "legacy-skill-name",
+            "--work-dir", "/tmp/work",
+            "--issue", "42",
+            "--title", "Title",
+            "--harness", "opencode",
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["tool"] == "opencode"
+    assert payload["same_context"] == "legacy-skill-name"
+
+
+def test_codex_passes_known_phase_through_unchanged(tmp_path: Path) -> None:
+    """Even a known phase under codex stays free-form — no agent key added."""
+    result = _run(
+        [
+            "--next-cmd", "create-plan",
+            "--work-dir", "/tmp/work",
+            "--issue", "42",
+            "--title", "Title",
+            "--harness", "codex",
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["tool"] == "codex"
+    # codex launcher is a stub; it doesn't resolve agents.
+    assert "agent" not in payload

--- a/tests/qs/launchers/test_next_step_cli.py
+++ b/tests/qs/launchers/test_next_step_cli.py
@@ -192,3 +192,38 @@ def test_codex_passes_known_phase_through_unchanged(tmp_path: Path) -> None:
     assert payload["tool"] == "codex"
     # codex launcher is a stub; it doesn't resolve agents.
     assert "agent" not in payload
+
+
+# --------------------------------------------------------------------------- #
+# Empty / whitespace --next-cmd must be rejected for ALL harnesses, including
+# codex/opencode (which previously accepted it silently and produced a
+# garbled payload with same_context: ""). Review-fix #02 SF2.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "harness", ["claude-code", "cursor", "codex", "opencode"],
+)
+@pytest.mark.parametrize("bad_next_cmd", ["", "   ", "\t"])
+def test_empty_or_whitespace_next_cmd_rejected_for_all_harnesses(
+    harness: str, bad_next_cmd: str, tmp_path: Path,
+) -> None:
+    """Empty / whitespace-only --next-cmd → JSON error + exit 1, every harness."""
+    result = _run(
+        [
+            "--next-cmd", bad_next_cmd,
+            "--work-dir", "/tmp/work",
+            "--issue", "42",
+            "--title", "Title",
+            "--harness", harness,
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode != 0, (
+        f"--harness {harness} accepted empty --next-cmd silently (regression)"
+    )
+    # JSON error shape is identical to the unknown-phase case so downstream
+    # parsing stays simple.
+    payload = json.loads(result.stdout)
+    assert payload["error"] == "empty next-cmd"
+    assert payload["value"] == bad_next_cmd

--- a/tests/qs/launchers/test_next_step_cli.py
+++ b/tests/qs/launchers/test_next_step_cli.py
@@ -1,0 +1,131 @@
+"""Tests for ``scripts/qs/next_step.py`` invoked as a subprocess.
+
+``next_step.py`` is stdlib-only and must work from any CWD (AC-9). The
+phase-name → agent-name resolution is a static dict — no filesystem
+scan, no ``Path.cwd()`` — so running from ``/tmp`` resolves the same as
+running from a worktree.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_QS = Path(__file__).resolve().parents[3] / "scripts" / "qs"
+NEXT_STEP_PY = SCRIPTS_QS / "next_step.py"
+
+
+def _run(args: list[str], *, cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Run ``next_step.py`` with the given args."""
+    return subprocess.run(
+        [sys.executable, str(NEXT_STEP_PY), *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd or str(SCRIPTS_QS),
+    )
+
+
+def test_valid_phase_emits_payload_and_exits_zero(tmp_path: Path) -> None:
+    """Valid phase → JSON payload on stdout, exit 0. CWD-independent."""
+    result = _run(
+        [
+            "--next-cmd", "create-plan",
+            "--work-dir", "/tmp/work",
+            "--issue", "42",
+            "--title", "Fix bug",
+            "--harness", "claude-code",
+        ],
+        cwd=str(tmp_path),  # outside the repo — AC-9
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["harness"] == "claude-code"
+    assert payload["agent"] == "qs-create-plan"
+    assert payload["same_context"] == "create-plan"
+    assert payload["new_context"].startswith("sh ")
+
+
+def test_slash_form_accepted_for_back_compat(tmp_path: Path) -> None:
+    """Slash form continues to work — old callers pass ``/create-plan``."""
+    result = _run(
+        [
+            "--next-cmd", "/create-plan",
+            "--work-dir", "/tmp/work",
+            "--issue", "42",
+            "--title", "Fix bug",
+            "--harness", "claude-code",
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["agent"] == "qs-create-plan"
+
+
+def test_unknown_phase_emits_error_json_and_exits_nonzero(tmp_path: Path) -> None:
+    """Unknown phase → JSON error on stdout, non-zero exit."""
+    result = _run(
+        [
+            "--next-cmd", "bogus-phase",
+            "--work-dir", "/tmp/work",
+            "--issue", "42",
+            "--title", "Fix bug",
+            "--harness", "claude-code",
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode != 0
+    payload = json.loads(result.stdout)
+    assert payload["error"] == "unknown phase"
+    assert payload["value"] == "bogus-phase"
+    assert "create-plan" in payload["known"]
+    assert "release" in payload["known"]
+
+
+def test_cursor_harness_branch(tmp_path: Path) -> None:
+    """``--harness cursor --next-cmd create-plan`` routes through cursor.py."""
+    result = _run(
+        [
+            "--next-cmd", "create-plan",
+            "--work-dir", "/tmp/work",
+            "--issue", "42",
+            "--title", "Fix bug",
+            "--harness", "cursor",
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["tool"] == "cursor"
+    assert payload["harness"] == "cursor"
+    assert payload["agent"] == "qs-create-plan"
+
+
+@pytest.mark.parametrize("phase", [
+    "setup-task",
+    "create-plan",
+    "implement-task",
+    "implement-setup-task",
+    "review-task",
+    "finish-task",
+    "release",
+])
+def test_every_known_phase_resolves(phase: str, tmp_path: Path) -> None:
+    """Every known phase resolves end-to-end via the CLI."""
+    result = _run(
+        [
+            "--next-cmd", phase,
+            "--work-dir", "/tmp/work",
+            "--issue", "42",
+            "--title", "Title",
+            "--harness", "claude-code",
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["agent"] == f"qs-{phase}"

--- a/tests/qs/launchers/test_next_step_unit.py
+++ b/tests/qs/launchers/test_next_step_unit.py
@@ -1,0 +1,113 @@
+"""In-process unit tests for ``scripts/qs/next_step.py``.
+
+Subprocess tests in ``test_next_step_cli.py`` cover the happy path and
+JSON error contract. These tests verify behaviour that's awkward to
+exercise via subprocess — specifically, the narrowing of the
+``except`` clause to ``UnknownPhaseError`` only (review-fix #02 SF1).
+
+Importing ``next_step`` in-process is safe under the launcher conftest
+which adds ``scripts/qs/`` to ``sys.path`` and tears it down per-test.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _set_argv(monkeypatch: pytest.MonkeyPatch, harness: str, next_cmd: str = "create-plan") -> None:
+    """Install a minimal valid sys.argv for ``next_step.main()``."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "next_step.py",
+            "--next-cmd", next_cmd,
+            "--work-dir", "/tmp/work",
+            "--issue", "1",
+            "--title", "Title",
+            "--harness", harness,
+        ],
+    )
+
+
+def test_next_step_propagates_non_phase_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-phase ``ValueError`` from build_payload propagates uncaught.
+
+    Before the SF1 fix, ``next_step.py`` caught every ``ValueError`` and
+    misreported it as 'unknown phase'. After the fix, only
+    ``UnknownPhaseError`` should be caught; everything else should
+    propagate (a non-zero exit with the original traceback).
+    """
+    import next_step  # type: ignore[import-not-found]
+
+    class FaultyLauncher:
+        @staticmethod
+        def build_payload(*_args: object, **_kwargs: object) -> dict:
+            raise ValueError("totally unrelated failure mode")
+
+    monkeypatch.setitem(next_step._LAUNCHERS, "claude-code", FaultyLauncher)
+    _set_argv(monkeypatch, harness="claude-code")
+
+    with pytest.raises(ValueError) as excinfo:
+        next_step.main()
+
+    # The original message survives — proving we did not silently
+    # rewrite it as 'unknown phase'.
+    assert "unrelated failure mode" in str(excinfo.value)
+
+
+def test_next_step_catches_unknown_phase_error(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """``UnknownPhaseError`` is caught and JSON-formatted as exit 1."""
+    import json
+
+    import next_step  # type: ignore[import-not-found]
+    from launchers.phases import UnknownPhaseError  # type: ignore[import-not-found]
+
+    class PhaseRejectingLauncher:
+        @staticmethod
+        def build_payload(*_args: object, **_kwargs: object) -> dict:
+            raise UnknownPhaseError("synthetic-bad", ["a", "b"])
+
+    monkeypatch.setitem(next_step._LAUNCHERS, "claude-code", PhaseRejectingLauncher)
+    _set_argv(monkeypatch, harness="claude-code")
+
+    with pytest.raises(SystemExit) as excinfo:
+        next_step.main()
+    assert excinfo.value.code == 1
+
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["error"] == "unknown phase"
+    assert payload["value"] == "synthetic-bad"
+    assert payload["known"] == ["a", "b"]
+
+
+def test_next_step_exits_zero_on_happy_path(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Sanity: happy path still exits 0 after SF1 refactor."""
+    import json
+
+    import next_step  # type: ignore[import-not-found]
+
+    class HappyLauncher:
+        @staticmethod
+        def build_payload(*_args: object, **_kwargs: object) -> dict:
+            return {"tool": "fake", "same_context": "x", "new_context": "y"}
+
+    monkeypatch.setitem(next_step._LAUNCHERS, "claude-code", HappyLauncher)
+    _set_argv(monkeypatch, harness="claude-code")
+
+    with pytest.raises(SystemExit) as excinfo:
+        next_step.main()
+    assert excinfo.value.code == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tool"] == "fake"
+    assert payload["harness"] == "claude-code"
+
+
+# Path imported only to satisfy ruff's "module first uses imports" check
+# for the absolute paths the conftest fixture relies on.
+_ = Path

--- a/tests/qs/launchers/test_next_step_unit.py
+++ b/tests/qs/launchers/test_next_step_unit.py
@@ -12,7 +12,6 @@ which adds ``scripts/qs/`` to ``sys.path`` and tears it down per-test.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 import pytest
 
@@ -48,7 +47,7 @@ def test_next_step_propagates_non_phase_value_error(monkeypatch: pytest.MonkeyPa
         def build_payload(*_args: object, **_kwargs: object) -> dict:
             raise ValueError("totally unrelated failure mode")
 
-    monkeypatch.setitem(next_step._LAUNCHERS, "claude-code", FaultyLauncher)
+    monkeypatch.setitem(next_step.LAUNCHERS, "claude-code", FaultyLauncher)
     _set_argv(monkeypatch, harness="claude-code")
 
     with pytest.raises(ValueError) as excinfo:
@@ -71,7 +70,7 @@ def test_next_step_catches_unknown_phase_error(monkeypatch: pytest.MonkeyPatch, 
         def build_payload(*_args: object, **_kwargs: object) -> dict:
             raise UnknownPhaseError("synthetic-bad", ["a", "b"])
 
-    monkeypatch.setitem(next_step._LAUNCHERS, "claude-code", PhaseRejectingLauncher)
+    monkeypatch.setitem(next_step.LAUNCHERS, "claude-code", PhaseRejectingLauncher)
     _set_argv(monkeypatch, harness="claude-code")
 
     with pytest.raises(SystemExit) as excinfo:
@@ -96,7 +95,7 @@ def test_next_step_exits_zero_on_happy_path(monkeypatch: pytest.MonkeyPatch, cap
         def build_payload(*_args: object, **_kwargs: object) -> dict:
             return {"tool": "fake", "same_context": "x", "new_context": "y"}
 
-    monkeypatch.setitem(next_step._LAUNCHERS, "claude-code", HappyLauncher)
+    monkeypatch.setitem(next_step.LAUNCHERS, "claude-code", HappyLauncher)
     _set_argv(monkeypatch, harness="claude-code")
 
     with pytest.raises(SystemExit) as excinfo:
@@ -106,8 +105,3 @@ def test_next_step_exits_zero_on_happy_path(monkeypatch: pytest.MonkeyPatch, cap
     payload = json.loads(capsys.readouterr().out)
     assert payload["tool"] == "fake"
     assert payload["harness"] == "claude-code"
-
-
-# Path imported only to satisfy ruff's "module first uses imports" check
-# for the absolute paths the conftest fixture relies on.
-_ = Path

--- a/tests/qs/launchers/test_phase_mapping.py
+++ b/tests/qs/launchers/test_phase_mapping.py
@@ -111,14 +111,44 @@ def test_unknown_phase_error_is_a_value_error() -> None:
 
 
 def test_unknown_phase_error_carries_value_and_known_attrs() -> None:
-    """The exception exposes ``.value`` and ``.known`` so callers needn't re-parse."""
+    """The exception exposes ``.value``, ``.phase``, and ``.known`` (review-fix #04 NTH4)."""
     from launchers.phases import UnknownPhaseError  # type: ignore[import-not-found]
 
     exc = UnknownPhaseError("bogus", ["a", "b"])
     assert exc.value == "bogus"
     assert exc.known == ["a", "b"]
+    # When ``value`` has no leading slash, ``.phase`` defaults to the
+    # same string — no normalization needed.
+    assert exc.phase == "bogus"
     # Message names the invalid value so a bare ``str(exc)`` is useful too.
     assert "bogus" in str(exc)
+
+
+def test_unknown_phase_error_phase_strips_leading_slash() -> None:
+    """``.phase`` carries the post-normalization lookup key (review-fix #04 NTH4)."""
+    from launchers.phases import UnknownPhaseError  # type: ignore[import-not-found]
+
+    exc = UnknownPhaseError("/bogus", ["a", "b"])
+    assert exc.value == "/bogus"
+    # ``.phase`` is what ``resolve_agent_for_next_cmd`` actually looked
+    # up — strips the single leading slash. Saves the debugger from
+    # re-deriving the lookup key.
+    assert exc.phase == "bogus"
+    # Message surfaces BOTH so the caller sees the user's input AND the
+    # internal lookup key.
+    msg = str(exc)
+    assert "/bogus" in msg
+    assert "bogus" in msg
+
+
+def test_unknown_phase_error_accepts_tuple_for_known() -> None:
+    """``known`` accepts any Sequence (review-fix #04 NTH3)."""
+    from launchers.phases import UnknownPhaseError  # type: ignore[import-not-found]
+
+    exc = UnknownPhaseError("bogus", ("a", "b"))
+    # Internally normalized to list so callers don't get surprised by
+    # mismatched return types.
+    assert exc.known == ["a", "b"]
 
 
 def test_resolve_raises_unknown_phase_error_specifically() -> None:

--- a/tests/qs/launchers/test_phase_mapping.py
+++ b/tests/qs/launchers/test_phase_mapping.py
@@ -82,3 +82,44 @@ def test_resolve_strips_only_leading_slash() -> None:
 
     with pytest.raises(ValueError):
         resolve_agent_for_next_cmd("//create-plan")
+
+
+# --------------------------------------------------------------------------- #
+# UnknownPhaseError contract — review-fix #02 SF1.
+#
+# The narrowing requires a dedicated exception so next_step.py can catch
+# JUST the "unknown phase" case (not every ValueError raised by build_payload
+# or its callees). The exception subclasses ValueError to preserve back-compat
+# with any legacy ``except ValueError`` block.
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_phase_error_is_a_value_error() -> None:
+    """``UnknownPhaseError`` is a subclass of ``ValueError`` (back-compat)."""
+    from launchers.phases import UnknownPhaseError  # type: ignore[import-not-found]
+
+    assert issubclass(UnknownPhaseError, ValueError)
+
+
+def test_unknown_phase_error_carries_value_and_known_attrs() -> None:
+    """The exception exposes ``.value`` and ``.known`` so callers needn't re-parse."""
+    from launchers.phases import UnknownPhaseError  # type: ignore[import-not-found]
+
+    exc = UnknownPhaseError("bogus", ["a", "b"])
+    assert exc.value == "bogus"
+    assert exc.known == ["a", "b"]
+    # Message names the invalid value so a bare ``str(exc)`` is useful too.
+    assert "bogus" in str(exc)
+
+
+def test_resolve_raises_unknown_phase_error_specifically() -> None:
+    """``resolve_agent_for_next_cmd`` raises ``UnknownPhaseError``, not plain ``ValueError``."""
+    from launchers.phases import (  # type: ignore[import-not-found]
+        UnknownPhaseError,
+        resolve_agent_for_next_cmd,
+    )
+
+    with pytest.raises(UnknownPhaseError) as excinfo:
+        resolve_agent_for_next_cmd("bogus-phase")
+    assert excinfo.value.value == "bogus-phase"
+    assert "create-plan" in excinfo.value.known

--- a/tests/qs/launchers/test_phase_mapping.py
+++ b/tests/qs/launchers/test_phase_mapping.py
@@ -2,7 +2,7 @@
 
 Lives in ``scripts/qs/launchers/phases.py`` and is imported by both
 ``claude.py`` and ``next_step.py``. The mapping covers every phase the
-QS pipeline knows about; ``_resolve_agent_for_next_cmd`` accepts either
+QS pipeline knows about; ``resolve_agent_for_next_cmd`` accepts either
 the slash form (``"/create-plan"``) or the bare phase name and raises
 ``ValueError`` for anything it does not know.
 """
@@ -11,9 +11,8 @@ from __future__ import annotations
 
 import pytest
 
-
 # The exhaustive list of phases the pipeline ships. Reviewers will catch any
-# drift between this and ``_PHASE_TO_AGENT``.
+# drift between this and ``PHASE_TO_AGENT``.
 _KNOWN_PHASES = (
     "setup-task",
     "create-plan",
@@ -27,16 +26,16 @@ _KNOWN_PHASES = (
 
 def test_phase_to_agent_covers_every_known_phase() -> None:
     """Every QS phase has an entry in the mapping."""
-    from launchers.phases import _PHASE_TO_AGENT  # type: ignore[import-not-found]
+    from launchers.phases import PHASE_TO_AGENT  # type: ignore[import-not-found]
 
-    assert set(_PHASE_TO_AGENT) == set(_KNOWN_PHASES)
+    assert set(PHASE_TO_AGENT) == set(_KNOWN_PHASES)
 
 
 def test_phase_to_agent_values_match_qs_prefix() -> None:
     """Every value is ``qs-<key>`` — the static-agent file convention."""
-    from launchers.phases import _PHASE_TO_AGENT  # type: ignore[import-not-found]
+    from launchers.phases import PHASE_TO_AGENT  # type: ignore[import-not-found]
 
-    for phase, agent in _PHASE_TO_AGENT.items():
+    for phase, agent in PHASE_TO_AGENT.items():
         assert agent == f"qs-{phase}", (
             f"Expected mapping {phase!r} → 'qs-{phase}', got {agent!r}"
         )
@@ -45,41 +44,41 @@ def test_phase_to_agent_values_match_qs_prefix() -> None:
 @pytest.mark.parametrize("phase", _KNOWN_PHASES)
 def test_resolve_bare_phase_name(phase: str) -> None:
     """Bare phase name resolves to the qs-prefixed agent."""
-    from launchers.phases import _resolve_agent_for_next_cmd  # type: ignore[import-not-found]
+    from launchers.phases import resolve_agent_for_next_cmd  # type: ignore[import-not-found]
 
-    assert _resolve_agent_for_next_cmd(phase) == f"qs-{phase}"
+    assert resolve_agent_for_next_cmd(phase) == f"qs-{phase}"
 
 
 @pytest.mark.parametrize("phase", _KNOWN_PHASES)
 def test_resolve_slash_phase_name(phase: str) -> None:
     """Slash form (back-compat for callers that pass /create-plan)."""
-    from launchers.phases import _resolve_agent_for_next_cmd  # type: ignore[import-not-found]
+    from launchers.phases import resolve_agent_for_next_cmd  # type: ignore[import-not-found]
 
-    assert _resolve_agent_for_next_cmd(f"/{phase}") == f"qs-{phase}"
+    assert resolve_agent_for_next_cmd(f"/{phase}") == f"qs-{phase}"
 
 
 @pytest.mark.parametrize("bogus", ["foo", "", "  ", "/nope", "/", "create plan"])
 def test_resolve_unknown_phase_raises(bogus: str) -> None:
     """Unknown phase raises ValueError naming the value and listing known phases."""
     from launchers.phases import (  # type: ignore[import-not-found]
-        _PHASE_TO_AGENT,
-        _resolve_agent_for_next_cmd,
+        PHASE_TO_AGENT,
+        resolve_agent_for_next_cmd,
     )
 
     with pytest.raises(ValueError) as excinfo:
-        _resolve_agent_for_next_cmd(bogus)
+        resolve_agent_for_next_cmd(bogus)
 
     msg = str(excinfo.value)
     # The message must name the invalid value AND list known phases (so the
     # user can see what they meant to type).
     assert repr(bogus) in msg or bogus in msg
-    for phase in _PHASE_TO_AGENT:
+    for phase in PHASE_TO_AGENT:
         assert phase in msg
 
 
 def test_resolve_strips_only_leading_slash() -> None:
     """``//create-plan`` is not valid — we strip exactly one leading slash."""
-    from launchers.phases import _resolve_agent_for_next_cmd  # type: ignore[import-not-found]
+    from launchers.phases import resolve_agent_for_next_cmd  # type: ignore[import-not-found]
 
     with pytest.raises(ValueError):
-        _resolve_agent_for_next_cmd("//create-plan")
+        resolve_agent_for_next_cmd("//create-plan")

--- a/tests/qs/launchers/test_phase_mapping.py
+++ b/tests/qs/launchers/test_phase_mapping.py
@@ -1,0 +1,85 @@
+"""Phase-name → agent-name mapping (single source of truth).
+
+Lives in ``scripts/qs/launchers/phases.py`` and is imported by both
+``claude.py`` and ``next_step.py``. The mapping covers every phase the
+QS pipeline knows about; ``_resolve_agent_for_next_cmd`` accepts either
+the slash form (``"/create-plan"``) or the bare phase name and raises
+``ValueError`` for anything it does not know.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# The exhaustive list of phases the pipeline ships. Reviewers will catch any
+# drift between this and ``_PHASE_TO_AGENT``.
+_KNOWN_PHASES = (
+    "setup-task",
+    "create-plan",
+    "implement-task",
+    "implement-setup-task",
+    "review-task",
+    "finish-task",
+    "release",
+)
+
+
+def test_phase_to_agent_covers_every_known_phase() -> None:
+    """Every QS phase has an entry in the mapping."""
+    from launchers.phases import _PHASE_TO_AGENT  # type: ignore[import-not-found]
+
+    assert set(_PHASE_TO_AGENT) == set(_KNOWN_PHASES)
+
+
+def test_phase_to_agent_values_match_qs_prefix() -> None:
+    """Every value is ``qs-<key>`` — the static-agent file convention."""
+    from launchers.phases import _PHASE_TO_AGENT  # type: ignore[import-not-found]
+
+    for phase, agent in _PHASE_TO_AGENT.items():
+        assert agent == f"qs-{phase}", (
+            f"Expected mapping {phase!r} → 'qs-{phase}', got {agent!r}"
+        )
+
+
+@pytest.mark.parametrize("phase", _KNOWN_PHASES)
+def test_resolve_bare_phase_name(phase: str) -> None:
+    """Bare phase name resolves to the qs-prefixed agent."""
+    from launchers.phases import _resolve_agent_for_next_cmd  # type: ignore[import-not-found]
+
+    assert _resolve_agent_for_next_cmd(phase) == f"qs-{phase}"
+
+
+@pytest.mark.parametrize("phase", _KNOWN_PHASES)
+def test_resolve_slash_phase_name(phase: str) -> None:
+    """Slash form (back-compat for callers that pass /create-plan)."""
+    from launchers.phases import _resolve_agent_for_next_cmd  # type: ignore[import-not-found]
+
+    assert _resolve_agent_for_next_cmd(f"/{phase}") == f"qs-{phase}"
+
+
+@pytest.mark.parametrize("bogus", ["foo", "", "  ", "/nope", "/", "create plan"])
+def test_resolve_unknown_phase_raises(bogus: str) -> None:
+    """Unknown phase raises ValueError naming the value and listing known phases."""
+    from launchers.phases import (  # type: ignore[import-not-found]
+        _PHASE_TO_AGENT,
+        _resolve_agent_for_next_cmd,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        _resolve_agent_for_next_cmd(bogus)
+
+    msg = str(excinfo.value)
+    # The message must name the invalid value AND list known phases (so the
+    # user can see what they meant to type).
+    assert repr(bogus) in msg or bogus in msg
+    for phase in _PHASE_TO_AGENT:
+        assert phase in msg
+
+
+def test_resolve_strips_only_leading_slash() -> None:
+    """``//create-plan`` is not valid — we strip exactly one leading slash."""
+    from launchers.phases import _resolve_agent_for_next_cmd  # type: ignore[import-not-found]
+
+    with pytest.raises(ValueError):
+        _resolve_agent_for_next_cmd("//create-plan")

--- a/tests/qs/launchers/test_phase_mapping.py
+++ b/tests/qs/launchers/test_phase_mapping.py
@@ -57,9 +57,18 @@ def test_resolve_slash_phase_name(phase: str) -> None:
     assert resolve_agent_for_next_cmd(f"/{phase}") == f"qs-{phase}"
 
 
-@pytest.mark.parametrize("bogus", ["foo", "", "  ", "/nope", "/", "create plan"])
+@pytest.mark.parametrize("bogus", ["foo", "  ", "/nope", "/", "create plan"])
 def test_resolve_unknown_phase_raises(bogus: str) -> None:
-    """Unknown phase raises ValueError naming the value and listing known phases."""
+    """Unknown phase raises ValueError naming the value and listing known phases.
+
+    Note: the empty string ``""`` is intentionally excluded from this
+    parametrise list (review-fix #03 MF1). It would make
+    ``bogus in msg`` vacuously true (every string contains ``""``),
+    silently masking a regression in error-message formatting. The
+    empty-input invariant is pinned at the CLI layer instead by
+    ``test_empty_or_whitespace_next_cmd_rejected_for_all_harnesses``
+    in ``test_next_step_cli.py``.
+    """
     from launchers.phases import (  # type: ignore[import-not-found]
         PHASE_TO_AGENT,
         resolve_agent_for_next_cmd,


### PR DESCRIPTION
## Summary
Refactor pipeline so each phase orchestrator runs as an interactive 'claude --agent qs-<phase>' session (system prompt = agent body) instead of a one-shot Agent-tool sub-process. Slash commands stay as a degraded fallback for Claude Desktop. Single-source-of-truth phase mapping in scripts/qs/launchers/phases.py; strict --next-cmd validation in next_step.py; cursor launcher parity when cursor-agent is on PATH.

Fixes #175

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preferred interactive phased workflow: opens fresh claude --agent qs-<phase> sessions and prints a launcher command plus a slash-command fallback.

* **Documentation**
  * Expanded guidance on interactive orchestrators vs non-interactive parallel sub-agents; standardized next-phase handoffs; clarified finish-task does not emit a release launcher.

* **Tests**
  * Added regression and E2E tests for launcher payloads, phase→agent mapping, CLI behavior, and orchestrator handoff text.

* **Bug Fixes**
  * Empty/unknown next-phase inputs now produce explicit JSON error payloads and non-zero exits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/176)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->