### PR TITLE
QS-183: silence pytest warnings + add quality_gate --quick mode

### DIFF
--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -37,16 +37,24 @@ if you haven't this session.
 
 ### 2. TDD implementation
 
-Red → green → refactor:
-1. Write failing tests under `tests/` that encode every acceptance
-   criterion from the story.
-2. Implement the minimum code under `custom_components/quiet_solar/` to
-   make them pass.
+Red → green → refactor. For every cycle:
+
+1. Write failing tests under `tests/` for each story acceptance criterion.
+2. Implement the minimum code under `custom_components/quiet_solar/`
+   to make them pass.
 3. Refactor while keeping tests green.
 
+Verify with `python scripts/qs/quality_gate.py --quick <path>` during
+the inner loop (the canonical TDD command; accepts files,
+directories, or both). The full quality gate runs at step 4 before
+commit. See the `## Commands` section of
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+for the full command grammar and the forbidden-vs-allowed raw-pytest
+rule.
+
 Edit scope: `custom_components/quiet_solar/**`, `tests/**`, plus the
-story file (for progress notes). All other paths are out of scope — if
-you need to edit elsewhere, stop and escalate.
+story file (for progress notes). Stop and escalate if you need to
+edit elsewhere.
 
 ### 3. Implementation summary
 

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -33,15 +33,24 @@ Capture `issue`, `title`, `branch`, `story_file`. Read
 
 ### 2. TDD implementation
 
-Red → green → refactor:
-1. Write failing tests under `tests/` that encode every acceptance
-   criterion.
-2. Implement the minimum code under `custom_components/quiet_solar/` to
-   make them pass.
+Red → green → refactor. For every cycle:
+
+1. Write failing tests under `tests/` for each story acceptance criterion.
+2. Implement the minimum code under `custom_components/quiet_solar/`
+   to make them pass.
 3. Refactor while keeping tests green.
 
+Verify with `python scripts/qs/quality_gate.py --quick <path>` during
+the inner loop (the canonical TDD command; accepts files,
+directories, or both). The full quality gate runs at step 4 before
+commit. See the `## Commands` section of
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+for the full command grammar and the forbidden-vs-allowed raw-pytest
+rule.
+
 Edit scope: `custom_components/quiet_solar/**`, `tests/**`, plus the
-story file. All other paths are out of scope.
+story file (for progress notes). Stop and escalate if you need to
+edit elsewhere.
 
 ### 3. Implementation summary
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,16 +28,20 @@ the cache, xdist, sysmon, and scope detection. Raw `pytest` bypasses
 all four; use it only for ad-hoc single-node debugging.
 
 ```bash
-# Run all quality gates (pytest 100% coverage + ruff + mypy + translations)
+# Run all quality gates (pytest 100% coverage + ruff + mypy + translations).
+# Required before every commit.
 python scripts/qs/quality_gate.py
 
-# Auto-fix formatting and lint
-python scripts/qs/quality_gate.py --fix
+# Cached dev-loop default — skips gates when git state matches last pass.
+python scripts/qs/quality_gate.py --cache
 
 # Fast iteration on one or more test paths (files or directories).
 # xdist + sysmon, skips coverage/ruff/mypy/translations.
 python scripts/qs/quality_gate.py --quick tests/test_<file>.py
 python scripts/qs/quality_gate.py --quick tests/ha_tests
+
+# Auto-fix formatting and lint
+python scripts/qs/quality_gate.py --fix
 ```
 
 ## Architecture constraints

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ load these before doing any substantive work:
 ## Commands
 
 Activate with `source venv/bin/activate` for all Python commands.
+`scripts/qs/quality_gate.py` is the single test entry point — it owns
+the cache, xdist, sysmon, and scope detection. Raw `pytest` bypasses
+all four; use it only for ad-hoc single-node debugging.
 
 ```bash
 # Run all quality gates (pytest 100% coverage + ruff + mypy + translations)
@@ -31,8 +34,10 @@ python scripts/qs/quality_gate.py
 # Auto-fix formatting and lint
 python scripts/qs/quality_gate.py --fix
 
-# Run tests only
-source venv/bin/activate && pytest tests/ -v
+# Fast iteration on one or more test paths (files or directories).
+# xdist + sysmon, skips coverage/ruff/mypy/translations.
+python scripts/qs/quality_gate.py --quick tests/test_<file>.py
+python scripts/qs/quality_gate.py --quick tests/ha_tests
 ```
 
 ## Architecture constraints

--- a/docs/stories/QS-183.story.md
+++ b/docs/stories/QS-183.story.md
@@ -1,0 +1,404 @@
+# QS-183: Fix test warnings — `TestXxxDouble` collection and unawaited bootstrap coroutine
+
+GitHub issue: #183
+Branch: `QS_183`
+
+## Context
+
+Two categories of warnings clutter the `pytest` run:
+
+1. **Pytest collection warnings (9 occurrences).** Three helper classes
+   in `tests/factories.py` (`TestCarDouble`, `TestChargerDouble`,
+   `TestDynamicGroupDouble`) match pytest's default
+   `python_classes = Test*` collection rule (configured in `pytest.ini`).
+   Because they have `__init__` constructors, pytest emits
+   `cannot collect test class '...' because it has a __init__ constructor`
+   and skips collection. Each test module that imports one of these
+   helpers triggers the warning once — 9 total.
+
+   Note: `TestCarDouble` is not currently imported by any `test_*.py`
+   module (it's only used via the `create_test_car_double` factory in
+   `tests/ha_tests/test_charger.py`), so it does not produce a live
+   warning today. We still add `__test__ = False` to it for defensive
+   consistency and so the AC6 regression guard is self-consistent.
+
+2. **Unawaited coroutine warnings (2 occurrences).** In
+   `tests/test_coverage_device.py`, two tests mock
+   `hass.async_create_task` as a bare `MagicMock`. The mock receives the
+   `_async_bootstrap_from_history(entity_id, time)` coroutine but never
+   awaits it. At GC time, Python emits
+   `RuntimeWarning: coroutine 'HADeviceMixin._async_bootstrap_from_history' was never awaited`.
+   Verified empirically with `pytest -W error::RuntimeWarning`.
+
+   The body of `_async_bootstrap_from_history` is fully covered by
+   `tests/ha_tests/test_device_mixin.py` (the dedicated `TestAsyncBootstrapFromHistory`
+   class). These unit tests in `test_coverage_device.py` only verify
+   `root_device_post_home_init`'s control flow — the bootstrap body
+   itself is incidental.
+
+   A parallel anti-pattern exists in `tests/test_ha_car_comprehensive.py`
+   (mocks `hass.async_create_task` to raise, triggering
+   `_async_bootstrap_efficiency_from_history`) but verified empirically
+   it does NOT emit a warning today — likely because the surrounding
+   pytest-asyncio test loop holds the coroutine reference. Out of scope.
+
+Both fixed categories are test-only. No production code under
+`custom_components/quiet_solar/` is touched.
+
+## Goals / Non-goals
+
+**Goals:**
+
+- Zero `cannot collect test class '...'` warnings for the three doubles.
+- Zero `coroutine 'HADeviceMixin._async_bootstrap_from_history' was never awaited`
+  warnings.
+- A regression guard so any future `Test*` helper added to
+  `tests/factories.py` without `__test__ = False` fails the suite.
+- 100% test coverage preserved.
+- Full quality gate stays green.
+
+**Non-goals:**
+
+- No production code changes.
+- No rename of the three helper classes (callsite churn rejected; we
+  opt out of collection instead).
+- No `filterwarnings` override in `pytest.ini` — fix the root cause,
+  not the symptom.
+- No fix for the parallel pattern in `test_ha_car_comprehensive.py` —
+  verified not warning today; surface as follow-up if it ever does.
+
+## Acceptance criteria
+
+### AC1 — `TestCarDouble` is opted out of pytest collection
+**Given** `tests/factories.py` defines class `TestCarDouble`,
+**when** the test suite is collected,
+**then** no warning of the form `cannot collect test class 'TestCarDouble'` is emitted,
+**and** `TestCarDouble.__test__ is False`.
+
+### AC2 — `TestChargerDouble` is opted out of pytest collection
+**Given** `tests/factories.py` defines class `TestChargerDouble`,
+**when** the test suite is collected,
+**then** no warning of the form `cannot collect test class 'TestChargerDouble'` is emitted,
+**and** `TestChargerDouble.__test__ is False`.
+
+### AC3 — `TestDynamicGroupDouble` is opted out of pytest collection
+**Given** `tests/factories.py` defines class `TestDynamicGroupDouble`,
+**when** the test suite is collected,
+**then** no warning of the form `cannot collect test class 'TestDynamicGroupDouble'` is emitted,
+**and** `TestDynamicGroupDouble.__test__ is False`.
+
+### AC4 — `test_root_device_post_home_init_with_entities_lines323_325` does not leak a coroutine
+**Given** the test substitutes `hass.async_create_task`,
+**when** the test runs and completes,
+**then** no `RuntimeWarning: coroutine '...' was never awaited` is emitted,
+**and** the original assertion `hass.async_create_task.assert_called()` still passes (the side-effect wrapper preserves call tracking).
+
+### AC5 — `test_root_device_post_home_init_exception_lines324_325` does not leak a coroutine, and the production exception branch is still exercised
+**Given** the test substitutes `hass.async_create_task` to raise,
+**when** the test runs and completes,
+**then** no `RuntimeWarning: coroutine '...' was never awaited` is emitted,
+**and** no exception escapes `dev.root_device_post_home_init(now)` (the test still returns normally),
+**and** the production error-handling branch in `custom_components/quiet_solar/ha_model/device.py` (the `try / except Exception as e: _LOGGER.error(...)` around the bootstrap launcher) is still covered.
+
+### AC6 — Regression guard for future `Test*` helpers in `factories.py`
+**Given** a new helper class is later added to `tests/factories.py`,
+**when** the suite runs,
+**then** if its name starts with `Test` and it lacks `__test__ = False`, a dedicated regression test fails with a message naming the offender,
+**and** the regression test also positively asserts that the three sanctioned doubles (`TestCarDouble`, `TestChargerDouble`, `TestDynamicGroupDouble`) are present and opted out — so a silent rename does not bypass the guard.
+
+### AC7 — Total warning-count regression check
+**Given** the modified test files,
+**when** they are run under `pytest -W error::RuntimeWarning -W error::pytest.PytestCollectionWarning`,
+**then** the run exits 0 (i.e., zero `RuntimeWarning` and zero `PytestCollectionWarning` for both categories on the affected files).
+
+Specifically:
+- `pytest tests/test_coverage_device.py -W error::RuntimeWarning -W error::pytest.PytestCollectionWarning` exits 0.
+- `pytest tests/test_factories_pytest_opt_out.py tests/test_bug_116_production_log_fixes.py tests/test_constraint_interaction_boundaries.py tests/test_constraints.py tests/test_constraints_deep.py tests/test_constraints_pre_discharge_guard.py tests/test_coverage_constraints.py tests/test_power_guard.py tests/test_solver.py -W error::pytest.PytestCollectionWarning` exits 0.
+
+(We do NOT enable these `-W error::` filters globally in `pytest.ini` —
+the suite is large and unrelated third-party warnings would flake.
+The AC is a one-shot verification step during implementation.)
+
+### AC8 — Full quality gate stays green
+**Given** these changes,
+**when** `python scripts/qs/quality_gate.py` runs,
+**then** it exits 0 (pytest 100% coverage + ruff + ruff format + mypy + translations all pass).
+
+## Task breakdown
+
+### T1 — `tests/factories.py`: opt out the three doubles
+
+Insert `__test__ = False` as the first class-body statement after the
+docstring on each of the three classes (`TestCarDouble`,
+`TestChargerDouble`, `TestDynamicGroupDouble`). All three are plain
+classes (no `@dataclass`, no `__slots__`) — verified — so a bare class
+attribute is sufficient (no `ClassVar` annotation needed).
+
+Exact pattern per class:
+
+```python
+class TestCarDouble:
+    """Test double for QSCar that provides minimal required interface.
+
+    Use this instead of SimpleNamespace for car mocks in unit tests.
+    """
+
+    # pytest opt-out: this is a test helper, not a test class, despite
+    # the `Test` prefix.  Pytest's default `python_classes = Test*`
+    # collection rule would otherwise try to instantiate it and emit
+    # `cannot collect test class 'TestCarDouble'` (it has an `__init__`).
+    __test__ = False
+
+    def __init__(self, ...):
+        ...
+```
+
+Apply the same pattern to `TestChargerDouble` and `TestDynamicGroupDouble`.
+
+### T2 — `tests/test_coverage_device.py`: close the unawaited coroutine
+
+Add a module-level helper near the top of `tests/test_coverage_device.py`
+(after the `ConcreteLoadDevice` class definition, before the first
+test):
+
+```python
+def _consume_coro(coro):
+    """Close a coroutine handed to a mocked `hass.async_create_task`.
+
+    Prevents `RuntimeWarning: coroutine '...' was never awaited`
+    when the test does not actually schedule the task.  Returns a
+    `MagicMock()` so the call site sees a Task-like return value.
+
+    `MagicMock` is permissible here: an `asyncio.Task` is an HA-runtime
+    object, not domain logic, so the "no MagicMock for domain objects"
+    rule does not apply.  We also do not need a real `Task` because the
+    production caller (`root_device_post_home_init`) discards the
+    return value.
+    """
+    coro.close()
+    return MagicMock()
+```
+
+Update `test_root_device_post_home_init_with_entities_lines323_325`
+(the test asserting `async_create_task` is called once per entity):
+
+```python
+# was: hass.async_create_task = MagicMock()
+hass.async_create_task = MagicMock(side_effect=_consume_coro)
+```
+
+The trailing `hass.async_create_task.assert_called()` assertion must be
+preserved (call tracking continues to work because `side_effect` runs
+inside the wrapped `MagicMock`).
+
+Update `test_root_device_post_home_init_exception_lines324_325` (the
+test asserting the bootstrap-launcher exception is caught and logged):
+
+```python
+def _consume_and_raise(coro):
+    coro.close()
+    raise Exception("bootstrap failed")
+
+# was: hass.async_create_task = MagicMock(side_effect=Exception("bootstrap failed"))
+hass.async_create_task = MagicMock(side_effect=_consume_and_raise)
+```
+
+The test must still verify no exception escapes
+`dev.root_device_post_home_init(now)` — keep the existing call;
+optionally tighten by asserting the device returns and the
+`_LOGGER.error` branch in `device.py` ran (use `caplog` if needed).
+
+### T3 — Regression guard
+
+Create the new file `tests/test_factories_pytest_opt_out.py`:
+
+```python
+"""Regression guard for pytest-collection opt-out on `tests/factories.py` helpers.
+
+Pytest's default `python_classes = Test*` rule (set in `pytest.ini`)
+collects every class named `Test...`.  Our doubles in `tests/factories.py`
+match that pattern but are helpers, not test classes — they all carry
+`__init__` constructors.  Without an opt-out, pytest emits
+`cannot collect test class '...' because it has a __init__ constructor`.
+
+This test fails fast if any class in `tests/factories.py` whose name
+starts with `Test` lacks `__test__ = False`, and also asserts the three
+currently sanctioned doubles are still present and opted out — so a
+silent rename or accidental removal of `__test__ = False` is caught.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from tests import factories
+
+# The three test-double helpers currently defined in tests/factories.py.
+# Update this set when intentionally adding/removing a sanctioned double.
+_SANCTIONED_DOUBLES: frozenset[str] = frozenset(
+    {"TestCarDouble", "TestChargerDouble", "TestDynamicGroupDouble"}
+)
+
+
+def _local_test_classes() -> list[tuple[str, type]]:
+    """Return [(name, cls)] of every `Test*` class defined directly in factories.py."""
+    return [
+        (name, obj)
+        for name, obj in inspect.getmembers(factories, inspect.isclass)
+        if name.startswith("Test") and inspect.getmodule(obj) is factories
+    ]
+
+
+def test_all_test_doubles_opt_out_of_collection() -> None:
+    """Every `Test*` class in factories.py must set `__test__ = False`."""
+    offenders = [
+        name for name, obj in _local_test_classes()
+        if getattr(obj, "__test__", True) is not False
+    ]
+    assert not offenders, (
+        "These factories.py helpers start with `Test` but do not set "
+        "`__test__ = False`.  Add it so pytest skips collection:\n"
+        + "\n".join(f"  - {n}" for n in offenders)
+    )
+
+
+def test_sanctioned_doubles_still_present_and_opted_out() -> None:
+    """The three known doubles must remain in factories.py with `__test__ = False`.
+
+    Guards against silent rename / removal that would bypass the
+    collection-opt-out regression test above.
+    """
+    present = {name for name, _ in _local_test_classes()}
+    missing = _SANCTIONED_DOUBLES - present
+    assert not missing, (
+        f"Expected doubles missing from tests/factories.py: {sorted(missing)}.  "
+        f"If you intentionally renamed/removed one, update _SANCTIONED_DOUBLES."
+    )
+    for name in _SANCTIONED_DOUBLES & present:
+        cls = getattr(factories, name)
+        assert getattr(cls, "__test__", True) is False, (
+            f"{name} is present but does not set `__test__ = False`."
+        )
+```
+
+Use `inspect.getmodule(obj) is factories` rather than comparing
+`__module__` strings — more robust against import-path quirks.
+
+### T4 — Verify warning suppression on the affected files
+
+After T1-T3 are in place, run the targeted `-W error` checks listed in
+AC7 manually:
+
+```bash
+source venv/bin/activate
+pytest tests/test_coverage_device.py -W error::RuntimeWarning -v
+pytest tests/test_factories_pytest_opt_out.py tests/test_bug_116_production_log_fixes.py \
+       tests/test_constraint_interaction_boundaries.py tests/test_constraints.py \
+       tests/test_constraints_deep.py tests/test_constraints_pre_discharge_guard.py \
+       tests/test_coverage_constraints.py tests/test_power_guard.py tests/test_solver.py \
+       -W error::pytest.PytestCollectionWarning -v
+```
+
+Both invocations must exit 0.  This step is a one-shot verification — we
+do NOT bake these `-W error` filters into `pytest.ini`.
+
+### T5 — Run the full quality gate
+
+```bash
+source venv/bin/activate
+python scripts/qs/quality_gate.py
+```
+
+Must exit 0:
+
+- pytest with 100% coverage on `custom_components/quiet_solar/`
+- ruff check + ruff format --check
+- mypy
+- translations (no regeneration needed)
+
+## Files touched
+
+- `tests/factories.py` — add `__test__ = False` to 3 classes.
+- `tests/test_coverage_device.py` — add `_consume_coro` helper; update 2 tests.
+- `tests/test_factories_pytest_opt_out.py` — new file: regression guard (2 tests).
+
+No production code under `custom_components/quiet_solar/` is touched.
+
+## Risk / Rollback
+
+- All changes are test-only.  Rollback = `git revert`.
+- `__test__ = False` is a documented pytest opt-out convention (pytest
+  3.x+).
+- `coro.close()` on an unstarted coroutine is a no-op semantically
+  (lets the GC reclaim it without warning).
+- Coverage risk: zero.  The two updated tests still exercise the same
+  `root_device_post_home_init` code paths.  The new regression file
+  uses pure introspection over `tests/factories.py` — no production
+  code reached.
+- If a future contributor adds a new `Test*` double without
+  `__test__ = False`, the regression test fails with a clear pointer.
+
+## Adversarial Review Notes
+
+Four parallel plan reviewers ran on the draft (`qs-plan-critic`,
+`qs-plan-concrete-planner`, `qs-plan-dev-proxy`, `qs-plan-scope-guardian`).
+16 findings; dispositions:
+
+**Accepted into the plan:**
+
+- *plan-critic / improve*: Add an explicit AC for total-warning-count
+  reaching 0 → became **AC7**.
+- *plan-critic / improve*: Justify the `MagicMock()` return from
+  `_consume_coro` → added to T2's helper docstring (Task is not domain).
+- *plan-critic / clarify*: Line numbers will scramble on merge → all
+  line numbers replaced with class / function names throughout.
+- *plan-critic / clarify*: Files-touched diff stat unverifiable →
+  stat row dropped, replaced with prose.
+- *plan-critic / critical*: AC5 didn't assert the production
+  exception path is reached → AC5 rewritten to assert (a) no exception
+  escapes, (b) device returns normally, (c) the `_LOGGER.error` branch
+  is still covered.
+- *concrete-planner / improve*: Confirm `assert_called()` stays in
+  the success test → explicit note added to T2.
+- *concrete-planner / clarify*: `tests/__init__.py` existence /
+  robust module match → switched to `inspect.getmodule(obj) is factories`
+  in T3 (more robust than `__module__` string compare).
+- *dev-proxy / clarify*: `MagicMock` justification (Task is not
+  domain) → covered by the docstring on `_consume_coro` in T2.
+- *dev-proxy / clarify*: T3 doesn't positively assert the 3 named
+  doubles exist → added `test_sanctioned_doubles_still_present_and_opted_out`
+  with `_SANCTIONED_DOUBLES` allow-list.
+- *scope-guardian / clarify*: `TestCarDouble` may not currently warn
+  → noted explicitly in Context section (it's not imported by any
+  `test_*.py`, so no live warning, but gets the opt-out defensively
+  + to keep the regression guard self-consistent).
+
+**Rejected (with reason):**
+
+- *concrete-planner / critical*: 3rd leak site at
+  `tests/test_ha_car_comprehensive.py:534`.  Verified empirically
+  with `pytest -W error::RuntimeWarning` — the test passes cleanly
+  today.  Different coroutine (`_async_bootstrap_efficiency_from_history`,
+  not `_async_bootstrap_from_history`).  Out of scope of this issue;
+  documented in Context section as a known parallel pattern.
+- *plan-critic / redesign*: Broaden T3 regression scan beyond
+  `factories.py`.  Bounded scope: factories.py is the sanctioned home
+  for test doubles per project-context.md.  Broader scan = scope creep.
+- *scope-guardian / improve*: T3 is gold-plating.  User authorized
+  the regression guard explicitly in chat ("3: ok"); stays.
+- *scope-guardian / improve*: `_consume_coro` could be inline lambda.
+  Used twice, carries a non-trivial docstring justifying MagicMock-for-Task;
+  named helper improves readability.  Stays.
+
+**Verified OK (no action needed):**
+
+- *concrete-planner / clarify*: `tests/__init__.py` exists.
+- *dev-proxy / clarify*: All 3 doubles are plain classes (no
+  `@dataclass`, no `__slots__`).  Noted in T1.
+- *scope-guardian / clarify*: Issue body attributes warnings to
+  `test_coverage_constraints.py / test_coverage_device.py`; empirically
+  the leaks are in `test_coverage_device.py` only.  Noted in Context.
+
+Net: 1 critical addressed (AC5 strengthened); 1 critical rejected
+after empirical check; 7 improvements accepted; T3 retained per user
+direction.

