### PR TITLE
QS-190: Agent handoff: pass explicit --harness flag and auto-spawn next session

### DIFF
--- a/.claude/agents/qs-create-plan.md
+++ b/.claude/agents/qs-create-plan.md
@@ -108,7 +108,8 @@ python scripts/qs/next_step.py \
     --next-cmd "{{NEXT_PHASE}}" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
-    --title "{{title}}"
+    --title "{{title}}" \
+    --harness claude-code
 ```
 
 Parse the JSON; capture `new_context`. Then print both blocks:

--- a/.claude/agents/qs-implement-setup-task.md
+++ b/.claude/agents/qs-implement-setup-task.md
@@ -92,7 +92,8 @@ python scripts/qs/next_step.py \
     --next-cmd "review-task" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
-    --title "{{title}}"
+    --title "{{title}}" \
+    --harness claude-code
 ```
 
 Parse the JSON; capture `new_context`. Then print both blocks:

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -103,7 +103,8 @@ python scripts/qs/next_step.py \
     --next-cmd "review-task" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
-    --title "{{title}}"
+    --title "{{title}}" \
+    --harness claude-code
 ```
 
 Parse the JSON; capture `new_context`. Then print both blocks:

--- a/.claude/agents/qs-review-task.md
+++ b/.claude/agents/qs-review-task.md
@@ -80,7 +80,8 @@ python scripts/qs/next_step.py \
     --next-cmd "finish-task" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
-    --title "{{title}}"
+    --title "{{title}}" \
+    --harness claude-code
 ```
 
 Parse the JSON; capture `new_context`. Then present both blocks:
@@ -191,7 +192,8 @@ python scripts/qs/next_step.py \
     --issue {{issue}} \
     --title "{{title}}" \
     --fix-plan-path "{{fix_plan_path}}" \
-    --pr-number {{pr_number}}
+    --pr-number {{pr_number}} \
+    --harness claude-code
 ```
 
 Parse the JSON; capture `new_context` and `existing_session_prompt`.

--- a/.claude/agents/qs-setup-task.md
+++ b/.claude/agents/qs-setup-task.md
@@ -58,7 +58,7 @@ Capture `issue_number` from the JSON output.
 One command does it all:
 
 ```bash
-python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "/create-plan"
+python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "/create-plan" --harness claude-code
 ```
 
 For `--no-worktree`, pass `--no-worktree`. The script:

--- a/.cursor/agents/qs-setup-task.md
+++ b/.cursor/agents/qs-setup-task.md
@@ -51,7 +51,7 @@ python scripts/qs/create_issue.py --title "{{title}}" --body "{{body}}"
 ### 2. Create branch and worktree + emit launcher
 
 ```bash
-python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "/qs-create-plan"
+python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "/qs-create-plan" --harness cursor
 ```
 
 This auto-detects the Cursor harness (`CURSOR_TRACE_ID` env var) and

--- a/.opencode/agents/qs-create-plan.md
+++ b/.opencode/agents/qs-create-plan.md
@@ -146,21 +146,41 @@ python scripts/qs/next_step.py \
     --next-cmd "{{NEXT_PHASE}}" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
-    --title "{{title}}"
+    --title "{{title}}" \
+    --harness opencode
 ```
 
-Parse the JSON; capture `new_context`. Then print:
+Parse the JSON output of ``next_step.py``; capture the
+``new_context`` string.
 
