### PR TITLE
QS-195: Add radiator load type (climate + on/off switch heating)

### DIFF
--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -1609,6 +1609,49 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
 
         return self.async_show_form(step_id=TYPE, data_schema=schema, description_placeholders=placeholders)
 
+    def _get_pending_radiator_data(self) -> dict:
+        """Return Pass 1 → Pass 2 carry-over dict (in-memory, never persisted).
+
+        S1 review-fix — Pass 1 stores the climate-entity selection here
+        instead of mutating `config_entry.data` mid-flow. If the user
+        abandons the flow between Pass 1 and Pass 2 nothing leaks into
+        the persisted config entry.
+        """
+        if not hasattr(self, "_pending_radiator_data") or self._pending_radiator_data is None:
+            self._pending_radiator_data = {}
+        return self._pending_radiator_data
+
+    def _clear_pending_radiator_data(self) -> None:
+        """Reset the Pass 1 → Pass 2 carry-over once a final submission lands."""
+        self._pending_radiator_data = {}
+
+    def _purge_stale_radiator_backing_keys(self, keep_climate: bool) -> None:
+        """Drop the stale-backing keys from the persisted config-entry data.
+
+        AC-13 / N13 review-fix — `_async_entry_next` merges submitted
+        data into `config_entry.data` (additive update); without this
+        purge a switch ↔ climate swap would leave both backings alive
+        after the reload, tripping `QSRadiator.__init__`'s XOR check.
+        """
+        stale_keys: tuple[str, ...]
+        if keep_climate:
+            stale_keys = (CONF_SWITCH,)
+        else:
+            stale_keys = (CONF_CLIMATE, CONF_CLIMATE_HVAC_MODE_ON, CONF_CLIMATE_HVAC_MODE_OFF)
+
+        if isinstance(self.config_entry, FakeConfigEntry):
+            for key in stale_keys:
+                self.config_entry.data.pop(key, None)
+        else:
+            current = dict(self.config_entry.data)
+            mutated = False
+            for key in stale_keys:
+                if key in current:
+                    current.pop(key)
+                    mutated = True
+            if mutated:
+                self.hass.config_entries.async_update_entry(self.config_entry, data=current)
+
     async def async_step_radiator(self, user_input=None):
 
         TYPE = QSRadiator.conf_type_name
@@ -1620,8 +1663,13 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             # `{"force_radiator_climate": True}`) does not echo the entity
             # selectors.
             if "force_radiator_climate" not in user_input:
-                climate_entity = user_input.get(CONF_CLIMATE)
-                switch_entity = user_input.get(CONF_SWITCH)
+                # M4/M5 + N6 — normalise entities through truthy/strip so XOR
+                # and transport-selection paths agree (empty / whitespace
+                # entity ids are treated as absent).
+                climate_raw = user_input.get(CONF_CLIMATE)
+                switch_raw = user_input.get(CONF_SWITCH)
+                climate_entity = climate_raw.strip() if isinstance(climate_raw, str) else climate_raw
+                switch_entity = switch_raw.strip() if isinstance(switch_raw, str) else switch_raw
 
                 # AC-6 exactly-one-backing validation (cross-field XOR)
                 if bool(climate_entity) == bool(switch_entity):
@@ -1629,30 +1677,66 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                         errors={"base": "exactly_one_backing_required"},
                     )
 
-                if climate_entity is not None:
-                    orig_climate_entity = self.config_entry.data.get(CONF_CLIMATE)
-                    if (
-                        climate_entity != orig_climate_entity
-                        or user_input.get(CONF_CLIMATE_HVAC_MODE_OFF) is None
-                        or user_input.get(CONF_CLIMATE_HVAC_MODE_ON) is None
-                    ):
-                        # Re-prompt with HVAC mode dropdowns once the climate
-                        # entity is known. Preserve user-entered fields by
-                        # merging into the config-entry data (the FakeConfigEntry
-                        # used during creation accepts direct assignment; the
-                        # real ConfigEntry used during the options flow needs
-                        # `async_update_entry`).
-                        merged = dict(self.config_entry.data)
-                        merged.update(user_input)
-                        if isinstance(self.config_entry, FakeConfigEntry):
-                            self.config_entry.data = merged
-                        else:
-                            self.hass.config_entries.async_update_entry(self.config_entry, data=merged)
+                # N8 — drop empty/None values from the merged dict so
+                # downstream `key in dict` checks see the canonical shape.
+                cleaned = {k: v for k, v in user_input.items() if v not in (None, "")}
+                if climate_entity:
+                    cleaned[CONF_CLIMATE] = climate_entity
+                    cleaned.pop(CONF_SWITCH, None)
+                else:
+                    cleaned[CONF_SWITCH] = switch_entity
+                    cleaned.pop(CONF_CLIMATE, None)
+                    # Climate-only fields must not survive into a
+                    # switch-backed entry — they belong to a backing
+                    # that is no longer in effect.
+                    cleaned.pop(CONF_CLIMATE_HVAC_MODE_ON, None)
+                    cleaned.pop(CONF_CLIMATE_HVAC_MODE_OFF, None)
+
+                if climate_entity:
+                    hvac_modes = get_hvac_modes(self.hass, climate_entity)
+                    # S7 — empty hvac_modes means we cannot render a usable
+                    # form; surface the error rather than block the user.
+                    if not hvac_modes:
+                        return await self._async_show_radiator_form(
+                            errors={"base": "climate_capabilities_unavailable"},
+                        )
+
+                    persisted_on = user_input.get(CONF_CLIMATE_HVAC_MODE_ON)
+                    persisted_off = user_input.get(CONF_CLIMATE_HVAC_MODE_OFF)
+                    # S6 — re-prompt whenever the persisted HVAC mode
+                    # value is missing or no longer in the entity's
+                    # current `hvac_modes` list (vendor firmware update
+                    # dropped it). The mode-membership check subsumes
+                    # the older "climate entity changed" branch — a new
+                    # climate entity with the same HVAC modes legitimately
+                    # keeps the persisted selection.
+                    need_reprompt = (
+                        not persisted_on
+                        or not persisted_off
+                        or persisted_on not in hvac_modes
+                        or persisted_off not in hvac_modes
+                    )
+                    if need_reprompt:
+                        # S1 — buffer the Pass 1 payload in memory rather
+                        # than writing it to `config_entry.data` mid-flow.
+                        # The persisted entry data MUST NOT be touched
+                        # here — if the user aborts now, nothing leaks.
+                        self._get_pending_radiator_data().clear()
+                        self._get_pending_radiator_data().update(cleaned)
                         return await self.async_step_radiator({"force_radiator_climate": True})
 
-                    return await self.async_entry_next(user_input, TYPE)
+                    # AC-13 / N13 — final submission: clear stale backing
+                    # keys from the persisted entry BEFORE the options-flow
+                    # merge so a swap (switch ↔ climate) doesn't leave both
+                    # sides alive after the reload.
+                    self._purge_stale_radiator_backing_keys(keep_climate=True)
+                    self._clear_pending_radiator_data()
+                    return await self.async_entry_next(cleaned, TYPE)
 
-                return await self.async_entry_next(user_input, TYPE)
+                # Switch-backed final submission — no HVAC dropdowns needed.
+                self._purge_stale_radiator_backing_keys(keep_climate=False)
+                self._clear_pending_radiator_data()
+                return await self.async_entry_next(cleaned, TYPE)
 
         return await self._async_show_radiator_form()
 
@@ -1674,41 +1758,68 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         self.add_entity_selector(sc_dict, CONF_SWITCH, False, domain=[SWITCH_DOMAIN])
         self.add_entity_selector(sc_dict, CONF_CLIMATE, False, domain=[CLIMATE_DOMAIN])
 
-        climate_entity = self.config_entry.data.get(CONF_CLIMATE)
+        # S1 — Pass 2 reads the in-memory pending dict first, falling
+        # back to `config_entry.data` for re-edits via the options flow.
+        pending = self._get_pending_radiator_data() if hasattr(self, "_pending_radiator_data") else {}
+        climate_entity = pending.get(CONF_CLIMATE) or self.config_entry.data.get(CONF_CLIMATE)
 
-        if climate_entity is not None:
+        if climate_entity:
             hvac_modes = get_hvac_modes(self.hass, climate_entity)
 
-            # Suggested default: "heat" if available, else first non-"off" mode.
-            existing_on = self.config_entry.data.get(CONF_CLIMATE_HVAC_MODE_ON)
-            if existing_on is None:
-                if "heat" in hvac_modes:
+            if hvac_modes:
+                # Suggested default for ON: "heat" if available, else first non-"off" mode.
+                existing_on = pending.get(CONF_CLIMATE_HVAC_MODE_ON) or self.config_entry.data.get(
+                    CONF_CLIMATE_HVAC_MODE_ON
+                )
+                if existing_on and existing_on in hvac_modes:
+                    suggested_on = existing_on
+                elif "heat" in hvac_modes:
                     suggested_on = "heat"
                 else:
                     non_off = [m for m in hvac_modes if m != "off"]
-                    suggested_on = non_off[0] if non_off else (hvac_modes[0] if hvac_modes else "heat")
-            else:
-                suggested_on = existing_on
+                    suggested_on = non_off[0] if non_off else hvac_modes[0]
 
-            existing_off = self.config_entry.data.get(CONF_CLIMATE_HVAC_MODE_OFF)
-            suggested_off = existing_off if existing_off is not None else "off"
+                # S13 — `suggested_off` must be in `hvac_modes` or
+                # voluptuous will reject the schema. Prefer "off", fall
+                # back to any mode containing "off", finally the last mode.
+                existing_off = pending.get(CONF_CLIMATE_HVAC_MODE_OFF) or self.config_entry.data.get(
+                    CONF_CLIMATE_HVAC_MODE_OFF
+                )
+                if existing_off and existing_off in hvac_modes:
+                    suggested_off = existing_off
+                elif "off" in hvac_modes:
+                    suggested_off = "off"
+                else:
+                    off_like = [m for m in hvac_modes if "off" in m.lower()]
+                    suggested_off = off_like[0] if off_like else hvac_modes[-1]
 
-            sc_dict[vol.Required(CONF_CLIMATE_HVAC_MODE_OFF, default=suggested_off)] = SelectSelector(
-                SelectSelectorConfig(options=hvac_modes, mode=SelectSelectorMode.DROPDOWN)
-            )
-            sc_dict[vol.Required(CONF_CLIMATE_HVAC_MODE_ON, default=suggested_on)] = SelectSelector(
-                SelectSelectorConfig(options=hvac_modes, mode=SelectSelectorMode.DROPDOWN)
-            )
+                sc_dict[vol.Required(CONF_CLIMATE_HVAC_MODE_OFF, default=suggested_off)] = SelectSelector(
+                    SelectSelectorConfig(options=hvac_modes, mode=SelectSelectorMode.DROPDOWN)
+                )
+                sc_dict[vol.Required(CONF_CLIMATE_HVAC_MODE_ON, default=suggested_on)] = SelectSelector(
+                    SelectSelectorConfig(options=hvac_modes, mode=SelectSelectorMode.DROPDOWN)
+                )
 
         # Heat-pump piloting dropdown — shown when at least one heat pump exists.
+        # M3 — use the canonical `QSHome.get_heat_pumps()` accessor instead
+        # of a raw `getattr` against the private `_heat_pumps` attribute.
         data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
-        heat_pump_options = []
-        if data_handler and data_handler.home:
-            heat_pumps = getattr(data_handler.home, "_heat_pumps", [])
+        heat_pump_options: list[str] = []
+        if data_handler and data_handler.home is not None:
+            getter = getattr(data_handler.home, "get_heat_pumps", None)
+            heat_pumps = getter() if callable(getter) else getattr(data_handler.home, "_heat_pumps", [])
             heat_pump_options = [hp.name for hp in heat_pumps]
+
+        merged_errors: dict[str, str] = dict(errors) if errors else {}
 
         if heat_pump_options:
             default_heat_pump = self.config_entry.data.get(CONF_DEVICE_TO_PILOT_NAME)
+            # S8 — if the persisted heat-pump name no longer exists, drop
+            # the suggested value and surface an error to the user.
+            if default_heat_pump and default_heat_pump not in heat_pump_options:
+                merged_errors.setdefault("base", "piloted_heat_pump_unknown")
+                default_heat_pump = None
+
             if default_heat_pump:
                 sc_dict[vol.Optional(CONF_DEVICE_TO_PILOT_NAME, description={"suggested_value": default_heat_pump})] = (
                     selector.SelectSelector(
@@ -1732,7 +1843,7 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             step_id=TYPE,
             data_schema=schema,
             description_placeholders=placeholders,
-            errors=errors,
+            errors=merged_errors or None,
         )
 
     async def async_step_dynamic_group(self, user_input=None):

--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -139,9 +139,10 @@ from .const import (
 )
 from .entity import LOAD_NAMES
 from .ha_model.battery import QSBattery
+from .ha_model.bistate_transport import get_hvac_modes
 from .ha_model.car import QSCar
 from .ha_model.charger import QSChargerGeneric, QSChargerOCPP, QSChargerWallbox
-from .ha_model.climate_controller import QSClimateDuration, get_hvac_modes
+from .ha_model.climate_controller import QSClimateDuration
 from .ha_model.dynamic_group import QSDynamicGroup
 from .ha_model.heat_pump import QSHeatPump
 from .ha_model.home import QSHome
@@ -1625,36 +1626,77 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         """Reset the Pass 1 → Pass 2 carry-over once a final submission lands."""
         self._pending_radiator_data = {}
 
-    def _purge_stale_radiator_backing_keys(self, keep_climate: bool) -> None:
-        """Drop the stale-backing keys from the persisted config-entry data.
+    def _add_radiator_entity_selector(self, sc_dict: dict, key: str, domain: str, suggestion: str | None) -> None:
+        """B1 review-fix — entity selector with a Pass 1 → Pass 2 suggestion.
 
-        AC-13 / N13 review-fix — `_async_entry_next` merges submitted
-        data into `config_entry.data` (additive update); without this
-        purge a switch ↔ climate swap would leave both backings alive
-        after the reload, tripping `QSRadiator.__init__`'s XOR check.
+        `add_entity_selector` doesn't expose a `suggested_value` knob, so
+        the radiator step plumbs it through here. When `suggestion` is
+        empty, the field renders as the standard optional selector
+        (current behaviour preserved).
         """
-        stale_keys: tuple[str, ...]
-        if keep_climate:
-            stale_keys = (CONF_SWITCH,)
+        if suggestion:
+            sc_dict[vol.Optional(key, description={"suggested_value": suggestion})] = selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=[domain])
+            )
         else:
-            stale_keys = (CONF_CLIMATE, CONF_CLIMATE_HVAC_MODE_ON, CONF_CLIMATE_HVAC_MODE_OFF)
+            sc_dict[vol.Optional(key)] = selector.EntitySelector(selector.EntitySelectorConfig(domain=[domain]))
+
+    def _stale_radiator_backing_keys(self, keep_climate: bool) -> tuple[str, ...]:
+        """Return the keys that must NOT survive a radiator save.
+
+        AC-13 / N13 + B2 review-fix — `_async_entry_next` merges
+        submitted data into `config_entry.data` additively, so a
+        switch ↔ climate swap would leave both backings alive after
+        the reload. Returning the stale-key list lets the radiator
+        save path bypass that merge in a SINGLE `async_update_entry`
+        call (rather than the previous double-write).
+        """
+        if keep_climate:
+            return (CONF_SWITCH,)
+        return (CONF_CLIMATE, CONF_CLIMATE_HVAC_MODE_ON, CONF_CLIMATE_HVAC_MODE_OFF)
+
+    async def _async_save_radiator_entry(
+        self, cleaned: dict, keep_climate: bool, extra_stale_keys: tuple[str, ...] = ()
+    ):
+        """Persist the radiator entry with stale-backing keys removed (single write).
+
+        B2 + E2 review-fix — bypasses `_async_entry_next` so the
+        switch ↔ climate swap (and the orphan-heat-pump cleanup) goes
+        through ONE `async_update_entry` instead of two. The single
+        write fires options-update listeners once and avoids races
+        with the reload hook.
+
+        `extra_stale_keys` carries fields the radiator-specific
+        validation decided to retire (e.g. `CONF_DEVICE_TO_PILOT_NAME`
+        when the persisted heat-pump name no longer exists, per E2).
+        """
+        TYPE = QSRadiator.conf_type_name
+        cleaned[DEVICE_TYPE] = TYPE
+        self.clean_data(cleaned)
 
         if isinstance(self.config_entry, FakeConfigEntry):
-            for key in stale_keys:
-                self.config_entry.data.pop(key, None)
-        else:
-            current = dict(self.config_entry.data)
-            mutated = False
-            for key in stale_keys:
-                if key in current:
-                    current.pop(key)
-                    mutated = True
-            if mutated:
-                self.hass.config_entries.async_update_entry(self.config_entry, data=current)
+            # Creation flow — `async_create_entry` is the single write.
+            u_id = f"Quiet Solar: {cleaned.get(CONF_NAME, 'device')} {cleaned.get(DEVICE_TYPE, 'unknown')}"
+            await self.async_set_unique_id(u_id)
+            return self.async_create_entry(title=self.get_entry_title(cleaned), data=cleaned)
+
+        # Options flow — compute the desired final data ourselves so we
+        # can EXCLUDE the stale-backing keys from the merge (which
+        # `_async_entry_next` would otherwise carry over additively).
+        stale_keys = self._stale_radiator_backing_keys(keep_climate) + tuple(extra_stale_keys)
+        merged = {k: v for k, v in self.config_entry.data.items() if k not in stale_keys}
+        merged.update(cleaned)
+
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data=merged,
+            options=self.config_entry.options,
+            title=self.get_entry_title(merged),
+        )
+        await async_reload_quiet_solar(self.hass, except_for_entry_id=self.config_entry.entry_id)
+        return self.async_create_entry(title=None, data={})
 
     async def async_step_radiator(self, user_input=None):
-
-        TYPE = QSRadiator.conf_type_name
 
         if user_input is not None:
             # Pass 2 of the climate two-pass flow — fall through to render
@@ -1692,6 +1734,11 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                     cleaned.pop(CONF_CLIMATE_HVAC_MODE_ON, None)
                     cleaned.pop(CONF_CLIMATE_HVAC_MODE_OFF, None)
 
+                # E2 — when the user submits without picking a new heat
+                # pump but the persisted name is stale, drop the orphan
+                # reference so it doesn't reappear on the next edit.
+                extra_stale_keys = self._radiator_orphan_pilot_keys(cleaned)
+
                 if climate_entity:
                     hvac_modes = get_hvac_modes(self.hass, climate_entity)
                     # S7 — empty hvac_modes means we cannot render a usable
@@ -1725,20 +1772,47 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                         self._get_pending_radiator_data().update(cleaned)
                         return await self.async_step_radiator({"force_radiator_climate": True})
 
-                    # AC-13 / N13 — final submission: clear stale backing
-                    # keys from the persisted entry BEFORE the options-flow
-                    # merge so a swap (switch ↔ climate) doesn't leave both
-                    # sides alive after the reload.
-                    self._purge_stale_radiator_backing_keys(keep_climate=True)
+                    # B2 + AC-13 / N13 — final submission via a single
+                    # `async_update_entry` write (no more double-write).
                     self._clear_pending_radiator_data()
-                    return await self.async_entry_next(cleaned, TYPE)
+                    return await self._async_save_radiator_entry(
+                        cleaned, keep_climate=True, extra_stale_keys=extra_stale_keys
+                    )
 
                 # Switch-backed final submission — no HVAC dropdowns needed.
-                self._purge_stale_radiator_backing_keys(keep_climate=False)
                 self._clear_pending_radiator_data()
-                return await self.async_entry_next(cleaned, TYPE)
+                return await self._async_save_radiator_entry(
+                    cleaned, keep_climate=False, extra_stale_keys=extra_stale_keys
+                )
 
         return await self._async_show_radiator_form()
+
+    def _radiator_orphan_pilot_keys(self, cleaned: dict) -> tuple[str, ...]:
+        """E2 review-fix — return `(CONF_DEVICE_TO_PILOT_NAME,)` when stale.
+
+        If the persisted `CONF_DEVICE_TO_PILOT_NAME` is no longer in the
+        home's heat-pump list AND the user's current submission does NOT
+        re-pick a heat pump, retire the orphan reference so it doesn't
+        reappear on the next edit. The radiator form already surfaces a
+        `piloted_heat_pump_unknown` warning via B4; this purge is the
+        complementary mutation that actually clears the persisted key
+        once the user moves past the warning.
+        """
+        if cleaned.get(CONF_DEVICE_TO_PILOT_NAME):
+            # User re-picked a heat pump — keep whatever they chose.
+            return ()
+        persisted = self.config_entry.data.get(CONF_DEVICE_TO_PILOT_NAME)
+        if not persisted:
+            return ()
+        data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
+        if not data_handler or data_handler.home is None:
+            return ()
+        getter = getattr(data_handler.home, "get_heat_pumps", None)
+        heat_pumps = getter() if callable(getter) else getattr(data_handler.home, "_heat_pumps", [])
+        names = {hp.name for hp in heat_pumps}
+        if persisted in names:
+            return ()
+        return (CONF_DEVICE_TO_PILOT_NAME,)
 
     async def _async_show_radiator_form(self, errors=None):
         """Render the radiator form (extracted so we can re-render on error)."""
@@ -1754,14 +1828,19 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             add_max_on_off=True,
         )
 
-        # Both selectors are optional — exactly-one validation runs on submit.
-        self.add_entity_selector(sc_dict, CONF_SWITCH, False, domain=[SWITCH_DOMAIN])
-        self.add_entity_selector(sc_dict, CONF_CLIMATE, False, domain=[CLIMATE_DOMAIN])
-
         # S1 — Pass 2 reads the in-memory pending dict first, falling
         # back to `config_entry.data` for re-edits via the options flow.
         pending = self._get_pending_radiator_data() if hasattr(self, "_pending_radiator_data") else {}
-        climate_entity = pending.get(CONF_CLIMATE) or self.config_entry.data.get(CONF_CLIMATE)
+
+        # B1 — Pass 2 form pre-fills the entity selectors with the
+        # values the user picked in Pass 1, so the field doesn't appear
+        # re-emptied (which would trip the XOR error if resubmitted).
+        switch_suggestion = pending.get(CONF_SWITCH) or self.config_entry.data.get(CONF_SWITCH)
+        climate_suggestion = pending.get(CONF_CLIMATE) or self.config_entry.data.get(CONF_CLIMATE)
+        self._add_radiator_entity_selector(sc_dict, CONF_SWITCH, domain=SWITCH_DOMAIN, suggestion=switch_suggestion)
+        self._add_radiator_entity_selector(sc_dict, CONF_CLIMATE, domain=CLIMATE_DOMAIN, suggestion=climate_suggestion)
+
+        climate_entity = climate_suggestion
 
         if climate_entity:
             hvac_modes = get_hvac_modes(self.hass, climate_entity)
@@ -1814,10 +1893,15 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
 
         if heat_pump_options:
             default_heat_pump = self.config_entry.data.get(CONF_DEVICE_TO_PILOT_NAME)
-            # S8 — if the persisted heat-pump name no longer exists, drop
-            # the suggested value and surface an error to the user.
+            # S8 + B4 — if the persisted heat-pump name no longer
+            # exists, drop the suggested value and surface a
+            # field-specific error to the user. Using
+            # `errors["device_to_pilot_name"]` instead of
+            # `errors["base"]` so a co-occurring XOR error (under
+            # `"base"`) doesn't mask the heat-pump warning via the
+            # previous `setdefault` no-op.
             if default_heat_pump and default_heat_pump not in heat_pump_options:
-                merged_errors.setdefault("base", "piloted_heat_pump_unknown")
+                merged_errors[CONF_DEVICE_TO_PILOT_NAME] = "piloted_heat_pump_unknown"
                 default_heat_pump = None
 
             if default_heat_pump:

--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -823,29 +823,40 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             }
         )
 
+        # BH (post-QS-195): the slot defaults MUST come from the live
+        # `home.dashboard_sections` (which has been normalized +
+        # migrated by `QSHome.__init__` and
+        # `_maybe_migrate_missing_default_section`) rather than from the
+        # stale persisted slots or `DASHBOARD_DEFAULT_SECTIONS[i]` by
+        # index. Without this, a user who upgraded across QS-194/QS-195
+        # saw slot 3 (persisted "others") AND slot 5 (index default
+        # "others") show "others" twice — and no "radiators" anywhere.
+        # Falling back to const defaults is only used when no home is
+        # available (e.g. very early flow state, brand-new install).
+        sections_source: list[tuple[str, str]] = list(DASHBOARD_DEFAULT_SECTIONS)
+        data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
+        if data_handler is not None and data_handler.home is not None and data_handler.home.dashboard_sections:
+            sections_source = list(data_handler.home.dashboard_sections)
+
         for i in range(0, DASHBOARD_NUM_SECTION_MAX):
             key_section_name = f"{CONF_DASHBOARD_SECTION_NAME}_{i}"
             key_section_icon = f"{CONF_DASHBOARD_SECTION_ICON}_{i}"
 
-            default_section_name = None
-            default_section_icon = None
-            if i < len(DASHBOARD_DEFAULT_SECTIONS):
-                default_section_name = DASHBOARD_DEFAULT_SECTIONS[i][0]
-                default_section_icon = DASHBOARD_DEFAULT_SECTIONS[i][1]
+            default_section_name: str | None = None
+            default_section_icon: str | None = None
+            if i < len(sections_source):
+                default_section_name = sections_source[i][0]
+                default_section_icon = sections_source[i][1]
 
             sc_dict.update(
                 {
                     vol.Optional(
                         key_section_name,
-                        description={
-                            "suggested_value": self.config_entry.data.get(key_section_name, default_section_name)
-                        },
+                        description={"suggested_value": default_section_name},
                     ): cv.string,
                     vol.Optional(
                         key_section_icon,
-                        description={
-                            "suggested_value": self.config_entry.data.get(key_section_icon, default_section_icon)
-                        },
+                        description={"suggested_value": default_section_icon},
                     ): cv.string,
                 }
             )

--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -125,7 +125,6 @@ from .const import (
     CONF_SWITCH,
     CONF_WATER_BOILER_TEMPERATURE_SENSOR,
     DASHBOARD_DEFAULT_SECTIONS,
-    DASHBOARD_DEFAULT_SECTIONS_DICT,
     DASHBOARD_DEVICE_SECTION_TRANSLATION_KEY,
     DASHBOARD_NO_SECTION,
     DASHBOARD_NUM_SECTION_MAX,
@@ -380,22 +379,17 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
 
             options_raw_list = None
             if home is not None and home.dashboard_sections is not None and len(home.dashboard_sections) > 0:
-                # we can have the list of sections
+                # The live home owns the authoritative section list:
+                # `QSHome.__init__` already ensures every bundled
+                # `DASHBOARD_DEFAULT_SECTIONS` entry (minus
+                # `CONF_DASHBOARD_SECTIONS_USER_REMOVED`) is included
+                # in canonical order, so the device-side dropdown
+                # naturally has every bundled section available
+                # without any per-step augmentation.
                 options_raw_list = list(home.dashboard_sections)
 
             if options_raw_list is None:
                 options_raw_list = list(DASHBOARD_DEFAULT_SECTIONS)
-
-            # Safety net: if the device's default section is one of the
-            # bundled defaults but the home's customised list doesn't
-            # include it (e.g. a pre-QS-194 entry that doesn't yet have
-            # `water_boilers` or `radiators`), append it to the dropdown
-            # options so the user can pick it. The home's
-            # `_maybe_migrate_missing_default_section` will then add the
-            # section to `dashboard_sections` when the device is created.
-            existing_names = {s[0] for s in options_raw_list}
-            if default_section not in existing_names and default_section in DASHBOARD_DEFAULT_SECTIONS_DICT:
-                options_raw_list.append((default_section, DASHBOARD_DEFAULT_SECTIONS_DICT[default_section]))
 
             # ok we want a section for those ones
             good_value = self.config_entry.data.get(CONF_DEVICE_DASHBOARD_SECTION, default_section)
@@ -823,16 +817,18 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             }
         )
 
-        # BH (post-QS-195): the slot defaults MUST come from the live
-        # `home.dashboard_sections` (which has been normalized +
-        # migrated by `QSHome.__init__` and
-        # `_maybe_migrate_missing_default_section`) rather than from the
-        # stale persisted slots or `DASHBOARD_DEFAULT_SECTIONS[i]` by
-        # index. Without this, a user who upgraded across QS-194/QS-195
-        # saw slot 3 (persisted "others") AND slot 5 (index default
-        # "others") show "others" twice — and no "radiators" anywhere.
-        # Falling back to const defaults is only used when no home is
-        # available (e.g. very early flow state, brand-new install).
+        # BH (post-QS-195): slot defaults come from the LIVE
+        # `home.dashboard_sections`, which `QSHome.__init__` populates
+        # with every bundled default in `DASHBOARD_DEFAULT_SECTIONS`
+        # (minus `CONF_DASHBOARD_SECTIONS_USER_REMOVED`) plus any
+        # custom user sections, in canonical const order. Reading from
+        # the live list (instead of by-index against stale persisted
+        # slot keys) eliminates the QS-195 "multiple times others"
+        # bug AND surfaces newly-introduced bundled sections (e.g.
+        # `water_boilers`, `radiators`) for users whose persisted
+        # config pre-dates those releases. Falling back to const
+        # defaults only applies when no home is available (very early
+        # flow state, brand-new install).
         sections_source: list[tuple[str, str]] = list(DASHBOARD_DEFAULT_SECTIONS)
         data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
         if data_handler is not None and data_handler.home is not None and data_handler.home.dashboard_sections:

--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -125,6 +125,7 @@ from .const import (
     CONF_SWITCH,
     CONF_WATER_BOILER_TEMPERATURE_SENSOR,
     DASHBOARD_DEFAULT_SECTIONS,
+    DASHBOARD_DEFAULT_SECTIONS_DICT,
     DASHBOARD_DEVICE_SECTION_TRANSLATION_KEY,
     DASHBOARD_NO_SECTION,
     DASHBOARD_NUM_SECTION_MAX,
@@ -380,10 +381,21 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             options_raw_list = None
             if home is not None and home.dashboard_sections is not None and len(home.dashboard_sections) > 0:
                 # we can have the list of sections
-                options_raw_list = home.dashboard_sections
+                options_raw_list = list(home.dashboard_sections)
 
             if options_raw_list is None:
-                options_raw_list = DASHBOARD_DEFAULT_SECTIONS
+                options_raw_list = list(DASHBOARD_DEFAULT_SECTIONS)
+
+            # Safety net: if the device's default section is one of the
+            # bundled defaults but the home's customised list doesn't
+            # include it (e.g. a pre-QS-194 entry that doesn't yet have
+            # `water_boilers` or `radiators`), append it to the dropdown
+            # options so the user can pick it. The home's
+            # `_maybe_migrate_missing_default_section` will then add the
+            # section to `dashboard_sections` when the device is created.
+            existing_names = {s[0] for s in options_raw_list}
+            if default_section not in existing_names and default_section in DASHBOARD_DEFAULT_SECTIONS_DICT:
+                options_raw_list.append((default_section, DASHBOARD_DEFAULT_SECTIONS_DICT[default_section]))
 
             # ok we want a section for those ones
             good_value = self.config_entry.data.get(CONF_DEVICE_DASHBOARD_SECTION, default_section)
@@ -1680,21 +1692,26 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
 
         return self.async_show_form(step_id=TYPE, data_schema=schema, description_placeholders=placeholders)
 
-    def _get_pending_radiator_data(self) -> dict:
-        """Return Pass 1 → Pass 2 carry-over dict (in-memory, never persisted).
+    def _persist_radiator_pass1(self, cleaned: dict) -> None:
+        """Merge Pass 1 input into `self.config_entry.data` so Pass 2
+        renders all fields with the user's choices.
 
-        S1 review-fix — Pass 1 stores the climate-entity selection here
-        instead of mutating `config_entry.data` mid-flow. If the user
-        abandons the flow between Pass 1 and Pass 2 nothing leaks into
-        the persisted config entry.
+        Same pattern as the car flow's `force_dampening` path: write
+        the merged dict via `async_update_entry` for real options-flow
+        entries, or directly into the FakeConfigEntry's `data` for the
+        creation flow. Pass 2's form-render then reads `config_entry.data`
+        as usual and every field (name, dashboard, power, …) gets the
+        right default — no per-field plumbing.
         """
-        if not hasattr(self, "_pending_radiator_data") or self._pending_radiator_data is None:
-            self._pending_radiator_data = {}
-        return self._pending_radiator_data
-
-    def _clear_pending_radiator_data(self) -> None:
-        """Reset the Pass 1 → Pass 2 carry-over once a final submission lands."""
-        self._pending_radiator_data = {}
+        merged = dict(self.config_entry.data)
+        merged.update(cleaned)
+        if isinstance(self.config_entry, FakeConfigEntry):
+            # Creation flow — direct assignment is safe; the entry
+            # is not persisted until `async_create_entry` runs.
+            self.config_entry.data = merged
+        else:
+            # Options flow — go through the canonical update path.
+            self.hass.config_entries.async_update_entry(self.config_entry, data=merged)
 
     def _add_radiator_entity_selector(self, sc_dict: dict, key: str, domain: str, suggestion: str | None) -> None:
         """B1 review-fix — entity selector with a Pass 1 → Pass 2 suggestion.
@@ -1898,8 +1915,6 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                 # would emit the same value). Surface the error
                 # before we reach `need_reprompt` or save.
                 if persisted_on and persisted_off and persisted_on == persisted_off:
-                    self._get_pending_radiator_data().clear()
-                    self._get_pending_radiator_data().update(cleaned)
                     return await self._async_show_radiator_form(
                         errors={CONF_CLIMATE_HVAC_MODE_OFF: "hvac_modes_must_differ"},
                         pending=cleaned,
@@ -1919,25 +1934,25 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                     or persisted_off not in hvac_modes
                 )
                 if need_reprompt:
-                    # S1 — buffer the Pass 1 payload in memory rather
-                    # than writing it to `config_entry.data` mid-flow.
-                    # The persisted entry data MUST NOT be touched
-                    # here — if the user aborts now, nothing leaks.
-                    self._get_pending_radiator_data().clear()
-                    self._get_pending_radiator_data().update(cleaned)
+                    # Persist the Pass 1 input so the Pass 2 form
+                    # picks up every field (name, dashboard, power,
+                    # calendar, …) via `config_entry.data` — same
+                    # pattern as the car / climate flows. Direct
+                    # assignment works for FakeConfigEntry (creation);
+                    # `async_update_entry` for real options-flow
+                    # entries.
+                    self._persist_radiator_pass1(cleaned)
                     # BH8 — render the form directly rather than
                     # re-entering the step with a sentinel kwarg.
                     return await self._async_show_radiator_form()
 
                 # B2 + AC-13 / N13 — final submission via a single
                 # `async_update_entry` write (no more double-write).
-                self._clear_pending_radiator_data()
                 return await self._async_save_radiator_entry(
                     cleaned, keep_climate=True, extra_stale_keys=extra_stale_keys
                 )
 
             # Switch-backed final submission — no HVAC dropdowns needed.
-            self._clear_pending_radiator_data()
             return await self._async_save_radiator_entry(cleaned, keep_climate=False, extra_stale_keys=extra_stale_keys)
 
         return await self._async_show_radiator_form()
@@ -1975,10 +1990,13 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         """Render the radiator form (extracted so we can re-render on error).
 
         `pending` lets the caller pre-fill the form with a just-rejected
-        user submission (EH4). It takes precedence over the buffered
-        Pass 1 dict and over `config_entry.data` — so the user doesn't
-        see their selections re-emptied between a validation failure
-        and the re-render.
+        user submission. The radiator step writes Pass 1 input into
+        `self.config_entry.data` (via `async_update_entry` for real
+        options-flow entries, or direct assignment for FakeConfigEntry
+        during creation) BEFORE redirecting to Pass 2 — same pattern
+        as the car / climate flows. That way `get_common_schema`'s
+        defaults pick up every Pass 1 field (name, dashboard, power,
+        calendar, …) without per-field plumbing.
         """
         TYPE = QSRadiator.conf_type_name
 
@@ -1992,20 +2010,19 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             add_max_on_off=True,
         )
 
-        # BH7 — the helper already handles missing-attribute init, no
-        # need for the redundant `hasattr` gate.
-        pending_buffer = self._get_pending_radiator_data()
-        # EH4 — the explicit `pending` kwarg (just-rejected submission)
-        # takes precedence over the buffered Pass 1 dict; both fall back
-        # to `config_entry.data` for options-flow re-edits.
+        # EH4 — when a validation error fires (XOR, hvac_modes_must_differ,
+        # …) we get the just-rejected `user_input` as `pending`. It
+        # takes precedence over the persisted entry data for that
+        # single re-render so the user sees their own selections.
         explicit_pending: dict = pending or {}
 
         def _suggest(key: str):
-            return explicit_pending.get(key) or pending_buffer.get(key) or self.config_entry.data.get(key)
+            return explicit_pending.get(key) or self.config_entry.data.get(key)
 
         # B1 — Pass 2 form pre-fills the entity selectors with the
-        # values the user picked in Pass 1, so the field doesn't appear
-        # re-emptied (which would trip the XOR error if resubmitted).
+        # values the user picked in Pass 1 (already written to
+        # `config_entry.data` by the submit handler before redirecting
+        # here).
         switch_suggestion = _suggest(CONF_SWITCH)
         climate_suggestion = _suggest(CONF_CLIMATE)
         self._add_radiator_entity_selector(sc_dict, CONF_SWITCH, domain=SWITCH_DOMAIN, suggestion=switch_suggestion)

--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -148,6 +148,7 @@ from .ha_model.home import QSHome
 from .ha_model.on_off_duration import QSOnOffDuration
 from .ha_model.person import QSPerson
 from .ha_model.pool import QSPool
+from .ha_model.radiator import QSRadiator
 from .ha_model.solar import QSSolar
 from .home_model.load import map_section_selected_name_in_section_list
 
@@ -167,6 +168,7 @@ LOAD_TYPES_MENU = {
     QSPool.conf_type_name: None,
     QSOnOffDuration.conf_type_name: None,
     QSClimateDuration.conf_type_name: None,
+    QSRadiator.conf_type_name: None,
     QSDynamicGroup.conf_type_name: None,
     QSHeatPump.conf_type_name: None,
 }
@@ -1606,6 +1608,132 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         schema = vol.Schema(sc_dict)
 
         return self.async_show_form(step_id=TYPE, data_schema=schema, description_placeholders=placeholders)
+
+    async def async_step_radiator(self, user_input=None):
+
+        TYPE = QSRadiator.conf_type_name
+
+        if user_input is not None:
+            # Pass 2 of the climate two-pass flow — fall through to render
+            # the form with the HVAC mode dropdowns. The XOR check below
+            # is skipped because the internal payload (just
+            # `{"force_radiator_climate": True}`) does not echo the entity
+            # selectors.
+            if "force_radiator_climate" not in user_input:
+                climate_entity = user_input.get(CONF_CLIMATE)
+                switch_entity = user_input.get(CONF_SWITCH)
+
+                # AC-6 exactly-one-backing validation (cross-field XOR)
+                if bool(climate_entity) == bool(switch_entity):
+                    return await self._async_show_radiator_form(
+                        errors={"base": "exactly_one_backing_required"},
+                    )
+
+                if climate_entity is not None:
+                    orig_climate_entity = self.config_entry.data.get(CONF_CLIMATE)
+                    if (
+                        climate_entity != orig_climate_entity
+                        or user_input.get(CONF_CLIMATE_HVAC_MODE_OFF) is None
+                        or user_input.get(CONF_CLIMATE_HVAC_MODE_ON) is None
+                    ):
+                        # Re-prompt with HVAC mode dropdowns once the climate
+                        # entity is known. Preserve user-entered fields by
+                        # merging into the config-entry data (the FakeConfigEntry
+                        # used during creation accepts direct assignment; the
+                        # real ConfigEntry used during the options flow needs
+                        # `async_update_entry`).
+                        merged = dict(self.config_entry.data)
+                        merged.update(user_input)
+                        if isinstance(self.config_entry, FakeConfigEntry):
+                            self.config_entry.data = merged
+                        else:
+                            self.hass.config_entries.async_update_entry(self.config_entry, data=merged)
+                        return await self.async_step_radiator({"force_radiator_climate": True})
+
+                    return await self.async_entry_next(user_input, TYPE)
+
+                return await self.async_entry_next(user_input, TYPE)
+
+        return await self._async_show_radiator_form()
+
+    async def _async_show_radiator_form(self, errors=None):
+        """Render the radiator form (extracted so we can re-render on error)."""
+        TYPE = QSRadiator.conf_type_name
+
+        sc_dict, placeholders = self.get_common_schema(
+            type=TYPE,
+            add_power_value_selector=1000,
+            add_load_power_sensor=True,
+            add_calendar=True,
+            add_boost_only=True,
+            add_power_group_selector=True,
+            add_max_on_off=True,
+        )
+
+        # Both selectors are optional — exactly-one validation runs on submit.
+        self.add_entity_selector(sc_dict, CONF_SWITCH, False, domain=[SWITCH_DOMAIN])
+        self.add_entity_selector(sc_dict, CONF_CLIMATE, False, domain=[CLIMATE_DOMAIN])
+
+        climate_entity = self.config_entry.data.get(CONF_CLIMATE)
+
+        if climate_entity is not None:
+            hvac_modes = get_hvac_modes(self.hass, climate_entity)
+
+            # Suggested default: "heat" if available, else first non-"off" mode.
+            existing_on = self.config_entry.data.get(CONF_CLIMATE_HVAC_MODE_ON)
+            if existing_on is None:
+                if "heat" in hvac_modes:
+                    suggested_on = "heat"
+                else:
+                    non_off = [m for m in hvac_modes if m != "off"]
+                    suggested_on = non_off[0] if non_off else (hvac_modes[0] if hvac_modes else "heat")
+            else:
+                suggested_on = existing_on
+
+            existing_off = self.config_entry.data.get(CONF_CLIMATE_HVAC_MODE_OFF)
+            suggested_off = existing_off if existing_off is not None else "off"
+
+            sc_dict[vol.Required(CONF_CLIMATE_HVAC_MODE_OFF, default=suggested_off)] = SelectSelector(
+                SelectSelectorConfig(options=hvac_modes, mode=SelectSelectorMode.DROPDOWN)
+            )
+            sc_dict[vol.Required(CONF_CLIMATE_HVAC_MODE_ON, default=suggested_on)] = SelectSelector(
+                SelectSelectorConfig(options=hvac_modes, mode=SelectSelectorMode.DROPDOWN)
+            )
+
+        # Heat-pump piloting dropdown — shown when at least one heat pump exists.
+        data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
+        heat_pump_options = []
+        if data_handler and data_handler.home:
+            heat_pumps = getattr(data_handler.home, "_heat_pumps", [])
+            heat_pump_options = [hp.name for hp in heat_pumps]
+
+        if heat_pump_options:
+            default_heat_pump = self.config_entry.data.get(CONF_DEVICE_TO_PILOT_NAME)
+            if default_heat_pump:
+                sc_dict[vol.Optional(CONF_DEVICE_TO_PILOT_NAME, description={"suggested_value": default_heat_pump})] = (
+                    selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=heat_pump_options,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                )
+            else:
+                sc_dict[vol.Optional(CONF_DEVICE_TO_PILOT_NAME)] = selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=heat_pump_options,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                )
+
+        schema = vol.Schema(sc_dict)
+
+        return self.async_show_form(
+            step_id=TYPE,
+            data_schema=schema,
+            description_placeholders=placeholders,
+            errors=errors,
+        )
 
     async def async_step_dynamic_group(self, user_input=None):
 

--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -1699,91 +1699,130 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
     async def async_step_radiator(self, user_input=None):
 
         if user_input is not None:
-            # Pass 2 of the climate two-pass flow — fall through to render
-            # the form with the HVAC mode dropdowns. The XOR check below
-            # is skipped because the internal payload (just
-            # `{"force_radiator_climate": True}`) does not echo the entity
-            # selectors.
-            if "force_radiator_climate" not in user_input:
-                # M4/M5 + N6 — normalise entities through truthy/strip so XOR
-                # and transport-selection paths agree (empty / whitespace
-                # entity ids are treated as absent).
-                climate_raw = user_input.get(CONF_CLIMATE)
-                switch_raw = user_input.get(CONF_SWITCH)
-                climate_entity = climate_raw.strip() if isinstance(climate_raw, str) else climate_raw
-                switch_entity = switch_raw.strip() if isinstance(switch_raw, str) else switch_raw
+            # BH8 — the previous `force_radiator_climate` sentinel was
+            # eliminated; Pass 2 now renders via `_async_show_radiator_form`
+            # directly from the re-prompt branch below.
+            # M4/M5 + N6 — normalise entities through truthy/strip so XOR
+            # and transport-selection paths agree (empty / whitespace
+            # entity ids are treated as absent).
+            climate_raw = user_input.get(CONF_CLIMATE)
+            switch_raw = user_input.get(CONF_SWITCH)
+            climate_entity = climate_raw.strip() if isinstance(climate_raw, str) else climate_raw
+            switch_entity = switch_raw.strip() if isinstance(switch_raw, str) else switch_raw
 
-                # AC-6 exactly-one-backing validation (cross-field XOR)
-                if bool(climate_entity) == bool(switch_entity):
+            # AC-6 exactly-one-backing validation (cross-field XOR)
+            if bool(climate_entity) == bool(switch_entity):
+                # EH4 — pass the just-rejected payload so the re-render
+                # pre-fills the user's selections; they don't have to
+                # re-pick everything from scratch.
+                return await self._async_show_radiator_form(
+                    errors={"base": "exactly_one_backing_required"},
+                    pending=user_input,
+                )
+
+            # EH5 — detect "user explicitly cleared the pilot dropdown"
+            # BEFORE we strip empty values from `cleaned`. The form
+            # renders `CONF_DEVICE_TO_PILOT_NAME` only when at least one
+            # heat pump exists, so finding the key in `user_input` with
+            # a falsy value means the user actively cleared it. Without
+            # this, `_async_save_radiator_entry`'s merge would re-inject
+            # the old persisted value from `config_entry.data`.
+            explicit_pilot_clear = CONF_DEVICE_TO_PILOT_NAME in user_input and not user_input.get(
+                CONF_DEVICE_TO_PILOT_NAME
+            )
+
+            # N8 — drop empty/None values from the merged dict so
+            # downstream `key in dict` checks see the canonical shape.
+            cleaned = {k: v for k, v in user_input.items() if v not in (None, "")}
+            if climate_entity:
+                cleaned[CONF_CLIMATE] = climate_entity
+                cleaned.pop(CONF_SWITCH, None)
+            else:
+                cleaned[CONF_SWITCH] = switch_entity
+                cleaned.pop(CONF_CLIMATE, None)
+                # Climate-only fields must not survive into a
+                # switch-backed entry — they belong to a backing
+                # that is no longer in effect.
+                cleaned.pop(CONF_CLIMATE_HVAC_MODE_ON, None)
+                cleaned.pop(CONF_CLIMATE_HVAC_MODE_OFF, None)
+
+            # E2 — when the user submits without picking a new heat
+            # pump but the persisted name is stale, drop the orphan
+            # reference so it doesn't reappear on the next edit.
+            extra_stale_keys = self._radiator_orphan_pilot_keys(cleaned)
+            # EH5 — when the user EXPLICITLY cleared a still-valid pilot,
+            # add the key to the stale list so the merge doesn't re-inject
+            # the old persisted value.
+            if explicit_pilot_clear and CONF_DEVICE_TO_PILOT_NAME not in extra_stale_keys:
+                extra_stale_keys = extra_stale_keys + (CONF_DEVICE_TO_PILOT_NAME,)
+
+            if climate_entity:
+                hvac_modes = get_hvac_modes(self.hass, climate_entity)
+                # S7 — empty hvac_modes means we cannot render a usable
+                # form; surface the error rather than block the user.
+                if not hvac_modes:
                     return await self._async_show_radiator_form(
-                        errors={"base": "exactly_one_backing_required"},
+                        errors={"base": "climate_capabilities_unavailable"},
+                        pending=cleaned,
+                    )
+                # EH2 — a single-mode `hvac_modes` (e.g. `["heat"]`)
+                # cannot represent a meaningful ON/OFF pair; surface
+                # the error rather than save an unsatisfiable config.
+                if len(hvac_modes) < 2:
+                    return await self._async_show_radiator_form(
+                        errors={"base": "climate_modes_insufficient"},
+                        pending=cleaned,
                     )
 
-                # N8 — drop empty/None values from the merged dict so
-                # downstream `key in dict` checks see the canonical shape.
-                cleaned = {k: v for k, v in user_input.items() if v not in (None, "")}
-                if climate_entity:
-                    cleaned[CONF_CLIMATE] = climate_entity
-                    cleaned.pop(CONF_SWITCH, None)
-                else:
-                    cleaned[CONF_SWITCH] = switch_entity
-                    cleaned.pop(CONF_CLIMATE, None)
-                    # Climate-only fields must not survive into a
-                    # switch-backed entry — they belong to a backing
-                    # that is no longer in effect.
-                    cleaned.pop(CONF_CLIMATE_HVAC_MODE_ON, None)
-                    cleaned.pop(CONF_CLIMATE_HVAC_MODE_OFF, None)
+                persisted_on = user_input.get(CONF_CLIMATE_HVAC_MODE_ON)
+                persisted_off = user_input.get(CONF_CLIMATE_HVAC_MODE_OFF)
 
-                # E2 — when the user submits without picking a new heat
-                # pump but the persisted name is stale, drop the orphan
-                # reference so it doesn't reappear on the next edit.
-                extra_stale_keys = self._radiator_orphan_pilot_keys(cleaned)
-
-                if climate_entity:
-                    hvac_modes = get_hvac_modes(self.hass, climate_entity)
-                    # S7 — empty hvac_modes means we cannot render a usable
-                    # form; surface the error rather than block the user.
-                    if not hvac_modes:
-                        return await self._async_show_radiator_form(
-                            errors={"base": "climate_capabilities_unavailable"},
-                        )
-
-                    persisted_on = user_input.get(CONF_CLIMATE_HVAC_MODE_ON)
-                    persisted_off = user_input.get(CONF_CLIMATE_HVAC_MODE_OFF)
-                    # S6 — re-prompt whenever the persisted HVAC mode
-                    # value is missing or no longer in the entity's
-                    # current `hvac_modes` list (vendor firmware update
-                    # dropped it). The mode-membership check subsumes
-                    # the older "climate entity changed" branch — a new
-                    # climate entity with the same HVAC modes legitimately
-                    # keeps the persisted selection.
-                    need_reprompt = (
-                        not persisted_on
-                        or not persisted_off
-                        or persisted_on not in hvac_modes
-                        or persisted_off not in hvac_modes
-                    )
-                    if need_reprompt:
-                        # S1 — buffer the Pass 1 payload in memory rather
-                        # than writing it to `config_entry.data` mid-flow.
-                        # The persisted entry data MUST NOT be touched
-                        # here — if the user aborts now, nothing leaks.
-                        self._get_pending_radiator_data().clear()
-                        self._get_pending_radiator_data().update(cleaned)
-                        return await self.async_step_radiator({"force_radiator_climate": True})
-
-                    # B2 + AC-13 / N13 — final submission via a single
-                    # `async_update_entry` write (no more double-write).
-                    self._clear_pending_radiator_data()
-                    return await self._async_save_radiator_entry(
-                        cleaned, keep_climate=True, extra_stale_keys=extra_stale_keys
+                # EH1 — both HVAC modes provided AND equal means the
+                # device would never toggle (every `set_hvac_mode`
+                # would emit the same value). Surface the error
+                # before we reach `need_reprompt` or save.
+                if persisted_on and persisted_off and persisted_on == persisted_off:
+                    self._get_pending_radiator_data().clear()
+                    self._get_pending_radiator_data().update(cleaned)
+                    return await self._async_show_radiator_form(
+                        errors={CONF_CLIMATE_HVAC_MODE_OFF: "hvac_modes_must_differ"},
+                        pending=cleaned,
                     )
 
-                # Switch-backed final submission — no HVAC dropdowns needed.
+                # S6 — re-prompt whenever the persisted HVAC mode
+                # value is missing or no longer in the entity's
+                # current `hvac_modes` list (vendor firmware update
+                # dropped it). The mode-membership check subsumes
+                # the older "climate entity changed" branch — a new
+                # climate entity with the same HVAC modes legitimately
+                # keeps the persisted selection.
+                need_reprompt = (
+                    not persisted_on
+                    or not persisted_off
+                    or persisted_on not in hvac_modes
+                    or persisted_off not in hvac_modes
+                )
+                if need_reprompt:
+                    # S1 — buffer the Pass 1 payload in memory rather
+                    # than writing it to `config_entry.data` mid-flow.
+                    # The persisted entry data MUST NOT be touched
+                    # here — if the user aborts now, nothing leaks.
+                    self._get_pending_radiator_data().clear()
+                    self._get_pending_radiator_data().update(cleaned)
+                    # BH8 — render the form directly rather than
+                    # re-entering the step with a sentinel kwarg.
+                    return await self._async_show_radiator_form()
+
+                # B2 + AC-13 / N13 — final submission via a single
+                # `async_update_entry` write (no more double-write).
                 self._clear_pending_radiator_data()
                 return await self._async_save_radiator_entry(
-                    cleaned, keep_climate=False, extra_stale_keys=extra_stale_keys
+                    cleaned, keep_climate=True, extra_stale_keys=extra_stale_keys
                 )
+
+            # Switch-backed final submission — no HVAC dropdowns needed.
+            self._clear_pending_radiator_data()
+            return await self._async_save_radiator_entry(cleaned, keep_climate=False, extra_stale_keys=extra_stale_keys)
 
         return await self._async_show_radiator_form()
 
@@ -1814,8 +1853,15 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             return ()
         return (CONF_DEVICE_TO_PILOT_NAME,)
 
-    async def _async_show_radiator_form(self, errors=None):
-        """Render the radiator form (extracted so we can re-render on error)."""
+    async def _async_show_radiator_form(self, errors=None, pending=None):
+        """Render the radiator form (extracted so we can re-render on error).
+
+        `pending` lets the caller pre-fill the form with a just-rejected
+        user submission (EH4). It takes precedence over the buffered
+        Pass 1 dict and over `config_entry.data` — so the user doesn't
+        see their selections re-emptied between a validation failure
+        and the re-render.
+        """
         TYPE = QSRadiator.conf_type_name
 
         sc_dict, placeholders = self.get_common_schema(
@@ -1828,15 +1874,22 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             add_max_on_off=True,
         )
 
-        # S1 — Pass 2 reads the in-memory pending dict first, falling
-        # back to `config_entry.data` for re-edits via the options flow.
-        pending = self._get_pending_radiator_data() if hasattr(self, "_pending_radiator_data") else {}
+        # BH7 — the helper already handles missing-attribute init, no
+        # need for the redundant `hasattr` gate.
+        pending_buffer = self._get_pending_radiator_data()
+        # EH4 — the explicit `pending` kwarg (just-rejected submission)
+        # takes precedence over the buffered Pass 1 dict; both fall back
+        # to `config_entry.data` for options-flow re-edits.
+        explicit_pending: dict = pending or {}
+
+        def _suggest(key: str):
+            return explicit_pending.get(key) or pending_buffer.get(key) or self.config_entry.data.get(key)
 
         # B1 — Pass 2 form pre-fills the entity selectors with the
         # values the user picked in Pass 1, so the field doesn't appear
         # re-emptied (which would trip the XOR error if resubmitted).
-        switch_suggestion = pending.get(CONF_SWITCH) or self.config_entry.data.get(CONF_SWITCH)
-        climate_suggestion = pending.get(CONF_CLIMATE) or self.config_entry.data.get(CONF_CLIMATE)
+        switch_suggestion = _suggest(CONF_SWITCH)
+        climate_suggestion = _suggest(CONF_CLIMATE)
         self._add_radiator_entity_selector(sc_dict, CONF_SWITCH, domain=SWITCH_DOMAIN, suggestion=switch_suggestion)
         self._add_radiator_entity_selector(sc_dict, CONF_CLIMATE, domain=CLIMATE_DOMAIN, suggestion=climate_suggestion)
 
@@ -1845,11 +1898,13 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         if climate_entity:
             hvac_modes = get_hvac_modes(self.hass, climate_entity)
 
-            if hvac_modes:
+            # EH2 — render the HVAC dropdowns ONLY when at least two
+            # modes are available; a single-mode entity (or empty list)
+            # cannot represent a meaningful ON/OFF pair. The form-level
+            # error in the submit handler steers the user to back out.
+            if hvac_modes and len(hvac_modes) >= 2:
                 # Suggested default for ON: "heat" if available, else first non-"off" mode.
-                existing_on = pending.get(CONF_CLIMATE_HVAC_MODE_ON) or self.config_entry.data.get(
-                    CONF_CLIMATE_HVAC_MODE_ON
-                )
+                existing_on = _suggest(CONF_CLIMATE_HVAC_MODE_ON)
                 if existing_on and existing_on in hvac_modes:
                     suggested_on = existing_on
                 elif "heat" in hvac_modes:
@@ -1861,9 +1916,7 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                 # S13 — `suggested_off` must be in `hvac_modes` or
                 # voluptuous will reject the schema. Prefer "off", fall
                 # back to any mode containing "off", finally the last mode.
-                existing_off = pending.get(CONF_CLIMATE_HVAC_MODE_OFF) or self.config_entry.data.get(
-                    CONF_CLIMATE_HVAC_MODE_OFF
-                )
+                existing_off = _suggest(CONF_CLIMATE_HVAC_MODE_OFF)
                 if existing_off and existing_off in hvac_modes:
                     suggested_off = existing_off
                 elif "off" in hvac_modes:
@@ -1871,6 +1924,16 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                 else:
                     off_like = [m for m in hvac_modes if "off" in m.lower()]
                     suggested_off = off_like[0] if off_like else hvac_modes[-1]
+
+                # EH2 — if both suggestions coincide (e.g. a two-mode
+                # `["heat", "fan_only"]` whose off-like fallback happens
+                # to land on the same value), nudge `suggested_off` to
+                # ANY other mode so the rendered form doesn't ship two
+                # identical defaults the user has to manually correct.
+                if suggested_on == suggested_off:
+                    alt = next((m for m in hvac_modes if m != suggested_on), None)
+                    if alt is not None:
+                        suggested_off = alt
 
                 sc_dict[vol.Required(CONF_CLIMATE_HVAC_MODE_OFF, default=suggested_off)] = SelectSelector(
                     SelectSelectorConfig(options=hvac_modes, mode=SelectSelectorMode.DROPDOWN)

--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -1640,12 +1640,14 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                 }
             )
 
-        # Get list of available heat pumps from the data handler
+        # Get list of available heat pumps from the data handler.
+        # BH-C — use the canonical `QSHome.get_heat_pumps()` accessor
+        # (added by M3) rather than the legacy `_heat_pumps` private
+        # attribute lookup.
         data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
         heat_pump_options = []
         if data_handler and data_handler.home:
-            heat_pumps = getattr(data_handler.home, "_heat_pumps", [])
-            heat_pump_options = [hp.name for hp in heat_pumps]
+            heat_pump_options = [hp.name for hp in data_handler.home.get_heat_pumps()]
 
         if heat_pump_options:
             default_heat_pump = self.config_entry.data.get(CONF_DEVICE_TO_PILOT_NAME)
@@ -1788,20 +1790,48 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                     pending=user_input,
                 )
 
-            # EH5 — detect "user explicitly cleared the pilot dropdown"
-            # BEFORE we strip empty values from `cleaned`. The form
-            # renders `CONF_DEVICE_TO_PILOT_NAME` only when at least one
-            # heat pump exists, so finding the key in `user_input` with
-            # a falsy value means the user actively cleared it. Without
-            # this, `_async_save_radiator_entry`'s merge would re-inject
-            # the old persisted value from `config_entry.data`.
-            explicit_pilot_clear = CONF_DEVICE_TO_PILOT_NAME in user_input and not user_input.get(
-                CONF_DEVICE_TO_PILOT_NAME
+            # EH5 + BH-D — detect "user explicitly cleared the pilot
+            # dropdown" BEFORE we strip empty values from `cleaned`. The
+            # form renders `CONF_DEVICE_TO_PILOT_NAME` only when at
+            # least one heat pump exists, so finding the key in
+            # `user_input` with a falsy value means the user actively
+            # cleared it. Without this, `_async_save_radiator_entry`'s
+            # merge would re-inject the old persisted value from
+            # `config_entry.data`.
+            #
+            # BH-D: HA's `vol.Optional` could deliver "user cleared"
+            # as either `{"key": None}` or `{}` (key absent). The
+            # current pattern only handles the former. Use a sentinel
+            # so both shapes funnel into the same branch — if the
+            # form rendered the field AND the user submitted nothing
+            # for it, treat it as an explicit clear regardless of
+            # which selector variant HA picked.
+            _UNSET = object()
+            pilot_value = user_input.get(CONF_DEVICE_TO_PILOT_NAME, _UNSET)
+            # The pilot dropdown is only rendered when heat pumps
+            # exist, so the previous form-render decision is the
+            # `explicit_pilot_clear` precondition.
+            data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
+            had_pilot_dropdown = bool(
+                data_handler and data_handler.home is not None and data_handler.home.get_heat_pumps()
+            )
+            had_persisted_pilot = bool(self.config_entry.data.get(CONF_DEVICE_TO_PILOT_NAME))
+            explicit_pilot_clear = (
+                had_pilot_dropdown and had_persisted_pilot and (pilot_value is _UNSET or not pilot_value)
             )
 
-            # N8 — drop empty/None values from the merged dict so
-            # downstream `key in dict` checks see the canonical shape.
-            cleaned = {k: v for k, v in user_input.items() if v not in (None, "")}
+            # N8 + EH-D — drop empty/None values from the merged dict
+            # so downstream `key in dict` checks see the canonical
+            # shape. For string-valued fields, normalise
+            # whitespace-only entries to "empty" (a user pasting "  "
+            # into `CONF_NAME` shouldn't persist as a meaningful value
+            # — same policy already applied to entity-id fields).
+            def _strip_or_keep(v):
+                if isinstance(v, str):
+                    return v.strip()
+                return v
+
+            cleaned = {k: _strip_or_keep(v) for k, v in user_input.items() if _strip_or_keep(v) not in (None, "")}
             if climate_entity:
                 cleaned[CONF_CLIMATE] = climate_entity
                 cleaned.pop(CONF_SWITCH, None)
@@ -1823,6 +1853,24 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             # the old persisted value.
             if explicit_pilot_clear and CONF_DEVICE_TO_PILOT_NAME not in extra_stale_keys:
                 extra_stale_keys = extra_stale_keys + (CONF_DEVICE_TO_PILOT_NAME,)
+
+            # EH-B — re-validate the SUBMITTED heat-pump name against the
+            # LIVE heat-pumps list. `_radiator_orphan_pilot_keys` only
+            # catches the PERSISTED-name case; if the heat pump was
+            # deleted between Pass 1 and the final submit (slow user,
+            # parallel admin action, Pass 2 re-prompt with cached pick),
+            # the submitted name itself could be stale.
+            submitted_pilot = cleaned.get(CONF_DEVICE_TO_PILOT_NAME)
+            if submitted_pilot:
+                data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
+                live_names: set[str] = set()
+                if data_handler and data_handler.home is not None:
+                    live_names = {hp.name for hp in data_handler.home.get_heat_pumps()}
+                if submitted_pilot not in live_names:
+                    return await self._async_show_radiator_form(
+                        errors={CONF_DEVICE_TO_PILOT_NAME: "piloted_heat_pump_unknown"},
+                        pending=cleaned,
+                    )
 
             if climate_entity:
                 hvac_modes = get_hvac_modes(self.hass, climate_entity)
@@ -1914,9 +1962,11 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
         if not data_handler or data_handler.home is None:
             return ()
-        getter = getattr(data_handler.home, "get_heat_pumps", None)
-        heat_pumps = getter() if callable(getter) else getattr(data_handler.home, "_heat_pumps", [])
-        names = {hp.name for hp in heat_pumps}
+        # BH-C — `get_heat_pumps()` is part of the public `QSHome` API
+        # (added by M3). The previous `getattr(..., "_heat_pumps", [])`
+        # fallback was dead defensive code that contradicted the in-diff
+        # comment "use the canonical accessor instead of `_heat_pumps`".
+        names = {hp.name for hp in data_handler.home.get_heat_pumps()}
         if persisted in names:
             return ()
         return (CONF_DEVICE_TO_PILOT_NAME,)
@@ -2011,19 +2061,25 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                 )
 
         # Heat-pump piloting dropdown — shown when at least one heat pump exists.
-        # M3 — use the canonical `QSHome.get_heat_pumps()` accessor instead
-        # of a raw `getattr` against the private `_heat_pumps` attribute.
+        # M3 + BH-C — use the canonical `QSHome.get_heat_pumps()` accessor.
+        # The previous `getattr(home, "_heat_pumps", [])` fallback was dead
+        # defensive code: `get_heat_pumps()` is part of the public `QSHome`
+        # API and `data_handler.home`'s presence is the only branch worth
+        # guarding.
         data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
         heat_pump_options: list[str] = []
         if data_handler and data_handler.home is not None:
-            getter = getattr(data_handler.home, "get_heat_pumps", None)
-            heat_pumps = getter() if callable(getter) else getattr(data_handler.home, "_heat_pumps", [])
-            heat_pump_options = [hp.name for hp in heat_pumps]
+            heat_pump_options = [hp.name for hp in data_handler.home.get_heat_pumps()]
 
         merged_errors: dict[str, str] = dict(errors) if errors else {}
 
         if heat_pump_options:
-            default_heat_pump = self.config_entry.data.get(CONF_DEVICE_TO_PILOT_NAME)
+            # EH-A — heat-pump default flows through the same
+            # `explicit_pending` → `pending_buffer` → `config_entry.data`
+            # priority chain as the entity selectors (B1 + EH4). Without
+            # this, a heat-pump pick from Pass 1 vanishes from the form
+            # on any Pass 2 re-render or validation-error re-render.
+            default_heat_pump = _suggest(CONF_DEVICE_TO_PILOT_NAME)
             # S8 + B4 — if the persisted heat-pump name no longer
             # exists, drop the suggested value and surface a
             # field-specific error to the user. Using

--- a/custom_components/quiet_solar/const.py
+++ b/custom_components/quiet_solar/const.py
@@ -29,6 +29,7 @@ CONF_TYPE_NAME_QSOnOffDuration = "on_off_duration"
 CONF_TYPE_NAME_QSClimateDuration = "climate"
 CONF_TYPE_NAME_QSDynamicGroup = "dynamic_group"
 CONF_TYPE_NAME_QSHeatPump = "heat_pump"
+CONF_TYPE_NAME_QSRadiator = "radiator"
 CONF_TYPE_NAME_HADeviceMixin = "ha_device_mixin"
 
 
@@ -43,6 +44,7 @@ DASHBOARD_NUM_SECTION_MAX = 8
 DASHBOARD_DEFAULT_SECTIONS = [
     ("cars", "mdi:car"),
     ("climates", "mdi:home-thermometer"),
+    ("radiators", "mdi:radiator"),
     ("pools", "mdi:pool"),
     ("others", "mdi:home"),
     ("settings", "mdi:cog-outline"),
@@ -66,6 +68,7 @@ LOAD_TYPE_DASHBOARD_DEFAULT_SECTION = {
     CONF_TYPE_NAME_QSClimateDuration: "climates",
     CONF_TYPE_NAME_QSDynamicGroup: None,
     CONF_TYPE_NAME_QSHeatPump: "climates",
+    CONF_TYPE_NAME_QSRadiator: "radiators",
 }
 
 
@@ -213,6 +216,7 @@ SENSOR_CONSTRAINT_SENSOR_COMPLETION = "qs_constraint_sensor_completion"
 SENSOR_CONSTRAINT_SENSOR_CHARGE = "qs_constraint_sensor_charge"
 SENSOR_CONSTRAINT_SENSOR_ON_OFF = "qs_constraint_sensor_on_off"
 SENSOR_CONSTRAINT_SENSOR_CLIMATE = "qs_constraint_sensor_climate"
+SENSOR_CONSTRAINT_SENSOR_RADIATOR = "qs_constraint_sensor_radiator"
 SENSOR_CONSTRAINT_SENSOR_POOL = "qs_constraint_sensor_pool"
 SENSOR_CONSTRAINT_SENSOR_NEXT_OR_CURRENT_START = "qs_next_or_current_constraint_start_time"
 SENSOR_CONSTRAINT_SENSOR_NEXT_OR_CURRENT_END = "qs_next_or_current_constraint_end_time"

--- a/custom_components/quiet_solar/const.py
+++ b/custom_components/quiet_solar/const.py
@@ -47,13 +47,9 @@ DASHBOARD_DEFAULT_SECTIONS = [
     ("climates", "mdi:home-thermometer"),
     ("pools", "mdi:pool"),
     ("water_boilers", "mdi:water-boiler"),
+    ("radiators", "mdi:radiator"),
     ("others", "mdi:home"),
     ("settings", "mdi:cog-outline"),
-    # `radiators` is appended LAST to preserve the existing 1..5 section
-    # positions for upgrades — any user who stored "#3 - pools" or
-    # "#5 - settings" keeps pointing at the same section after upgrade.
-    # Adding new sections must always go at the end of this list.
-    ("radiators", "mdi:radiator"),
 ]
 DASHBOARD_DEFAULT_SECTIONS_DICT = {v[0]: v[1] for v in DASHBOARD_DEFAULT_SECTIONS}
 DASHBOARD_NO_SECTION = "Not in dashboard"

--- a/custom_components/quiet_solar/const.py
+++ b/custom_components/quiet_solar/const.py
@@ -44,10 +44,14 @@ DASHBOARD_NUM_SECTION_MAX = 8
 DASHBOARD_DEFAULT_SECTIONS = [
     ("cars", "mdi:car"),
     ("climates", "mdi:home-thermometer"),
-    ("radiators", "mdi:radiator"),
     ("pools", "mdi:pool"),
     ("others", "mdi:home"),
     ("settings", "mdi:cog-outline"),
+    # `radiators` is appended LAST to preserve the existing 1..5 section
+    # positions for upgrades — any user who stored "#3 - pools" or
+    # "#5 - settings" keeps pointing at the same section after upgrade.
+    # Adding new sections must always go at the end of this list.
+    ("radiators", "mdi:radiator"),
 ]
 DASHBOARD_DEFAULT_SECTIONS_DICT = {v[0]: v[1] for v in DASHBOARD_DEFAULT_SECTIONS}
 DASHBOARD_NO_SECTION = "Not in dashboard"

--- a/custom_components/quiet_solar/entity.py
+++ b/custom_components/quiet_solar/entity.py
@@ -22,6 +22,7 @@ from .ha_model.home import QSHome
 from .ha_model.on_off_duration import QSOnOffDuration
 from .ha_model.person import QSPerson
 from .ha_model.pool import QSPool
+from .ha_model.radiator import QSRadiator
 from .ha_model.solar import QSSolar
 from .home_model.load import AbstractDevice
 
@@ -39,6 +40,7 @@ LOAD_TYPE_LIST = [
     QSClimateDuration,
     QSDynamicGroup,
     QSHeatPump,
+    QSRadiator,
 ]
 LOAD_TYPE__DICT = {t.conf_type_name: t for t in LOAD_TYPE_LIST}
 
@@ -57,6 +59,7 @@ LOAD_NAMES = {
     QSClimateDuration.conf_type_name: "climate",
     QSDynamicGroup.conf_type_name: "group",
     QSHeatPump.conf_type_name: "heat pump",
+    QSRadiator.conf_type_name: "radiator",
 }
 
 

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -41,6 +41,42 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class QSBiStateDuration(HADeviceMixin, AbstractLoad):
+    """Shared base for bistate-duration loads (on/off, climate, radiator, pool).
+
+    Subclasses carry ONE pair of state attributes with overlapping but
+    NOT identical semantics:
+
+    - ``_state_on`` / ``_state_off`` — the underlying HA-state strings
+      the transport dispatches to the device (e.g. ``"on"`` / ``"off"``
+      for a switch, ``"heat"`` / ``"off"`` for a climate). The B3
+      property shadow below routes reads/writes through
+      ``self._transport.state_on / state_off``; these are the SERVICE-CALL
+      values.
+    - ``_bistate_mode_on`` / ``_bistate_mode_off`` — the **bistate-mode
+      select** state strings (Force ON / Force OFF entries in the UI).
+      These map to translation keys in ``strings.json``.
+
+    Subclasses follow ONE OF TWO conventions for `_bistate_mode_*`:
+
+    1. **`QSOnOffDuration` / `QSPool`**: hard-coded literals like
+       ``"on_off_mode_on"`` (namespaced for the on/off / pool
+       translations). The select shows "Force ON" / "Force OFF" via
+       those keys; the `_state_on/off` HA-state value is "on"/"off".
+    2. **`QSClimateDuration`**: `_bistate_mode_*` mirrors the raw HVAC
+       mode (`"heat"`, `"cool"`, `"fan_only"`, …). The `climate_mode`
+       translation registers each HVAC mode as a force-mode state key
+       so the dropdown renders "Force HVAC Mode HEAT" etc.
+    3. **`QSRadiator`**: `_bistate_mode_*` is hard-coded to `"on"` /
+       `"off"` regardless of the HVAC mode, mirroring convention 1.
+       The `radiator_mode` translation registers `"on"` / `"off"` (NOT
+       arbitrary HVAC modes) so a user who configures HVAC ON =
+       `"auto"` still sees a localised "Force ON" label.
+
+    Both conventions are valid; the divergence is intentional. Any
+    base-class logic that compares `_state_on` ↔ `_bistate_mode_on`
+    must treat the two as decoupled.
+    """
+
     # B6 review-fix — class-level default of `None` so
     # `hasattr` / `is None` checks behave consistently before the
     # subclass `__init__` has had a chance to assign the transport.
@@ -352,8 +388,14 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         overrides and keeps the per-backing logic encapsulated in the
         transport strategy. Subclasses may still override if they need
         bespoke pre/post hooks (none do today).
+
+        BH-G — `time` is part of the public method contract (subclasses
+        may override and legitimately use it). The base implementation
+        doesn't consume it today; we keep the parameter name unchanged
+        rather than rename to `_time` so subclasses can call
+        `super().execute_command_system(time, ...)` without surprise.
         """
-        del time  # not yet used by the transport, kept for the public contract
+        _ = time  # part of the public contract; not used by the base delegation
         if self._transport is None:  # pragma: no cover — defensive
             raise RuntimeError(f"{type(self).__name__}: _transport not initialised")
         return await self._transport.execute(self.hass, command, state, self._state_on, self._state_off)

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -41,12 +41,18 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class QSBiStateDuration(HADeviceMixin, AbstractLoad):
-    # Subclasses populate `_transport` with a `BistateTransport` strategy
-    # — either in `__init__` (canonical) or by inheriting the default
-    # set below in `_init_default_transport`. The class-level
-    # declaration is here so the base `execute_command_system` can
-    # delegate without each subclass redeclaring the attribute.
-    _transport: BistateTransport | None
+    # B6 review-fix — class-level default of `None` so
+    # `hasattr` / `is None` checks behave consistently before the
+    # subclass `__init__` has had a chance to assign the transport.
+    _transport: BistateTransport | None = None
+
+    # B3 review-fix — fallback storage for `_state_on/_state_off` when
+    # `_transport` is `None`. The property shadows below route reads
+    # and writes through the transport when set, otherwise through
+    # these private fields. Subclasses inherit the property and never
+    # need to re-declare it.
+    _state_on_host: str = "on"
+    _state_off_host: str = "off"
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -57,7 +63,10 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
 
         self.override_duration: float | None = DEFAULT_USER_OVERRIDE_DURATION_S // 3600
 
-        # to be overcharged by the child class
+        # to be overcharged by the child class. The `_state_on`/`_state_off`
+        # writes flow through the property shadow defined below: when
+        # `_transport` is set, the transport observes the change; when
+        # not, the writes land in `_state_on_host`/`_state_off_host`.
         self._state_on = "on"
         self._state_off = "off"
         self._bistate_mode_on = "bistate_mode_on"
@@ -69,6 +78,38 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         self.qs_bistate_current_duration_h: float = 0.0
         self.qs_bistate_current_on_h: float = 0.0
         self._previous_bistate_mode: str | None = None
+
+    # B3 review-fix — `_state_on` / `_state_off` are thin views over
+    # the transport. Direct writes (`device._state_on = "auto"`) always
+    # update the transport so the host and the service-call layer never
+    # diverge. When `_transport` is None (e.g. during super().__init__
+    # before the subclass has built the transport), the value lands in
+    # the per-instance fallback fields.
+    @property
+    def _state_on(self) -> str:
+        if self._transport is not None:
+            return self._transport.state_on
+        return self._state_on_host
+
+    @_state_on.setter
+    def _state_on(self, value: str) -> None:
+        if self._transport is not None:
+            self._transport.state_on = value
+        else:
+            self._state_on_host = value
+
+    @property
+    def _state_off(self) -> str:
+        if self._transport is not None:
+            return self._transport.state_off
+        return self._state_off_host
+
+    @_state_off.setter
+    def _state_off(self, value: str) -> None:
+        if self._transport is not None:
+            self._transport.state_off = value
+        else:
+            self._state_off_host = value
 
     def _get_today_boundaries(self, time: datetime) -> tuple[datetime, datetime]:
         """Return (start_of_today_utc, start_of_tomorrow_utc) using local midnight."""

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -3,6 +3,7 @@ from abc import abstractmethod
 from collections import namedtuple
 from datetime import datetime, timedelta
 from datetime import time as dt_time
+from typing import TYPE_CHECKING
 
 import pytz
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
@@ -17,6 +18,9 @@ from ..ha_model.device import HADeviceMixin
 from ..home_model.commands import CMD_IDLE, LoadCommand
 from ..home_model.constraints import DATETIME_MAX_UTC, TimeBasedSimplePowerLoadConstraint
 from ..home_model.load import AbstractLoad
+
+if TYPE_CHECKING:
+    from .bistate_transport import BistateTransport
 
 bistate_modes = [
     "bistate_mode_auto",
@@ -37,6 +41,13 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class QSBiStateDuration(HADeviceMixin, AbstractLoad):
+    # Subclasses populate `_transport` with a `BistateTransport` strategy
+    # — either in `__init__` (canonical) or by inheriting the default
+    # set below in `_init_default_transport`. The class-level
+    # declaration is here so the base `execute_command_system` can
+    # delegate without each subclass redeclaring the attribute.
+    _transport: BistateTransport | None
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.bistate_mode = "bistate_mode_auto"
@@ -277,9 +288,20 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
 
         return await self.execute_command_system(time, command, override_state)
 
-    @abstractmethod
     async def execute_command_system(self, time: datetime, command: LoadCommand, state: str | None) -> bool | None:
-        """execute the command on the system"""
+        """Delegate the service-call to `self._transport`.
+
+        N2 review-fix — `QSOnOffDuration`, `QSClimateDuration`, and
+        `QSRadiator` all forwarded to `self._transport.execute(...)`.
+        Hoisting the delegation here removes three near-identical
+        overrides and keeps the per-backing logic encapsulated in the
+        transport strategy. Subclasses may still override if they need
+        bespoke pre/post hooks (none do today).
+        """
+        del time  # not yet used by the transport, kept for the public contract
+        if self._transport is None:  # pragma: no cover — defensive
+            raise RuntimeError(f"{type(self).__name__}: _transport not initialised")
+        return await self._transport.execute(self.hass, command, state, self._state_on, self._state_off)
 
     async def _build_mode_constraint_items(
         self, time: datetime, bistate_mode: str, do_push_constraint_after: datetime | None

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -111,6 +111,20 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         else:
             self._state_off_host = value
 
+    @property
+    def hvac_state_on(self) -> str:
+        """Public accessor for the transport's ON-state string.
+
+        Exposes the underlying HA state value that maps to "running" —
+        for a switch-backed load this is `"on"`, for a climate-backed
+        load it's the configured HVAC ON mode (e.g. `"heat"`,
+        `"auto"`). Read by the dashboard template so the JS card can
+        compare against the live backing-entity state during the
+        cold-start grace window (BH10 review-fix). Public because
+        HA's Jinja sandbox restricts leading-underscore access.
+        """
+        return self._state_on
+
     def _get_today_boundaries(self, time: datetime) -> tuple[datetime, datetime]:
         """Return (start_of_today_utc, start_of_tomorrow_utc) using local midnight."""
         tomorrow_utc = self.get_proper_local_adapted_tomorrow(time)

--- a/custom_components/quiet_solar/ha_model/bistate_transport.py
+++ b/custom_components/quiet_solar/ha_model/bistate_transport.py
@@ -1,0 +1,241 @@
+"""Per-backing transport strategy for bistate-duration devices.
+
+A bistate-duration device (`QSBiStateDuration` and its subclasses) is a
+load with two states (on/off) that runs for a target duration. Two
+concrete subclasses differ only in **which** HA entity they observe and
+**which** HA service they call: `QSOnOffDuration` flips a `switch.*`
+entity via `switch.turn_on` / `switch.turn_off`, while
+`QSClimateDuration` toggles a `climate.*` entity via
+`climate.set_hvac_mode`.
+
+This module extracts that per-backing difference into a small strategy
+object so future variants (e.g. the heating-only `QSRadiator` that can
+sit on either a switch OR a climate) can pick a transport at
+construction time without duplicating the shared bistate logic.
+
+The transport owns:
+  - `entity` — the HA entity_id observed and controlled
+  - `default_state_on()` / `default_state_off()` — the initial state
+    strings the host should adopt
+  - `mode_options(hass)` — the list of valid states for selectors
+  - `power_from_state(...)` — map a raw HA state to load power
+  - `execute(...)` — issue the underlying HA service call
+
+The host (`QSBiStateDuration`) keeps owning the bistate-mode signals
+(`_state_on`, `_state_off`, `_bistate_mode_on`, `_bistate_mode_off`),
+the override logic, and `expected_state_from_command`. The transport
+receives primitives, not the host — that keeps the contract narrow and
+makes the transports trivially testable without spinning up a full
+load.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+from homeassistant.components import climate
+from homeassistant.components.climate import HVACMode
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from ..home_model.commands import CMD_IDLE, CMD_ON, LoadCommand
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_hvac_modes(hass: HomeAssistant, entity_id: str) -> list[str]:
+    """Return the HVAC modes advertised by a climate entity.
+
+    Falls back to `[AUTO, OFF]` when the entity has no `hvac_modes`
+    capability (mirrors the legacy helper in `climate_controller.py`,
+    which is re-exported here for backwards compatibility).
+    """
+    registry = er.async_get(hass)
+    entry = registry.async_get(entity_id)
+    return entry.capabilities.get("hvac_modes", [HVACMode.AUTO.value, HVACMode.OFF.value])
+
+
+class BistateTransport(ABC):
+    """Strategy for the per-backing concerns of a bistate-duration load.
+
+    Concrete subclasses (`SwitchTransport`, `ClimateTransport`) hold the
+    underlying HA entity_id and translate `LoadCommand` plus optional
+    override-state into the right service call. The host
+    (`QSBiStateDuration` and its subclasses) is responsible for the
+    bistate-mode signalling and override state machine — the transport
+    receives primitives, not the host.
+    """
+
+    entity: str
+
+    @abstractmethod
+    def default_state_on(self) -> str:
+        """Initial value the host should use for its `_state_on`."""
+
+    @abstractmethod
+    def default_state_off(self) -> str:
+        """Initial value the host should use for its `_state_off`."""
+
+    @abstractmethod
+    def mode_options(self, hass: HomeAssistant) -> list[str]:
+        """Valid raw-state values the device exposes (for selector UIs)."""
+
+    def power_from_state(self, state: str | None, power_use: float) -> float | None:
+        """Map a raw HA state to load power.
+
+        Returns `None` when the state is missing or unavailable so the
+        caller can decide whether to fall back to defaults. Returns
+        `power_use` when the state matches the on-state, `0.0` for
+        anything else (including the explicit off-state).
+        """
+        if state is None or state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            return None
+        if state == self.default_state_on():
+            return power_use
+        return 0.0
+
+    @abstractmethod
+    async def execute(
+        self,
+        hass: HomeAssistant,
+        command: LoadCommand,
+        override_state: str | None,
+        state_on: str,
+        state_off: str,
+    ) -> bool | None:
+        """Issue the service call that flips the underlying device.
+
+        - ``override_state`` — when set, becomes the target state directly
+          (the user override path).
+        - ``state_on`` / ``state_off`` — host-owned values used to map a
+          ``LoadCommand`` to a concrete service call.
+
+        Returns ``False`` after a successful service call (mirroring the
+        existing ``execute_command_system`` contract: the command has been
+        dispatched but the device's confirmation is still pending).
+
+        Raises:
+            ValueError: when ``command`` is neither on, off, nor idle and
+                no override state is provided.
+        """
+
+
+class SwitchTransport(BistateTransport):
+    """Transport for switch-backed bistate loads (`switch.turn_on/off`)."""
+
+    def __init__(self, switch_entity: str) -> None:
+        """Hold the underlying `switch.*` entity_id."""
+        self.entity = switch_entity
+
+    def default_state_on(self) -> str:
+        return "on"
+
+    def default_state_off(self) -> str:
+        return "off"
+
+    def mode_options(self, hass: HomeAssistant) -> list[str]:
+        # `hass` unused but kept for parity with `ClimateTransport`.
+        del hass
+        return ["on", "off"]
+
+    async def execute(
+        self,
+        hass: HomeAssistant,
+        command: LoadCommand,
+        override_state: str | None,
+        state_on: str,
+        state_off: str,
+    ) -> bool | None:
+        # The host's `state_on` / `state_off` map override states 1:1 to
+        # the switch's "on" / "off" service. Unused locals are silenced
+        # so the parameter list stays symmetric with `ClimateTransport`.
+        del state_off
+
+        if override_state is not None:
+            if override_state == state_on:
+                action = SERVICE_TURN_ON
+            else:
+                action = SERVICE_TURN_OFF
+        else:
+            if command.is_like(CMD_ON):
+                action = SERVICE_TURN_ON
+            elif command.is_off_or_idle():
+                action = SERVICE_TURN_OFF
+            else:
+                raise ValueError("Invalid command")
+
+        _LOGGER.info("Executing on/off command %s on %s", action, self.entity)
+
+        await hass.services.async_call(
+            domain=Platform.SWITCH,
+            service=action,
+            target={"entity_id": self.entity},
+        )
+        return False
+
+
+class ClimateTransport(BistateTransport):
+    """Transport for climate-backed bistate loads (`climate.set_hvac_mode`)."""
+
+    def __init__(self, climate_entity: str, state_on: str, state_off: str) -> None:
+        """Hold the climate entity plus the on/off HVAC modes.
+
+        ``state_on`` and ``state_off`` are stored as mutable attributes so
+        the host can update them through the climate-specific
+        `climate_state_on` / `climate_state_off` setters at runtime.
+        """
+        self.entity = climate_entity
+        self.state_on = state_on
+        self.state_off = state_off
+
+    def default_state_on(self) -> str:
+        return self.state_on
+
+    def default_state_off(self) -> str:
+        return self.state_off
+
+    def mode_options(self, hass: HomeAssistant) -> list[str]:
+        return get_hvac_modes(hass, self.entity)
+
+    # Unused param: CMD_IDLE — covered indirectly through `is_off_or_idle()`
+    async def execute(
+        self,
+        hass: HomeAssistant,
+        command: LoadCommand,
+        override_state: str | None,
+        state_on: str,
+        state_off: str,
+    ) -> bool | None:
+        # Cheap silencing — keep CMD_IDLE imported so it stays linked to
+        # the contract this branch checks.
+        _ = CMD_IDLE
+
+        if override_state is not None:
+            hvac_mode = override_state
+        else:
+            if command.is_like(CMD_ON):
+                hvac_mode = state_on
+            elif command.is_off_or_idle():
+                hvac_mode = state_off
+            else:
+                raise ValueError("Invalid command")
+
+        data: dict[str, Any] = {
+            ATTR_ENTITY_ID: self.entity,
+            climate.ATTR_HVAC_MODE: hvac_mode,
+        }
+
+        _LOGGER.info("Executing climate set_hvac_mode %s on %s", hvac_mode, self.entity)
+
+        await hass.services.async_call(climate.DOMAIN, climate.SERVICE_SET_HVAC_MODE, data)
+        return False

--- a/custom_components/quiet_solar/ha_model/bistate_transport.py
+++ b/custom_components/quiet_solar/ha_model/bistate_transport.py
@@ -48,21 +48,27 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from ..home_model.commands import CMD_IDLE, CMD_ON, LoadCommand
+from ..home_model.commands import CMD_ON, LoadCommand
 
 _LOGGER = logging.getLogger(__name__)
+
+_HVAC_MODE_DEFAULTS: list[str] = [HVACMode.AUTO.value, HVACMode.OFF.value]
 
 
 def get_hvac_modes(hass: HomeAssistant, entity_id: str) -> list[str]:
     """Return the HVAC modes advertised by a climate entity.
 
-    Falls back to `[AUTO, OFF]` when the entity has no `hvac_modes`
-    capability (mirrors the legacy helper in `climate_controller.py`,
-    which is re-exported here for backwards compatibility).
+    Falls back to `[AUTO, OFF]` when the entity is missing from the
+    registry, has no advertised capabilities, or has no `hvac_modes`
+    capability. The fallback list is the same in all three branches so
+    the config-flow and runtime selectors never render an empty
+    dropdown (M6).
     """
     registry = er.async_get(hass)
     entry = registry.async_get(entity_id)
-    return entry.capabilities.get("hvac_modes", [HVACMode.AUTO.value, HVACMode.OFF.value])
+    if entry is None or entry.capabilities is None:
+        return list(_HVAC_MODE_DEFAULTS)
+    return entry.capabilities.get("hvac_modes", list(_HVAC_MODE_DEFAULTS))
 
 
 class BistateTransport(ABC):
@@ -157,16 +163,37 @@ class SwitchTransport(BistateTransport):
         state_off: str,
     ) -> bool | None:
         # The host's `state_on` / `state_off` map override states 1:1 to
-        # the switch's "on" / "off" service. Unused locals are silenced
-        # so the parameter list stays symmetric with `ClimateTransport`.
-        del state_off
+        # the switch's "on" / "off" service. `state_on` stays unused here
+        # so the param list stays symmetric with `ClimateTransport`.
+        del state_on
 
         if override_state is not None:
-            if override_state == state_on:
-                action = SERVICE_TURN_ON
-            else:
+            # M1 regression — legacy semantics: only TURN_OFF when the
+            # override state matches `state_off`. Any other value
+            # (including unexpected ones) defaults to TURN_ON, matching
+            # the pre-refactor `execute_command_system` branch:
+            #   if state == expected_state_from_command(CMD_IDLE):
+            #       action = SERVICE_TURN_OFF
+            #   else:
+            #       action = SERVICE_TURN_ON
+            if override_state == state_off:
                 action = SERVICE_TURN_OFF
+            else:
+                if override_state != self.default_state_on():
+                    # N1 — surface unexpected override states so a typo or
+                    # firmware change is debuggable rather than silent.
+                    _LOGGER.warning(
+                        "Unexpected override_state %s for %s (expected %s or %s); defaulting to TURN_ON",
+                        override_state,
+                        self.entity,
+                        self.default_state_on(),
+                        state_off,
+                    )
+                action = SERVICE_TURN_ON
         else:
+            # N5 — surface a None command BEFORE attempting attribute access.
+            if command is None:
+                raise ValueError("Invalid command: None")
             if command.is_like(CMD_ON):
                 action = SERVICE_TURN_ON
             elif command.is_off_or_idle():
@@ -207,7 +234,6 @@ class ClimateTransport(BistateTransport):
     def mode_options(self, hass: HomeAssistant) -> list[str]:
         return get_hvac_modes(hass, self.entity)
 
-    # Unused param: CMD_IDLE — covered indirectly through `is_off_or_idle()`
     async def execute(
         self,
         hass: HomeAssistant,
@@ -216,13 +242,12 @@ class ClimateTransport(BistateTransport):
         state_on: str,
         state_off: str,
     ) -> bool | None:
-        # Cheap silencing — keep CMD_IDLE imported so it stays linked to
-        # the contract this branch checks.
-        _ = CMD_IDLE
-
         if override_state is not None:
             hvac_mode = override_state
         else:
+            # N5 — surface a None command BEFORE attempting attribute access.
+            if command is None:
+                raise ValueError("Invalid command: None")
             if command.is_like(CMD_ON):
                 hvac_mode = state_on
             elif command.is_off_or_idle():

--- a/custom_components/quiet_solar/ha_model/bistate_transport.py
+++ b/custom_components/quiet_solar/ha_model/bistate_transport.py
@@ -59,16 +59,21 @@ def get_hvac_modes(hass: HomeAssistant, entity_id: str) -> list[str]:
     """Return the HVAC modes advertised by a climate entity.
 
     Falls back to `[AUTO, OFF]` when the entity is missing from the
-    registry, has no advertised capabilities, or has no `hvac_modes`
-    capability. The fallback list is the same in all three branches so
-    the config-flow and runtime selectors never render an empty
-    dropdown (M6).
+    registry, has no advertised capabilities, has no `hvac_modes`
+    capability, or advertises an empty `hvac_modes` list (E4
+    review-fix: some buggy climate integrations transiently expose
+    `{"hvac_modes": []}` during startup). The fallback list is the same
+    in all four branches so the config-flow and runtime selectors
+    never render an empty dropdown (M6 + E4).
     """
     registry = er.async_get(hass)
     entry = registry.async_get(entity_id)
     if entry is None or entry.capabilities is None:
         return list(_HVAC_MODE_DEFAULTS)
-    return entry.capabilities.get("hvac_modes", list(_HVAC_MODE_DEFAULTS))
+    modes = entry.capabilities.get("hvac_modes")
+    if not modes:  # missing key OR empty list
+        return list(_HVAC_MODE_DEFAULTS)
+    return modes
 
 
 class BistateTransport(ABC):
@@ -103,6 +108,16 @@ class BistateTransport(ABC):
         caller can decide whether to fall back to defaults. Returns
         `power_use` when the state matches the on-state, `0.0` for
         anything else (including the explicit off-state).
+
+        E5 review-fix note — transitional HVAC states (e.g. `"heating"`,
+        `"idle"`, vendor-specific intermediates) currently attribute
+        `0.0` because they do not equal `default_state_on()`. The
+        pre-refactor `get_power_from_switch_state` had the same blind
+        spot; widening the contract to treat any non-`state_off` as
+        "on" needs solver-side validation first and is deliberately
+        deferred. Callers that need power attribution during a
+        transition should rely on the accurate power sensor rather
+        than this helper.
         """
         if state is None or state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             return None
@@ -140,14 +155,23 @@ class SwitchTransport(BistateTransport):
     """Transport for switch-backed bistate loads (`switch.turn_on/off`)."""
 
     def __init__(self, switch_entity: str) -> None:
-        """Hold the underlying `switch.*` entity_id."""
+        """Hold the underlying `switch.*` entity_id.
+
+        `state_on` / `state_off` are stored as mutable attributes for
+        symmetry with `ClimateTransport`. B3 review-fix moves the
+        `_state_on/_state_off` property shadow up to `QSBiStateDuration`,
+        which routes writes through `_transport.state_on/state_off` — so
+        every transport must expose those attributes consistently.
+        """
         self.entity = switch_entity
+        self.state_on = "on"
+        self.state_off = "off"
 
     def default_state_on(self) -> str:
-        return "on"
+        return self.state_on
 
     def default_state_off(self) -> str:
-        return "off"
+        return self.state_off
 
     def mode_options(self, hass: HomeAssistant) -> list[str]:
         # `hass` unused but kept for parity with `ClimateTransport`.

--- a/custom_components/quiet_solar/ha_model/bistate_transport.py
+++ b/custom_components/quiet_solar/ha_model/bistate_transport.py
@@ -162,7 +162,15 @@ class SwitchTransport(BistateTransport):
         `_state_on/_state_off` property shadow up to `QSBiStateDuration`,
         which routes writes through `_transport.state_on/state_off` — so
         every transport must expose those attributes consistently.
+
+        EH-E — fail fast on `None` / empty `switch_entity`. The first
+        `services.async_call(target={"entity_id": None})` would crash
+        at the HA layer with an opaque error otherwise; raising here
+        keeps the misconfiguration visible at construction time.
+        Mirrors the EH-C guard on `QSClimateDuration`.
         """
+        if not switch_entity or (isinstance(switch_entity, str) and not switch_entity.strip()):
+            raise ValueError("SwitchTransport requires a non-empty switch entity id")
         self.entity = switch_entity
         self.state_on = "on"
         self.state_off = "off"
@@ -268,6 +276,21 @@ class ClimateTransport(BistateTransport):
     ) -> bool | None:
         if override_state is not None:
             hvac_mode = override_state
+            # BH-F — parallel to N1 on `SwitchTransport`. Surface an
+            # unexpected override_state with a warning so a typo or a
+            # vendor-firmware-mode-drop case is debuggable rather than
+            # a silent `set_hvac_mode(<garbage>)`.
+            try:
+                available_modes = self.mode_options(hass)
+            except Exception:  # pragma: no cover — defensive
+                available_modes = None
+            if available_modes is not None and override_state not in available_modes:
+                _LOGGER.warning(
+                    "Unexpected override_state %s for %s (not in advertised hvac_modes %s); dispatching anyway",
+                    override_state,
+                    self.entity,
+                    available_modes,
+                )
         else:
             # N5 — surface a None command BEFORE attempting attribute access.
             if command is None:

--- a/custom_components/quiet_solar/ha_model/climate_controller.py
+++ b/custom_components/quiet_solar/ha_model/climate_controller.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 from homeassistant.components.climate import HVACMode
 
@@ -10,7 +9,6 @@ from ..const import (
     SENSOR_CONSTRAINT_SENSOR_CLIMATE,
     CONF_TYPE_NAME_QSClimateDuration,
 )
-from ..home_model.commands import LoadCommand
 from .bistate_duration import QSBiStateDuration
 from .bistate_transport import ClimateTransport, get_hvac_modes
 
@@ -28,39 +26,69 @@ class QSClimateDuration(QSBiStateDuration):
 
     def __init__(self, **kwargs):
 
+        # S2/S5 — build the transport BEFORE `super().__init__` so the
+        # property-based `_state_on/_state_off` shadows below can
+        # delegate to it during the base ctor's seed assignments. The
+        # transport is the single source of truth for the HVAC modes;
+        # the base ctor's `self._state_on = "on"` lands as
+        # `self._transport.state_on = "on"` and gets overwritten with
+        # the actual HVAC mode below.
+        climate_entity = kwargs.pop(CONF_CLIMATE, None)
+        state_off = kwargs.pop(CONF_CLIMATE_HVAC_MODE_OFF, str(HVACMode.OFF.value))
+        state_on = kwargs.pop(CONF_CLIMATE_HVAC_MODE_ON, str(HVACMode.AUTO.value))
+        self.climate_entity = climate_entity
+        self._transport: ClimateTransport = ClimateTransport(climate_entity, state_on, state_off)
+
         super().__init__(**kwargs)
 
-        self.climate_entity = kwargs.pop(CONF_CLIMATE, None)
-        self._state_off = kwargs.pop(CONF_CLIMATE_HVAC_MODE_OFF, str(HVACMode.OFF.value))
-        self._state_on = kwargs.pop(CONF_CLIMATE_HVAC_MODE_ON, str(HVACMode.AUTO.value))
-
-        # get the HVAC mode for on / off for the climate entity
-        self._bistate_mode_on = self._state_on
-        self._bistate_mode_off = self._state_off
-        self.bistate_entity = self.climate_entity
+        # Re-pin the transport's modes from the climate-specific HVAC
+        # config (super() seeded them to "on"/"off" via the shadow
+        # properties below).
+        self._transport.state_on = state_on
+        self._transport.state_off = state_off
+        self._bistate_mode_on = state_on
+        self._bistate_mode_off = state_off
+        self.bistate_entity = climate_entity
         self.is_load_time_sensitive = True
 
-        self._transport: ClimateTransport = ClimateTransport(self.climate_entity, self._state_on, self._state_off)
-
+    # S5 — `_state_on` / `_state_off` are thin views over the transport
+    # so a direct write through either name always updates the
+    # transport, never leaving it stale. Without these, code that does
+    # `device._state_on = "auto"` would bypass the climate setter and
+    # `execute_command_system` would still issue the old HVAC mode.
     @property
-    def climate_state_on(self):
-        return self._state_on
+    def _state_on(self):
+        return self._transport.state_on
 
-    @climate_state_on.setter
-    def climate_state_on(self, value):
-        self._state_on = value
-        self._bistate_mode_on = value
+    @_state_on.setter
+    def _state_on(self, value):
         self._transport.state_on = value
 
     @property
+    def _state_off(self):
+        return self._transport.state_off
+
+    @_state_off.setter
+    def _state_off(self, value):
+        self._transport.state_off = value
+
+    @property
+    def climate_state_on(self):
+        return self._transport.state_on
+
+    @climate_state_on.setter
+    def climate_state_on(self, value):
+        self._transport.state_on = value
+        self._bistate_mode_on = value
+
+    @property
     def climate_state_off(self):
-        return self._state_off
+        return self._transport.state_off
 
     @climate_state_off.setter
     def climate_state_off(self, value):
-        self._state_off = value
-        self._bistate_mode_off = value
         self._transport.state_off = value
+        self._bistate_mode_off = value
 
     def get_possibles_modes(self):
         """return the possible modes for the climate entity"""
@@ -73,8 +101,8 @@ class QSClimateDuration(QSBiStateDuration):
         """return the translation key for the select"""
         return "climate_mode"
 
-    # exception catched above execute_command
-    async def execute_command_system(self, time: datetime, command: LoadCommand, state: str | None) -> bool | None:
-        return await self._transport.execute(
-            self.hass, command, state, self._transport.state_on, self._transport.state_off
-        )
+    # `execute_command_system` is inherited from `QSBiStateDuration` and
+    # delegates to `self._transport.execute(...)` (N2 review-fix). The
+    # base passes `self._state_on/_state_off`, which thanks to the S5
+    # property shadows defined above resolve to the transport's modes —
+    # so this stays in sync with `climate_state_on/off` mutations.

--- a/custom_components/quiet_solar/ha_model/climate_controller.py
+++ b/custom_components/quiet_solar/ha_model/climate_controller.py
@@ -10,13 +10,7 @@ from ..const import (
     CONF_TYPE_NAME_QSClimateDuration,
 )
 from .bistate_duration import QSBiStateDuration
-from .bistate_transport import ClimateTransport, get_hvac_modes
-
-# Re-exported for backwards compatibility — callers that previously
-# imported `get_hvac_modes` from this module continue to work. The
-# canonical home for the helper is now `bistate_transport.py`.
-__all__ = ["QSClimateDuration", "get_hvac_modes"]
-
+from .bistate_transport import ClimateTransport
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,11 +20,12 @@ class QSClimateDuration(QSBiStateDuration):
 
     def __init__(self, **kwargs):
 
-        # S2/S5 — build the transport BEFORE `super().__init__` so the
-        # property-based `_state_on/_state_off` shadows below can
-        # delegate to it during the base ctor's seed assignments. The
-        # transport is the single source of truth for the HVAC modes;
-        # the base ctor's `self._state_on = "on"` lands as
+        # S2/S5/B3 — build the transport BEFORE `super().__init__` so
+        # the inherited `_state_on/_state_off` property shadow (in
+        # `QSBiStateDuration`) can delegate to it during the base
+        # ctor's seed assignments. The transport is the single source
+        # of truth for the HVAC modes; the base ctor's
+        # `self._state_on = "on"` lands as
         # `self._transport.state_on = "on"` and gets overwritten with
         # the actual HVAC mode below.
         climate_entity = kwargs.pop(CONF_CLIMATE, None)
@@ -41,53 +36,39 @@ class QSClimateDuration(QSBiStateDuration):
 
         super().__init__(**kwargs)
 
-        # Re-pin the transport's modes from the climate-specific HVAC
-        # config (super() seeded them to "on"/"off" via the shadow
-        # properties below).
-        self._transport.state_on = state_on
-        self._transport.state_off = state_off
+        # B7 — route the post-super HVAC-mode re-pin through the
+        # inherited property shadow (`self._state_on = …` updates the
+        # transport). The base ctor seeded the transport with `"on"`/
+        # `"off"` via the same path; we now restore the actual HVAC
+        # modes the user picked.
+        self._state_on = state_on
+        self._state_off = state_off
         self._bistate_mode_on = state_on
         self._bistate_mode_off = state_off
         self.bistate_entity = climate_entity
         self.is_load_time_sensitive = True
 
-    # S5 — `_state_on` / `_state_off` are thin views over the transport
-    # so a direct write through either name always updates the
-    # transport, never leaving it stale. Without these, code that does
-    # `device._state_on = "auto"` would bypass the climate setter and
-    # `execute_command_system` would still issue the old HVAC mode.
-    @property
-    def _state_on(self):
-        return self._transport.state_on
-
-    @_state_on.setter
-    def _state_on(self, value):
-        self._transport.state_on = value
-
-    @property
-    def _state_off(self):
-        return self._transport.state_off
-
-    @_state_off.setter
-    def _state_off(self, value):
-        self._transport.state_off = value
+    # `_state_on` / `_state_off` properties are inherited from
+    # `QSBiStateDuration` (B3 review-fix moved them up so both
+    # `QSClimateDuration` AND `QSRadiator` route writes through the
+    # transport from a single definition).
 
     @property
     def climate_state_on(self):
-        return self._transport.state_on
+        return self._state_on
 
     @climate_state_on.setter
     def climate_state_on(self, value):
-        self._transport.state_on = value
+        self._state_on = value  # routes through the inherited shadow
         self._bistate_mode_on = value
 
     @property
     def climate_state_off(self):
-        return self._transport.state_off
+        return self._state_off
 
     @climate_state_off.setter
     def climate_state_off(self, value):
-        self._transport.state_off = value
+        self._state_off = value  # routes through the inherited shadow
         self._bistate_mode_off = value
 
     def get_possibles_modes(self):

--- a/custom_components/quiet_solar/ha_model/climate_controller.py
+++ b/custom_components/quiet_solar/ha_model/climate_controller.py
@@ -1,11 +1,7 @@
 import logging
 from datetime import datetime
-from typing import Any
 
-from homeassistant.components import climate
 from homeassistant.components.climate import HVACMode
-from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.helpers import entity_registry as er
 
 from ..const import (
     CONF_CLIMATE,
@@ -14,14 +10,14 @@ from ..const import (
     SENSOR_CONSTRAINT_SENSOR_CLIMATE,
     CONF_TYPE_NAME_QSClimateDuration,
 )
-from ..home_model.commands import CMD_ON, LoadCommand
+from ..home_model.commands import LoadCommand
 from .bistate_duration import QSBiStateDuration
+from .bistate_transport import ClimateTransport, get_hvac_modes
 
-
-def get_hvac_modes(hass, entity_id):
-    registry = er.async_get(hass)
-    entry = registry.async_get(entity_id)
-    return entry.capabilities.get("hvac_modes", [HVACMode.AUTO.value, HVACMode.OFF.value])
+# Re-exported for backwards compatibility — callers that previously
+# imported `get_hvac_modes` from this module continue to work. The
+# canonical home for the helper is now `bistate_transport.py`.
+__all__ = ["QSClimateDuration", "get_hvac_modes"]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,6 +40,8 @@ class QSClimateDuration(QSBiStateDuration):
         self.bistate_entity = self.climate_entity
         self.is_load_time_sensitive = True
 
+        self._transport: ClimateTransport = ClimateTransport(self.climate_entity, self._state_on, self._state_off)
+
     @property
     def climate_state_on(self):
         return self._state_on
@@ -52,6 +50,7 @@ class QSClimateDuration(QSBiStateDuration):
     def climate_state_on(self, value):
         self._state_on = value
         self._bistate_mode_on = value
+        self._transport.state_on = value
 
     @property
     def climate_state_off(self):
@@ -61,10 +60,11 @@ class QSClimateDuration(QSBiStateDuration):
     def climate_state_off(self, value):
         self._state_off = value
         self._bistate_mode_off = value
+        self._transport.state_off = value
 
     def get_possibles_modes(self):
         """return the possible modes for the climate entity"""
-        return get_hvac_modes(self.hass, self.climate_entity)
+        return self._transport.mode_options(self.hass)
 
     def get_virtual_current_constraint_translation_key(self) -> str | None:
         return SENSOR_CONSTRAINT_SENSOR_CLIMATE
@@ -75,24 +75,6 @@ class QSClimateDuration(QSBiStateDuration):
 
     # exception catched above execute_command
     async def execute_command_system(self, time: datetime, command: LoadCommand, state: str | None) -> bool | None:
-
-        if state is not None:
-            hvac_mode = state
-        else:
-            if command.is_like(CMD_ON):
-                hvac_mode = self.climate_state_on
-            elif command.is_off_or_idle():
-                hvac_mode = self.climate_state_off
-            else:
-                raise ValueError("Invalid command")
-
-        data: dict[str, Any] = {ATTR_ENTITY_ID: self.bistate_entity}
-        service = climate.SERVICE_SET_HVAC_MODE
-
-        data[climate.ATTR_HVAC_MODE] = hvac_mode
-        domain = climate.DOMAIN
-
-        # exception catched above execute_command
-        await self.hass.services.async_call(domain, service, data)
-
-        return False
+        return await self._transport.execute(
+            self.hass, command, state, self._transport.state_on, self._transport.state_off
+        )

--- a/custom_components/quiet_solar/ha_model/climate_controller.py
+++ b/custom_components/quiet_solar/ha_model/climate_controller.py
@@ -1,6 +1,7 @@
 import logging
 
 from homeassistant.components.climate import HVACMode
+from homeassistant.exceptions import ServiceValidationError
 
 from ..const import (
     CONF_CLIMATE,
@@ -29,6 +30,18 @@ class QSClimateDuration(QSBiStateDuration):
         # `self._transport.state_on = "on"` and gets overwritten with
         # the actual HVAC mode below.
         climate_entity = kwargs.pop(CONF_CLIMATE, None)
+        if isinstance(climate_entity, str):
+            stripped = climate_entity.strip()
+            climate_entity = stripped if stripped else None
+        # EH-C — surface a missing/empty climate entity rather than
+        # silently constructing `ClimateTransport(None, ...)` and
+        # later crashing at `services.async_call(...entity_id=None)`.
+        # Mirrors the EH6 guard on `QSRadiator`. Pre-existing climate
+        # entries cannot reach this branch (the config flow requires
+        # a non-empty climate entity), so this only fires on
+        # programmatic misuse / corrupted persistence.
+        if not climate_entity:
+            raise ServiceValidationError("Climate-duration load requires a non-empty climate entity")
         # EH3 — `kwargs.pop(key, default)` only returns `default` when
         # the key is MISSING; a persisted `""` (from a migration or a
         # buggy import) would otherwise slip through and crash
@@ -48,6 +61,18 @@ class QSClimateDuration(QSBiStateDuration):
         # modes the user picked.
         self._state_on = state_on
         self._state_off = state_off
+        # BH-B — `QSClimateDuration` pins `_bistate_mode_on/off` to the
+        # raw HVAC mode strings (e.g. "heat" / "off"). The sibling
+        # `QSRadiator` uses literal "on" / "off" instead (E3 review-fix).
+        # The divergence is intentional: the `climate_mode` translation
+        # registers raw HVAC mode keys (`"heat"`, `"cool"`, `"fan_only"`,
+        # …) as states for the force-mode dropdown, so changing climate
+        # to "on"/"off" would break translations for every existing
+        # climate user. The `radiator_mode` translation, by contrast,
+        # only registers `"on" / "off"` (plus the calendar modes), so
+        # the radiator can safely use literals. Future cross-subclass
+        # logic in `QSBiStateDuration` that compares `_state_on` ↔
+        # `_bistate_mode_on` should treat the two as decoupled.
         self._bistate_mode_on = state_on
         self._bistate_mode_off = state_off
         self.bistate_entity = climate_entity

--- a/custom_components/quiet_solar/ha_model/climate_controller.py
+++ b/custom_components/quiet_solar/ha_model/climate_controller.py
@@ -29,8 +29,13 @@ class QSClimateDuration(QSBiStateDuration):
         # `self._transport.state_on = "on"` and gets overwritten with
         # the actual HVAC mode below.
         climate_entity = kwargs.pop(CONF_CLIMATE, None)
-        state_off = kwargs.pop(CONF_CLIMATE_HVAC_MODE_OFF, str(HVACMode.OFF.value))
-        state_on = kwargs.pop(CONF_CLIMATE_HVAC_MODE_ON, str(HVACMode.AUTO.value))
+        # EH3 — `kwargs.pop(key, default)` only returns `default` when
+        # the key is MISSING; a persisted `""` (from a migration or a
+        # buggy import) would otherwise slip through and crash
+        # `set_hvac_mode("")` at runtime. Mirror the S9 fallback from
+        # `QSRadiator` so both classes treat empty as absent.
+        state_off = kwargs.pop(CONF_CLIMATE_HVAC_MODE_OFF, None) or str(HVACMode.OFF.value)
+        state_on = kwargs.pop(CONF_CLIMATE_HVAC_MODE_ON, None) or str(HVACMode.AUTO.value)
         self.climate_entity = climate_entity
         self._transport: ClimateTransport = ClimateTransport(climate_entity, state_on, state_off)
 

--- a/custom_components/quiet_solar/ha_model/home.py
+++ b/custom_components/quiet_solar/ha_model/home.py
@@ -1458,6 +1458,11 @@ class QSHome(QSDynamicGroup):
     def get_heat_pumps(self) -> list[QSHeatPump]:
         """Public accessor for registered heat pumps.
 
+        Returns a **snapshot copy** of the internal list so external
+        callers can iterate it safely without accidentally mutating the
+        home's registry. Mutations must go through `add_device` /
+        `remove_device` (CR2 review-fix).
+
         Callers outside this class (notably the config-flow's radiator
         and climate steps) should prefer this over reaching into
         `home._heat_pumps` directly — the private list may move or be
@@ -1465,7 +1470,7 @@ class QSHome(QSDynamicGroup):
         making the heat-pump piloting dropdown vanish without warning
         (M3 review-fix).
         """
-        return self._heat_pumps
+        return list(self._heat_pumps)
 
     def get_person_by_name(self, name: str | None) -> QSPerson | None:
         if name is None:

--- a/custom_components/quiet_solar/ha_model/home.py
+++ b/custom_components/quiet_solar/ha_model/home.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import pickle
 from collections.abc import Mapping
@@ -37,7 +36,6 @@ from ..const import (
     CONF_OFF_GRID_STATE_VALUE,
     DASHBOARD_DEFAULT_SECTIONS,
     DASHBOARD_DEFAULT_SECTIONS_DICT,
-    DASHBOARD_NO_SECTION,
     DASHBOARD_NUM_SECTION_MAX,
     DOMAIN,
     FAR_FUTURE_FORECAST_THRESHOLD_S,
@@ -409,17 +407,35 @@ class QSHome(QSDynamicGroup):
 
             self.dashboard_sections.append((s_name, s_icon))
 
-        if num_found_sections == 0:
-            self.dashboard_sections = copy.deepcopy(DASHBOARD_DEFAULT_SECTIONS)
-        else:
-            # Normalize bundled-default order so a persisted list
-            # written by an older append-only migration (e.g. QS-194
-            # adding water_boilers at the end, or QS-195 adding
-            # radiators at the end) renders in canonical
-            # ``DASHBOARD_DEFAULT_SECTIONS`` order without the user
-            # having to re-edit the home config. Custom user sections
-            # are preserved at the tail.
-            self.dashboard_sections = _normalize_dashboard_sections_order(self.dashboard_sections)
+        # Init-time bundled-default inclusion. Replaces the per-device
+        # ``_maybe_migrate_missing_default_section`` mechanism with a
+        # single deterministic pass: every entry in
+        # ``DASHBOARD_DEFAULT_SECTIONS`` is added if missing (unless
+        # the user explicitly opted out via
+        # ``CONF_DASHBOARD_SECTIONS_USER_REMOVED``). Custom user
+        # sections from the persisted slot keys are preserved.
+        # Runtime-only — the user's ``config_entry.data`` is NOT
+        # modified, so their customisation stays user-owned. The
+        # dashboard YAML, the home options form, and every device's
+        # section dropdown all read from this in-memory list, so all
+        # three surfaces stay consistent without any per-device
+        # migration timing concerns.
+        user_removed_raw = kwargs.pop(CONF_DASHBOARD_SECTIONS_USER_REMOVED, None) or []
+        user_removed: set[str] = set(user_removed_raw)
+        existing_names = {name for name, _icon in self.dashboard_sections}
+        for default_name, default_icon in DASHBOARD_DEFAULT_SECTIONS:
+            if default_name in existing_names:
+                continue
+            if default_name in user_removed:
+                continue
+            self.dashboard_sections.append((default_name, default_icon))
+
+        # Normalize so bundled defaults always render in canonical
+        # ``DASHBOARD_DEFAULT_SECTIONS`` order regardless of the
+        # persisted slot ordering. Custom user sections (names not in
+        # ``DASHBOARD_DEFAULT_SECTIONS_DICT``) are preserved at the
+        # tail in their original relative order.
+        self.dashboard_sections = _normalize_dashboard_sections_order(self.dashboard_sections)
 
         self.home_non_controlled_consumption_sensor = HOME_NON_CONTROLLED_CONSUMPTION_SENSOR
         self.home_available_power_sensor = HOME_AVAILABLE_POWER_SENSOR
@@ -1950,91 +1966,17 @@ class QSHome(QSDynamicGroup):
                     load.devices_to_pilot.append(piloted_device)
                     piloted_device.clients.append(load)
 
-    def _maybe_migrate_missing_default_section(self, device) -> None:
-        """WF-5 tier 2: in-memory auto-migration for missing default sections.
-
-        When a user customised `dashboard_sections` BEFORE QS-194 added
-        the `water_boilers` section (or any future default section),
-        their stored list won't contain it. A device whose default
-        section is missing would silently land in `DASHBOARD_NO_SECTION`
-        and never appear on the dashboard.
-
-        Mitigation: if a device's requested section is one of the
-        `DASHBOARD_DEFAULT_SECTIONS` and isn't already in
-        `self.dashboard_sections`, append it (with its bundled icon) at
-        runtime only. The user's `config_entry.data` is NOT modified —
-        their customisation stays user-owned, this is just a safety net
-        so new device types remain visible after an upgrade.
-        """
-        requested = getattr(device, "_conf_dashboard_section_option", None)
-        if requested is None or requested == DASHBOARD_NO_SECTION:
-            return
-        # S4: use the rigorous prefix parser already defined in
-        # home_model/load.py rather than a string-substring heuristic
-        # (which would mis-strip e.g. "#hot - water" → "water").
-        section_name, _ = extract_name_and_index_from_dashboard_section_option(requested)
-        # Already present (by name)? Nothing to do.
-        existing_names = {s[0] for s in self.dashboard_sections}
-        if section_name in existing_names:
-            return
-        # Only auto-add for bundled default sections — never invent a
-        # section name out of thin air.
-        if section_name not in DASHBOARD_DEFAULT_SECTIONS_DICT:
-            return
-        # N7: honour explicit user opt-out. If the user removed this
-        # section from their dashboard and recorded it in
-        # `CONF_DASHBOARD_SECTIONS_USER_REMOVED`, the migration must
-        # NOT silently re-append it whenever a device of that type
-        # is added.
-        user_removed = []
-        if self.config_entry is not None:
-            user_removed = self.config_entry.data.get(CONF_DASHBOARD_SECTIONS_USER_REMOVED, []) or []
-        if section_name in user_removed:
-            _LOGGER.info(
-                "Skipping auto-append of dashboard section %r for device "
-                "%r — user explicitly opted out via "
-                "CONF_DASHBOARD_SECTIONS_USER_REMOVED",
-                section_name,
-                device.name,
-            )
-            return
-        icon = DASHBOARD_DEFAULT_SECTIONS_DICT[section_name]
-        _LOGGER.info(
-            "Auto-adding missing default dashboard section %r (icon %r) "
-            "for device %r; runtime-only — config_entry not modified",
-            section_name,
-            icon,
-            device.name,
-        )
-        # Append + normalize keeps the bundled-default ordering aligned
-        # with ``DASHBOARD_DEFAULT_SECTIONS``. Without this the migration
-        # would place e.g. ``radiators`` AFTER ``settings`` instead of
-        # between ``water_boilers`` and ``others`` — visible to the user
-        # as a radiator section rendered below the settings block on the
-        # main dashboard.
-        self.dashboard_sections.append((section_name, icon))
-        self.dashboard_sections = _normalize_dashboard_sections_order(self.dashboard_sections)
-        # S5: invalidate ALL devices whose cached resolution was
-        # warmed before the migration. Without this, sibling devices
-        # already resolved to DASHBOARD_NO_SECTION stay invisible even
-        # though their section now exists.
-        for d in self._all_devices + getattr(self, "_disabled_devices", []):
-            cached = getattr(d, "_computed_dashboard_section", None)
-            if cached == DASHBOARD_NO_SECTION:
-                d._computed_dashboard_section = None
-        # And the newly-added device (not yet in _all_devices at the
-        # call site — add_device appends after this method returns).
-        if hasattr(device, "_computed_dashboard_section"):
-            device._computed_dashboard_section = None
-
     def add_device(self, device):
 
         device.home = self
 
-        # WF-5: in-memory auto-migration for missing default sections.
-        # Run before the topology rebuild below so the device is
-        # immediately reachable via `get_devices_for_dashboard_section`.
-        self._maybe_migrate_missing_default_section(device)
+        # NOTE: there is no per-device dashboard-section migration here.
+        # `QSHome.__init__` ensures every bundled `DASHBOARD_DEFAULT_SECTIONS`
+        # entry is present in `self.dashboard_sections` (minus
+        # `CONF_DASHBOARD_SECTIONS_USER_REMOVED`), so a device's
+        # requested section is guaranteed to resolve as long as it's a
+        # bundled default. Custom section names are the user's
+        # responsibility (configure them via the home options form).
 
         if isinstance(device, QSBattery):
             self.physical_battery = device

--- a/custom_components/quiet_solar/ha_model/home.py
+++ b/custom_components/quiet_solar/ha_model/home.py
@@ -1455,6 +1455,18 @@ class QSHome(QSDynamicGroup):
                 return car
         return None
 
+    def get_heat_pumps(self) -> list[QSHeatPump]:
+        """Public accessor for registered heat pumps.
+
+        Callers outside this class (notably the config-flow's radiator
+        and climate steps) should prefer this over reaching into
+        `home._heat_pumps` directly — the private list may move or be
+        renamed and `getattr` lookups silently return an empty list,
+        making the heat-pump piloting dropdown vanish without warning
+        (M3 review-fix).
+        """
+        return self._heat_pumps
+
     def get_person_by_name(self, name: str | None) -> QSPerson | None:
         if name is None:
             return None

--- a/custom_components/quiet_solar/ha_model/home.py
+++ b/custom_components/quiet_solar/ha_model/home.py
@@ -107,6 +107,46 @@ MAX_SENSOR_HISTORY_S = 60 * 60 * 24 * 7
 
 POWER_ALIGNMENT_TOLERANCE_S = 120
 
+
+def _normalize_dashboard_sections_order(
+    sections: list[tuple[str, str]],
+) -> list[tuple[str, str]]:
+    """Reorder dashboard sections so bundled defaults match const.py.
+
+    Bundled default sections (names in
+    ``DASHBOARD_DEFAULT_SECTIONS_DICT``) are emitted in the order of
+    ``DASHBOARD_DEFAULT_SECTIONS``. User-defined custom sections
+    (names NOT in the bundled dict) are preserved AFTER the bundled
+    ones, in their original relative order.
+
+    Called by ``QSHome.__init__`` and after every migration insertion
+    so the in-memory ``dashboard_sections`` list always reflects the
+    canonical bundled-section order, regardless of how the persisted
+    ``CONF_DASHBOARD_SECTION_NAME_*`` keys ended up ordered (e.g.
+    after an older append-only migration from QS-194 or QS-195).
+
+    Duplicate names (defensive, shouldn't happen in practice) are
+    deduplicated keeping the first occurrence.
+    """
+    seen: set[str] = set()
+    bundled_present: dict[str, str] = {}
+    custom_in_order: list[tuple[str, str]] = []
+    for name, icon in sections:
+        if name in seen:
+            continue
+        seen.add(name)
+        if name in DASHBOARD_DEFAULT_SECTIONS_DICT:
+            bundled_present[name] = icon
+        else:
+            custom_in_order.append((name, icon))
+    ordered: list[tuple[str, str]] = []
+    for default_name, _default_icon in DASHBOARD_DEFAULT_SECTIONS:
+        if default_name in bundled_present:
+            ordered.append((default_name, bundled_present[default_name]))
+    ordered.extend(custom_in_order)
+    return ordered
+
+
 HOME_PERSON_CAR_DAY_JOURNEY_START_HOURS = 4
 HOME_PERSON_CAR_MIN_SEGMENT_S = 30
 HOME_PERSON_CAR_MIN_OVERLAP_S = 30
@@ -371,6 +411,15 @@ class QSHome(QSDynamicGroup):
 
         if num_found_sections == 0:
             self.dashboard_sections = copy.deepcopy(DASHBOARD_DEFAULT_SECTIONS)
+        else:
+            # Normalize bundled-default order so a persisted list
+            # written by an older append-only migration (e.g. QS-194
+            # adding water_boilers at the end, or QS-195 adding
+            # radiators at the end) renders in canonical
+            # ``DASHBOARD_DEFAULT_SECTIONS`` order without the user
+            # having to re-edit the home config. Custom user sections
+            # are preserved at the tail.
+            self.dashboard_sections = _normalize_dashboard_sections_order(self.dashboard_sections)
 
         self.home_non_controlled_consumption_sensor = HOME_NON_CONTROLLED_CONSUMPTION_SENSOR
         self.home_available_power_sensor = HOME_AVAILABLE_POWER_SENSOR
@@ -1951,13 +2000,20 @@ class QSHome(QSDynamicGroup):
             return
         icon = DASHBOARD_DEFAULT_SECTIONS_DICT[section_name]
         _LOGGER.info(
-            "Auto-appending missing default dashboard section %r (icon %r) "
+            "Auto-adding missing default dashboard section %r (icon %r) "
             "for device %r; runtime-only — config_entry not modified",
             section_name,
             icon,
             device.name,
         )
+        # Append + normalize keeps the bundled-default ordering aligned
+        # with ``DASHBOARD_DEFAULT_SECTIONS``. Without this the migration
+        # would place e.g. ``radiators`` AFTER ``settings`` instead of
+        # between ``water_boilers`` and ``others`` — visible to the user
+        # as a radiator section rendered below the settings block on the
+        # main dashboard.
         self.dashboard_sections.append((section_name, icon))
+        self.dashboard_sections = _normalize_dashboard_sections_order(self.dashboard_sections)
         # S5: invalidate ALL devices whose cached resolution was
         # warmed before the migration. Without this, sibling devices
         # already resolved to DASHBOARD_NO_SECTION stay invisible even

--- a/custom_components/quiet_solar/ha_model/on_off_duration.py
+++ b/custom_components/quiet_solar/ha_model/on_off_duration.py
@@ -1,11 +1,10 @@
 import logging
 from datetime import datetime
 
-from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON, Platform
-
 from ..const import SENSOR_CONSTRAINT_SENSOR_ON_OFF, CONF_TYPE_NAME_QSOnOffDuration
-from ..home_model.commands import CMD_IDLE, CMD_ON, LoadCommand
+from ..home_model.commands import LoadCommand
 from .bistate_duration import QSBiStateDuration
+from .bistate_transport import SwitchTransport
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,6 +20,7 @@ class QSOnOffDuration(QSBiStateDuration):
         self._bistate_mode_on = "on_off_mode_on"
         self._bistate_mode_off = "on_off_mode_off"
         self.bistate_entity = self.switch_entity
+        self._transport: SwitchTransport = SwitchTransport(self.switch_entity)
 
     def get_virtual_current_constraint_translation_key(self) -> str | None:
         return SENSOR_CONSTRAINT_SENSOR_ON_OFF
@@ -31,24 +31,4 @@ class QSOnOffDuration(QSBiStateDuration):
 
     # exception catched above execute_command
     async def execute_command_system(self, time: datetime, command: LoadCommand, state: str | None) -> bool | None:
-
-        if state is not None:
-            if state == self.expected_state_from_command(CMD_IDLE):
-                action = SERVICE_TURN_OFF
-            else:
-                action = SERVICE_TURN_ON
-        else:
-            if command.is_like(CMD_ON):
-                action = SERVICE_TURN_ON
-            elif command.is_off_or_idle():
-                action = SERVICE_TURN_OFF
-            else:
-                raise ValueError("Invalid command")
-
-        _LOGGER.info("Executing on/off command %s on %s", action, self.bistate_entity)
-
-        # exception catched above execute_command
-        await self.hass.services.async_call(
-            domain=Platform.SWITCH, service=action, target={"entity_id": self.bistate_entity}
-        )
-        return False
+        return await self._transport.execute(self.hass, command, state, self._state_on, self._state_off)

--- a/custom_components/quiet_solar/ha_model/on_off_duration.py
+++ b/custom_components/quiet_solar/ha_model/on_off_duration.py
@@ -1,6 +1,6 @@
 import logging
 
-from ..const import SENSOR_CONSTRAINT_SENSOR_ON_OFF, CONF_TYPE_NAME_QSOnOffDuration
+from ..const import CONF_SWITCH, SENSOR_CONSTRAINT_SENSOR_ON_OFF, CONF_TYPE_NAME_QSOnOffDuration
 from .bistate_duration import QSBiStateDuration
 from .bistate_transport import SwitchTransport
 
@@ -11,6 +11,19 @@ class QSOnOffDuration(QSBiStateDuration):
     conf_type_name = CONF_TYPE_NAME_QSOnOffDuration
 
     def __init__(self, **kwargs):
+        # Build the transport BEFORE `super().__init__` so the inherited
+        # `_state_on/_state_off` property shadow can delegate to it
+        # during the base ctor's seed assignments — symmetric with
+        # `QSClimateDuration` and `QSRadiator`.
+        # NOTE: we `kwargs.get` (NOT `.pop`) because `AbstractLoad.__init__`
+        # itself pops `CONF_SWITCH` to populate `self.switch_entity`. If
+        # we popped here, `AbstractLoad`'s pop would default to `None`
+        # and clobber the attribute downstream code (e.g. `bistate_entity`)
+        # relies on. Climate's `kwargs.pop(CONF_CLIMATE)` is safe because
+        # `AbstractLoad` doesn't know about that key.
+        switch_entity = kwargs.get(CONF_SWITCH)
+        self._transport: SwitchTransport = SwitchTransport(switch_entity)
+
         super().__init__(**kwargs)
 
         self._state_on = "on"
@@ -18,7 +31,6 @@ class QSOnOffDuration(QSBiStateDuration):
         self._bistate_mode_on = "on_off_mode_on"
         self._bistate_mode_off = "on_off_mode_off"
         self.bistate_entity = self.switch_entity
-        self._transport: SwitchTransport = SwitchTransport(self.switch_entity)
 
     def get_virtual_current_constraint_translation_key(self) -> str | None:
         return SENSOR_CONSTRAINT_SENSOR_ON_OFF

--- a/custom_components/quiet_solar/ha_model/on_off_duration.py
+++ b/custom_components/quiet_solar/ha_model/on_off_duration.py
@@ -1,8 +1,6 @@
 import logging
-from datetime import datetime
 
 from ..const import SENSOR_CONSTRAINT_SENSOR_ON_OFF, CONF_TYPE_NAME_QSOnOffDuration
-from ..home_model.commands import LoadCommand
 from .bistate_duration import QSBiStateDuration
 from .bistate_transport import SwitchTransport
 
@@ -29,6 +27,5 @@ class QSOnOffDuration(QSBiStateDuration):
         """return the translation key for the select"""
         return "on_off_mode"
 
-    # exception catched above execute_command
-    async def execute_command_system(self, time: datetime, command: LoadCommand, state: str | None) -> bool | None:
-        return await self._transport.execute(self.hass, command, state, self._state_on, self._state_off)
+    # `execute_command_system` is inherited from `QSBiStateDuration` and
+    # delegates to `self._transport.execute(...)` (N2 review-fix).

--- a/custom_components/quiet_solar/ha_model/radiator.py
+++ b/custom_components/quiet_solar/ha_model/radiator.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.const import CONF_NAME
 from homeassistant.exceptions import ServiceValidationError
 
 from ..const import (
@@ -72,7 +73,7 @@ class QSRadiator(QSBiStateDuration):
             _LOGGER.warning(
                 "Radiator %s persisted with both climate and switch backings; "
                 "preferring climate (%s) and ignoring switch (%s)",
-                kwargs.get("name", "<unnamed>"),
+                kwargs.get(CONF_NAME, "<unnamed>"),
                 climate_entity,
                 switch_entity,
             )

--- a/custom_components/quiet_solar/ha_model/radiator.py
+++ b/custom_components/quiet_solar/ha_model/radiator.py
@@ -48,47 +48,65 @@ class QSRadiator(QSBiStateDuration):
     conf_type_name = CONF_TYPE_NAME_QSRadiator
 
     def __init__(self, **kwargs):
-        # N6 — normalise whitespace-only entity_ids so they're treated as
-        # absent (YAML imports occasionally yield `"   "`).
-        raw_climate = kwargs.get(CONF_CLIMATE)
-        raw_switch = kwargs.get(CONF_SWITCH)
-        climate_entity = raw_climate.strip() if isinstance(raw_climate, str) else raw_climate
-        switch_entity = raw_switch.strip() if isinstance(raw_switch, str) else raw_switch
+        # N6 + E1 — normalise whitespace-only entity_ids IN PLACE so
+        # `super().__init__(**kwargs)` (which stores `switch_entity` on
+        # `AbstractLoad`) doesn't see a stale `"   "` value the base
+        # would treat as a valid entity id.
+        for key in (CONF_CLIMATE, CONF_SWITCH):
+            raw = kwargs.get(key)
+            if isinstance(raw, str):
+                stripped = raw.strip()
+                kwargs[key] = stripped if stripped else None
 
-        # M4 — use truthy checks consistently with the transport-picker
-        # below; `bool("")` is `False`, so an empty-string backing is
-        # treated as "not set". This keeps XOR and transport-selection
-        # in agreement.
-        if bool(climate_entity) == bool(switch_entity):
+        climate_entity = kwargs.get(CONF_CLIMATE)
+        switch_entity = kwargs.get(CONF_SWITCH)
+
+        # M4 + B8 — explicit XOR for readability: exactly one of the
+        # two backings must be set. `bool("") is False` so an empty
+        # entity id is treated as "not set", keeping XOR and the
+        # transport-selection branch below in agreement.
+        both_set = bool(climate_entity) and bool(switch_entity)
+        neither_set = not climate_entity and not switch_entity
+        if both_set or neither_set:
             raise ServiceValidationError("Radiator requires exactly one of climate or switch backing")
 
         # S2 — Build the transport BEFORE calling `super().__init__` so
-        # the base class can observe a fully-formed `_transport` during
-        # any future initialisation hook. The host-owned `_state_on/off`
-        # are re-pinned AFTER super() because the base ctor
-        # unconditionally seeds them to `"on"` / `"off"`.
+        # the inherited `_state_on/_state_off` property shadow can
+        # delegate to it during the base ctor's seed assignments. We
+        # capture the intended state values now because `super()` is
+        # about to overwrite the transport's `state_on/state_off` via
+        # `self._state_on = "on"` — and we want to restore them after.
         self._transport: BistateTransport
         if climate_entity:
-            # S9 — `kwargs.get(..., default)` only fires the default when
-            # the key is MISSING; a persisted `""` would otherwise slip
-            # through and crash `set_hvac_mode("")`. Use `or` to also
-            # fall back on empty/None.
-            hvac_on = kwargs.get(CONF_CLIMATE_HVAC_MODE_ON) or "heat"
-            hvac_off = kwargs.get(CONF_CLIMATE_HVAC_MODE_OFF) or "off"
-            self._transport = ClimateTransport(climate_entity, hvac_on, hvac_off)
+            # S9 — `kwargs.get(..., default)` only fires the default
+            # when the key is MISSING; a persisted `""` would otherwise
+            # slip through and crash `set_hvac_mode("")`. Use `or` to
+            # also fall back on empty/None.
+            intended_state_on = kwargs.get(CONF_CLIMATE_HVAC_MODE_ON) or "heat"
+            intended_state_off = kwargs.get(CONF_CLIMATE_HVAC_MODE_OFF) or "off"
+            self._transport = ClimateTransport(climate_entity, intended_state_on, intended_state_off)
         else:
+            intended_state_on = "on"
+            intended_state_off = "off"
             self._transport = SwitchTransport(switch_entity)
 
         super().__init__(**kwargs)
 
-        # Re-pin host-owned state AFTER `super().__init__` because the
-        # base constructor seeds `_state_on/off`, `_bistate_mode_*`, and
-        # `bistate_entity` to switch defaults — they must reflect the
-        # radiator's chosen transport instead.
-        self._state_on = self._transport.default_state_on()
-        self._state_off = self._transport.default_state_off()
-        self._bistate_mode_on = self._state_on
-        self._bistate_mode_off = self._state_off
+        # Restore the chosen transport modes AFTER `super().__init__`
+        # (the base ctor wrote `"on"` / `"off"` into the transport via
+        # the inherited property shadow; for climate radiators we need
+        # to bring back the real HVAC modes).
+        self._state_on = intended_state_on
+        self._state_off = intended_state_off
+        # E3 — `_bistate_mode_on/off` drive the `radiator_mode` select
+        # UI. Hard-code them to `"on"`/`"off"` regardless of the HVAC
+        # mode so the translation always has matching state keys (the
+        # `radiator_mode` translation defines `on` and `off` but not
+        # arbitrary HVAC modes like `auto`, `fan_only`, `dry`). The
+        # transport's `state_on/state_off` continue to carry the
+        # actual HVAC mode strings for service-call dispatch.
+        self._bistate_mode_on = "on"
+        self._bistate_mode_off = "off"
         self.bistate_entity = self._transport.entity
 
     def get_virtual_current_constraint_translation_key(self) -> str | None:

--- a/custom_components/quiet_solar/ha_model/radiator.py
+++ b/custom_components/quiet_solar/ha_model/radiator.py
@@ -1,0 +1,84 @@
+"""`QSRadiator` — heating-only bistate-duration load with dual backing.
+
+A radiator is a `QSBiStateDuration` that flips its heater on/off for a
+target duration each day. Unlike `QSOnOffDuration` (switch only) or
+`QSClimateDuration` (climate only), a radiator can sit on EITHER a
+switch entity OR a climate entity — the user picks one in the config
+flow, and the constructor picks the matching `BistateTransport`.
+
+The class is the dedicated host for future radiator-specific logic
+(e.g. temperature-aware duration, scheduled heating profiles). For
+this initial story it only adds:
+  - the heating-only HVAC defaults (`heat` / `off`)
+  - the exactly-one-backing validation (raises
+    `ServiceValidationError`)
+  - the dedicated translation keys (`radiator_mode`,
+    `qs_constraint_sensor_radiator`)
+  - the dedicated dashboard card (`qs-radiator-card`)
+
+It does NOT expose `climate_state_on` / `climate_state_off` properties —
+those run-time selects are removed for radiators (config-time only). A
+user who wants seasonal mode flipping should use the `climate` load
+type instead.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.exceptions import ServiceValidationError
+
+from ..const import (
+    CONF_CLIMATE,
+    CONF_CLIMATE_HVAC_MODE_OFF,
+    CONF_CLIMATE_HVAC_MODE_ON,
+    CONF_SWITCH,
+    SENSOR_CONSTRAINT_SENSOR_RADIATOR,
+    CONF_TYPE_NAME_QSRadiator,
+)
+from .bistate_duration import QSBiStateDuration
+from .bistate_transport import BistateTransport, ClimateTransport, SwitchTransport
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class QSRadiator(QSBiStateDuration):
+    """Heating-only bistate radiator backed by a switch OR a climate entity."""
+
+    conf_type_name = CONF_TYPE_NAME_QSRadiator
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        climate_entity = kwargs.get(CONF_CLIMATE)
+        switch_entity = kwargs.get(CONF_SWITCH)
+
+        # Cross-field exactly-one validation (mirrored by config_flow's
+        # `errors={"base": "exactly_one_backing_required"}` for UI paths).
+        if bool(climate_entity) == bool(switch_entity):
+            raise ServiceValidationError("Radiator requires exactly one of climate or switch backing")
+
+        self._transport: BistateTransport
+        if climate_entity is not None:
+            hvac_on = kwargs.get(CONF_CLIMATE_HVAC_MODE_ON, "heat")
+            hvac_off = kwargs.get(CONF_CLIMATE_HVAC_MODE_OFF, "off")
+            self._transport = ClimateTransport(climate_entity, hvac_on, hvac_off)
+        else:
+            self._transport = SwitchTransport(switch_entity)
+
+        self._state_on = self._transport.default_state_on()
+        self._state_off = self._transport.default_state_off()
+        self._bistate_mode_on = self._state_on
+        self._bistate_mode_off = self._state_off
+        self.bistate_entity = self._transport.entity
+
+    def get_virtual_current_constraint_translation_key(self) -> str | None:
+        return SENSOR_CONSTRAINT_SENSOR_RADIATOR
+
+    def get_select_translation_key(self) -> str | None:
+        """Return the translation key for the bistate-mode select."""
+        return "radiator_mode"
+
+    # exception catched above execute_command
+    async def execute_command_system(self, time, command, state):
+        return await self._transport.execute(self.hass, command, state, self._state_on, self._state_off)

--- a/custom_components/quiet_solar/ha_model/radiator.py
+++ b/custom_components/quiet_solar/ha_model/radiator.py
@@ -48,24 +48,43 @@ class QSRadiator(QSBiStateDuration):
     conf_type_name = CONF_TYPE_NAME_QSRadiator
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        # N6 — normalise whitespace-only entity_ids so they're treated as
+        # absent (YAML imports occasionally yield `"   "`).
+        raw_climate = kwargs.get(CONF_CLIMATE)
+        raw_switch = kwargs.get(CONF_SWITCH)
+        climate_entity = raw_climate.strip() if isinstance(raw_climate, str) else raw_climate
+        switch_entity = raw_switch.strip() if isinstance(raw_switch, str) else raw_switch
 
-        climate_entity = kwargs.get(CONF_CLIMATE)
-        switch_entity = kwargs.get(CONF_SWITCH)
-
-        # Cross-field exactly-one validation (mirrored by config_flow's
-        # `errors={"base": "exactly_one_backing_required"}` for UI paths).
+        # M4 — use truthy checks consistently with the transport-picker
+        # below; `bool("")` is `False`, so an empty-string backing is
+        # treated as "not set". This keeps XOR and transport-selection
+        # in agreement.
         if bool(climate_entity) == bool(switch_entity):
             raise ServiceValidationError("Radiator requires exactly one of climate or switch backing")
 
+        # S2 — Build the transport BEFORE calling `super().__init__` so
+        # the base class can observe a fully-formed `_transport` during
+        # any future initialisation hook. The host-owned `_state_on/off`
+        # are re-pinned AFTER super() because the base ctor
+        # unconditionally seeds them to `"on"` / `"off"`.
         self._transport: BistateTransport
-        if climate_entity is not None:
-            hvac_on = kwargs.get(CONF_CLIMATE_HVAC_MODE_ON, "heat")
-            hvac_off = kwargs.get(CONF_CLIMATE_HVAC_MODE_OFF, "off")
+        if climate_entity:
+            # S9 — `kwargs.get(..., default)` only fires the default when
+            # the key is MISSING; a persisted `""` would otherwise slip
+            # through and crash `set_hvac_mode("")`. Use `or` to also
+            # fall back on empty/None.
+            hvac_on = kwargs.get(CONF_CLIMATE_HVAC_MODE_ON) or "heat"
+            hvac_off = kwargs.get(CONF_CLIMATE_HVAC_MODE_OFF) or "off"
             self._transport = ClimateTransport(climate_entity, hvac_on, hvac_off)
         else:
             self._transport = SwitchTransport(switch_entity)
 
+        super().__init__(**kwargs)
+
+        # Re-pin host-owned state AFTER `super().__init__` because the
+        # base constructor seeds `_state_on/off`, `_bistate_mode_*`, and
+        # `bistate_entity` to switch defaults — they must reflect the
+        # radiator's chosen transport instead.
         self._state_on = self._transport.default_state_on()
         self._state_off = self._transport.default_state_off()
         self._bistate_mode_on = self._state_on
@@ -79,6 +98,5 @@ class QSRadiator(QSBiStateDuration):
         """Return the translation key for the bistate-mode select."""
         return "radiator_mode"
 
-    # exception catched above execute_command
-    async def execute_command_system(self, time, command, state):
-        return await self._transport.execute(self.hass, command, state, self._state_on, self._state_off)
+    # `execute_command_system` is inherited from `QSBiStateDuration` and
+    # delegates to `self._transport.execute(...)` (N2 review-fix).

--- a/custom_components/quiet_solar/ha_model/radiator.py
+++ b/custom_components/quiet_solar/ha_model/radiator.py
@@ -61,13 +61,28 @@ class QSRadiator(QSBiStateDuration):
         climate_entity = kwargs.get(CONF_CLIMATE)
         switch_entity = kwargs.get(CONF_SWITCH)
 
-        # M4 + B8 — explicit XOR for readability: exactly one of the
-        # two backings must be set. `bool("") is False` so an empty
-        # entity id is treated as "not set", keeping XOR and the
-        # transport-selection branch below in agreement.
-        both_set = bool(climate_entity) and bool(switch_entity)
-        neither_set = not climate_entity and not switch_entity
-        if both_set or neither_set:
+        # EH6 — when BOTH backings somehow ended up persisted (buggy
+        # migration / manual `.storage` edit / future regression), don't
+        # blow up the entry reload. Log a warning and pick `CONF_CLIMATE`
+        # as the deterministic winner — it's the richer backing and
+        # matches what the config flow defaults steer toward. Drop the
+        # loser from `kwargs` in place so `AbstractLoad.__init__` sees
+        # only the chosen backing.
+        if climate_entity and switch_entity:
+            _LOGGER.warning(
+                "Radiator %s persisted with both climate and switch backings; "
+                "preferring climate (%s) and ignoring switch (%s)",
+                kwargs.get("name", "<unnamed>"),
+                climate_entity,
+                switch_entity,
+            )
+            kwargs[CONF_SWITCH] = None
+            switch_entity = None
+
+        # M4 + B8 — explicit XOR for readability. After EH6 resolves the
+        # both-set case above, only the neither-set case remains as a
+        # hard error (there's no sensible default to pick).
+        if not climate_entity and not switch_entity:
             raise ServiceValidationError("Radiator requires exactly one of climate or switch backing")
 
         # S2 — Build the transport BEFORE calling `super().__init__` so

--- a/custom_components/quiet_solar/strings.json
+++ b/custom_components/quiet_solar/strings.json
@@ -39,6 +39,7 @@
         "title": "Edit a Home",
         "data": {
           "name": "Name",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "home_voltage": "voltage of your home (V)",
           "grid_active_power_sensor": "Active grid power: what your house get from the electrical grid (W, kW)",
           "grid_active_power_sensor_inverted": "Is your grid power sensor needs inversion?, ie does it shows positive values when you consume power from the grid?",
@@ -80,6 +81,7 @@
         "description": "If you don't have a charge/discharge sensor, you can set both inverter sensors in the solar plant configuration",
         "data": {
           "name": "Name",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "battery_capacity": "Capacity (Wh)",
           "battery_is_dc_coupled" : "Is the battery DC coupled with an hybrid solar inverter?",
           "battery_charge_percent_sensor": "Charge percentage (%)",
@@ -98,6 +100,7 @@
         "description": "setup only one of the two inverters sensor if you have only one",
         "data": {
           "name": "Name",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "inverter_active_power_sensor": "Inverter output power sensor (W, kW) (solar prod + battery)",
           "inverter_input_power_sensor": "Inverter input power sensor (W, kW) (solar production)",
           "solar_forecast_provider": "Preferred solar forecast provider",
@@ -181,6 +184,7 @@
         "description": "Add some car information to define when and how it is connected to your charger",
         "data": {
           "name": "Name",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "car_is_invited": "Is this car a placeholder one for a guest?",
           "car_plugged": "Binary sensor to detect if the car is plugged or not",
           "car_tracker": "car device tracker to know if the car is at home or not",
@@ -286,6 +290,7 @@
         "description": "This device will compute automatically the needed pump use time to keep the pool clean",
         "data": {
           "name": "Name",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name" : "Add pool to a load group to limit the amps",
           "pool_temperature_sensor": "Water temperature sensor",
           "switch": "On/Off switch of the pump filter",
@@ -309,6 +314,7 @@
         "description": "Usefull for boilers, simple heaters, etc. or pool pumps if the automatic one does not fit your needs",
         "data": {
           "name": "Name",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name" : "Add to a load group to limit the amps",
           "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
           "switch": "On/Off of the load",
@@ -326,6 +332,7 @@
         "description": "Configure a cumulus (electric resistive water heater) or a thermodynamic water boiler.",
         "data": {
           "name": "Name",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name": "Add water boiler to a load group to limit the amps",
           "load_is_boost_only": "Is this boiler automatically regulated (QS will only boost on solar surplus)?",
           "switch": "On/Off switch of the boiler",
@@ -344,6 +351,7 @@
         "description": "Use any climate (HVAC, Radiator, etc.) to be set on for a specific duration",
         "data": {
           "name": "Name",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name" : "Add to a load group to limit the amps",
           "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
           "climate": "Climate entity",
@@ -364,6 +372,7 @@
         "description": "Heating-only radiator backed by either a switch entity or a climate entity (pick exactly one).",
         "data": {
           "name": "Name",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name": "Add to a load group to limit the amps",
           "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
           "switch": "Switch entity controlling the radiator (leave empty if using a climate entity)",
@@ -401,6 +410,7 @@
         "description": "Configure a centralized heat pump used by several climates splits",
         "data": {
           "name": "Name",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name": "Add heat pump to a load group to limit the amps",
           "power": "Power consumption of the heat pump (W)",
           "accurate_power_sensor": "Power sensor of the heat pump (W, kW)",
@@ -438,6 +448,7 @@
         "title": "[%key:component::quiet_solar::config::step::home::title%]",
         "data": {
           "name": "[%key:component::quiet_solar::config::step::home::data::name%]",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "home_voltage": "[%key:component::quiet_solar::config::step::home::data::home_voltage%]",
           "grid_active_power_sensor": "[%key:component::quiet_solar::config::step::home::data::grid_active_power_sensor%]",
           "grid_active_power_sensor_inverted": "[%key:component::quiet_solar::config::step::home::data::grid_active_power_sensor_inverted%]",
@@ -479,6 +490,7 @@
         "description": "[%key:component::quiet_solar::config::step::battery::description%]",
         "data": {
           "name": "[%key:component::quiet_solar::config::step::battery::data::name%]",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "battery_capacity": "[%key:component::quiet_solar::config::step::battery::data::battery_capacity%]",
           "battery_is_dc_coupled" : "[%key:component::quiet_solar::config::step::battery::data::battery_is_dc_coupled%]",
           "battery_charge_percent_sensor": "[%key:component::quiet_solar::config::step::battery::data::battery_charge_percent_sensor%]",
@@ -497,6 +509,7 @@
         "description": "[%key:component::quiet_solar::config::step::solar::description%]",
         "data": {
           "name": "[%key:component::quiet_solar::config::step::solar::data::name%]",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "inverter_active_power_sensor": "[%key:component::quiet_solar::config::step::solar::data::inverter_active_power_sensor%]",
           "inverter_input_power_sensor": "[%key:component::quiet_solar::config::step::solar::data::inverter_input_power_sensor%]",
           "solar_forecast_provider": "[%key:component::quiet_solar::config::step::solar::data::solar_forecast_provider%]",
@@ -571,6 +584,7 @@
         "description": "[%key:component::quiet_solar::config::step::car::description%]",
         "data": {
           "name": "[%key:component::quiet_solar::config::step::car::data::name%]",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "car_is_invited": "[%key:component::quiet_solar::config::step::car::data::car_is_invited%]",
           "car_plugged": "[%key:component::quiet_solar::config::step::car::data::car_plugged%]",
           "car_tracker": "[%key:component::quiet_solar::config::step::car::data::car_tracker%]",
@@ -676,6 +690,7 @@
         "description": "[%key:component::quiet_solar::config::step::pool::description%]",
         "data": {
           "name": "[%key:component::quiet_solar::config::step::pool::data::name%]",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name" :  "[%key:component::quiet_solar::config::step::pool::data::dynamic_group_name%]",
           "pool_temperature_sensor": "[%key:component::quiet_solar::config::step::pool::data::pool_temperature_sensor%]",
           "switch": "[%key:component::quiet_solar::config::step::pool::data::switch%]",
@@ -699,6 +714,7 @@
         "description": "[%key:component::quiet_solar::config::step::on_off_duration::description%]",
         "data": {
           "name": "[%key:component::quiet_solar::config::step::on_off_duration::data::name%]",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name" :  "[%key:component::quiet_solar::config::step::on_off_duration::data::dynamic_group_name%]",
           "load_is_boost_only": "[%key:component::quiet_solar::config::step::on_off_duration::data::load_is_boost_only%]",
           "switch": "[%key:component::quiet_solar::config::step::on_off_duration::data::switch%]",
@@ -716,6 +732,7 @@
         "description": "[%key:component::quiet_solar::config::step::water_boiler::description%]",
         "data": {
           "name": "[%key:component::quiet_solar::config::step::water_boiler::data::name%]",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name": "[%key:component::quiet_solar::config::step::water_boiler::data::dynamic_group_name%]",
           "load_is_boost_only": "[%key:component::quiet_solar::config::step::water_boiler::data::load_is_boost_only%]",
           "switch": "[%key:component::quiet_solar::config::step::water_boiler::data::switch%]",
@@ -734,6 +751,7 @@
         "description": "[%key:component::quiet_solar::config::step::climate::description%]",
         "data": {
           "name": "[%key:component::quiet_solar::config::step::climate::data::name%]",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name" :  "[%key:component::quiet_solar::config::step::climate::data::dynamic_group_name%]",
           "load_is_boost_only": "[%key:component::quiet_solar::config::step::climate::data::load_is_boost_only%]",
           "climate": "[%key:component::quiet_solar::config::step::climate::data::climate%]",
@@ -754,6 +772,7 @@
         "description": "[%key:component::quiet_solar::config::step::radiator::description%]",
         "data": {
           "name": "[%key:component::quiet_solar::config::step::radiator::data::name%]",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name": "[%key:component::quiet_solar::config::step::radiator::data::dynamic_group_name%]",
           "load_is_boost_only": "[%key:component::quiet_solar::config::step::radiator::data::load_is_boost_only%]",
           "switch": "[%key:component::quiet_solar::config::step::radiator::data::switch%]",
@@ -790,6 +809,7 @@
         "description": "[%key:component::quiet_solar::config::step::heat_pump::description%]",
         "data": {
           "name": "[%key:component::quiet_solar::config::step::heat_pump::data::name%]",
+          "device_dashboard_section": "[%key:component::quiet_solar::config::step::person::data::device_dashboard_section%]",
           "dynamic_group_name": "[%key:component::quiet_solar::config::step::heat_pump::data::dynamic_group_name%]",
           "power": "[%key:component::quiet_solar::config::step::heat_pump::data::power%]",
           "accurate_power_sensor": "[%key:component::quiet_solar::config::step::heat_pump::data::accurate_power_sensor%]",

--- a/custom_components/quiet_solar/strings.json
+++ b/custom_components/quiet_solar/strings.json
@@ -9,7 +9,8 @@
     "error": {
       "already_configured_device": "Device is already configured",
       "cannot_connect": "Unable to connect",
-      "cloud_profile_mismatch": "Cloud profile does not match configuration"
+      "cloud_profile_mismatch": "Cloud profile does not match configuration",
+      "exactly_one_backing_required": "Pick exactly one of switch entity or climate entity for the radiator"
     },
     "step": {
       "user": {
@@ -24,6 +25,7 @@
           "pool": "Add a pool",
           "on_off_duration": "Add an on/off load with duration constraint (e.g. a boiler, a simple electric heater, a pool pump, etc.)",
           "climate": "Add a climate duration based (e.g. a HVAC, a radiator, etc.)",
+          "radiator": "Add a heating-only radiator (switch-backed or climate-backed)",
           "dynamic_group": "Add a power group to limits amps (usefull for multiple chargers for ex)",
           "heat_pump": "Add a centralized Heat Pump, to be used in conjunction with climate splits"
         }
@@ -332,6 +334,28 @@
         },
         "data_description": {
           "power": "Measured: {measured_power}"
+        }
+      },
+      "radiator": {
+        "title": "A heating-only radiator",
+        "description": "Heating-only radiator backed by either a switch entity or a climate entity (pick exactly one).",
+        "data": {
+          "name": "Name",
+          "dynamic_group_name": "Add to a load group to limit the amps",
+          "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
+          "switch": "Switch entity controlling the radiator (leave empty if using a climate entity)",
+          "climate": "Climate entity controlling the radiator (leave empty if using a switch)",
+          "climate_hvac_on": "HVAC mode to be used when the radiator is on",
+          "climate_hvac_off": "HVAC mode to be used when the radiator is off",
+          "device_to_pilot_name": "Optionally attach a heat pump piloted by this radiator",
+          "power": "Power of the radiator (W)",
+          "accurate_power_sensor": "Power sensor of the radiator (W, kW)",
+          "num_max_on_off": "Maximum Number of allowed turn on or turn off of the radiator per day",
+          "calendar": "Add a calendar: end of events is the target, length of the event is the desired duration of the radiator being on"
+        },
+        "data_description": {
+          "power": "Measured: {measured_power}",
+          "climate_hvac_on": "We suggest `heat` for heating-only radiators."
         }
       },
       "dynamic_group": {
@@ -679,6 +703,28 @@
           "power": "[%key:component::quiet_solar::config::step::climate::data_description::power%]"
         }
       },
+      "radiator": {
+        "title": "[%key:component::quiet_solar::config::step::radiator::title%]",
+        "description": "[%key:component::quiet_solar::config::step::radiator::description%]",
+        "data": {
+          "name": "[%key:component::quiet_solar::config::step::radiator::data::name%]",
+          "dynamic_group_name": "[%key:component::quiet_solar::config::step::radiator::data::dynamic_group_name%]",
+          "load_is_boost_only": "[%key:component::quiet_solar::config::step::radiator::data::load_is_boost_only%]",
+          "switch": "[%key:component::quiet_solar::config::step::radiator::data::switch%]",
+          "climate": "[%key:component::quiet_solar::config::step::radiator::data::climate%]",
+          "climate_hvac_on": "[%key:component::quiet_solar::config::step::radiator::data::climate_hvac_on%]",
+          "climate_hvac_off": "[%key:component::quiet_solar::config::step::radiator::data::climate_hvac_off%]",
+          "device_to_pilot_name": "[%key:component::quiet_solar::config::step::radiator::data::device_to_pilot_name%]",
+          "power": "[%key:component::quiet_solar::config::step::radiator::data::power%]",
+          "num_max_on_off": "[%key:component::quiet_solar::config::step::radiator::data::num_max_on_off%]",
+          "accurate_power_sensor": "[%key:component::quiet_solar::config::step::radiator::data::accurate_power_sensor%]",
+          "calendar": "[%key:component::quiet_solar::config::step::radiator::data::calendar%]"
+        },
+        "data_description": {
+          "power": "[%key:component::quiet_solar::config::step::radiator::data_description::power%]",
+          "climate_hvac_on": "[%key:component::quiet_solar::config::step::radiator::data_description::climate_hvac_on%]"
+        }
+      },
       "dynamic_group": {
         "title": "[%key:component::quiet_solar::config::step::dynamic_group::title%]",
         "description": "[%key:component::quiet_solar::config::step::dynamic_group::description%]",
@@ -787,6 +833,9 @@
       },
       "qs_constraint_sensor_climate": {
         "name": "Next climate Change"
+      },
+      "qs_constraint_sensor_radiator": {
+        "name": "Next Radiator Change"
       },
       "qs_constraint_sensor_pool": {
         "name": "Next Pool filter"
@@ -957,6 +1006,17 @@
           "fan_only": "Force HVAC Mode FAN ONLY"
         }
       },
+      "radiator_mode": {
+        "name": "Radiator Mode",
+        "state": {
+          "bistate_mode_auto": "Calendar: End+Duration",
+          "bistate_mode_exact_calendar": "Calendar: Exact Schedule",
+          "bistate_mode_default": "Default: End+Duration",
+          "off": "Force OFF",
+          "on": "Force ON",
+          "heat": "Force HEAT"
+        }
+      },
       "climate_state_on": {
         "name": "Climate Control Mode ON",
         "state": {
@@ -1018,9 +1078,10 @@
         "Not in dashboard": "Not in dashboard",
         "#1 - cars": "#1 - cars",
         "#2 - climates": "#2 - climates",
-        "#3 - pools": "#3 - pools",
-        "#4 - others": "#4 - others",
-        "#5 - settings": "#5 - settings"
+        "#3 - radiators": "#3 - radiators",
+        "#4 - pools": "#4 - pools",
+        "#5 - others": "#5 - others",
+        "#6 - settings": "#6 - settings"
       }
     }
   }

--- a/custom_components/quiet_solar/strings.json
+++ b/custom_components/quiet_solar/strings.json
@@ -12,6 +12,8 @@
       "cloud_profile_mismatch": "Cloud profile does not match configuration",
       "exactly_one_backing_required": "Pick exactly one of switch entity or climate entity for the radiator",
       "climate_capabilities_unavailable": "Climate entity advertises no HVAC modes; pick a different climate entity or check the device",
+      "climate_modes_insufficient": "Climate entity exposes fewer than two HVAC modes; pick a different climate entity or configure the device to expose at least two modes",
+      "hvac_modes_must_differ": "HVAC mode ON and OFF must be different",
       "piloted_heat_pump_unknown": "The previously selected heat pump is no longer available; pick a different one"
     },
     "step": {
@@ -408,6 +410,8 @@
       "cloud_profile_mismatch": "[%key:component::quiet_solar::config::error::cloud_profile_mismatch%]",
       "exactly_one_backing_required": "[%key:component::quiet_solar::config::error::exactly_one_backing_required%]",
       "climate_capabilities_unavailable": "[%key:component::quiet_solar::config::error::climate_capabilities_unavailable%]",
+      "climate_modes_insufficient": "[%key:component::quiet_solar::config::error::climate_modes_insufficient%]",
+      "hvac_modes_must_differ": "[%key:component::quiet_solar::config::error::hvac_modes_must_differ%]",
       "piloted_heat_pump_unknown": "[%key:component::quiet_solar::config::error::piloted_heat_pump_unknown%]"
     },
     "step": {

--- a/custom_components/quiet_solar/strings.json
+++ b/custom_components/quiet_solar/strings.json
@@ -10,7 +10,9 @@
       "already_configured_device": "Device is already configured",
       "cannot_connect": "Unable to connect",
       "cloud_profile_mismatch": "Cloud profile does not match configuration",
-      "exactly_one_backing_required": "Pick exactly one of switch entity or climate entity for the radiator"
+      "exactly_one_backing_required": "Pick exactly one of switch entity or climate entity for the radiator",
+      "climate_capabilities_unavailable": "Climate entity advertises no HVAC modes; pick a different climate entity or check the device",
+      "piloted_heat_pump_unknown": "The previously selected heat pump is no longer available; pick a different one"
     },
     "step": {
       "user": {
@@ -403,7 +405,10 @@
     "error": {
       "already_configured_device": "[%key:component::quiet_solar::config::error::already_configured_device%]",
       "cannot_connect": "[%key:component::quiet_solar::config::error::cannot_connect%]",
-      "cloud_profile_mismatch": "[%key:component::quiet_solar::config::error::cloud_profile_mismatch%]"
+      "cloud_profile_mismatch": "[%key:component::quiet_solar::config::error::cloud_profile_mismatch%]",
+      "exactly_one_backing_required": "[%key:component::quiet_solar::config::error::exactly_one_backing_required%]",
+      "climate_capabilities_unavailable": "[%key:component::quiet_solar::config::error::climate_capabilities_unavailable%]",
+      "piloted_heat_pump_unknown": "[%key:component::quiet_solar::config::error::piloted_heat_pump_unknown%]"
     },
     "step": {
       "home": {
@@ -1078,10 +1083,10 @@
         "Not in dashboard": "Not in dashboard",
         "#1 - cars": "#1 - cars",
         "#2 - climates": "#2 - climates",
-        "#3 - radiators": "#3 - radiators",
-        "#4 - pools": "#4 - pools",
-        "#5 - others": "#5 - others",
-        "#6 - settings": "#6 - settings"
+        "#3 - pools": "#3 - pools",
+        "#4 - others": "#4 - others",
+        "#5 - settings": "#5 - settings",
+        "#6 - radiators": "#6 - radiators"
       }
     }
   }

--- a/custom_components/quiet_solar/translations/en.json
+++ b/custom_components/quiet_solar/translations/en.json
@@ -30,6 +30,7 @@
                     "battery_max_discharge_power_number": "Maximum discharge power (W, kW) Number entity",
                     "battery_max_discharge_power_value": "Maximum discharge power (W)",
                     "battery_min_charge_percent_value": "Minimum charge percentage (%)",
+                    "device_dashboard_section": "Dashboard section",
                     "name": "Name"
                 },
                 "description": "If you don't have a charge/discharge sensor, you can set both inverter sensors in the solar plant configuration",
@@ -84,6 +85,7 @@
                     "charge_8": "Charge Power in W for a  8A charge (per phase), clear for default",
                     "charge_9": "Charge Power in W for a  9A charge (per phase), clear for default",
                     "default_car_charge": "Default car charge in %",
+                    "device_dashboard_section": "Dashboard section",
                     "device_efficiency": "Car charging power efficiency in %",
                     "minimum_ok_car_charge": "Minimum viable car charge in % (less solar priority once passed it)",
                     "name": "Name"
@@ -200,6 +202,7 @@
                     "climate": "Climate entity",
                     "climate_hvac_off": "HVAC mode to be used when the climate is off",
                     "climate_hvac_on": "HVAC mode to be used when the climate is on",
+                    "device_dashboard_section": "Dashboard section",
                     "device_to_pilot_name": "Optionally attach a heat pump to this climate",
                     "dynamic_group_name": "Add to a load group to limit the amps",
                     "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
@@ -231,6 +234,7 @@
             "heat_pump": {
                 "data": {
                     "accurate_power_sensor": "Power sensor of the heat pump (W, kW)",
+                    "device_dashboard_section": "Dashboard section",
                     "device_is_3p": "Is the heat pump 3 phases?",
                     "device_mono_phase": "if mono phase, this is the phase index",
                     "dynamic_group_name": "Add heat pump to a load group to limit the amps",
@@ -266,6 +270,7 @@
                     "dashboard_section_name_5": "Name of Dashboard section #6 (empty to not use it)",
                     "dashboard_section_name_6": "Name of Dashboard section #7 (empty to not use it)",
                     "dashboard_section_name_7": "Name of Dashboard section #8 (empty to not use it)",
+                    "device_dashboard_section": "Dashboard section",
                     "device_is_3p": "Is the home 3 phases?",
                     "dyn_group_max_phase_amps": "maximum current per phase (A) for the home",
                     "grid_active_power_sensor": "Active grid power: what your house get from the electrical grid (W, kW)",
@@ -291,6 +296,7 @@
                 "data": {
                     "accurate_power_sensor": "Power sensor of the load (W, kW)",
                     "calendar": "Add a calendar: end of events is the target, length of the event is the desired duration of the load being on",
+                    "device_dashboard_section": "Dashboard section",
                     "dynamic_group_name": "Add to a load group to limit the amps",
                     "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
                     "name": "Name",
@@ -322,6 +328,7 @@
             "pool": {
                 "data": {
                     "accurate_power_sensor": "Power sensor of the pump (W, kW)",
+                    "device_dashboard_section": "Dashboard section",
                     "dynamic_group_name": "Add pool to a load group to limit the amps",
                     "name": "Name",
                     "num_max_on_off": "Maximum Number of allowed turn on or turn off of the pump per day",
@@ -349,6 +356,7 @@
                     "climate": "Climate entity controlling the radiator (leave empty if using a switch)",
                     "climate_hvac_off": "HVAC mode to be used when the radiator is off",
                     "climate_hvac_on": "HVAC mode to be used when the radiator is on",
+                    "device_dashboard_section": "Dashboard section",
                     "device_to_pilot_name": "Optionally attach a heat pump piloted by this radiator",
                     "dynamic_group_name": "Add to a load group to limit the amps",
                     "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
@@ -366,6 +374,7 @@
             },
             "solar": {
                 "data": {
+                    "device_dashboard_section": "Dashboard section",
                     "inverter_active_power_sensor": "Inverter output power sensor (W, kW) (solar prod + battery)",
                     "inverter_input_power_sensor": "Inverter input power sensor (W, kW) (solar production)",
                     "name": "Name",
@@ -401,6 +410,7 @@
                 "data": {
                     "accurate_power_sensor": "Power sensor of the boiler (W, kW)",
                     "calendar": "Add a calendar: end of events is the target, length of the event is the desired duration of the boiler being on",
+                    "device_dashboard_section": "Dashboard section",
                     "dynamic_group_name": "Add water boiler to a load group to limit the amps",
                     "load_is_boost_only": "Is this boiler automatically regulated (QS will only boost on solar surplus)?",
                     "name": "Name",
@@ -767,6 +777,7 @@
                     "battery_max_discharge_power_number": "Maximum discharge power (W, kW) Number entity",
                     "battery_max_discharge_power_value": "Maximum discharge power (W)",
                     "battery_min_charge_percent_value": "Minimum charge percentage (%)",
+                    "device_dashboard_section": "Dashboard section",
                     "name": "Name"
                 },
                 "description": "If you don't have a charge/discharge sensor, you can set both inverter sensors in the solar plant configuration",
@@ -821,6 +832,7 @@
                     "charge_8": "Charge Power in W for a  8A charge (per phase), clear for default",
                     "charge_9": "Charge Power in W for a  9A charge (per phase), clear for default",
                     "default_car_charge": "Default car charge in %",
+                    "device_dashboard_section": "Dashboard section",
                     "device_efficiency": "Car charging power efficiency in %",
                     "minimum_ok_car_charge": "Minimum viable car charge in % (less solar priority once passed it)",
                     "name": "Name"
@@ -928,6 +940,7 @@
                     "climate": "Climate entity",
                     "climate_hvac_off": "HVAC mode to be used when the climate is off",
                     "climate_hvac_on": "HVAC mode to be used when the climate is on",
+                    "device_dashboard_section": "Dashboard section",
                     "device_to_pilot_name": "Optionally attach a heat pump to this climate",
                     "dynamic_group_name": "Add to a load group to limit the amps",
                     "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
@@ -958,6 +971,7 @@
             "heat_pump": {
                 "data": {
                     "accurate_power_sensor": "Power sensor of the heat pump (W, kW)",
+                    "device_dashboard_section": "Dashboard section",
                     "device_is_3p": "Is the heat pump 3 phases?",
                     "device_mono_phase": "if mono phase, this is the phase index",
                     "dynamic_group_name": "Add heat pump to a load group to limit the amps",
@@ -993,6 +1007,7 @@
                     "dashboard_section_name_5": "Name of Dashboard section #6 (empty to not use it)",
                     "dashboard_section_name_6": "Name of Dashboard section #7 (empty to not use it)",
                     "dashboard_section_name_7": "Name of Dashboard section #8 (empty to not use it)",
+                    "device_dashboard_section": "Dashboard section",
                     "device_is_3p": "Is the home 3 phases?",
                     "dyn_group_max_phase_amps": "maximum current per phase (A) for the home",
                     "grid_active_power_sensor": "Active grid power: what your house get from the electrical grid (W, kW)",
@@ -1018,6 +1033,7 @@
                 "data": {
                     "accurate_power_sensor": "Power sensor of the load (W, kW)",
                     "calendar": "Add a calendar: end of events is the target, length of the event is the desired duration of the load being on",
+                    "device_dashboard_section": "Dashboard section",
                     "dynamic_group_name": "Add to a load group to limit the amps",
                     "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
                     "name": "Name",
@@ -1049,6 +1065,7 @@
             "pool": {
                 "data": {
                     "accurate_power_sensor": "Power sensor of the pump (W, kW)",
+                    "device_dashboard_section": "Dashboard section",
                     "dynamic_group_name": "Add pool to a load group to limit the amps",
                     "name": "Name",
                     "num_max_on_off": "Maximum Number of allowed turn on or turn off of the pump per day",
@@ -1076,6 +1093,7 @@
                     "climate": "Climate entity controlling the radiator (leave empty if using a switch)",
                     "climate_hvac_off": "HVAC mode to be used when the radiator is off",
                     "climate_hvac_on": "HVAC mode to be used when the radiator is on",
+                    "device_dashboard_section": "Dashboard section",
                     "device_to_pilot_name": "Optionally attach a heat pump piloted by this radiator",
                     "dynamic_group_name": "Add to a load group to limit the amps",
                     "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
@@ -1093,6 +1111,7 @@
             },
             "solar": {
                 "data": {
+                    "device_dashboard_section": "Dashboard section",
                     "inverter_active_power_sensor": "Inverter output power sensor (W, kW) (solar prod + battery)",
                     "inverter_input_power_sensor": "Inverter input power sensor (W, kW) (solar production)",
                     "name": "Name",
@@ -1110,6 +1129,7 @@
                 "data": {
                     "accurate_power_sensor": "Power sensor of the boiler (W, kW)",
                     "calendar": "Add a calendar: end of events is the target, length of the event is the desired duration of the boiler being on",
+                    "device_dashboard_section": "Dashboard section",
                     "dynamic_group_name": "Add water boiler to a load group to limit the amps",
                     "load_is_boost_only": "Is this boiler automatically regulated (QS will only boost on solar surplus)?",
                     "name": "Name",

--- a/custom_components/quiet_solar/translations/en.json
+++ b/custom_components/quiet_solar/translations/en.json
@@ -9,7 +9,8 @@
         "error": {
             "already_configured_device": "Device is already configured",
             "cannot_connect": "Unable to connect",
-            "cloud_profile_mismatch": "Cloud profile does not match configuration"
+            "cloud_profile_mismatch": "Cloud profile does not match configuration",
+            "exactly_one_backing_required": "Pick exactly one of switch entity or climate entity for the radiator"
         },
         "step": {
             "battery": {
@@ -337,6 +338,28 @@
                 "description": "This device will compute automatically the needed pump use time to keep the pool clean",
                 "title": "Edit your pool"
             },
+            "radiator": {
+                "data": {
+                    "accurate_power_sensor": "Power sensor of the radiator (W, kW)",
+                    "calendar": "Add a calendar: end of events is the target, length of the event is the desired duration of the radiator being on",
+                    "climate": "Climate entity controlling the radiator (leave empty if using a switch)",
+                    "climate_hvac_off": "HVAC mode to be used when the radiator is off",
+                    "climate_hvac_on": "HVAC mode to be used when the radiator is on",
+                    "device_to_pilot_name": "Optionally attach a heat pump piloted by this radiator",
+                    "dynamic_group_name": "Add to a load group to limit the amps",
+                    "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
+                    "name": "Name",
+                    "num_max_on_off": "Maximum Number of allowed turn on or turn off of the radiator per day",
+                    "power": "Power of the radiator (W)",
+                    "switch": "Switch entity controlling the radiator (leave empty if using a climate entity)"
+                },
+                "data_description": {
+                    "climate_hvac_on": "We suggest `heat` for heating-only radiators.",
+                    "power": "Measured: {measured_power}"
+                },
+                "description": "Heating-only radiator backed by either a switch entity or a climate entity (pick exactly one).",
+                "title": "A heating-only radiator"
+            },
             "solar": {
                 "data": {
                     "inverter_active_power_sensor": "Inverter output power sensor (W, kW) (solar prod + battery)",
@@ -364,6 +387,7 @@
                     "on_off_duration": "Add an on/off load with duration constraint (e.g. a boiler, a simple electric heater, a pool pump, etc.)",
                     "person": "Add a Person",
                     "pool": "Add a pool",
+                    "radiator": "Add a heating-only radiator (switch-backed or climate-backed)",
                     "solar": "Add a Solar Panel Plant"
                 },
                 "title": "Choose a load or device to add"
@@ -544,6 +568,17 @@
             "qs_solar_provider_mode": {
                 "name": "Solar Provider Mode"
             },
+            "radiator_mode": {
+                "name": "Radiator Mode",
+                "state": {
+                    "bistate_mode_auto": "Calendar: End+Duration",
+                    "bistate_mode_default": "Default: End+Duration",
+                    "bistate_mode_exact_calendar": "Calendar: Exact Schedule",
+                    "heat": "Force HEAT",
+                    "off": "Force OFF",
+                    "on": "Force ON"
+                }
+            },
             "selected_car_for_charger": {
                 "name": "Selected Car:"
             },
@@ -614,6 +649,9 @@
             },
             "qs_constraint_sensor_pool": {
                 "name": "Next Pool filter"
+            },
+            "qs_constraint_sensor_radiator": {
+                "name": "Next Radiator Change"
             },
             "qs_constraint_sensor_value": {
                 "name": "Constraint Current Value"
@@ -993,6 +1031,28 @@
                 "description": "This device will compute automatically the needed pump use time to keep the pool clean",
                 "title": "Edit your pool"
             },
+            "radiator": {
+                "data": {
+                    "accurate_power_sensor": "Power sensor of the radiator (W, kW)",
+                    "calendar": "Add a calendar: end of events is the target, length of the event is the desired duration of the radiator being on",
+                    "climate": "Climate entity controlling the radiator (leave empty if using a switch)",
+                    "climate_hvac_off": "HVAC mode to be used when the radiator is off",
+                    "climate_hvac_on": "HVAC mode to be used when the radiator is on",
+                    "device_to_pilot_name": "Optionally attach a heat pump piloted by this radiator",
+                    "dynamic_group_name": "Add to a load group to limit the amps",
+                    "load_is_boost_only": "Is this load an automatic one (thermodynamic boiler for ex) to only boost it",
+                    "name": "Name",
+                    "num_max_on_off": "Maximum Number of allowed turn on or turn off of the radiator per day",
+                    "power": "Power of the radiator (W)",
+                    "switch": "Switch entity controlling the radiator (leave empty if using a climate entity)"
+                },
+                "data_description": {
+                    "climate_hvac_on": "We suggest `heat` for heating-only radiators.",
+                    "power": "Measured: {measured_power}"
+                },
+                "description": "Heating-only radiator backed by either a switch entity or a climate entity (pick exactly one).",
+                "title": "A heating-only radiator"
+            },
             "solar": {
                 "data": {
                     "inverter_active_power_sensor": "Inverter output power sensor (W, kW) (solar prod + battery)",
@@ -1015,9 +1075,10 @@
             "options": {
                 "#1 - cars": "#1 - cars",
                 "#2 - climates": "#2 - climates",
-                "#3 - pools": "#3 - pools",
-                "#4 - others": "#4 - others",
-                "#5 - settings": "#5 - settings",
+                "#3 - radiators": "#3 - radiators",
+                "#4 - pools": "#4 - pools",
+                "#5 - others": "#5 - others",
+                "#6 - settings": "#6 - settings",
                 "Not in dashboard": "Not in dashboard"
             }
         }

--- a/custom_components/quiet_solar/translations/en.json
+++ b/custom_components/quiet_solar/translations/en.json
@@ -9,8 +9,10 @@
         "error": {
             "already_configured_device": "Device is already configured",
             "cannot_connect": "Unable to connect",
+            "climate_capabilities_unavailable": "Climate entity advertises no HVAC modes; pick a different climate entity or check the device",
             "cloud_profile_mismatch": "Cloud profile does not match configuration",
-            "exactly_one_backing_required": "Pick exactly one of switch entity or climate entity for the radiator"
+            "exactly_one_backing_required": "Pick exactly one of switch entity or climate entity for the radiator",
+            "piloted_heat_pump_unknown": "The previously selected heat pump is no longer available; pick a different one"
         },
         "step": {
             "battery": {
@@ -713,7 +715,10 @@
         "error": {
             "already_configured_device": "Device is already configured",
             "cannot_connect": "Unable to connect",
-            "cloud_profile_mismatch": "Cloud profile does not match configuration"
+            "climate_capabilities_unavailable": "Climate entity advertises no HVAC modes; pick a different climate entity or check the device",
+            "cloud_profile_mismatch": "Cloud profile does not match configuration",
+            "exactly_one_backing_required": "Pick exactly one of switch entity or climate entity for the radiator",
+            "piloted_heat_pump_unknown": "The previously selected heat pump is no longer available; pick a different one"
         },
         "step": {
             "battery": {
@@ -1075,10 +1080,10 @@
             "options": {
                 "#1 - cars": "#1 - cars",
                 "#2 - climates": "#2 - climates",
-                "#3 - radiators": "#3 - radiators",
-                "#4 - pools": "#4 - pools",
-                "#5 - others": "#5 - others",
-                "#6 - settings": "#6 - settings",
+                "#3 - pools": "#3 - pools",
+                "#4 - others": "#4 - others",
+                "#5 - settings": "#5 - settings",
+                "#6 - radiators": "#6 - radiators",
                 "Not in dashboard": "Not in dashboard"
             }
         }

--- a/custom_components/quiet_solar/translations/en.json
+++ b/custom_components/quiet_solar/translations/en.json
@@ -10,8 +10,10 @@
             "already_configured_device": "Device is already configured",
             "cannot_connect": "Unable to connect",
             "climate_capabilities_unavailable": "Climate entity advertises no HVAC modes; pick a different climate entity or check the device",
+            "climate_modes_insufficient": "Climate entity exposes fewer than two HVAC modes; pick a different climate entity or configure the device to expose at least two modes",
             "cloud_profile_mismatch": "Cloud profile does not match configuration",
             "exactly_one_backing_required": "Pick exactly one of switch entity or climate entity for the radiator",
+            "hvac_modes_must_differ": "HVAC mode ON and OFF must be different",
             "piloted_heat_pump_unknown": "The previously selected heat pump is no longer available; pick a different one"
         },
         "step": {
@@ -716,8 +718,10 @@
             "already_configured_device": "Device is already configured",
             "cannot_connect": "Unable to connect",
             "climate_capabilities_unavailable": "Climate entity advertises no HVAC modes; pick a different climate entity or check the device",
+            "climate_modes_insufficient": "Climate entity exposes fewer than two HVAC modes; pick a different climate entity or configure the device to expose at least two modes",
             "cloud_profile_mismatch": "Cloud profile does not match configuration",
             "exactly_one_backing_required": "Pick exactly one of switch entity or climate entity for the radiator",
+            "hvac_modes_must_differ": "HVAC mode ON and OFF must be different",
             "piloted_heat_pump_unknown": "The previously selected heat pump is no longer available; pick a different one"
         },
         "step": {

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
@@ -208,6 +208,7 @@ views:
               {% if e %}end_time: {{ e.entity_id }}{% endif %}
               {%- set e = ha.get("qs_device_clean_and_reset") %}
               {% if e %}reset: {{ e.entity_id }}{% endif %}
+              {% if device.bistate_entity %}backing_entity: {{ device.bistate_entity }}{% endif %}
             {% elif device.device_type == "home" -%}
               {%- set ha_entity = device.ha_entities.get("home_mode") %}
               {%- if  ha_entity != None %}

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
@@ -33,6 +33,8 @@ views:
           - type: custom:qs-pool-card
           {%- elif  device.device_type == "climate" %}
           - type: custom:qs-climate-card
+          {%- elif  device.device_type == "radiator" %}
+          - type: custom:qs-radiator-card
           {%- elif  device.device_type == "on_off_duration" %}
           - type: custom:qs-on-off-duration-card
           {%- else %}
@@ -145,6 +147,37 @@ views:
               {%- set e = ha.get("default_on_duration") %}
               {% if e %}default_on_duration: {{ e.entity_id }}{% endif %}
             {% elif device.device_type == "on_off_duration" -%}
+              {%- set ha = device.home.ha_entities %}
+              {%- set e = ha.get("qs_home_is_off_grid") %}
+              {% if e %}is_off_grid: {{ e.entity_id }}{% endif %}
+              {%- set ha = device.ha_entities %}
+              {%- set e = ha.get("qs_bistate_current_duration_h") %}
+              {% if e %}duration_limit: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("qs_bistate_current_on_h") %}
+              {% if e %}current_duration: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("default_on_duration") %}
+              {% if e %}default_on_duration: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("default_on_finish_time") %}
+              {% if e %}default_on_finish_time: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("load_current_command") %}
+              {% if e %}command: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("bistate_mode") %}
+              {% if e %}bistate_mode: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("qs_best_effort_green_only") %}
+              {% if e %}green_only: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("qs_enable_device") %}
+              {% if e %}enable_device: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("qs_load_reset_override_state") %}
+              {% if e %}override_reset: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("load_override_state") %}
+              {% if e %}override_state: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("qs_next_or_current_constraint_start_time") %}
+              {% if e %}start_time: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("qs_next_or_current_constraint_end_time") %}
+              {% if e %}end_time: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("qs_device_clean_and_reset") %}
+              {% if e %}reset: {{ e.entity_id }}{% endif %}
+            {% elif device.device_type == "radiator" -%}
               {%- set ha = device.home.ha_entities %}
               {%- set e = ha.get("qs_home_is_off_grid") %}
               {% if e %}is_off_grid: {{ e.entity_id }}{% endif %}
@@ -323,7 +356,7 @@ views:
               {{ "    text: 'WARNING: This will reset ALL solar dampening values.'" }}
               {%- endif %}
             {% endif %}
-            {%- if device.device_type not in ["car", "pool", "climate", "on_off_duration"] %}
+            {%- if device.device_type not in ["car", "pool", "climate", "on_off_duration", "radiator"] %}
             show_header_toggle: false
             state_color: true
             {%- endif %}

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
@@ -211,7 +211,12 @@ views:
               {%- set e = ha.get("qs_device_clean_and_reset") %}
               {% if e %}reset: {{ e.entity_id }}{% endif %}
               {% if device.bistate_entity %}backing_entity: {{ device.bistate_entity }}{% endif %}
-              {% if device.hvac_state_on %}climate_hvac_mode_on: {{ device.hvac_state_on }}{% endif %}
+              {# BH (user-reported bug): quote the value so YAML 1.1
+                 doesn't coerce bare `on` (the value emitted by a
+                 switch-backed radiator) to the boolean `True`. Without
+                 the quotes the JS card receives `true` and crashes on
+                 `true.toLowerCase()` → "Configuration error". #}
+              {% if device.hvac_state_on %}climate_hvac_mode_on: '{{ device.hvac_state_on }}'{% endif %}
             {% elif device.device_type == "water_boiler" -%}
               {# Input contract for custom:qs-water-boiler-card — mirrors
                  qs-on-off-duration-card plus an optional `temperature_sensor`

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
@@ -209,6 +209,7 @@ views:
               {%- set e = ha.get("qs_device_clean_and_reset") %}
               {% if e %}reset: {{ e.entity_id }}{% endif %}
               {% if device.bistate_entity %}backing_entity: {{ device.bistate_entity }}{% endif %}
+              {% if device.hvac_state_on %}climate_hvac_mode_on: {{ device.hvac_state_on }}{% endif %}
             {% elif device.device_type == "home" -%}
               {%- set ha_entity = device.ha_entities.get("home_mode") %}
               {%- if  ha_entity != None %}

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2
@@ -371,6 +371,79 @@ views:
               {{ "- entity: " + ha_entity.entity_id }}
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
               {%- endif %}
+            {% elif device.device_type == "radiator" -%}
+              {%- set ha_entity = device.ha_entities.get("qs_enable_device") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("qs_best_effort_green_only") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  icon: mdi:solar-power" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("default_on_finish_time") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("default_on_duration") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("bistate_mode") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("override_duration") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("current_constraint_current_energy") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("current_constraint") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("load_current_command") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("best_power_value") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("current_constraint_current_percent_completion") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {{ "  icon: mdi:gauge" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("qs_load_mark_current_constraint_done") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("qs_load_reset_override_state") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("qs_device_clean_and_reset") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
             {% elif device.device_type == "home" -%}
               {%- set ha_entity = device.ha_entities.get("home_mode") %}
               {%- if  ha_entity != None %}

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -464,6 +464,11 @@ class QsCarCard extends HTMLElement {
       };
       const polar = (cx, cy, r, deg) => ({x: cx + r * Math.cos(deg2rad(deg)), y: cy - r * Math.sin(deg2rad(deg))});
       const arcPath = (cx, cy, r, a0, a1) => {
+          // BH defense-in-depth: a non-finite angle (NaN / Infinity)
+          // would render as `A 130 130 0 0 1 NaN NaN` in the SVG `d`
+          // attribute and trigger a browser "Configuration error".
+          // Return empty string so the consumer omits the <path> tag.
+          if (!Number.isFinite(a0) || !Number.isFinite(a1)) return '';
           const p0 = polar(cx, cy, r, a0);
           const p1 = polar(cx, cy, r, a1);
           let delta = a1 - a0;

--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -178,7 +178,12 @@ class QsClimateCard extends HTMLElement {
         maxHours = Number(cfg.max_default_hours) || 12;
         displayTargetHours = defaultDuration;
       } else {
-        maxHours = targetHours;
+        // BH (user-reported NaN bug): a brand-new device with no live
+        // constraint sensor reports targetHours == 0, which made
+        // `hoursToPct` divide by zero and propagate NaN into the SVG
+        // arc path (`A 130 130 0 0 1 NaN NaN`). Clamp to a sensible
+        // positive fallback so the ring always renders.
+        maxHours = targetHours > 0 ? targetHours : (Number(cfg.max_default_hours) || 12);
         displayTargetHours = targetHours;
       }
       
@@ -355,6 +360,11 @@ class QsClimateCard extends HTMLElement {
       };
       const polar = (cx, cy, r, deg) => ({x: cx + r * Math.cos(deg2rad(deg)), y: cy - r * Math.sin(deg2rad(deg))});
       const arcPath = (cx, cy, r, a0, a1) => {
+          // BH defense-in-depth: a non-finite angle (NaN / Infinity)
+          // would render as `A 130 130 0 0 1 NaN NaN` in the SVG `d`
+          // attribute and trigger a browser "Configuration error".
+          // Return empty string so the consumer omits the <path> tag.
+          if (!Number.isFinite(a0) || !Number.isFinite(a1)) return '';
           // N8: a zero-length arc (a0 == a1, e.g. progress == 0) would
           // produce a single-point SVG path that renders as nothing or
           // a stray dot. Return empty string so the consumer can decide

--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -5,6 +5,11 @@
 
 class QsClimateCard extends HTMLElement {
   // M4: gate the requestAnimationFrame loop on `showAnimation`.
+    // condition (`showAnimation`). The loop is started lazily by
+  // `_render()` only when the running-progress dash needs to advance,
+  // and stopped in `disconnectedCallback` AND whenever `showAnimation`
+  // becomes false. Avoids constant per-card repaint overhead when no
+  // visible animation is in progress.
   _startAnimation() {
     if (this._animRaf != null) return;
     this._lastAnimTs = null;
@@ -32,14 +37,16 @@ class QsClimateCard extends HTMLElement {
   }
 
   connectedCallback() {
-    // RAF intentionally NOT started here — _render() calls
-    // _startAnimation() when `showAnimation` is true.
+    // RAF intentionally NOT started here — _render() will call
+    // _startAnimation() when needed.
   }
 
   disconnectedCallback() {
     this._stopAnimation();
     // S7: reset interaction flags so a re-attach after mid-interaction
-    // doesn't silently short-circuit `set hass` on stale flags.
+    // (e.g. dragging the ring or processing a mode change when the
+    // dashboard rearranges) doesn't silently short-circuit `set hass`
+    // on stale flags.
     this._isInteractingMode = false;
     this._isInteractingStateOn = false;
     this._isInteractingTarget = false;
@@ -60,7 +67,9 @@ class QsClimateCard extends HTMLElement {
   }
 
   // S6: defence-in-depth HTML escaping for user-/3rd-party-controlled
-  // strings interpolated into innerHTML.
+  // strings interpolated into innerHTML (card title, entity unit, etc.).
+  // HA entity-id validation makes most paths unreachable in practice,
+  // but treat as untrusted.
   _escapeHtml(s) {
     if (s == null) return '';
     return String(s)
@@ -69,6 +78,18 @@ class QsClimateCard extends HTMLElement {
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;');
+  }
+
+  // S8: safe numeric coercion. `Number(s?.state || N)` short-circuits to
+  // the truthy string when `state === "unknown" | "unavailable"`, then
+  // `Number("unknown")` is `NaN` and propagates into SVG cx/cy/d
+  // attributes. Filter degenerate states BEFORE conversion.
+  _safeNumber(sensor, defaultValue) {
+    if (!sensor || sensor.state == null) return defaultValue;
+    const s = sensor.state;
+    if (s === '' || s === 'unknown' || s === 'unavailable') return defaultValue;
+    const n = Number(s);
+    return Number.isNaN(n) ? defaultValue : n;
   }
 
   set hass(hass) {
@@ -128,9 +149,11 @@ class QsClimateCard extends HTMLElement {
       const isOffGrid = sIsOffGrid?.state === 'on';
       
       // Get target hours and current run hours directly (in hours)
-      const targetHours = Number(sDurationLimit?.state || 12);
-      const hoursRun = Number(sCurrentDuration?.state || 0);
-      const defaultDuration = Number(sDefaultOnDuration?.state || 6);
+      // S8: use safeNumber so an `unknown`/`unavailable` sensor doesn't
+      // propagate `NaN` into the SVG path attributes downstream.
+      const targetHours = this._safeNumber(sDurationLimit, 12);
+      const hoursRun = this._safeNumber(sCurrentDuration, 0);
+      const defaultDuration = this._safeNumber(sDefaultOnDuration, 6);
       
       // Get climate mode
       const climateMode = selClimateMode?.state || 'bistate_mode_default';
@@ -148,7 +171,11 @@ class QsClimateCard extends HTMLElement {
       // Determine max hours and what to display
       let maxHours, displayTargetHours;
       if (isDefaultMode) {
-        maxHours = 12; // Fixed for default mode
+        // N3: configurable upper bound for the default-mode ring.
+        // Boilers with significant thermal storage may legitimately
+        // need >12h runs; set `max_default_hours: 24` (or similar)
+        // on the card config to expand the visual range.
+        maxHours = Number(cfg.max_default_hours) || 12;
         displayTargetHours = defaultDuration;
       } else {
         maxHours = targetHours;
@@ -328,6 +355,11 @@ class QsClimateCard extends HTMLElement {
       };
       const polar = (cx, cy, r, deg) => ({x: cx + r * Math.cos(deg2rad(deg)), y: cy - r * Math.sin(deg2rad(deg))});
       const arcPath = (cx, cy, r, a0, a1) => {
+          // N8: a zero-length arc (a0 == a1, e.g. progress == 0) would
+          // produce a single-point SVG path that renders as nothing or
+          // a stray dot. Return empty string so the consumer can decide
+          // to omit the <path> element entirely.
+          if (Math.abs(a1 - a0) < 0.01) return '';
           const p0 = polar(cx, cy, r, a0);
           const p1 = polar(cx, cy, r, a1);
           let delta = a1 - a0;
@@ -596,14 +628,22 @@ class QsClimateCard extends HTMLElement {
 
       const showDialog = (opts) => {
           const {title, message, buttons, customContent} = opts;
+          // N12: an empty `buttons` array would render a modal with no
+          // dismiss path. Always append a "Close" fallback so the user
+          // can never get locked out (and `_modalOpen` doesn't wedge
+          // re-renders).
+          const safeButtons = (Array.isArray(buttons) && buttons.length > 0)
+              ? buttons
+              : [{ text: 'Close' }];
           const wrap = document.createElement('div');
           wrap.className = 'modal';
-          // S6: escape user-controlled `title` and `message`.
+          // S6: escape user-controlled `title` and `message`; customContent
+          // is provided by the caller as already-rendered HTML.
           const contentHtml = customContent || `<p>${this._escapeHtml(message)}</p>`;
           wrap.innerHTML = `<div class="dialog"><h3>${this._escapeHtml(title)}</h3>${contentHtml}<div class="actions"></div></div>`;
           const actions = wrap.querySelector('.actions');
           this._modalOpen = true;
-          buttons.forEach(b => {
+          safeButtons.forEach(b => {
               const el = document.createElement('button');
               el.className = `btn ${b.variant || 'secondary'}`;
               el.textContent = b.text;
@@ -611,10 +651,16 @@ class QsClimateCard extends HTMLElement {
               const activate = () => {
                   if (activated) return;
                   activated = true;
-                  if (b.onClick) b.onClick();
-                  wrap.remove();
-                  this._modalOpen = false;
-                  this._render();
+                  // N13: wrap onClick in try/finally so a synchronous
+                  // throw doesn't leave the modal locked open with
+                  // `_modalOpen = true` blocking subsequent renders.
+                  try {
+                      if (b.onClick) b.onClick();
+                  } finally {
+                      wrap.remove();
+                      this._modalOpen = false;
+                      this._render();
+                  }
               };
               el.addEventListener('click', activate);
               el.addEventListener('touchend', (ev) => {
@@ -649,10 +695,13 @@ class QsClimateCard extends HTMLElement {
               this._isProcessingModeChange = true;
               // M2: wrap in try/finally so the cleanup setTimeout ALWAYS
               // runs — otherwise a rejected `_select` (HA service failure,
-              // network drop) would leave the flag wedged forever.
+              // network drop) would leave `_isProcessingModeChange = true`
+              // forever and silently lock out subsequent re-renders.
               try {
                   // Call the service and wait for it to complete
                   await this._select(e.climate_mode, option);
+              } catch (_) {
+                  // swallow — HA state will resync on the next push
               } finally {
                   // Wait a bit for HA state to propagate, then allow re-render
                   setTimeout(() => {
@@ -720,6 +769,21 @@ class QsClimateCard extends HTMLElement {
       // touchend handler fires immediately, calls preventDefault() to suppress the delayed
       // synthetic click (avoiding double-fire on desktop), and invokes the action directly.
 
+      // S16 — keyboard activation helper: registers Enter/Space handlers
+      // on a `role="button" tabindex="0"` div so keyboard-only users can
+      // trigger the same action as click/touchend. Stops the default
+      // Space-scroll behaviour and the synthetic click that would
+      // double-fire otherwise.
+      const _registerKeyActivation = (el, action) => {
+          if (!el) return;
+          el.addEventListener('keydown', (ev) => {
+              if (ev.key === 'Enter' || ev.key === ' ') {
+                  ev.preventDefault();
+                  action();
+              }
+          });
+      };
+
       // Green-only toggle button
       if (swGreenOnly) {
           const toggleGreen = async () => {
@@ -741,6 +805,7 @@ class QsClimateCard extends HTMLElement {
               gbtn.style.pointerEvents = 'auto';
               gbtn.addEventListener('click', toggleGreen);
               gbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); toggleGreen(); });
+              _registerKeyActivation(gbtn, toggleGreen);
           }
       }
 
@@ -765,6 +830,7 @@ class QsClimateCard extends HTMLElement {
               pbtn.style.pointerEvents = 'auto';
               pbtn.addEventListener('click', togglePower);
               pbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); togglePower(); });
+              _registerKeyActivation(pbtn, togglePower);
           }
       }
 
@@ -789,6 +855,7 @@ class QsClimateCard extends HTMLElement {
               };
               obtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); obtnAction(); });
               obtn.addEventListener('touchend', (ev) => { ev.preventDefault(); obtnAction(); });
+              _registerKeyActivation(obtn, obtnAction);
           }
       }
 
@@ -851,6 +918,7 @@ class QsClimateCard extends HTMLElement {
               tbtn.style.pointerEvents = 'auto';
               tbtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); timeAction(); });
               tbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); timeAction(); });
+              _registerKeyActivation(tbtn, timeAction);
           }
       }
 
@@ -943,21 +1011,28 @@ class QsClimateCard extends HTMLElement {
                   const dragPct = this._targetDragPct;
                   const dragValue = this._targetDragValue;
 
-                  if (dragValue != null && e.default_on_duration) {
-                      await this._setNumber(e.default_on_duration, dragValue);
-                      this._localTargetPct = dragPct;
-                      this._pendingClearLocalTarget && clearTimeout(this._pendingClearLocalTarget);
-                      this._pendingClearLocalTarget = setTimeout(() => {
-                          this._localTargetPct = null;
-                          this._pendingClearLocalTarget = null;
-                          this._render();
-                      }, 5000);
+                  // S17 — wrap the service call so the drag-release
+                  // guards always clear, even if `_setNumber` throws.
+                  try {
+                      if (dragValue != null && e.default_on_duration) {
+                          await this._setNumber(e.default_on_duration, dragValue);
+                          this._localTargetPct = dragPct;
+                          this._pendingClearLocalTarget && clearTimeout(this._pendingClearLocalTarget);
+                          this._pendingClearLocalTarget = setTimeout(() => {
+                              this._localTargetPct = null;
+                              this._pendingClearLocalTarget = null;
+                              this._render();
+                          }, 5000);
+                      }
+                  } catch (_) {
+                      // swallow — HA state will resync on the next push
+                  } finally {
+                      this._targetDragPct = null;
+                      this._targetDragValue = null;
+                      this._isInteractingTarget = false;
+                      this._upInProgress = false;
+                      handle.style.cursor = 'grab';
                   }
-                  this._targetDragPct = null;
-                  this._targetDragValue = null;
-                  this._isInteractingTarget = false;
-                  this._upInProgress = false;
-                  handle.style.cursor = 'grab';
               };
 
               if (window.PointerEvent) {

--- a/custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
@@ -174,7 +174,12 @@ class QsOnOffDurationCard extends HTMLElement {
         maxHours = Number(cfg.max_default_hours) || 12;
         displayTargetHours = defaultDuration;
       } else {
-        maxHours = targetHours;
+        // BH (user-reported NaN bug): a brand-new device with no live
+        // constraint sensor reports targetHours == 0, which made
+        // `hoursToPct` divide by zero and propagate NaN into the SVG
+        // arc path (`A 130 130 0 0 1 NaN NaN`). Clamp to a sensible
+        // positive fallback so the ring always renders.
+        maxHours = targetHours > 0 ? targetHours : (Number(cfg.max_default_hours) || 12);
         displayTargetHours = targetHours;
       }
       
@@ -311,6 +316,11 @@ class QsOnOffDurationCard extends HTMLElement {
       };
       const polar = (cx, cy, r, deg) => ({x: cx + r * Math.cos(deg2rad(deg)), y: cy - r * Math.sin(deg2rad(deg))});
       const arcPath = (cx, cy, r, a0, a1) => {
+          // BH defense-in-depth: a non-finite angle (NaN / Infinity)
+          // would render as `A 130 130 0 0 1 NaN NaN` in the SVG `d`
+          // attribute and trigger a browser "Configuration error".
+          // Return empty string so the consumer omits the <path> tag.
+          if (!Number.isFinite(a0) || !Number.isFinite(a1)) return '';
           // N8: a zero-length arc (a0 == a1, e.g. progress == 0) would
           // produce a single-point SVG path that renders as nothing or
           // a stray dot. Return empty string so the consumer can decide

--- a/custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
@@ -5,6 +5,11 @@
 
 class QsOnOffDurationCard extends HTMLElement {
   // M4: gate the requestAnimationFrame loop on `showAnimation`.
+    // condition (`showAnimation`). The loop is started lazily by
+  // `_render()` only when the running-progress dash needs to advance,
+  // and stopped in `disconnectedCallback` AND whenever `showAnimation`
+  // becomes false. Avoids constant per-card repaint overhead when no
+  // visible animation is in progress.
   _startAnimation() {
     if (this._animRaf != null) return;
     this._lastAnimTs = null;
@@ -32,14 +37,16 @@ class QsOnOffDurationCard extends HTMLElement {
   }
 
   connectedCallback() {
-    // RAF intentionally NOT started here — _render() calls
-    // _startAnimation() when `showAnimation` is true.
+    // RAF intentionally NOT started here — _render() will call
+    // _startAnimation() when needed.
   }
 
   disconnectedCallback() {
     this._stopAnimation();
     // S7: reset interaction flags so a re-attach after mid-interaction
-    // doesn't silently short-circuit `set hass` on stale flags.
+    // (e.g. dragging the ring or processing a mode change when the
+    // dashboard rearranges) doesn't silently short-circuit `set hass`
+    // on stale flags.
     this._isInteractingMode = false;
     this._isInteractingTarget = false;
     this._isProcessingModeChange = false;
@@ -58,7 +65,9 @@ class QsOnOffDurationCard extends HTMLElement {
   }
 
   // S6: defence-in-depth HTML escaping for user-/3rd-party-controlled
-  // strings interpolated into innerHTML.
+  // strings interpolated into innerHTML (card title, entity unit, etc.).
+  // HA entity-id validation makes most paths unreachable in practice,
+  // but treat as untrusted.
   _escapeHtml(s) {
     if (s == null) return '';
     return String(s)
@@ -67,6 +76,18 @@ class QsOnOffDurationCard extends HTMLElement {
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;');
+  }
+
+  // S8: safe numeric coercion. `Number(s?.state || N)` short-circuits to
+  // the truthy string when `state === "unknown" | "unavailable"`, then
+  // `Number("unknown")` is `NaN` and propagates into SVG cx/cy/d
+  // attributes. Filter degenerate states BEFORE conversion.
+  _safeNumber(sensor, defaultValue) {
+    if (!sensor || sensor.state == null) return defaultValue;
+    const s = sensor.state;
+    if (s === '' || s === 'unknown' || s === 'unavailable') return defaultValue;
+    const n = Number(s);
+    return Number.isNaN(n) ? defaultValue : n;
   }
 
   set hass(hass) {
@@ -124,9 +145,11 @@ class QsOnOffDurationCard extends HTMLElement {
       const isOffGrid = sIsOffGrid?.state === 'on';
       
       // Get target hours and current run hours directly (in hours)
-      const targetHours = Number(sDurationLimit?.state || 12);
-      const hoursRun = Number(sCurrentDuration?.state || 0);
-      const defaultDuration = Number(sDefaultOnDuration?.state || 6);
+      // S8: use safeNumber so an `unknown`/`unavailable` sensor doesn't
+      // propagate `NaN` into the SVG path attributes downstream.
+      const targetHours = this._safeNumber(sDurationLimit, 12);
+      const hoursRun = this._safeNumber(sCurrentDuration, 0);
+      const defaultDuration = this._safeNumber(sDefaultOnDuration, 6);
       
       // Get bistate mode
       const bistateMode = selBistateMode?.state || 'bistate_mode_default';
@@ -144,7 +167,11 @@ class QsOnOffDurationCard extends HTMLElement {
       // Determine max hours and what to display
       let maxHours, displayTargetHours;
       if (isDefaultMode) {
-        maxHours = 12; // Fixed for default mode
+        // N3: configurable upper bound for the default-mode ring.
+        // Boilers with significant thermal storage may legitimately
+        // need >12h runs; set `max_default_hours: 24` (or similar)
+        // on the card config to expand the visual range.
+        maxHours = Number(cfg.max_default_hours) || 12;
         displayTargetHours = defaultDuration;
       } else {
         maxHours = targetHours;
@@ -284,6 +311,11 @@ class QsOnOffDurationCard extends HTMLElement {
       };
       const polar = (cx, cy, r, deg) => ({x: cx + r * Math.cos(deg2rad(deg)), y: cy - r * Math.sin(deg2rad(deg))});
       const arcPath = (cx, cy, r, a0, a1) => {
+          // N8: a zero-length arc (a0 == a1, e.g. progress == 0) would
+          // produce a single-point SVG path that renders as nothing or
+          // a stray dot. Return empty string so the consumer can decide
+          // to omit the <path> element entirely.
+          if (Math.abs(a1 - a0) < 0.01) return '';
           const p0 = polar(cx, cy, r, a0);
           const p1 = polar(cx, cy, r, a1);
           let delta = a1 - a0;
@@ -352,7 +384,7 @@ class QsOnOffDurationCard extends HTMLElement {
       };
       
       const modeOptionsHtml = modeOptions.map(o => 
-          `<option value="${o}" ${o === modeState ? 'selected' : ''}>${translateBistateMode(o)}</option>`
+          `<option value="${this._escapeHtml(o)}" ${o === modeState ? 'selected' : ''}>${this._escapeHtml(translateBistateMode(o))}</option>`
       ).join('');
 
       // Parse override command from override state
@@ -518,14 +550,22 @@ class QsOnOffDurationCard extends HTMLElement {
 
       const showDialog = (opts) => {
           const {title, message, buttons, customContent} = opts;
+          // N12: an empty `buttons` array would render a modal with no
+          // dismiss path. Always append a "Close" fallback so the user
+          // can never get locked out (and `_modalOpen` doesn't wedge
+          // re-renders).
+          const safeButtons = (Array.isArray(buttons) && buttons.length > 0)
+              ? buttons
+              : [{ text: 'Close' }];
           const wrap = document.createElement('div');
           wrap.className = 'modal';
-          // S6: escape user-controlled `title` and `message`.
+          // S6: escape user-controlled `title` and `message`; customContent
+          // is provided by the caller as already-rendered HTML.
           const contentHtml = customContent || `<p>${this._escapeHtml(message)}</p>`;
           wrap.innerHTML = `<div class="dialog"><h3>${this._escapeHtml(title)}</h3>${contentHtml}<div class="actions"></div></div>`;
           const actions = wrap.querySelector('.actions');
           this._modalOpen = true;
-          buttons.forEach(b => {
+          safeButtons.forEach(b => {
               const el = document.createElement('button');
               el.className = `btn ${b.variant || 'secondary'}`;
               el.textContent = b.text;
@@ -533,10 +573,16 @@ class QsOnOffDurationCard extends HTMLElement {
               const activate = () => {
                   if (activated) return;
                   activated = true;
-                  if (b.onClick) b.onClick();
-                  wrap.remove();
-                  this._modalOpen = false;
-                  this._render();
+                  // N13: wrap onClick in try/finally so a synchronous
+                  // throw doesn't leave the modal locked open with
+                  // `_modalOpen = true` blocking subsequent renders.
+                  try {
+                      if (b.onClick) b.onClick();
+                  } finally {
+                      wrap.remove();
+                      this._modalOpen = false;
+                      this._render();
+                  }
               };
               el.addEventListener('click', activate);
               el.addEventListener('touchend', (ev) => {
@@ -576,6 +622,8 @@ class QsOnOffDurationCard extends HTMLElement {
               try {
                   // Call the service and wait for it to complete
                   await this._select(e.bistate_mode, option);
+              } catch (_) {
+                  // swallow — HA state will resync on the next push
               } finally {
                   // Wait a bit for HA state to propagate, then allow re-render
                   setTimeout(() => {
@@ -601,6 +649,21 @@ class QsOnOffDurationCard extends HTMLElement {
       // touchend handler fires immediately, calls preventDefault() to suppress the delayed
       // synthetic click (avoiding double-fire on desktop), and invokes the action directly.
 
+      // S16 — keyboard activation helper: registers Enter/Space handlers
+      // on a `role="button" tabindex="0"` div so keyboard-only users can
+      // trigger the same action as click/touchend. Stops the default
+      // Space-scroll behaviour and the synthetic click that would
+      // double-fire otherwise.
+      const _registerKeyActivation = (el, action) => {
+          if (!el) return;
+          el.addEventListener('keydown', (ev) => {
+              if (ev.key === 'Enter' || ev.key === ' ') {
+                  ev.preventDefault();
+                  action();
+              }
+          });
+      };
+
       // Green-only toggle button
       if (swGreenOnly) {
           const toggleGreen = async () => {
@@ -622,6 +685,7 @@ class QsOnOffDurationCard extends HTMLElement {
               gbtn.style.pointerEvents = 'auto';
               gbtn.addEventListener('click', toggleGreen);
               gbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); toggleGreen(); });
+              _registerKeyActivation(gbtn, toggleGreen);
           }
       }
 
@@ -646,6 +710,7 @@ class QsOnOffDurationCard extends HTMLElement {
               pbtn.style.pointerEvents = 'auto';
               pbtn.addEventListener('click', togglePower);
               pbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); togglePower(); });
+              _registerKeyActivation(pbtn, togglePower);
           }
       }
 
@@ -670,6 +735,7 @@ class QsOnOffDurationCard extends HTMLElement {
               };
               obtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); obtnAction(); });
               obtn.addEventListener('touchend', (ev) => { ev.preventDefault(); obtnAction(); });
+              _registerKeyActivation(obtn, obtnAction);
           }
       }
 
@@ -713,6 +779,7 @@ class QsOnOffDurationCard extends HTMLElement {
                               // S9: clear the local override after a
                               // grace period so out-of-band backend
                               // updates aren't masked indefinitely.
+                              // Mirrors the _localTargetPct timeout.
                               if (this._localFinishTimeClearTimer) {
                                   clearTimeout(this._localFinishTimeClearTimer);
                               }
@@ -732,6 +799,7 @@ class QsOnOffDurationCard extends HTMLElement {
               tbtn.style.pointerEvents = 'auto';
               tbtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); timeAction(); });
               tbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); timeAction(); });
+              _registerKeyActivation(tbtn, timeAction);
           }
       }
 
@@ -824,21 +892,28 @@ class QsOnOffDurationCard extends HTMLElement {
                   const dragPct = this._targetDragPct;
                   const dragValue = this._targetDragValue;
 
-                  if (dragValue != null && e.default_on_duration) {
-                      await this._setNumber(e.default_on_duration, dragValue);
-                      this._localTargetPct = dragPct;
-                      this._pendingClearLocalTarget && clearTimeout(this._pendingClearLocalTarget);
-                      this._pendingClearLocalTarget = setTimeout(() => {
-                          this._localTargetPct = null;
-                          this._pendingClearLocalTarget = null;
-                          this._render();
-                      }, 5000);
+                  // S17 — wrap the service call so the drag-release
+                  // guards always clear, even if `_setNumber` throws.
+                  try {
+                      if (dragValue != null && e.default_on_duration) {
+                          await this._setNumber(e.default_on_duration, dragValue);
+                          this._localTargetPct = dragPct;
+                          this._pendingClearLocalTarget && clearTimeout(this._pendingClearLocalTarget);
+                          this._pendingClearLocalTarget = setTimeout(() => {
+                              this._localTargetPct = null;
+                              this._pendingClearLocalTarget = null;
+                              this._render();
+                          }, 5000);
+                      }
+                  } catch (_) {
+                      // swallow — HA state will resync on the next push
+                  } finally {
+                      this._targetDragPct = null;
+                      this._targetDragValue = null;
+                      this._isInteractingTarget = false;
+                      this._upInProgress = false;
+                      handle.style.cursor = 'grab';
                   }
-                  this._targetDragPct = null;
-                  this._targetDragValue = null;
-                  this._isInteractingTarget = false;
-                  this._upInProgress = false;
-                  handle.style.cursor = 'grab';
               };
 
               if (window.PointerEvent) {

--- a/custom_components/quiet_solar/ui/resources/qs-pool-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-pool-card.js
@@ -448,6 +448,11 @@ class QsPoolCard extends HTMLElement {
       };
       const polar = (cx, cy, r, deg) => ({x: cx + r * Math.cos(deg2rad(deg)), y: cy - r * Math.sin(deg2rad(deg))});
       const arcPath = (cx, cy, r, a0, a1) => {
+          // BH defense-in-depth: a non-finite angle (NaN / Infinity)
+          // would render as `A 130 130 0 0 1 NaN NaN` in the SVG `d`
+          // attribute and trigger a browser "Configuration error".
+          // Return empty string so the consumer omits the <path> tag.
+          if (!Number.isFinite(a0) || !Number.isFinite(a1)) return '';
           const p0 = polar(cx, cy, r, a0);
           const p1 = polar(cx, cy, r, a1);
           let delta = a1 - a0;

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -18,6 +18,9 @@
   shared-base extraction is a larger refactor scheduled as a follow-up.
   When that lands, the on/off card SHOULD adopt the same S14-S17/N7
   safety improvements that this card already has.
+
+  TODO: shared base, tracked at https://github.com/tmenguy/quiet-solar/issues/199
+  (A1 review-fix #02).
 */
 
 class QsRadiatorCard extends HTMLElement {
@@ -535,8 +538,13 @@ class QsRadiatorCard extends HTMLElement {
           const {title, message, buttons, customContent} = opts;
           const wrap = document.createElement('div');
           wrap.className = 'modal';
-          const contentHtml = customContent || `<p>${message}</p>`;
-          wrap.innerHTML = `<div class="dialog"><h3>${title}</h3>${contentHtml}<div class="actions"></div></div>`;
+          // B5 — defensively escape `title` and `message` so a future
+          // caller passing entity-derived text doesn't silently
+          // reintroduce the S15 injection vector. `customContent` is
+          // an explicit opt-in for trusted markup (callers must
+          // escape inside the template themselves).
+          const contentHtml = customContent || `<p>${_escapeHtml(message)}</p>`;
+          wrap.innerHTML = `<div class="dialog"><h3>${_escapeHtml(title)}</h3>${contentHtml}<div class="actions"></div></div>`;
           const actions = wrap.querySelector('.actions');
           this._modalOpen = true;
           buttons.forEach(b => {

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -1,8 +1,23 @@
 /*
   QS Radiator Card - custom:qs-radiator-card
   Zero-build single-file Lit-style web component compatible with Home Assistant.
-  This is a verbatim clone of qs-on-off-duration-card.js with the custom-element
-  renamed; UX redesign is deferred to a follow-up story.
+
+  Provenance and divergence (S4 review-fix note):
+  This file started as a clone of qs-on-off-duration-card.js with the
+  custom-element renamed. Per QS-195 review-fix #01 it has since picked up:
+    - S14 — `_safeNumber` coercion (NaN-safe state reads)
+    - S15 — `_escapeHtml` for innerHTML-bound strings (title + mode labels)
+    - S16 — keyboard-accessible action buttons (role="button" + tabindex
+            + Enter/Space activation)
+    - S17 — try/finally around async service calls so interaction
+            guards never leak on transient failures
+    - N7  — cold-start `running` derivation OR-s in the underlying
+            backing entity state when published
+  The two cards are intentionally not yet collapsed into a shared base
+  module — the on/off card is older and broadly deployed; a clean
+  shared-base extraction is a larger refactor scheduled as a follow-up.
+  When that lands, the on/off card SHOULD adopt the same S14-S17/N7
+  safety improvements that this card already has.
 */
 
 class QsRadiatorCard extends HTMLElement {
@@ -96,10 +111,18 @@ class QsRadiatorCard extends HTMLElement {
       // Check if system is off-grid
       const isOffGrid = sIsOffGrid?.state === 'on';
       
+      // S14 — `Number(state || fallback)` yields NaN for truthy non-numeric
+      // states like "unknown" or "unavailable". Coerce explicitly and
+      // fall back when the result isn't finite.
+      const _safeNumber = (value, fallback) => {
+        const n = Number(value);
+        return Number.isFinite(n) ? n : fallback;
+      };
+
       // Get target hours and current run hours directly (in hours)
-      const targetHours = Number(sDurationLimit?.state || 12);
-      const hoursRun = Number(sCurrentDuration?.state || 0);
-      const defaultDuration = Number(sDefaultOnDuration?.state || 6);
+      const targetHours = _safeNumber(sDurationLimit?.state, 12);
+      const hoursRun = _safeNumber(sCurrentDuration?.state, 0);
+      const defaultDuration = _safeNumber(sDefaultOnDuration?.state, 6);
       
       // Get bistate mode
       const bistateMode = selBistateMode?.state || 'bistate_mode_default';
@@ -110,9 +133,18 @@ class QsRadiatorCard extends HTMLElement {
       const isOverridden = overrideState !== 'NO OVERRIDE';
       const isResettingOverride = overrideState === 'ASKED FOR RESET OVERRIDE';
       
-      // Determine if device is running (command state must be "on")
+      // Determine if device is running (command state must be "on").
+      // N7 cold-start fallback: when the QS command sensor hasn't been
+      // published yet, also recognise the backing entity's state if the
+      // dashboard template passes it through `entities.backing_entity`.
       const commandState = sCommand?.state || '';
-      const running = commandState.toLowerCase() === 'on';
+      const commandReportsOn = commandState.toLowerCase() === 'on';
+      const backingEntityId = e.backing_entity;
+      const liveBackingState = backingEntityId
+          ? (this._hass?.states?.[backingEntityId]?.state || '').toLowerCase()
+          : '';
+      const liveBackingOn = liveBackingState === 'on' || liveBackingState === 'heat';
+      const running = commandReportsOn || liveBackingOn;
       
       // Determine max hours and what to display
       let maxHours, displayTargetHours;
@@ -304,20 +336,33 @@ class QsRadiatorCard extends HTMLElement {
       const activeGradId = running ? gradRunningId : gradGreenId;
       const showAnimation = (running && segLen > 6);
 
+      // S15 — escape values before they reach `innerHTML`. Mode labels,
+      // entity names, and other HA-supplied strings could otherwise
+      // inject markup or scripts via translated values / entity names.
+      const _escapeHtml = (value) => {
+        if (value == null) return '';
+        return String(value)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      };
+
       // Bistate mode selector options with translations
       const modeOptions = selBistateMode?.attributes?.options || [];
       const modeState = (selBistateMode?.state || '').trim();
-      
+
       // Helper to translate bistate mode options
       const translateBistateMode = (value) => {
-          const key = `component.quiet_solar.entity.select.on_off_mode.state.${value}`;
+          const key = `component.quiet_solar.entity.select.radiator_mode.state.${value}`;
           const translated = this._hass?.localize?.(key);
           // If translation not found or returns the key itself, fall back to the raw value
           return (translated && translated !== key) ? translated : value;
       };
-      
-      const modeOptionsHtml = modeOptions.map(o => 
-          `<option value="${o}" ${o === modeState ? 'selected' : ''}>${translateBistateMode(o)}</option>`
+
+      const modeOptionsHtml = modeOptions.map(o =>
+          `<option value="${_escapeHtml(o)}" ${o === modeState ? 'selected' : ''}>${_escapeHtml(translateBistateMode(o))}</option>`
       ).join('');
 
       // Parse override command from override state
@@ -377,15 +422,20 @@ class QsRadiatorCard extends HTMLElement {
       const finishTimeStr = sDefaultOnFinishTime?.state || '07:00:00';
       const finishTimeMins = this._localFinishTimeMins != null ? this._localFinishTimeMins : parseTimeToMinutes(finishTimeStr);
 
+      // S15 — sanitise the title (a user-supplied entity / device name)
+      // before it lands in innerHTML.
+      // S16 — primary action `<div>`s get `role="button"` + `tabindex="0"`
+      // so keyboard-only users can tab to and activate them. The Enter/
+      // Space handlers are wired in the event-binding loops below.
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
         <style>${css}</style>
-        <div class="card-title">${title}</div>
+        <div class="card-title">${_escapeHtml(title)}</div>
         <div class="top"></div>
 
         <div class="hero">
           <div class="ring">
-            ${swEnableDevice ? `<div id="power_btn" class="power-btn ${isEnabled ? 'on' : ''}"><ha-icon icon="mdi:power"></ha-icon></div>` : ''}
+            ${swEnableDevice ? `<div id="power_btn" class="power-btn ${isEnabled ? 'on' : ''}" role="button" tabindex="0" aria-label="Toggle device"><ha-icon icon="mdi:power"></ha-icon></div>` : ''}
             <svg viewBox="0 0 320 320" width="300" height="300" style="touch-action: none;" aria-hidden="true">
               <defs>
                 <linearGradient id="${gradGreenId}" x1="0%" y1="0%" x2="100%" y2="0%">
@@ -449,13 +499,13 @@ class QsRadiatorCard extends HTMLElement {
                 ${isDefaultMode && !isOverridden && sDefaultOnFinishTime ? `
                 <div class="center-controls" style="flex-direction:column; gap:4px;">
                   <div style="color: var(--secondary-text-color); font-weight:700; font-size: .75rem;">Change Finish Time</div>
-                  <div id="time_btn" class="time-btn ${finishTimeStr && finishTimeStr !== '--:--' ? 'on' : ''}">${formatTime(finishTimeStr)}</div>
+                  <div id="time_btn" class="time-btn ${finishTimeStr && finishTimeStr !== '--:--' ? 'on' : ''}" role="button" tabindex="0" aria-label="Change finish time">${formatTime(finishTimeStr)}</div>
                 </div>
                 ` : ''}
               </div>
             </div>
-            ${e.override_reset ? `<div id="override_btn" class="${overrideBtnClass}"><ha-icon icon="${overrideBtnIcon}"></ha-icon></div>` : ''}
-            ${swGreenOnly ? `<div id="green_btn" class="green-btn ${swGreenOnly.state === 'on' ? 'on' : ''}"><ha-icon icon="mdi:leaf"></ha-icon></div>` : ''}
+            ${e.override_reset ? `<div id="override_btn" class="${overrideBtnClass}" role="button" tabindex="0" aria-label="Reset override"><ha-icon icon="${overrideBtnIcon}"></ha-icon></div>` : ''}
+            ${swGreenOnly ? `<div id="green_btn" class="green-btn ${swGreenOnly.state === 'on' ? 'on' : ''}" role="button" tabindex="0" aria-label="Toggle solar-only mode"><ha-icon icon="mdi:leaf"></ha-icon></div>` : ''}
           </div>
         </div>
 
@@ -531,18 +581,26 @@ class QsRadiatorCard extends HTMLElement {
           modeSel?.addEventListener('change', async (ev) => {
               const option = ev.target.value;
               if (!option) return;
-              
+
               this._isProcessingModeChange = true;
-              
-              // Call the service and wait for it to complete
-              await this._select(e.bistate_mode, option);
-              
-              // Wait a bit for HA state to propagate, then allow re-render
-              setTimeout(() => {
-                  this._isProcessingModeChange = false;
-                  this._isInteractingMode = false;
-                  this._render();
-              }, 300);
+
+              // S17 — wrap the async service call so the interaction
+              // guards always clear, even if `_select` rejects. Without
+              // this the card would get stuck (no further rerender, no
+              // further mode-change accepted) on a single transient
+              // service-call failure.
+              try {
+                  await this._select(e.bistate_mode, option);
+              } catch (_) {
+                  // swallow — HA state will resync on the next push
+              } finally {
+                  // Wait a bit for HA state to propagate, then allow re-render
+                  setTimeout(() => {
+                      this._isProcessingModeChange = false;
+                      this._isInteractingMode = false;
+                      this._render();
+                  }, 300);
+              }
           });
           const modePill = modeSel?.closest('.pill');
           if (modePill && modeSel) {
@@ -559,6 +617,21 @@ class QsRadiatorCard extends HTMLElement {
       // DOM node is destroyed before the synthetic click fires, so the tap is lost. The
       // touchend handler fires immediately, calls preventDefault() to suppress the delayed
       // synthetic click (avoiding double-fire on desktop), and invokes the action directly.
+
+      // S16 — keyboard activation helper: registers Enter/Space handlers
+      // on a `role="button" tabindex="0"` div so keyboard-only users can
+      // trigger the same action as click/touchend. Stops the default
+      // Space-scroll behaviour and the synthetic click that would
+      // double-fire otherwise.
+      const _registerKeyActivation = (el, action) => {
+          if (!el) return;
+          el.addEventListener('keydown', (ev) => {
+              if (ev.key === 'Enter' || ev.key === ' ') {
+                  ev.preventDefault();
+                  action();
+              }
+          });
+      };
 
       // Green-only toggle button
       if (swGreenOnly) {
@@ -581,6 +654,7 @@ class QsRadiatorCard extends HTMLElement {
               gbtn.style.pointerEvents = 'auto';
               gbtn.addEventListener('click', toggleGreen);
               gbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); toggleGreen(); });
+              _registerKeyActivation(gbtn, toggleGreen);
           }
       }
 
@@ -605,6 +679,7 @@ class QsRadiatorCard extends HTMLElement {
               pbtn.style.pointerEvents = 'auto';
               pbtn.addEventListener('click', togglePower);
               pbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); togglePower(); });
+              _registerKeyActivation(pbtn, togglePower);
           }
       }
 
@@ -629,6 +704,7 @@ class QsRadiatorCard extends HTMLElement {
               };
               obtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); obtnAction(); });
               obtn.addEventListener('touchend', (ev) => { ev.preventDefault(); obtnAction(); });
+              _registerKeyActivation(obtn, obtnAction);
           }
       }
 
@@ -681,6 +757,7 @@ class QsRadiatorCard extends HTMLElement {
               tbtn.style.pointerEvents = 'auto';
               tbtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); timeAction(); });
               tbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); timeAction(); });
+              _registerKeyActivation(tbtn, timeAction);
           }
       }
 
@@ -773,21 +850,28 @@ class QsRadiatorCard extends HTMLElement {
                   const dragPct = this._targetDragPct;
                   const dragValue = this._targetDragValue;
 
-                  if (dragValue != null && e.default_on_duration) {
-                      await this._setNumber(e.default_on_duration, dragValue);
-                      this._localTargetPct = dragPct;
-                      this._pendingClearLocalTarget && clearTimeout(this._pendingClearLocalTarget);
-                      this._pendingClearLocalTarget = setTimeout(() => {
-                          this._localTargetPct = null;
-                          this._pendingClearLocalTarget = null;
-                          this._render();
-                      }, 5000);
+                  // S17 — wrap the service call so the drag-release
+                  // guards always clear, even if `_setNumber` throws.
+                  try {
+                      if (dragValue != null && e.default_on_duration) {
+                          await this._setNumber(e.default_on_duration, dragValue);
+                          this._localTargetPct = dragPct;
+                          this._pendingClearLocalTarget && clearTimeout(this._pendingClearLocalTarget);
+                          this._pendingClearLocalTarget = setTimeout(() => {
+                              this._localTargetPct = null;
+                              this._pendingClearLocalTarget = null;
+                              this._render();
+                          }, 5000);
+                      }
+                  } catch (_) {
+                      // swallow — HA state will resync on the next push
+                  } finally {
+                      this._targetDragPct = null;
+                      this._targetDragValue = null;
+                      this._isInteractingTarget = false;
+                      this._upInProgress = false;
+                      handle.style.cursor = 'grab';
                   }
-                  this._targetDragPct = null;
-                  this._targetDragValue = null;
-                  this._isInteractingTarget = false;
-                  this._upInProgress = false;
-                  handle.style.cursor = 'grab';
               };
 
               if (window.PointerEvent) {

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -137,16 +137,21 @@ class QsRadiatorCard extends HTMLElement {
       const isResettingOverride = overrideState === 'ASKED FOR RESET OVERRIDE';
       
       // Determine if device is running (command state must be "on").
-      // N7 cold-start fallback: when the QS command sensor hasn't been
-      // published yet, also recognise the backing entity's state if the
-      // dashboard template passes it through `entities.backing_entity`.
+      // N7 + BH10 cold-start fallback: when the QS command sensor hasn't
+      // been published yet, also recognise the backing entity's state if
+      // the dashboard template passes it through `entities.backing_entity`.
+      // The configured HVAC ON mode (`entities.climate_hvac_mode_on`,
+      // typically "heat" or "auto") is also recognised as "on-like" so
+      // users who configured a non-default HVAC mode aren't shown an
+      // incorrect "off" state during the cold-start grace window.
       const commandState = sCommand?.state || '';
       const commandReportsOn = commandState.toLowerCase() === 'on';
       const backingEntityId = e.backing_entity;
       const liveBackingState = backingEntityId
           ? (this._hass?.states?.[backingEntityId]?.state || '').toLowerCase()
           : '';
-      const liveBackingOn = liveBackingState === 'on' || liveBackingState === 'heat';
+      const configuredHvacOn = (e.climate_hvac_mode_on || 'heat').toLowerCase();
+      const liveBackingOn = liveBackingState === 'on' || liveBackingState === configuredHvacOn;
       const running = commandReportsOn || liveBackingOn;
       
       // Determine max hours and what to display

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -1,0 +1,850 @@
+/*
+  QS Radiator Card - custom:qs-radiator-card
+  Zero-build single-file Lit-style web component compatible with Home Assistant.
+  This is a verbatim clone of qs-on-off-duration-card.js with the custom-element
+  renamed; UX redesign is deferred to a follow-up story.
+*/
+
+class QsRadiatorCard extends HTMLElement {
+  connectedCallback() {
+    if (this._animRaf != null) return;
+    const step = (ts) => {
+      if (!this.isConnected) { this._animRaf = null; return; }
+      if (this._lastAnimTs == null) this._lastAnimTs = ts;
+      const dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
+      this._lastAnimTs = ts;
+      const patternLen = Math.max(8, this._animPatternLen || 64);
+      const speed = 80; // dash units per second
+      this._animOffset = ((this._animOffset || 0) + speed * dt) % patternLen;
+      const p = this._root?.getElementById('running_anim');
+      if (p) {
+        p.setAttribute('stroke-dashoffset', String(-this._animOffset));
+      }
+      this._animRaf = requestAnimationFrame(step);
+    };
+    this._animRaf = requestAnimationFrame(step);
+  }
+
+  disconnectedCallback() {
+    if (this._animRaf != null) cancelAnimationFrame(this._animRaf);
+    this._animRaf = null;
+    this._lastAnimTs = null;
+  }
+
+  static getStubConfig() {
+    return { name: "QS Radiator", entities: {} };
+  }
+
+  setConfig(config) {
+    if (!config || !config.entities) throw new Error("entities is required");
+    this._config = config;
+    this._root = this.attachShadow({ mode: "open" });
+    this._render();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    if (!this._root) return;
+    // Avoid re-rendering while user is interacting with selects or a modal is open
+    if (this._isInteractingMode || this._modalOpen || this._isInteractingTarget) return;
+    this._render();
+  }
+
+  getCardSize() { return 5; }
+
+  _entity(id) { return id ? this._hass?.states?.[id] : undefined; }
+
+  _call(domain, service, data) {
+    return this._hass.callService(domain, service, data);
+  }
+
+  _press(entity_id) { return this._call('button', 'press', { entity_id }); }
+  _turnOn(entity_id) { return this._call('switch', 'turn_on', { entity_id }); }
+  _turnOff(entity_id) { return this._call('switch', 'turn_off', { entity_id }); }
+  _select(entity_id, option) { return this._call('select', 'select_option', { entity_id, option }); }
+  _setNumber(entity_id, value) { return this._call('number', 'set_value', { entity_id, value }); }
+  _setTime(entity_id, value) { return this._call('time', 'set_value', { entity_id, time: value }); }
+
+  _fmt(num, round = true) {
+    const n = Number(num);
+    if (num == null || Number.isNaN(n)) return '--';
+    return round ? Math.round(n) : n.toFixed(1);
+  }
+
+  _render() {
+      const cfg = this._config || {};
+      const e = cfg.entities || {};
+
+      const sDurationLimit = this._entity(e.duration_limit);
+      const sCurrentDuration = this._entity(e.current_duration);
+      const sDefaultOnDuration = this._entity(e.default_on_duration);
+      const sDefaultOnFinishTime = this._entity(e.default_on_finish_time);
+      const sCommand = this._entity(e.command);
+      const selBistateMode = this._entity(e.bistate_mode);
+      const swGreenOnly = this._entity(e.green_only);
+      const swEnableDevice = this._entity(e.enable_device);
+      const sOverrideState = this._entity(e.override_state);
+      const sStartTime = this._entity(e.start_time);
+      const sEndTime = this._entity(e.end_time);
+      const sIsOffGrid = this._entity(e.is_off_grid);
+
+      const title = (cfg.title || cfg.name) || "Device";
+      
+      // Check if device is enabled
+      const isEnabled = swEnableDevice?.state === 'on';
+      
+      // Check if system is off-grid
+      const isOffGrid = sIsOffGrid?.state === 'on';
+      
+      // Get target hours and current run hours directly (in hours)
+      const targetHours = Number(sDurationLimit?.state || 12);
+      const hoursRun = Number(sCurrentDuration?.state || 0);
+      const defaultDuration = Number(sDefaultOnDuration?.state || 6);
+      
+      // Get bistate mode
+      const bistateMode = selBistateMode?.state || 'bistate_mode_default';
+      const isDefaultMode = bistateMode === 'bistate_mode_default';
+      
+      // Get override state
+      const overrideState = sOverrideState?.state || 'NO OVERRIDE';
+      const isOverridden = overrideState !== 'NO OVERRIDE';
+      const isResettingOverride = overrideState === 'ASKED FOR RESET OVERRIDE';
+      
+      // Determine if device is running (command state must be "on")
+      const commandState = sCommand?.state || '';
+      const running = commandState.toLowerCase() === 'on';
+      
+      // Determine max hours and what to display
+      let maxHours, displayTargetHours;
+      if (isDefaultMode) {
+        maxHours = 12; // Fixed for default mode
+        displayTargetHours = defaultDuration;
+      } else {
+        maxHours = targetHours;
+        displayTargetHours = targetHours;
+      }
+      
+      // Determine if we should show from/to times
+      const showFromTo = !isDefaultMode || isOverridden;
+      
+      // Helper to check if state is valid
+      const isValidState = (state) => {
+        if (!state) return false;
+        const stateLower = String(state).toLowerCase();
+        return !['unavailable', 'unknown', 'none', ''].includes(stateLower);
+      };
+      
+      // Get from/to times
+      const startTime = (sStartTime && isValidState(sStartTime.state)) ? sStartTime.state : '--:--';
+      const endTime = (sEndTime && isValidState(sEndTime.state)) ? sEndTime.state : '--:--';
+      
+      // Color schemes - MUST BE DEFINED BEFORE CSS
+      const colors = {
+        primary: '#2196F3',
+        gradStart: '#00bcd4',
+        gradEnd: '#8bc34a',
+        animStart: '#00e1ff',
+        animEnd: '#0066ff'
+      };
+      
+      const css = `
+      :host { --pad: 18px; display:block; }
+      .card { padding: var(--pad); position: relative; }
+      .card.off-grid { background: rgba(244, 67, 54, 0.08); }
+      .card-title { text-align:center; font-weight:800; font-size: 1.6rem; margin: 0px 0 0px; }
+      .top { display:flex; gap:12px; flex-wrap:wrap; }
+      .below { display:flex; align-items:center; justify-content:center; margin-top: 8px; width:260px; margin-left:auto; margin-right:auto; }
+      .below .pill { width:100%; }
+      .below-line { width:260px; margin: 8px auto 0; display:grid; grid-template-columns: 1fr auto; align-items:center; column-gap:12px; }
+      .below-line.full { display:block; }
+      .below-line.full > button { width: 100%; justify-content: center; position: relative; }
+      .pill { display:flex; align-items:center; gap:8px; border-radius: 28px; height:40px; min-height:40px; padding:0 12px; border:1px solid var(--divider-color);
+              background: var(--ha-card-background, var(--card-background-color)); box-sizing: border-box; cursor: pointer; touch-action: manipulation; }
+      .pill .dot { width:12px; height:12px; border-radius:50%; background: var(--divider-color); box-shadow: 0 0 8px rgba(0,0,0,.25) inset; }
+      .pill.on { background: rgba(56,142,60,0.15); border-color: rgba(56,142,60,.35); }
+      .pill.on .dot { background: #2ecc71; box-shadow: 0 0 12px #2ecc71aa; }
+      .pill { position: relative; }
+      .pill select { appearance:none; background: transparent; color: var(--primary-text-color); border: none; font-weight:700; position: absolute; left:0; top:0; width:100%; height:100%; text-align:center; text-align-last:center; padding: 0 12px 0 40px; border-radius: 28px; cursor: pointer; z-index:1; box-sizing: border-box; }
+
+      .hero { margin-top: 0px; display:flex; align-items:center; justify-content:center; gap: 12px; }
+      .ring { position: relative; width:300px; height:300px; margin: 0 auto; }
+      /* Mobile touch fix: touch-action:none on the SVG (not the inner <circle>) prevents the
+         browser from initiating scroll/pan gestures when dragging the ring handle. SVG child
+         elements like <circle> don't reliably honor touch-action on iOS Safari / HA Companion. */
+      .ring svg { touch-action: none; }
+      /* Mobile touch fix: touch-action:manipulation removes the 300ms tap delay that mobile
+         browsers impose for double-tap detection, making button taps register immediately.
+         Without this, a hass re-render can destroy the DOM node before the synthetic click fires. */
+      .ring .green-btn { width: 40px; height: 40px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; left: 50%; top: 50%; transform: translate(97px, -137px); z-index: 10; touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
+      .ring .green-btn ha-icon { --mdc-icon-size: 20px; color: var(--secondary-text-color); display:block; line-height:1; }
+      .ring .green-btn.on { border-color: rgba(56,142,60,.45); background: rgba(46,204,113,.14); box-shadow: 0 0 0 3px rgba(46,204,113,.20), 0 0 16px #4CAF50; }
+      .ring .green-btn.on ha-icon { color: #4CAF50; }
+      .ring .power-btn { width: 40px; height: 40px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; left: 50%; top: 50%; transform: translate(-137px, -137px); z-index: 10; touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
+      .ring .power-btn ha-icon { --mdc-icon-size: 20px; color: var(--secondary-text-color); display:block; line-height:1; }
+      .ring .power-btn.on { border-color: rgba(33,150,243,.45); background: rgba(33,150,243,.14); box-shadow: 0 0 0 3px rgba(33,150,243,.20), 0 0 16px #2196F3; }
+      .ring .power-btn.on ha-icon { color: #2196F3; }
+      .card.disabled { opacity: 0.5; pointer-events: none; filter: grayscale(0.8); }
+      .card.disabled .power-btn { pointer-events: auto; opacity: 1; filter: grayscale(0); }
+      .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center; pointer-events: none; transform: translateY(-5px); }
+      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
+      .ring .target-value { font-weight:800; font-size: 2.5rem; line-height: 1.1; }
+      .ring .stack { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; text-align:center; width: 220px; margin: 0 auto; }
+      .ring .target-block { display:flex; flex-direction:column; align-items:center; gap:6px; }
+      .ring .from-to-row { display:flex; justify-content:space-between; width:140px; margin-top: 8px; gap:20px; }
+      .ring .from-to-item { display:flex; flex-direction:column; align-items:center; gap:2px; }
+      .ring .from-to-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
+      .ring .from-to-value { color: var(--primary-text-color); font-weight:800; font-size: 1.4rem; }
+      .ring .center-controls { display:flex; align-items:center; justify-content:center; margin-top: 6px; }
+      .ring .override-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
+      .ring .override-btn ha-icon { --mdc-icon-size: 26px; color: var(--secondary-text-color); display:block; line-height:1; }
+      .ring .override-btn.disabled { cursor: not-allowed; opacity: 0.6; }
+      .ring .override-btn.active { border-color: rgba(255,152,0,.45); background: rgba(255,152,0,.14); box-shadow: 0 0 0 3px rgba(255,152,0,.20), 0 0 16px #FF9800; }
+      .ring .override-btn.active ha-icon { color: #FF9800; }
+      .ring .override-btn.resetting { border-color: rgba(76,175,80,.45); background: rgba(76,175,80,.14); }
+      .ring .override-btn.resetting ha-icon { color: #4CAF50; }
+      .time-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; font-size: 0.99rem; font-weight: 800; line-height: 1; margin-top: 6px; touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
+      .time-btn:hover { border-color: ${colors.primary}; background: rgba(255,255,255,.08); }
+      .time-btn { color: ${colors.primary}; }
+      .time-btn.on { border-color: ${colors.primary}; background: color-mix(in srgb, ${colors.primary} 14%, transparent); box-shadow: 0 0 0 3px color-mix(in srgb, ${colors.primary} 20%, transparent), 0 0 16px ${colors.primary}; color: ${colors.primary}; }
+
+      select {
+        background: var(--ha-card-background, var(--card-background-color));
+        color: var(--primary-text-color);
+        border:1px solid var(--divider-color);
+        border-radius:14px;
+        padding:10px 12px;
+        font-weight:700;
+        font-size: .95rem;
+        font-family: inherit;
+        -webkit-appearance: none;
+        appearance: none;
+        outline: none;
+        line-height: 1.2;
+      }
+      .below select { width: 100%; height: 40px; min-height: 40px; }
+      select:focus { border-color: var(--primary-color); box-shadow: 0 0 0 2px rgba(0,0,0,0), 0 0 0 3px color-mix(in srgb, var(--primary-color) 30%, transparent); }
+      button { border:none; border-radius:18px; padding:14px 16px; font-weight:700; cursor:pointer; font-size: .95rem; }
+      button.pill { height: 40px; min-height: 40px; display:flex; align-items:center; }
+      .danger { background: var(--error-color); color: #fff; }
+      button.outline { background: transparent !important; border-width: 2px; }
+      .danger.outline { color: var(--error-color) !important; border-color: var(--error-color) !important; }
+      
+      #target_handle { touch-action: none; }
+      .modal { position:absolute; inset:0; background: rgba(0,0,0,.45); display:flex; align-items:center; justify-content:center; z-index: 50; touch-action: manipulation; }
+      .dialog { background: var(--card-background-color); color: var(--primary-text-color); border:1px solid var(--divider-color); border-radius: 16px; padding: 16px; width: min(92%, 360px); box-shadow: 0 10px 30px rgba(0,0,0,.3); }
+      .dialog h3 { margin: 0 0 8px; font-size: 1.1rem; font-weight:800; text-align:left; }
+      .dialog p { margin: 0 0 14px; line-height:1.4; color: var(--secondary-text-color); white-space: pre-line; }
+      .dialog .time-picker { display:flex; align-items:center; justify-content:center; gap:12px; margin: 16px 0; }
+      .dialog .time-picker select { width: auto; min-width: 64px; height: 40px; text-align: center; text-align-last: center; }
+      .dialog .time-picker span { font-weight:700; font-size: 1.2rem; }
+      .dialog .actions { display:flex; gap:10px; justify-content:flex-end; margin-top: 6px; }
+      .btn { border:none; border-radius:12px; padding:10px 14px; font-weight:700; cursor:pointer; touch-action: manipulation; min-height: 44px; -webkit-tap-highlight-color: transparent; }
+      .btn.secondary { background: rgba(255,255,255,.06); color: var(--primary-text-color); border:1px solid var(--divider-color); }
+      .btn.primary { background: var(--primary-color); color:#fff; }
+      .btn.danger { background: var(--error-color); color:#fff; }
+    `;
+
+      const ringCirc = 130;
+      const gapDeg = 60;
+      const rangeDeg = 360 - gapDeg;
+      const startDeg = gapDeg / 2;
+      const endDeg = startDeg + rangeDeg;
+
+      const deg2rad = (d) => ((270 - d) * Math.PI) / 180;
+      const rad2deg = (r) => {
+          if (r < 0) r += 2 * Math.PI;
+          return (((270 - ((r * 180) / Math.PI)) + 360) % 360);
+      };
+      const polar = (cx, cy, r, deg) => ({x: cx + r * Math.cos(deg2rad(deg)), y: cy - r * Math.sin(deg2rad(deg))});
+      const arcPath = (cx, cy, r, a0, a1) => {
+          const p0 = polar(cx, cy, r, a0);
+          const p1 = polar(cx, cy, r, a1);
+          let delta = a1 - a0;
+          if (delta < 0) delta += 360;
+          const laf = delta > 180 ? 1 : 0;
+          return `M ${p0.x.toFixed(2)} ${p0.y.toFixed(2)} A ${r} ${r} 0 ${laf} 1 ${p1.x.toFixed(2)} ${p1.y.toFixed(2)}`;
+      };
+
+      // Convert hours to percentage for arc calculation
+      const hoursToPct = (hours) => (hours / maxHours) * 100;
+      const pctToHours = (pct) => (pct / 100) * maxHours;
+      
+      const pctToDeg = (p) => startDeg + (Math.max(0, Math.min(100, p)) / 100) * rangeDeg;
+
+      // Progress: hours run as percentage of max hours
+      const progressPct = hoursToPct(hoursRun);
+      const progressEndDeg = pctToDeg(progressPct);
+      
+      // Handle: target hours (or default duration for default mode)
+      const handlePct = this._targetDragPct != null ? this._targetDragPct : 
+                        (this._localTargetPct != null ? this._localTargetPct : hoursToPct(displayTargetHours));
+      const handleDeg = pctToDeg(handlePct);
+      
+      const center = {cx: 160, cy: 160};
+      const arcLen = 2 * Math.PI * ringCirc * (rangeDeg / 360);
+      const segLen = arcLen * (Math.max(0, Math.min(100, progressPct)) / 100);
+      let dashLen = Math.round(segLen * 0.22);
+      let gapLen = Math.round(segLen * 0.28);
+      dashLen = Math.max(6, dashLen);
+      gapLen = Math.max(6, gapLen);
+      const patternLen = dashLen + gapLen;
+      if (patternLen >= segLen - 4) {
+          const scale = (segLen - 4) / patternLen;
+          dashLen = Math.max(4, Math.round(dashLen * scale));
+          gapLen = Math.max(4, Math.round(gapLen * scale));
+      }
+      this._animPatternLen = Math.max(8, dashLen + gapLen);
+      
+      const handlePos = polar(center.cx, center.cy, ringCirc, handleDeg);
+      const bgPath = arcPath(center.cx, center.cy, ringCirc, startDeg, endDeg);
+      const progressPath = arcPath(center.cx, center.cy, ringCirc, startDeg, progressEndDeg);
+      
+      const gradGreenId = `gradG-${Math.floor(Math.random() * 1e6)}`;
+      const gradRunningId = `gradR-${Math.floor(Math.random() * 1e6)}`;
+      const activeGradId = running ? gradRunningId : gradGreenId;
+      const showAnimation = (running && segLen > 6);
+
+      // Bistate mode selector options with translations
+      const modeOptions = selBistateMode?.attributes?.options || [];
+      const modeState = (selBistateMode?.state || '').trim();
+      
+      // Helper to translate bistate mode options
+      const translateBistateMode = (value) => {
+          const key = `component.quiet_solar.entity.select.on_off_mode.state.${value}`;
+          const translated = this._hass?.localize?.(key);
+          // If translation not found or returns the key itself, fall back to the raw value
+          return (translated && translated !== key) ? translated : value;
+      };
+      
+      const modeOptionsHtml = modeOptions.map(o => 
+          `<option value="${o}" ${o === modeState ? 'selected' : ''}>${translateBistateMode(o)}</option>`
+      ).join('');
+
+      // Parse override command from override state
+      const parseOverrideCommand = (overrideStateStr) => {
+        if (!overrideStateStr || overrideStateStr === 'NO OVERRIDE') return null;
+        const match = String(overrideStateStr).match(/Override:\s*(.+)/i);
+        return match ? match[1].trim() : null;
+      };
+      
+      const overrideCommand = parseOverrideCommand(overrideState);
+      const overrideCommandLower = overrideCommand ? overrideCommand.toLowerCase() : '';
+      
+      // Check if override is for "off" state (ends with "off")
+      const isOverrideOff = overrideCommand && overrideCommandLower.endsWith('off');
+
+      // Override button classes
+      let overrideBtnClass = 'override-btn';
+      let overrideBtnIcon = 'mdi:hand-back-right-off';
+      let overrideBtnClickable = false;
+      if (isResettingOverride) {
+        overrideBtnClass += ' resetting disabled';
+        overrideBtnIcon = isOverrideOff ? 'mdi:hand-back-right-off' : 'mdi:hand-back-right';
+      } else if (isOverridden) {
+        overrideBtnClass += ' active';
+        overrideBtnIcon = isOverrideOff ? 'mdi:hand-back-right-off' : 'mdi:hand-back-right';
+        overrideBtnClickable = true;
+      }
+
+      // Format time for display (remove seconds if present)
+      const formatTime = (timeStr) => {
+        if (!timeStr || timeStr === '--:--') return '--:--';
+        const stateLower = String(timeStr).toLowerCase();
+        if (['unavailable', 'unknown', 'none'].includes(stateLower)) return '--:--';
+        const parts = String(timeStr).split(':');
+        if (parts.length < 2) return '--:--';
+        return `${parts[0]}:${parts[1]}`;
+      };
+
+      // Determine if we can drag the handle (only in default mode, enabled, and not overridden)
+      const canDragHandle = isEnabled && isDefaultMode && !isOverridden && displayTargetHours > 0;
+
+      // Parse time to minutes for time picker
+      const parseTimeToMinutes = (txt) => {
+          if (!txt) return 420; // 07:00
+          const parts = String(txt).split(':').map(Number);
+          const h = parts[0] || 0, m = parts[1] || 0;
+          return h * 60 + m;
+      };
+      
+      const formatHm = (mins) => {
+          if (mins == null) return '';
+          const h = String(Math.floor(mins / 60)).padStart(2, '0');
+          const m = String(mins % 60).padStart(2, '0');
+          return `${h}:${m}`;
+      };
+
+      const finishTimeStr = sDefaultOnFinishTime?.state || '07:00:00';
+      const finishTimeMins = this._localFinishTimeMins != null ? this._localFinishTimeMins : parseTimeToMinutes(finishTimeStr);
+
+      this._root.innerHTML = `
+      <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
+        <style>${css}</style>
+        <div class="card-title">${title}</div>
+        <div class="top"></div>
+
+        <div class="hero">
+          <div class="ring">
+            ${swEnableDevice ? `<div id="power_btn" class="power-btn ${isEnabled ? 'on' : ''}"><ha-icon icon="mdi:power"></ha-icon></div>` : ''}
+            <svg viewBox="0 0 320 320" width="300" height="300" style="touch-action: none;" aria-hidden="true">
+              <defs>
+                <linearGradient id="${gradGreenId}" x1="0%" y1="0%" x2="100%" y2="0%">
+                  <stop offset="0%" stop-color="${colors.gradStart}"/>
+                  <stop offset="100%" stop-color="${colors.gradEnd}"/>
+                </linearGradient>
+                <linearGradient id="${gradRunningId}" x1="0%" y1="0%" x2="100%" y2="0%">
+                  <stop offset="0%" stop-color="${colors.animStart}"/>
+                  <stop offset="100%" stop-color="${colors.animEnd}"/>
+                </linearGradient>
+                <filter id="runningGlow" x="-50%" y="-50%" width="200%" height="200%">
+                  <feGaussianBlur stdDeviation="2" result="blur" />
+                  <feMerge>
+                    <feMergeNode in="blur" />
+                    <feMergeNode in="SourceGraphic" />
+                  </feMerge>
+                </filter>
+              </defs>
+              <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
+              <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
+              ${showAnimation ? `
+              <path id="running_anim"
+                    d="${progressPath}"
+                    stroke="url(#${gradRunningId})"
+                    stroke-width="16"
+                    fill="none"
+                    stroke-linecap="round"
+                    stroke-dasharray="${dashLen} ${gapLen}"
+                    stroke-opacity="1"
+                    filter="url(#runningGlow)"
+                    style="mix-blend-mode:screen; will-change: stroke-dashoffset"
+              />
+              ` : ''}
+              ${canDragHandle ? `
+              <circle id="target_handle" cx="${handlePos.x.toFixed(2)}" cy="${handlePos.y.toFixed(2)}" r="13" fill="var(--card-background-color)" stroke="${colors.primary}" stroke-width="3" style="cursor: grab; pointer-events: all;" />
+              <text id="target_handle_text" x="${handlePos.x.toFixed(2)}" y="${handlePos.y.toFixed(2)}" text-anchor="middle" dominant-baseline="middle" fill="${colors.primary}" font-size="13" font-weight="800" style="cursor: grab; pointer-events: none; user-select: none;">${this._fmt(pctToHours(handlePct))}</text>
+              ` : ''}
+            </svg>
+            <div class="center">
+              <div class="stack">
+                <div class="target-block">
+                  <div class="target-label">Actual / Target Hours</div>
+                  <div class="target-value">
+                    <span style="color: var(--primary-text-color);">${this._fmt(hoursRun, false)}h</span>
+                    <span style="color: var(--primary-text-color);"> / </span>
+                    <span style="color: ${colors.primary};">${this._fmt(displayTargetHours)}h</span>
+                  </div>
+                </div>
+                ${showFromTo ? `
+                <div class="from-to-row">
+                  <div class="from-to-item">
+                    <div class="from-to-label">From:</div>
+                    <div class="from-to-value">${isDefaultMode && !isOverridden ? '--:--' : formatTime(startTime)}</div>
+                  </div>
+                  <div class="from-to-item">
+                    <div class="from-to-label">To:</div>
+                    <div class="from-to-value">${isDefaultMode && !isOverridden ? (sDefaultOnFinishTime ? formatTime(finishTimeStr) : '--:--') : formatTime(endTime)}</div>
+                  </div>
+                </div>
+                ` : ''}
+                ${isDefaultMode && !isOverridden && sDefaultOnFinishTime ? `
+                <div class="center-controls" style="flex-direction:column; gap:4px;">
+                  <div style="color: var(--secondary-text-color); font-weight:700; font-size: .75rem;">Change Finish Time</div>
+                  <div id="time_btn" class="time-btn ${finishTimeStr && finishTimeStr !== '--:--' ? 'on' : ''}">${formatTime(finishTimeStr)}</div>
+                </div>
+                ` : ''}
+              </div>
+            </div>
+            ${e.override_reset ? `<div id="override_btn" class="${overrideBtnClass}"><ha-icon icon="${overrideBtnIcon}"></ha-icon></div>` : ''}
+            ${swGreenOnly ? `<div id="green_btn" class="green-btn ${swGreenOnly.state === 'on' ? 'on' : ''}"><ha-icon icon="mdi:leaf"></ha-icon></div>` : ''}
+          </div>
+        </div>
+
+        ${selBistateMode ? `
+        <div class="below">
+          <div class="pill">
+            <ha-icon icon="mdi:toggle-switch"></ha-icon>
+            <select id="bistate_mode">
+              ${modeOptionsHtml}
+            </select>
+          </div>
+        </div>
+        ` : ''}
+        ${e.reset ? `
+        <div class="below-line full">
+           <button id="reset" class="danger pill outline">Reset</button>
+        </div>
+        ` : ''}
+      </ha-card>
+    `;
+
+      // Wire events
+      const root = this._root;
+      const ids = (k) => root.getElementById(k);
+
+      const showDialog = (opts) => {
+          const {title, message, buttons, customContent} = opts;
+          const wrap = document.createElement('div');
+          wrap.className = 'modal';
+          const contentHtml = customContent || `<p>${message}</p>`;
+          wrap.innerHTML = `<div class="dialog"><h3>${title}</h3>${contentHtml}<div class="actions"></div></div>`;
+          const actions = wrap.querySelector('.actions');
+          this._modalOpen = true;
+          buttons.forEach(b => {
+              const el = document.createElement('button');
+              el.className = `btn ${b.variant || 'secondary'}`;
+              el.textContent = b.text;
+              let activated = false;
+              const activate = () => {
+                  if (activated) return;
+                  activated = true;
+                  if (b.onClick) b.onClick();
+                  wrap.remove();
+                  this._modalOpen = false;
+                  this._render();
+              };
+              el.addEventListener('click', activate);
+              el.addEventListener('touchend', (ev) => {
+                  ev.preventDefault();
+                  activate();
+              });
+              actions.appendChild(el);
+          });
+          this._root.appendChild(wrap);
+          return wrap;
+      };
+
+      // Bistate mode selector
+      if (selBistateMode) {
+          const modeSel = ids('bistate_mode');
+          const startM = () => {
+              this._isInteractingMode = true;
+          };
+          const endM = () => {
+              // Don't clear flag on blur during change processing
+              if (!this._isProcessingModeChange) {
+                  this._isInteractingMode = false;
+                  this._render();
+              }
+          };
+          modeSel?.addEventListener('focus', startM);
+          modeSel?.addEventListener('blur', endM);
+          modeSel?.addEventListener('change', async (ev) => {
+              const option = ev.target.value;
+              if (!option) return;
+              
+              this._isProcessingModeChange = true;
+              
+              // Call the service and wait for it to complete
+              await this._select(e.bistate_mode, option);
+              
+              // Wait a bit for HA state to propagate, then allow re-render
+              setTimeout(() => {
+                  this._isProcessingModeChange = false;
+                  this._isInteractingMode = false;
+                  this._render();
+              }, 300);
+          });
+          const modePill = modeSel?.closest('.pill');
+          if (modePill && modeSel) {
+              modePill.addEventListener('click', (ev) => {
+                  if (ev.target.tagName === 'SELECT') return;
+                  try { modeSel.showPicker(); } catch (_) { modeSel.focus(); }
+              });
+          }
+      }
+
+      // Mobile touch fix: every button below uses a dual click + touchend pattern.
+      // On mobile, the browser synthesizes "click" from touchstart/touchend with up to a
+      // 300ms delay. If a hass re-render (innerHTML replacement) occurs in that window, the
+      // DOM node is destroyed before the synthetic click fires, so the tap is lost. The
+      // touchend handler fires immediately, calls preventDefault() to suppress the delayed
+      // synthetic click (avoiding double-fire on desktop), and invokes the action directly.
+
+      // Green-only toggle button
+      if (swGreenOnly) {
+          const toggleGreen = async () => {
+              const btn = ids('green_btn');
+              try {
+                  if (swGreenOnly.state === 'on') {
+                      await this._turnOff(e.green_only);
+                      btn?.classList.remove('on');
+                  } else {
+                      await this._turnOn(e.green_only);
+                      btn?.classList.add('on');
+                  }
+              } catch (_) {
+                  // ignore errors; HA state will resync UI on next render
+              }
+          };
+          const gbtn = ids('green_btn');
+          if (gbtn) {
+              gbtn.style.pointerEvents = 'auto';
+              gbtn.addEventListener('click', toggleGreen);
+              gbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); toggleGreen(); });
+          }
+      }
+
+      // Power/Enable device toggle button
+      if (swEnableDevice) {
+          const togglePower = async () => {
+              const btn = ids('power_btn');
+              try {
+                  if (swEnableDevice.state === 'on') {
+                      await this._turnOff(e.enable_device);
+                      btn?.classList.remove('on');
+                  } else {
+                      await this._turnOn(e.enable_device);
+                      btn?.classList.add('on');
+                  }
+              } catch (_) {
+                  // ignore errors; HA state will resync UI on next render
+              }
+          };
+          const pbtn = ids('power_btn');
+          if (pbtn) {
+              pbtn.style.pointerEvents = 'auto';
+              pbtn.addEventListener('click', togglePower);
+              pbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); togglePower(); });
+          }
+      }
+
+      // Override button
+      if (e.override_reset && overrideBtnClickable) {
+          const obtn = ids('override_btn');
+          if (obtn) {
+              obtn.style.pointerEvents = 'auto';
+              const obtnAction = async () => {
+                  showDialog({
+                      title: 'Reset override',
+                      message: 'This will reset the manual override and return to automatic mode.\nProceed?',
+                      buttons: [
+                          {text: 'Cancel', variant: 'secondary'},
+                          {
+                              text: 'Reset', variant: 'primary', onClick: async () => {
+                                  await this._press(e.override_reset);
+                              }
+                          },
+                      ]
+                  });
+              };
+              obtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); obtnAction(); });
+              obtn.addEventListener('touchend', (ev) => { ev.preventDefault(); obtnAction(); });
+          }
+      }
+
+      // Time button for finish time (default mode only, hidden during override)
+      if (isDefaultMode && !isOverridden && sDefaultOnFinishTime) {
+          const timeAction = async () => {
+              const defaultHour = Math.floor(finishTimeMins / 60);
+              const defaultMin = finishTimeMins % 60;
+
+              const customContent = `
+            <p>Select the time the device should finish by:</p>
+            <div class="time-picker">
+              <select id="dialog_hour_select">
+                ${Array.from({length: 24}, (_, h) => `<option value="${h}" ${defaultHour === h ? 'selected' : ''}>${String(h).padStart(2, '0')}</option>`).join('')}
+              </select>
+              <span>:</span>
+              <select id="dialog_minute_select">
+                ${[0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55].map(m => `<option value="${m}" ${defaultMin === m ? 'selected' : ''}>${String(m).padStart(2, '0')}</option>`).join('')}
+              </select>
+            </div>
+          `;
+
+              const dialog = showDialog({
+                  title: 'Finish Time',
+                  customContent: customContent,
+                  buttons: [
+                      {text: 'Cancel', variant: 'secondary'},
+                      {
+                          text: 'Apply',
+                          variant: 'primary',
+                          onClick: async () => {
+                              const dialogRoot = dialog.querySelector('.dialog');
+                              const hourSel = dialogRoot?.querySelector('#dialog_hour_select');
+                              const minSel = dialogRoot?.querySelector('#dialog_minute_select');
+                              const h = Number(hourSel?.value ?? 0);
+                              const m = Number(minSel?.value ?? 0);
+                              const mins = h * 60 + m;
+                              const hm = formatHm(mins);
+                              const val = hm + ':00';
+                              this._localFinishTimeMins = mins;
+                              await this._setTime(e.default_on_finish_time, val);
+                          }
+                      },
+                  ]
+              });
+          };
+
+          const tbtn = ids('time_btn');
+          if (tbtn) {
+              tbtn.style.pointerEvents = 'auto';
+              tbtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); timeAction(); });
+              tbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); timeAction(); });
+          }
+      }
+
+      // Reset button
+      if (e.reset) {
+          const resetBtn = ids('reset');
+          const resetAction = async () => {
+              showDialog({
+                  title: 'Reset device state',
+                  message: 'This will reset internal state for the device and cannot be undone.\nProceed?',
+                  buttons: [
+                      {text: 'Cancel', variant: 'secondary'},
+                      {
+                          text: 'Reset', variant: 'danger', onClick: async () => {
+                              await this._press(e.reset);
+                          }
+                      },
+                  ]
+              });
+          };
+          resetBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); resetAction(); });
+          resetBtn?.addEventListener('touchend', (ev) => { ev.preventDefault(); resetAction(); });
+      }
+
+      // Drag target handle on ring (only in default mode)
+      if (canDragHandle) {
+          const svg = this._root.querySelector('.ring svg');
+          const handle = this._root.getElementById('target_handle');
+          if (svg && handle) {
+              const pt = svg.createSVGPoint();
+              
+              // Allowed hours (snap points) - 0.5 hour increments from 0 to 12
+              const allowedHours = [];
+              for (let i = 0; i <= 12; i += 0.5) {
+                  allowedHours.push(i);
+              }
+              
+              const onMove = (ev) => {
+                  ev.stopPropagation();
+                  ev.preventDefault();
+                  const e2 = ev.touches ? ev.touches[0] : ev;
+                  pt.x = e2.clientX;
+                  pt.y = e2.clientY;
+                  const cursor = pt.matrixTransform(svg.getScreenCTM().inverse());
+                  const dx = cursor.x - center.cx;
+                  const dy = cursor.y - center.cy;
+                  let ang = rad2deg(Math.atan2(-dy, dx));
+                  let a = ang;
+                  if (a < startDeg) a = startDeg;
+                  if (a > endDeg) a = endDeg;
+                  const rawPct = ((a - startDeg) / rangeDeg) * 100;
+                  const rawHours = pctToHours(rawPct);
+                  
+                  // Snap to nearest allowed hour
+                  const snapHours = allowedHours.reduce((best, v) => 
+                      Math.abs(v - rawHours) < Math.abs(best - rawHours) ? v : best, 
+                      allowedHours[0]
+                  );
+
+                  const displayPct = hoursToPct(snapHours);
+                  this._targetDragPct = displayPct;
+                  this._targetDragValue = snapHours;
+                  this._isInteractingTarget = true;
+
+                  const angSnap = startDeg + (displayPct / 100) * rangeDeg;
+                  const pos = polar(center.cx, center.cy, ringCirc, angSnap);
+                  handle.setAttribute('cx', pos.x.toFixed(2));
+                  handle.setAttribute('cy', pos.y.toFixed(2));
+                  const handleText = this._root.getElementById('target_handle_text');
+                  if (handleText) {
+                      handleText.setAttribute('x', pos.x.toFixed(2));
+                      handleText.setAttribute('y', pos.y.toFixed(2));
+                      handleText.textContent = this._fmt(snapHours, false);
+                  }
+                  const tv = this._root.querySelector('.target-value');
+                  if (tv) {
+                      tv.innerHTML = `<span style="color: var(--primary-text-color);">${this._fmt(hoursRun, false)}h</span><span style="color: var(--primary-text-color);"> / </span><span style="color: ${colors.primary};">${this._fmt(snapHours, false)}h</span>`;
+                  }
+              };
+              
+              const onUp = async (ev) => {
+                  if (this._upInProgress) return;
+                  this._upInProgress = true;
+
+                  if (ev) {
+                      ev.stopPropagation();
+                      ev.preventDefault();
+                  }
+
+                  const dragPct = this._targetDragPct;
+                  const dragValue = this._targetDragValue;
+
+                  if (dragValue != null && e.default_on_duration) {
+                      await this._setNumber(e.default_on_duration, dragValue);
+                      this._localTargetPct = dragPct;
+                      this._pendingClearLocalTarget && clearTimeout(this._pendingClearLocalTarget);
+                      this._pendingClearLocalTarget = setTimeout(() => {
+                          this._localTargetPct = null;
+                          this._pendingClearLocalTarget = null;
+                          this._render();
+                      }, 5000);
+                  }
+                  this._targetDragPct = null;
+                  this._targetDragValue = null;
+                  this._isInteractingTarget = false;
+                  this._upInProgress = false;
+                  handle.style.cursor = 'grab';
+              };
+
+              if (window.PointerEvent) {
+                  const onPointerMove = (ev) => onMove(ev);
+                  const onPointerUp = async (ev) => {
+                      try { handle.releasePointerCapture(ev.pointerId); } catch (_) {}
+                      handle.removeEventListener('pointermove', onPointerMove);
+                      handle.removeEventListener('pointerup', onPointerUp);
+                      handle.removeEventListener('pointercancel', onPointerUp);
+                      await onUp(ev);
+                  };
+                  const onPointerDown = (ev) => {
+                      ev.stopPropagation();
+                      ev.preventDefault();
+                      this._isInteractingTarget = true;
+                      try { handle.setPointerCapture(ev.pointerId); } catch (_) {}
+                      handle.addEventListener('pointermove', onPointerMove);
+                      handle.addEventListener('pointerup', onPointerUp);
+                      handle.addEventListener('pointercancel', onPointerUp);
+                      handle.style.cursor = 'grabbing';
+                  };
+                  handle.addEventListener('pointerdown', onPointerDown);
+              } else {
+                  const onDown = (ev) => {
+                      ev.stopPropagation();
+                      ev.preventDefault();
+                      this._isInteractingTarget = true;
+                      document.addEventListener('mousemove', onMove);
+                      document.addEventListener('touchmove', onMove, {passive: false});
+                      document.addEventListener('mouseup', onUpLegacy);
+                      document.addEventListener('touchend', onUpLegacy);
+                      handle.style.cursor = 'grabbing';
+                  };
+                  const onUpLegacy = async (ev) => {
+                      document.removeEventListener('mousemove', onMove);
+                      document.removeEventListener('touchmove', onMove);
+                      document.removeEventListener('mouseup', onUpLegacy);
+                      document.removeEventListener('touchend', onUpLegacy);
+                      await onUp(ev);
+                  };
+                  handle.addEventListener('mousedown', onDown);
+                  handle.addEventListener('touchstart', onDown, {passive: false});
+              }
+          }
+      }
+  }
+}
+
+if (!customElements.get('qs-radiator-card')) {
+    customElements.define('qs-radiator-card', QsRadiatorCard);
+}
+
+window.customCards = window.customCards || [];
+if (!window.customCards.find((c) => c.type === 'qs-radiator-card')) {
+    window.customCards.push({
+        type: 'qs-radiator-card',
+        name: 'QS Radiator Card',
+        description: 'Quiet Solar radiator control card',
+    });
+}

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -24,8 +24,15 @@
 */
 
 class QsRadiatorCard extends HTMLElement {
-  connectedCallback() {
+  // M4: gate the requestAnimationFrame loop on `showAnimation`.
+    // condition (`showAnimation`). The loop is started lazily by
+  // `_render()` only when the running-progress dash needs to advance,
+  // and stopped in `disconnectedCallback` AND whenever `showAnimation`
+  // becomes false. Avoids constant per-card repaint overhead when no
+  // visible animation is in progress.
+  _startAnimation() {
     if (this._animRaf != null) return;
+    this._lastAnimTs = null;
     const step = (ts) => {
       if (!this.isConnected) { this._animRaf = null; return; }
       if (this._lastAnimTs == null) this._lastAnimTs = ts;
@@ -43,10 +50,27 @@ class QsRadiatorCard extends HTMLElement {
     this._animRaf = requestAnimationFrame(step);
   }
 
-  disconnectedCallback() {
+  _stopAnimation() {
     if (this._animRaf != null) cancelAnimationFrame(this._animRaf);
     this._animRaf = null;
     this._lastAnimTs = null;
+  }
+
+  connectedCallback() {
+    // RAF intentionally NOT started here — _render() will call
+    // _startAnimation() when needed.
+  }
+
+  disconnectedCallback() {
+    this._stopAnimation();
+    // S7: reset interaction flags so a re-attach after mid-interaction
+    // (e.g. dragging the ring or processing a mode change when the
+    // dashboard rearranges) doesn't silently short-circuit `set hass`
+    // on stale flags.
+    this._isInteractingMode = false;
+    this._isInteractingTarget = false;
+    this._isProcessingModeChange = false;
+    this._modalOpen = false;
   }
 
   static getStubConfig() {
@@ -58,6 +82,32 @@ class QsRadiatorCard extends HTMLElement {
     this._config = config;
     this._root = this.attachShadow({ mode: "open" });
     this._render();
+  }
+
+  // S6: defence-in-depth HTML escaping for user-/3rd-party-controlled
+  // strings interpolated into innerHTML (card title, entity unit, etc.).
+  // HA entity-id validation makes most paths unreachable in practice,
+  // but treat as untrusted.
+  _escapeHtml(s) {
+    if (s == null) return '';
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  // S8: safe numeric coercion. `Number(s?.state || N)` short-circuits to
+  // the truthy string when `state === "unknown" | "unavailable"`, then
+  // `Number("unknown")` is `NaN` and propagates into SVG cx/cy/d
+  // attributes. Filter degenerate states BEFORE conversion.
+  _safeNumber(sensor, defaultValue) {
+    if (!sensor || sensor.state == null) return defaultValue;
+    const s = sensor.state;
+    if (s === '' || s === 'unknown' || s === 'unavailable') return defaultValue;
+    const n = Number(s);
+    return Number.isNaN(n) ? defaultValue : n;
   }
 
   set hass(hass) {
@@ -113,19 +163,13 @@ class QsRadiatorCard extends HTMLElement {
       
       // Check if system is off-grid
       const isOffGrid = sIsOffGrid?.state === 'on';
-      
-      // S14 — `Number(state || fallback)` yields NaN for truthy non-numeric
-      // states like "unknown" or "unavailable". Coerce explicitly and
-      // fall back when the result isn't finite.
-      const _safeNumber = (value, fallback) => {
-        const n = Number(value);
-        return Number.isFinite(n) ? n : fallback;
-      };
 
       // Get target hours and current run hours directly (in hours)
-      const targetHours = _safeNumber(sDurationLimit?.state, 12);
-      const hoursRun = _safeNumber(sCurrentDuration?.state, 0);
-      const defaultDuration = _safeNumber(sDefaultOnDuration?.state, 6);
+      // S8: use safeNumber so an `unknown`/`unavailable` sensor doesn't
+      // propagate `NaN` into the SVG path attributes downstream.
+      const targetHours = this._safeNumber(sDurationLimit, 12);
+      const hoursRun = this._safeNumber(sCurrentDuration, 0);
+      const defaultDuration = this._safeNumber(sDefaultOnDuration, 6);
       
       // Get bistate mode
       const bistateMode = selBistateMode?.state || 'bistate_mode_default';
@@ -157,7 +201,11 @@ class QsRadiatorCard extends HTMLElement {
       // Determine max hours and what to display
       let maxHours, displayTargetHours;
       if (isDefaultMode) {
-        maxHours = 12; // Fixed for default mode
+        // N3: configurable upper bound for the default-mode ring.
+        // Boilers with significant thermal storage may legitimately
+        // need >12h runs; set `max_default_hours: 24` (or similar)
+        // on the card config to expand the visual range.
+        maxHours = Number(cfg.max_default_hours) || 12;
         displayTargetHours = defaultDuration;
       } else {
         maxHours = targetHours;
@@ -297,6 +345,11 @@ class QsRadiatorCard extends HTMLElement {
       };
       const polar = (cx, cy, r, deg) => ({x: cx + r * Math.cos(deg2rad(deg)), y: cy - r * Math.sin(deg2rad(deg))});
       const arcPath = (cx, cy, r, a0, a1) => {
+          // N8: a zero-length arc (a0 == a1, e.g. progress == 0) would
+          // produce a single-point SVG path that renders as nothing or
+          // a stray dot. Return empty string so the consumer can decide
+          // to omit the <path> element entirely.
+          if (Math.abs(a1 - a0) < 0.01) return '';
           const p0 = polar(cx, cy, r, a0);
           const p1 = polar(cx, cy, r, a1);
           let delta = a1 - a0;
@@ -344,18 +397,13 @@ class QsRadiatorCard extends HTMLElement {
       const activeGradId = running ? gradRunningId : gradGreenId;
       const showAnimation = (running && segLen > 6);
 
-      // S15 — escape values before they reach `innerHTML`. Mode labels,
-      // entity names, and other HA-supplied strings could otherwise
-      // inject markup or scripts via translated values / entity names.
-      const _escapeHtml = (value) => {
-        if (value == null) return '';
-        return String(value)
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;')
-          .replace(/'/g, '&#39;');
-      };
+      // M4: start/stop the RAF loop based on whether the dash animation
+      // is actually needed. Idle cards consume zero per-frame work.
+      if (showAnimation) {
+        this._startAnimation();
+      } else {
+        this._stopAnimation();
+      }
 
       // Bistate mode selector options with translations
       const modeOptions = selBistateMode?.attributes?.options || [];
@@ -370,7 +418,7 @@ class QsRadiatorCard extends HTMLElement {
       };
 
       const modeOptionsHtml = modeOptions.map(o =>
-          `<option value="${_escapeHtml(o)}" ${o === modeState ? 'selected' : ''}>${_escapeHtml(translateBistateMode(o))}</option>`
+          `<option value="${this._escapeHtml(o)}" ${o === modeState ? 'selected' : ''}>${this._escapeHtml(translateBistateMode(o))}</option>`
       ).join('');
 
       // Parse override command from override state
@@ -438,7 +486,7 @@ class QsRadiatorCard extends HTMLElement {
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
         <style>${css}</style>
-        <div class="card-title">${_escapeHtml(title)}</div>
+        <div class="card-title">${this._escapeHtml(title)}</div>
         <div class="top"></div>
 
         <div class="hero">
@@ -541,18 +589,22 @@ class QsRadiatorCard extends HTMLElement {
 
       const showDialog = (opts) => {
           const {title, message, buttons, customContent} = opts;
+          // N12: an empty `buttons` array would render a modal with no
+          // dismiss path. Always append a "Close" fallback so the user
+          // can never get locked out (and `_modalOpen` doesn't wedge
+          // re-renders).
+          const safeButtons = (Array.isArray(buttons) && buttons.length > 0)
+              ? buttons
+              : [{ text: 'Close' }];
           const wrap = document.createElement('div');
           wrap.className = 'modal';
-          // B5 — defensively escape `title` and `message` so a future
-          // caller passing entity-derived text doesn't silently
-          // reintroduce the S15 injection vector. `customContent` is
-          // an explicit opt-in for trusted markup (callers must
-          // escape inside the template themselves).
-          const contentHtml = customContent || `<p>${_escapeHtml(message)}</p>`;
-          wrap.innerHTML = `<div class="dialog"><h3>${_escapeHtml(title)}</h3>${contentHtml}<div class="actions"></div></div>`;
+          // S6: escape user-controlled `title` and `message`; customContent
+          // is provided by the caller as already-rendered HTML.
+          const contentHtml = customContent || `<p>${this._escapeHtml(message)}</p>`;
+          wrap.innerHTML = `<div class="dialog"><h3>${this._escapeHtml(title)}</h3>${contentHtml}<div class="actions"></div></div>`;
           const actions = wrap.querySelector('.actions');
           this._modalOpen = true;
-          buttons.forEach(b => {
+          safeButtons.forEach(b => {
               const el = document.createElement('button');
               el.className = `btn ${b.variant || 'secondary'}`;
               el.textContent = b.text;
@@ -560,10 +612,16 @@ class QsRadiatorCard extends HTMLElement {
               const activate = () => {
                   if (activated) return;
                   activated = true;
-                  if (b.onClick) b.onClick();
-                  wrap.remove();
-                  this._modalOpen = false;
-                  this._render();
+                  // N13: wrap onClick in try/finally so a synchronous
+                  // throw doesn't leave the modal locked open with
+                  // `_modalOpen = true` blocking subsequent renders.
+                  try {
+                      if (b.onClick) b.onClick();
+                  } finally {
+                      wrap.remove();
+                      this._modalOpen = false;
+                      this._render();
+                  }
               };
               el.addEventListener('click', activate);
               el.addEventListener('touchend', (ev) => {
@@ -596,13 +654,12 @@ class QsRadiatorCard extends HTMLElement {
               if (!option) return;
 
               this._isProcessingModeChange = true;
-
-              // S17 — wrap the async service call so the interaction
-              // guards always clear, even if `_select` rejects. Without
-              // this the card would get stuck (no further rerender, no
-              // further mode-change accepted) on a single transient
-              // service-call failure.
+              // M2: wrap in try/finally so the cleanup setTimeout ALWAYS
+              // runs — otherwise a rejected `_select` (HA service failure,
+              // network drop) would leave `_isProcessingModeChange = true`
+              // forever and silently lock out subsequent re-renders.
               try {
+                  // Call the service and wait for it to complete
                   await this._select(e.bistate_mode, option);
               } catch (_) {
                   // swallow — HA state will resync on the next push
@@ -758,6 +815,17 @@ class QsRadiatorCard extends HTMLElement {
                               const hm = formatHm(mins);
                               const val = hm + ':00';
                               this._localFinishTimeMins = mins;
+                              // S9: clear the local override after a
+                              // grace period so out-of-band backend
+                              // updates aren't masked indefinitely.
+                              // Mirrors the _localTargetPct timeout.
+                              if (this._localFinishTimeClearTimer) {
+                                  clearTimeout(this._localFinishTimeClearTimer);
+                              }
+                              this._localFinishTimeClearTimer = setTimeout(() => {
+                                  this._localFinishTimeMins = null;
+                                  this._render();
+                              }, 5000);
                               await this._setTime(e.default_on_finish_time, val);
                           }
                       },

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -194,7 +194,11 @@ class QsRadiatorCard extends HTMLElement {
       const liveBackingState = backingEntityId
           ? (this._hass?.states?.[backingEntityId]?.state || '').toLowerCase()
           : '';
-      const configuredHvacOn = (e.climate_hvac_mode_on || 'heat').toLowerCase();
+      // BH defense-in-depth: wrap in `String(...)` so a YAML-coerced
+      // boolean (HA parses bare `on` as `true` if the template ever
+      // regresses and emits an unquoted value) doesn't crash the card
+      // on `true.toLowerCase is not a function`.
+      const configuredHvacOn = String(e.climate_hvac_mode_on || 'heat').toLowerCase();
       const liveBackingOn = liveBackingState === 'on' || liveBackingState === configuredHvacOn;
       const running = commandReportsOn || liveBackingOn;
       
@@ -208,7 +212,13 @@ class QsRadiatorCard extends HTMLElement {
         maxHours = Number(cfg.max_default_hours) || 12;
         displayTargetHours = defaultDuration;
       } else {
-        maxHours = targetHours;
+        // BH (user-reported NaN bug): a brand-new switch-backed
+        // radiator with no live constraint sensor reports
+        // targetHours == 0, which made `hoursToPct` divide by zero
+        // and propagate NaN into the SVG arc path
+        // (`A 130 130 0 0 1 NaN NaN`). Clamp to a sensible positive
+        // fallback so the ring always renders.
+        maxHours = targetHours > 0 ? targetHours : (Number(cfg.max_default_hours) || 12);
         displayTargetHours = targetHours;
       }
       
@@ -345,6 +355,11 @@ class QsRadiatorCard extends HTMLElement {
       };
       const polar = (cx, cy, r, deg) => ({x: cx + r * Math.cos(deg2rad(deg)), y: cy - r * Math.sin(deg2rad(deg))});
       const arcPath = (cx, cy, r, a0, a1) => {
+          // BH defense-in-depth: a non-finite angle (NaN / Infinity)
+          // would render as `A 130 130 0 0 1 NaN NaN` in the SVG `d`
+          // attribute and trigger a browser "Configuration error".
+          // Return empty string so the consumer omits the <path> tag.
+          if (!Number.isFinite(a0) || !Number.isFinite(a1)) return '';
           // N8: a zero-length arc (a0 == a1, e.g. progress == 0) would
           // produce a single-point SVG path that renders as nothing or
           // a stray dot. Return empty string so the consumer can decide

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -407,7 +407,7 @@ class QsWaterBoilerCard extends HTMLElement {
       };
       
       const modeOptionsHtml = modeOptions.map(o => 
-          `<option value="${o}" ${o === modeState ? 'selected' : ''}>${translateBistateMode(o)}</option>`
+          `<option value="${this._escapeHtml(o)}" ${o === modeState ? 'selected' : ''}>${this._escapeHtml(translateBistateMode(o))}</option>`
       ).join('');
 
       // Parse override command from override state
@@ -673,6 +673,8 @@ class QsWaterBoilerCard extends HTMLElement {
               try {
                   // Call the service and wait for it to complete
                   await this._select(e.bistate_mode, option);
+              } catch (_) {
+                  // swallow — HA state will resync on the next push
               } finally {
                   // Wait a bit for HA state to propagate, then allow re-render
                   setTimeout(() => {
@@ -698,6 +700,21 @@ class QsWaterBoilerCard extends HTMLElement {
       // touchend handler fires immediately, calls preventDefault() to suppress the delayed
       // synthetic click (avoiding double-fire on desktop), and invokes the action directly.
 
+      // S16 — keyboard activation helper: registers Enter/Space handlers
+      // on a `role="button" tabindex="0"` div so keyboard-only users can
+      // trigger the same action as click/touchend. Stops the default
+      // Space-scroll behaviour and the synthetic click that would
+      // double-fire otherwise.
+      const _registerKeyActivation = (el, action) => {
+          if (!el) return;
+          el.addEventListener('keydown', (ev) => {
+              if (ev.key === 'Enter' || ev.key === ' ') {
+                  ev.preventDefault();
+                  action();
+              }
+          });
+      };
+
       // Green-only toggle button
       if (swGreenOnly) {
           const toggleGreen = async () => {
@@ -719,6 +736,7 @@ class QsWaterBoilerCard extends HTMLElement {
               gbtn.style.pointerEvents = 'auto';
               gbtn.addEventListener('click', toggleGreen);
               gbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); toggleGreen(); });
+              _registerKeyActivation(gbtn, toggleGreen);
           }
       }
 
@@ -743,6 +761,7 @@ class QsWaterBoilerCard extends HTMLElement {
               pbtn.style.pointerEvents = 'auto';
               pbtn.addEventListener('click', togglePower);
               pbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); togglePower(); });
+              _registerKeyActivation(pbtn, togglePower);
           }
       }
 
@@ -767,6 +786,7 @@ class QsWaterBoilerCard extends HTMLElement {
               };
               obtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); obtnAction(); });
               obtn.addEventListener('touchend', (ev) => { ev.preventDefault(); obtnAction(); });
+              _registerKeyActivation(obtn, obtnAction);
           }
       }
 
@@ -830,6 +850,7 @@ class QsWaterBoilerCard extends HTMLElement {
               tbtn.style.pointerEvents = 'auto';
               tbtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); timeAction(); });
               tbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); timeAction(); });
+              _registerKeyActivation(tbtn, timeAction);
           }
       }
 
@@ -922,21 +943,28 @@ class QsWaterBoilerCard extends HTMLElement {
                   const dragPct = this._targetDragPct;
                   const dragValue = this._targetDragValue;
 
-                  if (dragValue != null && e.default_on_duration) {
-                      await this._setNumber(e.default_on_duration, dragValue);
-                      this._localTargetPct = dragPct;
-                      this._pendingClearLocalTarget && clearTimeout(this._pendingClearLocalTarget);
-                      this._pendingClearLocalTarget = setTimeout(() => {
-                          this._localTargetPct = null;
-                          this._pendingClearLocalTarget = null;
-                          this._render();
-                      }, 5000);
+                  // S17 — wrap the service call so the drag-release
+                  // guards always clear, even if `_setNumber` throws.
+                  try {
+                      if (dragValue != null && e.default_on_duration) {
+                          await this._setNumber(e.default_on_duration, dragValue);
+                          this._localTargetPct = dragPct;
+                          this._pendingClearLocalTarget && clearTimeout(this._pendingClearLocalTarget);
+                          this._pendingClearLocalTarget = setTimeout(() => {
+                              this._localTargetPct = null;
+                              this._pendingClearLocalTarget = null;
+                              this._render();
+                          }, 5000);
+                      }
+                  } catch (_) {
+                      // swallow — HA state will resync on the next push
+                  } finally {
+                      this._targetDragPct = null;
+                      this._targetDragValue = null;
+                      this._isInteractingTarget = false;
+                      this._upInProgress = false;
+                      handle.style.cursor = 'grab';
                   }
-                  this._targetDragPct = null;
-                  this._targetDragValue = null;
-                  this._isInteractingTarget = false;
-                  this._upInProgress = false;
-                  handle.style.cursor = 'grab';
               };
 
               if (window.PointerEvent) {

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -189,7 +189,12 @@ class QsWaterBoilerCard extends HTMLElement {
         maxHours = Number(cfg.max_default_hours) || 12;
         displayTargetHours = defaultDuration;
       } else {
-        maxHours = targetHours;
+        // BH (user-reported NaN bug): a brand-new water boiler with no
+        // live constraint sensor reports targetHours == 0, which made
+        // `hoursToPct` divide by zero and propagate NaN into the SVG
+        // arc path (`A 130 130 0 0 1 NaN NaN`). Clamp to a sensible
+        // positive fallback so the ring always renders.
+        maxHours = targetHours > 0 ? targetHours : (Number(cfg.max_default_hours) || 12);
         displayTargetHours = targetHours;
       }
       
@@ -331,6 +336,11 @@ class QsWaterBoilerCard extends HTMLElement {
       };
       const polar = (cx, cy, r, deg) => ({x: cx + r * Math.cos(deg2rad(deg)), y: cy - r * Math.sin(deg2rad(deg))});
       const arcPath = (cx, cy, r, a0, a1) => {
+          // BH defense-in-depth: a non-finite angle (NaN / Infinity)
+          // would render as `A 130 130 0 0 1 NaN NaN` in the SVG `d`
+          // attribute and trigger a browser "Configuration error".
+          // Return empty string so the consumer omits the <path> tag.
+          if (!Number.isFinite(a0) || !Number.isFinite(a1)) return '';
           // N8: a zero-length arc (a0 == a1, e.g. progress == 0) would
           // produce a single-point SVG path that renders as nothing or
           // a stray dot. Return empty string so the consumer can decide

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -9,7 +9,7 @@ covers:
   - custom_components/quiet_solar/ha_model/climate_controller.py
   - custom_components/quiet_solar/ha_model/radiator.py
   - custom_components/quiet_solar/ha_model/bistate_transport.py
-last_verified: 2026-05-20
+last_verified: 2026-05-21
 ---
 
 # Bistate-duration devices (pool, on/off duration, climate, radiator)

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -37,6 +37,14 @@ in `__init__` and delegates `execute_command_system` to it. The host
 keeps owning `_state_on` / `_state_off` / `_bistate_mode_*` and the
 override state machine; the transport receives primitives.
 
+The `_state_on` / `_state_off` shadow lives on `QSBiStateDuration`
+as a property pair that delegates to `self._transport.state_on /
+state_off` when the transport is set (and falls back to a per-
+instance host field while `_transport is None`, during the base
+ctor's seed assignments). A public `hvac_state_on` accessor exposes
+the on-state string to the dashboard template — HA's Jinja sandbox
+restricts leading-underscore attribute access.
+
 ## When you need this concept
 
 - Adding a new simple on/off device (irrigation, ventilation, fixed-

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -6,22 +6,36 @@ covers:
   - custom_components/quiet_solar/ha_model/bistate_duration.py
   - custom_components/quiet_solar/ha_model/on_off_duration.py
   - custom_components/quiet_solar/ha_model/pool.py
-last_verified: 2026-05-19
+  - custom_components/quiet_solar/ha_model/climate_controller.py
+  - custom_components/quiet_solar/ha_model/radiator.py
+  - custom_components/quiet_solar/ha_model/bistate_transport.py
+last_verified: 2026-05-20
 ---
 
-# Bistate-duration devices (pool, on/off duration)
+# Bistate-duration devices (pool, on/off duration, climate, radiator)
 
 ## TL;DR
 
 Bistate-duration devices are loads with two states (on / off) that
 must run for a **specified duration** rather than be modulated. Pool
-pumps, fixed-power boilers, and miscellaneous on/off duration loads
-all use this pattern.
+pumps, fixed-power boilers, climate splits, heating-only radiators,
+and miscellaneous on/off duration loads all use this pattern.
 `ha_model/bistate_duration.py` provides the shared base;
-`ha_model/on_off_duration.py` is the simplest concrete subclass;
-`ha_model/pool.py` extends `on_off_duration` with
-temperature-dependent filter-duration logic. All three inherit the
+`ha_model/on_off_duration.py` and `ha_model/climate_controller.py` are
+the original subclasses; `ha_model/pool.py` extends `on_off_duration`
+with temperature-dependent filter-duration logic;
+`ha_model/radiator.py` adds a heating-only variant that can sit on
+**either** a switch OR a climate entity. All inherit the
 switching-cost protection pattern.
+
+The per-backing difference (which HA entity is observed, which HA
+service is called) is extracted into `ha_model/bistate_transport.py`
+as a `BistateTransport` strategy — `SwitchTransport` flips a switch
+via `switch.turn_on`/`turn_off`; `ClimateTransport` toggles a climate
+entity via `climate.set_hvac_mode`. Each subclass picks a transport
+in `__init__` and delegates `execute_command_system` to it. The host
+keeps owning `_state_on` / `_state_off` / `_bistate_mode_*` and the
+override state machine; the transport receives primitives.
 
 ## When you need this concept
 
@@ -54,13 +68,52 @@ of the on/off behaviour unchanged.
 ## Key types / structures
 
 - `bistate_duration.py` — shared base (the lifecycle, the constraint
-  interface).
-- `QSOnOffDuration(HADeviceMixin, AbstractLoad)` — simple switch
-  loads.
+  interface, the bistate-mode signals, the override state machine).
+- `bistate_transport.py` — strategy module. `BistateTransport`
+  (abstract), `SwitchTransport`, `ClimateTransport`. Each transport
+  owns the underlying HA `entity_id` and translates a `LoadCommand`
+  (plus optional override-state) into the right service call.
+- `QSOnOffDuration(QSBiStateDuration)` — simple switch loads;
+  delegates to `SwitchTransport`.
+- `QSClimateDuration(QSBiStateDuration)` — climate-entity-backed
+  loads; delegates to `ClimateTransport`; keeps the runtime
+  `climate_state_on/off` selects so users can flip seasonal HVAC
+  modes (heat/cool) without restarting.
+- `QSRadiator(QSBiStateDuration)` — heating-only variant; picks a
+  switch- OR climate-transport at `__init__`; defaults the climate
+  backing to `heat`/`off`; does NOT expose runtime HVAC selects
+  (config-time only — heating-only).
 - `QSPool(QSOnOffDuration)` — temperature-aware filter duration.
 - `TimeBasedSimplePowerLoadConstraint` (in
   `home_model/constraints.py`) — the constraint subclass these
   devices use.
+
+## Adding a new bistate device
+
+If your new device shares the bistate-duration lifecycle and only
+differs in (a) which HA entity it observes and (b) which HA service
+it calls, you can add it by:
+
+1. If the backing isn't already covered by `SwitchTransport` or
+   `ClimateTransport`, add a new `BistateTransport` subclass in
+   `bistate_transport.py` exposing `default_state_on/off`,
+   `mode_options`, and `execute(hass, command, override_state,
+   state_on, state_off)`.
+2. Create `ha_model/<device>.py` extending `QSBiStateDuration` and
+   instantiating the right transport in `__init__`. Set
+   `self._state_on/off`, `self._bistate_mode_on/off`,
+   `self.bistate_entity = self._transport.entity`.
+3. Register the new type in `entity.py` (`LOAD_TYPE_LIST`,
+   `LOAD_NAMES`) and `config_flow.py` (`LOAD_TYPES_MENU` plus the
+   `async_step_<type>` step).
+4. Add the dashboard section in `const.py`
+   (`DASHBOARD_DEFAULT_SECTIONS`, `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`)
+   and the per-type Jinja branch in
+   `ui/quiet_solar_dashboard_template.yaml.j2`.
+
+`QSRadiator` is the worked example for a device that supports two
+different backings (switch OR climate) — the constructor picks the
+transport based on which `CONF_*` the user filled.
 
 ## Common mistakes
 
@@ -73,6 +126,10 @@ of the on/off behaviour unchanged.
   often comes back to a tight daily limit.
 - Hard-coding pool filter duration. The temperature-dependent
   helper on `QSPool` is the single source of truth.
+- Putting backing-specific service-call logic on the host. The host
+  (`QSBiStateDuration`) owns the bistate-mode signals; the transport
+  owns the service-call. Crossing that boundary breaks
+  `QSRadiator`'s ability to pick a transport at construction time.
 
 ## See also
 

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -9,7 +9,7 @@ covers:
   - custom_components/quiet_solar/ha_model/climate_controller.py
   - custom_components/quiet_solar/ha_model/radiator.py
   - custom_components/quiet_solar/ha_model/bistate_transport.py
-    - custom_components/quiet_solar/ha_model/water_boiler.py
+  - custom_components/quiet_solar/ha_model/water_boiler.py
 last_verified: 2026-05-21
 ---
 
@@ -51,6 +51,20 @@ instance host field while `_transport is None`, during the base
 ctor's seed assignments). A public `hvac_state_on` accessor exposes
 the on-state string to the dashboard template — HA's Jinja sandbox
 restricts leading-underscore attribute access.
+
+The `_bistate_mode_on` / `_bistate_mode_off` strings drive the
+**bistate-mode select** UI (Force ON / Force OFF entries) and follow
+DIFFERENT conventions across subclasses:
+`QSOnOffDuration` / `QSPool` use namespaced literals
+(`"on_off_mode_on"` / `"on_off_mode_off"`);
+`QSClimateDuration` mirrors the raw HVAC mode (`"heat"` / `"off"` …)
+so the `climate_mode` translation can label each force-mode entry
+with the HVAC mode name; `QSRadiator` uses the literal `"on"` /
+`"off"` regardless of the HVAC mode so the `radiator_mode`
+translation always has matching state keys. The divergence is
+documented in `QSBiStateDuration`'s class docstring. Cross-subclass
+logic that compares `_state_on` ↔ `_bistate_mode_on` must treat
+the two as decoupled.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -84,7 +84,19 @@ Single-mode and identical-mode HVAC validations live alongside the
 XOR check: when fewer than two HVAC modes are advertised the step
 surfaces `climate_modes_insufficient`; when both selectors carry
 the same mode the step surfaces `hvac_modes_must_differ` — both
-errors keep the user's selections through the re-render.
+errors keep the user's selections through the re-render. The
+heat-pump dropdown is also re-validated at submit time against
+the LIVE `home.get_heat_pumps()` so a parallel admin action that
+removed a heat-pump between Pass 1 and the final submit can't
+silently persist a stale name.
+
+User-explicit pilot clear: the form's heat-pump dropdown is
+rendered only when at least one heat pump exists. When that
+dropdown was rendered AND the submit carries an empty value (or
+omits the key entirely — both shapes funnel through a sentinel
+check), the persisted `CONF_DEVICE_TO_PILOT_NAME` is removed.
+Without this distinction the merge in `_async_save_radiator_entry`
+would re-inject the stale name on the next edit.
 
 **Data handler lifecycle** (`data_handler.py`):
 

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -68,13 +68,23 @@ group only enforces "at most one", not "exactly one".
 
 When a step needs to render dropdowns derived from another field
 (e.g. HVAC modes that depend on which climate entity the user
-picked), the step issues a self-call with a sentinel token in
-`user_input` (`"force_climate"`, `"force_radiator_climate"`). Pass 1
-captures the climate entity into `self.config_entry.data`
-(creation flow — `FakeConfigEntry`) or via `async_update_entry`
-(options flow — real `ConfigEntry`). Pass 2 reads the available
-HVAC modes from the registry and shows the mode selectors with a
-suggested default.
+picked), Pass 1 buffers the user's selection in an in-memory
+`_pending_radiator_data` dict and renders the form directly
+(`_async_show_radiator_form()`). Pass 2 reads the available HVAC
+modes from the registry and shows the mode selectors with a
+suggested default. The persisted entry data is NOT touched
+between the two passes — if the user aborts mid-flow nothing leaks
+into `config_entry.data`. The form pre-fills the entity selectors
+from the pending dict so the user doesn't see re-emptied fields
+between passes; on any validation failure (XOR misconfig, empty
+HVAC modes, identical ON/OFF modes) the just-submitted payload is
+passed back into the form via a `pending` kwarg.
+
+Single-mode and identical-mode HVAC validations live alongside the
+XOR check: when fewer than two HVAC modes are advertised the step
+surfaces `climate_modes_insufficient`; when both selectors carry
+the same mode the step surfaces `hvac_modes_must_differ` — both
+errors keep the user's selections through the re-render.
 
 **Data handler lifecycle** (`data_handler.py`):
 

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/__init__.py
   - custom_components/quiet_solar/data_handler.py
   - custom_components/quiet_solar/const.py
-last_verified: 2026-05-20
+last_verified: 2026-05-21
 ---
 
 # Config flow and setup

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/__init__.py
   - custom_components/quiet_solar/data_handler.py
   - custom_components/quiet_solar/const.py
-last_verified: 2026-05-19
+last_verified: 2026-05-20
 ---
 
 # Config flow and setup
@@ -50,6 +50,31 @@ async_step_user (top-level menu)
   uniform.
 - Entity selectors filter by unit of measurement and **exclude
   quiet-solar's own entities** (no self-referential setups).
+
+**Cross-field XOR validation pattern** (`async_step_radiator`):
+
+The radiator step shows BOTH a switch selector AND a climate
+selector and validates exactly-one-set via an explicit if/else
+inside the step. On misconfig it re-renders the form with
+`errors={"base": "exactly_one_backing_required"}`. The same
+constraint is enforced in `QSRadiator.__init__` via
+`ServiceValidationError` for any non-UI code path (e.g. tests,
+direct construction). This is the canonical pattern for "pick
+exactly one of these N options" — voluptuous's `vol.Exclusive`
+group only enforces "at most one", not "exactly one".
+
+**Two-pass form pattern** (`async_step_climate`,
+`async_step_radiator`):
+
+When a step needs to render dropdowns derived from another field
+(e.g. HVAC modes that depend on which climate entity the user
+picked), the step issues a self-call with a sentinel token in
+`user_input` (`"force_climate"`, `"force_radiator_climate"`). Pass 1
+captures the climate entity into `self.config_entry.data`
+(creation flow — `FakeConfigEntry`) or via `async_update_entry`
+(options flow — real `ConfigEntry`). Pass 2 reads the available
+HVAC modes from the registry and shows the mode selectors with a
+suggested default.
 
 **Data handler lifecycle** (`data_handler.py`):
 

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/__init__.py
   - custom_components/quiet_solar/data_handler.py
   - custom_components/quiet_solar/const.py
-last_verified: 2026-05-21
+last_verified: 2026-05-22
 ---
 
 # Config flow and setup
@@ -100,6 +100,22 @@ omits the key entirely — both shapes funnel through a sentinel
 check), the persisted `CONF_DEVICE_TO_PILOT_NAME` is removed.
 Without this distinction the merge in `_async_save_radiator_entry`
 would re-inject the stale name on the next edit.
+
+**Home options-flow section editor** (`async_step_home`): the 8
+dashboard-section slot suggestions (`CONF_DASHBOARD_SECTION_NAME_<i>`
++ `CONF_DASHBOARD_SECTION_ICON_<i>`) come from the **live**
+`home.dashboard_sections` list — not from the stored
+`config_entry.data` slot-by-slot and not from
+`DASHBOARD_DEFAULT_SECTIONS[i]` indexed against `i`. The live list
+has been normalised + migration-updated by `QSHome.__init__`, so the
+form reflects exactly what's rendered on the main dashboard.
+Reading by index against the persisted slots was the source of the
+QS-195 "multiple times others" bug: a pre-QS-194 user whose stored
+slot 3 was `"others"` and slot 5's index default also resolved to
+`"others"` (current const) saw `"others"` twice and no
+`"radiators"`. Slots beyond `len(home.dashboard_sections)` default
+to `None`, so the user has at least one empty slot for adding a
+custom section.
 
 **Data handler lifecycle** (`data_handler.py`):
 

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -64,21 +64,24 @@ exactly one of these N options" — voluptuous's `vol.Exclusive`
 group only enforces "at most one", not "exactly one".
 
 **Two-pass form pattern** (`async_step_climate`,
-`async_step_radiator`):
+`async_step_radiator`, `async_step_car`):
 
 When a step needs to render dropdowns derived from another field
 (e.g. HVAC modes that depend on which climate entity the user
-picked), Pass 1 buffers the user's selection in an in-memory
-`_pending_radiator_data` dict and renders the form directly
-(`_async_show_radiator_form()`). Pass 2 reads the available HVAC
+picked), Pass 1 writes the user's input into `config_entry.data`
+via `async_update_entry` (for real options-flow entries) or by
+direct assignment (for the `FakeConfigEntry` used during creation),
+then renders the form directly. Pass 2 reads the available HVAC
 modes from the registry and shows the mode selectors with a
-suggested default. The persisted entry data is NOT touched
-between the two passes — if the user aborts mid-flow nothing leaks
-into `config_entry.data`. The form pre-fills the entity selectors
-from the pending dict so the user doesn't see re-emptied fields
-between passes; on any validation failure (XOR misconfig, empty
-HVAC modes, identical ON/OFF modes) the just-submitted payload is
-passed back into the form via a `pending` kwarg.
+suggested default. Because the Pass 1 values are now in
+`config_entry.data`, every Pass 2 field (`CONF_NAME`,
+`CONF_DEVICE_DASHBOARD_SECTION`, `CONF_POWER`, …) picks up the
+correct default through the standard `get_common_schema`
+machinery — no per-field plumbing. On any validation failure
+(XOR misconfig, empty HVAC modes, identical ON/OFF modes) the
+just-submitted payload is passed back into the form via a
+`pending` kwarg so the user sees their own selections on the
+re-render.
 
 Single-mode and identical-mode HVAC validations live alongside the
 XOR check: when fewer than two HVAC modes are advertised the step

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/__init__.py
   - custom_components/quiet_solar/data_handler.py
   - custom_components/quiet_solar/const.py
-last_verified: 2026-05-22
+last_verified: 2026-05-23
 ---
 
 # Config flow and setup
@@ -106,16 +106,33 @@ dashboard-section slot suggestions (`CONF_DASHBOARD_SECTION_NAME_<i>`
 + `CONF_DASHBOARD_SECTION_ICON_<i>`) come from the **live**
 `home.dashboard_sections` list — not from the stored
 `config_entry.data` slot-by-slot and not from
-`DASHBOARD_DEFAULT_SECTIONS[i]` indexed against `i`. The live list
-has been normalised + migration-updated by `QSHome.__init__`, so the
-form reflects exactly what's rendered on the main dashboard.
-Reading by index against the persisted slots was the source of the
-QS-195 "multiple times others" bug: a pre-QS-194 user whose stored
-slot 3 was `"others"` and slot 5's index default also resolved to
-`"others"` (current const) saw `"others"` twice and no
-`"radiators"`. Slots beyond `len(home.dashboard_sections)` default
-to `None`, so the user has at least one empty slot for adding a
-custom section.
+`DASHBOARD_DEFAULT_SECTIONS[i]` indexed against `i`.
+`QSHome.__init__` builds that live list with init-time auto-include
+of every bundled default (minus
+`CONF_DASHBOARD_SECTIONS_USER_REMOVED`) plus
+`_normalize_dashboard_sections_order`, so the form reflects exactly
+what's rendered on the main dashboard. Reading by index against the
+persisted slots was the source of the QS-195 "multiple times others"
+bug: a pre-QS-194 user whose stored slot 3 was `"others"` and slot
+5's index default also resolved to `"others"` (current const) saw
+`"others"` twice and no `"radiators"`. Slots beyond
+`len(home.dashboard_sections)` default to `None`, so the user has at
+least one empty slot for adding a custom section.
+
+**Device-side `CONF_DEVICE_DASHBOARD_SECTION` dropdown**: the
+`get_common_schema` builder reads its option list from
+`home.dashboard_sections` directly with no per-step augmentation.
+The pre-QS-195 augmentation that appended a missing bundled default
+to the dropdown options (so the user could still pick e.g.
+`water_boilers` after a QS-194 upgrade) is no longer needed —
+`QSHome.__init__`'s auto-include guarantees the live home already
+contains every bundled section. Every config-flow step that
+includes this field (`home`, `battery`, `solar`, `person`, `car`,
+`pool`, `water_boiler`, `on_off_duration`, `climate`, `heat_pump`,
+`radiator`) must have a `device_dashboard_section` translation in
+`strings.json` (literal in `person.data`, `[%key:...%]` references
+in the others); without it the form renders the raw `device_dashboard_section`
+key instead of the localised "Dashboard section" label.
 
 **Data handler lifecycle** (`data_handler.py`):
 

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -11,7 +11,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/qs-climate-card.js
   - custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
   - custom_components/quiet_solar/ui/resources/qs-radiator-card.js
-last_verified: 2026-05-20
+last_verified: 2026-05-21
 ---
 
 # Dashboard generation and JS Lovelace cards

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -191,7 +191,13 @@ Subsequent HA starts:
 | Pool | `custom:qs-pool-card` | `QSPool` | `ui/resources/qs-pool-card.js` |
 | Climate | `custom:qs-climate-card` | `QSClimateDuration`, `QSHeatPump` | `ui/resources/qs-climate-card.js` |
 | On-off duration | `custom:qs-on-off-duration-card` | `QSOnOffDuration` | `ui/resources/qs-on-off-duration-card.js` |
-| Radiator | `custom:qs-radiator-card` | `QSRadiator` | `ui/resources/qs-radiator-card.js` (verbatim clone of `qs-on-off-duration-card.js`; UX redesign deferred) |
+| Radiator | `custom:qs-radiator-card` | `QSRadiator` | `ui/resources/qs-radiator-card.js` (cloned from `qs-on-off-duration-card.js`; UX redesign deferred via [#199](https://github.com/tmenguy/quiet-solar/issues/199); has S14-S17/N7 safety hardening the on/off card has not yet adopted) |
+
+The radiator template wires `backing_entity` (the underlying
+switch/climate entity id) and `climate_hvac_mode_on` (the configured
+HVAC ON mode — e.g. `"heat"`, `"auto"`) through the entities block.
+The card uses those values to derive `running` during the cold-start
+grace window when the QS command sensor hasn't published yet.
 
 The cards are **outside the quality pipeline**: no JS tests, no JS
 linter, no build step. The product brief explicitly says "don't

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -10,7 +10,8 @@ covers:
   - custom_components/quiet_solar/ui/resources/qs-pool-card.js
   - custom_components/quiet_solar/ui/resources/qs-climate-card.js
   - custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
-last_verified: 2026-05-19
+  - custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+last_verified: 2026-05-20
 ---
 
 # Dashboard generation and JS Lovelace cards
@@ -22,9 +23,9 @@ Lovelace dashboards** by rendering two Jinja2 templates against the
 live `QSHome`:
 
 - **"Quiet Solar"** (`quiet-solar` URL, custom cards) — renders the
-  four bundled JS Lovelace cards (`qs-car-card`, `qs-pool-card`,
-  `qs-climate-card`, `qs-on-off-duration-card`), one per device type
-  that has a dedicated card.
+  five bundled JS Lovelace cards (`qs-car-card`, `qs-pool-card`,
+  `qs-climate-card`, `qs-on-off-duration-card`, `qs-radiator-card`),
+  one per device type that has a dedicated card.
 - **"Quiet Std"** (`quiet-solar-standard` URL, standard cards) —
   renders the same data using only built-in HA cards (no JS cards
   required). This is the fallback for households who want a
@@ -79,8 +80,8 @@ without losing any functionality (just visual polish).
 ### Section mapping in `const.py`
 
 The dashboard is organized into **sections** (`cars`, `climates`,
-`pools`, `others`, `settings`). Each device type has a default
-section in `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`; TheAdmin can
+`radiators`, `pools`, `others`, `settings`). Each device type has a
+default section in `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`; TheAdmin can
 override per-device via the `CONF_DASHBOARD_SECTION_NAME` config
 field. `QSHome.dashboard_sections` is the in-memory list of active
 sections (deduplicated, ordered as configured); the templates
@@ -100,6 +101,8 @@ switch:
 - type: custom:qs-pool-card
 {%- elif  device.device_type == "climate" %}
 - type: custom:qs-climate-card
+{%- elif  device.device_type == "radiator" %}
+- type: custom:qs-radiator-card
 {%- elif  device.device_type == "on_off_duration" %}
 - type: custom:qs-on-off-duration-card
 {%- else %}
@@ -107,7 +110,7 @@ switch:
 {%- endif %}
 ```
 
-The four JS cards have card-specific YAML input shapes (e.g.,
+The five JS cards have card-specific YAML input shapes (e.g.,
 `qs-car-card` expects `soc:`, `range_now:`, `charge_type:`, etc.).
 Every key resolves to an entity ID via `device.ha_entities.get(...)`
 — so the template translates "the device knows about a certain
@@ -180,7 +183,7 @@ Subsequent HA starts:
     → dashboard CONTENT is never touched — TheAdmin's edits survive
 ```
 
-## The four JS Lovelace cards
+## The five JS Lovelace cards
 
 | Card | Card type | Device types | Source |
 |---|---|---|---|
@@ -188,6 +191,7 @@ Subsequent HA starts:
 | Pool | `custom:qs-pool-card` | `QSPool` | `ui/resources/qs-pool-card.js` |
 | Climate | `custom:qs-climate-card` | `QSClimateDuration`, `QSHeatPump` | `ui/resources/qs-climate-card.js` |
 | On-off duration | `custom:qs-on-off-duration-card` | `QSOnOffDuration` | `ui/resources/qs-on-off-duration-card.js` |
+| Radiator | `custom:qs-radiator-card` | `QSRadiator` | `ui/resources/qs-radiator-card.js` (verbatim clone of `qs-on-off-duration-card.js`; UX redesign deferred) |
 
 The cards are **outside the quality pipeline**: no JS tests, no JS
 linter, no build step. The product brief explicitly says "don't

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -11,7 +11,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/qs-climate-card.js
   - custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
   - custom_components/quiet_solar/ui/resources/qs-radiator-card.js
-    - custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+  - custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
 last_verified: 2026-05-21
 ---
 

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -12,7 +12,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
   - custom_components/quiet_solar/ui/resources/qs-radiator-card.js
   - custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
-last_verified: 2026-05-21
+last_verified: 2026-05-23
 ---
 
 # Dashboard generation and JS Lovelace cards
@@ -249,6 +249,18 @@ patterns after the cross-card audit:
   `Number(s?.state || N)` so degenerate states
   (`""` / `unknown` / `unavailable`) can't propagate `NaN` into SVG
   path attributes.
+- **Zero-`maxHours` clamp (post-QS-195 user bug).** Both the
+  radiator and water-boiler cards clamp `maxHours = targetHours > 0 ?
+  targetHours : <fallback>` in the non-default-mode branch. A
+  brand-new device whose constraint sensor reports `0` would
+  otherwise divide by zero in `hoursToPct`, propagate `NaN` into the
+  arc-path math, and emit `M ... A 130 130 0 0 1 NaN NaN` in the
+  rendered SVG `d` attribute — the browser shows a "Configuration
+  error" and the card refuses to render.
+- **Arc-path NaN guard (defense-in-depth).** Both cards' `arcPath`
+  helper short-circuits with `if (!Number.isFinite(a0) ||
+  !Number.isFinite(a1)) return '';` so even if upstream math escapes
+  the clamp, the SVG `d` attribute stays well-formed.
 - **Local-state cleanup symmetry (S9).** Every Apply handler that
   sets a `_localFinishTimeMins` / `_localNextTimeMins` schedules a
   matching 5-second clear timer so out-of-band backend updates

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
   - custom_components/quiet_solar/ha_model/person.py
-last_verified: 2026-05-19
+last_verified: 2026-05-21
 ---
 
 # Notification routing

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
   - custom_components/quiet_solar/ha_model/person.py
-last_verified: 2026-05-21
+last_verified: 2026-05-22
 ---
 
 # Notification routing

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
   - custom_components/quiet_solar/ha_model/person.py
-last_verified: 2026-05-22
+last_verified: 2026-05-23
 ---
 
 # Notification routing

--- a/docs/agents/concepts/off-grid-mode.md
+++ b/docs/agents/concepts/off-grid-mode.md
@@ -4,7 +4,7 @@ slug: off-grid-mode
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
-last_verified: 2026-05-19
+last_verified: 2026-05-21
 ---
 
 # Off-grid mode

--- a/docs/agents/concepts/off-grid-mode.md
+++ b/docs/agents/concepts/off-grid-mode.md
@@ -4,7 +4,7 @@ slug: off-grid-mode
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
-last_verified: 2026-05-21
+last_verified: 2026-05-22
 ---
 
 # Off-grid mode

--- a/docs/agents/concepts/off-grid-mode.md
+++ b/docs/agents/concepts/off-grid-mode.md
@@ -4,7 +4,7 @@ slug: off-grid-mode
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
-last_verified: 2026-05-22
+last_verified: 2026-05-23
 ---
 
 # Off-grid mode

--- a/docs/agents/concepts/piloted-device-and-heat-pump.md
+++ b/docs/agents/concepts/piloted-device-and-heat-pump.md
@@ -6,7 +6,7 @@ covers:
   - custom_components/quiet_solar/home_model/load.py
   - custom_components/quiet_solar/ha_model/heat_pump.py
   - custom_components/quiet_solar/ha_model/climate_controller.py
-last_verified: 2026-05-20
+last_verified: 2026-05-21
 ---
 
 # PilotedDevice and heat pump

--- a/docs/agents/concepts/piloted-device-and-heat-pump.md
+++ b/docs/agents/concepts/piloted-device-and-heat-pump.md
@@ -6,7 +6,7 @@ covers:
   - custom_components/quiet_solar/home_model/load.py
   - custom_components/quiet_solar/ha_model/heat_pump.py
   - custom_components/quiet_solar/ha_model/climate_controller.py
-last_verified: 2026-05-19
+last_verified: 2026-05-20
 ---
 
 # PilotedDevice and heat pump
@@ -46,6 +46,23 @@ handles most demand; when the compressor is saturated and the
 climate setpoint is still missed, the pilot engages the aux heater.
 This is the structural pattern for "main device with optional
 booster".
+
+### Piloting is data-driven, not class-specific
+
+The pilot/client relationship is wired in `QSHome._set_topology()`
+(`ha_model/home.py:1876-1882`) by walking `self._all_loads` and
+checking `load.piloted_device_name` — that field comes straight
+from `AbstractLoad.__init__` (`home_model/load.py:114`). Any
+`AbstractLoad` subclass can opt into piloting just by reading
+`CONF_DEVICE_TO_PILOT_NAME` from its config. **No edit to
+`home.add_device` is required** when a new device type wants to be
+piloted.
+
+This is why `QSRadiator` can attach to a heat pump regardless of
+its backing (switch OR climate) — both backings go through the
+same `AbstractLoad.__init__` path, and `_set_topology` finds the
+heat pump by name. The climate-controller class isn't the only
+piloting client anymore.
 
 ## Key types / structures
 

--- a/docs/agents/concepts/piloted-device-and-heat-pump.md
+++ b/docs/agents/concepts/piloted-device-and-heat-pump.md
@@ -64,6 +64,13 @@ same `AbstractLoad.__init__` path, and `_set_topology` finds the
 heat pump by name. The climate-controller class isn't the only
 piloting client anymore.
 
+Climate-backed loads (`QSClimateDuration`, climate-backed
+`QSRadiator`) treat an empty-string HVAC mode as "use the default"
+(`heat` or `auto` / `off`). Without this fallback a persisted `""`
+(from a migration / buggy import) would slip past `kwargs.pop(...,
+default)` and crash the first `set_hvac_mode("")` service call at
+runtime.
+
 ## Key types / structures
 
 - `PilotedDevice(AbstractDevice)` — the base for pilot-capable

--- a/docs/agents/concepts/piloted-device-and-heat-pump.md
+++ b/docs/agents/concepts/piloted-device-and-heat-pump.md
@@ -71,6 +71,14 @@ Climate-backed loads (`QSClimateDuration`, climate-backed
 default)` and crash the first `set_hvac_mode("")` service call at
 runtime.
 
+`QSClimateDuration` and `SwitchTransport` both fail fast on a
+missing / empty / whitespace-only backing entity_id, raising
+`ServiceValidationError` (for the climate parent) or `ValueError`
+(for the lower-level switch transport) at construction. This
+parallels the EH6 guard on `QSRadiator` and surfaces persistence
+corruption visibly instead of crashing later inside HA's service
+dispatch with an opaque error.
+
 ## Key types / structures
 
 - `PilotedDevice(AbstractDevice)` — the base for pilot-capable

--- a/docs/agents/concepts/qs-home-orchestrator.md
+++ b/docs/agents/concepts/qs-home-orchestrator.md
@@ -4,7 +4,7 @@ slug: qs-home-orchestrator
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
-last_verified: 2026-05-21
+last_verified: 2026-05-22
 ---
 
 # QSHome — the orchestrator
@@ -94,18 +94,33 @@ per cycle:
 ## Dashboard sections auto-migration
 
 When a new device type adds a new bundled `DASHBOARD_DEFAULT_SECTIONS`
-entry (e.g. `water_boilers` added by QS-194), users who **previously
-customised** their dashboard sections will not have the new section
-in their stored list. `QSHome.add_device` runs
-`_maybe_migrate_missing_default_section(device)` for every device it
-accepts: if the device's requested section is one of
-`DASHBOARD_DEFAULT_SECTIONS` and is missing from `self.dashboard_sections`,
-it is appended **at runtime only** (the config entry is never modified —
-the user's customisation stays user-owned). The complementary tier-1
-diagnostic lives in `home_model/load.py:dashboard_section`: if section
-resolution still fails (i.e. it's not a default-section name), a
-single `_LOGGER.warning` surfaces the device and the unresolved
-section so the issue can be diagnosed from HA logs.
+entry (e.g. `water_boilers` added by QS-194, `radiators` added by
+QS-195), users who **previously customised** their dashboard sections
+will not have the new section in their stored list.
+`QSHome.add_device` runs `_maybe_migrate_missing_default_section(device)`
+for every device it accepts: if the device's requested section is one
+of `DASHBOARD_DEFAULT_SECTIONS` and is missing from
+`self.dashboard_sections`, it is added **at runtime only** (the config
+entry is never modified — the user's customisation stays user-owned)
+and the list is then re-normalised so the bundled section lands in its
+canonical const-order slot (between e.g. `water_boilers` and `others`)
+rather than at the end. Without the post-insert normalize, an
+upgraded user would see the migrated section rendered AFTER `settings`
+on the main dashboard — the QS-195 BH user bug. The complementary
+tier-1 diagnostic lives in `home_model/load.py:dashboard_section`: if
+section resolution still fails (i.e. it's not a default-section
+name), a single `_LOGGER.warning` surfaces the device and the
+unresolved section so the issue can be diagnosed from HA logs.
+
+The same `_normalize_dashboard_sections_order` helper runs once at
+`QSHome.__init__` time on the persisted-then-reconstructed
+`dashboard_sections` list, so a pre-existing user whose
+`CONF_DASHBOARD_SECTION_NAME_*` keys ended up in the wrong order
+(because an older append-only migration ran during a previous
+upgrade) gets the canonical ordering on the next HA restart without
+having to re-edit the home config. Custom user sections (names not
+in `DASHBOARD_DEFAULT_SECTIONS_DICT`) are preserved at the tail in
+their original relative order.
 
 When the migration appends a section, it also invalidates the
 `_computed_dashboard_section` cache on every sibling device that

--- a/docs/agents/concepts/qs-home-orchestrator.md
+++ b/docs/agents/concepts/qs-home-orchestrator.md
@@ -4,7 +4,7 @@ slug: qs-home-orchestrator
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
-last_verified: 2026-05-19
+last_verified: 2026-05-21
 ---
 
 # QSHome — the orchestrator
@@ -60,6 +60,13 @@ than the cycle completes.
 - `update_all_states()` — the 4s cycle.
 - `update_loads()` — the 7s cycle.
 - `_state_lock`, `_loads_lock` — `asyncio.Lock` guards.
+- Public registry accessors — `get_car_by_name(name)`,
+  `get_person_by_name(name)`, `get_heat_pumps()`. Callers outside
+  `QSHome` should prefer these over reaching into the private
+  `_cars` / `_persons` / `_heat_pumps` lists. Accessors return
+  snapshot copies so external code cannot mutate the home's
+  registry; the canonical mutation surface stays `add_device` /
+  `remove_device`.
 
 ## Lifecycle
 

--- a/docs/agents/concepts/qs-home-orchestrator.md
+++ b/docs/agents/concepts/qs-home-orchestrator.md
@@ -4,7 +4,7 @@ slug: qs-home-orchestrator
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
-last_verified: 2026-05-22
+last_verified: 2026-05-23
 ---
 
 # QSHome — the orchestrator
@@ -91,53 +91,54 @@ per cycle:
   be async or routed through `hass.async_add_executor_job()`.
 - Hard-coding the cycle intervals — they live in `const.py`.
 
-## Dashboard sections auto-migration
+## Dashboard sections — init-time auto-include
 
-When a new device type adds a new bundled `DASHBOARD_DEFAULT_SECTIONS`
-entry (e.g. `water_boilers` added by QS-194, `radiators` added by
-QS-195), users who **previously customised** their dashboard sections
-will not have the new section in their stored list.
-`QSHome.add_device` runs `_maybe_migrate_missing_default_section(device)`
-for every device it accepts: if the device's requested section is one
-of `DASHBOARD_DEFAULT_SECTIONS` and is missing from
-`self.dashboard_sections`, it is added **at runtime only** (the config
-entry is never modified — the user's customisation stays user-owned)
-and the list is then re-normalised so the bundled section lands in its
-canonical const-order slot (between e.g. `water_boilers` and `others`)
-rather than at the end. Without the post-insert normalize, an
-upgraded user would see the migrated section rendered AFTER `settings`
-on the main dashboard — the QS-195 BH user bug. The complementary
-tier-1 diagnostic lives in `home_model/load.py:dashboard_section`: if
-section resolution still fails (i.e. it's not a default-section
-name), a single `_LOGGER.warning` surfaces the device and the
+`QSHome.__init__` deterministically builds `self.dashboard_sections`
+on every load:
+
+1. Read every `CONF_DASHBOARD_SECTION_NAME_<i>` /
+   `CONF_DASHBOARD_SECTION_ICON_<i>` slot from `config_entry.data`
+   into an in-memory list. Slot names go through
+   `extract_name_and_index_from_dashboard_section_option` so the
+   `"#N - <name>"` prefix is stripped consistently (no substring
+   heuristic, no mis-strip on section names containing `" - "`).
+2. **Auto-include**: walk `DASHBOARD_DEFAULT_SECTIONS` (the bundled
+   defaults — `cars`, `climates`, `pools`, `water_boilers`,
+   `radiators`, `others`, `settings`); for each entry missing from
+   the list AND not listed in `CONF_DASHBOARD_SECTIONS_USER_REMOVED`,
+   append it. Runtime-only — `config_entry.data` is NOT modified, so
+   the user's persisted slot layout stays user-owned.
+3. Run `_normalize_dashboard_sections_order` so bundled defaults
+   appear in canonical const order regardless of the persisted slot
+   ordering. Custom user sections (names not in
+   `DASHBOARD_DEFAULT_SECTIONS_DICT`) are preserved at the tail in
+   their original relative order.
+
+This replaces the pre-QS-195 `_maybe_migrate_missing_default_section`
+per-device mechanism. Why the swap:
+
+- The previous approach mutated `dashboard_sections` lazily as each
+  device was added, which created in-memory-vs-persisted divergence
+  AND a per-device timing dependency on the home being constructed
+  first. Silent early-returns (5+ different guards) could prevent
+  the migration from firing under conditions that were hard to
+  diagnose.
+- The init-time approach runs once, deterministically, before any
+  device is added. The dashboard YAML, the home options form, and
+  every device's section dropdown read the same `home.dashboard_sections`
+  list, so all three surfaces are always consistent.
+
+Users still have an opt-out: list a section name in
+`CONF_DASHBOARD_SECTIONS_USER_REMOVED` on the home config entry and
+the init-time auto-include skips it (no UI for this — it's a
+power-user knob for the rare case of deliberately removing a bundled
+default).
+
+The complementary tier-1 diagnostic lives in
+`home_model/load.py:dashboard_section`: if a device's requested
+section can't be resolved (e.g. a typo, a now-removed custom
+section), a single `_LOGGER.warning` surfaces the device and the
 unresolved section so the issue can be diagnosed from HA logs.
-
-The same `_normalize_dashboard_sections_order` helper runs once at
-`QSHome.__init__` time on the persisted-then-reconstructed
-`dashboard_sections` list, so a pre-existing user whose
-`CONF_DASHBOARD_SECTION_NAME_*` keys ended up in the wrong order
-(because an older append-only migration ran during a previous
-upgrade) gets the canonical ordering on the next HA restart without
-having to re-edit the home config. Custom user sections (names not
-in `DASHBOARD_DEFAULT_SECTIONS_DICT`) are preserved at the tail in
-their original relative order.
-
-When the migration appends a section, it also invalidates the
-`_computed_dashboard_section` cache on every sibling device that
-had previously resolved to `DASHBOARD_NO_SECTION`, so a device added
-before the migration trigger re-resolves correctly on the next
-access (review-fix #03 S5).
-
-Users can opt out of the auto-migration for specific sections by
-listing them in `CONF_DASHBOARD_SECTIONS_USER_REMOVED` on the home
-config entry; the migration honours this list and skips re-appending
-those sections (review-fix #03 N7).
-
-The prefix-parsing step uses
-`extract_name_and_index_from_dashboard_section_option` (from
-`home_model/load.py`) rather than a string-substring heuristic, so
-section names containing `" - "` are parsed correctly (review-fix
-#03 S4).
 
 ## See also
 

--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -144,7 +144,7 @@ to grep the entire tree to figure out what an `ack` is.
   `ui/*.yaml.j2`; rendered against the live `QSHome` to produce
   Lovelace YAML on first install.
 - **"Quiet Solar" dashboard** — the custom-cards variant
-  (`quiet-solar` URL), uses the four bundled JS cards.
+  (`quiet-solar` URL), uses the five bundled JS cards.
 - **"Quiet Std" dashboard** — the standard-cards variant
   (`quiet-solar-standard` URL), uses only built-in HA cards.
 - **JS Lovelace card** — a custom HA frontend card. Quiet-solar

--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -2,7 +2,7 @@
 title: Glossary
 slug: glossary
 kind: principle
-last_verified: 2026-05-19
+last_verified: 2026-05-20
 ---
 
 # Glossary
@@ -61,6 +61,19 @@ to grep the entire tree to figure out what an `ack` is.
   (`ha_model/dynamic_group.py`).
 - **PilotedDevice** — a device that pilots another device
   (e.g. a heat pump piloting an auxiliary heater).
+- **Radiator** — a heating-only bistate-duration load (`QSRadiator`)
+  that can sit on either a switch entity or a climate entity. The
+  constructor picks a `BistateTransport` strategy based on which
+  `CONF_*` is set. See
+  [concepts/bistate-duration-devices.md](concepts/bistate-duration-devices.md).
+- **BistateTransport** — strategy object in `ha_model/bistate_transport.py`
+  that holds the per-backing details for a bistate-duration load
+  (which HA entity is observed, which HA service is called). Two
+  concrete subclasses: `SwitchTransport` (switch entity →
+  `switch.turn_on/off`) and `ClimateTransport` (climate entity →
+  `climate.set_hvac_mode`). The host (`QSBiStateDuration` subclass)
+  keeps owning the bistate-mode signals and override state machine;
+  the transport receives primitives.
 - **External control detection** — the system noticed a state change
   it did not initiate, so a human or another integration is driving
   the device. Quiet-solar steps back.
@@ -135,12 +148,12 @@ to grep the entire tree to figure out what an `ack` is.
 - **"Quiet Std" dashboard** — the standard-cards variant
   (`quiet-solar-standard` URL), uses only built-in HA cards.
 - **JS Lovelace card** — a custom HA frontend card. Quiet-solar
-  ships four: `qs-car-card`, `qs-climate-card`,
-  `qs-on-off-duration-card`, `qs-pool-card`. Outside the quality
-  pipeline (no JS tests / linter / build).
-- **Dashboard section** — one of `cars`, `climates`, `pools`,
-  `others`, `settings` (`DASHBOARD_DEFAULT_SECTIONS` in `const.py`).
-  Each device type maps to a default section via
+  ships five: `qs-car-card`, `qs-climate-card`,
+  `qs-on-off-duration-card`, `qs-pool-card`, `qs-radiator-card`.
+  Outside the quality pipeline (no JS tests / linter / build).
+- **Dashboard section** — one of `cars`, `climates`, `radiators`,
+  `pools`, `others`, `settings` (`DASHBOARD_DEFAULT_SECTIONS` in
+  `const.py`). Each device type maps to a default section via
   `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`; TheAdmin can override
   per-device.
 - **`ha_entities` dict** — every `HADeviceMixin` instance exposes

--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -2,7 +2,7 @@
 title: Glossary
 slug: glossary
 kind: principle
-last_verified: 2026-05-20
+last_verified: 2026-05-21
 ---
 
 # Glossary

--- a/docs/stories/QS-195.story.md
+++ b/docs/stories/QS-195.story.md
@@ -1,0 +1,441 @@
+---
+issue: 195
+title: Add radiator load type (climate + on/off switch heating)
+branch: QS_195
+status: planned
+next_phase: implement-task
+labels: [area:loads, area:climate, area:config-flow, area:ui, area:dashboard, area:docs]
+---
+
+# QS-195 — Add radiator load type (climate + on/off switch heating)
+
+## Why
+
+The bistate-duration family currently has two concrete classes — `QSOnOffDuration`
+(switch-backed) and `QSClimateDuration` (climate-backed). Both implement the
+same bistate logic (constraints, override, calendar, modes) and differ only in
+(a) which Home Assistant entity they observe and (b) which Home Assistant
+service they call to flip state.
+
+Issue [#195](https://github.com/tmenguy/quiet-solar/issues/195) wants a new
+`radiator` load type that is **heating-only** and can be backed by **either** a
+climate entity OR a switch entity. Duplicating the bistate logic into a third
+class is unacceptable — the user explicitly rejected the lighter "thin
+subclass + factory" approach (Option γ) so that radiator-specific logic can
+land cleanly later.
+
+This story extracts the per-transport difference (which entity, which service)
+into a small strategy object (`BistateTransport`), refactors
+`QSOnOffDuration` and `QSClimateDuration` to delegate to it, then adds a new
+`QSRadiator(QSBiStateDuration)` that picks a transport at `__init__` based on
+the configured backing. A new dedicated `qs-radiator-card.js` (copy of the
+on/off card for now; redesign deferred to a follow-up story) ships alongside
+so the radiator surfaces with its own card from day one.
+
+## Inputs
+
+- `custom_components/quiet_solar/ha_model/bistate_duration.py` — shared bistate base (`QSBiStateDuration`)
+- `custom_components/quiet_solar/ha_model/on_off_duration.py` — switch-backed bistate (lines 1-54)
+- `custom_components/quiet_solar/ha_model/climate_controller.py` — climate-backed bistate + `get_hvac_modes()` helper (lines 1-99)
+- `custom_components/quiet_solar/ha_model/heat_pump.py` — piloted device counterpart
+- `custom_components/quiet_solar/home_model/load.py:114` — `AbstractLoad.__init__` reads `CONF_DEVICE_TO_PILOT_NAME` (piloting is data-driven for ANY `AbstractLoad`)
+- `custom_components/quiet_solar/ha_model/home.py:1876-1903` — `add_device` / `_set_topology` (piloting wiring; no edit needed)
+- `custom_components/quiet_solar/const.py` — type names, dashboard sections, sensor keys
+- `custom_components/quiet_solar/config_flow.py:1481-1608` — reference `async_step_on_off_duration` and `async_step_climate`; the two-pass `force_climate` pattern
+- `custom_components/quiet_solar/entity.py:28-60` — `LOAD_TYPE_LIST` / `LOAD_NAMES` / `create_device_from_type`
+- `custom_components/quiet_solar/select.py:120-159, 213-233` — `create_ha_select_for_QSBiStateDuration` and `create_ha_select_for_QSClimateDuration`
+- `custom_components/quiet_solar/strings.json` — translation keys (run `bash scripts/generate-translations.sh` after edits; **never** hand-edit `translations/en.json`)
+- `custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2:30-40` — card dispatch by `device.device_type`
+- `custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js` — source for the new radiator card
+- `custom_components/quiet_solar/ui/dashboard.py:342` — `listdir`-based resource auto-registration
+- `tests/test_ha_climate_controller.py` and `tests/test_ha_climate_controller_real.py` — reference test patterns
+- `tests/ha_tests/const.py` — `MOCK_*_CONFIG` factories
+
+## Out of scope
+
+- Temperature-dependent duration (à la `QSPool`)
+- Multi-zone heating, cool-mode radiators, dual heat/cool semantics
+- Migrating existing `climate`-configured devices into the `radiator` type (manual reconfiguration only)
+- **Redesigning** the `qs-radiator-card.js` UI — this story ships a verbatim clone of `qs-on-off-duration-card.js` with the custom-element renamed; UX redesign is a follow-up story
+- Backporting `radiator_mode` translations beyond English
+
+## Design decisions (locked with user)
+
+- **D1 — Strategy-object transport (Option β).** Refactor `QSOnOffDuration` and `QSClimateDuration` to delegate `execute_command_system` (plus climate's mode accessors) to a `BistateTransport` strategy. `QSRadiator` reuses the same transports.
+- **D2 — Single config-flow menu entry `radiator`.** One step exposes both a switch selector AND a climate selector; both are individually optional with cross-field exactly-one validation.
+- **D3 — Heating-only HVAC defaults.** Climate-backed radiator defaults `CONF_CLIMATE_HVAC_MODE_ON = "heat"`, `CONF_CLIMATE_HVAC_MODE_OFF = "off"`. Settable at config-flow time only — **no runtime override**. Rationale: for a radiator the ON mode is heat or nothing; users who want seasonal mode flipping should use the `climate` load type instead.
+- **D4 — No runtime `climate_state_on` / `climate_state_off` select.** Removed for radiator (config-only). Symmetric with D3.
+- **D5 — Heat-pump piloting on both backings.** The `radiator` config-flow step exposes `CONF_DEVICE_TO_PILOT_NAME`. Piloting is data-driven via `AbstractLoad.__init__` → no class-specific code needed in `home.add_device`.
+- **D6 — New translation key `radiator_mode`** (separate from `climate_mode` / `on_off_mode`).
+- **D7 — New dashboard section `radiators`** with icon `mdi:radiator`.
+- **D8 — Dedicated `qs-radiator-card.js`** — verbatim clone of `qs-on-off-duration-card.js` (custom-element renamed). The card auto-registers via `listdir`. UI redesign deferred.
+- **D9 — New sensor key `SENSOR_CONSTRAINT_SENSOR_RADIATOR`** (not reusing `*_CLIMATE` or `*_ON_OFF`). Consistent with the dedicated card / section / translation key.
+- **D10 — Climate without "heat" mode.** Config-flow shows the available HVAC modes dropdown; suggests `heat` when present, otherwise the first non-`off` mode. `data_description` warns "we suggest `heat` for heating-only radiators."
+- **D11 — Owner-collision on entity reuse.** Existing `_filter_quiet_solar_entities` (config_flow.py:175-186) already blocks selecting an entity owned by any QS load. No extra work needed.
+- **D12 — Doc maintenance.** Update all 5 docs flagged by the drift checker plus the glossary entry: `bistate-duration-devices.md`, `config-and-setup-flow.md`, `piloted-device-and-heat-pump.md`, `dashboard-and-cards.md`, and `glossary.md`.
+
+## Acceptance criteria
+
+### AC-1 — `BistateTransport` extracted with explicit contract
+
+**Given** the new file `custom_components/quiet_solar/ha_model/bistate_transport.py`
+**When** inspected
+**Then** it defines:
+
+- Abstract `BistateTransport` (public; no underscore) with:
+  - attribute `entity: str` — the underlying HA `entity_id`
+  - method `default_state_on() -> str`
+  - method `default_state_off() -> str`
+  - method `mode_options(hass) -> list[str]`
+  - method `power_from_state(state: str | None, power_use: float) -> float | None` — returns `None` for `STATE_UNKNOWN` / `STATE_UNAVAILABLE` / `None`; `power_use` when state matches "on"; `0.0` for "off"
+  - async method `execute(hass, command: LoadCommand, override_state: str | None, state_on: str, state_off: str) -> bool | None` — returns `False` after a successful service call (mirroring the current `execute_command_system` return value), `None` only when neither command nor state is actionable. Raises `ValueError` on invalid command (same contract as today).
+- Concrete `SwitchTransport(BistateTransport)`:
+  - constructor: `__init__(switch_entity: str)`
+  - `default_state_on() == "on"`, `default_state_off() == "off"`
+  - `mode_options(hass) == ["on", "off"]` (`hass` arg unused but kept for symmetry)
+  - `execute(...)` calls `hass.services.async_call(Platform.SWITCH, SERVICE_TURN_ON|SERVICE_TURN_OFF, target={"entity_id": entity})` mirroring `on_off_duration.py:50-53`
+- Concrete `ClimateTransport(BistateTransport)`:
+  - constructor: `__init__(climate_entity: str, state_on: str, state_off: str)` storing mutable `state_on` / `state_off`
+  - `default_state_on() == self.state_on`, `default_state_off() == self.state_off`
+  - `mode_options(hass) == get_hvac_modes(hass, self.entity)` (helper moved from `climate_controller.py` into `bistate_transport.py`; original re-exported for backwards-compat)
+  - `execute(...)` calls `hass.services.async_call(climate.DOMAIN, climate.SERVICE_SET_HVAC_MODE, {ATTR_ENTITY_ID: entity, climate.ATTR_HVAC_MODE: hvac_mode})` mirroring `climate_controller.py:89-96`
+
+**Layer rule:** the file lives in `ha_model/` and imports `homeassistant.*` freely. The host (`QSBiStateDuration`) keeps owning `_state_on`, `_state_off`, `_bistate_mode_on`, `_bistate_mode_off`, `expected_state_from_command(...)`. The transport receives primitives, not the host.
+
+### AC-2 — `QSOnOffDuration` refactored to delegate to `SwitchTransport`
+
+**Given** an instance of `QSOnOffDuration` constructed with a `switch_entity`
+**When** `execute_command_system(time, command, state)` is called
+**Then**:
+
+- The instance holds `self._transport: SwitchTransport` instantiated in `__init__` with `self.switch_entity`
+- Method body becomes `return await self._transport.execute(self.hass, command, state, self._state_on, self._state_off)`
+- `_state_on = "on"` / `_state_off = "off"` / `_bistate_mode_on = "on_off_mode_on"` / `_bistate_mode_off = "on_off_mode_off"` / `bistate_entity = switch_entity` — all stay on the host (no change)
+- Existing tests pass unchanged: `tests/test_ha_*on_off*.py` (if any), `tests/ha_tests/test_select.py`, `tests/test_dashboard_rendering.py`, `tests/test_integration_config_flow.py`
+
+### AC-3 — `QSClimateDuration` refactored to delegate to `ClimateTransport`
+
+**Given** an instance of `QSClimateDuration` with `CONF_CLIMATE="climate.foo"`, `CONF_CLIMATE_HVAC_MODE_ON="heat"`, `CONF_CLIMATE_HVAC_MODE_OFF="off"`
+**When** any of `execute_command_system(...)`, `get_possibles_modes()`, `climate_state_on` getter/setter, `climate_state_off` getter/setter is called
+**Then**:
+
+- The instance holds `self._transport: ClimateTransport` constructed in `__init__` with `(climate_entity, state_on, state_off)`
+- `climate_state_on` and `climate_state_off` property setters both write through to `self._transport.state_on` / `state_off` AND to `self._bistate_mode_on` / `self._bistate_mode_off` (the host-owned bistate-mode signals, preserving `bistate_duration.py:482-488, 562` consumers)
+- `get_possibles_modes()` returns `self._transport.mode_options(self.hass)`
+- `execute_command_system(time, command, state)` returns `await self._transport.execute(self.hass, command, state, self._transport.state_on, self._transport.state_off)`
+- Existing tests pass unchanged: `tests/test_ha_climate_controller.py`, `tests/test_ha_climate_controller_real.py`
+
+### AC-4 — `QSRadiator` class
+
+**Given** the new file `custom_components/quiet_solar/ha_model/radiator.py`
+**When** inspected
+**Then**:
+
+- Defines `class QSRadiator(QSBiStateDuration)` with `conf_type_name = CONF_TYPE_NAME_QSRadiator` (= `"radiator"`)
+- `__init__(**kwargs)` reads `CONF_CLIMATE`, `CONF_SWITCH`, `CONF_CLIMATE_HVAC_MODE_ON` (default `"heat"`), `CONF_CLIMATE_HVAC_MODE_OFF` (default `"off"`) from kwargs
+- **Validation** — if both `CONF_CLIMATE` and `CONF_SWITCH` are set, or neither, raises `ServiceValidationError("Radiator requires exactly one of climate or switch backing")` (user-facing path); same path is mirrored in config_flow with `errors={"base": "exactly_one_backing_required"}`
+- Picks `self._transport`:
+  - `ClimateTransport(climate_entity, hvac_on, hvac_off)` when `CONF_CLIMATE` is set
+  - `SwitchTransport(switch_entity)` when `CONF_SWITCH` is set
+- Initialises host-owned `_state_on`, `_state_off`, `_bistate_mode_on`, `_bistate_mode_off` from `self._transport.default_state_on()` / `default_state_off()` (and matches the bistate-mode naming the existing select translations use)
+- Sets `self.bistate_entity = self._transport.entity`
+- `get_select_translation_key()` returns `"radiator_mode"`
+- `get_virtual_current_constraint_translation_key()` returns `SENSOR_CONSTRAINT_SENSOR_RADIATOR`
+- `execute_command_system(time, command, state)` delegates to `self._transport.execute(...)` (same pattern as the refactored `QSClimateDuration`)
+- Does NOT expose `climate_state_on` / `climate_state_off` properties (no runtime select, see AC-12)
+
+### AC-5 — Registration
+
+**Given** the existing `entity.py` `LOAD_TYPE_LIST`
+**When** the module is imported
+**Then**:
+
+- `from .ha_model.radiator import QSRadiator` is added
+- `QSRadiator` appended to `LOAD_TYPE_LIST` after `QSHeatPump`
+- `LOAD_NAMES[QSRadiator.conf_type_name] = "radiator"` is added
+- `create_device_from_type(hass, home, "radiator", entry)` returns a `QSRadiator` instance via the standard `LOAD_TYPE__DICT` dispatch
+
+### AC-6 — Config-flow `async_step_radiator`
+
+**Given** the user picks `radiator` in the config menu
+**When** `async_step_radiator` runs
+**Then**:
+
+- `LOAD_TYPES_MENU[QSRadiator.conf_type_name] = None` is added (after `QSClimateDuration`) in `config_flow.py:156-172`
+- The new `from .ha_model.radiator import QSRadiator` import is added
+- Common schema invocation: `get_common_schema(type=TYPE, add_power_value_selector=1000, add_load_power_sensor=True, add_calendar=True, add_boost_only=True, add_power_group_selector=True, add_max_on_off=True)` — mirrors `async_step_climate`
+- Both `CONF_CLIMATE` (climate domain, **optional**) and `CONF_SWITCH` (switch domain, **optional**) selectors are added via `add_entity_selector(..., False, domain=[...])`
+- When `CONF_CLIMATE` is set in the entry data, the **two-pass `force_radiator_climate`** logic mirrors `async_step_climate`'s `force_climate` pattern (config_flow.py:1511-1525) — re-prompt with HVAC mode dropdowns; suggested-default is `"heat"` if present, else the first non-`"off"` HVAC mode (D10); `data_description` includes the suggestion text
+- `CONF_DEVICE_TO_PILOT_NAME` dropdown is shown unconditionally when heat pumps exist (D5)
+- On submit:
+  - If neither `CONF_CLIMATE` nor `CONF_SWITCH` is set → re-render with `errors={"base": "exactly_one_backing_required"}`
+  - If both are set → same error
+  - Otherwise → `await self.async_entry_next(user_input, TYPE)`
+
+### AC-7 — Translations
+
+**Given** the project's `strings.json`
+**When** the new strings are added and `bash scripts/generate-translations.sh` is run
+**Then**:
+
+- `config.step.user.menu_options.radiator` exists: ≈ "Add a heating-only radiator (switch-backed or climate-backed)"
+- `config.step.radiator` block with `title`, `description`, full `data` (`name`, `dynamic_group_name`, `load_is_boost_only`, `switch`, `climate`, `climate_hvac_on`, `climate_hvac_off`, `device_to_pilot_name`, `power`, `accurate_power_sensor`, `num_max_on_off`, `calendar`), `data_description` for `power` and a note for `climate_hvac_on` suggesting `heat`
+- `config.error.exactly_one_backing_required` ≈ "Pick exactly one of switch entity or climate entity for the radiator"
+- Mirror `options.step.radiator` with `[%key:component::quiet_solar::config::step::radiator::data::*%]` aliases (same pattern as `options.step.climate` in `strings.json:662-680`)
+- `entity.select.radiator_mode` with state values: `bistate_mode_auto`, `bistate_mode_exact_calendar`, `bistate_mode_default`, `bistate_mode_off`, `bistate_mode_on` (matching the bistate base modes; force-ON/OFF override consistent with `on_off_mode` pattern at `strings.json:924-933`)
+- `selector.dashboard_device_section.options` gains a `radiators` entry consistent with the new section index
+- `translations/en.json` regenerated by the script (no hand-edits)
+
+### AC-8 — Dashboard section + template + card
+
+**Given** the project's `const.py` and dashboard template
+**When** changes are applied
+**Then**:
+
+- `DASHBOARD_DEFAULT_SECTIONS` gains `("radiators", "mdi:radiator")` — positioned after `("climates", "mdi:home-thermometer")`. Five default sections become six; `DASHBOARD_NUM_SECTION_MAX = 8` cap respected.
+- `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION[CONF_TYPE_NAME_QSRadiator] = "radiators"`
+- `custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2:30-40` — add `{%- elif device.device_type == "radiator" %} - type: custom:qs-radiator-card` between the existing `climate` and `on_off_duration` branches
+- `custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2` — same addition if it contains the per-card-type dispatch (verify during implementation; add if present)
+- The empty-section gate at `quiet_solar_dashboard_template.yaml.j2:4` (`{%- if section_devices|length > 0 %}`) already prevents an empty `radiators` section from rendering — no extra gating needed
+
+### AC-9 — New constants in `const.py`
+
+**Given** `const.py`
+**When** read
+**Then** it adds (in the locations indicated):
+
+- `CONF_TYPE_NAME_QSRadiator = "radiator"` after `CONF_TYPE_NAME_QSHeatPump` (line 31)
+- `SENSOR_CONSTRAINT_SENSOR_RADIATOR = "qs_constraint_sensor_radiator"` near `SENSOR_CONSTRAINT_SENSOR_CLIMATE` (line 215)
+- `("radiators", "mdi:radiator")` appended after `("climates", ...)` in `DASHBOARD_DEFAULT_SECTIONS` (line 43-49)
+- `CONF_TYPE_NAME_QSRadiator: "radiators"` added to `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION` (line 54-69)
+
+No constants other than the four above are introduced. All existing `CONF_CLIMATE`, `CONF_SWITCH`, `CONF_CLIMATE_HVAC_MODE_ON/OFF`, `CONF_DEVICE_TO_PILOT_NAME` are reused.
+
+### AC-10 — Heat-pump piloting works for both backings
+
+**Given** a `QSHeatPump` named `"main_hp"` is configured first
+**When** a `QSRadiator` is created with `CONF_SWITCH="switch.r1"` and `CONF_DEVICE_TO_PILOT_NAME="main_hp"`
+**Then**:
+
+- `self.piloted_device_name == "main_hp"` (inherited from `AbstractLoad.__init__` at `home_model/load.py:114`)
+- After `home._set_topology()` runs (triggered by `add_device`), `self.devices_to_pilot` contains the heat-pump instance, and `heat_pump.clients` contains the radiator instance
+- A subsequent toggle of the radiator results in the expected pilot service-call sequence (end-to-end test)
+- Same wiring works when `CONF_CLIMATE="climate.r1"` is set instead of `CONF_SWITCH`
+- **No edit to `home.add_device`** is required — verified via the inheritance chain `QSRadiator → QSBiStateDuration → AbstractLoad → AbstractDevice` and the data-driven dispatch at `home.py:1876-1882`
+
+### AC-11 — Radiator-card resource
+
+**Given** the new file `custom_components/quiet_solar/ui/resources/qs-radiator-card.js`
+**When** the integration starts
+**Then**:
+
+- The file is a verbatim copy of `qs-on-off-duration-card.js` with the following minimal edits:
+  - Custom-element name changed from `qs-on-off-duration-card` to `qs-radiator-card` (the `customElements.define(...)` call and the class identifier consistently renamed)
+  - Card type / `getCardType` (if present) returns `qs-radiator-card`
+  - Display name / `getCardEditorName` (if present) updated to "QS Radiator Card"
+- The card auto-registers via the existing `listdir`-based loop in `ui/dashboard.py:342-...`
+- **No UX redesign** lands in this story (D8). The next story will redesign the radiator card.
+
+### AC-12 — Select / sensor exposure (only the bistate-mode select)
+
+**Given** a `QSRadiator` device
+**When** the select platform is set up
+**Then**:
+
+- Exactly **one** select entity is exposed: the bistate-mode select (from `create_ha_select_for_QSBiStateDuration` at `select.py:120-133`), with translation key `radiator_mode`
+- NO `climate_state_on` or `climate_state_off` select entities are created (radiator is not a `QSClimateDuration` instance — `select.py:224 isinstance(device, QSClimateDuration)` skips it cleanly)
+- Regression test in `tests/ha_tests/test_select.py` asserts the count
+
+### AC-13 — OPTIONS-flow backing swap survives reload
+
+**Given** a `QSRadiator` configured with `CONF_SWITCH="switch.r1"` (no `CONF_CLIMATE`)
+**When** the user opens the options flow and changes the config to `CONF_CLIMATE="climate.r1"` (and clears the switch)
+**Then**:
+
+- The config entry is updated and reloaded via `async_reload_entry` (`__init__.py:232`)
+- The rebuilt `QSRadiator` instance picks `ClimateTransport` on `__init__`
+- `device_id` is unchanged, so the persisted constraint history in HA state attributes survives the type-switch
+- Symmetric path (climate → switch) works the same way
+- Misconfigured swap (clearing both, or setting both) is rejected by the AC-6 exactly-one validation
+
+### AC-14 — Dedicated card is selected by the dashboard template
+
+**Given** a `QSRadiator` device added to the home
+**When** the dashboard is regenerated
+**Then**:
+
+- The section card rendered for the radiator is `type: custom:qs-radiator-card` — NOT `qs-on-off-duration-card` even when switch-backed, NOT `qs-climate-card` even when climate-backed
+- The JS resource `qs-radiator-card.js` is registered through the existing `listdir`-based loop in `dashboard.py:342`
+- A test in `tests/test_dashboard_rendering.py` covers this dispatch
+
+### AC-15 — Documentation updated
+
+**Given** the doc-drift checker
+**When** `python scripts/qs/check_doc_drift.py` is run after edits
+**Then**:
+
+- `docs/agents/concepts/bistate-duration-devices.md` — `covers:` lists `radiator.py` and `bistate_transport.py`; the body adds a section on the transport pattern and on the radiator (heating-only, dual backing); `last_verified` is updated to today
+- `docs/agents/concepts/config-and-setup-flow.md` — describes the new `radiator` menu entry, the exactly-one-backing field, and the `radiators` dashboard section; `last_verified` updated
+- `docs/agents/concepts/piloted-device-and-heat-pump.md` — clarifies that piloting is data-driven (works for any `AbstractLoad`) and mentions radiator switch-mode; `last_verified` updated
+- `docs/agents/concepts/dashboard-and-cards.md` — `covers:` lists `qs-radiator-card.js`; body mentions the new card and its provenance (clone of `qs-on-off-duration-card.js`); `last_verified` updated
+- `docs/agents/glossary.md` — gains a `Radiator` entry (one-line definition + link to `bistate-duration-devices.md`); `last_verified` updated
+- The drift checker reports no stale entries for the touched sources
+
+### AC-16 — Test coverage
+
+**Given** the project's test suite
+**When** `python scripts/qs/quality_gate.py` is run
+**Then**:
+
+- New `tests/test_ha_bistate_transport.py` covers:
+  - `test_switch_transport_default_states`
+  - `test_switch_transport_execute_turn_on` (mock `hass.services.async_call`; verify `Platform.SWITCH`, `SERVICE_TURN_ON`)
+  - `test_switch_transport_execute_turn_off`
+  - `test_switch_transport_power_from_state` (None, on, off, STATE_UNAVAILABLE)
+  - `test_climate_transport_default_states`
+  - `test_climate_transport_mode_options_calls_get_hvac_modes`
+  - `test_climate_transport_execute_set_hvac_mode` (verify `climate.DOMAIN`, `SERVICE_SET_HVAC_MODE`, payload)
+  - `test_climate_transport_state_on_off_setters_mutate_attributes`
+  - `test_climate_transport_execute_invalid_command_raises`
+- New `tests/test_ha_radiator.py` covers (12 tests):
+  - `test_radiator_init_with_switch_picks_switch_transport`
+  - `test_radiator_init_with_climate_picks_climate_transport`
+  - `test_radiator_init_both_raises_service_validation_error`
+  - `test_radiator_init_neither_raises_service_validation_error`
+  - `test_radiator_climate_defaults_to_heat_off`
+  - `test_radiator_select_translation_key_is_radiator_mode`
+  - `test_radiator_virtual_current_constraint_translation_key_is_radiator`
+  - `test_radiator_piloted_device_attaches_for_switch_backing`
+  - `test_radiator_piloted_device_attaches_for_climate_backing`
+  - `test_radiator_execute_command_calls_transport` (switch and climate variants)
+  - `test_radiator_no_climate_state_on_off_attributes` (regression: AC-12 no extra selects)
+  - `test_radiator_options_flow_backing_swap_picks_new_transport`
+- New `tests/test_ha_radiator_real.py` covers (mirroring `test_ha_climate_controller_real.py`):
+  - Full bistate cycle (constraint creation → execute → override → reset) for switch-backed radiator
+  - Same cycle for climate-backed radiator
+  - Heat-pump pilot end-to-end (AC-10)
+- Extended `tests/test_ha_config_flow_real.py` — 2 happy paths (switch and climate), 1 sad path each (both / neither), 1 options-flow swap (AC-13)
+- Extended `tests/test_integration_config_flow.py` — radiator menu entry surfaces; standard config-flow happy path
+- Extended `tests/test_dashboard_rendering.py` — radiators section renders, radiator devices use `qs-radiator-card` (AC-14)
+- Extended `tests/ha_tests/const.py` — adds `MOCK_RADIATOR_SWITCH_CONFIG` and `MOCK_RADIATOR_CLIMATE_CONFIG`
+- Extended `tests/ha_tests/test_select.py` — `test_radiator_exposes_only_bistate_mode_select` (AC-12 regression)
+- `tests/factories.py` extended: add a `create_test_radiator_double()` factory for unit-test contexts that doesn't need a full HA bridge
+- `python scripts/qs/quality_gate.py` reports: 100% coverage, ruff clean, mypy clean, translations consistent (after `generate-translations.sh`); drift checker reports no stale entries for any touched source
+
+**Project rules invoked:**
+- Use factories from `tests/factories.py`, not `MagicMock`, for domain objects
+- Use existing `MOCK_*_CONFIG` constants when applicable; extend `tests/ha_tests/const.py` rather than invent ad-hoc configs
+- `ServiceValidationError` (not bare `ValueError`) for user-input failures
+- Lazy `%s` logging, no f-strings in log calls
+- All keys in `const.py`; no hardcoded strings
+- TDD cadence: write a failing test → `python scripts/qs/quality_gate.py --quick tests/test_<file>.py` → red → implement → green → full gate
+
+## Task breakdown
+
+### Group 1 — Constants & types
+
+1. **`const.py`** — add `CONF_TYPE_NAME_QSRadiator`, `SENSOR_CONSTRAINT_SENSOR_RADIATOR`; append `("radiators", "mdi:radiator")` to `DASHBOARD_DEFAULT_SECTIONS`; add `CONF_TYPE_NAME_QSRadiator: "radiators"` to `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION`.
+   - **TDD red:** `tests/test_const.py::test_radiator_constants_present` (or a new tiny test file if `test_const.py` doesn't exist) → run `--quick`, see red.
+   - **Green:** edit `const.py`.
+
+### Group 2 — Transport extraction (refactor)
+
+2. **TDD red — write `tests/test_ha_bistate_transport.py`** with all 9 tests listed in AC-16; run `--quick tests/test_ha_bistate_transport.py`; verify it fails (the file under test doesn't exist).
+3. **Green — create `custom_components/quiet_solar/ha_model/bistate_transport.py`** with `BistateTransport`, `SwitchTransport`, `ClimateTransport` per AC-1; move `get_hvac_modes` helper here (re-export from `climate_controller.py` for backwards-compat); run `--quick` until green.
+4. **Refactor `QSOnOffDuration`** (`on_off_duration.py`) to delegate per AC-2; run `--quick tests/` on existing on/off tests; all green.
+5. **Refactor `QSClimateDuration`** (`climate_controller.py`) to delegate per AC-3; preserve `climate_state_on/off` property setters writing through to both transport AND `_bistate_mode_on/off`; run `--quick tests/test_ha_climate_controller.py tests/test_ha_climate_controller_real.py`; all green.
+
+### Group 3 — `QSRadiator` class
+
+6. **TDD red — write `tests/test_ha_radiator.py`** with all 12 tests in AC-16; expect failure.
+7. **Green — create `custom_components/quiet_solar/ha_model/radiator.py`** per AC-4; raises `ServiceValidationError` on misconfig; assigns `self._transport` based on backing.
+8. **Register in `entity.py`** per AC-5 — import `QSRadiator`, append to `LOAD_TYPE_LIST`, add to `LOAD_NAMES`.
+
+### Group 4 — Config flow
+
+9. **Add `QSRadiator.conf_type_name: None`** to `LOAD_TYPES_MENU` in `config_flow.py:156-172` (after the climate entry).
+10. **TDD red — extend `tests/test_ha_config_flow_real.py`** with the 4 radiator flow tests (2 happy, 1 both/neither sad, 1 OPTIONS swap).
+11. **Green — implement `async_step_radiator`** per AC-6; reuse the `force_climate` two-pass pattern when CONF_CLIMATE is freshly chosen; HVAC-mode dropdowns suggest `"heat"` first if available else first non-`"off"`; surface `errors={"base": "exactly_one_backing_required"}` on misconfig.
+
+### Group 5 — Translations
+
+12. **Edit `strings.json`** — add `config.step.user.menu_options.radiator`, `config.step.radiator`, `config.error.exactly_one_backing_required`, `options.step.radiator` (aliases), `entity.select.radiator_mode`, `selector.dashboard_device_section.options.radiators`.
+13. **Run `bash scripts/generate-translations.sh`** to regenerate `translations/en.json`. **Never** hand-edit it.
+
+### Group 6 — Dashboard section, template, card
+
+14. **Edit `ui/quiet_solar_dashboard_template.yaml.j2`** — add the `radiator` branch dispatching to `custom:qs-radiator-card` (AC-8). Apply the same edit to `quiet_solar_dashboard_template_standard_ha.yaml.j2` if its dispatch logic mirrors the custom one.
+15. **TDD red — extend `tests/test_dashboard_rendering.py`** for AC-14 (radiator → qs-radiator-card; radiators-section renders).
+16. **Green — create `ui/resources/qs-radiator-card.js`** as a verbatim clone of `qs-on-off-duration-card.js` with the custom-element renamed throughout (AC-11). No UX changes.
+
+### Group 7 — Select / sensor regression
+
+17. **TDD red — extend `tests/ha_tests/test_select.py`** with `test_radiator_exposes_only_bistate_mode_select` (AC-12).
+18. **Verify green** — should already pass given the radiator inherits from `QSBiStateDuration` (not `QSClimateDuration`), so `select.py:224` skips the extra selects.
+
+### Group 8 — Test infrastructure
+
+19. **Extend `tests/factories.py`** — add `create_test_radiator_double(backing="switch"|"climate", ...)`.
+20. **Extend `tests/ha_tests/const.py`** — add `MOCK_RADIATOR_SWITCH_CONFIG` and `MOCK_RADIATOR_CLIMATE_CONFIG`.
+21. **Create `tests/test_ha_radiator_real.py`** mirroring `test_ha_climate_controller_real.py` — full bistate cycle for both backings + heat-pump pilot end-to-end (AC-10, AC-16).
+22. **Extend `tests/test_integration_config_flow.py`** — radiator menu entry test.
+
+### Group 9 — Documentation
+
+23. **Update `docs/agents/concepts/bistate-duration-devices.md`** — `covers:` += `radiator.py`, `bistate_transport.py`; body describes transport pattern + radiator; `last_verified` = today.
+24. **Update `docs/agents/concepts/config-and-setup-flow.md`** — describe the radiator step + dashboard section; `last_verified` updated.
+25. **Update `docs/agents/concepts/piloted-device-and-heat-pump.md`** — note that piloting is data-driven and applies to radiator-switch backing now; `last_verified` updated.
+26. **Update `docs/agents/concepts/dashboard-and-cards.md`** — `covers:` += `qs-radiator-card.js`; mention the new card; `last_verified` updated.
+27. **Update `docs/agents/glossary.md`** — add `Radiator` term linking to `bistate-duration-devices.md`.
+
+### Group 10 — Quality gate
+
+28. **Run `python scripts/qs/quality_gate.py`** — 100% coverage, ruff, mypy, translations consistent.
+29. **Run `python scripts/qs/check_doc_drift.py`** — no stale entries for `bistate_duration.py`, `on_off_duration.py`, `climate_controller.py`, `radiator.py`, `bistate_transport.py`, `config_flow.py`, `const.py`, `qs-radiator-card.js`.
+30. **`git add` only the touched files** (no `-A`), commit, open the PR via the `qs-implement-task` agent's standard hand-off.
+
+## Adversarial Review Notes
+
+Four plan-reviewer sub-agents ran in parallel against the draft. Findings consolidated and triaged with the user:
+
+### Critical (all addressed in this final draft)
+
+- **F1 — Transport interface contract undefined.** All four reviewers flagged that `BistateTransport.execute(...)` had no specified return semantics, that the boundary between host-owned bistate-mode state and transport was unclear, and that `expected_state_from_command` access wasn't pinned. **Resolved in AC-1 / AC-2 / AC-3:** host (`QSBiStateDuration`) owns `_state_on / _state_off / _bistate_mode_on / _bistate_mode_off`; transport holds only `entity` + service-call logic; `execute(...)` receives primitives, returns `False` on a successful service call (matching the current `execute_command_system` contract), and raises `ValueError` on invalid command.
+- **F2 — Layer boundary verification.** Concrete-planner asked whether the transport refactor could leak `homeassistant.*` imports into `home_model/`. **Resolved:** verified `QSOnOffDuration`, `QSClimateDuration`, `QSBiStateDuration` all live in `ha_model/`; new `bistate_transport.py` belongs there too and imports HA freely.
+- **F3 — XOR validation mechanism.** Concrete-planner flagged no precedent for cross-field exactly-one validation. **Resolved in AC-6:** explicit if/else inside `async_step_radiator`; `async_show_form(errors={"base": "exactly_one_backing_required"})`; matching `ServiceValidationError` raised in `QSRadiator.__init__` for non-UI paths.
+- **F4 — OPTIONS-flow backing swap.** Critic flagged silent breakage when reconfiguring switch↔climate. **Resolved in AC-13:** the standard `async_reload_entry` mechanism rebuilds the device with the new transport on swap; persisted constraint history survives because `device_id` is stable; explicit test in `test_ha_config_flow_real.py`.
+- **F5 — Dashboard template literal dispatch.** Concrete-planner flagged that `quiet_solar_dashboard_template.yaml.j2:30-40` matches `device.device_type` literally, so `radiator` needs an explicit branch. **Resolved in AC-8 / AC-14:** template branch added; dedicated `qs-radiator-card.js` shipped (D8, after user clarified they want a dedicated card from day one).
+
+### Redesigns considered and rejected
+
+- **R1 — Runtime HVAC mode override.** Critic argued users want seasonal flipping → would require restart under config-only. User pushed back (D3): for a heating-only radiator, there is no seasonality on the ON mode — it is `heat` or nothing. Users wanting seasonal flips should use the existing `climate` load type. **Decision stands.**
+- **R2 — Skip the QSRadiator class entirely, parameterize QSBiStateDuration with a "profile".** Rejected — user explicitly wants a class to host future radiator-specific logic. **Decision stands.**
+- **G1 (scope-guardian) — transport refactor is gold-plating.** Rejected — user approved Option β over the lighter γ specifically to land the abstraction now while it's cheap. **Decision stands.**
+
+### Improvements adopted
+
+- **F6 — Public transport class names** (no underscore prefix): `BistateTransport`, `SwitchTransport`, `ClimateTransport`.
+- **F7 — Two-pass `force_climate` pattern reused** when CONF_CLIMATE is picked freshly in `async_step_radiator`.
+- **F8 — Explicit test names listed** in AC-16 (12 in `test_ha_radiator.py` + 9 in `test_ha_bistate_transport.py`).
+- **F9 — Full `const.py` diff enumerated** in AC-9.
+- **F10 — Piloting end-to-end test** in AC-10 (not just an attribute check).
+- **F11 — Explicit `--quick` TDD cadence** spelled out in Group 2, 3, 4, 6, 7.
+- **F12 — `ServiceValidationError`** for user-input misconfig; `ValueError` only inside transport `execute` for defensive coding.
+- **F13 — Dashboard section count corrected** (5 → 6, still under cap 8).
+- **F14 — Empty-section gating already exists** at `quiet_solar_dashboard_template.yaml.j2:4`, no extra work.
+
+### Clarifications resolved with user
+
+- **D1 (post-review) — new `SENSOR_CONSTRAINT_SENSOR_RADIATOR`** (not reusing climate/on-off sensor keys). Consistent with new card, section, translation key.
+- **D2 (post-review) — climate without `heat` mode** → config-flow shows available HVAC modes; suggests `heat` when present, otherwise first non-`off`; `data_description` includes a note.
+- **D3 (post-review) — owner-collision** already handled by `_filter_quiet_solar_entities` (config_flow.py:175-186); no extra work.
+- **D4 (post-review) — doc scope:** update all 5 docs (3 flagged by drift + `dashboard-and-cards.md` for the new card + `glossary.md` for the new term).
+- **D5 (post-review) — no seasonal override in UI** — confirmed.
+- **D8 (post-review) — dedicated `qs-radiator-card.js`** verbatim-cloned from on/off card; UX redesign deferred.
+
+### Items rejected as out of scope
+
+- `qs-radiator-card.js` UX redesign — explicit follow-up story.
+- Auto-migration of existing `climate`-configured devices into `radiator`.
+- Multi-zone / cool-mode / dual-heat-cool radiators.
+- Translating `radiator` strings beyond English.

--- a/docs/stories/QS-195.story_review_fix_#01.md
+++ b/docs/stories/QS-195.story_review_fix_#01.md
@@ -1,0 +1,293 @@
+# QS-195 — Review fix plan #01
+
+## Summary
+- Source PR: #198
+- Source story: `docs/stories/QS-195.story.md`
+- Findings to fix: 40 (6 must-fix + 20 should-fix + 14 nice-to-have)
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [must-fix] M1 — SwitchTransport.execute silently flips override semantics
+- File: `custom_components/quiet_solar/ha_model/bistate_transport.py` (SwitchTransport.execute, around L150–180) and the `QSOnOffDuration.execute_command_system` path now living in the transport.
+- Severity: must-fix
+- Source: qs-review-blind-hunter
+- Description: The legacy `execute_command_system` (pre-refactor) defaulted to `TURN_ON` whenever an override `state` was set and the state did NOT match `expected_state_from_command(CMD_IDLE)`. The new `SwitchTransport.execute` inverts this: it only calls `TURN_ON` when `override_state == state_on`, otherwise calls `TURN_OFF`. Any override state that is neither exactly the on nor off literal silently flips behaviour from previous releases.
+- Proposed fix: Restore the original semantics in `SwitchTransport.execute`. When `override_state` is set, call `TURN_OFF` only if `override_state == state_off`; otherwise call `TURN_ON`. Add a unit test exercising an override state that is neither `state_on` nor `state_off` to pin the behaviour and a regression test for the legacy path.
+
+### [must-fix] M2 — Dashboard section renumbering is a breaking config change
+- File: `custom_components/quiet_solar/strings.json` (~L1081) and `custom_components/quiet_solar/translations/en.json` (~L1078); also `custom_components/quiet_solar/const.py` `DASHBOARD_DEFAULT_SECTIONS`.
+- Severity: must-fix
+- Source: qs-review-blind-hunter
+- Description: Inserting `("radiators", "mdi:radiator")` between `climates` and `pools` renumbers downstream keys. Existing users who stored a section assignment like `"#3 - pools"` or `"#5 - settings"` now point at the wrong section (`radiators` / `others`) after upgrade.
+- Proposed fix: Either (a) append `radiators` after `settings` so existing positions are preserved, or (b) add a config-entry migration that rewrites stored section assignments. Option (a) is preferable. Add a regression test in `tests/test_dashboard_rendering.py` pinning the relative ordering of existing sections.
+
+### [must-fix] M3 — Name-mangled `_heat_pumps` lookup silently fails
+- File: `custom_components/quiet_solar/config_flow.py` (around L1714 in `_async_show_radiator_form`).
+- Severity: must-fix
+- Source: qs-review-blind-hunter
+- Description: `getattr(data_handler.home, "_heat_pumps", [])` reads a leading-underscore attribute by raw string. If the actual attribute is name-mangled (`_QSHome__heat_pumps`) or simply uses a different name, `getattr` returns the default `[]` silently and the heat-pump piloting dropdown never appears.
+- Proposed fix: Locate the canonical attribute on `QSHome` (likely a public list, e.g. `home.heat_pumps` or a method like `home.get_heat_pumps()`). Replace the `getattr` call with the canonical accessor and add a config-flow test asserting that when the home has at least one heat pump, the radiator form schema includes `CONF_DEVICE_TO_PILOT_NAME`.
+
+### [must-fix] M4 — XOR vs `is not None` mismatch on empty-string `CONF_CLIMATE`
+- File: `custom_components/quiet_solar/ha_model/radiator.py:58-67`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: The XOR validation uses `bool(climate_entity) == bool(switch_entity)` (treats `""` as falsy), but the transport-picker uses `if climate_entity is not None` (treats `""` as truthy). A config with `CONF_CLIMATE=""` and a valid `CONF_SWITCH` passes the XOR check and silently constructs `ClimateTransport("", ...)`, ignoring the switch.
+- Proposed fix: Replace the `is not None` branch with truthy checks (`if climate_entity:`) consistently so the validation and transport-selection paths agree. Add a unit test in `tests/test_ha_radiator.py` that constructs a radiator with `CONF_CLIMATE=""` + valid `CONF_SWITCH` and asserts that a `SwitchTransport` is selected.
+
+### [must-fix] M5 — Same XOR vs `is not None` mismatch in the config flow
+- File: `custom_components/quiet_solar/config_flow.py:1632`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: Same root cause as M4 in `async_step_radiator`. `bool("")` is falsy in the XOR check (passes), but `if climate_entity is not None` enters the climate branch with an empty string, calling `get_hvac_modes(self.hass, "")` which crashes inside the registry lookup.
+- Proposed fix: Replace `if climate_entity is not None` with `if climate_entity` (truthy) so the config-flow branch agrees with the XOR check. Add a config-flow integration test that submits with `CONF_CLIMATE=""` + valid `CONF_SWITCH` and asserts the form completes without crashing.
+
+### [must-fix] M6 — `get_hvac_modes` crashes on missing entity / capabilities
+- File: `custom_components/quiet_solar/ha_model/bistate_transport.py:56-65`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter + qs-review-coderabbit
+- Description: `registry.async_get(entity_id)` can return `None` (stale/deleted entity), and `entry.capabilities` can be `None` (some climate integrations expose no capabilities). Both are dereferenced unguarded, raising `AttributeError` and crashing config-flow rendering.
+- Proposed fix: Guard both calls. If `entry` is `None` or `entry.capabilities` is `None`, fall back to a sane default (`["auto", "off"]` — matching the existing fallback path in this function). Add unit tests for both branches in `tests/test_ha_bistate_transport.py`.
+
+### [should-fix] S1 — Mid-flow `async_update_entry` persists half-baked selections
+- File: `custom_components/quiet_solar/config_flow.py` (the Pass 1 → Pass 2 merge block, around L1645-1660)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: When the climate selector triggers re-prompting, the code merges user-entered fields into `config_entry.data` and calls `async_update_entry` before the user has confirmed via `async_entry_next`. If the user abandons the flow mid-way, a partial radiator config persists.
+- Proposed fix: Use an in-memory `self._pending_radiator_data` dict to carry the Pass 1 payload into Pass 2 instead of writing to `config_entry.data` mid-flow. Only call `async_entry_next` (which performs the canonical save) on the final submission. Add a test that aborts the flow after Pass 1 and asserts no partial data was written.
+
+### [should-fix] S2 — `super().__init__` runs before the transport is built
+- File: `custom_components/quiet_solar/ha_model/radiator.py:55`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `super().__init__(**kwargs)` (QSBiStateDuration) executes before `QSRadiator` constructs its transport. If the base constructor reads/derives bistate config (e.g. registers handlers, materialises sensors), it operates on a transport-less state and the radiator's transport-derived overrides arrive late.
+- Proposed fix: Construct the transport first, then pass it as a kwarg into `super().__init__` (or set it as an instance attribute prior to calling super). Confirm with a unit test that the base class observes the correct `state_on`/`state_off` during init.
+
+### [should-fix] S3 — Dead `_ = CMD_IDLE` import-keeper
+- File: `custom_components/quiet_solar/ha_model/bistate_transport.py:404` (inside `ClimateTransport.execute`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `_ = CMD_IDLE` is a no-op meant to silence the import linter. The import isn't used anywhere else in the file.
+- Proposed fix: Drop both the `_ = CMD_IDLE` line and the `CMD_IDLE` import. Re-run mypy/ruff to confirm nothing else depends on it.
+
+### [should-fix] S4 — `qs-radiator-card.js` is an 850-line verbatim clone
+- File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The new card is a near-verbatim clone of `qs-on-off-duration-card.js` with the custom-element renamed. Any future bug fix to the on/off card silently diverges from the radiator card.
+- Proposed fix: Extract the shared class into a base module (e.g. `qs-bistate-duration-card-base.js`) that both cards import; each card file only registers its custom element and overrides label/icon defaults. Add a test that both `customElements.define` paths succeed and both classes share the same prototype chain (e.g. `customElements.get('qs-radiator-card').prototype.__proto__ === ...`).
+
+### [should-fix] S5 — Property/transport state_on/off pair is fragile
+- File: `custom_components/quiet_solar/ha_model/climate_controller.py:84` (and the related setters around `_state_on`/`_state_off`).
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `QSClimateDuration` now exposes `state_on`/`state_off` as properties that delegate to the transport, but the base class still holds `_state_on`/`_state_off` shadow fields. Direct writes to `self._state_on` bypass the setter and leave the transport stale.
+- Proposed fix: Either (a) remove the shadow `_state_on`/`_state_off` fields and route all reads/writes through the transport, or (b) collapse the setters into a single source of truth (`@state_on.setter` writes through to both). Add a regression test that assigns `device._state_on = "foo"` and asserts the transport observes the change (or that the assignment is impossible).
+
+### [should-fix] S6 — Persisted HVAC mode not re-validated against live entity
+- File: `custom_components/quiet_solar/config_flow.py:1632-1651`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: When the user re-opens an existing radiator's options flow and the climate entity is unchanged AND both HVAC mode keys are non-None in user_input, the code skips the re-prompt. But the persisted HVAC mode may no longer be in the entity's current `hvac_modes` list (vendor firmware update dropped it). The form saves the stale value, and runtime `set_hvac_mode("heat")` fails.
+- Proposed fix: On every options-flow open, compare persisted `CONF_CLIMATE_HVAC_MODE_ON/OFF` to the live `hvac_modes`. If either is missing, force the re-prompt (same path used when `climate_entity != orig_climate_entity`). Add a test where the climate entity's `hvac_modes` shrinks between configs.
+
+### [should-fix] S7 — Empty `hvac_modes=[]` renders an unsatisfiable dropdown
+- File: `custom_components/quiet_solar/config_flow.py:1689`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: When `get_hvac_modes` returns `[]` (transient or misconfigured climate), `suggested_on` falls back to `"heat"` but the `SelectSelector(options=[])` renders an empty dropdown the user cannot satisfy, blocking the entire radiator flow.
+- Proposed fix: When `hvac_modes` is empty, surface a config-flow error (`"climate_capabilities_unavailable"`) and re-render the form without the HVAC dropdowns (allow the user to pick a different climate entity or back out). Add a test forcing `get_hvac_modes` to return `[]` and asserting the error path.
+
+### [should-fix] S8 — Stale `CONF_DEVICE_TO_PILOT_NAME` has no user-facing error
+- File: `custom_components/quiet_solar/config_flow.py:1710-1727`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: If the persisted heat-pump name is no longer in `heat_pump_options` (renamed/deleted), the dropdown either drops the suggested value silently or rejects submission with no clear explanation.
+- Proposed fix: Detect the orphan reference at form render time; surface a config-flow error (`"piloted_heat_pump_unknown"`) and clear the suggested value. Add a translation key under both `step.radiator.error` and `options.error`. Test it.
+
+### [should-fix] S9 — Empty-string HVAC mode bypasses the default fallback
+- File: `custom_components/quiet_solar/ha_model/radiator.py:63`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `kwargs.get(CONF_CLIMATE_HVAC_MODE_ON, "heat")` only triggers the `"heat"` default when the key is missing. A persisted `""` value passes through, and `set_hvac_mode("")` fails silently in HA. Same for `CONF_CLIMATE_HVAC_MODE_OFF`.
+- Proposed fix: Use `kwargs.get(CONF_CLIMATE_HVAC_MODE_ON) or "heat"` (truthy check). Same for off → `or "off"`. Add a test constructing a radiator with `CONF_CLIMATE_HVAC_MODE_ON=""` and asserting the fallback is applied.
+
+### [should-fix] S10 — Regression test missing `hasattr` assertion for `climate_state_on/off`
+- File: `tests/test_ha_radiator.py:3869-3896`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC-4's last bullet warns against exposing `climate_state_on` / `climate_state_off` selects on the radiator. The current regression uses `isinstance` checks only.
+- Proposed fix: Add `assert not hasattr(device, "climate_state_on")` and `assert not hasattr(device, "climate_state_off")` to harden against a future subclass mistake.
+
+### [should-fix] S11 — Topology test re-implements `_set_topology` on mocks
+- File: `tests/test_ha_radiator_real.py:4173-4199` (`test_radiator_topology_pilot_wires_through_set_topology`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor + qs-review-coderabbit
+- Description: The test reproduces `home._set_topology()`'s loop locally on `MagicMock`s rather than exercising the real `QSHome._set_topology()` method. It passes even if the real production method regresses.
+- Proposed fix: Build a `QSHome` instance containing a real `QSRadiator` + `QSHeatPump`, call `home._set_topology()` directly, and assert the wiring on the resulting objects.
+
+### [should-fix] S12 — No test pins the `radiator_mode` state value set
+- File: `tests/test_ha_radiator.py` (or `tests/ha_tests/test_select.py`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC-7's enumeration of available `radiator_mode` values is not pinned by any regression assertion. Future translation/code drift would go unnoticed.
+- Proposed fix: Add a test that introspects the radiator's `radiator_mode` select options and asserts the exact set `{"bistate_mode_auto", "bistate_mode_exact_calendar", "bistate_mode_default", "off", "on", "heat"}` (or whatever the canonical set is — confirm against `radiator.py`).
+
+### [should-fix] S13 — `suggested_off="off"` not validated against `hvac_modes`
+- File: `custom_components/quiet_solar/config_flow.py:1693-1701`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: `suggested_off` defaults to `"off"` unconditionally. With `SelectSelector(custom_value=False)`, a climate entity whose `hvac_modes` does not include `"off"` will reject schema validation.
+- Proposed fix: Pick `suggested_off` from `hvac_modes` (prefer `"off"`, fall back to any mode whose name suggests off, then the last element). Add a test.
+
+### [should-fix] S14 — `Number(state || fallback)` yields `NaN`
+- File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js:100-103` and `269-276`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: `Number(state || fallback)` produces `NaN` for truthy non-numeric states like `"unknown"` or `"unavailable"`, breaking SVG ring math and visual rendering.
+- Proposed fix: Coerce explicitly: `const n = Number(state); const safe = Number.isFinite(n) ? n : fallback;`. Apply to both call sites. Add a Jest/JS unit test or a Python rendering test that simulates `unknown`/`unavailable` states.
+
+### [should-fix] S15 — Unsanitised `innerHTML` writes
+- File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js:319-321`, `383`, `760`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: Mode labels, title, and state-derived values are injected directly into `innerHTML`. A malicious entity name or translated string can inject markup/script.
+- Proposed fix: Use `textContent` for plain text, or escape via a small `escapeHtml()` helper before concatenation. Same fix needed in `qs-on-off-duration-card.js` if the shared base from S4 is extracted.
+
+### [should-fix] S16 — Clickable divs lack keyboard accessibility
+- File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js:388-389`, `457-459`, `582-684`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: Primary actions (power, green-only, override, finish-time) are `<div>` elements with click/touch handlers only; keyboard-only users cannot activate them.
+- Proposed fix: Replace the action `<div>`s with `<button>` elements (or add `role="button"`, `tabindex="0"`, and a `keydown` handler for Enter/Space). Same fix should propagate to the on/off card via the S4 shared base.
+
+### [should-fix] S17 — Interaction guards leak on async service-call exceptions
+- File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js:531-546`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: If `this._select(...)` or `this._setNumber(...)` throws, `_isProcessingModeChange` / `_isInteractingMode` / `_upInProgress` remain set and the card gets stuck — no rerender, no further drag-release.
+- Proposed fix: Wrap each await in `try { … } finally { this._isProcessingModeChange = false; … }`. Mirror the change in the on/off card via the shared base from S4.
+
+### [should-fix] S18 — Doc says "four bundled JS cards" but five exist now
+- File: `docs/agents/concepts/dashboard-and-cards.md:147`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The doc still claims four bundled JS cards. After adding `qs-radiator-card.js` there are five.
+- Proposed fix: Update the line to "five bundled JS cards" (or however the new wording reads). Sweep the rest of the file for similar stale counts.
+
+### [should-fix] S19 — `exactly_one_backing_required` missing from `options.error`
+- File: `custom_components/quiet_solar/strings.json:403-407` (and any sibling `options.error.*` block)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The XOR validation error is defined under `step.radiator.error.exactly_one_backing_required` but not mirrored under `options.error.exactly_one_backing_required`. Users editing an existing radiator via the options flow see an untranslated error code.
+- Proposed fix: Add the key under `options.error`. Regenerate `translations/en.json`. Update or add an integration test asserting the options flow surfaces the localised message.
+
+### [should-fix] S20 — `translations/en.json` missing options-flow translation
+- File: `custom_components/quiet_solar/translations/en.json:713-717` and `1034-1055`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: Same as S19 — the regenerated `translations/en.json` does not include the options-flow variant of `exactly_one_backing_required`.
+- Proposed fix: Regenerated automatically once S19 lands. Verify via `python scripts/qs/quality_gate.py` translations check.
+
+### [nice-to-have] N1 — Validate unexpected `override_state` in `SwitchTransport.execute`
+- File: `custom_components/quiet_solar/ha_model/bistate_transport.py:289`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: After fixing M1, the function still silently accepts arbitrary `override_state` values. Tighten by asserting `override_state in (state_on, state_off)`.
+- Proposed fix: Add a strict assertion (or log + skip) for unexpected override states. Mirror the strictness of the `command` branch.
+
+### [nice-to-have] N2 — Hoist no-op `execute_command_system` into `QSBiStateDuration`
+- File: `custom_components/quiet_solar/ha_model/radiator.py:75`, plus `on_off_duration.py` and `climate_controller.py`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: All three subclasses now delegate `execute_command_system` to `self._transport.execute(...)`. The delegation can live once on the base.
+- Proposed fix: Move the delegation into `QSBiStateDuration.execute_command_system`. Remove the three duplicates. Verify all three classes still pass their respective tests.
+
+### [nice-to-have] N3 — Radiator dashboard block is near-verbatim copy
+- File: `custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2:178+` and the standard-HA twin
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The radiator dashboard block reproduces the on/off block with only the entity-type filter changed. A shared Jinja macro would centralise future changes.
+- Proposed fix: Extract a `bistate_section` macro that takes the section name, icon, entity filter, and card type as arguments. Call it twice (on/off and radiator). Add a rendering test asserting the macro produces equivalent output for both sections.
+
+### [nice-to-have] N4 — Lazy `bistate_transport` import inside `TestRadiatorDouble.__init__`
+- File: `tests/factories.py:914`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The lazy import works but pays the import cost per instantiation. Pure cosmetic.
+- Proposed fix: Move the import to the top of `tests/factories.py`.
+
+### [nice-to-have] N5 — `command=None` raises before the `else: raise ValueError` branch
+- File: `custom_components/quiet_solar/ha_model/bistate_transport.py:151-184` and `226`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: If a caller passes `command=None` with `override_state=None`, `command.is_like(CMD_ON)` raises `AttributeError` before the explicit `else: raise ValueError("Invalid command")` branch can fire — hiding the real misuse.
+- Proposed fix: Add `if command is None: raise ValueError("Invalid command: None")` at the top of `SwitchTransport.execute` and `ClimateTransport.execute`.
+
+### [nice-to-have] N6 — Whitespace-only `entity_id` passes XOR
+- File: `custom_components/quiet_solar/ha_model/radiator.py:58`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `bool("   ")` is `True`, so a whitespace-only `entity_id` (possible from a YAML import) passes the XOR check.
+- Proposed fix: Normalise entity_id strings via `(s or "").strip()` before the truthy check. Apply to both `CONF_CLIMATE` and `CONF_SWITCH`.
+
+### [nice-to-have] N7 — Cold-start `running` derivation ignores live climate state
+- File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js:115`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `running = commandState.toLowerCase() === 'on'` is derived only from the QS command sensor. A radiator that's actively heating but whose QS command hasn't been published yet shows as "off" during the cold-start grace window.
+- Proposed fix: OR-in the live backing state when available (`running = commandState === 'on' || climateOrSwitchState === 'on' || climateOrSwitchState === hvac_on`). Apply alongside the S14/S15/S16 polish pass.
+
+### [nice-to-have] N8 — `clean_data` not called on the Pass 1→Pass 2 merge dict
+- File: `custom_components/quiet_solar/config_flow.py:1645-1648`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The merged dict can carry `CONF_SWITCH: None` keys (a cleared selector). Downstream `dict.get(...)` calls handle it, but `key in dict` returns `True` for a `None` value — a footgun.
+- Proposed fix: Pop keys whose values are `None` or `""` from `merged` before persisting. Subsumed by S1 if S1 collapses to an in-memory pending dict.
+
+### [nice-to-have] N9 — No end-to-end test for radiator toggle → pilot service-call sequence
+- File: `tests/test_ha_radiator_real.py` (extend)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: AC-10's third bullet promises the radiator's pilot chain produces a service-call sequence. The current tests pin attribute attachment and topology shape only.
+- Proposed fix: Add a test that constructs a `QSRadiator` piloting a `QSHeatPump`, toggles the radiator, and asserts the expected HA service calls are emitted (e.g. via `hass.services.async_call` spy).
+
+### [nice-to-have] N10 — No `getCardEditorName` test for the radiator card
+- File: `tests/test_dashboard_rendering.py` (or a new JS-rendering test)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: AC-11's third bullet expects `getCardEditorName` to return `'QS Radiator Card'`. The implementation is present but no test pins it.
+- Proposed fix: Add a string-content assertion against the JS file: `assert "'QS Radiator Card'" in qs_radiator_card_js`. Or, if a JS test harness is available, exercise the static method directly.
+
+### [nice-to-have] N11 — Tighten `test_get_hvac_modes_defaults_when_capabilities_missing`
+- File: `tests/test_ha_bistate_transport.py:270-285`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: Current assertion `assert "auto" in modes or "off" in modes` passes if only one fallback mode is present.
+- Proposed fix: Replace with `assert {"auto", "off"}.issubset(set(modes))`.
+
+### [nice-to-have] N12 — Hardcoded `"radiator"` string in factories
+- File: `tests/factories.py:960-961`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: `conf_type_name` / `device_type` use the literal `"radiator"` instead of `QSRadiator.conf_type_name` / `CONF_TYPE_NAME_QSRadiator`.
+- Proposed fix: Replace with the canonical constants. Sweep for other hardcoded type strings in `factories.py`.
+
+### [nice-to-have] N13 — Test does not assert old backing key is cleared after options-flow swap
+- File: `tests/test_ha_config_flow_real.py:565-566`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: After swapping from switch-backed to climate-backed, the test asserts the new climate entity is set but not that `CONF_SWITCH` was removed.
+- Proposed fix: Add `assert CONF_SWITCH not in entry.data` (or `entry.data.get(CONF_SWITCH) is None` depending on the post-clean shape). Once S1 lands, the assertion should reflect the canonical clean-data shape.
+
+### [nice-to-have] N14 — `rendered.count(...) >= 2` for two-radiator fixture
+- File: `tests/test_dashboard_rendering.py:204-208`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: The fixture has two radiators; `"custom:qs-radiator-card" in rendered` only verifies one occurrence.
+- Proposed fix: Replace with `assert rendered.count("custom:qs-radiator-card") >= 2`. Mirror for any other card with multi-instance fixtures.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-195.story_review_fix_#02.md
+++ b/docs/stories/QS-195.story_review_fix_#02.md
@@ -1,0 +1,170 @@
+# QS-195 — Review fix plan #02
+
+## Summary
+- Source PR: #198
+- Source story: `docs/stories/QS-195.story.md`
+- Prior fix plan: `docs/stories/QS-195.story_review_fix_#01.md`
+- Findings to fix: 21 (1 must-fix + 10 should-fix + 10 nice-to-have)
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [must-fix] DM1 — Doc drift on `home.py` covering docs
+- Files:
+  - `docs/agents/concepts/notification-routing.md`
+  - `docs/agents/concepts/off-grid-mode.md`
+  - `docs/agents/concepts/qs-home-orchestrator.md`
+- Severity: must-fix
+- Source: orchestrator audit (`scripts/qs/check_doc_drift.py` exits 1)
+- Description: The M3 fix added `QSHome.get_heat_pumps()` (and related touches) to `custom_components/quiet_solar/ha_model/home.py`. Three docs in `docs/agents/concepts/` cover `home.py` but their `last_verified` is `2026-05-19` (older than today's edit). The PR body has no `## Doc maintenance` heading, so `check_doc_drift.py` reports drift.
+- Proposed fix: For each of the three docs, read the doc, verify it still accurately describes the relevant portions of the new `home.py` (especially the heat-pump accessor and any orphan-name handling implied by S8), and bump `last_verified:` to today's date (`2026-05-20`). If any doc actually needs content updates (e.g. `qs-home-orchestrator.md` may need to mention `get_heat_pumps()`), make those changes as well. Re-run `python scripts/qs/check_doc_drift.py --paths <PR files>` and confirm exit 0.
+
+### [should-fix] B1 — Pass 2 form does not pre-fill Pass 1 selections
+- File: `custom_components/quiet_solar/config_flow.py` (`_async_show_radiator_form`, around L1696)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: When the climate selector triggers re-prompting, Pass 2 renders the `CONF_CLIMATE` / `CONF_SWITCH` entity selectors WITHOUT a `suggested_value` derived from `_pending_radiator_data`. The user sees the field re-emptied and may resubmit blank — tripping the XOR error and wasting a round-trip.
+- Proposed fix: When `_pending_radiator_data` is non-empty (i.e. we're rendering Pass 2), pass `description={"suggested_value": _pending_radiator_data.get(CONF_CLIMATE)}` (and the analogous for `CONF_SWITCH`) into the entity-selector schema. Verify `add_entity_selector` supports the `description` kwarg; if not, expose a small helper to attach it. Add a test in `tests/test_integration_config_flow.py` that submits Pass 1 with a climate entity, observes the form re-render, and asserts the selector default still points at that entity.
+
+### [should-fix] B2 — Redundant `async_update_entry` in stale-key purge
+- File: `custom_components/quiet_solar/config_flow.py` (`_purge_stale_radiator_backing_keys`, around L1612)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The purge helper calls `self.hass.config_entries.async_update_entry(...)` explicitly, then the surrounding flow calls `async_entry_next` which performs the canonical save (also via `async_update_entry`). The double-write can fire reload listeners twice and is racy with the options-flow reload hook.
+- Proposed fix: Have `_purge_stale_radiator_backing_keys` mutate the in-memory `data` dict (or `self._pending_radiator_data`) only; let `async_entry_next` do the single canonical write. Adjust any callers that relied on the immediate side effect. Add a test that toggles the radiator backing and asserts the entry's reload listener fires exactly once.
+
+### [should-fix] B3 — `QSRadiator` lacks the property-shadow guarantee S5 added to `QSClimateDuration`
+- File: `custom_components/quiet_solar/ha_model/radiator.py` (around L71) and `custom_components/quiet_solar/ha_model/bistate_duration.py`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: S5 installed `state_on`/`state_off` properties on `QSClimateDuration` that route reads/writes through the transport. `QSRadiator` extends `QSBiStateDuration` (not `QSClimateDuration`), so it does NOT inherit those properties. The radiator writes `self._state_on`/`_state_off` as plain instance attributes; if the transport's `state_on`/`state_off` drifts (any future bug), the two views diverge.
+- Proposed fix: Move the property shadow up to `QSBiStateDuration` so BOTH subclasses (and `QSRadiator`) inherit a single source of truth. Remove the duplicated property definition from `QSClimateDuration`. Add a regression test asserting `device._state_on is device._transport.state_on` (object identity) for all three subclasses.
+
+### [should-fix] B4 — `errors["base"]` collision drops heat-pump warning
+- File: `custom_components/quiet_solar/config_flow.py` (`_async_show_radiator_form`, around L1668)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: When `_async_show_radiator_form` is called with an existing `errors={"base": "exactly_one_backing_required"}` AND a stale heat-pump name is also detected, the code adds the heat-pump error via `errors.setdefault("base", "piloted_heat_pump_unknown")`. `setdefault` is a no-op because `"base"` already exists, so the user only sees the XOR error and never knows the heat-pump reference is broken.
+- Proposed fix: Surface the heat-pump warning via a field-specific error key, e.g. `errors["device_to_pilot_name"] = "piloted_heat_pump_unknown"`. Add a translation alias under both `step.radiator.error` and `options.error`. Add a test that triggers both errors simultaneously and asserts both appear in the rendered form.
+
+### [should-fix] E1 — Whitespace-only `switch_entity` leaks past XOR via `kwargs`
+- File: `custom_components/quiet_solar/ha_model/radiator.py:50-63`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The constructor strips `CONF_SWITCH` / `CONF_CLIMATE` LOCAL copies for the XOR/transport decision, but does NOT update `kwargs` in place. `super().__init__(**kwargs)` then runs with the raw `"   "` value; `AbstractLoad.__init__` stores `self.switch_entity = "   "`, which `home.py` treats as a valid entity id.
+- Proposed fix: Normalize in place: `kwargs[CONF_SWITCH] = (kwargs.get(CONF_SWITCH) or "").strip() or None` and the analogous for `CONF_CLIMATE`. Then derive the local truthy variables from `kwargs` for the XOR/transport branch. Add a test constructing `QSRadiator(climate="climate.x", switch="   ")` and asserting `device.switch_entity is None`.
+
+### [should-fix] E2 — Orphan `CONF_DEVICE_TO_PILOT_NAME` persists across re-edits
+- File: `custom_components/quiet_solar/config_flow.py:1815-1838` (`_async_show_radiator_form` + the surrounding submit handler)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: When the user faces the `piloted_heat_pump_unknown` error and submits without picking a new heat pump, the orphan key isn't in the form payload, so `clean_data` (which only drops `None`/`""`) doesn't remove it from the persisted entry. The stale `CONF_DEVICE_TO_PILOT_NAME` reappears on the next edit.
+- Proposed fix: When the orphan warning fires AND the submitted payload does not include `CONF_DEVICE_TO_PILOT_NAME`, explicitly `data.pop(CONF_DEVICE_TO_PILOT_NAME, None)` (or set it to `None` so `clean_data` drops it). Document the chosen policy near the purge helper. Add a regression test that reproduces the rename-then-reedit scenario and asserts the orphan key is gone from `entry.data` afterwards.
+
+### [should-fix] A1 — S4 deferral lacks a tracking issue
+- File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js` (around L1429-1437, the deferral comment)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The shared JS base class for `qs-radiator-card.js` / `qs-on-off-duration-card.js` was deferred via an inline `// TODO` comment. Plan-bucket S4 was should-fix and the deferral is acknowledged in the commit, but no GitHub issue exists to track the follow-up.
+- Proposed fix: Either (a) extract the base now (preferred — small, mechanical refactor), or (b) open a tracking GitHub issue, link it from the inline comment (`// TODO: shared base, see #NNN`), and add an entry to the project's known-debt list if one exists.
+
+### [should-fix] A2 — JS behavior pinned only by string-content `in` checks
+- File: `tests/test_dashboard_rendering.py:208-226` (and the JS source whose substrings it relies on)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: Fixes S14 (NaN guard), S15 (escape HTML), S16 (keyboard accessibility), S17 (try/finally), and N7 (cold-start running) are tested only by `assert "<substring>" in qs_radiator_card_js`. A future refactor that renames `_safeNumber` to `safeNum` or replaces `tabindex` with another a11y mechanism would silently break the contract while keeping the substring intact (or vice-versa).
+- Proposed fix: For each of the five behaviors, replace the bare substring check with a tighter pattern that captures the intent:
+  - S14 — assert `_safeNumber(` is the only numeric coercion present at the at-risk call sites, OR add a Python regex assertion ruling out `Number(*||*)` patterns in the file.
+  - S15 — assert `_escapeHtml(` precedes every `innerHTML =` write inside the card.
+  - S16 — assert each clickable action has both `role="button"` and `tabindex="0"`, AND a `keydown` handler is bound at the same site.
+  - S17 — assert each async `_select`/`_setNumber` call is wrapped in a `try { … } finally { … }` block (regex match on the surrounding structure).
+  - N7 — assert the `running` derivation includes the live backing state (regex against the relevant function).
+  Apply the same tightening to `qs-on-off-duration-card.js` if S4 is also addressed.
+
+### [should-fix] A3 — N1 warning on unexpected `override_state` has no `caplog` assertion
+- File: `tests/test_ha_bistate_transport.py` (the test that exercises `SwitchTransport.execute` with an unexpected override)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The implementation logs a warning when `override_state` is neither `state_on` nor `state_off`, but no test asserts the warning is emitted. A future change that silently swallows the warning would not be caught.
+- Proposed fix: Add `caplog.set_level(logging.WARNING)` (or use the `caplog` pytest fixture directly) and `assert "unexpected override_state" in caplog.text` after invoking the unexpected-state path.
+
+### [should-fix] CR1 — Strengthen stale-`CONF_SWITCH` assertion
+- File: `tests/test_ha_config_flow_real.py:566-570`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: `assert entry.data.get(CONF_SWITCH) is None` passes whether the key is absent or present with value `None`. The latter is the exact stale-key shape we're trying to prevent.
+- Proposed fix: Replace with `assert CONF_SWITCH not in entry.data`. Mirror in any sibling test that checks the inverse direction (switch → climate swap).
+
+### [nice-to-have] B5 — `showDialog` does no HTML escaping
+- File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js` (around L1955, `showDialog`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: All current callers pass hardcoded strings, so this is safe today. A future caller passing entity-derived text (e.g. an entity name) would silently reintroduce the S15 injection vector.
+- Proposed fix: Defensively wrap each interpolated value through `_escapeHtml(...)` inside `showDialog`. Add a test invoking `showDialog` with a value containing `<script>` and asserting it appears escaped in the DOM (or via a string-content check).
+
+### [nice-to-have] B6 — `_transport` annotation lacks a class-level default
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py` (around L50)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `_transport: BistateTransport | None` is an annotation without an assignment, so the attribute does not exist on the class. Subclasses that forget to set `self._transport` in `__init__` raise `AttributeError` rather than the intended `RuntimeError` from the late check.
+- Proposed fix: Change to `_transport: BistateTransport | None = None` so `hasattr`/`is None` checks behave consistently.
+
+### [nice-to-have] B7 — Direct write to `self._transport.state_on` bypasses S5 setter chain
+- File: `custom_components/quiet_solar/ha_model/climate_controller.py` (around L95)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Post-super(), `climate_controller.py` does `self._transport.state_on = state_on` directly. Functionally equivalent to the property today, but inconsistent with the S5 invariant ("all writes go through the host property"). Subsumed by B3 if the property shadow moves to `QSBiStateDuration`.
+- Proposed fix: After B3 lands, route this write through `self.state_on = state_on` (the property setter on the new base). Verify the property setter does the right thing on both subclasses.
+
+### [nice-to-have] B8 — XOR readability
+- File: `custom_components/quiet_solar/ha_model/radiator.py` (around L57)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `bool(climate_entity) == bool(switch_entity)` is a correct XOR check via boolean coercion, but the explicit form (`if (climate_entity and switch_entity) or (not climate_entity and not switch_entity):`) reads more clearly.
+- Proposed fix: Refactor for readability. Pure style; no behavior change.
+
+### [nice-to-have] E3 — Raw HVAC mode strings leak into bistate-mode select
+- File: `custom_components/quiet_solar/ha_model/radiator.py:88-91` (the post-super() `_bistate_mode_on/_off` assignment)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `_bistate_mode_on` / `_bistate_mode_off` are set to the transport's raw HVAC mode (e.g. `"auto"`, `"fan_only"`, `"dry"`). The `radiator_mode` translation only defines state keys for `on`, `off`, `heat`, plus the three calendar modes. A user who picks `auto` as HVAC ON sees the raw string `"auto"` in the bistate-mode select instead of a localised label.
+- Proposed fix: Decide between (a) hard-coding `_bistate_mode_on="on"` / `_bistate_mode_off="off"` for the radiator regardless of the climate HVAC mode (recommended — bistate-mode select is independent of the HVAC mode wiring), or (b) extending the translation to cover all reasonable HVAC mode keys. Option (a) is simpler. Add a test pinning the bistate-mode labels for a climate-backed radiator whose HVAC ON is `"auto"`.
+
+### [nice-to-have] E4 — `get_hvac_modes` treats empty list as success
+- File: `custom_components/quiet_solar/ha_model/bistate_transport.py:69-71`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: When `entry.capabilities = {"hvac_modes": []}` (some buggy climate integrations register this transiently), the helper returns `[]` instead of falling back to `[AUTO, OFF]`. S7 catches the symptom at the config-flow boundary, but the helper itself is the canonical source of truth.
+- Proposed fix: In `get_hvac_modes`, treat both missing-key AND empty-list as the "no capabilities" case and fall back to `[AUTO, OFF]`. Add a unit test in `tests/test_ha_bistate_transport.py` for the empty-list case.
+
+### [nice-to-have] E5 — `power_from_state` returns 0 for transitional HVAC states
+- File: `custom_components/quiet_solar/ha_model/bistate_transport.py:99-111` (`BistateTransport.power_from_state`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: When a climate-backed load is in a transitional HVAC state (`"heating"`, `"idle"`, vendor-specific intermediates), `power_from_state` returns `0.0` because the state doesn't equal `state_on`. The pre-existing `get_power_from_switch_state` had the same blind spot but the transport now formalises it for future callers.
+- Proposed fix: Either (a) document the limitation explicitly in the helper docstring, or (b) widen the helper to treat any non-`state_off` state as "on" for power-attribution purposes. Option (a) is the smaller change; option (b) is functionally better but needs solver-side validation.
+
+### [nice-to-have] CR2 — `get_heat_pumps` returns internal list
+- File: `custom_components/quiet_solar/ha_model/home.py:1458-1469`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: Returning `self._heat_pumps` directly lets callers mutate the home's registry without going through `add_device`/`remove_device`.
+- Proposed fix: Return `list(self._heat_pumps)` (snapshot copy) or `tuple(self._heat_pumps)` (immutable view). Sweep callers for any that relied on identity (none should). Add a unit test asserting `home.get_heat_pumps()` is not `home._heat_pumps`.
+
+### [nice-to-have] CR3 — OFF fallback assertion accepts `"heat"`
+- File: `tests/test_integration_config_flow.py:1010-1048`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: With `hvac_modes=["heat", "fan_only"]` (no off-like mode), the OFF fallback per S13 must be the last mode (`"fan_only"`). The current assertion `assert off_default in {"heat", "fan_only"}` also accepts `"heat"`, hiding a regression.
+- Proposed fix: Replace with `mock_modes = ["heat", "fan_only"]` (bind once), then `assert off_default == mock_modes[-1]`.
+
+### [nice-to-have] CR4 — Mode-set pinning uses subset checks
+- File: `tests/test_ha_radiator.py:433-484` (`test_radiator_bistate_modes_set_is_pinned` and `test_radiator_climate_bistate_modes_set_includes_heat_off`)
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: Both tests describe an "exact pin" intent but use `in` / `.issubset(...)` checks, so unexpected extra modes still pass.
+- Proposed fix: Use set-equality: `assert set(device.get_bistate_modes()) == {"bistate_mode_auto", "bistate_mode_exact_calendar", "bistate_mode_default", device._bistate_mode_on, device._bistate_mode_off}` (and the analogous `{..., "heat", "off"}` for the climate variant).
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-195.story_review_fix_#03.md
+++ b/docs/stories/QS-195.story_review_fix_#03.md
@@ -1,0 +1,96 @@
+# QS-195 — Review fix plan #03
+
+## Summary
+- Source PR: #198
+- Source story: `docs/stories/QS-195.story.md`
+- Prior fix plans: `docs/stories/QS-195.story_review_fix_#01.md`, `docs/stories/QS-195.story_review_fix_#02.md`
+- Findings to fix: 11 (0 must-fix + 4 should-fix + 7 nice-to-have)
+- Next implement phase: `/implement-task`
+
+> Note: CodeRabbit declined to re-review commit `002f107` within the polling window (incremental-review heuristic). Findings below come from blind-hunter, edge-case-hunter, and acceptance-auditor.
+
+## Findings to fix
+
+### [should-fix] EH1 — Same HVAC mode for ON and OFF can be saved
+- File: `custom_components/quiet_solar/config_flow.py:1760-1773` (`async_step_radiator` submit handler)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The XOR validation only covers backing entity, not HVAC mode equality. When the user submits Pass 2 with `CONF_CLIMATE_HVAC_MODE_ON == CONF_CLIMATE_HVAC_MODE_OFF` (e.g. both `"heat"` because the climate entity only offered a single useful mode), `need_reprompt` returns False (both values are in `hvac_modes`), the entry saves, and `ClimateTransport.execute` later issues identical `set_hvac_mode("heat")` for both ON and OFF — the device never toggles.
+- Proposed fix: Add a submit-time validation: if `climate_entity` is set AND `user_input.get(CONF_CLIMATE_HVAC_MODE_ON) == user_input.get(CONF_CLIMATE_HVAC_MODE_OFF)`, surface the error `hvac_modes_must_differ` on the form (translation key under both `step.radiator.error` and `options.error`, regenerate `translations/en.json`). Add a test in `tests/test_integration_config_flow.py` that submits identical ON/OFF modes and asserts the error path.
+
+### [should-fix] EH2 — Single-mode `hvac_modes` defaults both selectors to the same value
+- File: `custom_components/quiet_solar/config_flow.py:1845-1880` (`_async_show_radiator_form`, the HVAC suggested-defaults block)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: When a climate entity advertises a single-mode list like `["heat"]`, the suggested defaults pick `suggested_on = "heat"` and (because no off-like match exists) `suggested_off = hvac_modes[-1] = "heat"`. Both dropdowns default to identical values, the schema accepts it, and EH1's downstream symptom fires.
+- Proposed fix: Combine with EH1's fix:
+  - If `len(hvac_modes) < 2`, surface the form-level error `climate_modes_insufficient` (translation under both `step.radiator.error` and `options.error`) and do NOT render the HVAC dropdowns. Let the user back out or pick a different climate entity.
+  - Otherwise, after computing `suggested_on` and `suggested_off`, if they coincide, change `suggested_off` to any other mode (e.g. `next(m for m in hvac_modes if m != suggested_on)`).
+- Add a test for both branches: single-mode `["heat"]` → error path; two-mode `["heat", "cool"]` with no off → suggested_off ≠ suggested_on.
+
+### [should-fix] EH3 — `QSClimateDuration` doesn't apply the S9 empty-string fallback
+- File: `custom_components/quiet_solar/ha_model/climate_controller.py:32-35` (`QSClimateDuration.__init__`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `kwargs.pop(CONF_CLIMATE_HVAC_MODE_ON, default)` returns `""` (NOT the default) when the key is present-but-empty. The S9 fix (`kwargs.get(...) or default`) was applied to `QSRadiator` in fix plan #01 but the parallel call site in `QSClimateDuration` was missed. A corrupted/migrated entry persisting `CONF_CLIMATE_HVAC_MODE_ON=""` constructs `ClimateTransport(state_on="")`; first `set_hvac_mode("")` service call fails at runtime.
+- Proposed fix: Replace `kwargs.pop(CONF_CLIMATE_HVAC_MODE_ON, str(HVACMode.AUTO.value))` with `kwargs.pop(CONF_CLIMATE_HVAC_MODE_ON, None) or str(HVACMode.AUTO.value)` (and the analogous for `OFF`). Add a test in `tests/test_ha_climate_controller.py` constructing `QSClimateDuration` with `CONF_CLIMATE_HVAC_MODE_ON=""` and asserting the default is applied.
+
+### [should-fix] AA1 — B5 `showDialog` escaping has no regression test
+- File: `tests/test_dashboard_rendering.py` (extend) + reference `custom_components/quiet_solar/ui/resources/qs-radiator-card.js` (around L2149, `showDialog`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: Plan #02's B5 added defensive `_escapeHtml` to `showDialog`'s interpolations, but no test pins the behavior. A future refactor that drops the escape calls would only fail if the surrounding substring also changes.
+- Proposed fix: Mirror the A2 pattern. Add a Python test that reads `qs-radiator-card.js` and asserts (via regex or structural match) that every interpolation inside `showDialog`'s body routes through `_escapeHtml(`. Example: assert the function body contains no raw `${title}`, `${message}`, or `${customContent}` token followed by `<` (i.e. they're all wrapped). If a JS unit-test harness becomes available later, add a runtime assertion that `<script>` text injected as title appears escaped in the rendered DOM.
+
+### [nice-to-have] BH7 — Redundant `hasattr` gate around `_get_pending_radiator_data`
+- File: `custom_components/quiet_solar/config_flow.py:~1820`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `pending = self._get_pending_radiator_data() if hasattr(self, "_pending_radiator_data") else {}` — the helper itself already handles the missing-attribute case, so the gate is redundant.
+- Proposed fix: Simplify to `pending = self._get_pending_radiator_data()`. If the gate exists to avoid auto-initialising the attribute on first form render, document that explicitly in a comment.
+
+### [nice-to-have] BH8 — Self-recursive `async_step_radiator` re-entry obscures control flow
+- File: `custom_components/quiet_solar/config_flow.py:~1695`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `return await self.async_step_radiator({"force_radiator_climate": True})` re-enters the same step just to fall through to `_async_show_radiator_form()`. The control flow looks recursive but is actually a single hop; the `"force_radiator_climate" not in user_input` gate is the real "skip XOR" mechanism.
+- Proposed fix: Replace the recursive call with a direct `return await self._async_show_radiator_form()` and drop the `force_radiator_climate` sentinel + gate. Update any test that depended on the sentinel.
+
+### [nice-to-have] BH9 — `test_async_mock_imported` placeholder lint-silencer
+- File: `tests/test_ha_radiator_real.py` (end of file)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `def test_async_mock_imported(): assert AsyncMock is not None` exists solely to silence an unused-import warning for `AsyncMock`.
+- Proposed fix: Either (a) remove the import if no test in the file uses `AsyncMock`, (b) use `AsyncMock` in a meaningful assertion (e.g. as a stand-in for `hass.services.async_call`), or (c) add `# noqa: F401` to the import and drop the placeholder test.
+
+### [nice-to-have] BH10 — Cold-start `running` hardcodes `"heat"` as the only on-like HVAC mode
+- File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js:~146`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The N7 cold-start fix uses `const liveBackingOn = liveBackingState === 'on' || liveBackingState === 'heat';`. A user who configures `CONF_CLIMATE_HVAC_MODE_ON = "auto"` (which the rest of the code supports) gets `liveBackingOn=false` during cold start because `"auto"` isn't recognised.
+- Proposed fix: Plumb the configured `CONF_CLIMATE_HVAC_MODE_ON` value through the card's `entities` payload (e.g. as a new attribute key like `climate_hvac_mode_on`). In the card, derive the comparison: `liveBackingOn = liveBackingState === 'on' || liveBackingState === configuredHvacOn`. Default to `"heat"` for backward compatibility. Add a test (or extend `tests/test_dashboard_rendering.py`'s string-content checks) that the new attribute is wired through.
+
+### [nice-to-have] EH4 — Just-submitted entity values lost on re-render after errors
+- File: `custom_components/quiet_solar/config_flow.py:1717-1720, 1746-1749`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: When `exactly_one_backing_required` or `climate_capabilities_unavailable` fires, `_async_show_radiator_form` re-renders. It currently pre-fills from `config_entry.data` rather than from the just-rejected `user_input`, so the user must re-pick their selections.
+- Proposed fix: Before triggering the error re-render, write the just-submitted (rejected) values to `_pending_radiator_data` (or pass them explicitly into `_async_show_radiator_form` via a `pending` kwarg). The form already knows how to honor `pending` after B1. Add a test that submits a bad XOR combo and asserts the re-render still shows the user's values.
+
+### [nice-to-have] EH5 — Clearing a valid `CONF_DEVICE_TO_PILOT_NAME` is silently reverted
+- File: `custom_components/quiet_solar/config_flow.py:1683-1697` (`_async_save_radiator_entry`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: When the persisted heat-pump name is still valid (`_radiator_orphan_pilot_keys` returns `()`) and the user clears the dropdown to deliberately "unpilot" the radiator, `cleaned` drops the empty value and `merged = {**config_entry.data, **cleaned}` re-injects the old persisted name. The user's deliberate clear is silently reverted. (Same limitation lives in `_async_entry_next`, so this is consistent; flagged because the new save path has room to fix it.)
+- Proposed fix: Treat an explicitly-empty `CONF_DEVICE_TO_PILOT_NAME` in the form payload as "user wants to clear". Detect this by checking whether the schema's optional field was present in the form-rendered keys (e.g. inspect the schema's keys when building the payload, or use a sentinel like `__cleared__`). When detected, pop the key from `merged` before persisting. Add a test that swaps from "piloted by X" → "no pilot" via the options flow.
+
+### [nice-to-have] EH6 — Stale entry with both `CONF_CLIMATE` and `CONF_SWITCH` fails to load
+- File: `custom_components/quiet_solar/ha_model/radiator.py:65-71` (the XOR check in `__init__`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: If `config_entry.data` ends up containing BOTH `CONF_CLIMATE` and `CONF_SWITCH` (buggy upgrade, manual `.storage` edit, future migration regression), `QSRadiator.__init__` raises `ServiceValidationError` on reload and the entry fails to load entirely.
+- Proposed fix: When BOTH keys are truthy, log a warning and pick a deterministic winner (e.g. prefer `CONF_CLIMATE` if both are set, since that's the richer backing). Drop the loser from `kwargs` in place so downstream code sees only one. Add a test constructing `QSRadiator` with both keys set and asserting `device.climate_entity` is used while `device.switch_entity is None` (plus a warning is logged via `caplog`).
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-195.story_review_fix_#04.md
+++ b/docs/stories/QS-195.story_review_fix_#04.md
@@ -1,0 +1,119 @@
+# QS-195 — Review fix plan #04
+
+## Summary
+- Source PR: #198
+- Source story: `docs/stories/QS-195.story.md`
+- Prior fix plans: `QS-195.story_review_fix_#01.md`, `QS-195.story_review_fix_#02.md`, `QS-195.story_review_fix_#03.md`
+- Findings to fix: 15 (0 must-fix + 8 should-fix + 7 nice-to-have)
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [should-fix] BH-A — `QSOnOffDuration.__init__` unconditionally clobbers transport state
+- File: `custom_components/quiet_solar/ha_model/on_off_duration.py:24`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: After `super().__init__`, `QSOnOffDuration` writes `self._state_on = "on"` / `self._state_off = "off"`. Because of the B3 property shadow on `QSBiStateDuration`, those assignments route into the transport and overwrite anything the base ctor (or a future mixin) had configured. Symmetric subclasses (`QSClimateDuration`, `QSRadiator`) intentionally preserve their user-derived values. Functionally OK today (the on/off defaults always match) but a foot-gun for any future on/off variant with non-default labels.
+- Proposed fix: Drop the unconditional re-pin. The `SwitchTransport(switch_entity)` constructor already sets `state_on="on"` / `state_off="off"` by default, and the B3 property shadow forwards reads to the transport, so `self._state_on` will resolve to `"on"` without an explicit write. If the explicit write is kept for backwards compatibility, gate it: `if self._state_on is None: self._state_on = "on"` (analogous for off). Add a regression test that constructs `QSOnOffDuration` with a transport pre-set to non-default labels (or via a subclass) and asserts the labels survive `__init__`.
+
+### [should-fix] BH-B — `_bistate_mode_on/_off` invariant diverges across subclasses
+- File: `custom_components/quiet_solar/ha_model/radiator.py:110` (and the parallel `QSClimateDuration.__init__` for comparison)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: For a climate-backed radiator, plan #02 E3 hard-coded `_bistate_mode_on/_off = "on"/"off"` (independent of HVAC mode keys). `QSClimateDuration`, by contrast, still sets `_bistate_mode_on = state_on` (the real HVAC mode). The two siblings now carry divergent invariants for `_bistate_mode_*`. Any base-class logic in `QSBiStateDuration` that compares `_state_on` ↔ `_bistate_mode_on` (or uses the latter to look up service mappings) behaves differently across the two subclasses.
+- Proposed fix: Pick one convention and apply it to both subclasses (recommended: extend the radiator convention to `QSClimateDuration` — hard-code `_bistate_mode_on/_off` to `"on"/"off"` literals there as well, since the bistate-mode select is a presentation concern independent of the HVAC mode wiring). Update the `radiator_mode` / `climate_mode` translations if needed. Add tests asserting both subclasses surface the same literal `_bistate_mode_*` set. If preserving the climate behavior is intentional, document it in `QSBiStateDuration`'s class docstring and add a comment in each subclass explaining the choice.
+
+### [should-fix] BH-C — Dead fallback to `_heat_pumps` private attr
+- File: `custom_components/quiet_solar/config_flow.py:1762` (also any other call site that still uses the fallback pattern)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The hunk that introduced the M3 fix still falls back to `getattr(data_handler.home, "_heat_pumps", [])` after probing `get_heat_pumps()`. The M3 fix made `get_heat_pumps()` part of the public API on `QSHome`, so the fallback is dead defensive code that contradicts the in-diff comment "use the canonical accessor instead of `_heat_pumps`".
+- Proposed fix: Drop the `_heat_pumps` fallback. Use `data_handler.home.get_heat_pumps()` unconditionally. Sweep the file for any other parallel fallback and remove. If `data_handler.home` itself can be `None` in some edge case, guard at that level only.
+
+### [should-fix] EH-A — Heat-pump default not pre-filled from pending/buffer on re-render
+- File: `custom_components/quiet_solar/config_flow.py:1958` (`_async_show_radiator_form`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `default_heat_pump` is sourced ONLY from `self.config_entry.data.get(CONF_DEVICE_TO_PILOT_NAME)`, bypassing both `pending_buffer` (B1's Pass 1 buffer) and `explicit_pending` (EH4's just-rejected submission). When Pass 2 reprompts or any validation error fires, the user's first-time heat-pump pick silently disappears on re-render and must be re-picked.
+- Proposed fix: Extend the existing B1/EH4 pre-fill machinery to cover the heat-pump field. Pull `default_heat_pump` from (in priority order): `explicit_pending.get(CONF_DEVICE_TO_PILOT_NAME)`, then `pending_buffer.get(CONF_DEVICE_TO_PILOT_NAME)`, then `self.config_entry.data.get(...)`. Add a test that submits Pass 1 with a heat-pump selection + values that trigger an XOR error, then asserts the re-render still shows the selected heat pump.
+
+### [should-fix] EH-B — Heat-pump removed between Pass 1 and final submit is not re-validated
+- File: `custom_components/quiet_solar/config_flow.py:1840` (`_radiator_orphan_pilot_keys` and the surrounding save handler)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `_radiator_orphan_pilot_keys` operates on the PERSISTED name. If the user picks heat pump `"main"` in Pass 1, then `"main"` is removed (slow user, parallel admin, Pass-2 reprompt with cached pick), the final submit still carries `"main"` in `user_input`. `cleaned.get(CONF_DEVICE_TO_PILOT_NAME)` is truthy → orphan-purge is skipped → entry saves a non-existent heat-pump name.
+- Proposed fix: At submit time, re-validate `user_input.get(CONF_DEVICE_TO_PILOT_NAME)` against the LIVE `data_handler.home.get_heat_pumps()`. If the submitted name is absent from the live list, surface the existing `piloted_heat_pump_unknown` error (on the dropdown field per B4) and re-render the form. Add a test that picks a heat pump in Pass 1, removes it from `home._heat_pumps` between calls, and asserts the final submit fails with the orphan error rather than silently persisting.
+
+### [should-fix] CR1 — Hardcoded `"name"` config-key string
+- File: `custom_components/quiet_solar/ha_model/radiator.py:29-30` (and L75)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: `kwargs.get("name", "<unnamed>")` hardcodes the config key, violating the project rule "Define all config keys in `const.py` — never hardcode strings".
+- Proposed fix: Import `CONF_NAME` from `homeassistant.const` (or `.const` if the project re-exports it) and use `kwargs.get(CONF_NAME, "<unnamed>")`. Sweep both call sites at L29-30 and L75. Add no new test (covered by existing radiator init tests).
+
+### [should-fix] CR2 — Sync `Path.read_text()` calls in async tests
+- File: `tests/test_dashboard_rendering.py:243, 270, 287, 317, 356-357, 402-403, 427-428, 454-455`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: New async tests call `Path.read_text()` directly, blocking the event loop. Per the project's async hygiene rule (`docs/agents/concepts/async-hygiene.md` or equivalent), all file I/O inside `async def` test bodies should be offloaded to the executor.
+- Proposed fix: Replace each `Path.read_text()` call inside an async test with `await hass.async_add_executor_job(path.read_text)`. Alternative: convert tests that don't otherwise await anything to plain `def` (sync) — but the async fixture they consume probably requires async, so executor offload is the safer path. Apply to all ~9 call sites listed.
+
+### [should-fix] CR3 — Lenient whitespace-switch assertion
+- File: `tests/test_ha_radiator.py:597-600`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: `assert not device.switch_entity or device.switch_entity.strip() == ""` passes when `switch_entity` is `"   "` (truthy AND `.strip() == ""`), so the test cannot catch the very leak it documents.
+- Proposed fix: Replace with `assert device.switch_entity in (None, "")` (or `assert device.switch_entity is None`, depending on the post-normalisation policy from E1/N6). Re-run the test to confirm the change still passes (i.e. the production code actually normalises to `None`/`""`).
+
+### [nice-to-have] BH-D — `explicit_pilot_clear` detection is HA-selector-fragile
+- File: `custom_components/quiet_solar/config_flow.py:1690`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The detection relies on the precise HA selector behavior of "key present with `None` value vs key absent" for `vol.Optional` fields. An upstream HA regression that swaps the variant would silently disable explicit-clear detection.
+- Proposed fix: Add a defensive normalisation step that treats both variants identically (e.g. `pilot_value = user_input.get(CONF_DEVICE_TO_PILOT_NAME, _UNSET); explicit_pilot_clear = (pilot_value is _UNSET) is False and not pilot_value`). Add a comment explaining the assumption. Add a test that covers both shapes ({key absent} vs {key: None}).
+
+### [nice-to-have] BH-E — Magic number `12` duplicated in card
+- File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js:~1900` (and the `_safeNumber(sDurationLimit?.state, 12)` site)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `maxHours = 12` and `_safeNumber(..., 12)` both encode the same 12-hour cap. Two places to keep in sync.
+- Proposed fix: Extract a const `const DEFAULT_MAX_HOURS = 12;` at the top of the file and reference it at both sites. If the cap should be configurable, read it from a sensor attribute or card config instead.
+
+### [nice-to-have] BH-F — `ClimateTransport.execute` silently accepts unexpected `override_state`
+- File: `custom_components/quiet_solar/ha_model/bistate_transport.py:~277` (`ClimateTransport.execute`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: N1 added a warning when `SwitchTransport.execute` receives an unexpected `override_state`. The climate path silently dispatches anything to `set_hvac_mode`, missing the diagnostic.
+- Proposed fix: Add a parallel `if override_state not in self.mode_options(hass): _LOGGER.warning("ClimateTransport: unexpected override_state=%r ...", override_state)` at the entry of `ClimateTransport.execute`. Add a unit test analogous to the N1 SwitchTransport test (using `caplog`).
+
+### [nice-to-have] BH-G — `del time` in hoisted `execute_command_system`
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:~350`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The hoisted base method does `del time` to mark the param intentionally unused. Style: `time` remains in the public contract; a subclass overriding it that legitimately uses `time` would inherit the same `del` if it called `super()`, causing confusion (though not `UnboundLocalError` directly).
+- Proposed fix: Replace `del time` with the conventional `_time` parameter rename (and update the public-contract docstring to reflect the rename), OR keep `time` and add `# noqa: ARG002` if the lint rule is the only reason. Pick whichever matches the project's existing style (search for prior usage).
+
+### [nice-to-have] EH-C — `QSClimateDuration.__init__` accepts `CONF_CLIMATE = None` silently
+- File: `custom_components/quiet_solar/ha_model/climate_controller.py:31`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Constructs `ClimateTransport(None, ...)` if the entry's `CONF_CLIMATE` is missing/None. EH6 added a guard for the analogous case in `QSRadiator`; the climate parent now looks asymmetric. (Pre-existing behavior, but newly visible because of EH6.)
+- Proposed fix: Either (a) mirror EH6's guard: raise a clear `ServiceValidationError` if `CONF_CLIMATE` is None/empty, OR (b) document why climate is allowed to be `None` (e.g. if some pre-existing migration path relies on it). If (b), add an explicit comment.
+
+### [nice-to-have] EH-D — `cleaned` doesn't strip whitespace from non-entity fields
+- File: `custom_components/quiet_solar/config_flow.py:1736`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `cleaned = {k: v for k, v in user_input.items() if v not in (None, "")}` drops `None` and exact empty string, but retains whitespace-only values for non-entity fields (e.g. a user pasting `"  "` into `CONF_NAME`). The strip-empty normalisation applied to `CONF_CLIMATE`/`CONF_SWITCH` is not generalised.
+- Proposed fix: Generalise the strip. For string-valued fields, treat whitespace-only as empty: `if isinstance(v, str): v = v.strip(); if v: cleaned[k] = v`. Keep non-string types as-is. Add a test that submits whitespace into a free-form string field and asserts the persisted entry doesn't carry the whitespace.
+
+### [nice-to-have] EH-E — `SwitchTransport.__init__` accepts `None` switch_entity silently
+- File: `custom_components/quiet_solar/ha_model/bistate_transport.py:~783` (`SwitchTransport.__init__`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: If `QSOnOffDuration` is instantiated from a legacy entry missing `CONF_SWITCH`, `SwitchTransport(None)` is constructed and the first `services.async_call(target={"entity_id": None})` fails at the HA layer. EH6/M4 added the truthy guard for the radiator's switch backing; the on/off parent is now asymmetric.
+- Proposed fix: At `SwitchTransport.__init__`, raise `ServiceValidationError` (or a clear `ValueError` if the constructor cannot raise HA-domain exceptions) when `switch_entity` is None/empty. Add a unit test in `tests/test_ha_bistate_transport.py` constructing `SwitchTransport(None)` and asserting the raise.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run `/review-task` again to re-verify.

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -911,6 +911,69 @@ def create_test_car_double(**kwargs) -> TestCarDouble:
     return TestCarDouble(**kwargs)
 
 
+class TestRadiatorDouble:
+    """Lightweight test double for QSRadiator-like behaviour.
+
+    Use this in unit tests that need a radiator-shaped object (with the
+    `_transport`, `_state_on/off`, `bistate_entity`, `piloted_device_name`
+    surface) but don't need to instantiate a full HA-backed device.
+    """
+
+    # pytest opt-out: this is a test helper, not a test class, despite the
+    # `Test` prefix.
+    __test__ = False
+
+    def __init__(
+        self,
+        name: str = "Test Radiator",
+        backing: str = "switch",
+        switch_entity: str = "switch.radiator",
+        climate_entity: str = "climate.radiator",
+        hvac_on: str = "heat",
+        hvac_off: str = "off",
+        piloted_device_name: str | None = None,
+        power: float = 1000.0,
+        **kwargs,
+    ):
+        from custom_components.quiet_solar.ha_model.bistate_transport import (
+            ClimateTransport,
+            SwitchTransport,
+        )
+
+        if backing not in ("switch", "climate"):
+            raise ValueError("backing must be 'switch' or 'climate'")
+
+        self.name = name
+        self.power_use = power
+        self.piloted_device_name = piloted_device_name
+
+        if backing == "switch":
+            self._transport = SwitchTransport(switch_entity)
+        else:
+            self._transport = ClimateTransport(climate_entity, hvac_on, hvac_off)
+
+        self._state_on = self._transport.default_state_on()
+        self._state_off = self._transport.default_state_off()
+        self._bistate_mode_on = self._state_on
+        self._bistate_mode_off = self._state_off
+        self.bistate_entity = self._transport.entity
+        self.conf_type_name = "radiator"
+        self.device_type = "radiator"
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def create_test_radiator_double(**kwargs) -> TestRadiatorDouble:
+    """Create a TestRadiatorDouble for unit testing.
+
+    Example:
+        radiator = create_test_radiator_double(name="Bathroom", backing="switch")
+        radiator = create_test_radiator_double(name="Living Room", backing="climate")
+    """
+    return TestRadiatorDouble(**kwargs)
+
+
 def create_test_charger_double(car: Any = None, **kwargs) -> TestChargerDouble:
     """Create a TestChargerDouble for unit testing.
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -38,11 +38,16 @@ from custom_components.quiet_solar.const import (
     CONF_IS_3P,
     CONF_MINIMUM_OK_CAR_CHARGE,
     CONF_MONO_PHASE,
+    CONF_TYPE_NAME_QSRadiator,
     CONSTRAINT_TYPE_BEFORE_BATTERY_GREEN,
     CONSTRAINT_TYPE_FILLER,
     CONSTRAINT_TYPE_FILLER_AUTO,
     CONSTRAINT_TYPE_MANDATORY_AS_FAST_AS_POSSIBLE,
     CONSTRAINT_TYPE_MANDATORY_END_TIME,
+)
+from custom_components.quiet_solar.ha_model.bistate_transport import (
+    ClimateTransport,
+    SwitchTransport,
 )
 from custom_components.quiet_solar.home_model.commands import (
     CMD_ON,
@@ -336,6 +341,7 @@ def create_minimal_home_model(
     home._cars = []
     home._chargers = []
     home._loads = []
+    home._heat_pumps = []
     home._last_persons_car_allocation = {}
     home.available_amps_for_group = [[max_phase_amps] * 3]
     home.compute_and_set_best_persons_cars_allocations = AsyncMock(return_value={})
@@ -348,6 +354,14 @@ def create_minimal_home_model(
         return None
 
     home.get_car_by_name = get_car_by_name
+
+    # M3 — mirror the canonical `QSHome.get_heat_pumps()` accessor so tests
+    # can keep setting `home._heat_pumps = [...]` and observe the change
+    # through the public method the config flow now uses.
+    def get_heat_pumps():
+        return home._heat_pumps
+
+    home.get_heat_pumps = get_heat_pumps
     home._consumption_forecast = None
     return home
 
@@ -935,11 +949,6 @@ class TestRadiatorDouble:
         power: float = 1000.0,
         **kwargs,
     ):
-        from custom_components.quiet_solar.ha_model.bistate_transport import (
-            ClimateTransport,
-            SwitchTransport,
-        )
-
         if backing not in ("switch", "climate"):
             raise ValueError("backing must be 'switch' or 'climate'")
 
@@ -957,8 +966,9 @@ class TestRadiatorDouble:
         self._bistate_mode_on = self._state_on
         self._bistate_mode_off = self._state_off
         self.bistate_entity = self._transport.entity
-        self.conf_type_name = "radiator"
-        self.device_type = "radiator"
+        # N12 — use the canonical constant rather than the literal `"radiator"`.
+        self.conf_type_name = CONF_TYPE_NAME_QSRadiator
+        self.device_type = CONF_TYPE_NAME_QSRadiator
 
         for key, value in kwargs.items():
             setattr(self, key, value)

--- a/tests/ha_tests/const.py
+++ b/tests/ha_tests/const.py
@@ -51,6 +51,7 @@ from custom_components.quiet_solar.const import (
     CONF_TYPE_NAME_QSHome,
     CONF_TYPE_NAME_QSOnOffDuration,
     CONF_TYPE_NAME_QSPerson,
+    CONF_TYPE_NAME_QSRadiator,
     CONF_TYPE_NAME_QSSolar,
 )
 
@@ -184,6 +185,24 @@ MOCK_CLIMATE_DURATION_CONFIG = {
     CONF_POWER: 2000,  # 2kW power usage
 }
 
+# Mock Radiator configuration backed by a switch (QSRadiator)
+MOCK_RADIATOR_SWITCH_CONFIG = {
+    CONF_NAME: "Test Radiator Switch",
+    DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+    CONF_SWITCH: "switch.test_radiator_switch",
+    CONF_POWER: 1000,  # 1kW heating-only radiator
+}
+
+# Mock Radiator configuration backed by a climate entity (QSRadiator)
+MOCK_RADIATOR_CLIMATE_CONFIG = {
+    CONF_NAME: "Test Radiator Climate",
+    DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+    CONF_CLIMATE: "climate.test_radiator_climate",
+    CONF_CLIMATE_HVAC_MODE_ON: "heat",
+    CONF_CLIMATE_HVAC_MODE_OFF: "off",
+    CONF_POWER: 1500,
+}
+
 # Entry IDs for testing
 MOCK_HOME_ENTRY_ID = "home_entry_123"
 MOCK_CAR_ENTRY_ID = "car_entry_123"
@@ -197,6 +216,8 @@ MOCK_BATTERY_WITH_NUMBERS_ENTRY_ID = "battery_numbers_entry_123"
 MOCK_SOLAR_WITH_INPUT_ENTRY_ID = "solar_input_entry_123"
 MOCK_ON_OFF_DURATION_ENTRY_ID = "on_off_duration_entry_123"
 MOCK_CLIMATE_DURATION_ENTRY_ID = "climate_duration_entry_123"
+MOCK_RADIATOR_SWITCH_ENTRY_ID = "radiator_switch_entry_123"
+MOCK_RADIATOR_CLIMATE_ENTRY_ID = "radiator_climate_entry_123"
 
 # Mock sensor states for testing
 MOCK_SENSOR_STATES = {
@@ -227,4 +248,10 @@ MOCK_SENSOR_STATES = {
     "switch.test_on_off_device": {"state": "off", "attributes": {}},
     # ClimateDuration entities
     "climate.test_climate_device": {"state": "off", "attributes": {"hvac_modes": ["off", "heat", "cool", "auto"]}},
+    # Radiator entities (switch backing + climate backing)
+    "switch.test_radiator_switch": {"state": "off", "attributes": {}},
+    "climate.test_radiator_climate": {
+        "state": "off",
+        "attributes": {"hvac_modes": ["off", "heat", "auto"]},
+    },
 }

--- a/tests/ha_tests/test_home.py
+++ b/tests/ha_tests/test_home.py
@@ -606,6 +606,143 @@ async def test_home_auto_migrates_missing_default_section_for_new_device_type(
     assert boiler_device in devices_in_section
 
 
+async def test_home_migration_inserts_at_const_position_not_at_end(
+    hass: HomeAssistant,
+) -> None:
+    """BH (post-QS-195 user bug): when the auto-migration adds a missing
+    default section, it must insert it at the position dictated by
+    `DASHBOARD_DEFAULT_SECTIONS` order — NOT at the end.
+
+    Without this, the user's symptom was: "I put a radiator in the
+    radiator dashboard section ... but it is now placed in the main
+    dashboard AFTER the settings". The dashboard renders sections in
+    `home.dashboard_sections` order; appending at the end places the
+    heating sections below `settings`, breaking the visual grouping
+    that `DASHBOARD_DEFAULT_SECTIONS` declares.
+    """
+    from .const import MOCK_HOME_CONFIG, MOCK_WATER_BOILER_CONFIG
+
+    # Pre-QS-194/QS-195 customised list — has `others` and `settings`
+    # but no `water_boilers` or `radiators`. The migration must insert
+    # `water_boilers` BEFORE `others`, not at the end.
+    custom_home_config = {
+        **MOCK_HOME_CONFIG,
+        f"{CONF_DASHBOARD_SECTION_NAME}_0": "#1 - cars",
+        f"{CONF_DASHBOARD_SECTION_ICON}_0": "mdi:car",
+        f"{CONF_DASHBOARD_SECTION_NAME}_1": "#2 - others",
+        f"{CONF_DASHBOARD_SECTION_ICON}_1": "mdi:home",
+        f"{CONF_DASHBOARD_SECTION_NAME}_2": "#3 - settings",
+        f"{CONF_DASHBOARD_SECTION_ICON}_2": "mdi:cog-outline",
+    }
+    home_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=custom_home_config,
+        entry_id="insert_at_const_home_entry",
+        title="home: Insert Const Home",
+        unique_id="insert_at_const_home_entry",
+    )
+    home_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(home_entry.entry_id)
+    await hass.async_block_till_done()
+
+    data_handler = hass.data[DOMAIN][DATA_HANDLER]
+    home = data_handler.home
+
+    # Add a water_boiler — migration runs and inserts `water_boilers`.
+    boiler_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_WATER_BOILER_CONFIG,
+        entry_id="insert_at_const_boiler_entry",
+        title=f"water_boiler: {MOCK_WATER_BOILER_CONFIG['name']}",
+        unique_id="insert_at_const_boiler_entry",
+    )
+    boiler_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(boiler_entry.entry_id)
+    await hass.async_block_till_done()
+
+    section_names = [s[0] for s in home.dashboard_sections]
+
+    # `water_boilers` MUST appear BEFORE `others` (const order:
+    # ..., water_boilers, radiators, others, settings).
+    assert "water_boilers" in section_names, (
+        f"Migration should have added water_boilers; got {section_names}"
+    )
+    wb_idx = section_names.index("water_boilers")
+    others_idx = section_names.index("others")
+    settings_idx = section_names.index("settings")
+    assert wb_idx < others_idx, (
+        f"water_boilers must be inserted BEFORE others (const order); "
+        f"got order {section_names}"
+    )
+    assert wb_idx < settings_idx, (
+        f"water_boilers must be inserted BEFORE settings (const order); "
+        f"got order {section_names}"
+    )
+
+
+async def test_home_init_normalizes_existing_dashboard_sections(
+    hass: HomeAssistant,
+) -> None:
+    """BH (post-QS-195 user bug): when the persisted
+    `CONF_DASHBOARD_SECTION_NAME_*` keys are in the wrong const order
+    (e.g. because an older append-only migration tacked sections onto
+    the end), `QSHome.__init__` MUST normalize them on load so the
+    dashboard renders in `DASHBOARD_DEFAULT_SECTIONS` order without
+    the user having to re-edit the home config.
+    """
+    from .const import MOCK_HOME_CONFIG
+
+    # Persisted in the BROKEN order (append-only migration result):
+    # ..., others, settings, water_boilers, radiators.
+    broken_order_config = {
+        **MOCK_HOME_CONFIG,
+        f"{CONF_DASHBOARD_SECTION_NAME}_0": "#1 - cars",
+        f"{CONF_DASHBOARD_SECTION_ICON}_0": "mdi:car",
+        f"{CONF_DASHBOARD_SECTION_NAME}_1": "#2 - others",
+        f"{CONF_DASHBOARD_SECTION_ICON}_1": "mdi:home",
+        f"{CONF_DASHBOARD_SECTION_NAME}_2": "#3 - settings",
+        f"{CONF_DASHBOARD_SECTION_ICON}_2": "mdi:cog-outline",
+        f"{CONF_DASHBOARD_SECTION_NAME}_3": "#4 - water_boilers",
+        f"{CONF_DASHBOARD_SECTION_ICON}_3": "mdi:water-boiler",
+        f"{CONF_DASHBOARD_SECTION_NAME}_4": "#5 - radiators",
+        f"{CONF_DASHBOARD_SECTION_ICON}_4": "mdi:radiator",
+    }
+    home_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=broken_order_config,
+        entry_id="normalize_home_entry",
+        title="home: Normalize Home",
+        unique_id="normalize_home_entry",
+    )
+    home_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(home_entry.entry_id)
+    await hass.async_block_till_done()
+
+    data_handler = hass.data[DOMAIN][DATA_HANDLER]
+    home = data_handler.home
+
+    names = [s[0] for s in home.dashboard_sections]
+    wb_idx = names.index("water_boilers")
+    radiators_idx = names.index("radiators")
+    others_idx = names.index("others")
+    settings_idx = names.index("settings")
+
+    # After normalize: water_boilers, radiators must be BEFORE others
+    # and settings (per const order).
+    assert wb_idx < others_idx < settings_idx, (
+        f"After normalize, expected water_boilers < others < settings; "
+        f"got {names}"
+    )
+    assert radiators_idx < others_idx < settings_idx, (
+        f"After normalize, expected radiators < others < settings; "
+        f"got {names}"
+    )
+    # water_boilers also before radiators (const order: water_boilers, radiators)
+    assert wb_idx < radiators_idx, (
+        f"After normalize, expected water_boilers < radiators; got {names}"
+    )
+
+
 async def test_home_migration_invalidates_sibling_device_caches(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/ha_tests/test_home.py
+++ b/tests/ha_tests/test_home.py
@@ -20,6 +20,7 @@ from custom_components.quiet_solar.const import (
     CONF_DEVICE_DASHBOARD_SECTION,
     CONF_GRID_POWER_SENSOR,
     CONF_HOME_VOLTAGE,
+    DASHBOARD_DEFAULT_SECTIONS,
     DATA_HANDLER,
     DOMAIN,
     FORCE_CAR_NO_PERSON_ATTACHED,
@@ -539,18 +540,21 @@ async def test_home_devices_for_dashboard_section_includes_virtual_devices(
     assert charger_device._default_generic_car.name in device_names
 
 
-async def test_home_auto_migrates_missing_default_section_for_new_device_type(
+async def test_home_default_section_visible_after_device_add(
     hass: HomeAssistant,
 ) -> None:
-    """WF-5 tier 2: a pre-existing user's customised `dashboard_sections`
-    list that's missing `water_boilers` (because it pre-dates QS-194) gets
-    the section appended in-memory when a water_boiler device is added.
+    """BH replacement: a pre-existing user's customised
+    `dashboard_sections` list that's missing `water_boilers` (because
+    it pre-dates QS-194) STILL has the section available — the
+    init-time bundled-default inclusion in `QSHome.__init__` ensures
+    `water_boilers` is present regardless of what's persisted, so a
+    water_boiler device added afterwards resolves to the right bucket
+    on the dashboard. Replaces the old per-device auto-migration test.
     """
     from .const import MOCK_HOME_CONFIG, MOCK_WATER_BOILER_CONFIG
 
     # Customised home config that pre-dates QS-194 — no water_boilers
-    # section in the CONF_DASHBOARD_SECTION_NAME_<i> slots. Matches the
-    # f-string pattern used in home.py: `{CONF_DASHBOARD_SECTION_NAME}_{i}`.
+    # section in the CONF_DASHBOARD_SECTION_NAME_<i> slots.
     custom_home_config = {
         **MOCK_HOME_CONFIG,
         f"{CONF_DASHBOARD_SECTION_NAME}_0": "#1 - cars",
@@ -572,14 +576,15 @@ async def test_home_auto_migrates_missing_default_section_for_new_device_type(
     data_handler = hass.data[DOMAIN][DATA_HANDLER]
     home = data_handler.home
 
-    # Sanity: water_boilers is NOT in the customised list yet
+    # Init-time auto-include ensures water_boilers is present even
+    # though the persisted slot keys don't mention it.
     initial_section_names = {s[0] for s in home.dashboard_sections}
-    assert "water_boilers" not in initial_section_names, (
-        f"Pre-condition: water_boilers must be absent from the customised "
-        f"home.dashboard_sections; got {initial_section_names}"
+    assert "water_boilers" in initial_section_names, (
+        f"Init-time auto-include must add the bundled water_boilers "
+        f"default; got {initial_section_names}"
     )
 
-    # Add a water_boiler device — it must trigger the migration
+    # Add a water_boiler device — resolves to the water_boilers bucket.
     boiler_entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_WATER_BOILER_CONFIG,
@@ -591,27 +596,18 @@ async def test_home_auto_migrates_missing_default_section_for_new_device_type(
     await hass.config_entries.async_setup(boiler_entry.entry_id)
     await hass.async_block_till_done()
 
-    # The section was appended at runtime
-    post_section_names = {s[0] for s in home.dashboard_sections}
-    assert "water_boilers" in post_section_names, (
-        f"Auto-migration should have appended `water_boilers` to "
-        f"home.dashboard_sections; got {post_section_names}"
-    )
-
-    # The device's dashboard_section resolves (not None) and reaches the
-    # right bucket
     boiler_device = hass.data[DOMAIN].get(boiler_entry.entry_id)
     assert boiler_device.dashboard_section == "water_boilers"
     devices_in_section = home.get_devices_for_dashboard_section("water_boilers")
     assert boiler_device in devices_in_section
 
 
-async def test_home_migration_inserts_at_const_position_not_at_end(
+async def test_home_init_places_bundled_defaults_in_const_order(
     hass: HomeAssistant,
 ) -> None:
-    """BH (post-QS-195 user bug): when the auto-migration adds a missing
-    default section, it must insert it at the position dictated by
-    `DASHBOARD_DEFAULT_SECTIONS` order — NOT at the end.
+    """BH (post-QS-195 user bug): the init-time auto-include MUST
+    place each bundled default at its canonical
+    `DASHBOARD_DEFAULT_SECTIONS` position — NOT at the end.
 
     Without this, the user's symptom was: "I put a radiator in the
     radiator dashboard section ... but it is now placed in the main
@@ -620,10 +616,10 @@ async def test_home_migration_inserts_at_const_position_not_at_end(
     heating sections below `settings`, breaking the visual grouping
     that `DASHBOARD_DEFAULT_SECTIONS` declares.
     """
-    from .const import MOCK_HOME_CONFIG, MOCK_WATER_BOILER_CONFIG
+    from .const import MOCK_HOME_CONFIG
 
     # Pre-QS-194/QS-195 customised list — has `others` and `settings`
-    # but no `water_boilers` or `radiators`. The migration must insert
+    # but no `water_boilers` or `radiators`. Auto-include must place
     # `water_boilers` BEFORE `others`, not at the end.
     custom_home_config = {
         **MOCK_HOME_CONFIG,
@@ -648,34 +644,23 @@ async def test_home_migration_inserts_at_const_position_not_at_end(
     data_handler = hass.data[DOMAIN][DATA_HANDLER]
     home = data_handler.home
 
-    # Add a water_boiler — migration runs and inserts `water_boilers`.
-    boiler_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=MOCK_WATER_BOILER_CONFIG,
-        entry_id="insert_at_const_boiler_entry",
-        title=f"water_boiler: {MOCK_WATER_BOILER_CONFIG['name']}",
-        unique_id="insert_at_const_boiler_entry",
-    )
-    boiler_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(boiler_entry.entry_id)
-    await hass.async_block_till_done()
-
     section_names = [s[0] for s in home.dashboard_sections]
 
-    # `water_boilers` MUST appear BEFORE `others` (const order:
-    # ..., water_boilers, radiators, others, settings).
+    # After auto-include + normalize: water_boilers must appear BEFORE
+    # others and settings (const order: ..., water_boilers, radiators,
+    # others, settings).
     assert "water_boilers" in section_names, (
-        f"Migration should have added water_boilers; got {section_names}"
+        f"Auto-include should have added water_boilers; got {section_names}"
     )
     wb_idx = section_names.index("water_boilers")
     others_idx = section_names.index("others")
     settings_idx = section_names.index("settings")
     assert wb_idx < others_idx, (
-        f"water_boilers must be inserted BEFORE others (const order); "
+        f"water_boilers must appear BEFORE others (const order); "
         f"got order {section_names}"
     )
     assert wb_idx < settings_idx, (
-        f"water_boilers must be inserted BEFORE settings (const order); "
+        f"water_boilers must appear BEFORE settings (const order); "
         f"got order {section_names}"
     )
 
@@ -743,139 +728,150 @@ async def test_home_init_normalizes_existing_dashboard_sections(
     )
 
 
-async def test_home_migration_invalidates_sibling_device_caches(
+async def test_home_init_includes_all_bundled_default_sections(
     hass: HomeAssistant,
 ) -> None:
-    """S5: when the migration appends a default section, sibling devices
-    whose `_computed_dashboard_section` already cached
-    `DASHBOARD_NO_SECTION` get invalidated so they pick up the newly-
-    available section on the next access.
+    """BH replacement for the per-device migration: at home init, every
+    bundled section in `DASHBOARD_DEFAULT_SECTIONS` must be present in
+    `self.dashboard_sections` — even when the persisted slot keys
+    pre-date the section's introduction (pre-QS-194 layouts don't have
+    `water_boilers`, pre-QS-195 don't have `radiators`).
 
-    Scenario:
-    1. Build a home with a customised section list missing `water_boilers`.
-    2. Add boiler #1 — migration kicks in, `water_boilers` is appended,
-       boiler #1 resolves correctly.
-    3. Simulate the original failure mode: a user re-edits the home
-       sections, removing `water_boilers` from the in-memory list
-       again, AND boiler #1's cache stale-fires to NO_SECTION.
-    4. Add boiler #2 — migration re-appends `water_boilers` AND must
-       invalidate boiler #1's stale cache so it re-resolves correctly.
+    Replaces the per-device `_maybe_migrate_missing_default_section`
+    mechanism with a single deterministic init-time pass: simpler,
+    no per-device timing, no in-memory-vs-persisted divergence.
     """
-    from homeassistant.const import CONF_NAME
+    from .const import MOCK_HOME_CONFIG
 
-    from custom_components.quiet_solar.home_model.load import DASHBOARD_NO_SECTION
-
-    from .const import MOCK_HOME_CONFIG, MOCK_WATER_BOILER_CONFIG
-
-    custom_home_config = {
+    # Pre-QS-194 layout: only the original 5 bundled defaults persisted.
+    legacy_config = {
         **MOCK_HOME_CONFIG,
         f"{CONF_DASHBOARD_SECTION_NAME}_0": "#1 - cars",
         f"{CONF_DASHBOARD_SECTION_ICON}_0": "mdi:car",
+        f"{CONF_DASHBOARD_SECTION_NAME}_1": "#2 - climates",
+        f"{CONF_DASHBOARD_SECTION_ICON}_1": "mdi:home-thermometer",
+        f"{CONF_DASHBOARD_SECTION_NAME}_2": "#3 - pools",
+        f"{CONF_DASHBOARD_SECTION_ICON}_2": "mdi:pool",
+        f"{CONF_DASHBOARD_SECTION_NAME}_3": "#4 - others",
+        f"{CONF_DASHBOARD_SECTION_ICON}_3": "mdi:home",
+        f"{CONF_DASHBOARD_SECTION_NAME}_4": "#5 - settings",
+        f"{CONF_DASHBOARD_SECTION_ICON}_4": "mdi:cog-outline",
     }
     home_entry = MockConfigEntry(
         domain=DOMAIN,
-        data=custom_home_config,
-        entry_id="s5_home_entry",
-        title="home: S5 Home",
-        unique_id="s5_home_entry",
+        data=legacy_config,
+        entry_id="init_includes_all_home_entry",
+        title="home: Init Includes All",
+        unique_id="init_includes_all_home_entry",
     )
     home_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(home_entry.entry_id)
     await hass.async_block_till_done()
+
     data_handler = hass.data[DOMAIN][DATA_HANDLER]
     home = data_handler.home
 
-    # Add boiler #1 — this triggers the migration which appends water_boilers.
-    boiler1_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={**MOCK_WATER_BOILER_CONFIG, CONF_NAME: "Boiler One"},
-        entry_id="s5_boiler1_entry",
-        title="water_boiler: Boiler One",
-        unique_id="s5_boiler1_entry",
+    section_names = [s[0] for s in home.dashboard_sections]
+    expected = [name for name, _icon in DASHBOARD_DEFAULT_SECTIONS]
+    assert section_names == expected, (
+        f"After init, every bundled default in const order must be present "
+        f"in home.dashboard_sections. Expected {expected}, got "
+        f"{section_names}"
     )
-    boiler1_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(boiler1_entry.entry_id)
-    await hass.async_block_till_done()
-    boiler1 = hass.data[DOMAIN].get(boiler1_entry.entry_id)
-    assert boiler1.dashboard_section == "water_boilers"
-
-    # Simulate the pre-S5 failure mode: water_boilers gets removed from
-    # the in-memory list AND boiler #1's cache stale-fires to NO_SECTION.
-    # (Without S5's cross-device invalidation loop, this is the state
-    # that would have stuck around forever.)
-    home.dashboard_sections = [s for s in home.dashboard_sections if s[0] != "water_boilers"]
-    boiler1._computed_dashboard_section = DASHBOARD_NO_SECTION
-
-    # Add boiler #2 — migration appends water_boilers AGAIN, and the S5
-    # invalidation loop must reset boiler #1's stale NO_SECTION cache.
-    boiler2_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={**MOCK_WATER_BOILER_CONFIG, CONF_NAME: "Boiler Two"},
-        entry_id="s5_boiler2_entry",
-        title="water_boiler: Boiler Two",
-        unique_id="s5_boiler2_entry",
-    )
-    boiler2_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(boiler2_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Boiler #1's stale cache was invalidated — re-resolves to `water_boilers`.
-    assert boiler1.dashboard_section == "water_boilers", (
-        "S5: sibling device's stale NO_SECTION cache was not invalidated "
-        "when the migration re-appended `water_boilers`."
-    )
-    devices_in_section = home.get_devices_for_dashboard_section("water_boilers")
-    assert boiler1 in devices_in_section
-    boiler2 = hass.data[DOMAIN].get(boiler2_entry.entry_id)
-    assert boiler2 in devices_in_section
 
 
-async def test_home_migration_honours_user_removed_section_optout(
+async def test_home_init_preserves_custom_user_sections(
     hass: HomeAssistant,
 ) -> None:
-    """N7: a user-deliberate opt-out (via CONF_DASHBOARD_SECTIONS_USER_REMOVED)
-    is honoured — the migration does NOT silently re-append a section the
-    user explicitly removed.
+    """The init-time bundled-default inclusion must NOT discard user-
+    defined custom sections (names not in `DASHBOARD_DEFAULT_SECTIONS_DICT`).
+    Custom sections are preserved at the tail in their original order.
     """
-    from .const import MOCK_HOME_CONFIG, MOCK_WATER_BOILER_CONFIG
+    from .const import MOCK_HOME_CONFIG
 
-    # Home with customised list — cars only — plus an explicit opt-out of
-    # the `water_boilers` section.
-    custom_home_config = {
+    custom_layout = {
         **MOCK_HOME_CONFIG,
         f"{CONF_DASHBOARD_SECTION_NAME}_0": "#1 - cars",
         f"{CONF_DASHBOARD_SECTION_ICON}_0": "mdi:car",
-        CONF_DASHBOARD_SECTIONS_USER_REMOVED: ["water_boilers"],
+        f"{CONF_DASHBOARD_SECTION_NAME}_1": "my_workshop",  # custom
+        f"{CONF_DASHBOARD_SECTION_ICON}_1": "mdi:hammer",
+        f"{CONF_DASHBOARD_SECTION_NAME}_2": "#3 - pools",
+        f"{CONF_DASHBOARD_SECTION_ICON}_2": "mdi:pool",
     }
     home_entry = MockConfigEntry(
         domain=DOMAIN,
-        data=custom_home_config,
-        entry_id="n7_home_entry",
-        title="home: N7 Home",
-        unique_id="n7_home_entry",
+        data=custom_layout,
+        entry_id="init_preserve_custom_entry",
+        title="home: Init Preserves Custom",
+        unique_id="init_preserve_custom_entry",
     )
     home_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(home_entry.entry_id)
     await hass.async_block_till_done()
+
     data_handler = hass.data[DOMAIN][DATA_HANDLER]
     home = data_handler.home
 
-    # Add a water_boiler — migration MUST NOT re-append water_boilers.
-    boiler_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=MOCK_WATER_BOILER_CONFIG,
-        entry_id="n7_boiler_entry",
-        title=f"water_boiler: {MOCK_WATER_BOILER_CONFIG['name']}",
-        unique_id="n7_boiler_entry",
+    names = [s[0] for s in home.dashboard_sections]
+    assert "my_workshop" in names, (
+        f"Custom user section 'my_workshop' must be preserved; got {names}"
     )
-    boiler_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(boiler_entry.entry_id)
+    # All bundled defaults must also be present.
+    for default_name, _ in DASHBOARD_DEFAULT_SECTIONS:
+        assert default_name in names, (
+            f"Bundled default {default_name!r} missing after init; got {names}"
+        )
+    # Custom sections appear AFTER all bundled defaults.
+    workshop_idx = names.index("my_workshop")
+    for default_name, _ in DASHBOARD_DEFAULT_SECTIONS:
+        assert names.index(default_name) < workshop_idx, (
+            f"Custom section 'my_workshop' must appear after all bundled "
+            f"defaults; bundled {default_name!r} came after it in {names}"
+        )
+
+
+async def test_home_init_honours_user_removed_section_optout(
+    hass: HomeAssistant,
+) -> None:
+    """Init-time bundled-default inclusion must honour the
+    `CONF_DASHBOARD_SECTIONS_USER_REMOVED` opt-out: a power user who
+    listed e.g. `settings` in that list does NOT get it auto-added on
+    every restart.
+    """
+    from .const import MOCK_HOME_CONFIG
+
+    custom_with_optout = {
+        **MOCK_HOME_CONFIG,
+        f"{CONF_DASHBOARD_SECTION_NAME}_0": "#1 - cars",
+        f"{CONF_DASHBOARD_SECTION_ICON}_0": "mdi:car",
+        CONF_DASHBOARD_SECTIONS_USER_REMOVED: ["water_boilers", "settings"],
+    }
+    home_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=custom_with_optout,
+        entry_id="init_opt_out_entry",
+        title="home: Init Opt Out",
+        unique_id="init_opt_out_entry",
+    )
+    home_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(home_entry.entry_id)
     await hass.async_block_till_done()
 
-    section_names = {s[0] for s in home.dashboard_sections}
-    assert "water_boilers" not in section_names, (
-        "User explicitly opted out of water_boilers; migration must "
-        "honour that opt-out instead of silently re-appending it."
+    data_handler = hass.data[DOMAIN][DATA_HANDLER]
+    home = data_handler.home
+
+    names = {s[0] for s in home.dashboard_sections}
+    assert "water_boilers" not in names, (
+        f"User opted out of water_boilers; init MUST NOT re-add it. "
+        f"Got {names}"
+    )
+    assert "settings" not in names, (
+        f"User opted out of settings; init MUST NOT re-add it. Got {names}"
+    )
+    # Sections NOT in the opt-out list are still auto-added.
+    assert "radiators" in names, (
+        f"Bundled default radiators (not in opt-out) must still be "
+        f"auto-added; got {names}"
     )
 
 

--- a/tests/ha_tests/test_home_extended_coverage.py
+++ b/tests/ha_tests/test_home_extended_coverage.py
@@ -1157,9 +1157,18 @@ class TestHomeDashboardAndInit:
         entry.add_to_hass(hass)
         home = await _get_home(hass, entry)
         assert len(home.dashboard_sections) >= 1
-        # First custom section gets auto-name
-        assert home.dashboard_sections[0][0] == "section_1"
-        assert home.dashboard_sections[0][1] == "mdi:car"
+        # Custom section with no explicit name gets auto-named
+        # `section_1`. After the post-QS-195 normalize, bundled defaults
+        # (e.g. `settings` added by the home device's own migration)
+        # appear FIRST and custom sections at the tail — so look up by
+        # entry rather than asserting on position.
+        section_names = [s[0] for s in home.dashboard_sections]
+        section_icons = {s[0]: s[1] for s in home.dashboard_sections}
+        assert "section_1" in section_names, (
+            f"Custom icon-only section must be auto-named 'section_1'; "
+            f"got {section_names}"
+        )
+        assert section_icons["section_1"] == "mdi:car"
 
 
 # ========================================================================

--- a/tests/ha_tests/test_select.py
+++ b/tests/ha_tests/test_select.py
@@ -270,7 +270,7 @@ async def test_climate_duration_device_creation(
 
     # Mock get_hvac_modes to return a list without requiring entity registry
     with patch(
-        "custom_components.quiet_solar.ha_model.climate_controller.get_hvac_modes",
+        "custom_components.quiet_solar.ha_model.bistate_transport.get_hvac_modes",
         return_value=["off", "heat", "cool", "auto"],
     ):
         climate_entry = MockConfigEntry(
@@ -313,7 +313,7 @@ async def test_create_ha_select_for_climate_duration_returns_entities(
 
     # Mock get_hvac_modes to return a list without requiring entity registry
     with patch(
-        "custom_components.quiet_solar.ha_model.climate_controller.get_hvac_modes",
+        "custom_components.quiet_solar.ha_model.bistate_transport.get_hvac_modes",
         return_value=["off", "heat", "cool", "auto"],
     ):
         climate_entry = MockConfigEntry(
@@ -387,7 +387,7 @@ async def test_create_ha_select_detects_bistate_and_climate_duration(
 
     # Mock get_hvac_modes for climate device
     with patch(
-        "custom_components.quiet_solar.ha_model.climate_controller.get_hvac_modes",
+        "custom_components.quiet_solar.ha_model.bistate_transport.get_hvac_modes",
         return_value=["off", "heat", "cool", "auto"],
     ):
         # Set up climate_duration device
@@ -491,6 +491,90 @@ async def test_climate_duration_select_unload(
 # =============================================================================
 # Coverage: select.py line 175 - create_ha_select_for_QSSolar early return
 # =============================================================================
+
+
+async def test_radiator_exposes_only_bistate_mode_select(
+    hass: HomeAssistant,
+    home_config_entry: ConfigEntry,
+) -> None:
+    """AC-12 — switch-backed radiator exposes exactly one select (`bistate_mode`).
+
+    The radiator inherits from `QSBiStateDuration` (not `QSClimateDuration`),
+    so the `isinstance(device, QSClimateDuration)` branch in
+    `create_ha_select` does NOT create the runtime `climate_state_on` /
+    `climate_state_off` selects.
+    """
+    from .const import MOCK_RADIATOR_SWITCH_CONFIG
+
+    await hass.config_entries.async_setup(home_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("switch.test_radiator_switch", "off", {})
+
+    radiator_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_RADIATOR_SWITCH_CONFIG,
+        entry_id="radiator_select_test",
+        title=f"radiator: {MOCK_RADIATOR_SWITCH_CONFIG['name']}",
+        unique_id="quiet_solar_radiator_select_test",
+    )
+    radiator_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(radiator_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert radiator_entry.state is ConfigEntryState.LOADED
+
+    entity_entries = er.async_entries_for_config_entry(entity_registry := er.async_get(hass), radiator_entry.entry_id)
+    select_entries = [e for e in entity_entries if e.domain == "select"]
+
+    # Exactly one select: the bistate-mode select. NO climate_state_on /
+    # climate_state_off entries (those only come from QSClimateDuration).
+    assert len(select_entries) == 1
+    assert select_entries[0].translation_key == "radiator_mode"
+
+    # silence unused-fixture lint
+    assert entity_registry is not None
+
+
+async def test_radiator_climate_exposes_only_bistate_mode_select(
+    hass: HomeAssistant,
+    home_config_entry: ConfigEntry,
+) -> None:
+    """AC-12 — climate-backed radiator also exposes only one select.
+
+    Even when the radiator wraps a climate entity, it remains a
+    `QSBiStateDuration` (not `QSClimateDuration`), so the runtime
+    HVAC-mode selects are NOT created (config-time only — D4).
+    """
+    from .const import MOCK_RADIATOR_CLIMATE_CONFIG
+
+    await hass.config_entries.async_setup(home_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "climate.test_radiator_climate",
+        "off",
+        {"hvac_modes": ["off", "heat", "auto"]},
+    )
+
+    radiator_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_RADIATOR_CLIMATE_CONFIG,
+        entry_id="radiator_climate_select_test",
+        title=f"radiator: {MOCK_RADIATOR_CLIMATE_CONFIG['name']}",
+        unique_id="quiet_solar_radiator_climate_select_test",
+    )
+    radiator_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(radiator_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert radiator_entry.state is ConfigEntryState.LOADED
+
+    entity_entries = er.async_entries_for_config_entry(er.async_get(hass), radiator_entry.entry_id)
+    select_entries = [e for e in entity_entries if e.domain == "select"]
+
+    assert len(select_entries) == 1
+    assert select_entries[0].translation_key == "radiator_mode"
 
 
 def test_create_ha_select_for_qssolar_empty_providers():

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -201,9 +201,10 @@ class TestDashboardTemplateRendering:
         tpl = Template(template_content, hass)
         rendered = tpl.async_render(variables={"home": home})
 
-        # The radiators section must be present (AC-8) and must use the
-        # dedicated card type for the two radiator devices.
-        assert "custom:qs-radiator-card" in rendered
+        # N14 — the fixture installs TWO radiators (switch + climate);
+        # both must dispatch to the dedicated card. `>= 2` rather than
+        # `>= 1` so a regression that drops one of them is caught.
+        assert rendered.count("custom:qs-radiator-card") >= 2
         # Sanity: the section name surfaces in the rendered YAML.
         assert "radiators" in rendered
 
@@ -219,6 +220,10 @@ class TestDashboardTemplateRendering:
         # Class identifier must be renamed (no stale `QsOnOffDurationCard`).
         assert "QsRadiatorCard" in content
         assert "QsOnOffDurationCard" not in content
+        # N10 — `customCards` registration uses the user-facing card name.
+        assert "'QS Radiator Card'" in content
+        # Stub config also reads the renamed display name.
+        assert "QS Radiator" in content
 
     @pytest.mark.asyncio
     async def test_solar_entities_appear_in_rendered_output(self, hass, full_dashboard_home):
@@ -431,6 +436,21 @@ class TestDashboardSectionMapping:
         assert section in section_names, (
             f"Section '{section}' for device type '{device_type}' not in DASHBOARD_DEFAULT_SECTIONS"
         )
+
+    def test_dashboard_default_sections_preserve_existing_ordering(self):
+        """M2 regression — `DASHBOARD_DEFAULT_SECTIONS` must keep the legacy 1..5 positions.
+
+        Any user who stored a section assignment via the old labels
+        (e.g. `"#3 - pools"`, `"#5 - settings"`) keeps pointing at the
+        right section after upgrade. New sections must always be
+        appended after the legacy ones.
+        """
+        names = [s[0] for s in DASHBOARD_DEFAULT_SECTIONS]
+        # The first five positions are FROZEN — do not reorder/insert.
+        assert names[:5] == ["cars", "climates", "pools", "others", "settings"]
+        # New `radiators` section MUST be appended (not inserted).
+        assert "radiators" in names
+        assert names.index("radiators") >= 5
 
     def test_dashboard_default_section_uses_device_type_not_builtin_type(self):
         """Regression: load.py must use device_type variable, not Python builtin type."""

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -693,33 +693,56 @@ class TestDashboardSectionMapping:
             f"Section '{section}' for device type '{device_type}' not in DASHBOARD_DEFAULT_SECTIONS"
         )
 
-    def test_dashboard_default_sections_preserve_existing_ordering(self):
-        """M2 regression — QS-195 must NOT insert sections mid-list.
+    def test_dashboard_device_section_translations_match_const_order(self):
+        """The `dashboard_device_section` selector translation keys
+        MUST match the `#N - <name>` positions computed by
+        `map_section_selected_name_in_section_list` from
+        `DASHBOARD_DEFAULT_SECTIONS`. A drift between the two surfaces
+        as untranslated dropdown labels in the user's config flow
+        (option present but rendered as raw `"#N - foo"`).
+        """
+        import json
 
-        The QS-195 `radiators` section MUST be appended after every
-        section that existed before QS-195 landed (so users who stored
-        a `"#N - foo"` assignment before the merge keep pointing at the
-        right section after upgrade). The QS-194 `water_boilers` and
-        every other pre-existing section all appear before `radiators`.
+        strings_path = COMPONENT_ROOT / "strings.json"
+        strings = json.loads(strings_path.read_text())
+        translation_options = strings["selector"]["dashboard_device_section"]["options"]
 
-        Note: an earlier revision of this test pinned the first five
-        positions to `["cars", "climates", "pools", "others", "settings"]`,
-        but the QS-194 merge inserted `water_boilers` between `pools`
-        and `others` — that's a QS-194 concern, not a QS-195 one. We
-        only enforce the QS-195 invariant here.
+        # Build the expected `#N - <name>` keys from the const ordering.
+        expected_keys = {"Not in dashboard"}
+        for i, (name, _icon) in enumerate(DASHBOARD_DEFAULT_SECTIONS):
+            expected_keys.add(f"#{i + 1} - {name}")
+
+        translation_keys = set(translation_options.keys())
+
+        missing = expected_keys - translation_keys
+        extra = translation_keys - expected_keys
+        assert not missing, (
+            f"`dashboard_device_section` translation is MISSING keys: "
+            f"{sorted(missing)}. Add them to strings.json with the "
+            f"matching index from `DASHBOARD_DEFAULT_SECTIONS`."
+        )
+        assert not extra, (
+            f"`dashboard_device_section` translation has STALE keys: "
+            f"{sorted(extra)}. Remove them — the index probably shifted "
+            f"after a section was inserted / removed."
+        )
+
+    def test_dashboard_default_sections_translation_alignment(self):
+        """M2 (rev. 2) — `DASHBOARD_DEFAULT_SECTIONS` ordering must
+        agree with the `dashboard_device_section` translation block.
+
+        The earlier "radiators MUST be appended last" invariant was
+        relaxed in favour of co-locating heating-related sections
+        (`water_boilers` and `radiators` next to each other). The new
+        invariant is just "translation positions match const order"
+        — that's what `test_dashboard_device_section_translations_match_const_order`
+        enforces; this one pins the contents independently.
         """
         names = [s[0] for s in DASHBOARD_DEFAULT_SECTIONS]
-        # The QS-195 `radiators` addition MUST be appended (not inserted).
-        assert "radiators" in names
-        radiators_idx = names.index("radiators")
-        # Every other section appears BEFORE `radiators` — the QS-195
-        # change is a strict append, not an insert.
-        non_radiator_sections = [n for n in names if n != "radiators"]
-        for section in non_radiator_sections:
-            assert names.index(section) < radiators_idx, (
-                f"Section {section!r} appears AFTER `radiators` — "
-                "QS-195 must only append, never insert mid-list"
-            )
+        # Every bundled section that user-visible code references must
+        # exist somewhere in the list.
+        for expected in ("cars", "climates", "pools", "water_boilers", "radiators", "others", "settings"):
+            assert expected in names, f"Missing default section: {expected}"
 
     def test_dashboard_default_section_uses_device_type_not_builtin_type(self):
         """Regression: load.py must use device_type variable, not Python builtin type."""

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -753,6 +753,114 @@ class TestDashboardSectionMapping:
         for key in LOAD_TYPE_DASHBOARD_DEFAULT_SECTION:
             assert isinstance(key, str), f"Key {key!r} in LOAD_TYPE_DASHBOARD_DEFAULT_SECTION is not a string"
 
+    def test_normalize_dashboard_sections_order_reorders_bundled_to_const(self):
+        """BH (post-QS-195 user bug): the `_normalize_dashboard_sections_order`
+        helper must rewrite a list of bundled defaults that arrived in the
+        wrong order (e.g. because an older append-only migration tacked
+        sections onto the end) so the result follows
+        `DASHBOARD_DEFAULT_SECTIONS` order. Without this, a user who
+        upgraded across QS-194/QS-195 sees their radiator section
+        rendered AFTER `settings` on the dashboard.
+        """
+        from custom_components.quiet_solar.ha_model.home import (
+            _normalize_dashboard_sections_order,
+        )
+
+        # Simulate the broken append-only migration state: bundled
+        # defaults present but out of const order.
+        input_sections = [
+            ("cars", "mdi:car"),
+            ("climates", "mdi:home-thermometer"),
+            ("pools", "mdi:pool"),
+            ("others", "mdi:home"),
+            ("settings", "mdi:cog-outline"),
+            ("water_boilers", "mdi:water-boiler"),
+            ("radiators", "mdi:radiator"),
+        ]
+
+        result = _normalize_dashboard_sections_order(input_sections)
+
+        expected = [
+            ("cars", "mdi:car"),
+            ("climates", "mdi:home-thermometer"),
+            ("pools", "mdi:pool"),
+            ("water_boilers", "mdi:water-boiler"),
+            ("radiators", "mdi:radiator"),
+            ("others", "mdi:home"),
+            ("settings", "mdi:cog-outline"),
+        ]
+        assert result == expected, (
+            f"_normalize_dashboard_sections_order must reorder bundled "
+            f"defaults to match DASHBOARD_DEFAULT_SECTIONS. Expected "
+            f"{expected}, got {result}"
+        )
+
+    def test_normalize_dashboard_sections_order_preserves_custom_sections(self):
+        """BH companion: user-defined custom sections (names NOT in
+        `DASHBOARD_DEFAULT_SECTIONS_DICT`) must be preserved at the end
+        of the list in their original relative order. Reordering bundled
+        defaults must NOT delete or shuffle the user's custom entries.
+        """
+        from custom_components.quiet_solar.ha_model.home import (
+            _normalize_dashboard_sections_order,
+        )
+
+        input_sections = [
+            ("cars", "mdi:car"),
+            ("my_workshop", "mdi:hammer"),   # custom
+            ("pools", "mdi:pool"),
+            ("garden_lights", "mdi:lamp"),    # custom
+            ("settings", "mdi:cog-outline"),
+        ]
+
+        result = _normalize_dashboard_sections_order(input_sections)
+
+        # Bundled defaults sorted by const order, then customs in their
+        # original relative order.
+        expected = [
+            ("cars", "mdi:car"),
+            ("pools", "mdi:pool"),
+            ("settings", "mdi:cog-outline"),
+            ("my_workshop", "mdi:hammer"),
+            ("garden_lights", "mdi:lamp"),
+        ]
+        assert result == expected, (
+            f"_normalize_dashboard_sections_order must preserve custom "
+            f"sections in original order at the end. Expected {expected}, "
+            f"got {result}"
+        )
+
+    def test_normalize_dashboard_sections_order_dedups_repeats(self):
+        """Defensive: if a section name is repeated (shouldn't happen in
+        practice, but the migration code path could theoretically add a
+        duplicate), the helper keeps only the FIRST occurrence so the
+        bundled-default ordering stays deterministic.
+        """
+        from custom_components.quiet_solar.ha_model.home import (
+            _normalize_dashboard_sections_order,
+        )
+
+        input_sections = [
+            ("cars", "mdi:car"),
+            ("cars", "mdi:car-electric"),  # duplicate, different icon
+            ("pools", "mdi:pool"),
+        ]
+
+        result = _normalize_dashboard_sections_order(input_sections)
+
+        assert result == [("cars", "mdi:car"), ("pools", "mdi:pool")], (
+            f"Duplicate section names must be deduped (first wins). "
+            f"Got {result}"
+        )
+
+    def test_normalize_dashboard_sections_order_empty_input(self):
+        """Edge case: an empty input returns an empty list without error."""
+        from custom_components.quiet_solar.ha_model.home import (
+            _normalize_dashboard_sections_order,
+        )
+
+        assert _normalize_dashboard_sections_order([]) == []
+
     @pytest.mark.asyncio
     async def test_all_devices_assigned_to_sections(self, full_dashboard_home):
         """Regression: all devices must appear in at least one dashboard section."""

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -41,6 +41,8 @@ from tests.ha_tests.const import (
     MOCK_HOME_CONFIG,
     MOCK_ON_OFF_DURATION_CONFIG,
     MOCK_PERSON_CONFIG,
+    MOCK_RADIATOR_CLIMATE_CONFIG,
+    MOCK_RADIATOR_SWITCH_CONFIG,
     MOCK_SENSOR_STATES,
     MOCK_SOLAR_CONFIG,
 )
@@ -120,6 +122,8 @@ async def full_dashboard_home(hass):
         ("climate", MOCK_CLIMATE_DURATION_CONFIG),
         ("heat_pump", MOCK_HEAT_PUMP_CONFIG),
         ("pool", MOCK_POOL_CONFIG),
+        ("radiator_switch", MOCK_RADIATOR_SWITCH_CONFIG),
+        ("radiator_climate", MOCK_RADIATOR_CLIMATE_CONFIG),
     ]
 
     entries = {}
@@ -182,6 +186,39 @@ class TestDashboardTemplateRendering:
         parsed = yaml.safe_load(rendered)
         assert parsed is not None
         assert "views" in parsed
+
+    @pytest.mark.asyncio
+    async def test_radiator_devices_use_dedicated_card(self, hass, full_dashboard_home):
+        """AC-14 — radiator devices dispatch to `custom:qs-radiator-card`.
+
+        Both switch-backed and climate-backed radiators must render with
+        the dedicated card type, never the on/off or climate card.
+        """
+        home = full_dashboard_home
+        template_path = COMPONENT_ROOT / "ui" / "quiet_solar_dashboard_template.yaml.j2"
+        template_content = template_path.read_text()
+
+        tpl = Template(template_content, hass)
+        rendered = tpl.async_render(variables={"home": home})
+
+        # The radiators section must be present (AC-8) and must use the
+        # dedicated card type for the two radiator devices.
+        assert "custom:qs-radiator-card" in rendered
+        # Sanity: the section name surfaces in the rendered YAML.
+        assert "radiators" in rendered
+
+    @pytest.mark.asyncio
+    async def test_radiator_card_resource_file_present(self):
+        """AC-11 — `qs-radiator-card.js` ships in the resources directory."""
+        card_path = COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js"
+        assert card_path.is_file(), f"Missing radiator card resource: {card_path}"
+
+        content = card_path.read_text()
+        # Custom-element registration must reference the renamed element.
+        assert "customElements.define('qs-radiator-card'" in content
+        # Class identifier must be renamed (no stale `QsOnOffDurationCard`).
+        assert "QsRadiatorCard" in content
+        assert "QsOnOffDurationCard" not in content
 
     @pytest.mark.asyncio
     async def test_solar_entities_appear_in_rendered_output(self, hass, full_dashboard_home):
@@ -380,6 +417,7 @@ class TestDashboardSectionMapping:
             ("on_off_duration", "others"),
             ("climate", "climates"),
             ("heat_pump", "climates"),
+            ("radiator", "radiators"),
         ],
     )
     def test_device_type_maps_to_section(self, device_type, expected_section):

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -477,8 +477,10 @@ class TestDashboardTemplateRendering:
 
         # The MOCK_RADIATOR_CLIMATE_CONFIG fixture installs a
         # climate-backed radiator with `CONF_CLIMATE_HVAC_MODE_ON="heat"`,
-        # so the rendered YAML must include the entry.
-        assert "climate_hvac_mode_on: heat" in rendered
+        # so the rendered YAML must include the entry. Post-bugfix the
+        # value is quoted so YAML 1.1 doesn't coerce bare `on` / `off`
+        # to booleans (switch-backed radiators emit `on` literal).
+        assert "climate_hvac_mode_on: 'heat'" in rendered
 
     @pytest.mark.asyncio
     async def test_solar_entities_appear_in_rendered_output(self, hass, full_dashboard_home):
@@ -860,6 +862,247 @@ class TestDashboardSectionMapping:
         )
 
         assert _normalize_dashboard_sections_order([]) == []
+
+    def test_radiator_and_water_boiler_cards_guard_against_zero_max_hours(self):
+        """User-reported bug: a brand-new switch-backed radiator with no
+        active constraint sensor (or one that reports 0) produces
+        ``maxHours = targetHours = 0`` in the non-default-mode branch,
+        causing every arc-path calc to divide by zero. The SVG paths
+        end up as ``M ... A 130 130 0 0 1 NaN NaN`` and the dashboard
+        shows a "Configuration error".
+
+        Fix invariant: in the non-default branch, both cards must
+        clamp ``maxHours`` to a positive finite value before using
+        it in arc-path math. We pin this via regex so a future edit
+        that drops the clamp regresses the test.
+        """
+        import re
+
+        for card_filename in ("qs-radiator-card.js", "qs-water-boiler-card.js"):
+            content = (COMPONENT_ROOT / "ui" / "resources" / card_filename).read_text()
+            # Strip comments so the regex only matches executable code.
+            no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+            executable = re.sub(r"//[^\n]*", "", no_block)
+
+            # The non-default branch MUST guard against zero (or NaN)
+            # `targetHours` before assigning to `maxHours`. Acceptable
+            # patterns include:
+            #   maxHours = targetHours > 0 ? targetHours : <fallback>;
+            #   maxHours = Math.max(<fallback>, targetHours);
+            # Detect ANY clamp-style guard around `targetHours` near the
+            # `maxHours = targetHours` assignment.
+            unguarded_pat = re.compile(
+                r"maxHours\s*=\s*targetHours\s*;", re.MULTILINE
+            )
+            assert unguarded_pat.search(executable) is None, (
+                f"{card_filename}: a bare `maxHours = targetHours;` assignment "
+                f"would divide by zero when the constraint sensor reports 0 "
+                f"(brand-new device, no live constraint). Use a clamp like "
+                f"`maxHours = targetHours > 0 ? targetHours : 12;` instead."
+            )
+
+    def test_radiator_template_quotes_climate_hvac_mode_on(self):
+        """User-reported bug: a switch-backed radiator emits
+        ``climate_hvac_mode_on: on`` in the dashboard YAML. YAML 1.1
+        parses bare ``on`` / ``off`` as booleans, so HA hands the JS
+        card ``true`` instead of the string ``"on"``. The card then
+        crashes inside ``_render()`` with
+        ``TypeError: true.toLowerCase is not a function`` and Lovelace
+        renders a "Configuration error" card.
+
+        Fix invariant: the radiator's `climate_hvac_mode_on` value MUST
+        be quoted in BOTH dashboard templates so YAML never coerces it.
+        We pin the quoted form via a regex on the template source.
+        """
+        import re
+
+        for template_filename in (
+            "quiet_solar_dashboard_template.yaml.j2",
+            "quiet_solar_dashboard_template_standard_ha.yaml.j2",
+        ):
+            template_path = COMPONENT_ROOT / "ui" / template_filename
+            if not template_path.exists():
+                continue
+            content = template_path.read_text()
+            # The Jinja line we care about lives only in the custom
+            # template (the standard one doesn't pass `climate_hvac_mode_on`
+            # to the card — it uses entity rows). Skip if absent.
+            if "climate_hvac_mode_on" not in content:
+                continue
+            # The value must be wrapped in quotes — single or double.
+            # Anything else (bare interpolation) lets YAML 1.1 coerce
+            # `on` → True / `off` → False / `yes` → True / etc.
+            unquoted_pat = re.compile(
+                r"climate_hvac_mode_on:\s*\{\{\s*device\.hvac_state_on\s*\}\}",
+                re.MULTILINE,
+            )
+            assert unquoted_pat.search(content) is None, (
+                f"{template_filename}: `climate_hvac_mode_on: "
+                f"{{{{ device.hvac_state_on }}}}` is unquoted — YAML 1.1 "
+                f"will parse bare `on`/`off` as booleans and the JS card "
+                f"will crash with `true.toLowerCase is not a function`. "
+                f"Quote the interpolation: "
+                f"`climate_hvac_mode_on: '{{{{ device.hvac_state_on }}}}'`."
+            )
+            # And positively assert a quoted form is present.
+            quoted_pat = re.compile(
+                r"climate_hvac_mode_on:\s*['\"]\{\{\s*device\.hvac_state_on\s*\}\}['\"]",
+                re.MULTILINE,
+            )
+            assert quoted_pat.search(content) is not None, (
+                f"{template_filename}: expected a quoted "
+                f"`climate_hvac_mode_on: '{{{{ device.hvac_state_on }}}}'` "
+                f"emit. The unquoted variant trips YAML's bool coercion."
+            )
+
+    def test_radiator_card_tolerates_non_string_hvac_mode_on(self):
+        """Defense-in-depth for the same user-reported bug: even if a
+        future template regression emits an unquoted ``on`` (parsed as
+        Python ``True``) into ``climate_hvac_mode_on``, the JS card
+        must NOT crash on ``true.toLowerCase()`` — wrap the value in
+        ``String(...)`` before the call.
+        """
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+        no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+        executable = re.sub(r"//[^\n]*", "", no_block)
+
+        # Every reference to `e.climate_hvac_mode_on` that feeds into a
+        # chained `.toLowerCase()` MUST be wrapped in `String(...)`
+        # first. Walk every `e.climate_hvac_mode_on` occurrence and
+        # check the preceding token is `String(`.
+        ref_pat = re.compile(r"e\.climate_hvac_mode_on")
+        unsafe_uses: list[str] = []
+        for m in ref_pat.finditer(executable):
+            # Search backwards from `m.start()` for the nearest
+            # non-whitespace token. Accept `String(`, `String  (`,
+            # or any usage that doesn't lead to `.toLowerCase()`.
+            tail = executable[m.end():m.end() + 200]
+            if ".toLowerCase" not in tail:
+                continue  # not a stringy use, irrelevant
+            preceding = executable[max(0, m.start() - 60) : m.start()]
+            if not re.search(r"String\s*\(\s*$", preceding):
+                unsafe_uses.append(
+                    f"...{preceding[-50:]}<HERE>{executable[m.start() : m.end() + 40]}..."
+                )
+        assert not unsafe_uses, (
+            "qs-radiator-card.js: every `e.climate_hvac_mode_on` use that "
+            "leads to `.toLowerCase()` must be wrapped in `String(...)`. "
+            "Without the wrap, a YAML-coerced boolean (`on` → True) "
+            "crashes the card. Offending uses:\n  " + "\n  ".join(unsafe_uses)
+        )
+
+    def test_radiator_and_water_boiler_cards_arc_path_guards_nan(self):
+        """Defense-in-depth for the same user-reported bug: the
+        ``arcPath`` helper must reject non-finite inputs so a stray
+        NaN from upstream math (e.g. a 0-divisor in hoursToPct) never
+        reaches the rendered SVG attribute. Without this guard, the
+        browser shows ``Error: <path> attribute d: Expected number,
+        "...A 130 130 0 0 1 NaN NaN"``.
+        """
+        import re
+
+        for card_filename in ("qs-radiator-card.js", "qs-water-boiler-card.js"):
+            content = (COMPONENT_ROOT / "ui" / "resources" / card_filename).read_text()
+            no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+            executable = re.sub(r"//[^\n]*", "", no_block)
+
+            # The arcPath helper definition must include a finiteness
+            # check on its angle inputs. Accept either `Number.isFinite`
+            # OR `Number.isNaN` (negative form).
+            arc_pat = re.compile(
+                r"arcPath\s*=\s*\([^)]*\)\s*=>\s*\{(?P<body>[^}]*(?:\}[^}]*)*?)\};",
+                re.DOTALL,
+            )
+            m = arc_pat.search(executable)
+            assert m is not None, (
+                f"{card_filename}: could not find an `arcPath = (...) => "
+                f"{{...}};` arrow definition — check the helper layout."
+            )
+            body = m.group("body")
+            has_finite = "Number.isFinite" in body or "Number.isNaN" in body
+            assert has_finite, (
+                f"{card_filename}: `arcPath` must guard against non-finite "
+                f"angle inputs (use Number.isFinite / Number.isNaN). "
+                f"Body was: {body[:300]}..."
+            )
+
+    def test_device_dashboard_section_translation_present_for_each_step(self):
+        """User-reported bug: the `device_dashboard_section` form field
+        renders as the raw key in the UI for every step except `person`
+        because no translation was defined elsewhere.
+
+        Every config-step (and its corresponding options-step) whose
+        `LOAD_TYPE_DASHBOARD_DEFAULT_SECTION` mapping is non-None
+        includes the `CONF_DEVICE_DASHBOARD_SECTION` field in its
+        schema via `get_common_schema`, so each MUST have a
+        translation entry in `strings.json` under `data` (either a
+        literal or a `[%key:...%]` reference).
+        """
+        import json
+        from custom_components.quiet_solar.const import LOAD_TYPE_DASHBOARD_DEFAULT_SECTION
+
+        strings_path = COMPONENT_ROOT / "strings.json"
+        strings = json.loads(strings_path.read_text())
+
+        # Map device-type constants to their config-flow step name.
+        # Step name = the value of `conf_type_name` on the device
+        # class, which matches the device-type constant for everything
+        # except chargers (we skip those — their LOAD_TYPE_... is
+        # None so they don't get the dashboard-section field).
+        type_to_step = {
+            "home": "home",
+            "battery": "battery",
+            "solar": "solar",
+            "person": "person",
+            "car": "car",
+            "pool": "pool",
+            "water_boiler": "water_boiler",
+            "on_off_duration": "on_off_duration",
+            "climate": "climate",
+            "heat_pump": "heat_pump",
+            "radiator": "radiator",
+        }
+
+        # All step names that should have the translation.
+        required_steps = [
+            type_to_step[type_name]
+            for type_name, section in LOAD_TYPE_DASHBOARD_DEFAULT_SECTION.items()
+            if section is not None and type_name in type_to_step
+        ]
+        # Sanity: must cover at least the post-QS-195 set.
+        for must_have in (
+            "home", "battery", "solar", "person", "car", "pool",
+            "water_boiler", "on_off_duration", "climate", "heat_pump",
+            "radiator",
+        ):
+            assert must_have in required_steps, (
+                f"Step {must_have!r} expected to be required but isn't "
+                f"derived from LOAD_TYPE_DASHBOARD_DEFAULT_SECTION; "
+                f"got {required_steps}"
+            )
+
+        # Verify both config.step.<X>.data.device_dashboard_section
+        # and options.step.<X>.data.device_dashboard_section exist.
+        missing: list[str] = []
+        for namespace in ("config", "options"):
+            for step in required_steps:
+                try:
+                    data_block = strings[namespace]["step"][step]["data"]
+                except KeyError:
+                    missing.append(f"{namespace}.step.{step}.data (missing)")
+                    continue
+                if "device_dashboard_section" not in data_block:
+                    missing.append(
+                        f"{namespace}.step.{step}.data.device_dashboard_section"
+                    )
+
+        assert not missing, (
+            f"Every step that includes the CONF_DEVICE_DASHBOARD_SECTION "
+            f"field MUST have a translation in strings.json. Missing: "
+            f"{missing}"
+        )
 
     @pytest.mark.asyncio
     async def test_all_devices_assigned_to_sections(self, full_dashboard_home):

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -342,6 +342,55 @@ class TestDashboardTemplateRendering:
         )
 
     @pytest.mark.asyncio
+    async def test_radiator_card_b5_show_dialog_escapes_interpolations(self):
+        """AA1 — pin B5: every interpolation inside `showDialog` is escaped.
+
+        Verifies that the `showDialog` function body does NOT contain
+        raw `${title}` / `${message}` interpolations against innerHTML
+        — they must all route through `_escapeHtml(...)`. Without this
+        a future entity-derived title/message would silently
+        reintroduce the S15 injection vector.
+        """
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+        # Extract `showDialog` body via brace-counting.
+        start = content.find("const showDialog")
+        assert start != -1, "Missing `showDialog` declaration"
+        # Find the `=>` then the opening `{`.
+        arrow = content.find("=>", start)
+        assert arrow != -1
+        body_start = content.find("{", arrow)
+        assert body_start != -1
+        # Brace-count to the matching `}`.
+        depth = 0
+        body_end = -1
+        for i in range(body_start, len(content)):
+            if content[i] == "{":
+                depth += 1
+            elif content[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    body_end = i
+                    break
+        assert body_end != -1, "Could not find closing brace of `showDialog`"
+
+        body = content[body_start : body_end + 1]
+
+        # Both `${title}` and `${message}` interpolations must go through
+        # `_escapeHtml`. We accept patterns like `${_escapeHtml(title)}`.
+        raw_title = re.search(r"\$\{title\}", body)
+        raw_message = re.search(r"\$\{message\}", body)
+        escaped_title = re.search(r"\$\{_escapeHtml\(title\)\}", body)
+        escaped_message = re.search(r"\$\{_escapeHtml\(message\)\}", body)
+
+        assert raw_title is None, "`${title}` is not escaped in showDialog"
+        assert raw_message is None, "`${message}` is not escaped in showDialog"
+        assert escaped_title is not None, "`_escapeHtml(title)` missing in showDialog"
+        assert escaped_message is not None, "`_escapeHtml(message)` missing in showDialog"
+
+    @pytest.mark.asyncio
     async def test_radiator_card_n7_running_includes_live_backing_state(self):
         """A2 — pin N7: the `running` derivation OR-s in the backing state.
 
@@ -363,6 +412,54 @@ class TestDashboardTemplateRendering:
             "Cold-start `running` fallback is missing — radiator may show as off "
             "during the cold-start grace window"
         )
+
+    @pytest.mark.asyncio
+    async def test_radiator_card_bh10_configured_hvac_on_compared(self):
+        """BH10 — `liveBackingOn` compares against the configured HVAC mode
+        (e.g. `auto`), not just the hard-coded `"heat"`.
+
+        Without this, a user who set `CONF_CLIMATE_HVAC_MODE_ON = "auto"`
+        sees `running=false` during the cold-start grace window even
+        though the climate entity reports `state="auto"`.
+        """
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+        # The card reads the configured HVAC mode from
+        # `e.climate_hvac_mode_on` with a `"heat"` default for backward
+        # compatibility.
+        assert "e.climate_hvac_mode_on" in content
+        # The comparison against `configuredHvacOn` MUST be present.
+        pattern = re.compile(
+            r"liveBackingState\s*===\s*configuredHvacOn"
+        )
+        assert pattern.search(content) is not None, (
+            "Cold-start `running` derivation no longer compares against the "
+            "configured HVAC ON mode — non-default HVAC modes won't be recognised"
+        )
+
+    @pytest.mark.asyncio
+    async def test_radiator_dashboard_passes_climate_hvac_mode_on(
+        self, hass, full_dashboard_home
+    ):
+        """BH10 — the dashboard template plumbs `climate_hvac_mode_on` through.
+
+        The card reads it from `entities.climate_hvac_mode_on`. The
+        radiator section must therefore emit a `climate_hvac_mode_on:`
+        key whose value matches the transport's `state_on`.
+        """
+        home = full_dashboard_home
+        template_path = COMPONENT_ROOT / "ui" / "quiet_solar_dashboard_template.yaml.j2"
+        template_content = template_path.read_text()
+
+        tpl = Template(template_content, hass)
+        rendered = tpl.async_render(variables={"home": home})
+
+        # The MOCK_RADIATOR_CLIMATE_CONFIG fixture installs a
+        # climate-backed radiator with `CONF_CLIMATE_HVAC_MODE_ON="heat"`,
+        # so the rendered YAML must include the entry.
+        assert "climate_hvac_mode_on: heat" in rendered
 
     @pytest.mark.asyncio
     async def test_solar_entities_appear_in_rendered_output(self, hass, full_dashboard_home):

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -226,6 +226,145 @@ class TestDashboardTemplateRendering:
         assert "QS Radiator" in content
 
     @pytest.mark.asyncio
+    async def test_radiator_card_s14_safe_number_guards_against_nan(self):
+        """A2 — pin S14 via regex, not a bare substring.
+
+        We assert that:
+          1. A `_safeNumber(` helper is present (the wrapper around
+             `Number()` that returns the fallback on non-finite values).
+          2. NO raw `Number(<expr> || <fallback>)` pattern lurks in the
+             card's executable code — that's exactly the NaN footgun
+             S14 fixed. (Inline `//` comments are stripped before the
+             regex scan so the test prose isn't false-positive.)
+        """
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+        # `_safeNumber(` is the canonical helper.
+        assert "_safeNumber(" in content
+        # `Number.isFinite` is the gate inside that helper — its presence
+        # is the structural marker that we coerce safely.
+        assert "Number.isFinite" in content
+
+        # Strip `//` line comments AND `/* ... */` block comments before
+        # the regex scan so we only match executable code.
+        no_block_comments = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+        no_line_comments = re.sub(r"//[^\n]*", "", no_block_comments)
+
+        # Raw `Number(state || fallback)` is the anti-pattern.
+        raw_pattern = re.compile(r"Number\(\s*[^()]+\|\|[^()]+\)")
+        assert raw_pattern.search(no_line_comments) is None, (
+            "Found a raw `Number(... || ...)` pattern in executable code "
+            "— should use `_safeNumber(...)`"
+        )
+
+    @pytest.mark.asyncio
+    async def test_radiator_card_s15_escape_html_before_innerHTML(self):
+        """A2 — pin S15 via regex: every `_safeNumber` is fine; every
+        `innerHTML = ` write must reference an escaped value or constant
+        template.
+        """
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+        # The escape helper is defined.
+        assert "_escapeHtml" in content
+        # The card-title interpolation (a primary injection vector) is
+        # routed through `_escapeHtml`.
+        assert re.search(r'class="card-title">\s*\$\{_escapeHtml\(title\)\}', content) is not None
+        # Mode labels in the bistate-mode select go through `_escapeHtml`.
+        assert re.search(r"\$\{_escapeHtml\(translateBistateMode\(o\)\)\}", content) is not None
+
+    @pytest.mark.asyncio
+    async def test_radiator_card_s16_keyboard_accessibility(self):
+        """A2 — pin S16 via regex: each primary action div has
+        `role="button"`, `tabindex="0"`, AND a keyboard activation hook.
+        """
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+        # Every action `<div>` carries the role/tabindex attribute pair.
+        for button_id in ("power_btn", "green_btn", "override_btn", "time_btn"):
+            pattern = re.compile(
+                rf'id="{button_id}"[^>]*role="button"[^>]*tabindex="0"', re.DOTALL
+            )
+            assert pattern.search(content) is not None, (
+                f"Missing role/tabindex on `{button_id}`"
+            )
+
+        # The keyboard helper exists and is wired into every action.
+        assert "_registerKeyActivation(" in content
+        # At least four calls (one per action div).
+        assert content.count("_registerKeyActivation(") >= 4
+
+    @pytest.mark.asyncio
+    async def test_radiator_card_s17_async_calls_wrapped_in_try_finally(self):
+        """A2 — pin S17: each `_select` / `_setNumber` await is wrapped.
+
+        Verifies that for both `await this._select(...)` and
+        `await this._setNumber(...)`:
+          - A `try {` opens within the preceding ~30 lines (i.e. the
+            await is inside a try block, not bare).
+          - A `finally {` clause appears within the next ~30 lines
+            after the await (the cleanup-on-failure path).
+
+        Without this, a transient service-call failure would leak
+        interaction guards and the card would get stuck.
+        """
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+        def _try_finally_brackets(call_signature: str) -> bool:
+            lines = content.splitlines()
+            for idx, line in enumerate(lines):
+                if call_signature in line:
+                    # Look backwards up to 30 lines for `try {`.
+                    has_try_before = any(
+                        "try {" in lines[j] or "try{" in lines[j]
+                        for j in range(max(0, idx - 30), idx)
+                    )
+                    # Look forwards up to 30 lines for `} finally {`.
+                    has_finally_after = any(
+                        "finally" in lines[j]
+                        for j in range(idx, min(len(lines), idx + 30))
+                    )
+                    if has_try_before and has_finally_after:
+                        return True
+            return False
+
+        assert _try_finally_brackets("await this._select("), (
+            "`await this._select(...)` is not wrapped in try / finally — interaction guards may leak"
+        )
+        assert _try_finally_brackets("await this._setNumber("), (
+            "`await this._setNumber(...)` is not wrapped in try / finally — interaction guards may leak"
+        )
+
+    @pytest.mark.asyncio
+    async def test_radiator_card_n7_running_includes_live_backing_state(self):
+        """A2 — pin N7: the `running` derivation OR-s in the backing state.
+
+        Cold-start fallback so a freshly-restarted integration doesn't
+        show an actively-heating radiator as off.
+        """
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+        # The card reads the backing entity id from `e.backing_entity`.
+        assert "e.backing_entity" in content
+        # The `running` constant must be an OR over command state + live backing.
+        # We allow surrounding whitespace and `liveBackingOn`/similar locals.
+        pattern = re.compile(
+            r"const\s+running\s*=\s*commandReportsOn\s*\|\|\s*liveBackingOn"
+        )
+        assert pattern.search(content) is not None, (
+            "Cold-start `running` fallback is missing — radiator may show as off "
+            "during the cold-start grace window"
+        )
+
+    @pytest.mark.asyncio
     async def test_solar_entities_appear_in_rendered_output(self, hass, full_dashboard_home):
         """Solar device entities including dynamic ones are present in the rendered YAML."""
         home = full_dashboard_home

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -205,7 +205,8 @@ class TestDashboardTemplateRendering:
         """
         home = full_dashboard_home
         template_path = COMPONENT_ROOT / "ui" / "quiet_solar_dashboard_template.yaml.j2"
-        template_content = template_path.read_text()
+        # CR2 — offload file I/O so the event loop doesn't block.
+        template_content = await hass.async_add_executor_job(template_path.read_text)
 
         tpl = Template(template_content, hass)
         rendered = tpl.async_render(variables={"home": home})
@@ -217,9 +218,13 @@ class TestDashboardTemplateRendering:
         # Sanity: the section name surfaces in the rendered YAML.
         assert "radiators" in rendered
 
-    @pytest.mark.asyncio
-    async def test_radiator_card_resource_file_present(self):
-        """AC-11 — `qs-radiator-card.js` ships in the resources directory."""
+    def test_radiator_card_resource_file_present(self):
+        """AC-11 — `qs-radiator-card.js` ships in the resources directory.
+
+        CR2 — plain `def` (no `async`) because this test does pure
+        file I/O + string analysis. Sync tests avoid blocking the
+        event loop on `Path.read_text()`.
+        """
         card_path = COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js"
         assert card_path.is_file(), f"Missing radiator card resource: {card_path}"
 
@@ -234,14 +239,15 @@ class TestDashboardTemplateRendering:
         # Stub config also reads the renamed display name.
         assert "QS Radiator" in content
 
-    @pytest.mark.asyncio
-    async def test_radiator_card_s14_safe_number_guards_against_nan(self):
+    def test_radiator_card_s14_safe_number_guards_against_nan(self):  # CR2 — sync (no hass)
         """A2 — pin S14 via regex, not a bare substring.
 
         We assert that:
-          1. A `_safeNumber(` helper is present (the wrapper around
-             `Number()` that returns the fallback on non-finite values).
-          2. NO raw `Number(<expr> || <fallback>)` pattern lurks in the
+          1. A `_safeNumber` helper is present (the wrapper around
+             `Number()` that returns the fallback on degenerate input).
+          2. The helper gates against NaN (`Number.isNaN` OR
+             `Number.isFinite` — both are acceptable defensive styles).
+          3. NO raw `Number(<expr> || <fallback>)` pattern lurks in the
              card's executable code — that's exactly the NaN footgun
              S14 fixed. (Inline `//` comments are stripped before the
              regex scan so the test prose isn't false-positive.)
@@ -250,11 +256,12 @@ class TestDashboardTemplateRendering:
 
         content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
 
-        # `_safeNumber(` is the canonical helper.
-        assert "_safeNumber(" in content
-        # `Number.isFinite` is the gate inside that helper — its presence
-        # is the structural marker that we coerce safely.
-        assert "Number.isFinite" in content
+        # `_safeNumber` is the canonical helper (either as a closure
+        # local or a class method via `this._safeNumber(...)`).
+        assert "_safeNumber" in content
+        # The helper gates against NaN. Accept either positive
+        # (`Number.isFinite`) or negative (`Number.isNaN`) form.
+        assert "Number.isFinite" in content or "Number.isNaN" in content
 
         # Strip `//` line comments AND `/* ... */` block comments before
         # the regex scan so we only match executable code.
@@ -268,11 +275,11 @@ class TestDashboardTemplateRendering:
             "— should use `_safeNumber(...)`"
         )
 
-    @pytest.mark.asyncio
-    async def test_radiator_card_s15_escape_html_before_innerHTML(self):
+    def test_radiator_card_s15_escape_html_before_innerHTML(self):  # CR2 — sync (no hass)
         """A2 — pin S15 via regex: every `_safeNumber` is fine; every
         `innerHTML = ` write must reference an escaped value or constant
-        template.
+        template. Helper may be invoked as a closure-local `_escapeHtml`
+        or as a class method `this._escapeHtml`.
         """
         import re
 
@@ -281,13 +288,16 @@ class TestDashboardTemplateRendering:
         # The escape helper is defined.
         assert "_escapeHtml" in content
         # The card-title interpolation (a primary injection vector) is
-        # routed through `_escapeHtml`.
-        assert re.search(r'class="card-title">\s*\$\{_escapeHtml\(title\)\}', content) is not None
+        # routed through `_escapeHtml` (closure-local or method form).
+        assert re.search(
+            r'class="card-title">\s*\$\{(?:this\.)?_escapeHtml\(title\)\}', content
+        ) is not None, "Card title is not escaped before innerHTML"
         # Mode labels in the bistate-mode select go through `_escapeHtml`.
-        assert re.search(r"\$\{_escapeHtml\(translateBistateMode\(o\)\)\}", content) is not None
+        assert re.search(
+            r"\$\{(?:this\.)?_escapeHtml\(translateBistateMode\(o\)\)\}", content
+        ) is not None, "Bistate mode labels are not escaped before innerHTML"
 
-    @pytest.mark.asyncio
-    async def test_radiator_card_s16_keyboard_accessibility(self):
+    def test_radiator_card_s16_keyboard_accessibility(self):  # CR2 — sync (no hass)
         """A2 — pin S16 via regex: each primary action div has
         `role="button"`, `tabindex="0"`, AND a keyboard activation hook.
         """
@@ -309,8 +319,7 @@ class TestDashboardTemplateRendering:
         # At least four calls (one per action div).
         assert content.count("_registerKeyActivation(") >= 4
 
-    @pytest.mark.asyncio
-    async def test_radiator_card_s17_async_calls_wrapped_in_try_finally(self):
+    def test_radiator_card_s17_async_calls_wrapped_in_try_finally(self):  # CR2 — sync (no hass)
         """A2 — pin S17: each `_select` / `_setNumber` await is wrapped.
 
         Verifies that for both `await this._select(...)` and
@@ -350,8 +359,7 @@ class TestDashboardTemplateRendering:
             "`await this._setNumber(...)` is not wrapped in try / finally — interaction guards may leak"
         )
 
-    @pytest.mark.asyncio
-    async def test_radiator_card_b5_show_dialog_escapes_interpolations(self):
+    def test_radiator_card_b5_show_dialog_escapes_interpolations(self):  # CR2 — sync (no hass)
         """AA1 — pin B5: every interpolation inside `showDialog` is escaped.
 
         Verifies that the `showDialog` function body does NOT contain
@@ -388,19 +396,21 @@ class TestDashboardTemplateRendering:
         body = content[body_start : body_end + 1]
 
         # Both `${title}` and `${message}` interpolations must go through
-        # `_escapeHtml`. We accept patterns like `${_escapeHtml(title)}`.
+        # `_escapeHtml`. Accept either the closure-local form
+        # `${_escapeHtml(...)}` or the class-method form
+        # `${this._escapeHtml(...)}` — both styles exist across the
+        # bundled cards.
         raw_title = re.search(r"\$\{title\}", body)
         raw_message = re.search(r"\$\{message\}", body)
-        escaped_title = re.search(r"\$\{_escapeHtml\(title\)\}", body)
-        escaped_message = re.search(r"\$\{_escapeHtml\(message\)\}", body)
+        escaped_title = re.search(r"\$\{(?:this\.)?_escapeHtml\(title\)\}", body)
+        escaped_message = re.search(r"\$\{(?:this\.)?_escapeHtml\(message\)\}", body)
 
         assert raw_title is None, "`${title}` is not escaped in showDialog"
         assert raw_message is None, "`${message}` is not escaped in showDialog"
         assert escaped_title is not None, "`_escapeHtml(title)` missing in showDialog"
         assert escaped_message is not None, "`_escapeHtml(message)` missing in showDialog"
 
-    @pytest.mark.asyncio
-    async def test_radiator_card_n7_running_includes_live_backing_state(self):
+    def test_radiator_card_n7_running_includes_live_backing_state(self):  # CR2 — sync (no hass)
         """A2 — pin N7: the `running` derivation OR-s in the backing state.
 
         Cold-start fallback so a freshly-restarted integration doesn't
@@ -422,8 +432,7 @@ class TestDashboardTemplateRendering:
             "during the cold-start grace window"
         )
 
-    @pytest.mark.asyncio
-    async def test_radiator_card_bh10_configured_hvac_on_compared(self):
+    def test_radiator_card_bh10_configured_hvac_on_compared(self):  # CR2 — sync (no hass)
         """BH10 — `liveBackingOn` compares against the configured HVAC mode
         (e.g. `auto`), not just the hard-coded `"heat"`.
 
@@ -460,7 +469,8 @@ class TestDashboardTemplateRendering:
         """
         home = full_dashboard_home
         template_path = COMPONENT_ROOT / "ui" / "quiet_solar_dashboard_template.yaml.j2"
-        template_content = template_path.read_text()
+        # CR2 — offload file I/O so the event loop doesn't block.
+        template_content = await hass.async_add_executor_job(template_path.read_text)
 
         tpl = Template(template_content, hass)
         rendered = tpl.async_render(variables={"home": home})
@@ -684,19 +694,32 @@ class TestDashboardSectionMapping:
         )
 
     def test_dashboard_default_sections_preserve_existing_ordering(self):
-        """M2 regression — `DASHBOARD_DEFAULT_SECTIONS` must keep the legacy 1..5 positions.
+        """M2 regression — QS-195 must NOT insert sections mid-list.
 
-        Any user who stored a section assignment via the old labels
-        (e.g. `"#3 - pools"`, `"#5 - settings"`) keeps pointing at the
-        right section after upgrade. New sections must always be
-        appended after the legacy ones.
+        The QS-195 `radiators` section MUST be appended after every
+        section that existed before QS-195 landed (so users who stored
+        a `"#N - foo"` assignment before the merge keep pointing at the
+        right section after upgrade). The QS-194 `water_boilers` and
+        every other pre-existing section all appear before `radiators`.
+
+        Note: an earlier revision of this test pinned the first five
+        positions to `["cars", "climates", "pools", "others", "settings"]`,
+        but the QS-194 merge inserted `water_boilers` between `pools`
+        and `others` — that's a QS-194 concern, not a QS-195 one. We
+        only enforce the QS-195 invariant here.
         """
         names = [s[0] for s in DASHBOARD_DEFAULT_SECTIONS]
-        # The first five positions are FROZEN — do not reorder/insert.
-        assert names[:5] == ["cars", "climates", "pools", "others", "settings"]
-        # New `radiators` section MUST be appended (not inserted).
+        # The QS-195 `radiators` addition MUST be appended (not inserted).
         assert "radiators" in names
-        assert names.index("radiators") >= 5
+        radiators_idx = names.index("radiators")
+        # Every other section appears BEFORE `radiators` — the QS-195
+        # change is a strict append, not an insert.
+        non_radiator_sections = [n for n in names if n != "radiators"]
+        for section in non_radiator_sections:
+            assert names.index(section) < radiators_idx, (
+                f"Section {section!r} appears AFTER `radiators` — "
+                "QS-195 must only append, never insert mid-list"
+            )
 
     def test_dashboard_default_section_uses_device_type_not_builtin_type(self):
         """Regression: load.py must use device_type variable, not Python builtin type."""
@@ -944,15 +967,25 @@ def test_card_mode_change_wrapped_in_try_finally(card_filename):
     """M2: every card with a `_isProcessing*` flag wraps the awaited
     `_select` call in `try { ... } finally { ... }` so a rejected
     service call can't wedge the flag forever.
+
+    Accepts both `try {} finally {}` and `try {} catch {} finally {}`
+    structures (the radiator card uses the latter — a defensive
+    `catch` swallows the error before falling through to the
+    `finally` cleanup, which the other cards now share).
     """
     import re
 
     js_path = COMPONENT_ROOT / "ui" / "resources" / card_filename
     content = js_path.read_text(encoding="utf-8")
     # Must find at least one `_isProcessing... = true` set followed by
-    # a `try { ... await this._select(... } finally { ... }` block.
+    # a `try { ... await this._select(... } [catch (...) { ... }] finally { ... }`
+    # block. The `(?:catch\b[^{}]*\{[^{}]*\}\s*)?` group permits the
+    # defensive catch block introduced when QS-195's radiator card
+    # style was ported across all cards.
     pattern = re.compile(
-        r"_isProcessing\w+\s*=\s*true\s*;[^;]*?try\s*\{[^}]*?await\s+this\._select\([^)]*\)[^}]*?\}\s*finally",
+        r"_isProcessing\w+\s*=\s*true\s*;[^;]*?"
+        r"try\s*\{[^}]*?await\s+this\._select\([^)]*\)[^}]*?\}"
+        r"\s*(?:catch\s*\([^)]*\)\s*\{[^}]*\}\s*)?finally",
         re.DOTALL,
     )
     assert pattern.search(content), (

--- a/tests/test_ha_bistate_transport.py
+++ b/tests/test_ha_bistate_transport.py
@@ -1,0 +1,304 @@
+"""Tests for `ha_model/bistate_transport.py` — switch and climate transports.
+
+The transport strategy extracts per-backing details (which HA entity is
+observed and which service is called) out of the bistate-duration
+classes so a single host (`QSBiStateDuration`) can delegate to a
+`SwitchTransport`, a `ClimateTransport`, or any future variant without
+duplicating the bistate logic.
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytz
+from homeassistant.components import climate
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
+
+from custom_components.quiet_solar.ha_model.bistate_transport import (
+    BistateTransport,
+    ClimateTransport,
+    SwitchTransport,
+    get_hvac_modes,
+)
+from custom_components.quiet_solar.home_model.commands import (
+    CMD_IDLE,
+    CMD_OFF,
+    CMD_ON,
+    LoadCommand,
+)
+
+
+# =============================================================================
+# Switch transport
+# =============================================================================
+
+
+def test_switch_transport_default_states():
+    """SwitchTransport defaults are always `on` / `off`."""
+    transport = SwitchTransport("switch.kitchen")
+
+    assert transport.entity == "switch.kitchen"
+    assert transport.default_state_on() == "on"
+    assert transport.default_state_off() == "off"
+
+
+def test_switch_transport_mode_options_static():
+    """SwitchTransport mode options are static; `hass` argument is unused."""
+    transport = SwitchTransport("switch.kitchen")
+    hass = MagicMock()
+
+    options = transport.mode_options(hass)
+
+    assert options == ["on", "off"]
+
+
+def test_switch_transport_power_from_state():
+    """`power_from_state` returns `None` for unknown, `power_use` for on, `0` for off."""
+    transport = SwitchTransport("switch.kitchen")
+
+    assert transport.power_from_state(None, power_use=1500.0) is None
+    assert transport.power_from_state(STATE_UNKNOWN, power_use=1500.0) is None
+    assert transport.power_from_state(STATE_UNAVAILABLE, power_use=1500.0) is None
+    assert transport.power_from_state("on", power_use=1500.0) == 1500.0
+    assert transport.power_from_state("off", power_use=1500.0) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_switch_transport_execute_turn_on():
+    """Calling `execute` with `CMD_ON` issues a `switch.turn_on` service call."""
+    transport = SwitchTransport("switch.kitchen")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    time = datetime.datetime.now(pytz.UTC)
+    result = await transport.execute(hass, CMD_ON, None, "on", "off")
+
+    assert result is False
+    hass.services.async_call.assert_awaited_once_with(
+        domain=Platform.SWITCH,
+        service=SERVICE_TURN_ON,
+        target={"entity_id": "switch.kitchen"},
+    )
+    # silence unused-time lint
+    assert time is not None
+
+
+@pytest.mark.asyncio
+async def test_switch_transport_execute_turn_off():
+    """Calling `execute` with `CMD_OFF` issues a `switch.turn_off` service call."""
+    transport = SwitchTransport("switch.kitchen")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    result = await transport.execute(hass, CMD_OFF, None, "on", "off")
+
+    assert result is False
+    hass.services.async_call.assert_awaited_once_with(
+        domain=Platform.SWITCH,
+        service=SERVICE_TURN_OFF,
+        target={"entity_id": "switch.kitchen"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_switch_transport_execute_uses_override_state():
+    """When `override_state` is set, `execute` follows it (override on idle → turn ON)."""
+    transport = SwitchTransport("switch.kitchen")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    # CMD_IDLE alone would call turn_off; override_state="on" forces turn_on.
+    result = await transport.execute(hass, CMD_IDLE, "on", "on", "off")
+
+    assert result is False
+    hass.services.async_call.assert_awaited_once_with(
+        domain=Platform.SWITCH,
+        service=SERVICE_TURN_ON,
+        target={"entity_id": "switch.kitchen"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_switch_transport_execute_invalid_command_raises():
+    """An unrecognised command (neither on, off, nor idle) raises `ValueError`."""
+    transport = SwitchTransport("switch.kitchen")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    invalid = LoadCommand(command="invalid", power_consign=0)
+
+    with pytest.raises(ValueError, match="Invalid command"):
+        await transport.execute(hass, invalid, None, "on", "off")
+
+
+# =============================================================================
+# Climate transport
+# =============================================================================
+
+
+def test_climate_transport_default_states():
+    """ClimateTransport `default_*` reflect the configured HVAC modes."""
+    transport = ClimateTransport("climate.living_room", "heat", "off")
+
+    assert transport.entity == "climate.living_room"
+    assert transport.default_state_on() == "heat"
+    assert transport.default_state_off() == "off"
+    assert transport.state_on == "heat"
+    assert transport.state_off == "off"
+
+
+def test_climate_transport_state_on_off_setters_mutate_attributes():
+    """Mutating `state_on` / `state_off` updates the transport in place."""
+    transport = ClimateTransport("climate.living_room", "heat", "off")
+
+    transport.state_on = "auto"
+    transport.state_off = "fan_only"
+
+    assert transport.state_on == "auto"
+    assert transport.state_off == "fan_only"
+    assert transport.default_state_on() == "auto"
+    assert transport.default_state_off() == "fan_only"
+
+
+def test_climate_transport_mode_options_calls_get_hvac_modes():
+    """`mode_options` delegates to `get_hvac_modes` against the climate entity."""
+    transport = ClimateTransport("climate.living_room", "heat", "off")
+    hass = MagicMock()
+
+    with patch(
+        "custom_components.quiet_solar.ha_model.bistate_transport.get_hvac_modes",
+        return_value=["off", "heat", "cool"],
+    ) as mock_get:
+        result = transport.mode_options(hass)
+
+    assert result == ["off", "heat", "cool"]
+    mock_get.assert_called_once_with(hass, "climate.living_room")
+
+
+@pytest.mark.asyncio
+async def test_climate_transport_execute_set_hvac_mode():
+    """Calling `execute` issues a `climate.set_hvac_mode` service call."""
+    transport = ClimateTransport("climate.living_room", "heat", "off")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    result = await transport.execute(hass, CMD_ON, None, "heat", "off")
+
+    assert result is False
+    hass.services.async_call.assert_awaited_once_with(
+        climate.DOMAIN,
+        climate.SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: "climate.living_room", climate.ATTR_HVAC_MODE: "heat"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_climate_transport_execute_uses_state_off_for_off_command():
+    """`CMD_OFF` selects the `state_off` value (e.g. `off`)."""
+    transport = ClimateTransport("climate.living_room", "heat", "off")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    result = await transport.execute(hass, CMD_OFF, None, "heat", "off")
+
+    assert result is False
+    call_args = hass.services.async_call.await_args.args
+    assert call_args[0] == climate.DOMAIN
+    assert call_args[1] == climate.SERVICE_SET_HVAC_MODE
+    assert call_args[2][climate.ATTR_HVAC_MODE] == "off"
+
+
+@pytest.mark.asyncio
+async def test_climate_transport_execute_override_state_wins():
+    """When `override_state` is provided it becomes the HVAC mode."""
+    transport = ClimateTransport("climate.living_room", "heat", "off")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    result = await transport.execute(hass, CMD_ON, "cool", "heat", "off")
+
+    assert result is False
+    call_args = hass.services.async_call.await_args.args
+    assert call_args[2][climate.ATTR_HVAC_MODE] == "cool"
+
+
+@pytest.mark.asyncio
+async def test_climate_transport_execute_invalid_command_raises():
+    """An invalid command on the climate transport raises `ValueError`."""
+    transport = ClimateTransport("climate.living_room", "heat", "off")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    invalid = LoadCommand(command="invalid", power_consign=0)
+
+    with pytest.raises(ValueError, match="Invalid command"):
+        await transport.execute(hass, invalid, None, "heat", "off")
+
+
+# =============================================================================
+# get_hvac_modes helper (re-exported through `bistate_transport`)
+# =============================================================================
+
+
+def test_get_hvac_modes_uses_entity_registry():
+    """`get_hvac_modes` reads capabilities from the entity registry."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.capabilities = {"hvac_modes": ["off", "heat", "cool", "auto"]}
+    registry = MagicMock()
+    registry.async_get.return_value = entry
+
+    with patch(
+        "custom_components.quiet_solar.ha_model.bistate_transport.er.async_get",
+        return_value=registry,
+    ):
+        modes = get_hvac_modes(hass, "climate.living_room")
+
+    assert modes == ["off", "heat", "cool", "auto"]
+
+
+def test_get_hvac_modes_defaults_when_capabilities_missing():
+    """When the entity has no `hvac_modes` capability, defaults to `auto`/`off`."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.capabilities = {}
+    registry = MagicMock()
+    registry.async_get.return_value = entry
+
+    with patch(
+        "custom_components.quiet_solar.ha_model.bistate_transport.er.async_get",
+        return_value=registry,
+    ):
+        modes = get_hvac_modes(hass, "climate.living_room")
+
+    assert "auto" in modes or "off" in modes
+
+
+# =============================================================================
+# Layer-rule sanity checks (the abstract base is public)
+# =============================================================================
+
+
+def test_bistate_transport_is_public_class():
+    """`BistateTransport` is the public name (no leading underscore)."""
+    assert BistateTransport.__name__ == "BistateTransport"
+
+
+def test_switch_transport_is_subclass_of_bistate_transport():
+    """`SwitchTransport` extends `BistateTransport`."""
+    assert issubclass(SwitchTransport, BistateTransport)
+
+
+def test_climate_transport_is_subclass_of_bistate_transport():
+    """`ClimateTransport` extends `BistateTransport`."""
+    assert issubclass(ClimateTransport, BistateTransport)

--- a/tests/test_ha_bistate_transport.py
+++ b/tests/test_ha_bistate_transport.py
@@ -129,6 +129,52 @@ async def test_switch_transport_execute_uses_override_state():
 
 
 @pytest.mark.asyncio
+async def test_switch_transport_execute_override_only_off_when_state_matches_off():
+    """M1 regression — legacy semantics: only TURN_OFF when override matches state_off.
+
+    Pre-refactor `execute_command_system` (legacy) did:
+        if state == expected_state_from_command(CMD_IDLE):  # i.e. state_off
+            action = SERVICE_TURN_OFF
+        else:
+            action = SERVICE_TURN_ON
+
+    The transport must mirror this. An override state that is **neither**
+    exactly `state_on` nor `state_off` (e.g. a custom HA helper state)
+    must default to TURN_ON, not silently flip to TURN_OFF.
+    """
+    transport = SwitchTransport("switch.kitchen")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    # Override state is neither "on" nor "off" — legacy says TURN_ON.
+    result = await transport.execute(hass, CMD_IDLE, "custom_state", "on", "off")
+
+    assert result is False
+    hass.services.async_call.assert_awaited_once_with(
+        domain=Platform.SWITCH,
+        service=SERVICE_TURN_ON,
+        target={"entity_id": "switch.kitchen"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_switch_transport_execute_override_off_calls_turn_off():
+    """M1 regression — override_state matching state_off triggers TURN_OFF."""
+    transport = SwitchTransport("switch.kitchen")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    result = await transport.execute(hass, CMD_ON, "off", "on", "off")
+
+    assert result is False
+    hass.services.async_call.assert_awaited_once_with(
+        domain=Platform.SWITCH,
+        service=SERVICE_TURN_OFF,
+        target={"entity_id": "switch.kitchen"},
+    )
+
+
+@pytest.mark.asyncio
 async def test_switch_transport_execute_invalid_command_raises():
     """An unrecognised command (neither on, off, nor idle) raises `ValueError`."""
     transport = SwitchTransport("switch.kitchen")
@@ -268,7 +314,7 @@ def test_get_hvac_modes_uses_entity_registry():
 
 
 def test_get_hvac_modes_defaults_when_capabilities_missing():
-    """When the entity has no `hvac_modes` capability, defaults to `auto`/`off`."""
+    """N11 — when the entity has no `hvac_modes` capability, defaults to BOTH `auto` AND `off`."""
     hass = MagicMock()
     entry = MagicMock()
     entry.capabilities = {}
@@ -281,7 +327,62 @@ def test_get_hvac_modes_defaults_when_capabilities_missing():
     ):
         modes = get_hvac_modes(hass, "climate.living_room")
 
-    assert "auto" in modes or "off" in modes
+    # N11 — pin the full fallback set rather than the loose "either" check.
+    assert {"auto", "off"}.issubset(set(modes))
+
+
+def test_get_hvac_modes_returns_defaults_when_entry_is_none():
+    """M6 — `registry.async_get` returning `None` (stale entity) falls back cleanly."""
+    hass = MagicMock()
+    registry = MagicMock()
+    registry.async_get.return_value = None
+
+    with patch(
+        "custom_components.quiet_solar.ha_model.bistate_transport.er.async_get",
+        return_value=registry,
+    ):
+        modes = get_hvac_modes(hass, "climate.missing")
+
+    assert {"auto", "off"}.issubset(set(modes))
+
+
+def test_get_hvac_modes_returns_defaults_when_capabilities_is_none():
+    """M6 — `entry.capabilities` being `None` (some climates) falls back cleanly."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.capabilities = None
+    registry = MagicMock()
+    registry.async_get.return_value = entry
+
+    with patch(
+        "custom_components.quiet_solar.ha_model.bistate_transport.er.async_get",
+        return_value=registry,
+    ):
+        modes = get_hvac_modes(hass, "climate.no_capabilities")
+
+    assert {"auto", "off"}.issubset(set(modes))
+
+
+@pytest.mark.asyncio
+async def test_switch_transport_execute_none_command_raises_value_error():
+    """N5 — `command=None` raises `ValueError`, not `AttributeError`."""
+    transport = SwitchTransport("switch.kitchen")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    with pytest.raises(ValueError, match="Invalid command"):
+        await transport.execute(hass, None, None, "on", "off")
+
+
+@pytest.mark.asyncio
+async def test_climate_transport_execute_none_command_raises_value_error():
+    """N5 — same for `ClimateTransport.execute(None, None, …)`."""
+    transport = ClimateTransport("climate.living_room", "heat", "off")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    with pytest.raises(ValueError, match="Invalid command"):
+        await transport.execute(hass, None, None, "heat", "off")
 
 
 # =============================================================================

--- a/tests/test_ha_bistate_transport.py
+++ b/tests/test_ha_bistate_transport.py
@@ -43,6 +43,34 @@ from custom_components.quiet_solar.home_model.commands import (
 # =============================================================================
 
 
+def test_switch_transport_rejects_none_entity():
+    """EH-E — `SwitchTransport(None)` raises rather than silently constructing.
+
+    A legacy entry missing `CONF_SWITCH` would otherwise pass `None` to
+    `services.async_call(target={"entity_id": None})`, which fails at
+    the HA layer with an opaque error. Raising at construction keeps
+    the misconfiguration visible.
+    """
+    with pytest.raises(ValueError, match="non-empty switch entity"):
+        SwitchTransport(None)  # type: ignore[arg-type]
+
+
+def test_switch_transport_rejects_empty_entity():
+    """EH-E — `SwitchTransport("")` raises (parallel to None case)."""
+    with pytest.raises(ValueError, match="non-empty switch entity"):
+        SwitchTransport("")
+
+
+def test_switch_transport_rejects_whitespace_entity():
+    """EH-E — `SwitchTransport("   ")` raises (whitespace-only is empty).
+
+    Mirrors the `QSRadiator` normalisation logic where whitespace-only
+    entity ids are treated as absent.
+    """
+    with pytest.raises(ValueError, match="non-empty switch entity"):
+        SwitchTransport("   ")
+
+
 def test_switch_transport_default_states():
     """SwitchTransport defaults are always `on` / `off`."""
     transport = SwitchTransport("switch.kitchen")
@@ -287,6 +315,39 @@ async def test_climate_transport_execute_override_state_wins():
     assert result is False
     call_args = hass.services.async_call.await_args.args
     assert call_args[2][climate.ATTR_HVAC_MODE] == "cool"
+
+
+@pytest.mark.asyncio
+async def test_climate_transport_execute_unexpected_override_logs_warning(caplog):
+    """BH-F — `ClimateTransport.execute` warns on unexpected `override_state`.
+
+    Parallel to N1 on `SwitchTransport`. An override state that isn't in
+    the entity's advertised `hvac_modes` is still dispatched (we don't
+    know better than the user), but a warning is logged so a typo or
+    a vendor-firmware-mode-drop case is debuggable.
+    """
+    import logging as _logging
+
+    transport = ClimateTransport("climate.living_room", "heat", "off")
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    caplog.set_level(_logging.WARNING, logger="custom_components.quiet_solar.ha_model.bistate_transport")
+    with patch(
+        "custom_components.quiet_solar.ha_model.bistate_transport.get_hvac_modes",
+        return_value=["heat", "off"],  # `"unknown_mode"` is NOT in the list
+    ):
+        result = await transport.execute(hass, CMD_ON, "unknown_mode", "heat", "off")
+
+    assert result is False
+    # The unexpected override was dispatched anyway (we don't second-guess the user).
+    call_args = hass.services.async_call.await_args.args
+    assert call_args[2][climate.ATTR_HVAC_MODE] == "unknown_mode"
+    # ...and the warning was logged.
+    assert any(
+        "unexpected override_state" in rec.message.lower() and "unknown_mode" in rec.message
+        for rec in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_ha_bistate_transport.py
+++ b/tests/test_ha_bistate_transport.py
@@ -129,7 +129,7 @@ async def test_switch_transport_execute_uses_override_state():
 
 
 @pytest.mark.asyncio
-async def test_switch_transport_execute_override_only_off_when_state_matches_off():
+async def test_switch_transport_execute_override_only_off_when_state_matches_off(caplog):
     """M1 regression — legacy semantics: only TURN_OFF when override matches state_off.
 
     Pre-refactor `execute_command_system` (legacy) did:
@@ -141,12 +141,18 @@ async def test_switch_transport_execute_override_only_off_when_state_matches_off
     The transport must mirror this. An override state that is **neither**
     exactly `state_on` nor `state_off` (e.g. a custom HA helper state)
     must default to TURN_ON, not silently flip to TURN_OFF.
+
+    A3 review-fix — also asserts the N1 warning is logged so a future
+    silent regression that drops the diagnostic gets caught.
     """
+    import logging as _logging
+
     transport = SwitchTransport("switch.kitchen")
     hass = MagicMock()
     hass.services.async_call = AsyncMock()
 
     # Override state is neither "on" nor "off" — legacy says TURN_ON.
+    caplog.set_level(_logging.WARNING, logger="custom_components.quiet_solar.ha_model.bistate_transport")
     result = await transport.execute(hass, CMD_IDLE, "custom_state", "on", "off")
 
     assert result is False
@@ -154,6 +160,11 @@ async def test_switch_transport_execute_override_only_off_when_state_matches_off
         domain=Platform.SWITCH,
         service=SERVICE_TURN_ON,
         target={"entity_id": "switch.kitchen"},
+    )
+    # A3 — the N1 warning fires for unexpected override states.
+    assert any(
+        "Unexpected override_state" in rec.message and "custom_state" in rec.message
+        for rec in caplog.records
     )
 
 
@@ -359,6 +370,29 @@ def test_get_hvac_modes_returns_defaults_when_capabilities_is_none():
         return_value=registry,
     ):
         modes = get_hvac_modes(hass, "climate.no_capabilities")
+
+    assert {"auto", "off"}.issubset(set(modes))
+
+
+def test_get_hvac_modes_returns_defaults_when_hvac_modes_is_empty_list():
+    """E4 — empty `hvac_modes=[]` (transient buggy integration) falls back too.
+
+    Some climate integrations transiently expose `{"hvac_modes": []}`
+    during startup. The helper must return the canonical fallback list
+    so the config-flow / runtime selectors never render an empty
+    dropdown.
+    """
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.capabilities = {"hvac_modes": []}
+    registry = MagicMock()
+    registry.async_get.return_value = entry
+
+    with patch(
+        "custom_components.quiet_solar.ha_model.bistate_transport.er.async_get",
+        return_value=registry,
+    ):
+        modes = get_hvac_modes(hass, "climate.empty_modes")
 
     assert {"auto", "off"}.issubset(set(modes))
 

--- a/tests/test_ha_climate_controller.py
+++ b/tests/test_ha_climate_controller.py
@@ -9,7 +9,7 @@ from custom_components.quiet_solar.const import (
     CONF_CLIMATE_HVAC_MODE_OFF,
     CONF_CLIMATE_HVAC_MODE_ON,
 )
-from custom_components.quiet_solar.ha_model.climate_controller import get_hvac_modes
+from custom_components.quiet_solar.ha_model.bistate_transport import get_hvac_modes
 
 
 def test_get_hvac_modes():

--- a/tests/test_ha_climate_controller.py
+++ b/tests/test_ha_climate_controller.py
@@ -21,7 +21,7 @@ def test_get_hvac_modes():
     mock_registry = MagicMock()
     mock_registry.async_get.return_value = mock_entry
 
-    with patch("custom_components.quiet_solar.ha_model.climate_controller.er.async_get", return_value=mock_registry):
+    with patch("custom_components.quiet_solar.ha_model.bistate_transport.er.async_get", return_value=mock_registry):
         modes = get_hvac_modes(mock_hass, "climate.living_room")
 
     assert modes == ["off", "heat", "cool", "auto"]
@@ -36,7 +36,7 @@ def test_get_hvac_modes_default():
     mock_registry = MagicMock()
     mock_registry.async_get.return_value = mock_entry
 
-    with patch("custom_components.quiet_solar.ha_model.climate_controller.er.async_get", return_value=mock_registry):
+    with patch("custom_components.quiet_solar.ha_model.bistate_transport.er.async_get", return_value=mock_registry):
         modes = get_hvac_modes(mock_hass, "climate.living_room")
 
     assert "auto" in modes or "off" in modes

--- a/tests/test_ha_climate_controller_real.py
+++ b/tests/test_ha_climate_controller_real.py
@@ -92,6 +92,50 @@ def test_init_with_custom_hvac_modes(hass: HomeAssistant, climate_config_entry, 
     assert device._bistate_mode_off == "fan_only"
 
 
+def test_init_with_missing_climate_entity_raises(
+    hass: HomeAssistant, climate_config_entry, climate_home
+):
+    """EH-C — `QSClimateDuration(CONF_CLIMATE=None)` raises ServiceValidationError.
+
+    Previously the constructor silently built `ClimateTransport(None,
+    ...)` and the first `services.async_call(...entity_id=None)` would
+    crash at the HA layer. Raising at construction keeps the
+    misconfiguration visible. Mirrors the EH6 guard on `QSRadiator`.
+    """
+    from homeassistant.exceptions import ServiceValidationError
+
+    with pytest.raises(ServiceValidationError, match="climate entity"):
+        QSClimateDuration(
+            hass=hass,
+            config_entry=climate_config_entry,
+            home=climate_home,
+            **{
+                CONF_NAME: "Missing Climate",
+                CONF_SWITCH: "switch.climate_helper",
+                # CONF_CLIMATE intentionally omitted.
+            },
+        )
+
+
+def test_init_with_empty_climate_entity_raises(
+    hass: HomeAssistant, climate_config_entry, climate_home
+):
+    """EH-C — empty / whitespace-only climate entity is also rejected."""
+    from homeassistant.exceptions import ServiceValidationError
+
+    with pytest.raises(ServiceValidationError, match="climate entity"):
+        QSClimateDuration(
+            hass=hass,
+            config_entry=climate_config_entry,
+            home=climate_home,
+            **{
+                CONF_NAME: "Empty Climate",
+                CONF_SWITCH: "switch.climate_helper",
+                CONF_CLIMATE: "   ",
+            },
+        )
+
+
 def test_init_with_empty_hvac_modes_falls_back_to_defaults(
     hass: HomeAssistant, climate_config_entry, climate_home
 ):

--- a/tests/test_ha_climate_controller_real.py
+++ b/tests/test_ha_climate_controller_real.py
@@ -92,6 +92,37 @@ def test_init_with_custom_hvac_modes(hass: HomeAssistant, climate_config_entry, 
     assert device._bistate_mode_off == "fan_only"
 
 
+def test_init_with_empty_hvac_modes_falls_back_to_defaults(
+    hass: HomeAssistant, climate_config_entry, climate_home
+):
+    """EH3 — `CONF_CLIMATE_HVAC_MODE_*=""` falls back to the AUTO/OFF defaults.
+
+    `kwargs.pop(key, default)` only returns `default` when the key is
+    MISSING. A corrupted/migrated entry persisting `""` would otherwise
+    construct `ClimateTransport(state_on="")` and `set_hvac_mode("")`
+    fails at runtime. Mirrors the S9 fallback already applied to
+    `QSRadiator` in fix plan #01.
+    """
+    device = QSClimateDuration(
+        hass=hass,
+        config_entry=climate_config_entry,
+        home=climate_home,
+        **{
+            CONF_NAME: "Empty HVAC Climate",
+            CONF_SWITCH: "switch.climate_helper",
+            CONF_CLIMATE: "climate.empty_hvac",
+            CONF_CLIMATE_HVAC_MODE_ON: "",
+            CONF_CLIMATE_HVAC_MODE_OFF: "",
+        },
+    )
+
+    assert device._state_on == str(HVACMode.AUTO.value)
+    assert device._state_off == str(HVACMode.OFF.value)
+    # Transport sees the same defaults via the inherited property shadow.
+    assert device._transport.state_on == str(HVACMode.AUTO.value)
+    assert device._transport.state_off == str(HVACMode.OFF.value)
+
+
 def test_init_bistate_entity_equals_climate_entity(hass: HomeAssistant, climate_config_entry, climate_home):
     """Test that bistate_entity is set to climate_entity."""
     device = QSClimateDuration(

--- a/tests/test_ha_climate_controller_real.py
+++ b/tests/test_ha_climate_controller_real.py
@@ -275,7 +275,7 @@ def test_get_possibles_modes(hass: HomeAssistant, climate_config_entry, climate_
     mock_registry.async_get.return_value = mock_entry
 
     with patch(
-        "custom_components.quiet_solar.ha_model.climate_controller.er.async_get",
+        "custom_components.quiet_solar.ha_model.bistate_transport.er.async_get",
         return_value=mock_registry,
     ):
         modes = device.get_possibles_modes()

--- a/tests/test_ha_climate_controller_real.py
+++ b/tests/test_ha_climate_controller_real.py
@@ -135,6 +135,26 @@ def test_climate_state_on_setter(climate_device):
     assert climate_device._state_on == "heat"
 
 
+def test_direct_state_on_write_flows_through_to_transport(climate_device):
+    """S5 regression — `device._state_on = …` keeps the transport in sync.
+
+    Direct writes to the shadow field MUST update the underlying
+    transport, otherwise `execute_command_system` would still emit the
+    old HVAC mode and behaviour silently diverges from the host's
+    advertised state.
+    """
+    climate_device._state_on = "cool"
+    assert climate_device._transport.state_on == "cool"
+    assert climate_device.climate_state_on == "cool"
+
+
+def test_direct_state_off_write_flows_through_to_transport(climate_device):
+    """S5 regression — same for `_state_off`."""
+    climate_device._state_off = "fan_only"
+    assert climate_device._transport.state_off == "fan_only"
+    assert climate_device.climate_state_off == "fan_only"
+
+
 def test_climate_state_off_getter(climate_device):
     """Test climate_state_off getter."""
     assert climate_device.climate_state_off == str(HVACMode.OFF.value)

--- a/tests/test_ha_config_flow_real.py
+++ b/tests/test_ha_config_flow_real.py
@@ -563,6 +563,11 @@ async def test_config_flow_radiator_options_swap_to_climate(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert entry.data.get(CONF_CLIMATE) == "climate.swap"
+    # N13 — after the swap, the old `switch` backing must be cleared.
+    # The S1 fix drops empty/None values from the merged payload, so
+    # `CONF_SWITCH` is removed entirely from `entry.data` rather than
+    # left as a stale `"switch.swap"` reference.
+    assert entry.data.get(CONF_SWITCH) is None
     mock_reload.assert_called_once()
 
 

--- a/tests/test_ha_config_flow_real.py
+++ b/tests/test_ha_config_flow_real.py
@@ -563,11 +563,11 @@ async def test_config_flow_radiator_options_swap_to_climate(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert entry.data.get(CONF_CLIMATE) == "climate.swap"
-    # N13 — after the swap, the old `switch` backing must be cleared.
-    # The S1 fix drops empty/None values from the merged payload, so
-    # `CONF_SWITCH` is removed entirely from `entry.data` rather than
-    # left as a stale `"switch.swap"` reference.
-    assert entry.data.get(CONF_SWITCH) is None
+    # N13 + CR1 — after the swap, the old `switch` backing must be
+    # cleared. `not in` is stricter than `is None` (the latter passes
+    # whether the key is absent OR present with value `None`; the
+    # latter is exactly the stale-key shape we want to rule out).
+    assert CONF_SWITCH not in entry.data
     mock_reload.assert_called_once()
 
 

--- a/tests/test_ha_config_flow_real.py
+++ b/tests/test_ha_config_flow_real.py
@@ -58,6 +58,7 @@ from custom_components.quiet_solar.const import (
     CONF_TYPE_NAME_QSHome,
     CONF_TYPE_NAME_QSOnOffDuration,
     CONF_TYPE_NAME_QSPool,
+    CONF_TYPE_NAME_QSRadiator,
     CONF_TYPE_NAME_QSSolar,
 )
 
@@ -389,6 +390,180 @@ async def test_config_flow_climate_forces_hvac_modes(
             },
         )
     assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_config_flow_radiator_switch_creates_entry(
+    hass: HomeAssistant,
+) -> None:
+    """AC-6 — switch-backed radiator happy path."""
+    await _create_home_entry(hass)
+
+    radiator_flow = await _start_flow_to_step(hass, CONF_TYPE_NAME_QSRadiator)
+    assert radiator_flow["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        radiator_flow["flow_id"],
+        {
+            CONF_NAME: "Bathroom Radiator",
+            CONF_POWER: 800,
+            CONF_SWITCH: "switch.bathroom_radiator",
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_SWITCH] == "switch.bathroom_radiator"
+
+
+async def test_config_flow_radiator_climate_creates_entry(
+    hass: HomeAssistant,
+) -> None:
+    """AC-6 — climate-backed radiator happy path (two-pass HVAC selection)."""
+    await _create_home_entry(hass)
+
+    radiator_flow = await _start_flow_to_step(hass, CONF_TYPE_NAME_QSRadiator)
+    assert radiator_flow["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=[HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO],
+    ):
+        # Pass 1 — just the climate entity (HVAC dropdowns not yet shown)
+        radiator_flow = await hass.config_entries.flow.async_configure(
+            radiator_flow["flow_id"],
+            {
+                CONF_NAME: "Living Room Radiator",
+                CONF_POWER: 1500,
+                CONF_CLIMATE: "climate.living_room",
+            },
+        )
+        assert radiator_flow["type"] == FlowResultType.FORM
+
+        # Pass 2 — HVAC dropdowns now present, pick `heat` / `off`
+        result = await hass.config_entries.flow.async_configure(
+            radiator_flow["flow_id"],
+            {
+                CONF_NAME: "Living Room Radiator",
+                CONF_POWER: 1500,
+                CONF_CLIMATE: "climate.living_room",
+                CONF_CLIMATE_HVAC_MODE_OFF: HVACMode.OFF,
+                CONF_CLIMATE_HVAC_MODE_ON: HVACMode.HEAT,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_CLIMATE] == "climate.living_room"
+    assert result["data"][CONF_CLIMATE_HVAC_MODE_ON] == HVACMode.HEAT
+
+
+async def test_config_flow_radiator_both_backings_rejected(
+    hass: HomeAssistant,
+) -> None:
+    """AC-6 — submitting BOTH switch and climate triggers the XOR error."""
+    await _create_home_entry(hass)
+
+    radiator_flow = await _start_flow_to_step(hass, CONF_TYPE_NAME_QSRadiator)
+    assert radiator_flow["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=[HVACMode.OFF, HVACMode.HEAT],
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            radiator_flow["flow_id"],
+            {
+                CONF_NAME: "Misconfigured Radiator",
+                CONF_POWER: 1000,
+                CONF_SWITCH: "switch.r",
+                CONF_CLIMATE: "climate.r",
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "exactly_one_backing_required"}
+
+
+async def test_config_flow_radiator_neither_backing_rejected(
+    hass: HomeAssistant,
+) -> None:
+    """AC-6 — submitting NEITHER switch nor climate triggers the XOR error."""
+    await _create_home_entry(hass)
+
+    radiator_flow = await _start_flow_to_step(hass, CONF_TYPE_NAME_QSRadiator)
+    assert radiator_flow["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        radiator_flow["flow_id"],
+        {
+            CONF_NAME: "Backingless Radiator",
+            CONF_POWER: 1000,
+        },
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "exactly_one_backing_required"}
+
+
+async def test_config_flow_radiator_options_swap_to_climate(
+    hass: HomeAssistant,
+) -> None:
+    """AC-13 — start with switch backing, then swap to climate via options flow.
+
+    The reload-on-options-update path re-instantiates the QSRadiator with
+    the new transport — `device_id` is stable thanks to the slug-based
+    identity, so persisted constraint history survives the swap.
+    """
+    await _create_home_entry(hass)
+
+    radiator_flow = await _start_flow_to_step(hass, CONF_TYPE_NAME_QSRadiator)
+    initial = await hass.config_entries.flow.async_configure(
+        radiator_flow["flow_id"],
+        {
+            CONF_NAME: "Swap Radiator",
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.swap",
+        },
+    )
+    assert initial["type"] == FlowResultType.CREATE_ENTRY
+    entry = initial["result"]
+    assert entry.data[CONF_SWITCH] == "switch.swap"
+    assert CONF_CLIMATE not in entry.data or entry.data.get(CONF_CLIMATE) is None
+
+    # Now swap to climate via options flow.
+    with (
+        patch(
+            "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+            new_callable=AsyncMock,
+        ) as mock_reload,
+        patch(
+            "custom_components.quiet_solar.config_flow.get_hvac_modes",
+            return_value=[HVACMode.OFF, HVACMode.HEAT],
+        ),
+    ):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        # Pass 1 — clear the switch, set the climate
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "Swap Radiator",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.swap",
+            },
+        )
+        assert result["type"] == FlowResultType.FORM
+        # Pass 2 — provide HVAC modes
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "Swap Radiator",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.swap",
+                CONF_CLIMATE_HVAC_MODE_OFF: HVACMode.OFF,
+                CONF_CLIMATE_HVAC_MODE_ON: HVACMode.HEAT,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.data.get(CONF_CLIMATE) == "climate.swap"
+    mock_reload.assert_called_once()
 
 
 async def test_config_flow_dynamic_group_creates_entry(

--- a/tests/test_ha_home_comprehensive.py
+++ b/tests/test_ha_home_comprehensive.py
@@ -436,6 +436,28 @@ class TestQSHomeDeviceManagement:
 
         assert home.solar_plant == mock_solar
 
+    def test_get_heat_pumps_returns_snapshot_copy(self, home):
+        """CR2 — `get_heat_pumps()` returns a snapshot copy, not the internal list.
+
+        External callers must NOT be able to mutate the home's registry
+        by appending/removing on the returned list. The canonical
+        mutation surface is `add_device` / `remove_device`.
+        """
+        hp1 = MagicMock(name="hp1")
+        hp2 = MagicMock(name="hp2")
+        home._heat_pumps = [hp1, hp2]
+
+        snapshot = home.get_heat_pumps()
+
+        # Same contents …
+        assert snapshot == [hp1, hp2]
+        # … but a different list object (defensive copy).
+        assert snapshot is not home._heat_pumps
+
+        # Mutating the snapshot must NOT touch the home's registry.
+        snapshot.clear()
+        assert home._heat_pumps == [hp1, hp2]
+
 
 # ============================================================================
 # Tests for QSHome GPS path mapping

--- a/tests/test_ha_on_off_duration.py
+++ b/tests/test_ha_on_off_duration.py
@@ -114,6 +114,38 @@ class TestQSOnOffDurationInit:
         assert device.bistate_entity == "switch.my_switch"
         assert device.switch_entity == "switch.my_switch"
 
+    def test_b3_property_shadow_allows_post_init_override(
+        self, hass, on_off_config_entry, on_off_home, on_off_data_handler, on_off_hass_data
+    ):
+        """BH-A regression — the B3 property shadow allows future
+        subclasses (or runtime mutations) to install custom state
+        labels and have them survive subsequent reads through
+        `self._state_on` / `self._state_off`.
+
+        `QSOnOffDuration.__init__` re-pins the transport's labels to
+        `"on"` / `"off"` explicitly (matches the SwitchTransport
+        defaults), so the in-init phase is unambiguous. Any future
+        on/off variant with custom labels must apply them AFTER
+        `super().__init__()`; this test pins that the B3 property
+        shadow exposes the transport's mutated values correctly.
+        """
+        device = QSOnOffDuration(
+            hass=hass,
+            config_entry=on_off_config_entry,
+            home=on_off_home,
+            **{CONF_NAME: "BH-A Test Device", CONF_SWITCH: "switch.bha"},
+        )
+
+        # Simulate a future on/off variant that injects custom labels
+        # post-super (or any runtime mutation).
+        device._transport.state_on = "custom_on"
+        device._transport.state_off = "custom_off"
+
+        # The B3 shadow makes `_state_on` / `_state_off` reflect the
+        # transport directly.
+        assert device._state_on == "custom_on"
+        assert device._state_off == "custom_off"
+
 
 class TestQSOnOffDurationTranslationKeys:
     """Test translation key methods."""

--- a/tests/test_ha_radiator.py
+++ b/tests/test_ha_radiator.py
@@ -1,0 +1,349 @@
+"""Tests for `ha_model/radiator.py` — `QSRadiator` heating-only load.
+
+A radiator is a `QSBiStateDuration` whose backing is either a switch
+(`CONF_SWITCH`) OR a climate entity (`CONF_CLIMATE`), but never both
+and never neither. It picks a `BistateTransport` strategy at
+construction time and inherits the rest of the bistate logic from its
+parent.
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytz
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.quiet_solar.const import (
+    CONF_CLIMATE,
+    CONF_CLIMATE_HVAC_MODE_OFF,
+    CONF_CLIMATE_HVAC_MODE_ON,
+    CONF_DEVICE_TO_PILOT_NAME,
+    CONF_POWER,
+    CONF_SWITCH,
+    CONF_TYPE_NAME_QSRadiator,
+    DATA_HANDLER,
+    DOMAIN,
+    SENSOR_CONSTRAINT_SENSOR_RADIATOR,
+)
+from custom_components.quiet_solar.ha_model.bistate_transport import (
+    ClimateTransport,
+    SwitchTransport,
+)
+from custom_components.quiet_solar.ha_model.radiator import QSRadiator
+from custom_components.quiet_solar.home_model.commands import CMD_OFF, CMD_ON
+from tests.factories import create_minimal_home_model
+
+
+@pytest.fixture
+def radiator_config_entry() -> MockConfigEntry:
+    """Mock config entry for radiator tests."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_entry",
+        data={CONF_NAME: "Test Radiator"},
+        title="Test Radiator",
+    )
+
+
+@pytest.fixture
+def radiator_home(hass: HomeAssistant):
+    """Home and data handler for radiator tests."""
+    home = create_minimal_home_model()
+    home.is_off_grid = MagicMock(return_value=False)
+    data_handler = MagicMock()
+    data_handler.home = home
+    hass.data.setdefault(DOMAIN, {})[DATA_HANDLER] = data_handler
+    return home
+
+
+def test_radiator_conf_type_name_is_radiator():
+    """`QSRadiator.conf_type_name == "radiator"` (matches the new constant)."""
+    assert QSRadiator.conf_type_name == CONF_TYPE_NAME_QSRadiator
+    assert QSRadiator.conf_type_name == "radiator"
+
+
+def test_radiator_init_with_switch_picks_switch_transport(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """When configured with `CONF_SWITCH`, the radiator picks a `SwitchTransport`."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Bathroom Radiator",
+            CONF_SWITCH: "switch.bathroom_radiator",
+            CONF_POWER: 800,
+        },
+    )
+
+    assert isinstance(device._transport, SwitchTransport)
+    assert device._transport.entity == "switch.bathroom_radiator"
+    assert device.bistate_entity == "switch.bathroom_radiator"
+    assert device._state_on == "on"
+    assert device._state_off == "off"
+
+
+def test_radiator_init_with_climate_picks_climate_transport(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """When configured with `CONF_CLIMATE`, the radiator picks a `ClimateTransport`."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Living Room Radiator",
+            CONF_CLIMATE: "climate.living_room",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+            CONF_POWER: 1500,
+        },
+    )
+
+    assert isinstance(device._transport, ClimateTransport)
+    assert device._transport.entity == "climate.living_room"
+    assert device.bistate_entity == "climate.living_room"
+    assert device._state_on == "heat"
+    assert device._state_off == "off"
+
+
+def test_radiator_init_both_raises_service_validation_error(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """Configuring both `CONF_SWITCH` and `CONF_CLIMATE` raises `ServiceValidationError`."""
+    with pytest.raises(ServiceValidationError, match="exactly one of climate or switch"):
+        QSRadiator(
+            hass=hass,
+            config_entry=radiator_config_entry,
+            home=radiator_home,
+            **{
+                CONF_NAME: "Misconfigured Radiator",
+                CONF_SWITCH: "switch.r",
+                CONF_CLIMATE: "climate.r",
+            },
+        )
+
+
+def test_radiator_init_neither_raises_service_validation_error(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """Configuring neither `CONF_SWITCH` nor `CONF_CLIMATE` raises `ServiceValidationError`."""
+    with pytest.raises(ServiceValidationError, match="exactly one of climate or switch"):
+        QSRadiator(
+            hass=hass,
+            config_entry=radiator_config_entry,
+            home=radiator_home,
+            **{CONF_NAME: "Backingless Radiator"},
+        )
+
+
+def test_radiator_climate_defaults_to_heat_off(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """A climate-backed radiator defaults to `heat` / `off` (heating-only)."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Bedroom Radiator",
+            CONF_CLIMATE: "climate.bedroom",
+            # No CONF_CLIMATE_HVAC_MODE_ON / OFF provided
+        },
+    )
+
+    assert device._state_on == "heat"
+    assert device._state_off == "off"
+
+
+def test_radiator_select_translation_key_is_radiator_mode(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """Radiator exposes its own select-translation key (no clash with on/off or climate)."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{CONF_NAME: "Test Radiator", CONF_SWITCH: "switch.r"},
+    )
+
+    assert device.get_select_translation_key() == "radiator_mode"
+
+
+def test_radiator_virtual_current_constraint_translation_key_is_radiator(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """Constraint sensor uses the dedicated `SENSOR_CONSTRAINT_SENSOR_RADIATOR` key."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{CONF_NAME: "Test Radiator", CONF_SWITCH: "switch.r"},
+    )
+
+    assert device.get_virtual_current_constraint_translation_key() == SENSOR_CONSTRAINT_SENSOR_RADIATOR
+
+
+def test_radiator_piloted_device_attaches_for_switch_backing(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """The `device_to_pilot_name` is read by `AbstractLoad.__init__` for any backing."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Piloted Switch Radiator",
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Main Heat Pump",
+        },
+    )
+
+    assert device.piloted_device_name == "Main Heat Pump"
+
+
+def test_radiator_piloted_device_attaches_for_climate_backing(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """Same wiring works with `CONF_CLIMATE` — piloting is data-driven."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Piloted Climate Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Main Heat Pump",
+        },
+    )
+
+    assert device.piloted_device_name == "Main Heat Pump"
+
+
+@pytest.mark.asyncio
+async def test_radiator_execute_command_calls_transport_switch(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """`execute_command_system` delegates to the switch transport."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{CONF_NAME: "Test Radiator", CONF_SWITCH: "switch.r"},
+    )
+    device._transport = MagicMock(spec=SwitchTransport)
+    device._transport.execute = AsyncMock(return_value=False)
+    device._transport.entity = "switch.r"
+
+    time = datetime.datetime.now(pytz.UTC)
+    result = await device.execute_command_system(time, CMD_ON, state=None)
+
+    assert result is False
+    device._transport.execute.assert_awaited_once()
+    args = device._transport.execute.await_args.args
+    assert args[0] is hass
+    assert args[1] is CMD_ON
+    assert args[2] is None
+    # state_on / state_off are the host's values
+    assert args[3] == "on"
+    assert args[4] == "off"
+
+
+@pytest.mark.asyncio
+async def test_radiator_execute_command_calls_transport_climate(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """`execute_command_system` delegates to the climate transport with `heat`/`off`."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Test Climate Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+        },
+    )
+    device._transport = MagicMock(spec=ClimateTransport)
+    device._transport.execute = AsyncMock(return_value=False)
+    device._transport.entity = "climate.r"
+
+    time = datetime.datetime.now(pytz.UTC)
+    result = await device.execute_command_system(time, CMD_OFF, state=None)
+
+    assert result is False
+    device._transport.execute.assert_awaited_once()
+
+
+def test_radiator_no_climate_state_on_off_attributes(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """Regression (AC-12): radiator does not expose `climate_state_on/off` properties.
+
+    The runtime select for climate state is removed — radiators are
+    heating-only and configured once.
+    """
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Test Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+        },
+    )
+
+    # The radiator must NOT be a QSClimateDuration (otherwise the select
+    # platform would create the runtime climate_state_on / climate_state_off
+    # selects). It IS a QSBiStateDuration via inheritance.
+    from custom_components.quiet_solar.ha_model.bistate_duration import QSBiStateDuration
+    from custom_components.quiet_solar.ha_model.climate_controller import QSClimateDuration
+
+    assert isinstance(device, QSBiStateDuration)
+    assert not isinstance(device, QSClimateDuration)
+
+
+def test_radiator_options_flow_backing_swap_picks_new_transport(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """AC-13 — re-creating a radiator with a different backing picks the new transport.
+
+    The options-flow swap is wired through `async_reload_entry` →
+    re-instantiation. Verifying that re-instantiating with the new
+    backing picks the right transport is the same property the reload
+    relies on.
+    """
+    switch_device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{CONF_NAME: "Swap Radiator", CONF_SWITCH: "switch.r"},
+    )
+    assert isinstance(switch_device._transport, SwitchTransport)
+
+    # Simulate the options-flow swap: rebuild the device with the new
+    # config (the same device_id thanks to the stable slug-based id).
+    climate_device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Swap Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+        },
+    )
+    assert isinstance(climate_device._transport, ClimateTransport)
+    # Stable identity across the swap (device_id is derived from name + type).
+    assert switch_device.device_id == climate_device.device_id

--- a/tests/test_ha_radiator.py
+++ b/tests/test_ha_radiator.py
@@ -114,27 +114,53 @@ def test_radiator_init_with_climate_picks_climate_transport(
     assert device._state_off == "off"
 
 
-def test_radiator_init_both_raises_service_validation_error(
-    hass: HomeAssistant, radiator_config_entry, radiator_home
+def test_radiator_init_both_truthy_picks_climate_and_logs(
+    hass: HomeAssistant, radiator_config_entry, radiator_home, caplog
 ):
-    """Configuring both `CONF_SWITCH` and `CONF_CLIMATE` raises `ServiceValidationError`."""
-    with pytest.raises(ServiceValidationError, match="exactly one of climate or switch"):
-        QSRadiator(
-            hass=hass,
-            config_entry=radiator_config_entry,
-            home=radiator_home,
-            **{
-                CONF_NAME: "Misconfigured Radiator",
-                CONF_SWITCH: "switch.r",
-                CONF_CLIMATE: "climate.r",
-            },
-        )
+    """EH6 — a stale entry with BOTH backings deterministically prefers climate.
+
+    A buggy migration or a manual `.storage/` edit could end up with
+    both `CONF_CLIMATE` and `CONF_SWITCH` set. Rather than crashing the
+    entry's reload (the old `ServiceValidationError` path), we log a
+    warning and pick `CONF_CLIMATE` as the canonical winner — it's the
+    richer backing and matches what the config-flow defaults steer to.
+    The other key is dropped from `kwargs` in place so the base
+    `AbstractLoad` doesn't pick up the loser.
+    """
+    import logging as _logging
+
+    caplog.set_level(_logging.WARNING, logger="custom_components.quiet_solar.ha_model.radiator")
+
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Stale Both Backings Radiator",
+            CONF_SWITCH: "switch.r",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+        },
+    )
+
+    assert isinstance(device._transport, ClimateTransport)
+    assert device._transport.entity == "climate.r"
+    # `AbstractLoad.__init__` populated `switch_entity` from kwargs — we
+    # popped `CONF_SWITCH` before super so it lands as `None`.
+    assert device.switch_entity is None
+    assert any("both" in rec.message.lower() and "backing" in rec.message.lower() for rec in caplog.records)
 
 
 def test_radiator_init_neither_raises_service_validation_error(
     hass: HomeAssistant, radiator_config_entry, radiator_home
 ):
-    """Configuring neither `CONF_SWITCH` nor `CONF_CLIMATE` raises `ServiceValidationError`."""
+    """Configuring neither `CONF_SWITCH` nor `CONF_CLIMATE` raises `ServiceValidationError`.
+
+    EH6 turns the both-set case into a warn-and-pick, but the
+    neither-set case remains a hard error — there's no sensible
+    default to pick from.
+    """
     with pytest.raises(ServiceValidationError, match="exactly one of climate or switch"):
         QSRadiator(
             hass=hass,

--- a/tests/test_ha_radiator.py
+++ b/tests/test_ha_radiator.py
@@ -595,8 +595,11 @@ def test_radiator_kwargs_normalised_in_place(
     )
 
     # `switch_entity` is the attribute that downstream code (home.py
-    # device registry, dashboard template) sees. It must NOT be "   ".
-    assert not device.switch_entity or device.switch_entity.strip() == ""
+    # device registry, dashboard template) sees. It must NOT be a
+    # whitespace-only string. CR3 review-fix — the previous form
+    # `not x or x.strip() == ""` was vacuously true for `"   "` (both
+    # halves of the `or` held), so the test couldn't catch the leak.
+    assert device.switch_entity is None
 
 
 def test_radiator_bistate_mode_labels_independent_of_hvac_mode(
@@ -625,6 +628,65 @@ def test_radiator_bistate_mode_labels_independent_of_hvac_mode(
     assert device._bistate_mode_off == "off"
     # The transport still uses the raw HVAC mode for service calls.
     assert device._transport.state_on == "auto"
+
+
+def test_bh_b_climate_vs_radiator_bistate_mode_convention_divergence(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """BH-B regression — `QSClimateDuration` and `QSRadiator` use DIFFERENT
+    `_bistate_mode_*` conventions, and that's intentional.
+
+    - `QSClimateDuration` carries the raw HVAC mode (the `climate_mode`
+      translation registers each HVAC mode as a force-mode state key,
+      so `"heat"` → "Force HVAC Mode HEAT").
+    - `QSRadiator` carries the literal `"on"` / `"off"` (the
+      `radiator_mode` translation only registers `"on"` / `"off"`, so
+      raw HVAC modes like `"auto"` would render unlocalised).
+
+    The divergence is documented in `QSBiStateDuration`'s docstring.
+    This test pins the contract so the divergence is observable in CI.
+    """
+    from custom_components.quiet_solar.const import (
+        CONF_CLIMATE_HVAC_MODE_OFF as _OFF,
+        CONF_CLIMATE_HVAC_MODE_ON as _ON,
+    )
+    from custom_components.quiet_solar.ha_model.climate_controller import QSClimateDuration
+
+    climate = QSClimateDuration(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "BH-B Climate",
+            CONF_CLIMATE: "climate.bh_b",
+            CONF_SWITCH: "switch.bh_b_climate_helper",
+            _ON: "heat",
+            _OFF: "off",
+        },
+    )
+    radiator = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "BH-B Radiator",
+            CONF_CLIMATE: "climate.bh_b_radiator",
+            _ON: "heat",
+            _OFF: "off",
+        },
+    )
+
+    # Climate carries the raw HVAC mode.
+    assert climate._bistate_mode_on == "heat"
+    assert climate._bistate_mode_off == "off"
+    # Radiator carries the literal `"on"`/`"off"`, regardless of HVAC mode.
+    assert radiator._bistate_mode_on == "on"
+    assert radiator._bistate_mode_off == "off"
+
+    # Both classes still emit the actual HVAC mode through the
+    # transport for service calls.
+    assert climate._transport.state_on == "heat"
+    assert radiator._transport.state_on == "heat"
 
 
 def test_radiator_options_flow_backing_swap_picks_new_transport(

--- a/tests/test_ha_radiator.py
+++ b/tests/test_ha_radiator.py
@@ -313,6 +313,177 @@ def test_radiator_no_climate_state_on_off_attributes(
     assert not isinstance(device, QSClimateDuration)
 
 
+def test_radiator_empty_climate_with_switch_picks_switch_transport(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """M4 regression — `CONF_CLIMATE=""` is treated as absent; switch wins."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Empty Climate Radiator",
+            CONF_CLIMATE: "",
+            CONF_SWITCH: "switch.r",
+        },
+    )
+
+    assert isinstance(device._transport, SwitchTransport)
+    assert device._transport.entity == "switch.r"
+
+
+def test_radiator_empty_switch_with_climate_picks_climate_transport(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """M4 regression — `CONF_SWITCH=""` is treated as absent; climate wins."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Empty Switch Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_SWITCH: "",
+        },
+    )
+
+    assert isinstance(device._transport, ClimateTransport)
+    assert device._transport.entity == "climate.r"
+
+
+def test_radiator_whitespace_entity_is_treated_as_absent(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """N6 regression — `CONF_CLIMATE="   "` is normalised away."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Whitespace Climate Radiator",
+            CONF_CLIMATE: "   ",
+            CONF_SWITCH: "switch.r",
+        },
+    )
+
+    assert isinstance(device._transport, SwitchTransport)
+
+
+def test_radiator_empty_hvac_mode_falls_back_to_heat(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """S9 regression — persisted `CONF_CLIMATE_HVAC_MODE_ON=""` falls back to `heat`."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Empty HVAC Mode Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "",
+            CONF_CLIMATE_HVAC_MODE_OFF: "",
+        },
+    )
+
+    assert device._state_on == "heat"
+    assert device._state_off == "off"
+
+
+def test_radiator_no_climate_state_on_off_attribute_hasattr(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """S10 — `hasattr` regression: radiator must NOT expose `climate_state_on/off`."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Hasattr Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+        },
+    )
+
+    assert not hasattr(device, "climate_state_on")
+    assert not hasattr(device, "climate_state_off")
+
+
+def test_radiator_transport_built_before_super_init(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """S2 regression — `self._transport` is available during `super().__init__`."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{CONF_NAME: "Init Order Radiator", CONF_SWITCH: "switch.r"},
+    )
+
+    # After init, host-owned values reflect the transport's defaults.
+    # The fact that init didn't crash plus that bistate_entity matches
+    # the transport's entity (rather than `switch_entity` overridden by
+    # the base ctor) proves the transport was built first.
+    assert device._transport.entity == "switch.r"
+    assert device.bistate_entity == "switch.r"
+    assert device._state_on == "on"
+    assert device._state_off == "off"
+
+
+def test_radiator_bistate_modes_set_is_pinned(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """S12 — pin the exact set of `radiator_mode` select states.
+
+    AC-7 enumerated which states the `radiator_mode` select must
+    expose. Future translation/code drift would silently break the UX
+    without this assertion.
+    """
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{CONF_NAME: "Modes Pin Radiator", CONF_SWITCH: "switch.r"},
+    )
+
+    modes = device.get_bistate_modes()
+
+    # The canonical user-visible state set:
+    #   - `bistate_mode_auto`         — calendar end + duration
+    #   - `bistate_mode_exact_calendar` — calendar exact schedule
+    #   - `bistate_mode_default`      — fixed end + duration
+    #   - the host's `_bistate_mode_on/off` values (radiator: "on"/"off"
+    #     for switch backing, hvac modes for climate backing)
+    assert "bistate_mode_auto" in modes
+    assert "bistate_mode_exact_calendar" in modes
+    assert "bistate_mode_default" in modes
+    assert device._bistate_mode_on in modes
+    assert device._bistate_mode_off in modes
+
+
+def test_radiator_climate_bistate_modes_set_includes_heat_off(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """S12 — climate-backed radiator exposes `heat`/`off` as the override states."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Climate Modes Pin Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+        },
+    )
+
+    modes = device.get_bistate_modes()
+
+    assert {"bistate_mode_auto", "bistate_mode_exact_calendar", "bistate_mode_default", "heat", "off"}.issubset(
+        set(modes)
+    )
+
+
 def test_radiator_options_flow_backing_swap_picks_new_transport(
     hass: HomeAssistant, radiator_config_entry, radiator_home
 ):

--- a/tests/test_ha_radiator.py
+++ b/tests/test_ha_radiator.py
@@ -238,9 +238,14 @@ async def test_radiator_execute_command_calls_transport_switch(
         home=radiator_home,
         **{CONF_NAME: "Test Radiator", CONF_SWITCH: "switch.r"},
     )
-    device._transport = MagicMock(spec=SwitchTransport)
-    device._transport.execute = AsyncMock(return_value=False)
-    device._transport.entity = "switch.r"
+    # B3 — the inherited `_state_on/_state_off` property reads through
+    # the transport, so the mock must expose `state_on`/`state_off`.
+    mock_transport = MagicMock(spec=SwitchTransport)
+    mock_transport.execute = AsyncMock(return_value=False)
+    mock_transport.entity = "switch.r"
+    mock_transport.state_on = "on"
+    mock_transport.state_off = "off"
+    device._transport = mock_transport
 
     time = datetime.datetime.now(pytz.UTC)
     result = await device.execute_command_system(time, CMD_ON, state=None)
@@ -251,7 +256,7 @@ async def test_radiator_execute_command_calls_transport_switch(
     assert args[0] is hass
     assert args[1] is CMD_ON
     assert args[2] is None
-    # state_on / state_off are the host's values
+    # state_on / state_off are the host's values (now routed via property → transport)
     assert args[3] == "on"
     assert args[4] == "off"
 
@@ -272,9 +277,14 @@ async def test_radiator_execute_command_calls_transport_climate(
             CONF_CLIMATE_HVAC_MODE_OFF: "off",
         },
     )
-    device._transport = MagicMock(spec=ClimateTransport)
-    device._transport.execute = AsyncMock(return_value=False)
-    device._transport.entity = "climate.r"
+    # B3 — the inherited `_state_on/_state_off` property reads through
+    # the transport, so the mock must expose `state_on`/`state_off`.
+    mock_transport = MagicMock(spec=ClimateTransport)
+    mock_transport.execute = AsyncMock(return_value=False)
+    mock_transport.entity = "climate.r"
+    mock_transport.state_on = "heat"
+    mock_transport.state_off = "off"
+    device._transport = mock_transport
 
     time = datetime.datetime.now(pytz.UTC)
     result = await device.execute_command_system(time, CMD_OFF, state=None)
@@ -433,11 +443,11 @@ def test_radiator_transport_built_before_super_init(
 def test_radiator_bistate_modes_set_is_pinned(
     hass: HomeAssistant, radiator_config_entry, radiator_home
 ):
-    """S12 — pin the exact set of `radiator_mode` select states.
+    """S12 + CR4 — pin the EXACT set of `radiator_mode` select states.
 
     AC-7 enumerated which states the `radiator_mode` select must
-    expose. Future translation/code drift would silently break the UX
-    without this assertion.
+    expose. Set-equality (rather than `issubset`) catches both
+    missing and unexpected modes.
     """
     device = QSRadiator(
         hass=hass,
@@ -448,23 +458,26 @@ def test_radiator_bistate_modes_set_is_pinned(
 
     modes = device.get_bistate_modes()
 
-    # The canonical user-visible state set:
-    #   - `bistate_mode_auto`         — calendar end + duration
-    #   - `bistate_mode_exact_calendar` — calendar exact schedule
-    #   - `bistate_mode_default`      — fixed end + duration
-    #   - the host's `_bistate_mode_on/off` values (radiator: "on"/"off"
-    #     for switch backing, hvac modes for climate backing)
-    assert "bistate_mode_auto" in modes
-    assert "bistate_mode_exact_calendar" in modes
-    assert "bistate_mode_default" in modes
-    assert device._bistate_mode_on in modes
-    assert device._bistate_mode_off in modes
+    assert set(modes) == {
+        "bistate_mode_auto",
+        "bistate_mode_exact_calendar",
+        "bistate_mode_default",
+        "on",
+        "off",
+    }
 
 
-def test_radiator_climate_bistate_modes_set_includes_heat_off(
+def test_radiator_climate_bistate_modes_set_includes_on_off(
     hass: HomeAssistant, radiator_config_entry, radiator_home
 ):
-    """S12 — climate-backed radiator exposes `heat`/`off` as the override states."""
+    """E3 + CR4 — climate-backed radiator also exposes `on`/`off` (not raw HVAC modes).
+
+    E3 hardcoded the bistate-mode labels to `on`/`off` regardless of
+    the HVAC mode configured for the underlying climate entity. The
+    `radiator_mode` translation only carries `on` / `off` / calendar
+    keys; raw HVAC mode strings like `auto` would render unlocalised
+    otherwise.
+    """
     device = QSRadiator(
         hass=hass,
         config_entry=radiator_config_entry,
@@ -479,9 +492,113 @@ def test_radiator_climate_bistate_modes_set_includes_heat_off(
 
     modes = device.get_bistate_modes()
 
-    assert {"bistate_mode_auto", "bistate_mode_exact_calendar", "bistate_mode_default", "heat", "off"}.issubset(
-        set(modes)
+    assert set(modes) == {
+        "bistate_mode_auto",
+        "bistate_mode_exact_calendar",
+        "bistate_mode_default",
+        "on",
+        "off",
+    }
+
+
+def test_radiator_state_on_routes_through_transport(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """B3 regression — radiator inherits the `_state_on` property shadow.
+
+    Writing through `self._state_on` MUST update the transport so the
+    host and the underlying service-call layer never diverge. Mirrors
+    the climate-controller round-trip test for parity.
+    """
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Property Shadow Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+        },
     )
+
+    device._state_on = "cool"
+    assert device._transport.state_on == "cool"
+    assert device._state_on == "cool"
+
+
+def test_radiator_state_off_routes_through_transport(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """B3 regression — same for `_state_off`."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Property Shadow Off Radiator",
+            CONF_SWITCH: "switch.r",
+        },
+    )
+
+    device._state_off = "stopped"
+    assert device._transport.state_off == "stopped"
+    assert device._state_off == "stopped"
+
+
+def test_radiator_kwargs_normalised_in_place(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """E1 regression — whitespace switch entity must NOT leak into base ctor.
+
+    Constructing with `switch="   "` plus a real climate must leave
+    `device.switch_entity` empty/None (the base ctor reads `CONF_SWITCH`
+    from kwargs, which must be normalised before super runs).
+    """
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Whitespace Switch Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_SWITCH: "   ",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+        },
+    )
+
+    # `switch_entity` is the attribute that downstream code (home.py
+    # device registry, dashboard template) sees. It must NOT be "   ".
+    assert not device.switch_entity or device.switch_entity.strip() == ""
+
+
+def test_radiator_bistate_mode_labels_independent_of_hvac_mode(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """E3 regression — radiator bistate-mode labels are always `on`/`off`.
+
+    Even when the climate-backed radiator's HVAC ON is `auto`, the
+    bistate-mode select must expose `on`/`off` so the `radiator_mode`
+    translation can label them ("Force ON" / "Force OFF") instead of
+    showing the raw HVAC mode string.
+    """
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Auto HVAC Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "auto",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+        },
+    )
+
+    assert device._bistate_mode_on == "on"
+    assert device._bistate_mode_off == "off"
+    # The transport still uses the raw HVAC mode for service calls.
+    assert device._transport.state_on == "auto"
 
 
 def test_radiator_options_flow_backing_swap_picks_new_transport(

--- a/tests/test_ha_radiator_real.py
+++ b/tests/test_ha_radiator_real.py
@@ -9,7 +9,7 @@ relationship (AC-10).
 from __future__ import annotations
 
 import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import pytz
@@ -407,13 +407,3 @@ async def test_radiator_climate_executes_with_override_state(
         and c[2].get(climate.ATTR_HVAC_MODE) == "auto"
     ]
     assert len(climate_calls) == 1
-
-
-# =============================================================================
-# `AsyncMock` smoke check (silence lint warning on unused import)
-# =============================================================================
-
-
-def test_async_mock_imported() -> None:
-    """Ensure `AsyncMock` import stays used (other tests rely on it indirectly)."""
-    assert AsyncMock is not None

--- a/tests/test_ha_radiator_real.py
+++ b/tests/test_ha_radiator_real.py
@@ -1,0 +1,353 @@
+"""End-to-end tests for `QSRadiator` against a real `hass` fixture.
+
+These tests cover the integration boundary the unit tests in
+`test_ha_radiator.py` mock out: the actual HA service call, the
+constraint / select / sensor wiring, and the heat-pump piloting
+relationship (AC-10).
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytz
+from homeassistant.components import climate
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_NAME,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.quiet_solar.const import (
+    CONF_CLIMATE,
+    CONF_CLIMATE_HVAC_MODE_OFF,
+    CONF_CLIMATE_HVAC_MODE_ON,
+    CONF_DEVICE_TO_PILOT_NAME,
+    CONF_POWER,
+    CONF_SWITCH,
+    DATA_HANDLER,
+    DOMAIN,
+)
+from custom_components.quiet_solar.ha_model.bistate_transport import (
+    ClimateTransport,
+    SwitchTransport,
+)
+from custom_components.quiet_solar.ha_model.radiator import QSRadiator
+from custom_components.quiet_solar.home_model.commands import CMD_OFF, CMD_ON
+from tests.factories import create_minimal_home_model
+
+
+@pytest.fixture
+def radiator_config_entry() -> MockConfigEntry:
+    """Mock config entry for radiator tests."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_real_entry",
+        data={CONF_NAME: "Real Radiator"},
+        title="Real Radiator",
+    )
+
+
+@pytest.fixture
+def radiator_home(hass: HomeAssistant):
+    """Home and data handler for radiator tests."""
+    home = create_minimal_home_model()
+    home.is_off_grid = MagicMock(return_value=False)
+    data_handler = MagicMock()
+    data_handler.home = home
+    hass.data.setdefault(DOMAIN, {})[DATA_HANDLER] = data_handler
+    return home
+
+
+@pytest.fixture
+def recorded_service_calls(hass: HomeAssistant):
+    """Record service calls (domain, service, payload) for assertions.
+
+    The fourth tuple element captures `service_data` OR (when only
+    `target` is set, as for switch.turn_on/off) the target dict — so a
+    single recorder works for both climate and switch flows. Mirrors
+    `test_ha_climate_controller_real.py` but tolerant of `target=`.
+    """
+    from homeassistant.core import ServiceRegistry
+
+    recorded = []
+
+    async def record_only(self, domain, service, service_data=None, **kwargs):
+        if self is hass.services:
+            payload = service_data or kwargs.get("target") or {}
+            recorded.append((domain, service, payload))
+        return None
+
+    with patch.object(ServiceRegistry, "async_call", record_only):
+        yield recorded
+
+
+# =============================================================================
+# Switch-backed full cycle
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_radiator_switch_full_cycle(
+    hass: HomeAssistant, radiator_config_entry, radiator_home, recorded_service_calls
+):
+    """Full bistate cycle for a switch-backed radiator: ON then OFF service calls."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Switch Radiator",
+            CONF_SWITCH: "switch.r",
+            CONF_POWER: 1000,
+        },
+    )
+    assert isinstance(device._transport, SwitchTransport)
+
+    time = datetime.datetime.now(pytz.UTC)
+
+    # ON command — turn_on service call
+    result = await device.execute_command_system(time, CMD_ON, state=None)
+    assert result is False
+    on_calls = [c for c in recorded_service_calls if c[0] == Platform.SWITCH and c[1] == SERVICE_TURN_ON]
+    assert len(on_calls) == 1
+    assert on_calls[0][2] == {"entity_id": "switch.r"}
+
+    # OFF command — turn_off service call
+    result = await device.execute_command_system(time, CMD_OFF, state=None)
+    assert result is False
+    off_calls = [c for c in recorded_service_calls if c[0] == Platform.SWITCH and c[1] == SERVICE_TURN_OFF]
+    assert len(off_calls) == 1
+
+
+# =============================================================================
+# Climate-backed full cycle
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_radiator_climate_full_cycle(
+    hass: HomeAssistant, radiator_config_entry, radiator_home, recorded_service_calls
+):
+    """Full bistate cycle for a climate-backed radiator: `heat` then `off`."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Climate Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+            CONF_POWER: 1500,
+        },
+    )
+    assert isinstance(device._transport, ClimateTransport)
+
+    time = datetime.datetime.now(pytz.UTC)
+
+    # ON — set_hvac_mode with `heat`
+    result = await device.execute_command_system(time, CMD_ON, state=None)
+    assert result is False
+    on_calls = [
+        c
+        for c in recorded_service_calls
+        if c[0] == climate.DOMAIN and c[1] == climate.SERVICE_SET_HVAC_MODE
+    ]
+    assert len(on_calls) == 1
+    assert on_calls[0][2][ATTR_ENTITY_ID] == "climate.r"
+    assert on_calls[0][2][climate.ATTR_HVAC_MODE] == "heat"
+
+    # OFF — set_hvac_mode with `off`
+    result = await device.execute_command_system(time, CMD_OFF, state=None)
+    assert result is False
+    off_calls = [
+        c
+        for c in recorded_service_calls
+        if c[0] == climate.DOMAIN
+        and c[1] == climate.SERVICE_SET_HVAC_MODE
+        and c[2].get(climate.ATTR_HVAC_MODE) == "off"
+    ]
+    assert len(off_calls) == 1
+
+
+# =============================================================================
+# Heat-pump piloting — AC-10
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_radiator_attaches_to_heat_pump_for_switch_backing(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """AC-10 — switch-backed radiator with `CONF_DEVICE_TO_PILOT_NAME` reads it through.
+
+    Piloting is data-driven via `AbstractLoad.__init__` → no class-specific
+    code in `home.add_device`. The name is on the load; the actual
+    wiring happens in `_set_topology()` (exercised in HA-integration
+    tests below).
+    """
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Piloted Switch Radiator",
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Main Heat Pump",
+        },
+    )
+
+    assert device.piloted_device_name == "Main Heat Pump"
+    # Sanity: the transport is the switch one — piloting works regardless.
+    assert isinstance(device._transport, SwitchTransport)
+
+
+@pytest.mark.asyncio
+async def test_radiator_attaches_to_heat_pump_for_climate_backing(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """AC-10 — climate-backed radiator with `CONF_DEVICE_TO_PILOT_NAME` reads it through."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Piloted Climate Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+            CONF_DEVICE_TO_PILOT_NAME: "Main Heat Pump",
+        },
+    )
+
+    assert device.piloted_device_name == "Main Heat Pump"
+    assert isinstance(device._transport, ClimateTransport)
+
+
+@pytest.mark.asyncio
+async def test_radiator_topology_pilot_wires_through_set_topology(hass: HomeAssistant):
+    """AC-10 end-to-end — `home._set_topology()` populates `devices_to_pilot` for a radiator.
+
+    Uses a stub home that mirrors the relevant slice of `QSHome` and runs
+    the data-driven pilot wiring identically to production code.
+    """
+    radiator = MagicMock()
+    radiator.name = "Bedroom Radiator"
+    radiator.piloted_device_name = "Main Heat Pump"
+    radiator.devices_to_pilot = []
+
+    heat_pump = MagicMock()
+    heat_pump.name = "Main Heat Pump"
+    heat_pump.clients = []
+
+    # Run the same loop as `home._set_topology()` (home.py:1876-1882).
+    name_to_piloted = {heat_pump.name: heat_pump}
+    for load in [radiator]:
+        load.devices_to_pilot = []
+        if load.piloted_device_name is not None:
+            piloted = name_to_piloted.get(load.piloted_device_name)
+            if piloted is not None:
+                load.devices_to_pilot.append(piloted)
+                piloted.clients.append(load)
+
+    assert radiator.devices_to_pilot == [heat_pump]
+    assert heat_pump.clients == [radiator]
+
+
+# =============================================================================
+# Initial state defaults
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_radiator_climate_state_defaults_when_unset(
+    hass: HomeAssistant, radiator_config_entry, radiator_home
+):
+    """Climate-backed radiator defaults to `heat`/`off` when HVAC modes aren't set."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Defaults Radiator",
+            CONF_CLIMATE: "climate.r",
+        },
+    )
+
+    assert device._state_on == "heat"
+    assert device._state_off == "off"
+    assert device._transport.default_state_on() == "heat"
+
+
+# =============================================================================
+# Override-state path — `execute_command_system` passes the override through
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_radiator_switch_executes_with_override_state(
+    hass: HomeAssistant, radiator_config_entry, radiator_home, recorded_service_calls
+):
+    """An override state (e.g. user forced ON) drives `switch.turn_on` regardless of command."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{CONF_NAME: "Override Radiator", CONF_SWITCH: "switch.r"},
+    )
+
+    time = datetime.datetime.now(pytz.UTC)
+    # CMD_OFF + override_state="on" → turn_on
+    result = await device.execute_command_system(time, CMD_OFF, state="on")
+
+    assert result is False
+    on_calls = [c for c in recorded_service_calls if c[0] == Platform.SWITCH and c[1] == SERVICE_TURN_ON]
+    assert len(on_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_radiator_climate_executes_with_override_state(
+    hass: HomeAssistant, radiator_config_entry, radiator_home, recorded_service_calls
+):
+    """For a climate radiator, `override_state` becomes the HVAC mode directly."""
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Climate Override Radiator",
+            CONF_CLIMATE: "climate.r",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+        },
+    )
+
+    time = datetime.datetime.now(pytz.UTC)
+    result = await device.execute_command_system(time, CMD_OFF, state="auto")
+
+    assert result is False
+    climate_calls = [
+        c
+        for c in recorded_service_calls
+        if c[0] == climate.DOMAIN
+        and c[1] == climate.SERVICE_SET_HVAC_MODE
+        and c[2].get(climate.ATTR_HVAC_MODE) == "auto"
+    ]
+    assert len(climate_calls) == 1
+
+
+# =============================================================================
+# `AsyncMock` smoke check (silence lint warning on unused import)
+# =============================================================================
+
+
+def test_async_mock_imported() -> None:
+    """Ensure `AsyncMock` import stays used (other tests rely on it indirectly)."""
+    assert AsyncMock is not None

--- a/tests/test_ha_radiator_real.py
+++ b/tests/test_ha_radiator_real.py
@@ -233,32 +233,98 @@ async def test_radiator_attaches_to_heat_pump_for_climate_backing(
 
 @pytest.mark.asyncio
 async def test_radiator_topology_pilot_wires_through_set_topology(hass: HomeAssistant):
-    """AC-10 end-to-end — `home._set_topology()` populates `devices_to_pilot` for a radiator.
+    """AC-10 end-to-end — `QSHome._set_topology()` populates `devices_to_pilot`.
 
-    Uses a stub home that mirrors the relevant slice of `QSHome` and runs
-    the data-driven pilot wiring identically to production code.
+    S11 review-fix — exercises the REAL `QSHome._set_topology()` method
+    against a real `QSRadiator` + `QSHeatPump`, rather than re-implementing
+    the loop locally on `MagicMock`s. A future regression in the
+    production method now actually fails the test.
     """
-    radiator = MagicMock()
+    # Build a stub-but-real QSHome by bypassing the heavy `__init__`. We
+    # populate the in-memory lists `_set_topology` reads from and call
+    # the method directly, mirroring how `add_device` / `remove_device`
+    # would orchestrate it in production.
+    from custom_components.quiet_solar.ha_model.heat_pump import QSHeatPump
+    from custom_components.quiet_solar.ha_model.home import QSHome
+    from custom_components.quiet_solar.ha_model.radiator import QSRadiator
+
+    home = QSHome.__new__(QSHome)
+    home._all_dynamic_groups = []
+    home._all_loads = []
+    home._all_piloted_devices = []
+    home._name_to_groups = {}
+    home._name_to_piloted_devices = {}
+    home._heat_pumps = []
+    home._cars = []
+    home._chargers = []
+    home._persons = []
+    home._disabled_devices = []
+    home._all_devices = []
+    # `_set_topology` re-parents each load into `home._childrens` when
+    # the load has no `dynamic_group_name`, so the attribute must exist.
+    home._childrens = []
+    home.dynamic_group_name = None
+
+    heat_pump = QSHeatPump.__new__(QSHeatPump)
+    heat_pump.name = "Main Heat Pump"
+    heat_pump.dynamic_group_name = None
+    heat_pump.clients = []
+    heat_pump.father_device = None
+
+    radiator = QSRadiator.__new__(QSRadiator)
     radiator.name = "Bedroom Radiator"
     radiator.piloted_device_name = "Main Heat Pump"
+    radiator.dynamic_group_name = None
     radiator.devices_to_pilot = []
+    radiator.father_device = None
 
-    heat_pump = MagicMock()
-    heat_pump.name = "Main Heat Pump"
-    heat_pump.clients = []
+    home._all_piloted_devices = [heat_pump]
+    home._all_loads = [radiator]
 
-    # Run the same loop as `home._set_topology()` (home.py:1876-1882).
-    name_to_piloted = {heat_pump.name: heat_pump}
-    for load in [radiator]:
-        load.devices_to_pilot = []
-        if load.piloted_device_name is not None:
-            piloted = name_to_piloted.get(load.piloted_device_name)
-            if piloted is not None:
-                load.devices_to_pilot.append(piloted)
-                piloted.clients.append(load)
+    home._set_topology()
 
     assert radiator.devices_to_pilot == [heat_pump]
     assert heat_pump.clients == [radiator]
+
+
+@pytest.mark.asyncio
+async def test_radiator_pilot_end_to_end_service_call_sequence(
+    hass: HomeAssistant, radiator_config_entry, radiator_home, recorded_service_calls
+):
+    """N9 — AC-10 third bullet: toggling a piloted radiator emits the expected service call.
+
+    Verifies the pilot wiring is observable on the load: the radiator's
+    `devices_to_pilot` list contains the heat-pump instance after the
+    topology pass, and a subsequent `execute_command_system` call emits
+    the underlying HA service call (the pilot chain itself is exercised
+    separately in `test_piloted_device.py`).
+    """
+    device = QSRadiator(
+        hass=hass,
+        config_entry=radiator_config_entry,
+        home=radiator_home,
+        **{
+            CONF_NAME: "Piloted End-to-End Radiator",
+            CONF_SWITCH: "switch.pilot_e2e",
+            CONF_DEVICE_TO_PILOT_NAME: "Main HP",
+        },
+    )
+
+    # Simulate the pilot topology hand-off without running the full
+    # `QSHome.add_device` / `_set_topology` (covered separately above).
+    fake_heat_pump = MagicMock()
+    fake_heat_pump.name = "Main HP"
+    device.devices_to_pilot = [fake_heat_pump]
+
+    time = datetime.datetime.now(pytz.UTC)
+    result = await device.execute_command_system(time, CMD_ON, state=None)
+
+    assert result is False
+    switch_calls = [c for c in recorded_service_calls if c[0] == Platform.SWITCH and c[1] == SERVICE_TURN_ON]
+    assert len(switch_calls) == 1
+    # The pilot relationship survives the command emission — the
+    # heat-pump instance is still in `devices_to_pilot`.
+    assert fake_heat_pump in device.devices_to_pilot
 
 
 # =============================================================================

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -1238,6 +1238,258 @@ async def test_radiator_options_flow_single_async_update_entry(
 
 
 @pytest.mark.asyncio
+async def test_radiator_step_same_hvac_on_off_surfaces_error(
+    hass: HomeAssistant, mock_data_handler
+):
+    """EH1 — submitting `HVAC_MODE_ON == HVAC_MODE_OFF` surfaces an error.
+
+    Without this guard the radiator would save a config where every
+    `set_hvac_mode` call emits the same value (the device never
+    toggles).
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_same_hvac_123",
+        data={
+            CONF_NAME: "Same HVAC Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_CLIMATE: "climate.same",
+        },
+        title="radiator: Same HVAC",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat", "off"],
+    ):
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Same HVAC Radiator",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.same",
+                CONF_CLIMATE_HVAC_MODE_ON: "heat",
+                CONF_CLIMATE_HVAC_MODE_OFF: "heat",  # SAME as ON — invalid
+            }
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"].get(CONF_CLIMATE_HVAC_MODE_OFF) == "hvac_modes_must_differ"
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_single_mode_hvac_surfaces_error(
+    hass: HomeAssistant, mock_data_handler
+):
+    """EH2 — `len(hvac_modes) < 2` surfaces `climate_modes_insufficient`.
+
+    A single-mode list (e.g. `["heat"]`) cannot represent a meaningful
+    ON/OFF pair. The form rejects the submission rather than save an
+    unsatisfiable config.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_single_mode_123",
+        data={
+            CONF_NAME: "Single Mode Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_CLIMATE: "climate.single",
+        },
+        title="radiator: Single Mode",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat"],  # Single-mode list
+    ):
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Single Mode Radiator",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.single",
+                CONF_CLIMATE_HVAC_MODE_ON: "heat",
+                CONF_CLIMATE_HVAC_MODE_OFF: "heat",
+            }
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"].get("base") == "climate_modes_insufficient"
+
+
+@pytest.mark.asyncio
+async def test_radiator_form_single_mode_skips_hvac_dropdowns(
+    hass: HomeAssistant, mock_data_handler
+):
+    """EH2 — `_async_show_radiator_form` does NOT render HVAC dropdowns
+    when fewer than two modes are available.
+
+    The form-level error from the submit path steers the user to back
+    out; rendering an unsatisfiable dropdown would otherwise dead-end
+    them.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_render_single_mode_123",
+        data={
+            CONF_NAME: "Render Single Mode",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_CLIMATE: "climate.single",
+        },
+        title="radiator: Render Single Mode",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat"],
+    ):
+        result = await flow.async_step_radiator()
+
+    assert result["type"] == FlowResultType.FORM
+    # HVAC mode dropdowns must NOT appear when the entity has fewer
+    # than two modes.
+    assert not _schema_has_key(result["data_schema"], CONF_CLIMATE_HVAC_MODE_ON)
+    assert not _schema_has_key(result["data_schema"], CONF_CLIMATE_HVAC_MODE_OFF)
+
+
+@pytest.mark.asyncio
+async def test_radiator_form_two_mode_no_off_nudges_suggested_off(
+    hass: HomeAssistant, mock_data_handler
+):
+    """EH2 — when `suggested_on == suggested_off` would coincide, the
+    form picks an alternative `suggested_off` so the rendered defaults
+    are distinct.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_two_mode_no_off_123",
+        data={
+            CONF_NAME: "Two Mode No Off",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_CLIMATE: "climate.two_mode",
+        },
+        title="radiator: Two Mode No Off",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    # `["heat", "cool"]` — no "off" or off-like mode. Both suggested_on
+    # and the previous suggested_off fallback would have landed on
+    # `hvac_modes[-1]` = "cool", but suggested_on is "heat" so they
+    # differ. Let's exercise the case where both land on the same mode:
+    # `["heat", "fan_only"]` where existing_off was "heat" (would have
+    # been kept due to membership in hvac_modes). But that's stale.
+    #
+    # Simplest scenario: `hvac_modes = ["auto", "heat"]`, no existing
+    # off persisted → suggested_off chain: no "off", no off-like, picks
+    # `hvac_modes[-1]` = "heat". suggested_on = "heat". They coincide.
+    # The nudge should pick "auto" for suggested_off.
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["auto", "heat"],
+    ):
+        result = await flow.async_step_radiator()
+
+    on_default = None
+    off_default = None
+    for item in result["data_schema"].schema:
+        if getattr(item, "schema", None) == CONF_CLIMATE_HVAC_MODE_ON:
+            on_default = item.default()
+        elif getattr(item, "schema", None) == CONF_CLIMATE_HVAC_MODE_OFF:
+            off_default = item.default()
+
+    assert on_default == "heat"
+    assert off_default == "auto"
+    assert on_default != off_default
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_xor_error_preserves_user_input(
+    hass: HomeAssistant, mock_data_handler
+):
+    """EH4 — XOR error re-render keeps the user's just-rejected values.
+
+    The form previously re-rendered with `config_entry.data` defaults,
+    forcing the user to re-pick the entities they had just submitted.
+    The `pending` kwarg now carries the rejected submission through.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_xor_preserve_123",
+        data={
+            CONF_NAME: "Preserve On Error",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+        },
+        title="radiator: Preserve",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    # Submit BOTH backings → XOR error. The re-rendered form must
+    # carry both values forward in the entity selectors' suggestions.
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat", "off"],
+    ):
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Preserve On Error",
+                CONF_POWER: 1000,
+                CONF_SWITCH: "switch.user_picked",
+                CONF_CLIMATE: "climate.user_picked",
+            }
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "exactly_one_backing_required"}
+
+    climate_default = None
+    switch_default = None
+    for item in result["data_schema"].schema:
+        if getattr(item, "schema", None) == CONF_CLIMATE:
+            climate_default = item.description.get("suggested_value") if item.description else None
+        elif getattr(item, "schema", None) == CONF_SWITCH:
+            switch_default = item.description.get("suggested_value") if item.description else None
+
+    assert climate_default == "climate.user_picked"
+    assert switch_default == "switch.user_picked"
+
+
+@pytest.mark.asyncio
 async def test_radiator_step_orphan_helper_keeps_user_picked_heat_pump(
     hass: HomeAssistant, mock_data_handler
 ):
@@ -1384,6 +1636,59 @@ async def test_radiator_step_orphan_pilot_cleared_on_reedit(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     # The orphan reference must NOT survive into the persisted entry.
+    assert CONF_DEVICE_TO_PILOT_NAME not in config_entry.data
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_explicit_pilot_clear_removes_persisted_key(
+    hass: HomeAssistant, mock_data_handler
+):
+    """EH5 — submitting an explicit-empty `CONF_DEVICE_TO_PILOT_NAME`
+    clears the persisted value (the user can now "unpilot" a radiator).
+
+    Previously the cleanup stripped the empty value, the merge re-injected
+    the old persisted name, and the user's deliberate clear was silently
+    reverted.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_unpilot_123",
+        data={
+            CONF_NAME: "Unpilot Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Existing HP",
+        },
+        title="radiator: Unpilot",
+    )
+    config_entry.add_to_hass(hass)
+
+    existing_hp = MagicMock()
+    existing_hp.name = "Existing HP"
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [existing_hp]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+        new_callable=AsyncMock,
+    ):
+        # User submits with the pilot field present but emptied — this is
+        # the form's way of saying "remove the pilot reference".
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Unpilot Radiator",
+                CONF_POWER: 1000,
+                CONF_SWITCH: "switch.r",
+                CONF_DEVICE_TO_PILOT_NAME: None,
+            }
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # The persisted pilot must be GONE.
     assert CONF_DEVICE_TO_PILOT_NAME not in config_entry.data
 
 

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -79,6 +79,7 @@ from custom_components.quiet_solar.const import (
     CONF_SOLAR_MAX_OUTPUT_POWER_VALUE,
     CONF_SOLAR_MAX_PHASE_AMPS,
     CONF_SOLAR_PROVIDER_DOMAIN,
+    CONF_SWITCH,
     DASHBOARD_NO_SECTION,
     DATA_HANDLER,
     DEVICE_TYPE,
@@ -89,6 +90,7 @@ from custom_components.quiet_solar.const import (
     CONF_TYPE_NAME_QSClimateDuration,
     CONF_TYPE_NAME_QSHeatPump,
     CONF_TYPE_NAME_QSHome,
+    CONF_TYPE_NAME_QSRadiator,
 )
 from custom_components.quiet_solar.ha_model.battery import QSBattery
 from custom_components.quiet_solar.ha_model.car import QSCar
@@ -240,6 +242,8 @@ async def test_flow_user_init_with_home(hass, mock_data_handler):
     assert QSHome.conf_type_name not in result["menu_options"]
     assert "charger" in result["menu_options"]  # Charger is a submenu
     assert QSCar.conf_type_name in result["menu_options"]
+    # Radiator must surface as a top-level menu option (AC-6).
+    assert CONF_TYPE_NAME_QSRadiator in result["menu_options"]
 
 
 @pytest.mark.asyncio
@@ -806,6 +810,124 @@ async def test_options_flow_heat_pump_updates_entry(hass: HomeAssistant, mock_da
 # =============================================================================
 # Climate with Heat Pump Options Tests
 # =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_with_heat_pumps_and_default(hass: HomeAssistant, mock_data_handler):
+    """Test radiator step shows heat pump selector with default value."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_hp_default_123",
+        data={
+            CONF_NAME: "Test Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_CLIMATE: "climate.living_room",
+            CONF_CLIMATE_HVAC_MODE_OFF: "off",
+            CONF_CLIMATE_HVAC_MODE_ON: "heat",
+            CONF_DEVICE_TO_PILOT_NAME: "My Heat Pump",
+        },
+        title="radiator: Test Radiator",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_hp = MagicMock()
+    mock_hp.name = "My Heat Pump"
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [mock_hp]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["off", "heat"],
+    ):
+        result = await flow.async_step_radiator()
+
+    assert result["type"] == FlowResultType.FORM
+    schema = result["data_schema"]
+    assert _schema_has_key(schema, CONF_DEVICE_TO_PILOT_NAME)
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_with_heat_pumps_no_default(hass: HomeAssistant, mock_data_handler):
+    """Test radiator step shows heat pump selector without default value."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_hp_nodef_123",
+        data={
+            CONF_NAME: "Test Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.radiator_no_hp",
+        },
+        title="radiator: Test Radiator",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_hp1 = MagicMock()
+    mock_hp1.name = "Heat Pump A"
+    mock_hp2 = MagicMock()
+    mock_hp2.name = "Heat Pump B"
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [mock_hp1, mock_hp2]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    result = await flow.async_step_radiator()
+
+    assert result["type"] == FlowResultType.FORM
+    schema = result["data_schema"]
+    assert _schema_has_key(schema, CONF_DEVICE_TO_PILOT_NAME)
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_climate_without_heat_mode_suggests_first_non_off(
+    hass: HomeAssistant, mock_data_handler
+):
+    """AC-6 D10 — radiator climate-mode dropdown falls back to first non-`off` mode.
+
+    When the climate entity advertises HVAC modes but doesn't include
+    `heat`, the form must suggest the first non-`off` mode (`auto` here),
+    not crash and not leave the field empty.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_no_heat_123",
+        data={
+            CONF_NAME: "Test Radiator No Heat",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_CLIMATE: "climate.heat_less_radiator",
+        },
+        title="radiator: No Heat",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["off", "auto"],
+    ):
+        result = await flow.async_step_radiator()
+
+    assert result["type"] == FlowResultType.FORM
+    schema = result["data_schema"]
+    # The HVAC mode selector for ON must be present and default to the
+    # first non-`off` mode (i.e. `auto`).
+    on_default = None
+    for item in schema.schema:
+        if getattr(item, "schema", None) == CONF_CLIMATE_HVAC_MODE_ON:
+            on_default = item.default()
+            break
+    assert on_default == "auto"
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -1640,6 +1640,171 @@ async def test_radiator_step_orphan_pilot_cleared_on_reedit(
 
 
 @pytest.mark.asyncio
+async def test_radiator_step_explicit_pilot_clear_with_absent_key(
+    hass: HomeAssistant, mock_data_handler
+):
+    """BH-D — explicit-clear detection works whether the form omits the key
+    or submits it with `None`.
+
+    HA's `vol.Optional` could deliver either shape (key absent vs key
+    present with `None`). The fix uses a sentinel so both variants
+    funnel into the same `explicit_pilot_clear` branch.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_pilot_absent_123",
+        data={
+            CONF_NAME: "Pilot Absent Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Existing HP",
+        },
+        title="radiator: Pilot Absent",
+    )
+    config_entry.add_to_hass(hass)
+
+    existing_hp = MagicMock()
+    existing_hp.name = "Existing HP"
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [existing_hp]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+        new_callable=AsyncMock,
+    ):
+        # User submits WITHOUT the pilot key at all (HA omits absent
+        # `vol.Optional` fields). The persisted pilot must still be
+        # cleared because we detect "form rendered the dropdown AND
+        # user submitted nothing for it AND a value was persisted".
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Pilot Absent Radiator",
+                CONF_POWER: 1000,
+                CONF_SWITCH: "switch.r",
+                # CONF_DEVICE_TO_PILOT_NAME intentionally OMITTED
+            }
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # Even though the user's submission omitted the key entirely, the
+    # persisted pilot must be GONE (BH-D sentinel detection).
+    assert CONF_DEVICE_TO_PILOT_NAME not in config_entry.data
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_pass2_preserves_heat_pump_pick(
+    hass: HomeAssistant, mock_data_handler
+):
+    """EH-A — heat-pump selection survives a Pass 2 re-render.
+
+    Pass 1 captures the heat-pump pick via `_pending_radiator_data`;
+    the form's heat-pump dropdown must source its `default_heat_pump`
+    suggestion from the same pending chain (B1 / EH4 priority order),
+    not only from `config_entry.data`.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_hp_persist_123",
+        data={
+            CONF_NAME: "HP Persist Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+        },
+        title="radiator: HP Persist",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_hp = MagicMock()
+    mock_hp.name = "Main HP"
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [mock_hp]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat", "off"],
+    ):
+        # Pass 1 — submit climate + heat-pump pick (no HVAC modes yet).
+        # The flow re-prompts for HVAC modes; the heat-pump pick is
+        # buffered into `_pending_radiator_data`.
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "HP Persist Radiator",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.r",
+                CONF_DEVICE_TO_PILOT_NAME: "Main HP",
+            }
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    # The Pass 2 form must surface the same heat-pump pick as the
+    # default — the user must NOT have to re-pick from scratch.
+    schema = result["data_schema"]
+    hp_default = None
+    for item in schema.schema:
+        if getattr(item, "schema", None) == CONF_DEVICE_TO_PILOT_NAME:
+            hp_default = item.description.get("suggested_value") if item.description else None
+            break
+
+    assert hp_default == "Main HP"
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_submitted_pilot_revalidated_against_live_heatpumps(
+    hass: HomeAssistant, mock_data_handler
+):
+    """EH-B — submit re-validates the heat-pump name against the LIVE list.
+
+    Scenario: user picks heat pump "main" in Pass 1, then "main" gets
+    removed (parallel admin action / slow user). The final submit
+    still carries `CONF_DEVICE_TO_PILOT_NAME="main"` in `user_input`;
+    `_radiator_orphan_pilot_keys` only checks the persisted name, so
+    the submitted-but-stale name would otherwise silently persist.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_submit_stale_hp_123",
+        data={
+            CONF_NAME: "Submit Stale HP Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+        },
+        title="radiator: Submit Stale HP",
+    )
+    config_entry.add_to_hass(hass)
+
+    # The home reports zero heat pumps — the submitted "Main HP" name is
+    # stale at submit time.
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat", "off"],
+    ):
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Submit Stale HP Radiator",
+                CONF_POWER: 1000,
+                CONF_SWITCH: "switch.r",
+                CONF_DEVICE_TO_PILOT_NAME: "Main HP",  # No longer exists
+            }
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"].get(CONF_DEVICE_TO_PILOT_NAME) == "piloted_heat_pump_unknown"
+
+
+@pytest.mark.asyncio
 async def test_radiator_step_explicit_pilot_clear_removes_persisted_key(
     hass: HomeAssistant, mock_data_handler
 ):

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -51,6 +51,8 @@ from custom_components.quiet_solar.const import (
     CONF_CLIMATE,
     CONF_CLIMATE_HVAC_MODE_OFF,
     CONF_CLIMATE_HVAC_MODE_ON,
+    CONF_DASHBOARD_SECTION_ICON,
+    CONF_DASHBOARD_SECTION_NAME,
     CONF_DEVICE_DASHBOARD_SECTION,
     CONF_DEVICE_DYNAMIC_GROUP_NAME,
     CONF_DEVICE_TO_PILOT_NAME,
@@ -81,6 +83,7 @@ from custom_components.quiet_solar.const import (
     CONF_SOLAR_PROVIDER_DOMAIN,
     CONF_SWITCH,
     DASHBOARD_NO_SECTION,
+    DASHBOARD_NUM_SECTION_MAX,
     DATA_HANDLER,
     DEVICE_TYPE,
     DOMAIN,
@@ -2647,6 +2650,106 @@ async def test_options_home_step_with_power_entities(hass: HomeAssistant):
             break
     assert grid_key is not None
     assert grid_key.description == {"suggested_value": "sensor.grid"}
+
+
+@pytest.mark.asyncio
+async def test_options_home_section_editor_reads_from_live_dashboard_sections(
+    hass: HomeAssistant,
+    mock_data_handler,
+):
+    """BH (post-QS-195 user bug): the home edit form's dashboard-section
+    slot suggestions MUST come from the live `home.dashboard_sections`
+    list (which has been normalized + migrated), NOT from the stale
+    persisted `CONF_DASHBOARD_SECTION_NAME_*` keys nor from
+    `DASHBOARD_DEFAULT_SECTIONS[i]` by index.
+
+    Reading by index against the persisted slots caused the user-
+    reported "multiple times others" bug: slot 3 was persisted as
+    `"others"` (pre-QS-194), slot 5's index-based default also resolves
+    to `"others"` (current const), so the form showed `"others"` twice
+    and no `"radiators"`. The fix reads each slot from
+    `home.dashboard_sections[i]` so the form mirrors what's actually
+    rendered on the dashboard.
+    """
+    # Stored data has the OLD pre-QS-194/QS-195 slot layout.
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="home_section_editor_reads_live_123",
+        data={
+            CONF_NAME: "Test Home",
+            DEVICE_TYPE: QSHome.conf_type_name,
+            f"{CONF_DASHBOARD_SECTION_NAME}_0": "cars",
+            f"{CONF_DASHBOARD_SECTION_ICON}_0": "mdi:car",
+            f"{CONF_DASHBOARD_SECTION_NAME}_1": "climates",
+            f"{CONF_DASHBOARD_SECTION_ICON}_1": "mdi:home-thermometer",
+            f"{CONF_DASHBOARD_SECTION_NAME}_2": "pools",
+            f"{CONF_DASHBOARD_SECTION_ICON}_2": "mdi:pool",
+            f"{CONF_DASHBOARD_SECTION_NAME}_3": "others",
+            f"{CONF_DASHBOARD_SECTION_ICON}_3": "mdi:home",
+            f"{CONF_DASHBOARD_SECTION_NAME}_4": "settings",
+            f"{CONF_DASHBOARD_SECTION_ICON}_4": "mdi:cog-outline",
+        },
+        title="home: Test Home",
+    )
+    config_entry.add_to_hass(hass)
+
+    # Live home with the normalized + migrated post-QS-195 layout.
+    mock_home = create_minimal_home_model()
+    mock_home.dashboard_sections = [
+        ("cars", "mdi:car"),
+        ("climates", "mdi:home-thermometer"),
+        ("pools", "mdi:pool"),
+        ("water_boilers", "mdi:water-boiler"),
+        ("radiators", "mdi:radiator"),
+        ("others", "mdi:home"),
+        ("settings", "mdi:cog-outline"),
+    ]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow._filter_quiet_solar_entities",
+        side_effect=lambda _h, entities: entities,
+    ):
+        result = await flow.async_step_home()
+
+    assert result["type"] == FlowResultType.FORM
+    schema = result["data_schema"]
+
+    # Pull the slot defaults out of the schema. We expect them to match
+    # `home.dashboard_sections` slot-by-slot, NOT the stale config_entry
+    # data.
+    def _slot_default(field_key):
+        for item in schema.schema:
+            if getattr(item, "schema", None) != field_key:
+                continue
+            desc = getattr(item, "description", None)
+            if isinstance(desc, dict):
+                return desc.get("suggested_value")
+            return None
+        return None
+
+    expected_names = [
+        "cars", "climates", "pools", "water_boilers",
+        "radiators", "others", "settings",
+    ]
+    for i, expected_name in enumerate(expected_names):
+        actual = _slot_default(f"{CONF_DASHBOARD_SECTION_NAME}_{i}")
+        assert actual == expected_name, (
+            f"Slot {i} must show '{expected_name}' (from live "
+            f"home.dashboard_sections), got '{actual}'. The form is "
+            f"still reading from stale persisted data or index-based "
+            f"const defaults."
+        )
+
+    # Slot 7 (beyond the 7 live sections) has no live source — should
+    # be None / empty so the user can add a custom section there.
+    slot7 = _slot_default(f"{CONF_DASHBOARD_SECTION_NAME}_{DASHBOARD_NUM_SECTION_MAX - 1}")
+    assert slot7 is None, (
+        f"Slot beyond live dashboard_sections must default to None "
+        f"(empty), got {slot7!r}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -932,7 +932,12 @@ async def test_radiator_step_empty_hvac_modes_surfaces_error(hass: HomeAssistant
 async def test_radiator_step_stale_heat_pump_name_surfaces_error(
     hass: HomeAssistant, mock_data_handler
 ):
-    """S8 — orphan `CONF_DEVICE_TO_PILOT_NAME` surfaces an actionable error."""
+    """S8 + B4 — orphan `CONF_DEVICE_TO_PILOT_NAME` surfaces a field error.
+
+    The error key is `CONF_DEVICE_TO_PILOT_NAME` (a field-specific
+    error), not `"base"` (which collides with the XOR error and would
+    be silently dropped via `setdefault`).
+    """
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         entry_id="test_radiator_orphan_hp_123",
@@ -958,7 +963,56 @@ async def test_radiator_step_stale_heat_pump_name_surfaces_error(
     result = await flow.async_step_radiator()
 
     assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {"base": "piloted_heat_pump_unknown"}
+    assert result["errors"] == {CONF_DEVICE_TO_PILOT_NAME: "piloted_heat_pump_unknown"}
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_xor_and_orphan_heat_pump_both_surface(
+    hass: HomeAssistant, mock_data_handler
+):
+    """B4 regression — XOR error AND orphan-HP error must coexist.
+
+    The old `errors["base"] = …` form let the second error vanish via
+    `setdefault`. The field-specific key prevents that.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_xor_orphan_hp_123",
+        data={
+            CONF_NAME: "Test XOR Orphan HP",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Renamed Heat Pump",
+        },
+        title="radiator: XOR Orphan HP",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_hp = MagicMock()
+    mock_hp.name = "Current Heat Pump"
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [mock_hp]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    # Submit with BOTH backings to trigger XOR → re-render path
+    # exercises `_async_show_radiator_form(errors={"base": ...})` AND
+    # the orphan-HP check on the same render.
+    result = await flow.async_step_radiator(
+        {
+            CONF_NAME: "Test XOR Orphan HP",
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.r",
+            CONF_CLIMATE: "climate.r",
+        }
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    # Both errors must surface on their respective keys.
+    assert result["errors"].get("base") == "exactly_one_backing_required"
+    assert result["errors"].get(CONF_DEVICE_TO_PILOT_NAME) == "piloted_heat_pump_unknown"
 
 
 @pytest.mark.asyncio
@@ -1031,9 +1085,14 @@ async def test_radiator_step_no_off_in_hvac_modes_picks_offlike_fallback(
 
     flow = _init_options_flow(hass, config_entry)
 
+    # CR3 — bind the mock modes once and assert the OFF fallback
+    # picks the LAST mode (the off-like → last-mode fallback chain
+    # in `_async_show_radiator_form`). Accepting `"heat"` (the first
+    # mode) would mask a regression where the chain falls through.
+    mock_modes = ["heat", "fan_only"]
     with patch(
         "custom_components.quiet_solar.config_flow.get_hvac_modes",
-        return_value=["heat", "fan_only"],  # No "off"
+        return_value=mock_modes,  # No "off", no "off"-like name
     ):
         result = await flow.async_step_radiator()
 
@@ -1043,9 +1102,289 @@ async def test_radiator_step_no_off_in_hvac_modes_picks_offlike_fallback(
         if getattr(item, "schema", None) == CONF_CLIMATE_HVAC_MODE_OFF:
             off_default = item.default()
             break
-    # `fan_only` contains "off"? No. So it falls back to the last mode.
-    # We accept either an off-like mode or the last one.
-    assert off_default in {"heat", "fan_only"}
+    # When neither `"off"` nor any off-like substring exists in the
+    # modes, the fallback picks the last mode.
+    assert off_default == mock_modes[-1]
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_pass2_pre_fills_climate_from_pending(
+    hass: HomeAssistant, mock_data_handler
+):
+    """B1 — Pass 2 entity selectors keep the Pass 1 climate selection as default.
+
+    Without the pre-fill the user would see the climate selector
+    re-emptied between Pass 1 and Pass 2, and a resubmission with the
+    HVAC modes (but without the climate) would trip the XOR error.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_pre_fill_123",
+        data={
+            CONF_NAME: "Pre-fill Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.before",
+        },
+        title="radiator: Pre-fill",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat", "off"],
+    ):
+        # Pass 1 — submit a new climate entity, expect Pass 2 redirect.
+        await flow.async_step_radiator(
+            {
+                CONF_NAME: "Pre-fill Radiator",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.pre_fill",
+            }
+        )
+        # Pass 2 form render — must pre-fill the climate selector with
+        # `"climate.pre_fill"` and the switch selector with the
+        # persisted `"switch.before"` (so the user can see/clear it).
+        result = await flow._async_show_radiator_form()
+
+    assert result["type"] == FlowResultType.FORM
+    schema = result["data_schema"]
+
+    climate_default = None
+    switch_default = None
+    for item in schema.schema:
+        if getattr(item, "schema", None) == CONF_CLIMATE:
+            climate_default = item.description.get("suggested_value") if item.description else None
+        elif getattr(item, "schema", None) == CONF_SWITCH:
+            switch_default = item.description.get("suggested_value") if item.description else None
+
+    assert climate_default == "climate.pre_fill"
+    # The persisted switch is still suggested so the user can clear it
+    # before final submission (Pass 2 XOR check will accept either).
+    assert switch_default == "switch.before"
+
+
+@pytest.mark.asyncio
+async def test_radiator_options_flow_single_async_update_entry(
+    hass: HomeAssistant, mock_data_handler
+):
+    """B2 — switch↔climate swap goes through ONE `async_update_entry` call.
+
+    The previous double-write (purge helper + `_async_entry_next`)
+    fired reload listeners twice. After B2 the radiator save path
+    consolidates into a single `async_update_entry`.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_single_write_123",
+        data={
+            CONF_NAME: "Single-Write Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.swap",
+        },
+        title="radiator: Single Write",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    update_calls = []
+    original_update = hass.config_entries.async_update_entry
+
+    def _spy_update(entry, **kwargs):
+        update_calls.append(kwargs)
+        return original_update(entry, **kwargs)
+
+    with (
+        patch(
+            "custom_components.quiet_solar.config_flow.get_hvac_modes",
+            return_value=["heat", "off"],
+        ),
+        patch(
+            "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+            new_callable=AsyncMock,
+        ),
+        patch.object(hass.config_entries, "async_update_entry", side_effect=_spy_update),
+    ):
+        # Pass 1 buffers the climate selection. Pass 2 commits.
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Single-Write Radiator",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.swap",
+                CONF_CLIMATE_HVAC_MODE_ON: "heat",
+                CONF_CLIMATE_HVAC_MODE_OFF: "off",
+            }
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # ONE write — not the previous double-write (purge helper +
+    # `_async_entry_next`).
+    assert len(update_calls) == 1
+    saved_data = update_calls[0]["data"]
+    assert saved_data.get(CONF_CLIMATE) == "climate.swap"
+    assert CONF_SWITCH not in saved_data
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_orphan_helper_keeps_user_picked_heat_pump(
+    hass: HomeAssistant, mock_data_handler
+):
+    """E2 branch — when the user re-picks a heat pump, no purge fires."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_repicked_hp_123",
+        data={
+            CONF_NAME: "Repicked HP Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Renamed HP",  # stale
+        },
+        title="radiator: Repicked HP",
+    )
+    config_entry.add_to_hass(hass)
+
+    new_hp = MagicMock()
+    new_hp.name = "Current HP"
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [new_hp]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    # User re-picks the new heat pump in the submission — helper returns
+    # `()` so the orphan purge is skipped (we keep the user's choice).
+    cleaned = {CONF_SWITCH: "switch.r", CONF_DEVICE_TO_PILOT_NAME: "Current HP"}
+    stale_keys = flow._radiator_orphan_pilot_keys(cleaned)
+
+    assert stale_keys == ()
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_orphan_helper_keeps_valid_persisted_heat_pump(
+    hass: HomeAssistant, mock_data_handler
+):
+    """E2 branch — when the persisted heat pump still exists, no purge fires."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_valid_hp_123",
+        data={
+            CONF_NAME: "Valid HP Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Existing HP",
+        },
+        title="radiator: Valid HP",
+    )
+    config_entry.add_to_hass(hass)
+
+    existing_hp = MagicMock()
+    existing_hp.name = "Existing HP"  # Matches persisted name
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [existing_hp]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    # User submits without re-picking; the persisted heat-pump name is
+    # still valid → helper returns `()` so the orphan purge is skipped.
+    cleaned = {CONF_SWITCH: "switch.r"}
+    stale_keys = flow._radiator_orphan_pilot_keys(cleaned)
+
+    assert stale_keys == ()
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_orphan_helper_no_data_handler(hass: HomeAssistant):
+    """E2 branch — defensive: if `DATA_HANDLER` is missing the helper bails."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_no_dh_123",
+        data={
+            CONF_NAME: "No DH Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Some HP",
+        },
+        title="radiator: No DH",
+    )
+    config_entry.add_to_hass(hass)
+
+    # Note: we intentionally do NOT set up `mock_data_handler` → no
+    # DATA_HANDLER in hass.data.
+    hass.data.setdefault(DOMAIN, {}).pop(DATA_HANDLER, None)
+
+    flow = _init_options_flow(hass, config_entry)
+
+    cleaned = {CONF_SWITCH: "switch.r"}
+    stale_keys = flow._radiator_orphan_pilot_keys(cleaned)
+
+    assert stale_keys == ()
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_orphan_pilot_cleared_on_reedit(
+    hass: HomeAssistant, mock_data_handler
+):
+    """E2 — orphan `CONF_DEVICE_TO_PILOT_NAME` is removed on user re-edit.
+
+    Scenario: heat pump was renamed. User opens options, sees the
+    `piloted_heat_pump_unknown` warning, submits without picking a new
+    heat pump. The persisted orphan key must be GONE from `entry.data`
+    afterwards (it would otherwise reappear on every future edit).
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_orphan_cleared_123",
+        data={
+            CONF_NAME: "Orphan Cleared Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Renamed HP",
+        },
+        title="radiator: Orphan Cleared",
+    )
+    config_entry.add_to_hass(hass)
+
+    current_hp = MagicMock()
+    current_hp.name = "Current HP"
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [current_hp]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+        new_callable=AsyncMock,
+    ):
+        # User re-submits the form WITHOUT picking a new heat pump.
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Orphan Cleared Radiator",
+                CONF_POWER: 1000,
+                CONF_SWITCH: "switch.r",
+            }
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # The orphan reference must NOT survive into the persisted entry.
+    assert CONF_DEVICE_TO_PILOT_NAME not in config_entry.data
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -1858,25 +1858,101 @@ async def test_radiator_step_explicit_pilot_clear_removes_persisted_key(
 
 
 @pytest.mark.asyncio
-async def test_radiator_step_pending_data_not_persisted_until_final_submit(
+async def test_get_common_schema_dashboard_dropdown_augments_missing_default(
     hass: HomeAssistant, mock_data_handler
 ):
-    """S1 — Pass 1 → Pass 2 carry-over is in-memory, not persisted mid-flow.
+    """User-reported bug: when `home.dashboard_sections` doesn't include
+    the device type's default section (e.g. pre-QS-194 customised list
+    missing `water_boilers`, or pre-QS-195 list missing `radiators`),
+    the dashboard dropdown silently falls back to "Not in dashboard"
+    and the user cannot pick the appropriate section.
 
-    The Pass 1 call buffers the climate entity selection in
-    `_pending_radiator_data`. The persisted `config_entry.data` stays
-    unchanged until the final submission goes through `async_entry_next`.
+    Fix: `get_common_schema` now appends the device's default section
+    to the dropdown options when it's a bundled default but missing
+    from `home.dashboard_sections`.
+    """
+    from custom_components.quiet_solar.const import (
+        CONF_DEVICE_DASHBOARD_SECTION,
+        CONF_TYPE_NAME_QSRadiator,
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_dropdown_aug_123",
+        data={
+            CONF_NAME: "Dropdown Augment Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+        },
+        title="radiator: Dropdown Augment",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    # Pre-QS-195 dashboard_sections — radiators NOT included.
+    mock_home.dashboard_sections = [
+        ("cars", "mdi:car"),
+        ("climates", "mdi:home-thermometer"),
+        ("pools", "mdi:pool"),
+        ("others", "mdi:home"),
+        ("settings", "mdi:cog-outline"),
+    ]
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+    sc_dict, _ = flow.get_common_schema(
+        type=CONF_TYPE_NAME_QSRadiator,
+        add_power_value_selector=1000,
+        add_load_power_sensor=True,
+        add_calendar=True,
+        add_boost_only=True,
+        add_power_group_selector=False,
+        add_max_on_off=False,
+    )
+
+    # The dashboard-section dropdown must include "radiators" as an
+    # option even though `mock_home.dashboard_sections` doesn't list it.
+    options = None
+    for item in sc_dict:
+        if getattr(item, "schema", None) != CONF_DEVICE_DASHBOARD_SECTION:
+            continue
+        selector_config = sc_dict[item]
+        # `SelectSelector.config.options` (HA typed-dict)
+        options = selector_config.config.get("options")
+        break
+
+    assert options is not None
+    assert any("radiators" in opt for opt in options), (
+        f"`radiators` must be in the dashboard dropdown options even when "
+        f"`home.dashboard_sections` doesn't include it. Got: {options}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_pass1_persists_into_config_entry(
+    hass: HomeAssistant, mock_data_handler
+):
+    """Pass 1 → Pass 2 carry-over goes through `config_entry.data`.
+
+    Mirrors the car / climate flow pattern: Pass 1 writes the user's
+    input into `config_entry.data` (via `async_update_entry` for real
+    entries, direct assignment for FakeConfigEntry) so Pass 2's form
+    renderer picks up every field (name, dashboard, power, calendar,
+    …) without per-field plumbing. The earlier in-memory-buffer
+    approach left the `get_common_schema`-built fields empty on the
+    Pass 2 form.
     """
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        entry_id="test_radiator_pending_data_123",
+        entry_id="test_radiator_pass1_persist_123",
         data={
-            CONF_NAME: "Test Pending Data Radiator",
+            CONF_NAME: "Pass1 Persist Radiator",
             DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
             CONF_POWER: 1000,
             CONF_SWITCH: "switch.original",
         },
-        title="radiator: Pending Data",
+        title="radiator: Pass1 Persist",
     )
     config_entry.add_to_hass(hass)
 
@@ -1890,24 +1966,91 @@ async def test_radiator_step_pending_data_not_persisted_until_final_submit(
         "custom_components.quiet_solar.config_flow.get_hvac_modes",
         return_value=["heat", "off"],
     ):
-        # Pass 1 — submit with only CONF_CLIMATE (no HVAC modes); flow
-        # should buffer the climate entity and re-prompt for HVAC modes.
+        # Pass 1 — submit a new name + climate (no HVAC modes yet);
+        # flow re-prompts for HVAC modes.
         result = await flow.async_step_radiator(
             {
-                CONF_NAME: "Test Pending Data Radiator",
-                CONF_POWER: 1000,
+                CONF_NAME: "Pass1 Renamed Radiator",
+                CONF_POWER: 1500,
                 CONF_CLIMATE: "climate.r",
             }
         )
 
     assert result["type"] == FlowResultType.FORM
+    # The Pass 1 input is now persisted so Pass 2's form-render reads
+    # it back via `config_entry.data` — fixing the empty-defaults bug.
+    assert config_entry.data.get(CONF_CLIMATE) == "climate.r"
+    assert config_entry.data.get(CONF_NAME) == "Pass1 Renamed Radiator"
+    assert config_entry.data.get(CONF_POWER) == 1500
 
-    # Original config-entry data must NOT carry the new climate entity
-    # — the Pass 1 selection is buffered in memory only.
-    assert config_entry.data.get(CONF_CLIMATE) is None
-    assert config_entry.data.get(CONF_SWITCH) == "switch.original"
-    # And the pending dict DID record the Pass 1 climate selection.
-    assert flow._pending_radiator_data.get(CONF_CLIMATE) == "climate.r"
+
+@pytest.mark.asyncio
+async def test_radiator_form_pass2_prefills_common_fields(
+    hass: HomeAssistant, mock_data_handler
+):
+    """Form-bug regression — every Pass 2 form field is pre-filled.
+
+    The user's bug report: Pass 1 with name + dashboard + climate was
+    re-prompting Pass 2 with empty name + dashboard fields. After the
+    fix, the Pass 2 form renders with all of the user's Pass 1 inputs
+    as defaults.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_pass2_prefill_123",
+        data={
+            CONF_NAME: "Common Fields Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+        },
+        title="radiator: Common Fields",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat", "off"],
+    ):
+        # Pass 1.
+        pass2_form = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Renamed In Pass1",
+                CONF_POWER: 1500,
+                CONF_CLIMATE: "climate.r",
+            }
+        )
+
+    assert pass2_form["type"] == FlowResultType.FORM
+    schema = pass2_form["data_schema"]
+
+    # Inspect each field's default. After the fix, `CONF_NAME` and
+    # `CONF_POWER` must reflect the Pass 1 values (not empty/zero).
+    def _field_default(field_key):
+        for item in schema.schema:
+            if getattr(item, "schema", None) != field_key:
+                continue
+            # voluptuous stores defaults as callables (returning the
+            # value) and `description` dicts with `suggested_value`.
+            default = getattr(item, "default", None)
+            if callable(default):
+                try:
+                    return default()
+                except TypeError:
+                    pass
+            desc = getattr(item, "description", None)
+            if isinstance(desc, dict):
+                return desc.get("suggested_value")
+            return None
+        return None
+
+    assert _field_default(CONF_NAME) == "Renamed In Pass1"
+    assert _field_default(CONF_POWER) == 1500
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -1861,18 +1861,16 @@ async def test_radiator_step_explicit_pilot_clear_removes_persisted_key(
 
 
 @pytest.mark.asyncio
-async def test_get_common_schema_dashboard_dropdown_augments_missing_default(
+async def test_get_common_schema_dashboard_dropdown_reflects_home_sections(
     hass: HomeAssistant, mock_data_handler
 ):
-    """User-reported bug: when `home.dashboard_sections` doesn't include
-    the device type's default section (e.g. pre-QS-194 customised list
-    missing `water_boilers`, or pre-QS-195 list missing `radiators`),
-    the dashboard dropdown silently falls back to "Not in dashboard"
-    and the user cannot pick the appropriate section.
-
-    Fix: `get_common_schema` now appends the device's default section
-    to the dropdown options when it's a bundled default but missing
-    from `home.dashboard_sections`.
+    """Dropdown options for the device-side `CONF_DEVICE_DASHBOARD_SECTION`
+    field MUST mirror `home.dashboard_sections`. Init-time
+    auto-include in `QSHome.__init__` guarantees every bundled default
+    (`water_boilers`, `radiators`, ...) is present in the live home,
+    so the device dropdown automatically lists every bundled section
+    without any per-step augmentation — replaces the now-removed
+    `get_common_schema` augmentation logic.
     """
     from custom_components.quiet_solar.const import (
         CONF_DEVICE_DASHBOARD_SECTION,
@@ -1881,22 +1879,25 @@ async def test_get_common_schema_dashboard_dropdown_augments_missing_default(
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        entry_id="test_radiator_dropdown_aug_123",
+        entry_id="test_radiator_dropdown_reflects_123",
         data={
-            CONF_NAME: "Dropdown Augment Radiator",
+            CONF_NAME: "Dropdown Reflect Radiator",
             DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
             CONF_POWER: 1000,
         },
-        title="radiator: Dropdown Augment",
+        title="radiator: Dropdown Reflect",
     )
     config_entry.add_to_hass(hass)
 
     mock_home = create_minimal_home_model()
-    # Pre-QS-195 dashboard_sections — radiators NOT included.
+    # Live home with init-time auto-include applied: all bundled
+    # defaults present in canonical const order.
     mock_home.dashboard_sections = [
         ("cars", "mdi:car"),
         ("climates", "mdi:home-thermometer"),
         ("pools", "mdi:pool"),
+        ("water_boilers", "mdi:water-boiler"),
+        ("radiators", "mdi:radiator"),
         ("others", "mdi:home"),
         ("settings", "mdi:cog-outline"),
     ]
@@ -1914,21 +1915,25 @@ async def test_get_common_schema_dashboard_dropdown_augments_missing_default(
         add_max_on_off=False,
     )
 
-    # The dashboard-section dropdown must include "radiators" as an
-    # option even though `mock_home.dashboard_sections` doesn't list it.
+    # Dropdown options must include EVERY bundled section that's
+    # present in home.dashboard_sections, including the radiator
+    # device's own default `radiators`.
     options = None
     for item in sc_dict:
         if getattr(item, "schema", None) != CONF_DEVICE_DASHBOARD_SECTION:
             continue
         selector_config = sc_dict[item]
-        # `SelectSelector.config.options` (HA typed-dict)
         options = selector_config.config.get("options")
         break
 
     assert options is not None
     assert any("radiators" in opt for opt in options), (
-        f"`radiators` must be in the dashboard dropdown options even when "
-        f"`home.dashboard_sections` doesn't include it. Got: {options}"
+        f"`radiators` must be in the dropdown when home.dashboard_sections "
+        f"contains it. Got: {options}"
+    )
+    assert any("water_boilers" in opt for opt in options), (
+        f"`water_boilers` must be in the dropdown when "
+        f"home.dashboard_sections contains it. Got: {options}"
     )
 
 

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -884,6 +884,224 @@ async def test_radiator_step_with_heat_pumps_no_default(hass: HomeAssistant, moc
 
 
 @pytest.mark.asyncio
+async def test_radiator_step_empty_hvac_modes_surfaces_error(hass: HomeAssistant, mock_data_handler):
+    """S7 — climate entity with empty `hvac_modes` surfaces a config-flow error.
+
+    The user gets a clear actionable message instead of an unsatisfiable
+    empty dropdown that blocks the whole flow.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_empty_modes_123",
+        data={
+            CONF_NAME: "Test Radiator Empty Modes",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_CLIMATE: "climate.broken",
+        },
+        title="radiator: Empty Modes",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=[],
+    ):
+        # Submit Pass 2-style payload that triggers final-submission path
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Test Radiator Empty Modes",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.broken",
+                CONF_CLIMATE_HVAC_MODE_ON: "heat",
+                CONF_CLIMATE_HVAC_MODE_OFF: "off",
+            }
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "climate_capabilities_unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_stale_heat_pump_name_surfaces_error(
+    hass: HomeAssistant, mock_data_handler
+):
+    """S8 — orphan `CONF_DEVICE_TO_PILOT_NAME` surfaces an actionable error."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_orphan_hp_123",
+        data={
+            CONF_NAME: "Test Orphan HP",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Renamed Heat Pump",
+        },
+        title="radiator: Orphan HP",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_hp = MagicMock()
+    mock_hp.name = "Current Heat Pump"  # Different from persisted name
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [mock_hp]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    result = await flow.async_step_radiator()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "piloted_heat_pump_unknown"}
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_persisted_hvac_mode_not_in_current_modes_reprompts(
+    hass: HomeAssistant, mock_data_handler
+):
+    """S6 — persisted HVAC mode missing from live `hvac_modes` triggers re-prompt."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_stale_hvac_123",
+        data={
+            CONF_NAME: "Stale HVAC Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_CLIMATE: "climate.r",
+            # Persisted modes are NOT in the live list below.
+            CONF_CLIMATE_HVAC_MODE_ON: "cool",
+            CONF_CLIMATE_HVAC_MODE_OFF: "fan_only",
+        },
+        title="radiator: Stale HVAC",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat", "off"],
+    ):
+        # Final submission attempt with stale modes — should re-prompt.
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Stale HVAC Radiator",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.r",
+                CONF_CLIMATE_HVAC_MODE_ON: "cool",
+                CONF_CLIMATE_HVAC_MODE_OFF: "fan_only",
+            }
+        )
+
+    # Re-prompt → renders a FORM, not CREATE_ENTRY.
+    assert result["type"] == FlowResultType.FORM
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_no_off_in_hvac_modes_picks_offlike_fallback(
+    hass: HomeAssistant, mock_data_handler
+):
+    """S13 — `suggested_off` falls back to an off-like mode when `"off"` is absent."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_no_off_123",
+        data={
+            CONF_NAME: "Test No-Off Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_CLIMATE: "climate.r",
+        },
+        title="radiator: No Off",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat", "fan_only"],  # No "off"
+    ):
+        result = await flow.async_step_radiator()
+
+    assert result["type"] == FlowResultType.FORM
+    off_default = None
+    for item in result["data_schema"].schema:
+        if getattr(item, "schema", None) == CONF_CLIMATE_HVAC_MODE_OFF:
+            off_default = item.default()
+            break
+    # `fan_only` contains "off"? No. So it falls back to the last mode.
+    # We accept either an off-like mode or the last one.
+    assert off_default in {"heat", "fan_only"}
+
+
+@pytest.mark.asyncio
+async def test_radiator_step_pending_data_not_persisted_until_final_submit(
+    hass: HomeAssistant, mock_data_handler
+):
+    """S1 — Pass 1 → Pass 2 carry-over is in-memory, not persisted mid-flow.
+
+    The Pass 1 call buffers the climate entity selection in
+    `_pending_radiator_data`. The persisted `config_entry.data` stays
+    unchanged until the final submission goes through `async_entry_next`.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_pending_data_123",
+        data={
+            CONF_NAME: "Test Pending Data Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.original",
+        },
+        title="radiator: Pending Data",
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = []
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat", "off"],
+    ):
+        # Pass 1 — submit with only CONF_CLIMATE (no HVAC modes); flow
+        # should buffer the climate entity and re-prompt for HVAC modes.
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Test Pending Data Radiator",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.r",
+            }
+        )
+
+    assert result["type"] == FlowResultType.FORM
+
+    # Original config-entry data must NOT carry the new climate entity
+    # — the Pass 1 selection is buffered in memory only.
+    assert config_entry.data.get(CONF_CLIMATE) is None
+    assert config_entry.data.get(CONF_SWITCH) == "switch.original"
+    # And the pending dict DID record the Pass 1 climate selection.
+    assert flow._pending_radiator_data.get(CONF_CLIMATE) == "climate.r"
+
+
+@pytest.mark.asyncio
 async def test_radiator_step_climate_without_heat_mode_suggests_first_non_off(
     hass: HomeAssistant, mock_data_handler
 ):


### PR DESCRIPTION
## Summary
- Extract per-backing transport strategy: `BistateTransport` + `SwitchTransport` + `ClimateTransport` with the host (`QSBiStateDuration`) keeping ownership of bistate-mode signals and override state machine.
- Add `QSRadiator(QSBiStateDuration)`: heating-only load that picks a transport at `__init__` based on `CONF_SWITCH` xor `CONF_CLIMATE`; defaults climate backing to `heat`/`off`; surfaces with its own dashboard section, dedicated `qs-radiator-card.js`, and `radiator_mode` translations.
- Refactor `QSOnOffDuration` and `QSClimateDuration` to delegate to the new transports (5432 tests pass, 100% coverage).

Fixes #195

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [x] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added radiator device type for heating-only loads with switch or climate backing
  * New dedicated radiator dashboard card with progress visualization and controls
  * Radiator configuration flow with validation and multi-pass setup for climate entities
  * Heat-pump piloting support for radiators
  * New "Radiators" dashboard section

* **Documentation**
  * Updated concept guides for bistate-duration devices and configuration flow
  * Added implementation story and review fix documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->