--- a/docs/stories/QS-183.story.md
+++ b/docs/stories/QS-183.story.md
@@ -1,11 +1,15 @@
-# QS-183: Fix test warnings — `TestXxxDouble` collection and unawaited bootstrap coroutine
+# QS-183: Fix test warnings AND speed up the implement TDD loop
 
 GitHub issue: #183
 Branch: `QS_183`
 
 ## Context
 
-Two categories of warnings clutter the `pytest` run:
+This story bundles two related but distinct cleanups:
+
+### Category A — pytest test warnings (original issue scope)
+
+Two flavours of warning clutter the `pytest` run:
 
 1. **Pytest collection warnings (9 occurrences).** Three helper classes
    in `tests/factories.py` (`TestCarDouble`, `TestChargerDouble`,
@@ -31,19 +35,62 @@ Two categories of warnings clutter the `pytest` run:
    Verified empirically with `pytest -W error::RuntimeWarning`.
 
    The body of `_async_bootstrap_from_history` is fully covered by
-   `tests/ha_tests/test_device_mixin.py` (the dedicated `TestAsyncBootstrapFromHistory`
-   class). These unit tests in `test_coverage_device.py` only verify
-   `root_device_post_home_init`'s control flow — the bootstrap body
-   itself is incidental.
+   `tests/ha_tests/test_device_mixin.py`. These unit tests in
+   `test_coverage_device.py` only verify `root_device_post_home_init`'s
+   control flow — the bootstrap body itself is incidental.
 
    A parallel anti-pattern exists in `tests/test_ha_car_comprehensive.py`
    (mocks `hass.async_create_task` to raise, triggering
-   `_async_bootstrap_efficiency_from_history`) but verified empirically
-   it does NOT emit a warning today — likely because the surrounding
-   pytest-asyncio test loop holds the coroutine reference. Out of scope.
+   `_async_bootstrap_efficiency_from_history`) — empirically verified
+   that it does NOT emit a warning today (likely because the
+   surrounding pytest-asyncio test loop holds the coroutine reference).
+   Out of scope.
 
-Both fixed categories are test-only. No production code under
-`custom_components/quiet_solar/` is touched.
+### Category B — workflow optimization (added per user direction)
+
+During TDD red / green / refactor inside `qs-implement-task`, the agent
+invokes raw `pytest tests/ -v` rather than the optimized quality gate.
+This is because `docs/workflow/project-rules.md`,
+`docs/workflow/project-context.md`, and `AGENTS.md` all carry
+unparallelized snippets like `pytest tests/ -v` and
+`pytest tests/ --cov=...`. Raw pytest bypasses every optimization in
+`scripts/qs/quality_gate.py`:
+
+- no `pytest-xdist` (`-n auto`) parallelization
+- no `COVERAGE_CORE=sysmon` (sysmon is wired only inside `_pytest_env()`
+  in `quality_gate.py`)
+- no scope-aware skipping
+
+Additionally, the existing `check_pytest_files` function inside the
+gate (used by the dev-only fast path) does NOT add `-n {workers}`
+either — it runs the changed test files serially. So even the gate's
+own fast path is leaving xdist on the table.
+
+The fix is two-pronged:
+
+- Add `python scripts/qs/quality_gate.py --quick PATH [PATH...]`: a
+  new single-purpose iteration mode that runs `pytest` on the cited
+  paths with xdist + sysmon, skipping ruff / mypy / translations /
+  coverage / scope detection. **Each PATH may be a test file or a
+  directory** (e.g., `tests/test_foo.py`, `tests/ha_tests/`,
+  `tests/ha_tests/test_charger.py`, `tests/`). Pytest natively accepts
+  both, and our agent uses both patterns. Also wire `-n {workers}`
+  into the existing `check_pytest_files` so the dev-only fast path
+  benefits.
+- Patch `.claude/agents/qs-implement-task.md` step 2 to explicitly
+  direct the agent to use `--quick` for ALL iteration test runs and
+  forbid raw `pytest tests/...` invocations. Strip the unparallelized
+  snippets from `docs/workflow/project-rules.md`,
+  `docs/workflow/project-context.md`, and `AGENTS.md`, and reframe
+  them around `quality_gate.py` as the canonical test entry point
+  (full gate, `--quick`, `--cache`). Raw `pytest` survives only as a
+  documented "ad-hoc single-node debugging" escape hatch, never as
+  the canonical iteration command.
+
+Both categories are fixed together because (a) Category B is small and
+isolated, (b) the AC7 warning-count check naturally lifts onto
+`--quick` once it exists, and (c) shipping them as one PR avoids a
+second round-trip through setup-task / create-plan / review-task.
 
 ## Goals / Non-goals
 
@@ -54,87 +101,170 @@ Both fixed categories are test-only. No production code under
   warnings.
 - A regression guard so any future `Test*` helper added to
   `tests/factories.py` without `__test__ = False` fails the suite.
-- 100% test coverage preserved.
+- `python scripts/qs/quality_gate.py --quick PATH [...]` exists,
+  behaves as specified, and has dedicated tests in
+  `tests/test_quality_gate.py`.
+- `check_pytest_files` (dev-only fast path) uses `-n {workers}` when
+  xdist is available.
+- `qs-implement-task` agent step 2 documents `--quick` as the
+  canonical iteration command and forbids raw `pytest tests/ -v`.
+- `docs/workflow/project-rules.md`, `docs/workflow/project-context.md`,
+  and `AGENTS.md` no longer encourage unparallelized full-suite
+  `pytest tests/ -v` snippets.
+- 100% test coverage preserved on `custom_components/quiet_solar/`.
 - Full quality gate stays green.
 
 **Non-goals:**
 
-- No production code changes.
-- No rename of the three helper classes (callsite churn rejected; we
-  opt out of collection instead).
-- No `filterwarnings` override in `pytest.ini` — fix the root cause,
-  not the symptom.
-- No fix for the parallel pattern in `test_ha_car_comprehensive.py` —
-  verified not warning today; surface as follow-up if it ever does.
+- No production code changes under `custom_components/quiet_solar/`.
+- No rename of the three doubles.
+- No `filterwarnings` override in `pytest.ini`.
+- No fix for the parallel coroutine pattern in
+  `test_ha_car_comprehensive.py` — verified not warning today; surface
+  as follow-up if it ever does.
+- No change to the legacy `_qsprocess_opencode/agent_templates/*.tmpl`
+  files — they are frozen per `CLAUDE.md`.
+- No new `.opencode/agents/qs-implement-task.md` — the file does not
+  exist today (only `qs-setup-task.md` and `qs-release.md` are static
+  agents under `.opencode/agents/`; the implement-task agent is
+  template-rendered from the frozen `_qsprocess_opencode/` templates).
+  Per user direction Q2, the OpenCode entry doc `AGENTS.md` IS updated
+  so the OpenCode user reads the same canonical command set on first
+  sight.
+
+### Design rationale (Category B)
+
+- **Mutex `--quick` × `--cache`.** Cache keys on `(branch, commit, clean tree)` for the full-suite scope. `--quick` runs an arbitrary path subset, so a cache hit would be misleading (the cached pass covered different paths). Mutex enforced via `parser.error` so the user gets a clear message instead of a silent footgun. Use bare `python scripts/qs/quality_gate.py --cache` for the cached default loop.
+- **`--quick` always honors `_pytest_workers()`.** No special-case for single-file paths. xdist's startup cost is small (~100 ms) and consistent behavior is easier to reason about than a "sometimes parallel, sometimes serial" heuristic.
+- **Process-authority compliance.** Per `docs/workflow/project-rules.md` Process authority section, harness-specific config files (`.claude/`, `.cursor/`, `.opencode/`) reference `docs/workflow/` instead of duplicating its content. T8 (`project-rules.md`) owns the canonical Commands block; T7/T7b (`.claude/.cursor` agent step 2) keep their step 2 short and reference the project-rules section by link.
+- **Forbidden-vs-allowed pytest grammar (T7/T8/AC12).** Allowed: `pytest <path>::<nodeid> [-v]` — ad-hoc single-node debugging. Forbidden as a habitual command: any `pytest` invocation whose positional arg lacks `::` (i.e., a bare file or directory). The agent / docs state this rule once in `project-rules.md` and reference it elsewhere.
 
 ## Acceptance criteria
 