-```text
-✅ Story written: docs/stories/QS-{{issue}}.story.md
-✅ Committed and pushed to {{branch}}.
+**Run `new_context` via the Bash tool**. The string is a
+``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
+<wd> --title ... --prompt ...`` invocation — already inside the
+allow-listed ``python scripts/qs/*`` pattern. Do NOT extract only the
+prompt and send it to the current session. Do NOT strip
+``--agent qs-<phase>``. The ``--agent`` flag is what binds the
+next-phase orchestrator to the new session via OpenCode's HTTP API
+``POST /session/<id>/prompt_async`` body — strip it and the prompt
+lands on the default agent, breaking the pipeline silently.
 
-Next phase: {{NEXT_PHASE}}.
+Parse the stdout of that command as JSON. The success contract is
+**binary**:
 
-Preferred (activate `qs-{{NEXT_PHASE}}` from the OpenCode agent picker,
-or paste the spawn-session one-liner below into a fresh terminal):
-  {{new_context}}
-```
+- ``status == "session_created"`` AND ``agent == "qs-{{NEXT_PHASE}}"``
+  → success; report to the user:
+
+  ```text
+  ✅ Next phase session created: qs-{{NEXT_PHASE}}
+     (visible in the OpenCode session list on the left)
+  ```
+
+- **Anything else** (any other ``status`` value, missing or mismatched
+  ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
+  the raw JSON output verbatim to the user. Do NOT claim the next
+  phase started. The user inspects the JSON and acts on the specific
+  failure mode (``agent_file_missing``, ``fallback_cli``,
+  ``fallback_unavailable``, ``session_orphaned`` — each documented in
+  ``scripts/qs/spawn_session.py``).
 
 ## Hard rules
 

--- a/.opencode/agents/qs-create-plan.md
+++ b/.opencode/agents/qs-create-plan.md
@@ -141,6 +141,10 @@ Inspect the file paths your task breakdown will touch:
 Build the launcher payload for the next phase so the user has a copy/paste
 command to open a fresh session bound to the next agent:
 
+**Before running** — substitute `{{NEXT_PHASE}}` with the next phase
+name you determined above (one of: `implement-task`,
+`implement-setup-task`). Run the bash block with the resolved value:
+
 ```bash
 python scripts/qs/next_step.py \
     --next-cmd "{{NEXT_PHASE}}" \
@@ -150,8 +154,12 @@ python scripts/qs/next_step.py \
     --harness opencode
 ```
 
-Parse the JSON output of ``next_step.py``; capture the
-``new_context`` string.
+Parse the JSON output of ``next_step.py``.
+
+**If the `next_step.py` JSON contains an `error` key**, STOP and print
+the raw JSON to the user. Do not proceed to run `new_context`.
+
+Otherwise capture the ``new_context`` string.
 
 **Run `new_context` via the Bash tool**. The string is a
 ``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
@@ -163,22 +171,29 @@ next-phase orchestrator to the new session via OpenCode's HTTP API
 ``POST /session/<id>/prompt_async`` body — strip it and the prompt
 lands on the default agent, breaking the pipeline silently.
 
+**If the Bash tool returns an error before producing any JSON output**
+(e.g., permission denied, missing interpreter), STOP and print the
+Bash tool's error message verbatim. Do not attempt to parse JSON.
+
 Parse the stdout of that command as JSON. The success contract is
 **binary**:
 
-- ``status == "session_created"`` AND ``agent == "qs-{{NEXT_PHASE}}"``
-  → success; report to the user:
+- ``status == "session_created"`` AND ``agent`` equals `qs-` followed
+  by the phase name passed to `--next-cmd` (e.g., `qs-implement-task`
+  when `--next-cmd "implement-task"` was passed) → success; report
+  to the user:
 
   ```text
-  ✅ Next phase session created: qs-{{NEXT_PHASE}}
-     (visible in the OpenCode session list on the left)
+  [OK] Next phase session created: qs-<phase>
+       (visible in the OpenCode session list on the left)
   ```
 
 - **Anything else** (any other ``status`` value, missing or mismatched
   ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
   the raw JSON output verbatim to the user. Do NOT claim the next
   phase started. The user inspects the JSON and acts on the specific
-  failure mode (``agent_file_missing``, ``fallback_cli``,
+  failure mode (``agent_file_missing``, ``agent_file_unreadable``,
+  ``agent_file_empty``, ``worktree_invalid``, ``fallback_cli``,
   ``fallback_unavailable``, ``session_orphaned`` — each documented in
   ``scripts/qs/spawn_session.py``).
 

--- a/.opencode/agents/qs-implement-setup-task.md
+++ b/.opencode/agents/qs-implement-setup-task.md
@@ -143,6 +143,10 @@ empty directories. `legacy/` is only staged when you've performed a
 Build the launcher payload for the review phase so the user has a copy/paste
 command to open a fresh session bound to `qs-review-task`:
 
+**Before running** — substitute `{{worktree}}`, `{{issue}}`, and
+`{{title}}` with the values you captured earlier; the `--next-cmd`
+value is fixed (`review-task`):
+
 ```bash
 python scripts/qs/next_step.py \
     --next-cmd "review-task" \
@@ -152,8 +156,12 @@ python scripts/qs/next_step.py \
     --harness opencode
 ```
 
-Parse the JSON output of ``next_step.py``; capture the
-``new_context`` string.
+Parse the JSON output of ``next_step.py``.
+
+**If the `next_step.py` JSON contains an `error` key**, STOP and print
+the raw JSON to the user. Do not proceed to run `new_context`.
+
+Otherwise capture the ``new_context`` string.
 
 **Run `new_context` via the Bash tool**. The string is a
 ``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
@@ -165,25 +173,32 @@ next-phase orchestrator to the new session via OpenCode's HTTP API
 ``POST /session/<id>/prompt_async`` body — strip it and the prompt
 lands on the default agent, breaking the pipeline silently.
 
+**If the Bash tool returns an error before producing any JSON output**
+(e.g., permission denied, missing interpreter), STOP and print the
+Bash tool's error message verbatim. Do not attempt to parse JSON.
+
 Parse the stdout of that command as JSON. The success contract is
 **binary**:
 
-- ``status == "session_created"`` AND ``agent == "qs-review-task"``
-  → success; report to the user:
+- ``status == "session_created"`` AND ``agent`` equals `qs-` followed
+  by the phase name passed to `--next-cmd` (here: `qs-review-task`
+  since `--next-cmd "review-task"` was passed) → success; report to
+  the user:
 
   ```text
-  ✅ Implementation complete — quality gate passed.
-  ✅ Committed and pushed to {{branch}}.
-  ✅ PR #{{pr_number}} opened: {{pr_url}}
-  ✅ Next phase session created: qs-review-task
-     (visible in the OpenCode session list on the left)
+  [OK] Implementation complete — quality gate passed.
+  [OK] Committed and pushed to {{branch}}.
+  [OK] PR #{{pr_number}} opened: {{pr_url}}
+  [OK] Next phase session created: qs-review-task
+       (visible in the OpenCode session list on the left)
   ```
 
 - **Anything else** (any other ``status`` value, missing or mismatched
   ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
   the raw JSON output verbatim to the user. Do NOT claim the next
   phase started. The user inspects the JSON and acts on the specific
-  failure mode (``agent_file_missing``, ``fallback_cli``,
+  failure mode (``agent_file_missing``, ``agent_file_unreadable``,
+  ``agent_file_empty``, ``worktree_invalid``, ``fallback_cli``,
   ``fallback_unavailable``, ``session_orphaned`` — each documented in
   ``scripts/qs/spawn_session.py``).
 

--- a/.opencode/agents/qs-implement-setup-task.md
+++ b/.opencode/agents/qs-implement-setup-task.md
@@ -148,22 +148,44 @@ python scripts/qs/next_step.py \
     --next-cmd "review-task" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
-    --title "{{title}}"
+    --title "{{title}}" \
+    --harness opencode
 ```
 
-Parse the JSON; capture `new_context`. Then print:
+Parse the JSON output of ``next_step.py``; capture the
+``new_context`` string.
 
-```text
-✅ Implementation complete — quality gate passed.
-✅ Committed and pushed to {{branch}}.
-✅ PR #{{pr_number}} opened: {{pr_url}}
+**Run `new_context` via the Bash tool**. The string is a
+``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
+<wd> --title ... --prompt ...`` invocation — already inside the
+allow-listed ``python scripts/qs/*`` pattern. Do NOT extract only the
+prompt and send it to the current session. Do NOT strip
+``--agent qs-<phase>``. The ``--agent`` flag is what binds the
+next-phase orchestrator to the new session via OpenCode's HTTP API
+``POST /session/<id>/prompt_async`` body — strip it and the prompt
+lands on the default agent, breaking the pipeline silently.
 
-Next phase: review-task.
+Parse the stdout of that command as JSON. The success contract is
+**binary**:
 
-Preferred (activate `qs-review-task` from the OpenCode agent picker,
-or paste the spawn-session one-liner below into a fresh terminal):
-  {{new_context}}
-```
+- ``status == "session_created"`` AND ``agent == "qs-review-task"``
+  → success; report to the user:
+
+  ```text
+  ✅ Implementation complete — quality gate passed.
+  ✅ Committed and pushed to {{branch}}.
+  ✅ PR #{{pr_number}} opened: {{pr_url}}
+  ✅ Next phase session created: qs-review-task
+     (visible in the OpenCode session list on the left)
+  ```
+
+- **Anything else** (any other ``status`` value, missing or mismatched
+  ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
+  the raw JSON output verbatim to the user. Do NOT claim the next
+  phase started. The user inspects the JSON and acts on the specific
+  failure mode (``agent_file_missing``, ``fallback_cli``,
+  ``fallback_unavailable``, ``session_orphaned`` — each documented in
+  ``scripts/qs/spawn_session.py``).
 
 ## Hard rules
 

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -137,6 +137,10 @@ workflow — no user confirmation needed for any of these three.
 Build the launcher payload for the review phase so the user has a copy/paste
 command to open a fresh session bound to `qs-review-task`:
 
+**Before running** — substitute `{{worktree}}`, `{{issue}}`, and
+`{{title}}` with the values you captured earlier; the `--next-cmd`
+value is fixed (`review-task`):
+
 ```bash
 python scripts/qs/next_step.py \
     --next-cmd "review-task" \
@@ -146,8 +150,12 @@ python scripts/qs/next_step.py \
     --harness opencode
 ```
 
-Parse the JSON output of ``next_step.py``; capture the
-``new_context`` string.
+Parse the JSON output of ``next_step.py``.
+
+**If the `next_step.py` JSON contains an `error` key**, STOP and print
+the raw JSON to the user. Do not proceed to run `new_context`.
+
+Otherwise capture the ``new_context`` string.
 
 **Run `new_context` via the Bash tool**. The string is a
 ``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
@@ -159,25 +167,32 @@ next-phase orchestrator to the new session via OpenCode's HTTP API
 ``POST /session/<id>/prompt_async`` body — strip it and the prompt
 lands on the default agent, breaking the pipeline silently.
 
+**If the Bash tool returns an error before producing any JSON output**
+(e.g., permission denied, missing interpreter), STOP and print the
+Bash tool's error message verbatim. Do not attempt to parse JSON.
+
 Parse the stdout of that command as JSON. The success contract is
 **binary**:
 
-- ``status == "session_created"`` AND ``agent == "qs-review-task"``
-  → success; report to the user:
+- ``status == "session_created"`` AND ``agent`` equals `qs-` followed
+  by the phase name passed to `--next-cmd` (here: `qs-review-task`
+  since `--next-cmd "review-task"` was passed) → success; report to
+  the user:
 
   ```text
-  ✅ Implementation complete — quality gate passed.
-  ✅ Committed and pushed to {{branch}}.
-  ✅ PR #{{pr_number}} opened: {{pr_url}}
-  ✅ Next phase session created: qs-review-task
-     (visible in the OpenCode session list on the left)
+  [OK] Implementation complete — quality gate passed.
+  [OK] Committed and pushed to {{branch}}.
+  [OK] PR #{{pr_number}} opened: {{pr_url}}
+  [OK] Next phase session created: qs-review-task
+       (visible in the OpenCode session list on the left)
   ```
 
 - **Anything else** (any other ``status`` value, missing or mismatched
   ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
   the raw JSON output verbatim to the user. Do NOT claim the next
   phase started. The user inspects the JSON and acts on the specific
-  failure mode (``agent_file_missing``, ``fallback_cli``,
+  failure mode (``agent_file_missing``, ``agent_file_unreadable``,
+  ``agent_file_empty``, ``worktree_invalid``, ``fallback_cli``,
   ``fallback_unavailable``, ``session_orphaned`` — each documented in
   ``scripts/qs/spawn_session.py``).
 

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -142,22 +142,44 @@ python scripts/qs/next_step.py \
     --next-cmd "review-task" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
-    --title "{{title}}"
+    --title "{{title}}" \
+    --harness opencode
 ```
 
-Parse the JSON; capture `new_context`. Then print:
+Parse the JSON output of ``next_step.py``; capture the
+``new_context`` string.
 
-```text
-✅ Implementation complete — quality gate passed.
-✅ Committed and pushed to {{branch}}.
-✅ PR #{{pr_number}} opened: {{pr_url}}
+**Run `new_context` via the Bash tool**. The string is a
+``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
+<wd> --title ... --prompt ...`` invocation — already inside the
+allow-listed ``python scripts/qs/*`` pattern. Do NOT extract only the
+prompt and send it to the current session. Do NOT strip
+``--agent qs-<phase>``. The ``--agent`` flag is what binds the
+next-phase orchestrator to the new session via OpenCode's HTTP API
+``POST /session/<id>/prompt_async`` body — strip it and the prompt
+lands on the default agent, breaking the pipeline silently.
 
-Next phase: review-task.
+Parse the stdout of that command as JSON. The success contract is
+**binary**:
 
-Preferred (activate `qs-review-task` from the OpenCode agent picker,
-or paste the spawn-session one-liner below into a fresh terminal):
-  {{new_context}}
-```
+- ``status == "session_created"`` AND ``agent == "qs-review-task"``
+  → success; report to the user:
+
+  ```text
+  ✅ Implementation complete — quality gate passed.
+  ✅ Committed and pushed to {{branch}}.
+  ✅ PR #{{pr_number}} opened: {{pr_url}}
+  ✅ Next phase session created: qs-review-task
+     (visible in the OpenCode session list on the left)
+  ```
+
+- **Anything else** (any other ``status`` value, missing or mismatched
+  ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
+  the raw JSON output verbatim to the user. Do NOT claim the next
+  phase started. The user inspects the JSON and acts on the specific
+  failure mode (``agent_file_missing``, ``fallback_cli``,
+  ``fallback_unavailable``, ``session_orphaned`` — each documented in
+  ``scripts/qs/spawn_session.py``).
 
 ## Hard rules
 

--- a/.opencode/agents/qs-review-task.md
+++ b/.opencode/agents/qs-review-task.md
@@ -107,6 +107,10 @@ Deduplicate across reviewers (`file:line` + similar text → one entry).
 If there are no must-fix or should-fix findings, build the launcher
 payload for `finish-task`:
 
+**Before running** — substitute `{{worktree}}`, `{{issue}}`, and
+`{{title}}` with the values you captured earlier; the `--next-cmd`
+value is fixed (`finish-task`):
+
 ```bash
 python scripts/qs/next_step.py \
     --next-cmd "finish-task" \
@@ -116,8 +120,12 @@ python scripts/qs/next_step.py \
     --harness opencode
 ```
 
-Parse the JSON output of ``next_step.py``; capture the
-``new_context`` string.
+Parse the JSON output of ``next_step.py``.
+
+**If the `next_step.py` JSON contains an `error` key**, STOP and print
+the raw JSON to the user. Do not proceed to run `new_context`.
+
+Otherwise capture the ``new_context`` string.
 
 **Run `new_context` via the Bash tool**. The string is a
 ``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
@@ -129,23 +137,30 @@ next-phase orchestrator to the new session via OpenCode's HTTP API
 ``POST /session/<id>/prompt_async`` body — strip it and the prompt
 lands on the default agent, breaking the pipeline silently.
 
+**If the Bash tool returns an error before producing any JSON output**
+(e.g., permission denied, missing interpreter), STOP and print the
+Bash tool's error message verbatim. Do not attempt to parse JSON.
+
 Parse the stdout of that command as JSON. The success contract is
 **binary**:
 
-- ``status == "session_created"`` AND ``agent == "qs-finish-task"``
-  → success; report to the user:
+- ``status == "session_created"`` AND ``agent`` equals `qs-` followed
+  by the phase name passed to `--next-cmd` (here: `qs-finish-task`
+  since `--next-cmd "finish-task"` was passed) → success; report to
+  the user:
 
   ```text
-  ✅ Adversarial review complete. No blocking findings.
-  ✅ Next phase session created: qs-finish-task
-     (visible in the OpenCode session list on the left)
+  [OK] Adversarial review complete. No blocking findings.
+  [OK] Next phase session created: qs-finish-task
+       (visible in the OpenCode session list on the left)
   ```
 
 - **Anything else** (any other ``status`` value, missing or mismatched
   ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
   the raw JSON output verbatim to the user. Do NOT claim the next
   phase started. The user inspects the JSON and acts on the specific
-  failure mode (``agent_file_missing``, ``fallback_cli``,
+  failure mode (``agent_file_missing``, ``agent_file_unreadable``,
+  ``agent_file_empty``, ``worktree_invalid``, ``fallback_cli``,
   ``fallback_unavailable``, ``session_orphaned`` — each documented in
   ``scripts/qs/spawn_session.py``).
 
@@ -235,6 +250,11 @@ implementation session (review-task → `{{next_implement}}` is the
 most common loop; pasting a prompt into the existing terminal is
 faster than opening a new one):
 
+**Before running** — substitute `{{next_implement}}` with the chosen
+implement variant (one of: `implement-task`, `implement-setup-task`),
+and `{{worktree}}` / `{{issue}}` / `{{title}}` / `{{fix_plan_path}}` /
+`{{pr_number}}` with their captured values:
+
 ```bash
 python scripts/qs/next_step.py \
     --next-cmd "{{next_implement}}" \
@@ -246,11 +266,19 @@ python scripts/qs/next_step.py \
     --harness opencode
 ```
 
-Parse the JSON output of ``next_step.py``; capture the ``new_context``
-string and the ``existing_session_prompt`` string. The
-``existing_session_prompt`` is a paste-into-already-running-session
-prompt — it is NOT a session-spawn command. Do NOT execute it; print
-it for the user.
+Parse the JSON output of ``next_step.py``.
+
+**If the `next_step.py` JSON contains an `error` key**, STOP and print
+the raw JSON to the user. Do not proceed to run `new_context`.
+
+Otherwise capture the ``new_context`` string and the
+``existing_session_prompt`` value. The ``existing_session_prompt`` is
+a paste-into-already-running-session prompt — it is NOT a
+session-spawn command. Do NOT execute it. **If
+`existing_session_prompt` is missing or null, omit the "Already
+running an implementation session?" block from the user report;
+only emit it when the field is a non-empty string** (review-fix #01
+S9).
 
 **Run `new_context` via the Bash tool**. The string is a
 ``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
@@ -262,18 +290,24 @@ next-phase orchestrator to the new session via OpenCode's HTTP API
 ``POST /session/<id>/prompt_async`` body — strip it and the prompt
 lands on the default agent, breaking the pipeline silently.
 
+**If the Bash tool returns an error before producing any JSON output**
+(e.g., permission denied, missing interpreter), STOP and print the
+Bash tool's error message verbatim. Do not attempt to parse JSON.
+
 Parse the stdout of that command as JSON. The success contract is
 **binary**:
 
-- ``status == "session_created"`` AND ``agent == "qs-{{next_implement}}"``
-  → success; report to the user (substitute `{{next_implement}}`
-  consistently — same value the launcher payload was built with):
+- ``status == "session_created"`` AND ``agent`` equals `qs-` followed
+  by the phase name passed to `--next-cmd` (here: `qs-{{next_implement}}`
+  after you substituted the chosen variant) → success; report to the
+  user (substitute `{{next_implement}}` consistently — same value
+  the launcher payload was built with):
 
   ```text
-  ✅ Fix plan written: {{fix_plan_path}}
-  ✅ Committed and pushed.
-  ✅ Next phase session created: qs-{{next_implement}}
-     (visible in the OpenCode session list on the left)
+  [OK] Fix plan written: {{fix_plan_path}}
+  [OK] Committed and pushed.
+  [OK] Next phase session created: qs-{{next_implement}}
+       (visible in the OpenCode session list on the left)
 
   Already running an implementation session?
   Paste this prompt into it:
@@ -283,11 +317,15 @@ Parse the stdout of that command as JSON. The success contract is
   it) to verify.
   ```
 
+  (Omit the "Already running an implementation session?" block when
+  `existing_session_prompt` is missing or null.)
+
 - **Anything else** (any other ``status`` value, missing or mismatched
   ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
   the raw JSON output verbatim to the user. Do NOT claim the next
   phase started. The user inspects the JSON and acts on the specific
-  failure mode (``agent_file_missing``, ``fallback_cli``,
+  failure mode (``agent_file_missing``, ``agent_file_unreadable``,
+  ``agent_file_empty``, ``worktree_invalid``, ``fallback_cli``,
   ``fallback_unavailable``, ``session_orphaned`` — each documented in
   ``scripts/qs/spawn_session.py``).
 

--- a/.opencode/agents/qs-review-task.md
+++ b/.opencode/agents/qs-review-task.md
@@ -112,20 +112,42 @@ python scripts/qs/next_step.py \
     --next-cmd "finish-task" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
-    --title "{{title}}"
+    --title "{{title}}" \
+    --harness opencode
 ```
 
-Parse the JSON; capture `new_context`. Then present:
+Parse the JSON output of ``next_step.py``; capture the
+``new_context`` string.
 
-```text
-✅ Adversarial review complete. No blocking findings.
+**Run `new_context` via the Bash tool**. The string is a
+``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
+<wd> --title ... --prompt ...`` invocation — already inside the
+allow-listed ``python scripts/qs/*`` pattern. Do NOT extract only the
+prompt and send it to the current session. Do NOT strip
+``--agent qs-<phase>``. The ``--agent`` flag is what binds the
+next-phase orchestrator to the new session via OpenCode's HTTP API
+``POST /session/<id>/prompt_async`` body — strip it and the prompt
+lands on the default agent, breaking the pipeline silently.
 
-Next phase: finish-task.
+Parse the stdout of that command as JSON. The success contract is
+**binary**:
 
-Preferred (activate `qs-finish-task` from the OpenCode agent picker,
-or paste the spawn-session one-liner below into a fresh terminal):
-  {{new_context}}
-```
+- ``status == "session_created"`` AND ``agent == "qs-finish-task"``
+  → success; report to the user:
+
+  ```text
+  ✅ Adversarial review complete. No blocking findings.
+  ✅ Next phase session created: qs-finish-task
+     (visible in the OpenCode session list on the left)
+  ```
+
+- **Anything else** (any other ``status`` value, missing or mismatched
+  ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
+  the raw JSON output verbatim to the user. Do NOT claim the next
+  phase started. The user inspects the JSON and acts on the specific
+  failure mode (``agent_file_missing``, ``fallback_cli``,
+  ``fallback_unavailable``, ``session_orphaned`` — each documented in
+  ``scripts/qs/spawn_session.py``).
 
 Stop here.
 
@@ -220,31 +242,54 @@ python scripts/qs/next_step.py \
     --issue {{issue}} \
     --title "{{title}}" \
     --fix-plan-path "{{fix_plan_path}}" \
-    --pr-number {{pr_number}}
+    --pr-number {{pr_number}} \
+    --harness opencode
 ```
 
-Parse the JSON; capture `new_context` and `existing_session_prompt`.
-Then present two blocks (substitute `{{next_implement}}`
-consistently — same value the launcher payload was built with):
+Parse the JSON output of ``next_step.py``; capture the ``new_context``
+string and the ``existing_session_prompt`` string. The
+``existing_session_prompt`` is a paste-into-already-running-session
+prompt — it is NOT a session-spawn command. Do NOT execute it; print
+it for the user.
 
-```text
-✅ Fix plan written: {{fix_plan_path}}
-✅ Committed and pushed.
+**Run `new_context` via the Bash tool**. The string is a
+``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
+<wd> --title ... --prompt ...`` invocation — already inside the
+allow-listed ``python scripts/qs/*`` pattern. Do NOT extract only the
+prompt and send it to the current session. Do NOT strip
+``--agent qs-<phase>``. The ``--agent`` flag is what binds the
+next-phase orchestrator to the new session via OpenCode's HTTP API
+``POST /session/<id>/prompt_async`` body — strip it and the prompt
+lands on the default agent, breaking the pipeline silently.
 
-Next phase: {{next_implement}}.
+Parse the stdout of that command as JSON. The success contract is
+**binary**:
 
-Preferred (activate `qs-{{next_implement}}` from the OpenCode agent
-picker, or paste the spawn-session one-liner below into a fresh
-terminal):
-  {{new_context}}
+- ``status == "session_created"`` AND ``agent == "qs-{{next_implement}}"``
+  → success; report to the user (substitute `{{next_implement}}`
+  consistently — same value the launcher payload was built with):
 
-Already running an implementation session?
-Paste this prompt into it:
-  {{existing_session_prompt}}
+  ```text
+  ✅ Fix plan written: {{fix_plan_path}}
+  ✅ Committed and pushed.
+  ✅ Next phase session created: qs-{{next_implement}}
+     (visible in the OpenCode session list on the left)
 
-Then re-activate `qs-review-task` (or open a fresh session bound to
-it) to verify.
-```
+  Already running an implementation session?
+  Paste this prompt into it:
+    {{existing_session_prompt}}
+
+  Then re-activate `qs-review-task` (or open a fresh session bound to
+  it) to verify.
+  ```
+
+- **Anything else** (any other ``status`` value, missing or mismatched
+  ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
+  the raw JSON output verbatim to the user. Do NOT claim the next
+  phase started. The user inspects the JSON and acts on the specific
+  failure mode (``agent_file_missing``, ``fallback_cli``,
+  ``fallback_unavailable``, ``session_orphaned`` — each documented in
+  ``scripts/qs/spawn_session.py``).
 
 ### 7. Re-review loop
 

--- a/.opencode/agents/qs-setup-task.md
+++ b/.opencode/agents/qs-setup-task.md
@@ -93,8 +93,19 @@ Capture `issue_number` from the JSON output.
 One command does it all:
 
 ```bash
-python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "create-plan"
+python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "create-plan" --harness opencode
 ```
+
+**Why setup-task stays print-for-user**: the new worktree is a
+different OpenCode workspace than the main checkout, so the launcher
+emits the CLI-form ``sh /tmp/qs_oc_launch_<N>.sh`` one-liner whose
+generated script runs ``opencode <worktree> --agent <name>`` against
+the new workspace's OpenCode instance. We cannot ``spawn_session.py``
+across workspaces — the HTTP API only knows about the current
+workspace. Sibling OpenCode agents (``qs-create-plan``,
+``qs-implement-task``, ``qs-implement-setup-task``,
+``qs-review-task``) execute ``new_context`` in-band because they stay
+in the same worktree.
 
 For `--no-worktree`, pass `--no-worktree`. The script:
 - creates branch `QS_{{issue_number}}` from `origin/main`

--- a/docs/stories/QS-190.story.md
+++ b/docs/stories/QS-190.story.md
@@ -1,0 +1,826 @@
+# QS-190 — Agent handoff: pass explicit `--harness` flag and auto-spawn next session
+
+## Summary
+
+Make the agent handoff between Quiet Solar pipeline phases deterministic
+and harness-correct:
+
+1. **Explicit `--harness` flag.** Every `next_step.py` / `setup_task.py`
+   callsite inside `.opencode/agents/`, `.claude/agents/`, and
+   `.cursor/agents/` passes its harness name explicitly — closing the
+   env-var auto-detection failure when tool execution environments
+   don't carry `OPENCODE_SERVER_PORT` / `CURSOR_TRACE_ID`.
+2. **Pre-flight check in `spawn_session.py`.** Verify
+   `<work_dir>/.opencode/agents/<agent>.md` exists before calling the
+   OpenCode HTTP API — closes the QS-177 AC #12 known limitation where
+   the HTTP API silently lands the session on the default agent if the
+   target agent file is missing.
+3. **Auto-execute `new_context` in OpenCode mid-pipeline agents.** The
+   four post-setup OpenCode agents (`qs-create-plan`,
+   `qs-implement-task`, `qs-implement-setup-task`, `qs-review-task`)
+   execute the captured `new_context` via the Bash tool and verify a
+   binary success contract (`status == "session_created"` AND
+   `agent == "qs-<expected>"`) — guaranteeing the next-phase session
+   lands on the right agent persona, in-band, with no copy/paste UX.
+   Setup-task stays print-for-user (cross-workspace launcher), and
+   Claude / Cursor agents preserve the existing print-for-user pattern.
+
+## Why this matters
+
+Without an explicit `--harness` flag, an OpenCode agent that does not
+inherit `OPENCODE_SERVER_PORT` in its tool environment ships a Claude
+CLI launcher to the user — the wrong activation path for OpenCode. The
+same regression hits Cursor whenever `CURSOR_TRACE_ID` is unset in the
+tool env.
+
+Without the agent-file pre-flight, an OpenCode agent can request
+`spawn_session.py --agent qs-implement-task` against a worktree whose
+`.opencode/agents/qs-implement-task.md` is missing or stale; the HTTP
+API silently lands the session on the default agent, the phase
+orchestration never starts, and the user has no error to act on. **The
+session must always be created with the right agent already bound.**
+
+## Acceptance criteria
+
+### AC-1 — Explicit `--harness` flag in every callsite
+
+**Given** any of the **13** `next_step.py` / `setup_task.py` callsites
+in:
+
+| # | File | Line (advisory) | Script | Expected flag |
+| - | ---- | --------------- | ------ | ------------- |
+| 1 | `.opencode/agents/qs-setup-task.md` | 96 | `setup_task.py` | `--harness opencode` |
+| 2 | `.opencode/agents/qs-create-plan.md` | 145 | `next_step.py` | `--harness opencode` |
+| 3 | `.opencode/agents/qs-implement-task.md` | 141 | `next_step.py` | `--harness opencode` |
+| 4 | `.opencode/agents/qs-implement-setup-task.md` | 147 | `next_step.py` | `--harness opencode` |
+| 5 | `.opencode/agents/qs-review-task.md` (zero-findings) | 111 | `next_step.py` | `--harness opencode` |
+| 6 | `.opencode/agents/qs-review-task.md` (fix-plan) | 217 | `next_step.py` | `--harness opencode` |
+| 7 | `.claude/agents/qs-setup-task.md` | 61 | `setup_task.py` | `--harness claude-code` |
+| 8 | `.claude/agents/qs-create-plan.md` | 107 | `next_step.py` | `--harness claude-code` |
+| 9 | `.claude/agents/qs-implement-task.md` | 102 | `next_step.py` | `--harness claude-code` |
+| 10 | `.claude/agents/qs-implement-setup-task.md` | 91 | `next_step.py` | `--harness claude-code` |
+| 11 | `.claude/agents/qs-review-task.md` (zero-findings) | 79 | `next_step.py` | `--harness claude-code` |
+| 12 | `.claude/agents/qs-review-task.md` (fix-plan) | 188 | `next_step.py` | `--harness claude-code` |
+| 13 | `.cursor/agents/qs-setup-task.md` | 54 | `setup_task.py` | `--harness cursor` |
+
+**When** the file body is inspected
+**Then** the callsite contains the literal `--harness <name>` flag
+matching the agent directory (`opencode` / `claude-code` / `cursor`),
+joined into the same logical invocation as the script name (regex
+`(next_step\.py|setup_task\.py).*?--harness\s+<name>` with `re.DOTALL`
+matches).
+
+### AC-2 — `spawn_session.py` pre-flight rejects missing agent file
+
+**Given** `python scripts/qs/spawn_session.py --agent qs-foo --directory
+/work --prompt p` invoked when `/work/.opencode/agents/qs-foo.md` does
+**not** exist
+**When** the script runs
+**Then** it routes through the existing `_emit(...)` helper to:
+
+- write to stderr:
+  `"ERROR: OpenCode agent file not found at /work/.opencode/agents/qs-foo.md; the HTTP API would silently fall back to the default agent. Mirror .claude/agents/qs-foo.md into .opencode/agents/ or create the file before retrying."`
+- write the following JSON to stdout (formatted via `output_json`):
+  ```json
+  {
+    "status": "agent_file_missing",
+    "agent": "qs-foo",
+    "directory": "/work",
+    "expected_path": "/work/.opencode/agents/qs-foo.md",
+    "detail": "OpenCode agent file not found at /work/.opencode/agents/qs-foo.md; the HTTP API would silently fall back to the default agent. Mirror .claude/agents/qs-foo.md into .opencode/agents/ or create the file before retrying."
+  }
+  ```
+- exit with code `2`
+- **never** call `urllib.request.urlopen` (asserted via mock).
+
+### AC-3 — `spawn_session.py` proceeds normally when agent file present
+
+**Given** `<work_dir>/.opencode/agents/<agent>.md` exists
+**When** `spawn_session.py main()` runs (with `urlopen` mocked)
+**Then** the pre-flight passes silently and the script proceeds to
+`POST /session` (verified by the mock being invoked).
+
+### AC-4 — OpenCode mid-pipeline agents auto-execute `new_context`
+
+**Given** any of:
+- `.opencode/agents/qs-create-plan.md`
+- `.opencode/agents/qs-implement-task.md`
+- `.opencode/agents/qs-implement-setup-task.md`
+- `.opencode/agents/qs-review-task.md`
+
+**When** the file body is inspected
+**Then** the handoff section instructs the agent to:
+
+1. **Run** the captured `new_context` string via the Bash tool (the
+   `python scripts/qs/*` pattern is already allow-listed).
+2. **Parse** the resulting stdout JSON.
+3. **Verify** the binary success contract:
+   `status == "session_created"` AND `agent == "qs-<expected-phase>"`
+   → report success to the user.
+4. **Else** (any other status, missing `agent` field, mismatched agent
+   name, non-zero exit) → print the raw JSON to the user and STOP. Do
+   NOT claim the next phase started.
+
+The body explicitly forbids:
+- extracting only the prompt from `new_context` and sending it to the
+  current session;
+- stripping the `--agent qs-<phase>` flag from `new_context`;
+- continuing past a non-`session_created` status as if the next phase
+  had started.
+
+### AC-5 — OpenCode `qs-setup-task.md` keeps print-for-user
+
+**Given** `.opencode/agents/qs-setup-task.md`
+**When** inspected
+**Then** the body preserves the existing print-for-user pattern AND
+contains an inline rationale block explaining why setup-task is the
+exception (cross-workspace launch — the launcher emits a
+`sh /tmp/qs_oc_launch_<N>.sh` form whose generated script invokes the
+external `opencode <worktree> --agent <name>` CLI, not the in-process
+HTTP API).
+
+### AC-6 — Claude and Cursor agents preserve print-for-user
+
+**Given** any `.claude/agents/qs-*.md` file or
+`.cursor/agents/qs-setup-task.md`
+**When** inspected
+**Then** the body preserves the existing two-block "Preferred /
+Fallback" print-for-user pattern. The only change is the added
+`--harness <name>` flag. The body does **not** contain an
+auto-execute imperative (no "Run `new_context` via the Bash tool"
+prose).
+
+### AC-7 — Updated docs and docstrings reflect the closed limitation
+
+**Given** every reference to the QS-177 AC #12 known limitation in:
+
+- `scripts/qs/spawn_session.py` module docstring (the
+  "Known limitation (per AC #12 of QS-177)" paragraph)
+- `scripts/qs/launchers/opencode.py` module docstring (the
+  "Known limitation (per QS-177 AC #12)" paragraph)
+- `docs/workflow/harness.md` (the OpenCode launcher row's
+  "**Known limitation**" paragraph in the "Launcher dispatch" section)
+
+**When** read after this story lands
+**Then** each paragraph is rephrased to a closed-historical note
+pointing to QS-190's pre-flight guard. The replacement text in each
+location MUST contain the exact substring
+`"spawn_session.py performs a pre-flight check"` (so the existing
+pin tests can be updated to a unique, non-substring-overlapping
+phrase).
+
+### AC-8 — Manual smoke test (PR-review responsibility)
+
+**Given** the PR is open
+**When** the PR description is reviewed
+**Then** the author attaches evidence of a one-time manual smoke test:
+a screenshot or transcript showing a fresh OpenCode session in the
+sidebar after the agent executed `new_context`. **This is not an
+automated assertion** — it satisfies the issue's "[ ] Manual test"
+checkbox without inventing a flaky E2E harness.
+
+## Task breakdown
+
+### Task 1 — `scripts/qs/spawn_session.py`: agent-file pre-flight check
+
+**File**: `scripts/qs/spawn_session.py`
+
+1.1. Insert helper between `_reject_control_chars` (~line 477) and
+`main()` (~line 502):
+
+```python
+def _agent_file_path(directory: str, agent: str) -> Path:
+    """Return the expected ``.opencode/agents/<agent>.md`` path under ``directory``.
+
+    Centralises the convention so the pre-flight guard in ``main()``
+    and any future caller (e.g. the OpenCode launcher's CLI-form
+    branch in ``launchers/opencode.py``) compute the same path.
+    """
+    return Path(directory) / ".opencode" / "agents" / f"{agent}.md"
+```
+
+1.2. In `main()`, insert the pre-flight block **between** the
+strip-back tail (line 591, `args.title = args.title.strip()`) and the
+existing `try: result = spawn_session(...)` block at line 593:
+
+```python
+# Pre-flight: verify the target agent file exists in the worktree.
+# Without this, the OpenCode HTTP API silently lands the session on the
+# default agent if .opencode/agents/<agent>.md is missing — the
+# QS-177 AC #12 known limitation. Closes that gap (QS-190 AC-2).
+expected = _agent_file_path(args.directory, args.agent)
+if not expected.is_file():
+    detail = (
+        f"ERROR: OpenCode agent file not found at {expected}; "
+        f"the HTTP API would silently fall back to the default agent. "
+        f"Mirror .claude/agents/{args.agent}.md into .opencode/agents/ "
+        f"or create the file before retrying."
+    )
+    sys.exit(_emit(
+        {
+            "status": "agent_file_missing",
+            "agent": args.agent,
+            "directory": args.directory,
+            "expected_path": str(expected),
+            "detail": detail,
+        },
+        stderr_msg=detail,
+        exit_code=2,
+    ))
+```
+
+The reuse of `_emit(payload, stderr_msg=..., exit_code=...)` matches
+the centralised pattern introduced by QS-177 review-fix #02 should-fix
+#5 (every failure-emission path goes through `_emit`).
+
+1.3. Update the module docstring's "CLI fallback semantics" section
+(lines 16-32) to add a new bullet after the existing fallback list:
+
+```text
+- **Agent-file pre-flight** (QS-190): before any HTTP call, ``main()``
+  verifies that ``<directory>/.opencode/agents/<agent>.md`` exists. If
+  not, the script emits ``{"status": "agent_file_missing", ...}`` on
+  stdout, a clear error on stderr, and exits 2 (parallel to the
+  ``fallback_unavailable`` branch shape). This closes the QS-177 AC #12
+  known limitation where a missing agent file silently lands the
+  session on the default OpenCode agent.
+```
+
+1.4. Rephrase the "Known limitation (per AC #12 of QS-177)" paragraph
+(lines 34-40) to a closed-historical note:
+
+```text
+Closed limitation (per QS-177 AC #12, closed by QS-190):
+``spawn_session.py`` performs a pre-flight check that aborts with
+``status: "agent_file_missing"`` before the HTTP API can silently
+land a session on the default agent. The pre-flight is documented
+in the CLI fallback semantics section above.
+```
+
+### Task 2 — `tests/qs/test_spawn_session.py`: pin pre-flight contract
+
+**File**: `tests/qs/test_spawn_session.py`
+
+2.1. Add `test_preflight_aborts_when_agent_file_missing(tmp_path,
+monkeypatch, capsys)`:
+
+- `tmp_path` worktree with NO `.opencode/agents/` subdir.
+- Monkeypatch `urllib.request.urlopen` with a `MagicMock` (so we can
+  assert it's NEVER called).
+- Invoke via the existing `_run_main(monkeypatch, "--agent",
+  "qs-create-plan", "--directory", str(tmp_path))`.
+- Assert exit code == 2.
+- Parse `capsys.readouterr().out` via `json.loads` — every key
+  asserted:
+  - `payload["status"] == "agent_file_missing"`
+  - `payload["agent"] == "qs-create-plan"`
+  - `payload["directory"] == str(tmp_path)`
+  - `payload["expected_path"].endswith("/.opencode/agents/qs-create-plan.md")`
+  - `payload["detail"].startswith("ERROR: OpenCode agent file not found at ")`
+- Assert `capsys.readouterr().err` contains the stderr message
+  (caught via `capsys` in the same call as stdout).
+- Assert the `urlopen` mock was called 0 times
+  (`mock.assert_not_called()`).
+
+2.2. Add `test_preflight_passes_when_agent_file_present(tmp_path,
+monkeypatch, capsys)`:
+
+- Create `<tmp_path>/.opencode/agents/qs-create-plan.md` (empty
+  content is fine — the pre-flight only checks `is_file()`).
+- Reuse the happy-path `_capture` helper pattern (see
+  `test_spawn_session_happy_path` lines 99-145).
+- Assert exit code == 0 + `status == "session_created"`.
+
+2.3. Add `test_preflight_checks_correct_path(tmp_path, monkeypatch,
+capsys)`:
+
+- Create `<tmp_path>/.opencode/agents/qs-implement-task.md` (NOT
+  `qs-create-plan.md`).
+- Invoke with `--agent qs-create-plan`.
+- Assert exit code == 2 + `status == "agent_file_missing"` (the
+  pre-flight pins the agent → path mapping, not just "any file under
+  .opencode/agents/").
+
+All three tests follow the project convention:
+- `from __future__ import annotations` at the top of the file (already
+  present).
+- Reuse `_run_main`, `_mock_response`, `monkeypatch`, `capsys` from
+  the existing test module — no new helpers.
+- Parse stdout via `json.loads(...)` (never substring matching — see
+  module docstring "Format-agnostic assertions").
+
+2.4. Update the existing limitation-note tests in
+`tests/qs/launchers/test_opencode_launcher.py`:
+
+- `test_build_payload_emits_known_limitation_note` (line 177-187):
+  rephrase the assertion to pin the new closed-limitation phrasing —
+  assert the docstring contains `"spawn_session.py performs a
+  pre-flight check"`. Rename the test to
+  `test_build_payload_documents_closed_limitation` and update its
+  docstring + failure message.
+- `test_harness_md_contains_known_limitation_note` (line 598-610):
+  same treatment — assert `harness.md` contains
+  `"spawn_session.py performs a pre-flight check"`. Rename to
+  `test_harness_md_documents_closed_limitation`.
+
+### Task 3 — `.opencode/agents/`: add `--harness opencode` + auto-execute
+
+For each of the 5 OpenCode agent files, follow the rules below.
+Reference the surrounding handoff anchors rather than line numbers
+(line numbers may drift between plan drafting and implementation —
+treat them as advisory).
+
+#### 3.1 `.opencode/agents/qs-setup-task.md` — `--harness opencode` only
+
+Locate the `setup_task.py` invocation (anchor: the bash code block
+under the "### 2. Set up branch and worktree + emit launcher" heading).
+Add ` --harness opencode` to the command line.
+
+**No auto-execute change** — setup-task crosses workspaces. Insert a
+new rationale paragraph **after** the bash block, before the "Capture"
+sentence:
+
+```text
+**Why setup-task stays print-for-user**: the new worktree is a
+different OpenCode workspace than the main checkout, so the launcher
+emits the CLI-form ``sh /tmp/qs_oc_launch_<N>.sh`` one-liner whose
+generated script runs ``opencode <worktree> --agent <name>`` against
+the new workspace's OpenCode instance. We cannot ``spawn_session.py``
+across workspaces — the HTTP API only knows about the current
+workspace. Sibling OpenCode agents (``qs-create-plan``,
+``qs-implement-task``, ``qs-implement-setup-task``,
+``qs-review-task``) execute ``new_context`` in-band because they stay
+in the same worktree.
+```
+
+#### 3.2-3.5 OpenCode mid-pipeline agents
+
+For each of:
+- `.opencode/agents/qs-create-plan.md` (1 callsite)
+- `.opencode/agents/qs-implement-task.md` (1 callsite)
+- `.opencode/agents/qs-implement-setup-task.md` (1 callsite)
+- `.opencode/agents/qs-review-task.md` (**2 callsites**: zero-findings
+  fast path AND fix-plan flow)
+
+Apply BOTH changes:
+
+**(a)** Add ` --harness opencode` to the `next_step.py` invocation
+(anchor: the bash code block immediately preceding the "Parse the
+JSON; capture `new_context`" sentence).
+
+**(b)** Replace the "Parse the JSON; capture `new_context`. Then
+print:" block (everything from that sentence through the closing
+text code-fence) with the **canonical auto-execute block** below.
+
+**Canonical auto-execute block** (used at all 5 in-worktree callsites
+across `qs-create-plan`, `qs-implement-task`, `qs-implement-setup-task`,
+and both review-task sites):
+
+````text
+Parse the JSON output of ``next_step.py``; capture the
+``new_context`` string.
+
+**Run `new_context` via the Bash tool**. The string is a
+``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
+<wd> --title ... --prompt ...`` invocation — already inside the
+allow-listed ``python scripts/qs/*`` pattern. Do NOT extract only the
+prompt and send it to the current session. Do NOT strip
+``--agent qs-<phase>``. The ``--agent`` flag is what binds the
+next-phase orchestrator to the new session via OpenCode's HTTP API
+``POST /session/<id>/prompt_async`` body — strip it and the prompt
+lands on the default agent, breaking the pipeline silently.
+
+Parse the stdout of that command as JSON. The success contract is
+**binary**:
+
+- ``status == "session_created"`` AND ``agent == "qs-<expected-phase>"``
+  → success; report to the user:
+
+  ```text
+  ✅ Next phase session created: qs-<expected-phase>
+     (visible in the OpenCode session list on the left)
+  ```
+
+- **Anything else** (any other ``status`` value, missing or mismatched
+  ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
+  the raw JSON output verbatim to the user. Do NOT claim the next
+  phase started. The user inspects the JSON and acts on the specific
+  failure mode (``agent_file_missing``, ``fallback_cli``,
+  ``fallback_unavailable``, ``session_orphaned`` — each documented in
+  ``scripts/qs/spawn_session.py``).
+````
+
+Use the **same canonical block verbatim** at all 5 in-worktree
+callsites — this lets Task 7's contract test assert a single fixed
+substring across all 4 files (and twice in `qs-review-task.md`).
+
+For `qs-review-task.md` specifically: the **two** `next_step.py`
+callsites each emit their own `new_context`, and both get the
+canonical auto-execute block. The `existing_session_prompt` field
+(emitted by the same `next_step.py` call when `--fix-plan-path` +
+`--pr-number` are passed) is a SEPARATE string for pasting into an
+already-running session — it stays print-for-paste in both review-task
+sites; it is NOT executed.
+
+### Task 4 — `.claude/agents/`: add `--harness claude-code`
+
+For each of:
+- `.claude/agents/qs-setup-task.md` (anchor: bash block under
+  "### 2. Set up branch and worktree + emit launcher")
+- `.claude/agents/qs-create-plan.md` (anchor: bash block under
+  "### 8. Tell the user the next command")
+- `.claude/agents/qs-implement-task.md` (anchor: bash block under
+  "### 6. Tell the user the next command")
+- `.claude/agents/qs-implement-setup-task.md` (anchor: same heading)
+- `.claude/agents/qs-review-task.md` — **2 callsites**: bash block
+  under "### 4. Zero-findings fast path" AND bash block under "### 6.
+  Fix plan (if any fixes)"
+
+Add ` --harness claude-code` to each `next_step.py` / `setup_task.py`
+invocation. **Preserve the existing two-block "Preferred / Fallback"
+print-for-user pattern verbatim** — no auto-execute prose.
+
+### Task 5 — `.cursor/agents/qs-setup-task.md`: add `--harness cursor`
+
+Anchor: bash block under "### 2. Create branch and worktree + emit
+launcher". Add ` --harness cursor`. Preserve the existing
+`--next-cmd "/qs-create-plan"` form (asymmetric with Claude's
+`"/create-plan"` — out of scope for this story; tracked separately if
+ever revisited).
+
+No other `.cursor/agents/*.md` file invokes `next_step.py` or
+`setup_task.py` (audited via grep). The post-setup Cursor flow uses
+slash-in-same-session UX, not session spawn.
+
+### Task 6 — `tests/qs/agents/test_harness_flag_explicit.py` (NEW)
+
+**File**: `tests/qs/agents/test_harness_flag_explicit.py`
+
+A SINGLE parameterized test walks all three harness directories and
+asserts each `next_step.py` / `setup_task.py` invocation carries the
+correct `--harness` flag derived from the directory prefix (no
+hand-maintained table — the directory IS the source of truth).
+
+```python
+"""Pin the AC-1 contract: every next_step.py / setup_task.py callsite
+inside .opencode/agents/, .claude/agents/, .cursor/agents/ passes
+the explicit ``--harness <name>`` flag matching its directory.
+
+Without this guard, env-var-based harness auto-detection
+(scripts/qs/harness.py) silently degrades to the ``claude-code``
+default whenever the tool execution environment doesn't carry
+``OPENCODE_SERVER_PORT`` / ``CURSOR_TRACE_ID`` — which is precisely
+the failure mode QS-190 closes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+HARNESS_BY_DIR = {
+    ".opencode/agents": "opencode",
+    ".claude/agents": "claude-code",
+    ".cursor/agents": "cursor",
+}
+
+# Regex matches either next_step.py or setup_task.py followed by any
+# characters (DOTALL — so backslash-continued multi-line invocations
+# still match), then ``--harness <name>``. The greedy gap is bounded
+# by ``.{0,400}`` so the pattern can't drift across an unrelated
+# downstream invocation in the same file body.
+_CALLSITE_RE_FMT = (
+    r"(next_step\.py|setup_task\.py).{{0,400}}?--harness\s+{harness}\b"
+)
+
+
+def _all_agent_files() -> list[tuple[Path, str]]:
+    """Yield (file, expected_harness) for every .md file in each harness dir.
+
+    Files that DO NOT contain a next_step.py / setup_task.py
+    invocation are skipped — only callsite-bearing files are
+    asserted. Today that's 11 files yielding 13 callsites; the helper
+    re-scans the live filesystem so new agent files are picked up
+    automatically.
+    """
+    out: list[tuple[Path, str]] = []
+    for rel, harness in HARNESS_BY_DIR.items():
+        for f in (REPO_ROOT / rel).glob("*.md"):
+            body = f.read_text(encoding="utf-8")
+            if "next_step.py" in body or "setup_task.py" in body:
+                out.append((f, harness))
+    return out
+
+
+@pytest.mark.parametrize(("agent_file", "expected_harness"), _all_agent_files())
+def test_callsite_passes_explicit_harness_flag(
+    agent_file: Path, expected_harness: str,
+) -> None:
+    body = agent_file.read_text(encoding="utf-8")
+    pattern = re.compile(
+        _CALLSITE_RE_FMT.format(harness=re.escape(expected_harness)),
+        re.DOTALL,
+    )
+    assert pattern.search(body), (
+        f"{agent_file.relative_to(REPO_ROOT)} contains a next_step.py / "
+        f"setup_task.py invocation but no matching "
+        f"`--harness {expected_harness}` flag within 400 chars of the "
+        f"script name. Env-var harness auto-detection is unreliable "
+        f"inside tool execution environments — the flag must be "
+        f"explicit (see QS-190 AC-1)."
+    )
+
+
+def test_thirteen_callsites_total() -> None:
+    """Sanity-check pin: today there are exactly 13 callsites across the
+    three harness dirs (6 OpenCode + 6 Claude + 1 Cursor). If this drifts,
+    update the count + AC-1 enumeration in the story.
+    """
+    total = 0
+    for rel in HARNESS_BY_DIR:
+        for f in (REPO_ROOT / rel).glob("*.md"):
+            body = f.read_text(encoding="utf-8")
+            total += body.count("next_step.py")
+            total += body.count("setup_task.py")
+    assert total == 13, (
+        f"Expected 13 next_step.py / setup_task.py callsites across "
+        f"the three harness dirs; found {total}. If this changed "
+        f"intentionally, update the count + the AC-1 enumeration in "
+        f"docs/stories/QS-190.story.md."
+    )
+```
+
+### Task 7 — `tests/qs/agents/test_opencode_execute_contract.py` (NEW)
+
+**File**: `tests/qs/agents/test_opencode_execute_contract.py`
+
+Pins AC-4 / AC-5 / AC-6: OpenCode mid-pipeline agents auto-execute;
+OpenCode setup-task + all Claude + Cursor agents stay print-for-user.
+
+```python
+"""Pin the OpenCode auto-execute contract (AC-4 / AC-5 / AC-6).
+
+OpenCode mid-pipeline agents (create-plan, implement-task,
+implement-setup-task, review-task) must instruct the agent to RUN
+``new_context`` via the Bash tool and verify the binary
+``status == "session_created"`` AND ``agent == "qs-<expected>"``
+contract. The OpenCode setup-task agent + every Claude / Cursor agent
+preserve the existing print-for-user pattern (no auto-execute prose).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OPENCODE_DIR = REPO_ROOT / ".opencode" / "agents"
+CLAUDE_DIR = REPO_ROOT / ".claude" / "agents"
+CURSOR_DIR = REPO_ROOT / ".cursor" / "agents"
+
+# Distinctive substring from the canonical auto-execute block (Task
+# 3.2-3.5). Choosing a phrase that is unique to the auto-execute
+# pattern AND unlikely to drift; the print-for-user block uses
+# "Preferred (..." / "Fallback (..." instead.
+EXECUTE_MARKER = "Run `new_context` via the Bash tool"
+SUCCESS_CONTRACT_MARKER = 'status == "session_created"'
+AGENT_VERIFY_MARKER = 'agent == "qs-'  # partial — phase varies
+
+OPENCODE_EXECUTE_AGENTS = (
+    "qs-create-plan",
+    "qs-implement-task",
+    "qs-implement-setup-task",
+    "qs-review-task",
+)
+
+
+@pytest.mark.parametrize("name", OPENCODE_EXECUTE_AGENTS)
+def test_opencode_agent_auto_executes_new_context(name: str) -> None:
+    body = (OPENCODE_DIR / f"{name}.md").read_text(encoding="utf-8")
+    assert EXECUTE_MARKER in body, (
+        f"{name}: missing auto-execute imperative. The body must "
+        f"instruct the agent to run new_context via the Bash tool "
+        f"(see QS-190 AC-4)."
+    )
+    assert SUCCESS_CONTRACT_MARKER in body, (
+        f"{name}: missing the binary success-contract check on "
+        f"`status == \"session_created\"`."
+    )
+    assert AGENT_VERIFY_MARKER in body, (
+        f"{name}: missing the `agent == \"qs-...\"` verification."
+    )
+
+
+def test_opencode_review_task_has_two_execute_blocks() -> None:
+    """review-task has 2 next_step.py callsites — both must auto-execute.
+
+    Counts occurrences of the EXECUTE_MARKER. Asserts ``>= 2`` so the
+    test is robust to future prose elaboration; the lower bound is
+    what matters.
+    """
+    body = (OPENCODE_DIR / "qs-review-task.md").read_text(encoding="utf-8")
+    count = body.count(EXECUTE_MARKER)
+    assert count >= 2, (
+        f"qs-review-task.md should auto-execute both new_context "
+        f"callsites (zero-findings + fix-plan); found {count} "
+        f"occurrences of {EXECUTE_MARKER!r}."
+    )
+
+
+def test_opencode_setup_task_preserves_print_for_user() -> None:
+    """Cross-workspace setup-task keeps the print-for-user pattern (AC-5)."""
+    body = (OPENCODE_DIR / "qs-setup-task.md").read_text(encoding="utf-8")
+    assert EXECUTE_MARKER not in body, (
+        "qs-setup-task.md should NOT auto-execute new_context — "
+        "setup-task crosses OpenCode workspaces and emits a CLI-form "
+        "launcher (see QS-190 AC-5)."
+    )
+
+
+@pytest.mark.parametrize("agent_file", sorted(CLAUDE_DIR.glob("qs-*.md")))
+def test_claude_agents_preserve_print_for_user(agent_file: Path) -> None:
+    """Every Claude phase orchestrator stays print-for-user (AC-6)."""
+    body = agent_file.read_text(encoding="utf-8")
+    assert EXECUTE_MARKER not in body, (
+        f"{agent_file.relative_to(REPO_ROOT)}: Claude agents must "
+        f"preserve the existing print-for-user pattern. Found the "
+        f"auto-execute marker — that's OpenCode-only (QS-190 AC-6)."
+    )
+
+
+@pytest.mark.parametrize("agent_file", sorted(CURSOR_DIR.glob("qs-*.md")))
+def test_cursor_agents_preserve_print_for_user(agent_file: Path) -> None:
+    """Every Cursor phase orchestrator stays print-for-user (AC-6)."""
+    body = agent_file.read_text(encoding="utf-8")
+    assert EXECUTE_MARKER not in body, (
+        f"{agent_file.relative_to(REPO_ROOT)}: Cursor agents must "
+        f"preserve the existing print-for-user pattern (QS-190 AC-6)."
+    )
+```
+
+### Task 8 — Update `docs/workflow/harness.md` and launcher docstring
+
+8.1. `scripts/qs/launchers/opencode.py` module docstring (lines 27-33):
+
+Replace the "Known limitation (per QS-177 AC #12)" paragraph with:
+
+```text
+Closed limitation (per QS-177 AC #12, closed by QS-190):
+``spawn_session.py`` performs a pre-flight check that verifies
+``<work_dir>/.opencode/agents/<agent>.md`` exists before calling the
+HTTP API. If the agent file is missing, the script emits
+``status: "agent_file_missing"`` and exits 2 — the API can no longer
+silently land the session on the default agent.
+```
+
+8.2. `docs/workflow/harness.md` — "Launcher dispatch" section, OpenCode
+row paragraph (lines 55-68 area):
+
+Replace the "**Known limitation**:" sentence with:
+
+```text
+**Closed limitation** (QS-177 AC #12, closed by QS-190):
+``spawn_session.py`` performs a pre-flight check on
+``<work_dir>/.opencode/agents/<agent>.md`` before the HTTP API call;
+a missing agent file now produces a clean ``agent_file_missing`` exit
+shape instead of silently landing on the default agent.
+```
+
+8.3. Final grep verification (manual, by the implementer):
+
+```bash
+grep -rni "QS-177.*AC #12" docs/ scripts/qs/
+grep -rni "known limitation" docs/ scripts/qs/
+```
+
+Every match must point to a closed-historical reference (not a live
+warning). If the grep surfaces an unaddressed location, fix it before
+the quality gate.
+
+### Task 9 — Quality gate, commit, push, PR
+
+```bash
+python scripts/qs/quality_gate.py
+```
+
+All touched paths (`scripts/qs/spawn_session.py`,
+`scripts/qs/launchers/opencode.py`, `tests/qs/**`, `.opencode/agents/**`,
+`.claude/agents/**`, `.cursor/agents/**`, `docs/workflow/harness.md`)
+match `_DEV_ONLY_PATTERNS`, so `quality_gate.py` will engage its
+dev-only fast path automatically — only the modified test files run,
+the full pytest suite is skipped. Coverage of the NEW `spawn_session.py`
+pre-flight branch is provided by the three new tests in Task 2 (100%
+mandatory, no `# pragma: no cover`).
+
+Stderr `print(f"...", file=sys.stderr)` in `spawn_session.py` Task 1 is
+**not** subject to the lazy-logging rule. The lazy-logging convention
+(`_LOGGER.debug("...%s", x)`) applies only to `logging`-module calls;
+CLI stderr output is plain Python prints and uses f-strings throughout
+`scripts/qs/` already.
+
+After the gate passes, the implement-setup-task agent auto-commits and
+opens the PR.
+
+## Files touched (full list)
+
+Total: **18** files (1 production-shaped script + 1 launcher + 3 test
+files + 11 agent files + 1 doc — but every path is under
+`_DEV_ONLY_PATTERNS`).
+
+| # | Path | Reason |
+|---|------|--------|
+| 1 | `scripts/qs/spawn_session.py` | Pre-flight check + docstring update |
+| 2 | `scripts/qs/launchers/opencode.py` | Docstring update (closed limitation) |
+| 3 | `tests/qs/test_spawn_session.py` | 3 new pre-flight tests |
+| 4 | `tests/qs/launchers/test_opencode_launcher.py` | Rename + update 2 existing limitation-note tests |
+| 5 | `tests/qs/agents/test_harness_flag_explicit.py` | NEW |
+| 6 | `tests/qs/agents/test_opencode_execute_contract.py` | NEW |
+| 7 | `.opencode/agents/qs-setup-task.md` | `--harness opencode` + rationale comment |
+| 8 | `.opencode/agents/qs-create-plan.md` | `--harness opencode` + auto-execute block |
+| 9 | `.opencode/agents/qs-implement-task.md` | Same |
+| 10 | `.opencode/agents/qs-implement-setup-task.md` | Same |
+| 11 | `.opencode/agents/qs-review-task.md` | Same (×2 callsites) |
+| 12 | `.claude/agents/qs-setup-task.md` | `--harness claude-code` |
+| 13 | `.claude/agents/qs-create-plan.md` | Same |
+| 14 | `.claude/agents/qs-implement-task.md` | Same |
+| 15 | `.claude/agents/qs-implement-setup-task.md` | Same |
+| 16 | `.claude/agents/qs-review-task.md` | Same (×2 callsites) |
+| 17 | `.cursor/agents/qs-setup-task.md` | `--harness cursor` |
+| 18 | `docs/workflow/harness.md` | Closed-limitation note |
+
+**NEXT_PHASE = `implement-setup-task`** — every path matches
+`_DEV_ONLY_PATTERNS`.
+
+## Out of scope
+
+- Normalising the `--next-cmd "create-plan"` vs `"/create-plan"` vs
+  `"/qs-create-plan"` form inconsistency across harnesses (user
+  confirmed Q4).
+- Adding `next_step.py` invocations to the 5 Cursor agents that
+  currently use slash-in-same-session UX. Their existing UX is
+  intentional; expanding it is a separate story.
+- Replacing `_DEV_ONLY_PATTERNS`-based scope detection with a more
+  granular gate trigger. Out of scope.
+
+## Adversarial review notes
+
+Four plan-reviewer sub-agents (`qs-plan-critic`,
+`qs-plan-concrete-planner`, `qs-plan-dev-proxy`, `qs-plan-scope-guardian`)
+spawned in parallel before this story was finalised. Total: 21
+distinct findings after cross-reviewer deduplication. **All 21 were
+addressed** (user chose "fix all"). Notable design decisions driven by
+review:
+
+- **Status-branch model collapsed from 5 → 2** (per scope-guardian
+  SG-R1 + critic PC-C3): the canonical auto-execute block tests only
+  `status == "session_created"` AND `agent == "qs-<expected>"`; every
+  other case prints the raw JSON and STOPs. Drops per-status fallback
+  prose duplication across 5 agent callsites; preserves the
+  user-stated "right agent" guarantee; eliminates the AC/template
+  branch-count mismatch.
+- **Test files use ONE parameterized walk** of the three harness
+  directories instead of a 13-case hand-maintained table (per
+  scope-guardian SG-I1 + critic PC-I5): the expected harness is
+  derived from the directory prefix, so a future agent file is picked
+  up automatically. Plus a `test_thirteen_callsites_total` sanity-pin
+  catches drift.
+- **`{{new_context}}` template placeholder removed** (per critic
+  PC-C2): the canonical auto-execute block instructs the agent to
+  "Run `new_context` via the Bash tool" with prose, NOT a literal
+  Jinja-style template the agent can't expand.
+- **`_emit` helper reused** for the pre-flight failure path (per
+  concrete-planner CP-R1): matches QS-177 review-fix #02 should-fix
+  #5's "no duplicate stderr+output_json+sys.exit triplets" invariant.
+- **Pre-flight insertion point pinned** to "after strip-back (line
+  591), before the `try: spawn_session(...)` block (line 593)" (per
+  concrete-planner CP-I1): uses canonical post-strip values for
+  `args.agent` / `args.directory`.
+- **Setup-task asymmetry explained inline** in
+  `.opencode/agents/qs-setup-task.md` (per critic PC-R2): a rationale
+  paragraph after the bash block — no buried parenthetical.
+- **Anti-execute pin** for every Claude + Cursor agent (per critic
+  PC-I4): `test_opencode_execute_contract.py` asserts the
+  `EXECUTE_MARKER` is ABSENT from those files, catching accidental
+  cross-harness contamination.
+- **Existing launcher-docstring test at line 177 enumerated** (per
+  concrete-planner CP-C2): Task 2.4 explicitly renames and rephrases
+  both `test_build_payload_emits_known_limitation_note` (line 177)
+  and `test_harness_md_contains_known_limitation_note` (line 598-610),
+  not just the latter.
+- **AC-7 docs sweep verified by grep step** (per critic PC-CL2): Task
+  8.3 mandates the implementer grep `QS-177.*AC #12` + `known
+  limitation` across `docs/` + `scripts/qs/` to catch any reference
+  the plan missed.
+- **AC-8 manual test acknowledged** (per scope-guardian SG-CL1): the
+  issue's "[ ] Manual test" checkbox is satisfied as a PR-review
+  responsibility (evidence pasted into the PR description), not by an
+  invented automated E2E harness.
+
+Issues NOT actioned: none. The two reviewer-raised "out of scope"
+items (CL2 `--next-cmd` form normalisation, CL5 rollback plan) are
+documented in the "Out of scope" section above for traceability.

--- a/docs/stories/QS-190.story_review_fix_#01.md
+++ b/docs/stories/QS-190.story_review_fix_#01.md
@@ -1,0 +1,481 @@
+# QS-190 — Review fix plan #01
+
+## Summary
+- Source PR: #192
+- Source story: `docs/stories/QS-190.story.md`
+- Findings to fix: 27 (2 must-fix + 13 should-fix + 12 nice-to-have)
+- Next implement phase: `/implement-setup-task`
+
+Adversarial review (qs-review-blind-hunter, qs-review-edge-case-hunter,
+qs-review-acceptance-auditor, qs-review-coderabbit) produced 27
+actionable findings; the user requested "fix all". CodeRabbit was
+rate-limited and returned no file-level findings (1 invalid entry, not
+included here).
+
+## Findings to fix
+
+### must-fix
+
+#### M1 — `is_file()` swallows `PermissionError` in pre-flight
+- File: `scripts/qs/spawn_session.py:614-615`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: `expected.is_file()` returns `False` silently when the
+  parent directory is unreadable (e.g., `0o000` mode). The pre-flight
+  then emits `agent_file_missing` even though the file is physically
+  present, misleading the user into creating a duplicate file. The
+  actual fix is `chmod`, but the diagnostic doesn't say so.
+- Proposed fix: Wrap the `is_file()` check in `try/except OSError`. On
+  `OSError`, emit a distinct `agent_file_unreadable` status (and
+  corresponding stderr message) carrying the OS-level errno. Keep
+  `agent_file_missing` for the bona-fide "file does not exist on disk"
+  case (re-stat with `expected.parent.exists()` to distinguish).
+- Tests: add `test_preflight_emits_unreadable_when_parent_dir_unreadable`
+  in `tests/qs/test_spawn_session.py` (mock `Path.is_file` to raise
+  `PermissionError`; assert status, stderr msg, exit code 2).
+
+#### M2 — AC-8 evidence (manual smoke-test screenshot/transcript) absent from PR body
+- File: PR #192 description
+- Severity: must-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC-8 explicitly requires the author to attach a
+  screenshot/transcript of a manual smoke test showing a fresh
+  OpenCode session in the sidebar after the agent executed
+  `new_context`. The current PR body only carries the standard
+  template — no evidence.
+- Proposed fix: The implementer (or the user) must:
+  1. Reproduce the auto-execute flow once locally in OpenCode
+     (e.g., run `qs-create-plan` against an existing worktree, observe
+     the new `qs-implement-setup-task` session appear in the sidebar).
+  2. Capture a screenshot or terminal transcript.
+  3. Edit the PR body via `gh pr edit 192 --body-file <path>` and
+     append a "## Manual smoke test (AC-8)" section linking to or
+     embedding the evidence.
+- Tests: N/A (this is a one-time PR-author obligation, not a regression
+  test). No code change required.
+
+### should-fix
+
+#### S1 — `from pathlib import Path` out of alphabetical order
+- File: `scripts/qs/spawn_session.py:78`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: New `from pathlib import Path` is inserted after the
+  `urllib.*` block; `pathlib` should come before `urllib` alphabetically
+  in the stdlib group (Ruff/isort `I001`).
+- Proposed fix: Move `from pathlib import Path` above
+  `import urllib.error`. Run `ruff format scripts/qs/spawn_session.py`
+  and `ruff check scripts/qs/spawn_session.py --select I` to verify.
+- Tests: caught by the quality gate (`ruff check`).
+
+#### S2 — Test regex doesn't require `scripts/qs/` prefix
+- File: `tests/qs/agents/test_harness_flag_explicit.py:60-71` (the
+  regex inside `test_callsite_passes_explicit_harness_flag`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: Regex matches `next_step.py|setup_task.py` without the
+  `scripts/qs/` prefix. Could match prose mentions ("Parse the JSON
+  output of next_step.py") rather than the actual bash invocation.
+  The sibling `test_thirteen_callsites_total` already uses the
+  prefixed form — they should be consistent.
+- Proposed fix: Update the regex to require `scripts/qs/` prefix:
+  `r"scripts/qs/(next_step\.py|setup_task\.py).{0,400}?--harness\s+{harness}\b"`.
+- Tests: the test itself.
+
+#### S3 — Hard-coded `total == 13` is brittle
+- File: `tests/qs/agents/test_harness_flag_explicit.py:90-93`
+  (`test_thirteen_callsites_total`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: A new agent file that legitimately adds a callsite
+  would fail the test even when the new callsite carries `--harness`.
+  More useful: count callsites *missing* `--harness` and assert
+  the count is zero.
+- Proposed fix: Rewrite the test to:
+  1. For each `(file, harness)` pair, count `scripts/qs/(next_step|setup_task)\.py`
+     callsite occurrences.
+  2. For the same `(file, harness)`, count
+     `scripts/qs/(next_step|setup_task)\.py.{0,400}?--harness\s+{harness}\b`
+     matches.
+  3. Assert the two counts are equal (every callsite must carry
+     `--harness`).
+  4. Keep an aggregate sanity check (`total >= 13`) but not strict
+     equality; document the AC-1 enumeration table as the canonical
+     reference.
+- Tests: the test itself.
+
+#### S4 — autouse pre-flight stub fixture masks real check
+- File: `tests/qs/test_spawn_session.py:55-68`
+  (`_stub_agent_file_preflight`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The autouse fixture replaces `spawn_session._agent_file_path`
+  for every test by default. Future tests can silently pass even if
+  the real pre-flight regresses, because they never exercise it.
+- Proposed fix: Flip the fixture from opt-out (`autouse=True` + opt-out
+  marker) to opt-in. Define a fixture named `stub_agent_file_preflight`
+  (no `autouse`) and explicitly use it via `pytest.fixture` injection
+  in tests that need it. The two new pre-flight tests
+  (`test_preflight_aborts_when_agent_file_missing`,
+  `test_preflight_passes_when_agent_file_present`) skip the stub. All
+  other existing tests opt in via fixture injection.
+- Tests: the existing test suite must still pass with explicit opt-in.
+
+#### S5 — TOCTOU race in pre-flight
+- File: `scripts/qs/spawn_session.py:614-632`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: File can be deleted between `is_file()` check and the
+  HTTP `POST /session/<id>/prompt_async` call. A concurrent IDE rename
+  reproduces this. The closed-limitation docstring ("closes QS-177
+  AC #12") becomes technically incorrect.
+- Proposed fix: Reword the closed-limitation docstring at all three
+  sites (spawn_session.py, opencode launcher, harness.md) to clarify
+  the pre-flight is **best-effort**: "spawn_session.py performs a
+  pre-flight check that aborts before issuing the HTTP request when
+  the agent file is missing at check time; a TOCTOU window remains
+  for files deleted in the millisecond between check and request."
+  No code change to the check itself — the cost of a second stat would
+  not eliminate the window, only shrink it further.
+- Tests: pin the new docstring substring in
+  `test_build_payload_documents_closed_limitation` and
+  `test_harness_md_documents_closed_limitation`.
+
+#### S6 — Pre-flight accepts zero-byte agent files
+- File: `scripts/qs/spawn_session.py:614-615`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `is_file()` returns True for a 0-byte file (`touch`'d
+  placeholder, partial checkout). OpenCode's server falls back to the
+  default agent — re-opens the QS-177 AC #12 silent-fallback hole.
+  The test `test_preflight_passes_when_agent_file_present` literally
+  uses `touch()` to create an empty file, confirming the gap.
+- Proposed fix: Add `expected.stat().st_size > 0` check to the
+  pre-flight. If size is zero, emit a new status
+  `agent_file_empty` with a stderr message pointing the user at
+  the file path. Update the test to write a minimal valid YAML
+  frontmatter (`---\nmode: subagent\n---\n`) instead of `touch()`.
+- Tests:
+  - Update `test_preflight_passes_when_agent_file_present` to write
+    `"---\nmode: subagent\n---\n"`.
+  - Add `test_preflight_emits_empty_when_agent_file_zero_bytes`.
+
+#### S7 — Auto-execute comparison string uses unsubstituted Jinja placeholders
+- File: `.opencode/agents/qs-create-plan.md` (auto-execute block) and
+  `.opencode/agents/qs-review-task.md` (fix-plan auto-execute block)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The comparison strings `agent == "qs-{{NEXT_PHASE}}"`
+  and `agent == "qs-{{next_implement}}"` rely on the LLM agent
+  substituting the template before comparing. Critic PC-C2 already
+  flagged this pattern elsewhere and it slipped through here. If the
+  LLM compares literally, a successful spawn looks like a failure.
+- Proposed fix: Rewrite the contract in prose:
+  - `status == "session_created"` AND `agent` equals `qs-` followed by
+    the phase name passed to `--next-cmd` (e.g., `qs-implement-task`
+    when `--next-cmd "implement-task"` was passed). Apply across all
+    four mid-pipeline OpenCode agent files for consistency
+    (`qs-create-plan.md`, `qs-implement-task.md`,
+    `qs-implement-setup-task.md`, both blocks in `qs-review-task.md`).
+- Tests: pin the new prose phrase ("equals `qs-` followed by the
+  phase name") in `test_opencode_execute_contract.py`.
+
+#### S8 — Auto-execute prose doesn't handle `next_step.py` failure
+- File: All four OpenCode mid-pipeline agents'
+  auto-execute blocks (`.opencode/agents/qs-create-plan.md`,
+  `qs-implement-task.md`, `qs-implement-setup-task.md`,
+  `qs-review-task.md` — both blocks).
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: If `next_step.py` itself returns an error JSON
+  (`{"error": "unknown phase", ...}` with exit 1), `new_context` is
+  absent. Current prose says "capture `new_context`" without telling
+  the agent to check for `error` first.
+- Proposed fix: Prepend a sentence in each auto-execute block:
+  "If the `next_step.py` JSON contains an `error` key, STOP and print
+  the raw JSON to the user. Do not proceed to run `new_context`."
+- Tests: pin the substring "If the `next_step.py` JSON contains an
+  `error` key" in `test_opencode_execute_contract.py`.
+
+#### S9 — Fix-plan auto-execute doesn't handle absent `existing_session_prompt`
+- File: `.opencode/agents/qs-review-task.md:249-253` (fix-plan
+  block)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `next_step.py`'s `build_existing_session_prompt`
+  returns None when `fix_plan_path` is whitespace-only, omitting the
+  key. The agent would then interpolate the literal token
+  `{{existing_session_prompt}}` into its output.
+- Proposed fix: Two-part:
+  1. (Optional, defense in depth) In `scripts/qs/next_step.py`, when
+     `build_existing_session_prompt` returns None, still include
+     `existing_session_prompt: null` in the JSON payload so the field
+     is never missing.
+  2. In `qs-review-task.md` fix-plan prose: "If
+     `existing_session_prompt` is missing or null, omit the
+     'Already running an implementation session?' block; only emit it
+     when the field is a non-empty string."
+- Tests:
+  - Add `test_payload_includes_null_existing_session_prompt_when_omitted`
+    in `tests/qs/test_next_step.py`.
+  - Pin the conditional emission prose in
+    `test_opencode_execute_contract.py`.
+
+#### S10 — Regex 400-char bound can cross-contaminate callsites
+- File: `tests/qs/agents/test_harness_flag_explicit.py:32-34, 60-71`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `qs-review-task.md` carries two `next_step.py`
+  callsites. The non-greedy `.{0,400}?` regex could pair callsite #1
+  with the `--harness` flag from callsite #2 if a future refactor
+  brings them within 400 chars of each other.
+- Proposed fix: Replace the regex with a code-fence-scoped check:
+  parse the markdown into ```` ```bash ```` fenced blocks; assert each
+  bash block containing `scripts/qs/(next_step|setup_task)\.py` also
+  contains `--harness <expected-name>` *within the same fence*.
+  Documents the canonical relationship rather than tolerating it via
+  bound-tuning.
+- Tests: the test itself; covers S2/S3/S10 together.
+
+#### S11 — Auto-execute blocks don't disambiguate Bash-level failure
+- File: All four OpenCode mid-pipeline agents'
+  auto-execute blocks.
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Contract lumps all post-Bash failure modes into "STOP +
+  print raw JSON". When the Bash tool itself fails (sandbox denial,
+  missing allow rule), there is no JSON — only a tool error. User
+  gets no clear diagnostic.
+- Proposed fix: Add a sentence to each auto-execute block: "If the
+  Bash tool returns an error *before* producing any JSON output (e.g.,
+  permission denied, missing interpreter), STOP and print the Bash
+  tool's error message verbatim. Do not attempt to parse JSON."
+- Tests: pin the substring "If the Bash tool returns an error before
+  producing any JSON output" in `test_opencode_execute_contract.py`.
+
+#### S12 — Missing automated pin on `scripts/qs/spawn_session.py`'s docstring (AC-7)
+- File: `tests/qs/test_spawn_session.py` (test missing)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC-7 mandates the exact substring "spawn_session.py
+  performs a pre-flight check" at three sites: launcher docstring,
+  `harness.md`, AND `spawn_session.py`'s own module docstring. The
+  first two are pinned by tests; the third is not.
+- Proposed fix: Add `test_spawn_session_docstring_documents_closed_limitation`
+  in `tests/qs/test_spawn_session.py`, mirroring the two existing pin
+  tests. Read `scripts/qs/spawn_session.py`, slice the module
+  docstring, assert the substring is present.
+- Tests: the test itself.
+
+#### S13 — Missing automated pin on the AC-5 rationale paragraph
+- File: `tests/qs/agents/test_opencode_execute_contract.py`
+  (`test_opencode_setup_task_preserves_print_for_user`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC-5 requires the rationale block in
+  `.opencode/agents/qs-setup-task.md`, but the existing test only
+  asserts the EXECUTE_MARKER is absent. A future agent-file edit
+  could silently remove the rationale.
+- Proposed fix: Extend the test with an assertion pinning a
+  distinctive substring: `assert "Why setup-task stays print-for-user"
+  in body` (or any unique phrase from the rationale block).
+- Tests: the test itself.
+
+### nice-to-have
+
+#### N1 — Cosmetic blank-line collapse after `import pytest`
+- File: `tests/qs/launchers/test_opencode_launcher.py:22`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Two consecutive blank lines collapsed to one.
+- Proposed fix: Restore the double blank line if isort/ruff prefers
+  it; otherwise leave as-is. Run `ruff format` to canonicalize.
+- Tests: caught by quality gate.
+
+#### N2 — Removed blank line between imports
+- File: `tests/qs/launchers/test_opencode_launcher.py:639`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Blank line between `import spawn_session` and
+  `from launchers import opencode as opencode_launcher` removed.
+  Possible isort group concern.
+- Proposed fix: Run `ruff format` on the file; accept whatever the
+  formatter produces.
+- Tests: caught by quality gate.
+
+#### N3 — `✅` emoji usage in agent file success-report text
+- File: `.opencode/agents/qs-create-plan.md`,
+  `qs-implement-task.md`, `qs-implement-setup-task.md`,
+  `qs-review-task.md` (auto-execute report blocks).
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Project rules: "Only use emojis if the user explicitly
+  requests it." The success-report text uses `✅`. This is a directive
+  the agent prints to the user, so emoji is borderline acceptable —
+  but project-rules forbid it without explicit ask.
+- Proposed fix: Replace `✅` with `[OK]` or `Done:` in every
+  affected line across the four agent files. Apply consistently to
+  parallel Claude/Cursor agent files for consistency.
+- Tests: extend the existing `test_*_preserves_print_for_user` /
+  `test_opencode_agent_auto_executes_new_context` assertions to fail
+  on the `✅` character if present.
+
+#### N4 — Large story file (826 lines)
+- File: `docs/stories/QS-190.story.md`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The story carries inline adversarial-review notes that
+  contribute to a 826-line file.
+- Proposed fix: No action this round — the inline review notes
+  document the planning rationale and are valuable. Acknowledge as
+  acceptable; do not split into a separate file.
+- Tests: N/A.
+
+#### N5 — Duplicated canonical auto-execute block across agent files
+- File: `.opencode/agents/qs-create-plan.md`,
+  `qs-implement-task.md`, `qs-implement-setup-task.md`, `qs-review-task.md`
+  (two blocks each).
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The canonical auto-execute prose is duplicated ~5x.
+  A shared include/anchor would reduce drift risk.
+- Proposed fix: Defer. The test contract pins the marker phrase
+  across all callsites, providing drift protection. Extracting a
+  shared snippet would require a new include mechanism in the
+  agent-file format. Out of scope for this fix round; track as a
+  separate refactor task if drift becomes an issue.
+- Tests: N/A.
+
+#### N6 — Dangling-symlink `--directory` misdiagnoses error
+- File: `scripts/qs/spawn_session.py:614-615`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: When the worktree directory itself is a dangling
+  symlink, the pre-flight reports "agent file not found" — misleading.
+- Proposed fix: Add a pre-pre-flight check on `args.directory`: if
+  `Path(args.directory).is_dir()` is False, emit a new status
+  `worktree_invalid` with a stderr message pointing at the directory.
+  Place this check before the agent-file pre-flight.
+- Tests: add `test_preflight_emits_worktree_invalid_when_directory_missing`.
+
+#### N7 — Asymmetric `choices=` source between callers
+- File: `scripts/qs/setup_task.py:57` vs `scripts/qs/next_step.py:132`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `setup_task.py` uses `choices=list(VALID_HARNESSES)`;
+  `next_step.py` uses `choices=list(LAUNCHERS)`. Identical today;
+  could drift if `harness.py` adds a name without a matching
+  launcher.
+- Proposed fix: Align `setup_task.py` to `choices=list(LAUNCHERS)`
+  (same one `next_step.py` uses). Add an inline comment referencing
+  `next_step.py`'s rationale.
+- Tests: existing `test_setup_task_*` tests should still pass; add
+  one that asserts both scripts use `list(LAUNCHERS)`.
+
+#### N8 — `QS_HARNESS=claude` legacy alias rejected by `--harness claude`
+- File: `scripts/qs/harness.py:45-46`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `detect()` accepts the legacy alias `claude` (maps to
+  `claude-code`); explicit `--harness claude` fails argparse with
+  exit 2.
+- Proposed fix: Add a small `_canonicalize(name: str) -> str` helper
+  in `harness.py` that maps legacy aliases (`claude` → `claude-code`,
+  etc.) to canonical names. Both `setup_task.py` and `next_step.py`
+  call it on `args.harness` before using the value.
+- Tests:
+  - `test_canonicalize_legacy_alias` in `tests/qs/test_harness.py`.
+  - End-to-end test: passing `--harness claude` to either script
+    produces the same launcher output as `--harness claude-code`.
+
+#### N9 — `agent_file_missing` payload omits `prompt` field
+- File: `scripts/qs/spawn_session.py:611-632`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Every other failure payload (`fallback_cli`,
+  `session_orphaned`, `fallback_unavailable`) includes the `prompt`
+  field; `agent_file_missing` does not.
+- Proposed fix: Add `"prompt": args.prompt` to the
+  `agent_file_missing` payload.
+- Tests: update `test_preflight_aborts_when_agent_file_missing` to
+  assert the `prompt` field is present and equals the input.
+
+#### N10 — `{{NEXT_PHASE}}` substitution failure not defended against
+- File: `.opencode/agents/qs-create-plan.md` (and siblings)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: If the LLM runs the bash block verbatim with
+  `--next-cmd "{{NEXT_PHASE}}"` unsubstituted, `next_step.py` will
+  emit an error. The error handling from S8 catches it, but earlier
+  defense is better.
+- Proposed fix: Add a "**Before running** — substitute `{{NEXT_PHASE}}`
+  with the next phase name you determined above (one of:
+  `implement-task`, `implement-setup-task`)" instruction line above
+  the bash block. (Pair across siblings as appropriate.)
+- Tests: pin the substring "**Before running** — substitute" in the
+  existing agent-file contract tests.
+
+#### N11 — Comment in `test_thirteen_callsites_total` referencing AC-1 table
+- File: `tests/qs/agents/test_harness_flag_explicit.py`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: AC-1 enumeration table is the authoritative list of
+  callsites. The test should reference it so a future reader knows
+  where to update.
+- Proposed fix: Add a docstring/comment in the test pointing at
+  `docs/stories/QS-190.story.md` AC-1 enumeration.
+- Tests: the test itself (documentation only).
+
+#### N12 — Clarifying comment that `{{next_implement}}` is a substitution prompt
+- File: `.opencode/agents/qs-review-task.md` (fix-plan
+  auto-execute block)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: Subsumed by S7 — the prose rewrite for S7 already
+  removes the literal `{{next_implement}}` from the comparison
+  string, replacing it with prose. No additional action needed.
+- Proposed fix: Confirm S7 application also satisfies N12. No
+  separate work item.
+- Tests: covered by S7.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. The implementation
+order should be:
+
+1. **S5 (docstring rewording, three sites)** — purely documentation;
+   no behavior change.
+2. **M1 + S6 + N6 + N9 (pre-flight refinements)** — refactor the
+   pre-flight block into a small helper that returns one of
+   {`ok`, `agent_file_missing`, `agent_file_unreadable`,
+   `agent_file_empty`, `worktree_invalid`}; expand the
+   `agent_file_missing` payload to include `prompt`; corresponding
+   test additions.
+3. **S1 (pathlib import order)** — fixed automatically by
+   `ruff format`.
+4. **S2 + S3 + S10 + N11 (test_harness_flag_explicit refactor)** —
+   replace the regex with a code-fence-scoped check; drop the
+   strict `total == 13` for a per-file "no missing flag" assertion;
+   add the AC-1 reference comment.
+5. **S4 (autouse → opt-in stub)** — refactor the fixture; update
+   call sites.
+6. **S7 + S8 + S11 + N10 (auto-execute prose hardening)** — across
+   all four mid-pipeline OpenCode agents (8 blocks total counting
+   `qs-review-task.md`'s two blocks); pin new substrings in
+   `test_opencode_execute_contract.py`.
+7. **S9 (existing_session_prompt null handling)** — change
+   `scripts/qs/next_step.py` to always emit the key (null when not
+   applicable); update `qs-review-task.md` prose.
+8. **S12 + S13 (missing pin tests)** — two new tests.
+9. **N3 (emoji removal)** — straight find-and-replace across the
+   relevant agent files; update assertions to forbid `✅`.
+10. **N7 + N8 (CLI symmetry + legacy alias)** — small helper in
+    `harness.py`, both scripts use it.
+11. **N1 + N2 + N4 + N5 (cosmetic / accepted)** — N1/N2 fixed by
+    `ruff format`; N4/N5 documented as accepted-deferred.
+12. **M2 (PR body update)** — author/user runs `gh pr edit 192 --body-file`
+    after the implementation push lands and they have a screenshot or
+    transcript on hand. This is a one-time PR-author obligation and
+    does NOT block the implementation push.
+
+When done, return and run `/review-task` again to re-verify.

--- a/docs/workflow/harness.md
+++ b/docs/workflow/harness.md
@@ -62,11 +62,15 @@ no filesystem scan, so this works from any CWD.
   the new worktree is a different OpenCode workspace. Falls back to
   the CLI form when the OpenCode server is unreachable
   (`shutil.which('opencode')` probe required). **Closed limitation**
-  (QS-177 AC #12, closed by QS-190):
+  (QS-177 AC #12, closed by QS-190 — best-effort):
   spawn_session.py performs a pre-flight check on
-  `<work_dir>/.opencode/agents/<agent>.md` before the HTTP API call;
-  a missing agent file now produces a clean `agent_file_missing`
-  exit shape instead of silently landing on the default agent.
+  `<work_dir>/.opencode/agents/<agent>.md` (existence + readability +
+  non-empty) AND on the worktree directory itself before the HTTP API
+  call; missing / unreadable / empty agent files and an invalid
+  worktree produce clean `agent_file_missing` / `agent_file_unreadable` /
+  `agent_file_empty` / `worktree_invalid` exit shapes instead of
+  silently landing on the default agent. A TOCTOU window remains
+  between the pre-flight and the HTTP request.
 - **`launchers/codex.py`** — stub.
 
 All launchers return a dict with at minimum:

--- a/docs/workflow/harness.md
+++ b/docs/workflow/harness.md
@@ -61,11 +61,12 @@ no filesystem scan, so this works from any CWD.
   `opencode <worktree> --agent <name>` invocation instead, because
   the new worktree is a different OpenCode workspace. Falls back to
   the CLI form when the OpenCode server is unreachable
-  (`shutil.which('opencode')` probe required). **Known limitation**:
-  requires static `.opencode/agents/qs-<phase>.md` files (mirror of
-  `.claude/agents/`); without them, the API call succeeds but the
-  session lands on the default OpenCode agent. Mirroring these files
-  is a follow-up task; this PR only ships the launcher.
+  (`shutil.which('opencode')` probe required). **Closed limitation**
+  (QS-177 AC #12, closed by QS-190):
+  spawn_session.py performs a pre-flight check on
+  `<work_dir>/.opencode/agents/<agent>.md` before the HTTP API call;
+  a missing agent file now produces a clean `agent_file_missing`
+  exit shape instead of silently landing on the default agent.
 - **`launchers/codex.py`** — stub.
 
 All launchers return a dict with at minimum:

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,7 +22,6 @@ markers =
     integration: mark test as integration test
     unit: mark test as unit test
     slow: mark test as slow running
-    real_preflight: opt out of the QS-190 agent-file pre-flight autouse stub (exercises the real filesystem check)
 
 # Ignore patterns
 testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,6 +22,7 @@ markers =
     integration: mark test as integration test
     unit: mark test as unit test
     slow: mark test as slow running
+    real_preflight: opt out of the QS-190 agent-file pre-flight autouse stub (exercises the real filesystem check)
 
 # Ignore patterns
 testpaths = tests

--- a/scripts/qs/harness.py
+++ b/scripts/qs/harness.py
@@ -35,15 +35,54 @@ Harness = Literal["claude-code", "cursor", "opencode", "codex"]
 
 VALID_HARNESSES: tuple[Harness, ...] = ("claude-code", "cursor", "opencode", "codex")
 
+# Legacy-alias map. ``detect`` (QS_HARNESS env var) and ``canonicalize``
+# (--harness argparse flag, review fix #01 N8) share this table so the
+# two entry points agree on what the user-typed name resolves to.
+_LEGACY_ALIASES: dict[str, str] = {
+    "claude": "claude-code",
+    "claude_code": "claude-code",
+    "claudecode": "claude-code",
+}
+
+
+def canonicalize(name: str) -> str:
+    """Return the canonical harness name, mapping legacy aliases through.
+
+    Idempotent: a canonical name passes through unchanged. An unknown
+    name passes through unchanged too — argparse's ``choices=`` is
+    the upstream guard that rejects garbage; ``canonicalize`` only
+    collapses the documented aliases (review fix #01 N8).
+
+    Whitespace and case are normalised before mapping so a user-typed
+    ``"  Claude  "`` resolves the same as ``"claude-code"``.
+    """
+    normalised = name.lower().strip()
+    if normalised in _LEGACY_ALIASES:
+        return _LEGACY_ALIASES[normalised]
+    return normalised if normalised in VALID_HARNESSES else name
+
+
+def harness_choices() -> list[str]:
+    """Return the full list of acceptable ``--harness`` argparse choices.
+
+    Includes the canonical names AND every legacy alias from
+    ``_LEGACY_ALIASES`` so a user typing ``--harness claude`` passes
+    argparse's ``choices=`` guard (review fix #01 N8). ``canonicalize``
+    is then applied post-argparse to collapse aliases to canonical
+    names before dispatch.
+    """
+    return [*VALID_HARNESSES, *_LEGACY_ALIASES.keys()]
+
 
 def detect() -> Harness:
     """Return the detected harness, defaulting to ``claude-code``."""
     explicit = os.environ.get("QS_HARNESS", "").lower().strip()
     if explicit in VALID_HARNESSES:
         return explicit  # type: ignore[return-value]
-    # Legacy alias kept for ergonomics.
-    if explicit in ("claude", "claude_code", "claudecode"):
-        return "claude-code"
+    # Legacy alias kept for ergonomics — shares the same table as
+    # ``canonicalize`` (review fix #01 N8).
+    if explicit in _LEGACY_ALIASES:
+        return _LEGACY_ALIASES[explicit]  # type: ignore[return-value]
 
     if os.environ.get("CLAUDECODE"):
         return "claude-code"

--- a/scripts/qs/launchers/opencode.py
+++ b/scripts/qs/launchers/opencode.py
@@ -24,13 +24,12 @@ is unreachable; ``spawn_session.py`` decides the fallback at runtime
 and surfaces the result via stdout JSON. See the script's docstring
 for the full fallback decision tree.
 
-Known limitation (per QS-177 AC #12): the activation API call succeeds
-even when ``.opencode/agents/qs-<phase>.md`` does not yet exist, but
-the session lands on the default OpenCode agent instead of the
-intended phase orchestrator. Mirror ``.claude/agents/*.md`` into
-``.opencode/agents/`` (with frontmatter conversion: ``tools:`` →
-``permission:``, ``mode: primary`` / ``mode: subagent``) to enable
-agent activation. This is a documented follow-up, not a silent bug.
+Closed limitation (per QS-177 AC #12, closed by QS-190):
+spawn_session.py performs a pre-flight check that verifies
+``<work_dir>/.opencode/agents/<agent>.md`` exists before calling the
+HTTP API. If the agent file is missing, the script emits
+``status: "agent_file_missing"`` and exits 2 — the API can no longer
+silently land the session on the default agent.
 """
 
 from __future__ import annotations

--- a/scripts/qs/launchers/opencode.py
+++ b/scripts/qs/launchers/opencode.py
@@ -24,12 +24,16 @@ is unreachable; ``spawn_session.py`` decides the fallback at runtime
 and surfaces the result via stdout JSON. See the script's docstring
 for the full fallback decision tree.
 
-Closed limitation (per QS-177 AC #12, closed by QS-190):
+Closed limitation (per QS-177 AC #12, closed by QS-190 — best-effort):
 spawn_session.py performs a pre-flight check that verifies
-``<work_dir>/.opencode/agents/<agent>.md`` exists before calling the
-HTTP API. If the agent file is missing, the script emits
-``status: "agent_file_missing"`` and exits 2 — the API can no longer
-silently land the session on the default agent.
+``<work_dir>/.opencode/agents/<agent>.md`` exists, is readable, and is
+non-empty before calling the HTTP API; an invalid worktree directory
+is also caught. The script emits ``status: "agent_file_missing"`` /
+``agent_file_unreadable`` / ``agent_file_empty`` / ``worktree_invalid``
+and exits 2 as appropriate — the API can no longer silently land the
+session on the default agent at check time. A TOCTOU window remains
+for files deleted between the pre-flight and the HTTP request; this
+is acceptable.
 """
 
 from __future__ import annotations

--- a/scripts/qs/next_step.py
+++ b/scripts/qs/next_step.py
@@ -75,7 +75,9 @@ from __future__ import annotations
 import argparse
 import sys
 
+from harness import canonicalize as canonicalize_harness  # type: ignore[import-not-found]
 from harness import detect as detect_harness
+from harness import harness_choices
 from launchers import claude as claude_launcher  # type: ignore[import-not-found]
 from launchers import codex as codex_launcher  # type: ignore[import-not-found]
 from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
@@ -121,15 +123,13 @@ def main() -> None:
     parser.add_argument(
         "--harness",
         default=None,
-        # Use ``LAUNCHERS`` (this module's dispatch table) rather than
-        # ``VALID_HARNESSES`` (harness.py's enum) as the choices source.
-        # The two sets are identical today but ``LAUNCHERS`` is the
-        # actual source of truth for what this script can dispatch — if
-        # someone ever adds a harness to ``VALID_HARNESSES`` without a
-        # corresponding launcher, argparse rejects the bad value cleanly
-        # instead of letting it KeyError inside main(). Review-fix #04
-        # NTH7.
-        choices=list(LAUNCHERS),
+        # ``harness_choices()`` returns the canonical names PLUS the
+        # legacy aliases (review fix #01 N7 + N8): the canonical names
+        # match ``LAUNCHERS`` (this module's dispatch table), and the
+        # aliases let a user typing ``--harness claude`` pass argparse
+        # before ``canonicalize`` collapses it to ``claude-code`` for
+        # dispatch.
+        choices=harness_choices(),
         help="Override the detected harness.",
     )
     # Optional flags for the review-task → implement-task common loop.
@@ -193,7 +193,11 @@ def main() -> None:
     if args.pr_number is not None and args.pr_number <= 0:
         parser.error("--pr-number must be a positive integer")
 
-    harness = args.harness or detect_harness()
+    # Canonicalize legacy aliases (review fix #01 N8) before dispatch
+    # so the ``LAUNCHERS[harness]`` lookup is keyed on the canonical
+    # name — even if the user typed an alias accepted by
+    # ``harness_choices()``.
+    harness = canonicalize_harness(args.harness) if args.harness else detect_harness()
     launcher = LAUNCHERS[harness]
     # Delegate validation to the launcher: claude/cursor enforce the
     # phase mapping inside ``build_payload``; codex/opencode accept any
@@ -225,6 +229,14 @@ def main() -> None:
         })
         sys.exit(1)
     payload["harness"] = harness
+    # Review fix #01 S9: always emit ``existing_session_prompt`` so the
+    # consuming agent prose has a single shape to check
+    # (``null`` vs. non-empty string) instead of distinguishing
+    # ``key missing`` from ``key present but null``. The launchers
+    # only add the key when both ``--fix-plan-path`` and ``--pr-number``
+    # are provided; ``setdefault`` fills the gap without overriding a
+    # legitimate launcher-emitted value.
+    payload.setdefault("existing_session_prompt", None)
     output_json(payload)
     sys.exit(0)
 

--- a/scripts/qs/setup_task.py
+++ b/scripts/qs/setup_task.py
@@ -17,8 +17,9 @@ import argparse
 import subprocess
 import sys
 
-from harness import VALID_HARNESSES  # type: ignore[import-not-found]
+from harness import canonicalize as canonicalize_harness  # type: ignore[import-not-found]
 from harness import detect as detect_harness
+from harness import harness_choices
 from launchers import claude as claude_launcher  # type: ignore[import-not-found]
 from launchers import codex as codex_launcher  # type: ignore[import-not-found]
 from launchers import cursor as cursor_launcher  # type: ignore[import-not-found]
@@ -54,7 +55,11 @@ def main() -> None:
     parser.add_argument(
         "--harness",
         default=None,
-        choices=list(VALID_HARNESSES),
+        # ``harness_choices()`` returns the canonical names PLUS the
+        # legacy aliases (review fix #01 N7 + N8) so a user typing
+        # ``--harness claude`` passes argparse and is canonicalized to
+        # ``claude-code`` before dispatch.
+        choices=harness_choices(),
         help="Override the detected harness.",
     )
     parser.add_argument(
@@ -99,7 +104,11 @@ def main() -> None:
 
     title = args.title or f"Issue #{issue}"
 
-    harness = args.harness or detect_harness()
+    # Apply the legacy-alias mapping (review fix #01 N8): argparse
+    # accepted aliases via ``choices=harness_choices()``; canonicalize
+    # collapses them to canonical names before dispatch so the
+    # ``LAUNCHERS[harness]`` lookup never KeyErrors on a legacy alias.
+    harness = canonicalize_harness(args.harness) if args.harness else detect_harness()
     launcher = LAUNCHERS[harness]
     # ``caller="setup_task"`` tells the OpenCode launcher that this is
     # the Phase 1 → create-plan cross-workspace handoff (the new worktree

--- a/scripts/qs/spawn_session.py
+++ b/scripts/qs/spawn_session.py
@@ -31,13 +31,19 @@ up). On DELETE failure the orphan session id is surfaced via
 ``status: "session_orphaned"`` (exit 2) so the user can clean it up
 manually in the OpenCode UI.
 
-Known limitation (per AC #12 of QS-177): the kickoff API succeeds
-even when ``.opencode/agents/qs-<phase>.md`` does not yet exist, but
-the session lands on the default OpenCode agent instead of the
-intended phase orchestrator. Mirror ``.claude/agents/*.md`` into
-``.opencode/agents/`` (with frontmatter conversion: ``tools:`` →
-``permission:``, ``mode: primary`` / ``mode: subagent``) to enable
-agent activation. This is a documented follow-up, not a silent bug.
+- **Agent-file pre-flight** (QS-190): before any HTTP call, ``main()``
+  verifies that ``<directory>/.opencode/agents/<agent>.md`` exists. If
+  not, the script emits ``{"status": "agent_file_missing", ...}`` on
+  stdout, a clear error on stderr, and exits 2 (parallel to the
+  ``fallback_unavailable`` branch shape). This closes the QS-177 AC #12
+  known limitation where a missing agent file silently lands the
+  session on the default OpenCode agent.
+
+Closed limitation (per QS-177 AC #12, closed by QS-190):
+spawn_session.py performs a pre-flight check that aborts with
+``status: "agent_file_missing"`` before the HTTP API can silently
+land a session on the default agent. The pre-flight is documented
+in the CLI fallback semantics section above.
 
 Usage::
 
@@ -69,6 +75,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 
 from utils import output_json  # type: ignore[import-not-found]
 
@@ -474,6 +481,16 @@ def _emit_fallback(
     )
 
 
+def _agent_file_path(directory: str, agent: str) -> Path:
+    """Return the expected ``.opencode/agents/<agent>.md`` path under ``directory``.
+
+    Centralises the convention so the pre-flight guard in ``main()``
+    and any future caller (e.g. the OpenCode launcher's CLI-form
+    branch in ``launchers/opencode.py``) compute the same path.
+    """
+    return Path(directory) / ".opencode" / "agents" / f"{agent}.md"
+
+
 def _reject_control_chars(
     parser: argparse.ArgumentParser, name: str, value: str,
 ) -> None:
@@ -589,6 +606,30 @@ def main() -> None:
     args.prompt = args.prompt.strip()
     if args.title is not None:
         args.title = args.title.strip()
+
+    # Pre-flight: verify the target agent file exists in the worktree.
+    # Without this, the OpenCode HTTP API silently lands the session on the
+    # default agent if .opencode/agents/<agent>.md is missing — the
+    # QS-177 AC #12 known limitation. Closes that gap (QS-190 AC-2).
+    expected = _agent_file_path(args.directory, args.agent)
+    if not expected.is_file():
+        detail = (
+            f"ERROR: OpenCode agent file not found at {expected}; "
+            f"the HTTP API would silently fall back to the default agent. "
+            f"Mirror .claude/agents/{args.agent}.md into .opencode/agents/ "
+            f"or create the file before retrying."
+        )
+        sys.exit(_emit(
+            {
+                "status": "agent_file_missing",
+                "agent": args.agent,
+                "directory": args.directory,
+                "expected_path": str(expected),
+                "detail": detail,
+            },
+            stderr_msg=detail,
+            exit_code=2,
+        ))
 
     try:
         result = spawn_session(

--- a/scripts/qs/spawn_session.py
+++ b/scripts/qs/spawn_session.py
@@ -32,18 +32,32 @@ up). On DELETE failure the orphan session id is surfaced via
 manually in the OpenCode UI.
 
 - **Agent-file pre-flight** (QS-190): before any HTTP call, ``main()``
-  verifies that ``<directory>/.opencode/agents/<agent>.md`` exists. If
-  not, the script emits ``{"status": "agent_file_missing", ...}`` on
-  stdout, a clear error on stderr, and exits 2 (parallel to the
-  ``fallback_unavailable`` branch shape). This closes the QS-177 AC #12
-  known limitation where a missing agent file silently lands the
-  session on the default OpenCode agent.
+  verifies the worktree and agent file via the ``_preflight`` helper,
+  which returns one of five statuses:
 
-Closed limitation (per QS-177 AC #12, closed by QS-190):
-spawn_session.py performs a pre-flight check that aborts with
-``status: "agent_file_missing"`` before the HTTP API can silently
-land a session on the default agent. The pre-flight is documented
-in the CLI fallback semantics section above.
+    - ``ok`` — proceed to the HTTP call.
+    - ``worktree_invalid`` — ``--directory`` is not a real directory
+      (typo / dangling symlink). Exits 2.
+    - ``agent_file_missing`` — worktree exists but
+      ``.opencode/agents/<agent>.md`` does not. Exits 2.
+    - ``agent_file_unreadable`` — the ``is_file()`` probe raised
+      ``OSError`` (e.g. ``PermissionError``). Exits 2.
+    - ``agent_file_empty`` — file exists but is 0 bytes
+      (``touch``'d placeholder); the server would silently fall back.
+      Exits 2.
+
+  Every non-``ok`` payload carries ``status``, ``agent``, ``directory``,
+  ``expected_path``, ``prompt``, ``detail`` (parallel to the
+  ``fallback_*`` branch shapes), and a clear stderr line.
+
+Closed limitation (per QS-177 AC #12, closed by QS-190 — best-effort):
+spawn_session.py performs a pre-flight check that aborts before
+issuing the HTTP request when the agent file is missing / unreadable /
+empty, or when the worktree itself is invalid, at check time. A
+TOCTOU window remains for files deleted in the millisecond between
+check and request; tightening that window further would only shrink,
+not eliminate, the race. The pre-flight is documented in the CLI
+fallback semantics section above.
 
 Usage::
 
@@ -491,6 +505,101 @@ def _agent_file_path(directory: str, agent: str) -> Path:
     return Path(directory) / ".opencode" / "agents" / f"{agent}.md"
 
 
+def _preflight(directory: str, agent: str) -> tuple[str, Path, str]:
+    """Best-effort pre-flight check for the agent-file landing path.
+
+    Returns a 3-tuple ``(status, expected_path, detail)``:
+
+    - ``("ok", path, "")`` — the worktree exists, the agent file exists,
+      is readable, and is non-empty. Proceed to the HTTP call.
+    - ``("worktree_invalid", path, detail)`` — ``directory`` is not a
+      real directory (typo, dangling symlink, missing worktree).
+      Closes review-fix #01 N6.
+    - ``("agent_file_missing", path, detail)`` — worktree exists but
+      the agent file does not. Closes QS-177 AC #12.
+    - ``("agent_file_unreadable", path, detail)`` — the ``is_file()``
+      probe raised ``OSError`` (e.g. ``PermissionError`` when the
+      parent is ``chmod 0o000``). Closes review-fix #01 M1.
+    - ``("agent_file_empty", path, detail)`` — the file exists but is
+      0 bytes (``touch``'d placeholder). The OpenCode server would
+      silently fall back to the default agent, re-opening the AC #12
+      hole. Closes review-fix #01 S6.
+
+    This is **best-effort** (review-fix #01 S5): a TOCTOU window remains
+    between this check and the subsequent HTTP request — a file
+    deleted in the millisecond between check and request would still
+    cause the silent fallback. Tightening that window would require a
+    second stat call inside ``spawn_session`` and would only shrink,
+    not eliminate, the race.
+    """
+    work_path = Path(directory)
+    if not work_path.is_dir():
+        return (
+            "worktree_invalid",
+            work_path,
+            (
+                f"ERROR: worktree directory does not exist or is not "
+                f"a directory: {directory}. Check the path or recreate "
+                f"the worktree."
+            ),
+        )
+
+    expected = _agent_file_path(directory, agent)
+    try:
+        present = expected.is_file()
+    except OSError as exc:
+        return (
+            "agent_file_unreadable",
+            expected,
+            (
+                f"ERROR: cannot stat OpenCode agent file at {expected}: "
+                f"{exc.strerror or exc} (errno {exc.errno}). The file "
+                f"may exist but the parent directory is unreadable; "
+                f"check permissions with `ls -la "
+                f"{expected.parent}` and `chmod` as needed."
+            ),
+        )
+    if not present:
+        return (
+            "agent_file_missing",
+            expected,
+            (
+                f"ERROR: OpenCode agent file not found at {expected}; "
+                f"the HTTP API would silently fall back to the default "
+                f"agent. Mirror .claude/agents/{agent}.md into "
+                f".opencode/agents/ or create the file before retrying."
+            ),
+        )
+
+    try:
+        size = expected.stat().st_size
+    except OSError as exc:
+        # Very narrow race: file disappeared between is_file() and stat().
+        # Surface as unreadable so the user knows to investigate.
+        return (
+            "agent_file_unreadable",
+            expected,
+            (
+                f"ERROR: cannot stat OpenCode agent file at {expected}: "
+                f"{exc.strerror or exc} (errno {exc.errno})."
+            ),
+        )
+    if size == 0:
+        return (
+            "agent_file_empty",
+            expected,
+            (
+                f"ERROR: OpenCode agent file at {expected} is empty "
+                f"(0 bytes). The OpenCode server would silently fall "
+                f"back to the default agent. Restore the file's "
+                f"contents from .claude/agents/{agent}.md before "
+                f"retrying."
+            ),
+        )
+
+    return ("ok", expected, "")
+
+
 def _reject_control_chars(
     parser: argparse.ArgumentParser, name: str, value: str,
 ) -> None:
@@ -607,24 +716,23 @@ def main() -> None:
     if args.title is not None:
         args.title = args.title.strip()
 
-    # Pre-flight: verify the target agent file exists in the worktree.
-    # Without this, the OpenCode HTTP API silently lands the session on the
-    # default agent if .opencode/agents/<agent>.md is missing — the
-    # QS-177 AC #12 known limitation. Closes that gap (QS-190 AC-2).
-    expected = _agent_file_path(args.directory, args.agent)
-    if not expected.is_file():
-        detail = (
-            f"ERROR: OpenCode agent file not found at {expected}; "
-            f"the HTTP API would silently fall back to the default agent. "
-            f"Mirror .claude/agents/{args.agent}.md into .opencode/agents/ "
-            f"or create the file before retrying."
-        )
+    # Pre-flight: verify the worktree and agent file before any HTTP call.
+    # Closes the QS-177 AC #12 known limitation (best-effort — a TOCTOU
+    # window remains; see _preflight's docstring). Review-fix #01
+    # widens the check to distinguish missing / unreadable / empty
+    # files and an invalid worktree (M1 + S6 + N6).
+    status, expected, detail = _preflight(args.directory, args.agent)
+    if status != "ok":
+        # Every failure payload carries the input ``prompt`` (review-fix
+        # #01 N9) so a consumer (next-phase orchestrator) has the full
+        # original CLI shape for diagnostic / retry.
         sys.exit(_emit(
             {
-                "status": "agent_file_missing",
+                "status": status,
                 "agent": args.agent,
                 "directory": args.directory,
                 "expected_path": str(expected),
+                "prompt": args.prompt,
                 "detail": detail,
             },
             stderr_msg=detail,

--- a/tests/qs/agents/test_harness_flag_explicit.py
+++ b/tests/qs/agents/test_harness_flag_explicit.py
@@ -1,0 +1,95 @@
+"""Pin the AC-1 contract: every next_step.py / setup_task.py callsite
+inside .opencode/agents/, .claude/agents/, .cursor/agents/ passes
+the explicit ``--harness <name>`` flag matching its directory.
+
+Without this guard, env-var-based harness auto-detection
+(scripts/qs/harness.py) silently degrades to the ``claude-code``
+default whenever the tool execution environment doesn't carry
+``OPENCODE_SERVER_PORT`` / ``CURSOR_TRACE_ID`` — which is precisely
+the failure mode QS-190 closes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+HARNESS_BY_DIR = {
+    ".opencode/agents": "opencode",
+    ".claude/agents": "claude-code",
+    ".cursor/agents": "cursor",
+}
+
+# Regex matches either next_step.py or setup_task.py followed by any
+# characters (DOTALL — so backslash-continued multi-line invocations
+# still match), then ``--harness <name>``. The greedy gap is bounded
+# by ``.{0,400}`` so the pattern can't drift across an unrelated
+# downstream invocation in the same file body.
+_CALLSITE_RE_FMT = (
+    r"(next_step\.py|setup_task\.py).{{0,400}}?--harness\s+{harness}\b"
+)
+
+
+def _all_agent_files() -> list[tuple[Path, str]]:
+    """Yield (file, expected_harness) for every .md file in each harness dir.
+
+    Files that DO NOT contain a next_step.py / setup_task.py
+    invocation are skipped — only callsite-bearing files are
+    asserted. Today that's 11 files yielding 13 callsites; the helper
+    re-scans the live filesystem so new agent files are picked up
+    automatically.
+    """
+    out: list[tuple[Path, str]] = []
+    for rel, harness in HARNESS_BY_DIR.items():
+        for f in sorted((REPO_ROOT / rel).glob("*.md")):
+            body = f.read_text(encoding="utf-8")
+            if "next_step.py" in body or "setup_task.py" in body:
+                out.append((f, harness))
+    return out
+
+
+@pytest.mark.parametrize(("agent_file", "expected_harness"), _all_agent_files())
+def test_callsite_passes_explicit_harness_flag(
+    agent_file: Path, expected_harness: str,
+) -> None:
+    body = agent_file.read_text(encoding="utf-8")
+    pattern = re.compile(
+        _CALLSITE_RE_FMT.format(harness=re.escape(expected_harness)),
+        re.DOTALL,
+    )
+    assert pattern.search(body), (
+        f"{agent_file.relative_to(REPO_ROOT)} contains a next_step.py / "
+        f"setup_task.py invocation but no matching "
+        f"`--harness {expected_harness}` flag within 400 chars of the "
+        f"script name. Env-var harness auto-detection is unreliable "
+        f"inside tool execution environments — the flag must be "
+        f"explicit (see QS-190 AC-1)."
+    )
+
+
+def test_thirteen_callsites_total() -> None:
+    """Sanity-check pin: today there are exactly 13 callsites across the
+    three harness dirs (6 OpenCode + 6 Claude + 1 Cursor). If this drifts,
+    update the count + AC-1 enumeration in the story.
+
+    Counts the literal invocation prefix ``scripts/qs/next_step.py`` /
+    ``scripts/qs/setup_task.py`` so the canonical auto-execute block's
+    prose mention of ``next_step.py`` (without the ``scripts/qs/``
+    prefix) is excluded — only actual bash invocations are counted.
+    """
+    total = 0
+    for rel in HARNESS_BY_DIR:
+        for f in (REPO_ROOT / rel).glob("*.md"):
+            body = f.read_text(encoding="utf-8")
+            total += body.count("scripts/qs/next_step.py")
+            total += body.count("scripts/qs/setup_task.py")
+    assert total == 13, (
+        f"Expected 13 scripts/qs/next_step.py / scripts/qs/setup_task.py "
+        f"callsites across the three harness dirs; found {total}. If "
+        f"this changed intentionally, update the count + the AC-1 "
+        f"enumeration in docs/stories/QS-190.story.md."
+    )

--- a/tests/qs/agents/test_harness_flag_explicit.py
+++ b/tests/qs/agents/test_harness_flag_explicit.py
@@ -7,6 +7,27 @@ Without this guard, env-var-based harness auto-detection
 default whenever the tool execution environment doesn't carry
 ``OPENCODE_SERVER_PORT`` / ``CURSOR_TRACE_ID`` — which is precisely
 the failure mode QS-190 closes.
+
+Review fix #01 — S2 + S3 + S10 + N11:
+
+- The check is now **code-fence-scoped**: we extract ``` ```bash ``` ```
+  fenced blocks from each agent .md, and for every block that contains
+  ``scripts/qs/next_step.py`` or ``scripts/qs/setup_task.py`` we
+  require the *same* block to also contain ``--harness <expected>``.
+  This eliminates the regex's 400-char cross-contamination risk where
+  callsite #1 in a multi-callsite file could pair with callsite #2's
+  flag (S10).
+- The ``scripts/qs/`` prefix is required, so prose mentions of
+  ``next_step.py`` in surrounding text don't count as callsites (S2).
+- The 13-callsites-total sanity-pin is replaced by a per-file "no
+  callsite missing its flag" assertion (S3); the sanity-pin now only
+  requires ``>= 13`` so a future legitimate addition doesn't break
+  the test.
+- The AC-1 enumeration table in
+  ``docs/stories/QS-190.story.md`` is the authoritative reference
+  (N11) — see the table headed
+  "**Given** any of the **13** ``next_step.py`` / ``setup_task.py``
+  callsites" for the source of truth.
 """
 
 from __future__ import annotations
@@ -24,72 +45,111 @@ HARNESS_BY_DIR = {
     ".cursor/agents": "cursor",
 }
 
-# Regex matches either next_step.py or setup_task.py followed by any
-# characters (DOTALL — so backslash-continued multi-line invocations
-# still match), then ``--harness <name>``. The greedy gap is bounded
-# by ``.{0,400}`` so the pattern can't drift across an unrelated
-# downstream invocation in the same file body.
-_CALLSITE_RE_FMT = (
-    r"(next_step\.py|setup_task\.py).{{0,400}}?--harness\s+{harness}\b"
+# Matches a ``` ```bash ... ``` ``` fenced block whose opening and
+# closing fences are both at start-of-line (no leading indent). The
+# ``bash`` language tag is required so other fenced blocks (e.g.
+# ``` ```text ``` ```) aren't picked up as bash callsites. The
+# anchoring is needed because indented fences (e.g. a ``` ```bash ``` ```
+# nested inside a numbered list — 3-space indent) would otherwise
+# confuse the closing-fence match: an indented opening followed by an
+# indented closing has whitespace between the newline and the
+# backticks, which breaks a naive ``\n```\`` close pattern; line-anchoring
+# both ends makes the match unambiguous (review-fix #01 S10).
+_BASH_FENCE_RE = re.compile(
+    r"^```bash\n(.*?)\n^```$",
+    re.DOTALL | re.MULTILINE,
 )
+
+# A callsite is a ``scripts/qs/(next_step|setup_task).py`` literal inside
+# a ``bash`` fence. The ``scripts/qs/`` prefix is required so prose
+# mentions of the bare script name don't count.
+_CALLSITE_RE = re.compile(r"scripts/qs/(?:next_step|setup_task)\.py")
+
+
+def _bash_fences(body: str) -> list[str]:
+    """Return the body of every ``` ```bash ``` ``` fenced block in ``body``."""
+    return _BASH_FENCE_RE.findall(body)
+
+
+def _callsite_fences(body: str) -> list[str]:
+    """Return ``bash``-fenced blocks that actually invoke a callsite."""
+    return [fence for fence in _bash_fences(body) if _CALLSITE_RE.search(fence)]
 
 
 def _all_agent_files() -> list[tuple[Path, str]]:
-    """Yield (file, expected_harness) for every .md file in each harness dir.
-
-    Files that DO NOT contain a next_step.py / setup_task.py
-    invocation are skipped — only callsite-bearing files are
-    asserted. Today that's 11 files yielding 13 callsites; the helper
-    re-scans the live filesystem so new agent files are picked up
-    automatically.
-    """
+    """Yield (file, expected_harness) for every callsite-bearing .md file."""
     out: list[tuple[Path, str]] = []
     for rel, harness in HARNESS_BY_DIR.items():
         for f in sorted((REPO_ROOT / rel).glob("*.md")):
             body = f.read_text(encoding="utf-8")
-            if "next_step.py" in body or "setup_task.py" in body:
+            if _callsite_fences(body):
                 out.append((f, harness))
     return out
 
 
 @pytest.mark.parametrize(("agent_file", "expected_harness"), _all_agent_files())
-def test_callsite_passes_explicit_harness_flag(
+def test_every_callsite_fence_carries_explicit_harness_flag(
     agent_file: Path, expected_harness: str,
 ) -> None:
+    """Per-file pin (S2 + S3 + S10): every callsite fence in this file
+    contains the matching ``--harness <name>`` flag inside the same
+    fence. Counts callsites missing the flag and asserts zero.
+    """
     body = agent_file.read_text(encoding="utf-8")
-    pattern = re.compile(
-        _CALLSITE_RE_FMT.format(harness=re.escape(expected_harness)),
-        re.DOTALL,
+    flag_re = re.compile(
+        rf"--harness\s+{re.escape(expected_harness)}\b",
     )
-    assert pattern.search(body), (
-        f"{agent_file.relative_to(REPO_ROOT)} contains a next_step.py / "
-        f"setup_task.py invocation but no matching "
-        f"`--harness {expected_harness}` flag within 400 chars of the "
-        f"script name. Env-var harness auto-detection is unreliable "
-        f"inside tool execution environments — the flag must be "
-        f"explicit (see QS-190 AC-1)."
+    callsite_count = 0
+    missing_count = 0
+    for fence in _callsite_fences(body):
+        # A single fence can carry MULTIPLE callsites (today none do, but
+        # a future refactor might consolidate). Count each callsite
+        # occurrence and require the flag to appear at least once per
+        # callsite in the same fence.
+        callsites_in_fence = len(_CALLSITE_RE.findall(fence))
+        flags_in_fence = len(flag_re.findall(fence))
+        callsite_count += callsites_in_fence
+        if flags_in_fence < callsites_in_fence:
+            missing_count += callsites_in_fence - flags_in_fence
+
+    assert callsite_count > 0, (
+        f"{agent_file.relative_to(REPO_ROOT)}: contained no "
+        f"scripts/qs/next_step.py / setup_task.py callsite — was this "
+        f"file picked up correctly?"
+    )
+    assert missing_count == 0, (
+        f"{agent_file.relative_to(REPO_ROOT)}: {missing_count} of "
+        f"{callsite_count} callsite(s) in this file are missing a "
+        f"matching `--harness {expected_harness}` flag inside the "
+        f"SAME ```bash``` fence. Env-var harness auto-detection is "
+        f"unreliable inside tool execution environments — the flag "
+        f"must be explicit and co-located with the script invocation "
+        f"(QS-190 AC-1; review-fix #01 S10)."
     )
 
 
-def test_thirteen_callsites_total() -> None:
-    """Sanity-check pin: today there are exactly 13 callsites across the
-    three harness dirs (6 OpenCode + 6 Claude + 1 Cursor). If this drifts,
-    update the count + AC-1 enumeration in the story.
+def test_aggregate_callsites_at_least_thirteen() -> None:
+    """Sanity-pin (S3): the AC-1 enumeration table lists 13 callsites.
 
-    Counts the literal invocation prefix ``scripts/qs/next_step.py`` /
-    ``scripts/qs/setup_task.py`` so the canonical auto-execute block's
-    prose mention of ``next_step.py`` (without the ``scripts/qs/``
-    prefix) is excluded — only actual bash invocations are counted.
+    Today there are exactly 13 (6 OpenCode + 6 Claude + 1 Cursor); a
+    future legitimate addition should not break this test as long as
+    the new callsite ALSO carries its ``--harness`` flag — that
+    invariant is enforced per-file by
+    ``test_every_callsite_fence_carries_explicit_harness_flag``.
+
+    Authoritative reference: the AC-1 enumeration table in
+    ``docs/stories/QS-190.story.md`` (look for the row table headed
+    "Given any of the 13 next_step.py / setup_task.py callsites").
     """
     total = 0
     for rel in HARNESS_BY_DIR:
         for f in (REPO_ROOT / rel).glob("*.md"):
             body = f.read_text(encoding="utf-8")
-            total += body.count("scripts/qs/next_step.py")
-            total += body.count("scripts/qs/setup_task.py")
-    assert total == 13, (
-        f"Expected 13 scripts/qs/next_step.py / scripts/qs/setup_task.py "
-        f"callsites across the three harness dirs; found {total}. If "
-        f"this changed intentionally, update the count + the AC-1 "
-        f"enumeration in docs/stories/QS-190.story.md."
+            for fence in _callsite_fences(body):
+                total += len(_CALLSITE_RE.findall(fence))
+    assert total >= 13, (
+        f"Expected at least 13 scripts/qs/next_step.py / setup_task.py "
+        f"callsites across the three harness dirs; found {total}. The "
+        f"AC-1 enumeration table in docs/stories/QS-190.story.md lists "
+        f"the canonical 13."
     )

--- a/tests/qs/agents/test_opencode_execute_contract.py
+++ b/tests/qs/agents/test_opencode_execute_contract.py
@@ -3,13 +3,34 @@
 OpenCode mid-pipeline agents (create-plan, implement-task,
 implement-setup-task, review-task) must instruct the agent to RUN
 ``new_context`` via the Bash tool and verify the binary
-``status == "session_created"`` AND ``agent == "qs-<expected>"``
-contract. The OpenCode setup-task agent + every Claude / Cursor agent
-preserve the existing print-for-user pattern (no auto-execute prose).
+``status == "session_created"`` AND the resolved agent name contract.
+The OpenCode setup-task agent + every Claude / Cursor agent preserve
+the existing print-for-user pattern (no auto-execute prose).
+
+Review fix #01 hardens the prose:
+
+- **S7** — the agent-name comparison is in **prose** ("equals
+  ``qs-`` followed by the phase name passed to ``--next-cmd``"); the
+  ``agent == "qs-{{NEXT_PHASE}}"`` literal previously relied on the
+  LLM substituting the template, and a literal comparison would
+  misfire.
+- **S8** — each block tells the agent to STOP on a ``next_step.py``
+  error payload (key ``error`` in the JSON) BEFORE attempting to run
+  ``new_context``.
+- **S11** — each block tells the agent to handle a Bash-tool failure
+  that produces no JSON output (e.g. permission denied).
+- **N10** — the bash block above is prefaced by a substitution
+  reminder so the agent doesn't run it with unresolved Jinja
+  placeholders.
+- **N3** — emoji-free success-report blocks (project rule: "only use
+  emojis if the user explicitly requests it").
+- **S13** — the AC-5 rationale paragraph in the OpenCode setup-task
+  agent file is pinned by a distinctive substring.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -19,13 +40,22 @@ OPENCODE_DIR = REPO_ROOT / ".opencode" / "agents"
 CLAUDE_DIR = REPO_ROOT / ".claude" / "agents"
 CURSOR_DIR = REPO_ROOT / ".cursor" / "agents"
 
-# Distinctive substring from the canonical auto-execute block (Task
-# 3.2-3.5). Choosing a phrase that is unique to the auto-execute
+# Distinctive substring from the canonical auto-execute block (QS-190
+# Task 3.2-3.5). Choosing a phrase that is unique to the auto-execute
 # pattern AND unlikely to drift; the print-for-user block uses
 # "Preferred (..." / "Fallback (..." instead.
 EXECUTE_MARKER = "Run `new_context` via the Bash tool"
 SUCCESS_CONTRACT_MARKER = 'status == "session_created"'
-AGENT_VERIFY_MARKER = 'agent == "qs-'  # partial — phase varies
+
+# Review fix #01 prose pins. ``AGENT_VERIFY_PROSE_RE`` accepts any
+# whitespace (including a wrapped line) between tokens because the
+# canonical prose naturally wraps inside markdown bullets.
+AGENT_VERIFY_PROSE_RE = re.compile(
+    r"equals\s+`qs-`\s+followed\s+by\s+the\s+phase\s+name",
+)
+NEXT_STEP_ERROR_GUARD = "If the `next_step.py` JSON contains an `error` key"
+BASH_FAILURE_GUARD = "If the Bash tool returns an error before producing any JSON output"
+SUBSTITUTION_REMINDER = "**Before running** — substitute"
 
 OPENCODE_EXECUTE_AGENTS = (
     "qs-create-plan",
@@ -37,6 +67,7 @@ OPENCODE_EXECUTE_AGENTS = (
 
 @pytest.mark.parametrize("name", OPENCODE_EXECUTE_AGENTS)
 def test_opencode_agent_auto_executes_new_context(name: str) -> None:
+    """Core auto-execute imperative + success contract markers (AC-4)."""
     body = (OPENCODE_DIR / f"{name}.md").read_text(encoding="utf-8")
     assert EXECUTE_MARKER in body, (
         f"{name}: missing auto-execute imperative. The body must "
@@ -47,8 +78,91 @@ def test_opencode_agent_auto_executes_new_context(name: str) -> None:
         f"{name}: missing the binary success-contract check on "
         f"`status == \"session_created\"`."
     )
-    assert AGENT_VERIFY_MARKER in body, (
-        f"{name}: missing the `agent == \"qs-...\"` verification."
+
+
+@pytest.mark.parametrize("name", OPENCODE_EXECUTE_AGENTS)
+def test_opencode_agent_uses_prose_for_agent_name_check(name: str) -> None:
+    """S7: the agent-name half of the contract is in prose, not template.
+
+    The QS-190 v1 canonical block compared ``agent == "qs-{{phase}}"``
+    with a literal Jinja-style placeholder. An LLM that compared
+    literally would treat every successful spawn as a failure. The
+    prose form ("equals ``qs-`` followed by the phase name passed to
+    ``--next-cmd``") leaves no ambiguity.
+    """
+    body = (OPENCODE_DIR / f"{name}.md").read_text(encoding="utf-8")
+    assert AGENT_VERIFY_PROSE_RE.search(body), (
+        f"{name}: agent-name verification must be in prose, not a "
+        f"literal `agent == \"qs-{{...}}\"` template (review-fix #01 S7). "
+        f"Look for `equals \\`qs-\\` followed by the phase name` "
+        f"(line wraps allowed)."
+    )
+    # Inverse: a literal ``"qs-{{NEXT_PHASE}}"`` or
+    # ``"qs-{{next_implement}}"`` template (i.e. the dangerous form
+    # used in the QS-190 v1 comparison) must NOT appear. The bash
+    # argument ``--next-cmd "{{NEXT_PHASE}}"`` is fine — that's the
+    # legitimate placeholder for the user to substitute.
+    assert '"qs-{{NEXT_PHASE}}"' not in body, (
+        f"{name}: still contains the literal "
+        f"`\"qs-{{NEXT_PHASE}}\"` comparison string; review-fix #01 "
+        f"S7 wants this replaced with prose."
+    )
+    assert '"qs-{{next_implement}}"' not in body, (
+        f"{name}: still contains the literal "
+        f"`\"qs-{{next_implement}}\"` comparison string; review-fix "
+        f"#01 S7 wants this replaced with prose."
+    )
+
+
+@pytest.mark.parametrize("name", OPENCODE_EXECUTE_AGENTS)
+def test_opencode_agent_handles_next_step_error_payload(name: str) -> None:
+    """S8: each auto-execute block tells the agent how to STOP on
+    a ``next_step.py`` error JSON before running ``new_context``.
+    """
+    body = (OPENCODE_DIR / f"{name}.md").read_text(encoding="utf-8")
+    assert NEXT_STEP_ERROR_GUARD in body, (
+        f"{name}: missing the next_step.py error-key guard. The "
+        f"prose must say: '{NEXT_STEP_ERROR_GUARD}' (review-fix #01 S8)."
+    )
+
+
+@pytest.mark.parametrize("name", OPENCODE_EXECUTE_AGENTS)
+def test_opencode_agent_handles_bash_tool_failure(name: str) -> None:
+    """S11: each auto-execute block tells the agent how to handle a
+    Bash-tool failure that produces no JSON output (e.g. permission
+    denied, missing interpreter).
+    """
+    body = (OPENCODE_DIR / f"{name}.md").read_text(encoding="utf-8")
+    assert BASH_FAILURE_GUARD in body, (
+        f"{name}: missing the Bash-tool failure guard. The prose must "
+        f"say: '{BASH_FAILURE_GUARD}' (review-fix #01 S11)."
+    )
+
+
+@pytest.mark.parametrize("name", OPENCODE_EXECUTE_AGENTS)
+def test_opencode_agent_substitution_reminder(name: str) -> None:
+    """N10: each auto-execute bash block is prefaced by a substitution
+    reminder so the agent doesn't run the block with literal
+    ``{{NEXT_PHASE}}`` / ``{{next_implement}}`` tokens.
+    """
+    body = (OPENCODE_DIR / f"{name}.md").read_text(encoding="utf-8")
+    assert SUBSTITUTION_REMINDER in body, (
+        f"{name}: missing the substitution reminder above the bash "
+        f"block. The prose must say (verbatim): "
+        f"'{SUBSTITUTION_REMINDER}' (review-fix #01 N10)."
+    )
+
+
+@pytest.mark.parametrize("name", OPENCODE_EXECUTE_AGENTS)
+def test_opencode_agent_no_emoji_in_success_block(name: str) -> None:
+    """N3: project rule forbids emoji in agent files unless the user
+    asked for them. The QS-190 v1 success-report blocks used ``✅``;
+    review-fix #01 N3 replaces them with ``[OK]``.
+    """
+    body = (OPENCODE_DIR / f"{name}.md").read_text(encoding="utf-8")
+    assert "✅" not in body, (
+        f"{name}: contains ``✅`` emoji — project rule forbids emojis "
+        f"in agent files. Replace with ``[OK]`` (review-fix #01 N3)."
     )
 
 
@@ -75,6 +189,25 @@ def test_opencode_setup_task_preserves_print_for_user() -> None:
         "qs-setup-task.md should NOT auto-execute new_context — "
         "setup-task crosses OpenCode workspaces and emits a CLI-form "
         "launcher (see QS-190 AC-5)."
+    )
+
+
+def test_opencode_setup_task_carries_rationale_block() -> None:
+    """S13: AC-5 rationale paragraph is present (not just the EXECUTE_MARKER
+    absence).
+
+    The rationale block explains WHY setup-task is the print-for-user
+    exception (cross-workspace launch). The previous test only
+    asserted EXECUTE_MARKER absence, which a future refactor could
+    silently satisfy by deleting the rationale. Pinning a distinctive
+    phrase guards against that.
+    """
+    body = (OPENCODE_DIR / "qs-setup-task.md").read_text(encoding="utf-8")
+    assert "Why setup-task stays print-for-user" in body, (
+        "qs-setup-task.md: missing the AC-5 rationale block headed "
+        "'Why setup-task stays print-for-user'. Without this, a "
+        "future reader has no explanation for why setup-task is the "
+        "asymmetric exception (review-fix #01 S13)."
     )
 
 

--- a/tests/qs/agents/test_opencode_execute_contract.py
+++ b/tests/qs/agents/test_opencode_execute_contract.py
@@ -1,0 +1,99 @@
+"""Pin the OpenCode auto-execute contract (AC-4 / AC-5 / AC-6).
+
+OpenCode mid-pipeline agents (create-plan, implement-task,
+implement-setup-task, review-task) must instruct the agent to RUN
+``new_context`` via the Bash tool and verify the binary
+``status == "session_created"`` AND ``agent == "qs-<expected>"``
+contract. The OpenCode setup-task agent + every Claude / Cursor agent
+preserve the existing print-for-user pattern (no auto-execute prose).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OPENCODE_DIR = REPO_ROOT / ".opencode" / "agents"
+CLAUDE_DIR = REPO_ROOT / ".claude" / "agents"
+CURSOR_DIR = REPO_ROOT / ".cursor" / "agents"
+
+# Distinctive substring from the canonical auto-execute block (Task
+# 3.2-3.5). Choosing a phrase that is unique to the auto-execute
+# pattern AND unlikely to drift; the print-for-user block uses
+# "Preferred (..." / "Fallback (..." instead.
+EXECUTE_MARKER = "Run `new_context` via the Bash tool"
+SUCCESS_CONTRACT_MARKER = 'status == "session_created"'
+AGENT_VERIFY_MARKER = 'agent == "qs-'  # partial — phase varies
+
+OPENCODE_EXECUTE_AGENTS = (
+    "qs-create-plan",
+    "qs-implement-task",
+    "qs-implement-setup-task",
+    "qs-review-task",
+)
+
+
+@pytest.mark.parametrize("name", OPENCODE_EXECUTE_AGENTS)
+def test_opencode_agent_auto_executes_new_context(name: str) -> None:
+    body = (OPENCODE_DIR / f"{name}.md").read_text(encoding="utf-8")
+    assert EXECUTE_MARKER in body, (
+        f"{name}: missing auto-execute imperative. The body must "
+        f"instruct the agent to run new_context via the Bash tool "
+        f"(see QS-190 AC-4)."
+    )
+    assert SUCCESS_CONTRACT_MARKER in body, (
+        f"{name}: missing the binary success-contract check on "
+        f"`status == \"session_created\"`."
+    )
+    assert AGENT_VERIFY_MARKER in body, (
+        f"{name}: missing the `agent == \"qs-...\"` verification."
+    )
+
+
+def test_opencode_review_task_has_two_execute_blocks() -> None:
+    """review-task has 2 next_step.py callsites — both must auto-execute.
+
+    Counts occurrences of the EXECUTE_MARKER. Asserts ``>= 2`` so the
+    test is robust to future prose elaboration; the lower bound is
+    what matters.
+    """
+    body = (OPENCODE_DIR / "qs-review-task.md").read_text(encoding="utf-8")
+    count = body.count(EXECUTE_MARKER)
+    assert count >= 2, (
+        f"qs-review-task.md should auto-execute both new_context "
+        f"callsites (zero-findings + fix-plan); found {count} "
+        f"occurrences of {EXECUTE_MARKER!r}."
+    )
+
+
+def test_opencode_setup_task_preserves_print_for_user() -> None:
+    """Cross-workspace setup-task keeps the print-for-user pattern (AC-5)."""
+    body = (OPENCODE_DIR / "qs-setup-task.md").read_text(encoding="utf-8")
+    assert EXECUTE_MARKER not in body, (
+        "qs-setup-task.md should NOT auto-execute new_context — "
+        "setup-task crosses OpenCode workspaces and emits a CLI-form "
+        "launcher (see QS-190 AC-5)."
+    )
+
+
+@pytest.mark.parametrize("agent_file", sorted(CLAUDE_DIR.glob("qs-*.md")))
+def test_claude_agents_preserve_print_for_user(agent_file: Path) -> None:
+    """Every Claude phase orchestrator stays print-for-user (AC-6)."""
+    body = agent_file.read_text(encoding="utf-8")
+    assert EXECUTE_MARKER not in body, (
+        f"{agent_file.relative_to(REPO_ROOT)}: Claude agents must "
+        f"preserve the existing print-for-user pattern. Found the "
+        f"auto-execute marker — that's OpenCode-only (QS-190 AC-6)."
+    )
+
+
+@pytest.mark.parametrize("agent_file", sorted(CURSOR_DIR.glob("qs-*.md")))
+def test_cursor_agents_preserve_print_for_user(agent_file: Path) -> None:
+    """Every Cursor phase orchestrator stays print-for-user (AC-6)."""
+    body = agent_file.read_text(encoding="utf-8")
+    assert EXECUTE_MARKER not in body, (
+        f"{agent_file.relative_to(REPO_ROOT)}: Cursor agents must "
+        f"preserve the existing print-for-user pattern (QS-190 AC-6)."
+    )

--- a/tests/qs/launchers/test_next_step_cli.py
+++ b/tests/qs/launchers/test_next_step_cli.py
@@ -284,8 +284,14 @@ def test_existing_session_prompt_emitted_when_fix_plan_and_pr_provided(tmp_path:
     assert "#179" in prompt
 
 
-def test_existing_session_prompt_omitted_when_flags_missing(tmp_path: Path) -> None:
-    """Neither flag provided → payload has NO ``existing_session_prompt`` key."""
+def test_existing_session_prompt_null_when_flags_missing(tmp_path: Path) -> None:
+    """Neither flag provided → payload carries ``existing_session_prompt: null``.
+
+    Review fix #01 S9: the key is always present so the consuming
+    agent prose has a single shape to check (``null`` vs.
+    non-empty string) instead of having to disambiguate ``key
+    missing`` from ``key present but null``.
+    """
     result = _run(
         [
             "--next-cmd", "implement-task",
@@ -298,11 +304,12 @@ def test_existing_session_prompt_omitted_when_flags_missing(tmp_path: Path) -> N
     )
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
-    assert "existing_session_prompt" not in payload
+    assert "existing_session_prompt" in payload
+    assert payload["existing_session_prompt"] is None
 
 
-def test_existing_session_prompt_omitted_when_only_fix_plan_provided(tmp_path: Path) -> None:
-    """``--fix-plan-path`` alone (no PR) → key omitted (back-compat preservation)."""
+def test_existing_session_prompt_null_when_only_fix_plan_provided(tmp_path: Path) -> None:
+    """``--fix-plan-path`` alone (no PR) → key present with null value (review fix #01 S9)."""
     result = _run(
         [
             "--next-cmd", "implement-task",
@@ -316,11 +323,12 @@ def test_existing_session_prompt_omitted_when_only_fix_plan_provided(tmp_path: P
     )
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
-    assert "existing_session_prompt" not in payload
+    assert "existing_session_prompt" in payload
+    assert payload["existing_session_prompt"] is None
 
 
-def test_existing_session_prompt_omitted_when_only_pr_provided(tmp_path: Path) -> None:
-    """``--pr-number`` alone (no fix-plan path) → key omitted (back-compat preservation)."""
+def test_existing_session_prompt_null_when_only_pr_provided(tmp_path: Path) -> None:
+    """``--pr-number`` alone (no fix-plan path) → key present with null value (review fix #01 S9)."""
     result = _run(
         [
             "--next-cmd", "implement-task",
@@ -334,7 +342,8 @@ def test_existing_session_prompt_omitted_when_only_pr_provided(tmp_path: Path) -
     )
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
-    assert "existing_session_prompt" not in payload
+    assert "existing_session_prompt" in payload
+    assert payload["existing_session_prompt"] is None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/qs/launchers/test_opencode_launcher.py
+++ b/tests/qs/launchers/test_opencode_launcher.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 # --------------------------------------------------------------------------- #
 # Task 6.2 — next_step branch (HTTP API form, default)
 # --------------------------------------------------------------------------- #
@@ -170,20 +169,29 @@ def test_build_payload_shell_escapes_path_with_spaces(
 
 
 # --------------------------------------------------------------------------- #
-# Task 6.8 — docstring documents the AC #12 limitation
+# QS-190 Task 8.1 — docstring records the closed-limitation note
 # --------------------------------------------------------------------------- #
 
 
-def test_build_payload_emits_known_limitation_note() -> None:
-    """The module docstring documents the missing ``.opencode/agents/qs-<phase>.md`` limitation."""
+def test_build_payload_documents_closed_limitation() -> None:
+    """The module docstring records that QS-190 closed the QS-177 AC #12 limitation.
+
+    Renamed from ``test_build_payload_emits_known_limitation_note`` —
+    the QS-177 AC #12 known limitation (HTTP API silently lands the
+    session on the default agent when ``.opencode/agents/<agent>.md``
+    is missing) is now closed by QS-190's pre-flight guard in
+    ``spawn_session.py``. The docstring text is rephrased to a
+    closed-historical note and the pinning substring is updated to a
+    phrase unique to the new wording.
+    """
     from launchers import opencode as opencode_launcher  # type: ignore[import-not-found]
 
     assert opencode_launcher.__doc__ is not None
     doc = opencode_launcher.__doc__
-    assert ".opencode/agents/qs-" in doc, (
-        "Module docstring must document the AC #12 limitation that "
-        "static `.opencode/agents/qs-<phase>.md` files are required "
-        "for agent activation to take effect."
+    assert "spawn_session.py performs a pre-flight check" in doc, (
+        "Module docstring must record the closed-limitation note "
+        "introduced by QS-190 — the pre-flight in spawn_session.py "
+        "now guards against the missing-agent-file failure mode."
     )
 
 
@@ -591,22 +599,27 @@ def test_harness_md_contains_new_opencode_row() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Review fix plan #01 — should-fix #14: harness.md known-limitation note pinned
+# QS-190 Task 8.2 — harness.md records the closed-limitation note
 # --------------------------------------------------------------------------- #
 
 
-def test_harness_md_contains_known_limitation_note() -> None:
-    """``docs/workflow/harness.md`` carries the AC #12 ``.opencode/agents/`` limitation note.
+def test_harness_md_documents_closed_limitation() -> None:
+    """``docs/workflow/harness.md`` records the QS-190 closed-limitation note.
 
-    Parallel to the launcher docstring pin in
-    ``test_build_payload_emits_known_limitation_note``.
+    Renamed from ``test_harness_md_contains_known_limitation_note`` —
+    parallel to the launcher docstring pin in
+    ``test_build_payload_documents_closed_limitation``. The QS-177
+    AC #12 known limitation is now closed; the harness.md paragraph
+    points to QS-190's pre-flight guard.
     """
     harness_md = (
         Path(__file__).resolve().parents[3]
         / "docs" / "workflow" / "harness.md"
     ).read_text()
-    assert ".opencode/agents/qs-<phase>.md" in harness_md, (
-        "harness.md is missing the AC #12 known-limitation note"
+    assert "spawn_session.py performs a pre-flight check" in harness_md, (
+        "harness.md must record the closed-limitation note introduced "
+        "by QS-190 — a missing OpenCode agent file now produces a "
+        "clean `agent_file_missing` exit shape via the pre-flight."
     )
 
 
@@ -623,7 +636,6 @@ def test_default_kickoff_constants_match() -> None:
     silent drift.
     """
     import spawn_session  # type: ignore[import-not-found]
-
     from launchers import opencode as opencode_launcher  # type: ignore[import-not-found]
 
     assert opencode_launcher.DEFAULT_KICKOFF == spawn_session.DEFAULT_KICKOFF

--- a/tests/qs/test_harness.py
+++ b/tests/qs/test_harness.py
@@ -1,0 +1,156 @@
+"""Tests for ``scripts/qs/harness.py`` and harness-flag symmetry between
+``setup_task.py`` and ``next_step.py``.
+
+Review fix #01 — N7 + N8:
+
+- **N7**: ``setup_task.py`` and ``next_step.py`` both surface
+  ``--harness`` with a ``choices=`` enumeration. Today both lists are
+  identical, but ``setup_task.py`` sources its choices from
+  ``harness.VALID_HARNESSES`` and ``next_step.py`` sources from its
+  local ``LAUNCHERS`` dispatch table. Aligning both on
+  ``list(LAUNCHERS)`` (the dispatch table is the authoritative source
+  — a name absent from it would ``KeyError`` at runtime) prevents
+  silent drift.
+- **N8**: ``harness.detect()`` accepts legacy aliases (``claude`` →
+  ``claude-code``) when sourced from ``QS_HARNESS``; the new
+  ``canonicalize()`` helper exposes the same alias-mapping for the
+  ``--harness`` argparse flag so a user typing ``--harness claude``
+  doesn't trip ``argparse.error("invalid choice")``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# N8 — canonicalize() helper maps legacy aliases to canonical names
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(("alias", "expected"), [
+    ("claude", "claude-code"),
+    ("claude_code", "claude-code"),
+    ("claudecode", "claude-code"),
+    ("claude-code", "claude-code"),  # canonical → canonical (idempotent)
+    ("opencode", "opencode"),
+    ("cursor", "cursor"),
+    ("codex", "codex"),
+])
+def test_canonicalize_legacy_alias(alias: str, expected: str) -> None:
+    """``canonicalize(alias)`` maps every legacy alias to a canonical name."""
+    import harness  # type: ignore[import-not-found]
+
+    assert harness.canonicalize(alias) == expected
+
+
+def test_canonicalize_passes_through_unknown_name() -> None:
+    """An unknown name passes through unchanged — argparse ``choices=``
+    is the upstream guard. ``canonicalize`` only collapses known
+    aliases; it doesn't validate the result.
+    """
+    import harness  # type: ignore[import-not-found]
+
+    # Unknown alias not in the map → unchanged.
+    assert harness.canonicalize("bogus") == "bogus"
+
+
+def test_canonicalize_is_case_insensitive() -> None:
+    """Case normalisation: ``Claude`` / ``CLAUDE`` map to ``claude-code``."""
+    import harness  # type: ignore[import-not-found]
+
+    assert harness.canonicalize("Claude") == "claude-code"
+    assert harness.canonicalize("CLAUDE") == "claude-code"
+
+
+def test_canonicalize_strips_whitespace() -> None:
+    """Leading / trailing whitespace is stripped before mapping."""
+    import harness  # type: ignore[import-not-found]
+
+    assert harness.canonicalize("  claude  ") == "claude-code"
+
+
+# --------------------------------------------------------------------------- #
+# N7 — setup_task.py and next_step.py both use list(LAUNCHERS) as choices
+# --------------------------------------------------------------------------- #
+
+
+def test_setup_task_choices_match_next_step_choices() -> None:
+    """N7: ``--harness`` choices in both scripts come from the same
+    source. The dispatch table (``LAUNCHERS``) is authoritative —
+    a harness name without a launcher would ``KeyError`` at runtime.
+    """
+    import next_step  # type: ignore[import-not-found]
+    import setup_task  # type: ignore[import-not-found]
+
+    # The two LAUNCHERS dispatch tables are independently defined but
+    # logically the same set of harnesses (both map ``claude-code`` /
+    # ``cursor`` / ``opencode`` / ``codex`` to the corresponding
+    # launcher module).
+    assert set(next_step.LAUNCHERS) == set(setup_task.LAUNCHERS), (
+        "next_step.LAUNCHERS and setup_task.LAUNCHERS must enumerate "
+        "the same set of harness names (review fix #01 N7)."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# detect() preserved-behaviour pins
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_explicit_qs_harness_canonical(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``QS_HARNESS=claude-code`` (canonical) → ``claude-code``."""
+    import harness  # type: ignore[import-not-found]
+
+    monkeypatch.setenv("QS_HARNESS", "claude-code")
+    assert harness.detect() == "claude-code"
+
+
+def test_detect_explicit_qs_harness_legacy_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``QS_HARNESS=claude`` (legacy alias) → ``claude-code``."""
+    import harness  # type: ignore[import-not-found]
+
+    monkeypatch.setenv("QS_HARNESS", "claude")
+    assert harness.detect() == "claude-code"
+
+
+def test_detect_defaults_to_claude_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No harness signals → ``claude-code`` (default)."""
+    import harness  # type: ignore[import-not-found]
+
+    for var in (
+        "QS_HARNESS",
+        "CLAUDECODE",
+        "OPENCODE_SERVER_PORT",
+        "CURSOR_TRACE_ID",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # Remove any CODEX_AGENT_* env var
+    import os  # noqa: PLC0415
+    for k in list(os.environ):
+        if k.startswith("CODEX_AGENT_"):
+            monkeypatch.delenv(k, raising=False)
+    assert harness.detect() == "claude-code"
+
+
+# --------------------------------------------------------------------------- #
+# N8 — harness_choices() includes both canonical names and legacy aliases
+# --------------------------------------------------------------------------- #
+
+
+def test_harness_choices_contains_canonical_and_aliases() -> None:
+    """``harness_choices()`` covers every canonical name AND every alias."""
+    import harness  # type: ignore[import-not-found]
+
+    choices = harness.harness_choices()
+    # Canonical names from VALID_HARNESSES.
+    for canonical in harness.VALID_HARNESSES:
+        assert canonical in choices, (
+            f"harness_choices missing canonical name: {canonical}"
+        )
+    # Legacy aliases — at minimum the three documented in QS-190 review-fix #01.
+    for alias in ("claude", "claude_code", "claudecode"):
+        assert alias in choices, (
+            f"harness_choices missing legacy alias: {alias} "
+            f"(review fix #01 N8 — `--harness claude` must pass argparse)"
+        )

--- a/tests/qs/test_spawn_session.py
+++ b/tests/qs/test_spawn_session.py
@@ -27,18 +27,47 @@ import http.client
 import json
 import shlex
 import shutil
-import socket
 import subprocess
 import urllib.error
 import urllib.request
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # --------------------------------------------------------------------------- #
 # Test helpers
 # --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _stub_agent_file_preflight(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Auto-stub the QS-190 agent-file pre-flight for post-pre-flight tests.
+
+    Most tests in this module exercise behaviour AFTER the pre-flight
+    (the urlopen mocks, the fallback branches, the strip / validation
+    guards). They pass hardcoded ``--directory`` paths like ``/tmp/x``
+    that don't exist on disk, so the pre-flight ``is_file()`` check
+    would abort them with ``status: "agent_file_missing"`` before any
+    urlopen is reached.
+
+    This autouse fixture monkeypatches ``spawn_session._agent_file_path``
+    to point to a stub file under ``tmp_path``, satisfying the
+    pre-flight. Tests marked with ``@pytest.mark.real_preflight`` opt
+    out and exercise the real path computation against the actual
+    filesystem (using the explicit ``--directory`` they pass).
+    """
+    if "real_preflight" in request.keywords:
+        return
+    import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    stub = tmp_path / "stub_agent.md"
+    stub.touch()
+    monkeypatch.setattr(spawn_session, "_agent_file_path", lambda _d, _a: stub)
 
 
 def _mock_response(data: bytes = b"", status: int = 200) -> MagicMock:
@@ -332,7 +361,7 @@ def test_timeout_falls_back(
 
     monkeypatch.setattr(
         spawn_session.urllib.request, "urlopen",
-        MagicMock(side_effect=socket.timeout("timed out")),
+        MagicMock(side_effect=TimeoutError("timed out")),
     )
     monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/opencode" if name == "opencode" else None)
 
@@ -827,7 +856,7 @@ def test_prompt_async_timeout_attempts_delete(
         if method == "POST" and url.endswith("/session"):
             return _mock_response(json.dumps({"id": "sess-X"}).encode())
         if method == "POST" and "prompt_async" in url:
-            raise socket.timeout("timed out")
+            raise TimeoutError("timed out")
         if method == "DELETE":
             return _mock_response(b"true")
         raise AssertionError(f"unexpected: {method} {url}")
@@ -1351,3 +1380,134 @@ def test_spawn_session_normalizes_whitespace_title(
         agent="qs-create-plan", directory="/tmp/x", title=bad_title,
     )
     assert result["title"] == "qs-create-plan"
+
+
+# --------------------------------------------------------------------------- #
+# QS-190 — Task 2: agent-file pre-flight guard
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.real_preflight
+def test_preflight_aborts_when_agent_file_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing ``<worktree>/.opencode/agents/<agent>.md`` aborts before urlopen.
+
+    Closes the QS-177 AC #12 known limitation: without the pre-flight,
+    the HTTP API silently lands the session on the default OpenCode
+    agent. With the pre-flight, the script emits
+    ``status: "agent_file_missing"`` on stdout, a clear stderr line,
+    and exits 2 — and never makes the HTTP call.
+    """
+    import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    # tmp_path has NO .opencode/agents/ subdir → pre-flight must abort.
+    mock_urlopen = MagicMock()
+    monkeypatch.setattr(spawn_session.urllib.request, "urlopen", mock_urlopen)
+
+    exit_code = _run_main(
+        monkeypatch,
+        "--agent", "qs-create-plan",
+        "--directory", str(tmp_path),
+    )
+    assert exit_code == 2
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "agent_file_missing"
+    assert payload["agent"] == "qs-create-plan"
+    assert payload["directory"] == str(tmp_path)
+    assert payload["expected_path"].endswith(
+        "/.opencode/agents/qs-create-plan.md",
+    )
+    assert payload["detail"].startswith(
+        "ERROR: OpenCode agent file not found at ",
+    )
+
+    # Stderr carries the human-readable line.
+    assert "OpenCode agent file not found at " in captured.err
+
+    # The HTTP API was never called.
+    mock_urlopen.assert_not_called()
+
+
+@pytest.mark.real_preflight
+def test_preflight_passes_when_agent_file_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When ``<worktree>/.opencode/agents/<agent>.md`` exists, the pre-flight passes silently.
+
+    The script proceeds to ``POST /session`` (verified by the mock being
+    invoked) and emits the standard ``status: "session_created"``
+    payload.
+    """
+    import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    # Create the expected agent file under tmp_path.
+    agent_dir = tmp_path / ".opencode" / "agents"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "qs-create-plan.md").touch()
+
+    def _capture(req: urllib.request.Request, timeout: int = 10) -> MagicMock:
+        del timeout
+        if req.full_url.endswith("/session"):
+            return _mock_response(json.dumps({"id": "sess-X"}).encode())
+        return _mock_response(b"")
+
+    mock_urlopen = MagicMock(side_effect=_capture)
+    monkeypatch.setattr(spawn_session.urllib.request, "urlopen", mock_urlopen)
+
+    exit_code = _run_main(
+        monkeypatch,
+        "--agent", "qs-create-plan",
+        "--directory", str(tmp_path),
+    )
+    assert exit_code == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "session_created"
+    # The HTTP API WAS called (pre-flight passed).
+    assert mock_urlopen.called
+
+
+@pytest.mark.real_preflight
+def test_preflight_checks_correct_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pre-flight pins the agent→path mapping, not just "any file under .opencode/agents/".
+
+    Creates ``qs-implement-task.md`` but the CLI requests
+    ``qs-create-plan`` — the pre-flight must still reject because the
+    SPECIFIC agent file is absent.
+    """
+    import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    # Wrong agent file present.
+    agent_dir = tmp_path / ".opencode" / "agents"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "qs-implement-task.md").touch()
+
+    mock_urlopen = MagicMock()
+    monkeypatch.setattr(spawn_session.urllib.request, "urlopen", mock_urlopen)
+
+    exit_code = _run_main(
+        monkeypatch,
+        "--agent", "qs-create-plan",
+        "--directory", str(tmp_path),
+    )
+    assert exit_code == 2
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "agent_file_missing"
+    assert payload["agent"] == "qs-create-plan"
+    # The expected_path is the SPECIFIC qs-create-plan.md, not a
+    # generic "any .md under .opencode/agents/".
+    assert payload["expected_path"].endswith("/qs-create-plan.md")
+    # And the HTTP API was never reached.
+    mock_urlopen.assert_not_called()

--- a/tests/qs/test_spawn_session.py
+++ b/tests/qs/test_spawn_session.py
@@ -40,34 +40,44 @@ import pytest
 # --------------------------------------------------------------------------- #
 
 
-@pytest.fixture(autouse=True)
-def _stub_agent_file_preflight(
-    request: pytest.FixtureRequest,
+@pytest.fixture
+def stub_agent_file_preflight(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Auto-stub the QS-190 agent-file pre-flight for post-pre-flight tests.
+    """Opt-in fixture: stub the QS-190 agent-file pre-flight.
 
-    Most tests in this module exercise behaviour AFTER the pre-flight
-    (the urlopen mocks, the fallback branches, the strip / validation
-    guards). They pass hardcoded ``--directory`` paths like ``/tmp/x``
-    that don't exist on disk, so the pre-flight ``is_file()`` check
-    would abort them with ``status: "agent_file_missing"`` before any
+    Tests that exercise behaviour AFTER the pre-flight (urlopen mocks,
+    fallback branches, strip / validation guards) typically pass
+    hardcoded ``--directory`` paths like ``/tmp/x`` that don't exist on
+    disk. Without this stub, the pre-flight check would abort them
+    with one of {``worktree_invalid``, ``agent_file_missing``,
+    ``agent_file_empty``, ``agent_file_unreadable``} before any
     urlopen is reached.
 
-    This autouse fixture monkeypatches ``spawn_session._agent_file_path``
-    to point to a stub file under ``tmp_path``, satisfying the
-    pre-flight. Tests marked with ``@pytest.mark.real_preflight`` opt
-    out and exercise the real path computation against the actual
-    filesystem (using the explicit ``--directory`` they pass).
+    Use opt-in (review fix #01 S4): the dedicated pre-flight tests
+    (``test_preflight_*``) DON'T request this fixture and exercise the
+    real ``_preflight`` against the actual filesystem. Tests that
+    request this fixture explicitly declare "I am bypassing the
+    pre-flight" — no silent bypass, no risk of future tests masking a
+    pre-flight regression.
     """
-    if "real_preflight" in request.keywords:
-        return
     import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
 
     stub = tmp_path / "stub_agent.md"
-    stub.touch()
+    # Write a non-empty body so a future direct ``_agent_file_path``
+    # caller (e.g. a test that monkeypatches only one helper) sees
+    # the same successful-shape file.
+    stub.write_text("---\nmode: subagent\n---\n", encoding="utf-8")
     monkeypatch.setattr(spawn_session, "_agent_file_path", lambda _d, _a: stub)
+    # Stub the full _preflight too — bypasses all four branches
+    # (worktree_invalid / agent_file_missing / agent_file_unreadable /
+    # agent_file_empty) so tests with hardcoded ``--directory /tmp/x``
+    # don't trip the new worktree-existence check.
+    monkeypatch.setattr(
+        spawn_session, "_preflight",
+        lambda _d, _a: ("ok", stub, ""),
+    )
 
 
 def _mock_response(data: bytes = b"", status: int = 200) -> MagicMock:
@@ -126,7 +136,7 @@ def test_api_helper_sends_directory_header() -> None:
 
 
 def test_spawn_session_happy_path(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """``main()`` posts /session, then prompt_async, emits AC #1 payload, exit 0."""
     import spawn_session  # type: ignore[import-not-found]
@@ -179,7 +189,7 @@ def test_spawn_session_happy_path(
 # --------------------------------------------------------------------------- #
 
 
-def test_no_instance_reload_call(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_no_instance_reload_call(monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None) -> None:
     """Happy path must not touch /instance/reload nor spawn a subprocess."""
     import spawn_session  # type: ignore[import-not-found]
 
@@ -226,7 +236,7 @@ def test_no_delay_flag_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_default_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_prompt(monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None) -> None:
     """Without ``--prompt``, the prompt_async body carries the default kickoff."""
     import spawn_session  # type: ignore[import-not-found]
 
@@ -250,7 +260,7 @@ def test_default_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
     assert prompt_body["parts"][0]["text"] == "Begin your phase protocol."
 
 
-def test_custom_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_custom_prompt(monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None) -> None:
     """``--prompt`` is forwarded verbatim into prompt_async."""
     import spawn_session  # type: ignore[import-not-found]
 
@@ -281,7 +291,7 @@ def test_custom_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_server_unreachable_fallback_cli(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """URLError + opencode on PATH → fallback_cli, exit 0."""
     import spawn_session  # type: ignore[import-not-found]
@@ -320,7 +330,7 @@ def test_server_unreachable_fallback_cli(
 
 
 def test_server_unreachable_no_cli(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """URLError + no opencode on PATH → fallback_unavailable, exit 2."""
     import spawn_session  # type: ignore[import-not-found]
@@ -354,7 +364,7 @@ def test_server_unreachable_no_cli(
 
 
 def test_timeout_falls_back(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A socket.timeout raised by urlopen routes through the fallback path."""
     import spawn_session  # type: ignore[import-not-found]
@@ -382,7 +392,7 @@ def test_timeout_falls_back(
 
 
 def test_http_error_falls_back(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """An HTTPError (e.g. 500) from /session routes through the fallback path."""
     import spawn_session  # type: ignore[import-not-found]
@@ -409,7 +419,7 @@ def test_http_error_falls_back(
 
 
 def test_malformed_json_falls_back(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A non-JSON response body from /session triggers the fallback path."""
     import spawn_session  # type: ignore[import-not-found]
@@ -436,7 +446,7 @@ def test_malformed_json_falls_back(
 
 
 def test_missing_session_id_falls_back(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """``/session`` returning ``{}`` (no ``id``) triggers the fallback path."""
     import spawn_session  # type: ignore[import-not-found]
@@ -458,7 +468,7 @@ def test_missing_session_id_falls_back(
 
 
 def test_non_dict_session_response_falls_back(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """``/session`` returning a JSON array (not a dict) triggers fallback.
 
@@ -493,7 +503,7 @@ def test_non_dict_session_response_falls_back(
 
 
 def test_prompt_async_failure_attempts_delete(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """prompt_async fails → DELETE attempted → on success, fallback_cli."""
     import spawn_session  # type: ignore[import-not-found]
@@ -538,7 +548,7 @@ def test_prompt_async_failure_attempts_delete(
 
 
 def test_prompt_async_failure_delete_fails_emits_orphan(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """If DELETE also fails, surface ``session_orphaned`` with the id, exit 2."""
     import spawn_session  # type: ignore[import-not-found]
@@ -585,7 +595,7 @@ def test_prompt_async_failure_delete_fails_emits_orphan(
 
 
 def test_stderr_message_on_failure(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A human-readable line lands on stderr describing the failure."""
     import spawn_session  # type: ignore[import-not-found]
@@ -612,7 +622,7 @@ def test_stderr_message_on_failure(
 # --------------------------------------------------------------------------- #
 
 
-def test_title_defaults_to_agent_name(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_title_defaults_to_agent_name(monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None) -> None:
     """Without ``--title``, ``POST /session`` body uses the agent name."""
     import spawn_session  # type: ignore[import-not-found]
 
@@ -641,7 +651,7 @@ def test_title_defaults_to_agent_name(monkeypatch: pytest.MonkeyPatch) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_custom_title_forwarded_to_session(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_custom_title_forwarded_to_session(monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None) -> None:
     """``--title`` is forwarded verbatim into ``POST /session`` body."""
     import spawn_session  # type: ignore[import-not-found]
 
@@ -705,7 +715,7 @@ def test_base_url_defaults_to_4096(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_invalid_url_falls_back(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """``http.client.InvalidURL`` (malformed port, control chars) routes through fallback.
 
@@ -739,7 +749,7 @@ def test_invalid_url_falls_back(
 # --------------------------------------------------------------------------- #
 
 
-def test_spawn_session_url_escapes_session_id(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_spawn_session_url_escapes_session_id(monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None) -> None:
     """A server-provided ``id`` with embedded ``/`` is URL-escaped before interpolation.
 
     Note: ids containing ``..`` are now rejected upfront by review fix
@@ -801,7 +811,7 @@ def test_empty_directory_rejected(monkeypatch: pytest.MonkeyPatch, bad_dir: str)
 
 
 def test_oserror_falls_back(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A bare ``OSError`` (disk-level / socket-level) routes through the fallback path.
 
@@ -835,7 +845,7 @@ def test_oserror_falls_back(
 
 
 def test_prompt_async_timeout_attempts_delete(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A ``socket.timeout`` raised by prompt_async still triggers DELETE cleanup.
 
@@ -882,7 +892,7 @@ def test_prompt_async_timeout_attempts_delete(
 
 
 def test_orphan_without_opencode_cli(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Orphan + no opencode CLI on PATH → drop ``new_context_cli``, surface the issue.
 
@@ -966,7 +976,7 @@ def test_empty_title_rejected(monkeypatch: pytest.MonkeyPatch, bad_title: str) -
     b'{"id": null}',    # the case the None-guard already caught
 ])
 def test_falsy_or_non_string_id_falls_back(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None,
     capsys: pytest.CaptureFixture[str],
     session_body: bytes,
 ) -> None:
@@ -1033,7 +1043,7 @@ def test_empty_agent_rejected(monkeypatch: pytest.MonkeyPatch, bad_agent: str) -
 # --------------------------------------------------------------------------- #
 
 
-def test_directory_whitespace_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_directory_whitespace_stripped(monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None) -> None:
     """``--directory '  /tmp/wt  '`` lands ``"/tmp/wt"`` (no surrounding ws) in the header.
 
     Shell-history copy-paste artifacts shouldn't break the
@@ -1061,7 +1071,7 @@ def test_directory_whitespace_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
     assert seen_headers[0] == "/tmp/wt", f"header was not stripped: {seen_headers[0]!r}"
 
 
-def test_agent_whitespace_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_agent_whitespace_stripped(monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None) -> None:
     """``--agent '  qs-create-plan  '`` lands stripped in the prompt_async body."""
     import spawn_session  # type: ignore[import-not-found]
 
@@ -1085,7 +1095,7 @@ def test_agent_whitespace_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
     assert prompt_body["agent"] == "qs-create-plan"
 
 
-def test_prompt_whitespace_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_prompt_whitespace_stripped(monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None) -> None:
     """``--prompt '  hi  '`` lands stripped in the prompt_async body."""
     import spawn_session  # type: ignore[import-not-found]
 
@@ -1110,7 +1120,7 @@ def test_prompt_whitespace_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
     assert prompt_body["parts"][0]["text"] == "hi"
 
 
-def test_title_whitespace_stripped_when_provided(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_title_whitespace_stripped_when_provided(monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None) -> None:
     """``--title '  T  '`` (explicit) lands stripped in the /session body."""
     import spawn_session  # type: ignore[import-not-found]
 
@@ -1141,7 +1151,7 @@ def test_title_whitespace_stripped_when_provided(monkeypatch: pytest.MonkeyPatch
 
 
 def test_invalid_header_value_falls_back(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A ``ValueError`` from ``urlopen`` (invalid header value) routes through fallback.
 
@@ -1249,7 +1259,7 @@ def test_control_chars_in_title_rejected(
     "abc..def",           # interior `..` (rejected for uniformity)
 ])
 def test_spawn_session_rejects_traversal_id(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None,
     capsys: pytest.CaptureFixture[str],
     bad_id: str,
 ) -> None:
@@ -1296,7 +1306,7 @@ def test_spawn_session_rejects_traversal_id(
 
 
 def test_orphan_stderr_mentions_missing_cli(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch, stub_agent_file_preflight: None, capsys: pytest.CaptureFixture[str],
 ) -> None:
     """When orphan + no opencode CLI, stderr line includes the CLI-missing hint."""
     import spawn_session  # type: ignore[import-not-found]
@@ -1387,7 +1397,9 @@ def test_spawn_session_normalizes_whitespace_title(
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.real_preflight
+_VALID_AGENT_BODY = "---\nmode: subagent\n---\n"
+
+
 def test_preflight_aborts_when_agent_file_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1403,7 +1415,9 @@ def test_preflight_aborts_when_agent_file_missing(
     """
     import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
 
-    # tmp_path has NO .opencode/agents/ subdir → pre-flight must abort.
+    # Worktree dir exists but has NO .opencode/agents/ subdir → pre-flight
+    # must abort with ``agent_file_missing`` (the worktree itself IS
+    # valid; what's missing is the specific agent file).
     mock_urlopen = MagicMock()
     monkeypatch.setattr(spawn_session.urllib.request, "urlopen", mock_urlopen)
 
@@ -1411,6 +1425,7 @@ def test_preflight_aborts_when_agent_file_missing(
         monkeypatch,
         "--agent", "qs-create-plan",
         "--directory", str(tmp_path),
+        "--prompt", "Custom kickoff prompt",
     )
     assert exit_code == 2
 
@@ -1425,6 +1440,10 @@ def test_preflight_aborts_when_agent_file_missing(
     assert payload["detail"].startswith(
         "ERROR: OpenCode agent file not found at ",
     )
+    # N9: every failure payload carries the input ``prompt`` so the
+    # consumer (next-phase orchestrator) has the full original CLI shape
+    # for diagnostic / retry purposes.
+    assert payload["prompt"] == "Custom kickoff prompt"
 
     # Stderr carries the human-readable line.
     assert "OpenCode agent file not found at " in captured.err
@@ -1433,13 +1452,12 @@ def test_preflight_aborts_when_agent_file_missing(
     mock_urlopen.assert_not_called()
 
 
-@pytest.mark.real_preflight
 def test_preflight_passes_when_agent_file_present(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """When ``<worktree>/.opencode/agents/<agent>.md`` exists, the pre-flight passes silently.
+    """When ``<worktree>/.opencode/agents/<agent>.md`` exists AND is non-empty, the pre-flight passes silently.
 
     The script proceeds to ``POST /session`` (verified by the mock being
     invoked) and emits the standard ``status: "session_created"``
@@ -1447,10 +1465,14 @@ def test_preflight_passes_when_agent_file_present(
     """
     import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
 
-    # Create the expected agent file under tmp_path.
+    # Create the expected agent file with a minimal valid YAML
+    # frontmatter (S6 — pre-flight rejects 0-byte placeholders, so
+    # ``.touch()`` would now flag ``agent_file_empty``).
     agent_dir = tmp_path / ".opencode" / "agents"
     agent_dir.mkdir(parents=True)
-    (agent_dir / "qs-create-plan.md").touch()
+    (agent_dir / "qs-create-plan.md").write_text(
+        _VALID_AGENT_BODY, encoding="utf-8",
+    )
 
     def _capture(req: urllib.request.Request, timeout: int = 10) -> MagicMock:
         del timeout
@@ -1474,7 +1496,6 @@ def test_preflight_passes_when_agent_file_present(
     assert mock_urlopen.called
 
 
-@pytest.mark.real_preflight
 def test_preflight_checks_correct_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1488,10 +1509,13 @@ def test_preflight_checks_correct_path(
     """
     import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
 
-    # Wrong agent file present.
+    # Wrong agent file present (non-empty body so the empty-file guard
+    # doesn't preempt the missing-file check).
     agent_dir = tmp_path / ".opencode" / "agents"
     agent_dir.mkdir(parents=True)
-    (agent_dir / "qs-implement-task.md").touch()
+    (agent_dir / "qs-implement-task.md").write_text(
+        _VALID_AGENT_BODY, encoding="utf-8",
+    )
 
     mock_urlopen = MagicMock()
     monkeypatch.setattr(spawn_session.urllib.request, "urlopen", mock_urlopen)
@@ -1511,3 +1535,165 @@ def test_preflight_checks_correct_path(
     assert payload["expected_path"].endswith("/qs-create-plan.md")
     # And the HTTP API was never reached.
     mock_urlopen.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Review fix #01 — M1: PermissionError → distinct ``agent_file_unreadable``
+# --------------------------------------------------------------------------- #
+
+
+def test_preflight_emits_unreadable_when_parent_dir_unreadable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``is_file()`` raising ``PermissionError`` → ``agent_file_unreadable``.
+
+    Closes M1: when the parent directory is unreadable (e.g. ``0o000``
+    mode), ``Path.is_file`` returns False on most platforms, but on
+    some it raises ``OSError``. Either way, the diagnostic must
+    distinguish "file does not exist" from "file exists but can't be
+    accessed" so the user knows to ``chmod`` instead of creating a
+    duplicate file.
+    """
+    import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    # The worktree directory exists (so we get past the worktree_invalid
+    # branch), and the .opencode/agents/ subdir exists too, BUT
+    # ``is_file()`` will be monkeypatched to raise PermissionError for
+    # the specific agent file (simulating an unreadable parent).
+    agent_dir = tmp_path / ".opencode" / "agents"
+    agent_dir.mkdir(parents=True)
+
+    real_is_file = Path.is_file
+
+    def _is_file(self: Path) -> bool:
+        if self.name == "qs-create-plan.md":
+            raise PermissionError(13, "Permission denied")
+        return real_is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", _is_file)
+
+    mock_urlopen = MagicMock()
+    monkeypatch.setattr(spawn_session.urllib.request, "urlopen", mock_urlopen)
+
+    exit_code = _run_main(
+        monkeypatch,
+        "--agent", "qs-create-plan",
+        "--directory", str(tmp_path),
+    )
+    assert exit_code == 2
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "agent_file_unreadable"
+    assert payload["agent"] == "qs-create-plan"
+    assert payload["expected_path"].endswith("/qs-create-plan.md")
+    # The OS-level errno is surfaced so the user can disambiguate.
+    assert "Permission denied" in payload["detail"]
+    # Stderr surfaces the same line.
+    assert "agent file" in captured.err.lower()
+    # And HTTP was never reached.
+    mock_urlopen.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Review fix #01 — S6: empty agent file → ``agent_file_empty``
+# --------------------------------------------------------------------------- #
+
+
+def test_preflight_emits_empty_when_agent_file_zero_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A 0-byte agent file → ``agent_file_empty``, not ``session_created``.
+
+    Closes S6: ``is_file()`` returns True for a ``touch``'d placeholder,
+    so the QS-190 v1 pre-flight let it through and the OpenCode server
+    silently fell back to the default agent — re-opening the QS-177
+    AC #12 hole.
+    """
+    import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    agent_dir = tmp_path / ".opencode" / "agents"
+    agent_dir.mkdir(parents=True)
+    # 0-byte placeholder
+    (agent_dir / "qs-create-plan.md").touch()
+
+    mock_urlopen = MagicMock()
+    monkeypatch.setattr(spawn_session.urllib.request, "urlopen", mock_urlopen)
+
+    exit_code = _run_main(
+        monkeypatch,
+        "--agent", "qs-create-plan",
+        "--directory", str(tmp_path),
+    )
+    assert exit_code == 2
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "agent_file_empty"
+    assert payload["agent"] == "qs-create-plan"
+    assert payload["expected_path"].endswith("/qs-create-plan.md")
+    assert "empty" in payload["detail"].lower()
+    assert "empty" in captured.err.lower()
+    mock_urlopen.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Review fix #01 — N6: missing worktree → ``worktree_invalid``
+# --------------------------------------------------------------------------- #
+
+
+def test_preflight_emits_worktree_invalid_when_directory_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A ``--directory`` that isn't a real directory → ``worktree_invalid``.
+
+    Closes N6: pre-pre-flight check on ``args.directory``. Without
+    this, a dangling symlink or typo'd worktree path produces a
+    misleading "agent file not found" diagnostic.
+    """
+    import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    missing_dir = tmp_path / "does_not_exist"
+    # Don't create it.
+
+    mock_urlopen = MagicMock()
+    monkeypatch.setattr(spawn_session.urllib.request, "urlopen", mock_urlopen)
+
+    exit_code = _run_main(
+        monkeypatch,
+        "--agent", "qs-create-plan",
+        "--directory", str(missing_dir),
+    )
+    assert exit_code == 2
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "worktree_invalid"
+    assert payload["directory"] == str(missing_dir)
+    assert "directory" in payload["detail"].lower()
+    assert "directory" in captured.err.lower()
+    mock_urlopen.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Review fix #01 — S12: AC-7 docstring pin for spawn_session.py itself
+# --------------------------------------------------------------------------- #
+
+
+def test_spawn_session_docstring_documents_closed_limitation() -> None:
+    """Mirrors the launcher/harness.md AC-7 pins for spawn_session.py's docstring.
+
+    Closes S12: AC-7 mandates the exact substring at three sites
+    (launcher docstring, harness.md, spawn_session.py docstring). The
+    first two were pinned; this closes the third.
+    """
+    import spawn_session  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    assert spawn_session.__doc__ is not None
+    assert "spawn_session.py performs a pre-flight check" in spawn_session.__doc__


### PR DESCRIPTION
## Summary
- spawn_session.py: agent-file pre-flight aborts with status=agent_file_missing if .opencode/agents/<agent>.md is absent, closing QS-177 AC #12.
- 13 next_step.py / setup_task.py callsites across .opencode/, .claude/, .cursor/ now pass an explicit --harness flag matching their directory.
- OpenCode mid-pipeline agents auto-execute new_context via Bash and verify the binary status=session_created + agent=qs-<expected> contract; setup-task + every Claude/Cursor agent preserve the print-for-user pattern.

Fixes #190

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved agent platform selection and workflow transitions across OpenCode, Claude, and Cursor environments
  * Enhanced pre-flight validation for agent configuration with clearer error messages when files are missing or invalid
  * Automatic session progression in OpenCode workflows with robust error recovery

* **Tests**
  * Added comprehensive test coverage for agent handoff, configuration validation, and platform-specific behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->