### PR TITLE
QS-189: Pool card — animated water level inside the circle

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-pool-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-pool-card.js
@@ -5,7 +5,7 @@
 
 class QsPoolCard extends HTMLElement {
 
-  // --- Wave path generation helper (Task 1) ---
+  // Generate an SVG path for a sine-wave-based closed shape
   _generateWavePath(width, amplitude, frequency, phase, yOffset) {
     const points = [];
     const steps = 60;
@@ -19,7 +19,7 @@ class QsPoolCard extends HTMLElement {
            ` L ${width.toFixed(2)} 400 L 0 400 Z`;
   }
 
-  // --- Temperature-based color tinting (Task 6) ---
+  // Map pool temperature to per-layer water HSL colors
   _tempToColor(tempC) {
     // Map 10°C–35°C to HSL interpolation
     // Cool (≤15°C): hsl(195, 70%, 18%) — deeper blue-teal
@@ -32,7 +32,7 @@ class QsPoolCard extends HTMLElement {
         'hsla(185, 60%, 18%, 0.35)',
       ];
     }
-    const t = Math.max(0, Math.min(1, (tempC - 10) / 20)); // 0 at 10°C, 1 at 30°C
+    const t = Math.max(0, Math.min(1, (tempC - 15) / 15)); // 0 at 15°C, 1 at 30°C
     const h = 195 - t * 20;   // 195 → 175
     const s = 70 - t * 15;    // 70 → 55
     const l = 18 + t * 10;    // 18 → 28
@@ -50,6 +50,7 @@ class QsPoolCard extends HTMLElement {
     this._currentSpeed = 0.3;
     this._wavePhase = 0;
     this._lastWaterBaseY = null;
+    this._lastAmplitude = null;
 
     const step = (ts) => {
       if (!this.isConnected) { this._animRaf = null; return; }
@@ -64,7 +65,7 @@ class QsPoolCard extends HTMLElement {
         p.setAttribute('stroke-dashoffset', String(-this._animOffset));
       }
 
-      // --- Wave animation update (Task 5) ---
+      // --- Wave animation update ---
       const pumpOn = this._pumpRunning === true;
       const targetAmplitude = pumpOn ? 6 : 2;
       const targetSpeed = pumpOn ? 1.2 : 0.3;
@@ -73,6 +74,7 @@ class QsPoolCard extends HTMLElement {
       this._currentAmplitude += (targetAmplitude - this._currentAmplitude) * lerpFactor;
       this._currentSpeed += (targetSpeed - this._currentSpeed) * lerpFactor;
       this._wavePhase += this._currentSpeed * dt;
+      if (this._wavePhase > 1e6) this._wavePhase -= 1e6;
 
       // Update wave transforms (CSS translateX for GPU compositing)
       // Wave paths span x=[0, 480]. Clip circle spans x=[40, 280].
@@ -83,16 +85,20 @@ class QsPoolCard extends HTMLElement {
         const wEl = this._root?.getElementById('wave' + i);
         if (wEl) {
           const phaseOffset = i * 1.2;
-          const scrollOffset = ((this._wavePhase + phaseOffset) * 60) % waveWidth;
+          const raw = (this._wavePhase + phaseOffset) * 60;
+          const scrollOffset = ((raw % waveWidth) + waveWidth) % waveWidth;
           const tx = -120 - scrollOffset; // -120 centers path over clip circle
           wEl.style.transform = `translateX(${tx.toFixed(1)}px)`;
         }
       }
 
-      // Regenerate wave paths only when water level changes
+      // Regenerate wave paths when water level or amplitude changes
       const waterBaseY = this._waterBaseY;
-      if (waterBaseY != null && waterBaseY !== this._lastWaterBaseY) {
+      const ampDelta = this._lastAmplitude == null ? 1 : Math.abs(this._currentAmplitude - this._lastAmplitude);
+      const levelChanged = waterBaseY != null && waterBaseY !== this._lastWaterBaseY;
+      if (levelChanged || ampDelta > 0.1) {
         this._lastWaterBaseY = waterBaseY;
+        this._lastAmplitude = this._currentAmplitude;
         const colors = this._waterColors || ['hsla(185,60%,22%,0.55)', 'hsla(185,60%,20%,0.45)', 'hsla(185,60%,18%,0.35)'];
         for (let i = 0; i < 3; i++) {
           const wEl = this._root?.getElementById('wave' + i);
@@ -186,30 +192,31 @@ class QsPoolCard extends HTMLElement {
       const maxHours = 24;
       const rawTarget = sDurationLimit ? Number(sDurationLimit.state) : null;
       const targetHours = (rawTarget != null && !Number.isNaN(rawTarget)) ? rawTarget : 0;
-      const hoursRun = Number(sCurrentDailyRunDuration?.state || 0);
+      const hoursRun = Number(sCurrentDailyRunDuration?.state) || 0;
       
       // Determine if pool is running (command state must be "on")
       const commandState = sCommand?.state || '';
       const running = commandState.toLowerCase() === 'on';
 
-      // --- Store pump state for RAF loop (Task 4/5) ---
+      // Store pump state for RAF loop
       this._pumpRunning = running;
 
-      // --- Water level from runtime progress (Task 4) ---
+      // Water level from runtime progress
       const progressRatio = targetHours > 0
           ? Math.min(1, hoursRun / targetHours)
           : 0;
       const clipR = 120;
       // center.cy is always 160; using literal to avoid forward-reference
       const waterBaseY = 160 + clipR - (0.2 + progressRatio * 0.6) * 2 * clipR;
-      this._waterBaseY = waterBaseY;
+      this._waterBaseY = Number.isNaN(waterBaseY) ? null : waterBaseY;
 
-      // --- Temperature-based water colors (Task 6) ---
+      // Temperature-based water colors
       this._waterColors = this._tempToColor(tempNum);
 
-      // --- Instance-unique clip ID (Task 2) ---
+      // Instance-unique clip ID (stable across re-renders)
       if (!this._waterClipId) {
-          this._waterClipId = 'wClip-' + Math.floor(Math.random() * 1e6);
+          QsPoolCard._nextClipId = (QsPoolCard._nextClipId || 0) + 1;
+          this._waterClipId = 'wClip-' + QsPoolCard._nextClipId;
       }
       const waterClipId = this._waterClipId;
 

--- a/custom_components/quiet_solar/ui/resources/qs-pool-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-pool-card.js
@@ -3,39 +3,68 @@
   Zero-build single-file Lit-style web component compatible with Home Assistant
 */
 
+// --- Geometry (must match the SVG <clipPath> circle attributes below) ---
+const CENTER_CY = 160;            // SVG y-center of the ring / clip circle
+const CLIP_R = 120;               // water clip circle radius
+const WAVE_WIDTH = 480;           // single wave period in SVG px (2× clip diameter)
+const WAVE_BOTTOM_Y = 400;        // path closing edge y; outside viewBox, clipped
+
+// --- Water color (HSL endpoints) ---
+const COOL_HUE = 195, WARM_HUE = 175;     // deeper blue-teal → warmer cyan
+const COOL_SAT = 70,  WARM_SAT = 55;
+const COOL_LIGHT = 18, WARM_LIGHT = 28;
+const COOL_TEMP_C = 15;           // °C at which tint is coolest
+const WARM_TEMP_C = 30;           // °C at which tint is warmest
+
+// --- Animation tuning ---
+const LERP_RATE = 2;              // exp time-constant; ~95% of lerp in ~1.5s
+const LERP_DT_CEIL = 0.1;         // s; clamp lerp dt to avoid snap-to after tab hidden
+const AMP_REGEN_THRESHOLD = 0.25; // amplitude delta threshold for path regen (throttle)
+const PHASE_WRAP = 1e6;           // wrap _wavePhase to preserve float precision
+const PHASE_TO_PX = 60;           // scroll px per phase-unit
+
+// --- Wave dynamics targets (calm vs pumping) ---
+const CALM_AMP = 2,  PUMP_AMP = 6;
+const CALM_SPEED = 0.3, PUMP_SPEED = 1.2;
+
 class QsPoolCard extends HTMLElement {
 
-  // Generate an SVG path for a sine-wave-based closed shape
+  // Generate an SVG path for a sine-wave-based closed shape.
+  // Emits TWO repetitions of the wave (path extent = [0, 2*width]) so the
+  // translated path always covers the clip region regardless of scroll offset.
+  // `frequency` is in cycles per `width`, so each period is identical.
   _generateWavePath(width, amplitude, frequency, phase, yOffset) {
     const points = [];
-    const steps = 60;
-    for (let i = 0; i <= steps; i++) {
-      const x = (i / steps) * width;
-      const y = yOffset + amplitude * Math.sin((i / steps) * frequency * 2 * Math.PI + phase);
+    const stepsPerPeriod = 60;
+    const totalSteps = stepsPerPeriod * 2;
+    const totalWidth = 2 * width;
+    for (let i = 0; i <= totalSteps; i++) {
+      const x = (i / stepsPerPeriod) * width; // 0 .. 2*width
+      const y = yOffset + amplitude * Math.sin((x / width) * frequency * 2 * Math.PI + phase);
       points.push(`${x.toFixed(2)} ${y.toFixed(2)}`);
     }
     return `M ${points[0]} ` +
            points.slice(1).map(p => `L ${p}`).join(' ') +
-           ` L ${width.toFixed(2)} 400 L 0 400 Z`;
+           ` L ${totalWidth.toFixed(2)} ${WAVE_BOTTOM_Y} L 0 ${WAVE_BOTTOM_Y} Z`;
   }
 
-  // Map pool temperature to per-layer water HSL colors
+  // Map pool temperature to per-layer water HSL colors.
+  // Cool end → deeper blue-teal; warm end → warmer cyan-turquoise.
   _tempToColor(tempC) {
-    // Map 10°C–35°C to HSL interpolation
-    // Cool (≤15°C): hsl(195, 70%, 18%) — deeper blue-teal
-    // Warm (≥30°C): hsl(175, 55%, 28%) — warmer cyan-turquoise
-    if (tempC == null || Number.isNaN(tempC)) {
-      // Neutral teal fallback
+    // Explicit guard: tempC may be null/undefined (no sensor bound) or
+    // NaN (bad parse). Loose equality would also catch this, but be explicit.
+    if (tempC === null || tempC === undefined || Number.isNaN(tempC)) {
       return [
         'hsla(185, 60%, 22%, 0.55)',
         'hsla(185, 60%, 20%, 0.45)',
         'hsla(185, 60%, 18%, 0.35)',
       ];
     }
-    const t = Math.max(0, Math.min(1, (tempC - 15) / 15)); // 0 at 15°C, 1 at 30°C
-    const h = 195 - t * 20;   // 195 → 175
-    const s = 70 - t * 15;    // 70 → 55
-    const l = 18 + t * 10;    // 18 → 28
+    const span = WARM_TEMP_C - COOL_TEMP_C;
+    const t = Math.max(0, Math.min(1, (tempC - COOL_TEMP_C) / span));
+    const h = COOL_HUE + t * (WARM_HUE - COOL_HUE);
+    const s = COOL_SAT + t * (WARM_SAT - COOL_SAT);
+    const l = COOL_LIGHT + t * (WARM_LIGHT - COOL_LIGHT);
     return [
       `hsla(${h.toFixed(0)}, ${s.toFixed(0)}%, ${(l + 2).toFixed(0)}%, 0.55)`,
       `hsla(${h.toFixed(0)}, ${s.toFixed(0)}%, ${l.toFixed(0)}%, 0.45)`,
@@ -43,14 +72,19 @@ class QsPoolCard extends HTMLElement {
     ];
   }
 
+  // Clear the wave-path memoization keys so the next RAF tick regenerates paths.
+  _invalidateWaveCache() {
+    this._lastWaterBaseY = null;
+    this._lastAmplitude = null;
+  }
+
   connectedCallback() {
     if (this._animRaf != null) return;
     // Initialize wave animation state
-    this._currentAmplitude = 2;
-    this._currentSpeed = 0.3;
+    this._currentAmplitude = CALM_AMP;
+    this._currentSpeed = CALM_SPEED;
     this._wavePhase = 0;
-    this._lastWaterBaseY = null;
-    this._lastAmplitude = null;
+    this._invalidateWaveCache();
 
     const step = (ts) => {
       if (!this.isConnected) { this._animRaf = null; return; }
@@ -67,36 +101,44 @@ class QsPoolCard extends HTMLElement {
 
       // --- Wave animation update ---
       const pumpOn = this._pumpRunning === true;
-      const targetAmplitude = pumpOn ? 6 : 2;
-      const targetSpeed = pumpOn ? 1.2 : 0.3;
-      // Smooth lerp: 1 - exp(-3 * dt) ≈ 3·dt for small dt
-      const lerpFactor = 1 - Math.exp(-3 * dt);
+      const targetAmplitude = pumpOn ? PUMP_AMP : CALM_AMP;
+      const targetSpeed = pumpOn ? PUMP_SPEED : CALM_SPEED;
+      // Clamp the lerp dt: after a tab is hidden for several seconds, the
+      // first frame back has huge dt and lerpFactor ≈ 1, which would snap
+      // the amplitude/speed to target. The story requires a ~1–2 s smooth
+      // interpolation. Wave phase keeps using raw dt so scroll catches up.
+      const lerpDt = Math.min(dt, LERP_DT_CEIL);
+      const lerpFactor = 1 - Math.exp(-LERP_RATE * lerpDt);
       this._currentAmplitude += (targetAmplitude - this._currentAmplitude) * lerpFactor;
       this._currentSpeed += (targetSpeed - this._currentSpeed) * lerpFactor;
       this._wavePhase += this._currentSpeed * dt;
-      if (this._wavePhase > 1e6) this._wavePhase -= 1e6;
+      if (this._wavePhase > PHASE_WRAP) this._wavePhase -= PHASE_WRAP;
 
-      // Update wave transforms (CSS translateX for GPU compositing)
-      // Wave paths span x=[0, 480]. Clip circle spans x=[40, 280].
-      // We offset by -120 so the path center aligns with the clip center,
-      // then scroll within one wave-width period.
-      const waveWidth = 480; // 2× circle diameter (240)
+      // Update wave transforms (CSS translateX for GPU compositing).
+      // Path extent is [0, 2*WAVE_WIDTH] so the translated path always
+      // covers the clip region. We offset by -CLIP_R to align the path
+      // start with the clip's left edge, then scroll within one period.
       for (let i = 0; i < 3; i++) {
         const wEl = this._root?.getElementById('wave' + i);
         if (wEl) {
           const phaseOffset = i * 1.2;
-          const raw = (this._wavePhase + phaseOffset) * 60;
-          const scrollOffset = ((raw % waveWidth) + waveWidth) % waveWidth;
-          const tx = -120 - scrollOffset; // -120 centers path over clip circle
+          const raw = (this._wavePhase + phaseOffset) * PHASE_TO_PX;
+          const scrollOffset = ((raw % WAVE_WIDTH) + WAVE_WIDTH) % WAVE_WIDTH;
+          const tx = -CLIP_R - scrollOffset;
           wEl.style.transform = `translateX(${tx.toFixed(1)}px)`;
         }
       }
 
-      // Regenerate wave paths when water level or amplitude changes
+      // Regenerate wave paths when water level or amplitude changes.
+      // Guard against undefined/NaN base — the RAF loop can fire before
+      // _render() populates _waterBaseY on cold start.
       const waterBaseY = this._waterBaseY;
-      const ampDelta = this._lastAmplitude == null ? 1 : Math.abs(this._currentAmplitude - this._lastAmplitude);
-      const levelChanged = waterBaseY != null && waterBaseY !== this._lastWaterBaseY;
-      if (levelChanged || ampDelta > 0.1) {
+      const hasValidBase = waterBaseY != null && !Number.isNaN(waterBaseY);
+      const ampDelta = this._lastAmplitude == null
+          ? Infinity
+          : Math.abs(this._currentAmplitude - this._lastAmplitude);
+      const levelChanged = waterBaseY !== this._lastWaterBaseY;
+      if (hasValidBase && (levelChanged || ampDelta > AMP_REGEN_THRESHOLD)) {
         this._lastWaterBaseY = waterBaseY;
         this._lastAmplitude = this._currentAmplitude;
         const colors = this._waterColors || ['hsla(185,60%,22%,0.55)', 'hsla(185,60%,20%,0.45)', 'hsla(185,60%,18%,0.35)'];
@@ -104,8 +146,8 @@ class QsPoolCard extends HTMLElement {
           const wEl = this._root?.getElementById('wave' + i);
           if (wEl) {
             const phaseOffset = i * 2.1;
-            const freq = 2 + i * 0.5;
-            const d = this._generateWavePath(waveWidth, this._currentAmplitude, freq, phaseOffset, waterBaseY);
+            const freq = 2 + i; // integer freq → seamless wrap at WAVE_WIDTH
+            const d = this._generateWavePath(WAVE_WIDTH, this._currentAmplitude, freq, phaseOffset, waterBaseY);
             wEl.setAttribute('d', d);
             wEl.setAttribute('fill', colors[i]);
           }
@@ -201,13 +243,15 @@ class QsPoolCard extends HTMLElement {
       // Store pump state for RAF loop
       this._pumpRunning = running;
 
-      // Water level from runtime progress
+      // Water level from runtime progress. Clamp on both sides: a negative
+      // hoursRun (sensor reset glitch / device reporting -1) would otherwise
+      // push waterBaseY past WAVE_BOTTOM_Y and self-intersect the polygon.
       const progressRatio = targetHours > 0
-          ? Math.min(1, hoursRun / targetHours)
+          ? Math.max(0, Math.min(1, hoursRun / targetHours))
           : 0;
-      const clipR = 120;
-      // center.cy is always 160; using literal to avoid forward-reference
-      const waterBaseY = 160 + clipR - (0.2 + progressRatio * 0.6) * 2 * clipR;
+      // Map 0..1 progress → 1/5..4/5 fill of the clip circle.
+      // CENTER_CY / CLIP_R MUST match the <clipPath> circle attributes below.
+      const waterBaseY = CENTER_CY + CLIP_R - (0.2 + progressRatio * 0.6) * 2 * CLIP_R;
       this._waterBaseY = Number.isNaN(waterBaseY) ? null : waterBaseY;
 
       // Temperature-based water colors
@@ -406,7 +450,7 @@ class QsPoolCard extends HTMLElement {
                   </feMerge>
                 </filter>
                 <clipPath id="${waterClipId}">
-                  <circle cx="160" cy="160" r="120" />
+                  <circle cx="160" cy="${CENTER_CY}" r="${CLIP_R}" />
                 </clipPath>
               </defs>
               <g clip-path="url(#${waterClipId})">
@@ -471,8 +515,8 @@ class QsPoolCard extends HTMLElement {
       const root = this._root;
       const ids = (k) => root.getElementById(k);
 
-      // --- Force initial wave path generation ---
-      this._lastWaterBaseY = null; // reset so RAF loop regenerates paths
+      // Force initial wave path generation after each (re-)render.
+      this._invalidateWaveCache();
 
       // Pool mode selector
       if (selPoolMode) {

--- a/custom_components/quiet_solar/ui/resources/qs-pool-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-pool-card.js
@@ -4,8 +4,53 @@
 */
 
 class QsPoolCard extends HTMLElement {
+
+  // --- Wave path generation helper (Task 1) ---
+  _generateWavePath(width, amplitude, frequency, phase, yOffset) {
+    const points = [];
+    const steps = 60;
+    for (let i = 0; i <= steps; i++) {
+      const x = (i / steps) * width;
+      const y = yOffset + amplitude * Math.sin((i / steps) * frequency * 2 * Math.PI + phase);
+      points.push(`${x.toFixed(2)} ${y.toFixed(2)}`);
+    }
+    return `M ${points[0]} ` +
+           points.slice(1).map(p => `L ${p}`).join(' ') +
+           ` L ${width.toFixed(2)} 400 L 0 400 Z`;
+  }
+
+  // --- Temperature-based color tinting (Task 6) ---
+  _tempToColor(tempC) {
+    // Map 10°C–35°C to HSL interpolation
+    // Cool (≤15°C): hsl(195, 70%, 18%) — deeper blue-teal
+    // Warm (≥30°C): hsl(175, 55%, 28%) — warmer cyan-turquoise
+    if (tempC == null || Number.isNaN(tempC)) {
+      // Neutral teal fallback
+      return [
+        'hsla(185, 60%, 22%, 0.55)',
+        'hsla(185, 60%, 20%, 0.45)',
+        'hsla(185, 60%, 18%, 0.35)',
+      ];
+    }
+    const t = Math.max(0, Math.min(1, (tempC - 10) / 20)); // 0 at 10°C, 1 at 30°C
+    const h = 195 - t * 20;   // 195 → 175
+    const s = 70 - t * 15;    // 70 → 55
+    const l = 18 + t * 10;    // 18 → 28
+    return [
+      `hsla(${h.toFixed(0)}, ${s.toFixed(0)}%, ${(l + 2).toFixed(0)}%, 0.55)`,
+      `hsla(${h.toFixed(0)}, ${s.toFixed(0)}%, ${l.toFixed(0)}%, 0.45)`,
+      `hsla(${h.toFixed(0)}, ${s.toFixed(0)}%, ${(l - 2).toFixed(0)}%, 0.35)`,
+    ];
+  }
+
   connectedCallback() {
     if (this._animRaf != null) return;
+    // Initialize wave animation state
+    this._currentAmplitude = 2;
+    this._currentSpeed = 0.3;
+    this._wavePhase = 0;
+    this._lastWaterBaseY = null;
+
     const step = (ts) => {
       if (!this.isConnected) { this._animRaf = null; return; }
       if (this._lastAnimTs == null) this._lastAnimTs = ts;
@@ -18,6 +63,45 @@ class QsPoolCard extends HTMLElement {
       if (p) {
         p.setAttribute('stroke-dashoffset', String(-this._animOffset));
       }
+
+      // --- Wave animation update (Task 5) ---
+      const pumpOn = this._pumpRunning === true;
+      const targetAmplitude = pumpOn ? 6 : 2;
+      const targetSpeed = pumpOn ? 1.2 : 0.3;
+      // Smooth lerp: 1 - exp(-3 * dt) ≈ 3·dt for small dt
+      const lerpFactor = 1 - Math.exp(-3 * dt);
+      this._currentAmplitude += (targetAmplitude - this._currentAmplitude) * lerpFactor;
+      this._currentSpeed += (targetSpeed - this._currentSpeed) * lerpFactor;
+      this._wavePhase += this._currentSpeed * dt;
+
+      // Update wave transforms (CSS translateX for GPU compositing)
+      const waveWidth = 480; // 2× circle diameter (240)
+      for (let i = 0; i < 3; i++) {
+        const wEl = this._root?.getElementById('wave' + i);
+        if (wEl) {
+          const phaseOffset = i * 1.2;
+          const tx = -((this._wavePhase + phaseOffset) * 60) % waveWidth;
+          wEl.style.transform = `translateX(${tx.toFixed(1)}px)`;
+        }
+      }
+
+      // Regenerate wave paths only when water level changes
+      const waterBaseY = this._waterBaseY;
+      if (waterBaseY != null && waterBaseY !== this._lastWaterBaseY) {
+        this._lastWaterBaseY = waterBaseY;
+        const colors = this._waterColors || ['hsla(185,60%,22%,0.55)', 'hsla(185,60%,20%,0.45)', 'hsla(185,60%,18%,0.35)'];
+        for (let i = 0; i < 3; i++) {
+          const wEl = this._root?.getElementById('wave' + i);
+          if (wEl) {
+            const phaseOffset = i * 2.1;
+            const freq = 2 + i * 0.5;
+            const d = this._generateWavePath(waveWidth, this._currentAmplitude, freq, phaseOffset, waterBaseY);
+            wEl.setAttribute('d', d);
+            wEl.setAttribute('fill', colors[i]);
+          }
+        }
+      }
+
       this._animRaf = requestAnimationFrame(step);
     };
     this._animRaf = requestAnimationFrame(step);
@@ -103,7 +187,27 @@ class QsPoolCard extends HTMLElement {
       // Determine if pool is running (command state must be "on")
       const commandState = sCommand?.state || '';
       const running = commandState.toLowerCase() === 'on';
-      
+
+      // --- Store pump state for RAF loop (Task 4/5) ---
+      this._pumpRunning = running;
+
+      // --- Water level from runtime progress (Task 4) ---
+      const progressRatio = targetHours > 0
+          ? Math.min(1, hoursRun / targetHours)
+          : 0;
+      const clipR = 120;
+      const waterBaseY = center.cy + clipR - (0.2 + progressRatio * 0.6) * 2 * clipR;
+      this._waterBaseY = waterBaseY;
+
+      // --- Temperature-based water colors (Task 6) ---
+      this._waterColors = this._tempToColor(tempNum);
+
+      // --- Instance-unique clip ID (Task 2) ---
+      if (!this._waterClipId) {
+          this._waterClipId = 'wClip-' + Math.floor(Math.random() * 1e6);
+      }
+      const waterClipId = this._waterClipId;
+
       const css = `
       :host { --pad: 18px; display:block; }
       .card { padding: var(--pad); position: relative; }
@@ -143,9 +247,9 @@ class QsPoolCard extends HTMLElement {
       .card.disabled { opacity: 0.5; pointer-events: none; filter: grayscale(0.8); }
       .card.disabled .power-btn { pointer-events: auto; opacity: 1; filter: grayscale(0); }
       .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center; pointer-events: none; transform: translateY(16px); }
-      .ring .pct { font-size: 4rem; font-weight:800; letter-spacing:-1px; line-height:1; }
-      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .target-value { color: var(--primary-color); font-weight:800; font-size: 1.5rem; line-height: 1; }
+      .ring .pct { font-size: 4rem; font-weight:800; letter-spacing:-1px; line-height:1; text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); }
+      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); }
+      .ring .target-value { color: var(--primary-color); font-weight:800; font-size: 1.5rem; line-height: 1; text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); }
       .ring .stack { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:4px; text-align:center; width: 180px; margin: 0 auto; }
       .ring .temp-block { display:flex; flex-direction:column; align-items:center; gap:2px; margin-top:4px; margin-bottom:8px; }
       .ring .stack > * { text-align:center; }
@@ -289,7 +393,15 @@ class QsPoolCard extends HTMLElement {
                     <feMergeNode in="SourceGraphic" />
                   </feMerge>
                 </filter>
+                <clipPath id="${waterClipId}">
+                  <circle cx="160" cy="160" r="120" />
+                </clipPath>
               </defs>
+              <g clip-path="url(#${waterClipId})">
+                <path id="wave0" d="" fill="hsla(185,60%,22%,0.55)" opacity="1" pointer-events="none" style="will-change: transform;" />
+                <path id="wave1" d="" fill="hsla(185,60%,20%,0.45)" opacity="1" pointer-events="none" style="will-change: transform;" />
+                <path id="wave2" d="" fill="hsla(185,60%,18%,0.35)" opacity="1" pointer-events="none" style="will-change: transform;" />
+              </g>
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
               ${showAnimation ? `
@@ -346,6 +458,9 @@ class QsPoolCard extends HTMLElement {
       // Wire events
       const root = this._root;
       const ids = (k) => root.getElementById(k);
+
+      // --- Force initial wave path generation ---
+      this._lastWaterBaseY = null; // reset so RAF loop regenerates paths
 
       // Pool mode selector
       if (selPoolMode) {

--- a/custom_components/quiet_solar/ui/resources/qs-pool-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-pool-card.js
@@ -75,12 +75,16 @@ class QsPoolCard extends HTMLElement {
       this._wavePhase += this._currentSpeed * dt;
 
       // Update wave transforms (CSS translateX for GPU compositing)
+      // Wave paths span x=[0, 480]. Clip circle spans x=[40, 280].
+      // We offset by -120 so the path center aligns with the clip center,
+      // then scroll within one wave-width period.
       const waveWidth = 480; // 2× circle diameter (240)
       for (let i = 0; i < 3; i++) {
         const wEl = this._root?.getElementById('wave' + i);
         if (wEl) {
           const phaseOffset = i * 1.2;
-          const tx = -((this._wavePhase + phaseOffset) * 60) % waveWidth;
+          const scrollOffset = ((this._wavePhase + phaseOffset) * 60) % waveWidth;
+          const tx = -120 - scrollOffset; // -120 centers path over clip circle
           wEl.style.transform = `translateX(${tx.toFixed(1)}px)`;
         }
       }
@@ -196,7 +200,8 @@ class QsPoolCard extends HTMLElement {
           ? Math.min(1, hoursRun / targetHours)
           : 0;
       const clipR = 120;
-      const waterBaseY = center.cy + clipR - (0.2 + progressRatio * 0.6) * 2 * clipR;
+      // center.cy is always 160; using literal to avoid forward-reference
+      const waterBaseY = 160 + clipR - (0.2 + progressRatio * 0.6) * 2 * clipR;
       this._waterBaseY = waterBaseY;
 
       // --- Temperature-based water colors (Task 6) ---

--- a/custom_components/quiet_solar/ui/resources/qs-pool-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-pool-card.js
@@ -7,7 +7,12 @@
 const CENTER_CY = 160;            // SVG y-center of the ring / clip circle
 const CLIP_R = 120;               // water clip circle radius
 const WAVE_WIDTH = 480;           // single wave period in SVG px (2× clip diameter)
-const WAVE_BOTTOM_Y = 400;        // path closing edge y; outside viewBox, clipped
+// Must be ≥ SVG viewBox max-y (320) so the closing rectangle is clipped.
+const WAVE_BOTTOM_Y = 400;
+
+// --- Per-layer wave offsets (different magic numbers, different purposes) ---
+const LAYER_SCROLL_OFFSET = 1.2;  // per-layer extra scroll phase (visual depth)
+const LAYER_PHASE_OFFSET = 2.1;   // per-layer static sine phase (shape variety)
 
 // --- Water color (HSL endpoints) ---
 const COOL_HUE = 195, WARM_HUE = 175;     // deeper blue-teal → warmer cyan
@@ -16,10 +21,18 @@ const COOL_LIGHT = 18, WARM_LIGHT = 28;
 const COOL_TEMP_C = 15;           // °C at which tint is coolest
 const WARM_TEMP_C = 30;           // °C at which tint is warmest
 
+// --- Fallback water colors (no temp sensor / NaN / non-number input) ---
+const DEFAULT_WATER_COLORS = [
+    'hsla(185, 60%, 22%, 0.55)',
+    'hsla(185, 60%, 20%, 0.45)',
+    'hsla(185, 60%, 18%, 0.35)',
+];
+
 // --- Animation tuning ---
 const LERP_RATE = 2;              // exp time-constant; ~95% of lerp in ~1.5s
 const LERP_DT_CEIL = 0.1;         // s; clamp lerp dt to avoid snap-to after tab hidden
 const AMP_REGEN_THRESHOLD = 0.25; // amplitude delta threshold for path regen (throttle)
+const LEVEL_REGEN_THRESHOLD = 0.01; // px; threshold for water-level path regen (jitter-proof)
 const PHASE_WRAP = 1e6;           // wrap _wavePhase to preserve float precision
 const PHASE_TO_PX = 60;           // scroll px per phase-unit
 
@@ -48,17 +61,13 @@ class QsPoolCard extends HTMLElement {
            ` L ${totalWidth.toFixed(2)} ${WAVE_BOTTOM_Y} L 0 ${WAVE_BOTTOM_Y} Z`;
   }
 
-  // Map pool temperature to per-layer water HSL colors.
+  // Map pool temperature (°C, finite number) to per-layer water HSL colors.
   // Cool end → deeper blue-teal; warm end → warmer cyan-turquoise.
+  // Rejects null, undefined, NaN, Infinity, and any non-number input —
+  // callers must coerce strings via `Number(...)` before calling.
   _tempToColor(tempC) {
-    // Explicit guard: tempC may be null/undefined (no sensor bound) or
-    // NaN (bad parse). Loose equality would also catch this, but be explicit.
-    if (tempC === null || tempC === undefined || Number.isNaN(tempC)) {
-      return [
-        'hsla(185, 60%, 22%, 0.55)',
-        'hsla(185, 60%, 20%, 0.45)',
-        'hsla(185, 60%, 18%, 0.35)',
-      ];
+    if (typeof tempC !== 'number' || !Number.isFinite(tempC)) {
+      return DEFAULT_WATER_COLORS;
     }
     const span = WARM_TEMP_C - COOL_TEMP_C;
     const t = Math.max(0, Math.min(1, (tempC - COOL_TEMP_C) / span));
@@ -72,18 +81,29 @@ class QsPoolCard extends HTMLElement {
     ];
   }
 
-  // Clear the wave-path memoization keys so the next RAF tick regenerates paths.
+  // Clear the wave-path memoization keys and cached DOM refs. Called on
+  // every (re-)connect and after each _render() innerHTML rewrite.
   _invalidateWaveCache() {
     this._lastWaterBaseY = null;
     this._lastAmplitude = null;
+    this._waveEls = null;
   }
 
   connectedCallback() {
     if (this._animRaf != null) return;
-    // Initialize wave animation state
-    this._currentAmplitude = CALM_AMP;
-    this._currentSpeed = CALM_SPEED;
-    this._wavePhase = 0;
+    // Initialize wave animation state ONLY on the first-ever connect, so
+    // that detach/re-attach (HA dashboard rearrangement, tab navigation)
+    // preserves _currentAmplitude/_currentSpeed/_wavePhase. Without this
+    // guard, a pump-on wave would visibly snap back to CALM on each
+    // reconnect and re-lerp up over ~1.5s.
+    if (this._currentAmplitude == null) {
+      this._currentAmplitude = CALM_AMP;
+      this._currentSpeed = CALM_SPEED;
+      this._wavePhase = 0;
+      // Tell the next _render() to prime amp/speed directly to the actual
+      // pump state, skipping the 1.5s lerp envelope at boot.
+      this._needsAnimationPrime = true;
+    }
     this._invalidateWaveCache();
 
     const step = (ts) => {
@@ -112,16 +132,28 @@ class QsPoolCard extends HTMLElement {
       this._currentAmplitude += (targetAmplitude - this._currentAmplitude) * lerpFactor;
       this._currentSpeed += (targetSpeed - this._currentSpeed) * lerpFactor;
       this._wavePhase += this._currentSpeed * dt;
-      if (this._wavePhase > PHASE_WRAP) this._wavePhase -= PHASE_WRAP;
+      // Modulo wrap is robust to any sign / magnitude of accumulated phase.
+      this._wavePhase = this._wavePhase % PHASE_WRAP;
+
+      // Lazy-resolve wave DOM refs once per innerHTML rewrite. This collapses
+      // 6 getElementById calls/frame (3 in transform loop + 3 in regen loop)
+      // down to 3 calls per render.
+      if (!this._waveEls) {
+        this._waveEls = [
+          this._root?.getElementById('wave0') ?? null,
+          this._root?.getElementById('wave1') ?? null,
+          this._root?.getElementById('wave2') ?? null,
+        ];
+      }
 
       // Update wave transforms (CSS translateX for GPU compositing).
       // Path extent is [0, 2*WAVE_WIDTH] so the translated path always
       // covers the clip region. We offset by -CLIP_R to align the path
       // start with the clip's left edge, then scroll within one period.
       for (let i = 0; i < 3; i++) {
-        const wEl = this._root?.getElementById('wave' + i);
+        const wEl = this._waveEls[i];
         if (wEl) {
-          const phaseOffset = i * 1.2;
+          const phaseOffset = i * LAYER_SCROLL_OFFSET;
           const raw = (this._wavePhase + phaseOffset) * PHASE_TO_PX;
           const scrollOffset = ((raw % WAVE_WIDTH) + WAVE_WIDTH) % WAVE_WIDTH;
           const tx = -CLIP_R - scrollOffset;
@@ -137,15 +169,17 @@ class QsPoolCard extends HTMLElement {
       const ampDelta = this._lastAmplitude == null
           ? Infinity
           : Math.abs(this._currentAmplitude - this._lastAmplitude);
-      const levelChanged = waterBaseY !== this._lastWaterBaseY;
+      // Threshold compare for float-jitter robustness vs strict !==.
+      const levelChanged = hasValidBase &&
+          Math.abs(waterBaseY - (this._lastWaterBaseY ?? Number.NEGATIVE_INFINITY)) > LEVEL_REGEN_THRESHOLD;
       if (hasValidBase && (levelChanged || ampDelta > AMP_REGEN_THRESHOLD)) {
         this._lastWaterBaseY = waterBaseY;
         this._lastAmplitude = this._currentAmplitude;
-        const colors = this._waterColors || ['hsla(185,60%,22%,0.55)', 'hsla(185,60%,20%,0.45)', 'hsla(185,60%,18%,0.35)'];
+        const colors = this._waterColors || DEFAULT_WATER_COLORS;
         for (let i = 0; i < 3; i++) {
-          const wEl = this._root?.getElementById('wave' + i);
+          const wEl = this._waveEls[i];
           if (wEl) {
-            const phaseOffset = i * 2.1;
+            const phaseOffset = i * LAYER_PHASE_OFFSET;
             const freq = 2 + i; // integer freq → seamless wrap at WAVE_WIDTH
             const d = this._generateWavePath(WAVE_WIDTH, this._currentAmplitude, freq, phaseOffset, waterBaseY);
             wEl.setAttribute('d', d);
@@ -243,6 +277,16 @@ class QsPoolCard extends HTMLElement {
       // Store pump state for RAF loop
       this._pumpRunning = running;
 
+      // Prime animation state to the actual pump targets on the first
+      // render after connect — avoids a ~1.5s boot transient where the
+      // wave lerps up from CALM_AMP to PUMP_AMP if the pump was already
+      // running when the card mounted.
+      if (this._needsAnimationPrime) {
+        this._currentAmplitude = running ? PUMP_AMP : CALM_AMP;
+        this._currentSpeed = running ? PUMP_SPEED : CALM_SPEED;
+        this._needsAnimationPrime = false;
+      }
+
       // Water level from runtime progress. Clamp on both sides: a negative
       // hoursRun (sensor reset glitch / device reporting -1) would otherwise
       // push waterBaseY past WAVE_BOTTOM_Y and self-intersect the polygon.
@@ -257,6 +301,19 @@ class QsPoolCard extends HTMLElement {
       // Temperature-based water colors
       this._waterColors = this._tempToColor(tempNum);
 
+      // Pre-generate wave paths so the SVG renders with water immediately,
+      // avoiding the empty-d="" flash between the innerHTML rewrite and the
+      // next RAF tick. The RAF loop continues animating from these initial
+      // shapes seamlessly (memo keys synced below after the innerHTML write).
+      const initialAmp = this._currentAmplitude ?? CALM_AMP;
+      const initialBaseY = this._waterBaseY ?? CENTER_CY;
+      const initialColors = this._waterColors ?? DEFAULT_WATER_COLORS;
+      const initialWavePaths = [0, 1, 2].map(i => {
+        const freq = 2 + i;
+        const phaseOffset = i * LAYER_PHASE_OFFSET;
+        return this._generateWavePath(WAVE_WIDTH, initialAmp, freq, phaseOffset, initialBaseY);
+      });
+
       // Instance-unique clip ID (stable across re-renders)
       if (!this._waterClipId) {
           QsPoolCard._nextClipId = (QsPoolCard._nextClipId || 0) + 1;
@@ -265,7 +322,7 @@ class QsPoolCard extends HTMLElement {
       const waterClipId = this._waterClipId;
 
       const css = `
-      :host { --pad: 18px; display:block; }
+      :host { --pad: 18px; --ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); display:block; }
       .card { padding: var(--pad); position: relative; }
       .card.off-grid { background: rgba(244, 67, 54, 0.08); }
       .card-title { text-align:center; font-weight:800; font-size: 1.6rem; margin: 0px 0 0px; }
@@ -303,9 +360,9 @@ class QsPoolCard extends HTMLElement {
       .card.disabled { opacity: 0.5; pointer-events: none; filter: grayscale(0.8); }
       .card.disabled .power-btn { pointer-events: auto; opacity: 1; filter: grayscale(0); }
       .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center; pointer-events: none; transform: translateY(16px); }
-      .ring .pct { font-size: 4rem; font-weight:800; letter-spacing:-1px; line-height:1; text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); }
-      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); }
-      .ring .target-value { color: var(--primary-color); font-weight:800; font-size: 1.5rem; line-height: 1; text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); }
+      .ring .pct { font-size: 4rem; font-weight:800; letter-spacing:-1px; line-height:1; text-shadow: var(--ring-text-shadow); }
+      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .target-value { color: var(--primary-color); font-weight:800; font-size: 1.5rem; line-height: 1; text-shadow: var(--ring-text-shadow); }
       .ring .stack { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:4px; text-align:center; width: 180px; margin: 0 auto; }
       .ring .temp-block { display:flex; flex-direction:column; align-items:center; gap:2px; margin-top:4px; margin-bottom:8px; }
       .ring .stack > * { text-align:center; }
@@ -454,9 +511,9 @@ class QsPoolCard extends HTMLElement {
                 </clipPath>
               </defs>
               <g clip-path="url(#${waterClipId})">
-                <path id="wave0" d="" fill="hsla(185,60%,22%,0.55)" opacity="1" pointer-events="none" style="will-change: transform;" />
-                <path id="wave1" d="" fill="hsla(185,60%,20%,0.45)" opacity="1" pointer-events="none" style="will-change: transform;" />
-                <path id="wave2" d="" fill="hsla(185,60%,18%,0.35)" opacity="1" pointer-events="none" style="will-change: transform;" />
+                <path id="wave0" d="${initialWavePaths[0]}" fill="${initialColors[0]}" opacity="1" pointer-events="none" style="will-change: transform;" />
+                <path id="wave1" d="${initialWavePaths[1]}" fill="${initialColors[1]}" opacity="1" pointer-events="none" style="will-change: transform;" />
+                <path id="wave2" d="${initialWavePaths[2]}" fill="${initialColors[2]}" opacity="1" pointer-events="none" style="will-change: transform;" />
               </g>
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
@@ -515,8 +572,14 @@ class QsPoolCard extends HTMLElement {
       const root = this._root;
       const ids = (k) => root.getElementById(k);
 
-      // Force initial wave path generation after each (re-)render.
-      this._invalidateWaveCache();
+      // innerHTML rewrite just replaced the wave <path> nodes. The new nodes
+      // already carry the freshly-generated `d` and `fill` (initialWavePaths
+      // / initialColors), so we sync RAF's memo keys to the rendered state
+      // — this prevents a redundant regen on the next frame. We also clear
+      // the cached wave element refs so RAF re-resolves them lazily.
+      this._lastWaterBaseY = this._waterBaseY;
+      this._lastAmplitude = initialAmp;
+      this._waveEls = null;
 
       // Pool mode selector
       if (selPoolMode) {

--- a/docs/stories/QS-189.story.md
+++ b/docs/stories/QS-189.story.md
@@ -1,0 +1,231 @@
+# QS-189: Pool card — animated water level inside the circle
+
+## Summary
+
+Add an animated SVG water surface inside the pool card's circular gauge.
+The water level represents pump runtime progress (0–100% of target maps
+to 1/5–4/5 fill height). Two animation modes: gentle calm waves when
+the pump is off, dynamic turbulent waves when the pump is on. Water
+color tint shifts subtly with pool temperature.
+
+**Explicit instruction**: the project owner opened issue #189 requesting
+this JS card modification. This satisfies the project rule "Custom JS
+card code should not be modified without explicit instruction."
+
+## Acceptance Criteria
+
+### AC1: Water rendering inside the circle
+
+- **Given** the pool card is displayed
+- **When** the card renders
+- **Then** animated SVG wave shapes are visible inside the circular ring
+  area, clipped to a circle boundary inside the arc stroke
+
+### AC2: Water level represents pump runtime progress
+
+- **Given** the pump has run for X% of its target hours (`hoursRun /
+  targetHours`)
+- **When** the card renders
+- **Then** the water level fills from 1/5 (0% progress) to 4/5 (100%
+  progress) of the circle height
+- **And** if `targetHours` is 0 or unavailable, the level defaults to
+  1/5 fill (minimum)
+
+### AC3: Calm animation when pump is off
+
+- **Given** the pump command state is not `"on"`
+- **When** the card renders
+- **Then** the water waves move very slowly and gently with low
+  amplitude (calm, subtle motion)
+
+### AC4: Dynamic animation when pump is on
+
+- **Given** the pump command state is `"on"`
+- **When** the card renders
+- **Then** the water waves move noticeably faster with higher amplitude
+  and more turbulent motion
+- **And** the transition between calm and dynamic modes is smoothly
+  interpolated (~1–2 s lerp), not an instant jump
+
+### AC5: Temperature-influenced color tint
+
+- **Given** the pool has a temperature reading
+- **When** the card renders
+- **Then** the water color shifts subtly based on temperature (cooler
+  ≈ deeper blue-teal, warmer ≈ warmer cyan-turquoise)
+- **And** if no temperature sensor is available, a neutral teal
+  fallback is used
+
+### AC6: Text readability preserved
+
+- **Given** the water animation is active
+- **When** the user views the card
+- **Then** the center text (temperature display, hours) remains clearly
+  readable over the water (the center text is an HTML overlay absolutely
+  positioned above the SVG; wave opacity and optional text-shadow are
+  the primary readability levers)
+
+### AC7: Touch interactions unaffected
+
+- **Given** the water animation is rendered
+- **When** the user drags the target handle or taps buttons
+- **Then** all existing touch/pointer interactions work as before (wave
+  elements use `pointer-events: none`)
+
+### AC8: Performance acceptable
+
+- **Given** the card runs on desktop or mobile HA companion app
+- **When** the animation is playing
+- **Then** the animation uses the single existing `requestAnimationFrame`
+  loop (no second RAF loop), performs no per-frame DOM creation, and
+  wave elements have `pointer-events: none` to avoid hit-testing cost.
+  Wave motion uses CSS `transform: translateX()` on pre-generated paths
+  for GPU compositing rather than per-frame SVG path `d` recalculation.
+
+## Task Breakdown
+
+All changes are in a single file:
+`custom_components/quiet_solar/ui/resources/qs-pool-card.js`
+(647 lines, zero-build single-file vanilla JS web component — no
+imports, no build tools, no external dependencies).
+
+### Task 1: Add a wave path generation helper
+
+Add a `_generateWavePath(width, amplitude, frequency, phase, yOffset)`
+class method that returns an SVG path `d` string for a single wide
+sine-wave-based closed shape (wave top edge → right side → rectangle
+bottom → left side). The path should be **wider than the clip circle**
+(e.g., 2× the circle diameter) so it can be translated horizontally
+via CSS `transform` to create the illusion of infinite scrolling.
+
+### Task 2: Add SVG `<clipPath>` with instance-unique ID
+
+In the SVG `<defs>` block (after the existing gradient and filter
+definitions), add a `<clipPath>` containing a `<circle>` at
+`(160, 160)` with radius ≈ 120 (inside the 130-radius arc stroke).
+
+**Critical**: use an instance-unique ID following the existing pattern
+(`const waterClipId = 'wClip-' + Math.floor(Math.random() * 1e6)`)
+to avoid DOM ID collisions when multiple pool cards are on one
+dashboard.
+
+### Task 3: Add water wave `<g>` group with 2–3 layered `<path>` elements
+
+Insert a `<g clip-path="url(#${waterClipId})">` group in the SVG
+**after `</defs>` and before the background arc `<path>`** (so arcs
+render on top of water).
+
+Each wave layer (`id="wave0"`, `"wave1"`, `"wave2"`) has:
+- A different initial phase offset for visual depth
+- Slightly different opacity (0.3–0.6)
+- Dark teal/cyan fill colors matching the mockup
+- `pointer-events="none"`
+- A CSS `will-change: transform` hint for GPU compositing
+
+### Task 4: Calculate water level from runtime progress
+
+After the existing `hoursRun` / `targetHours` computation (lines
+98–101 in `_render()`), add:
+
+```js
+const progressRatio = targetHours > 0
+    ? Math.min(1, hoursRun / targetHours)
+    : 0;
+// Map 0–1 → 1/5–4/5 fill of the clip circle (SVG Y-down coords)
+const clipR = 120;
+const waterBaseY = center.cy + clipR - (0.2 + progressRatio * 0.6) * 2 * clipR;
+```
+
+Store `this._waterBaseY = waterBaseY` for use in the RAF loop.
+
+### Task 5: Extend the existing RAF loop for wave animation
+
+In the existing `connectedCallback()` RAF `step` function (lines 9–23):
+
+- After the current dash-offset update, add wave phase updates.
+- Read pump state from `this._pumpRunning` (set in `_render()` after
+  line 105: `this._pumpRunning = running`).
+- **Smooth transitions**: lerp `this._currentAmplitude` and
+  `this._currentSpeed` toward target values each frame
+  (`lerp(current, target, 1 - Math.exp(-3 * dt))`).
+  - Pump OFF targets: low speed, low amplitude (gentle, subtle)
+  - Pump ON targets: higher speed, higher amplitude (dynamic, turbulent)
+- For each wave layer, update `style.transform = 'translateX(…px)'`
+  using the accumulated phase. Also update the `d` attribute's
+  `yOffset` only when `this._waterBaseY` changes (not every frame).
+- Access wave elements via `this._root?.getElementById('wave0')` etc.,
+  matching the existing `getElementById('running_anim')` pattern.
+
+### Task 6: Add temperature-based color tinting
+
+Add a `_tempToColor(tempC)` class method:
+- Input: temperature in °C (from existing `tempNum` at line 95)
+- Map 10°C–35°C to an HSL interpolation:
+  - Cool (≤ 15°C): deeper blue-teal `hsl(195, 70%, 18%)`
+  - Warm (≥ 30°C): warmer cyan-turquoise `hsl(175, 55%, 28%)`
+  - Linear interpolation between
+- Fallback (no sensor / NaN): neutral teal
+- Store as `this._waterColors` (array of per-layer colors with
+  varying lightness) for the RAF loop to apply as `fill`.
+
+### Task 7: Ensure text contrast and readability
+
+Add text-shadow CSS to `.ring .pct`, `.ring .target-label`, and
+`.ring .target-value`:
+
+```css
+text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5);
+```
+
+This is a bonus layer — the primary readability guarantee is wave
+opacity (0.3–0.6) combined with the HTML overlay sitting above the SVG.
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `custom_components/quiet_solar/ui/resources/qs-pool-card.js` | Add water animation (sole file) |
+
+## Testing
+
+This is a pure JS/UI change with no Python code modified. The project's
+100% Python coverage requirement is unaffected.
+
+Manual visual verification checklist:
+- [ ] Pump off → calm, slow waves
+- [ ] Pump on → dynamic, turbulent waves
+- [ ] Pump toggle → smooth transition (~1–2 s)
+- [ ] Various temperatures → subtle color shift
+- [ ] 0% runtime → water at 1/5 fill; 100% → 4/5 fill
+- [ ] Drag handle → still works over water area
+- [ ] Green-only / power buttons → still work
+- [ ] Mobile HA companion → smooth animation
+- [ ] Multiple pool cards on one dashboard → no visual glitches
+
+## NEXT_PHASE
+
+`implement-task` — touches `custom_components/` (product code).
+
+---
+
+## Adversarial Review Notes
+
+Four parallel reviewers (critic, concrete-planner, dev-proxy,
+scope-guardian) were run against the draft plan. Summary of findings
+and decisions:
+
+| # | Category | Finding | Decision |
+|---|----------|---------|----------|
+| 1 | critical | `<clipPath id>` collision across multiple card instances | **Fixed** — use instance-unique ID (Task 2) |
+| 2 | critical | AC8 has no concrete pass/fail criterion | **Fixed** — reworded AC8 with concrete constraints (single RAF loop, no per-frame DOM creation, CSS transform compositing) |
+| 3 | critical | JS card modification rule compliance | **Fixed** — added explicit instruction note in Summary |
+| 4 | redesign | Per-frame SVG path `d` recalculation is expensive | **Fixed** — switched to CSS `transform: translateX()` on pre-generated wide paths for GPU compositing; `d` update only on water level change (Task 5) |
+| 5 | improve | No smooth transition between calm/turbulent states | **Fixed** — added lerp interpolation to AC4 and Task 5 |
+| 6 | improve | Hard-coded dark colors may clash with light themes | **Skipped** — QS dashboard is dark-themed by design |
+| 7 | improve | Confirm `disconnectedCallback` cleanup | **Confirmed** — existing `disconnectedCallback` cancels the single RAF loop; wave state is properties on the same loop |
+| 8 | improve | Center text HTML-over-SVG layering unclear | **Fixed** — clarified in AC6 and Task 7 |
+| 9 | improve | Maintain zero-build single-file pattern | **Fixed** — confirmed in task breakdown header |
+| 10 | improve | No rollback/feature-flag | **Skipped** — YAGNI for visual enhancement; iterate if needed |
+| 11 | clarify | Missing references to existing variables/lines | **Fixed** — added exact variable names and line references throughout |
+| 12 | clarify | Exact SVG insertion point for water group | **Fixed** — specified in Task 3: after `</defs>`, before background arc |
+| 13 | clarify | Pixel amplitudes in ACs are premature over-specification | **Fixed** — ACs now qualitative; numbers moved to implementation guidance in tasks |

--- a/docs/stories/QS-189.story_review_fix_#01.md
+++ b/docs/stories/QS-189.story_review_fix_#01.md
@@ -1,0 +1,63 @@
+# QS-189 — Review fix plan #01
+
+## Summary
+- Source PR: #191
+- Source story: docs/stories/QS-189.story.md
+- Findings to fix: 7 (1 must-fix, 3 should-fix, 3 nice-to-have)
+- Next implement phase: `implement-task`
+
+## Findings to fix
+
+### [must-fix] Wave amplitude lerp is dead code
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:86-99`
+- Severity: must-fix
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter, qs-review-acceptance-auditor
+- Description: Wave paths are only regenerated when `waterBaseY` changes, but `_currentAmplitude` lerps every frame during pump on/off transitions. The amplitude change is never reflected in the rendered wave shapes until the next water level change.
+- Proposed fix: Also regenerate wave paths when the amplitude delta exceeds a small threshold (e.g., 0.1). Track `_lastAmplitude` alongside `_lastWaterBaseY` and trigger path regeneration when either changes.
+
+### [should-fix] `hoursRun` can be NaN — propagates to broken SVG paths
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:193-199`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: When HA sensor state is `"unavailable"` or `"unknown"`, `Number("unavailable")` → `NaN`. This propagates through `progressRatio` → `waterBaseY` → `_generateWavePath`, producing SVG paths full of `NaN` coordinates. The guard `waterBaseY != null` passes because `NaN !== null`.
+- Proposed fix: Default `hoursRun` and `targetHours` to 0 when non-numeric (use `|| 0` or explicit `isNaN` guard). Also guard `waterBaseY` with `isNaN()` before storing it.
+
+### [should-fix] JS `%` on negative floats produces inconsistent translateX
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:82-83`
+- Severity: should-fix
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+- Description: `const tx = -((this._wavePhase + phaseOffset) * 60) % waveWidth;` — JS `%` preserves sign on negative values, producing inconsistent scroll direction.
+- Proposed fix: Use true positive modulo: `const raw = (this._wavePhase + phaseOffset) * 60; const tx = -(((raw % waveWidth) + waveWidth) % waveWidth);`
+
+### [should-fix] Temperature range mismatch vs story
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:37`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: Story specifies cool ≤15°C / warm ≥30°C, but code maps `(tempC - 10) / 20` making 10°C the coolest and 15°C already 25% warm.
+- Proposed fix: Change to `(tempC - 15) / 15` so 15°C maps to 0 (coolest) and 30°C maps to 1 (warmest), matching the story.
+
+### [nice-to-have] Strip internal `// --- Task N ---` comments
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js` (multiple locations)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Comments like `// --- Wave path generation helper (Task 1) ---` reference internal story task numbering that is meaningless to future readers.
+- Proposed fix: Remove or replace with descriptive comments that don't reference task numbers.
+
+### [nice-to-have] `_wavePhase` grows unbounded
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:75`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: After days/weeks of continuous display, `_wavePhase` loses floating-point precision.
+- Proposed fix: Periodically wrap: `if (this._wavePhase > 1e6) this._wavePhase -= 1e6;`
+
+### [nice-to-have] Clip ID collision — use monotonic counter
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:201-203`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+- Description: `Math.floor(Math.random() * 1e6)` has birthday-paradox collision risk with many instances.
+- Proposed fix: Use a static monotonic counter: `QsPoolCard._nextClipId = (QsPoolCard._nextClipId || 0) + 1; this._waterClipId = 'wClip-' + QsPoolCard._nextClipId;`
+
+## How to apply
+
+Run `implement-task` against this fix plan. When done, return and
+run `review-task` again to re-verify.

--- a/docs/stories/QS-189.story_review_fix_#02.md
+++ b/docs/stories/QS-189.story_review_fix_#02.md
@@ -1,0 +1,123 @@
+# QS-189 — Review fix plan #02
+
+## Summary
+- Source PR: #191
+- Source story: docs/stories/QS-189.story.md
+- Findings to fix: 12 (1 must-fix, 5 should-fix, 6 nice-to-have)
+- Next implement phase: `implement-task`
+
+## Findings to fix
+
+### [must-fix] Wave path too narrow — visibly disappears from clip area
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:14-21, 83-94`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: The wave path is `width = waveWidth = 480` and is translated by `tx ∈ (-600, -120]`. The translated path covers viewBox x range `[tx, tx + 480]`. The clip circle covers `[40, 280]`. The translated path covers the clip only when `tx ∈ [-200, -120]`, i.e. `scrollOffset ∈ [0, 80]`. For the remaining ~5/6 of the cycle, the right portion of the clip has no wave content, producing a visible "wave scrolls out and disappears" artifact. The wave content is periodic but the path drawn is finite.
+- Proposed fix: make `_generateWavePath` emit two repetitions of the wave so the path extent becomes `[0, 2 * waveWidth]`. Iterate from `i=0..2*steps` over `x ∈ [0, 2*waveWidth]` (keep frequency referenced to the original `waveWidth` so each period is identical). Keep `scrollOffset ∈ [0, waveWidth)` and `tx = -120 - scrollOffset`. With path extent `2 * waveWidth = 960`, translated path covers `[tx, tx + 960]`. For `tx ∈ (-600, -120]`, that's `(-600 + 960, -120 + 960] = (360, 840]` on the right and `(-600, -120]` on the left — always covers clip `[40, 280]`. Also update the path's closing-line geometry from `L ${width.toFixed(2)} 400 L 0 400 Z` to use the new total width `(2 * waveWidth)`.
+
+### [should-fix] Non-integer frequency on middle wave layer creates seam jump
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:107`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `freq = 2 + i * 0.5` gives layer `i=1` a frequency of 2.5 (non-integer). Since `sin(2.5 * 2π + phase) = -sin(phase)`, the wave shape at `x = 0` and `x = waveWidth` are not equal — when `scrollOffset` wraps from `waveWidth - ε` back to `0`, the rendered wave has a visible y-discontinuity at the seam.
+- Proposed fix: change the frequency stepping to integer values, e.g. `const freq = 2 + i;` → layers get freq 2, 3, 4. All seamless across `waveWidth`.
+
+### [should-fix] `progressRatio` not clamped to ≥ 0
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:205-211`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `progressRatio = targetHours > 0 ? Math.min(1, hoursRun / targetHours) : 0` allows `progressRatio < 0` when `hoursRun` is negative (e.g. sensor reset glitch or device reporting `-1`). Then `waterBaseY = 160 + 120 - (0.2 + negative * 0.6) * 240` can exceed 280 (water below the clip circle bottom) or exceed 400 (the SVG closing edge), producing a self-intersecting polygon with a broken fill.
+- Proposed fix: clamp on both sides: `const progressRatio = targetHours > 0 ? Math.max(0, Math.min(1, hoursRun / targetHours)) : 0;`.
+
+### [should-fix] RAF regen with undefined `waterBaseY` produces NaN path coords
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:99-113`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: On cold start, `connectedCallback` may fire before `_render()` populates `this._waterBaseY`. The RAF loop then enters the regen branch because `ampDelta > 0.1` (since `_lastAmplitude == null` defaults to `1`), and calls `_generateWavePath(waveWidth, currentAmplitude, freq, phaseOffset, undefined)`. The `yOffset = undefined` propagates through `undefined + amplitude * Math.sin(...)` to produce `NaN` for every coordinate. The browser silently ignores invalid path coordinates, but the state is briefly inconsistent.
+- Proposed fix: guard the regeneration branch with both `waterBaseY != null` and `!Number.isNaN(waterBaseY)`:
+  ```js
+  const hasValidBase = waterBaseY != null && !Number.isNaN(waterBaseY);
+  if (hasValidBase && (levelChanged || ampDelta > 0.1)) { ... }
+  ```
+
+### [should-fix] Lerp snaps to target after long frame gap (tab hidden)
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:74-75`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: After the tab is hidden for several seconds (or the system suspends), `dt` on the first frame back can be many seconds. `lerpFactor = 1 - Math.exp(-3 * dt)` then ≈ 1, snapping `_currentAmplitude` and `_currentSpeed` instantly to target. This violates AC4: "the transition between calm and dynamic modes is smoothly interpolated (~1–2 s lerp), not an instant jump".
+- Proposed fix: clamp the lerp `dt` to a small ceiling (e.g. 100 ms): `const lerpDt = Math.min(dt, 0.1); const lerpFactor = 1 - Math.exp(-3 * lerpDt);`. Keep the un-clamped `dt` for `_wavePhase` accumulation (the wave scroll is fine catching up). The visual effect is that after a long pause, the lerp continues smoothly rather than snapping.
+
+### [should-fix] Hardcoded `160` for `center.cy` with stale-reference comment
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:201`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The water-base computation hardcodes `160` for the SVG center y and includes a comment "center.cy is always 160; using literal to avoid forward-reference". If future SVG geometry changes alter `center.cy`, the water level will silently drift without obvious failure.
+- Proposed fix: hoist a named constant near the other geometry constants: `const CENTER_CY = 160; const CLIP_R = 120;` and use them in `waterBaseY = CENTER_CY + CLIP_R - (0.2 + progressRatio * 0.6) * 2 * CLIP_R;`. Replace the inline comment with a single-line note that this must match the `<clipPath>` circle's `cy`.
+
+### [nice-to-have] `tempC == null` loose equality
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:34`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `tempC == null` uses loose equality intentionally to catch both `null` and `undefined`. Functionally correct but inconsistent with the strict equality used elsewhere in the file.
+- Proposed fix: replace with `tempC === null || tempC === undefined || Number.isNaN(tempC)` for explicitness, or leave a one-line comment noting the loose check is intentional.
+
+### [nice-to-have] Hardcoded `400` in `_generateWavePath` closing edge
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:19`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+- Description: The path closing edge `L ${width.toFixed(2)} 400 L 0 400 Z` hardcodes `400` as the bottom of the SVG viewBox. If the viewBox ever changes, the closing rectangle bottom will be wrong. Today the viewBox is `0 0 320 320`, so `400` is even outside the viewBox (intentional — anything past 320 is just clipped).
+- Proposed fix: hoist a constant `const WAVE_BOTTOM_Y = 400;` (or pass it as a parameter) and reuse. With the must-fix path-width doubling, this becomes the perfect time to centralize all geometry constants at the top of the file or as static class properties.
+
+### [nice-to-have] Magic HSL / lerp / threshold constants
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:35-44, 70-79, 99`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Magic numbers scattered across:
+  - HSL endpoints `195/175`, `70/55`, `18/28` (cool/warm hue, saturation, lightness)
+  - Lerp coefficient `-3` (time-constant of the smoothing)
+  - `ampDelta > 0.1` (threshold for path regen)
+  - `targetAmplitude` 2/6, `targetSpeed` 0.3/1.2 (calm vs pumping)
+- Proposed fix: hoist named constants at the top of the file, e.g.:
+  ```js
+  const COOL_HUE = 195, WARM_HUE = 175;
+  const COOL_SAT = 70,  WARM_SAT = 55;
+  const COOL_LIGHT = 18, WARM_LIGHT = 28;
+  const LERP_RATE = 3;           // time-constant ~ 1/3 s
+  const AMP_REGEN_THRESHOLD = 0.1;
+  const CALM_AMP = 2,  PUMP_AMP = 6;
+  const CALM_SPEED = 0.3, PUMP_SPEED = 1.2;
+  ```
+  Document why each constant has its current value in a one-line comment.
+
+### [nice-to-have] Extract `_invalidateWaveCache()` helper
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:474`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `this._lastWaterBaseY = null;` reset with comment "force initial wave path generation" would be clearer as a named method.
+- Proposed fix: extract to `_invalidateWaveCache()` that also clears `_lastAmplitude`:
+  ```js
+  _invalidateWaveCache() {
+    this._lastWaterBaseY = null;
+    this._lastAmplitude = null;
+  }
+  ```
+  Call it where the inline reset currently lives.
+
+### [nice-to-have] Lerp time-constant `-3` feels tight vs story's 1–2 s envelope
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:74`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: With `1 - exp(-3 * dt)`, 95% of the lerp completes in ~1 second. The story specifies "~1–2 s lerp". The current value lands at the fast end of that envelope.
+- Proposed fix: change the coefficient to `-2` (≈ 1.5 s to 95%) for a more middle-of-the-band feel. Easy to tune via the `LERP_RATE` constant introduced above.
+
+### [nice-to-have] RAF path regeneration throttling on low-end mobile
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:99-113`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: During a pump on/off transition, `ampDelta > 0.1` triggers full `d` regeneration (3 layers × ~60 path points) on every frame for the ~1 second lerp duration. On low-end mobile, this DOM mutation cost may cause stutters.
+- Proposed fix: raise the regen threshold during steady-state, e.g. `AMP_REGEN_THRESHOLD = 0.25` so regen fires only ~4 times across the lerp envelope, or use a CSS `transform: scaleY(amplitude/baseAmplitude)` on the wave layer to scale the rendered amplitude without re-emitting `d`. (The second approach is more invasive; raise the threshold first and measure.)
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify.

--- a/docs/stories/QS-189.story_review_fix_#03.md
+++ b/docs/stories/QS-189.story_review_fix_#03.md
@@ -1,0 +1,159 @@
+# QS-189 — Review fix plan #03
+
+## Summary
+- Source PR: #191
+- Source story: docs/stories/QS-189.story.md
+- Findings to fix: 11 (0 must-fix, 2 should-fix, 9 nice-to-have)
+- Next implement phase: `implement-task`
+
+## Findings to fix
+
+### [should-fix] `connectedCallback` resets wave state on every reconnect
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:81-87`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `connectedCallback` unconditionally assigns `this._currentAmplitude = CALM_AMP`, `this._currentSpeed = CALM_SPEED`, `this._wavePhase = 0` whenever the element is (re)connected. If a Home Assistant dashboard rearrangement, tab navigation, or parent re-render detaches and re-attaches the element while the pump is on, the wave amplitude visibly snaps from PUMP_AMP=6 back to CALM_AMP=2 and then lerps back up over ~1.5 s.
+- Proposed fix: only initialize the wave state when it was never set (first-ever connect). Replace the unconditional block with a guard:
+  ```js
+  if (this._currentAmplitude == null) {
+      this._currentAmplitude = CALM_AMP;
+      this._currentSpeed = CALM_SPEED;
+      this._wavePhase = 0;
+  }
+  this._lastWaterBaseY = null;
+  this._lastAmplitude = null;
+  ```
+  This preserves wave state across detach/reattach while still ensuring a fresh path regen on reconnect via the cache invalidation.
+
+### [should-fix] `_render()` rebuilds innerHTML with empty `d=""` on every state update
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:457-459, 518-519`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Every Home Assistant entity state update triggers `_render()`, which rewrites `this._root.innerHTML`. The three `<path id="wave0/1/2">` elements are baked into the SVG template with `d=""` and recreated empty each time. They stay empty for up to ~16 ms (one RAF tick) until the next animation frame regenerates the path data. On busy HA setups, this produces a perceptible "flash" of empty water several times per second.
+- Proposed fix: compute the initial wave paths inside `_render()` (using `this._currentAmplitude` and `this._waterBaseY` that are already computed there) and inline them into the SVG template. Concretely, after `this._waterBaseY` is set:
+  ```js
+  // Pre-generate wave paths so the SVG renders with water immediately
+  const initialAmp = this._currentAmplitude ?? CALM_AMP;
+  const initialBaseY = this._waterBaseY ?? CENTER_CY;
+  const initialColors = this._waterColors ?? DEFAULT_WATER_COLORS;
+  const initialWavePaths = [0, 1, 2].map(i => {
+      const freq = 2 + i;
+      const phaseOffset = i * LAYER_PHASE_OFFSET;
+      return this._generateWavePath(WAVE_WIDTH, initialAmp, freq, phaseOffset, initialBaseY);
+  });
+  ```
+  Then in the SVG template:
+  ```html
+  <path id="wave0" d="${initialWavePaths[0]}" fill="${initialColors[0]}" ... />
+  <path id="wave1" d="${initialWavePaths[1]}" fill="${initialColors[1]}" ... />
+  <path id="wave2" d="${initialWavePaths[2]}" fill="${initialColors[2]}" ... />
+  ```
+  The RAF loop continues animating from there with no perceptible gap.
+
+### [nice-to-have] Text-shadow CSS duplicated across 3 selectors
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:306-308`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5);` is repeated verbatim across `.ring .pct`, `.ring .target-label`, `.ring .target-value`. Future tweaks risk drift.
+- Proposed fix: extract a CSS custom property at `:host`:
+  ```css
+  :host { --pad: 18px; --ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); display:block; }
+  ```
+  and reference `text-shadow: var(--ring-text-shadow);` from each selector. Alternatively use a `:where(.pct, .target-label, .target-value)` grouped selector.
+
+### [nice-to-have] Cache `getElementById('wave'+i)` references; RAF does 6 DOM lookups/frame
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:~125, ~145`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The RAF loop calls `this._root?.getElementById('wave' + i)` twice per layer (once in the transform loop, once in the regen loop), totaling 6 DOM lookups per frame.
+- Proposed fix: cache the three node references on `this._waveEls` after the first successful lookup, and invalidate alongside `_invalidateWaveCache()`. Example:
+  ```js
+  _invalidateWaveCache() {
+      this._lastWaterBaseY = null;
+      this._lastAmplitude = null;
+      this._waveEls = null; // re-resolve on next RAF
+  }
+  ```
+  Then in the RAF step:
+  ```js
+  if (!this._waveEls) {
+      this._waveEls = [0, 1, 2].map(i => this._root?.getElementById('wave' + i) ?? null);
+  }
+  ```
+  Use `this._waveEls[i]` in both loops.
+
+### [nice-to-have] Two per-layer phase offset magic numbers (1.2 and 2.1)
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:~128, ~150`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `phaseOffset = i * 1.2` in the transform loop and `phaseOffset = i * 2.1` in the regen loop are two unrelated per-layer offsets that serve different purposes (scroll offset vs. spatial sine phase). They are intentionally different but the magic numbers and shared variable name invite "are these supposed to match?" confusion.
+- Proposed fix: promote both to named constants at the top of the file with a one-line comment each:
+  ```js
+  const LAYER_SCROLL_OFFSET = 1.2; // per-layer extra scroll phase (visual depth)
+  const LAYER_PHASE_OFFSET = 2.1;  // per-layer static sine phase (shape variety)
+  ```
+  Use `i * LAYER_SCROLL_OFFSET` in the transform loop and `i * LAYER_PHASE_OFFSET` in the regen loop.
+
+### [nice-to-have] Hoist `DEFAULT_WATER_COLORS` constant
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:~56, ~144, ~457`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The fallback HSL triplet `'hsla(185, 60%, 22%, 0.55)' / '...20%, 0.45)' / '...18%, 0.35)'` is duplicated across the `_tempToColor` NaN branch, the inline fallback in the RAF regen loop, and the SVG markup's static `fill="hsla(...)"` defaults. Three copies, easy to drift.
+- Proposed fix: hoist a single source of truth:
+  ```js
+  const DEFAULT_WATER_COLORS = [
+      'hsla(185, 60%, 22%, 0.55)',
+      'hsla(185, 60%, 20%, 0.45)',
+      'hsla(185, 60%, 18%, 0.35)',
+  ];
+  ```
+  Reference from all three sites. For the SVG template, splice the colors via template literal: `fill="${DEFAULT_WATER_COLORS[0]}"` etc.
+
+### [nice-to-have] `WAVE_BOTTOM_Y` viewBox assumption is implicit
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:~37`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `WAVE_BOTTOM_Y = 400` sits outside the SVG viewBox (`0 0 320 320`) and is intentional — the closing edge is clipped by the viewBox. The relationship is fragile if the viewBox ever changes.
+- Proposed fix: add a single-line comment naming the assumption, e.g.:
+  ```js
+  // Must be ≥ SVG viewBox max-y (320) so the closing rectangle is clipped.
+  const WAVE_BOTTOM_Y = 400;
+  ```
+
+### [nice-to-have] `_tempToColor` could tighten input guard to `Number.isFinite`
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:~52`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The current guard `tempC === null || tempC === undefined || Number.isNaN(tempC)` correctly rejects today's caller, which always passes a `Number(...)` result. A future caller that forgets to coerce (passing `"10"`) would proceed silently via JS string coercion.
+- Proposed fix: replace with `if (typeof tempC !== 'number' || !Number.isFinite(tempC))`. `Number.isFinite` rejects `NaN`, `Infinity`, `-Infinity`, and (combined with the `typeof` check) all non-number types. Document the contract in a one-line comment above the function.
+
+### [nice-to-have] One-sided `_wavePhase` wrap
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:~115`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+- Description: `if (this._wavePhase > PHASE_WRAP) this._wavePhase -= PHASE_WRAP;` wraps at most once per condition check. Today `_currentSpeed` is always positive (CALM_SPEED=0.3, PUMP_SPEED=1.2), so phase always grows monotonically and one subtraction suffices. A future reverse-direction effect or a single very large `dt` after suspend would break this.
+- Proposed fix: use `this._wavePhase = this._wavePhase % PHASE_WRAP;` (or `Math.abs(this._wavePhase) > PHASE_WRAP` with symmetric reduction). Cheap and robust.
+
+### [nice-to-have] Strict-float `levelChanged` comparison
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:~140`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `levelChanged = waterBaseY !== this._lastWaterBaseY` uses strict inequality. Today `waterBaseY` is derived freshly each render (bitwise identical when inputs are unchanged), so this works. A future change that accumulates `waterBaseY` via increments (or any float-jitter source) would force regen every frame.
+- Proposed fix: threshold-compare:
+  ```js
+  const levelChanged = waterBaseY != null &&
+      Math.abs(waterBaseY - (this._lastWaterBaseY ?? Number.NEGATIVE_INFINITY)) > 0.01;
+  ```
+  Cheap defense against float jitter.
+
+### [nice-to-have] `_pumpRunning` undefined on first RAF frame
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:~103`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `pumpOn = this._pumpRunning === true`. On the very first RAF frame after `connectedCallback`, if `setConfig`/`set hass` haven't run yet, `_pumpRunning` is `undefined` → `pumpOn = false` → wave lerps toward CALM. After `_render()` runs and sets `_pumpRunning = true`, the wave lerps back up. Minor visible "boot" transient if the pump was already running when the element mounts.
+- Proposed fix: at the end of `_render()`, if this is the first render after connect, prime `_currentAmplitude` and `_currentSpeed` directly to the target values rather than relying on the lerp. Track with a `this._firstRender = true/false` flag. Cosmetic only — most users won't see a 1.5 s boot transient.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify.


### PR DESCRIPTION
## Summary

Add animated SVG water surface inside the pool card's circular gauge.

- Water level represents pump runtime progress (0–100% of target → 1/5–4/5 fill height)
- Calm gentle waves when pump is off, dynamic turbulent waves when pump is on
- Smooth ~1-2s lerp transition between calm/turbulent states
- Temperature-influenced color tint (cool blue-teal ≤15°C → warm cyan-turquoise ≥30°C)
- GPU-composited animation via CSS `transform: translateX()` on pre-generated wide paths
- Instance-unique `clipPath` ID prevents DOM collisions on multi-card dashboards
- `pointer-events: none` on wave elements preserves all existing touch interactions
- Text-shadow added for center text readability over waves

## Files changed

| File | Change |
|------|--------|
| `custom_components/quiet_solar/ui/resources/qs-pool-card.js` | Add water wave animation (sole file) |

## Testing

Pure JS/UI change — no Python code modified. All 5220 tests pass, 100% coverage maintained.

Closes #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pool card shows animated, layered water inside the circular gauge representing pump operation and runtime progress.
  * Water color tints dynamically based on pool temperature.
  * Animation modes: calm when pump is off, dynamic/turbulent when running, with smooth transitions.

* **Documentation**
  * Added story and review notes detailing rendering, animation behavior, verification checklist, and fix plans.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->