-### AC1 — `TestCarDouble` is opted out of pytest collection
+### Category A — test warnings
+
+#### AC1 — `TestCarDouble` is opted out of pytest collection
 **Given** `tests/factories.py` defines class `TestCarDouble`,
 **when** the test suite is collected,
 **then** no warning of the form `cannot collect test class 'TestCarDouble'` is emitted,
 **and** `TestCarDouble.__test__ is False`.
 
-### AC2 — `TestChargerDouble` is opted out of pytest collection
+#### AC2 — `TestChargerDouble` is opted out of pytest collection
 **Given** `tests/factories.py` defines class `TestChargerDouble`,
 **when** the test suite is collected,
 **then** no warning of the form `cannot collect test class 'TestChargerDouble'` is emitted,
 **and** `TestChargerDouble.__test__ is False`.
 
-### AC3 — `TestDynamicGroupDouble` is opted out of pytest collection
+#### AC3 — `TestDynamicGroupDouble` is opted out of pytest collection
 **Given** `tests/factories.py` defines class `TestDynamicGroupDouble`,
 **when** the test suite is collected,
 **then** no warning of the form `cannot collect test class 'TestDynamicGroupDouble'` is emitted,
 **and** `TestDynamicGroupDouble.__test__ is False`.
 
-### AC4 — `test_root_device_post_home_init_with_entities_lines323_325` does not leak a coroutine
+#### AC4 — `test_root_device_post_home_init_with_entities_lines323_325` does not leak a coroutine
 **Given** the test substitutes `hass.async_create_task`,
 **when** the test runs and completes,
 **then** no `RuntimeWarning: coroutine '...' was never awaited` is emitted,
 **and** the original assertion `hass.async_create_task.assert_called()` still passes (the side-effect wrapper preserves call tracking).
 
-### AC5 — `test_root_device_post_home_init_exception_lines324_325` does not leak a coroutine, and the production exception branch is still exercised
+#### AC5 — `test_root_device_post_home_init_exception_lines324_325` does not leak a coroutine, and the production exception branch is still exercised
 **Given** the test substitutes `hass.async_create_task` to raise,
 **when** the test runs and completes,
 **then** no `RuntimeWarning: coroutine '...' was never awaited` is emitted,
-**and** no exception escapes `dev.root_device_post_home_init(now)` (the test still returns normally),
+**and** no exception escapes `dev.root_device_post_home_init(now)`,
 **and** the production error-handling branch in `custom_components/quiet_solar/ha_model/device.py` (the `try / except Exception as e: _LOGGER.error(...)` around the bootstrap launcher) is still covered.
 
-### AC6 — Regression guard for future `Test*` helpers in `factories.py`
+#### AC6 — Regression guard for future `Test*` helpers in `factories.py`
 **Given** a new helper class is later added to `tests/factories.py`,
 **when** the suite runs,
 **then** if its name starts with `Test` and it lacks `__test__ = False`, a dedicated regression test fails with a message naming the offender,
-**and** the regression test also positively asserts that the three sanctioned doubles (`TestCarDouble`, `TestChargerDouble`, `TestDynamicGroupDouble`) are present and opted out — so a silent rename does not bypass the guard.
+**and** the regression test also positively asserts that the three sanctioned doubles (`TestCarDouble`, `TestChargerDouble`, `TestDynamicGroupDouble`) are present and opted out.
 
-### AC7 — Total warning-count regression check
+#### AC7 — Targeted warning-count regression check
 **Given** the modified test files,
 **when** they are run under `pytest -W error::RuntimeWarning -W error::pytest.PytestCollectionWarning`,
-**then** the run exits 0 (i.e., zero `RuntimeWarning` and zero `PytestCollectionWarning` for both categories on the affected files).
+**then** the run exits 0.
 
 Specifically:
+
 - `pytest tests/test_coverage_device.py -W error::RuntimeWarning -W error::pytest.PytestCollectionWarning` exits 0.
 - `pytest tests/test_factories_pytest_opt_out.py tests/test_bug_116_production_log_fixes.py tests/test_constraint_interaction_boundaries.py tests/test_constraints.py tests/test_constraints_deep.py tests/test_constraints_pre_discharge_guard.py tests/test_coverage_constraints.py tests/test_power_guard.py tests/test_solver.py -W error::pytest.PytestCollectionWarning` exits 0.
 
 (We do NOT enable these `-W error::` filters globally in `pytest.ini` —
-the suite is large and unrelated third-party warnings would flake.
-The AC is a one-shot verification step during implementation.)
+the suite is large and unrelated third-party warnings would flake. The
+AC is a one-shot verification step during implementation.)
 
-### AC8 — Full quality gate stays green
-**Given** these changes,
+### Category B — `--quick` mode and workflow patches
+
+#### AC8 — `quality_gate.py --quick` runs cited tests fast and skips everything else
+**Given** `python scripts/qs/quality_gate.py --quick PATH [PATH ...]`, where each `PATH` is either a test file (e.g., `tests/test_solver.py`, `tests/ha_tests/test_charger.py`) or a directory (e.g., `tests/`, `tests/ha_tests/`),
+**when** invoked,
+**then** the script runs `pytest` on the provided paths with `pytest-xdist` (`-n auto` when `pytest-xdist` is importable, or the value of `QS_QG_PYTEST_WORKERS`; serial otherwise) and `COVERAGE_CORE=sysmon` set on the subprocess env,
+**and** the script does NOT call `check_ruff_lint`, `check_ruff_format`, `check_mypy`, `check_translations`, `check_pytest`, `_detect_scope`, or any cache read/write,
+**and** the script exits 0 iff every cited test passes, 1 otherwise,
+**and** at least one of the dedicated tests (T6) exercises a directory path (e.g., `--quick tests/ha_tests`) to lock in directory support.
+
+#### AC9 — `--quick` is mutually exclusive with `--cache`, `--no-cache`, `--full`, `--fix`
+**Given** `python scripts/qs/quality_gate.py --quick tests/test_foo.py` combined with any of `--cache` / `--no-cache` / `--full` / `--fix`,
+**when** invoked,
+**then** the script exits with code 2 (argparse `parser.error()` convention),
+**and** stderr contains the substring `"you cannot combine --quick with --cache, --no-cache, --full, or --fix"` (sentence case, plain text, no backticks since the message renders to a terminal).
+
+#### AC10 — `--quick` requires at least one path
+**Given** `python scripts/qs/quality_gate.py --quick` with no trailing paths,
+**when** invoked,
+**then** argparse's own `nargs="+"` validation fires first (before the mutex check) and the script exits with code 2,
+**and** stderr contains an argparse-standard "expected at least one argument" message naming `--quick`.
+
+#### AC11 — `check_pytest_files` propagates xdist via the same resolver as the full gate
+**Given** `pytest-xdist` is importable in the venv,
+**when** `check_pytest_files(["tests/test_foo.py"])` is called,
+**then** the resulting `pytest` subprocess command includes `-n {workers}` where `{workers}` is whatever `_pytest_workers()` returns (which itself honours `QS_QG_PYTEST_WORKERS`, defaults to `"auto"`, and returns `None` when xdist is missing or the env var is `"0"` / empty),
+**and** when `_pytest_workers()` returns `None` (no xdist, or user-forced serial), no `-n` flag is added,
+**and** `check_pytest_files` does NOT add any stderr serial-fallback warning of its own (matching its pre-existing behaviour; only `check_pytest()` warns).
+
+#### AC12 — `qs-implement-task.md` step 2 directs the agent to `--quick`
+**Given** `.claude/agents/qs-implement-task.md` AND `.cursor/agents/qs-implement-task.md`,
+**when** their "TDD implementation" step (step 2) is read,
+**then** each file names `python scripts/qs/quality_gate.py --quick <path>` as the canonical TDD-loop command and references the `## Commands` section of `docs/workflow/project-rules.md` for the full grammar (rather than duplicating it),
+**and** each file states that the full quality gate runs at step 4 before commit,
+**and** neither file contains a duplicated copy of the forbidden-grammar rule or the file/directory/multi examples — those live in `project-rules.md` per the Process-authority rule in that same doc.
+
+#### AC13 — Project docs funnel ALL test-running through `quality_gate.py`
+**Given** `docs/workflow/project-rules.md`, `docs/workflow/project-context.md`, and `AGENTS.md`,
+**when** read,
+**then** the canonical commands shown are, in this order of precedence:
+
+1. `python scripts/qs/quality_gate.py` — full gate; required before every commit.
+2. `python scripts/qs/quality_gate.py --cache` — recommended default for repeated dev-loop runs on a clean tree (skips gates when git state matches the last pass).
+3. `python scripts/qs/quality_gate.py --quick PATH [PATH ...]` — fast iteration on cited files or directories.
+4. `python scripts/qs/quality_gate.py --fix` — auto-fix formatting/lint.
+
+**and** each of the three doc files contains a sentence stating that `quality_gate.py` is the single test entry point (cache, xdist, sysmon, scope detection all live there) and that raw `pytest` bypasses all four,
+**and** the forbidden-grammar rule is stated once (in `project-rules.md` per process-authority): "Allowed: `pytest <path>::<nodeid> [-v]` for ad-hoc single-node debugging. Forbidden as a habitual command: any `pytest` invocation whose positional arg lacks `::` (e.g., `pytest tests/`, `pytest tests/ha_tests`, `pytest tests/test_foo.py`).",
+**and** any remaining raw `pytest <path>::<node>` snippet in any of the three files is annotated as "ad-hoc single-node debugging only".
+
+#### AC14 — Doc strips landed (objective grep check)
+**Given** `docs/workflow/project-rules.md`, `docs/workflow/project-context.md`, `AGENTS.md`,
+**when** `grep -nE 'pytest +tests(/|$)' {docs/workflow/project-rules.md,docs/workflow/project-context.md,AGENTS.md}` is run,
+**then** the only matches are `pytest <path>::<nodeid>` debugging examples (i.e., every positional argument contains `::`) OR lines inside an explicitly quoted "forbidden" example block in `project-rules.md`,
+**and** zero matches present `pytest tests/`, `pytest tests/ha_tests`, or `pytest tests/<file>.py` as the recommended command.
+
+#### AC15 — Full quality gate stays green
+**Given** all the changes in this story,
 **when** `python scripts/qs/quality_gate.py` runs,
-**then** it exits 0 (pytest 100% coverage + ruff + ruff format + mypy + translations all pass).
+**then** it exits 0 (pytest 100% coverage on `custom_components/quiet_solar/` + ruff + ruff format + mypy + translations all pass).
 
 ## Task breakdown
 
 ### T1 — `tests/factories.py`: opt out the three doubles
 
 Insert `__test__ = False` as the first class-body statement after the
-docstring on each of the three classes (`TestCarDouble`,
-`TestChargerDouble`, `TestDynamicGroupDouble`). All three are plain
-classes (no `@dataclass`, no `__slots__`) — verified — so a bare class
-attribute is sufficient (no `ClassVar` annotation needed).
+docstring on each of `TestCarDouble`, `TestChargerDouble`,
+`TestDynamicGroupDouble`. All three are plain classes (no `@dataclass`,
+no `__slots__`) — verified — so a bare class attribute is sufficient.
 
-Exact pattern per class:
+Pattern per class:
 
 ```python
 class TestCarDouble:
@@ -153,34 +283,29 @@ class TestCarDouble:
         ...
 ```
 
-Apply the same pattern to `TestChargerDouble` and `TestDynamicGroupDouble`.
-
 ### T2 — `tests/test_coverage_device.py`: close the unawaited coroutine
 
-Add a module-level helper near the top of `tests/test_coverage_device.py`
-(after the `ConcreteLoadDevice` class definition, before the first
-test):
+Add a module-level helper near the top (after `ConcreteLoadDevice`,
+before the first test):
 
 ```python
 def _consume_coro(coro):
     """Close a coroutine handed to a mocked `hass.async_create_task`.
 
-    Prevents `RuntimeWarning: coroutine '...' was never awaited`
-    when the test does not actually schedule the task.  Returns a
+    Prevents `RuntimeWarning: coroutine '...' was never awaited` when
+    the test does not actually schedule the task.  Returns a
     `MagicMock()` so the call site sees a Task-like return value.
 
     `MagicMock` is permissible here: an `asyncio.Task` is an HA-runtime
     object, not domain logic, so the "no MagicMock for domain objects"
-    rule does not apply.  We also do not need a real `Task` because the
-    production caller (`root_device_post_home_init`) discards the
-    return value.
+    rule does not apply.  The production caller
+    (`root_device_post_home_init`) discards the return value.
     """
     coro.close()
     return MagicMock()
 ```
 
-Update `test_root_device_post_home_init_with_entities_lines323_325`
-(the test asserting `async_create_task` is called once per entity):
+Update `test_root_device_post_home_init_with_entities_lines323_325`:
 
 ```python
 # was: hass.async_create_task = MagicMock()
@@ -188,25 +313,25 @@ hass.async_create_task = MagicMock(side_effect=_consume_coro)
 ```
 
 The trailing `hass.async_create_task.assert_called()` assertion must be
-preserved (call tracking continues to work because `side_effect` runs
-inside the wrapped `MagicMock`).
+preserved (`side_effect` does not change call tracking).
 
-Update `test_root_device_post_home_init_exception_lines324_325` (the
-test asserting the bootstrap-launcher exception is caught and logged):
+Update `test_root_device_post_home_init_exception_lines324_325`:
 
 ```python
 def _consume_and_raise(coro):
     coro.close()
     raise Exception("bootstrap failed")
 
-# was: hass.async_create_task = MagicMock(side_effect=Exception("bootstrap failed"))
+# was: hass.async_create_task = MagicMock(side_effect=Exception(...))
 hass.async_create_task = MagicMock(side_effect=_consume_and_raise)
 ```
 
 The test must still verify no exception escapes
-`dev.root_device_post_home_init(now)` — keep the existing call;
-optionally tighten by asserting the device returns and the
-`_LOGGER.error` branch in `device.py` ran (use `caplog` if needed).
+`dev.root_device_post_home_init(now)` (i.e., the existing call to
+`dev.root_device_post_home_init(now)` must continue to return
+normally). Use `caplog` if needed to assert the `_LOGGER.error` branch
+ran — only add it if missing-coverage on `device.py:407-408` is
+otherwise hit by AC15.
 
 ### T3 — Regression guard
 
@@ -217,14 +342,14 @@ Create the new file `tests/test_factories_pytest_opt_out.py`:
 
 Pytest's default `python_classes = Test*` rule (set in `pytest.ini`)
 collects every class named `Test...`.  Our doubles in `tests/factories.py`
-match that pattern but are helpers, not test classes — they all carry
+match that pattern but are helpers, not test classes — they carry
 `__init__` constructors.  Without an opt-out, pytest emits
 `cannot collect test class '...' because it has a __init__ constructor`.
 
-This test fails fast if any class in `tests/factories.py` whose name
+This module fails fast if any class in `tests/factories.py` whose name
 starts with `Test` lacks `__test__ = False`, and also asserts the three
 currently sanctioned doubles are still present and opted out — so a
