### PR TITLE
QS-185: build documentation hierarchy for AI agents (plan/implement/review) + drift checker + LSP evaluation

### DIFF
--- a/.claude/agents/qs-create-plan.md
+++ b/.claude/agents/qs-create-plan.md
@@ -47,6 +47,19 @@ Acceptance criteria as Given/When/Then. Task breakdown with concrete
 file paths and function names. Holds in memory — do NOT write the file
 yet.
 
+**Doc-maintenance sub-step.** Before finalising the breakdown, run
+
+```bash
+python scripts/qs/check_doc_drift.py --paths <planned_files>
+```
+
+(pass the list of files the plan intends to touch). For every doc
+surfaced by the checker, add a "Update `docs/agents/<path>`" task to
+the breakdown, OR add an explicit `Doc-OK: <reason>` note in the
+story explaining why the doc is unaffected. See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
 ### 4. Adversarial review (parallel)
 
 Spawn the four plan-reviewer subagents in **one message with four

--- a/.claude/agents/qs-implement-setup-task.md
+++ b/.claude/agents/qs-implement-setup-task.md
@@ -65,13 +65,14 @@ Smart scope detection skips the full suite when only dev files changed —
 runs the modified test files only. To force the full suite, use
 `--full`. Pass on a green gate; fix on red.
 
-**Doc-maintenance pre-commit sub-step.** Before staging, run
+**Doc-maintenance pre-commit sub-step.** After staging your
+intended changes (`git add` first so the diff is populated), run
 
 ```bash
 python scripts/qs/check_doc_drift.py
 ```
 
-on the staged diff. If exit 1, either update the listed
+against the staged diff. If exit 1, either update the listed
 `docs/agents/` docs and re-stage, or include a justification
 paragraph in the PR body under a `## Doc maintenance` heading
 explaining why the docs are unaffected. See

--- a/.claude/agents/qs-implement-setup-task.md
+++ b/.claude/agents/qs-implement-setup-task.md
@@ -65,6 +65,19 @@ Smart scope detection skips the full suite when only dev files changed —
 runs the modified test files only. To force the full suite, use
 `--full`. Pass on a green gate; fix on red.
 
+**Doc-maintenance pre-commit sub-step.** Before staging, run
+
+```bash
+python scripts/qs/check_doc_drift.py
+```
+
+on the staged diff. If exit 1, either update the listed
+`docs/agents/` docs and re-stage, or include a justification
+paragraph in the PR body under a `## Doc maintenance` heading
+explaining why the docs are unaffected. See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
 ### 5. Commit, push, open PR (automatic)
 
 ```bash

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -75,6 +75,19 @@ Must exit 0: pytest 100% coverage + ruff + mypy + translations. If it
 fails, fix autonomously and re-run. Only ask the user for direction
 after 2–3 unsuccessful attempts.
 
+**Doc-maintenance pre-commit sub-step.** Before staging, run
+
+```bash
+python scripts/qs/check_doc_drift.py
+```
+
+on the staged diff. If exit 1, either update the listed
+`docs/agents/` docs and re-stage, or include a justification
+paragraph in the PR body under a `## Doc maintenance` heading
+explaining why the docs are unaffected. See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
 ### 5. Commit, push, open PR (automatic)
 
 Once the gate is green, proceed **without asking**:

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -75,13 +75,14 @@ Must exit 0: pytest 100% coverage + ruff + mypy + translations. If it
 fails, fix autonomously and re-run. Only ask the user for direction
 after 2–3 unsuccessful attempts.
 
-**Doc-maintenance pre-commit sub-step.** Before staging, run
+**Doc-maintenance pre-commit sub-step.** After staging your
+intended changes (`git add` first so the diff is populated), run
 
 ```bash
 python scripts/qs/check_doc_drift.py
 ```
 
-on the staged diff. If exit 1, either update the listed
+against the staged diff. If exit 1, either update the listed
 `docs/agents/` docs and re-stage, or include a justification
 paragraph in the PR body under a `## Doc maintenance` heading
 explaining why the docs are unaffected. See

--- a/.claude/agents/qs-review-task.md
+++ b/.claude/agents/qs-review-task.md
@@ -71,11 +71,13 @@ Bucket into:
 Deduplicate across reviewers (`file:line` + similar text → one entry).
 
 **Doc-maintenance audit.** Inspect the PR body. If it contains no
-`## Doc maintenance` heading AND `python scripts/qs/check_doc_drift.py`
-against the PR's staged diff would exit 1 (drift detected), add a
+`## Doc maintenance` heading AND
+`python scripts/qs/check_doc_drift.py --paths <PR-changed-files>`
+invoked against the PR diff would exit 1 (drift detected), add a
 **must-fix** finding: "PR touches docs-tracked source without
 updating `docs/agents/` or providing a `## Doc maintenance`
-justification." See
+justification." Fetch the PR's changed paths via
+`gh pr view {{pr_number}} --json files --jq '.files[].path'`. See
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 "Doc maintenance".
 

--- a/.claude/agents/qs-review-task.md
+++ b/.claude/agents/qs-review-task.md
@@ -70,6 +70,15 @@ Bucket into:
 
 Deduplicate across reviewers (`file:line` + similar text → one entry).
 
+**Doc-maintenance audit.** Inspect the PR body. If it contains no
+`## Doc maintenance` heading AND `python scripts/qs/check_doc_drift.py`
+against the PR's staged diff would exit 1 (drift detected), add a
+**must-fix** finding: "PR touches docs-tracked source without
+updating `docs/agents/` or providing a `## Doc maintenance`
+justification." See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
 ### 4. Zero-findings fast path
 
 If there are no must-fix or should-fix findings, build the launcher

--- a/.cursor/agents/qs-create-plan.md
+++ b/.cursor/agents/qs-create-plan.md
@@ -44,6 +44,18 @@ Short scope/risk summary; ask clarifying questions; wait.
 Acceptance criteria as Given/When/Then. Task breakdown with concrete
 file paths and function names.
 
+**Doc-maintenance sub-step.** Before finalising the breakdown, run
+
+```bash
+python scripts/qs/check_doc_drift.py --paths <planned_files>
+```
+
+(pass the list of files the plan intends to touch). For every doc
+surfaced by the checker, add a "Update `docs/agents/<path>`" task to
+the breakdown, OR add an explicit `Doc-OK: <reason>` note in the
+story explaining why the doc is unaffected. See
+`docs/workflow/project-rules.md` "Doc maintenance".
+
 ### 4. Adversarial review (parallel)
 
 Spawn the four plan-reviewer subagents in **one message with four

--- a/.cursor/agents/qs-implement-setup-task.md
+++ b/.cursor/agents/qs-implement-setup-task.md
@@ -57,13 +57,14 @@ Present, ask "Ready to run the quality gate?".
 python scripts/qs/quality_gate.py
 ```
 
-**Doc-maintenance pre-commit sub-step.** Before staging, run
+**Doc-maintenance pre-commit sub-step.** After staging your
+intended changes (`git add` first so the diff is populated), run
 
 ```bash
 python scripts/qs/check_doc_drift.py
 ```
 
-on the staged diff. If exit 1, either update the listed
+against the staged diff. If exit 1, either update the listed
 `docs/agents/` docs and re-stage, or include a justification
 paragraph in the PR body under a `## Doc maintenance` heading
 explaining why the docs are unaffected. See

--- a/.cursor/agents/qs-implement-setup-task.md
+++ b/.cursor/agents/qs-implement-setup-task.md
@@ -57,6 +57,18 @@ Present, ask "Ready to run the quality gate?".
 python scripts/qs/quality_gate.py
 ```
 
+**Doc-maintenance pre-commit sub-step.** Before staging, run
+
+```bash
+python scripts/qs/check_doc_drift.py
+```
+
+on the staged diff. If exit 1, either update the listed
+`docs/agents/` docs and re-stage, or include a justification
+paragraph in the PR body under a `## Doc maintenance` heading
+explaining why the docs are unaffected. See
+`docs/workflow/project-rules.md` "Doc maintenance".
+
 ### 5. Commit, push, open PR (automatic)
 
 ```bash

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -65,13 +65,14 @@ python scripts/qs/quality_gate.py
 
 Must exit 0. Fix autonomously on failure. Escalate after 2–3 attempts.
 
-**Doc-maintenance pre-commit sub-step.** Before staging, run
+**Doc-maintenance pre-commit sub-step.** After staging your
+intended changes (`git add` first so the diff is populated), run
 
 ```bash
 python scripts/qs/check_doc_drift.py
 ```
 
-on the staged diff. If exit 1, either update the listed
+against the staged diff. If exit 1, either update the listed
 `docs/agents/` docs and re-stage, or include a justification
 paragraph in the PR body under a `## Doc maintenance` heading
 explaining why the docs are unaffected. See

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -65,6 +65,18 @@ python scripts/qs/quality_gate.py
 
 Must exit 0. Fix autonomously on failure. Escalate after 2–3 attempts.
 
+**Doc-maintenance pre-commit sub-step.** Before staging, run
+
+```bash
+python scripts/qs/check_doc_drift.py
+```
+
+on the staged diff. If exit 1, either update the listed
+`docs/agents/` docs and re-stage, or include a justification
+paragraph in the PR body under a `## Doc maintenance` heading
+explaining why the docs are unaffected. See
+`docs/workflow/project-rules.md` "Doc maintenance".
+
 ### 5. Commit, push, open PR (automatic)
 
 Once the gate is green, proceed **without asking**:

--- a/.cursor/agents/qs-review-task.md
+++ b/.cursor/agents/qs-review-task.md
@@ -50,12 +50,14 @@ Bucket: must-fix / should-fix / nice-to-have / invalid. Dedupe across
 reviewers.
 
 **Doc-maintenance audit.** Inspect the PR body. If it contains no
-`## Doc maintenance` heading AND `python scripts/qs/check_doc_drift.py`
-against the PR's staged diff would exit 1 (drift detected), add a
+`## Doc maintenance` heading AND
+`python scripts/qs/check_doc_drift.py --paths <PR-changed-files>`
+invoked against the PR diff would exit 1 (drift detected), add a
 **must-fix** finding: "PR touches docs-tracked source without
 updating `docs/agents/` or providing a `## Doc maintenance`
-justification." See `docs/workflow/project-rules.md` "Doc
-maintenance".
+justification." Fetch the PR's changed paths via
+`gh pr view {{pr_number}} --json files --jq '.files[].path'`. See
+`docs/workflow/project-rules.md` "Doc maintenance".
 
 ### 4. Zero-findings fast path
 

--- a/.cursor/agents/qs-review-task.md
+++ b/.cursor/agents/qs-review-task.md
@@ -49,6 +49,14 @@ invocations**:
 Bucket: must-fix / should-fix / nice-to-have / invalid. Dedupe across
 reviewers.
 
+**Doc-maintenance audit.** Inspect the PR body. If it contains no
+`## Doc maintenance` heading AND `python scripts/qs/check_doc_drift.py`
+against the PR's staged diff would exit 1 (drift detected), add a
+**must-fix** finding: "PR touches docs-tracked source without
+updating `docs/agents/` or providing a `## Doc maintenance`
+justification." See `docs/workflow/project-rules.md` "Doc
+maintenance".
+
 ### 4. Zero-findings fast path
 
 If no must-fix or should-fix:

--- a/.opencode/agents/qs-create-plan.md
+++ b/.opencode/agents/qs-create-plan.md
@@ -84,6 +84,19 @@ Acceptance criteria as Given/When/Then. Task breakdown with concrete
 file paths and function names. Holds in memory — do NOT write the file
 yet.
 
+**Doc-maintenance sub-step.** Before finalising the breakdown, run
+
+```bash
+python scripts/qs/check_doc_drift.py --paths <planned_files>
+```
+
+(pass the list of files the plan intends to touch). For every doc
+surfaced by the checker, add a "Update `docs/agents/<path>`" task to
+the breakdown, OR add an explicit `Doc-OK: <reason>` note in the
+story explaining why the doc is unaffected. See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
 ### 4. Adversarial review (parallel)
 
 Spawn the four plan-reviewer subagents in **one message with four

--- a/.opencode/agents/qs-implement-setup-task.md
+++ b/.opencode/agents/qs-implement-setup-task.md
@@ -119,13 +119,14 @@ Smart scope detection skips the full suite when only dev files changed —
 runs the modified test files only. To force the full suite, use
 `--full`. Pass on a green gate; fix on red.
 
-**Doc-maintenance pre-commit sub-step.** Before staging, run
+**Doc-maintenance pre-commit sub-step.** After staging your
+intended changes (`git add` first so the diff is populated), run
 
 ```bash
 python scripts/qs/check_doc_drift.py
 ```
 
-on the staged diff. If exit 1, either update the listed
+against the staged diff. If exit 1, either update the listed
 `docs/agents/` docs and re-stage, or include a justification
 paragraph in the PR body under a `## Doc maintenance` heading
 explaining why the docs are unaffected. See

--- a/.opencode/agents/qs-implement-setup-task.md
+++ b/.opencode/agents/qs-implement-setup-task.md
@@ -119,6 +119,19 @@ Smart scope detection skips the full suite when only dev files changed —
 runs the modified test files only. To force the full suite, use
 `--full`. Pass on a green gate; fix on red.
 
+**Doc-maintenance pre-commit sub-step.** Before staging, run
+
+```bash
+python scripts/qs/check_doc_drift.py
+```
+
+on the staged diff. If exit 1, either update the listed
+`docs/agents/` docs and re-stage, or include a justification
+paragraph in the PR body under a `## Doc maintenance` heading
+explaining why the docs are unaffected. See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
 ### 5. Commit, push, open PR (automatic)
 
 ```bash

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -114,13 +114,14 @@ Must exit 0: pytest 100% coverage + ruff + mypy + translations. If it
 fails, fix autonomously and re-run. Only ask the user for direction
 after 2–3 unsuccessful attempts.
 
-**Doc-maintenance pre-commit sub-step.** Before staging, run
+**Doc-maintenance pre-commit sub-step.** After staging your
+intended changes (`git add` first so the diff is populated), run
 
 ```bash
 python scripts/qs/check_doc_drift.py
 ```
 
-on the staged diff. If exit 1, either update the listed
+against the staged diff. If exit 1, either update the listed
 `docs/agents/` docs and re-stage, or include a justification
 paragraph in the PR body under a `## Doc maintenance` heading
 explaining why the docs are unaffected. See

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -114,6 +114,19 @@ Must exit 0: pytest 100% coverage + ruff + mypy + translations. If it
 fails, fix autonomously and re-run. Only ask the user for direction
 after 2–3 unsuccessful attempts.
 
+**Doc-maintenance pre-commit sub-step.** Before staging, run
+
+```bash
+python scripts/qs/check_doc_drift.py
+```
+
+on the staged diff. If exit 1, either update the listed
+`docs/agents/` docs and re-stage, or include a justification
+paragraph in the PR body under a `## Doc maintenance` heading
+explaining why the docs are unaffected. See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
 ### 5. Commit, push, open PR (automatic)
 
 Once the gate is green, proceed **without asking**:

--- a/.opencode/agents/qs-review-task.md
+++ b/.opencode/agents/qs-review-task.md
@@ -102,6 +102,15 @@ Bucket into:
 
 Deduplicate across reviewers (`file:line` + similar text → one entry).
 
+**Doc-maintenance audit.** Inspect the PR body. If it contains no
+`## Doc maintenance` heading AND `python scripts/qs/check_doc_drift.py`
+against the PR's staged diff would exit 1 (drift detected), add a
+**must-fix** finding: "PR touches docs-tracked source without
+updating `docs/agents/` or providing a `## Doc maintenance`
+justification." See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
 ### 4. Zero-findings fast path
 
 If there are no must-fix or should-fix findings, build the launcher

--- a/.opencode/agents/qs-review-task.md
+++ b/.opencode/agents/qs-review-task.md
@@ -103,11 +103,13 @@ Bucket into:
 Deduplicate across reviewers (`file:line` + similar text → one entry).
 
 **Doc-maintenance audit.** Inspect the PR body. If it contains no
-`## Doc maintenance` heading AND `python scripts/qs/check_doc_drift.py`
-against the PR's staged diff would exit 1 (drift detected), add a
+`## Doc maintenance` heading AND
+`python scripts/qs/check_doc_drift.py --paths <PR-changed-files>`
+invoked against the PR diff would exit 1 (drift detected), add a
 **must-fix** finding: "PR touches docs-tracked source without
 updating `docs/agents/` or providing a `## Doc maintenance`
-justification." See
+justification." Fetch the PR's changed paths via
+`gh pr view {{pr_number}} --json files --jq '.files[].path'`. See
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 "Doc maintenance".
 

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -1,0 +1,83 @@
+---
+title: Bistate-duration devices
+slug: bistate-duration-devices
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/bistate_duration.py
+  - custom_components/quiet_solar/ha_model/on_off_duration.py
+  - custom_components/quiet_solar/ha_model/pool.py
+last_verified: 2026-05-19
+---
+
+# Bistate-duration devices (pool, on/off duration)
+
+## TL;DR
+
+Bistate-duration devices are loads with two states (on / off) that
+must run for a **specified duration** rather than be modulated. Pool
+pumps, fixed-power boilers, and miscellaneous on/off duration loads
+all use this pattern.
+`ha_model/bistate_duration.py` provides the shared base;
+`ha_model/on_off_duration.py` is the simplest concrete subclass;
+`ha_model/pool.py` extends `on_off_duration` with
+temperature-dependent filter-duration logic. All three inherit the
+switching-cost protection pattern.
+
+## When you need this concept
+
+- Adding a new simple on/off device (irrigation, ventilation, fixed-
+  power resistive heater).
+- Touching pool-pump duration logic.
+- Working on the bistate constraint type
+  (`TimeBasedSimplePowerLoadConstraint`).
+- Tweaking switching-cost / hysteresis behaviour for on/off
+  devices.
+
+## Core idea
+
+A bistate-duration device has:
+
+- A fixed power draw when on.
+- A **target duration** (e.g., "run for 4 hours").
+- The same `num_max_on_off` + 10-minute hysteresis as every other
+  switching device.
+
+The solver consumes `TimeBasedSimplePowerLoadConstraint` for these
+— the constraint specifies "X hours at Y watts before deadline";
+the solver picks the cheapest contiguous (or split) windows.
+
+`QSPool` adds **temperature-dependent duration** on top of
+`QSOnOffDuration`: warmer water → longer filter duration. The
+extension overrides the duration calculation but inherits the rest
+of the on/off behaviour unchanged.
+
+## Key types / structures
+
+- `bistate_duration.py` — shared base (the lifecycle, the constraint
+  interface).
+- `QSOnOffDuration(HADeviceMixin, AbstractLoad)` — simple switch
+  loads.
+- `QSPool(QSOnOffDuration)` — temperature-aware filter duration.
+- `TimeBasedSimplePowerLoadConstraint` (in
+  `home_model/constraints.py`) — the constraint subclass these
+  devices use.
+
+## Common mistakes
+
+- Modulating power on a bistate device. The whole point is that
+  it's on or off; if you can modulate, use
+  [piloted-device-and-heat-pump.md](piloted-device-and-heat-pump.md)
+  or a charger pattern instead.
+- Forgetting the switching budget. On/off devices are the heaviest
+  consumers of `num_max_on_off` — debugging "the pool never ran"
+  often comes back to a tight daily limit.
+- Hard-coding pool filter duration. The temperature-dependent
+  helper on `QSPool` is the single source of truth.
+
+## See also
+
+- [load-base.md](load-base.md) — `AbstractLoad` base contract.
+- [constraints.md](constraints.md) — the
+  `TimeBasedSimplePowerLoadConstraint` subclass.
+- [../principles/hysteresis-and-switching-cost.md](../principles/hysteresis-and-switching-cost.md)
+  — the daily-budget pattern these devices inherit.

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -70,7 +70,7 @@ Then `apply_budget_strategy()`:
 
 ## Lifecycle / sequence (one update cycle)
 
-```
+```text
 All chargers stable for 45s? → dampening update (measure real power)
   ↓
 Detect transitions (single charger change → record power delta)

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -1,0 +1,112 @@
+---
+title: Charger Dynamic Budgeting
+slug: charger-budgeting
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/charger.py
+last_verified: 2026-05-19
+---
+
+# Charger Dynamic Budgeting — the tactical layer
+
+## TL;DR
+
+`ha_model/charger.py` is **trust-critical**: it's where the solver's
+strategic plan meets physical reality. The charger budgeting layer
+operates in 45-second adaptation windows (`CHARGER_ADAPTATION_WINDOW_S`),
+manages per-phase amp distribution across multiple chargers on the
+same circuit, and **can override the solver** when amp budgets
+conflict. Phase switching (1P↔3P), staged transitions, and dampening
+(real-power measurement) all live here. A bug in the solver makes a
+bad plan; a bug here trips a breaker.
+
+## When you need this concept
+
+- Implementing or modifying any charger behaviour
+  (`QSChargerGeneric`, `QSChargerOCPP`, `QSChargerWallbox`).
+- Touching the dynamic-group budgeting tree (see
+  [dynamic-group-tree.md](dynamic-group-tree.md)).
+- Working on phase switching, dampening, or adaptation-window logic.
+- Anything that could affect physical safety — circuit limits,
+  breaker margins, max amp per phase.
+
+## Core idea
+
+The budgeting algorithm (`budgeting_algorithm_minimize_diffs`):
+
+1. **Priority check**: if the highest-priority charger isn't charging
+   but a lower one is, trigger a reset allocation.
+2. **Prepare budgets**: either keep current amps (minimise
+   transitions) or reset to minimum (rebalance).
+3. **Shave mandatory**: if the minimum amps still exceed the group
+   limit, stop the lowest-score chargers first.
+4. **Shave current**: try phase switching (1P→3P) for lower-score
+   chargers before reducing amps.
+5. **Smart allocation loop**: iteratively adjust each charger's
+   budget toward the power target while respecting all constraints.
+
+Then `apply_budget_strategy()`:
+
+- For large changes, **stage** across two cycles: phase 1 reduces
+  decreasing chargers (frees up amps), phase 2 increases other
+  chargers next cycle (already validated safe).
+- `remaining_budget_to_apply` persists between cycles to complete
+  phase 2.
+
+## Key types / structures
+
+- `QSChargerGeneric` — base class. Power ramping, phase switching,
+  budgeting state machine.
+- `QSChargerOCPP` — OCPP variant. Adds transaction handling.
+- `QSChargerWallbox` — Wallbox variant. Maps vendor status enums.
+- `QSChargerGroup` — aggregates chargers on the same circuit.
+- `QSChargerStatus` — per-charger state (amps, phases, real power,
+  adaptation state).
+- `charge_score` — per-charger priority. Higher = wins budget
+  conflicts first.
+- `CHARGER_ADAPTATION_WINDOW_S = 45` — stability requirement before
+  rebalancing.
+- `CHARGER_STATE_REFRESH_INTERVAL_S = 14` — state-polling cadence.
+
+## Lifecycle / sequence (one update cycle)
+
+```
+All chargers stable for 45s? → dampening update (measure real power)
+  ↓
+Detect transitions (single charger change → record power delta)
+  ↓
+Budget reset opportunity? (20-min timeout or HP charger waiting)
+  ↓
+budgeting_algorithm_minimize_diffs()
+  → priority check → prepare budgets → shave mandatory → shave current
+  → smart allocation loop (iterative, phase limits)
+  ↓
+apply_budget_strategy()
+  IF large change: phase 1 (reduce first) → phase 2 (next cycle)
+  ELSE: apply directly
+```
+
+## Common mistakes
+
+- Changing budgeting logic without integration tests that simulate
+  multi-charger rebalancing sequences over time. Unit tests on a
+  single charger miss the trust-critical interactions.
+- Bypassing the dynamic-group tree's recursive validation. A leaf
+  charger can pass its local check while violating the parent
+  group's circuit limit.
+- Skipping the staged-transition split for "small" changes that
+  turn out to overshoot per-phase limits in transient. Apply
+  staging whenever the change crosses a phase boundary.
+- Treating `charge_score` as a tiebreaker. It's the primary ranking
+  for budget conflicts.
+
+## See also
+
+- [dynamic-group-tree.md](dynamic-group-tree.md) — the topology
+  budgeting walks.
+- [solver.md](solver.md) — the strategic layer that produces the
+  plan this layer may override.
+- [../principles/strategic-tactical-control.md](../principles/strategic-tactical-control.md)
+  — why the split exists.
+- [../use-cases/magali-plugs-in-car.md](../use-cases/magali-plugs-in-car.md)
+  — the magic-moment use case this layer enables.

--- a/docs/agents/concepts/commands.md
+++ b/docs/agents/concepts/commands.md
@@ -1,0 +1,89 @@
+---
+title: LoadCommand
+slug: commands
+kind: concept
+covers:
+  - custom_components/quiet_solar/home_model/commands.py
+last_verified: 2026-05-19
+---
+
+# LoadCommand
+
+## TL;DR
+
+A `LoadCommand` is a discrete action at a specific power level — the
+atom of quiet-solar's control vocabulary. 10 command types are
+ordered by a score (`CMD_ON=100` down to `CMD_OFF=10`); the score
+determines which command wins when two constraints overlap on the
+same load. Higher score = more aggressive intervention.
+`merge_commands()` combines two commands by taking the higher-scored
+type and the max power.
+
+## When you need this concept
+
+- Adding a new command type or modifying command merge semantics.
+- Implementing constraint conflict resolution.
+- Working on a device's `execute_command()` translation.
+- Debugging "wrong command was launched" issues.
+
+## Core idea
+
+A `LoadCommand` carries two fields: a `command` string (one of the
+10 constants `CMD_CST_*`) and a `power_consign` float (watts). The
+command string maps to a score in `commands_scores` — score ordering
+is the semantic meaning of the command hierarchy. When two
+constraints fire on the same load simultaneously, `merge_commands()`
+picks the higher-scored command type and the higher `power_consign`.
+
+Key distinction: `is_auto()` (green/price-aware modes that adapt to
+context), `is_green()` (solar-only modes that never import from the
+grid), and `is_off_or_idle()` (the device should not consume).
+
+## Key types / structures
+
+- `LoadCommand` — dataclass with `command: str`, `power_consign: float`.
+- `commands_scores` — dict mapping command type → integer score.
+- `merge_commands(cmd1, cmd2)` — merge two commands by score + max power.
+- `copy_command(cmd, power_consign=None)` — copy with optional power
+  override.
+- `copy_command_and_change_type(cmd, new_type)` — preserve power,
+  change command type.
+- Singleton commands: `CMD_ON`, `CMD_OFF`, `CMD_IDLE`, `CMD_AUTO_GREEN_ONLY`,
+  `CMD_AUTO_GREEN_CAP`, `CMD_AUTO_GREEN_CONSIGN`,
+  `CMD_AUTO_FROM_CONSIGN`, `CMD_AUTO_PRICE`, `CMD_FORCE_CHARGE`,
+  `CMD_GREEN_CHARGE_ONLY`, `CMD_GREEN_CHARGE_AND_DISCHARGE`.
+
+## Command-score table (descending)
+
+| Score | Constant | Meaning |
+|---|---|---|
+| 100 | `CMD_CST_ON` | Hard on, no constraint on power. |
+| 90 | `CMD_CST_FORCE_CHARGE` | Force-charge regardless of solar / price. |
+| 80 | `CMD_CST_AUTO_CONSIGN` | Auto, follows an explicit power setpoint. |
+| 70 | `CMD_CST_AUTO_PRICE` | Auto, price-aware. |
+| 60 | `CMD_CST_AUTO_GREEN_CONSIGN` | Auto-green with setpoint floor. |
+| 50 | `CMD_CST_GREEN_CHARGE_ONLY` | Solar-only charging (battery: charge only, no discharge). |
+| 40 | `CMD_CST_AUTO_GREEN` | Solar-aware (default). |
+| 30 | `CMD_CST_AUTO_GREEN_CAP` | Solar-aware with a hard cap (less flexible). |
+| 20 | `CMD_CST_IDLE` | Device is idle. |
+| 10 | `CMD_CST_OFF` | Device is off. |
+
+## Common mistakes
+
+- Comparing `LoadCommand` objects by identity instead of using `==`
+  (`__eq__` compares command + power_consign).
+- Assuming `merge_commands(a, b) == merge_commands(b, a)` for power
+  (it is, via `max`) but writing code that depends on the order of
+  the command type (the merge is deterministic but the score
+  ordering matters).
+- Introducing a new command without updating `commands_scores` — it
+  silently scores 0 (via `.get(command, 0)`) and loses every merge.
+
+## See also
+
+- [constraints.md](constraints.md) — constraints produce commands.
+- [solver.md](solver.md) — the solver assembles commands into a
+  timeline.
+- [../principles/strategic-tactical-control.md](../principles/strategic-tactical-control.md)
+  — the strategic vs tactical split that determines when commands
+  are launched vs when they're overridden.

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -1,0 +1,108 @@
+---
+title: Config flow and setup
+slug: config-and-setup-flow
+kind: concept
+covers:
+  - custom_components/quiet_solar/config_flow.py
+  - custom_components/quiet_solar/__init__.py
+  - custom_components/quiet_solar/data_handler.py
+  - custom_components/quiet_solar/const.py
+last_verified: 2026-05-19
+---
+
+# Config flow and setup
+
+## TL;DR
+
+The config flow is hierarchical: a top-level menu routes to device-
+type-specific steps, each of which composes a schema via the
+shared `get_common_schema()` builder. `__init__.py:async_setup_entry`
+hands control to `QSDataHandler`, which creates `QSHome` on the
+first config entry and queues subsequent device entries.
+`const.py` is the **single source of truth** for config keys —
+strings are never hardcoded anywhere else.
+
+## When you need this concept
+
+- Adding a new device type (you'll add a `CONF_TYPE_NAME_QS<Name>`
+  constant + a config-flow step + schema entries).
+- Modifying the common schema (3-phase, calendar, groups,
+  max on/off, etc.).
+- Touching device construction or config-entry lifecycle.
+- Working on UI translations (`strings.json`).
+
+## Core idea
+
+**Hierarchical menu pattern**:
+
+```
+async_step_user (top-level menu)
+  ├── async_step_<device_type> (per-type steps)
+  │   └── get_common_schema() → vol.Schema(...)
+  └── ConfigEntry created
+```
+
+**Common schema builder** (`get_common_schema()`):
+
+- Composable field set: name, power, 3-phase config, calendar
+  entity, group membership, max on/off, etc.
+- Reused across every device-type step so the user experience is
+  uniform.
+- Entity selectors filter by unit of measurement and **exclude
+  quiet-solar's own entities** (no self-referential setups).
+
+**Data handler lifecycle** (`data_handler.py`):
+
+1. First config entry → create `QSHome`.
+2. Subsequent entries → queue device construction via
+   `async_add_entry()` → `create_device_from_type()`.
+3. Device added to home → platforms (sensor/switch/number/select/
+   button) get factory calls → entities registered.
+
+## Key types / structures
+
+- `config_flow.py` — the flow steps.
+- `get_common_schema()` — the field composer.
+- `QSDataHandler` (in `data_handler.py`) — entry lifecycle manager.
+- `create_device_from_type()` — the per-type construction switch.
+- `CONF_*` constants in `const.py` — the only place config keys
+  exist.
+
+## Lifecycle
+
+```
+HA UI → config_flow.py step → ConfigEntry created
+  ↓
+__init__.py:async_setup_entry → QSDataHandler.async_add_entry
+  ↓
+create_device_from_type(config_entry.data) → device class instance
+  ↓
+home.add_device(device) → device.get_platforms()
+  ↓
+HA platform setup → create_ha_<platform>(device) → entities registered
+  ↓
+device.attach_ha_state_to_probe(...) for each tracked entity
+```
+
+## Common mistakes
+
+- Hardcoding a config key string instead of using a `CONF_*`
+  constant. Breaks every test that depends on the constant.
+- Adding a config-flow step that bypasses `get_common_schema()`. The
+  user experience diverges across device types.
+- Adding `CONF_*` keys directly in the flow file. Every key lives
+  in `const.py` — the flow imports them.
+- Editing `translations/en.json` directly. Always edit
+  `strings.json` and run `bash scripts/generate-translations.sh`.
+- Creating a device that doesn't register itself with `QSHome` via
+  `add_device()`. The device is invisible to the solver.
+
+## See also
+
+- [load-base.md](load-base.md) — what each device extends.
+- [ha-device-mixin.md](ha-device-mixin.md) — the bridge layer
+  every HA device class uses.
+- [qs-home-orchestrator.md](qs-home-orchestrator.md) — what
+  `QSDataHandler` instantiates.
+- [../../workflow/project-rules.md](../../workflow/project-rules.md)
+  — the `const.py` and translations rules.

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -35,7 +35,7 @@ strings are never hardcoded anywhere else.
 
 **Hierarchical menu pattern**:
 
-```
+```text
 async_step_user (top-level menu)
   ├── async_step_<device_type> (per-type steps)
   │   └── get_common_schema() → vol.Schema(...)
@@ -70,7 +70,7 @@ async_step_user (top-level menu)
 
 ## Lifecycle
 
-```
+```text
 HA UI → config_flow.py step → ConfigEntry created
   ↓
 __init__.py:async_setup_entry → QSDataHandler.async_add_entry

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -104,5 +104,8 @@ device.attach_ha_state_to_probe(...) for each tracked entity
   every HA device class uses.
 - [qs-home-orchestrator.md](qs-home-orchestrator.md) — what
   `QSDataHandler` instantiates.
+- [dashboard-and-cards.md](dashboard-and-cards.md) — step 0 of
+  the device-type checklist (the `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`
+  mapping) decides whether the new device appears on the dashboard.
 - [../../workflow/project-rules.md](../../workflow/project-rules.md)
   — the `const.py` and translations rules.

--- a/docs/agents/concepts/constraints.md
+++ b/docs/agents/concepts/constraints.md
@@ -1,0 +1,100 @@
+---
+title: LoadConstraint
+slug: constraints
+kind: concept
+covers:
+  - custom_components/quiet_solar/home_model/constraints.py
+last_verified: 2026-05-19
+---
+
+# LoadConstraint
+
+## TL;DR
+
+A `LoadConstraint` is a time-windowed demand on a load with progress
+tracking. Five priority tiers (MANDATORY_AS_FAST_AS_POSSIBLE down to
+FILLER_AUTO) determine the solver's allocation order. Every constraint
+carries `load_info` metadata (originator: prediction, agenda,
+user_override, system) so notifications and conflict resolution can
+trace where a demand came from. The solver reads constraints via
+`AbstractLoad.get_for_solver_constraints()` each cycle — never modify
+constraints in place; create new ones.
+
+## When you need this concept
+
+- Adding a feature that creates demand (a prediction, a calendar
+  trigger, a user override).
+- Designing a new constraint subclass for a new demand shape (power
+  vs duration vs SOC%).
+- Debugging "the system didn't honour my deadline" issues.
+- Working on the solver's allocation algorithm.
+
+## Core idea
+
+A constraint tracks `initial_value → current_value → target_value`
+with a percent-complete progress signal. It has a `start_time`
+(when the demand becomes eligible) and a deadline (varies by
+subclass). The solver walks constraints in priority order; for each,
+it picks the cheapest power slots that get from `current_value` to
+`target_value` before the deadline.
+
+The five priority tiers (highest first):
+
+1. **MANDATORY_AS_FAST_AS_POSSIBLE** (score 9) — schedule first,
+   minimize completion time regardless of cost or solar.
+2. **MANDATORY_END_TIME** (score 7) — must complete by deadline;
+   solver picks cheapest fitting slots.
+3. **BEFORE_BATTERY_GREEN** (score 5) — runs before battery switches
+   to solar-only mode (typically morning grid arbitrage).
+4. **FILLER** (score 3) — uses surplus only; never imports from grid.
+5. **FILLER_AUTO** (score 1) — opportunistic; runs whenever any
+   surplus exists.
+
+## Key types / structures
+
+- `LoadConstraint` — base class. Tracks progress and deadline.
+- `MultiStepsPowerLoadConstraint` — power-based with step options
+  (e.g., charger amperage levels).
+- `MultiStepsPowerLoadConstraintChargePercent` — SOC-based; target
+  is a battery percentage, not raw kWh.
+- `TimeBasedSimplePowerLoadConstraint` — duration-based (e.g., pool
+  pump runs for N hours at fixed power).
+- `load_info` dict — `{originator: "user_override" | "agenda" |
+  "prediction" | "system"}`. Mandatory metadata.
+
+## Lifecycle
+
+1. **Creation** — in `update_loads_constraints()` (the 7-second load
+   management cycle), constraints are pushed via
+   `push_live_constraint()` or `push_agenda_constraints()`.
+2. **Read** — `AbstractLoad.get_for_solver_constraints()` returns
+   active constraints to the solver.
+3. **Allocation** — solver assigns power slots; allocation order is
+   priority tier, then constraint score within tier.
+4. **Progress update** — as commands execute, `current_value`
+   advances; the constraint completes when `current_value >=
+   target_value`.
+5. **Completion / expiry** — completed constraints stay until the
+   next cycle, then are pruned.
+
+## Common mistakes
+
+- Creating a constraint in `__init__()` (too early — the solver
+  hasn't started). Always in `update_loads_constraints()`.
+- Creating a constraint without `load_info`. Notifications can't
+  explain "why" without it.
+- Modifying an existing constraint instead of creating a new one.
+  The solver re-reads constraints each cycle; mutating mid-cycle
+  causes inconsistent allocations.
+- Picking the wrong tier — `MANDATORY_AS_FAST_AS_POSSIBLE` over-eager
+  scheduling that ignores cheap-grid windows; or `FILLER` for a
+  user-pinned demand that ends up never running on a cloudy day.
+
+## See also
+
+- [commands.md](commands.md) — constraints produce `LoadCommand`s.
+- [solver.md](solver.md) — the allocator.
+- [user-override.md](user-override.md) — `load_info: {originator:
+  "user_override"}` flow.
+- [../principles/observe-predict-optimize.md](../principles/observe-predict-optimize.md)
+  — why constraints are the right abstraction.

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -1,0 +1,242 @@
+---
+title: Dashboard generation and JS Lovelace cards
+slug: dashboard-and-cards
+kind: concept
+covers:
+  - custom_components/quiet_solar/ui/dashboard.py
+  - custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
+  - custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2
+  - custom_components/quiet_solar/ui/resources/qs-car-card.js
+  - custom_components/quiet_solar/ui/resources/qs-pool-card.js
+  - custom_components/quiet_solar/ui/resources/qs-climate-card.js
+  - custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
+last_verified: 2026-05-19
+---
+
+# Dashboard generation and JS Lovelace cards
+
+## TL;DR
+
+On first install, quiet-solar **auto-generates two storage-mode HA
+Lovelace dashboards** by rendering two Jinja2 templates against the
+live `QSHome`:
+
+- **"Quiet Solar"** (`quiet-solar` URL, custom cards) — renders the
+  four bundled JS Lovelace cards (`qs-car-card`, `qs-pool-card`,
+  `qs-climate-card`, `qs-on-off-duration-card`), one per device type
+  that has a dedicated card.
+- **"Quiet Std"** (`quiet-solar-standard` URL, standard cards) —
+  renders the same data using only built-in HA cards (no JS cards
+  required). This is the fallback for households who want a
+  zero-custom-resource setup.
+
+Both dashboards iterate `home.dashboard_sections` (a list of
+`(section_name, icon)` tuples derived from
+`LOAD_TYPE_DASHBOARD_DEFAULT_SECTION` in `const.py`) and pull
+devices via `home.get_devices_for_dashboard_section(name)`. Cards
+within each section read the device's `ha_entities` dict to wire
+specific entity IDs — the dashboard never hard-codes entity ids; it
+always asks the device. JS resources live under
+`ui/resources/`, are copied to `<config>/www/quiet_solar/` on every
+HA start, and are registered as Lovelace resources with a
+`?qs_tag=<epoch>` cache-buster so a component update reloads them in
+the browser.
+
+## When you need this concept
+
+- Adding a new device type — decide whether it gets a dedicated JS
+  card (rare) or just appears as a standard `entities` card; map it
+  to a dashboard section via `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`
+  in `const.py`.
+- Modifying either Jinja2 template (e.g. surfacing a new entity in a
+  card, changing section ordering, conditionally hiding a card).
+- Touching the JS cards' input contract — i.e., the per-type
+  `entities:` block in the template that the JS card consumes.
+- Working on dashboard registration, restoration after restart, or
+  the JS resource cache-busting.
+- Debugging "my device appears under the wrong section" or "the
+  dashboard didn't refresh after I added a charger" issues.
+
+## Core idea
+
+### Two dashboards, one source of truth
+
+`ui/dashboard.py` defines two `dashboard_def` dicts
+(`DASHBOARD_CUSTOM` and `DASHBOARD_STANDARD`) and a list
+`ALL_DASHBOARDS = [DASHBOARD_CUSTOM, DASHBOARD_STANDARD]`.
+`generate_dashboard_yaml(home)` walks that list, reads each
+`template_filename`, renders it with HA's `Template` engine (so the
+templates have full access to HA jinja helpers), parses the
+resulting YAML with `yaml.safe_load`, and pushes the dict into a
+**storage-mode** `LovelaceStorage` instance. Storage mode means no
+YAML on disk and no `configuration.yaml` entries — the dashboard
+lives entirely in HA's `.storage/` directory and survives restarts.
+
+The "Quiet Std" template uses only built-in HA cards, so a household
+that doesn't trust the bundled JS can switch to that dashboard
+without losing any functionality (just visual polish).
+
+### Section mapping in `const.py`
+
+The dashboard is organized into **sections** (`cars`, `climates`,
+`pools`, `others`, `settings`). Each device type has a default
+section in `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`; TheAdmin can
+override per-device via the `CONF_DASHBOARD_SECTION_NAME` config
+field. `QSHome.dashboard_sections` is the in-memory list of active
+sections (deduplicated, ordered as configured); the templates
+iterate this list and call
+`home.get_devices_for_dashboard_section(section_name)` to find
+which devices to render in that section.
+
+### Per-device-type card dispatch (custom template)
+
+`quiet_solar_dashboard_template.yaml.j2` contains the per-type
+switch:
+
+```jinja
+{%- if  device.device_type == "car" %}
+- type: custom:qs-car-card
+{%- elif  device.device_type == "pool" %}
+- type: custom:qs-pool-card
+{%- elif  device.device_type == "climate" %}
+- type: custom:qs-climate-card
+{%- elif  device.device_type == "on_off_duration" %}
+- type: custom:qs-on-off-duration-card
+{%- else %}
+- type: entities
+{%- endif %}
+```
+
+The four JS cards have card-specific YAML input shapes (e.g.,
+`qs-car-card` expects `soc:`, `range_now:`, `charge_type:`, etc.).
+Every key resolves to an entity ID via `device.ha_entities.get(...)`
+— so the template translates "the device knows about a certain
+state" into "the JS card reads this entity". If a key is missing on
+the device, the template skips that line and the JS card simply
+doesn't render that row.
+
+### JS resources lifecycle
+
+`async_update_resources(hass)` runs on **every** HA start. It walks
+the bundled `ui/resources/` directory, copies each JS file to
+`<config>/www/quiet_solar/<filename>`, and registers it as a
+Lovelace resource at URL
+`/local/quiet_solar/<filename>?qs_tag=<epoch>`. The `qs_tag` query
+parameter changes on each start (epoch-derived), so browsers reload
+the updated JS without a hard refresh. Dashboard **content** is NOT
+touched on startup — only the JS resources — so any manual edits
+TheAdmin made to the dashboards survive an upgrade.
+
+### Tracking storage (survives restart)
+
+`QS_DASHBOARDS_STORAGE_KEY` (`quiet_solar_dashboards`) records which
+dashboards have been generated. On first install (no tracking data),
+`async_auto_generate_if_first_install(home)` triggers the full
+render. On subsequent starts, `async_restore_dashboards_and_update_resources(hass)`
+just re-registers the panels (so they reappear in the sidebar) and
+refreshes the JS resources — dashboard content is left alone.
+
+## Key types / structures
+
+- `generate_dashboard_yaml(home)` — main entry. Renders both Jinja
+  templates and pushes the result into Lovelace storage.
+- `async_auto_generate_if_first_install(home)` — gated by tracking
+  data; runs the full generate once.
+- `async_restore_dashboards_and_update_resources(hass)` — per-start
+  re-registration + JS refresh.
+- `async_update_resources(hass)` — copy + cache-bust JS card files.
+- `async_unregister_dashboards(hass)` — full teardown (called from
+  the data handler on integration removal).
+- `DASHBOARD_CUSTOM`, `DASHBOARD_STANDARD`, `ALL_DASHBOARDS` —
+  dashboard definitions in `ui/dashboard.py`.
+- `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION` / `DASHBOARD_DEFAULT_SECTIONS`
+  / `DASHBOARD_DEFAULT_SECTIONS_DICT` / `DASHBOARD_NO_SECTION`
+  — section taxonomy in `const.py`.
+- `QSHome.dashboard_sections` — in-memory ordered list of active
+  sections.
+- `QSHome.get_devices_for_dashboard_section(name)` — per-section
+  device lookup the templates rely on.
+- `HADeviceMixin.ha_entities` — the dict the templates query
+  (`device.ha_entities.get("car_soc_percentage")` etc.).
+
+## Lifecycle
+
+```text
+First install:
+  QSDataHandler.async_setup_entry()
+    → QSHome created → devices created → ha_entities populated
+    → async_auto_generate_if_first_install(home)
+      → no tracking data → generate_dashboard_yaml(home)
+        → for each dashboard_def in ALL_DASHBOARDS:
+            read template → Template.async_render(home=home)
+            → yaml.safe_load → push into LovelaceStorage
+        → _async_save_dashboard_tracking(hass) [records "done"]
+        → async_update_resources(hass) [copy + cache-bust JS]
+
+Subsequent HA starts:
+  async_setup → async_restore_dashboards_and_update_resources(hass)
+    → tracking data present → re-register panels (sidebar entries)
+    → async_update_resources(hass) [refresh JS only]
+    → dashboard CONTENT is never touched — TheAdmin's edits survive
+```
+
+## The four JS Lovelace cards
+
+| Card | Card type | Device types | Source |
+|---|---|---|---|
+| Car | `custom:qs-car-card` | `QSCar` | `ui/resources/qs-car-card.js` |
+| Pool | `custom:qs-pool-card` | `QSPool` | `ui/resources/qs-pool-card.js` |
+| Climate | `custom:qs-climate-card` | `QSClimateDuration`, `QSHeatPump` | `ui/resources/qs-climate-card.js` |
+| On-off duration | `custom:qs-on-off-duration-card` | `QSOnOffDuration` | `ui/resources/qs-on-off-duration-card.js` |
+
+The cards are **outside the quality pipeline**: no JS tests, no JS
+linter, no build step. The product brief explicitly says "don't
+modify JS without explicit instruction" — this is a known gap
+(architecture.md "UI Stack KNOWN GAP"). Any change to a card's
+input contract (new YAML key, renamed key, type change) must be
+mirrored in **both** templates AND the JS file, or the dashboard
+silently degrades for one of the two configurations.
+
+## Common mistakes
+
+- **Forgetting the section mapping in `const.py`** when adding a
+  new device type. The device exists and works, but is invisible
+  on both dashboards — `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`
+  defaulting to `None` puts it in `DASHBOARD_NO_SECTION`. The 7-
+  file device-type checklist mentions this; the dashboard is
+  step 0.
+- **Hard-coding an entity ID in a template**. Always go through
+  `device.ha_entities.get("key")` so the template stays portable
+  across config changes. Adding `entity_id` strings directly
+  breaks the moment HA re-allocates them.
+- **Modifying one template and forgetting the other**. The custom
+  and standard templates render the same data through different
+  card families. A new entity in one must land in both, or the
+  "Quiet Std" dashboard becomes incomplete.
+- **Modifying a JS card without testing**. The cards are
+  untested artifacts (KNOWN GAP). Changes must be visually
+  verified against a real HA install — they cannot be caught by
+  the quality gate.
+- **Skipping the cache-buster**. If JS is updated without a new
+  `qs_tag`, browsers serve a stale cached version. The
+  `_generate_qs_tag()` helper uses `time.time()` so every restart
+  produces a fresh tag — don't bypass it.
+- **Calling `generate_dashboard_yaml` on every startup**. It
+  overwrites manual edits TheAdmin made. Only the first-install
+  helper triggers the full render; subsequent starts use the
+  restore path.
+
+## See also
+
+- [config-and-setup-flow.md](config-and-setup-flow.md) — the 7-file
+  device-type checklist, including the `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`
+  step 0.
+- [ha-device-mixin.md](ha-device-mixin.md) — the `ha_entities` dict
+  the templates query.
+- [qs-home-orchestrator.md](qs-home-orchestrator.md) — `QSHome`
+  owns `dashboard_sections` and the per-section device lookup.
+- [../personas/the-admin.md](../personas/the-admin.md) — the
+  persona who lives on the dashboard.
+- [../personas/magali.md](../personas/magali.md) — Magali doesn't
+  open the dashboard, she taps the mobile app — but her override
+  flow surfaces in the qs-car-card.

--- a/docs/agents/concepts/dynamic-group-tree.md
+++ b/docs/agents/concepts/dynamic-group-tree.md
@@ -45,7 +45,7 @@ Per-phase operations on amp arrays:
 
 Tree topology:
 
-```
+```text
 QSHome (root, phase limit = main breaker)
 ├── QSDynamicGroup "EV charging circuit" (limit = sub-breaker)
 │   ├── QSChargerGeneric "car_1"

--- a/docs/agents/concepts/dynamic-group-tree.md
+++ b/docs/agents/concepts/dynamic-group-tree.md
@@ -1,0 +1,85 @@
+---
+title: QSDynamicGroup (amp-budget tree)
+slug: dynamic-group-tree
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/dynamic_group.py
+last_verified: 2026-05-19
+---
+
+# QSDynamicGroup — hierarchical amp budgeting
+
+## TL;DR
+
+`QSDynamicGroup` is the tree topology that enforces phase-by-phase
+amp budgets across the whole house. `QSHome` is the root; dynamic
+groups are interior nodes; chargers are leaves. Budgets are always
+expressed as `[phase1, phase2, phase3]` arrays. Validation is
+**recursive**: a leaf can pass its local check yet still fail the
+parent group's circuit limit, so every command launch walks the tree
+from leaf to root.
+
+## When you need this concept
+
+- Adding a new circuit topology (e.g., a sub-panel with its own
+  breaker).
+- Modifying budget validation, phase math, or amp diff calculations.
+- Debugging "the system tripped a breaker" issues — start here.
+- Working on the staged-transition logic that interacts with the
+  tree.
+
+## Core idea
+
+Two validation methods:
+
+- `is_delta_current_acceptable()` — planning-phase check: "will this
+  change fit in my budget?". Used before scheduling.
+- `is_current_acceptable_and_diff()` — execution-phase check: takes
+  the worst-case max of (actual measured current + estimated
+  consumption). Used right before a command is launched.
+
+Per-phase operations on amp arrays:
+
+- `add_amps(a, b)`, `diff_amps(a, b)`, `is_amps_greater(a, b)`,
+  `min_amps(a, b)`, `max_amps(a, b)`.
+
+Tree topology:
+
+```
+QSHome (root, phase limit = main breaker)
+├── QSDynamicGroup "EV charging circuit" (limit = sub-breaker)
+│   ├── QSChargerGeneric "car_1"
+│   └── QSChargerOCPP "car_2"
+└── QSChargerWallbox "wallbox_main"
+```
+
+Every command launch validates from leaf to root.
+
+## Key types / structures
+
+- `QSDynamicGroup(HADeviceMixin, AbstractDevice)` — tree node.
+- `is_delta_current_acceptable(delta_amps)` — planning check.
+- `is_current_acceptable_and_diff(target_amps)` — execution check
+  with measured worst case.
+- Phase-arithmetic helpers — all operate on length-3 arrays.
+
+## Common mistakes
+
+- Working with scalar amps when the rest of the system expects
+  3-phase arrays. Treat amps as `[phase1, phase2, phase3]`
+  everywhere.
+- Skipping the recursive walk. A leaf-only validation can pass while
+  the home root is already at its main-breaker limit.
+- Confusing the two validation methods. Planning-phase is for "will
+  this fit"; execution-phase is for "is it safe right now".
+- Forgetting that phase switching (1P→3P) reduces per-phase load but
+  doesn't change total power. The tree validation accounts for
+  that.
+
+## See also
+
+- [charger-budgeting.md](charger-budgeting.md) — the algorithm that
+  walks this tree.
+- [qs-home-orchestrator.md](qs-home-orchestrator.md) — the root.
+- [../principles/strategic-tactical-control.md](../principles/strategic-tactical-control.md)
+  — why amp budgeting is tactical, not strategic.

--- a/docs/agents/concepts/external-control-detection.md
+++ b/docs/agents/concepts/external-control-detection.md
@@ -1,0 +1,83 @@
+---
+title: External control detection
+slug: external-control-detection
+kind: concept
+covers:
+  - custom_components/quiet_solar/home_model/load.py
+  - custom_components/quiet_solar/ha_model/device.py
+last_verified: 2026-05-19
+---
+
+# External control detection
+
+## TL;DR
+
+If a device's state changes in a way quiet-solar didn't request —
+because a human pressed a physical button, another HA integration
+sent a command, or the device's own app issued an instruction —
+quiet-solar **detects this** and steps back rather than fighting the
+human. The detection logic lives in `home_model/load.py`
+(`external_user_initiated_state`) and is set during
+`HADeviceMixin.update_states()` in `ha_model/device.py`.
+
+## When you need this concept
+
+- Implementing a new device's `probe_if_command_set()` or
+  `update_states()`.
+- Designing a feature that interacts with externally-controlled
+  devices.
+- Debugging "quiet-solar keeps overriding my manual setting" issues.
+- Working on the boost-only / free-solar-only flows.
+
+## Core idea
+
+Every cycle, `update_states()` compares observed HA state to the
+state quiet-solar expected based on the most recently launched
+command. If they don't match — and the mismatch can't be explained
+by transient noise — the device was controlled externally.
+
+When external control is detected:
+
+1. `external_user_initiated_state` is set on the load.
+2. The solver sees the device as effectively unavailable for
+   automation: existing constraints are paused, no new commands
+   are issued.
+3. The behaviour persists for a configurable cool-down — long
+   enough that the human knows they have the device, short enough
+   that quiet-solar resumes once the external session ends.
+4. Recovery is automatic: once observed state stabilises in a way
+   consistent with quiet-solar control, the flag clears.
+
+This is the structural defence behind "embrace uncertainty" —
+quiet-solar doesn't assume it has exclusive control of the device.
+
+## Key types / structures
+
+- `AbstractLoad.external_user_initiated_state` — the flag.
+- `HADeviceMixin.update_states()` — sets the flag based on state
+  divergence.
+- `probe_if_command_set()` — per-device override point for
+  device-specific divergence semantics.
+
+## Common mistakes
+
+- Treating any state divergence as "command failed" instead of
+  "external control". The two need separate handling.
+- Implementing a `probe_if_command_set` that's too lenient (accepts
+  any state as "command set"). External control then goes
+  undetected.
+- Forgetting to clear the flag on recovery. The device gets stuck
+  in "external" mode and quiet-solar never resumes control.
+- Conflating external control with user override. External =
+  someone else is driving; user override = the user told *us* to
+  drive differently. See [user-override.md](user-override.md).
+
+## See also
+
+- [load-base.md](load-base.md) — where the flag lives.
+- [ha-device-mixin.md](ha-device-mixin.md) — where the detection
+  happens.
+- [user-override.md](user-override.md) — the related-but-distinct
+  flow.
+- [../use-cases/external-override.md](../use-cases/external-override.md)
+  — end-to-end scenario.

--- a/docs/agents/concepts/ha-battery.md
+++ b/docs/agents/concepts/ha-battery.md
@@ -1,0 +1,82 @@
+---
+title: QSBattery (ha_model)
+slug: ha-battery
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/battery.py
+last_verified: 2026-05-19
+---
+
+# QSBattery (ha_model) — HA-facing battery integration
+
+## TL;DR
+
+`QSBattery` is the HA-side battery class. It inherits
+`HADeviceMixin` plus the pure-domain `home_model/battery.py` model
+([home-model-battery.md](home-model-battery.md)) and translates the
+solver's `LoadCommand`s into HA service calls (write SOC setpoint via
+an HA number entity, toggle charge/discharge enable via switch
+entities). It attaches HA state probes for SOC, charge power, and
+discharge power so the solver always sees fresh state.
+
+## When you need this concept
+
+- Integrating a new battery vendor (e.g., a new inverter brand).
+- Changing how SOC / power are read from HA entities.
+- Modifying the discharge-enable / charge-enable switch wiring.
+- Debugging "the battery isn't following the plan" issues.
+
+## Core idea
+
+The `HADeviceMixin` bridge pattern: `QSBattery` extends both
+`HADeviceMixin` and the domain `Battery` class. State flows in
+through `HADeviceMixin.add_to_history()` (SOC, power, capacity-derived
+signals); commands flow out through `execute_command()` →
+`hass.services.async_call(...)`. The probe-update cycle handles
+external state changes: if a human turns off discharge via the
+inverter UI, `probe_if_command_set()` detects the discrepancy and the
+device's `external_user_initiated_state` is updated.
+
+## Key types / structures
+
+- `QSBattery(HADeviceMixin, Battery)` — the bridge class.
+- `execute_command(time, command)` — maps `LoadCommand` →
+  `hass.services.async_call(number/switch)`.
+- `probe_if_command_set(time, command)` — reads HA entity state to
+  verify command landed.
+- HA entities attached: SOC sensor, charge/discharge power sensors,
+  charge enable + discharge enable switches, target-SOC number.
+
+## Lifecycle
+
+```
+Config flow → QSBattery created → attach HA probes
+  ↓
+update_states() reads HA → updates Battery SOC, power
+  ↓
+solver computes LoadCommand
+  ↓
+execute_command() → hass.services.async_call(...)
+  ↓
+probe_if_command_set() observes state change → acked
+```
+
+## Common mistakes
+
+- Adding battery logic in `ha_model/battery.py` that doesn't need
+  HA. It belongs in `home_model/battery.py`.
+- Calling `hass.services.async_call` synchronously. All HA I/O is
+  async; blocking calls freeze the event loop.
+- Forgetting to attach a probe for a state quiet-solar needs to
+  trust. If the SOC sensor isn't wired, the solver plans on stale
+  data.
+
+## See also
+
+- [home-model-battery.md](home-model-battery.md) — the pure-domain
+  counterpart.
+- [ha-device-mixin.md](ha-device-mixin.md) — the bridge layer.
+- [commands.md](commands.md) — the action language `execute_command`
+  consumes.
+- [../use-cases/solar-surplus-allocation.md](../use-cases/solar-surplus-allocation.md)
+  — surplus → battery charging end-to-end.

--- a/docs/agents/concepts/ha-battery.md
+++ b/docs/agents/concepts/ha-battery.md
@@ -49,7 +49,7 @@ device's `external_user_initiated_state` is updated.
 
 ## Lifecycle
 
-```
+```text
 Config flow → QSBattery created → attach HA probes
   ↓
 update_states() reads HA → updates Battery SOC, power

--- a/docs/agents/concepts/ha-device-mixin.md
+++ b/docs/agents/concepts/ha-device-mixin.md
@@ -1,0 +1,79 @@
+---
+title: HADeviceMixin
+slug: ha-device-mixin
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/device.py
+last_verified: 2026-05-19
+---
+
+# HADeviceMixin — the bridge layer
+
+## TL;DR
+
+`HADeviceMixin` is the bridge between HA entities and quiet-solar's
+domain model. Every HA device class inherits from `HADeviceMixin`
+plus a domain class (e.g., `QSBattery(HADeviceMixin, Battery)`). It
+owns: HA entity probing (`attach_ha_state_to_probe()` with numerical
+conversion and custom getters), time-series history (auto-trimmed to
+3 days), power-to-energy conversion via Riemann sum, and a reverse
+index of HA entities by description key (`ha_entities` dict) that
+the dashboard templates query.
+
+## When you need this concept
+
+- Adding a new device type — the HA-side class extends this mixin.
+- Modifying how HA state flows into the domain model.
+- Working on the dashboard (which queries `ha_entities`).
+- Touching history trimming, Riemann-sum energy computation, or
+  state probing.
+
+## Core idea
+
+The bridge pattern: every HA device class is two halves stitched
+together. `HADeviceMixin` is one half — it knows about HA service
+calls, entity registries, and state changes. The domain class is the
+other half — it knows about the solver, constraints, and commands.
+The mixin's job is to translate between them:
+
+- **State in**: `add_to_history(time, value)` appends to a numpy
+  ring buffer; trimmed to 3 days. Used by the solver for "what's
+  happened recently".
+- **State probing**: `attach_ha_state_to_probe(entity_id, key,
+  getter=..., transform=..., numerical_conversion=True)` —
+  declarative wiring of one HA entity → one tracked state.
+- **Commands out**: the domain class (`AbstractDevice`) calls
+  `execute_command()`; the device-specific subclass translates to
+  `hass.services.async_call(...)`.
+- **Dashboard index**: every probed entity registers itself in
+  `ha_entities` keyed by description; the Jinja2 dashboard reads
+  `device.ha_entities.get(key)` to find the entity ID at render
+  time.
+
+## Key types / structures
+
+- `HADeviceMixin` — the mixin.
+- `attach_ha_state_to_probe(...)` — declarative entity wiring.
+- `add_to_history(time, value)` — numpy-backed time series.
+- `ha_entities` dict — reverse index from description key → entity.
+- Riemann-sum energy helpers (power → energy over a time window).
+
+## Common mistakes
+
+- Storing HA state directly on the domain object instead of going
+  through `add_to_history()`. The history is what the solver uses.
+- Forgetting to register a description key in `ha_entities` — the
+  entity exists but the dashboard can't find it.
+- Treating the 3-day history as authoritative for long-term analysis.
+  It's deliberately short-lived; persistent history lives in the
+  numpy ring buffer (separate concept).
+- Doing custom transforms in the dashboard template. All conversion
+  happens in `attach_ha_state_to_probe` via `transform=...`.
+
+## See also
+
+- [load-base.md](load-base.md) — the domain-side counterpart.
+- [config-and-setup-flow.md](config-and-setup-flow.md) — how devices
+  are constructed and wired.
+- [../principles/two-layer-boundary.md](../principles/two-layer-boundary.md)
+  — why this bridge exists.

--- a/docs/agents/concepts/home-model-battery.md
+++ b/docs/agents/concepts/home-model-battery.md
@@ -1,0 +1,73 @@
+---
+title: Battery (home_model)
+slug: home-model-battery
+kind: concept
+covers:
+  - custom_components/quiet_solar/home_model/battery.py
+last_verified: 2026-05-19
+---
+
+# Battery (home_model) — pure-domain charge/discharge model
+
+## TL;DR
+
+`home_model/battery.py` is the pure-Python battery model used by the
+solver. It computes safe charge / discharge power respecting SOC
+bounds, inverter power limits, and DC-coupled awareness (whether the
+battery shares an inverter with PV). It is **independent of HA** —
+the HA-facing `QSBattery` lives in `ha_model/battery.py`
+([ha-battery.md](ha-battery.md)). The split exists so the solver can
+reason about batteries in unit tests without any HA dependency.
+
+## When you need this concept
+
+- Modifying the solver's battery optimisation step.
+- Adding a new battery topology (e.g., AC-coupled vs DC-coupled).
+- Changing how SOC bounds, charge/discharge power, or efficiency
+  factor in.
+- Writing tests that exercise battery logic without HA fixtures.
+
+## Core idea
+
+The model exposes battery state and safe-action queries:
+
+- **SOC bounds**: floor and ceiling expressed as percentages; the
+  model refuses to charge above the ceiling or discharge below the
+  floor.
+- **Power limits**: charge and discharge are clamped to the inverter's
+  rated limits, separately.
+- **DC-coupled awareness**: when the battery shares an inverter with
+  the PV array, charging from PV avoids the AC↔DC round-trip — the
+  model exposes this so the solver can prefer DC-coupled charging
+  during PV surplus windows.
+
+The solver calls into this model during step 3 of the allocation
+algorithm (battery optimisation to minimise grid imports).
+
+## Key types / structures
+
+- `Battery` — dataclass-style domain object. Holds SOC, capacity,
+  charge/discharge power limits, DC-coupled flag.
+- Safe-charge / safe-discharge helpers — clamp to SOC bounds +
+  inverter limits.
+
+## Common mistakes
+
+- Implementing battery logic in `ha_model/battery.py` that should
+  live in this file. Anything that doesn't need HA APIs belongs in
+  `home_model/`.
+- Forgetting the DC-coupled distinction when reasoning about
+  efficiency. AC-coupled batteries have a round-trip penalty that
+  DC-coupled don't.
+- Ignoring SOC bounds when computing "available capacity". The solver
+  must use the *usable* range, not the nominal capacity.
+
+## See also
+
+- [ha-battery.md](ha-battery.md) — the HA-side `QSBattery`.
+- [solver.md](solver.md) — calls into this model during battery
+  optimisation.
+- [../principles/two-layer-boundary.md](../principles/two-layer-boundary.md)
+  — why this file is HA-free.
+- [../use-cases/cheap-grid-charging.md](../use-cases/cheap-grid-charging.md)
+  — battery + tariff interaction.

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -1,0 +1,102 @@
+---
+title: AbstractDevice / AbstractLoad
+slug: load-base
+kind: concept
+covers:
+  - custom_components/quiet_solar/home_model/load.py
+last_verified: 2026-05-19
+---
+
+# AbstractDevice & AbstractLoad
+
+## TL;DR
+
+`AbstractDevice` is the base for all controllable devices. It owns
+configuration, the command lifecycle (pending → launched → acked,
+with stacking for busy devices), and switching-cost protection
+(`num_max_on_off` daily budget plus a 10-minute hysteresis). It is
+3-phase aware. `AbstractLoad` extends `AbstractDevice` and adds the
+constraint-management surface (`get_for_solver_constraints()` is the
+solver's entry point), plus green-only mode, user override state, and
+external-control detection. **Both live in `home_model/load.py` —
+strict zero-HA-import boundary.**
+
+## When you need this concept
+
+- Adding a new device type — you'll extend `AbstractLoad` (or, rarely,
+  `AbstractDevice` if it doesn't participate in solving).
+- Changing command lifecycle semantics.
+- Touching switching-cost protection (the daily on/off budget +
+  hysteresis pattern).
+- Working on external-control detection or user-override handling.
+
+## Core idea
+
+**Behavioral contract**: `AbstractLoad` defines guarantees every
+device type must honour. Device-specific tests validate *deviations*
+from that contract — don't re-test the contract itself. This is a
+contract-testing pattern.
+
+Command lifecycle (`AbstractDevice`):
+
+- `pending` — solver decided to run; queued for launch.
+- `launched` / `running_command` — command dispatched via HA service
+  call, ACK not yet observed.
+- `acked` / `current_command` — `probe_if_command_set()` confirmed.
+- Stacking: when a device is busy with a `running_command`, additional
+  pending commands stack until ACK clears the slot.
+
+Switching-cost protection (`AbstractDevice`):
+
+- `num_max_on_off` — daily on/off budget.
+- `CHANGE_ON_OFF_STATE_HYSTERESIS_S = 600` — minimum delay (10 min)
+  between state changes for the same device.
+- **Multi-pass adaptation**: try free transitions first; only spend
+  the daily budget on the second pass.
+
+3-phase awareness:
+
+- Phase configuration tracked per device.
+- Power → per-phase amperage conversion for budgeting checks.
+
+## Key types / structures
+
+- `AbstractDevice` — base. Config, lifecycle, switching cost,
+  3-phase awareness.
+- `AbstractLoad(AbstractDevice)` — adds constraint surface.
+- `PilotedDevice(AbstractDevice)` — devices that pilot other devices
+  (e.g., heat pump with aux heater). Tracks client list and per-slot
+  demand counts.
+- `get_for_solver_constraints()` — the solver's entry point for
+  reading active constraints.
+- `push_live_constraint(...)` — runtime constraint push.
+- `push_agenda_constraints(...)` — calendar / schedule push.
+- `external_user_initiated_state` — set when the device state
+  changes without a command quiet-solar sent.
+
+## Common mistakes
+
+- Adding a device only in `ha_model/` without a `home_model/`
+  counterpart. The solver can't see it — it's a ghost device.
+- Calling `execute_command()` from a test and awaiting the ACK in
+  the same call. ACK arrives asynchronously via
+  `probe_if_command_set()`; tests need to advance time.
+- Bypassing `num_max_on_off` for "important" devices. The whole
+  hysteresis pattern depends on the budget being respected
+  uniformly.
+- Importing `homeassistant.*` into `home_model/load.py`. The two-
+  layer boundary is non-negotiable.
+
+## See also
+
+- [ha-device-mixin.md](ha-device-mixin.md) — the HA-side counterpart.
+- [constraints.md](constraints.md) — the constraint API.
+- [piloted-device-and-heat-pump.md](piloted-device-and-heat-pump.md)
+  — the `PilotedDevice` subclass.
+- [external-control-detection.md](external-control-detection.md) — the
+  external-state detection flow.
+- [user-override.md](user-override.md) — user-originated state.
+- [../principles/two-layer-boundary.md](../principles/two-layer-boundary.md)
+  — why `home_model/` never imports HA.
+- [../principles/hysteresis-and-switching-cost.md](../principles/hysteresis-and-switching-cost.md)
+  — the daily-budget + hysteresis pattern.

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -1,0 +1,83 @@
+---
+title: Notification routing
+slug: notification-routing
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/home.py
+  - custom_components/quiet_solar/ha_model/person.py
+last_verified: 2026-05-19
+---
+
+# Notification routing
+
+## TL;DR
+
+Notifications are routed per-`QSPerson` — each household member has
+their own `mobile_app` entity, their own subscription list (daily
+forecasts, constraint changes, errors, off-grid alarms), and their
+own quiet-hours. `QSHome` owns the broadcast helpers; `QSPerson`
+owns the per-person delivery and preferences. Constraint-change
+notifications carry the `load_info` originator so the user can tell
+why a decision was made.
+
+## When you need this concept
+
+- Adding a new notification trigger (e.g., "battery hit floor").
+- Designing per-person preferences (quiet hours, channel
+  selection, opt-in flags).
+- Touching the broadcast helpers used by off-grid mode.
+- Debugging "Magali got 50 notifications today" issues.
+
+## Core idea
+
+Three notification categories:
+
+- **Per-person scheduled**: daily forecast / morning brief. Routed
+  to one person's `mobile_app`.
+- **Per-person event**: constraint change, override confirmation,
+  command failure. Routed to the affected person.
+- **Broadcast**: off-grid alarm, grid restored, system-wide error.
+  Routed to *every* configured `QSPerson` at high priority.
+
+The `load_info.originator` on a constraint propagates into the
+notification body: "Your car's charge target was raised by *Magali's
+override*", or "by *tomorrow's predicted commute*". Without
+`load_info`, the notification is mute about the why — which erodes
+trust.
+
+Quiet hours, channel selection (alarm vs default), and rate-limiting
+are per-person. The broadcast path ignores quiet-hours (an outage
+alarm at 3am is supposed to wake you).
+
+## Key types / structures
+
+- Broadcast helper on `QSHome` (routes through every `QSPerson`).
+- `QSPerson.notify(category, body, priority)` — per-person delivery.
+- Per-person preferences (quiet hours, channel, opt-in flags) live
+  on `QSPerson`.
+
+## Common mistakes
+
+- Sending a notification per cycle. The 7s load management cycle
+  fires too often for human attention; batch / dedup or the user
+  mutes the integration.
+- Bypassing the per-person routing for "important" notifications.
+  Anything that should reach everyone is a broadcast — use the
+  helper.
+- Forgetting `load_info` on the constraint that drives the notif.
+  Trust depends on traceable "why".
+- Hard-coding the recipient. Always route through `QSPerson` so
+  per-person preferences apply.
+
+## See also
+
+- [qs-home-orchestrator.md](qs-home-orchestrator.md) — the
+  broadcast surface.
+- [person-trip-prediction.md](person-trip-prediction.md) — the
+  per-person tracking that backs routing.
+- [off-grid-mode.md](off-grid-mode.md) — the canonical broadcast
+  consumer.
+- [constraints.md](constraints.md) — the `load_info.originator`
+  that powers the "why".
+- [../personas/magali.md](../personas/magali.md) — the persona
+  that judges trust by notification quality.

--- a/docs/agents/concepts/off-grid-mode.md
+++ b/docs/agents/concepts/off-grid-mode.md
@@ -58,7 +58,7 @@ mode for maintenance windows. It does not auto-recover.
 
 ## Lifecycle
 
-```
+```text
 Grid sensor steady at 0W (debounced) → mode = OFF_GRID
   ↓
 suspend FILLER constraints

--- a/docs/agents/concepts/off-grid-mode.md
+++ b/docs/agents/concepts/off-grid-mode.md
@@ -1,0 +1,91 @@
+---
+title: Off-grid mode
+slug: off-grid-mode
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/home.py
+last_verified: 2026-05-19
+---
+
+# Off-grid mode
+
+## TL;DR
+
+When the grid power sensor drops to zero, `QSHome` detects an outage
+and transitions into `QSHomeMode.OFF_GRID`: it sheds non-mandatory
+loads, restricts consumption to (solar + battery) capacity, and
+broadcasts a high-priority alarm to every household member's mobile
+app. `FORCED_OFF_GRID` is the admin-pinned variant (used during
+inverter maintenance). The mode reverses automatically when grid
+power returns; recovery is also broadcast.
+
+## When you need this concept
+
+- Touching grid-outage detection, the consumption-shedding policy,
+  or the broadcast notification flow.
+- Adding a new device whose behaviour must differ when off-grid.
+- Working on `QSHomeMode` state transitions.
+- Debugging "the system didn't shed load when the power went out"
+  issues.
+
+## Core idea
+
+Off-grid mode lives in `ha_model/home.py` on `QSHome`. The detection
+trigger is "grid power sensor drops to zero" (with a small debounce
+to avoid false positives from sensor noise). Once tripped:
+
+1. **Load shedding**: `FILLER` and `FILLER_AUTO` constraints are
+   suspended. `MANDATORY` constraints remain — they're still
+   honoured but capped at (solar + battery) available power.
+2. **Battery policy switch**: battery's normal "save for evening
+   arbitrage" goal is overridden by "keep the house running".
+3. **Broadcast**: every household member's `mobile_app` notification
+   service receives a high-priority alarm-channel message.
+
+Recovery: when the grid sensor returns to a non-zero stable reading,
+mode reverts to `NORMAL`, suspended `FILLER` constraints resume, and
+a "grid restored" broadcast goes out.
+
+`FORCED_OFF_GRID` is a manual variant: an admin toggle that pins the
+mode for maintenance windows. It does not auto-recover.
+
+## Key types / structures
+
+- `QSHomeMode` enum: `NORMAL`, `OFF_GRID`, `FORCED_OFF_GRID`.
+- Off-grid detection logic on `QSHome` (in the state polling cycle).
+- Broadcast helper: routes through every configured `QSPerson`'s
+  mobile-app entity.
+
+## Lifecycle
+
+```
+Grid sensor steady at 0W (debounced) → mode = OFF_GRID
+  ↓
+suspend FILLER constraints
+  ↓
+broadcast alarm to all household members
+  ↓
+... grid restored ...
+  ↓
+mode = NORMAL → resume FILLER → broadcast recovery
+```
+
+## Common mistakes
+
+- Forgetting to test recovery. The "outage detected" path is easy;
+  the "grid restored" path is where bugs hide.
+- Treating `FORCED_OFF_GRID` like `OFF_GRID`. The admin pinned it
+  for a reason — auto-recovery would defeat the purpose.
+- Skipping the debounce. A flickering grid sensor causes alarm
+  storms.
+- Trying to keep `FILLER_AUTO` loads running on battery. The whole
+  point of shedding is to extend battery life during the outage.
+
+## See also
+
+- [qs-home-orchestrator.md](qs-home-orchestrator.md) — `QSHome` and
+  its cycles.
+- [notification-routing.md](notification-routing.md) — the
+  per-person broadcast path.
+- [../use-cases/off-grid-kicks-in.md](../use-cases/off-grid-kicks-in.md)
+  — end-to-end outage scenario.

--- a/docs/agents/concepts/person-trip-prediction.md
+++ b/docs/agents/concepts/person-trip-prediction.md
@@ -62,7 +62,7 @@ prediction_kWh + margin` is pushed for the car's charger.
 
 ## Lifecycle
 
-```
+```text
 GPS reading → presence state → trip detection
   ↓
 Trip ended → distance recorded → mileage ring updated

--- a/docs/agents/concepts/person-trip-prediction.md
+++ b/docs/agents/concepts/person-trip-prediction.md
@@ -1,0 +1,103 @@
+---
+title: Person & trip prediction
+slug: person-trip-prediction
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/person.py
+  - custom_components/quiet_solar/ha_model/car.py
+last_verified: 2026-05-19
+---
+
+# Person, Car, and trip prediction
+
+## TL;DR
+
+`QSPerson` (`ha_model/person.py`) tracks presence and predicts trips
+from GPS and historical mileage (31-day rolling window). `QSCar`
+(`ha_model/car.py`) tracks SOC, charger assignment, and a custom
+power→amperage lookup table per car. The two together produce the
+constraints behind the "Magali plugs in her car" magic moment: the
+prediction-derived constraint targets a SOC that lets the car cover
+tomorrow's predicted trips with margin.
+
+## When you need this concept
+
+- Modifying trip prediction, mileage estimation, or the 31-day
+  rolling window.
+- Adding a new car model with non-linear charging curves.
+- Working on person-car allocation (which car belongs to which
+  person).
+- Touching SOC tracking or dampening on the car side.
+
+## Core idea
+
+**Person side**:
+
+- GPS-based presence detection (home / away / commuting).
+- Mileage history (31 days, sensor-attribute restored) →
+  per-day-of-week average → next-day prediction.
+- Prediction confidence: if history is sparse or pattern match is
+  weak, fall back to a conservative (over-charged) target.
+
+**Car side**:
+
+- SOC tracking via HA entity (manufacturer-specific).
+- Charger assignment: which charger this car is plugged into.
+- Person allocation: which person owns this car (drives prediction
+  targeting).
+- Custom power → amperage table per car: different cars accept
+  different voltage / phase combinations differently.
+
+The two compose: `QSPerson.predict_next_trip()` returns a distance →
+`QSCar.distance_to_kWh()` converts → constraint `target = current +
+prediction_kWh + margin` is pushed for the car's charger.
+
+## Key types / structures
+
+- `QSPerson(HADeviceMixin, AbstractDevice)` — person tracking class.
+- `QSCar(HADeviceMixin, AbstractLoad)` — car class. Inherits constraint
+  surface from `AbstractLoad`.
+- 31-day mileage ring (sensor-attribute restored).
+- Custom power-to-amperage lookup table on `QSCar`.
+
+## Lifecycle
+
+```
+GPS reading → presence state → trip detection
+  ↓
+Trip ended → distance recorded → mileage ring updated
+  ↓
+Next cycle: predict_next_trip() → distance_to_kWh()
+  ↓
+push_live_constraint(target_SOC, load_info={originator: "prediction"})
+  ↓
+Solver allocates → charger executes → SOC reaches target → constraint
+  completes
+```
+
+## Common mistakes
+
+- Treating the mileage ring as authoritative for the first few days
+  after install. Cold-start predictions are deliberately
+  conservative.
+- Hard-coding a power → amperage curve. Each car model has its own;
+  the lookup table on `QSCar` is the single source of truth.
+- Forgetting `load_info={originator: "prediction"}` on
+  prediction-derived constraints. Without it, the user can't tell
+  why the constraint exists.
+- Confusing person-car allocation with car-charger assignment. They
+  are independent: a person can own multiple cars; a car can be
+  plugged into any charger.
+
+## See also
+
+- [constraints.md](constraints.md) — the prediction creates a
+  constraint.
+- [user-override.md](user-override.md) — what happens when the
+  prediction is wrong.
+- [notification-routing.md](notification-routing.md) — per-person
+  notifications.
+- [../use-cases/magali-plugs-in-car.md](../use-cases/magali-plugs-in-car.md)
+  — end-to-end magic moment.
+- [../personas/magali.md](../personas/magali.md) — the user behind
+  the prediction.

--- a/docs/agents/concepts/piloted-device-and-heat-pump.md
+++ b/docs/agents/concepts/piloted-device-and-heat-pump.md
@@ -1,0 +1,76 @@
+---
+title: PilotedDevice and heat pump
+slug: piloted-device-and-heat-pump
+kind: concept
+covers:
+  - custom_components/quiet_solar/home_model/load.py
+  - custom_components/quiet_solar/ha_model/heat_pump.py
+  - custom_components/quiet_solar/ha_model/climate_controller.py
+last_verified: 2026-05-19
+---
+
+# PilotedDevice and heat pump
+
+## TL;DR
+
+`PilotedDevice` (in `home_model/load.py`) extends `AbstractDevice`
+for devices that **pilot other devices** — they track a list of
+clients and per-slot demand counts, and their command affects what
+the clients see. `QSHeatPump` (`ha_model/heat_pump.py`) is the
+canonical user: it pilots an auxiliary electric heater that kicks in
+when the heat pump alone can't meet the climate setpoint.
+`climate_controller.py` is the thin HA-facing controller that
+translates climate setpoints into the heat pump's command vocabulary.
+
+## When you need this concept
+
+- Adding a new "primary + secondary" device (e.g., HVAC + emergency
+  resistive heater).
+- Modifying the heat pump's behaviour or the auxiliary trigger
+  logic.
+- Working on multi-client demand aggregation.
+- Touching the climate controller's HA integration.
+
+## Core idea
+
+`PilotedDevice` adds two extensions on top of `AbstractDevice`:
+
+- **Client list**: the devices being piloted register themselves as
+  clients. The pilot's command propagates to all clients.
+- **Per-slot demand counts**: when multiple clients each request
+  some power, the pilot aggregates the demand and decides whether
+  to engage the secondary device (e.g., turn on the aux heater).
+
+`QSHeatPump` wraps this pattern: the primary heat-pump compressor
+handles most demand; when the compressor is saturated and the
+climate setpoint is still missed, the pilot engages the aux heater.
+This is the structural pattern for "main device with optional
+booster".
+
+## Key types / structures
+
+- `PilotedDevice(AbstractDevice)` — the base for pilot-capable
+  devices.
+- `QSHeatPump(HADeviceMixin, PilotedDevice)` — the canonical user.
+- `climate_controller.py` — HA climate-entity translation.
+- Client registration and demand aggregation helpers.
+
+## Common mistakes
+
+- Implementing a "primary + secondary" device without using
+  `PilotedDevice`. You'll re-invent the client list and demand
+  aggregation badly.
+- Triggering the aux heater on every cycle the setpoint is missed.
+  The hysteresis pattern (`hysteresis-and-switching-cost`) still
+  applies — aux heaters are expensive switches.
+- Conflating the pilot's command with the clients' state. The
+  pilot says "engage"; whether each client engaged is observed
+  through their own probes.
+
+## See also
+
+- [load-base.md](load-base.md) — the `AbstractDevice` base.
+- [bistate-duration-devices.md](bistate-duration-devices.md) — the
+  cousin pattern for simple on/off duration loads.
+- [../principles/hysteresis-and-switching-cost.md](../principles/hysteresis-and-switching-cost.md)
+  — the daily-budget + hysteresis pattern.

--- a/docs/agents/concepts/qs-home-orchestrator.md
+++ b/docs/agents/concepts/qs-home-orchestrator.md
@@ -1,0 +1,98 @@
+---
+title: QSHome (orchestrator)
+slug: qs-home-orchestrator
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/home.py
+last_verified: 2026-05-19
+---
+
+# QSHome — the orchestrator
+
+## TL;DR
+
+`QSHome` extends `QSDynamicGroup` (which extends `HADeviceMixin` +
+`AbstractDevice`) and sits at the root of the dynamic-group tree.
+`QSDataHandler` drives three async cycles against it: state polling
+(~4s), load management (~7s), forecast refresh (~30s). The load
+management cycle is where the solver runs, ACKs are checked, and
+commands are launched. `QSHome` also owns the `QSHomeMode` state
+(NORMAL / OFF_GRID / FORCED_OFF_GRID) and routes household-member
+notifications.
+
+## When you need this concept
+
+- Touching the orchestration cycles (state polling, load management,
+  forecast refresh).
+- Working on `QSHomeMode` transitions (e.g., grid outage detection).
+- Modifying notification routing.
+- Anything that affects multiple device types at once.
+
+## Core idea
+
+Three cycles, three responsibilities:
+
+- **State polling (~4s)** — `update_all_states()` reads HA entities
+  into history, refreshes forecasts.
+- **Load management (~7s)** — `update_loads()` updates constraints,
+  checks command ACKs, triggers solver if needed, launches commands
+  (max 1 per load per cycle, amp budget checked).
+- **Forecast refresh (~30s)** — solar forecast provider polling
+  (Solcast / OpenMeteo).
+
+Each cycle is guarded by an `asyncio.Lock` to prevent re-entrance.
+The locks are independent (state polling and load management can
+overlap their *non-locked* sections), but a single cycle can't run
+twice concurrently — important when HA's scheduler fires faster
+than the cycle completes.
+
+`QSHomeMode` is a state machine:
+
+- `NORMAL` — default; full optimisation.
+- `OFF_GRID` — grid outage detected (sensor dropped to 0W);
+  emergency consumption reduction and broadcast to all mobile apps.
+- `FORCED_OFF_GRID` — admin-pinned off-grid (used for maintenance).
+
+## Key types / structures
+
+- `QSHome(QSDynamicGroup)` — orchestrator class.
+- `QSHomeMode` — `NORMAL` / `OFF_GRID` / `FORCED_OFF_GRID`.
+- `update_all_states()` — the 4s cycle.
+- `update_loads()` — the 7s cycle.
+- `_state_lock`, `_loads_lock` — `asyncio.Lock` guards.
+
+## Lifecycle
+
+```
+QSDataHandler.async_setup_entry()
+  → creates QSHome
+  → registers async_track_time_interval for the 3 cycles
+  → QSHome.async_init()
+  → cycles start firing
+
+per cycle:
+  acquire lock → do work → release lock
+```
+
+## Common mistakes
+
+- Adding a fourth cycle. Three is the design contract — anything
+  that needs more frequent updates should hook into state polling.
+- Sharing state between cycles without a lock. The locks are per-
+  cycle; cross-cycle shared mutable state is a footgun.
+- Blocking inside a cycle (sync I/O, long compute). All work must
+  be async or routed through `hass.async_add_executor_job()`.
+- Hard-coding the cycle intervals — they live in `const.py`.
+
+## See also
+
+- [dynamic-group-tree.md](dynamic-group-tree.md) — the topology
+  `QSHome` roots.
+- [off-grid-mode.md](off-grid-mode.md) — the `OFF_GRID` path.
+- [notification-routing.md](notification-routing.md) — who gets
+  notified about what.
+- [solver.md](solver.md) — runs inside the load management cycle.
+- [config-and-setup-flow.md](config-and-setup-flow.md) — how
+  `QSDataHandler` brings `QSHome` to life.
+- [../principles/event-driven-with-fallback.md](../principles/event-driven-with-fallback.md)
+  — the 5-minute fallback timer logic.

--- a/docs/agents/concepts/qs-home-orchestrator.md
+++ b/docs/agents/concepts/qs-home-orchestrator.md
@@ -63,7 +63,7 @@ than the cycle completes.
 
 ## Lifecycle
 
-```
+```text
 QSDataHandler.async_setup_entry()
   → creates QSHome
   → registers async_track_time_interval for the 3 cycles

--- a/docs/agents/concepts/solar-providers.md
+++ b/docs/agents/concepts/solar-providers.md
@@ -1,0 +1,79 @@
+---
+title: Solar providers and dampening
+slug: solar-providers
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/solar.py
+last_verified: 2026-05-19
+---
+
+# Solar providers and dampening
+
+## TL;DR
+
+`QSSolar` (`ha_model/solar.py`) tracks live PV production and stitches
+together forecasts from **multiple providers** (Solcast, OpenMeteo)
+with dampening so transient noise doesn't whip the solver. The
+forecast refresh cycle runs every ~30 seconds; failed providers fall
+back to the last successful response (and, if stale > 6h, to historic
+patterns from the numpy ring buffer). The solver consumes a single
+unified forecast — provider arbitration lives entirely in this file.
+
+## When you need this concept
+
+- Integrating a new solar forecast provider.
+- Modifying dampening or multi-provider arbitration.
+- Working on the forecast refresh cycle.
+- Debugging "the system is reacting to every passing cloud" issues.
+
+## Core idea
+
+The provider abstraction is a per-provider class with a uniform
+interface (`async fetch_forecast(time_range) -> ProductionSeries`).
+`QSSolar` calls each configured provider on the forecast-refresh
+cycle, then:
+
+- Dampens raw measurements (low-pass filter on the live PV reading).
+- Combines forecasts via a weighted average (provider weight is
+  tunable per config-flow entry).
+- Caches the merged forecast for the solver and the dashboard.
+
+Failure handling per the resilience strategy:
+
+- Provider API timeout / HTTP error → use last successful response.
+- Stale > 6h → fall back to historical consumption / production
+  patterns from the 560-day numpy ring buffer.
+- Conservative defaults (over-estimate consumption, under-estimate
+  production) so the fallback doesn't promise more than the system
+  can deliver.
+
+## Key types / structures
+
+- `QSSolar(HADeviceMixin, AbstractDevice)` — the solar tracking
+  class.
+- Per-provider classes (Solcast, OpenMeteo) implementing the
+  fetch-forecast interface.
+- Dampening filter on the live measurement path.
+- Merged-forecast cache consumed by the solver.
+
+## Common mistakes
+
+- Adding a provider that bypasses the dampening / merging layer.
+  The solver expects one forecast; provider arbitration is this
+  file's job.
+- Hard-coding provider URLs or API keys. Everything comes through
+  the config-flow entry.
+- Forgetting the stale-fallback path. The forecast layer must
+  degrade gracefully — the solver can't gate on "do I have a fresh
+  forecast?".
+- Treating dampening as smoothing-for-display. It's smoothing-for-
+  decisions: undampened raw production whips the solver into
+  unstable plans.
+
+## See also
+
+- [solver.md](solver.md) — the consumer of the merged forecast.
+- [qs-home-orchestrator.md](qs-home-orchestrator.md) — drives the
+  ~30s forecast cycle.
+- [../use-cases/solar-surplus-allocation.md](../use-cases/solar-surplus-allocation.md)
+  — surplus → load allocation end-to-end.

--- a/docs/agents/concepts/solver.md
+++ b/docs/agents/concepts/solver.md
@@ -63,7 +63,7 @@ constraint-specific criteria (e.g., deadline proximity).
 
 ## Lifecycle / sequence
 
-```
+```text
 update_loads() cycle (~7s)
   ↓
 update_loads_constraints()           ← constraints pushed here

--- a/docs/agents/concepts/solver.md
+++ b/docs/agents/concepts/solver.md
@@ -1,0 +1,105 @@
+---
+title: PeriodSolver
+slug: solver
+kind: concept
+covers:
+  - custom_components/quiet_solar/home_model/solver.py
+last_verified: 2026-05-19
+---
+
+# PeriodSolver
+
+## TL;DR
+
+`PeriodSolver` is the strategic optimization engine. It creates
+15-minute time slots aligned with constraint boundaries and tariff
+changes (`SOLVER_STEP_S = 900`), then allocates power across all
+loads simultaneously. The allocation hierarchy is strict: maximize
+solar self-consumption → minimize grid cost → maintain comfort
+commitments. The solver returns a command timeline `(load, [(time,
+LoadCommand)])` — strategic by design; the tactical charger budgeting
+layer (`charger-budgeting.md`) may override.
+
+## When you need this concept
+
+- Improving the allocation algorithm (within the existing input/output
+  contract — see "Solver Optimization Strategy" in
+  architecture.md).
+- Debugging "the plan looked wrong yesterday" issues.
+- Adding a new constraint tier or scoring axis.
+- Working on a feature where the solver and charger budgeting
+  interact (e.g., car charging during a tariff transition).
+
+## Core idea
+
+The solver runs **event-driven with a 5-minute fallback**: it
+re-evaluates when constraints change or device state changes (which
+reset `_last_solve_done`), and as a safety net it re-runs every 5
+minutes even when nothing has changed.
+
+Allocation algorithm:
+
+1. Create time slots and power slots from the PV forecast +
+   unavoidable consumption.
+2. Allocate mandatory constraints in priority order (`MANDATORY_AS_FAST_AS_POSSIBLE`
+   first, then `MANDATORY_END_TIME`, then `BEFORE_BATTERY_GREEN`).
+3. Optimize battery charge/discharge to minimize grid imports.
+4. Allocate filler constraints (`FILLER`, then `FILLER_AUTO`) using
+   remaining surplus.
+5. Return the command timeline.
+
+Within each tier, constraints are ordered by score; ties broken by
+constraint-specific criteria (e.g., deadline proximity).
+
+## Key types / structures
+
+- `PeriodSolver.solve()` — the entry point. Inputs: constraints,
+  tariffs, PV forecast, battery state, loads. Output: command
+  timeline.
+- `SOLVER_STEP_S = 900` — discretisation step (15 minutes). Lives
+  in `const.py`. **Do not touch.**
+- `_last_solve_done` — timestamp guarding the 5-minute fallback;
+  reset by constraint/state changes for event-driven re-evaluation.
+
+## Lifecycle / sequence
+
+```
+update_loads() cycle (~7s)
+  ↓
+update_loads_constraints()           ← constraints pushed here
+  ↓
+check_loads_commands()               ← ACK validation
+  ↓
+solver re-evaluation needed?
+  YES (event or 5-min fallback) ↓
+    PeriodSolver.solve()
+      → command timeline
+  ↓
+launch commands (max 1/load/cycle, amp budget checked)
+```
+
+## Common mistakes
+
+- Changing `SOLVER_STEP_S` — breaks every test assumption and every
+  time-aligned constraint.
+- Adding logic outside the solver that depends on a specific
+  allocation order. The solver's contract is the timeline, not the
+  intermediate decisions.
+- Modifying the solver's input/output contract — see the
+  "Decision 3: Solver Optimization Strategy" boundary.
+- Forgetting that the **tactical charger budgeting may override** the
+  solver's plan. The solver decides "charge at 7kW"; the budgeting
+  layer may deliver 5kW because of a circuit constraint.
+
+## See also
+
+- [constraints.md](constraints.md) — the demand language the solver
+  consumes.
+- [commands.md](commands.md) — the action language the solver
+  produces.
+- [charger-budgeting.md](charger-budgeting.md) — the tactical layer
+  that overrides.
+- [../principles/strategic-tactical-control.md](../principles/strategic-tactical-control.md)
+  — why the split exists.
+- [../principles/event-driven-with-fallback.md](../principles/event-driven-with-fallback.md)
+  — the re-evaluation trigger model.

--- a/docs/agents/concepts/testing-layers.md
+++ b/docs/agents/concepts/testing-layers.md
@@ -1,0 +1,98 @@
+---
+title: Testing layers (FakeHass vs real HA)
+slug: testing-layers
+kind: concept
+covers:
+  - tests/conftest.py
+  - tests/factories.py
+  - tests/ha_tests/conftest.py
+  - tests/ha_tests/const.py
+last_verified: 2026-05-19
+---
+
+# Testing layers — FakeHass, factories, and real HA fixtures
+
+## TL;DR
+
+Quiet-solar has a **dual test infrastructure**. Domain / unit tests
+use `FakeHass` (a lightweight in-memory HA stand-in) plus factories
+that build real domain objects (no mocks). HA-integration tests use
+`pytest-homeassistant-custom-component`'s real HA fixtures
+(`tests/ha_tests/`). Each layer has its own `conftest.py` —
+`tests/conftest.py` for the fast/lightweight layer,
+`tests/ha_tests/conftest.py` for the real-HA layer. The two must
+stay in sync or tests pass while testing the wrong thing.
+
+## When you need this concept
+
+- Writing a new test — choose the right layer.
+- Touching test infrastructure (`conftest.py`, `factories.py`,
+  `FakeHass`).
+- Investigating "this test passed but production broke" issues —
+  often the FakeHass/real-HA divergence.
+- Adding a fixture or factory for a new device type.
+
+## Core idea
+
+**Layer 1 — domain / unit tests (`tests/`, FakeHass + factories)**:
+
+- Use cases: solver, constraint, command lifecycle, home-model
+  logic.
+- Speed: fast (no HA boot).
+- Fixtures: `FakeHass` (provides the minimum HA surface domain code
+  touches).
+- Test doubles: real domain objects built by factories — **not
+  mocks**. Mocks lie; factories produce objects with the same
+  invariants as production.
+- Layer pattern files: `tests/conftest.py`, `tests/factories.py`.
+
+**Layer 2 — HA-integration tests (`tests/ha_tests/`, real HA)**:
+
+- Use cases: config flow, entity creation, service-call wiring,
+  HADeviceMixin, real HA service-call behaviour.
+- Speed: slow (real HA boot).
+- Fixtures: provided by `pytest-homeassistant-custom-component`.
+- Layer pattern files: `tests/ha_tests/conftest.py`,
+  `tests/ha_tests/const.py`.
+
+**Rule**: pick the lowest layer that exercises the code you're
+testing. A solver bug is a domain test; a config-flow bug is an HA
+test. Don't run the slow layer for logic that the fast layer can
+cover.
+
+## Key types / structures
+
+- `FakeHass` — lightweight HA stand-in. Provides `services`,
+  `states`, `bus`, the parts domain code touches.
+- `tests/factories.py` — real-object builders for every domain
+  class. The single source of truth for "how do I build a valid
+  X in a test?".
+- `tests/conftest.py` — shared fixtures for the fast layer.
+- `tests/ha_tests/conftest.py` — shared fixtures for the real-HA
+  layer (mostly pytest-homeassistant-custom-component re-exports
+  + per-test bootstrap helpers).
+- `tests/ha_tests/const.py` — constants specific to the HA layer
+  (entity IDs, test config payloads).
+
+## Common mistakes
+
+- Using mocks instead of factories. Mocks pass tests against
+  themselves; factories pass tests against the real object's
+  invariants.
+- Writing a real-HA test for logic the fast layer covers. You
+  burn CI time and slow the dev loop.
+- Letting FakeHass diverge from real HA. Smoke tests
+  (`@pytest.mark.integration`) should verify FakeHass behaves like
+  real HA for the operations the fast layer relies on.
+- Hardcoding entity IDs / config payloads in tests. They live in
+  `tests/ha_tests/const.py` for the HA layer or the factory call
+  signatures for the fast layer.
+
+## See also
+
+- [../../workflow/project-rules.md](../../workflow/project-rules.md)
+  — the quality-gate entry points (`--quick` for fast iteration).
+- [../../workflow/project-context.md](../../workflow/project-context.md)
+  — the broader test-style rules.
+- [../personas/the-dev.md](../personas/the-dev.md) — the persona
+  whose pipeline depends on a fast inner loop.

--- a/docs/agents/concepts/user-override.md
+++ b/docs/agents/concepts/user-override.md
@@ -1,0 +1,91 @@
+---
+title: User override
+slug: user-override
+kind: concept
+covers:
+  - custom_components/quiet_solar/home_model/load.py
+last_verified: 2026-05-19
+---
+
+# User override
+
+## TL;DR
+
+A **user override** is a constraint a human created to overrule
+quiet-solar's defaults — "charge my car to 90% tonight regardless of
+solar". Overrides land as constraints with `load_info={originator:
+"user_override"}`, take precedence in conflict resolution, and trigger
+a confirmation notification to the user who created them. User
+override is **distinct** from external control detection
+([external-control-detection.md](external-control-detection.md)):
+override = "user told *us* to do this differently"; external = "user
+is driving the device themselves".
+
+## When you need this concept
+
+- Designing a user-facing override UI (Magali's mobile app prompt,
+  TheAdmin's dashboard tile).
+- Working on conflict resolution between prediction-derived and
+  override-derived constraints.
+- Touching the confirmation-notification flow.
+- Debugging "my override didn't stick" issues.
+
+## Core idea
+
+Origin tracking via `load_info` is the structural foundation:
+
+- A constraint without `load_info` is anonymous — the system can't
+  explain why it exists.
+- A constraint with `load_info={originator: "prediction"}` is
+  automatic and can be displaced by an override.
+- A constraint with `load_info={originator: "user_override"}` is
+  pinned — the solver does not auto-replace it.
+
+When a user creates an override, the workflow is:
+
+1. UI captures the desired target (extend trip, force charge, cancel
+   scheduled run).
+2. Existing prediction-derived constraint on the same load is
+   replaced with a `user_override` variant of the same constraint
+   tier.
+3. Solver re-evaluates → potential plan change.
+4. Confirmation notification fires to the user who issued the
+   override, citing the new target.
+
+User overrides are still subject to physical limits (amp budgets,
+SOC bounds). They don't trip breakers — they bend the plan.
+
+## Key types / structures
+
+- `load_info` dict — `{originator: "user_override" | "agenda" |
+  "prediction" | "system"}`.
+- Constraint creation helpers that stamp `load_info` at the API
+  level.
+- The confirmation-notification path on `QSPerson`.
+
+## Common mistakes
+
+- Forgetting to stamp `load_info` on the override. The override
+  ranks like a prediction and gets auto-replaced.
+- Replacing the override constraint directly instead of creating a
+  new one. The solver re-reads constraints each cycle — mutate in
+  place and the cycle sees inconsistent state.
+- Skipping the confirmation notification. Magali presses "extend"
+  and gets no feedback → she presses it again, twice, then files
+  a bug report.
+- Confusing override with external control. If the user pressed
+  the override button in the mobile app, it's override; if they
+  walked over to the charger and unplugged it, it's external.
+
+## See also
+
+- [constraints.md](constraints.md) — the constraint API and
+  `load_info` field.
+- [external-control-detection.md](external-control-detection.md) —
+  the cousin concept.
+- [notification-routing.md](notification-routing.md) — the
+  confirmation channel.
+- [../use-cases/magali-plugs-in-car.md](../use-cases/magali-plugs-in-car.md)
+  — override is the 5% case in this flow.
+- [../personas/magali.md](../personas/magali.md) — the persona
+  whose 5-second rule shapes the override UI.

--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -121,6 +121,35 @@ to grep the entire tree to figure out what an `ack` is.
 - **Person-car allocation** — which car is "assigned" to which
   person, affects prediction targeting.
 
+## UI & dashboard
+
+- **Storage-mode Lovelace dashboard** — a dashboard whose content
+  lives in HA's `.storage/` directory (not in `configuration.yaml`).
+  Quiet-solar uses storage mode so manual edits survive component
+  upgrades.
+- **Jinja2 dashboard template** — one of the two files under
+  `ui/*.yaml.j2`; rendered against the live `QSHome` to produce
+  Lovelace YAML on first install.
+- **"Quiet Solar" dashboard** — the custom-cards variant
+  (`quiet-solar` URL), uses the four bundled JS cards.
+- **"Quiet Std" dashboard** — the standard-cards variant
+  (`quiet-solar-standard` URL), uses only built-in HA cards.
+- **JS Lovelace card** — a custom HA frontend card. Quiet-solar
+  ships four: `qs-car-card`, `qs-climate-card`,
+  `qs-on-off-duration-card`, `qs-pool-card`. Outside the quality
+  pipeline (no JS tests / linter / build).
+- **Dashboard section** — one of `cars`, `climates`, `pools`,
+  `others`, `settings` (`DASHBOARD_DEFAULT_SECTIONS` in `const.py`).
+  Each device type maps to a default section via
+  `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`; TheAdmin can override
+  per-device.
+- **`ha_entities` dict** — every `HADeviceMixin` instance exposes
+  `device.ha_entities.get("key")` so dashboards translate
+  description keys → entity IDs without hard-coding entity strings.
+- **`qs_tag` cache-buster** — epoch query parameter appended to JS
+  resource URLs (`?qs_tag=<epoch>`) so browsers reload updated card
+  code on component upgrade.
+
 ## Workflow & infrastructure
 
 - **HACS** — Home Assistant Community Store. Quiet-solar's

--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -1,0 +1,148 @@
+---
+title: Glossary
+slug: glossary
+kind: principle
+last_verified: 2026-05-19
+---
+
+# Glossary
+
+Domain terms that appear throughout the codebase, the concept docs,
+and PR discussions. New term? Add it here so future agents don't have
+to grep the entire tree to figure out what an `ack` is.
+
+## Solver vocabulary
+
+- **MANDATORY_AS_FAST_AS_POSSIBLE** — highest-priority constraint
+  tier (score 9). The solver schedules these first, minimizing
+  completion time regardless of solar production.
+- **MANDATORY_END_TIME** — priority tier 7. Must complete by a
+  deadline; the solver picks the cheapest power slots that finish in
+  time.
+- **BEFORE_BATTERY_GREEN** — priority tier 5. Runs before the battery
+  switches to solar-only mode (i.e., during the morning when grid
+  arbitrage still beats holding battery for evening).
+- **FILLER** — priority tier 3. Uses surplus energy only; never
+  triggers grid imports.
+- **FILLER_AUTO** — priority tier 1, lowest. Automatic / opportunistic
+  filler — runs whenever any surplus exists.
+- **LoadConstraint** — a time-windowed demand on a load with progress
+  tracking (initial → current → target).
+- **LoadCommand** — a discrete action at a specific power level
+  (one of 10 command types, ordered by score).
+- **PeriodSolver** — the strategic optimization engine. Plans in
+  15-minute slots. Defined in `home_model/solver.py`.
+- **SOLVER_STEP_S** — 900 seconds (15 minutes). The solver's
+  discretisation step. Constant in `const.py`. Do not touch.
+
+## Command lifecycle
+
+- **pending** — the solver has decided a command should run; it is
+  queued for launch.
+- **launched / running_command** — the command was dispatched to HA
+  (service call sent) but not yet confirmed.
+- **acked / current_command** — the device confirmed the command via
+  `probe_if_command_set()`; the command is now the device's reality.
+- **stacking** — when a device is busy, additional pending commands
+  stack instead of overwriting.
+
+## Device & topology
+
+- **AbstractDevice** — base for all controllable devices (in
+  `home_model/load.py`). Configuration, command lifecycle, state
+  tracking, switching-cost protection.
+- **AbstractLoad** — extends AbstractDevice. Adds constraint
+  management and the solver interface.
+- **HADeviceMixin** — the bridge layer (in `ha_model/device.py`).
+  Every HA device class inherits this + a domain class.
+- **QSHome** — the orchestrator (`ha_model/home.py`). Root of the
+  dynamic-group tree.
+- **QSDynamicGroup** — a non-leaf node in the amp budgeting tree
+  (`ha_model/dynamic_group.py`).
+- **PilotedDevice** — a device that pilots another device
+  (e.g. a heat pump piloting an auxiliary heater).
+- **External control detection** — the system noticed a state change
+  it did not initiate, so a human or another integration is driving
+  the device. Quiet-solar steps back.
+
+## Charger budgeting
+
+- **Charger Dynamic Budgeting** — the tactical layer (in
+  `ha_model/charger.py`). Manages real-time power distribution within
+  circuit constraints. Can override the strategic solver.
+- **Adaptation window** — `CHARGER_ADAPTATION_WINDOW_S = 45` seconds.
+  Chargers must be stable this long before rebalancing.
+- **3P / 1P** — three-phase vs single-phase charging. Phase switching
+  redistributes load across phases (`1P@32A → 3P@11A` reduces
+  per-phase amps).
+- **Dampening** — using real measured power (not just the target) to
+  drive future estimates.
+- **Staged transitions** — large budget changes split across two
+  cycles to prevent transient overages.
+- **charge_score** — per-charger priority. Higher score wins when
+  budgets conflict.
+
+## Battery & solar
+
+- **SOC** — state of charge, %. Battery's current energy as a fraction
+  of capacity.
+- **DC-coupled** — the battery shares an inverter with the PV array;
+  charging from PV avoids the DC↔AC round trip.
+- **Multi-provider solar** — quiet-solar combines multiple forecast
+  providers (Solcast, OpenMeteo) with dampening.
+- **Off-grid mode** — automatic load shedding triggered by grid
+  outage detection.
+
+## Constraint metadata
+
+- **load_info** — dict on every constraint tracking its
+  **originator** (`user_override`, `agenda`, `prediction`, `system`).
+  Used for notification routing and conflict resolution.
+- **agenda** — a calendar-derived constraint (e.g., HA calendar
+  entity).
+- **prediction** — a constraint derived from historical patterns
+  (e.g., trip prediction for a person/car pair).
+- **user_override** — a constraint a human created to overrule the
+  prediction or the schedule.
+
+## Hysteresis & switching cost
+
+- **num_max_on_off** — daily on/off budget. Defaults vary per device
+  type.
+- **CHANGE_ON_OFF_STATE_HYSTERESIS_S** — 10 minutes. Minimum delay
+  between state changes for a single device.
+- **Multi-pass adaptation** — the solver tries free transitions
+  first, only spending switching budget when necessary.
+
+## Persons & cars
+
+- **Trip prediction** — based on GPS + mileage history (31-day
+  window). Generates constraints for the person's car.
+- **Person-car allocation** — which car is "assigned" to which
+  person, affects prediction targeting.
+
+## Workflow & infrastructure
+
+- **HACS** — Home Assistant Community Store. Quiet-solar's
+  distribution channel.
+- **HA** — Home Assistant. The host platform.
+- **FakeHass** — the lightweight test double for the HA layer
+  (`tests/conftest.py` + `tests/factories.py`).
+- **Quality gate** — `scripts/qs/quality_gate.py`. Runs pytest 100%
+  cov + ruff + mypy + translations. Required before every commit.
+- **Static agents** — agents whose body is committed to the repo
+  (`.claude/agents/`, `.cursor/agents/`, `.opencode/agents/`),
+  versus per-task rendering (legacy approach in `legacy/`).
+- **Worktree** — a separate working directory tied to the same git
+  repo. Each task runs in its own worktree (`QS_<N>` branch).
+- **`covers:` frontmatter** — list of source files a doc claims to
+  describe. Validated by `scripts/qs/check_doc_drift.py`.
+- **Drift checker** — `scripts/qs/check_doc_drift.py`. Catches docs
+  that fall out of sync with their `covers:` source.
+
+## See also
+
+- [index.md](index.md) — entry point to the whole `docs/agents/`
+  hierarchy.
+- [../workflow/project-context.md](../workflow/project-context.md)
+  — the 42-rule code-style reference.

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -43,6 +43,7 @@ docs covering it before you write the change.
 | `ha_model/bistate_duration.py`, `ha_model/on_off_duration.py`, `ha_model/pool.py` | [concepts/bistate-duration-devices.md](concepts/bistate-duration-devices.md) |
 | `ha_model/solar.py` | [concepts/solar-providers.md](concepts/solar-providers.md) |
 | `config_flow.py`, `__init__.py`, `data_handler.py`, `const.py` | [concepts/config-and-setup-flow.md](concepts/config-and-setup-flow.md) |
+| `ui/dashboard.py`, `ui/*.yaml.j2`, `ui/resources/qs-*.js` | [concepts/dashboard-and-cards.md](concepts/dashboard-and-cards.md) |
 | `tests/conftest.py`, `tests/factories.py`, `tests/ha_tests/` | [concepts/testing-layers.md](concepts/testing-layers.md) |
 
 ## Lookup by concept
@@ -68,6 +69,7 @@ docs covering it before you write the change.
 | User override | concept | [concepts/user-override.md](concepts/user-override.md) |
 | Solar providers + dampening | concept | [concepts/solar-providers.md](concepts/solar-providers.md) |
 | Config flow & setup | concept | [concepts/config-and-setup-flow.md](concepts/config-and-setup-flow.md) |
+| Dashboard generation & JS Lovelace cards | concept | [concepts/dashboard-and-cards.md](concepts/dashboard-and-cards.md) |
 | Testing layers (FakeHass vs real HA) | concept | [concepts/testing-layers.md](concepts/testing-layers.md) |
 | Observe → predict → optimize | principle | [principles/observe-predict-optimize.md](principles/observe-predict-optimize.md) |
 | Two-layer boundary | principle | [principles/two-layer-boundary.md](principles/two-layer-boundary.md) |

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1,0 +1,124 @@
+---
+title: docs/agents/ index
+slug: index
+kind: principle
+last_verified: 2026-05-19
+---
+
+# docs/agents/ — addressable knowledge for AI agents
+
+This tree is the **single entry point** for plan / implement / review
+agents that need a slice of quiet-solar domain knowledge. Every file
+is short and scoped to one topic; pull the file, get the answer,
+move on. Drift between docs and code is caught by
+`scripts/qs/check_doc_drift.py` (see "Maintenance contract" at the
+bottom).
+
+For broader architectural context (decisions, validation tables, CI
+strategy), see [../product/architecture.md](../product/architecture.md).
+For the workflow itself, see
+[../workflow/overview.md](../workflow/overview.md).
+
+## Lookup by source file
+
+Modifying a file under `custom_components/quiet_solar/`? Pull the
+docs covering it before you write the change.
+
+| If you're modifying… | Read |
+|---|---|
+| `home_model/commands.py` | [concepts/commands.md](concepts/commands.md) |
+| `home_model/constraints.py` | [concepts/constraints.md](concepts/constraints.md) |
+| `home_model/solver.py` | [concepts/solver.md](concepts/solver.md) |
+| `home_model/load.py` (AbstractDevice / AbstractLoad) | [concepts/load-base.md](concepts/load-base.md) |
+| `home_model/load.py` (PilotedDevice) | [concepts/piloted-device-and-heat-pump.md](concepts/piloted-device-and-heat-pump.md) |
+| `home_model/load.py` (external control + user override) | [concepts/external-control-detection.md](concepts/external-control-detection.md), [concepts/user-override.md](concepts/user-override.md) |
+| `home_model/battery.py` | [concepts/home-model-battery.md](concepts/home-model-battery.md) |
+| `ha_model/battery.py` | [concepts/ha-battery.md](concepts/ha-battery.md) |
+| `ha_model/charger.py` | [concepts/charger-budgeting.md](concepts/charger-budgeting.md) |
+| `ha_model/dynamic_group.py` | [concepts/dynamic-group-tree.md](concepts/dynamic-group-tree.md) |
+| `ha_model/home.py` (cycles + QSHomeMode) | [concepts/qs-home-orchestrator.md](concepts/qs-home-orchestrator.md), [concepts/off-grid-mode.md](concepts/off-grid-mode.md), [concepts/notification-routing.md](concepts/notification-routing.md) |
+| `ha_model/device.py` (HADeviceMixin) | [concepts/ha-device-mixin.md](concepts/ha-device-mixin.md) |
+| `ha_model/person.py`, `ha_model/car.py` | [concepts/person-trip-prediction.md](concepts/person-trip-prediction.md) |
+| `ha_model/heat_pump.py`, `ha_model/climate_controller.py` | [concepts/piloted-device-and-heat-pump.md](concepts/piloted-device-and-heat-pump.md) |
+| `ha_model/bistate_duration.py`, `ha_model/on_off_duration.py`, `ha_model/pool.py` | [concepts/bistate-duration-devices.md](concepts/bistate-duration-devices.md) |
+| `ha_model/solar.py` | [concepts/solar-providers.md](concepts/solar-providers.md) |
+| `config_flow.py`, `__init__.py`, `data_handler.py`, `const.py` | [concepts/config-and-setup-flow.md](concepts/config-and-setup-flow.md) |
+| `tests/conftest.py`, `tests/factories.py`, `tests/ha_tests/` | [concepts/testing-layers.md](concepts/testing-layers.md) |
+
+## Lookup by concept
+
+| Concept | Kind | File |
+|---|---|---|
+| LoadCommand | concept | [concepts/commands.md](concepts/commands.md) |
+| LoadConstraint | concept | [concepts/constraints.md](concepts/constraints.md) |
+| PeriodSolver | concept | [concepts/solver.md](concepts/solver.md) |
+| AbstractDevice / AbstractLoad | concept | [concepts/load-base.md](concepts/load-base.md) |
+| PilotedDevice + heat pump | concept | [concepts/piloted-device-and-heat-pump.md](concepts/piloted-device-and-heat-pump.md) |
+| Battery (home_model) | concept | [concepts/home-model-battery.md](concepts/home-model-battery.md) |
+| QSBattery (ha_model) | concept | [concepts/ha-battery.md](concepts/ha-battery.md) |
+| Charger dynamic budgeting | concept | [concepts/charger-budgeting.md](concepts/charger-budgeting.md) |
+| QSDynamicGroup amp-budget tree | concept | [concepts/dynamic-group-tree.md](concepts/dynamic-group-tree.md) |
+| QSHome orchestrator | concept | [concepts/qs-home-orchestrator.md](concepts/qs-home-orchestrator.md) |
+| HADeviceMixin bridge | concept | [concepts/ha-device-mixin.md](concepts/ha-device-mixin.md) |
+| Person / car / trip prediction | concept | [concepts/person-trip-prediction.md](concepts/person-trip-prediction.md) |
+| Off-grid mode | concept | [concepts/off-grid-mode.md](concepts/off-grid-mode.md) |
+| External control detection | concept | [concepts/external-control-detection.md](concepts/external-control-detection.md) |
+| Notification routing | concept | [concepts/notification-routing.md](concepts/notification-routing.md) |
+| Bistate-duration devices (pool / on-off) | concept | [concepts/bistate-duration-devices.md](concepts/bistate-duration-devices.md) |
+| User override | concept | [concepts/user-override.md](concepts/user-override.md) |
+| Solar providers + dampening | concept | [concepts/solar-providers.md](concepts/solar-providers.md) |
+| Config flow & setup | concept | [concepts/config-and-setup-flow.md](concepts/config-and-setup-flow.md) |
+| Testing layers (FakeHass vs real HA) | concept | [concepts/testing-layers.md](concepts/testing-layers.md) |
+| Observe → predict → optimize | principle | [principles/observe-predict-optimize.md](principles/observe-predict-optimize.md) |
+| Two-layer boundary | principle | [principles/two-layer-boundary.md](principles/two-layer-boundary.md) |
+| Hysteresis & switching cost | principle | [principles/hysteresis-and-switching-cost.md](principles/hysteresis-and-switching-cost.md) |
+| Strategic vs tactical control | principle | [principles/strategic-tactical-control.md](principles/strategic-tactical-control.md) |
+| Event-driven with periodic fallback | principle | [principles/event-driven-with-fallback.md](principles/event-driven-with-fallback.md) |
+
+## Lookup by persona / use case
+
+| Persona / use case | File | Cross-links |
+|---|---|---|
+| TheAdmin | [personas/the-admin.md](personas/the-admin.md) | [config-and-setup-flow.md](concepts/config-and-setup-flow.md), [external-override.md](use-cases/external-override.md) |
+| TheDev | [personas/the-dev.md](personas/the-dev.md) | [testing-layers.md](concepts/testing-layers.md), `../workflow/overview.md` |
+| Magali | [personas/magali.md](personas/magali.md) | [magali-plugs-in-car.md](use-cases/magali-plugs-in-car.md), [user-override.md](concepts/user-override.md) |
+| Magali plugs in her car | [use-cases/magali-plugs-in-car.md](use-cases/magali-plugs-in-car.md) | [person-trip-prediction.md](concepts/person-trip-prediction.md), [solver.md](concepts/solver.md), [charger-budgeting.md](concepts/charger-budgeting.md) |
+| Solar surplus allocation | [use-cases/solar-surplus-allocation.md](use-cases/solar-surplus-allocation.md) | [solver.md](concepts/solver.md), [solar-providers.md](concepts/solar-providers.md), [ha-battery.md](concepts/ha-battery.md) |
+| Cheap-grid charging | [use-cases/cheap-grid-charging.md](use-cases/cheap-grid-charging.md) | [solver.md](concepts/solver.md), [constraints.md](concepts/constraints.md) |
+| Off-grid kicks in | [use-cases/off-grid-kicks-in.md](use-cases/off-grid-kicks-in.md) | [off-grid-mode.md](concepts/off-grid-mode.md), [notification-routing.md](concepts/notification-routing.md) |
+| External override | [use-cases/external-override.md](use-cases/external-override.md) | [external-control-detection.md](concepts/external-control-detection.md), [user-override.md](concepts/user-override.md) |
+| Solver replans on state change | [use-cases/solver-replans-on-state-change.md](use-cases/solver-replans-on-state-change.md) | [event-driven-with-fallback.md](principles/event-driven-with-fallback.md), [qs-home-orchestrator.md](concepts/qs-home-orchestrator.md) |
+
+## Out of tree — other docs
+
+- [glossary.md](glossary.md) — ~40 domain terms.
+- [lsp-evaluation.md](lsp-evaluation.md) — should agents pair with a
+  Python LSP server? (Decision: defer.)
+- [../workflow/project-rules.md](../workflow/project-rules.md) —
+  the quality-gate rules and the "Doc maintenance" subsection.
+- [../workflow/project-context.md](../workflow/project-context.md)
+  — the 42-rule code-style reference.
+- [../product/architecture.md](../product/architecture.md) — the
+  decisions log + validation tables + CI strategy (everything not
+  covered by this tree).
+
+## Maintenance contract
+
+This tree stays in sync with the code via three layered defences:
+
+- **`covers:` frontmatter** — every concept doc lists the source
+  files it claims to describe. The drift checker
+  (`scripts/qs/check_doc_drift.py`) validates that every path
+  exists; missing paths → exit 2.
+- **Agent body steps** — the create-plan, implement-task,
+  implement-setup-task, and review-task agents each invoke
+  `check_doc_drift.py` at the right phase. See
+  [../workflow/project-rules.md](../workflow/project-rules.md) ("Doc
+  maintenance" subsection) for the contract; the agent bodies under
+  `.claude/agents/`, `.cursor/agents/`, `.opencode/agents/` are the
+  implementation. Parity across the three harnesses is pinned by
+  `tests/qs/agents/test_doc_maintenance_parity.py`.
+- **`last_verified` frontmatter** — every doc records the date the
+  content was last cross-checked. A reviewer can say "still
+  accurate after the last refactor" by bumping the date in the
+  same PR.

--- a/docs/agents/lsp-evaluation.md
+++ b/docs/agents/lsp-evaluation.md
@@ -1,0 +1,127 @@
+---
+title: LSP evaluation
+slug: lsp-evaluation
+kind: principle
+last_verified: 2026-05-19
+---
+
+# LSP evaluation — should agents pair with a Python language server?
+
+## Problem statement
+
+When a plan, implement, or review agent needs symbol-level information
+about the codebase — "find all callers of `Battery.charge`", "what's
+the return type of `LoadConstraint.score`", "where is `SOLVER_STEP_S`
+referenced?" — its only tools today are `grep`, `glob`, and reading
+whole files. The token cost is significant: a `grep` for `SOLVER_STEP_S`
+returns ~20 lines of context per match; reading even a moderate file
+like `home_model/solver.py` (1,683 LOC) burns roughly 35k tokens; a
+broad grep across `custom_components/quiet_solar/` consumes O(50k)
+tokens for a single lookup. A Python LSP server, by contrast, returns
+**structured** answers (definition location, call sites, type) in
+hundreds of bytes — two orders of magnitude cheaper.
+
+This document evaluates whether the cost of installing, running, and
+wiring an LSP into the agent harness is worth that token savings —
+and, if so, which LSP and which integration mechanism.
+
+## Three Python LSP options
+
+| LSP | Install footprint | Query latency | Output verbosity | Strengths | Weaknesses |
+|---|---|---|---|---|---|
+| **pyright** (Microsoft) | npm package, ~50MB | <100ms typical | Verbose, structured JSON | Best type inference of the three; well-maintained; understands modern Python (3.13+) including `from __future__ import annotations`. | Node.js runtime dependency; not Python-native. |
+| **jedi-language-server** | Single `pip install` (~30MB with deps) | <50ms for symbol lookup | Compact LSP-spec responses | Pure-Python; understands quiet-solar's `numpy`/`scipy` stack via Jedi's type-stub bundling; no Node dependency. | Weaker type inference than pyright; struggles with complex generics. |
+| **pylsp** (Palantir/python-lsp) | `pip install python-lsp-server` + plugins | ~75ms typical | Variable per plugin | Plugin ecosystem (rope, pylint integration, etc.); the most extensible option. | Configuration burden; plugins have overlapping/conflicting behaviour. |
+
+## Three consumption mechanisms for an agent
+
+| Mechanism | Setup cost | Per-call cost | Privacy | Notes |
+|---|---|---|---|---|
+| **MCP server wrapper** (Model Context Protocol) | One-time MCP server scaffold (~1 day eng); restart the harness to pick it up. | Single JSON-RPC round trip. | LSP stays local — no data leaves the machine. | Best long-term: works across Claude / Cursor / OpenCode / Codex harnesses, matching the multi-harness story (QS-184). |
+| **Direct subprocess via Bash tool** | Zero — `pyright --outputjson <symbol>` is callable from the existing Bash tool. | Per-call subprocess spawn (~200ms overhead). | Local. | Cheapest to prototype; awkward for repeated queries in one session. |
+| **Custom Claude Code / Cursor tool** | Per-harness tool implementation. | Native tool call. | Local. | Most ergonomic for the user (autocomplete, dedicated tool surface), but multiplies maintenance — one tool per harness. |
+
+## Quantitative comparison on three sample agent queries
+
+The numbers below are order-of-magnitude estimates from running the
+relevant `grep`/`glob` commands against the current repo (May 2026)
+and from the LSP-spec responses for the same queries. They are meant
+to anchor the recommendation, not to be precise benchmarks.
+
+### Query 1 — "find all callers of `Battery.charge`"
+
+| Approach | Tokens | Wall-clock |
+|---|---|---|
+| `grep -rn "\.charge(" custom_components/` then filter, then re-read context | ~3,500 (multiple file excerpts) | ~10s |
+| LSP `textDocument/references` | ~250 (file:line list) | <1s |
+
+**Savings: ~14× tokens, ~10× wall-clock.**
+
+### Query 2 — "list the type of `LoadConstraint.score`"
+
+| Approach | Tokens | Wall-clock |
+|---|---|---|
+| Read `home_model/constraints.py` (2,683 LOC, ~55k tokens) and trace the attribute | ~55,000 | ~30s |
+| LSP `textDocument/hover` on `LoadConstraint.score` | ~150 (one signature + docstring) | <1s |
+
+**Savings: ~360× tokens.**
+
+### Query 3 — "find references to `SOLVER_STEP_S`"
+
+| Approach | Tokens | Wall-clock |
+|---|---|---|
+| `grep -rn SOLVER_STEP_S custom_components/ tests/` | ~1,800 (~30 matches with context) | ~5s |
+| LSP `workspace/symbol` + `textDocument/references` | ~400 | <1s |
+
+**Savings: ~4× tokens.**
+
+### Cumulative across a typical implement session
+
+A typical implement-task session for a charger change runs 8–12 such
+queries. Estimated savings:
+
+- **Token cost reduction**: 20–40% of the implement-task session
+  (queries are not the dominant cost — code reading and writing
+  dominate — but they are still meaningful).
+- **Latency reduction**: cumulative ~30–60s per session.
+
+## Recommendation
+
+**Defer** — until at least one of the following unlocks:
+
+1. **Token cost becomes the dominant constraint on agent throughput.**
+   Today, code generation and quality-gate iteration dominate cost.
+   Until lookups are >30% of session tokens, the LSP wiring is
+   premature optimisation.
+2. **A multi-harness MCP standard ships** that doesn't require us
+   to maintain a per-harness tool. The MCP path is the only one
+   that scales across Claude / Cursor / OpenCode / Codex without
+   parallel maintenance.
+3. **A reviewer agent shows it would catch defects** that the
+   current adversarial-review fan-out misses because the reviewers
+   can't trace symbol references at scale. Hypothetical today; no
+   evidence yet.
+
+In the meantime, the `docs/agents/` hierarchy (created by QS-185)
+addresses the **same problem from a different angle**: agents pull
+small, scoped, addressable documentation files instead of grep-ing
+the whole codebase. This is structurally cheaper than even an LSP
+for the common queries ("what's a LoadCommand?") because the answer
+is pre-curated. The LSP only pulls ahead for **dynamic** queries
+(call sites, type inference on arbitrary expressions).
+
+If the LSP becomes worth adopting, the path is:
+
+1. Install **jedi-language-server** locally (pure-Python, no Node).
+2. Wrap it in an **MCP server** that exposes `findReferences`,
+   `hover`, and `workspaceSymbols` to all harnesses uniformly.
+3. Add an opt-in note to `docs/workflow/overview.md` so agents
+   know the tool exists.
+
+## See also
+
+- [index.md](index.md) — the doc hierarchy LSP would augment, not
+  replace.
+- [../workflow/harness.md](../workflow/harness.md) — multi-harness
+  abstraction (Claude / Cursor / OpenCode / Codex) any LSP wiring
+  must respect.

--- a/docs/agents/personas/magali.md
+++ b/docs/agents/personas/magali.md
@@ -1,0 +1,73 @@
+---
+title: Magali
+slug: magali
+kind: persona
+last_verified: 2026-05-19
+---
+
+# Magali
+
+## TL;DR
+
+Magali is the household member who lives in a quiet-solar home but
+**did not install it and does not configure it**. She receives
+notifications, occasionally overrides decisions, and forms her opinion
+of the system based on how it handles edge cases — not the happy
+path. Override must be a **5-second interaction** or trust erodes.
+She is the persona that defines the "magic moment" — the day she plugs
+in her car and the system silently does the right thing without her
+having to think about energy.
+
+## When you need this persona
+
+- Designing a notification, mobile-app prompt, or any household-facing
+  message.
+- Building an override flow (extend trip, force charge, cancel
+  scheduled run).
+- Sizing the response time / number of taps for any user-facing
+  action.
+- Making a behaviour change that could surprise a household member
+  who doesn't read changelogs.
+
+## Core idea
+
+Magali is **passive 95% of the time**. She:
+
+- Plugs in her car, expects it to be ready when she needs it.
+- Sees a notification only when something demands her attention.
+- Overrides via a single button in the HA mobile app — never opens
+  configuration, never reads logs.
+- Stops thinking about energy. That's the success metric.
+
+## Characteristic interaction path
+
+```
+Magali plugs car in → person presence + trip prediction
+→ Constraint created (load_info: {originator: "prediction"})
+→ Solver allocates power → charger executes
+→ "Done by 7am" notification → Magali ignores it (95% case)
+→ Edge case: business trip tomorrow → Magali taps "extend"
+→ user_override constraint → solver re-plans → confirmation push
+```
+
+## Common mistakes
+
+- Adding a notification per cycle. Magali will mute the integration
+  within a week.
+- Putting override controls behind multiple taps. The 5-second rule
+  is a hard ceiling.
+- Forgetting Magali doesn't know what a `LoadConstraint` is. User
+  copy must speak in domain terms — car / room / pool — never in
+  solver vocabulary.
+- Designing for the happy path. Magali judges trust based on the
+  recovery story when predictions fail.
+
+## See also
+
+- [the-admin.md](the-admin.md) — who configured the system Magali
+  uses.
+- [use-cases/magali-plugs-in-car.md](../use-cases/magali-plugs-in-car.md)
+  — the end-to-end "magic moment".
+- [use-cases/external-override.md](../use-cases/external-override.md)
+  — what happens when Magali (or anyone) operates a device outside
+  quiet-solar.

--- a/docs/agents/personas/magali.md
+++ b/docs/agents/personas/magali.md
@@ -41,7 +41,7 @@ Magali is **passive 95% of the time**. She:
 
 ## Characteristic interaction path
 
-```
+```text
 Magali plugs car in → person presence + trip prediction
 → Constraint created (load_info: {originator: "prediction"})
 → Solver allocates power → charger executes

--- a/docs/agents/personas/the-admin.md
+++ b/docs/agents/personas/the-admin.md
@@ -63,6 +63,9 @@ Install via HACS → config flow steps → device-type wizard
   notifications TheAdmin's config produced.
 - [the-dev.md](the-dev.md) — the developer (often the same person)
   improving the code.
+- [../concepts/dashboard-and-cards.md](../concepts/dashboard-and-cards.md)
+  — the two auto-generated dashboards + four JS cards that ARE
+  TheAdmin's primary UX.
 - [use-cases/external-override.md](../use-cases/external-override.md)
   — what happens when TheAdmin (or anyone) controls a device
   outside quiet-solar.

--- a/docs/agents/personas/the-admin.md
+++ b/docs/agents/personas/the-admin.md
@@ -1,0 +1,68 @@
+---
+title: TheAdmin
+slug: the-admin
+kind: persona
+last_verified: 2026-05-19
+---
+
+# TheAdmin
+
+## TL;DR
+
+TheAdmin is the homeowner who installed quiet-solar. They're comfortable
+with Home Assistant, configure devices, monitor performance, and tweak
+priorities. They operate in two modes — **setup** (learning, cautious,
+needs guidance) and **operational** (confident, wants efficiency). Trust
+is built through transparent diagnostics when things go wrong, not by
+the system being perfect.
+
+## When you need this persona
+
+- Designing a config-flow step or device configuration UI.
+- Adding a diagnostic sensor, error notification, or troubleshooting
+  dashboard tile.
+- Changing default behaviour, priority ordering, or any tunable
+  parameter — TheAdmin must be able to explain it.
+- Writing user-facing copy in `strings.json`.
+
+## Core idea
+
+TheAdmin is the only persona who reads logs, opens GitHub issues, and
+modifies `configuration.yaml`. They need:
+
+- **Transparent diagnostics**: every solver decision must be traceable
+  to the constraint, score, and tariff window that drove it.
+- **Confident defaults**: a fresh install should "just work" — no
+  required tuning to get value on day one.
+- **Surgical override**: the rare power-user who wants to disable
+  filler scheduling for one device, force a charge, or pin a tariff
+  must be able to do so without forking the code.
+
+## Characteristic interaction path
+
+```
+Install via HACS → config flow steps → device-type wizard
+→ Dashboard with constraint progress, command history, forecast accuracy
+→ "Why didn't the car charge last night?" → diagnostic sensors + logs
+→ Tune number/select entity → solver re-plans → behaviour shifts
+```
+
+## Common mistakes
+
+- Designing a feature that requires TheAdmin to keep tweaking parameters
+  every week. If it isn't self-tuning, it isn't trustworthy.
+- Burying diagnostic information in logs instead of surfacing it on
+  the dashboard. TheAdmin should not have to `tail -f` to understand
+  the system.
+- Assuming TheAdmin will read documentation. Inline help text in the
+  config flow and entity descriptions matters more.
+
+## See also
+
+- [magali.md](magali.md) — the household member who only sees the
+  notifications TheAdmin's config produced.
+- [the-dev.md](the-dev.md) — the developer (often the same person)
+  improving the code.
+- [use-cases/external-override.md](../use-cases/external-override.md)
+  — what happens when TheAdmin (or anyone) controls a device
+  outside quiet-solar.

--- a/docs/agents/personas/the-admin.md
+++ b/docs/agents/personas/the-admin.md
@@ -40,7 +40,7 @@ modifies `configuration.yaml`. They need:
 
 ## Characteristic interaction path
 
-```
+```text
 Install via HACS → config flow steps → device-type wizard
 → Dashboard with constraint progress, command history, forecast accuracy
 → "Why didn't the car charge last night?" → diagnostic sensors + logs

--- a/docs/agents/personas/the-dev.md
+++ b/docs/agents/personas/the-dev.md
@@ -1,0 +1,69 @@
+---
+title: TheDev
+slug: the-dev
+kind: persona
+last_verified: 2026-05-19
+---
+
+# TheDev
+
+## TL;DR
+
+TheDev is the developer working on quiet-solar — often the same person
+as TheAdmin. They find joy in solving real family problems through
+code. Two modes: **building** (smooth pipeline, no manual GitHub ops,
+expressive tests) and **exploring** (agentic pairing, fast feedback,
+green/red TDD loops). They are **allergic to bureaucracy** — every
+extra ceremony, every duplicate doc, every "fill out this form before
+you commit" is friction that erodes velocity.
+
+## When you need this persona
+
+- Designing a workflow phase, slash command, or static agent.
+- Adding a quality-gate check, a test fixture, or a CI job.
+- Writing documentation under `docs/workflow/` or `docs/agents/`.
+- Choosing between "build a tool" vs "add a rule to docs".
+
+## Core idea
+
+TheDev demands:
+
+- **TDD discipline without ceremony**: `--quick` for the inner loop,
+  full gate before commit, 100% coverage. No exceptions, no
+  `# pragma: no cover` without authorization.
+- **Pipelined releases**: setup → plan → implement → review → finish.
+  Each phase is a single command. Agents auto-commit, auto-push,
+  auto-open PRs.
+- **No GitHub UI for routine work**: PR creation, fix-plan iteration,
+  release tagging — all happen from the terminal.
+- **Hostile to gold-plating**: a feature that needs three meetings to
+  justify is a feature that shouldn't exist.
+
+## Characteristic interaction path
+
+```
+Idea → /setup-task → worktree on QS_<N>
+→ /create-plan → story + 4-reviewer adversarial review
+→ /implement-task or /implement-setup-task → TDD loop, quality gate, PR
+→ /review-task → 4-reviewer adversarial review of the PR
+→ /finish-task → merge, cleanup, return to main
+```
+
+## Common mistakes
+
+- Adding a workflow step that requires TheDev to fill in a template
+  twice. They will route around it.
+- Writing a doc that paraphrases another doc — duplication is friction.
+  The drift checker (`scripts/qs/check_doc_drift.py`) plus the
+  `covers:` frontmatter is the structural defence.
+- Building a feature that requires manual git ops. TheDev's pipeline
+  is the contract; if it bypasses the pipeline, it doesn't ship.
+
+## See also
+
+- [the-admin.md](the-admin.md) — the user TheDev is ultimately
+  serving.
+- [../../workflow/overview.md](../../workflow/overview.md) — the
+  static-agent pipeline TheDev runs against.
+- [../../workflow/project-rules.md](../../workflow/project-rules.md)
+  — the rules TheDev's code must follow.

--- a/docs/agents/personas/the-dev.md
+++ b/docs/agents/personas/the-dev.md
@@ -41,7 +41,7 @@ TheDev demands:
 
 ## Characteristic interaction path
 
-```
+```text
 Idea → /setup-task → worktree on QS_<N>
 → /create-plan → story + 4-reviewer adversarial review
 → /implement-task or /implement-setup-task → TDD loop, quality gate, PR

--- a/docs/agents/principles/event-driven-with-fallback.md
+++ b/docs/agents/principles/event-driven-with-fallback.md
@@ -1,0 +1,89 @@
+---
+title: Event-driven with periodic fallback
+slug: event-driven-with-fallback
+kind: principle
+last_verified: 2026-05-19
+---
+
+# Event-driven with periodic fallback
+
+## TL;DR
+
+The solver re-evaluates **on events** — constraint changes, device
+state changes, command ACKs — and re-runs as a safety net every 5
+minutes even when nothing has changed. This is the architectural
+principle that lets the system be both responsive (sub-second when
+something happens) and self-healing (the periodic fallback catches
+any missed event). Combined with the hysteresis principle
+([hysteresis-and-switching-cost.md](hysteresis-and-switching-cost.md)),
+frequent re-evaluation doesn't produce frequent state changes —
+because most re-evaluations decide "the plan is still right".
+
+## When you need this principle
+
+- Adding a new trigger for solver re-evaluation.
+- Touching the `_last_solve_done` timestamp logic.
+- Working on event propagation between device state changes and the
+  solver.
+- Debugging "the system didn't react to X" issues.
+
+## Core idea
+
+**Event-driven**: state changes that *could* invalidate the current
+plan reset `_last_solve_done`. The next ~7s load-management cycle
+sees `_last_solve_done is None` (or stale) and triggers a fresh
+solve.
+
+**Periodic fallback**: independent of events, the load-management
+cycle checks: has it been >5 minutes since the last solve? If yes,
+solve anyway. This catches:
+
+- Missed events (e.g., an HA state change that didn't propagate).
+- Time-based triggers (a constraint's deadline approaching).
+- External condition changes the system can't observe directly.
+
+**Why both?**
+
+- Event-driven alone is fragile: any missed event leaves the system
+  with a stale plan, possibly forever.
+- Periodic alone is wasteful and slow: a 5-minute lag on user
+  override is unacceptable.
+
+Combined, the system is responsive **and** self-healing.
+
+## Concrete implications
+
+- **Every "the solver should consider X" path must reset
+  `_last_solve_done`**. State changes, constraint pushes, command
+  ACKs.
+- **Don't shorten the 5-minute fallback** to "make the system more
+  responsive". Responsiveness comes from events; the fallback is
+  the safety net.
+- **Don't lengthen the 5-minute fallback** either. 5 minutes is the
+  tolerated worst-case staleness — longer becomes user-visible.
+- **The hysteresis principle is the counterweight**. Frequent
+  re-evaluation is safe because frequent state changes aren't
+  allowed.
+
+## Common mistakes
+
+- Adding a re-evaluation trigger but forgetting to reset
+  `_last_solve_done`. The trigger never fires the solver.
+- Replacing the periodic fallback with "trust the events". Always
+  a regret — events are lossy in distributed systems.
+- Treating the 5-minute fallback as the primary cadence and the
+  events as optimisation. It's the other way around.
+- Running the solver inside an event handler synchronously. The
+  ~7s load-management cycle is the right surface; events queue work
+  for the next cycle.
+
+## See also
+
+- [../concepts/solver.md](../concepts/solver.md) — the
+  re-evaluation entry point.
+- [../concepts/qs-home-orchestrator.md](../concepts/qs-home-orchestrator.md)
+  — the cycle that triggers the solver.
+- [hysteresis-and-switching-cost.md](hysteresis-and-switching-cost.md)
+  — the counterweight to frequent re-evaluation.
+- [../use-cases/solver-replans-on-state-change.md](../use-cases/solver-replans-on-state-change.md)
+  — the canonical event-driven scenario.

--- a/docs/agents/principles/hysteresis-and-switching-cost.md
+++ b/docs/agents/principles/hysteresis-and-switching-cost.md
@@ -14,7 +14,7 @@ change has a **real cost** (mechanical wear on relays, user
 confusion, transient over-current). Quiet-solar uses three layered
 defences to keep plans stable: a **daily on/off budget**
 (`num_max_on_off`), **time-based hysteresis**
-(`CHANGE_ON_OFF_STATE_HYSTERESIS_S = 600`s = 10 minutes minimum
+(`CHANGE_ON_OFF_STATE_HYSTERESIS_S = 600s` — 10 minutes minimum
 between state changes), and **multi-pass constraint adaptation**
 (try free transitions first, only spend budget on the second pass).
 This is an architectural principle, not a per-device tweak.

--- a/docs/agents/principles/hysteresis-and-switching-cost.md
+++ b/docs/agents/principles/hysteresis-and-switching-cost.md
@@ -1,0 +1,87 @@
+---
+title: Hysteresis & switching cost
+slug: hysteresis-and-switching-cost
+kind: principle
+last_verified: 2026-05-19
+---
+
+# Hysteresis and switching-cost protection
+
+## TL;DR
+
+Solver re-evaluation is event-driven and frequent — but every state
+change has a **real cost** (mechanical wear on relays, user
+confusion, transient over-current). Quiet-solar uses three layered
+defences to keep plans stable: a **daily on/off budget**
+(`num_max_on_off`), **time-based hysteresis**
+(`CHANGE_ON_OFF_STATE_HYSTERESIS_S = 600`s = 10 minutes minimum
+between state changes), and **multi-pass constraint adaptation**
+(try free transitions first, only spend budget on the second pass).
+This is an architectural principle, not a per-device tweak.
+
+## When you need this principle
+
+- Adding a new on/off device. You'll inherit the pattern; don't
+  bypass it.
+- Tuning a device's `num_max_on_off` default. The default matters —
+  too tight → device never runs; too loose → relay wears out.
+- Debugging "the device chattered all afternoon" issues.
+- Working on the solver's adaptation loop.
+
+## Core idea
+
+**Three defences, layered**:
+
+1. **Daily on/off budget** (`num_max_on_off`): per-device count of
+   how many on→off or off→on transitions are allowed per 24 hours.
+   When the budget is exhausted, the device stays in its current
+   state for the rest of the day even if the solver wants to switch.
+2. **Hysteresis** (`CHANGE_ON_OFF_STATE_HYSTERESIS_S`): minimum delay
+   between consecutive state changes for the *same* device. A
+   device that just turned on can't turn off for 10 minutes, no
+   matter what.
+3. **Multi-pass adaptation**: in the solver's allocation step, the
+   first pass tries to honour constraints **without** spending
+   switching budget (use the existing state where possible). Only
+   if the first pass can't satisfy a constraint does the second
+   pass spend a switch.
+
+These compose: a solver running every cycle doesn't trigger a
+state change every cycle. The combined effect is stability — plans
+that hold over the time horizon they were planned for.
+
+## Concrete implications
+
+- **Every on/off device inherits this pattern** via `AbstractDevice`.
+  Pool, heat pump, on/off duration, any new bistate device.
+- **Modulating devices (chargers, batteries) don't use
+  `num_max_on_off`** the same way. Their continuous control plane
+  is a different stability problem (see
+  [strategic-tactical-control.md](strategic-tactical-control.md)).
+- **Solver tests must exercise the multi-pass adaptation**. A
+  single-pass test passes against a single-pass solver but breaks
+  in production.
+
+## Common mistakes
+
+- Bypassing the budget for a "special" device. Every bypass is a
+  future bug report ("my X keeps switching").
+- Setting `num_max_on_off` from a user's gut feel instead of from
+  device wear tolerance. The default lives in `const.py` for a
+  reason.
+- Implementing hysteresis ad-hoc per device. The shared base
+  enforces 10 minutes; reinventing it produces inconsistency.
+- Triggering an extra switch in the solver because "the optimal
+  plan needs it". The optimal plan that ignores switching cost
+  isn't optimal — it just defers the cost.
+
+## See also
+
+- [../concepts/load-base.md](../concepts/load-base.md) — where the
+  budget and hysteresis live.
+- [../concepts/bistate-duration-devices.md](../concepts/bistate-duration-devices.md)
+  — the canonical on/off consumers.
+- [event-driven-with-fallback.md](event-driven-with-fallback.md) —
+  the re-evaluation trigger that this principle counterbalances.
+- [strategic-tactical-control.md](strategic-tactical-control.md)
+  — the stability story for continuous-control devices.

--- a/docs/agents/principles/observe-predict-optimize.md
+++ b/docs/agents/principles/observe-predict-optimize.md
@@ -1,0 +1,86 @@
+---
+title: Observe → predict → optimize
+slug: observe-predict-optimize
+kind: principle
+last_verified: 2026-05-19
+---
+
+# Observe → predict → optimize
+
+## TL;DR
+
+Quiet-solar's foundational design philosophy is **observe → predict
+→ optimize**. The system continuously observes household state,
+predicts upcoming energy needs and production, and optimizes the
+allocation of power across all controllable devices. This is the
+right engineering approach because home energy is inherently
+unpredictable: simple rules and manual schedules break under real
+variability, while a constraint-based solver handles uncertainty
+gracefully and makes the best possible decision at every moment.
+
+## When you need this principle
+
+- Designing a new feature that introduces a "rule" or a
+  "schedule" — you're probably reaching for the wrong abstraction.
+- Choosing between hardcoding behaviour vs creating a
+  `LoadConstraint`.
+- Justifying why we don't ship an "if solar > 3kW, turn on pool
+  pump" automation.
+
+## Core idea
+
+**Observe**: every device reports state into history (the 3-day
+ring buffer per device + the 560-day numpy ring buffer for
+long-term patterns). The system has rich, time-aligned visibility
+into what's happening.
+
+**Predict**: forecasts come from outside (Solcast / OpenMeteo for
+PV) and from inside (person trip prediction from mileage history,
+pool temperature evolution, etc.). Predictions are probabilistic by
+nature — the system must work even when predictions are wrong.
+
+**Optimize**: the `PeriodSolver` consumes observations + predictions
++ constraints and produces a command timeline. The strict hierarchy
+(solar self-consumption → grid cost → comfort commitments) governs
+every trade-off.
+
+Rules-based systems work only when reality is predictable. Home
+energy is not. The constraint-based solver is the **correct
+abstraction**: it expresses *what* the user wants (constraints) and
+lets the optimiser figure out *how*, given current state.
+
+## Concrete implications
+
+- **Don't add an `automations.yaml` rule** to do what a constraint
+  could do. Rules are brittle; constraints compose.
+- **Don't hardcode time windows** ("charge between 22:00 and
+  06:00"). Express the demand as a constraint with the relevant
+  metadata; let the solver pick the windows.
+- **Embrace uncertainty**: predictions will be wrong. The recovery
+  story matters more than the happy path. See
+  [magali.md](../personas/magali.md).
+- **Make decisions traceable**: every decision must be explicable
+  in terms of (observation, prediction, constraint). That's why
+  `load_info.originator` exists.
+
+## Common mistakes
+
+- Adding a rule that bypasses the solver "for performance" or
+  "because the solver is too slow". The solver runs in ~milliseconds
+  on a typical home; complexity hides elsewhere.
+- Treating predictions as ground truth. They're inputs, not facts.
+- Inventing a parallel optimisation surface for a "special" device.
+  Every controllable device joins the solver via constraints.
+
+## See also
+
+- [strategic-tactical-control.md](strategic-tactical-control.md) —
+  the split that makes the solver tractable.
+- [event-driven-with-fallback.md](event-driven-with-fallback.md) —
+  the re-evaluation trigger model that keeps the solver responsive.
+- [../concepts/constraints.md](../concepts/constraints.md) — the
+  demand language the principle produces.
+- [../concepts/solver.md](../concepts/solver.md) — the optimisation
+  engine.
+- [../personas/magali.md](../personas/magali.md) — the persona
+  whose trust hinges on the recovery story.

--- a/docs/agents/principles/strategic-tactical-control.md
+++ b/docs/agents/principles/strategic-tactical-control.md
@@ -1,0 +1,104 @@
+---
+title: Strategic vs tactical control
+slug: strategic-tactical-control
+kind: principle
+last_verified: 2026-05-19
+---
+
+# Strategic (solver) vs tactical (charger budgeting) control
+
+## TL;DR
+
+Quiet-solar runs **two layers of control**. The **strategic layer**
+(`PeriodSolver` in `home_model/solver.py`) plans in 15-minute
+windows: "this car should get 7kW from 14:00 to 16:00". The
+**tactical layer** (charger dynamic budgeting in
+`ha_model/charger.py`) operates in real time: it manages the
+physical realities of per-phase amp budgets across multiple
+chargers on the same circuit, with 45-second adaptation windows,
+phase switching, and staged transitions. **The tactical layer can
+override the strategic layer**. If the solver says 7kW but the
+circuit only allows 5kW right now, tactical wins. A solver bug
+produces a bad plan; a tactical bug trips a breaker.
+
+## When you need this principle
+
+- Designing any feature that touches charger control. You'll need
+  to understand both layers and their interaction.
+- Working on the solver. Remember: your plan may be overridden.
+- Touching the dynamic-group tree or per-phase budgeting.
+- Reviewing a "charging improvement" PR. Ask: which layer does it
+  modify? Both?
+
+## Core idea
+
+**Strategic** (solver):
+
+- Time horizon: 15-minute windows, up to 24 hours ahead.
+- Cadence: event-driven, with 5-minute fallback. Runs inside the
+  ~7s load-management cycle.
+- Output: command timeline.
+- Optimises across all loads simultaneously.
+- Stateless between runs — each cycle re-plans from scratch.
+
+**Tactical** (charger budgeting):
+
+- Time horizon: now to ~45 seconds.
+- Cadence: every load-management cycle, with 45-second adaptation
+  windows.
+- Output: per-charger amp / phase setpoints applied right now.
+- Manages physical-circuit constraints (per-phase amp limits).
+- **Stateful** between runs — adaptation windows, staged
+  transitions, dampening measurements persist.
+
+**Why the split?**
+
+- The solver's job is global optimisation; the tactical layer's job
+  is local safety. Mixing them produces a layer that does neither
+  well.
+- The solver wants to take "long" decisions (charge until SOC=90%);
+  the tactical layer wants to take "short" decisions (rebalance
+  this circuit right now). The cadence mismatch makes them
+  incompatible in one engine.
+- The tactical layer's blast radius (tripped breakers, physical
+  damage) demands defensive engineering the solver's algorithm
+  doesn't need.
+
+## Concrete implications
+
+- **Solver bugs produce bad plans.** Detectable, recoverable in the
+  next cycle.
+- **Tactical bugs trip breakers.** Physical, immediate, household
+  incident.
+- **A feature that changes solver behaviour must verify tactical
+  doesn't routinely override**. If the solver's plan is constantly
+  rejected, that's a sign the plan is unrealistic.
+- **Tactical can only restrict, never expand.** It will deliver
+  less than the solver asked for, never more.
+
+## Common mistakes
+
+- Adding circuit-limit logic to the solver. The solver doesn't
+  know about real-time circuit state; that's tactical.
+- Adding global-optimisation logic to the tactical layer. The
+  tactical layer optimises locally over 45 seconds; it can't
+  reason about "what's cheapest over the next 6 hours".
+- Forgetting that the solver may have already accounted for some
+  tactical-layer behaviour (e.g., phase switching to maximise
+  total power). Read both layers before changing either.
+- Treating the solver as authoritative. Production behaviour =
+  what the tactical layer actually delivered, not what the solver
+  planned.
+
+## See also
+
+- [../concepts/solver.md](../concepts/solver.md) — the strategic
+  layer.
+- [../concepts/charger-budgeting.md](../concepts/charger-budgeting.md)
+  — the tactical layer.
+- [../concepts/dynamic-group-tree.md](../concepts/dynamic-group-tree.md)
+  — the topology tactical walks.
+- [event-driven-with-fallback.md](event-driven-with-fallback.md) —
+  when the solver re-runs.
+- [../use-cases/magali-plugs-in-car.md](../use-cases/magali-plugs-in-car.md)
+  — the magic-moment use case where both layers cooperate.

--- a/docs/agents/principles/two-layer-boundary.md
+++ b/docs/agents/principles/two-layer-boundary.md
@@ -1,0 +1,90 @@
+---
+title: Two-layer boundary
+slug: two-layer-boundary
+kind: principle
+last_verified: 2026-05-19
+---
+
+# Two-layer boundary — `home_model/` vs `ha_model/`
+
+## TL;DR
+
+`home_model/` is **pure-Python domain** code with **zero Home
+Assistant imports**. `ha_model/` is the HA-integration layer that
+bridges the two — every HA device class inherits both
+`HADeviceMixin` (HA half) and a `home_model/` domain class
+(pure-Python half). This is a non-negotiable architectural rule:
+violations cause CI failures, force test setups to boot HA for
+domain logic, and erode the project's testability over time.
+
+## When you need this principle
+
+- Choosing which file a new piece of logic lives in.
+- Adding a new device type (you'll touch both layers).
+- Writing tests — domain code uses FakeHass and factories; HA code
+  uses real HA fixtures.
+- Reviewing PRs — any `from homeassistant.*` import in
+  `home_model/` is a must-fix.
+
+## Core idea
+
+**Why two layers?**
+
+- **Testability**: `home_model/` tests run in milliseconds without
+  HA boot. Without the split, every solver test would need a real
+  HA stack.
+- **Portability**: if quiet-solar ever needs to live outside HA
+  (Home Assistant fork, alternative platform), the domain core is
+  ready.
+- **Cognitive load**: developers reasoning about constraints don't
+  need to understand HA's entity model.
+
+**Mechanics**:
+
+- `home_model/` files: `commands.py`, `constraints.py`, `load.py`,
+  `solver.py`, `battery.py`, `home_utils.py`. None import
+  `homeassistant.*`.
+- `ha_model/` files: every other device file. Each device class
+  inherits both `HADeviceMixin` and a domain class — the bridge
+  pattern.
+- `HADeviceMixin.add_to_history()` is the **only** path HA state
+  enters the domain. `execute_command()` is the **only** path
+  commands leave the domain.
+
+## Concrete implications
+
+- **Domain code receives data as parameters**, never as HA entity
+  reads.
+- **HA code never knows about constraint priorities** beyond
+  passing them through.
+- **Test fixtures split along the boundary**: `tests/conftest.py`
+  for the domain layer (FakeHass + factories); `tests/ha_tests/`
+  for the integration layer (real HA fixtures).
+- **A function that needs both domains lives in `ha_model/`**, not
+  `home_model/`. The boundary is asymmetric: `home_model/` knows
+  nothing about HA; `ha_model/` knows about both.
+
+## Common mistakes
+
+- Importing `homeassistant.*` in `home_model/` "just to grab a
+  helper". The helper belongs in a `home_model/`-friendly module
+  or in `ha_model/` as a wrapper.
+- Writing logic in `ha_model/battery.py` that doesn't need HA. It
+  belongs in `home_model/battery.py`.
+- Adding a constant in `homeassistant.const` rather than
+  `quiet_solar/const.py`. The two `const.py` files are independent
+  worlds.
+- Testing domain logic via real HA fixtures because "it's easier".
+  The fast layer exists for a reason — using the slow layer for
+  domain logic erodes the dev-loop story.
+
+## See also
+
+- [../concepts/load-base.md](../concepts/load-base.md) — the domain
+  base.
+- [../concepts/ha-device-mixin.md](../concepts/ha-device-mixin.md)
+  — the bridge.
+- [../concepts/testing-layers.md](../concepts/testing-layers.md) —
+  the test infrastructure that mirrors the boundary.
+- [../../workflow/project-rules.md](../../workflow/project-rules.md)
+  — the "Architecture constraints" section pins this rule.

--- a/docs/agents/use-cases/cheap-grid-charging.md
+++ b/docs/agents/use-cases/cheap-grid-charging.md
@@ -1,0 +1,91 @@
+---
+title: Cheap-grid charging
+slug: cheap-grid-charging
+kind: use-case
+last_verified: 2026-05-19
+---
+
+# Cheap-grid charging
+
+## TL;DR
+
+It's cloudy / nighttime / the battery is empty. Quiet-solar still
+needs to honour mandatory constraints (car must be ready by 7am,
+hot water tank must reach setpoint). The solver picks the cheapest
+grid windows from the tariff schedule and allocates loads inside
+those windows. This is the "no surplus available" complement to
+[solar-surplus-allocation.md](solar-surplus-allocation.md).
+
+## When you need this use case
+
+- Modifying tariff-aware scheduling.
+- Reasoning about MANDATORY constraint behaviour with no PV.
+- Designing a feature that interacts with off-peak windows.
+- Debugging "the car charged at peak rate" issues.
+
+## End-to-end sequence
+
+```
+1. Evening: PV forecast = 0 from sundown to sunup
+   ↓
+2. Tariff schedule: peak 18:00–22:00; off-peak 22:00–06:00; peak
+   06:00–10:00; off-peak 10:00–14:00; etc.
+   ↓
+3. Solver runs (event or 5-min fallback):
+   step 1: time slots aligned with tariff transitions + forecast
+   step 2: MANDATORY constraints allocated first
+     → MANDATORY_END_TIME (car ready by 7am): solver picks cheapest
+       slots within [now, deadline] that satisfy energy demand
+     → off-peak slots from 22:00–06:00 dominate
+   step 3: battery — discharge during peak windows to avoid grid
+     imports during evening; charge during off-peak if SOC permits
+   step 4: filler constraints stay paused (no surplus)
+   ↓
+4. Battery contribution:
+   peak window (18:00–22:00): discharge to cover the home's load,
+     avoiding grid import at unfavourable rate
+   off-peak window (22:00–06:00): charge battery if SOC < target
+     AND the math says next-day-PV won't suffice
+   ↓
+5. Result: car charged from cheap off-peak grid; battery played
+   the arbitrage game; peak-window grid imports minimised
+```
+
+## Decision: battery as buffer vs car as direct off-peak consumer
+
+When both the battery and the car want off-peak slots, the solver
+prefers **direct car charging** over "battery first, car later" —
+because the round-trip efficiency penalty (charge battery → later
+discharge to charge car) wastes ~15% of the energy. Direct grid →
+car charging is more efficient when the car is plugged in during
+the off-peak window.
+
+## What each layer contributes
+
+| Layer | Contribution |
+|---|---|
+| Solver ([solver.md](../concepts/solver.md)) | Time-slot creation aligned with tariff schedule; allocation by priority. |
+| Constraints ([constraints.md](../concepts/constraints.md)) | `MANDATORY_END_TIME` semantics. |
+| Battery ([home-model-battery.md](../concepts/home-model-battery.md), [ha-battery.md](../concepts/ha-battery.md)) | Arbitrage between peak and off-peak windows. |
+| Charger budgeting ([charger-budgeting.md](../concepts/charger-budgeting.md)) | Per-phase amp distribution still applies even when total power is constrained by tariff window. |
+
+## Common mistakes when modifying this path
+
+- Treating tariff windows as soft hints rather than the cost
+  function. The solver's job is cheapest-feasible.
+- Round-tripping through the battery when the car could charge
+  directly. ~15% efficiency loss multiplied by every night.
+- Forgetting that MANDATORY constraints must be honoured even when
+  the cheapest off-peak window is too narrow. The solver may need
+  to spill into adjacent peak slots — and that's correct.
+
+## See also
+
+- [solar-surplus-allocation.md](solar-surplus-allocation.md) — the
+  opposite case.
+- [magali-plugs-in-car.md](magali-plugs-in-car.md) — uses cheap-grid
+  charging during cloudy nights.
+- [../concepts/solver.md](../concepts/solver.md) — the optimisation
+  engine.
+- [../principles/observe-predict-optimize.md](../principles/observe-predict-optimize.md)
+  — the cost-minimisation tier of the hierarchy.

--- a/docs/agents/use-cases/cheap-grid-charging.md
+++ b/docs/agents/use-cases/cheap-grid-charging.md
@@ -25,7 +25,7 @@ those windows. This is the "no surplus available" complement to
 
 ## End-to-end sequence
 
-```
+```text
 1. Evening: PV forecast = 0 from sundown to sunup
    ↓
 2. Tariff schedule: peak 18:00–22:00; off-peak 22:00–06:00; peak

--- a/docs/agents/use-cases/external-override.md
+++ b/docs/agents/use-cases/external-override.md
@@ -29,7 +29,7 @@ principle made concrete: quiet-solar doesn't fight the human.
 
 ## End-to-end sequence
 
-```
+```text
 1. Solver decided: car charges at 11kW between 22:00 and 06:00.
    Charger executes — observed power matches plan.
    ↓

--- a/docs/agents/use-cases/external-override.md
+++ b/docs/agents/use-cases/external-override.md
@@ -1,0 +1,111 @@
+---
+title: External override
+slug: external-override
+kind: use-case
+last_verified: 2026-05-19
+---
+
+# External override — somebody else is driving
+
+## TL;DR
+
+A human walks over to the charger and presses the physical "stop"
+button. Or another HA integration sends a command to the same
+charger. Or the device's manufacturer app interferes. Whatever the
+cause, quiet-solar **detects** the discrepancy between the command
+it sent and the device's observed state, and **steps back** —
+existing constraints pause, no new commands are issued, automation
+resumes only when control is back. This is the "embrace uncertainty"
+principle made concrete: quiet-solar doesn't fight the human.
+
+## When you need this use case
+
+- Implementing or modifying a device's `probe_if_command_set()`.
+- Designing a feature that must behave correctly under external
+  control.
+- Debugging "quiet-solar overrides my manual setting" issues —
+  almost always a detection gap.
+- Working on the cool-down before automation resumes.
+
+## End-to-end sequence
+
+```
+1. Solver decided: car charges at 11kW between 22:00 and 06:00.
+   Charger executes — observed power matches plan.
+   ↓
+2. At 23:00, a human (or another integration) issues "stop
+   charging" to the charger directly.
+   ↓
+3. Next state-polling cycle (~4s): observed charger power = 0W;
+   the last quiet-solar command was "11kW" → divergence detected.
+   ↓
+4. probe_if_command_set() returns False; HADeviceMixin.update_states
+   sets external_user_initiated_state on the load.
+   ↓
+5. AbstractLoad: existing constraints paused; get_for_solver_
+   constraints() returns no active constraints for this load.
+   ↓
+6. Next solver cycle: this load is excluded from the allocation.
+   The household keeps operating around it.
+   ↓
+7. ... cool-down window passes; state polling observes the load
+   returned to a state consistent with quiet-solar control ...
+   ↓
+8. external_user_initiated_state cleared; constraints resume; next
+   solver cycle re-includes the load in the plan.
+```
+
+## What "consistent with quiet-solar control" means
+
+The cool-down doesn't just wait for a timer; it observes:
+
+- The device's state hasn't changed in a way quiet-solar didn't
+  initiate for `external_user_initiated_cooldown_s` seconds.
+- The device is back in a state quiet-solar could have produced
+  (e.g., off, idle, or accepting a fresh command).
+
+If both hold, quiet-solar resumes.
+
+## Difference vs user override
+
+| | External control | User override |
+|---|---|---|
+| Triggered by | Human or other integration operating the device directly | Human telling quiet-solar to do something different |
+| Detection | State divergence between observed and expected | UI / API call into quiet-solar |
+| Effect | Pause automation; let the human drive | Update the constraint set; let the solver replan |
+| Recovery | Auto-recover when device returns to expected behaviour | Override expires (e.g., next solver cycle); constraint regenerates |
+
+See [user-override.md](../concepts/user-override.md) for the
+counterpart.
+
+## What each layer contributes
+
+| Layer | Contribution |
+|---|---|
+| External control detection ([external-control-detection.md](../concepts/external-control-detection.md)) | The detection logic and the flag. |
+| HADeviceMixin ([ha-device-mixin.md](../concepts/ha-device-mixin.md)) | The state-divergence check during `update_states()`. |
+| AbstractLoad ([load-base.md](../concepts/load-base.md)) | Hosts `external_user_initiated_state`; gates the constraint surface. |
+| Solver ([solver.md](../concepts/solver.md)) | Excludes externally-controlled loads from the plan. |
+
+## Common mistakes when modifying this path
+
+- Implementing a lenient `probe_if_command_set()` that returns True
+  for any state. External control then goes undetected.
+- Forgetting to clear the flag on recovery. The load stays
+  permanently external; automation never resumes.
+- Conflating with user override and routing through the override
+  notification path. External is *silent* by design — the user is
+  driving, no need to notify.
+- Triggering a "command failed" alert instead. The flow is "user
+  is driving", not "system error".
+
+## See also
+
+- [../concepts/external-control-detection.md](../concepts/external-control-detection.md)
+  — the mechanics.
+- [../concepts/user-override.md](../concepts/user-override.md) —
+  the related-but-distinct flow.
+- [magali-plugs-in-car.md](magali-plugs-in-car.md) — what happens
+  if Magali unplugs mid-charge (a subspecies of external control).
+- [../principles/observe-predict-optimize.md](../principles/observe-predict-optimize.md)
+  — "embrace uncertainty" is the design philosophy.

--- a/docs/agents/use-cases/magali-plugs-in-car.md
+++ b/docs/agents/use-cases/magali-plugs-in-car.md
@@ -1,0 +1,115 @@
+---
+title: Magali plugs in her car
+slug: magali-plugs-in-car
+kind: use-case
+last_verified: 2026-05-19
+---
+
+# Magali plugs in her car — the "magic moment"
+
+## TL;DR
+
+This is the canonical end-to-end use case. Magali pulls into the
+driveway, plugs in her car, and walks away. Several layers cooperate
+behind the scenes: presence detection, trip prediction, constraint
+creation, solver allocation, charger budgeting, command execution,
+notification. Nothing requires her attention. The car is ready when
+she needs it. **This is the use case quiet-solar exists for.**
+
+## When you need this use case
+
+- Onboarding a new contributor — this is the system in one
+  scenario.
+- Reasoning about end-to-end paths when modifying any one layer.
+- Designing a feature whose value would be visible in this path.
+- Writing the README / marketing material.
+
+## End-to-end sequence
+
+```
+1. Magali parks her car → HA detects presence (GPS + zone)
+   ↓
+2. QSPerson.update_states() observes presence transition
+   ↓
+3. Magali plugs in → charger HA entity reports "plugged in"
+   ↓
+4. QSCar observes the charger-car pairing → SOC reading available
+   ↓
+5. Person-trip-prediction runs:
+   QSPerson.predict_next_trip() → distance from 31-day mileage ring
+   QSCar.distance_to_kWh() → target SOC = current + prediction + margin
+   ↓
+6. push_live_constraint(target_SOC,
+     load_info={originator: "prediction"})
+   on the car-charger pair
+   ↓
+7. Next load-management cycle (~7s):
+   PeriodSolver picks up the new constraint, allocates power slots
+   over the night (prefers solar surplus tomorrow morning, cheap
+   off-peak grid windows otherwise)
+   ↓
+8. Charger budgeting cycle (~45s):
+   verifies amp budget across all chargers on the same circuit,
+   sets the per-charger amps + phase, applies via OCPP/Wallbox/
+   Generic protocol
+   ↓
+9. Notification: "Your car will be ready by 7am, charged to 78%
+   (predicted trip: 42km to office)"
+   ↓
+10. Magali ignores the notification (95% case) — system did the
+    right thing
+```
+
+## The 5% case — Magali overrides
+
+Magali knows she has an unplanned trip tomorrow. She opens the
+mobile app, taps "extend trip", picks "350km tomorrow":
+
+```
+1. Override UI captures input → user_override constraint pushed
+   with load_info={originator: "user_override"}
+   ↓
+2. Existing prediction constraint replaced by the override
+   ↓
+3. Solver re-evaluates → may shift battery / grid allocation
+   ↓
+4. Confirmation notification: "Got it. Car will be ready by 7am,
+   charged to 95%."
+```
+
+The interaction must take less than 5 seconds end-to-end. See
+[../personas/magali.md](../personas/magali.md).
+
+## What each layer contributes
+
+| Layer | Contribution |
+|---|---|
+| Person & car ([person-trip-prediction.md](../concepts/person-trip-prediction.md)) | Presence detection, trip prediction, SOC tracking, person-car allocation. |
+| Constraints ([constraints.md](../concepts/constraints.md)) | The demand language. `load_info` traces origin. |
+| Solver ([solver.md](../concepts/solver.md)) | Strategic allocation across the night's tariff windows. |
+| Charger budgeting ([charger-budgeting.md](../concepts/charger-budgeting.md)) | Tactical per-circuit amp distribution. Physical safety. |
+| Notification ([notification-routing.md](../concepts/notification-routing.md)) | Per-person delivery; explains "why" via `load_info`. |
+| User override ([user-override.md](../concepts/user-override.md)) | The 5% case that protects trust. |
+
+## Common mistakes when modifying this path
+
+- Optimising one layer without checking that the next layer can
+  consume the change. Solver "improvement" that produces plans
+  charger budgeting routinely overrides isn't an improvement.
+- Surfacing implementation details in the notification. Magali
+  cares about "ready by 7am", not "MANDATORY_END_TIME 9 with
+  load_info originator prediction".
+- Designing a new override flow that takes more than 5 seconds.
+
+## See also
+
+- [../personas/magali.md](../personas/magali.md) — the persona this
+  serves.
+- [solar-surplus-allocation.md](solar-surplus-allocation.md) — the
+  morning-after surplus story that gets the car charged for free.
+- [cheap-grid-charging.md](cheap-grid-charging.md) — the cloudy-
+  night fallback path.
+- [external-override.md](external-override.md) — what happens if
+  Magali unplugs the cable mid-charge.
+- [solver-replans-on-state-change.md](solver-replans-on-state-change.md)
+  — the event-driven re-evaluation behind step 7.

--- a/docs/agents/use-cases/magali-plugs-in-car.md
+++ b/docs/agents/use-cases/magali-plugs-in-car.md
@@ -26,7 +26,7 @@ she needs it. **This is the use case quiet-solar exists for.**
 
 ## End-to-end sequence
 
-```
+```text
 1. Magali parks her car → HA detects presence (GPS + zone)
    ↓
 2. QSPerson.update_states() observes presence transition
@@ -65,7 +65,7 @@ she needs it. **This is the use case quiet-solar exists for.**
 Magali knows she has an unplanned trip tomorrow. She opens the
 mobile app, taps "extend trip", picks "350km tomorrow":
 
-```
+```text
 1. Override UI captures input → user_override constraint pushed
    with load_info={originator: "user_override"}
    ↓

--- a/docs/agents/use-cases/off-grid-kicks-in.md
+++ b/docs/agents/use-cases/off-grid-kicks-in.md
@@ -27,7 +27,7 @@ trustworthy in homes that get grid outages.
 
 ## End-to-end sequence
 
-```
+```text
 1. Grid sensor: 4200W → 0W (outage)
    ↓
 2. State-polling cycle (~4s) detects the drop; debounces (~10s) to

--- a/docs/agents/use-cases/off-grid-kicks-in.md
+++ b/docs/agents/use-cases/off-grid-kicks-in.md
@@ -1,0 +1,98 @@
+---
+title: Off-grid mode kicks in
+slug: off-grid-kicks-in
+kind: use-case
+last_verified: 2026-05-19
+---
+
+# Off-grid mode kicks in
+
+## TL;DR
+
+The grid drops at 3am during a storm. Quiet-solar detects the outage
+within seconds, sheds non-mandatory loads, caps consumption at
+(battery + solar) capacity, and **broadcasts a high-priority alarm
+to every household member's mobile app**. The home keeps running on
+solar + battery for as long as the math allows. When the grid
+returns, the system reverts automatically and broadcasts the
+recovery. This is the resilience story that makes quiet-solar
+trustworthy in homes that get grid outages.
+
+## When you need this use case
+
+- Modifying off-grid detection or load-shedding policy.
+- Working on the broadcast notification path.
+- Adding a new device whose off-grid behaviour must differ.
+- Reasoning about battery-as-buffer behaviour during outages.
+
+## End-to-end sequence
+
+```
+1. Grid sensor: 4200W → 0W (outage)
+   ↓
+2. State-polling cycle (~4s) detects the drop; debounces (~10s) to
+   filter sensor noise
+   ↓
+3. QSHomeMode transitions: NORMAL → OFF_GRID
+   ↓
+4. Load shedding:
+   FILLER and FILLER_AUTO constraints suspended
+   MANDATORY constraints kept but capped at (battery_kW + solar_kW)
+   ↓
+5. Battery policy override:
+   normal "save for evening peak" goal disabled
+   new goal: "keep the house running as long as possible"
+   ↓
+6. Broadcast notification (alarm channel, high priority) to every
+   configured QSPerson's mobile_app entity:
+   "Power outage detected. Solar + battery active. Estimated
+   runtime: 8 hours at current load."
+   ↓
+7. ... grid returns: sensor reads stable non-zero value for the
+   debounce window ...
+   ↓
+8. QSHomeMode: OFF_GRID → NORMAL
+   ↓
+9. FILLER constraints resume; battery policy reverts
+   ↓
+10. Broadcast recovery: "Grid restored. Normal operation resumed."
+```
+
+## The FORCED_OFF_GRID variant
+
+`FORCED_OFF_GRID` is an admin toggle for maintenance windows. It
+behaves like `OFF_GRID` but does **not** auto-revert. Step 8 is
+skipped — the admin explicitly clears the flag.
+
+## What each layer contributes
+
+| Layer | Contribution |
+|---|---|
+| QSHome ([qs-home-orchestrator.md](../concepts/qs-home-orchestrator.md)) | Detects the outage; manages mode state. |
+| Off-grid mode ([off-grid-mode.md](../concepts/off-grid-mode.md)) | The shedding policy and the broadcast helper. |
+| Battery ([home-model-battery.md](../concepts/home-model-battery.md)) | Becomes the home's primary supply during the outage. |
+| Notification ([notification-routing.md](../concepts/notification-routing.md)) | Broadcast to every household member. |
+| Solver ([solver.md](../concepts/solver.md)) | Re-plans within the new cap; honours MANDATORY only. |
+
+## Common mistakes when modifying this path
+
+- Skipping the debounce. A flickering grid sensor causes alarm
+  storms — Magali's phone buzzes every 30 seconds.
+- Forgetting the recovery path. The "outage detected" code is easy;
+  the "grid restored" code is where regressions hide.
+- Sending the broadcast through the per-person event surface
+  instead of the broadcast helper. Per-person honours quiet-hours;
+  broadcast ignores them. Off-grid is broadcast.
+- Letting `FILLER_AUTO` run during off-grid because "the battery
+  has plenty of juice". The whole point is to extend runtime.
+
+## See also
+
+- [../concepts/off-grid-mode.md](../concepts/off-grid-mode.md) —
+  the mechanics.
+- [../concepts/qs-home-orchestrator.md](../concepts/qs-home-orchestrator.md)
+  — the orchestrator that hosts the state machine.
+- [../concepts/notification-routing.md](../concepts/notification-routing.md)
+  — the broadcast surface.
+- [../personas/magali.md](../personas/magali.md) — the persona
+  whose trust the broadcast preserves.

--- a/docs/agents/use-cases/solar-surplus-allocation.md
+++ b/docs/agents/use-cases/solar-surplus-allocation.md
@@ -25,7 +25,7 @@ day-to-day "where does the surplus go?" use case.
 
 ## End-to-end sequence
 
-```
+```text
 1. Solar production rises → QSSolar updates merged forecast (~30s
    refresh)
    ↓

--- a/docs/agents/use-cases/solar-surplus-allocation.md
+++ b/docs/agents/use-cases/solar-surplus-allocation.md
@@ -1,0 +1,97 @@
+---
+title: Solar surplus allocation
+slug: solar-surplus-allocation
+kind: use-case
+last_verified: 2026-05-19
+---
+
+# Solar surplus allocation
+
+## TL;DR
+
+The sun comes up; PV production exceeds the home's baseload. Quiet-
+solar's optimisation hierarchy says **maximise free solar self-
+consumption first** — so the surplus goes to controllable loads
+(battery charge, pool pump, car charging) in priority order, before
+any kWh is exported to the grid at unfavourable rates. This is the
+day-to-day "where does the surplus go?" use case.
+
+## When you need this use case
+
+- Reasoning about FILLER constraint behaviour.
+- Modifying the solver's surplus-allocation step.
+- Designing a feature that touches the optimisation hierarchy.
+- Debugging "the battery isn't charging when it's sunny" issues.
+
+## End-to-end sequence
+
+```
+1. Solar production rises → QSSolar updates merged forecast (~30s
+   refresh)
+   ↓
+2. Load-management cycle (~7s) observes surplus = production -
+   unavoidable consumption
+   ↓
+3. Solver re-evaluates (event triggered by forecast update OR
+   constraint change OR 5-min fallback)
+   ↓
+4. Allocation algorithm:
+   step 1: time-slot creation (15-min slots aligned with forecast)
+   step 2: mandatory constraints already allocated this morning
+   step 3: battery → DC-coupled charge preferred (avoids round-trip
+     loss); SOC bounds respected
+   step 4: filler constraints (pool, on/off duration loads) get
+     the remaining surplus
+   ↓
+5. Charger budgeting cycle accepts the new per-load amp targets,
+   applies staged transitions if changes are large
+   ↓
+6. Devices execute → real power matches plan within dampening
+   tolerance → next cycle reads back the actuals
+```
+
+## Priority order within the surplus pool
+
+Per the optimisation hierarchy:
+
+1. **Mandatory** constraints that are not yet satisfied get surplus
+   first (even though they would have been served at a higher tier
+   too).
+2. **Battery charge** (DC-coupled preferred). Saving energy for
+   the evening peak-tariff window has higher economic value than
+   running a filler load now.
+3. **Filler** constraints (pool, on/off duration, FILLER-tier car
+   charging).
+4. **Filler-auto** (`FILLER_AUTO`) — only if surplus remains after
+   all other tiers.
+
+## What each layer contributes
+
+| Layer | Contribution |
+|---|---|
+| Solar providers ([solar-providers.md](../concepts/solar-providers.md)) | Dampened, merged production forecast. |
+| Solver ([solver.md](../concepts/solver.md)) | Allocates surplus across loads. |
+| Battery ([home-model-battery.md](../concepts/home-model-battery.md), [ha-battery.md](../concepts/ha-battery.md)) | Consumes surplus within SOC + power limits. |
+| Bistate-duration ([bistate-duration-devices.md](../concepts/bistate-duration-devices.md)) | Pool / on-off loads sized to surplus windows. |
+| Charger budgeting ([charger-budgeting.md](../concepts/charger-budgeting.md)) | Physical-safety check on the surplus going to chargers. |
+
+## Common mistakes when modifying this path
+
+- Inserting a rule that diverts surplus to a "favourite" load. The
+  hierarchy is global; per-load preference happens at the
+  constraint level, not by bypassing the solver.
+- Forgetting the dampening on the forecast. Raw production whips
+  the allocation; dampened forecast yields stable plans.
+- Charging the battery from grid during a surplus window. This is
+  the most expensive thing the system can do — a bug here costs
+  the user real money every day.
+
+## See also
+
+- [cheap-grid-charging.md](cheap-grid-charging.md) — the opposite
+  case (no surplus, cheap grid).
+- [magali-plugs-in-car.md](magali-plugs-in-car.md) — surplus
+  feeding the car-charging story.
+- [../principles/observe-predict-optimize.md](../principles/observe-predict-optimize.md)
+  — why the solver is the right surface.
+- [../concepts/solver.md](../concepts/solver.md) — the allocator.

--- a/docs/agents/use-cases/solver-replans-on-state-change.md
+++ b/docs/agents/use-cases/solver-replans-on-state-change.md
@@ -26,7 +26,7 @@ event-driven-with-fallback principle in action.
 
 ## End-to-end sequence
 
-```
+```text
 1. Some event happens (one of):
    a. New constraint pushed (push_live_constraint or push_agenda_
       constraints)

--- a/docs/agents/use-cases/solver-replans-on-state-change.md
+++ b/docs/agents/use-cases/solver-replans-on-state-change.md
@@ -1,0 +1,102 @@
+---
+title: Solver replans on state change
+slug: solver-replans-on-state-change
+kind: use-case
+last_verified: 2026-05-19
+---
+
+# Solver replans on state change — event-driven re-evaluation
+
+## TL;DR
+
+The solver doesn't run on a clock — it runs because **something
+happened**. A constraint was pushed, a device state changed, a
+command was ACKed, the user issued an override, the grid sensor
+flickered. Each of these resets `_last_solve_done`; the next
+load-management cycle (~7s) sees stale state and re-solves. The
+periodic 5-minute fallback catches any missed event. This is the
+event-driven-with-fallback principle in action.
+
+## When you need this use case
+
+- Adding a new trigger for solver re-evaluation.
+- Touching the `_last_solve_done` reset path.
+- Debugging "the solver didn't react to X" issues.
+- Designing a feature whose value depends on quick replanning.
+
+## End-to-end sequence
+
+```
+1. Some event happens (one of):
+   a. New constraint pushed (push_live_constraint or push_agenda_
+      constraints)
+   b. Device state changed (HADeviceMixin.add_to_history records
+      a meaningful delta)
+   c. Command ACKed (probe_if_command_set returned True)
+   d. User override created in the UI
+   e. Grid sensor flickered (OFF_GRID detection / recovery)
+   ↓
+2. Event handler resets _last_solve_done = None on QSHome
+   ↓
+3. Next load-management cycle (~7s):
+   QSHome.update_loads() observes _last_solve_done is stale
+   triggers PeriodSolver.solve() within this cycle
+   ↓
+4. Solver produces fresh command timeline; commands launched
+   (max 1 per load per cycle, amp budget validated)
+   ↓
+5. Charger budgeting cycle accepts new amp targets; applies
+   staged transitions if needed
+   ↓
+6. _last_solve_done updated to the solve completion timestamp
+   ↓
+7. ... no events happen for 5 minutes ...
+   ↓
+8. Periodic fallback: load-management cycle observes "5 minutes
+   since last solve" → solves anyway (safety net)
+```
+
+## Why 5 minutes for the fallback?
+
+- Long enough that the safety-net solve doesn't waste CPU when
+  nothing changed.
+- Short enough that any missed event surfaces within tolerable
+  staleness (the user shouldn't notice).
+- Hysteresis ([hysteresis-and-switching-cost.md](../principles/hysteresis-and-switching-cost.md))
+  keeps frequent solves from producing frequent state changes.
+
+## What each layer contributes
+
+| Layer | Contribution |
+|---|---|
+| Solver ([solver.md](../concepts/solver.md)) | The re-evaluation entry point. |
+| QSHome ([qs-home-orchestrator.md](../concepts/qs-home-orchestrator.md)) | Hosts `_last_solve_done`; runs the load-management cycle. |
+| Constraints ([constraints.md](../concepts/constraints.md)) | One source of events (constraint pushes reset the timestamp). |
+| HADeviceMixin ([ha-device-mixin.md](../concepts/ha-device-mixin.md)) | Another source (state changes via `add_to_history`). |
+| Event-driven principle ([event-driven-with-fallback.md](../principles/event-driven-with-fallback.md)) | The architectural rule the use case embodies. |
+
+## Common mistakes when modifying this path
+
+- Adding a re-evaluation trigger but forgetting to reset
+  `_last_solve_done`. The trigger never fires the solver.
+- Bypassing the load-management cycle and calling
+  `PeriodSolver.solve()` directly from an event handler. Synchronous
+  invocations break the rate-limiting and concurrency guarantees.
+- Lengthening the 5-minute fallback to "make it less wasteful". The
+  fallback is the safety net; shortening it is fine, lengthening
+  is regret.
+- Treating every state delta as a re-evaluation trigger. Only
+  *meaningful* deltas (the device crossed a threshold, the
+  forecast shifted enough to matter) reset the timestamp.
+
+## See also
+
+- [../concepts/solver.md](../concepts/solver.md) — the engine.
+- [../concepts/qs-home-orchestrator.md](../concepts/qs-home-orchestrator.md)
+  — the host of the cycle that triggers it.
+- [../principles/event-driven-with-fallback.md](../principles/event-driven-with-fallback.md)
+  — the principle.
+- [../principles/hysteresis-and-switching-cost.md](../principles/hysteresis-and-switching-cost.md)
+  — the counterweight that keeps the system stable.
+- [magali-plugs-in-car.md](magali-plugs-in-car.md) — step 7 is
+  this use case in action.

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -14,6 +14,20 @@ date: '2026-03-18'
 
 # Architecture Decision Document
 
+> **See also**: [docs/agents/index.md](../agents/index.md) — the
+> addressable documentation hierarchy for plan / implement / review
+> agents. Per-concept files live under `docs/agents/concepts/`,
+> `docs/agents/principles/`, `docs/agents/use-cases/`, and
+> `docs/agents/personas/`. This architecture document keeps the
+> **decisions log**, **CI/CD strategy**, **validation tables**, and
+> **architectural boundaries** — everything *not* covered by the
+> per-concept docs.
+>
+> QS-185 trimmed sections describing concepts, hierarchical control
+> mechanics, user interaction architecture, and the 9 implementation
+> patterns. Where content was relocated, this document now points to
+> the new home rather than duplicating it.
+
 _This document builds collaboratively through step-by-step discovery. Sections are appended as we work through each architectural decision together._
 
 ## Project Context Analysis
@@ -52,194 +66,62 @@ _This document builds collaboratively through step-by-step discovery. Sections a
 
 ### Conceptual Component Model
 
-#### Domain Layer (`home_model/`)
+The per-concept descriptions live under
+[docs/agents/concepts/](../agents/concepts/). Use the
+[docs/agents/index.md](../agents/index.md) "Lookup by source file"
+table to find the right doc.
 
-**LoadCommand** (`commands.py`)
-- Represents a discrete action at a specific power level
-- 10 command types ordered by priority score (CMD_ON=100 down to CMD_OFF=10)
-- Commands merge by taking the higher-scored type and max power
-- Command scores determine which command wins when two constraints overlap on the same load. Higher score = more aggressive intervention. This is the semantic meaning of the command hierarchy — an AI agent implementing constraint logic must understand that score ordering drives conflict resolution.
-- Key distinction: `is_auto()` (green/price-aware modes) vs forced modes vs `is_off_or_idle()`
-
-**LoadConstraint** (`constraints.py`)
-- Time-windowed demand on a load with progress tracking
-- Five priority tiers determine solver allocation order:
-  - MANDATORY_AS_FAST_AS_POSSIBLE (9) — highest priority, minimize time
-  - MANDATORY_END_TIME (7) — must complete by deadline
-  - BEFORE_BATTERY_GREEN (5) — before battery goes solar-only
-  - FILLER (3) — uses surplus energy, non-mandatory
-  - FILLER_AUTO (1) — lowest priority, auto-only
-- Tracks: initial_value -> current_value -> target_value with percent completion
-- Carries metadata (`load_info` dict) for origin tracking (user override, agenda, prediction)
-- Subclasses: MultiStepsPowerLoadConstraint (power-based with step options), ChargePercent variant (SOC-based), TimeBasedSimplePower (duration-based)
-
-**AbstractDevice** (`load.py`)
-- Base for all controllable devices. Manages configuration, command lifecycle, and state tracking
-- Command lifecycle: pending -> launched (running_command) -> acked (current_command), with stacking for busy devices
-- Switching cost protection: `num_max_on_off` daily budget, hysteresis enforcement (CHANGE_ON_OFF_STATE_HYSTERESIS_S = 10 min minimum between changes), multi-pass adaptation that tries free transitions first
-- 3-phase aware: tracks phase configuration, converts power to per-phase amps for budgeting
-- **AbstractLoad behavioral contract**: AbstractLoad defines a behavioral contract that all device types must honor. Device-specific tests should validate deviations from that contract, not re-test the contract itself. This is a contract testing pattern — test the guarantees once at the base level, then test device-specific behavior in isolation.
-
-**PilotedDevice** (`load.py`)
-- Extends AbstractDevice for devices that pilot other devices (e.g., heat pump with auxiliary heater)
-- Tracks client list and per-slot demand counts
-
-**AbstractLoad** (`load.py`)
-- Extends AbstractDevice. Adds constraint management and solver interface
-- Provides `get_for_solver_constraints()` — the solver's entry point to read active constraints
-- Supports green-only mode, user override state, external control detection
-- Tracks constraint progress for UI display
-
-**Battery** (`battery.py`)
-- Charge/discharge model with SOC bounds, power limits, DC-coupled awareness
-- Calculates safe charge/discharge power respecting inverter limits and capacity boundaries
-
-**PeriodSolver** (`solver.py`)
-- The strategic optimization engine. Creates 15-minute time slots aligned with constraint boundaries and tariff changes
-- **Optimization hierarchy** (strict priority ordering): maximize solar self-consumption, then minimize energy cost, then maintain comfort commitments. This hierarchy governs all solver trade-off decisions.
-- Allocation algorithm:
-  1. Create time slots and power slots from PV forecast + unavoidable consumption
-  2. Allocate mandatory constraints (highest priority first, by score)
-  3. Optimize battery charge/discharge to minimize grid imports
-  4. Allocate filler constraints with remaining surplus
-  5. Return command timeline: list of (load, [(time, LoadCommand)]) tuples
-- Constraint scoring determines allocation order within each tier
-- Re-evaluation trigger: event-driven (constraint/state changes reset `_last_solve_done`) with 5-minute periodic fallback
-
-#### HA Integration Layer (`ha_model/`)
-
-**HADeviceMixin** (`device.py`)
-- The bridge pattern. Every HA device inherits from this + a domain class
-- State tracking: polls HA entities into time-series history (`_entity_probed_state`), auto-trims to 3 days
-- Power measurement: attaches power sensors with unit conversion, computes energy via Riemann sum
-- Entity probing: `attach_ha_state_to_probe()` with numerical conversion, custom getters, transform functions
-- Maintains reverse index of HA entities by description key (`ha_entities` dict) for dashboard template queries
-
-**QSHome** (`home.py`)
-- The orchestrator. Extends QSDynamicGroup (which extends HADeviceMixin + AbstractDevice)
-- Root of the dynamic group tree — enforces phase-by-phase amperage budgets
-- Three async cycles driven by QSDataHandler:
-  - State polling (~4s): updates all device states from HA, refreshes forecasts
-  - Load management (~7s): updates constraints, checks command ACKs, triggers solver, launches commands
-  - Forecast refresh (~30s): solar forecast API polling
-- Command launch: rate-limited to max 1 per load per cycle, validates amp budget before each launch
-
-**QSDataHandler** (`data_handler.py`)
-- HA config entry lifecycle manager. Creates QSHome on first entry, queues subsequent device entries
-- Sets up `async_track_time_interval` for the three timing cycles
-- Uses `asyncio.Lock` to prevent re-entrance on all cycles
-
-**Charger Dynamic Budgeting** (`charger.py`, `dynamic_group.py`) — TRUST-CRITICAL COMPONENT
-- This is where quiet-solar's value proposition is most visible to users. When Magali plugs in her car and the system seamlessly redistributes power — that's the "magic moment." When it fails and a breaker trips at 2am — that's a household incident. Changes to this component require extra scrutiny because failures are physically visible and immediate.
-- See dedicated section: "Hierarchical Control Architecture" below
-
-**Device Implementations:**
-- QSChargerGeneric / QSChargerOCPP / QSChargerWallbox (`charger.py`): EV charging with power ramping, phase switching, multi-protocol adaptation. OCPP adds transaction handling; Wallbox maps vendor status enums
-- QSCar (`car.py`): SOC tracking, charger assignment, person allocation, custom power-to-amperage lookup tables per car
-- QSBattery (`battery.py`): Charge/discharge control via HA number and switch entities
-- QSSolar (`solar.py`): Production tracking + forecast provider integration (Solcast, OpenMeteo)
-- QSPerson (`person.py`): Presence tracking, GPS-based trip detection, historical mileage prediction (31-day window)
-- QSPool (`pool.py`): Temperature-dependent filter duration, extends QSOnOffDuration
-- QSOnOffDuration (`on_off_duration.py`): Simple binary switch loads via HA switch service calls
-- QSHeatPump (`heat_pump.py`): Wraps PilotedDevice for multi-client control
-- QSDynamicGroup (`dynamic_group.py`): Tree topology for hierarchical amperage budgeting
-
-#### UI & Configuration Layer
-
-**Config Flow** (`config_flow.py`):
-- Hierarchical menu -> device-type steps -> common schema builder pattern
-- `get_common_schema()` provides reusable field composition (power, 3-phase, calendar, groups, max on/off)
-- Entity selectors filter by unit of measurement, exclude quiet-solar's own entities
-
-**Platform Files** (sensor.py, switch.py, number.py, select.py, button.py):
-- Factory pattern: type-specific creator functions -> polymorphic dispatcher -> platform setup
-- Custom EntityDescription dataclasses with callable value_fn, option_fn, set_fn for dynamic behavior
-
-**Dashboard Generation** (`ui/dashboard.py`):
-- Jinja2 template iterates devices, accesses `device.ha_entities.get(key)` for entity IDs
-- 4 custom JS Lovelace cards (car, pool, climate, on-off-duration)
-- Programmatic registration via HA's lovelace API, version-tagged for cache busting
+- Domain layer (`home_model/`) — see
+  [commands.md](../agents/concepts/commands.md),
+  [constraints.md](../agents/concepts/constraints.md),
+  [solver.md](../agents/concepts/solver.md),
+  [load-base.md](../agents/concepts/load-base.md),
+  [home-model-battery.md](../agents/concepts/home-model-battery.md).
+- HA integration layer (`ha_model/`) — see
+  [ha-device-mixin.md](../agents/concepts/ha-device-mixin.md),
+  [qs-home-orchestrator.md](../agents/concepts/qs-home-orchestrator.md),
+  [charger-budgeting.md](../agents/concepts/charger-budgeting.md),
+  [dynamic-group-tree.md](../agents/concepts/dynamic-group-tree.md),
+  [ha-battery.md](../agents/concepts/ha-battery.md),
+  [solar-providers.md](../agents/concepts/solar-providers.md),
+  [person-trip-prediction.md](../agents/concepts/person-trip-prediction.md),
+  [bistate-duration-devices.md](../agents/concepts/bistate-duration-devices.md),
+  [piloted-device-and-heat-pump.md](../agents/concepts/piloted-device-and-heat-pump.md),
+  [off-grid-mode.md](../agents/concepts/off-grid-mode.md),
+  [external-control-detection.md](../agents/concepts/external-control-detection.md),
+  [notification-routing.md](../agents/concepts/notification-routing.md),
+  [user-override.md](../agents/concepts/user-override.md).
+- UI & configuration layer — see
+  [config-and-setup-flow.md](../agents/concepts/config-and-setup-flow.md).
+- Testing layers — see
+  [testing-layers.md](../agents/concepts/testing-layers.md).
 
 ### Hierarchical Control Architecture
 
-The system operates as a **two-level hierarchical control architecture**:
-
-**Strategic Layer: PeriodSolver**
-- Plans in 15-minute discrete windows
-- Produces optimal command timelines: "charger A should get 7kW for the next 2 hours"
-- Optimizes across all loads simultaneously
-- Re-evaluates when triggered by constraint/state changes, or every 5 minutes as fallback (runs within the ~7s load management cycle)
-
-**Tactical Layer: Charger Dynamic Budgeting**
-- Operates in continuous real-time with 45-second adaptation windows
-- Manages the physical realities of power distribution within circuit constraints
-- **Can override the strategic layer.** If the solver says "charge at 7kW" but the amp budget only allows 5kW, the tactical layer wins
-- Has its own independent state machine (adaptation windows, staged transitions, dampening measurements) that persists between solver runs
-
-**Why this distinction matters for AI agents:**
-- Modifying the solver modifies only the strategic half. The tactical layer may constrain or override solver intentions.
-- A solver bug produces a bad plan. A budgeting bug can trip a breaker. The blast radius is physical, not just computational.
-- An agent implementing a "charging improvement" must understand both layers and their interaction.
-
-#### Charger Dynamic Budgeting: Detailed Architecture
-
-**QSDynamicGroup Tree** (`dynamic_group.py`):
-- Tree topology where QSHome is root, dynamic groups are interior nodes, chargers are leaves
-- Phase-aware budget: always represented as `[phase1, phase2, phase3]` arrays
-- Per-phase operations: `add_amps()`, `diff_amps()`, `is_amps_greater()`, `min_amps()`, `max_amps()`
-- Budget validation propagates recursively up the tree (child -> parent -> root)
-- Two validation methods:
-  - `is_delta_current_acceptable()`: planning-phase check — "will this change fit?"
-  - `is_current_acceptable_and_diff()`: execution-phase check — takes worst-case max of actual + estimated consumption
-
-**Charger Group State Machine** (`charger.py`):
-- QSChargerGroup aggregates chargers on the same circuit
-- QSChargerStatus tracks per-charger state (amps, phases, real power, adaptation state)
-- Each charger has a `charge_score` — higher priority chargers get power first when budget conflicts arise
-
-**Budgeting Algorithm** (`budgeting_algorithm_minimize_diffs`):
-1. Priority check: if highest-priority charger isn't charging but a lower one is, trigger reset allocation
-2. Prepare budgets: either keep current amps (minimize transitions) or reset to minimum (rebalance)
-3. Shave mandatory: if minimum amps still exceed group limit, stop lowest-score chargers first
-4. Shave current: try phase switching (1P->3P) for lower-score chargers before reducing amps
-5. Smart allocation loop: iteratively adjust each charger's budget toward power target while respecting all constraints
-
-**Phase Switching** (3P <-> 1P):
-- Tactical power redistribution: 1P@32A -> 3P@11A (reduces per-phase load)
-- Phase switch attempted before amp reduction (less disruptive)
-- May require charger reboot (`do_reboot_on_phase_switch`)
-
-**Staged Transitions** (`apply_budget_strategy`):
-- Large budget changes split into two phases to prevent transient overages:
-  - Phase 1: Reduce decreasing chargers first (frees up amps)
-  - Phase 2: Increase other chargers in next cycle (already validated safe)
-- `remaining_budget_to_apply` persists between cycles to complete Phase 2
-
-**Adaptation Windows**:
-- CHARGER_ADAPTATION_WINDOW_S = 45 seconds — chargers must be stable before rebalancing
-- CHARGER_STATE_REFRESH_INTERVAL_S = 14 seconds — state polling frequency
-- Dampening: real power measurements (not just targets) drive future estimates
+The strategic (PeriodSolver) vs tactical (charger dynamic budgeting)
+split is the central control architecture. Full description in
+[docs/agents/principles/strategic-tactical-control.md](../agents/principles/strategic-tactical-control.md).
+Charger-budgeting detail (algorithm, phase switching, staged
+transitions, adaptation windows) lives in
+[docs/agents/concepts/charger-budgeting.md](../agents/concepts/charger-budgeting.md);
+the tree topology in
+[docs/agents/concepts/dynamic-group-tree.md](../agents/concepts/dynamic-group-tree.md).
 
 ### Key Architectural Patterns
 
-**1. Hysteresis-as-Stabilizer**
-The solver re-evaluates when triggered by constraint or state changes (with a 5-minute periodic fallback via `_last_solve_done`), but switching budgets (`num_max_on_off` daily limit) and hysteresis (10-minute minimum between state changes) prevent plan instability. This is an explicit architectural principle: event-driven re-evaluation for responsiveness, budget-limited actuation for stability.
+The reusable architectural patterns are now formalised as
+**principles** under
+[docs/agents/principles/](../agents/principles/):
 
-**2. Switching Cost Protection** (reusable pattern)
-Daily on/off budget + hysteresis + multi-pass constraint adaptation (try free transitions first, then spend budget). All on/off device types (pool, heat pump, on/off duration) inherit this pattern. New device types should use it.
-
-**3. AbstractLoad Behavioral Contract**
-AbstractLoad defines guarantees (constraint management, command lifecycle, solver interface). Device-specific tests validate deviations from the contract. This is a contract testing pattern.
-
-**4. Bridge Pattern (HADeviceMixin)**
-Every HA device inherits from HADeviceMixin + a domain class. All HA state flows through `add_to_history()`. All commands flow through `execute_command()` -> HA service calls. This is the single integration seam.
-
-**5. Recursive Budget Validation**
-Amp budget checks propagate up the QSDynamicGroup tree. No charger can exceed its parent group's limit, which in turn respects the home's total circuit capacity.
+- [observe-predict-optimize.md](../agents/principles/observe-predict-optimize.md)
+- [two-layer-boundary.md](../agents/principles/two-layer-boundary.md)
+- [hysteresis-and-switching-cost.md](../agents/principles/hysteresis-and-switching-cost.md)
+- [strategic-tactical-control.md](../agents/principles/strategic-tactical-control.md)
+- [event-driven-with-fallback.md](../agents/principles/event-driven-with-fallback.md)
 
 ### Key Data Flows
 
-**Runtime Solve Cycle:**
+**Runtime solve cycle:**
 ```
 HA State Changes -> HADeviceMixin.add_to_history() [~4s polling]
 -> QSHome.update_all_states() -> device.update_states() for all devices
@@ -252,7 +134,7 @@ HA State Changes -> HADeviceMixin.add_to_history() [~4s polling]
     -> device.execute_command() -> HA service calls
 ```
 
-**Charger Dynamic Budgeting Cycle** (within update_loads):
+**Charger dynamic budgeting cycle** (within update_loads):
 ```
 All chargers stable for 45s? -> dampening update (measure real power)
 -> Detect transitions (single charger change -> record power delta)
@@ -265,7 +147,7 @@ All chargers stable for 45s? -> dampening update (measure real power)
   -> ELSE: apply directly
 ```
 
-**Device Configuration Flow:**
+**Device configuration flow:**
 ```
 HA UI -> config_flow.py step -> ConfigEntry created
 -> __init__.py async_setup_entry() -> QSDataHandler.async_add_entry()
@@ -276,35 +158,18 @@ HA UI -> config_flow.py step -> ConfigEntry created
 
 ### User Interaction Architecture
 
-The system serves three user personas through distinct architectural paths:
+Persona-by-persona interaction paths are extracted to
+[docs/agents/personas/](../agents/personas/) (TheAdmin, TheDev,
+Magali). The canonical end-to-end magic-moment scenario lives in
+[docs/agents/use-cases/magali-plugs-in-car.md](../agents/use-cases/magali-plugs-in-car.md).
 
-**TheAdmin's Path (Home Energy Manager):**
-```
-Config flow -> device setup -> entity creation
--> Dashboard (Jinja2 template -> custom JS cards) -> monitoring sensors
--> Constraint tuning (number/select entities) -> solver re-plan
--> Troubleshooting: constraint progress sensors, command history, forecast accuracy
-```
-
-**Magali's Path (Household Member):**
-```
-Person model -> trip prediction (GPS/mileage history)
--> Constraint creation (load_info: {originator: "prediction"})
--> Solver allocates power -> charger executes
--> Notification (via HA mobile app)
--> Override needed? -> user_override state -> constraint update (load_info: {originator: "user_override"})
--> Solver re-plans -> charger budgeting rebalances -> confirmation notification
-```
-
-**TheDev's Path (Developer):**
-```
-Code change -> pytest (100% coverage gate) -> Ruff + MyPy
--> CI pipeline (PR quality gate -> merge gate -> release pipeline)
--> Test infrastructure: factories (domain) + FakeHass (lightweight) + real HA fixtures (integration)
--> Failure mode catalog -> scenario-based tests -> confident deployment
-```
-
-**Architectural implication**: An agent implementing a notification or override story must trace through the full path: person prediction -> constraint metadata -> solver -> charger budgeting -> notification service. These are not isolated components. An agent implementing developer workflow improvements must understand the dual test infrastructure (FakeHass vs real HA fixtures) and the risk-weighted CI strategy.
+**Architectural implication**: An agent implementing a notification
+or override story must trace through the full path: person
+prediction → constraint metadata → solver → charger budgeting →
+notification. These are not isolated components. An agent
+implementing developer workflow improvements must understand the
+dual test infrastructure (FakeHass vs real HA fixtures) and the
+risk-weighted CI strategy.
 
 ### Technical Constraints & Dependencies
 
@@ -318,26 +183,28 @@ Code change -> pytest (100% coverage gate) -> Ruff + MyPy
 
 ### Cross-Cutting Concerns
 
-- **Domain/HA boundary enforcement**: Every feature must respect the strict two-layer separation. Domain logic receives data as parameters, never imports HA
-- **Device lifecycle management**: Adding a new device type touches 6+ files (const, home_model, ha_model, config_flow, platforms, tests)
-- **Async discipline**: Event loop safety across all layers — @callback decorators, executor jobs for blocking ops, gather over await-in-loops
-- **State consistency**: Three async cycles (4s/7s/30s) share device state via asyncio.Lock guards. Solver re-evaluates frequently but hysteresis and switching budgets prevent plan instability. Charger budgeting has its own 45-second adaptation windows that interleave with the solver cycles.
-- **Constraint propagation**: Constraints from multiple sources (predictions, calendar, manual overrides) must compose correctly. Metadata tracking (load_info dict) preserves origin for conflict resolution
-- **Hierarchical amperage budgeting**: QSDynamicGroup tree (rooted at QSHome) enforces per-phase current limits during command acceptance. Budget checks are recursive and phase-aware.
-- **Switching cost protection**: num_max_on_off daily budget + hysteresis + multi-pass constraint adaptation is a reusable pattern all on/off device types inherit
-- **Testing infrastructure**: Domain factories for real objects (not mocks), FakeHass for HA layer — both must stay in sync with production code
+Most cross-cutting concerns are now expressed as **principles**
+under [docs/agents/principles/](../agents/principles/). The
+remaining architecture-specific concerns:
+
+- **State consistency**: Three async cycles (4s/7s/30s) share device
+  state via asyncio.Lock guards. See
+  [qs-home-orchestrator.md](../agents/concepts/qs-home-orchestrator.md).
+- **Device lifecycle management**: Adding a new device type touches
+  6+ files. See pattern reference below + the 7-file checklist in
+  [docs/agents/concepts/config-and-setup-flow.md](../agents/concepts/config-and-setup-flow.md).
+- **Async discipline**: Event loop safety across all layers — see
+  the relevant code-level rules in
+  [docs/workflow/project-context.md](../workflow/project-context.md).
+- **Testing infrastructure**: Domain factories for real objects (not
+  mocks), FakeHass for HA layer — see
+  [testing-layers.md](../agents/concepts/testing-layers.md).
 
 ### Decision Map for AI Agents
 
-| If you're implementing... | You need to understand... | Key files |
-|---|---|---|
-| A new device type | AbstractLoad behavioral contract, config flow pattern, platform factories, const.py, 6-file checklist in project-context.md | load.py, config_flow.py, const.py, sensor.py/switch.py/etc |
-| A constraint change | LoadConstraint hierarchy, solver allocation order, switching budget interaction, command score semantics | constraints.py, solver.py, load.py |
-| A notification/override | Person model -> constraint metadata (load_info) -> QSHome command flow -> notification. Trace the full Magali path. | person.py, home.py, constraints.py, charger.py |
-| A solver improvement | PeriodSolver algorithm, constraint scoring, battery optimization. Remember: solver is strategic only — tactical charger budgeting may override. | solver.py, constraints.py, battery.py |
-| A charger budgeting change | TRUST-CRITICAL. Dynamic group tree, QSChargerGroup state machine, phase switching protocol, staged transitions, adaptation windows. Failures trip breakers. | charger.py, dynamic_group.py, home.py |
-| A dashboard change | Jinja2 template, ha_entities dict lookup, JS card API, dashboard section organization | ui/dashboard.py, device.py, const.py |
-| A config flow change | Common schema builder, entity selectors, data cleaning, config entry -> device creation flow | config_flow.py, const.py, data_handler.py |
+The full Decision Map is now hosted in the
+[docs/agents/index.md](../agents/index.md) "Lookup by source file"
+table. Use it as the entry point.
 
 ### Architectural Gaps (Prioritized by Risk)
 
@@ -374,7 +241,9 @@ CI must validate the full chain, not just quiet-solar in isolation. Pin to HA's 
 - syrupy >= 4.6.0 (snapshot testing, used sparingly)
 - pytest-homeassistant-custom-component >= 0.13.0 (real HA fixtures)
 - Factory-based test doubles (not mocks) for domain objects
-- **Dual test infrastructure**: FakeHass (lightweight, fast) for domain/unit tests AND real HA fixtures (pytest-homeassistant-custom-component) for integration tests. Document which tests use which — mixing them creates confusion about what's being tested.
+- **Dual test infrastructure**: see
+  [testing-layers.md](../agents/concepts/testing-layers.md) for the
+  full FakeHass vs real-HA layer rules.
 
 **Code Quality:**
 - Ruff for formatting and linting
@@ -517,6 +386,15 @@ As the test suite grows, support targeted execution via existing pytest markers 
 
 **Note**: No starter template initialization story needed. CI/CD pipeline setup (GitHub Actions) is the first infrastructure story per the product brief. Test infrastructure smoke tests (verify FakeHass behaves like real HA) should ship as part of the CI/CD story, not as a separate item — the CI pipeline's own self-test.
 
+## Checklist
+
+(Pre-implementation checklist for AI agents — kept in place; the
+content has been moved into the validation tables below.)
+
+## Risk Assessment
+
+See the Risk-Weighted CI Strategy table above.
+
 ## Core Architectural Decisions
 
 ### Decision Priority Analysis
@@ -597,163 +475,62 @@ As the test suite grows, support targeted execution via existing pytest markers 
 - Solver optimization touches: solver.py, constraints.py only (stable interface protects other components)
 - Both testing and resilience decisions feed into the CI/CD risk-weighted strategy from step 3
 
-**Documentation note**: This architecture document partially satisfies product brief success criterion #5 ("documentation started"). Combined with the project-context.md, the foundational documentation is in place.
+**Documentation note**: This architecture document partially satisfies product brief success criterion #5 ("documentation started"). Combined with the project-context.md and the new `docs/agents/` hierarchy, the foundational documentation is in place.
 
 ## Implementation Patterns & Consistency Rules
 
-### Relationship to project-context.md
+### Relationship to project-context.md and docs/agents/
 
-project-context.md contains 42 rules covering code-level conventions (naming, async, logging, error handling, testing anti-patterns). This section covers **architectural-level patterns** — how to extend and modify the system without breaking its design. AI agents MUST read both documents before implementing any code.
+[docs/workflow/project-context.md](../workflow/project-context.md)
+contains 42 rules covering code-level conventions (naming, async,
+logging, error handling, testing anti-patterns).
+[docs/agents/principles/](../agents/principles/) covers the
+**architectural-level patterns** — how to extend and modify the
+system without breaking its design. AI agents MUST read both
+project-context and the relevant concept/principle docs before
+implementing any code.
 
-### Pattern 1: Adding a New Device Type
+The 9 extension patterns previously described here have been moved
+to the addressable docs:
 
-This is the most common extension pattern and touches 7+ files. Follow this exact sequence:
-
-0. **const.py** (dashboard): Map device to dashboard section in `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`. Without this, the device is functional but invisible on the dashboard.
-1. **const.py** (config): Add `CONF_TYPE_NAME_QS<Name>` constant + all `CONF_<NAME>_*` config keys
-2. **home_model/<name>.py**: Create domain class extending `AbstractLoad` or `AbstractDevice` (pure Python, zero HA imports)
-3. **ha_model/<name>.py**: Create HA class extending `HADeviceMixin` + domain class. Implement:
-   - `__init__()`: call `attach_ha_state_to_probe()` for each tracked entity
-   - `execute_command()`: translate LoadCommand -> HA service calls
-   - `probe_if_command_set()`: verify command took effect by reading entity state
-4. **config_flow.py**: Add `async_step_<name>()` using `get_common_schema()` builder
-5. **Platform files**: Add `create_ha_<platform>_for_<Name>()` factory in each relevant platform
-6. **Tests**: Full coverage for domain logic (using factories in `tests/`) AND HA integration (using real fixtures in `tests/ha_tests/`)
-7. **Verify**: Device appears on dashboard with correct section mapping
-
-**Anti-pattern**: Adding a device only in ha_model/ without a domain model class. Even simple devices need a domain layer presence to participate in the solver. Also: forgetting the dashboard section mapping — creates a ghost device that works but nobody can see.
-
-### Pattern 2: Creating and Managing Constraints
-
-Constraints are the system's demand language. When implementing features that create demand:
-
-- **Choose the right constraint type** by priority: MANDATORY_AS_FAST_AS_POSSIBLE (must happen now) > MANDATORY_END_TIME (must happen by deadline) > BEFORE_BATTERY_GREEN (before battery goes solar) > FILLER (use surplus) > FILLER_AUTO (lowest priority)
-- **Always include load_info metadata**: `{originator: "user_override" | "agenda" | "prediction" | "system"}` — this traces where the constraint came from for notification and debugging
-- **Push constraints through the correct API**: `push_live_constraint()` for dynamic runtime constraints, `push_agenda_constraints()` for calendar/schedule-based constraints
-- **Create constraints in the right lifecycle phase**: Create and push constraints in `update_loads_constraints()` (called during the 7s load management cycle). Never in `__init__()` (too early, solver hasn't started) or `update_states()` (wrong cycle, creates timing issues with the solver).
-- **Never modify constraints directly** — create new ones. The solver reads constraints via `get_for_solver_constraints()` each cycle.
-
-**Anti-pattern**: Creating a constraint without load_info metadata. This breaks notification tracing — the system can't tell the user why a decision was made. Also: creating constraints in the wrong lifecycle phase causes solver timing issues.
-
-### Pattern 3: Command Execution & Verification
-
-All device commands follow a launch -> execute -> verify cycle:
-
-- **execute_command(time, command)**: Translate the domain LoadCommand into HA service calls. Return False (async, not awaiting ACK).
-- **probe_if_command_set(time, command)**: Read the actual device state from HA and compare to expected state. Return True only when the device has confirmed the command.
-- **Respect rate limiting**: Max 1 command per load per solve cycle. The orchestrator handles timing — individual devices should not implement their own scheduling.
-- **Handle external control**: If the device state doesn't match any command quiet-solar sent, someone controlled it externally. Detect this in `update_states()` and set `external_user_initiated_state` appropriately.
-
-**Anti-pattern**: Awaiting inside execute_command(). The HA event loop must not be blocked. All verification happens asynchronously via probe_if_command_set().
-
-### Pattern 4: State Tracking via HADeviceMixin
-
-All HA entity state flows through HADeviceMixin:
-
-- **Attach entities on init**: `attach_ha_state_to_probe(entity_id, is_numerical=True, conversion_fn=...)` for auto-polled entities
-- **Use standard conversion functions**: `convert_power_to_w`, `convert_amps`, `convert_km` — don't invent new converters
-- **Query state via the mixin API**: `get_sensor_latest_possible_valid_value()` for current state, `get_state_history_data()` for time-series
-- **Polling vs event-driven**: Most entities go in `_entity_probed_auto` (polled every 4s). High-frequency or critical-change entities can use `_entity_on_change` (event-driven). When in doubt, use auto-polled — it's the safer default.
-- **Never access hass.states directly** in ha_model code — always go through the mixin's history
-
-**Anti-pattern**: Reading HA state directly via `hass.states.get()` in device code. This bypasses history tracking and conversion functions.
-
-### Pattern 5: Charger Budgeting Interaction
-
-When modifying charger behavior or the dynamic group tree:
-
-- **Budget validation is recursive**: Always call `is_delta_current_acceptable()` or `is_current_acceptable_and_diff()` before changing charger amps. These propagate up the tree.
-- **Phase switching before amp reduction**: Try 1P->3P conversion (reduces per-phase load) before reducing amperage. Less disruptive.
-- **Staged transitions for large changes**: If changing multiple chargers, reduce first (Phase 1), then increase (Phase 2 in next cycle). Never increase and decrease simultaneously — transient overages trip breakers.
-- **Respect the 45-second adaptation window**: No budget changes until all chargers in the group have been stable for CHARGER_ADAPTATION_WINDOW_S.
-- **Per-car charging curves**: Amp-to-power conversion uses per-car lookup tables (`amp_to_power_1p[amps]`, `amp_to_power_3p[amps]`), not linear calculation. Different EVs have different charging curves. Always use the car's LUT for power budget calculations.
-
-**Anti-pattern**: Changing charger amps without calling budget validation. This bypasses circuit protection and can cause physical damage. Also: using linear amp-to-power conversion instead of per-car lookup tables — gives wrong power budget for every car except the one you tested with.
-
-### Pattern 6: Solver Extension
-
-When modifying the solver (within the stable interface per Decision 3):
-
-- **Input contract**: (constraints, tariffs, PV forecast, battery state, loads) — don't add new input types without explicit architectural decision
-- **Output contract**: list of (load, [(time, LoadCommand)]) — don't change the output format
-- **Constraint scoring drives allocation order**: Modify scoring to change priorities, don't hardcode allocation sequences
-- **15-minute time slots are fixed**: SOLVER_STEP_S = 900. Don't change without understanding the full impact on all constraint and budgeting logic.
-- **Optimization hierarchy**: maximize solar self-consumption → minimize energy cost → maintain comfort. All trade-off decisions follow this strict priority ordering.
-- **Mandatory before filler**: The allocation sequence (mandatory constraints -> battery optimization -> filler constraints) is an architectural invariant, not an implementation detail.
-- **Battery is the ONE exception**: Battery has dedicated solver phases (`_battery_get_charging_power`, `_prepare_battery_segmentation`). All OTHER device types are device-agnostic in the solver. Don't add new device-specific logic — express device behavior through constraints and commands.
-
-**Anti-pattern**: Adding special-case logic for a specific device type inside the solver. The solver is device-agnostic (except battery). Device-specific behavior belongs in the constraint or load implementation.
-
-### Pattern 7: Notification Triggers
-
-When implementing features that should notify household members:
-
-- **Use `on_device_state_change()`** with the appropriate status type: `DEVICE_STATUS_CHANGE_CONSTRAINT`, `DEVICE_STATUS_CHANGE_CONSTRAINT_COMPLETED`, `DEVICE_STATUS_CHANGE_ERROR`
-- **Notification routing**: Charger notifications route to the car's forecasted person's mobile app. Person notifications use the person's configured mobile app. Device notifications use the device's own mobile_app config.
-- **Off-grid broadcasts**: Only QSHome sends emergency broadcasts to ALL mobile apps. Individual devices should never broadcast.
-- **Human-readable messages**: Use `get_active_readable_name(time, filter_for_human_notification=True)` for constraint descriptions. Never expose internal IDs or technical details in notifications.
-- **Deduplication is automatic**: The system tracks `_last_notification_hash` to avoid sending duplicates. When using `on_device_state_change()`, deduplication is handled for you. If you bypass this and call notify directly, you will spam the user every load management cycle (~7 seconds).
-
-**Anti-pattern**: Sending notifications directly via hass.services.async_call(notify, ...) from device code. Always go through on_device_state_change() for consistent routing, message formatting, and deduplication.
-
-### Pattern 8: Config Entry Persistence
-
-When a device needs to persist runtime data back to its configuration:
-
-- **Use `save_entry_data_no_reload()`** to persist data without triggering a reload. This updates the config entry data in place.
-- **Never call `hass.config_entries.async_update_entry()`** for runtime data updates — this triggers a full reload cycle: all devices re-initialize, solver restarts, chargers lose their adaptation state, adaptation windows reset. A full reload for a config update is destructive.
-
-**Anti-pattern**: Using `async_update_entry()` for runtime persistence. This causes a cascade: reload -> all devices re-init -> solver cold start -> charger adaptation lost -> 45-second stabilization delay before budgeting resumes.
-
-### Pattern 9: Test Layer Selection
-
-Tests live in two distinct layers. Choosing the wrong layer creates slow, brittle, or misleading tests:
-
-| What you're testing | Where to write tests | Infrastructure to use |
-|---|---|---|
-| Domain logic (solver, constraints, commands, load behavior) | `tests/` | FakeHass + factories from `factories.py` |
-| HA integration (entity lifecycle, service calls, state tracking, config flow) | `tests/ha_tests/` | Real HA fixtures from `tests/ha_tests/conftest.py` |
-| Cross-cutting integration (full device setup + solver + command execution) | `tests/` with composite fixtures | `home_and_charger`, `home_charger_and_car` fixtures |
-
-- **Never test pure domain logic through real HA fixtures** — slow, brittle, tests the framework more than your code
-- **Never test HA-specific behavior with FakeHass** — misses real HA interactions, gives false confidence
-- **Use factories for domain objects, mock configs for HA objects**: Check `factories.py` and `tests/ha_tests/const.py` before writing new test infrastructure
-
-**Anti-pattern**: Writing all tests in `tests/ha_tests/` because "it's more realistic." Domain logic tests should be fast and isolated. Reserve HA fixtures for testing the HA integration surface.
+| Pattern | New home |
+|---|---|
+| Pattern 1 — Adding a New Device Type | [config-and-setup-flow.md](../agents/concepts/config-and-setup-flow.md) (6-file checklist) + [load-base.md](../agents/concepts/load-base.md) (`AbstractLoad` contract) |
+| Pattern 2 — Creating and Managing Constraints | [constraints.md](../agents/concepts/constraints.md) |
+| Pattern 3 — Command Execution & Verification | [commands.md](../agents/concepts/commands.md) + [ha-device-mixin.md](../agents/concepts/ha-device-mixin.md) |
+| Pattern 4 — State Tracking via HADeviceMixin | [ha-device-mixin.md](../agents/concepts/ha-device-mixin.md) |
+| Pattern 5 — Charger Budgeting Interaction | [charger-budgeting.md](../agents/concepts/charger-budgeting.md) + [dynamic-group-tree.md](../agents/concepts/dynamic-group-tree.md) |
+| Pattern 6 — Solver Extension | [solver.md](../agents/concepts/solver.md) + [strategic-tactical-control.md](../agents/principles/strategic-tactical-control.md) |
+| Pattern 7 — Notification Triggers | [notification-routing.md](../agents/concepts/notification-routing.md) |
+| Pattern 8 — Config Entry Persistence | [config-and-setup-flow.md](../agents/concepts/config-and-setup-flow.md) |
+| Pattern 9 — Test Layer Selection | [testing-layers.md](../agents/concepts/testing-layers.md) |
 
 ### Enforcement Guidelines
 
 **All AI Agents MUST:**
-1. Read project-context.md (code-level rules) AND this architecture document (architectural patterns) before implementing
-2. Follow the Decision Map (step 2) to identify which components are affected
+1. Read [docs/workflow/project-context.md](../workflow/project-context.md) (code-level rules) AND the relevant `docs/agents/` files (architectural patterns) before implementing
+2. Use the [docs/agents/index.md](../agents/index.md) "Lookup by source file" table to identify which concept docs apply to your change
 3. Check the Risk-Weighted CI table (step 3) to understand the blast radius of their changes
 4. Use the correct extension pattern for the type of change (device, constraint, command, state, notification)
 5. Never bypass budget validation, rate limiting, or the domain/HA boundary
-6. Choose the correct test layer (Pattern 9) before writing any tests
-7. Use `save_entry_data_no_reload()` for runtime persistence, never `async_update_entry()`
+6. Choose the correct test layer ([testing-layers.md](../agents/concepts/testing-layers.md)) before writing any tests
+7. Use `save_entry_data_no_reload()` for runtime persistence, never `async_update_entry()` (see [config-and-setup-flow.md](../agents/concepts/config-and-setup-flow.md))
 
 **Pattern Violations:**
 - Ruff and MyPy catch code-level violations automatically
 - Architectural violations (wrong layer, missing load_info, bypassed budget validation) must be caught in code review
 - CI risk assessment comment (auto-review workflow) flags changes to trust-critical components
+- The drift checker (`scripts/qs/check_doc_drift.py`) catches docs falling out of sync — see
+  [docs/workflow/project-rules.md](../workflow/project-rules.md) "Doc maintenance".
 
 ## Project Structure & Boundaries
 
 ### Quick Navigation for AI Agents
 
-When implementing a story, use this decision tree to find your files. For deeper context on what you need to *understand* before modifying those files, see the Decision Map in the Conceptual Component Model section.
-
-| If you're implementing... | Start here | Test location |
-|---|---|---|
-| New device type | Pattern 1 (7-file checklist) | `tests/` (domain) + `tests/ha_tests/` (HA) |
-| New constraint behavior | `home_model/constraints.py` | `tests/test_constraints*.py` |
-| New HA integration for existing device | `ha_model/<device>.py` | `tests/ha_tests/test_<device>.py` |
-| New platform entity | `<platform>.py` (factory pattern) | `tests/test_platform_<platform>.py` |
-| Notification or override flow | Trace full path: `person.py` → `home.py` → notify | Tests across domain + HA layers |
-| CI/CD change | `.github/workflows/` | Validate by running pipeline on test PR |
-| Before writing test helpers | Check `tests/utils/` first | `energy_validation.py`, `scenario_builders.py` |
-
-**Marker legend**: `[PLANNED]` = committed in the implementation sequence. `[FUTURE]` = architectural preparation, no commitment yet.
+The Quick Navigation table has moved to
+[docs/agents/index.md](../agents/index.md). Use it to find concept
+docs by source file; come back here for the architectural
+boundaries and the directory tree.
 
 ### Complete Project Directory Structure
 
@@ -836,7 +613,7 @@ quiet-solar/
 
 **[FUTURE] — Provider abstractions**: When dynamic tariff support (deferred decision) or additional forecast providers are implemented, provider abstractions would live in `home_model/providers/` (domain interface) + `ha_model/providers/` (HA-specific bridges). Do not create these directories until needed.
 
-**CLAUDE.md role**: CLAUDE.md is the Claude Code bootstrap file (auto-loaded at conversation start). It should contain only operational essentials (venv, commands) and point to `docs/workflow/project-context.md` and `docs/product/architecture.md` (this document) for the full rules. Do not duplicate content between CLAUDE.md and the project context files.
+**CLAUDE.md role**: CLAUDE.md is the Claude Code bootstrap file (auto-loaded at conversation start). It should contain only operational essentials (venv, commands) and point to `docs/workflow/project-context.md`, this document, and `docs/agents/index.md` for the full rules. Do not duplicate content between CLAUDE.md and the project context files.
 
 #### Runtime Data
 
@@ -851,50 +628,30 @@ Runtime data at `{HA config dir}/quiet_solar/` is distinct from the component so
 
 ```
 quiet-solar/
-├── CLAUDE.md                          # AI agent bootstrap (points to project context files for full rules)
+├── CLAUDE.md                          # AI agent bootstrap (points to project context + docs/agents/)
 ├── requirements_test.txt              # Test dependencies
 ├── pytest.ini                         # Pytest configuration (asyncio_mode=auto, pythonpath=., markers)
 ├── setenv.sh                          # Development environment setup (venv + pip install)
 │
-├── docs/                              # [PLANNED — documentation story, does not exist yet]
-│                                      # User guide, setup guide, contribution guide
-│                                      # Do NOT create documentation files under legacy/ (frozen)
+├── docs/                              # Documentation hierarchy
+│   ├── product/                       # product-brief.md, this document
+│   ├── workflow/                      # process / pipeline rules
+│   └── agents/                        # AI-agent addressable concept hierarchy (QS-185)
 │
-├── .github/                           # [PLANNED — CI/CD story, does not exist yet]
-│   ├── workflows/
-│   │   ├── pr-quality.yml             # Tier 1: lint + typecheck + test + HACS
-│   │   ├── pr-merge.yml               # Tier 2: matrix test + coverage report
-│   │   ├── release.yml                # Tier 3: release pipeline
-│   │   ├── auto-review.yml            # Auto-label, auto-assign, risk assessment
-│   │   ├── issue-triage.yml           # Issue auto-labeling
-│   │   └── stale.yml                  # Stale issue/PR management
-│   ├── CODEOWNERS
-│   ├── labeler.yml
-│   ├── ISSUE_TEMPLATE/
-│   │   ├── bug_report.yml
-│   │   └── feature_request.yml
-│   └── PULL_REQUEST_TEMPLATE.md
+├── .github/                           # [PLANNED — CI/CD story]
 │
 ├── tests/                             # === TEST SUITE (~3,800+ tests) ===
-│   ├── __init__.py
 │   ├── conftest.py                    # ⚠ PROTECTED: FakeHass, FakeConfigEntry, FakeState
-│   ├── factories.py                   # ⚠ PROTECTED: Factory functions for domain test doubles
-│   │
-│   ├── [domain + cross-cutting tests — see Test File Organization below]
-│   │
-│   ├── ha_tests/                      # === HA INTEGRATION TESTS (real HA fixtures) ===
-│   │   ├── __init__.py
-│   │   ├── conftest.py                # ⚠ PROTECTED: Real HA fixtures (hass, mock_config_entry)
-│   │   ├── const.py                   # ⚠ PROTECTED: MOCK_HOME_CONFIG, MOCK_CAR_CONFIG, etc.
-│   │   └── [test files using real HA fixtures]
-│   │
-│   └── utils/                         # === TEST UTILITIES ===
-│       ├── __init__.py
-│       ├── energy_validation.py       # Energy conservation assertion helpers
-│       └── scenario_builders.py       # Scenario construction for multi-device tests
+│   ├── factories.py                   # ⚠ PROTECTED: factory functions
+│   ├── ha_tests/                      # === HA integration layer (real HA fixtures) ===
+│   │   ├── conftest.py                # ⚠ PROTECTED
+│   │   └── const.py                   # ⚠ PROTECTED
+│   ├── qs/                            # tests for dev-tooling (scripts/qs/, agents)
+│   └── utils/                         # test helpers (energy_validation, scenario_builders)
 │
+├── scripts/qs/                        # dev-pipeline scripts (quality_gate, context, ...)
+├── .claude/, .cursor/, .opencode/     # per-harness agent definitions + slash commands
 └── legacy/                            # === FROZEN HISTORICAL CODE ===
-    └── (retired per-task-rendering OpenCode pipeline; do not modify)
 ```
 
 **Build artifacts** (`coverage.xml`, `*.pyc`, `__pycache__/`) live at project root and should be gitignored. Do not commit build artifacts.
@@ -909,12 +666,17 @@ quiet-solar/
 | Domain purity | Domain layer receives all HA data as parameters | Code review |
 | Constant centralization | All config keys in `const.py`, never hardcoded | Ruff linting |
 
+See [two-layer-boundary.md](../agents/principles/two-layer-boundary.md)
+for the full rule and rationale.
+
 **Strategic/Tactical boundary:**
 
 | Layer | Component | Scope | Override behavior |
 |---|---|---|---|
 | Strategic | PeriodSolver | 15-min windows, all loads | Plans optimal allocation |
 | Tactical | Charger dynamic budgeting | Real-time, chargers only | Can override strategic layer when amp budget constrains |
+
+See [strategic-tactical-control.md](../agents/principles/strategic-tactical-control.md).
 
 **Component Communication Boundaries:**
 
@@ -946,20 +708,18 @@ quiet-solar/
 |---|---|---|---|
 | CI/CD pipeline | `.github/` (entire directory) | `pytest.ini` (markers) | First structural addition. Creates all `[PLANNED]` .github files. Implement `paths:` filters in workflow triggers to map to the risk-weighted CI strategy (step 3). |
 | CLAUDE.md slim-down | None | `CLAUDE.md` | Reduce to bootstrap: commands + pointers to project context files. Remove duplicated content. |
-| Legacy cleanup | None | Remove `setup.py` | Not needed — `pytest.ini` handles pythonpath, `manifest.json` handles distribution. |
 | Bug fix: person-car assignment | None | `ha_model/person.py`, `ha_model/car.py`, `ha_model/home.py`, tests | First story through CI pipeline. Contained changes. |
-| Trust-critical component tests | New test file(s) for scenario-based charger integration tests — exact structure TBD during test design story. Name should reflect test *type* (scenario sequences), not coverage target. | `tests/conftest.py` (new fixtures) | Add infrastructure smoke tests alongside. |
+| Trust-critical component tests | New test file(s) for scenario-based charger integration tests — exact structure TBD during test design story. | `tests/conftest.py` (new fixtures) | Add infrastructure smoke tests alongside. |
 | Resilience strategy | None | `ha_model/solar.py`, `ha_model/charger.py`, `ha_model/home.py`, `ha_model/device.py`, `ha_model/person.py` | Touches many files but each change is contained (fallback logic per dependency). |
 | Solver optimization | None | `home_model/solver.py`, `home_model/constraints.py` | Contained within stable interface (Decision 3). |
-| Documentation | `docs/` directory at project root | None | Not in current implementation sequence. When stories are created, establish `docs/` — do NOT put user-facing docs under `legacy/` (frozen). |
 
 ### Test File Organization
 
-**File selection rule for agents**: When adding tests, extend existing files by test type rather than creating new files. If a file exceeds ~500 tests, split by sub-concern (e.g., phase switching, budgeting, dampening). Do not create `test_*_additional_coverage.py` or `test_*_deep.py` files — these names reflect organic growth, not intentional structure.
+**File selection rule for agents**: When adding tests, extend existing files by test type rather than creating new files. If a file exceeds ~500 tests, split by sub-concern. Do not create `test_*_additional_coverage.py` or `test_*_deep.py` files.
 
-**Root `tests/` naming clarification**: Files prefixed `test_ha_*` in `tests/` root use **FakeHass infrastructure** (lightweight, fast). Files in `tests/ha_tests/` use **real HA fixtures** (full HA instance). The naming overlap is historical. When determining which infrastructure a test uses, **check the imports** (FakeHass from `conftest.py` vs real `hass` fixture from `ha_tests/conftest.py`), not the file name.
+**Root `tests/` naming clarification**: Files prefixed `test_ha_*` in `tests/` root use **FakeHass infrastructure** (lightweight, fast). Files in `tests/ha_tests/` use **real HA fixtures**. When determining which infrastructure a test uses, **check the imports**, not the file name. See [testing-layers.md](../agents/concepts/testing-layers.md).
 
-**Shared test utilities**: Before writing test helper functions, check `tests/utils/` for existing utilities. `energy_validation.py` provides energy conservation assertion helpers. `scenario_builders.py` provides scenario construction helpers for multi-device tests. Do not reinvent helpers that already exist.
+**Shared test utilities**: Before writing test helper functions, check `tests/utils/` for existing utilities. `energy_validation.py` provides energy conservation assertion helpers. `scenario_builders.py` provides scenario construction helpers for multi-device tests.
 
 ### Protected Infrastructure Files
 
@@ -971,8 +731,6 @@ These files are load-bearing — changes silently affect the behavior of hundred
 | `tests/factories.py` | Factory functions for all domain test doubles | Same — silently alters 100+ test files |
 | `tests/ha_tests/conftest.py` | Real HA fixtures | Every HA integration test affected |
 | `tests/ha_tests/const.py` | Standard mock configurations | HA tests use wrong config silently |
-
-These files are covered by the CI/CD risk-weighted strategy (HIGH blast radius) and should be included in CODEOWNERS for mandatory review. When modifying these files, check for in-flight PRs that touch the same file to avoid merge conflicts on load-bearing test infrastructure.
 
 ## Architecture Validation Results
 
@@ -989,15 +747,13 @@ All decisions work together without conflicts:
 - No contradictory decisions found
 
 **Pattern Consistency:**
-- All 9 implementation patterns reference correct APIs, files, and lifecycle phases
+- The 9 extension patterns have been relocated to the per-concept docs under [docs/agents/](../agents/) (table above). The patterns themselves remain consistent in their new locations.
 - Naming conventions are consistent: `CONF_*` for config keys, `CONF_TYPE_NAME_QS*` for device types, `*_SENSOR` suffixes
-- Pattern 9 (test layer selection) aligns with the test file organization in Step 6
-- Pattern 1 references "7+ files" which correctly matches the 0-7 numbered sequence (including step 0: dashboard mapping)
-- Anti-patterns complement the positive patterns — no gaps where an agent could follow the pattern correctly but still make a mistake
+- Anti-patterns are documented alongside their patterns in each concept doc
 
 **Structure Alignment:**
 - Directory structure supports all 3 architectural layers with clear separation
-- Quick Navigation cross-references the Decision Map — agents have both "where" and "why"
+- Architectural boundaries (this document) + the per-source-file lookup ([docs/agents/index.md](../agents/index.md)) provide both "why" and "where"
 - Structural notes explain anomalies (data_handler.py location, thin wrapper devices) so agents don't try to "fix" what isn't broken
 - `[PLANNED]` vs `[FUTURE]` markers distinguish committed work from speculative preparation
 
@@ -1007,16 +763,16 @@ All decisions work together without conflicts:
 
 | Product brief requirement | Architectural support | Covered in |
 |---|---|---|
-| Whole-house energy orchestration | PeriodSolver + constraint system + 8+ device types | Conceptual Component Model |
-| Constraint-based solver (4 priority tiers) | PeriodSolver, LoadConstraint hierarchy | Component Model + Pattern 6 |
-| People-aware automation | Person model, trip prediction, person-car allocation | Component Model + Pattern 2 |
-| Smart device handling (external control) | `external_user_initiated_state` detection | Pattern 3 |
-| Off-grid resilience | Grid outage row in resilience table | Decision 1 |
-| Tariff-aware scheduling | Solver accepts tariff tuples; dynamic tariffs deferred | Decision 3 + Deferred |
-| UI dashboards | Jinja2 + 4 custom JS cards + programmatic HA API | Component Model (UI layer) |
-| Notification & override flows | `on_device_state_change()`, per-person routing, dedup | Pattern 7 |
-| Multi-protocol charger support | OCPP/Wallbox/Generic variants | Component Model |
-| Real-time charger budgeting | Tactical layer, QSDynamicGroup tree, staged transitions | Hierarchical Control Architecture |
+| Whole-house energy orchestration | PeriodSolver + constraint system + 8+ device types | [solver.md](../agents/concepts/solver.md), [constraints.md](../agents/concepts/constraints.md) |
+| Constraint-based solver (4 priority tiers) | PeriodSolver, LoadConstraint hierarchy | [solver.md](../agents/concepts/solver.md), [constraints.md](../agents/concepts/constraints.md) |
+| People-aware automation | Person model, trip prediction, person-car allocation | [person-trip-prediction.md](../agents/concepts/person-trip-prediction.md) |
+| Smart device handling (external control) | `external_user_initiated_state` detection | [external-control-detection.md](../agents/concepts/external-control-detection.md) |
+| Off-grid resilience | Grid outage row in resilience table | Decision 1 + [off-grid-mode.md](../agents/concepts/off-grid-mode.md) |
+| Tariff-aware scheduling | Solver accepts tariff tuples; dynamic tariffs deferred | Decision 3 + [cheap-grid-charging.md](../agents/use-cases/cheap-grid-charging.md) |
+| UI dashboards | Jinja2 + 4 custom JS cards + programmatic HA API | This document (UI layer) |
+| Notification & override flows | `on_device_state_change()`, per-person routing, dedup | [notification-routing.md](../agents/concepts/notification-routing.md), [user-override.md](../agents/concepts/user-override.md) |
+| Multi-protocol charger support | OCPP/Wallbox/Generic variants | [charger-budgeting.md](../agents/concepts/charger-budgeting.md) |
+| Real-time charger budgeting | Tactical layer, QSDynamicGroup tree, staged transitions | [strategic-tactical-control.md](../agents/principles/strategic-tactical-control.md) |
 | 100% test coverage | CI pipeline threshold = 100%, mandatory | CI/CD Pipeline Architecture |
 | HACS distribution | manifest.json, hacs.json, HACS validation in CI | Technology Stack + CI |
 
@@ -1028,8 +784,8 @@ All decisions work together without conflicts:
 | Development workflow validated | Bug fix as first story through pipeline | ✅ Sequenced as step 2 |
 | Solver improved | Stable interface boundary (Decision 3) | ✅ Boundary defined |
 | 100% coverage maintained | CI enforces, risk-weighted strategy prioritizes | ✅ Pipeline designed |
-| Documentation started | Architecture doc + project-context.md | ✅ This document |
-| Ready for structured feature work | 9 patterns + structure mapping + decision map | ✅ Complete |
+| Documentation started | Architecture doc + project-context.md + docs/agents/ hierarchy | ✅ This document + QS-185 |
+| Ready for structured feature work | Patterns relocated to concept docs + structure mapping + drift checker | ✅ Complete |
 
 **Non-Functional Requirements:**
 
@@ -1053,23 +809,21 @@ All decisions work together without conflicts:
 - Full directory tree with per-file annotations ✅
 - Structural notes for 4 anomalies/clarifications ✅
 - Runtime data paths documented ✅
-- Near-term work → structure mapping (8 work items) ✅
+- Near-term work → structure mapping ✅
 - Protected infrastructure files identified ✅
 
 **Pattern Completeness:**
-- 9 patterns covering all extension types ✅
-- Every pattern has an anti-pattern ✅
-- Decision Map (step 2) provides component-level guidance ✅
-- Quick Navigation (step 6) provides file-level guidance ✅
-- Enforcement guidelines with 7 mandatory agent rules ✅
-- Patterns cover *extension* (add device, add constraint, add notification). *Modification* stories (bug fixes, behavior changes in existing code) require agents to read existing code and apply patterns contextually — this is expected and correct behavior.
+- 9 patterns relocated to [docs/agents/](../agents/) with cross-references in this document ✅
+- Every pattern has an anti-pattern in its new home ✅
+- Lookup-by-source-file table provides component-level guidance ([docs/agents/index.md](../agents/index.md)) ✅
+- Enforcement guidelines preserved ✅
 
 **Agent Navigation Test** — can an agent find what it needs?
-- "I need to add a new device" → Quick Nav → Pattern 1 → 7-file checklist → test layer (Pattern 9) ✅
-- "I need to fix a charger bug" → Decision Map → charger files → Risk table (CRITICAL, physical) → trust-critical testing ✅
-- "I need to set up CI/CD" → Quick Nav → `.github/` → CI/CD Pipeline Architecture → risk-weighted strategy → Near-Term Work mapping ✅
-- "I need to understand why the solver made this decision" → Data Flows → PeriodSolver → constraint scoring → command timeline ✅
-- "I need to add a notification for a new event" → Pattern 7 → notification routing → `on_device_state_change()` → trace Magali path (person → constraint → solver → charger → notification) → test in domain + HA layers ✅
+- "I need to add a new device" → [docs/agents/index.md](../agents/index.md) → concept docs for relevant device-base patterns + [config-and-setup-flow.md](../agents/concepts/config-and-setup-flow.md) ✅
+- "I need to fix a charger bug" → [docs/agents/index.md](../agents/index.md) → [charger-budgeting.md](../agents/concepts/charger-budgeting.md) + risk table in this doc (CRITICAL, physical) ✅
+- "I need to set up CI/CD" → CI/CD Pipeline Architecture (this doc) → risk-weighted strategy → Near-Term Work mapping ✅
+- "I need to understand why the solver made this decision" → [solver.md](../agents/concepts/solver.md) → Data Flows (this doc) ✅
+- "I need to add a notification for a new event" → [notification-routing.md](../agents/concepts/notification-routing.md) + [magali-plugs-in-car.md](../agents/use-cases/magali-plugs-in-car.md) ✅
 
 ### Gap Analysis Results
 
@@ -1100,12 +854,12 @@ All decisions work together without conflicts:
 - [x] Project context analyzed with codebase deep dive
 - [x] Scale and complexity assessed (8+ device types, 2 optimization engines)
 - [x] Technical constraints identified (HA platform, physical circuits, async discipline)
-- [x] Cross-cutting concerns mapped (7 concerns with interaction points)
-- [x] Decision Map created for agent guidance
+- [x] Cross-cutting concerns mapped (now expressed as principles under [docs/agents/principles/](../agents/principles/))
+- [x] Decision Map relocated to [docs/agents/index.md](../agents/index.md)
 
 **✅ Technology Stack & CI/CD (Step 3)**
 - [x] Technology stack fully specified with version pinning concerns
-- [x] Dual test infrastructure documented (FakeHass + real HA fixtures)
+- [x] Dual test infrastructure documented (pointer to [testing-layers.md](../agents/concepts/testing-layers.md))
 - [x] Risk-weighted CI strategy mapping change areas to blast radius
 - [x] 3-tier CI/CD pipeline architecture with 3 automation workflows
 - [x] Test suite inventory with gap analysis
@@ -1118,10 +872,9 @@ All decisions work together without conflicts:
 - [x] Cross-component dependency analysis
 
 **✅ Implementation Patterns (Step 5)**
-- [x] 9 patterns covering all extension types
-- [x] Anti-patterns for each pattern
-- [x] Enforcement guidelines with 7 mandatory rules
-- [x] Relationship to project-context.md clarified
+- [x] 9 patterns covering all extension types (relocated to [docs/agents/](../agents/))
+- [x] Anti-patterns documented in each concept doc
+- [x] Enforcement guidelines preserved here
 
 **✅ Project Structure (Step 6)**
 - [x] Complete directory tree with annotations
@@ -1130,7 +883,7 @@ All decisions work together without conflicts:
 - [x] External integration points with failure modes
 - [x] Near-term work → structure mapping
 - [x] Test file organization with protected files
-- [x] Quick Navigation for agent file discovery
+- [x] Quick Navigation moved to [docs/agents/index.md](../agents/index.md)
 
 **✅ Architecture Validation (Step 7)**
 - [x] Coherence validation passed
@@ -1144,14 +897,15 @@ All decisions work together without conflicts:
 
 **Confidence Level: HIGH**
 
-The architecture document covers a mature, production brownfield codebase with established patterns. Most decisions were "already decided" by the existing code — this document makes them explicit and navigable for AI agents.
+The architecture document covers a mature, production brownfield codebase with established patterns. Most decisions were "already decided" by the existing code — this document makes them explicit and navigable for AI agents. As of QS-185, per-concept documentation lives in [docs/agents/](../agents/); this document is the decisions / CI / structure layer above it.
 
 **Key Strengths:**
-- Two-level hierarchy (Decision Map + Quick Navigation) provides both understanding and file-level navigation
+- Two-level hierarchy ([docs/agents/index.md](../agents/index.md) Decision Map + Quick Navigation) provides both understanding and file-level navigation
 - Risk-weighted CI strategy connects code changes to their real-world impact
 - Trust-critical components (charger budgeting, constraint interactions) are explicitly flagged with testing commitments
-- 9 implementation patterns with anti-patterns cover all common extension types
+- 9 implementation patterns relocated to per-concept docs — agents pull just the pattern they need
 - Protected infrastructure files identified to prevent silent test regression
+- Drift checker (`scripts/qs/check_doc_drift.py`) catches docs falling out of sync with their `covers:` source
 
 **Areas for Future Enhancement:**
 - Solver quality benchmarks (when refactoring begins)
@@ -1163,13 +917,13 @@ The architecture document covers a mature, production brownfield codebase with e
 ### Implementation Handoff
 
 **AI Agent Guidelines:**
-1. Read `docs/workflow/project-context.md` (42 code-level rules) AND this architecture document before implementing any code
-2. Use the Quick Navigation table (step 6) to find your files
-3. Use the Decision Map (step 2) to understand what you need to know
-4. Check the Risk-Weighted CI table (step 3) to understand your blast radius
-5. Follow the correct implementation pattern (step 5) for your change type
-6. Choose the correct test layer (Pattern 9) before writing tests
-7. Never bypass budget validation, rate limiting, or the domain/HA boundary
+1. Read [docs/workflow/project-context.md](../workflow/project-context.md) (42 code-level rules), the relevant `docs/agents/concepts/` files for the components you're touching, and this architecture document for decisions / CI / structure context
+2. Use [docs/agents/index.md](../agents/index.md) "Lookup by source file" to find concept docs from a source path
+3. Check the Risk-Weighted CI table (Technology Stack section) to understand your blast radius
+4. Follow the correct extension pattern via the "Pattern N → new home" table in the Implementation Patterns section
+5. Choose the correct test layer ([testing-layers.md](../agents/concepts/testing-layers.md)) before writing tests
+6. Never bypass budget validation, rate limiting, or the domain/HA boundary
+7. Run `python scripts/qs/check_doc_drift.py` before staging — see [docs/workflow/project-rules.md](../workflow/project-rules.md) "Doc maintenance"
 
 **First Implementation Priority:**
 CI/CD pipeline (`.github/` directory) — enables all subsequent work through the structured workflow. After CI/CD, the first *code* story is the person-car assignment bug fix — see implementation sequence in the Decision Impact Analysis section.

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -92,7 +92,8 @@ table to find the right doc.
   [notification-routing.md](../agents/concepts/notification-routing.md),
   [user-override.md](../agents/concepts/user-override.md).
 - UI & configuration layer — see
-  [config-and-setup-flow.md](../agents/concepts/config-and-setup-flow.md).
+  [config-and-setup-flow.md](../agents/concepts/config-and-setup-flow.md)
+  and [dashboard-and-cards.md](../agents/concepts/dashboard-and-cards.md).
 - Testing layers — see
   [testing-layers.md](../agents/concepts/testing-layers.md).
 
@@ -769,7 +770,7 @@ All decisions work together without conflicts:
 | Smart device handling (external control) | `external_user_initiated_state` detection | [external-control-detection.md](../agents/concepts/external-control-detection.md) |
 | Off-grid resilience | Grid outage row in resilience table | Decision 1 + [off-grid-mode.md](../agents/concepts/off-grid-mode.md) |
 | Tariff-aware scheduling | Solver accepts tariff tuples; dynamic tariffs deferred | Decision 3 + [cheap-grid-charging.md](../agents/use-cases/cheap-grid-charging.md) |
-| UI dashboards | Jinja2 + 4 custom JS cards + programmatic HA API | This document (UI layer) |
+| UI dashboards | Jinja2 + 4 custom JS cards + programmatic HA API | [dashboard-and-cards.md](../agents/concepts/dashboard-and-cards.md) |
 | Notification & override flows | `on_device_state_change()`, per-person routing, dedup | [notification-routing.md](../agents/concepts/notification-routing.md), [user-override.md](../agents/concepts/user-override.md) |
 | Multi-protocol charger support | OCPP/Wallbox/Generic variants | [charger-budgeting.md](../agents/concepts/charger-budgeting.md) |
 | Real-time charger budgeting | Tactical layer, QSDynamicGroup tree, staged transitions | [strategic-tactical-control.md](../agents/principles/strategic-tactical-control.md) |

--- a/docs/product/product-brief.md
+++ b/docs/product/product-brief.md
@@ -41,11 +41,17 @@ Quiet Solar follows an **observe-predict-optimize** approach. It continuously ob
 
 ## Target Users
 
-- **TheAdmin** — homeowner with solar, comfortable with Home Assistant. Configures devices, monitors performance, tweaks priorities. Two modes: setup (learning, cautious, needs guidance) and operational (confident, wants efficiency). Trust is built through transparent diagnostics when things go wrong, not through being perfect.
+The full persona descriptions live in
+[docs/agents/personas/](../agents/personas/) as individual files —
+`the-admin.md`, `the-dev.md`, and `magali.md` — so agents can pull
+them addressably without reading the whole product brief. Summary:
 
-- **TheDev** — developer (often the same person as TheAdmin) who finds joy in solving real family problems through code. Building mode: smooth pipeline, no manual GitHub ops, expressive tests. Exploring mode: agentic pairing, fast feedback. Allergic to bureaucracy.
-
-- **Household members** (e.g., Magali) — passive 95% of the time; receive notifications and occasionally override. Override must be a 5-second interaction or trust erodes.
+- **TheAdmin** — homeowner with solar, comfortable with HA. Two modes
+  (setup vs operational); trust built via transparent diagnostics.
+- **TheDev** — developer (often the same person as TheAdmin); building
+  vs exploring modes; allergic to bureaucracy.
+- **Household members** (e.g., Magali) — passive 95% of the time;
+  override must be a 5-second interaction or trust erodes.
 
 ## Optimization Hierarchy
 

--- a/docs/stories/QS-185.story.md
+++ b/docs/stories/QS-185.story.md
@@ -143,11 +143,12 @@ load constraints)
 **And** the file follows the doc format above
 **And** the index ≤180 lines and acts as the only entry point.
 
-### AC-2 — Concept coverage (20 concept files)
+### AC-2 — Concept coverage (21 concept files)
 
-The following 20 concept files exist under
+The following 21 concept files exist under
 `docs/agents/concepts/`, each `covers:`-anchored to one primary source
-file:
+file (or a tightly-related cluster of files in the case of the
+multi-file UI / config-flow concepts):
 
 All `covers:` paths in the table below are full
 `custom_components/quiet_solar/<path>` (or `tests/<path>` for the
@@ -175,7 +176,21 @@ testing-layers off-tree exception) — matching the drift checker's
 | `user-override` | `custom_components/quiet_solar/home_model/load.py` (user-originated state) |
 | `solar-providers` | `custom_components/quiet_solar/ha_model/solar.py` (multi-provider, dampening) |
 | `config-and-setup-flow` | `custom_components/quiet_solar/config_flow.py`, `custom_components/quiet_solar/__init__.py`, `custom_components/quiet_solar/data_handler.py`, `custom_components/quiet_solar/const.py` |
+| `dashboard-and-cards` | `custom_components/quiet_solar/ui/dashboard.py`, `custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2`, `custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2`, `custom_components/quiet_solar/ui/resources/qs-car-card.js`, `custom_components/quiet_solar/ui/resources/qs-pool-card.js`, `custom_components/quiet_solar/ui/resources/qs-climate-card.js`, `custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js` |
 | `testing-layers` | `tests/conftest.py`, `tests/factories.py`, `tests/ha_tests/conftest.py`, `tests/ha_tests/const.py` (off-tree — warnings only per the drift checker's TRACKED_PREFIX rule) |
+
+**Note on `dashboard-and-cards`** (added by review-fix #02, user
+direction): the UI layer ships **two Jinja2 dashboard templates** that
+HA renders to Lovelace YAML on first install + **four custom JS
+Lovelace cards** (`qs-car-card`, `qs-pool-card`, `qs-climate-card`,
+`qs-on-off-duration-card`) — one per device type that needs richer
+interaction than a stock `entities` card. The custom-cards dashboard
+(`quiet-solar`) and the standard-cards dashboard (`quiet-solar-standard`)
+both iterate `home.dashboard_sections` and pull devices via
+`home.get_devices_for_dashboard_section(...)`. The JS cards are
+explicitly outside the quality pipeline (product brief: "don't modify
+JS without explicit instruction"); the concept doc captures this as a
+hard rule.
 
 ### AC-3 — Principle coverage (5 principle files)
 
@@ -351,9 +366,9 @@ No LSP code is added in this story — decision document only.
 
 ### AC-14 — architecture.md trim (LAST task)
 
-**Only after** all 37 new doc files (1 index + 20 concepts + 5
+**Only after** all 38 new doc files (1 index + 21 concepts + 5
 principles + 6 use cases + 3 personas + 1 glossary + 1 LSP eval =
-**37**) are written and committed, `docs/product/architecture.md`
+**38**) are written and committed, `docs/product/architecture.md`
 is trimmed
 section-by-section. The implementer reads it top-to-bottom and:
 
@@ -397,7 +412,7 @@ review-able. All phases run inside `qs-implement-setup-task`.
 
 ### Phase C — Concept docs
 
-8. Write 20 concept files per AC-2. Each: read the source file,
+8. Write 21 concept files per AC-2. Each: read the source file,
    write the 6 sections, add `covers:` frontmatter.
 9. As each concept lands, fill its row in `index.md`'s lookup
    tables.
@@ -473,7 +488,10 @@ draft plan. Findings were triaged with the user.
 - **Concept-name ambiguity** (concrete-planner C1): renamed to
   source-file-anchored slugs (e.g., `commands.md` not
   `load-command.md`; `home-model-battery.md` and `ha-battery.md`
-  instead of one ambiguous `battery.md`). 20 concepts total.
+  instead of one ambiguous `battery.md`). 20 concepts initially;
+  a 21st (`dashboard-and-cards`) was added in review-fix #02
+  after the user requested explicit coverage of the UI layer
+  (two Jinja templates + four per-device JS Lovelace cards).
 - **PyYAML availability** (concrete-planner C2): contrary to the
   reviewer's claim, PyYAML is transitively available via
   `homeassistant>=2026.4.2` (confirmed by

--- a/docs/stories/QS-185.story.md
+++ b/docs/stories/QS-185.story.md
@@ -1,0 +1,532 @@
+---
+issue: 185
+title: Build documentation hierarchy for AI agents (plan/implement/review) and evaluate LSP server
+branch: QS_185
+status: planned
+next_phase: implement-setup-task
+labels: [area:battery, area:car, area:person, area:ui, area:docs]
+---
+
+# QS-185 — Build documentation hierarchy for AI agents (plan/implement/review) and evaluate LSP server
+
+## Why
+
+Today, the canonical doc reference for AI agents is
+`docs/product/architecture.md` (1,180 lines, ~25k tokens) plus
+`docs/workflow/project-context.md`, `docs/workflow/project-rules.md`,
+and the product brief. When a plan, implement, or review agent needs a
+specific slice of knowledge — "what's a `LoadCommand`?", "how does
+charger budgeting interact with the solver?", "what does Magali's
+plug-in flow look like end-to-end?" — it must either pull the whole
+architecture document or fall back to grepping the code. Both are
+expensive.
+
+This story builds an **addressable** documentation hierarchy under
+`docs/agents/` — short, topic-scoped files that agents can pull
+individually. Each file declares the source files it covers; a new
+drift-check script (`scripts/qs/check_doc_drift.py`) makes
+the maintenance contract enforceable. The plan/implement/review agent
+bodies are updated across all three harnesses (Claude / Cursor /
+OpenCode) so doc upkeep is part of the workflow, not an afterthought.
+The story also produces a decision document evaluating whether a
+Python LSP server would complement the doc hierarchy. Finally,
+`docs/product/architecture.md` is trimmed after the new hierarchy is
+in place — content now covered elsewhere is removed or shortened so
+no concept lives in two places.
+
+## Inputs
+
+- `docs/product/product-brief.md` — vision, personas, optimization
+  hierarchy.
+- `docs/product/architecture.md` — current canonical reference; will be
+  trimmed at the end of this story.
+- `docs/workflow/project-context.md`, `docs/workflow/project-rules.md`,
+  `docs/workflow/overview.md`, `docs/workflow/phase-protocols.md`,
+  `docs/workflow/adversarial-review.md`, `docs/workflow/harness.md`.
+- `docs/failure-mode-catalog.md` — existing living-doc precedent.
+- Source under `custom_components/quiet_solar/**`.
+- Existing agent-parity test pattern:
+  `tests/qs/agents/test_opencode_agents.py` and
+  `tests/qs/agents/const.py`.
+
+## Out of scope
+
+- Changes to production behavior under
+  `custom_components/quiet_solar/**`.
+- Touching `legacy/**` (the frozen retired pipeline).
+- Building an LSP server, MCP wrapper, or prototype integration — the
+  LSP work in this story is a **decision document only**.
+- Auto-generating doc content from source code (e.g., via docstring
+  extraction). Deferred to a follow-up.
+- A blocking quality-gate hook for the drift checker — it ships
+  non-blocking in this story.
+- A `.claude/.cursor/.opencode` mirror-generator script — manual
+  mirroring is documented; automation deferred.
+
+## Concept vs principle vs use-case vs persona — taxonomy
+
+The new hierarchy uses four categories with a 1-sentence rule for each:
+
+- **Concept** — a specific runtime construct, class, or mechanism
+  anchored to one primary source file (e.g., `LoadCommand`,
+  `LoadConstraint`, `PeriodSolver`).
+- **Principle** — a cross-cutting design rule that governs many
+  concepts (e.g., observe-predict-optimize, two-layer boundary).
+- **Use case** — an end-to-end scenario showing how concepts and
+  principles compose in practice (e.g., "Magali plugs in her car").
+- **Persona** — a user archetype with goals, pain points, and a
+  characteristic interaction path (TheAdmin / TheDev / Magali).
+
+Boundary case heuristic: a topic is a **concept** if it answers
+"what is X" with reference to specific code; a **principle** if it
+answers "why X over Y" without code; a **use case** if it answers
+"what happens when …".
+
+## Doc file format
+
+```text
+---
+title: <human-readable name>
+slug: <kebab-case>
+kind: concept | principle | use-case | persona
+covers:
+  - custom_components/quiet_solar/<path-to-source>
+  - ...
+last_verified: YYYY-MM-DD
+---
+
+# <Title>
+
+## TL;DR
+<≥3 sentences>
+
+## When you need this concept
+- <≥3 bullets describing the agent task that should pull this doc>
+
+## Core idea
+<≥1 paragraph>
+
+## Key types / structures (concepts only)
+<class/function names with one-line purpose>
+
+## Lifecycle / sequence (where applicable)
+
+## Common mistakes
+- <≥1 bullet>
+
+## See also
+- <≥1 cross-link to a related doc>
+```
+
+**Rules:**
+
+- `covers:` paths are validated by `check_doc_drift.py`; missing paths
+  exit code 2.
+- `covers:` is restricted to `custom_components/quiet_solar/**`. Files
+  under `docs/`, `scripts/`, `tests/`, `legacy/`, `.claude/`,
+  `.cursor/`, `.opencode/`, or `.github/` are **not** drift-tracked
+  (avoids self-reference paradoxes and noise on dev-infrastructure
+  churn).
+- Line-count guidance (not enforced): concepts ≤100, principles ≤80,
+  use cases ≤80, personas ≤50. Minimums are the section list above
+  (e.g., TL;DR ≥3 sentences, "When you need this" ≥3 bullets).
+
+## Acceptance criteria
+
+### AC-1 — Addressable hierarchy exists
+
+**Given** an AI agent needs to learn about a domain concept (e.g.,
+load constraints)
+**When** it opens `docs/agents/index.md`
+**Then** the index resolves the concept to exactly one file at
+`docs/agents/concepts/<slug>.md`
+**And** the file follows the doc format above
+**And** the index ≤180 lines and acts as the only entry point.
+
+### AC-2 — Concept coverage (20 concept files)
+
+The following 20 concept files exist under
+`docs/agents/concepts/`, each `covers:`-anchored to one primary source
+file:
+
+| Slug | Covers |
+|---|---|
+| `commands` | `home_model/commands.py` |
+| `constraints` | `home_model/constraints.py` |
+| `solver` | `home_model/solver.py` |
+| `load-base` | `home_model/load.py` (AbstractDevice + AbstractLoad) |
+| `home-model-battery` | `home_model/battery.py` |
+| `ha-battery` | `ha_model/battery.py` |
+| `charger-budgeting` | `ha_model/charger.py` |
+| `dynamic-group-tree` | `ha_model/dynamic_group.py` |
+| `qs-home-orchestrator` | `ha_model/home.py` (cycles + QSHomeMode) |
+| `ha-device-mixin` | `ha_model/device.py` (HADeviceMixin) |
+| `person-trip-prediction` | `ha_model/person.py`, `ha_model/car.py` |
+| `off-grid-mode` | `ha_model/home.py` (off-grid path) |
+| `external-control-detection` | `home_model/load.py`, `ha_model/device.py` |
+| `notification-routing` | `ha_model/home.py`, `ha_model/person.py` |
+| `piloted-device-and-heat-pump` | `home_model/load.py` (PilotedDevice), `ha_model/heat_pump.py`, `ha_model/climate_controller.py` |
+| `bistate-duration-devices` | `ha_model/bistate_duration.py`, `ha_model/on_off_duration.py`, `ha_model/pool.py` |
+| `user-override` | `home_model/load.py` (user-originated state) |
+| `solar-providers` | `ha_model/solar.py` (multi-provider, dampening) |
+| `config-and-setup-flow` | `config_flow.py`, `__init__.py`, `data_handler.py`, `const.py` |
+| `testing-layers` | `tests/conftest.py`, `tests/factories.py`, `tests/ha_tests/conftest.py`, `tests/ha_tests/const.py` |
+
+### AC-3 — Principle coverage (5 principle files)
+
+The following 5 principle files exist under `docs/agents/principles/`:
+
+- `observe-predict-optimize` — the foundational design philosophy.
+- `two-layer-boundary` — `home_model/` vs `ha_model/` strict
+  separation.
+- `hysteresis-and-switching-cost` — switching budgets, hysteresis
+  windows.
+- `strategic-tactical-control` — PeriodSolver (strategic) vs charger
+  budgeting (tactical).
+- `event-driven-with-fallback` — solver re-evaluation triggers + the
+  5-minute fallback timer.
+
+### AC-4 — Use-case coverage (6 use cases)
+
+The following 6 use-case files exist under `docs/agents/use-cases/`:
+
+- `magali-plugs-in-car` — end-to-end "magic moment".
+- `solar-surplus-allocation` — system maximizes free self-consumption.
+- `cheap-grid-charging` — battery/car charges during off-peak windows
+  to reduce grid cost.
+- `off-grid-kicks-in` — grid outage detection and emergency broadcast.
+- `external-override` — smart device adapts when controlled outside QS.
+- `solver-replans-on-state-change` — event-driven re-evaluation.
+
+### AC-5 — Persona coverage (3 personas)
+
+`docs/agents/personas/` contains `the-admin.md`, `the-dev.md`, and
+`magali.md`. Content is extracted from
+`docs/product/product-brief.md` — the brief's "Target Users" section
+is replaced with a pointer to these files.
+
+### AC-6 — Glossary
+
+`docs/agents/glossary.md` lists ≥30 domain terms with short
+definitions (e.g., SOC, MANDATORY constraint, FILLER, dampening,
+3P/1P, dynamic group, adaptation window, ack/launched/pending command,
+HACS, …).
+
+### AC-7 — Drift checker (`scripts/qs/check_doc_drift.py`)
+
+**Given** a developer modifies a tracked source file
+**When** they run `python scripts/qs/check_doc_drift.py`
+**Then** the script:
+
+- Discovers all `docs/agents/**/*.md`, parses their YAML frontmatter
+  with PyYAML, and builds the inverse index source → covering docs.
+- Identifies modified source files via
+  `git diff --cached --diff-filter=ACMRD --name-only` in default
+  (staged) mode.
+- Accepts `--paths <file> [<file>…]` to override the staged-diff source.
+- Accepts `--json` for machine-readable output with schema:
+
+  ```json
+  {
+    "stale_docs": [
+      {"doc": "docs/agents/concepts/X.md",
+       "stale_sources": ["custom_components/.../X.py"],
+       "last_verified": "YYYY-MM-DD"}
+    ],
+    "missing_covers": ["docs/agents/concepts/Y.md::custom_components/.../Z.py"],
+    "malformed_frontmatter": ["docs/agents/concepts/W.md"]
+  }
+  ```
+
+- Exit codes: `0` = clean, `1` = drift detected, `2` = malformed
+  frontmatter or `covers:` path doesn't exist.
+- Handles file renames via `--diff-filter=ACMRD` (rename = delete +
+  add); a renamed source listed as `covers:` produces exit 2.
+- Ignores `covers:` entries outside
+  `custom_components/quiet_solar/**` (returns warning only).
+
+### AC-8 — Drift checker tests
+
+`tests/qs/test_check_doc_drift.py` covers, at minimum, these test
+functions on isolated `tmp_path` doc trees (no dependency on the real
+`docs/agents/` content):
+
+- `test_clean_when_no_changes`
+- `test_drift_when_source_modified_alone`
+- `test_silent_when_doc_co_modified`
+- `test_handles_added_source`
+- `test_handles_renamed_source_exits_2`
+- `test_handles_deleted_source_exits_2`
+- `test_malformed_frontmatter_exits_2`
+- `test_missing_covers_path_exits_2`
+- `test_paths_flag_overrides_staged`
+- `test_json_schema_matches`
+- `test_ignores_non_quiet_solar_paths`
+- `test_works_in_arbitrary_cwd`
+
+100% coverage on `scripts/qs/check_doc_drift.py` (no
+`# pragma: no cover`).
+
+### AC-9 — Agent body updates (3 harnesses)
+
+Each of the four orchestrator agents is updated **identically** (body
+content only — frontmatter format is harness-specific and stays
+untouched) in `.claude/agents/`, `.cursor/agents/`, and
+`.opencode/agents/`:
+
+- **`qs-create-plan.md`** — step 3 (plan drafting) gains a sub-step:
+  "Run `python scripts/qs/check_doc_drift.py --paths <planned_files>`;
+  for every doc surfaced, add a 'Update `docs/agents/<path>`' task to
+  the breakdown OR add an explicit 'Doc-OK: <reason>' note in the
+  story explaining why the doc is unaffected."
+- **`qs-implement-task.md`** — step 4 (quality gate) gains a
+  pre-commit sub-step: "Run `python scripts/qs/check_doc_drift.py`
+  on the staged diff. If exit 1, either update the listed docs and
+  restage, or include a justification paragraph in the PR body under a
+  `## Doc maintenance` heading."
+- **`qs-implement-setup-task.md`** — identical sub-step inserted at
+  step 4.
+- **`qs-review-task.md`** — step 3 (consolidation) gains: "If the PR
+  shows no `## Doc maintenance` justification and
+  `check_doc_drift.py` would have failed, flag it as a must-fix
+  finding."
+
+### AC-10 — Three-harness mirror parity
+
+`tests/qs/agents/test_doc_maintenance_parity.py` (NEW) verifies that
+each of the four updated agent bodies contains the
+`check_doc_drift.py` invocation token in all three harnesses. Pattern
+follows `tests/qs/agents/test_opencode_agents.py`.
+
+### AC-11 — Lightweight maintenance note in project-rules.md
+
+`docs/workflow/project-rules.md` gains a 5–7-line "Doc maintenance"
+subsection under "## Architecture constraints" pointing to:
+
+- The drift checker (`scripts/qs/check_doc_drift.py`).
+- The four updated agent bodies.
+- The taxonomy (concept/principle/use-case/persona).
+
+No new pattern in `docs/workflow/project-context.md` (scope-guardian's
+compromise: prose lives in the agent bodies, not in the 42-rule set).
+
+### AC-12 — LSP evaluation decision doc
+
+`docs/agents/lsp-evaluation.md` contains:
+
+- Problem statement: when agents need symbol lookup / references /
+  type info, they currently `grep` + `glob` and pay a token cost.
+- Three Python LSP options evaluated: `pyright`, `jedi-language-server`,
+  `pylsp` — install footprint, query latency, output verbosity.
+- Three consumption mechanisms for an agent: MCP server wrapper,
+  direct subprocess via Bash, custom Claude Code / Cursor tool.
+- Quantitative comparison on 3 sample agent queries (e.g., "find all
+  callers of `Battery.charge`", "list type of `LoadConstraint.score`",
+  "find references to `SOLVER_STEP_S`") — token cost of Grep+Glob vs
+  estimated LSP response size for each.
+- **Explicit recommendation**: `adopt now` / `prototype` / `defer` /
+  `reject`, with conditions if `defer` (what would unlock adoption).
+
+No LSP code is added in this story — decision document only.
+
+### AC-13 — Index design
+
+`docs/agents/index.md` ≤180 lines, structured as:
+
+1. Overview — 1 paragraph on what this tree is.
+2. **Lookup by source file** — "I'm modifying X → read these docs"
+   table. Path → concept doc.
+3. **Lookup by concept name** — Concept → file table (with kind
+   marker).
+4. **Lookup by persona / use case** — cross-link table.
+5. Pointers to `glossary.md`, `lsp-evaluation.md`, and (out-of-tree)
+   `project-rules.md`, `project-context.md`, `architecture.md`.
+6. Maintenance contract — 3 bullets describing how the docs stay in
+   sync with code (covers + drift checker + agent-body steps).
+
+### AC-14 — architecture.md trim (LAST task)
+
+**Only after** all 35 new doc files (1 index + 20 concepts + 5
+principles + 6 use cases + 3 personas + glossary + LSP eval) are
+written and committed, `docs/product/architecture.md` is trimmed
+section-by-section. The implementer reads it top-to-bottom and:
+
+- For every section whose content is now in a new doc, replaces the
+  section with a short pointer (e.g., "See
+  [docs/agents/concepts/solver.md](../agents/concepts/solver.md) for
+  the solver allocation algorithm.").
+- For every section that survives (architectural decisions log,
+  validation results, completeness checklist), keeps it verbatim or
+  shortens.
+- Adds a "See also" pointer to `docs/agents/index.md` at the top.
+
+The implementer documents in the PR body which architecture.md
+sections were trimmed, kept, or shortened (transparency for review).
+No hard line-count target — judgment call, scored by no-duplication.
+
+## Task breakdown
+
+The story is implemented in **6 phases** to keep the diff
+review-able. All phases run inside `qs-implement-setup-task`.
+
+### Phase A — Drift checker (TDD)
+
+1. Write `tests/qs/test_check_doc_drift.py` with the 12 test
+   functions from AC-8. All red.
+2. Implement `scripts/qs/check_doc_drift.py` to pass them. PyYAML
+   parsing, git-diff discovery, JSON output, exit codes.
+3. `python scripts/qs/quality_gate.py --quick tests/qs/test_check_doc_drift.py`
+   → green.
+
+### Phase B — Hierarchy scaffold
+
+4. Create `docs/agents/index.md` skeleton (sections per AC-13;
+   tables empty for now).
+5. Create `docs/agents/glossary.md` with ≥30 terms.
+6. Create `docs/agents/personas/{the-admin,the-dev,magali}.md`,
+   extracting from `docs/product/product-brief.md`. Replace the
+   brief's "Target Users" section with a pointer.
+7. Create `docs/agents/lsp-evaluation.md` with the structure from
+   AC-12.
+
+### Phase C — Concept docs
+
+8. Write 20 concept files per AC-2. Each: read the source file,
+   write the 6 sections, add `covers:` frontmatter.
+9. As each concept lands, fill its row in `index.md`'s lookup
+   tables.
+
+### Phase D — Principle and use-case docs
+
+10. Write 5 principle files per AC-3.
+11. Write 6 use-case files per AC-4. Each cross-links to the
+    concepts and principles it composes.
+12. Fill the remaining `index.md` tables.
+
+### Phase E — Agent body + maintenance enforcement
+
+13. Update `.claude/agents/qs-create-plan.md`,
+    `qs-implement-task.md`, `qs-implement-setup-task.md`,
+    `qs-review-task.md` per AC-9. **Body content only.**
+14. Mirror identical body changes to `.cursor/agents/*.md` and
+    `.opencode/agents/*.md` (12 file edits total: 4 agents × 3
+    harnesses).
+15. Add `tests/qs/agents/test_doc_maintenance_parity.py` (per
+    AC-10) — red first, then make it green with the mirrored
+    edits.
+16. Add the 5–7-line "Doc maintenance" subsection to
+    `docs/workflow/project-rules.md` per AC-11.
+
+### Phase F — architecture.md trim (LAST)
+
+17. Read `docs/product/architecture.md` top-to-bottom; for each
+    section, decide: keep / trim / replace-with-pointer.
+18. Apply edits.
+19. Run a final manual no-duplication audit: pick 3 random
+    concepts and grep architecture.md to confirm they aren't
+    described in detail there anymore (pointers only).
+
+### Phase G — Gate, commit, PR
+
+20. `python scripts/qs/quality_gate.py` → green (dev-only fast
+    path; runs `test_check_doc_drift.py` and
+    `test_doc_maintenance_parity.py`).
+21. Commit. Suggested commit grouping (one branch, multiple
+    commits for review hygiene):
+    - C1: `Phase A` — drift checker + tests
+    - C2: `Phase B+C+D` — new docs/agents/ hierarchy
+    - C3: `Phase E` — agent body mirror + parity test + project-rules note
+    - C4: `Phase F` — architecture.md trim
+22. Push branch.
+23. Open PR with `--risk MEDIUM` (workflow agents touched in 3
+    harnesses; impacts all subsequent PRs).
+24. PR body documents which architecture.md sections were trimmed
+    (per AC-14 transparency requirement).
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Doc content goes stale | High over time | Drift checker + agent body steps + last_verified header |
+| Drift checker becomes noise (too many false positives) | Medium | `last_verified` lets reviewer say "still accurate after last change"; `## Doc maintenance` PR-body justification escape hatch |
+| `.cursor/` and `.opencode/` agent bodies drift from `.claude/` | High | Parity test in `tests/qs/agents/test_doc_maintenance_parity.py` |
+| architecture.md trim removes something agents actually need | Medium | architecture.md retains decisions + validation tables; PR-body lists trimmed sections for review; reviewer can request restoration |
+| 35 doc files in one branch is a heavy diff | Medium | Commit-grouped into 4 logical commits for review |
+| LSP eval recommendation is subjective | Low | Quantitative 3-query comparison anchors the recommendation |
+| OpenCode harness mirror needs a frontmatter that differs from Claude/Cursor | Medium | Plan explicitly says "body content only — frontmatter format is harness-specific" |
+| Self-reference paradox if covers: includes docs/workflow/ | Avoided | `covers:` restricted to `custom_components/quiet_solar/**` |
+
+## Adversarial review notes
+
+Four sub-agent reviewers (qs-plan-critic, qs-plan-concrete-planner,
+qs-plan-dev-proxy, qs-plan-scope-guardian) ran in parallel against the
+draft plan. Findings were triaged with the user.
+
+### Findings addressed in this plan
+
+- **Concept-name ambiguity** (concrete-planner C1): renamed to
+  source-file-anchored slugs (e.g., `commands.md` not
+  `load-command.md`; `home-model-battery.md` and `ha-battery.md`
+  instead of one ambiguous `battery.md`). 20 concepts total.
+- **PyYAML availability** (concrete-planner C2): contrary to the
+  reviewer's claim, PyYAML is transitively available via
+  `homeassistant>=2026.4.2` (confirmed by
+  `tests/qs/agents/test_opencode_agents.py` importing `yaml`
+  directly). Plan uses PyYAML.
+- **Frontmatter path existence** (critic + concrete-planner C7):
+  drift checker validates every `covers:` path exists; exit 2 on
+  missing/renamed.
+- **TDD scope** (dev-proxy): plan explicitly states docs are content
+  (TDD exempt) and only `check_doc_drift.py` is TDD-shaped.
+- **Self-reference paradox** (dev-proxy): `covers:` restricted to
+  `custom_components/quiet_solar/**`. Docs under `docs/workflow/`,
+  `docs/agents/`, `docs/product/` are not drift-tracked.
+- **Pattern 10 placement** (critic, scope-guardian): dropped from
+  `project-context.md`; replaced with a 5–7-line subsection in
+  `project-rules.md` (lighter footprint).
+- **Doc-unchanged trailer** (critic, scope-guardian): dropped
+  entirely. Replaced with a `## Doc maintenance` heading in the PR
+  body (existing review surface).
+- **Three-harness mirror** (post-merge from QS-184): updated to mirror
+  to `.claude/`, `.cursor/`, AND `.opencode/`. Parity test pins this.
+- **PR risk** (dev-proxy): set to MEDIUM, not LOW (workflow agents
+  touched in 3 harnesses).
+- **`tests/qs/` convention for dev-tooling tests** (dev-proxy):
+  confirmed — `tests/qs/conftest.py` and existing
+  `tests/qs/agents/*` establish the convention.
+- **architecture.md slim placement**: per user direction, kept in this
+  story but as the LAST task (Phase F), so the new docs exist when
+  the trim happens.
+
+### Findings deferred to follow-up
+
+- **Blocking quality-gate hook** for the drift checker (critic): ships
+  non-blocking in this story. Promotion to blocking is a follow-up
+  once we know it doesn't flag false positives.
+- **Auto-generated mirror script** for `.claude/` ↔ `.cursor/` ↔
+  `.opencode/` (concrete-planner, dev-proxy): manual mirror documented
+  in the agent bodies; parity test catches drift. Automation is a
+  follow-up.
+- **Reason validation** on the `## Doc maintenance` PR-body
+  justification (critic): plan accepts free-form prose; reviewer
+  judgment is the gate. Tightening can be added if abuse occurs.
+
+### Findings explicitly rejected
+
+- **Scope-guardian's "trim to ~10 docs"**: rejected — the user
+  explicitly directed "find others by analysing more code where you
+  see complexity"; the 20-concept set maps to the codebase's actual
+  complexity hotspots (charger.py 5,737 LOC, home.py 4,517 LOC,
+  constraints.py 2,683 LOC, etc.).
+- **Scope-guardian's "drop check_doc_drift.py"**: rejected — the user
+  explicitly chose level (b)+(c): agent-body prose AND a tooling
+  layer. The script is the mechanical fail-stop that prose alone
+  can't provide.
+- **Scope-guardian's "split architecture.md trim to a follow-up"**:
+  rejected — user directed slim IN this story, AFTER new docs land
+  (Phase F).
+
+## Next phase
+
+`implement-setup-task` (all touched files are under `docs/`,
+`scripts/`, `tests/qs/`, `.claude/`, `.cursor/`, `.opencode/`).

--- a/docs/stories/QS-185.story.md
+++ b/docs/stories/QS-185.story.md
@@ -149,28 +149,33 @@ The following 20 concept files exist under
 `docs/agents/concepts/`, each `covers:`-anchored to one primary source
 file:
 
+All `covers:` paths in the table below are full
+`custom_components/quiet_solar/<path>` (or `tests/<path>` for the
+testing-layers off-tree exception) — matching the drift checker's
+`TRACKED_PREFIX` contract from line 93 above.
+
 | Slug | Covers |
 |---|---|
-| `commands` | `home_model/commands.py` |
-| `constraints` | `home_model/constraints.py` |
-| `solver` | `home_model/solver.py` |
-| `load-base` | `home_model/load.py` (AbstractDevice + AbstractLoad) |
-| `home-model-battery` | `home_model/battery.py` |
-| `ha-battery` | `ha_model/battery.py` |
-| `charger-budgeting` | `ha_model/charger.py` |
-| `dynamic-group-tree` | `ha_model/dynamic_group.py` |
-| `qs-home-orchestrator` | `ha_model/home.py` (cycles + QSHomeMode) |
-| `ha-device-mixin` | `ha_model/device.py` (HADeviceMixin) |
-| `person-trip-prediction` | `ha_model/person.py`, `ha_model/car.py` |
-| `off-grid-mode` | `ha_model/home.py` (off-grid path) |
-| `external-control-detection` | `home_model/load.py`, `ha_model/device.py` |
-| `notification-routing` | `ha_model/home.py`, `ha_model/person.py` |
-| `piloted-device-and-heat-pump` | `home_model/load.py` (PilotedDevice), `ha_model/heat_pump.py`, `ha_model/climate_controller.py` |
-| `bistate-duration-devices` | `ha_model/bistate_duration.py`, `ha_model/on_off_duration.py`, `ha_model/pool.py` |
-| `user-override` | `home_model/load.py` (user-originated state) |
-| `solar-providers` | `ha_model/solar.py` (multi-provider, dampening) |
-| `config-and-setup-flow` | `config_flow.py`, `__init__.py`, `data_handler.py`, `const.py` |
-| `testing-layers` | `tests/conftest.py`, `tests/factories.py`, `tests/ha_tests/conftest.py`, `tests/ha_tests/const.py` |
+| `commands` | `custom_components/quiet_solar/home_model/commands.py` |
+| `constraints` | `custom_components/quiet_solar/home_model/constraints.py` |
+| `solver` | `custom_components/quiet_solar/home_model/solver.py` |
+| `load-base` | `custom_components/quiet_solar/home_model/load.py` (AbstractDevice + AbstractLoad) |
+| `home-model-battery` | `custom_components/quiet_solar/home_model/battery.py` |
+| `ha-battery` | `custom_components/quiet_solar/ha_model/battery.py` |
+| `charger-budgeting` | `custom_components/quiet_solar/ha_model/charger.py` |
+| `dynamic-group-tree` | `custom_components/quiet_solar/ha_model/dynamic_group.py` |
+| `qs-home-orchestrator` | `custom_components/quiet_solar/ha_model/home.py` (cycles + QSHomeMode) |
+| `ha-device-mixin` | `custom_components/quiet_solar/ha_model/device.py` (HADeviceMixin) |
+| `person-trip-prediction` | `custom_components/quiet_solar/ha_model/person.py`, `custom_components/quiet_solar/ha_model/car.py` |
+| `off-grid-mode` | `custom_components/quiet_solar/ha_model/home.py` (off-grid path) |
+| `external-control-detection` | `custom_components/quiet_solar/home_model/load.py`, `custom_components/quiet_solar/ha_model/device.py` |
+| `notification-routing` | `custom_components/quiet_solar/ha_model/home.py`, `custom_components/quiet_solar/ha_model/person.py` |
+| `piloted-device-and-heat-pump` | `custom_components/quiet_solar/home_model/load.py` (PilotedDevice), `custom_components/quiet_solar/ha_model/heat_pump.py`, `custom_components/quiet_solar/ha_model/climate_controller.py` |
+| `bistate-duration-devices` | `custom_components/quiet_solar/ha_model/bistate_duration.py`, `custom_components/quiet_solar/ha_model/on_off_duration.py`, `custom_components/quiet_solar/ha_model/pool.py` |
+| `user-override` | `custom_components/quiet_solar/home_model/load.py` (user-originated state) |
+| `solar-providers` | `custom_components/quiet_solar/ha_model/solar.py` (multi-provider, dampening) |
+| `config-and-setup-flow` | `custom_components/quiet_solar/config_flow.py`, `custom_components/quiet_solar/__init__.py`, `custom_components/quiet_solar/data_handler.py`, `custom_components/quiet_solar/const.py` |
+| `testing-layers` | `tests/conftest.py`, `tests/factories.py`, `tests/ha_tests/conftest.py`, `tests/ha_tests/const.py` (off-tree — warnings only per the drift checker's TRACKED_PREFIX rule) |
 
 ### AC-3 — Principle coverage (5 principle files)
 
@@ -346,9 +351,10 @@ No LSP code is added in this story — decision document only.
 
 ### AC-14 — architecture.md trim (LAST task)
 
-**Only after** all 35 new doc files (1 index + 20 concepts + 5
-principles + 6 use cases + 3 personas + glossary + LSP eval) are
-written and committed, `docs/product/architecture.md` is trimmed
+**Only after** all 37 new doc files (1 index + 20 concepts + 5
+principles + 6 use cases + 3 personas + 1 glossary + 1 LSP eval =
+**37**) are written and committed, `docs/product/architecture.md`
+is trimmed
 section-by-section. The implementer reads it top-to-bottom and:
 
 - For every section whose content is now in a new doc, replaces the

--- a/docs/stories/QS-185.story_review_fix_#01.md
+++ b/docs/stories/QS-185.story_review_fix_#01.md
@@ -1,0 +1,412 @@
+# QS-185 — Review fix plan #01
+
+## Summary
+- Source PR: #188
+- Source story: `docs/stories/QS-185.story.md`
+- Findings to fix: 40 (2 must-fix, 9 should-fix, 29 nice-to-have)
+- Next implement phase: `/implement-task`
+  - Rationale: fixes touch `tests/qs/test_check_doc_drift.py` and
+    `tests/qs/agents/test_doc_maintenance_parity.py`, which are
+    outside `qs-implement-setup-task`'s edit scope. New tests in
+    `tests/qs/test_check_doc_drift.py` will also be needed to maintain
+    100% coverage on the new code paths in `check_doc_drift.py`.
+
+## Findings to fix
+
+### [must-fix] M1: `_git_staged_paths` doesn't catch `FileNotFoundError`
+- File: `scripts/qs/check_doc_drift.py:191-217` (`_git_staged_paths`)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: When `git` is not on `PATH` (sandboxed CI image,
+  bare docker container), `subprocess.run(['git', ...])` raises
+  `FileNotFoundError`, which is not caught. The module docstring
+  contract promises that non-git environments yield an empty list /
+  clean gate.
+- Proposed fix:
+  - Wrap the `subprocess.run` call in `try/except FileNotFoundError`
+    and treat it identically to the existing non-zero-exit branch
+    (log warning to stderr, return `[]`).
+  - Add a test that monkeypatches `subprocess.run` to raise
+    `FileNotFoundError` and asserts `_git_staged_paths(...)` returns
+    `[]` and emits the warning.
+
+### [must-fix] M2: `--paths` doesn't normalize path forms
+- File: `scripts/qs/check_doc_drift.py:224-249` (`_detect_drift` /
+  `main`)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: Non-canonical path forms (leading `./`, absolute paths,
+  Windows backslashes, trailing slash) fail to match `source_to_docs`
+  keys via plain set lookup, so a real drift returns exit 0. An
+  automation that calls
+  `check_doc_drift.py --paths /abs/path/custom_components/quiet_solar/foo.py`
+  would silently bypass detection.
+- Proposed fix:
+  - In `main()`, build a helper `_normalize_path(p, repo_root) -> str`
+    that:
+    - Converts backslashes to forward slashes.
+    - Strips leading `./`.
+    - If absolute, computes `Path.relative_to(repo_root)` (falling back
+      to leaving absolute when outside repo).
+    - Strips trailing `/`.
+    - Returns POSIX form.
+  - Apply this normalization to `args.paths` AND to git output before
+    stuffing into the `modified` set.
+  - Add tests:
+    - `test_paths_flag_accepts_absolute_paths`
+    - `test_paths_flag_accepts_dot_prefix`
+    - `test_paths_flag_accepts_backslashes`
+
+### [should-fix] S1: Doc-maintenance step "Before staging" vs "staged diff" contradiction (9 files)
+- Files (verbatim list of 9 agent files; identical body change):
+  - `.claude/agents/qs-implement-task.md`
+  - `.claude/agents/qs-implement-setup-task.md`
+  - `.claude/agents/qs-review-task.md`
+  - `.cursor/agents/qs-implement-task.md`
+  - `.cursor/agents/qs-implement-setup-task.md`
+  - `.cursor/agents/qs-review-task.md`
+  - `.opencode/agents/qs-implement-task.md`
+  - `.opencode/agents/qs-implement-setup-task.md`
+  - `.opencode/agents/qs-review-task.md`
+- Severity: should-fix
+- Source: qs-review-coderabbit (×9), qs-review-blind-hunter (review-task variant)
+- Description:
+  - In the 6 `implement-task` / `implement-setup-task` files: instruction
+    says "Before staging, run `check_doc_drift.py` ... on the staged
+    diff". A pre-stage run sees an empty cached diff, so the gate
+    silently no-ops.
+  - In the 3 `review-task` files: instruction says "against the PR's
+    staged diff", which is meaningless at review time (no canonical
+    staged state). Should evaluate the PR diff directly.
+- Proposed fix:
+  - In the 6 implement-{task,setup-task} files: replace `**Before
+    staging,** run` with `**After staging your intended changes,** run`,
+    and tighten the surrounding sentence to clearly tell the agent to
+    `git add` first, then run the checker on the staged diff.
+  - In the 3 review-task files: replace `against the PR's staged diff`
+    with `against the PR diff` (or, better, spell out the command:
+    `gh pr diff {{pr_number}} --name-only | xargs python
+    scripts/qs/check_doc_drift.py --paths`).
+  - Update `tests/qs/agents/test_doc_maintenance_parity.py` if the
+    pinned tokens change. The drift-checker invocation
+    (`scripts/qs/check_doc_drift.py`) MUST still be present in every
+    agent body. Add a new parameterised assertion that the implement
+    variants contain "After staging" and the review variants contain
+    "PR diff" but not "PR's staged diff".
+
+### [should-fix] S2: Story AC-2 `Covers` paths use shortened form
+- File: `docs/stories/QS-185.story.md:152-173` (AC-2 covers table)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: AC-2's Covers table uses shortened entries
+  (`home_model/commands.py`, `ha_model/...`) but the frontmatter
+  contract declared at line 93 of the same file mandates
+  `custom_components/quiet_solar/<path>`. This is purely a story-text
+  inconsistency (the actual doc files already use the full prefix;
+  the drift checker validates against the full prefix), but readers
+  who hand-author new docs from the story may copy the wrong form.
+- Proposed fix:
+  - Edit every Covers entry in the AC-2 table to prepend
+    `custom_components/quiet_solar/`.
+  - Verify the resulting strings match what's actually in each doc
+    file's frontmatter today (no semantic change).
+
+### [should-fix] S3: Dead `doc_is_malformed` variable + `del`
+- File: `scripts/qs/check_doc_drift.py` (in `_scan_docs`, near line 147
+  init / line 152 set / line 182 `del`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+- Description: `doc_is_malformed` is set inside the for-loop but
+  never read after the loop exits (the loop already `break`s after
+  `malformed.append(...)`). The trailing `del doc_is_malformed` is
+  noise. Will likely be flagged by ruff F841.
+- Proposed fix: remove the `doc_is_malformed = False` initialization,
+  the `doc_is_malformed = True` assignment, and the `del
+  doc_is_malformed` line. The `break` already accomplishes early exit.
+
+### [should-fix] S4: `subprocess.run` lacks `check=False` + `timeout=`
+- File: `scripts/qs/check_doc_drift.py` (`_git_staged_paths` body)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: With no `timeout=`, an unresponsive `git diff --cached`
+  (e.g., index lock contention) will hang the implement/review agents
+  indefinitely. `check=False` should be passed explicitly per project
+  convention.
+- Proposed fix:
+  - Pass `check=False` explicitly.
+  - Pass `timeout=30`.
+  - Wrap in `try/except subprocess.TimeoutExpired` and treat the
+    timeout the same way as a non-zero exit (log to stderr, return
+    `[]`).
+  - Add a test that monkeypatches `subprocess.run` to raise
+    `subprocess.TimeoutExpired` and asserts `_git_staged_paths`
+    returns `[]` and emits a warning.
+
+### [should-fix] S5: Frontmatter closing delimiter / line-ending robustness
+- File: `scripts/qs/check_doc_drift.py:80-85` (`_parse_frontmatter`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter, qs-review-blind-hunter
+- Description: The current parser requires `\n---\n` for the closing
+  delimiter, so a file whose body ends with `---` on the final line
+  with no trailing newline is flagged malformed. CRLF normalization
+  exists but bare `\r` (legacy macOS line endings) is not handled.
+- Proposed fix:
+  - Allow the closing delimiter to be terminated by either `\n` or
+    EOF (search for `\n---\n` first, then fall back to
+    `text.rstrip().endswith('\n---')`).
+  - Normalize bare `\r` to `\n` in addition to the current `\r\n`
+    handling.
+  - Add tests:
+    - `test_frontmatter_without_trailing_newline_is_valid`
+    - `test_frontmatter_with_bare_cr_lineendings_is_normalized`
+
+### [should-fix] S6: UTF-8 BOM at start of doc → false malformed report
+- File: `scripts/qs/check_doc_drift.py:79-80` (`_parse_frontmatter`,
+  delimiter check) and the file-read site in `_scan_docs`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: A doc saved with a UTF-8 BOM (`﻿` prefix — common
+  when edited in some Windows tools) fails the `startswith('---\n')`
+  delimiter check and is reported malformed.
+- Proposed fix: read the doc file with `encoding='utf-8-sig'` (Python
+  strips the BOM transparently). Add a test
+  `test_doc_with_utf8_bom_parses_correctly` that writes a doc with
+  `﻿` prefix and asserts no malformed flag.
+
+### [should-fix] S7: Duplicate `covers:` entries duplicated in JSON output
+- File: `scripts/qs/check_doc_drift.py` (around line 178 — the
+  `source_to_docs.setdefault(entry, []).append(doc_path)` site)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter, qs-review-blind-hunter
+- Description: If a doc lists the same source path twice in its
+  `covers:` list (typo / paste error), the same `(doc, source)` pair is
+  recorded twice, and the JSON report's `stale_sources` list contains
+  duplicates.
+- Proposed fix:
+  - Either de-duplicate `covers:` entries at parse time (`covers =
+    list(dict.fromkeys(covers))` to preserve order) AND/OR change
+    `source_to_docs[entry]` to a set-like collection.
+  - When building the JSON, wrap `sources` in
+    `sorted(set(sources))`.
+  - Add test `test_duplicate_covers_entries_dedup_in_json_output`.
+
+### [should-fix] S8: Git path quoting silently bypasses detection
+- File: `scripts/qs/check_doc_drift.py:198-216` (`_git_staged_paths`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: With `core.quotepath=true` (the git default), paths
+  containing non-ASCII / spaces / shell-metachars are returned in
+  C-style quoted form (e.g., `"voiture_\303\251lectrique.py"`). These
+  quoted strings will never match `source_to_docs` keys, so a real
+  drift on such a file is missed.
+- Proposed fix:
+  - Add `-c core.quotepath=false` to the git invocation (simplest), OR
+    pass `-z` and split the output on `\0` (more robust against any
+    whitespace in paths).
+  - Add a test that stages a file with a non-ASCII filename in a
+    temp git repo fixture and asserts the path is returned unquoted.
+
+### [should-fix] S9: `.resolve()` called inside inner loop (O(N×M))
+- File: `scripts/qs/check_doc_drift.py` (`_detect_drift` body — the
+  inner `for doc in docs: if doc.resolve() in modified_docs: ...`
+  loop)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `doc.resolve()` is recomputed for every iteration of
+  the inner loop. With many sources covered by the same doc, the same
+  `.resolve()` repeats. On Windows / network filesystems this is a
+  real cost.
+- Proposed fix: pre-resolve in `_scan_docs` (store resolved POSIX
+  strings in the index from the start) OR hoist the resolution into a
+  local dict at the top of `_detect_drift`:
+  `resolved = {doc: doc.resolve() for source_docs in
+  source_to_docs.values() for doc in source_docs}`.
+  No new test required (perf only); existing tests must still pass.
+
+### [nice-to-have] 18 MD040 fence-language fixes
+- Files (18 files; identical fix pattern — add `text` after the
+  opening triple-backtick):
+  - `docs/agents/concepts/config-and-setup-flow.md:38` and `:73`
+  - `docs/agents/concepts/charger-budgeting.md:73`
+  - `docs/agents/concepts/dynamic-group-tree.md:48`
+  - `docs/agents/concepts/ha-battery.md:52`
+  - `docs/agents/concepts/qs-home-orchestrator.md:66`
+  - `docs/agents/concepts/person-trip-prediction.md:65`
+  - `docs/agents/concepts/off-grid-mode.md:61`
+  - `docs/agents/concepts/solver.md:66`
+  - `docs/agents/use-cases/magali-plugs-in-car.md:29` and `:61`
+  - `docs/agents/use-cases/cheap-grid-charging.md:28`
+  - `docs/agents/use-cases/external-override.md:32`
+  - `docs/agents/use-cases/solver-replans-on-state-change.md:29`
+  - `docs/agents/use-cases/solar-surplus-allocation.md:28`
+  - `docs/agents/use-cases/off-grid-kicks-in.md:30`
+  - `docs/agents/personas/magali.md:44`
+  - `docs/agents/personas/the-dev.md:44`
+  - `docs/agents/personas/the-admin.md:43`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: Markdownlint rule MD040 — code fences should declare a
+  language. Use `text` for plain-text sequence/lifecycle blocks.
+- Proposed fix: replace each unlabeled opening fence ```` ``` ```` with
+  ```` ```text ````. No semantic change; renders identically in
+  GitHub/IDEs.
+
+### [nice-to-have] N1: Malformed inline-code formatting in hysteresis principle
+- File: `docs/agents/principles/hysteresis-and-switching-cost.md:17-18`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: The constant is rendered as `` `CHANGE_ON_OFF_STATE_HYSTERESIS_S = 600`s ``
+  — the closing backtick lands before the `s` unit, producing two
+  pieces of inline code split by a literal `s`. Should read
+  `` `CHANGE_ON_OFF_STATE_HYSTERESIS_S = 600s` `` (single inline-code span).
+- Proposed fix: move the closing backtick to after the `s` so the full
+  expression is one inline-code span.
+
+### [nice-to-have] N2: AC-14 file-count arithmetic inconsistent in story
+- File: `docs/stories/QS-185.story.md:349-351`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: AC-14 says "all 35 new doc files" but the listed
+  components (1 index + 20 concepts + 5 principles + 6 use cases +
+  3 personas + 1 glossary + 1 LSP eval) sum to 37, not 35.
+- Proposed fix: either change "35" to "37", or restate the breakdown.
+  Pick whichever is closer to actual content (`ls docs/agents/**/*.md
+  | wc -l` is the source of truth).
+
+### [nice-to-have] N3: `--paths` zero-args ambiguity
+- File: `scripts/qs/check_doc_drift.py` (argparse `--paths` option)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `--paths` with no args (empty list) means "no
+  modifications"; omitting the flag means "use git". These are easy
+  to confuse, especially when a shell-expanded `$files` is empty.
+- Proposed fix: tighten the help text — "`--paths` with no arguments
+  explicitly means 'no modifications'; omit the flag to read from
+  staged diff." Optionally, log a stderr note when `--paths` is given
+  with an empty list, to flag the likely-empty-shell-var case.
+
+### [nice-to-have] N4: Exit-code precedence not documented
+- File: `scripts/qs/check_doc_drift.py` module docstring
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Docstring lists exit codes 0/1/2 but the precedence
+  rule (malformed/missing > stale, i.e., exit 2 wins) is buried in
+  `main()`'s control flow.
+- Proposed fix: add a sentence to the docstring: "When both stale docs
+  and malformed/missing covers are present, exit 2 wins."
+
+### [nice-to-have] N5: Test path math `parents[2]` fragile
+- File: `tests/qs/test_check_doc_drift.py` (in
+  `test_script_main_entry_invokes_sys_exit` or wherever the script
+  path is computed)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `Path(__file__).resolve().parents[2] / 'scripts' /
+  'qs' / 'check_doc_drift.py'` silently breaks if the test file is
+  relocated.
+- Proposed fix: define a module-level constant
+  `REPO_ROOT = Path(__file__).resolve().parents[2]` with a comment
+  explaining the layout, and assert `script_path.is_file()` before
+  invoking `runpy.run_path` so a future move produces a clear failure.
+
+### [nice-to-have] N6: Parametrize ids include leading dot (breaks `pytest -k`)
+- File: `tests/qs/agents/test_doc_maintenance_parity.py` (the
+  `ids=lambda p: p.parent.name` argument)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Ids become `.claude` / `.cursor` / `.opencode`. The
+  leading dot is treated as a regex meta-char in `pytest -k`
+  expressions, so `pytest -k '.claude'` won't match.
+- Proposed fix: `ids=lambda p: p.parent.name.lstrip('.')` so ids
+  become `claude`, `cursor`, `opencode`.
+
+### [nice-to-have] N7: Off-tree covers with leading whitespace silently ignored
+- File: `scripts/qs/check_doc_drift.py:163-171` (`TRACKED_PREFIX`
+  startswith check)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: A `covers:` entry like `"  custom_components/quiet_solar/foo.py"`
+  (with leading whitespace from a stray YAML quoted-string indent)
+  fails the `startswith(TRACKED_PREFIX)` check and is treated as
+  off-tree (warning only), even though intent was clearly to cover
+  that file.
+- Proposed fix: `entry = entry.strip()` before the startswith check.
+  Add a test `test_covers_entry_with_stray_whitespace_is_normalized`.
+
+### [nice-to-have] N8: Directory `covers:` entries don't cascade
+- File: `scripts/qs/check_doc_drift.py:163-171`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: A `covers: [custom_components/quiet_solar/home/]` entry
+  is keyed literally on the directory path. Modifications to files
+  inside that directory don't match the key, so no drift is detected.
+- Proposed fix: simplest — explicitly reject directory entries as
+  malformed (`if full.is_dir(): record malformed`). Add a test
+  `test_covers_entry_pointing_to_directory_is_malformed`.
+
+### [nice-to-have] N9: `rglob` follows symlinks
+- File: `scripts/qs/check_doc_drift.py:127` (`_scan_docs` `rglob('*.md')`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `Path.rglob('*.md')` follows symlinks by default. A
+  symlink cycle in `docs/agents/` would hang the scan; a symlink
+  pointing into another tree would duplicate reports.
+- Proposed fix: replace `rglob` with `os.walk(followlinks=False)` or
+  filter out symlinked paths with `if path.is_symlink(): continue`.
+  Add a test that creates a symlink inside the temp docs root and
+  asserts it's skipped.
+
+### [nice-to-have] N10: Misleading "NoneType" message when `covers:` is null
+- File: `scripts/qs/check_doc_drift.py:144-150` (`covers` type check)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `covers:` with no value parses to `None`; the
+  `isinstance(covers, list)` check correctly flags it, but the
+  message `'covers' must be a list, got NoneType` doesn't tell the
+  author the actionable fix.
+- Proposed fix: special-case `covers is None` with a clearer message:
+  "`covers:` has no value — either omit the key or write
+  `covers: []`."
+
+### [nice-to-have] N11: Non-existent `--repo-root` doesn't error early
+- File: `scripts/qs/check_doc_drift.py:281` (`main` arg parsing /
+  repo_root resolution)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `Path(args.repo_root).resolve()` does not validate
+  existence; `_scan_docs` then sees an empty docs dir and returns 0
+  — a misconfiguration silently greens the gate.
+- Proposed fix: after resolving, assert `repo_root.is_dir()` and exit
+  with a clear error message + non-zero exit code if missing. Add a
+  test `test_nonexistent_repo_root_exits_nonzero`.
+
+## Quality gate notes
+
+- All new and modified code paths in `scripts/qs/check_doc_drift.py`
+  must keep 100% line + branch coverage (no `# pragma: no cover`).
+- New tests should follow the existing naming convention in
+  `tests/qs/test_check_doc_drift.py` (no `test_` prefix is needed
+  beyond what's there; mirror the surrounding test-case structure).
+- The 9 agent-file edits (S1) must keep
+  `tests/qs/agents/test_doc_maintenance_parity.py` green. If the
+  pinned token strings change, update the parity test in lockstep.
+- The MD040 fence-language fixes are purely cosmetic — no test
+  expected to flip, but markdownlint (if it runs in CI) should now
+  be quiet.
+
+## How to apply
+
+Run `/implement-task` against this fix plan in TDD order:
+1. Tests first for M1, M2, S4, S5, S6, S7, S8, N7, N8, N9, N11
+   (new behaviour requires red tests).
+2. Implementation for the scripts/qs/check_doc_drift.py changes
+   (M1, M2, S3, S4, S5, S6, S7, S8, S9, N3, N4, N7, N8, N9, N10,
+   N11).
+3. Test refactors for N5, N6.
+4. Pure-text fixes for S1 (9 agent files), S2 (story AC-2 covers
+   table), N1 (hysteresis principle inline-code), N2 (story
+   AC-14 arithmetic), and the 18 MD040 fence-language fixes.
+5. Parity test update for S1 if needed.
+6. Run full quality gate.
+
+When done, return and run `/review-task` again to re-verify.

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -61,6 +61,22 @@ directory instead.
 - **Logging**: lazy `%s`, no f-strings in log calls, no periods at end.
 - **Translations**: NEVER edit `translations/en.json` — edit `strings.json`, run `bash scripts/generate-translations.sh`.
 
+### Doc maintenance
+
+The agent-facing documentation hierarchy lives under
+[../agents/](../agents/) — short, addressable files anchored to source
+via `covers:` frontmatter. The drift checker
+`scripts/qs/check_doc_drift.py` validates that every `covers:` path
+exists and flags docs whose source was modified without a
+co-modification. The four orchestrator agents
+([qs-create-plan](../../.claude/agents/qs-create-plan.md),
+[qs-implement-task](../../.claude/agents/qs-implement-task.md),
+[qs-implement-setup-task](../../.claude/agents/qs-implement-setup-task.md),
+[qs-review-task](../../.claude/agents/qs-review-task.md)) wire the
+checker into their phase protocol. Taxonomy: **concept** (one source
+file), **principle** (cross-cutting rule), **use-case** (end-to-end
+scenario), **persona** (user archetype).
+
 ## Workflow routing
 
 Each phase runs as an interactive `claude --agent qs-<phase>` session

--- a/scripts/qs/check_doc_drift.py
+++ b/scripts/qs/check_doc_drift.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Check that ``docs/agents/`` docs stay in sync with their ``covers:`` source.
+
+A documentation entry under ``docs/agents/`` declares a ``covers:``
+list in its YAML frontmatter — the source files it summarizes. This
+script:
+
+1. Walks every ``docs/agents/**/*.md``, parses the frontmatter, and
+   builds the inverse index ``source -> [docs]``.
+2. Validates that every ``covers:`` path actually exists on disk
+   (a renamed / deleted source produces exit 2 because the doc still
+   claims to describe it).
+3. Reads a list of "modified paths" — either from the staged diff
+   (``git diff --cached --diff-filter=ACMRD --name-only`` — default)
+   or from ``--paths`` (override; what the create-plan / implement
+   agents pass).
+4. Flags every doc that covers a modified source but was not itself
+   co-modified as drift.
+
+Exit codes (AC-7):
+    0 — clean
+    1 — drift detected (covered source changed, covering doc did not)
+    2 — malformed frontmatter or missing ``covers:`` path
+
+Output (non-JSON) is human-readable lines on stdout. ``--json``
+switches to the machine-readable schema:
+
+.. code-block:: json
+
+    {
+      "stale_docs": [
+        {"doc": "docs/agents/concepts/X.md",
+         "stale_sources": ["custom_components/.../X.py"],
+         "last_verified": "YYYY-MM-DD"}
+      ],
+      "missing_covers": ["docs/agents/concepts/Y.md::custom_components/.../Z.py"],
+      "malformed_frontmatter": ["docs/agents/concepts/W.md"]
+    }
+
+``covers:`` entries outside ``custom_components/quiet_solar/`` are
+ignored (warning on stderr only) — see story QS-185 for the
+self-reference paradox rationale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Resolve paths relative to repo root (parent of scripts/qs/).
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_REPO_ROOT = SCRIPT_DIR.parent.parent
+
+# Drift is only tracked for source files under this prefix. Off-tree
+# ``covers:`` entries get a warning, not an error, so a doc can
+# legitimately reference an out-of-scope path (e.g., a workflow doc)
+# without tripping exit 2.
+TRACKED_PREFIX = "custom_components/quiet_solar/"
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+
+
+def _parse_frontmatter(path: Path) -> dict[str, Any]:
+    """Return the YAML frontmatter of ``path`` as a dict.
+
+    Raises ``ValueError`` (or ``yaml.YAMLError``) if the frontmatter
+    can't be parsed — main()'s scan loop turns those into the
+    ``malformed_frontmatter`` bucket.
+    """
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n")
+    if not text.startswith("---\n"):
+        raise ValueError(f"{path}: missing opening '---' delimiter")
+    rest = text[len("---\n") :]
+    end = rest.find("\n---\n")
+    if end == -1:
+        raise ValueError(f"{path}: missing closing '---' delimiter")
+    data = yaml.safe_load(rest[:end])
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: frontmatter is not a mapping")
+    return data
+
+
+def _stringify_last_verified(value: Any) -> str:
+    """Coerce a frontmatter ``last_verified`` value to an ISO string.
+
+    PyYAML auto-parses ``YYYY-MM-DD`` as ``datetime.date``; we want
+    the JSON output to be the original string form.
+    """
+    if isinstance(value, _dt.date):
+        return value.isoformat()
+    if value is None:
+        return ""
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Doc-tree scan
+
+
+def _scan_docs(
+    repo_root: Path,
+) -> tuple[
+    dict[str, list[Path]],  # source-path -> [doc paths]
+    list[Path],  # malformed docs
+    list[tuple[Path, str]],  # missing covers: (doc, source_path)
+    dict[Path, str],  # doc -> last_verified
+]:
+    """Walk ``docs/agents/`` and return the index + malformed/missing buckets."""
+    docs_root = repo_root / "docs" / "agents"
+    source_to_docs: dict[str, list[Path]] = {}
+    malformed: list[Path] = []
+    missing: list[tuple[Path, str]] = []
+    last_verified: dict[Path, str] = {}
+
+    if not docs_root.exists():
+        return source_to_docs, malformed, missing, last_verified
+
+    for doc_path in sorted(docs_root.rglob("*.md")):
+        try:
+            fm = _parse_frontmatter(doc_path)
+        except (ValueError, yaml.YAMLError) as exc:
+            print(f"warning: {doc_path}: {exc}", file=sys.stderr)
+            malformed.append(doc_path)
+            continue
+
+        last_verified[doc_path] = _stringify_last_verified(fm.get("last_verified"))
+
+        if "covers" not in fm:
+            # Index / glossary / persona docs that don't anchor to a
+            # specific source file. They live happily inside the
+            # ``docs/agents/`` tree without being drift-tracked.
+            continue
+
+        covers = fm["covers"]
+        if not isinstance(covers, list):
+            print(
+                f"warning: {doc_path}: 'covers' must be a list, got {type(covers).__name__}",
+                file=sys.stderr,
+            )
+            malformed.append(doc_path)
+            continue
+
+        doc_is_malformed = False
+        for entry in covers:
+            if not isinstance(entry, str):
+                print(
+                    f"warning: {doc_path}: 'covers' entry must be a string, got {type(entry).__name__}",
+                    file=sys.stderr,
+                )
+                malformed.append(doc_path)
+                doc_is_malformed = True
+                break
+
+            if not entry.startswith(TRACKED_PREFIX):
+                # Off-tree entry — warn but don't flag as error or
+                # add to the drift index.
+                print(
+                    f"warning: {doc_path}: covers entry {entry!r} is outside "
+                    f"'{TRACKED_PREFIX}'; ignored (not drift-tracked)",
+                    file=sys.stderr,
+                )
+                continue
+
+            full = repo_root / entry
+            if not full.exists():
+                missing.append((doc_path, entry))
+                continue
+
+            source_to_docs.setdefault(entry, []).append(doc_path)
+
+        # If a covers item was malformed (not a string), break already
+        # ran and skipped further entries; nothing else to do here.
+        del doc_is_malformed
+
+    return source_to_docs, malformed, missing, last_verified
+
+
+# ---------------------------------------------------------------------------
+# Modified-path source (staged diff or --paths override)
+
+
+def _git_staged_paths(repo_root: Path) -> list[str]:
+    """Return the staged file paths via ``git diff --cached``.
+
+    On non-zero exit (e.g., not a git repo), log to stderr and return
+    an empty list. The caller treats "no modifications" as a clean
+    gate, which is the right behaviour for a non-git environment.
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--cached",
+            "--diff-filter=ACMRD",
+            "--name-only",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+    )
+    if result.returncode != 0:
+        print(
+            f"warning: git diff failed (exit {result.returncode}): "
+            f"{result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Drift detection
+
+
+def _detect_drift(
+    source_to_docs: dict[str, list[Path]],
+    modified: set[str],
+    repo_root: Path,
+) -> dict[Path, list[str]]:
+    """Return ``doc -> [stale sources]`` for every uncovered modification."""
+    # Resolve modified doc paths against ``repo_root`` so we can
+    # compare with the absolute paths returned by ``_scan_docs``.
+    modified_docs: set[Path] = set()
+    for entry in modified:
+        if not entry.endswith(".md"):
+            continue
+        candidate = Path(entry)
+        if not candidate.is_absolute():
+            candidate = repo_root / candidate
+        modified_docs.add(candidate.resolve())
+
+    stale: dict[Path, list[str]] = {}
+    for source, docs in source_to_docs.items():
+        if source not in modified:
+            continue
+        for doc in docs:
+            if doc.resolve() in modified_docs:
+                continue
+            stale.setdefault(doc, []).append(source)
+    return stale
+
+
+# ---------------------------------------------------------------------------
+# CLI
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check_doc_drift.py",
+        description="Verify docs/agents/ docs are in sync with their covers: source files.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(DEFAULT_REPO_ROOT),
+        help="Repository root (default: this script's grand-parent directory).",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Override the staged-diff source. Any number of paths "
+        "(0 = 'no modifications'). When omitted, the script runs "
+        "git diff --cached.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON report instead of text.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+
+    source_to_docs, malformed, missing, last_verified = _scan_docs(repo_root)
+
+    if args.paths is not None:
+        modified = set(args.paths)
+    else:
+        modified = set(_git_staged_paths(repo_root))
+
+    stale = _detect_drift(source_to_docs, modified, repo_root)
+
+    def _rel(p: Path) -> str:
+        # ``_scan_docs`` walks ``repo_root/docs/agents/``, so every
+        # path in the report is guaranteed to be a descendant of
+        # ``repo_root``. No fallback branch needed.
+        return str(p.relative_to(repo_root))
+
+    report: dict[str, Any] = {
+        "stale_docs": [
+            {
+                "doc": _rel(doc),
+                "stale_sources": sorted(sources),
+                "last_verified": last_verified.get(doc, ""),
+            }
+            for doc, sources in sorted(stale.items(), key=lambda kv: _rel(kv[0]))
+        ],
+        "missing_covers": sorted(f"{_rel(doc)}::{src}" for doc, src in missing),
+        "malformed_frontmatter": sorted(_rel(p) for p in malformed),
+    }
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        for path in report["malformed_frontmatter"]:
+            print(f"malformed: {path}")
+        for entry in report["missing_covers"]:
+            print(f"missing covers path: {entry}")
+        for item in report["stale_docs"]:
+            print(
+                f"stale: {item['doc']} "
+                f"(sources: {', '.join(item['stale_sources'])}; "
+                f"last_verified={item['last_verified']})"
+            )
+
+    if report["malformed_frontmatter"] or report["missing_covers"]:
+        return 2
+    if report["stale_docs"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/qs/check_doc_drift.py
+++ b/scripts/qs/check_doc_drift.py
@@ -20,7 +20,12 @@ script:
 Exit codes (AC-7):
     0 — clean
     1 — drift detected (covered source changed, covering doc did not)
-    2 — malformed frontmatter or missing ``covers:`` path
+    2 — malformed frontmatter, missing ``covers:`` path, or
+        non-existent ``--repo-root``
+
+Exit-code precedence (review-fix #01 N4): when both stale docs and
+malformed/missing covers are present, **exit 2 wins**. Drift (exit 1)
+is reported only when the doc tree is internally consistent.
 
 Output (non-JSON) is human-readable lines on stdout. ``--json``
 switches to the machine-readable schema:
@@ -64,6 +69,12 @@ DEFAULT_REPO_ROOT = SCRIPT_DIR.parent.parent
 # without tripping exit 2.
 TRACKED_PREFIX = "custom_components/quiet_solar/"
 
+# Subprocess hard timeout. Long enough that a healthy ``git diff
+# --cached`` returns; short enough that an index-lock-contention hang
+# can't stall the implement/review agents indefinitely. Review-fix
+# #01 S4.
+GIT_TIMEOUT_S = 30
+
 
 # ---------------------------------------------------------------------------
 # Frontmatter parsing
@@ -75,14 +86,33 @@ def _parse_frontmatter(path: Path) -> dict[str, Any]:
     Raises ``ValueError`` (or ``yaml.YAMLError``) if the frontmatter
     can't be parsed — main()'s scan loop turns those into the
     ``malformed_frontmatter`` bucket.
+
+    Robust to:
+    - UTF-8 BOM (``utf-8-sig`` — review-fix #01 S6).
+    - CRLF and bare ``\\r`` (legacy macOS / corrupted) line endings
+      (review-fix #01 S5).
+    - Closing ``---`` at end of file with no trailing newline
+      (review-fix #01 S5).
     """
-    text = path.read_text(encoding="utf-8").replace("\r\n", "\n")
+    # ``utf-8-sig`` transparently strips a UTF-8 BOM if present.
+    text = path.read_text(encoding="utf-8-sig")
+    # Normalize all common line-ending variants. Replace CRLF before
+    # bare CR so we don't double-replace the LF.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+
     if not text.startswith("---\n"):
         raise ValueError(f"{path}: missing opening '---' delimiter")
     rest = text[len("---\n") :]
+
     end = rest.find("\n---\n")
     if end == -1:
-        raise ValueError(f"{path}: missing closing '---' delimiter")
+        # Fall back to ``\n---`` at end-of-file (no trailing newline).
+        stripped = rest.rstrip()
+        if stripped.endswith("\n---"):
+            end = len(stripped) - len("\n---")
+        else:
+            raise ValueError(f"{path}: missing closing '---' delimiter")
+
     data = yaml.safe_load(rest[:end])
     if not isinstance(data, dict):
         raise ValueError(f"{path}: frontmatter is not a mapping")
@@ -100,6 +130,48 @@ def _stringify_last_verified(value: Any) -> str:
     if value is None:
         return ""
     return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Path normalization
+
+
+def _normalize_path(raw: str, repo_root: Path) -> str:
+    """Normalize a path string for comparison with ``source_to_docs`` keys.
+
+    Review-fix #01 M2: covers a list of malformations that agents and
+    automation realistically produce — Windows backslashes, leading
+    ``./``, absolute paths from ``$PWD`` expansion, trailing slashes,
+    stray whitespace.
+
+    - Backslashes → forward slashes.
+    - Strip leading ``./`` (any number of times).
+    - If absolute, attempt to relativize against ``repo_root``; if the
+      path lives outside the repo, leave it absolute (the caller will
+      then see no match in ``source_to_docs``, which is correct —
+      drift detection only fires for in-tree paths).
+    - Strip trailing ``/``.
+    """
+    s = raw.strip().replace("\\", "/")
+    while s.startswith("./"):
+        s = s[2:]
+
+    # Detect absolute paths. POSIX: leading ``/``. Windows-style drive
+    # letters (``C:/...``) are not used in this repo but we tolerate
+    # them for forward compatibility.
+    is_absolute = s.startswith("/") or (len(s) >= 2 and s[1] == ":")
+    if is_absolute:
+        try:
+            s = Path(s).resolve().relative_to(repo_root).as_posix()
+        except (ValueError, OSError):
+            # Outside ``repo_root`` (or unresolvable): leave the
+            # absolute string alone. No source under
+            # ``custom_components/quiet_solar/`` could ever match.
+            pass
+
+    while s.endswith("/") and len(s) > 1:
+        s = s[:-1]
+    return s
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +197,11 @@ def _scan_docs(
         return source_to_docs, malformed, missing, last_verified
 
     for doc_path in sorted(docs_root.rglob("*.md")):
+        # Skip symlinks. ``rglob`` follows them by default; a self-
+        # referential symlink would hang the scan, and a symlink into
+        # another tree would duplicate reports (review-fix #01 N9).
+        if doc_path.is_symlink():
+            continue
         try:
             fm = _parse_frontmatter(doc_path)
         except (ValueError, yaml.YAMLError) as exc:
@@ -141,6 +218,17 @@ def _scan_docs(
             continue
 
         covers = fm["covers"]
+        # Review-fix #01 N10: surface a clearer message when the
+        # ``covers:`` key parses to ``None`` (the author wrote
+        # ``covers:`` with no value).
+        if covers is None:
+            print(
+                f"warning: {doc_path}: 'covers:' has no value — either "
+                "omit the key or write 'covers: []'.",
+                file=sys.stderr,
+            )
+            malformed.append(doc_path)
+            continue
         if not isinstance(covers, list):
             print(
                 f"warning: {doc_path}: 'covers' must be a list, got {type(covers).__name__}",
@@ -149,16 +237,23 @@ def _scan_docs(
             malformed.append(doc_path)
             continue
 
-        doc_is_malformed = False
-        for entry in covers:
+        # De-duplicate while preserving first-occurrence order
+        # (review-fix #01 S7). A typo / paste error in a ``covers:``
+        # list shouldn't double-report drift in the JSON output.
+        deduped: list[Any] = list(dict.fromkeys(covers))
+        for entry in deduped:
             if not isinstance(entry, str):
                 print(
                     f"warning: {doc_path}: 'covers' entry must be a string, got {type(entry).__name__}",
                     file=sys.stderr,
                 )
                 malformed.append(doc_path)
-                doc_is_malformed = True
                 break
+
+            # Review-fix #01 N7: strip stray whitespace so a YAML
+            # quoted-string indent doesn't silently demote a
+            # ``covers:`` entry to "off-tree".
+            entry = entry.strip()
 
             if not entry.startswith(TRACKED_PREFIX):
                 # Off-tree entry — warn but don't flag as error or
@@ -175,11 +270,19 @@ def _scan_docs(
                 missing.append((doc_path, entry))
                 continue
 
-            source_to_docs.setdefault(entry, []).append(doc_path)
+            # Review-fix #01 N8: directory entries don't cascade.
+            # Reject them explicitly so the author writes a file
+            # path (or a glob, when we support that).
+            if full.is_dir():
+                print(
+                    f"warning: {doc_path}: covers entry {entry!r} is a directory; "
+                    "use a file path (directory entries don't cascade).",
+                    file=sys.stderr,
+                )
+                malformed.append(doc_path)
+                break
 
-        # If a covers item was malformed (not a string), break already
-        # ran and skipped further entries; nothing else to do here.
-        del doc_is_malformed
+            source_to_docs.setdefault(entry, []).append(doc_path)
 
     return source_to_docs, malformed, missing, last_verified
 
@@ -191,22 +294,48 @@ def _scan_docs(
 def _git_staged_paths(repo_root: Path) -> list[str]:
     """Return the staged file paths via ``git diff --cached``.
 
-    On non-zero exit (e.g., not a git repo), log to stderr and return
-    an empty list. The caller treats "no modifications" as a clean
-    gate, which is the right behaviour for a non-git environment.
+    On non-zero exit (e.g., not a git repo), missing ``git`` binary
+    (review-fix #01 M1), or hung index lock (review-fix #01 S4), log
+    to stderr and return an empty list. The caller treats "no
+    modifications" as a clean gate, which is the right behaviour for
+    a non-git environment.
+
+    ``-c core.quotepath=false`` (review-fix #01 S8) disables git's
+    default C-style escaping of non-ASCII paths so the returned
+    strings match ``source_to_docs`` keys directly.
     """
-    result = subprocess.run(
-        [
-            "git",
-            "diff",
-            "--cached",
-            "--diff-filter=ACMRD",
-            "--name-only",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(repo_root),
-    )
+    cmd = [
+        "git",
+        "-c",
+        "core.quotepath=false",
+        "diff",
+        "--cached",
+        "--diff-filter=ACMRD",
+        "--name-only",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            check=False,
+            timeout=GIT_TIMEOUT_S,
+        )
+    except FileNotFoundError:
+        print(
+            "warning: git binary not found on PATH; treating as no staged changes",
+            file=sys.stderr,
+        )
+        return []
+    except subprocess.TimeoutExpired:
+        print(
+            f"warning: git diff timeout exceeded ({GIT_TIMEOUT_S}s); "
+            "treating as no staged changes",
+            file=sys.stderr,
+        )
+        return []
+
     if result.returncode != 0:
         print(
             f"warning: git diff failed (exit {result.returncode}): "
@@ -238,12 +367,19 @@ def _detect_drift(
             candidate = repo_root / candidate
         modified_docs.add(candidate.resolve())
 
+    # Pre-resolve every doc once so the inner loop is a hash lookup
+    # rather than an O(N) resolve per source (review-fix #01 S9).
+    # On Windows / network filesystems, ``Path.resolve()`` is non-
+    # trivial; hoisting the call here turns O(N×M) into O(N+M).
+    all_docs = {doc for docs in source_to_docs.values() for doc in docs}
+    resolved: dict[Path, Path] = {doc: doc.resolve() for doc in all_docs}
+
     stale: dict[Path, list[str]] = {}
     for source, docs in source_to_docs.items():
         if source not in modified:
             continue
         for doc in docs:
-            if doc.resolve() in modified_docs:
+            if resolved[doc] in modified_docs:
                 continue
             stale.setdefault(doc, []).append(source)
     return stale
@@ -267,9 +403,14 @@ def main(argv: list[str] | None = None) -> int:
         "--paths",
         nargs="*",
         default=None,
-        help="Override the staged-diff source. Any number of paths "
-        "(0 = 'no modifications'). When omitted, the script runs "
-        "git diff --cached.",
+        help=(
+            "Override the staged-diff source. ``--paths`` with no "
+            "arguments explicitly means 'no modifications' (clean "
+            "gate). Omit the flag entirely to read modifications from "
+            "``git diff --cached``. Path forms are normalized: "
+            "backslashes → forward slashes, leading ``./`` stripped, "
+            "absolute paths inside ``--repo-root`` relativized."
+        ),
     )
     parser.add_argument(
         "--json",
@@ -280,12 +421,22 @@ def main(argv: list[str] | None = None) -> int:
 
     repo_root = Path(args.repo_root).resolve()
 
+    # Review-fix #01 N11: a typo in ``--repo-root`` previously
+    # produced a silent green gate (the scan returns an empty index).
+    # Fail loudly instead so misconfiguration is visible.
+    if not repo_root.is_dir():
+        print(
+            f"error: --repo-root does not exist or is not a directory: {repo_root}",
+            file=sys.stderr,
+        )
+        return 2
+
     source_to_docs, malformed, missing, last_verified = _scan_docs(repo_root)
 
     if args.paths is not None:
-        modified = set(args.paths)
+        modified = {_normalize_path(p, repo_root) for p in args.paths}
     else:
-        modified = set(_git_staged_paths(repo_root))
+        modified = {_normalize_path(p, repo_root) for p in _git_staged_paths(repo_root)}
 
     stale = _detect_drift(source_to_docs, modified, repo_root)
 
@@ -299,7 +450,12 @@ def main(argv: list[str] | None = None) -> int:
         "stale_docs": [
             {
                 "doc": _rel(doc),
-                "stale_sources": sorted(sources),
+                # Dedup sources defensively for the JSON output —
+                # the dedup at parse-time handles the common case
+                # but two ``covers:`` entries could still differ
+                # by whitespace and resolve to the same canonical
+                # form (review-fix #01 S7).
+                "stale_sources": sorted(set(sources)),
                 "last_verified": last_verified.get(doc, ""),
             }
             for doc, sources in sorted(stale.items(), key=lambda kv: _rel(kv[0]))

--- a/tests/qs/agents/test_doc_maintenance_parity.py
+++ b/tests/qs/agents/test_doc_maintenance_parity.py
@@ -53,7 +53,29 @@ HARNESS_DIRS: tuple[Path, ...] = (
 DRIFT_CHECKER_TOKEN: str = "scripts/qs/check_doc_drift.py"
 
 
-@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=lambda p: p.parent.name)
+# Implement-variant agents (run between TDD red-green-refactor and
+# the commit): the doc-maintenance step must instruct the agent to
+# stage first, then run the checker. Pinned post-review-fix #01 S1.
+IMPLEMENT_AGENT_NAMES: tuple[str, ...] = (
+    "qs-implement-task",
+    "qs-implement-setup-task",
+)
+
+# Review-variant agents (post-PR): the doc-maintenance step inspects
+# the PR diff, not a "staged" diff (no canonical staged state exists
+# at review time). Pinned post-review-fix #01 S1.
+REVIEW_AGENT_NAMES: tuple[str, ...] = ("qs-review-task",)
+
+
+# Review-fix #01 N6: strip the leading dot from harness ids so
+# ``pytest -k claude`` works without quoting concerns. Without
+# ``lstrip('.')``, the id is ``.claude`` and the dot is treated as a
+# regex meta-char in ``-k`` expressions.
+def _harness_id(p: Path) -> str:
+    return p.parent.name.lstrip(".")
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
 @pytest.mark.parametrize("agent_name", DOC_MAINTENANCE_AGENT_NAMES)
 def test_agent_body_invokes_drift_checker(harness_dir: Path, agent_name: str) -> None:
     """Every orchestrator agent in every harness mentions the drift checker."""
@@ -65,4 +87,47 @@ def test_agent_body_invokes_drift_checker(harness_dir: Path, agent_name: str) ->
         f"QS-185 AC-9 / AC-10 require every orchestrator agent to wire "
         f"the doc-maintenance step into its phase protocol; this test "
         f"pins the contract across .claude/, .cursor/, and .opencode/."
+    )
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+@pytest.mark.parametrize("agent_name", IMPLEMENT_AGENT_NAMES)
+def test_implement_agents_say_after_staging(harness_dir: Path, agent_name: str) -> None:
+    """Implement-variant agents must say "After staging", not "Before staging".
+
+    Review-fix #01 S1: a pre-stage drift check sees an empty cached
+    diff and silently no-ops. The contract is now: stage first
+    (``git add``), then run the checker.
+    """
+    body = (harness_dir / f"{agent_name}.md").read_text(encoding="utf-8")
+    assert "After staging" in body, (
+        f"{harness_dir / f'{agent_name}.md'}: implement-variant agents "
+        "must instruct the agent to stage *first* and then run the "
+        "drift checker (review-fix #01 S1). Look for 'After staging'."
+    )
+    assert "Before staging," not in body, (
+        f"{harness_dir / f'{agent_name}.md'}: the legacy 'Before "
+        "staging,' wording silently no-ops because the cached diff "
+        "is empty (review-fix #01 S1)."
+    )
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+@pytest.mark.parametrize("agent_name", REVIEW_AGENT_NAMES)
+def test_review_agents_avoid_pr_staged_diff(harness_dir: Path, agent_name: str) -> None:
+    """Review-variant agents must reference "PR diff", not "PR's staged diff".
+
+    Review-fix #01 S1: there is no canonical staged state at review
+    time; the reviewer evaluates the PR diff directly.
+    """
+    body = (harness_dir / f"{agent_name}.md").read_text(encoding="utf-8")
+    assert "PR's staged diff" not in body, (
+        f"{harness_dir / f'{agent_name}.md'}: 'PR's staged diff' is "
+        "meaningless at review time (review-fix #01 S1). Reference "
+        "the PR diff directly."
+    )
+    assert "PR diff" in body, (
+        f"{harness_dir / f'{agent_name}.md'}: review-variant agents "
+        "must explain the doc-maintenance audit against the PR diff "
+        "(review-fix #01 S1)."
     )

--- a/tests/qs/agents/test_doc_maintenance_parity.py
+++ b/tests/qs/agents/test_doc_maintenance_parity.py
@@ -1,0 +1,68 @@
+"""Pin the doc-maintenance step across the four orchestrator agents.
+
+QS-185 introduced an addressable documentation hierarchy under
+``docs/agents/`` plus a drift-checker script
+(``scripts/qs/check_doc_drift.py``). For the drift checker to be
+useful, four agent bodies must invoke it at the right phase:
+
+- ``qs-create-plan``      — during plan drafting, run
+  ``check_doc_drift.py --paths <planned_files>``.
+- ``qs-implement-task``   — at the quality gate, run
+  ``check_doc_drift.py`` on the staged diff.
+- ``qs-implement-setup-task`` — same.
+- ``qs-review-task``      — during consolidation, flag a must-fix
+  finding if the PR shows no ``## Doc maintenance`` justification
+  and ``check_doc_drift.py`` would have failed.
+
+Body content is mirrored across three harnesses (Claude / Cursor /
+OpenCode) — the frontmatter format is harness-specific and stays
+untouched. This test pins the invocation token in every harness so
+a future edit that only touches one harness fails CI.
+
+Pattern follows ``test_opencode_agents.py`` (the existing static-
+agent contract test).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# The four orchestrator agents that AC-9 requires us to update.
+DOC_MAINTENANCE_AGENT_NAMES: tuple[str, ...] = (
+    "qs-create-plan",
+    "qs-implement-task",
+    "qs-implement-setup-task",
+    "qs-review-task",
+)
+
+# Three harnesses to mirror across.
+HARNESS_DIRS: tuple[Path, ...] = (
+    REPO_ROOT / ".claude" / "agents",
+    REPO_ROOT / ".cursor" / "agents",
+    REPO_ROOT / ".opencode" / "agents",
+)
+
+# The exact token that every agent body must contain. The trailing
+# space-and-no-arg form lets each agent customize its own invocation
+# (``--paths``, ``--json``, on-the-staged-diff, etc.) without
+# fragmenting the contract.
+DRIFT_CHECKER_TOKEN: str = "scripts/qs/check_doc_drift.py"
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=lambda p: p.parent.name)
+@pytest.mark.parametrize("agent_name", DOC_MAINTENANCE_AGENT_NAMES)
+def test_agent_body_invokes_drift_checker(harness_dir: Path, agent_name: str) -> None:
+    """Every orchestrator agent in every harness mentions the drift checker."""
+    path = harness_dir / f"{agent_name}.md"
+    assert path.is_file(), f"Missing agent file: {path}"
+    body = path.read_text(encoding="utf-8")
+    assert DRIFT_CHECKER_TOKEN in body, (
+        f"{path}: agent body does not invoke '{DRIFT_CHECKER_TOKEN}'. "
+        f"QS-185 AC-9 / AC-10 require every orchestrator agent to wire "
+        f"the doc-maintenance step into its phase protocol; this test "
+        f"pins the contract across .claude/, .cursor/, and .opencode/."
+    )

--- a/tests/qs/test_check_doc_drift.py
+++ b/tests/qs/test_check_doc_drift.py
@@ -1,0 +1,572 @@
+"""Tests for ``scripts/qs/check_doc_drift.py``.
+
+The drift checker exists so the doc hierarchy under ``docs/agents/``
+stays anchored to the source files it claims to ``covers:``. Every
+test here drives the script through an isolated ``tmp_path`` repo —
+no dependency on the real ``docs/agents/`` contents (which don't
+exist yet at the time these tests were written).
+
+The 12 acceptance-criterion tests from AC-8 are present and named
+verbatim. A handful of additional tests cover branches that the
+named 12 don't reach (``--paths``-less mode that calls git, the
+non-JSON text output paths, the "covers not a list" malformed
+branch, etc.) so the script reaches 100% coverage without any
+``# pragma: no cover`` markers (AC-8 requirement).
+
+The autouse ``_add_scripts_qs_to_syspath`` fixture in
+``tests/qs/conftest.py`` puts ``scripts/qs/`` on ``sys.path``, so
+tests can ``import check_doc_drift`` in-process — both faster than
+subprocess and visible to coverage measurement.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+
+
+def _setup_repo(tmp_path: Path) -> Path:
+    """Create a minimal ``repo_root`` layout under ``tmp_path``.
+
+    The drift checker expects ``docs/agents/`` and
+    ``custom_components/quiet_solar/`` to live at the repo root. We
+    materialize both directories so the tests can drop docs and
+    source files into them without further setup.
+    """
+    (tmp_path / "docs" / "agents").mkdir(parents=True)
+    (tmp_path / "custom_components" / "quiet_solar").mkdir(parents=True)
+    return tmp_path
+
+
+def _make_source(repo: Path, rel: str) -> Path:
+    """Touch a file at ``repo/rel`` so a ``covers:`` entry resolves."""
+    src = repo / rel
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text("# source\n", encoding="utf-8")
+    return src
+
+
+def _write_doc(
+    repo: Path,
+    slug: str,
+    *,
+    covers: list[str] | None,
+    last_verified: str = "2026-05-19",
+    kind: str = "concept",
+    subdir: str = "concepts",
+) -> Path:
+    """Write a doc with the canonical frontmatter shape.
+
+    ``covers=None`` omits the key entirely (mimics an index/glossary
+    doc that isn't drift-tracked). ``covers=[]`` writes an empty list.
+    """
+    lines = [
+        "---",
+        f"title: Title for {slug}",
+        f"slug: {slug}",
+        f"kind: {kind}",
+    ]
+    if covers is not None:
+        lines.append("covers:")
+        for entry in covers:
+            lines.append(f"  - {entry}")
+    lines.extend([f"last_verified: {last_verified}", "---", "", f"# {slug}", "", "body", ""])
+    doc_path = repo / "docs" / "agents" / subdir / f"{slug}.md"
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_path.write_text("\n".join(lines), encoding="utf-8")
+    return doc_path
+
+
+def _import_module() -> Any:
+    """Return the freshly-imported ``check_doc_drift`` module.
+
+    Imported per-test (under the autouse conftest fixture) so the
+    syspath setup/teardown stays consistent with the other
+    ``tests/qs/`` modules.
+    """
+    import check_doc_drift  # type: ignore[import-not-found]
+
+    return check_doc_drift
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — the 12 named tests
+
+
+def test_clean_when_no_changes(tmp_path: Path) -> None:
+    """No modified sources → clean gate, exit 0."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 0
+
+
+def test_drift_when_source_modified_alone(tmp_path: Path) -> None:
+    """A covered source is modified but the doc is not → exit 1."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+    exit_code = mod.main(
+        [
+            "--repo-root",
+            str(repo),
+            "--paths",
+            "custom_components/quiet_solar/foo.py",
+        ]
+    )
+    assert exit_code == 1
+
+
+def test_silent_when_doc_co_modified(tmp_path: Path) -> None:
+    """Source AND doc co-modified → no drift."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    doc = _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+    exit_code = mod.main(
+        [
+            "--repo-root",
+            str(repo),
+            "--paths",
+            "custom_components/quiet_solar/foo.py",
+            str(doc.relative_to(repo)),
+        ]
+    )
+    assert exit_code == 0
+
+
+def test_handles_added_source(tmp_path: Path) -> None:
+    """An added source covered by a doc still flags drift unless co-mod.
+
+    ``--diff-filter=ACMRD`` includes ``A`` (added). The drift
+    detector should treat an added source identically to a modified
+    one: if a doc covers it but isn't co-modified, drift.
+    """
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/new.py")
+    _write_doc(repo, "new", covers=["custom_components/quiet_solar/new.py"])
+
+    mod = _import_module()
+    exit_code = mod.main(
+        [
+            "--repo-root",
+            str(repo),
+            "--paths",
+            "custom_components/quiet_solar/new.py",
+        ]
+    )
+    assert exit_code == 1
+
+
+def test_handles_renamed_source_exits_2(tmp_path: Path) -> None:
+    """Rename = delete + add. The doc still references the old path → exit 2."""
+    repo = _setup_repo(tmp_path)
+    # Old path doesn't exist any more (the rename has happened); the
+    # doc's ``covers:`` is stale.
+    _write_doc(
+        repo, "renamed", covers=["custom_components/quiet_solar/old_path.py"]
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+
+
+def test_handles_deleted_source_exits_2(tmp_path: Path) -> None:
+    """A doc covering a deleted source → exit 2 (missing covers path)."""
+    repo = _setup_repo(tmp_path)
+    _write_doc(
+        repo, "deleted", covers=["custom_components/quiet_solar/deleted.py"]
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+
+
+def test_malformed_frontmatter_exits_2(tmp_path: Path) -> None:
+    """A doc without the YAML frontmatter delimiters → exit 2."""
+    repo = _setup_repo(tmp_path)
+    bad = repo / "docs" / "agents" / "concepts" / "bad.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("# no frontmatter at all\n", encoding="utf-8")
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+
+
+def test_missing_covers_path_exits_2(tmp_path: Path) -> None:
+    """A ``covers:`` path that doesn't exist on disk → exit 2."""
+    repo = _setup_repo(tmp_path)
+    _write_doc(
+        repo,
+        "missing",
+        covers=["custom_components/quiet_solar/never_existed.py"],
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+
+
+def test_paths_flag_overrides_staged(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--paths`` bypasses the git invocation entirely.
+
+    The test installs a ``subprocess.run`` that would explode if it
+    were called for the git path. ``--paths`` must short-circuit
+    before reaching it.
+    """
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+
+    def _no_git_calls(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        raise AssertionError("git should not have been invoked when --paths is supplied")
+
+    monkeypatch.setattr(mod.subprocess, "run", _no_git_calls)
+
+    # Empty --paths means "no modifications" → clean.
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 0
+
+
+def test_json_schema_matches(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--json`` emits the AC-7 schema: stale_docs / missing_covers / malformed_frontmatter."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+    exit_code = mod.main(
+        [
+            "--repo-root",
+            str(repo),
+            "--paths",
+            "custom_components/quiet_solar/foo.py",
+            "--json",
+        ]
+    )
+    assert exit_code == 1
+
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload.keys()) >= {"stale_docs", "missing_covers", "malformed_frontmatter"}
+    assert isinstance(payload["stale_docs"], list)
+    assert len(payload["stale_docs"]) == 1
+    entry = payload["stale_docs"][0]
+    assert set(entry.keys()) >= {"doc", "stale_sources", "last_verified"}
+    assert entry["doc"].endswith("foo.md")
+    assert entry["stale_sources"] == ["custom_components/quiet_solar/foo.py"]
+    assert entry["last_verified"] == "2026-05-19"
+    assert payload["missing_covers"] == []
+    assert payload["malformed_frontmatter"] == []
+
+
+def test_ignores_non_quiet_solar_paths(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A ``covers:`` entry outside ``custom_components/quiet_solar/`` → warning only.
+
+    The off-tree path must NOT be added to ``missing_covers`` (which
+    would trigger exit 2). A warning lands on stderr instead.
+    """
+    repo = _setup_repo(tmp_path)
+    _write_doc(repo, "off_tree", covers=["docs/workflow/foo.md"])
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 0
+    captured = capsys.readouterr()
+    assert "docs/workflow/foo.md" in captured.err
+
+
+def test_works_in_arbitrary_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The script is cwd-independent — only ``--repo-root`` matters."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    monkeypatch.chdir(foreign)
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Additional tests for branches the named-12 don't reach (kept for the
+# AC-8 "100% coverage, no # pragma: no cover" rule).
+
+
+def test_staged_diff_default_path_invokes_git(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without ``--paths``, the script reads from ``git diff --cached``."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+
+    captured_cmd: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        captured_cmd.append(cmd)
+        return SimpleNamespace(
+            returncode=0,
+            stdout="custom_components/quiet_solar/foo.py\n\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    exit_code = mod.main(["--repo-root", str(repo)])
+    assert exit_code == 1  # source modified, doc not co-modified → drift
+    assert captured_cmd, "git was not invoked"
+    assert captured_cmd[0][:5] == [
+        "git",
+        "diff",
+        "--cached",
+        "--diff-filter=ACMRD",
+        "--name-only",
+    ]
+
+
+def test_staged_diff_git_failure_handled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """If ``git diff`` fails, the script logs and treats the diff as empty."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+
+    def fake_run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(returncode=128, stdout="", stderr="fatal: not a git repo\n")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    exit_code = mod.main(["--repo-root", str(repo)])
+    assert exit_code == 0
+    assert "git diff failed" in capsys.readouterr().err
+
+
+def test_malformed_missing_closing_delimiter(tmp_path: Path) -> None:
+    """Frontmatter with no closing ``---`` → malformed, exit 2."""
+    repo = _setup_repo(tmp_path)
+    bad = repo / "docs" / "agents" / "concepts" / "bad.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("---\ntitle: bad\nslug: bad\n# never closed\n", encoding="utf-8")
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+
+
+def test_malformed_yaml_payload(tmp_path: Path) -> None:
+    """YAML that can't be parsed → malformed, exit 2."""
+    repo = _setup_repo(tmp_path)
+    bad = repo / "docs" / "agents" / "concepts" / "yaml_bad.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text(
+        "---\n:\n  - this is\n   - intentionally invalid yaml mapping\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+
+
+def test_malformed_frontmatter_not_a_mapping(tmp_path: Path) -> None:
+    """Frontmatter whose YAML payload is a list (not a dict) → malformed."""
+    repo = _setup_repo(tmp_path)
+    bad = repo / "docs" / "agents" / "concepts" / "list_fm.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("---\n- foo\n- bar\n---\n\nbody\n", encoding="utf-8")
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+
+
+def test_malformed_covers_not_a_list(tmp_path: Path) -> None:
+    """``covers: <string>`` instead of a list → malformed."""
+    repo = _setup_repo(tmp_path)
+    bad = repo / "docs" / "agents" / "concepts" / "bad_covers_scalar.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text(
+        "---\ntitle: x\nslug: x\nkind: concept\ncovers: custom_components/quiet_solar/x.py\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+
+
+def test_malformed_covers_item_not_string(tmp_path: Path) -> None:
+    """A ``covers:`` list with a non-string item → malformed."""
+    repo = _setup_repo(tmp_path)
+    bad = repo / "docs" / "agents" / "concepts" / "bad_covers_item.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text(
+        "---\ntitle: x\nslug: x\nkind: concept\ncovers:\n  - 123\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+
+
+def test_doc_without_covers_is_not_tracked(tmp_path: Path) -> None:
+    """A doc without a ``covers:`` key (like ``index.md``) is silently skipped."""
+    repo = _setup_repo(tmp_path)
+    _write_doc(repo, "index", covers=None, subdir=".")
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 0
+
+
+def test_docs_root_missing_is_clean(tmp_path: Path) -> None:
+    """No ``docs/agents/`` tree → clean (nothing to check)."""
+    # Don't call _setup_repo here — we want docs/agents/ to NOT exist.
+    (tmp_path / "custom_components" / "quiet_solar").mkdir(parents=True)
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(tmp_path), "--paths"]) == 0
+
+
+def test_text_output_for_stale(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Non-JSON mode prints stale-doc lines to stdout."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+    exit_code = mod.main(
+        [
+            "--repo-root",
+            str(repo),
+            "--paths",
+            "custom_components/quiet_solar/foo.py",
+        ]
+    )
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "foo.md" in out
+    assert "stale" in out.lower()
+
+
+def test_text_output_for_missing_covers(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Non-JSON mode prints missing-covers lines to stdout."""
+    repo = _setup_repo(tmp_path)
+    _write_doc(repo, "gone", covers=["custom_components/quiet_solar/gone.py"])
+
+    mod = _import_module()
+    exit_code = mod.main(["--repo-root", str(repo), "--paths"])
+    assert exit_code == 2
+    out = capsys.readouterr().out
+    assert "gone.py" in out
+    assert "gone.md" in out
+
+
+def test_text_output_for_malformed(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Non-JSON mode prints malformed-doc lines to stdout."""
+    repo = _setup_repo(tmp_path)
+    bad = repo / "docs" / "agents" / "concepts" / "bad.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("no frontmatter\n", encoding="utf-8")
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+    out = capsys.readouterr().out
+    assert "bad.md" in out
+    assert "malformed" in out.lower()
+
+
+def test_last_verified_non_date_string_stringified(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A quoted ``last_verified`` value (or non-date) is stringified verbatim.
+
+    PyYAML parses ``last_verified: 2026-05-19`` as ``datetime.date``;
+    we want to preserve quoted strings (e.g., ``"unknown"``) as-is.
+    Exercises the ``str(value)`` fallback in
+    ``_stringify_last_verified``.
+    """
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    bad_lv = repo / "docs" / "agents" / "concepts" / "foo.md"
+    bad_lv.parent.mkdir(parents=True, exist_ok=True)
+    bad_lv.write_text(
+        "---\n"
+        "title: foo\n"
+        "slug: foo\n"
+        "kind: concept\n"
+        "covers:\n"
+        "  - custom_components/quiet_solar/foo.py\n"
+        'last_verified: "unknown"\n'
+        "---\n\nbody\n",
+        encoding="utf-8",
+    )
+
+    mod = _import_module()
+    exit_code = mod.main(
+        [
+            "--repo-root",
+            str(repo),
+            "--paths",
+            "custom_components/quiet_solar/foo.py",
+            "--json",
+        ]
+    )
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["stale_docs"][0]["last_verified"] == "unknown"
+
+
+def test_script_main_entry_invokes_sys_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``python check_doc_drift.py`` exits via ``sys.exit(main())``.
+
+    Executes the script through ``runpy`` with ``run_name='__main__'``
+    so the ``if __name__ == '__main__':`` guard fires under the
+    coverage tracer. AC-8's "no ``# pragma: no cover``" rule means
+    every line must be reached by a real test.
+    """
+    import runpy
+
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "qs" / "check_doc_drift.py"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [str(script_path), "--repo-root", str(repo), "--paths"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(script_path), run_name="__main__")
+
+    assert excinfo.value.code == 0
+
+
+def test_json_schema_for_missing_and_malformed(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """JSON output carries both ``missing_covers`` and ``malformed_frontmatter``."""
+    repo = _setup_repo(tmp_path)
+    _write_doc(repo, "gone", covers=["custom_components/quiet_solar/gone.py"])
+    bad = repo / "docs" / "agents" / "concepts" / "bad.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("no frontmatter\n", encoding="utf-8")
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths", "--json"]) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["stale_docs"] == []
+    assert any("gone.py" in entry for entry in payload["missing_covers"])
+    assert any("bad.md" in entry for entry in payload["malformed_frontmatter"])

--- a/tests/qs/test_check_doc_drift.py
+++ b/tests/qs/test_check_doc_drift.py
@@ -22,11 +22,22 @@ subprocess and visible to coverage measurement.
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+
+# Module-level constants for path math (review-fix #01 N5). Keeping
+# the layout assumption in one place means a future move of this
+# test file produces a clear ``script_path.is_file()`` failure
+# instead of an opaque ``ModuleNotFoundError`` deep inside ``runpy``.
+TESTS_QS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = TESTS_QS_DIR.parents[1]
+CHECK_DOC_DRIFT_PATH = REPO_ROOT / "scripts" / "qs" / "check_doc_drift.py"
 
 
 # ---------------------------------------------------------------------------
@@ -329,12 +340,15 @@ def test_staged_diff_default_path_invokes_git(tmp_path: Path, monkeypatch: pytes
     exit_code = mod.main(["--repo-root", str(repo)])
     assert exit_code == 1  # source modified, doc not co-modified → drift
     assert captured_cmd, "git was not invoked"
-    assert captured_cmd[0][:5] == [
+    # Review-fix #01 S8 inserts ``-c core.quotepath=false`` before
+    # the ``diff`` subcommand. Verify the canonical post-S8 layout.
+    assert captured_cmd[0][:6] == [
         "git",
+        "-c",
+        "core.quotepath=false",
         "diff",
         "--cached",
         "--diff-filter=ACMRD",
-        "--name-only",
     ]
 
 
@@ -543,7 +557,13 @@ def test_script_main_entry_invokes_sys_exit(
     _make_source(repo, "custom_components/quiet_solar/foo.py")
     _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
 
-    script_path = Path(__file__).resolve().parents[2] / "scripts" / "qs" / "check_doc_drift.py"
+    # Review-fix #01 N5: assert the path exists before invoking runpy
+    # so a future relocation produces a clear failure here, not deep
+    # inside ``runpy.run_path``.
+    script_path = CHECK_DOC_DRIFT_PATH
+    assert script_path.is_file(), (
+        f"check_doc_drift.py not found at {script_path} — has the script moved?"
+    )
 
     monkeypatch.setattr(
         "sys.argv",
@@ -570,3 +590,476 @@ def test_json_schema_for_missing_and_malformed(tmp_path: Path, capsys: pytest.Ca
     assert payload["stale_docs"] == []
     assert any("gone.py" in entry for entry in payload["missing_covers"])
     assert any("bad.md" in entry for entry in payload["malformed_frontmatter"])
+
+
+# ---------------------------------------------------------------------------
+# Review-fix #01 — tests for the must-fix / should-fix / nice-to-have
+# findings landed in docs/stories/QS-185.story_review_fix_#01.md.
+
+
+# M1: ``_git_staged_paths`` doesn't catch ``FileNotFoundError``
+
+
+def test_git_not_on_path_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``FileNotFoundError`` from a missing ``git`` binary is treated as 'no git env'.
+
+    Review-fix #01 M1: in a sandboxed CI image with no ``git`` on
+    ``PATH``, ``subprocess.run(['git', ...])`` raises
+    ``FileNotFoundError``. The module contract promises a clean
+    empty-diff return; this test pins that contract.
+    """
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+
+    def _no_git(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        raise FileNotFoundError("git: command not found")
+
+    monkeypatch.setattr(mod.subprocess, "run", _no_git)
+
+    assert mod.main(["--repo-root", str(repo)]) == 0
+    assert "git" in capsys.readouterr().err.lower()
+
+
+# M2: ``--paths`` doesn't normalize path forms
+
+
+def test_paths_flag_accepts_absolute_paths(tmp_path: Path) -> None:
+    """An absolute path inside the repo is normalized to a relative POSIX form."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+    abs_source = str(repo / "custom_components" / "quiet_solar" / "foo.py")
+    assert mod.main(["--repo-root", str(repo), "--paths", abs_source]) == 1
+
+
+def test_paths_flag_accepts_dot_prefix(tmp_path: Path) -> None:
+    """A leading ``./`` is stripped before matching."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+    assert (
+        mod.main(
+            [
+                "--repo-root",
+                str(repo),
+                "--paths",
+                "./custom_components/quiet_solar/foo.py",
+            ]
+        )
+        == 1
+    )
+
+
+def test_paths_flag_accepts_backslashes(tmp_path: Path) -> None:
+    """Windows-style backslashes are converted to forward slashes."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+    assert (
+        mod.main(
+            [
+                "--repo-root",
+                str(repo),
+                "--paths",
+                "custom_components\\quiet_solar\\foo.py",
+            ]
+        )
+        == 1
+    )
+
+
+def test_paths_flag_strips_trailing_slash(tmp_path: Path) -> None:
+    """Trailing-slash variants normalize the same way as the canonical form."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+    # No trailing slash on a *file* is impossible to construct
+    # naturally, but the normalizer should still tolerate a stray
+    # one. Exercise the strip branch explicitly.
+    assert (
+        mod.main(
+            [
+                "--repo-root",
+                str(repo),
+                "--paths",
+                "custom_components/quiet_solar/foo.py/",
+            ]
+        )
+        == 1
+    )
+
+
+def test_paths_flag_absolute_outside_repo_kept_as_is(tmp_path: Path) -> None:
+    """An absolute path outside ``repo_root`` keeps its absolute form.
+
+    The normalizer can't relativize it; the entry is then simply
+    irrelevant to drift detection (no source matches), so the gate
+    stays clean.
+    """
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    # Use ``/etc/hostname`` as a stable absolute path that won't be
+    # under ``repo``. On systems where it doesn't exist, the test is
+    # still valid because we only care about path-string handling.
+    outside = "/etc/hostname"
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths", outside]) == 0
+
+
+# S4: ``subprocess.run`` lacks ``timeout``
+
+
+def test_git_timeout_handled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A hung ``git diff`` (index lock contention) is bounded by ``timeout=``."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    mod = _import_module()
+
+    def _timeout(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        raise subprocess.TimeoutExpired(cmd=["git"], timeout=30)
+
+    monkeypatch.setattr(mod.subprocess, "run", _timeout)
+
+    assert mod.main(["--repo-root", str(repo)]) == 0
+    assert "timeout" in capsys.readouterr().err.lower()
+
+
+def test_git_invocation_passes_timeout_and_check_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_git_staged_paths`` invokes ``subprocess.run`` with safety kwargs."""
+    repo = _setup_repo(tmp_path)
+
+    mod = _import_module()
+
+    captured_kwargs: dict[str, Any] = {}
+
+    def _capture(cmd: list[str], **kwargs: Any) -> SimpleNamespace:
+        captured_kwargs.update(kwargs)
+        captured_kwargs["__cmd__"] = cmd
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", _capture)
+
+    mod.main(["--repo-root", str(repo)])
+
+    assert captured_kwargs.get("check") is False, (
+        "subprocess.run must pass check=False explicitly (review-fix #01 S4)"
+    )
+    assert "timeout" in captured_kwargs and captured_kwargs["timeout"] >= 1, (
+        "subprocess.run must pass a finite timeout (review-fix #01 S4)"
+    )
+
+
+# S5: closing-delimiter / line-ending robustness
+
+
+def test_frontmatter_without_trailing_newline_is_valid(tmp_path: Path) -> None:
+    """A doc that ends with ``---`` (no trailing newline) is accepted."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    doc_path = repo / "docs" / "agents" / "concepts" / "foo.md"
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_path.write_text(
+        "---\n"
+        "title: foo\n"
+        "slug: foo\n"
+        "kind: concept\n"
+        "covers:\n"
+        "  - custom_components/quiet_solar/foo.py\n"
+        "last_verified: 2026-05-19\n"
+        "---",  # no trailing newline; no body
+        encoding="utf-8",
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 0
+
+
+def test_frontmatter_with_bare_cr_lineendings_is_normalized(tmp_path: Path) -> None:
+    """Bare ``\\r`` line endings (legacy macOS / corrupted files) parse correctly."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    doc_path = repo / "docs" / "agents" / "concepts" / "foo.md"
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_path.write_bytes(
+        b"---\r"
+        b"title: foo\r"
+        b"slug: foo\r"
+        b"kind: concept\r"
+        b"covers:\r"
+        b"  - custom_components/quiet_solar/foo.py\r"
+        b"last_verified: 2026-05-19\r"
+        b"---\r"
+        b"\r"
+        b"body\r"
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 0
+
+
+# S6: UTF-8 BOM at start of doc
+
+
+def test_doc_with_utf8_bom_parses_correctly(tmp_path: Path) -> None:
+    """A doc saved with a UTF-8 BOM (Windows editors) is not flagged malformed."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    doc_path = repo / "docs" / "agents" / "concepts" / "foo.md"
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_path.write_bytes(
+        b"\xef\xbb\xbf"  # UTF-8 BOM
+        b"---\n"
+        b"title: foo\n"
+        b"slug: foo\n"
+        b"kind: concept\n"
+        b"covers:\n"
+        b"  - custom_components/quiet_solar/foo.py\n"
+        b"last_verified: 2026-05-19\n"
+        b"---\n"
+        b"\n"
+        b"body\n"
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 0
+
+
+# S7: duplicate ``covers:`` entries
+
+
+def test_duplicate_covers_entries_dedup_in_json_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A doc with the same source in ``covers:`` twice de-dups in the JSON report."""
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    doc_path = repo / "docs" / "agents" / "concepts" / "foo.md"
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_path.write_text(
+        "---\n"
+        "title: foo\n"
+        "slug: foo\n"
+        "kind: concept\n"
+        "covers:\n"
+        "  - custom_components/quiet_solar/foo.py\n"
+        "  - custom_components/quiet_solar/foo.py\n"
+        "last_verified: 2026-05-19\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    mod = _import_module()
+    exit_code = mod.main(
+        [
+            "--repo-root",
+            str(repo),
+            "--paths",
+            "custom_components/quiet_solar/foo.py",
+            "--json",
+        ]
+    )
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    sources = payload["stale_docs"][0]["stale_sources"]
+    assert sources == ["custom_components/quiet_solar/foo.py"], (
+        f"Duplicate covers entries should de-dup in the JSON output; got {sources!r}"
+    )
+
+
+# S8: git path quoting / non-ASCII filenames
+
+
+def test_git_invocation_disables_quotepath(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_git_staged_paths`` passes ``-c core.quotepath=false`` to git.
+
+    Without this flag, git's default ``core.quotepath=true`` returns
+    non-ASCII paths in C-style escapes, which never match
+    ``source_to_docs`` keys (review-fix #01 S8).
+    """
+    repo = _setup_repo(tmp_path)
+
+    mod = _import_module()
+    captured_cmd: list[str] = []
+
+    def _capture(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
+        captured_cmd.extend(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", _capture)
+    mod.main(["--repo-root", str(repo)])
+
+    cmd_str = " ".join(captured_cmd)
+    assert "core.quotepath=false" in cmd_str, (
+        f"git invocation must disable quotepath (review-fix #01 S8); got: {cmd_str}"
+    )
+
+
+# N7: leading whitespace on covers entry
+
+
+def test_covers_entry_with_stray_whitespace_is_normalized(tmp_path: Path) -> None:
+    """``covers:`` entries with stray leading/trailing whitespace still resolve.
+
+    Review-fix #01 N7: a YAML quoted-string indent can produce
+    ``"  custom_components/quiet_solar/foo.py"``, which previously
+    failed the ``startswith(TRACKED_PREFIX)`` check and was treated
+    as off-tree (warning only).
+    """
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    doc_path = repo / "docs" / "agents" / "concepts" / "foo.md"
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_path.write_text(
+        "---\n"
+        "title: foo\n"
+        "slug: foo\n"
+        "kind: concept\n"
+        "covers:\n"
+        '  - "  custom_components/quiet_solar/foo.py  "\n'
+        "last_verified: 2026-05-19\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    mod = _import_module()
+    # The normalized entry resolves under ``custom_components/quiet_solar/``,
+    # so modifying that source flags drift on the doc.
+    exit_code = mod.main(
+        [
+            "--repo-root",
+            str(repo),
+            "--paths",
+            "custom_components/quiet_solar/foo.py",
+        ]
+    )
+    assert exit_code == 1
+
+
+# N8: directory ``covers:`` entries
+
+
+def test_covers_entry_pointing_to_directory_is_malformed(tmp_path: Path) -> None:
+    """A ``covers:`` entry pointing to a directory is flagged malformed.
+
+    Directory entries don't cascade to their contents, so accepting
+    them silently misses every drift inside that directory. Explicit
+    rejection is the safer contract.
+    """
+    repo = _setup_repo(tmp_path)
+    # Create a directory inside the tracked tree.
+    (repo / "custom_components" / "quiet_solar" / "home_model").mkdir(parents=True, exist_ok=True)
+    _write_doc(
+        repo, "dir_covers", covers=["custom_components/quiet_solar/home_model"]
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+
+
+# N9: rglob follows symlinks
+
+
+def test_rglob_skips_symlinks(tmp_path: Path) -> None:
+    """Symlinked docs inside ``docs/agents/`` are skipped to avoid cycles.
+
+    Review-fix #01 N9: ``Path.rglob('*.md')`` follows symlinks by
+    default. A self-referential symlink would hang the scan; a
+    symlink pointing into another tree would duplicate reports.
+    """
+    if not hasattr(os, "symlink"):  # pragma: no cover — platform guard
+        pytest.skip("symlinks unavailable on this platform")
+
+    repo = _setup_repo(tmp_path)
+    _make_source(repo, "custom_components/quiet_solar/foo.py")
+    real_doc = _write_doc(repo, "foo", covers=["custom_components/quiet_solar/foo.py"])
+
+    symlink_target = repo / "docs" / "agents" / "concepts" / "symlinked.md"
+    try:
+        os.symlink(real_doc, symlink_target)
+    except (OSError, NotImplementedError):  # pragma: no cover — Windows without admin
+        pytest.skip("symlink creation requires elevated privileges on this platform")
+
+    mod = _import_module()
+    # The symlinked doc shouldn't double-report drift or cause a cycle.
+    assert (
+        mod.main(
+            [
+                "--repo-root",
+                str(repo),
+                "--paths",
+                "custom_components/quiet_solar/foo.py",
+            ]
+        )
+        == 1
+    )
+
+
+# N10: misleading "NoneType" message when ``covers:`` is null
+
+
+def test_null_covers_value_emits_clear_message(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``covers:`` with no value yields a help-tier message, not 'NoneType'."""
+    repo = _setup_repo(tmp_path)
+    doc_path = repo / "docs" / "agents" / "concepts" / "nullc.md"
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_path.write_text(
+        "---\n"
+        "title: nullc\n"
+        "slug: nullc\n"
+        "kind: concept\n"
+        "covers:\n"  # no value → parses to None
+        "last_verified: 2026-05-19\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    mod = _import_module()
+    assert mod.main(["--repo-root", str(repo), "--paths"]) == 2
+    err = capsys.readouterr().err
+    # The legacy message would say "NoneType"; the new message names
+    # the actionable fix.
+    assert "covers" in err.lower()
+    assert "omit the key" in err or "covers: []" in err
+
+
+# N11: ``--repo-root`` validation
+
+
+def test_nonexistent_repo_root_exits_nonzero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A non-existent ``--repo-root`` exits with a clear non-zero error code."""
+    missing = tmp_path / "does_not_exist"
+    assert not missing.exists()
+
+    mod = _import_module()
+    exit_code = mod.main(["--repo-root", str(missing), "--paths"])
+    assert exit_code != 0
+    err = capsys.readouterr().err
+    assert "repo-root" in err.lower() or str(missing) in err


### PR DESCRIPTION
## Summary
- Adds docs/agents/ hierarchy (36 files: 20 concepts, 5 principles, 6 use cases, 3 personas, glossary, LSP eval, index) so plan/implement/review agents pull small scoped knowledge files instead of grep-ing the codebase.
- scripts/qs/check_doc_drift.py validates covers: paths exist and flags docs whose source was modified without a co-modification. 100% test coverage (27 tests). All 4 orchestrator agents wire it into their phase protocol across .claude/, .cursor/, .opencode/ (12 file edits); parity pinned by tests/qs/agents/test_doc_maintenance_parity.py.
- docs/product/architecture.md trimmed 1,175 → 929 lines: sections describing concepts, hierarchical control mechanics, the 9 patterns, decision map, and quick navigation replaced with pointers to docs/agents/. Decisions log, CI/CD strategy, validation tables, directory structure, and boundaries kept verbatim. Doc maintenance subsection added to docs/workflow/project-rules.md.

Fixes #185

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive agents docs hub: index, glossary, ~20 concept pages, principles, use-cases, and personas to explain architecture, behaviors, and workflows.

* **Chores**
  * Introduced a doc‑maintenance workflow: automated drift checks on changes, required doc updates or PR justification when relevant, and parity tests ensuring agent guidance includes the drift check step.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->