-silent rename or accidental removal of `__test__ = False` is caught.
+silent rename or accidental removal is caught.
 """
 
 from __future__ import annotations
@@ -263,11 +388,7 @@ def test_all_test_doubles_opt_out_of_collection() -> None:
 
 
 def test_sanctioned_doubles_still_present_and_opted_out() -> None:
-    """The three known doubles must remain in factories.py with `__test__ = False`.
-
-    Guards against silent rename / removal that would bypass the
-    collection-opt-out regression test above.
-    """
+    """The three known doubles must remain in factories.py with `__test__ = False`."""
     present = {name for name, _ in _local_test_classes()}
     missing = _SANCTIONED_DOUBLES - present
     assert not missing, (
@@ -281,28 +402,324 @@ def test_sanctioned_doubles_still_present_and_opted_out() -> None:
         )
 ```
 
-Use `inspect.getmodule(obj) is factories` rather than comparing
-`__module__` strings — more robust against import-path quirks.
+### T4 — Targeted warning-suppression verification
 
-### T4 — Verify warning suppression on the affected files
+After T1-T3, run the targeted `-W error` checks listed in AC7
+manually. Both invocations must exit 0. This is a one-shot
+verification — we do NOT bake these filters into `pytest.ini`.
 
-After T1-T3 are in place, run the targeted `-W error` checks listed in
-AC7 manually:
+### T5 — Add `--quick` mode to `scripts/qs/quality_gate.py`
 
-```bash
-source venv/bin/activate
-pytest tests/test_coverage_device.py -W error::RuntimeWarning -v
-pytest tests/test_factories_pytest_opt_out.py tests/test_bug_116_production_log_fixes.py \
-       tests/test_constraint_interaction_boundaries.py tests/test_constraints.py \
-       tests/test_constraints_deep.py tests/test_constraints_pre_discharge_guard.py \
-       tests/test_coverage_constraints.py tests/test_power_guard.py tests/test_solver.py \
-       -W error::pytest.PytestCollectionWarning -v
+**Module docstring (top of file).** Add `--quick` to the `Usage:`
+line and add an `Options:` row:
+
+```
+    --quick PATH [PATH ...]  Fast iteration: run only the cited test
+                             paths (files or directories) with xdist +
+                             sysmon; skip ruff/mypy/translations/
+                             coverage/cache/scope. Mutex with
+                             --cache/--no-cache/--full/--fix.
 ```
 
-Both invocations must exit 0.  This step is a one-shot verification — we
-do NOT bake these `-W error` filters into `pytest.ini`.
+**`main()` — argparse setup and ordering.** Three changes, in this
+exact order so the mutex check fires before any cache / scope logic:
 
-### T5 — Run the full quality gate
+1. Add the new flag (any position in the `add_argument` block is fine
+   structurally; `nargs="+"` makes argparse itself enforce AC10):
+
+   ```python
+   parser.add_argument(
+       "--quick",
+       nargs="+",
+       metavar="PATH",
+       help=(
+           "Fast iteration mode: run only the cited test paths (files "
+           "or directories) with xdist + sysmon; skip ruff/mypy/"
+           "translations/coverage."
+       ),
+   )
+   ```
+
+2. Custom mutex validation IMMEDIATELY after `parser.parse_args()`
+   and BEFORE the existing `use_cache = ...` line (AC9):
+
+   ```python
+   if args.quick and (args.cache or args.no_cache or args.full or args.fix):
+       parser.error(
+           "you cannot combine --quick with --cache, --no-cache, "
+           "--full, or --fix"
+       )
+   ```
+
+   Sentence case, plain text (no backticks — the message renders in a
+   terminal). `parser.error()` writes to stderr and raises
+   `SystemExit(2)`.
+
+3. `--quick` branch BEFORE the cache check, BEFORE
+   `_get_changed_files()`, BEFORE `_detect_scope()`:
+
+   ```python
+   if args.quick:
+       sys.stderr.write(
+           f"[quick] running {len(args.quick)} path(s) with xdist + "
+           f"sysmon (no coverage / ruff / mypy / translations)\n"
+       )
+       sys.stderr.flush()
+       result = check_pytest_files(args.quick)
+       result["name"] = f"pytest --quick ({len(args.quick)} path(s))"
+       _output_results(
+           [result],
+           all_passed=result["passed"],
+           cached=False,
+           json_mode=args.json,
+           scope="quick",
+       )
+       sys.exit(0 if result["passed"] else 1)
+   ```
+
+   Pin the stderr banner exactly as shown — T6 asserts on the
+   `[quick] running ` prefix and the worker-count substring.
+
+**`check_pytest_files(test_files: list[str])`.** Inside the function,
+between the existing `abs_files = ...` line and the `cmd = ...` line,
+honour `_pytest_workers()`:
+
+```python
+abs_files = [str(REPO_ROOT / f) for f in test_files]
+workers = _pytest_workers()
+cmd = [VENV_PYTHON, "-m", "pytest", *abs_files, "-q"]
+if workers is not None:
+    cmd.extend(["-n", workers])
+return _stream_pytest(cmd)
+```
+
+Do NOT emit a serial-fallback stderr warning from
+`check_pytest_files` — match the function's pre-existing silent
+behaviour. The dev-only scope and `--quick` would otherwise both spam
+the same warning. Only `check_pytest()` keeps the warning emit.
+
+**Path handling.** `check_pytest_files` already converts paths to
+absolute via `REPO_ROOT / f`, which works for both files
+(`tests/test_foo.py`) and directories (`tests/`, `tests/ha_tests/`).
+Pytest accepts both natively. No path-normalization needed.
+
+**`COVERAGE_CORE=sysmon`.** Already wired via `_pytest_env()` inside
+`_stream_pytest()`. `--quick` and `check_pytest_files` get sysmon for
+free — no extra change.
+
+**Coverage scope note.** `scripts/qs/quality_gate.py` is NOT under the
+100% coverage gate (coverage is measured on
+`custom_components/quiet_solar/` only per `--cov={SRC_DIR}`). T6
+tests every new branch (mutex matrix, banner, xdist flag inclusion,
+exit codes) for behavioural correctness, not coverage compliance.
+
+**Risk vs existing tests.** The
+`test_dev_only_scope_skips_lint_gates_and_runs_pytest_only` test in
+`tests/test_quality_gate.py` patches `check_pytest_files` directly, so
+it remains unaffected by the body change. Any newly-added test in T6
+that exercises `check_pytest_files` end-to-end must
+`patch.object(quality_gate, "_pytest_workers", return_value=<value>)`
+to avoid the real `VENV_PYTHON -c …` xdist-probe subprocess.
+
+### T6 — Tests for `--quick` mode in `tests/test_quality_gate.py`
+
+Add a new test class `TestQuickMode` at the end of the file, matching
+the existing `class Test…:` + `patch.object`-heavy style. Use
+`pytest.mark.parametrize` to compress the mutex matrix and the
+path-shape matrix into single parametrized tests. Target ~7 tests:
+
+1. **`test_quick_invokes_check_pytest_files_with_paths`** (parametrized
+   on path shape):
+   ```python
+   @pytest.mark.parametrize(
+       "argv_paths",
+       [
+           ["tests/test_foo.py"],
+           ["tests/test_foo.py", "tests/test_bar.py"],
+           ["tests/ha_tests"],
+           ["tests/test_foo.py", "tests/ha_tests"],
+       ],
+       ids=["single-file", "multi-file", "directory", "mixed-file-and-dir"],
+   )
+   ```
+   Patch `check_pytest_files` → pass dict; patch `sys.exit`; invoke
+   `main()` via `patch("sys.argv", ["quality_gate.py", "--quick", *argv_paths])`;
+   assert `check_pytest_files` called once with `argv_paths`.
+
+2. **`test_quick_skips_everything_else`**: patch each of
+   `check_ruff_lint`, `check_ruff_format`, `check_mypy`,
+   `check_translations`, `check_pytest`, `_get_git_state`,
+   `_detect_scope`, `_read_cache`, `_write_cache` to `MagicMock`s;
+   patch `check_pytest_files` to a pass dict; invoke `main()` with
+   `--quick tests/test_foo.py`; assert NONE of the patched mocks were
+   called.
+
+3. **`test_quick_exit_code_propagates`** (parametrized
+   `[(True, 0), (False, 1)]`): patch `check_pytest_files` to return
+   `{"passed": <bool>, "name": "x", "detail": ""}`; capture
+   `sys.exit`; assert the captured exit code matches the parameter.
+
+4. **`test_quick_emits_banner`**: capture stderr via
+   `capsys.readouterr().err`; assert the banner starts with
+   `"[quick] running "` and contains `"xdist + sysmon"`.
+
+5. **`test_quick_rejects_empty_args`**: argv =
+   `["quality_gate.py", "--quick"]` (no trailing path); assert
+   `pytest.raises(SystemExit) as exc`, `exc.value.code == 2`, and
+   `"--quick" in capsys.readouterr().err`.
+
+6. **`test_quick_mutex_matrix`** (parametrized on the conflicting
+   flag):
+   ```python
+   @pytest.mark.parametrize(
+       "conflict_flag",
+       ["--cache", "--no-cache", "--full", "--fix"],
+   )
+   ```
+   argv = `["quality_gate.py", "--quick", "tests/x.py", conflict_flag]`;
+   assert `pytest.raises(SystemExit) as exc`, `exc.value.code == 2`,
+   and `"you cannot combine --quick with --cache, --no-cache, --full, or --fix"
+   in capsys.readouterr().err`.
+
+7. **`test_check_pytest_files_uses_workers_when_resolver_returns_value`**
+   (parametrized `[("auto", True), ("4", True), (None, False)]`):
+   patch `_pytest_workers` to return the parameter; patch
+   `_stream_pytest` to capture `cmd`; call
+   `check_pytest_files(["tests/test_x.py"])`; assert
+   `("-n" in cmd) == expected_in_cmd` and (when present) the workers
+   value follows `-n` in the cmd list.
+
+The parametrization collapses what would have been 13 individual tests
+down to 7 test functions while preserving every behavioural assertion
+from the original list.
+
+### T7 — Patch `.claude/agents/qs-implement-task.md` (brief reference)
+
+Per the Process-authority rule in `docs/workflow/project-rules.md`
+("Harness-specific config … references these docs; it never duplicates
+them"), keep step 2 short and point at `project-rules.md` for the
+canonical command list. Replace the existing
+`### 2. TDD implementation` block (the file's lines 38-49 today) with:
+
+```
+### 2. TDD implementation
+
+Red → green → refactor. For every cycle:
+
+1. Write failing tests under `tests/` for each story acceptance criterion.
+2. Implement the minimum code under `custom_components/quiet_solar/`
+   to make them pass.
+3. Refactor while keeping tests green.
+
+Verify with `python scripts/qs/quality_gate.py --quick <path>` during
+the inner loop (the canonical TDD command; accepts files,
+directories, or both). The full quality gate runs at step 4 before
+commit. See the `## Commands` section of
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+for the full command grammar and the forbidden-vs-allowed raw-pytest
+rule.
+
+Edit scope: `custom_components/quiet_solar/**`, `tests/**`, plus the
+story file (for progress notes). Stop and escalate if you need to
+edit elsewhere.
+```
+
+### T7b — Patch `.cursor/agents/qs-implement-task.md` (brief mirror)
+
+Replace the equivalent `### 2. TDD implementation` block in
+`.cursor/agents/qs-implement-task.md` with the SAME text as T7. The
+Cursor agent file is a near-mirror of the Claude one (project-context
+documents this). Keeping both in sync avoids the drift hazard that
+both Round-2 reviewers flagged.
+
+### T8 — Patch `docs/workflow/project-rules.md` (canonical Commands)
+
+Replace the existing `## Commands` block with a `quality_gate.py`-
+centric version that includes the forbidden-vs-allowed grammar rule
+referenced by T7 / T7b / AC12:
+
+```
+## Commands
+
+Activate `source venv/bin/activate` for all Python commands.
+`scripts/qs/quality_gate.py` is the **single test entry point** —
+it owns the cache, `pytest-xdist` parallelization,
+`COVERAGE_CORE=sysmon`, and scope detection. Raw `pytest` bypasses
+all four; use it only for ad-hoc single-node debugging.
+
+```bash
+# Full quality gate (pytest 100% cov + ruff + mypy + translations).
+# Required before every commit.
+python scripts/qs/quality_gate.py
+
+# Recommended default for repeated dev-loop runs — skips gates when
+# git state matches a previous pass on a clean tree.
+python scripts/qs/quality_gate.py --cache
+
+# Auto-fix formatting and lint.
+python scripts/qs/quality_gate.py --fix
+
+# JSON output for scripts.
+python scripts/qs/quality_gate.py --json
+
+# Fast iteration on one or more test paths (files or directories).
+# Uses xdist + sysmon, skips coverage / ruff / mypy / translations.
+# The canonical TDD red/green/refactor command.
+python scripts/qs/quality_gate.py --quick tests/test_solver.py
+python scripts/qs/quality_gate.py --quick tests/ha_tests
+python scripts/qs/quality_gate.py --quick tests/test_solver.py tests/test_constraints.py
+
+# Ad-hoc single-node pytest — debugging only.
+source venv/bin/activate && pytest tests/test_solver.py::test_function_name -v
+```
+
+**Raw-`pytest` grammar rule.** Allowed: `pytest <path>::<nodeid> [-v]`
+— the positional argument MUST contain `::`. Forbidden as a habitual
+command: any `pytest` invocation whose positional argument lacks
+`::`, e.g., `pytest tests/`, `pytest tests/ha_tests`,
+`pytest tests/test_foo.py`. Use `--quick` on the enclosing file or
+directory instead.
+```
+
+### T9 — Patch `docs/workflow/project-context.md`
+
+Find the existing line (currently around line 149 — find by content,
+not by number, since merges may shift) that reads
+`Run: pytest tests/ --cov=custom_components/quiet_solar ...`. Replace
+the surrounding Coverage bullet with:
+
+```
+- `scripts/qs/quality_gate.py` is the single test entry point (owns cache, xdist, sysmon, scope detection). Raw `pytest` bypasses all four.
+- Full gate (pytest 100% cov + ruff + mypy + translations): `python scripts/qs/quality_gate.py`.  Add `--cache` for cheap repeat runs on a clean tree.
+- Fast iteration on a single file or directory during TDD: `python scripts/qs/quality_gate.py --quick tests/test_<file>.py` (also accepts `tests/ha_tests`, `tests/`, or multiple paths).
+- Ad-hoc single-node debugging only: `source venv/bin/activate && pytest tests/test_<file>.py::test_specific -v`.
+```
+
+After editing, grep the file for any other `pytest tests/` snippet
+and replace it with the equivalent `quality_gate.py` form (per AC14).
+
+### T10 — Patch `AGENTS.md`
+
+In the `## Commands` block:
+
+- Replace the existing `# Run tests only` snippet
+  (`source venv/bin/activate && pytest tests/ -v`) with:
+  ```bash
+  # Fast iteration on one or more test paths (files or directories).
+  # xdist + sysmon, skips coverage/ruff/mypy/translations.
+  python scripts/qs/quality_gate.py --quick tests/test_<file>.py
+  python scripts/qs/quality_gate.py --quick tests/ha_tests
+  ```
+- Add a leading sentence at the top of the Commands block, identical
+  in spirit to `project-rules.md`:
+  `"scripts/qs/quality_gate.py is the single test entry point — it owns the cache, xdist, sysmon, and scope detection."`
+- The existing `python scripts/qs/quality_gate.py` and `--fix`
+  snippets stay.
+- Then grep the rest of `AGENTS.md` for any other `pytest tests/`
+  snippet and either remove it or convert it to
+  `quality_gate.py --quick` (per AC14).
+
+### T11 — Run the full quality gate
 
 ```bash
 source venv/bin/activate
@@ -318,87 +735,227 @@ Must exit 0:
 
 ## Files touched
 
-- `tests/factories.py` — add `__test__ = False` to 3 classes.
-- `tests/test_coverage_device.py` — add `_consume_coro` helper; update 2 tests.
-- `tests/test_factories_pytest_opt_out.py` — new file: regression guard (2 tests).
+- `tests/factories.py` — `__test__ = False` on 3 classes.
+- `tests/test_coverage_device.py` — `_consume_coro` helper; update 2 tests.
+- `tests/test_factories_pytest_opt_out.py` — NEW: regression guard.
+- `scripts/qs/quality_gate.py` — add `--quick` flag + mutex validation
+  + module-docstring update; wire `_pytest_workers()` into
+  `check_pytest_files`.
+- `tests/test_quality_gate.py` — NEW test class `TestQuickMode`
+  (~7 parametrized tests).
+- `.claude/agents/qs-implement-task.md` — replace step 2 with brief
+  reference to `project-rules.md`.
+- `.cursor/agents/qs-implement-task.md` — mirror of above (T7b).
+- `docs/workflow/project-rules.md` — replace `## Commands` block with
+  the canonical `quality_gate.py`-centric block plus the
+  forbidden-grammar rule.
+- `docs/workflow/project-context.md` — patch the
+  `pytest tests/ --cov=...` snippet + sweep for stragglers.
+- `AGENTS.md` — replace the `# Run tests only` snippet + add the
+  "single entry point" sentence + sweep.
 
 No production code under `custom_components/quiet_solar/` is touched.
+No new files under `.opencode/agents/` — the OpenCode implement-task
+agent is template-rendered from frozen `_qsprocess_opencode/`
+templates per `CLAUDE.md`. Per user direction Q2, `AGENTS.md`
+(OpenCode entry point) is patched so the canonical command set is at
+least readable at first sight by OpenCode users.
 
 ## Risk / Rollback
 
-- All changes are test-only.  Rollback = `git revert`.
-- `__test__ = False` is a documented pytest opt-out convention (pytest
-  3.x+).
-- `coro.close()` on an unstarted coroutine is a no-op semantically
-  (lets the GC reclaim it without warning).
-- Coverage risk: zero.  The two updated tests still exercise the same
-  `root_device_post_home_init` code paths.  The new regression file
-  uses pure introspection over `tests/factories.py` — no production
-  code reached.
-- If a future contributor adds a new `Test*` double without
-  `__test__ = False`, the regression test fails with a clear pointer.
+- All code changes are test-infrastructure + workflow-doc.
+  Rollback = `git revert`.
+- `__test__ = False` is documented pytest convention (pytest 3.x+).
+- `coro.close()` on an unstarted coroutine is a no-op semantically.
+- `--quick` is strictly additive to the CLI surface — it does not
+  alter any existing flag's behaviour. Mutex validation against
+  `--cache` / `--no-cache` / `--full` / `--fix` is explicit and tested
+  in T6 with exit-code-2 + stderr-substring assertions.
+- `check_pytest_files` modification adds `-n {workers}` when
+  `_pytest_workers()` returns non-None. The pre-existing test
+  `test_dev_only_scope_skips_lint_gates_and_runs_pytest_only` patches
+  `check_pytest_files` directly (concrete-planner verified at
+  `tests/test_quality_gate.py:464`), so it remains unaffected by the
+  body change. New T6 tests that exercise `check_pytest_files`
+  end-to-end MUST patch `_pytest_workers` to avoid the real xdist-probe
+  subprocess.
+- Coverage scope on `scripts/qs/quality_gate.py` is unchanged: the
+  full gate measures coverage on `custom_components/quiet_solar/` only.
+  T6 covers every new branch behaviourally, not for coverage-percent
+  compliance.
+- Doc-only files (T7 / T7b / T8 / T9 / T10): no executable risk.
+  AC13 + AC14 grep checks enforce no regressions and lock in the
+  canonical command set.
 
 ## Adversarial Review Notes
 
-Four parallel plan reviewers ran on the draft (`qs-plan-critic`,
+### Round 1 — original Category A plan
+
+Four parallel plan reviewers ran on the initial draft (`qs-plan-critic`,
 `qs-plan-concrete-planner`, `qs-plan-dev-proxy`, `qs-plan-scope-guardian`).
 16 findings; dispositions:
 
 **Accepted into the plan:**
 
-- *plan-critic / improve*: Add an explicit AC for total-warning-count
+- *plan-critic / improve*: add explicit AC for total-warning-count
   reaching 0 → became **AC7**.
-- *plan-critic / improve*: Justify the `MagicMock()` return from
-  `_consume_coro` → added to T2's helper docstring (Task is not domain).
-- *plan-critic / clarify*: Line numbers will scramble on merge → all
-  line numbers replaced with class / function names throughout.
-- *plan-critic / clarify*: Files-touched diff stat unverifiable →
-  stat row dropped, replaced with prose.
-- *plan-critic / critical*: AC5 didn't assert the production
-  exception path is reached → AC5 rewritten to assert (a) no exception
-  escapes, (b) device returns normally, (c) the `_LOGGER.error` branch
-  is still covered.
-- *concrete-planner / improve*: Confirm `assert_called()` stays in
-  the success test → explicit note added to T2.
-- *concrete-planner / clarify*: `tests/__init__.py` existence /
-  robust module match → switched to `inspect.getmodule(obj) is factories`
-  in T3 (more robust than `__module__` string compare).
-- *dev-proxy / clarify*: `MagicMock` justification (Task is not
-  domain) → covered by the docstring on `_consume_coro` in T2.
-- *dev-proxy / clarify*: T3 doesn't positively assert the 3 named
+- *plan-critic / improve*: justify the `MagicMock()` return from
+  `_consume_coro` → docstring on the helper in T2.
+- *plan-critic / clarify*: drop line numbers (merge-fragile) → all
+  cited as class / function names.
+- *plan-critic / clarify*: drop unverifiable diff stats → done.
+- *plan-critic / critical*: AC5 didn't assert production exception
+  path is reached → AC5 rewritten to assert (a) no exception escapes,
+  (b) device returns normally, (c) `_LOGGER.error` branch still
+  covered.
+- *concrete-planner / improve*: confirm `assert_called()` stays →
+  explicit note in T2.
+- *concrete-planner / clarify*: robust module match → switched to
+  `inspect.getmodule(obj) is factories` in T3.
+- *dev-proxy / clarify*: MagicMock-for-Task justification →
+  covered by `_consume_coro` docstring.
+- *dev-proxy / clarify*: T3 should positively assert the 3 named
   doubles exist → added `test_sanctioned_doubles_still_present_and_opted_out`
   with `_SANCTIONED_DOUBLES` allow-list.
 - *scope-guardian / clarify*: `TestCarDouble` may not currently warn
-  → noted explicitly in Context section (it's not imported by any
-  `test_*.py`, so no live warning, but gets the opt-out defensively
-  + to keep the regression guard self-consistent).
+  → noted in Context (Category A § note).
 
 **Rejected (with reason):**
 
 - *concrete-planner / critical*: 3rd leak site at
-  `tests/test_ha_car_comprehensive.py:534`.  Verified empirically
-  with `pytest -W error::RuntimeWarning` — the test passes cleanly
-  today.  Different coroutine (`_async_bootstrap_efficiency_from_history`,
-  not `_async_bootstrap_from_history`).  Out of scope of this issue;
-  documented in Context section as a known parallel pattern.
-- *plan-critic / redesign*: Broaden T3 regression scan beyond
-  `factories.py`.  Bounded scope: factories.py is the sanctioned home
-  for test doubles per project-context.md.  Broader scan = scope creep.
-- *scope-guardian / improve*: T3 is gold-plating.  User authorized
-  the regression guard explicitly in chat ("3: ok"); stays.
+  `test_ha_car_comprehensive.py:534`. Verified empirically with
+  `pytest -W error::RuntimeWarning` — passes cleanly today. Different
+  coroutine. Out of scope.
+- *plan-critic / redesign*: broaden T3 regression scan beyond
+  `factories.py`. Bounded scope; broader scan = scope creep.
+- *scope-guardian / improve*: T3 is gold-plating. User authorized
+  the regression guard explicitly ("3: ok"). Stays.
 - *scope-guardian / improve*: `_consume_coro` could be inline lambda.
-  Used twice, carries a non-trivial docstring justifying MagicMock-for-Task;
-  named helper improves readability.  Stays.
+  Used twice, carries justifying docstring. Stays.
 
-**Verified OK (no action needed):**
+**Verified OK (no action needed):** `tests/__init__.py` exists; all 3
+doubles are plain classes; issue's "around test_coverage_constraints.py"
+attribution is approximate (leaks are in `test_coverage_device.py`).
 
-- *concrete-planner / clarify*: `tests/__init__.py` exists.
-- *dev-proxy / clarify*: All 3 doubles are plain classes (no
-  `@dataclass`, no `__slots__`).  Noted in T1.
-- *scope-guardian / clarify*: Issue body attributes warnings to
-  `test_coverage_constraints.py / test_coverage_device.py`; empirically
-  the leaks are in `test_coverage_device.py` only.  Noted in Context.
+### Round 2 — Category B expansion
 
-Net: 1 critical addressed (AC5 strengthened); 1 critical rejected
-after empirical check; 7 improvements accepted; T3 retained per user
-direction.
+After Round 1 finalized, the user expanded scope to bundle the
+workflow optimization (Category B) into the same plan: add a `--quick`
+mode to `quality_gate.py`, patch `qs-implement-task.md` step 2, strip
+unparallelized snippets from project rules / context / AGENTS.md.
+Subsequent user feedback expanded `--quick` to accept directories
+(not just files) and reframed the doc patches around "funnel
+everything through `quality_gate.py`".
+
+Four parallel plan reviewers ran a second time on the Category B
+delta only. 21 distinct findings; dispositions:
+
+**Accepted into the plan:**
+
+- *plan-critic / critical*: AC11 was silent on env-var resolution
+  (potential conflict with AC8) → AC11 reworded to explicitly defer
+  to `_pytest_workers()` (same semantics as the full gate, including
+  `QS_QG_PYTEST_WORKERS` env override).
+- *plan-critic / critical*: T5's "stderr fallback warning" requirement
+  was unverifiable / untested → dropped from T5. `check_pytest_files`
+  now silently falls back to serial (matching its pre-existing
+  behaviour). AC11 explicitly documents this.
+- *plan-critic / improve*: forbidden-vs-allowed pytest grammar was
+  vague → AC12 / AC13 / T8 now state the exact rule:
+  "Allowed: `pytest <path>::<nodeid>`; forbidden: any `pytest`
+  invocation whose positional arg lacks `::`."
+- *plan-critic / improve*: no AC verified doc strips landed → added
+  AC14 with an objective `grep -nE 'pytest +tests(/|$)'` check across
+  the three doc files.
+- *plan-critic / clarify*: AC9/AC10 ordering + nargs ambiguous →
+  pinned `nargs="+"` (argparse fires first, returns exit 2 with
+  "expected at least one argument"; custom mutex fires second via
+  `parser.error()`).
+- *plan-critic / clarify*: banner format unspecified → pinned exactly
+  `"[quick] running {N} path(s) with xdist + sysmon (no coverage / ruff / mypy / translations)"`.
+- *concrete-planner / improve*: mutex tests should assert exit code +
+  stderr substring → T6 now requires `exc.value.code == 2` plus
+  `"you cannot combine --quick with --cache, --no-cache, --full, or --fix"
+  in capsys.readouterr().err`.
+- *concrete-planner / improve*: mutex validation order ambiguous →
+  T5 now pins "immediately after `parser.parse_args()`, BEFORE
+  `use_cache = ...`, BEFORE `_get_changed_files() / _detect_scope()`".
+- *concrete-planner / clarify*: module docstring update should be a
+  sub-bullet of T5 → added explicit "Module docstring" sub-section
+  with the exact `Options:` row format.
+- *concrete-planner / clarify*: T7 section bounds → pinned "the file's
+  lines 38-49 today (the existing `### 2. TDD implementation` block)".
+- *dev-proxy / improve*: `.cursor` mirror untouched → drift hazard.
+  Added **T7b** explicitly mirroring T7 into
+  `.cursor/agents/qs-implement-task.md`.
+- *dev-proxy / improve*: T7 was duplicating substantive content that
+  belongs in `docs/workflow/` (process-authority rule). **Restructured
+  T7 / T7b / T8**: substantive content (commands, forbidden-grammar
+  rule, examples) lives in `project-rules.md` (T8 owns it). T7 and
+  T7b are now short reference blocks (3 paragraphs each) that link
+  back to T8.
+- *dev-proxy / clarify*: coverage scope for `scripts/qs/quality_gate.py`
+  not stated → T5's "Coverage scope note" now spells out that
+  quality_gate.py isn't under the 100% gate and T6 covers branches
+  behaviourally.
+- *dev-proxy / clarify*: error message style (sentence case, no
+  backticks since it's a terminal message) → reworded to
+  `"you cannot combine --quick with --cache, --no-cache, --full, or --fix"`.
+- *scope-guardian / improve*: T6 had ~13 tests, parametrize → T6 now
+  uses `pytest.mark.parametrize` to collapse the mutex matrix (4
+  flags), the path-shape matrix (4 cases), and the exit-code matrix
+  (2 cases) into 7 test functions.
+- *scope-guardian / improve*: AC13 was strip-only, should positively
+  recommend `--cache` → AC13 now lists the 4 canonical commands in
+  precedence order, including `--cache` as the recommended default
+  dev-loop command.
+- *scope-guardian / clarify*: mutex `--quick × --cache` rationale not
+  stated → added under "Design rationale (Category B)" in the plan
+  body.
+
+**Rejected (with reason):**
+
+- *plan-critic / redesign*: `check_pytest_files` mod affects the full
+  gate. REJECT — the full gate calls `check_pytest()` (the
+  cov+xdist+sysmon path), NOT `check_pytest_files()`. The latter is
+  only invoked by the dev-only fast path and by `--quick`. No
+  coupling. Concrete-planner independently verified the call graph.
+- *scope-guardian / redesign*: AC11 (xdist in `check_pytest_files`)
+  is piggybacking. REJECT — `--quick` calls `check_pytest_files()`,
+  so without AC11, AC8's xdist contract cannot hold. AC11 is a
+  prerequisite for AC8, not an additive concern.
+- *dev-proxy / clarify*: single-file `--quick` should skip xdist due
+  to startup overhead. REJECT — xdist startup is ~100 ms, consistent
+  behaviour is easier to reason about than a heuristic. Always honour
+  `_pytest_workers()` regardless of path count. Noted in plan
+  rationale.
+
+**User-direction items:**
+
+- *dev-proxy / clarify* + *scope-guardian / clarify*: cross-harness
+  mirrors. User answered Q1 = "yes update .cursor" → T7b added.
+  Q2 = option (b) → `AGENTS.md` updated + `.opencode/agents/qs-implement-task.md`
+  would have been added, but verification shows the file does not
+  exist (only `qs-setup-task.md` and `qs-release.md` are static
+  OpenCode agents; implement-task is template-rendered from the
+  frozen `_qsprocess_opencode/agent_templates/`). So Q2-(b) reduces
+  to "update `AGENTS.md` only", which is exactly what T10 does.
+  Non-goals updated accordingly.
+
+**Verified OK (no plan change):**
+
+- `_pytest_workers()` is the correct helper (already handles xdist
+  missing + env override + validation + caching).
+- `COVERAGE_CORE=sysmon` already wired via `_pytest_env()` →
+  `_stream_pytest()`; `--quick` inherits sysmon for free.
+- `TestQuickMode` class at end of `tests/test_quality_gate.py` fits
+  the existing class-based + `patch.object`-heavy idiom.
+- `.cursor/.opencode/_qsprocess_opencode` are clean of
+  `pytest tests/` matches today (concrete-planner grep verified) →
+  de-scoping them is safe.
+- `CLAUDE.md` line 40 mentions `pytest` inside the quality-gate
+  description but does not include a `pytest tests/...` invocation,
+  so AC13/AC14's grep rule does not flag it. No change needed.
+
+Net: 17 accepted (10 + 7 reorganization-driven), 3 rejected with
+rationale, 5 verified OK, 2 user-direction items resolved.

--- a/docs/stories/QS-183.story.md
+++ b/docs/stories/QS-183.story.md
@@ -413,7 +413,7 @@ verification — we do NOT bake these filters into `pytest.ini`.
 **Module docstring (top of file).** Add `--quick` to the `Usage:`
 line and add an `Options:` row:
 
-```
+```text
     --quick PATH [PATH ...]  Fast iteration: run only the cited test
                              paths (files or directories) with xdist +
                              sysmon; skip ruff/mypy/translations/
@@ -478,7 +478,7 @@ exact order so the mutex check fires before any cache / scope logic:
    ```
 
    Pin the stderr banner exactly as shown — T6 asserts on the
-   `[quick] running ` prefix and the worker-count substring.
+   `[quick] running` prefix and the worker-count substring.
 
 **`check_pytest_files(test_files: list[str])`.** Inside the function,
 between the existing `abs_files = ...` line and the `cmd = ...` line,
@@ -601,7 +601,7 @@ them"), keep step 2 short and point at `project-rules.md` for the
 canonical command list. Replace the existing
 `### 2. TDD implementation` block (the file's lines 38-49 today) with:
 
-```
+```text
 ### 2. TDD implementation
 
 Red → green → refactor. For every cycle:
@@ -638,7 +638,7 @@ Replace the existing `## Commands` block with a `quality_gate.py`-
 centric version that includes the forbidden-vs-allowed grammar rule
 referenced by T7 / T7b / AC12:
 
-```
+```text
 ## Commands
 
 Activate `source venv/bin/activate` for all Python commands.
@@ -688,7 +688,7 @@ not by number, since merges may shift) that reads
 `Run: pytest tests/ --cov=custom_components/quiet_solar ...`. Replace
 the surrounding Coverage bullet with:
 
-```
+```text
 - `scripts/qs/quality_gate.py` is the single test entry point (owns cache, xdist, sysmon, scope detection). Raw `pytest` bypasses all four.
 - Full gate (pytest 100% cov + ruff + mypy + translations): `python scripts/qs/quality_gate.py`.  Add `--cache` for cheap repeat runs on a clean tree.
 - Fast iteration on a single file or directory during TDD: `python scripts/qs/quality_gate.py --quick tests/test_<file>.py` (also accepts `tests/ha_tests`, `tests/`, or multiple paths).

--- a/docs/stories/QS-183.story_review_fix_#01.md
+++ b/docs/stories/QS-183.story_review_fix_#01.md
@@ -1,0 +1,177 @@
+# QS-183 — Review fix plan #01
+
+## Summary
+
+- Source PR: #186
+- Source story: `docs/stories/QS-183.story.md`
+- Findings to fix: 8 (2 should-fix + 6 nice-to-have)
+- Next implement phase: `/implement-task`
+
+The next phase is `/implement-task` (not `/implement-setup-task`) because two
+findings touch `tests/test_coverage_device.py`, which is outside the
+setup-task scope allow-list (`scripts/`, `.claude/`, `.cursor/`, `.opencode/`,
+`_qsprocess_opencode/`, `docs/`, `.github/`, top-level config).
+
+## Findings to fix
+
+### [should-fix] AC13 violation — `AGENTS.md` missing `--cache` and wrong precedence order
+
+- File: `AGENTS.md:30-41`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC13 mandates that all three doc files (`docs/workflow/project-rules.md`,
+  `docs/workflow/project-context.md`, `AGENTS.md`) list 4 canonical commands in
+  this exact order of precedence:
+  1. `python scripts/qs/quality_gate.py` — full gate
+  2. `python scripts/qs/quality_gate.py --cache` — recommended default for repeated runs
+  3. `python scripts/qs/quality_gate.py --quick PATH [PATH ...]` — fast iteration
+  4. `python scripts/qs/quality_gate.py --fix` — auto-fix lint/format
+
+  `project-rules.md` and `project-context.md` comply. `AGENTS.md` currently
+  shows only #1, #4, #3 (in that wrong order) and omits #2 entirely.
+- Proposed fix: Rewrite the `AGENTS.md` ` ```bash ` block under `## Commands`
+  to emit all four canonical commands in the AC13 precedence order. Keep
+  the existing single-entry-point sentence above the block. Pattern:
+
+  ```bash
+  # Run all quality gates (pytest 100% coverage + ruff + mypy + translations)
+  python scripts/qs/quality_gate.py
+
+  # Cached dev-loop default — skips gates when git state matches last pass.
+  python scripts/qs/quality_gate.py --cache
+
+  # Fast iteration on one or more test paths (files or directories).
+  # xdist + sysmon, skips coverage/ruff/mypy/translations.
+  python scripts/qs/quality_gate.py --quick tests/test_<file>.py
+  python scripts/qs/quality_gate.py --quick tests/ha_tests
+
+  # Auto-fix formatting and lint
+  python scripts/qs/quality_gate.py --fix
+  ```
+
+### [should-fix] `--quick` still pays full-suite `--collect-only` cost
+
+- File: `scripts/qs/quality_gate.py:384` (call site at `:557` via `check_pytest_files`)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: `_stream_pytest` hardcodes
+  `count_cmd = [VENV_PYTHON, "-m", "pytest", "--collect-only", "-q", str(TESTS_DIR)]`
+  regardless of caller. When `--quick tests/test_foo.py` ultimately reaches
+  `_stream_pytest` via `check_pytest_files`, the upfront count subprocess
+  still walks the entire `tests/` tree (~1-3s cold) — wasted overhead that
+  meaningfully undermines AC8's "fast iteration mode" promise.
+- Proposed fix: Add a `collect_targets: list[str] | None = None` keyword
+  parameter to `_stream_pytest`. When provided, build
+  `count_cmd = [VENV_PYTHON, "-m", "pytest", "--collect-only", "-q", *collect_targets]`
+  instead of `str(TESTS_DIR)`. Update `check_pytest_files` (line 557) to
+  pass `collect_targets=abs_files` (the same paths used in the main
+  invocation). The existing `check_pytest` full-coverage caller passes
+  nothing → falls through to the default `TESTS_DIR` collection,
+  preserving its behavior. Add a regression test in
+  `tests/test_quality_gate.py` that monkey-patches `subprocess.Popen` to
+  capture the count-subprocess command and asserts the targeted paths
+  appear in it (NOT `TESTS_DIR`) for the `--quick` code path.
+
+### [nice-to-have] Add language identifiers to fenced code blocks in story file
+
+- File: `docs/stories/QS-183.story.md:416-423, 604-626, 641-683, 691-696`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: Several fenced ` ``` ` blocks lack language identifiers,
+  triggering markdownlint MD040. Inventory by line range:
+  - 416-423: ad-hoc shell session demo → `bash`
+  - 604-626, 641-683, 691-696: review-discussion blocks → `text` (plain prose)
+- Proposed fix: Read each block, infer the language from content, and
+  append the appropriate tag to the opening fence. Use `bash` for shell
+  commands, `python` for code, `text` for free-form prose.
+
+### [nice-to-have] Remove padding spaces inside inline code span
+
+- File: `docs/stories/QS-183.story.md:481`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: An inline code span has padding spaces inside the
+  backticks (`` ` foo ` ``), triggering markdownlint MD038.
+- Proposed fix: Trim the internal whitespace so the span is tight
+  (`` `foo` ``).
+
+### [nice-to-have] Hoist `_consume_and_raise` to module level
+
+- File: `tests/test_coverage_device.py:977-981`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `_consume_and_raise` is currently defined as a nested
+  function inside `test_root_device_post_home_init_exception_lines324_325`.
+  For symmetry with the existing module-level `_consume_coro` (which
+  shares the `coro.close()` pattern), hoist it next to `_consume_coro`.
+- Proposed fix: Move `_consume_and_raise` to module level near
+  `_consume_coro` (around lines 71-86). The implementation signature is
+  unchanged: it closes the coroutine, then raises `Exception("bootstrap failed")`.
+  Update the test to reference the module-level helper. Add a one-line
+  comment noting "single-shot — valid only for tests with one entity in
+  `_entities_to_fill_from_history`."
+
+### [nice-to-have] AC5: assert `_LOGGER.error` branch directly via `caplog`
+
+- File: `tests/test_coverage_device.py:975-991`
+  (`test_root_device_post_home_init_exception_lines324_325`)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The AC5 test currently relies on AC15 coverage transitivity
+  to verify the `_LOGGER.error(...)` branch in `device.py:407-408` ran.
+  Story T2 explicitly allows adding a `caplog` assertion if coverage is
+  otherwise missing — coverage is fine, but a direct behavioral assertion
+  reads better.
+- Proposed fix: Inject the `caplog` fixture into the test and assert
+  exactly one record in `caplog.records` at `ERROR` level whose message
+  references "bootstrap" (or whatever the production log message text
+  is — read `custom_components/quiet_solar/ha_model/device.py:407-408`
+  first to grab the exact wording). Keep the existing "no exception
+  escapes" assertion.
+
+### [nice-to-have] Guard `check_pytest_files` against path-escape inputs
+
+- File: `scripts/qs/quality_gate.py:552`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `abs_files = [str(REPO_ROOT / f) for f in test_files]`
+  silently accepts absolute paths (`REPO_ROOT / "/etc/passwd"` discards
+  `REPO_ROOT`) and `../` escapes. Dev-only tool, minor footgun.
+- Proposed fix: After resolving each path with
+  `(REPO_ROOT / f).resolve()`, check `is_relative_to(REPO_ROOT)`. On
+  violation, `parser.error(f"--quick path must be inside the repo: {f}")`.
+  Add a regression test in `tests/test_quality_gate.py` that asserts a
+  `SystemExit(2)` for `--quick /etc/passwd` and for `--quick ../outside.py`.
+
+### [nice-to-have] Guard `check_pytest_files` against empty-string positional
+
+- File: `scripts/qs/quality_gate.py:552`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `argparse nargs="+"` accepts `--quick ""` as a single empty
+  positional. `REPO_ROOT / ""` resolves to `REPO_ROOT`, so pytest collects
+  the entire suite serially under sysmon — silently subverting the
+  "skip everything else" contract of `--quick`.
+- Proposed fix: In `main()`, after parsing args, validate
+  `if args.quick and any(not p for p in args.quick): parser.error("--quick paths must be non-empty")`.
+  Add a regression test in `tests/test_quality_gate.py` (`TestQuickMode`)
+  that asserts `SystemExit(2)` for `--quick ""` and `--quick tests/foo.py ""`.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. The agent should:
+
+1. Read this plan in full plus the source story (`docs/stories/QS-183.story.md`)
+   for context on the original ACs.
+2. Apply fixes in TDD order — for each finding that introduces or modifies
+   behavior, write the failing test first, then fix.
+3. Re-run `python scripts/qs/quality_gate.py` (full gate) at the end.
+4. Commit and push, then return and run `/review-task` again to re-verify.
+
+The full quality gate MUST stay green (AC15 still applies to this fix-up
+PR). Edit scope is unchanged from `qs-implement-task`'s normal contract:
+`custom_components/quiet_solar/**`, `tests/**`, plus the story file
+(and the supporting setup-scope files — `AGENTS.md`,
+`scripts/qs/quality_gate.py`, `docs/stories/QS-183.story.md` — which are
+already touched by the parent PR, so editing them here is in-scope for
+the fix-up).

--- a/docs/workflow/project-context.md
+++ b/docs/workflow/project-context.md
@@ -146,7 +146,10 @@ When adding a new device type, agents must touch:
 ### Coverage
 
 - **100% test coverage is MANDATORY and NON-NEGOTIABLE.** Every PR must maintain 100% coverage.
-- Run: `source venv/bin/activate && pytest tests/ --cov=custom_components/quiet_solar --cov-report=term-missing`
+- `scripts/qs/quality_gate.py` is the single test entry point (owns cache, xdist, sysmon, scope detection). Raw `pytest` bypasses all four.
+- Full gate (pytest 100% cov + ruff + mypy + translations): `python scripts/qs/quality_gate.py`. Add `--cache` for cheap repeat runs on a clean tree.
+- Fast iteration on a single file or directory during TDD: `python scripts/qs/quality_gate.py --quick tests/test_<file>.py` (also accepts `tests/ha_tests`, `tests/`, or multiple paths).
+- Ad-hoc single-node debugging only: `source venv/bin/activate && pytest tests/test_<file>.py::test_specific -v`.
 
 ### Test Infrastructure
 

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -14,23 +14,43 @@ energy self-consumption through a constraint-based solver.
 ## Commands
 
 Activate `source venv/bin/activate` for all Python commands.
+`scripts/qs/quality_gate.py` is the **single test entry point** —
+it owns the cache, `pytest-xdist` parallelization,
+`COVERAGE_CORE=sysmon`, and scope detection. Raw `pytest` bypasses
+all four; use it only for ad-hoc single-node debugging.
 
 ```bash
-# Run all quality gates (pytest 100% coverage + ruff + mypy + translations)
+# Full quality gate (pytest 100% cov + ruff + mypy + translations).
+# Required before every commit.
 python scripts/qs/quality_gate.py
 
-# Auto-fix formatting and lint
+# Recommended default for repeated dev-loop runs — skips gates when
+# git state matches a previous pass on a clean tree.
+python scripts/qs/quality_gate.py --cache
+
+# Auto-fix formatting and lint.
 python scripts/qs/quality_gate.py --fix
 
-# JSON output for scripts
+# JSON output for scripts.
 python scripts/qs/quality_gate.py --json
 
-# Run tests only
-source venv/bin/activate && pytest tests/ -v
+# Fast iteration on one or more test paths (files or directories).
+# Uses xdist + sysmon, skips coverage / ruff / mypy / translations.
+# The canonical TDD red/green/refactor command.
+python scripts/qs/quality_gate.py --quick tests/test_solver.py
+python scripts/qs/quality_gate.py --quick tests/ha_tests
+python scripts/qs/quality_gate.py --quick tests/test_solver.py tests/test_constraints.py
 
-# Single test
+# Ad-hoc single-node pytest — debugging only.
 source venv/bin/activate && pytest tests/test_solver.py::test_function_name -v
 ```
+
+**Raw-`pytest` grammar rule.** Allowed: `pytest <path>::<nodeid> [-v]`
+— the positional argument MUST contain `::`. Forbidden as a habitual
+command: any `pytest` invocation whose positional argument lacks
+`::`, e.g., `pytest tests/`, `pytest tests/ha_tests`,
+`pytest tests/test_foo.py`. Use `--quick` on the enclosing file or
+directory instead.
 
 ## Architecture constraints
 

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -362,7 +362,10 @@ def _parse_pytest_output(text: str) -> dict[str, int]:
     return summary if summary is not None else tally
 
 
-def _stream_pytest(cmd: list[str]) -> dict:
+def _stream_pytest(
+    cmd: list[str],
+    collect_targets: list[str] | None = None,
+) -> dict:
     """Run pytest with real-time progress reporting.
 
     Prints a progress line every ~10% of tests. Returns the same dict
@@ -370,6 +373,14 @@ def _stream_pytest(cmd: list[str]) -> dict:
     `COVERAGE_CORE=sysmon` for faster coverage tracking; the upfront
     `--collect-only` count subprocess uses the parent env (coverage is
     not active during collection).
+
+    `collect_targets` (review-fix #01 finding 2): when provided, the
+    upfront `--collect-only` subprocess walks ONLY those paths instead
+    of the whole `TESTS_DIR` tree. `check_pytest_files` passes the same
+    `abs_files` it gives to the main run so `--quick tests/test_foo.py`
+    doesn't pay the 1–3 s cold cost of collecting the entire suite.
+    The full-coverage caller (`check_pytest`) passes `None` and keeps
+    the whole-tree collection semantics.
 
     Both subprocess invocations explicitly pass `encoding="utf-8"` and
     `errors="replace"` so decoding pytest output never crashes under
@@ -381,7 +392,8 @@ def _stream_pytest(cmd: list[str]) -> dict:
     # First, collect test count — single-process, no coverage env override.
     # We use Popen directly (instead of `_run`) so the test suite can verify
     # this subprocess gets utf-8 encoding AND does NOT inherit COVERAGE_CORE.
-    count_cmd = [VENV_PYTHON, "-m", "pytest", "--collect-only", "-q", str(TESTS_DIR)]
+    count_targets = collect_targets if collect_targets is not None else [str(TESTS_DIR)]
+    count_cmd = [VENV_PYTHON, "-m", "pytest", "--collect-only", "-q", *count_targets]
     count_proc = subprocess.Popen(
         count_cmd,
         stdout=subprocess.PIPE,
@@ -554,7 +566,9 @@ def check_pytest_files(test_files: list[str]) -> dict:
     cmd = [VENV_PYTHON, "-m", "pytest", *abs_files, "-q"]
     if workers is not None:
         cmd.extend(["-n", workers])
-    return _stream_pytest(cmd)
+    # Narrow the collect-only subprocess to the same paths so we don't
+    # walk the whole `tests/` tree just to count one file's tests.
+    return _stream_pytest(cmd, collect_targets=abs_files)
 
 
 def check_ruff_lint(fix: bool = False) -> dict:
@@ -743,6 +757,24 @@ def main() -> None:
         parser.error(
             "you cannot combine --quick with --cache, --no-cache, --full, or --fix"
         )
+
+    # Review-fix #01 finding 8 — `--quick ""` would otherwise resolve to
+    # REPO_ROOT and silently collect the whole suite. Reject before any
+    # path resolution.
+    if args.quick and any(not p for p in args.quick):
+        parser.error("--quick paths must be non-empty")
+
+    # Review-fix #01 finding 7 — `REPO_ROOT / "/etc/passwd"` discards
+    # REPO_ROOT (pathlib semantics) and `..` escapes the worktree. Both
+    # would silently run pytest outside the repo. Resolve each path and
+    # confirm it sits under REPO_ROOT before continuing.
+    if args.quick:
+        for raw in args.quick:
+            resolved = (REPO_ROOT / raw).resolve()
+            try:
+                resolved.relative_to(REPO_ROOT)
+            except ValueError:
+                parser.error(f"--quick path must be inside the repo: {raw}")
 
     if args.quick:
         sys.stderr.write(

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -3,13 +3,18 @@
 
 Usage:
     python scripts/qs/quality_gate.py [--fix] [--json] [--cache] [--no-cache] [--full]
+    python scripts/qs/quality_gate.py --quick PATH [PATH ...]
 
 Options:
-    --fix       Auto-fix what can be fixed (ruff format, ruff check --fix)
-    --json      Output JSON instead of human-readable text
-    --cache     Enable caching — skip gates if git state matches a previous pass
-    --no-cache  Force fresh run even when --cache is present
-    --full      Force full gate run even if only dev/test files changed
+    --fix                    Auto-fix what can be fixed (ruff format, ruff check --fix)
+    --json                   Output JSON instead of human-readable text
+    --cache                  Enable caching — skip gates if git state matches a previous pass
+    --no-cache               Force fresh run even when --cache is present
+    --full                   Force full gate run even if only dev/test files changed
+    --quick PATH [PATH ...]  Fast iteration: run only the cited test paths (files
+                             or directories) with xdist + sysmon; skip ruff/mypy/
+                             translations/coverage/cache/scope. Mutex with
+                             --cache/--no-cache/--full/--fix.
 
 Smart scope detection:
     When only dev-infrastructure files are modified (tests/, _qsprocess*/, docs/,
@@ -20,6 +25,7 @@ Smart scope detection:
 Exit codes:
     0 = all gates pass
     1 = one or more gates failed
+    2 = argument parsing error (e.g., --quick with no paths, or mutex violation)
 """
 
 from __future__ import annotations
@@ -532,12 +538,22 @@ def check_pytest() -> dict:
 
 
 def check_pytest_files(test_files: list[str]) -> dict:
-    """Run pytest on specific test files only (no coverage)."""
+    """Run pytest on specific test paths (files or directories), no coverage.
+
+    Honours `_pytest_workers()` for xdist parallelization — same resolver as
+    the full gate (`check_pytest`), so `QS_QG_PYTEST_WORKERS` overrides apply
+    here too. Silent serial fallback when xdist is missing or explicitly
+    disabled (no stderr warning; only the full gate warns to avoid duplicate
+    noise from the dev-only fast path and `--quick`).
+    """
     if not test_files:
         return {"name": "pytest (no test files changed)", "passed": True, "detail": ""}
 
     abs_files = [str(REPO_ROOT / f) for f in test_files]
+    workers = _pytest_workers()
     cmd = [VENV_PYTHON, "-m", "pytest", *abs_files, "-q"]
+    if workers is not None:
+        cmd.extend(["-n", workers])
     return _stream_pytest(cmd)
 
 
@@ -707,7 +723,43 @@ def main() -> None:
     parser.add_argument("--cache", action="store_true", help="Enable result caching based on git state")
     parser.add_argument("--no-cache", action="store_true", help="Force fresh run (overrides --cache)")
     parser.add_argument("--full", action="store_true", help="Force full gate run regardless of scope")
+    parser.add_argument(
+        "--quick",
+        nargs="+",
+        metavar="PATH",
+        help=(
+            "Fast iteration mode: run only the cited test paths (files "
+            "or directories) with xdist + sysmon; skip ruff/mypy/"
+            "translations/coverage."
+        ),
+    )
     args = parser.parse_args()
+
+    # --quick is mutually exclusive with cache/full/fix. argparse's nargs="+"
+    # validation fires first for the "no paths" case (exit 2 with its own
+    # "expected at least one argument" message), so this only handles the
+    # explicit-conflict case.
+    if args.quick and (args.cache or args.no_cache or args.full or args.fix):
+        parser.error(
+            "you cannot combine --quick with --cache, --no-cache, --full, or --fix"
+        )
+
+    if args.quick:
+        sys.stderr.write(
+            f"[quick] running {len(args.quick)} path(s) with xdist + "
+            f"sysmon (no coverage / ruff / mypy / translations)\n"
+        )
+        sys.stderr.flush()
+        result = check_pytest_files(args.quick)
+        result["name"] = f"pytest --quick ({len(args.quick)} path(s))"
+        _output_results(
+            [result],
+            all_passed=result["passed"],
+            cached=False,
+            json_mode=args.json,
+            scope="quick",
+        )
+        sys.exit(0 if result["passed"] else 1)
 
     use_cache = args.cache and not args.fix and not args.no_cache
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -680,6 +680,12 @@ class TestCarDouble:
     Use this instead of SimpleNamespace for car mocks in unit tests.
     """
 
+    # pytest opt-out: this is a test helper, not a test class, despite the
+    # `Test` prefix.  Pytest's default `python_classes = Test*` collection
+    # rule would otherwise try to instantiate it and emit
+    # `cannot collect test class 'TestCarDouble'` (it has an `__init__`).
+    __test__ = False
+
     def __init__(
         self,
         name: str = "Test Car",
@@ -738,6 +744,12 @@ class TestChargerDouble:
 
     Use this instead of SimpleNamespace for charger mocks in unit tests.
     """
+
+    # pytest opt-out: this is a test helper, not a test class, despite the
+    # `Test` prefix.  Pytest's default `python_classes = Test*` collection
+    # rule would otherwise try to instantiate it and emit
+    # `cannot collect test class 'TestChargerDouble'` (it has an `__init__`).
+    __test__ = False
 
     def __init__(
         self,
@@ -820,6 +832,12 @@ class TestDynamicGroupDouble:
 
     Supports multi-slot amp budgets.
     """
+
+    # pytest opt-out: this is a test helper, not a test class, despite the
+    # `Test` prefix.  Pytest's default `python_classes = Test*` collection
+    # rule would otherwise try to instantiate it and emit
+    # `cannot collect test class 'TestDynamicGroupDouble'` (it has an `__init__`).
+    __test__ = False
 
     def __init__(
         self,

--- a/tests/test_coverage_device.py
+++ b/tests/test_coverage_device.py
@@ -84,6 +84,18 @@ def _consume_coro(coro):
     return MagicMock()
 
 
+def _consume_and_raise(coro):
+    """Close the coroutine, then raise — for exception-path tests.
+
+    Single-shot — valid only for tests with one entity in
+    `_entities_to_fill_from_history`, since the production loop in
+    `root_device_post_home_init` would call `async_create_task` once
+    per entity but the very first call raises here.
+    """
+    coro.close()
+    raise Exception("bootstrap failed")
+
+
 # --------------------------------------------------------------------------
 # Fixture helpers
 # --------------------------------------------------------------------------
@@ -972,23 +984,37 @@ async def test_get_next_scheduled_events_duplicate_start_line523():
 # ==========================================================================
 
 
-def test_root_device_post_home_init_exception_lines324_325():
-    """Cover lines 324-325: exception in bootstrap -> log error and continue."""
+def test_root_device_post_home_init_exception_lines324_325(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cover lines 324-325: exception in bootstrap -> log error and continue.
 
-    def _consume_and_raise(coro):
-        # Close the coroutine first so the side-effect Exception doesn't
-        # leave it un-awaited at GC time (RuntimeWarning).
-        coro.close()
-        raise Exception("bootstrap failed")
-
+    Asserts the production `_LOGGER.error(...)` branch at
+    `device.py:407-408` fires (directly via `caplog`, not just via
+    coverage transitivity).
+    """
     hass = _make_fake_hass()
     hass.async_create_task = MagicMock(side_effect=_consume_and_raise)
     dev = _make_load_device(hass=hass)
     dev._entities_to_fill_from_history.add("sensor.test_entity")
 
     now = datetime.now(tz=pytz.UTC)
-    dev.root_device_post_home_init(now)
-    # Should not raise; error is caught and logged
+    with caplog.at_level("ERROR", logger="custom_components.quiet_solar.ha_model.device"):
+        dev.root_device_post_home_init(now)
+        # Should not raise; error is caught and logged.
+
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(error_records) == 1, (
+        f"expected exactly one ERROR record from the bootstrap except branch, "
+        f"got {len(error_records)}: {[r.getMessage() for r in error_records]}"
+    )
+    message = error_records[0].getMessage()
+    assert "root_device_post_home_init" in message, (
+        f"log message must reference the bootstrap function; got {message!r}"
+    )
+    assert "bootstrap failed" in message, (
+        f"log message must surface the underlying exception text; got {message!r}"
+    )
 
 
 # ==========================================================================

--- a/tests/test_coverage_device.py
+++ b/tests/test_coverage_device.py
@@ -68,6 +68,22 @@ class ConcreteLoadDevice(HADeviceMixin, AbstractLoad):
         return False
 
 
+def _consume_coro(coro):
+    """Close a coroutine handed to a mocked `hass.async_create_task`.
+
+    Prevents `RuntimeWarning: coroutine '...' was never awaited` when
+    the test does not actually schedule the task.  Returns a
+    `MagicMock()` so the call site sees a Task-like return value.
+
+    `MagicMock` is permissible here: an `asyncio.Task` is an HA-runtime
+    object, not domain logic, so the "no MagicMock for domain objects"
+    rule does not apply.  The production caller
+    (`root_device_post_home_init`) discards the return value.
+    """
+    coro.close()
+    return MagicMock()
+
+
 # --------------------------------------------------------------------------
 # Fixture helpers
 # --------------------------------------------------------------------------
@@ -831,8 +847,10 @@ def test_get_state_history_data_ret_none_fallback_line1296():
 def test_root_device_post_home_init_with_entities_lines323_325():
     """Cover lines 323-325: entities_to_fill_from_history triggers async_create_task."""
     hass = _make_fake_hass()
-    # Add async_create_task to FakeHass
-    hass.async_create_task = MagicMock()
+    # Add async_create_task to FakeHass — wrap via `_consume_coro` so the
+    # coroutine passed in is closed cleanly (no RuntimeWarning) and the
+    # mock still tracks the call for the assertion below.
+    hass.async_create_task = MagicMock(side_effect=_consume_coro)
     dev = _make_load_device(hass=hass)
 
     # Add an entity to fill from history
@@ -956,8 +974,15 @@ async def test_get_next_scheduled_events_duplicate_start_line523():
 
 def test_root_device_post_home_init_exception_lines324_325():
     """Cover lines 324-325: exception in bootstrap -> log error and continue."""
+
+    def _consume_and_raise(coro):
+        # Close the coroutine first so the side-effect Exception doesn't
+        # leave it un-awaited at GC time (RuntimeWarning).
+        coro.close()
+        raise Exception("bootstrap failed")
+
     hass = _make_fake_hass()
-    hass.async_create_task = MagicMock(side_effect=Exception("bootstrap failed"))
+    hass.async_create_task = MagicMock(side_effect=_consume_and_raise)
     dev = _make_load_device(hass=hass)
     dev._entities_to_fill_from_history.add("sensor.test_entity")
 

--- a/tests/test_factories_pytest_opt_out.py
+++ b/tests/test_factories_pytest_opt_out.py
@@ -1,0 +1,62 @@
+"""Regression guard for pytest-collection opt-out on `tests/factories.py` helpers.
+
+Pytest's default `python_classes = Test*` rule (set in `pytest.ini`)
+collects every class named `Test...`.  Our doubles in `tests/factories.py`
+match that pattern but are helpers, not test classes — they carry
+`__init__` constructors.  Without an opt-out, pytest emits
+`cannot collect test class '...' because it has a __init__ constructor`.
+
+This module fails fast if any class in `tests/factories.py` whose name
+starts with `Test` lacks `__test__ = False`, and also asserts the three
+currently sanctioned doubles are still present and opted out — so a
+silent rename or accidental removal is caught.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from tests import factories
+
+# The three test-double helpers currently defined in tests/factories.py.
+# Update this set when intentionally adding/removing a sanctioned double.
+_SANCTIONED_DOUBLES: frozenset[str] = frozenset(
+    {"TestCarDouble", "TestChargerDouble", "TestDynamicGroupDouble"}
+)
+
+
+def _local_test_classes() -> list[tuple[str, type]]:
+    """Return [(name, cls)] of every `Test*` class defined directly in factories.py."""
+    return [
+        (name, obj)
+        for name, obj in inspect.getmembers(factories, inspect.isclass)
+        if name.startswith("Test") and inspect.getmodule(obj) is factories
+    ]
+
+
+def test_all_test_doubles_opt_out_of_collection() -> None:
+    """Every `Test*` class in factories.py must set `__test__ = False`."""
+    offenders = [
+        name for name, obj in _local_test_classes()
+        if getattr(obj, "__test__", True) is not False
+    ]
+    assert not offenders, (
+        "These factories.py helpers start with `Test` but do not set "
+        "`__test__ = False`.  Add it so pytest skips collection:\n"
+        + "\n".join(f"  - {n}" for n in offenders)
+    )
+
+
+def test_sanctioned_doubles_still_present_and_opted_out() -> None:
+    """The three known doubles must remain in factories.py with `__test__ = False`."""
+    present = {name for name, _ in _local_test_classes()}
+    missing = _SANCTIONED_DOUBLES - present
+    assert not missing, (
+        f"Expected doubles missing from tests/factories.py: {sorted(missing)}.  "
+        f"If you intentionally renamed/removed one, update _SANCTIONED_DOUBLES."
+    )
+    for name in _SANCTIONED_DOUBLES & present:
+        cls = getattr(factories, name)
+        assert getattr(cls, "__test__", True) is False, (
+            f"{name} is present but does not set `__test__ = False`."
+        )

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -1505,3 +1505,205 @@ class TestHtmlcovNotWritten:
             "htmlcov/ was unexpectedly created — pytest.ini addopts or the QG"
             " cmd construction re-enabled the html report"
         )
+
+
+# --- QS-183 T6: --quick fast-iteration mode ---
+
+
+class TestQuickMode:
+    """Tests for `--quick PATH [PATH ...]` (QS-183 Category B).
+
+    `--quick` runs `pytest` on the cited paths with xdist + sysmon, and
+    skips every other gate (ruff / mypy / translations / coverage / cache
+    / scope detection). Mutually exclusive with `--cache`, `--no-cache`,
+    `--full`, and `--fix`.
+    """
+
+    @pytest.mark.parametrize(
+        "argv_paths",
+        [
+            ["tests/test_foo.py"],
+            ["tests/test_foo.py", "tests/test_bar.py"],
+            ["tests/ha_tests"],
+            ["tests/test_foo.py", "tests/ha_tests"],
+        ],
+        ids=["single-file", "multi-file", "directory", "mixed-file-and-dir"],
+    )
+    def test_quick_invokes_check_pytest_files_with_paths(
+        self,
+        argv_paths: list[str],
+    ) -> None:
+        """`--quick` forwards positional paths to `check_pytest_files` unchanged."""
+        pytest_result = {"name": "pytest", "passed": True, "detail": ""}
+
+        with (
+            patch(
+                "sys.argv",
+                ["quality_gate.py", "--quick", *argv_paths],
+            ),
+            patch.object(
+                quality_gate,
+                "check_pytest_files",
+                return_value=pytest_result,
+            ) as mock_pytest_files,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+
+        assert exc_info.value.code == 0
+        mock_pytest_files.assert_called_once_with(argv_paths)
+
+    def test_quick_skips_everything_else(self, tmp_path: Path) -> None:
+        """`--quick` does not call any other gate, cache, or scope helper."""
+        pytest_result = {"name": "pytest", "passed": True, "detail": ""}
+
+        with (
+            patch("sys.argv", ["quality_gate.py", "--quick", "tests/test_foo.py"]),
+            patch.object(quality_gate, "CACHE_FILE", tmp_path / ".quality_gate_cache"),
+            patch.object(quality_gate, "check_ruff_lint") as mock_ruff_lint,
+            patch.object(quality_gate, "check_ruff_format") as mock_ruff_format,
+            patch.object(quality_gate, "check_mypy") as mock_mypy,
+            patch.object(quality_gate, "check_translations") as mock_trans,
+            patch.object(quality_gate, "check_pytest") as mock_full_pytest,
+            patch.object(quality_gate, "_get_git_state") as mock_git_state,
+            patch.object(quality_gate, "_detect_scope") as mock_detect_scope,
+            patch.object(quality_gate, "_read_cache") as mock_read_cache,
+            patch.object(quality_gate, "_write_cache") as mock_write_cache,
+            patch.object(
+                quality_gate,
+                "check_pytest_files",
+                return_value=pytest_result,
+            ),
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+
+        # None of the skipped helpers may have been called.
+        for mock in (
+            mock_ruff_lint,
+            mock_ruff_format,
+            mock_mypy,
+            mock_trans,
+            mock_full_pytest,
+            mock_git_state,
+            mock_detect_scope,
+            mock_read_cache,
+            mock_write_cache,
+        ):
+            mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("pytest_passed", "expected_exit"),
+        [(True, 0), (False, 1)],
+        ids=["pass→0", "fail→1"],
+    )
+    def test_quick_exit_code_propagates(
+        self,
+        pytest_passed: bool,
+        expected_exit: int,
+    ) -> None:
+        """`--quick` exits 0 iff the underlying pytest passes, 1 otherwise."""
+        result = {"name": "pytest", "passed": pytest_passed, "detail": ""}
+        with (
+            patch("sys.argv", ["quality_gate.py", "--quick", "tests/test_foo.py"]),
+            patch.object(quality_gate, "check_pytest_files", return_value=result),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == expected_exit
+
+    def test_quick_emits_banner(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`--quick` prints a `[quick] running ...` banner to stderr."""
+        result = {"name": "pytest", "passed": True, "detail": ""}
+        with (
+            patch(
+                "sys.argv",
+                ["quality_gate.py", "--quick", "tests/test_foo.py", "tests/ha_tests"],
+            ),
+            patch.object(quality_gate, "check_pytest_files", return_value=result),
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+        err = capsys.readouterr().err
+        assert err.startswith("[quick] running "), f"banner missing/wrong: {err!r}"
+        assert "xdist + sysmon" in err, f"banner missing 'xdist + sysmon': {err!r}"
+
+    def test_quick_rejects_empty_args(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`--quick` with no paths fails at argparse layer (exit 2)."""
+        with (
+            patch("sys.argv", ["quality_gate.py", "--quick"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "--quick" in err, f"argparse error must name --quick: {err!r}"
+
+    @pytest.mark.parametrize(
+        "conflict_flag",
+        ["--cache", "--no-cache", "--full", "--fix"],
+    )
+    def test_quick_mutex_matrix(
+        self,
+        conflict_flag: str,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`--quick` combined with any of --cache/--no-cache/--full/--fix → exit 2."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "quality_gate.py",
+                    "--quick",
+                    "tests/test_x.py",
+                    conflict_flag,
+                ],
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert (
+            "you cannot combine --quick with --cache, --no-cache, --full, or --fix"
+            in err
+        ), f"mutex message missing/changed: {err!r}"
+
+    @pytest.mark.parametrize(
+        ("workers_value", "expected_in_cmd"),
+        [("auto", True), ("4", True), (None, False)],
+        ids=["auto", "fixed-count", "serial"],
+    )
+    def test_check_pytest_files_uses_workers_when_resolver_returns_value(
+        self,
+        workers_value: str | None,
+        expected_in_cmd: bool,
+    ) -> None:
+        """`check_pytest_files` adds `-n <workers>` iff `_pytest_workers()` returns one."""
+        captured: dict = {}
+
+        def fake_stream(cmd: list[str]) -> dict:
+            captured["cmd"] = cmd
+            return {"name": "pytest", "passed": True, "detail": ""}
+
+        with (
+            patch.object(quality_gate, "_pytest_workers", return_value=workers_value),
+            patch.object(quality_gate, "_stream_pytest", side_effect=fake_stream),
+        ):
+            quality_gate.check_pytest_files(["tests/test_x.py"])
+
+        cmd = captured["cmd"]
+        assert ("-n" in cmd) is expected_in_cmd, (
+            f"-n presence ({'-n' in cmd}) != expected ({expected_in_cmd}); cmd={cmd!r}"
+        )
+        if expected_in_cmd:
+            n_idx = cmd.index("-n")
+            assert cmd[n_idx + 1] == workers_value, (
+                f"-n value mismatch; want {workers_value!r}, got {cmd[n_idx + 1]!r}"
+            )

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -1688,8 +1688,12 @@ class TestQuickMode:
         """`check_pytest_files` adds `-n <workers>` iff `_pytest_workers()` returns one."""
         captured: dict = {}
 
-        def fake_stream(cmd: list[str]) -> dict:
+        def fake_stream(
+            cmd: list[str],
+            collect_targets: list[str] | None = None,
+        ) -> dict:
             captured["cmd"] = cmd
+            captured["collect_targets"] = collect_targets
             return {"name": "pytest", "passed": True, "detail": ""}
 
         with (
@@ -1707,3 +1711,146 @@ class TestQuickMode:
             assert cmd[n_idx + 1] == workers_value, (
                 f"-n value mismatch; want {workers_value!r}, got {cmd[n_idx + 1]!r}"
             )
+
+    def test_quick_collect_only_uses_cited_paths_not_tests_dir(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Review-fix #01 finding 2: `--quick` count subprocess must collect only
+        the cited paths, not walk the entire `tests/` tree.
+
+        `_stream_pytest`'s upfront `pytest --collect-only` call has historically
+        been hardcoded to `TESTS_DIR`, costing 1–3s cold even when the caller
+        only wants a single file. Wire `collect_targets` end-to-end from
+        `check_pytest_files` so the count subprocess receives the same paths
+        as the main run.
+        """
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        popen_calls: list[dict] = []
+
+        class FakePopen:
+            def __init__(self, cmd, **kwargs):  # type: ignore[no-untyped-def]
+                popen_calls.append({"cmd": list(cmd), "kwargs": kwargs})
+                self.stdout = io.StringIO("0 tests collected\n")
+                self.stderr = io.StringIO("")
+                self.returncode = 0
+
+            def communicate(self, *a, **kw):  # type: ignore[no-untyped-def]
+                return ("0 tests collected\n", "")
+
+            def wait(self):  # type: ignore[no-untyped-def]
+                return 0
+
+        with (
+            patch.object(quality_gate, "_has_xdist", return_value=False),
+            patch.object(quality_gate.subprocess, "Popen", FakePopen),
+        ):
+            quality_gate.check_pytest_files(["tests/test_factories_pytest_opt_out.py"])
+
+        assert len(popen_calls) == 2, f"expected 2 Popen calls, got {len(popen_calls)}"
+        collect_cmd = popen_calls[0]["cmd"]
+        assert "--collect-only" in collect_cmd
+
+        # The cited file (resolved against REPO_ROOT) must appear in the count
+        # cmd; the full tests/ tree path must NOT.
+        cited = str(quality_gate.REPO_ROOT / "tests/test_factories_pytest_opt_out.py")
+        assert cited in collect_cmd, (
+            f"collect-only cmd must include the cited path {cited!r}; got {collect_cmd!r}"
+        )
+        assert str(quality_gate.TESTS_DIR) not in collect_cmd, (
+            f"collect-only cmd must NOT walk full TESTS_DIR; got {collect_cmd!r}"
+        )
+
+    def test_check_pytest_full_path_still_uses_tests_dir_for_collect(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Negative half of finding 2 — the full-gate `check_pytest()` caller
+        must KEEP collecting against `TESTS_DIR` (its semantics are
+        "whole-suite coverage", so the count subprocess walking everything
+        is correct there).
+        """
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        popen_calls: list[dict] = []
+
+        class FakePopen:
+            def __init__(self, cmd, **kwargs):  # type: ignore[no-untyped-def]
+                popen_calls.append({"cmd": list(cmd), "kwargs": kwargs})
+                self.stdout = io.StringIO("0 tests collected\n")
+                self.stderr = io.StringIO("")
+                self.returncode = 0
+
+            def communicate(self, *a, **kw):  # type: ignore[no-untyped-def]
+                return ("0 tests collected\n", "")
+
+            def wait(self):  # type: ignore[no-untyped-def]
+                return 0
+
+        with (
+            patch.object(quality_gate, "_has_xdist", return_value=False),
+            patch.object(quality_gate.subprocess, "Popen", FakePopen),
+        ):
+            quality_gate.check_pytest()
+
+        assert len(popen_calls) == 2, f"expected 2 Popen calls, got {len(popen_calls)}"
+        collect_cmd = popen_calls[0]["cmd"]
+        assert "--collect-only" in collect_cmd
+        assert str(quality_gate.TESTS_DIR) in collect_cmd, (
+            f"full-gate collect-only must include TESTS_DIR; got {collect_cmd!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        ["/etc/passwd", "../outside.py", "/tmp/foo.py"],
+        ids=["absolute-system", "parent-escape", "absolute-tmp"],
+    )
+    def test_quick_rejects_paths_outside_repo(
+        self,
+        bad_path: str,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Review-fix #01 finding 7: `--quick` rejects paths that escape REPO_ROOT.
+
+        `REPO_ROOT / "/etc/passwd"` silently discards REPO_ROOT (pathlib
+        semantics) and `../foo` walks out of the tree. Both must error
+        with exit 2 + a clear message.
+        """
+        with (
+            patch("sys.argv", ["quality_gate.py", "--quick", bad_path]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "must be inside the repo" in err, (
+            f"path-escape message missing/changed: {err!r}"
+        )
+        assert bad_path in err, f"offending path must appear in error: {err!r}"
+
+    @pytest.mark.parametrize(
+        "argv_tail",
+        [[""], ["tests/test_foo.py", ""], ["", "tests/test_foo.py"]],
+        ids=["only-empty", "trailing-empty", "leading-empty"],
+    )
+    def test_quick_rejects_empty_string_paths(
+        self,
+        argv_tail: list[str],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Review-fix #01 finding 8: `--quick ""` must NOT silently subvert
+        the contract.
+
+        argparse `nargs="+"` accepts an empty string as a positional, and
+        `REPO_ROOT / ""` resolves back to REPO_ROOT, so pytest would walk
+        the entire suite. Reject empty-string paths explicitly.
+        """
+        with (
+            patch("sys.argv", ["quality_gate.py", "--quick", *argv_tail]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "must be non-empty" in err, (
+            f"empty-path message missing/changed: {err!r}"
+        )


### PR DESCRIPTION
## Summary
- Silence 9 pytest collection warnings (`__test__ = False` on the three `Test*Double` helpers in `tests/factories.py`) and 2 unawaited-coroutine warnings (mock `hass.async_create_task` via a `_consume_coro` side-effect that closes the bootstrap coroutine). Add a `tests/test_factories_pytest_opt_out.py` regression guard.
- Add `python scripts/qs/quality_gate.py --quick PATH [PATH ...]` for the TDD inner loop — runs pytest on cited files/dirs with xdist + sysmon, skips ruff/mypy/translations/coverage/cache/scope. Mutex with `--cache/--no-cache/--full/--fix`. Wire `_pytest_workers()` into `check_pytest_files` so the dev-only fast path also benefits from xdist.
- Update `qs-implement-task` agent (both `.claude/` and `.cursor/` mirrors), `docs/workflow/project-rules.md`, `docs/workflow/project-context.md`, and `AGENTS.md` to funnel test-running through `quality_gate.py` and document the forbidden-vs-allowed raw-`pytest` grammar rule.

Fixes #183

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a targeted "quick" mode to the quality gate for faster, focused test runs with validation and explicit error responses for bad flags/paths.

* **Documentation**
  * Made the quality gate the canonical test entry point and documented supported run modes, quick-mode usage, and constrained raw-test grammar.

* **Tests**
  * Added regression and coverage tests to enforce test-helper opt-outs, quick-mode behavior, and to prevent coroutine-related warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->