### PR TITLE
QS-200: Boiler card heat palette + boiling water animation

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-pool-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-pool-card.js
@@ -119,7 +119,13 @@ class QsPoolCard extends HTMLElement {
     const step = (ts) => {
       if (!this.isConnected) { this._animRaf = null; return; }
       if (this._lastAnimTs == null) this._lastAnimTs = ts;
-      const dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
+      // QS-200 S6: cap `dt` against hidden-tab return. Without this,
+      // the first frame after a multi-second tab-hidden window
+      // produces a huge `dt`, snapping wave phase by hundreds of pixels
+      // in one frame. The cap matches `LERP_DT_CEIL` so all step-loop
+      // subsystems are bounded by the same envelope.
+      let dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
+      dt = Math.min(dt, LERP_DT_CEIL);
       this._lastAnimTs = ts;
       const patternLen = Math.max(8, this._animPatternLen || 64);
       const speed = 80; // dash units per second
@@ -130,15 +136,14 @@ class QsPoolCard extends HTMLElement {
       }
 
       // --- Wave animation update ---
+      // `dt` is already clamped at LERP_DT_CEIL above (QS-200 S6), so
+      // the lerpFactor envelope and phase advance share the same upper
+      // bound. The lerp itself reads from the clamped `dt` directly —
+      // no local `lerpDt` variable needed.
       const pumpOn = this._pumpRunning === true;
       const targetAmplitude = pumpOn ? PUMP_AMP : CALM_AMP;
       const targetSpeed = pumpOn ? PUMP_SPEED : CALM_SPEED;
-      // Clamp the lerp dt: after a tab is hidden for several seconds, the
-      // first frame back has huge dt and lerpFactor ≈ 1, which would snap
-      // the amplitude/speed to target. The story requires a ~1–2 s smooth
-      // interpolation. Wave phase keeps using raw dt so scroll catches up.
-      const lerpDt = Math.min(dt, LERP_DT_CEIL);
-      const lerpFactor = 1 - Math.exp(-LERP_RATE * lerpDt);
+      const lerpFactor = 1 - Math.exp(-LERP_RATE * dt);
       this._currentAmplitude += (targetAmplitude - this._currentAmplitude) * lerpFactor;
       this._currentSpeed += (targetSpeed - this._currentSpeed) * lerpFactor;
       this._wavePhase += this._currentSpeed * dt;

--- a/custom_components/quiet_solar/ui/resources/qs-pool-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-pool-card.js
@@ -124,6 +124,13 @@ class QsPoolCard extends HTMLElement {
       // produces a huge `dt`, snapping wave phase by hundreds of pixels
       // in one frame. The cap matches `LERP_DT_CEIL` so all step-loop
       // subsystems are bounded by the same envelope.
+      // Review-fix #02 N3 trade-off note: the prior pool-card behavior
+      // intentionally let phase accumulate raw `dt` so scroll "caught
+      // up" after a hidden-tab return. Capping at 100ms trades that
+      // catch-up for a single-frame visual freeze on return — defensible
+      // either way; we picked the cap for cross-card consistency with
+      // qs-water-boiler-card.js (which also drives bubble life off `dt`,
+      // making the cap necessary there).
       let dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
       dt = Math.min(dt, LERP_DT_CEIL);
       this._lastAnimTs = ts;

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -400,6 +400,14 @@ class QsWaterBoilerCard extends HTMLElement {
     // is no longer gated on `showAnimation`. See also
     // docs/agents/concepts/dashboard-and-cards.md.
     this._startAnimation();
+    // Review-fix #04 M1: arm the one-shot `_pendingReattachCheck`
+    // flag so the next `_render()` consumes the `_runningAtStop`
+    // stash exactly once. Setting it here (NOT in `_stopAnimation`)
+    // is what distinguishes "first post-reattach render" from "any
+    // mid-detach hass-push render" — `set hass` doesn't gate on
+    // `this.isConnected`, so renders DO fire during the detached
+    // window, and those must NOT consume the stash.
+    this._pendingReattachCheck = true;
   }
 
   disconnectedCallback() {
@@ -427,6 +435,12 @@ class QsWaterBoilerCard extends HTMLElement {
     if (!config || !config.entities) throw new Error("entities is required");
     this._config = config;
     this._root = this.attachShadow({ mode: "open" });
+    // Review-fix #04 M1: explicitly initialise the reconnect-consume
+    // flag to false so the very first `_render` after mount doesn't
+    // trigger a phantom consume. `connectedCallback` flips it to true
+    // before the next render, and `_render` clears it after the
+    // one-shot consume.
+    this._pendingReattachCheck = false;
     this._render();
   }
 
@@ -764,22 +778,39 @@ class QsWaterBoilerCard extends HTMLElement {
 
       // QS-200: stash the running state for the RAF loop (drives the
       // calm ↔ boiling lerp and the bubble spawn cadence).
-      // Review-fix #02 N12: if the running state flipped while the
-      // card was disconnected, force a re-prime so the wave snaps to
-      // the new target on first paint instead of lerping from the
-      // pre-disconnect state. `_runningAtStop` is set in
-      // `_stopAnimation`, consumed here.
-      // Review-fix #03 S1: the clear MUST live inside the if-body so
-      // the stash survives intervening hass-pushes during the
-      // detached window where `running` happens to match the stashed
-      // value. Without that — i.e. with an unconditional clear after
-      // the if — a 4-step sequence (detach, mid-detach hass push
-      // with running unchanged, mid-detach hass push with running
-      // flipped, reattach) would silently lose the prime signal and
-      // the wave would visibly "calm down" on reattach.
-      if (this._runningAtStop !== undefined && this._runningAtStop !== running) {
-        this._needsAnimationPrime = true;
+      //
+      // Reconnect re-prime — third revision (review-fix #04 M1).
+      // The N12 / S1 / M1 chain threads the needle on a subtle
+      // lifecycle invariant: `_runningAtStop` must be consumed
+      // EXACTLY ONCE on the first post-reattach `_render`,
+      // regardless of inner-guard outcome.
+      //
+      // - Plan #02 N12 introduced `_runningAtStop` (stashed in
+      //   `_stopAnimation`, consumed here, cleared unconditionally
+      //   after the guard).
+      // - Plan #03 S1 moved the clear INSIDE the guard's if-body
+      //   to fix "mid-detach hass-push consumes stash too early".
+      // - Plan #04 M1 gates the entire consume on
+      //   `_pendingReattachCheck` (set in `connectedCallback`),
+      //   because the pass-3 form leaked the stash across renders
+      //   when reattach happened with `running` unchanged — and
+      //   the next in-place state flip (hours later, no detach
+      //   involved) would falsely fire the prime → snap instead
+      //   of lerp.
+      //
+      // The flag-gated block below handles all three paths:
+      // * mid-detach hass-pushes → flag is false (only set in
+      //   `connectedCallback`) → consume skipped → stash preserved.
+      // * reattach with `running` unchanged → flag true → consume →
+      //   inner guard fails → no prime → stash + flag cleared.
+      // * reattach with `running` flipped → flag true → consume →
+      //   inner guard fires → prime queued → stash + flag cleared.
+      if (this._pendingReattachCheck) {
+        if (this._runningAtStop !== undefined && this._runningAtStop !== running) {
+          this._needsAnimationPrime = true;
+        }
         this._runningAtStop = undefined;
+        this._pendingReattachCheck = false;
       }
       this._running = running;
 

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -23,6 +23,7 @@
 */
 
 // --- Geometry (must match the SVG <clipPath> circle attributes below) ---
+const CENTER_CX = 160;              // SVG x-center of the ring / clip circle
 const CENTER_CY = 160;              // SVG y-center of the ring / clip circle
 const CLIP_R = 120;                 // water clip circle radius (10px inside ringCirc=130 — same as pool, intentional)
 const WAVE_WIDTH = 480;             // single wave period (2× clip diameter)
@@ -66,6 +67,7 @@ const BUBBLE_RADIUS_MAX = 4;
 const BUBBLE_SPEED_PX_PER_S_MIN = 40;
 const BUBBLE_SPEED_PX_PER_S_MAX = 80;
 const BUBBLE_MAX_LIFE_S = 2.5;
+const BUBBLE_FILL_COLOR = 'rgba(255,255,255,0.85)';
 
 // --- Surface glow ---
 const SURFACE_GLOW_COLOR = '#FF3D00';
@@ -95,13 +97,12 @@ class QsWaterBoilerCard extends HTMLElement {
 
   // Clear the wave-path memoization keys and cached DOM refs. Called on
   // every (re-)connect and after each _render() innerHTML rewrite.
-  // QS-200 additions vs. pool: `_lastColorMix` (per-frame opacity
-  // throttle would be possible, but we update unconditionally — cheap),
-  // `_bubbleLayerEl`, `_surfaceGlowEl` (new DOM refs).
+  // QS-200 additions vs. pool: `_bubbleLayerEl`, `_surfaceGlowEl` (new
+  // DOM refs). Wave opacity is updated unconditionally per frame so it
+  // doesn't need a memo key.
   _invalidateWaveCache() {
     this._lastWaterBaseY = null;
     this._lastAmplitude = null;
-    this._lastColorMix = null;
     this._waveEls = null;
     this._bubbleLayerEl = null;
     this._surfaceGlowEl = null;
@@ -136,7 +137,14 @@ class QsWaterBoilerCard extends HTMLElement {
     const step = (ts) => {
       if (!this.isConnected) { this._animRaf = null; return; }
       if (this._lastAnimTs == null) this._lastAnimTs = ts;
-      const dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
+      // S6: cap `dt` against hidden-tab return. Without this, the first
+      // frame after a multi-second tab-hidden window produces a huge
+      // `dt`, snapping wave phase by hundreds of pixels in one frame
+      // and aging every bubble past `BUBBLE_MAX_LIFE_S` simultaneously.
+      // The cap matches `LERP_DT_CEIL` so all step-loop subsystems are
+      // bounded by the same envelope.
+      let dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
+      dt = Math.min(dt, LERP_DT_CEIL);
       this._lastAnimTs = ts;
 
       // --- Existing dashed-arc animation (preserved verbatim).
@@ -153,22 +161,26 @@ class QsWaterBoilerCard extends HTMLElement {
       }
 
       // --- Lerp amplitude / speed / colorMix toward boiling targets.
-      // Clamp the lerp dt so a hidden-tab return doesn't snap the
-      // envelope to target (story requires the ~1–2 s smooth
-      // transition). Raw `dt` is used for phase advance, bubble cy
-      // advance, and bubble life so scroll catches up.
+      // `dt` is already clamped at LERP_DT_CEIL above (S6), so the
+      // lerpFactor envelope, phase advance, and bubble life all share
+      // the same upper bound — no per-system local clamp needed.
+      // N7: `_currentColorMix` is initialised to 0 in the lazy-init
+      // block at the top of _startAnimation, so the lerp can read it
+      // directly without an `?? 0` fallback (matches amp/speed style).
       const boiling = this._running === true;
       const targetAmplitude = boiling ? BOIL_AMP : CALM_AMP;
       const targetSpeed = boiling ? BOIL_SPEED : CALM_SPEED;
       const targetColorMix = boiling ? 1 : 0;
-      const lerpDt = Math.min(dt, LERP_DT_CEIL);
-      const lerpFactor = 1 - Math.exp(-LERP_RATE * lerpDt);
+      const lerpFactor = 1 - Math.exp(-LERP_RATE * dt);
       this._currentAmplitude += (targetAmplitude - this._currentAmplitude) * lerpFactor;
       this._currentSpeed += (targetSpeed - this._currentSpeed) * lerpFactor;
-      this._currentColorMix += (targetColorMix - (this._currentColorMix ?? 0)) * lerpFactor;
+      this._currentColorMix += (targetColorMix - this._currentColorMix) * lerpFactor;
       this._wavePhase += this._currentSpeed * dt;
-      // Modulo wrap is robust to any sign / magnitude of accumulated phase.
-      this._wavePhase = this._wavePhase % PHASE_WRAP;
+      // N6: sign-safe modulo for consistency with the `scrollOffset`
+      // wrap below. Phase is monotonically non-decreasing today (speed
+      // is always positive), so the prior `%` worked — the new form is
+      // robust to any sign / magnitude of accumulated phase.
+      this._wavePhase = ((this._wavePhase % PHASE_WRAP) + PHASE_WRAP) % PHASE_WRAP;
 
       // Lazy-resolve wave / bubble layer / surface glow DOM refs once per
       // innerHTML rewrite. Six wave nodes (3 cool + 3 boil pairs) — the
@@ -271,7 +283,7 @@ class QsWaterBoilerCard extends HTMLElement {
         if (this._running === true) {
           this._nextBubbleAt = (this._nextBubbleAt ?? 0) - dt;
           while (this._nextBubbleAt <= 0 && this._bubbles.length < MAX_CONCURRENT_BUBBLES) {
-            const cx = 160 - CLIP_R + 8 + Math.random() * (2 * (CLIP_R - 8));
+            const cx = CENTER_CX - CLIP_R + 8 + Math.random() * (2 * (CLIP_R - 8));
             const cy = CENTER_CY + CLIP_R - 8;
             const r = BUBBLE_RADIUS_MIN + Math.random() * (BUBBLE_RADIUS_MAX - BUBBLE_RADIUS_MIN);
             const vy = BUBBLE_SPEED_PX_PER_S_MIN + Math.random() * (BUBBLE_SPEED_PX_PER_S_MAX - BUBBLE_SPEED_PX_PER_S_MIN);
@@ -282,7 +294,7 @@ class QsWaterBoilerCard extends HTMLElement {
             el.setAttribute('cx', cx.toFixed(2));
             el.setAttribute('cy', cy.toFixed(2));
             el.setAttribute('r', r.toFixed(2));
-            el.setAttribute('fill', 'rgba(255,255,255,0.85)');
+            el.setAttribute('fill', BUBBLE_FILL_COLOR);
             el.setAttribute('pointer-events', 'none');
             el.setAttribute('opacity', '0.9');
             bubbleLayer.appendChild(el);
@@ -882,7 +894,7 @@ class QsWaterBoilerCard extends HTMLElement {
                   </feMerge>
                 </filter>
                 <clipPath id="${waterClipId}">
-                  <circle cx="160" cy="${CENTER_CY}" r="${CLIP_R}" />
+                  <circle cx="${CENTER_CX}" cy="${CENTER_CY}" r="${CLIP_R}" />
                 </clipPath>
                 <filter id="${surfaceGlowFilterId}" x="-50%" y="-50%" width="200%" height="200%">
                   <feGaussianBlur stdDeviation="${SURFACE_GLOW_BLUR_STDDEV}" result="blur" />
@@ -989,7 +1001,6 @@ class QsWaterBoilerCard extends HTMLElement {
       // perceptible blip on a hass push, accepted per pool precedent).
       this._lastWaterBaseY = this._waterBaseY;
       this._lastAmplitude = initialAmp;
-      this._lastColorMix = initialColorMix;
       this._waveEls = null;
       this._bubbleLayerEl = null;
       this._surfaceGlowEl = null;

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -95,17 +95,32 @@ class QsWaterBoilerCard extends HTMLElement {
            ` L ${totalWidth.toFixed(2)} ${WAVE_BOTTOM_Y} L 0 ${WAVE_BOTTOM_Y} Z`;
   }
 
+  // Reset cached DOM refs and the logical bubble array. Shared between
+  // `_invalidateWaveCache()` (full memo reset on (re-)connect) and the
+  // post-`innerHTML` cleanup block in `_render()`. Factored out so a
+  // future memo-key addition (a new `_fooEl`) lands at BOTH call
+  // sites — without the helper, the two paths would silently drift
+  // and the post-render block would carry stale refs into the next
+  // RAF frame.
+  _resetDomRefs() {
+    this._waveEls = null;
+    this._bubbleLayerEl = null;
+    this._surfaceGlowEl = null;
+    this._bubbles = [];
+  }
+
   // Clear the wave-path memoization keys and cached DOM refs. Called on
   // every (re-)connect and after each _render() innerHTML rewrite.
   // QS-200 additions vs. pool: `_bubbleLayerEl`, `_surfaceGlowEl` (new
   // DOM refs). Wave opacity is updated unconditionally per frame so it
-  // doesn't need a memo key.
+  // doesn't need a memo key. `_lastWaterBaseY` / `_lastAmplitude` get
+  // nulled here (full invalidation) but are SYNCED to the current
+  // render state in the post-innerHTML block — that's why they stay
+  // outside `_resetDomRefs()`.
   _invalidateWaveCache() {
     this._lastWaterBaseY = null;
     this._lastAmplitude = null;
-    this._waveEls = null;
-    this._bubbleLayerEl = null;
-    this._surfaceGlowEl = null;
+    this._resetDomRefs();
   }
 
   // QS-200: continuous RAF while connected, mirroring `qs-pool-card.js`.
@@ -208,7 +223,11 @@ class QsWaterBoilerCard extends HTMLElement {
       // Same `tx` applied to both cool+boil siblings of each layer, and
       // to surface_glow (locked to wave 0's tx so the glow trace stays
       // with the visible crest).
-      let wave0Tx = '';
+      // N13: initialised to a safe `translateX(0px)` so a future early
+      // return / throw before the i===0 iteration can't leave
+      // `surfaceGlow.style.transform = ''` (which CSS resets to `none`
+      // — the glow would snap to SVG origin while waves stay translated).
+      let wave0Tx = 'translateX(0px)';
       for (let i = 0; i < 3; i++) {
         const phaseOffset = i * LAYER_SCROLL_OFFSET;
         const raw = (this._wavePhase + phaseOffset) * PHASE_TO_PX;
@@ -251,7 +270,15 @@ class QsWaterBoilerCard extends HTMLElement {
       // --- Surface glow sync (per AC-8).
       // d: only resynced when wave 0 was regenerated (geometry hasn't
       //    changed otherwise — opacity / transform updates handle the
-      //    visible motion).
+      //    visible motion). First-frame parity (review-fix #02 N4):
+      //    on the first RAF tick after `_render()`, neither `levelChanged`
+      //    nor `ampDelta > AMP_REGEN_THRESHOLD` is true (memo keys
+      //    were just synced post-innerHTML), so we DON'T enter the
+      //    regen branch — but the SVG markup anchors both wave 0 and
+      //    surface_glow to `initialWavePaths[0]`, so they're already
+      //    parity-aligned at paint time. Any future refactor that
+      //    diverges those two initial `d` strings must also force a
+      //    surface_glow.setAttribute('d', ...) on the first frame.
       // transform: synced EVERY frame so the glow trace stays locked to
       //            wave 0's translated crest.
       // opacity: bound to colorMix every frame (0 when calm, 1 when boiling).
@@ -279,9 +306,15 @@ class QsWaterBoilerCard extends HTMLElement {
 
       // === AC-7 bubble system: dynamic spawn, soft-capped at MAX_CONCURRENT_BUBBLES ===
       if (bubbleLayer) {
-        // Spawn cadence (only while running, capped at MAX_CONCURRENT_BUBBLES).
-        if (this._running === true) {
-          this._nextBubbleAt = (this._nextBubbleAt ?? 0) - dt;
+        // Spawn cadence (only while boiling, capped at MAX_CONCURRENT_BUBBLES).
+        // N7: reuse the `boiling` const computed above instead of
+        //     re-evaluating `this._running === true`.
+        // N6: drop the `?? 0` defence — the lazy-init in
+        //     _startAnimation guarantees `_nextBubbleAt = 0` before
+        //     the first step runs (matches the N7 simplification
+        //     applied to `_currentColorMix` in fix #01).
+        if (boiling) {
+          this._nextBubbleAt -= dt;
           while (this._nextBubbleAt <= 0 && this._bubbles.length < MAX_CONCURRENT_BUBBLES) {
             const cx = CENTER_CX - CLIP_R + 8 + Math.random() * (2 * (CLIP_R - 8));
             const cy = CENTER_CY + CLIP_R - 8;
@@ -309,7 +342,11 @@ class QsWaterBoilerCard extends HTMLElement {
         // Advance + retire active bubbles regardless of running state
         // (graceful exit: existing bubbles continue to rise until they
         // retire naturally; no abrupt vanish on running → false).
-        const surfaceY = (this._waterBaseY ?? 0) + 4;
+        // N5: drop the `?? 0` fallback — _render() always sets
+        // _waterBaseY to a finite number before any RAF frame runs,
+        // and the bubble-retire loop only fires when bubbles exist
+        // (= at least one spawn happened, = _render() ran).
+        const surfaceY = this._waterBaseY + 4;
         const alive = [];
         for (const b of this._bubbles) {
           b.life += dt;
@@ -338,6 +375,14 @@ class QsWaterBoilerCard extends HTMLElement {
     if (this._animRaf != null) cancelAnimationFrame(this._animRaf);
     this._animRaf = null;
     this._lastAnimTs = null;
+    // Review-fix #02 N12: capture the running state at stop time so
+    // a re-attach after the boiler flipped state can detect the
+    // mismatch and force `_needsAnimationPrime = true` on the next
+    // `_render`. Without this, the wave would lerp from the
+    // pre-disconnect colorMix (~1 if boiling at detach) toward the
+    // new target over ~1.5s — visually wrong if the boiler was off
+    // for the entire detach window.
+    this._runningAtStop = this._running;
   }
 
   connectedCallback() {
@@ -677,7 +722,12 @@ class QsWaterBoilerCard extends HTMLElement {
                         (this._localTargetPct != null ? this._localTargetPct : hoursToPct(displayTargetHours));
       const handleDeg = pctToDeg(handlePct);
       
-      const center = {cx: 160, cy: 160};
+      // Review-fix #02 S1: align the arc / handle / progress-ring
+      // center with the water clip circle's CENTER_CX/CENTER_CY. A
+      // future tweak to either constant must move every part of the
+      // ring (waves AND ring/handle/arc) together — using the named
+      // constants here closes that gap.
+      const center = {cx: CENTER_CX, cy: CENTER_CY};
       const arcLen = 2 * Math.PI * ringCirc * (rangeDeg / 360);
       const segLen = arcLen * (Math.max(0, Math.min(100, progressPct)) / 100);
       let dashLen = Math.round(segLen * 0.22);
@@ -706,6 +756,16 @@ class QsWaterBoilerCard extends HTMLElement {
 
       // QS-200: stash the running state for the RAF loop (drives the
       // calm ↔ boiling lerp and the bubble spawn cadence).
+      // Review-fix #02 N12: if the running state flipped while the
+      // card was disconnected, force a re-prime so the wave snaps to
+      // the new target on first paint instead of lerping from the
+      // pre-disconnect state. `_runningAtStop` is set in
+      // `_stopAnimation`, consumed here, and cleared so a subsequent
+      // hass-push doesn't accidentally re-trigger the prime.
+      if (this._runningAtStop !== undefined && this._runningAtStop !== running) {
+        this._needsAnimationPrime = true;
+      }
+      this._runningAtStop = undefined;
       this._running = running;
 
       // QS-200: per-instance unique SVG ids so two boiler cards on the
@@ -914,6 +974,10 @@ class QsWaterBoilerCard extends HTMLElement {
                 <path id="wave2_cool" d="${initialWavePaths[2]}" fill="${COOL_WATER_COLORS[2]}" opacity="${initialCoolOpacity}" pointer-events="none" style="will-change: transform; mix-blend-mode: normal;" />
                 <path id="wave2_boil" d="${initialWavePaths[2]}" fill="${BOIL_WATER_COLORS[2]}" opacity="${initialBoilOpacity}" pointer-events="none" style="will-change: transform;" />
                 <g id="${bubbleLayerId}"></g>
+                <!-- review-fix #02 N4: surface_glow.d MUST equal wave 0's d on every frame.
+                     First-frame parity is anchored by the shared `initialWavePaths[0]`
+                     below and on wave0_cool/wave0_boil above; the RAF regen block then
+                     resyncs `d` only when wave 0's geometry changes. -->
                 <path id="surface_glow" d="${initialWavePaths[0]}" stroke="${SURFACE_GLOW_COLOR}" stroke-width="${SURFACE_GLOW_STROKE_WIDTH}" fill="none" filter="url(#${surfaceGlowFilterId})" opacity="${initialBoilOpacity}" pointer-events="none" style="mix-blend-mode: screen; will-change: transform, opacity, d;" />
               </g>
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
@@ -999,12 +1063,13 @@ class QsWaterBoilerCard extends HTMLElement {
       // elements; reset it so subsequent spawns don't try to advance
       // dead nodes (the next spawn fires within ~167ms — a barely-
       // perceptible blip on a hass push, accepted per pool precedent).
+      // Sync the memo keys to the rendered state (prevents a redundant
+      // regen on the next frame). DOM refs + logical bubble array are
+      // reset via `_resetDomRefs()` so adding a new memo key in one
+      // place automatically lands in both.
       this._lastWaterBaseY = this._waterBaseY;
       this._lastAmplitude = initialAmp;
-      this._waveEls = null;
-      this._bubbleLayerEl = null;
-      this._surfaceGlowEl = null;
-      this._bubbles = [];
+      this._resetDomRefs();
 
       // Wire events
       const root = this._root;

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -102,6 +102,14 @@ class QsWaterBoilerCard extends HTMLElement {
   // sites — without the helper, the two paths would silently drift
   // and the post-render block would carry stale refs into the next
   // RAF frame.
+  // Review-fix #03 N1: this helper ALSO resets `this._bubbles = []`.
+  // That's a no-op at today's two call sites (both happen after the
+  // shadow root was rewritten / bubbles already drained on disconnect)
+  // but the bubble wipe is intentional: any caller using this helper
+  // to force a "fresh wave canvas" wants the bubble layer reset too.
+  // If a future caller needs DOM-only reset WITHOUT touching bubbles,
+  // split this into `_resetWaveDomRefs()` + explicit
+  // `this._bubbles = []` at the call sites.
   _resetDomRefs() {
     this._waveEls = null;
     this._bubbleLayerEl = null;
@@ -760,12 +768,19 @@ class QsWaterBoilerCard extends HTMLElement {
       // card was disconnected, force a re-prime so the wave snaps to
       // the new target on first paint instead of lerping from the
       // pre-disconnect state. `_runningAtStop` is set in
-      // `_stopAnimation`, consumed here, and cleared so a subsequent
-      // hass-push doesn't accidentally re-trigger the prime.
+      // `_stopAnimation`, consumed here.
+      // Review-fix #03 S1: the clear MUST live inside the if-body so
+      // the stash survives intervening hass-pushes during the
+      // detached window where `running` happens to match the stashed
+      // value. Without that — i.e. with an unconditional clear after
+      // the if — a 4-step sequence (detach, mid-detach hass push
+      // with running unchanged, mid-detach hass push with running
+      // flipped, reattach) would silently lose the prime signal and
+      // the wave would visibly "calm down" on reattach.
       if (this._runningAtStop !== undefined && this._runningAtStop !== running) {
         this._needsAnimationPrime = true;
+        this._runningAtStop = undefined;
       }
-      this._runningAtStop = undefined;
       this._running = running;
 
       // QS-200: per-instance unique SVG ids so two boiler cards on the

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -3,39 +3,320 @@
   Zero-build single-file Lit-style web component compatible with Home Assistant.
 
   Dedicated card for QSWaterBoiler (cumulus / thermodynamic boiler) loads.
-  Initial release intentionally mirrors the on/off-duration card's
-  layout — the dedicated card exists so future boiler-specific UI
-  (temperature display, water usage, anti-legionella indicators, etc.)
-  has a place to land without churning every on/off-duration user.
+  Originally forked from `qs-on-off-duration-card.js` (QS-194) with one
+  boiler-specific addition: an optional water-tank temperature row.
 
-  Already lit up vs. the on/off-duration card:
+  QS-200 layered three visual upgrades on top:
+  - Heat palette (red/orange) replacing the cool-blue scheme.
+  - Water animation inside the ring, mirroring `qs-pool-card.js` — three
+    sine-wave layers in a circular clipPath, water level driven by
+    progress.
+  - "Boiling" state when `running === true`: water cross-fades from cool
+    blue to near-white translucent (dual-layer opacity, not HSL lerp),
+    bubbles rise bottom→top, and a red Gaussian-blurred glow with
+    `mix-blend-mode: screen` traces the water surface.
+
+  Other lit features:
   - Optional `temperature_sensor` entity row, rendered at the top of
-    the card when configured (the only QS-194 customisation).
+    the card when configured (the QS-194 customisation).
   All other entity keys match the on/off-duration card's input shape.
 */
 
+// --- Geometry (must match the SVG <clipPath> circle attributes below) ---
+const CENTER_CY = 160;              // SVG y-center of the ring / clip circle
+const CLIP_R = 120;                 // water clip circle radius (10px inside ringCirc=130 — same as pool, intentional)
+const WAVE_WIDTH = 480;             // single wave period (2× clip diameter)
+const WAVE_BOTTOM_Y = 400;          // closing rectangle y; clipped by circle
+
+// --- Per-layer wave offsets ---
+const LAYER_SCROLL_OFFSET = 1.2;
+const LAYER_PHASE_OFFSET = 2.1;
+
+// --- Water palettes ---
+const COOL_WATER_COLORS = [
+  'hsla(185, 60%, 22%, 0.55)',
+  'hsla(185, 60%, 20%, 0.45)',
+  'hsla(185, 60%, 18%, 0.35)',
+];
+const BOIL_WATER_COLORS = [
+  'hsla(0, 0%, 95%, 0.65)',
+  'hsla(0, 0%, 90%, 0.55)',
+  'hsla(0, 0%, 85%, 0.45)',
+];
+
+// --- Animation tuning (lerp envelope; mirror pool) ---
+const LERP_RATE = 2;
+const LERP_DT_CEIL = 0.1;
+const AMP_REGEN_THRESHOLD = 0.25;
+const LEVEL_REGEN_THRESHOLD = 0.01;
+const PHASE_WRAP = 1e6;
+const PHASE_TO_PX = 60;
+
+// --- Calm vs boil targets ---
+const CALM_AMP = 1.5;
+const BOIL_AMP = 8;
+const CALM_SPEED = 0.2;
+const BOIL_SPEED = 1.6;
+
+// --- Bubbles ---
+const MAX_CONCURRENT_BUBBLES = 12;
+const BUBBLE_SPAWN_RATE_HZ = 6;
+const BUBBLE_RADIUS_MIN = 1.5;
+const BUBBLE_RADIUS_MAX = 4;
+const BUBBLE_SPEED_PX_PER_S_MIN = 40;
+const BUBBLE_SPEED_PX_PER_S_MAX = 80;
+const BUBBLE_MAX_LIFE_S = 2.5;
+
+// --- Surface glow ---
+const SURFACE_GLOW_COLOR = '#FF3D00';
+const SURFACE_GLOW_STROKE_WIDTH = 4;
+const SURFACE_GLOW_BLUR_STDDEV = 6;
+
 class QsWaterBoilerCard extends HTMLElement {
-  // M4: gate the requestAnimationFrame loop on the animation-needed
-  // condition (`showAnimation`). The loop is started lazily by
-  // `_render()` only when the running-progress dash needs to advance,
-  // and stopped in `disconnectedCallback` AND whenever `showAnimation`
-  // becomes false. Avoids constant per-card repaint overhead when no
-  // visible animation is in progress.
+
+  // Generate an SVG path for a sine-wave-based closed shape (ported
+  // verbatim from `qs-pool-card.js`). Emits TWO repetitions of the wave
+  // (path extent = [0, 2*width]) so the translated path always covers
+  // the clip region regardless of scroll offset.
+  _generateWavePath(width, amplitude, frequency, phase, yOffset) {
+    const points = [];
+    const stepsPerPeriod = 60;
+    const totalSteps = stepsPerPeriod * 2;
+    const totalWidth = 2 * width;
+    for (let i = 0; i <= totalSteps; i++) {
+      const x = (i / stepsPerPeriod) * width;
+      const y = yOffset + amplitude * Math.sin((x / width) * frequency * 2 * Math.PI + phase);
+      points.push(`${x.toFixed(2)} ${y.toFixed(2)}`);
+    }
+    return `M ${points[0]} ` +
+           points.slice(1).map(p => `L ${p}`).join(' ') +
+           ` L ${totalWidth.toFixed(2)} ${WAVE_BOTTOM_Y} L 0 ${WAVE_BOTTOM_Y} Z`;
+  }
+
+  // Clear the wave-path memoization keys and cached DOM refs. Called on
+  // every (re-)connect and after each _render() innerHTML rewrite.
+  // QS-200 additions vs. pool: `_lastColorMix` (per-frame opacity
+  // throttle would be possible, but we update unconditionally — cheap),
+  // `_bubbleLayerEl`, `_surfaceGlowEl` (new DOM refs).
+  _invalidateWaveCache() {
+    this._lastWaterBaseY = null;
+    this._lastAmplitude = null;
+    this._lastColorMix = null;
+    this._waveEls = null;
+    this._bubbleLayerEl = null;
+    this._surfaceGlowEl = null;
+  }
+
+  // QS-200: continuous RAF while connected, mirroring `qs-pool-card.js`.
+  // The water is intrinsically visible at all times (cool blue when not
+  // running, near-white translucent boiling when running) so RAF is no
+  // longer gated on `showAnimation`. Calm vs. boiling is amplitude /
+  // speed / color-mix lerp, not RAF on/off.
   _startAnimation() {
     if (this._animRaf != null) return;
+    // Initialize wave animation state ONLY on the first-ever connect, so
+    // that detach/re-attach (HA dashboard rearrangement, tab navigation)
+    // preserves _currentAmplitude/_currentSpeed/_wavePhase. Without this
+    // guard, a boiling wave would visibly snap back to CALM on each
+    // reconnect and re-lerp up over ~1.5s.
+    if (this._currentAmplitude == null) {
+      this._currentAmplitude = CALM_AMP;
+      this._currentSpeed = CALM_SPEED;
+      this._wavePhase = 0;
+      this._currentColorMix = 0;
+      this._bubbles = [];
+      this._nextBubbleAt = 0;
+      // Tell the next _render() to prime amp/speed/colorMix directly to
+      // the actual running-state targets, skipping the 1.5s lerp envelope.
+      this._needsAnimationPrime = true;
+    }
     this._lastAnimTs = null;
+    this._invalidateWaveCache();
+
     const step = (ts) => {
       if (!this.isConnected) { this._animRaf = null; return; }
       if (this._lastAnimTs == null) this._lastAnimTs = ts;
       const dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
       this._lastAnimTs = ts;
+
+      // --- Existing dashed-arc animation (preserved verbatim).
+      // The running-progress dash still drives off `showAnimation`,
+      // which is now applied as a render-time switch on the
+      // `<path id="running_anim">` element. The RAF loop itself no
+      // longer gates on it.
       const patternLen = Math.max(8, this._animPatternLen || 64);
-      const speed = 80; // dash units per second
-      this._animOffset = ((this._animOffset || 0) + speed * dt) % patternLen;
-      const p = this._root?.getElementById('running_anim');
-      if (p) {
-        p.setAttribute('stroke-dashoffset', String(-this._animOffset));
+      const dashSpeed = 80; // dash units per second
+      this._animOffset = ((this._animOffset || 0) + dashSpeed * dt) % patternLen;
+      const dashPath = this._root?.getElementById('running_anim');
+      if (dashPath) {
+        dashPath.setAttribute('stroke-dashoffset', String(-this._animOffset));
       }
+
+      // --- Lerp amplitude / speed / colorMix toward boiling targets.
+      // Clamp the lerp dt so a hidden-tab return doesn't snap the
+      // envelope to target (story requires the ~1–2 s smooth
+      // transition). Raw `dt` is used for phase advance, bubble cy
+      // advance, and bubble life so scroll catches up.
+      const boiling = this._running === true;
+      const targetAmplitude = boiling ? BOIL_AMP : CALM_AMP;
+      const targetSpeed = boiling ? BOIL_SPEED : CALM_SPEED;
+      const targetColorMix = boiling ? 1 : 0;
+      const lerpDt = Math.min(dt, LERP_DT_CEIL);
+      const lerpFactor = 1 - Math.exp(-LERP_RATE * lerpDt);
+      this._currentAmplitude += (targetAmplitude - this._currentAmplitude) * lerpFactor;
+      this._currentSpeed += (targetSpeed - this._currentSpeed) * lerpFactor;
+      this._currentColorMix += (targetColorMix - (this._currentColorMix ?? 0)) * lerpFactor;
+      this._wavePhase += this._currentSpeed * dt;
+      // Modulo wrap is robust to any sign / magnitude of accumulated phase.
+      this._wavePhase = this._wavePhase % PHASE_WRAP;
+
+      // Lazy-resolve wave / bubble layer / surface glow DOM refs once per
+      // innerHTML rewrite. Six wave nodes (3 cool + 3 boil pairs) — the
+      // pair shares geometry; only `fill` differs.
+      if (!this._waveEls) {
+        const cool0 = this._root?.getElementById('wave0_cool') ?? null;
+        const boil0 = this._root?.getElementById('wave0_boil') ?? null;
+        const cool1 = this._root?.getElementById('wave1_cool') ?? null;
+        const boil1 = this._root?.getElementById('wave1_boil') ?? null;
+        const cool2 = this._root?.getElementById('wave2_cool') ?? null;
+        const boil2 = this._root?.getElementById('wave2_boil') ?? null;
+        this._waveEls = [cool0, boil0, cool1, boil1, cool2, boil2];
+      }
+      const surfaceGlow = this._surfaceGlowEl
+        ?? (this._surfaceGlowEl = this._root?.getElementById('surface_glow') ?? null);
+      const bubbleLayer = this._bubbleLayerEl
+        ?? (this._bubbleLayerEl = this._bubbleLayerId
+              ? (this._root?.getElementById(this._bubbleLayerId) ?? null)
+              : null);
+
+      // --- Wave transforms (per-layer translateX).
+      // Path extent is [0, 2*WAVE_WIDTH] so the translated path always
+      // covers the clip region. We offset by -CLIP_R to align the path
+      // start with the clip's left edge, then scroll within one period.
+      // Same `tx` applied to both cool+boil siblings of each layer, and
+      // to surface_glow (locked to wave 0's tx so the glow trace stays
+      // with the visible crest).
+      let wave0Tx = '';
+      for (let i = 0; i < 3; i++) {
+        const phaseOffset = i * LAYER_SCROLL_OFFSET;
+        const raw = (this._wavePhase + phaseOffset) * PHASE_TO_PX;
+        const scrollOffset = ((raw % WAVE_WIDTH) + WAVE_WIDTH) % WAVE_WIDTH;
+        const tx = -CLIP_R - scrollOffset;
+        const txStr = `translateX(${tx.toFixed(1)}px)`;
+        if (i === 0) wave0Tx = txStr;
+        const coolEl = this._waveEls[i * 2];
+        const boilEl = this._waveEls[i * 2 + 1];
+        if (coolEl) coolEl.style.transform = txStr;
+        if (boilEl) boilEl.style.transform = txStr;
+      }
+
+      // --- Wave path regen (throttled by amplitude / water-level delta).
+      // Both cool and boil siblings share the same `d` string; only fill
+      // differs (already set in _render()).
+      const waterBaseY = this._waterBaseY;
+      const hasValidBase = waterBaseY != null && !Number.isNaN(waterBaseY);
+      const ampDelta = this._lastAmplitude == null
+          ? Infinity
+          : Math.abs(this._currentAmplitude - this._lastAmplitude);
+      const levelChanged = hasValidBase &&
+          Math.abs(waterBaseY - (this._lastWaterBaseY ?? Number.NEGATIVE_INFINITY)) > LEVEL_REGEN_THRESHOLD;
+      let regenerated = false;
+      if (hasValidBase && (levelChanged || ampDelta > AMP_REGEN_THRESHOLD)) {
+        this._lastWaterBaseY = waterBaseY;
+        this._lastAmplitude = this._currentAmplitude;
+        for (let i = 0; i < 3; i++) {
+          const phaseOffset = i * LAYER_PHASE_OFFSET;
+          const freq = 2 + i; // integer freq → seamless wrap at WAVE_WIDTH
+          const d = this._generateWavePath(WAVE_WIDTH, this._currentAmplitude, freq, phaseOffset, waterBaseY);
+          const coolEl = this._waveEls[i * 2];
+          const boilEl = this._waveEls[i * 2 + 1];
+          if (coolEl) coolEl.setAttribute('d', d);
+          if (boilEl) boilEl.setAttribute('d', d);
+        }
+        regenerated = true;
+      }
+
+      // --- Surface glow sync (per AC-8).
+      // d: only resynced when wave 0 was regenerated (geometry hasn't
+      //    changed otherwise — opacity / transform updates handle the
+      //    visible motion).
+      // transform: synced EVERY frame so the glow trace stays locked to
+      //            wave 0's translated crest.
+      // opacity: bound to colorMix every frame (0 when calm, 1 when boiling).
+      if (surfaceGlow) {
+        if (regenerated && this._waveEls?.[0]) {
+          const wave0d = this._waveEls[0].getAttribute('d');
+          if (wave0d) surfaceGlow.setAttribute('d', wave0d);
+        }
+        surfaceGlow.style.transform = wave0Tx;
+        surfaceGlow.setAttribute('opacity', this._currentColorMix.toFixed(3));
+      }
+
+      // --- Per-frame wave opacity update (cool ↔ boil cross-fade).
+      // Dual-layer opacity rather than HSL lerp — see story D2 / D11
+      // (HSL lerp from cyan to orange passes through yellow-green at
+      // the midpoint; opacity cross-fade is artifact-free).
+      const coolOpacity = (1 - this._currentColorMix).toFixed(3);
+      const boilOpacity = this._currentColorMix.toFixed(3);
+      for (let i = 0; i < 3; i++) {
+        const coolEl = this._waveEls[i * 2];
+        const boilEl = this._waveEls[i * 2 + 1];
+        if (coolEl) coolEl.setAttribute('opacity', coolOpacity);
+        if (boilEl) boilEl.setAttribute('opacity', boilOpacity);
+      }
+
+      // === AC-7 bubble system: dynamic spawn, soft-capped at MAX_CONCURRENT_BUBBLES ===
+      if (bubbleLayer) {
+        // Spawn cadence (only while running, capped at MAX_CONCURRENT_BUBBLES).
+        if (this._running === true) {
+          this._nextBubbleAt = (this._nextBubbleAt ?? 0) - dt;
+          while (this._nextBubbleAt <= 0 && this._bubbles.length < MAX_CONCURRENT_BUBBLES) {
+            const cx = 160 - CLIP_R + 8 + Math.random() * (2 * (CLIP_R - 8));
+            const cy = CENTER_CY + CLIP_R - 8;
+            const r = BUBBLE_RADIUS_MIN + Math.random() * (BUBBLE_RADIUS_MAX - BUBBLE_RADIUS_MIN);
+            const vy = BUBBLE_SPEED_PX_PER_S_MIN + Math.random() * (BUBBLE_SPEED_PX_PER_S_MAX - BUBBLE_SPEED_PX_PER_S_MIN);
+            // createElementNS is REQUIRED for SVG inside a Shadow DOM.
+            // `document.createElement('circle')` would create an HTML
+            // element, not an SVG one.
+            const el = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            el.setAttribute('cx', cx.toFixed(2));
+            el.setAttribute('cy', cy.toFixed(2));
+            el.setAttribute('r', r.toFixed(2));
+            el.setAttribute('fill', 'rgba(255,255,255,0.85)');
+            el.setAttribute('pointer-events', 'none');
+            el.setAttribute('opacity', '0.9');
+            bubbleLayer.appendChild(el);
+            this._bubbles.push({el, cx, cy, r, vy, life: 0, maxLife: BUBBLE_MAX_LIFE_S});
+            this._nextBubbleAt += 1 / BUBBLE_SPAWN_RATE_HZ;
+          }
+          // Clamp to 0 to avoid a spawn-backlog burst when running
+          // re-engages after a cap-hit window.
+          if (this._nextBubbleAt < 0) this._nextBubbleAt = 0;
+        }
+
+        // Advance + retire active bubbles regardless of running state
+        // (graceful exit: existing bubbles continue to rise until they
+        // retire naturally; no abrupt vanish on running → false).
+        const surfaceY = (this._waterBaseY ?? 0) + 4;
+        const alive = [];
+        for (const b of this._bubbles) {
+          b.life += dt;
+          b.cy -= b.vy * dt;
+          b.r = Math.min(b.r + 0.5 * dt, BUBBLE_RADIUS_MAX + 2);
+          if (b.cy < surfaceY || b.life >= b.maxLife) {
+            b.el.remove();
+            continue;
+          }
+          const lifeT = b.life / b.maxLife;
+          const opacity = Math.max(0, 1 - lifeT) * this._currentColorMix;
+          b.el.setAttribute('cy', b.cy.toFixed(2));
+          b.el.setAttribute('r', b.r.toFixed(2));
+          b.el.setAttribute('opacity', opacity.toFixed(3));
+          alive.push(b);
+        }
+        this._bubbles = alive;
+      }
+
       this._animRaf = requestAnimationFrame(step);
     };
     this._animRaf = requestAnimationFrame(step);
@@ -48,8 +329,12 @@ class QsWaterBoilerCard extends HTMLElement {
   }
 
   connectedCallback() {
-    // RAF intentionally NOT started here — _render() will call
-    // _startAnimation() when needed.
+    // QS-200: continuous RAF while connected, mirroring qs-pool-card.
+    // The wave animation is intrinsically visible at all times (cool
+    // blue when not running, near-white boiling when running) so RAF
+    // is no longer gated on `showAnimation`. See also
+    // docs/agents/concepts/dashboard-and-cards.md.
+    this._startAnimation();
   }
 
   disconnectedCallback() {
@@ -62,6 +347,11 @@ class QsWaterBoilerCard extends HTMLElement {
     this._isInteractingTarget = false;
     this._isProcessingModeChange = false;
     this._modalOpen = false;
+    // QS-200: eagerly tear down bubble DOM nodes. Without this they
+    // would be GC'd along with the shadow root, but explicit cleanup is
+    // cheap and avoids dangling SVG nodes during a rapid detach/attach.
+    this._bubbles?.forEach(b => b.el?.remove?.());
+    this._bubbles = [];
   }
 
   static getStubConfig() {
@@ -212,13 +502,19 @@ class QsWaterBoilerCard extends HTMLElement {
       const startTime = (sStartTime && isValidState(sStartTime.state)) ? sStartTime.state : '--:--';
       const endTime = (sEndTime && isValidState(sEndTime.state)) ? sEndTime.state : '--:--';
       
-      // Color schemes - MUST BE DEFINED BEFORE CSS
+      // QS-200: heat palette (mirrors `qs-climate-card.js` `colorSchemes.heat`).
+      // Hard-coded — boilers always render in the warm scheme. The cool blue
+      // values previously here (`#2196F3` / `#00bcd4` / `#8bc34a` /
+      // `#00e1ff` / `#0066ff`) were swapped to the climate-card heat hex
+      // codes. Cool blue may still appear ELSEWHERE in the file — e.g.
+      // `.power-btn.on` uses HA-blue `#2196F3` as a semantic "power"
+      // anchor, which is intentional and unrelated to this palette.
       const colors = {
-        primary: '#2196F3',
-        gradStart: '#00bcd4',
-        gradEnd: '#8bc34a',
-        animStart: '#00e1ff',
-        animEnd: '#0066ff'
+        primary:    '#FF5722',
+        gradStart:  '#FF5722',
+        gradEnd:    '#D32F2F',
+        animStart:  '#FF6E40',
+        animEnd:    '#E64A19',
       };
       
       const css = `
@@ -391,15 +687,69 @@ class QsWaterBoilerCard extends HTMLElement {
       const gradGreenId = `gradG-${Math.floor(Math.random() * 1e6)}`;
       const gradRunningId = `gradR-${Math.floor(Math.random() * 1e6)}`;
       const activeGradId = running ? gradRunningId : gradGreenId;
+      // `showAnimation` is now a render-time switch for the dashed-arc
+      // <path id="running_anim"> element only — the RAF loop itself is
+      // continuous (started from connectedCallback per QS-200).
       const showAnimation = (running && segLen > 6);
 
-      // M4: start/stop the RAF loop based on whether the dash animation
-      // is actually needed. Idle cards consume zero per-frame work.
-      if (showAnimation) {
-        this._startAnimation();
-      } else {
-        this._stopAnimation();
+      // QS-200: stash the running state for the RAF loop (drives the
+      // calm ↔ boiling lerp and the bubble spawn cadence).
+      this._running = running;
+
+      // QS-200: per-instance unique SVG ids so two boiler cards on the
+      // same dashboard don't collide on `id="surface_glow"` /
+      // `clipPath` / bubble-layer attributes (mirrors the pool card's
+      // _nextClipId pattern).
+      if (!this._waterClipId) {
+        QsWaterBoilerCard._nextClipId = (QsWaterBoilerCard._nextClipId || 0) + 1;
+        const uid = QsWaterBoilerCard._nextClipId;
+        this._waterClipId = `wb_wClip_${uid}`;
+        this._surfaceGlowFilterId = `wb_surfGlow_${uid}`;
+        this._bubbleLayerId = `wb_bubbleLayer_${uid}`;
       }
+      const waterClipId = this._waterClipId;
+      const surfaceGlowFilterId = this._surfaceGlowFilterId;
+      const bubbleLayerId = this._bubbleLayerId;
+
+      // QS-200: water level from progress fill (same mapping as pool).
+      // Treat null / NaN / negative / zero `displayTargetHours` as "no
+      // progress yet" so a brand-new device renders an empty-ish tank
+      // rather than a NaN-propagating ring.
+      const progressRatio = (Number.isFinite(displayTargetHours) && displayTargetHours > 0)
+        ? Math.max(0, Math.min(1, hoursRun / displayTargetHours))
+        : 0;
+      const rawWaterBaseY = CENTER_CY + CLIP_R - (0.2 + progressRatio * 0.6) * 2 * CLIP_R;
+      this._waterBaseY = Number.isFinite(rawWaterBaseY)
+        ? rawWaterBaseY
+        : (CENTER_CY + CLIP_R - 0.2 * 2 * CLIP_R);
+
+      // QS-200: prime the wave animation state to the actual running
+      // targets on the first render after connect, avoiding the
+      // ~1.5s boot transient. Without this, a card mounted while the
+      // boiler is already boiling would visibly lerp up from CALM.
+      if (this._needsAnimationPrime) {
+        this._currentAmplitude = running ? BOIL_AMP : CALM_AMP;
+        this._currentSpeed = running ? BOIL_SPEED : CALM_SPEED;
+        this._currentColorMix = running ? 1 : 0;
+        this._needsAnimationPrime = false;
+      }
+
+      // QS-200: pre-generate the 3 initial wave path `d` strings so the
+      // SVG renders with water immediately, avoiding the empty-`d=""`
+      // flash between the innerHTML rewrite and the first RAF tick. The
+      // cool/boil siblings of each layer share the same `d`. Memo keys
+      // are synced post-innerHTML so the next frame skips a redundant
+      // regen.
+      const initialAmp = this._currentAmplitude ?? CALM_AMP;
+      const initialBaseY = this._waterBaseY;
+      const initialColorMix = this._currentColorMix ?? 0;
+      const initialWavePaths = [0, 1, 2].map(i => {
+        const freq = 2 + i;
+        const phaseOffset = i * LAYER_PHASE_OFFSET;
+        return this._generateWavePath(WAVE_WIDTH, initialAmp, freq, phaseOffset, initialBaseY);
+      });
+      const initialCoolOpacity = (1 - initialColorMix).toFixed(3);
+      const initialBoilOpacity = initialColorMix.toFixed(3);
 
       // Bistate mode selector options with translations
       const modeOptions = selBistateMode?.attributes?.options || [];
@@ -531,7 +881,29 @@ class QsWaterBoilerCard extends HTMLElement {
                     <feMergeNode in="SourceGraphic" />
                   </feMerge>
                 </filter>
+                <clipPath id="${waterClipId}">
+                  <circle cx="160" cy="${CENTER_CY}" r="${CLIP_R}" />
+                </clipPath>
+                <filter id="${surfaceGlowFilterId}" x="-50%" y="-50%" width="200%" height="200%">
+                  <feGaussianBlur stdDeviation="${SURFACE_GLOW_BLUR_STDDEV}" result="blur" />
+                  <feFlood flood-color="${SURFACE_GLOW_COLOR}" flood-opacity="1" />
+                  <feComposite in2="blur" operator="in" result="glow" />
+                  <feMerge>
+                    <feMergeNode in="glow" />
+                    <feMergeNode in="SourceGraphic" />
+                  </feMerge>
+                </filter>
               </defs>
+              <g clip-path="url(#${waterClipId})">
+                <path id="wave0_cool" d="${initialWavePaths[0]}" fill="${COOL_WATER_COLORS[0]}" opacity="${initialCoolOpacity}" pointer-events="none" style="will-change: transform; mix-blend-mode: normal;" />
+                <path id="wave0_boil" d="${initialWavePaths[0]}" fill="${BOIL_WATER_COLORS[0]}" opacity="${initialBoilOpacity}" pointer-events="none" style="will-change: transform;" />
+                <path id="wave1_cool" d="${initialWavePaths[1]}" fill="${COOL_WATER_COLORS[1]}" opacity="${initialCoolOpacity}" pointer-events="none" style="will-change: transform; mix-blend-mode: normal;" />
+                <path id="wave1_boil" d="${initialWavePaths[1]}" fill="${BOIL_WATER_COLORS[1]}" opacity="${initialBoilOpacity}" pointer-events="none" style="will-change: transform;" />
+                <path id="wave2_cool" d="${initialWavePaths[2]}" fill="${COOL_WATER_COLORS[2]}" opacity="${initialCoolOpacity}" pointer-events="none" style="will-change: transform; mix-blend-mode: normal;" />
+                <path id="wave2_boil" d="${initialWavePaths[2]}" fill="${BOIL_WATER_COLORS[2]}" opacity="${initialBoilOpacity}" pointer-events="none" style="will-change: transform;" />
+                <g id="${bubbleLayerId}"></g>
+                <path id="surface_glow" d="${initialWavePaths[0]}" stroke="${SURFACE_GLOW_COLOR}" stroke-width="${SURFACE_GLOW_STROKE_WIDTH}" fill="none" filter="url(#${surfaceGlowFilterId})" opacity="${initialBoilOpacity}" pointer-events="none" style="mix-blend-mode: screen; will-change: transform, opacity, d;" />
+              </g>
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
               ${showAnimation ? `
@@ -604,6 +976,24 @@ class QsWaterBoilerCard extends HTMLElement {
         ` : ''}
       </ha-card>
     `;
+
+      // QS-200: innerHTML rewrite just replaced the 6 wave <path> nodes,
+      // the surface_glow, and the bubble-layer <g>. The new wave nodes
+      // already carry the freshly-generated `d` (initialWavePaths) and
+      // the correct `fill` (COOL_/BOIL_WATER_COLORS), so we sync RAF's
+      // memo keys to the rendered state — prevents a redundant regen on
+      // the next frame. Cached DOM refs are nulled so RAF re-resolves
+      // them lazily. The logical `_bubbles` array now points to detached
+      // elements; reset it so subsequent spawns don't try to advance
+      // dead nodes (the next spawn fires within ~167ms — a barely-
+      // perceptible blip on a hass push, accepted per pool precedent).
+      this._lastWaterBaseY = this._waterBaseY;
+      this._lastAmplitude = initialAmp;
+      this._lastColorMix = initialColorMix;
+      this._waveEls = null;
+      this._bubbleLayerEl = null;
+      this._surfaceGlowEl = null;
+      this._bubbles = [];
 
       // Wire events
       const root = this._root;

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -12,7 +12,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
   - custom_components/quiet_solar/ui/resources/qs-radiator-card.js
   - custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
-last_verified: 2026-05-23
+last_verified: 2026-05-21
 ---
 
 # Dashboard generation and JS Lovelace cards
@@ -218,6 +218,58 @@ New Jinja branches added by QS-194 use the idiomatic `is not none`
 test (rather than the pre-existing `!= None`) and `{# NOTE: ... #}`
 documentation comments (rather than `{# TODO: ... #}`); follow these
 conventions for any future template additions.
+
+**QS-200 — boiler card visual upgrade.** The water-boiler card
+adopted three layered visual changes on top of the QS-194 baseline,
+overriding the project-context "don't modify JS cards without explicit
+instruction" rule via direct issue-#200 authorisation:
+
+- **Heat palette.** The `const colors = { ... }` block was swapped
+  from the cool-blue scheme (`#2196F3` / `#00bcd4` / `#8bc34a` /
+  `#00e1ff` / `#0066ff`) to the climate card's `heat` scheme
+  (`#FF5722` / `#D32F2F` / `#FF6E40` / `#E64A19`). The cool-blue
+  hexes may still appear elsewhere in the file — e.g. `.power-btn.on`
+  uses `#2196F3` as a semantic "power" anchor — and that's preserved.
+- **Continuous RAF, mirroring the pool card.** `connectedCallback()`
+  calls `_startAnimation()` directly with no `showAnimation` gate;
+  `disconnectedCallback()` stops it. The wave is intrinsically
+  visible at all times (cool blue when not running, near-white
+  translucent when boiling) so the RAF loop itself is no longer
+  conditional. `showAnimation` survives only as a render-time switch
+  for the existing dashed-arc `<path id="running_anim">`. The
+  boiler is therefore removed from `test_card_raf_idle_gated`'s
+  parametrize list — that test pins the idle-gated model that the
+  other duration cards still follow.
+- **Dual-layer water cross-fade + bubbles + surface glow.** Inside
+  a circular `clipPath` (radius `CLIP_R = 120`), the card renders
+  six wave paths in pairs: `wave{0,1,2}_cool` (cool-blue HSLA) and
+  `wave{0,1,2}_boil` (near-white HSLA). Each pair shares geometry;
+  only `fill` and `opacity` differ. The RAF loop lerps
+  `_currentColorMix` toward `running ? 1 : 0` with the standard
+  `LERP_RATE` envelope and updates per-frame opacity: cool layer
+  gets `1 - colorMix`, boil layer gets `colorMix`. This avoids the
+  yellow-green midpoint that an HSL hue lerp from cyan to orange
+  would pass through, and eliminates the staircase a
+  `COLOR_MIX_REGEN_THRESHOLD` would have introduced. A dynamic
+  bubble system spawns `<circle>` nodes inside a bubble `<g>` layer
+  (capped at `MAX_CONCURRENT_BUBBLES = 12`, spawn rate
+  `BUBBLE_SPAWN_RATE_HZ = 6` Hz, paused when not running) — bubbles
+  rise from the bottom, expand slightly, fade with life, and retire
+  on surface contact or life expiry. A red surface glow
+  (`SURFACE_GLOW_COLOR = '#FF3D00'`) traces wave 0 via a Gaussian
+  blur + `mix-blend-mode: screen` filter; its `d` resyncs on
+  amplitude/level regen, `transform` resyncs every frame to follow
+  wave 0's `translateX`, and `opacity` is bound to `_currentColorMix`
+  so it cross-fades in/out with the boiling state.
+
+Per-instance SVG ids (`waterClipId`, `surfaceGlowFilterId`,
+`bubbleLayerId`) are derived from `QsWaterBoilerCard._nextClipId` so
+two boiler cards on the same dashboard never collide. The water
+layer renders BEFORE the dashed ring / progress arc / handle in DOM
+order (= lowest z), so the controls sit on top. The QS-194 optional
+`temperature_sensor` row is untouched: water level, wave amplitude,
+bubble rate, and surface-glow opacity are all independent of the
+temperature sensor (boiling is binary, driven by `running === true`).
 
 ## Hardened JS-card patterns (QS-194 review-fix #03)
 

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -271,6 +271,17 @@ order (= lowest z), so the controls sit on top. The QS-194 optional
 bubble rate, and surface-glow opacity are all independent of the
 temperature sensor (boiling is binary, driven by `running === true`).
 
+Review-fix #01 also caps the RAF step `dt` at `LERP_DT_CEIL` (`0.1s`)
+in BOTH `qs-water-boiler-card.js` AND `qs-pool-card.js`. Without the
+cap, the first frame after a multi-second hidden-tab window
+produced a huge `dt` that advanced wave phase by hundreds of pixels
+in one frame (visible "snap") and aged every bubble past
+`BUBBLE_MAX_LIFE_S` simultaneously. After the cap, all step-loop
+subsystems — phase advance, lerp envelope, bubble life — share the
+same upper-bound envelope and the visual smoothly resumes from where
+it left off. Pinned via the parametrized
+`test_card_caps_raf_dt_against_hidden_tab`.
+
 ## Hardened JS-card patterns (QS-194 review-fix #03)
 
 Every JS card in `ui/resources/` follows the same defensive

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -282,6 +282,30 @@ same upper-bound envelope and the visual smoothly resumes from where
 it left off. Pinned via the parametrized
 `test_card_caps_raf_dt_against_hidden_tab`.
 
+Review-fix #02 added one behavioral change to the boiler card and
+several internal refactors:
+
+- **N12 — reconnect re-prime.** `_stopAnimation()` now stashes
+  `_runningAtStop`. On the first `_render()` after reconnect, if
+  `_runningAtStop !== running`, `_needsAnimationPrime` is forced
+  true so the wave snaps to the current target instead of lerping
+  from the pre-disconnect state (otherwise a card detached while
+  boiling, with the boiler turning off mid-detach, would visibly
+  "calm down" on reattach despite the boiler having been off the
+  whole detach window).
+- **S3 — `_resetDomRefs()` helper.** Both `_invalidateWaveCache()`
+  and the post-`innerHTML` cleanup block now share a single helper
+  that nulls DOM-ref memo keys and resets `_bubbles = []`. A future
+  memo-key addition lands at both call sites by construction.
+- **S1 — `CENTER_CX`/`CENTER_CY` for the ring center.** The arc /
+  handle / progress-ring center literal now uses the named
+  constants, completing the migration started by review-fix #01 N4
+  (water-clip cx/cy). The N4 finding had only migrated bubble
+  spawn and clipPath markup; the ring geometry was left inlined.
+- **N3 — pool-card dt-cap rationale note.** A code comment on
+  `qs-pool-card.js`'s `dt` cap documents the trade-off: cross-card
+  consistency over the prior "catch up after hidden tab" behavior.
+
 ## Hardened JS-card patterns (QS-194 review-fix #03)
 
 Every JS card in `ui/resources/` follows the same defensive

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -292,13 +292,28 @@ several internal refactors:
   from the pre-disconnect state (otherwise a card detached while
   boiling, with the boiler turning off mid-detach, would visibly
   "calm down" on reattach despite the boiler having been off the
-  whole detach window). Review-fix #03 S1 tightened the consumption
-  rule: the `_runningAtStop = undefined` clear MUST live inside the
-  matching `if` body, not after it. `set hass` fires during the
-  detached window too, so an unconditional clear after the if would
-  consume the stash on the first mid-detach push (where `running`
-  is unchanged), letting a SUBSEQUENT push that flips `running`
-  miss the re-prime signal entirely.
+  whole detach window). The consume rule has gone through three
+  revisions (see code comments in `_render()` for the full
+  history):
+  - Plan #02 N12: stash cleared unconditionally after the inner
+    guard. Hole: mid-detach hass-pushes (which fire `set hass →
+    _render` even while disconnected, since `set hass` doesn't gate
+    on `this.isConnected`) consume the stash on a stable-running
+    push, defeating the prime on the eventual reattach.
+  - Plan #03 S1: clear moved INSIDE the inner guard's if-body.
+    Closes the mid-detach-pushes hole, but opens a new one — on a
+    reattach where `running` is unchanged at reattach, the stash
+    leaks across renders and the next normal in-place state flip
+    (hours later, no detach involved) falsely fires the prime.
+  - Plan #04 M1: the entire consume is now gated by
+    `_pendingReattachCheck`, a one-shot flag set in
+    `connectedCallback` after `_startAnimation()`, cleared after
+    the one-shot consume in `_render`. The stash is consumed
+    EXACTLY ONCE on the first post-reattach render, regardless of
+    inner-guard outcome. Mid-detach pushes see the flag false and
+    skip the entire block, preserving the stash for the eventual
+    reattach. Subsequent renders after the consume see the flag
+    false and don't re-fire.
 - **S3 — `_resetDomRefs()` helper.** Both `_invalidateWaveCache()`
   and the post-`innerHTML` cleanup block now share a single helper
   that nulls DOM-ref memo keys and resets `_bubbles = []`. A future

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -292,7 +292,13 @@ several internal refactors:
   from the pre-disconnect state (otherwise a card detached while
   boiling, with the boiler turning off mid-detach, would visibly
   "calm down" on reattach despite the boiler having been off the
-  whole detach window).
+  whole detach window). Review-fix #03 S1 tightened the consumption
+  rule: the `_runningAtStop = undefined` clear MUST live inside the
+  matching `if` body, not after it. `set hass` fires during the
+  detached window too, so an unconditional clear after the if would
+  consume the stash on the first mid-detach push (where `running`
+  is unchanged), letting a SUBSEQUENT push that flips `running`
+  miss the re-prime signal entirely.
 - **S3 — `_resetDomRefs()` helper.** Both `_invalidateWaveCache()`
   and the post-`innerHTML` cleanup block now share a single helper
   that nulls DOM-ref memo keys and resets `_bubbles = []`. A future

--- a/docs/stories/QS-200.story.md
+++ b/docs/stories/QS-200.story.md
@@ -3,7 +3,7 @@ issue: 200
 title: Boiler card — heat-mode color shift + boiling water with bubbles and red surface glow
 branch: QS_200
 status: implemented
-next_phase: review-task
+next_phase: finish-task
 labels: [area:ui, area:dashboard, area:docs]
 ---
 

--- a/docs/stories/QS-200.story.md
+++ b/docs/stories/QS-200.story.md
@@ -2,8 +2,8 @@
 issue: 200
 title: Boiler card — heat-mode color shift + boiling water with bubbles and red surface glow
 branch: QS_200
-status: planned
-next_phase: implement-task
+status: implemented
+next_phase: review-task
 labels: [area:ui, area:dashboard, area:docs]
 ---
 

--- a/docs/stories/QS-200.story.md
+++ b/docs/stories/QS-200.story.md
@@ -1,0 +1,1149 @@
+---
+issue: 200
+title: Boiler card — heat-mode color shift + boiling water with bubbles and red surface glow
+branch: QS_200
+status: planned
+next_phase: implement-task
+labels: [area:ui, area:dashboard, area:docs]
+---
+
+# QS-200 — Boiler card: heat-mode color shift + boiling water with bubbles and red surface glow
+
+## Why
+
+Issue [#200](https://github.com/tmenguy/quiet-solar/issues/200) asks for
+three layered visual upgrades to `qs-water-boiler-card.js`:
+
+1. Shift the card's color palette to the climate card's **Heat** scheme
+   (red/orange), replacing today's cool blue.
+2. Add a **water animation inside the ring** mirroring the pool card —
+   three sine-wave layers in a circular `clipPath`, water level driven
+   by progress.
+3. When the boiler is **ON** (`running === true`), render a **boiling
+   state**: water lerps to near-white translucent, **bubbles** rise
+   bottom→top, and a **red glow** traces the water surface.
+
+The boiler card today is a QS-194 fork of `qs-on-off-duration-card.js`
+with one boiler-specific addition (an optional water-tank temperature
+row at the top). It has no water animation, no boiling state, and uses
+the cool-blue palette. This story brings the boiler card to visual
+parity with the pool card and adds the boiling-state semantics on top.
+
+**Explicit instruction granted by issue #200** — this story overrides
+the [project-context.md](../workflow/project-context.md) rule "Custom
+JS card code should not be modified without explicit instruction."
+
+## Inputs
+
+- `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js` —
+  the only file with behavioral changes (~1037 LOC today → ~1300 LOC)
+- `custom_components/quiet_solar/ui/resources/qs-pool-card.js` —
+  reference for the wave / clipPath / RAF / lerp pattern
+  (`_generateWavePath` at lines 49-62, `_startAnimation` at lines
+  101-204, module constants at lines 6-41)
+- `custom_components/quiet_solar/ui/resources/qs-climate-card.js` —
+  reference for the heat palette (`colorSchemes.heat` at lines 214-220)
+- `tests/test_dashboard_rendering.py` — new module-level regex tests
+  appended alongside `test_card_raf_idle_gated` (~line 1373) and
+  `test_water_boiler_card_uses_safe_number_helper` (~line 1409)
+- `docs/agents/concepts/dashboard-and-cards.md` — `covers:` list
+  already includes `qs-water-boiler-card.js` (line 14); needs a
+  QS-200 paragraph + `last_verified` bump
+
+## Out of scope
+
+- Temperature-sensor influence on water tint, boiling intensity, or
+  bubble rate — the optional `temperature_sensor` row plumbing stays
+  exactly as it is (QS-194 contract preserved).
+- Updates to other JS cards (`qs-on-off-duration-card.js`,
+  `qs-radiator-card.js`, `qs-climate-card.js`, `qs-pool-card.js`).
+- Any change to `dashboard.py`, the Jinja templates, `const.py`,
+  `strings.json`, or `ha_model/water_boiler.py`.
+- A new `bistate_mode_boiling` / new HA state — boiling is **purely
+  visual**, driven from the existing `command` sensor.
+- Sound effects, bubble interactivity (click/tap), configurable color
+  scheme via card YAML.
+- `prefers-reduced-motion` accessibility fallback (deferred to a
+  follow-up).
+- Migrating the existing `qs-on-off-duration-card.js` /
+  `qs-radiator-card.js` to the same visual model.
+
+## Design decisions (locked with user)
+
+- **D1 — Always heat palette.** Hard-coded; no YAML override.
+- **D2 — Water palette: cool blue when not running, near-white
+  translucent when running.** Cross-fade via **dual-layer opacity**
+  (not HSL interpolation). Three cool wave paths + three boil wave
+  paths are rendered simultaneously; per-frame the cool layer's
+  `opacity = 1 - _currentColorMix` and the boil layer's `opacity =
+  _currentColorMix`. `_currentColorMix` lerps with the standard
+  `LERP_RATE` exp envelope toward `running ? 1 : 0`. No hue rotation,
+  no staircase regen threshold on color.
+- **D3 — No temperature-sensor input.** The water-level basis, wave
+  amplitude/speed, color mix, bubble rate, and surface-glow opacity
+  are all independent of the temperature sensor. The sensor row at
+  the top of the card stays as-is.
+- **D4 — Boiling trigger: `running === true` only.** Binary. No
+  temperature-driven scaling.
+- **D5 — Water level basis: progress fill.** Same mapping as pool:
+  `progressRatio = clamp(0, 1, hoursRun / displayTargetHours)` (treat
+  `displayTargetHours <= 0` as 0); `waterBaseY = CENTER_CY + CLIP_R -
+  (0.2 + progressRatio * 0.6) * 2 * CLIP_R`. 1/5..4/5 fill range. This
+  is a user-confirmed design choice, not derived from the issue text.
+- **D6 — Continuous RAF while connected, pool pattern.** Boiler today
+  only runs RAF when `showAnimation = running && segLen > 6`. This
+  story switches to the pool model: `connectedCallback` →
+  `_startAnimation()` unconditionally; `disconnectedCallback` →
+  `_stopAnimation()`. Calm-vs-boiling is amplitude/speed/colorMix
+  lerp, NOT RAF on/off.
+- **D7 — Surface red glow: stroked path with Gaussian blur +
+  `mix-blend-mode: screen`.** Traces wave 0's current `d` AND wave 0's
+  current `translateX` transform per frame (so the glow stays locked
+  to the wave crest, not a static shape). Opacity bound to
+  `_currentColorMix` (0 when calm, 1 when boiling).
+- **D8 — Bubble system: dynamic spawn, soft-capped at
+  `MAX_CONCURRENT_BUBBLES = 12`.** No pre-allocated pool. RAF inserts
+  a `<circle>` into `bubble_layer` on spawn, removes on death
+  (`cy < waterBaseY + 4` OR `life >= maxLife`). Spawn cadence
+  `BUBBLE_SPAWN_RATE_HZ = 6` Hz, paused when not running OR cap hit.
+- **D9 — Z-order inside the clipPath group:** wave0_cool, wave0_boil,
+  wave1_cool, wave1_boil, wave2_cool, wave2_boil, bubble_layer,
+  surface_glow. (Cool/boil pairs grouped so the implementer's reading
+  order matches; opacity selects which is visible.) Full SVG child
+  order: `<defs>` → clipped `<g>` (the above) → bgPath → progressPath
+  → running_anim → target_handle/_text. The clipped water group is
+  drawn **first** (lowest z), so the dashed ring + progress arc +
+  handle + buttons sit ON TOP.
+- **D10 — Unique SVG ids per card instance.** `waterClipId`,
+  `surfaceGlowFilterId`, `bubbleLayerId` all use a per-instance
+  counter `QsWaterBoilerCard._nextClipId` (mirror pool card line
+  353) to avoid id collisions when multiple boiler cards render on
+  the same dashboard.
+- **D11 — Color cross-fade via opacity (not HSL lerp).** Rationale:
+  HSL lerp from `h=185` to `h=20` passes through `h=100` (yellow-
+  green) at midpoint, regardless of arc direction. Opacity cross-fade
+  avoids the artifact entirely, eliminates the staircase that a
+  `COLOR_MIX_REGEN_THRESHOLD` would introduce, and reduces per-frame
+  work to `setAttribute('opacity', ...)` calls on 6 wave nodes.
+- **D12 — Test home: module-level functions, not class members.** The
+  5 new regex tests are appended at module level in
+  `tests/test_dashboard_rendering.py`, alongside the existing
+  `test_card_raf_idle_gated` (~line 1373) and
+  `test_water_boiler_card_uses_safe_number_helper` (~line 1409).
+- **D13 — Drop the boiler from `test_card_raf_idle_gated`
+  parametrization.** Necessary because D6 removes the gated RAF.
+  Compensated by a new sibling test
+  `test_water_boiler_card_has_start_stop_helpers` mirroring the
+  pool's helpers assertion (the pool card is the existing
+  precedent — see lines 1409-1419 in the test file).
+
+## Acceptance criteria
+
+### AC-1 — Heat palette only (cool-blue palette removed from the `colors` const)
+
+**Given** `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`
+**When** inspected
+**Then** the existing `const colors = { ... }` block (at line ~216) is
+replaced with the climate-card heat scheme:
+
+```js
+const colors = {
+  primary:    '#FF5722',
+  gradStart:  '#FF5722',
+  gradEnd:    '#D32F2F',
+  animStart:  '#FF6E40',
+  animEnd:    '#E64A19',
+};
+```
+
+**And** none of the prior cool-blue values (`#2196F3`, `#00bcd4`,
+`#8bc34a`, `#00e1ff`, `#0066ff`) appear inside the `const colors = {
+... };` block. (They MAY still appear elsewhere in the file — e.g.
+`.power-btn.on` at lines 263-264 legitimately uses HA-blue `#2196F3`
+as a semantic "power" anchor. The regex test scopes its absence
+assertion to the `colors` const block only.)
+
+### AC-2 — Module-level wave/bubble constants
+
+**Given** `qs-water-boiler-card.js`
+**When** inspected
+**Then** a module-level `const` block exists ABOVE the
+`class QsWaterBoilerCard extends HTMLElement` declaration, containing
+EXACTLY these literal values (copied from / adapted from pool card
+lines 6-41):
+
+```js
+// --- Geometry (must match the SVG <clipPath> circle attributes below) ---
+const CENTER_CY = 160;             // SVG y-center of the ring / clip circle
+const CLIP_R = 120;                // water clip circle radius (10px inside ringCirc=130 — same as pool, intentional)
+const WAVE_WIDTH = 480;            // single wave period (2× clip diameter)
+const WAVE_BOTTOM_Y = 400;         // closing rectangle y; clipped by circle
+
+// --- Per-layer wave offsets ---
+const LAYER_SCROLL_OFFSET = 1.2;
+const LAYER_PHASE_OFFSET = 2.1;
+
+// --- Water palettes ---
+const COOL_WATER_COLORS = [
+  'hsla(185, 60%, 22%, 0.55)',
+  'hsla(185, 60%, 20%, 0.45)',
+  'hsla(185, 60%, 18%, 0.35)',
+];
+const BOIL_WATER_COLORS = [
+  'hsla(0, 0%, 95%, 0.65)',
+  'hsla(0, 0%, 90%, 0.55)',
+  'hsla(0, 0%, 85%, 0.45)',
+];
+
+// --- Animation tuning (lerp envelope; mirror pool) ---
+const LERP_RATE = 2;
+const LERP_DT_CEIL = 0.1;
+const AMP_REGEN_THRESHOLD = 0.25;
+const LEVEL_REGEN_THRESHOLD = 0.01;
+const PHASE_WRAP = 1e6;
+const PHASE_TO_PX = 60;
+
+// --- Calm vs boil targets ---
+const CALM_AMP = 1.5;
+const BOIL_AMP = 8;
+const CALM_SPEED = 0.2;
+const BOIL_SPEED = 1.6;
+
+// --- Bubbles ---
+const MAX_CONCURRENT_BUBBLES = 12;
+const BUBBLE_SPAWN_RATE_HZ = 6;
+const BUBBLE_RADIUS_MIN = 1.5;
+const BUBBLE_RADIUS_MAX = 4;
+const BUBBLE_SPEED_PX_PER_S_MIN = 40;
+const BUBBLE_SPEED_PX_PER_S_MAX = 80;
+const BUBBLE_MAX_LIFE_S = 2.5;
+
+// --- Surface glow ---
+const SURFACE_GLOW_COLOR = '#FF3D00';
+const SURFACE_GLOW_STROKE_WIDTH = 4;
+const SURFACE_GLOW_BLUR_STDDEV = 6;
+```
+
+### AC-3 — Water layer inside the ring (SVG structure)
+
+**Given** the card's `_render()` output
+**When** the SVG is inspected
+**Then** the `<defs>` block contains:
+
+- A `<clipPath id="${waterClipId}"><circle cx="160" cy="${CENTER_CY}"
+  r="${CLIP_R}"/></clipPath>` (the existing
+  `linearGradient` / `runningGlow` `<defs>` entries are preserved).
+- A `<filter id="${surfaceGlowFilterId}" x="-50%" y="-50%" width="200%"
+  height="200%">` containing at minimum a
+  `<feGaussianBlur stdDeviation="${SURFACE_GLOW_BLUR_STDDEV}"/>` and a
+  merge / flood / composite chain producing the red glow.
+
+**And** a `<g clip-path="url(#${waterClipId})">` is emitted **before**
+the existing `<path d="${bgPath}">` (so the dashed ring renders on top
+of the water). Inside this group, in DOM order:
+
+1. `<path id="wave0_cool" d="..." fill="${COOL_WATER_COLORS[0]}" opacity="..." style="will-change: transform; mix-blend-mode: normal;"/>`
+2. `<path id="wave0_boil" d="..." fill="${BOIL_WATER_COLORS[0]}" opacity="..." style="will-change: transform;"/>`
+3. `<path id="wave1_cool" d="..." ...>` / `<path id="wave1_boil" ...>`
+4. `<path id="wave2_cool" d="..." ...>` / `<path id="wave2_boil" ...>`
+5. `<g id="${bubbleLayerId}"></g>` (initially empty; populated dynamically by RAF)
+6. `<path id="surface_glow" d="..." stroke="${SURFACE_GLOW_COLOR}" stroke-width="${SURFACE_GLOW_STROKE_WIDTH}" fill="none" filter="url(#${surfaceGlowFilterId})" style="mix-blend-mode: screen; will-change: transform, opacity, d;" opacity="..."/>`
+
+**And** the SVG ids `${waterClipId}`, `${surfaceGlowFilterId}`, and
+`${bubbleLayerId}` are derived from a per-instance counter
+`QsWaterBoilerCard._nextClipId` (mirror pool card line 353), so two
+boiler cards on the same dashboard do not collide.
+
+**And** the full SVG child order (after the new additions) is:
+
+1. `<defs>` (gradients + runningGlow filter + waterClipId clipPath + surfaceGlowFilterId filter)
+2. Clipped water group `<g>` (waves + bubbles + surface_glow)
+3. `<path d="${bgPath}">` (background dashed ring)
+4. `<path d="${progressPath}">` (progress arc, full opacity)
+5. `<path id="running_anim">` (when `showAnimation === true` — existing logic preserved)
+6. `<circle id="target_handle">` + `<text id="target_handle_text">` (when `canDragHandle === true`)
+
+### AC-4 — Water level from progress
+
+**Given** `hoursRun` and `displayTargetHours` already computed in
+`_render()` (lines ~165-199 today)
+**When** the new water-level math runs
+**Then**:
+
+```js
+const progressRatio = (Number.isFinite(displayTargetHours) && displayTargetHours > 0)
+  ? Math.max(0, Math.min(1, hoursRun / displayTargetHours))
+  : 0;
+const rawWaterBaseY = CENTER_CY + CLIP_R - (0.2 + progressRatio * 0.6) * 2 * CLIP_R;
+this._waterBaseY = Number.isFinite(rawWaterBaseY) ? rawWaterBaseY : (CENTER_CY + CLIP_R - 0.2 * 2 * CLIP_R);
+```
+
+**And** `this._waterBaseY`, `this._running` are stashed on `this`
+before innerHTML rewrite so RAF can read them.
+
+### AC-5 — Cool water palette when `running === false`
+
+**Given** `running === false` (after the lerp settles,
+`_currentColorMix ≈ 0`)
+**When** the RAF loop updates per-frame opacity
+**Then** for each layer index `i ∈ {0,1,2}`:
+
+- `wave{i}_cool` has `opacity = 1 - _currentColorMix` (effectively 1)
+- `wave{i}_boil` has `opacity = _currentColorMix` (effectively 0)
+- `wave{i}_cool` retains its `fill = COOL_WATER_COLORS[i]` from
+  `_render()`; never re-assigned at RAF rate.
+
+### AC-6 — Boiling palette when `running === true`
+
+**Given** `running === true` (after lerp settles,
+`_currentColorMix ≈ 1`)
+**When** the RAF loop updates per-frame opacity
+**Then**:
+
+- `wave{i}_cool` has `opacity ≈ 0` and `wave{i}_boil` has
+  `opacity ≈ 1`.
+- The boil layer's fill is `BOIL_WATER_COLORS[i]` (set once in
+  `_render()` from the const).
+- During the transition (`_currentColorMix ∈ (0, 1)`) both layers
+  contribute via alpha-blending — the visual is a smooth cross-fade,
+  not a staircase or a hue-rotation through yellow-green.
+- The `_currentColorMix` lerp envelope (target `running ? 1 : 0`)
+  uses the same `LERP_RATE` / `LERP_DT_CEIL` discipline as the
+  amplitude/speed lerps.
+
+### AC-7 — Bubble system (dynamic, soft-capped)
+
+**Given** the boiler card is rendered
+**When** the RAF loop ticks
+**Then**:
+
+1. **Instance state on first connect** (lazy-initialized like pool's
+   amplitude/speed/phase):
+   - `this._bubbles = []` — array of `{el, cx, cy, r, vy, life,
+     maxLife}` records, one per active bubble.
+   - `this._nextBubbleAt = 0` — accumulator (seconds) until next
+     spawn allowed.
+
+2. **Per-frame spawn logic** (only when `this._running === true`):
+   - `this._nextBubbleAt -= dt`
+   - While `this._nextBubbleAt <= 0` AND `this._bubbles.length <
+     MAX_CONCURRENT_BUBBLES`:
+     - Spawn a new bubble (see below).
+     - `this._nextBubbleAt += 1 / BUBBLE_SPAWN_RATE_HZ`
+   - If `this._nextBubbleAt < 0` after the loop (cap hit, can't
+     drain), clamp to 0 to avoid backlog explosions when
+     `running` re-engages.
+
+3. **Spawn — new bubble**:
+   - `cx`: uniform random in `[160 - CLIP_R + 8, 160 + CLIP_R - 8]`.
+   - `cy`: `CENTER_CY + CLIP_R - 8` (just inside the bottom of the
+     clip circle).
+   - `r`: uniform random in `[BUBBLE_RADIUS_MIN,
+     BUBBLE_RADIUS_MAX]`.
+   - `vy`: uniform random in `[BUBBLE_SPEED_PX_PER_S_MIN,
+     BUBBLE_SPEED_PX_PER_S_MAX]`.
+   - `life = 0`; `maxLife = BUBBLE_MAX_LIFE_S`.
+   - Create a new `<circle>` element inside `bubble_layer` with
+     `cx`, `cy`, `r`, `fill="rgba(255,255,255,0.8)"`,
+     `pointer-events="none"`, `opacity="0.9"`.
+   - Push `{el, cx, cy, r, vy, life, maxLife}` onto `this._bubbles`.
+
+4. **Per-frame update — each active bubble** (advance + retire):
+   - `b.life += dt`
+   - `b.cy -= b.vy * dt`
+   - `b.r += 0.5 * dt` (capped so `r <= BUBBLE_RADIUS_MAX + 2`)
+   - Compute `opacity = Math.max(0, 1 - b.life / b.maxLife) *
+     this._currentColorMix` (so bubbles fade as colorMix lerps out
+     when running toggles to false).
+   - `b.el.setAttribute('cy', b.cy.toFixed(2))`,
+     `setAttribute('r', b.r.toFixed(2))`,
+     `setAttribute('opacity', opacity.toFixed(3))`.
+   - **Retire** when `b.cy < (this._waterBaseY ?? 0) + 4` OR
+     `b.life >= b.maxLife`:
+     - `b.el.remove()`
+     - Drop from `this._bubbles`.
+
+5. **`running === false` graceful exit**: spawn loop pauses
+   immediately, existing bubbles continue to rise/fade until they
+   retire naturally. No abrupt vanish.
+
+6. **innerHTML rewrite (`_render()`) wipes the bubble DOM**: after
+   every innerHTML write, clear `this._bubbles = []` (the logical
+   array refs now point to detached elements; safer to reset). The
+   first frame after re-render starts with no bubbles; new ones
+   spawn within ~167 ms (one spawn period) — a barely-perceptible
+   blip on a state push, accepted per the pool-card precedent.
+
+### AC-8 — Surface red glow (locked to wave 0)
+
+**Given** `<defs>` and the clipped water group
+**When** inspected
+**Then**:
+
+- `<defs>` contains
+  `<filter id="${surfaceGlowFilterId}" x="-50%" y="-50%" width="200%"
+  height="200%">` with a Gaussian-blur element
+  `<feGaussianBlur stdDeviation="${SURFACE_GLOW_BLUR_STDDEV}"/>` (the
+  internal filter graph may also include `<feFlood
+  flood-color="${SURFACE_GLOW_COLOR}"/>` + composite chain, but the
+  Gaussian blur is the load-bearing element).
+- Inside the clipped water group, AFTER `bubble_layer`, the
+  `<path id="surface_glow">` exists with attributes per AC-3
+  (stroke red, stroke-width 4, fill none, filter url, mix-blend-mode
+  screen, opacity bound to colorMix).
+
+**And** the RAF loop, on every frame where wave 0's `d` is
+regenerated:
+
+```js
+const wave0d = wave0Cool?.getAttribute('d');  // boil shares the same path geometry — see AC-9
+if (wave0d) surfaceGlow?.setAttribute('d', wave0d);
+```
+
+**And** the surface_glow's `transform` attribute is updated EVERY
+frame (not just on regen) to match wave 0's current `translateX`, so
+the glow stays locked to the visible crest:
+
+```js
+surfaceGlow?.style?.setProperty('transform', `translateX(${tx.toFixed(1)}px)`);
+```
+
+(`tx` is the per-frame computed scroll offset shared with the wave 0
+transform.)
+
+**And** the surface_glow's opacity is updated EVERY frame:
+
+```js
+surfaceGlow?.setAttribute('opacity', this._currentColorMix.toFixed(3));
+```
+
+### AC-9 — Continuous RAF, no `showAnimation` gate
+
+**Given** the rewritten `_startAnimation` / `connectedCallback` /
+`_render` logic
+**When** the card is connected to the DOM
+**Then**:
+
+- `connectedCallback()` calls `this._startAnimation()` directly (no
+  conditional gate). Mirror pool card line 92-94.
+- `_render()` NO LONGER contains the
+  `if (showAnimation) this._startAnimation(); else this._stopAnimation();`
+  block — RAF is unconditional while connected.
+- `disconnectedCallback()` calls `this._stopAnimation()` and resets
+  `_isInteractingMode`, `_isInteractingTarget`,
+  `_isProcessingModeChange`, `_modalOpen` (preserve existing S7
+  cleanup). Also `cancelAnimationFrame(this._animRaf)` and
+  `this._animRaf = null` (existing `_stopAnimation` already does
+  this — keep as-is).
+
+**And** the RAF `step(ts)` body computes `dt`, then in this exact
+order:
+
+1. **Existing dashed-arc animation** (preserved verbatim): advance
+   `_animOffset` and call
+   `runningAnimPath?.setAttribute('stroke-dashoffset', String(-_animOffset))`
+   if `showAnimation` is currently true. This is the only place
+   `showAnimation` survives — purely as a render-time switch for
+   the existing `<path id="running_anim">` element. The RAF loop
+   itself no longer gates on it.
+2. **Lerp** `_currentAmplitude`, `_currentSpeed`, `_currentColorMix`
+   toward `running ? BOIL_*: CALM_*` (or `running ? 1 : 0` for
+   colorMix), using `lerpFactor = 1 - Math.exp(-LERP_RATE *
+   min(dt, LERP_DT_CEIL))`.
+3. **Advance** `_wavePhase += _currentSpeed * dt; _wavePhase %=
+   PHASE_WRAP`.
+4. **Lazy-resolve** `_waveEls` (array of `[wave0_cool, wave0_boil,
+   wave1_cool, wave1_boil, wave2_cool, wave2_boil]`),
+   `_surfaceGlowEl`, `_bubbleLayerEl` from the DOM if `null`.
+5. **Wave transforms** (per-layer translateX): identical math to
+   pool card lines 163-172. Apply the SAME `tx` to both the cool
+   AND boil sibling of each layer, AND to `surface_glow` (wave 0's
+   `tx`).
+6. **Wave path regen** (on amplitude / waterBaseY threshold trip):
+   for each layer `i`, recompute `d` via `_generateWavePath(...)`
+   and set on BOTH `wave{i}_cool` AND `wave{i}_boil` (they share
+   geometry; only `fill` differs — set once at `_render()` time).
+7. **Surface glow sync**: `surfaceGlow.setAttribute('d',
+   wave0Cool.getAttribute('d'))` whenever wave 0 is regenerated.
+   `surfaceGlow.setAttribute('opacity',
+   _currentColorMix.toFixed(3))` every frame.
+8. **Wave opacity update** (every frame): for each layer `i`, set
+   `wave{i}_cool.setAttribute('opacity', (1 - _currentColorMix).toFixed(3))`
+   and `wave{i}_boil.setAttribute('opacity',
+   _currentColorMix.toFixed(3))`. Cheap; no threshold needed.
+9. **Bubble update** (per AC-7).
+10. `this._animRaf = requestAnimationFrame(step);`
+
+### AC-10 — Defensive patterns preserved
+
+**Given** the existing dashboard-rendering tests
+**Then** these all stay green WITHOUT modification (verify
+post-implementation):
+
+- `test_radiator_and_water_boiler_cards_guard_against_zero_max_hours`
+  (file:866) — `maxHours` clamp untouched.
+- `test_radiator_and_water_boiler_cards_arc_path_guards_nan`
+  (file:996) — `arcPath` finite-input guard untouched.
+- `test_water_boiler_temperature_sensor_row_present_when_configured`
+  (file:1210) — temperature row plumbing unchanged.
+- `test_water_boiler_renders_dedicated_js_card_in_custom_template`
+  (file:1231) — card-type dispatch unchanged.
+- `test_water_boiler_card_uses_safe_number_helper` (file:~1409) —
+  `_safeNumber` usage preserved on every sensor read.
+
+**And** all QS-194 defensive patterns survive in new code paths:
+
+- All user-/sensor-controlled strings interpolated into innerHTML
+  pass through `_escapeHtml` (S6) — applies to any new dynamic
+  attributes (e.g. the unique-id template literals are computed
+  from a counter, not user input, so `_escapeHtml` not required;
+  but if any sensor `.attributes.unit_of_measurement` etc. leaks
+  in, it must be escaped).
+- All sensor numeric reads use `_safeNumber(sensor, default)` (S8).
+- `disconnectedCallback` resets `_isInteracting*` /
+  `_isProcessing*` / `_modalOpen` (S7).
+- The `arcPath` helper's `Number.isFinite(a0) && Number.isFinite(a1)`
+  guard is preserved verbatim.
+- The `maxHours = targetHours > 0 ? targetHours : (Number(cfg.max_default_hours)
+  || 12);` clamp at line ~197 is preserved verbatim.
+- Any new service-call path (NONE expected — this story is purely
+  visual) would be wrapped in `try/finally` (M2).
+
+### AC-11 — Drop boiler from `test_card_raf_idle_gated`; add helpers test
+
+**Given** `tests/test_dashboard_rendering.py:1373-1406` defines the
+parametrized `test_card_raf_idle_gated`
+**When** the parametrize list is inspected
+**Then** `qs-water-boiler-card.js` is removed from the list (only
+`qs-radiator-card.js` / `qs-on-off-duration-card.js` /
+`qs-climate-card.js` / `qs-car-card.js` — whichever cards remain
+intentionally gated — stay). Justification comment cites this
+story: "QS-200 — boiler now mirrors pool's intrinsically-continuous
+RAF model".
+
+**And** a new module-level test `test_water_boiler_card_has_start_stop_helpers`
+is added near the other water-boiler tests, asserting:
+
+```python
+content = (COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js").read_text()
+# Strip comments first (existing helper pattern from sibling tests).
+no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+executable = re.sub(r"//[^\n]*", "", no_block)
+assert re.search(r"_startAnimation\s*\(\s*\)\s*\{", executable), \
+    "qs-water-boiler-card.js: missing _startAnimation method"
+assert re.search(r"_stopAnimation\s*\(\s*\)\s*\{", executable), \
+    "qs-water-boiler-card.js: missing _stopAnimation method"
+assert re.search(r"connectedCallback\s*\(\s*\)\s*\{[^}]*this\._startAnimation\s*\(\s*\)", executable, re.DOTALL), \
+    "qs-water-boiler-card.js: connectedCallback must call _startAnimation directly (continuous-RAF model, mirror pool)"
+```
+
+The `connectedCallback → _startAnimation` regex uses a NON-conditional
+match (no `if` between `connectedCallback() {` and
+`this._startAnimation()`) — enforces the "no gate" architecture.
+
+### AC-12 — 5 new regex tests (module-level)
+
+**Given** `tests/test_dashboard_rendering.py`
+**Then** 5 new module-level functions are appended near the existing
+per-card JS regex tests (~end of file, alongside lines 1373-1429),
+with the EXACT names and assertions below.
+
+**AC-12.1 — `test_water_boiler_card_uses_heat_palette`**
+
+```python
+def test_water_boiler_card_uses_heat_palette():
+    """QS-200: boiler card adopts the climate-card heat palette.
+
+    The `const colors = { ... };` block at the top of `_render()`
+    MUST contain the heat hex codes and MUST NOT contain any of the
+    legacy cool-blue values. Cool-blue may still appear ELSEWHERE in
+    the file (e.g. `.power-btn.on` legitimately uses HA-blue
+    `#2196F3` as a semantic anchor) — the assertion is scoped to the
+    `colors` const only.
+    """
+    content = (COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js").read_text()
+    block_match = re.search(
+        r"const\s+colors\s*=\s*\{(?P<body>.*?)\};",
+        content,
+        flags=re.DOTALL,
+    )
+    assert block_match is not None, \
+        "qs-water-boiler-card.js: expected `const colors = { ... };` block"
+    body = block_match.group("body")
+    for heat_hex in ("#FF5722", "#D32F2F", "#FF6E40", "#E64A19"):
+        assert heat_hex in body, \
+            f"qs-water-boiler-card.js: heat-palette color {heat_hex} missing from `const colors`"
+    for cool_hex in ("#2196F3", "#00bcd4", "#8bc34a", "#00e1ff", "#0066ff"):
+        assert cool_hex not in body, \
+            f"qs-water-boiler-card.js: legacy cool-blue color {cool_hex} still present in `const colors`"
+```
+
+**AC-12.2 — `test_water_boiler_card_renders_water_layer`**
+
+```python
+def test_water_boiler_card_renders_water_layer():
+    """QS-200: boiler card renders a circular clipPath wrapping the
+    six wave paths (3 cool + 3 boil cross-fade layers)."""
+    content = (COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js").read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    assert re.search(r"<clipPath\s+id=", executable), \
+        "qs-water-boiler-card.js: missing <clipPath> definition"
+    for layer in ("wave0_cool", "wave0_boil", "wave1_cool", "wave1_boil", "wave2_cool", "wave2_boil"):
+        assert re.search(rf'id="{layer}"', executable), \
+            f"qs-water-boiler-card.js: missing <path id=\"{layer}\">"
+    assert re.search(r"_generateWavePath\s*\(", executable), \
+        "qs-water-boiler-card.js: missing _generateWavePath method"
+```
+
+**AC-12.3 — `test_water_boiler_card_has_continuous_raf`**
+(see AC-11 above — same content; the AC-11 test IS AC-12.3, renamed
+`test_water_boiler_card_has_start_stop_helpers` because that's what
+it actually asserts. AC-12 counts it as one of the 5.)
+
+**AC-12.4 — `test_water_boiler_card_has_bubble_system`**
+
+```python
+def test_water_boiler_card_has_bubble_system():
+    """QS-200: boiler card has a dynamic bubble system with a soft cap."""
+    content = (COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js").read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    assert re.search(r"MAX_CONCURRENT_BUBBLES\s*=\s*12", executable), \
+        "qs-water-boiler-card.js: missing `MAX_CONCURRENT_BUBBLES = 12` constant"
+    assert re.search(r"BUBBLE_SPAWN_RATE_HZ\s*=", executable), \
+        "qs-water-boiler-card.js: missing BUBBLE_SPAWN_RATE_HZ constant"
+    assert re.search(r"this\._bubbles\s*=", executable), \
+        "qs-water-boiler-card.js: missing `this._bubbles` instance array"
+```
+
+**AC-12.5 — `test_water_boiler_card_has_surface_glow`**
+
+```python
+def test_water_boiler_card_has_surface_glow():
+    """QS-200: boiler card renders a red Gaussian-blurred surface glow
+    with mix-blend-mode: screen, locked to wave 0."""
+    content = (COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js").read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    assert re.search(r'<filter\s+id=', executable) and "feGaussianBlur" in executable, \
+        "qs-water-boiler-card.js: missing <filter>/<feGaussianBlur> in defs"
+    assert re.search(r'id="surface_glow"', executable), \
+        "qs-water-boiler-card.js: missing <path id=\"surface_glow\">"
+    assert re.search(r"mix-blend-mode\s*:\s*screen", executable), \
+        "qs-water-boiler-card.js: surface_glow must use `mix-blend-mode: screen`"
+    assert re.search(r"SURFACE_GLOW_COLOR\s*=\s*['\"]#FF[0-9A-Fa-f]{4}['\"]", executable), \
+        "qs-water-boiler-card.js: missing SURFACE_GLOW_COLOR red constant"
+```
+
+### AC-13 — Doc update
+
+**Given** `docs/agents/concepts/dashboard-and-cards.md` already lists
+`qs-water-boiler-card.js` in its `covers:` block (line 14)
+**When** the file is edited
+**Then**:
+
+- A new subsection or paragraph titled **"QS-200 — boiler card
+  visual upgrade"** is added after the existing "QS-194 initial
+  release" paragraph (around line 204-220). It MUST cover:
+  - Heat palette adoption (mirroring climate-card heat scheme).
+  - Continuous RAF mirroring the pool-card pattern (replacing the
+    prior `showAnimation`-gated RAF).
+  - Cool blue water palette when `running === false`, near-white
+    translucent when `running === true`, via dual-layer opacity
+    cross-fade (not HSL lerp).
+  - Dynamic bubble system with soft cap
+    `MAX_CONCURRENT_BUBBLES = 12`.
+  - Red surface glow via Gaussian blur + `mix-blend-mode: screen`,
+    `d`/transform locked to wave 0.
+  - Boiler now removed from the `test_card_raf_idle_gated`
+    parametrization — visually-continuous water RAF model is
+    distinct from the duration-card idle-gated model.
+- `last_verified: 2026-05-23` → `last_verified: 2026-05-21` (today's
+  system date per the doc-maintenance convention — verify on each
+  edit; the existing future-dated value is corrected).
+
+### AC-14 — Quality gate green
+
+**Given** the full implementation + tests + doc edit
+**When** `python scripts/qs/quality_gate.py` is run
+**Then** it exits 0 — pytest 100% coverage + ruff + mypy +
+translations all pass.
+
+## Task breakdown (TDD-ordered)
+
+> **NB**: tasks are numbered in execution order. T1 establishes RED;
+> T2-T13 drive to GREEN; T14 is doc; T15 is quality gate.
+
+### T1 — RED: write the 5 new regex tests + helpers test + drop the parametrize entry
+
+Edit `tests/test_dashboard_rendering.py`:
+
+- **T1a — Drop boiler from `test_card_raf_idle_gated`.** Locate the
+  parametrize call (~line 1373). Remove the
+  `("qs-water-boiler-card.js", ...)` tuple. Add a comment citing
+  QS-200.
+- **T1b — Add `test_water_boiler_card_has_start_stop_helpers`**
+  (AC-11 / AC-12.3 spec — module-level function).
+- **T1c — Add `test_water_boiler_card_uses_heat_palette`** (AC-12.1).
+- **T1d — Add `test_water_boiler_card_renders_water_layer`** (AC-12.2).
+- **T1e — Add `test_water_boiler_card_has_bubble_system`** (AC-12.4).
+- **T1f — Add `test_water_boiler_card_has_surface_glow`** (AC-12.5).
+
+**RED verification step**: run
+`python scripts/qs/quality_gate.py --quick tests/test_dashboard_rendering.py`.
+Confirm:
+
+- The 5 new tests FAIL with messages mentioning the missing
+  patterns (heat palette / clipPath + wave layers / bubble const /
+  surface_glow / `connectedCallback → _startAnimation` direct
+  call).
+- The `test_card_raf_idle_gated` parametrization runs without the
+  boiler entry (no regression — the remaining parametrized cards
+  still pass).
+- All OTHER existing tests still pass.
+
+If any of the 5 new tests accidentally pass on current source, the
+regex is too lax — tighten it before moving on.
+
+### T2 — Hoist module-level constants
+
+Insert the constant block (see AC-2 for the exact literal values)
+ABOVE the `class QsWaterBoilerCard extends HTMLElement` line in
+`qs-water-boiler-card.js`. Mirror the structure of pool-card lines
+6-41. Include the comment headers (`// --- Geometry ---`, etc.) so
+the file's readability matches pool.
+
+### T3 — Replace `colors` const with heat palette
+
+Locate the `const colors = { primary: '#2196F3', gradStart:
+'#00bcd4', gradEnd: '#8bc34a', animStart: '#00e1ff', animEnd:
+'#0066ff' };` block at lines 216-222 in
+`qs-water-boiler-card.js`. Replace verbatim with the heat scheme
+from `qs-climate-card.js` lines 214-220:
+
+```js
+const colors = {
+  primary:    '#FF5722',
+  gradStart:  '#FF5722',
+  gradEnd:    '#D32F2F',
+  animStart:  '#FF6E40',
+  animEnd:    '#E64A19',
+};
+```
+
+Run `--quick` after this edit: the heat-palette test should now
+pass; the other 4 still fail.
+
+### T4 — Port `_generateWavePath` method
+
+Copy verbatim from `qs-pool-card.js` lines 49-62 into the
+`QsWaterBoilerCard` class (placement: near top of class, just
+under the static `_nextClipId` declaration — see T8). No edits.
+
+### T5 — Port `_invalidateWaveCache` method
+
+Copy verbatim from `qs-pool-card.js` lines 86-90. Plus add cache
+keys specific to this story: `_lastWaterBaseY`, `_lastAmplitude`,
+`_lastColorMix` (new), `_waveEls`, `_bubbleLayerEl` (new),
+`_surfaceGlowEl` (new). Pattern:
+
+```js
+_invalidateWaveCache() {
+  this._lastWaterBaseY = null;
+  this._lastAmplitude = null;
+  this._lastColorMix = null;
+  this._waveEls = null;
+  this._bubbleLayerEl = null;
+  this._surfaceGlowEl = null;
+}
+```
+
+### T6 — Rewrite `_startAnimation` + `_stopAnimation`
+
+Replace the existing `_startAnimation` (lines ~24-42) with a port
+of `qs-pool-card.js` lines 101-204, adapted with these
+boiler-specific changes:
+
+- Initialize `_currentColorMix = 0` and `_bubbles = []`,
+  `_nextBubbleAt = 0` on first connect (lazy-init pattern).
+- Inside the `step` function, do AC-9's 10 actions in the specified
+  order (existing dashed-arc advance first, then lerp / phase /
+  transforms / regen / glow sync / wave opacity / bubbles).
+- Existing dashed-arc advance code (advance `_animOffset`, set
+  `stroke-dashoffset` on `#running_anim`) — preserve verbatim from
+  current implementation; it now lives at the top of `step`.
+- Use `lerpDt = Math.min(dt, LERP_DT_CEIL)` for all 3 lerps
+  (amplitude, speed, colorMix); raw `dt` for phase advance, bubble
+  cy advance, and bubble life.
+- For bubbles: see T9.
+
+`_stopAnimation` stays as it is (lines ~44-48) — `cancelAnimationFrame`,
+null `_animRaf`, null `_lastAnimTs`.
+
+### T7 — Update `connectedCallback`
+
+Replace the current `connectedCallback() { /* RAF intentionally NOT
+started ... */ }` (lines 50-53) with:
+
+```js
+connectedCallback() {
+  // QS-200: continuous RAF while connected, mirroring qs-pool-card.
+  // The wave animation is intrinsically visible at all times (calm
+  // when not running, boiling when running) so RAF is no longer
+  // gated on `showAnimation`. See also docs/agents/concepts/dashboard-and-cards.md.
+  this._startAnimation();
+}
+```
+
+### T8 — Update `_render()` SVG output + state stashing
+
+In `_render()`, BEFORE the `this._root.innerHTML = ...` template
+literal (around line 507):
+
+- **T8a — unique-id strategy**: assign per-instance ids on first
+  render (mirror pool card lines 352-355):
+
+```js
+if (!this._waterClipId) {
+  QsWaterBoilerCard._nextClipId = (QsWaterBoilerCard._nextClipId || 0) + 1;
+  const uid = QsWaterBoilerCard._nextClipId;
+  this._waterClipId = `wb_wClip_${uid}`;
+  this._surfaceGlowFilterId = `wb_surfGlow_${uid}`;
+  this._bubbleLayerId = `wb_bubbleLayer_${uid}`;
+}
+```
+
+- **T8b — water level math** (AC-4): compute `progressRatio`,
+  `rawWaterBaseY`, stash on `this._waterBaseY` (with the
+  `Number.isFinite` fallback).
+- **T8c — running state**: stash `this._running = running`.
+- **T8d — first-render prime** (mirror pool lines 318-322): if
+  `this._currentAmplitude == null`, prime `_currentAmplitude /
+  _currentSpeed / _wavePhase / _currentColorMix / _bubbles /
+  _nextBubbleAt` directly to running-state targets (skip the 1.5s
+  lerp-up at boot if mounted in boiling state).
+- **T8e — pre-generate initial wave paths** (mirror pool lines
+  342-349): produce 3 initial `d` strings using `this._waterBaseY`
+  and `_currentAmplitude ?? CALM_AMP`. Each wave layer's pair
+  (cool + boil) shares the same `d`.
+- **T8f — SVG block** in the template literal: insert AFTER the
+  existing `<defs>` content's closing tag, BEFORE
+  `<path d="${bgPath}">`. See AC-3 for the full expected structure.
+  The `<filter>` block for the surface glow:
+
+```html
+<filter id="${this._surfaceGlowFilterId}" x="-50%" y="-50%" width="200%" height="200%">
+  <feGaussianBlur stdDeviation="${SURFACE_GLOW_BLUR_STDDEV}" result="blur"/>
+  <feFlood flood-color="${SURFACE_GLOW_COLOR}" flood-opacity="1"/>
+  <feComposite in2="blur" operator="in" result="glow"/>
+  <feMerge>
+    <feMergeNode in="glow"/>
+    <feMergeNode in="SourceGraphic"/>
+  </feMerge>
+</filter>
+```
+
+- **T8g — initial opacity values** on the 6 wave paths and the
+  surface_glow: use `_currentColorMix ?? 0`. Avoids a 0→target flash
+  on first paint after a hass push when boiler is already running.
+
+After the innerHTML rewrite (mirror pool lines 617-621):
+
+```js
+this._lastWaterBaseY = this._waterBaseY;
+this._lastAmplitude = this._currentAmplitude ?? CALM_AMP;
+this._lastColorMix = this._currentColorMix ?? 0;
+this._waveEls = null;
+this._bubbleLayerEl = null;
+this._surfaceGlowEl = null;
+this._bubbles = [];  // bubble DOM nodes inside bubble_layer were destroyed; reset logical array
+```
+
+### T9 — Bubble system code
+
+Add INSIDE the RAF `step` body (after AC-9 step 8 "wave opacity
+update"):
+
+```js
+// === AC-7 bubble system ===
+const bubbleLayer = this._bubbleLayerEl ?? (this._bubbleLayerEl = this._root.getElementById(this._bubbleLayerId));
+if (bubbleLayer) {
+  // Spawn cadence (only while running, capped at MAX_CONCURRENT_BUBBLES).
+  if (this._running === true) {
+    this._nextBubbleAt = (this._nextBubbleAt ?? 0) - dt;
+    while (this._nextBubbleAt <= 0 && this._bubbles.length < MAX_CONCURRENT_BUBBLES) {
+      const cx = 160 - CLIP_R + 8 + Math.random() * (2 * (CLIP_R - 8));
+      const cy = CENTER_CY + CLIP_R - 8;
+      const r = BUBBLE_RADIUS_MIN + Math.random() * (BUBBLE_RADIUS_MAX - BUBBLE_RADIUS_MIN);
+      const vy = BUBBLE_SPEED_PX_PER_S_MIN + Math.random() * (BUBBLE_SPEED_PX_PER_S_MAX - BUBBLE_SPEED_PX_PER_S_MIN);
+      const el = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      el.setAttribute('cx', cx.toFixed(2));
+      el.setAttribute('cy', cy.toFixed(2));
+      el.setAttribute('r', r.toFixed(2));
+      el.setAttribute('fill', 'rgba(255,255,255,0.85)');
+      el.setAttribute('pointer-events', 'none');
+      el.setAttribute('opacity', '0.9');
+      bubbleLayer.appendChild(el);
+      this._bubbles.push({el, cx, cy, r, vy, life: 0, maxLife: BUBBLE_MAX_LIFE_S});
+      this._nextBubbleAt += 1 / BUBBLE_SPAWN_RATE_HZ;
+    }
+    if (this._nextBubbleAt < 0) this._nextBubbleAt = 0;
+  }
+  // Advance + retire active bubbles regardless of running (graceful exit).
+  const surfaceY = (this._waterBaseY ?? 0) + 4;
+  const alive = [];
+  for (const b of this._bubbles) {
+    b.life += dt;
+    b.cy -= b.vy * dt;
+    b.r = Math.min(b.r + 0.5 * dt, BUBBLE_RADIUS_MAX + 2);
+    if (b.cy < surfaceY || b.life >= b.maxLife) {
+      b.el.remove();
+      continue;
+    }
+    const lifeT = b.life / b.maxLife;
+    const opacity = Math.max(0, 1 - lifeT) * this._currentColorMix;
+    b.el.setAttribute('cy', b.cy.toFixed(2));
+    b.el.setAttribute('r', b.r.toFixed(2));
+    b.el.setAttribute('opacity', opacity.toFixed(3));
+    alive.push(b);
+  }
+  this._bubbles = alive;
+}
+```
+
+(The `createElementNS` call is required for SVG element creation
+inside a Shadow DOM root — `document.createElement('circle')`
+would create an HTML element, not an SVG one.)
+
+### T10 — Surface glow per-frame update
+
+Inside the RAF `step` body, after the wave-path regen block but
+before the bubble update:
+
+```js
+const surfaceGlow = this._surfaceGlowEl ?? (this._surfaceGlowEl = this._root.getElementById('surface_glow'));
+if (surfaceGlow) {
+  // Sync 'd' on regen
+  if (regenerated && this._waveEls?.[0]) {
+    const wave0d = this._waveEls[0].getAttribute('d');
+    if (wave0d) surfaceGlow.setAttribute('d', wave0d);
+  }
+  // Sync transform every frame (locked to wave 0's translateX, which is `tx` for layer 0)
+  surfaceGlow.style.transform = wave0Tx;  // the same string assigned to wave 0's style.transform this frame
+  // Opacity bound to colorMix
+  surfaceGlow.setAttribute('opacity', this._currentColorMix.toFixed(3));
+}
+```
+
+Note: `wave0Tx` is the layer-0 transform string computed in step 5
+of AC-9; reuse it directly (don't recompute).
+
+### T11 — Update `disconnectedCallback`
+
+Preserve existing S7 behavior. Add one line at the end:
+
+```js
+this._bubbles?.forEach(b => b.el?.remove?.());
+this._bubbles = [];
+```
+
+Cleans up bubble DOM eagerly on disconnect (without it, the bubbles
+would be GC'd along with the shadow root, but explicit cleanup is
+cheap and safe).
+
+### T12 — Don't touch (regression-proofing reminder)
+
+Verify these remain UNCHANGED:
+
+- `arcPath` helper (lines ~338-355) — finite-input guard intact.
+- `maxHours` clamp at line ~197 — `targetHours > 0 ? targetHours
+  : (Number(cfg.max_default_hours) || 12)`.
+- `_safeNumber`, `_escapeHtml` helpers — bit-identical.
+- `set hass` interaction guards (lines 104-110) — re-render still
+  skipped during mode/target interaction. No new flag added.
+- Temperature row rendering (lines 484-505 today) — bit-identical.
+- All other entity wiring, dialogs, override-state handling — no
+  changes.
+
+### T13 — GREEN verification
+
+Run `python scripts/qs/quality_gate.py --quick tests/test_dashboard_rendering.py`.
+All 5 new tests AND all existing tests pass.
+
+Manual smoke check (visual — outside the quality pipeline):
+implementer pulls up a local HA dev container, configures a
+water-boiler load with a switch entity, watches the card render in
+both states (running + not running). Acceptance: water visible
+always, smooth transition, bubbles when running, red glow follows
+the wave crest.
+
+### T14 — Doc update
+
+Edit `docs/agents/concepts/dashboard-and-cards.md`:
+
+- Insert a new paragraph titled **"QS-200 — boiler card visual
+  upgrade"** AFTER the existing "QS-194 initial release" paragraph
+  (around lines 204-220). Content per AC-13.
+- Change `last_verified: 2026-05-23` to `last_verified: 2026-05-21`
+  in the frontmatter.
+
+Run `python scripts/qs/check_doc_drift.py --paths
+custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`
+— should report clean (no stale entries).
+
+### T15 — Quality gate (full)
+
+Run `python scripts/qs/quality_gate.py`. Exit 0.
+
+If anything red: fix, re-run. (Most likely red: 100% coverage on
+new Python test code in `tests/test_dashboard_rendering.py` — those
+are pure assertions, no branches, coverage will be trivially 100%.)
+
+## Risks and mitigations
+
+- **R1 — Continuous RAF perf cost.** Mitigation: pool card already
+  runs this pattern in production. Memo thresholds throttle wave
+  path regen; opacity updates are 6 setAttribute calls per frame
+  (cheap). Bubble system has a hard cap (12) and dynamically frees
+  DOM on retire.
+- **R2 — innerHTML rewrite kills bubble DOM mid-rise.** Mitigation:
+  T8 resets `this._bubbles = []` after every rewrite. Next frame
+  spawns new bubbles within 167ms. Brief visual blip on hass push,
+  acceptable per pool-card precedent.
+- **R3 — Surface glow blur clipping at circle edge.** Mitigation:
+  the clipPath is the OUTER circle; the glow blur extends both above
+  and below the wave-0 surface line, both of which are inside the
+  clip circle in the typical 1/5..4/5 fill range. Near the
+  extremes (very low or very high fill), half the glow may clip —
+  acceptable degradation (still glows on the visible side).
+- **R4 — Test regex too loose / too tight.** Mitigation: each AC-12
+  test asserts both presence (positive) and uniqueness (e.g. heat
+  palette block scoping). T1 RED-verification confirms each new
+  test fails on current source before any JS edit.
+- **R5 — Doc drift checker false positive.** Mitigation: the doc's
+  `covers:` list already includes the JS file (line 14). T14
+  edits the doc + bumps `last_verified`, satisfying the checker.
+- **R6 — Z-order regression (handle/buttons hidden by water).**
+  Mitigation: T8f places the water `<g>` BEFORE bgPath/progressPath
+  in DOM order (= lowest z). Power/green/override buttons are HTML
+  divs outside the SVG, z-index 10 (existing) — always on top.
+- **R7 — Boil color "near-white" with high saturation looks wrong.**
+  Mitigation: AC-2 specifies `hsla(0, 0%, 95%, 0.65)` etc. — h=0,
+  s=0% means pure white regardless of hue; only lightness and alpha
+  vary across layers.
+
+## Files touched (final)
+
+- `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`
+  — heat palette + water animation + bubbles + surface glow (~250 LOC delta)
+- `tests/test_dashboard_rendering.py` — 5 new module-level tests +
+  drop `qs-water-boiler-card.js` from `test_card_raf_idle_gated`
+  parametrization
+- `docs/agents/concepts/dashboard-and-cards.md` — QS-200 paragraph +
+  `last_verified` bump
+
+NEXT_PHASE = **implement-task** (touches `custom_components/quiet_solar/`).
+
+## Adversarial Review Notes
+
+Four reviewers (`qs-plan-critic`, `qs-plan-concrete-planner`,
+`qs-plan-dev-proxy`, `qs-plan-scope-guardian`) ran in parallel against
+a draft plan. Findings normalized below; user decisions in **bold**.
+
+### Critical (4 findings → all fixed)
+
+- **C1 (concrete-planner)** — Plan targeted non-existent class
+  `TestDashboardRendering`. Actual sibling tests live at module
+  level (alongside `test_card_raf_idle_gated`,
+  `test_water_boiler_card_uses_safe_number_helper`). **Decision**:
+  module-level tests, baked into D12.
+- **C2 (concrete-planner)** — Removing the `showAnimation` RAF gate
+  regresses the existing parametrized
+  `test_card_raf_idle_gated`. **Decision**: drop the water-boiler
+  entry from that parametrize (justified — boiler now mirrors
+  pool's continuous-RAF model) and add
+  `test_water_boiler_card_has_start_stop_helpers` as compensation.
+  Baked into D13 / AC-11.
+- **C3 (plan-critic PC-1)** — Z-order phrasing in AC-2 vs T10 was
+  ambiguous. **Decision**: enumerate full SVG child order in AC-3.
+- **C4 (plan-critic PC-3)** — Wave 0's per-frame translateX wasn't
+  applied to `surface_glow`, would desync the glow trace.
+  **Decision**: apply same transform to surface_glow every frame.
+  Baked into AC-8 / AC-9 step 7 / T10.
+
+### Redesign (3 findings adopted, 1 rejected)
+
+- **R1 (plan-critic PC-4)** — "Near-white" `hsla(20, 80%, 92%)`
+  was actually peachy-pink. **Adopted**: use
+  `hsla(0, 0%, {95,90,85}%, ...)` — pure-white desaturated palette.
+- **R2 (plan-critic PC-5)** — HSL lerp from cyan to orange passes
+  through yellow-green; `COLOR_MIX_REGEN_THRESHOLD` would also
+  staircase the transition. **Adopted**: dual-layer opacity
+  cross-fade (D2 / D11) — drops `_lerpHsla` entirely, eliminates
+  hue rotation, eliminates staircase. Slightly heavier DOM
+  (6 wave paths vs 3) but cheaper per-frame updates.
+- **R3 (scope-guardian)** — Pre-allocated bubble pool with recycle
+  was over-engineering for "bubbles coming from bottom to top".
+  **Adopted**: dynamic spawn (`document.createElementNS`) +
+  remove-on-death, soft cap 12. Baked into D8 / AC-7.
+- **Rejected (scope-guardian RD-5)** — "Drop continuous RAF entirely;
+  use `showAnimation`-gated RAF." User confirmed pool pattern in the
+  planning chat; water must be visible (cool blue) when off, not
+  invisible. Continuous RAF stays.
+
+### Improvements (12 adopted)
+
+- **I1 (PC-13/14, concrete-planner)** — Inline numeric values for
+  all module-level constants. **Adopted**: AC-2 enumerates every
+  constant with its value.
+- **I2 (concrete-planner)** — `CLIP_R=120` vs `ringCirc=130`
+  (10px gap, same as pool). **Adopted**: comment in T2.
+- **I3 (PC-16)** — Per-instance unique id strategy missing.
+  **Adopted**: `QsWaterBoilerCard._nextClipId` counter. Baked into
+  D10 / T8a.
+- **I4 (concrete-planner)** — `last_verified: 2026-05-23` was a
+  future date relative to system clock. **Adopted**: set to
+  `2026-05-21` (today) per the doc-maintenance "verify on each
+  edit" convention.
+- **I5 (concrete-planner)** — T6 missed enumerating the existing
+  dashed-arc animation as a preserved RAF tick output. **Adopted**:
+  AC-9 lists all 10 tick outputs explicitly with the dashed-arc
+  advance at position 1.
+- **I6 (dev-proxy)** — Tasks numbered with tests last but text said
+  "tests first". **Adopted**: tests are now T1 (RED), JS edits
+  T2..T13, doc T14, quality gate T15.
+- **I7 (concrete-planner)** — Heat-palette regex would trip on
+  `.power-btn` legitimate HA-blue. **Adopted**: scope the absence
+  assertion to the `const colors = {...};` block only (AC-12.1).
+- **I8 (dev-proxy)** — Add an explicit RED-verification step.
+  **Adopted**: T1 has its own "verify exactly N new failures"
+  procedure.
+- **I9 (dev-proxy)** — Add an explicit "explicit instruction
+  granted by issue #200" note. **Adopted**: top of "Why" section.
+- **I10 (PC-12)** — `displayTargetHours` edge case (null / NaN /
+  negative). **Adopted**: AC-4's `progressRatio` formula uses
+  `Number.isFinite(displayTargetHours) && displayTargetHours > 0`
+  as gating predicate.
+- **I11 (PC-17)** — Bubble fade-in not specified. **Decision**:
+  no fade-in. Bubbles pop in at opacity 0.9, fade to 0 as life
+  approaches maxLife. Baked into AC-7.
+- **I12 (PC-11)** — No `prefers-reduced-motion` fallback.
+  **Decision**: explicitly out of scope, deferred to a follow-up
+  story. Baked into "Out of scope".
+
+### Clarifications (all addressed inline)
+
+- **Test names + regex assertions**: spelled out in AC-12.1
+  through AC-12.5.
+- **Pool card reference**: explicit line numbers in Inputs and Tx.
+- **Project rule "don't modify JS cards"**: override note in Why.
+- **Doc `covers:` already includes the JS file**: verified at
+  line 14.
+- **Coverage rules**: JS files are excluded from Python coverage
+  by default (coverage.py only includes `.py`). New Python tests
+  are pure assertions; coverage is trivially 100%.
+- **Bubble spawn cy at low fill**: bubbles still spawn at clip
+  bottom; retire at surface+4. At very low fill, bubbles travel
+  briefly — visually less boiling, semantically accurate (less
+  water).

--- a/docs/stories/QS-200.story_review_fix_#01.md
+++ b/docs/stories/QS-200.story_review_fix_#01.md
@@ -1,0 +1,182 @@
+---
+title: QS-200 — Review fix plan #01
+slug: QS-200-review-fix-01
+kind: review-fix
+parent_story: docs/stories/QS-200.story.md
+pr_number: 202
+next_phase: implement-task
+last_verified: 2026-05-21
+---
+
+# QS-200 — Review fix plan #01
+
+## Summary
+
+- Source PR: [#202](https://github.com/tmenguy/quiet-solar/pull/202)
+- Source story: `docs/stories/QS-200.story.md`
+- Findings to fix: **16** (6 should-fix + 10 nice-to-have)
+- Next implement phase: `implement-task` (touches `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js` and `tests/test_dashboard_rendering.py` — outside the dev-env-only scope)
+- CI on PR #202: all green (Tests 100% cov, Ruff, MyPy, HACS, label)
+
+The PR delivers the heat-palette + boiling-water-animation + bubbles + surface-glow upgrade for the water-boiler card. Adversarial review surfaced no blocking correctness bugs (edge-case-hunter's speculative null hazards are covered by the synchronous lazy-init in `_startAnimation()` at line 126). The 16 findings below address: (1) story lifecycle metadata, (2) test fragility, (3) regression-pinning gaps for AC-2/3/4/5/6, (4) one inherited RAF `dt`-cap edge case from the pool-card pattern, and (5) ten polish items.
+
+## Findings to fix
+
+### [should-fix] S1 — Update story lifecycle metadata
+
+- File: `docs/stories/QS-200.story.md:5-6`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The story still declares `status: planned` and `next_phase: implement-task`, but the implementation has landed (PR #202 open, CI green). Lifecycle metadata is out of sync with the actual state.
+- Proposed fix: Set `status: completed` (or `implemented`) and `next_phase: release` (or `none`, whichever the project convention prefers — match QS-195/QS-198 if precedent exists).
+
+### [should-fix] S2 — `connectedCallback` regex brittle to nested braces
+
+- File: `tests/test_dashboard_rendering.py:~1466` (the `cb_pat` regex in `test_water_boiler_card_has_start_stop_helpers`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The current pattern `connectedCallback\s*\(\s*\)\s*\{(?P<body>[^{}]*?this\._startAnimation\s*\(\s*\))` uses `[^{}]*?` to disallow nested braces. Any future addition to `connectedCallback` that introduces a template literal `${…}`, object literal, or arrow function body silently breaks the match — the test then reports "must call `_startAnimation` directly" even though it actually does, just with extra surrounding code. This produces a misleading failure that wastes debugging time.
+- Proposed fix: Either (a) match only up to the first `this._startAnimation()` call with a more permissive body pattern (e.g. `(?P<body>.*?this\._startAnimation\s*\(\s*\))` with `re.DOTALL` and post-validate the body span doesn't contain other top-level constructs), or (b) extract `connectedCallback`'s body via a balanced-brace walk, then run the `if`-gate check on that body. Keep the assertion message clear.
+
+### [should-fix] S3 — Pin water-level formula (AC-4)
+
+- File: `tests/test_dashboard_rendering.py` — extend `test_water_boiler_card_renders_water_layer` (or add a new sibling test)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC-4 mandates the exact water-level mapping:
+  - `progressRatio = Number.isFinite(displayTargetHours) && displayTargetHours > 0 ? clamp(0,1, hoursRun/displayTargetHours) : 0`
+  - `rawWaterBaseY = CENTER_CY + CLIP_R - (0.2 + progressRatio * 0.6) * 2 * CLIP_R`
+  - `Number.isFinite(rawWaterBaseY)` fallback
+  
+  Implementation at `qs-water-boiler-card.js:434-440` is correct, but no regex test asserts these literals. A refactor could silently regress (e.g. drop `> 0`, change `0.2 + … * 0.6`).
+- Proposed fix: Add regex assertions in the test for the literal strings:
+  - `0.2 + progressRatio * 0.6`
+  - `2 * CLIP_R` (in the `rawWaterBaseY` expression — match contextually so the geometry literal is pinned)
+  - `Number.isFinite(displayTargetHours) && displayTargetHours > 0` (or the equivalent guarded clamp predicate)
+
+### [should-fix] S4 — Pin per-frame opacity cross-fade formula (AC-5 + AC-6)
+
+- File: `tests/test_dashboard_rendering.py` — extend a new or existing test
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC-5 and AC-6 mandate the dual-layer cross-fade: cool layer opacity = `1 - _currentColorMix`, boil layer opacity = `_currentColorMix`, with `_currentColorMix` lerping toward `running ? 1 : 0` via `LERP_RATE`/`LERP_DT_CEIL`. Implementation at `qs-water-boiler-card.js:259-260` and `:168` is correct, but no test pins these formulae.
+- Proposed fix: Add regex assertions for:
+  - `(1 - this._currentColorMix)` (cool opacity, with `.toFixed(3)` tolerated)
+  - `this._currentColorMix.toFixed(3)` (boil opacity)
+  - `targetColorMix = running ? 1 : 0` (or equivalent — pin the lerp target form)
+
+### [should-fix] S5 — Pin geometry constants (AC-2)
+
+- File: `tests/test_dashboard_rendering.py` — extend an existing constants test or add a new one
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The SVG layout depends on three geometry constants whose values flow into `<circle cx="..." cy="${CENTER_CY}" r="${CLIP_R}">` and the wave path step calculation. The current tests pin `MAX_CONCURRENT_BUBBLES = 12`, `BUBBLE_SPAWN_RATE_HZ`, and the surface-glow color, but leave the three geometry constants untested.
+- Proposed fix: Add regex assertions for the module-level declarations:
+  - `const CLIP_R = 120`
+  - `const CENTER_CY = 160`
+  - `const WAVE_WIDTH = 480`
+  
+  Use simple `re.search(r"const\s+CLIP_R\s*=\s*120\b", source)` style. If a `CENTER_CX = 160` constant is also introduced (see N4), pin it too.
+
+### [should-fix] S6 — Cap RAF `dt` against hidden-tab return
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~139` (`step()` function, where `dt` is computed)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `dt = Math.max(0, (ts - lastTs) / 1000)` has a floor but no ceiling. When the browser tab is hidden for several seconds (or hours), the first frame on return produces a single large `dt`. Effects:
+  - bubble `b.life += dt` can exceed `BUBBLE_MAX_LIFE_S` in one frame (self-cleaning via retire, but visible "pop")
+  - `_wavePhase += _currentSpeed * dt` advances by `1.6 * 10 = 16` phase units → 960px visual jump (modulo wrap saves correctness, but the wave snaps)
+  
+  The pool-card uses the same pattern, so this is an inherited edge case rather than a QS-200 regression — but worth fixing once for both.
+- Proposed fix: In `step()`, after computing `dt`, clamp with `dt = Math.min(dt, 0.1);` (matching the existing `LERP_DT_CEIL = 0.1` philosophy — at 100ms cap, RAF resumes smoothly even if real elapsed was hours). Apply the same clamp in `qs-pool-card.js` for consistency. Add a test pinning the `Math.min(dt, 0.1)` literal in both card files (or a shared regex).
+
+### [nice-to-have] N1 — Tighten `if`-gate test check
+
+- File: `tests/test_dashboard_rendering.py:1488-1492`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: `assert "if" not in m.group("body")` is a raw substring search; identifiers like `verify`, `notify`, `gif`, `modifier`, `lifecycle` would falsely trip the assertion.
+- Proposed fix: Replace with `assert re.search(r"\bif\s*\(", m.group("body")) is None`, keeping the same failure message.
+
+### [nice-to-have] N2 — Loosen surface-glow color regex
+
+- File: `tests/test_dashboard_rendering.py:1582-1609`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: `SURFACE_GLOW_COLOR` regex `#FF[0-9A-Fa-f]{4}` only accepts the 6-digit `#FF????` form. It rejects 3-digit shorthand (`#F00`), 8-digit RGBA, and other red-leaning hex codes from the heat palette (`#E64A19`).
+- Proposed fix: Either (a) relax to a generic hex matcher `#[0-9A-Fa-f]{3,8}` and assert the captured color appears in a known red-set list, or (b) pin the exact literal expected (e.g. `#FF6F00` or whichever is canonical). Match the assertion message to whichever is chosen.
+
+### [nice-to-have] N3 — Drop dead `_lastColorMix` field
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~88`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `_lastColorMix` is initialised in `_invalidateWaveCache`, assigned in `_render` (`this._lastColorMix = initialColorMix;`), but is never read anywhere. The inline comment even says "we update unconditionally — cheap". The field is dead state.
+- Proposed fix: Remove `_lastColorMix` from `_invalidateWaveCache`, from `_render`'s assignment block, and from any constructor init. OR keep it and add a code comment `// reserved for future opacity-change short-circuit; currently always updated unconditionally`.
+
+### [nice-to-have] N4 — Extract `CENTER_CX` constant
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~194` (bubble spawn) and `:480ish` (clipPath SVG markup)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+- Description: Bubble spawn uses `cx = 160 - CLIP_R + 8 + Math.random() * (2 * (CLIP_R - 8))`, where `160` is the SVG clip-circle center x. The clipPath markup also hard-codes `cx="160"`. The corresponding y-center is already named `CENTER_CY = 160`. The magic number should be named.
+- Proposed fix: Add `const CENTER_CX = 160;` to the module-level constants block (next to `CENTER_CY`). Replace the literal `160` in bubble spawn with `CENTER_CX` and use `${CENTER_CX}` in the clipPath SVG template literal. If S5 is being implemented, pin the new constant in the same regression test.
+
+### [nice-to-have] N5 — Extract `BUBBLE_FILL_COLOR` constant
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~204` (bubble creation)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Bubble fill `'rgba(255,255,255,0.85)'` is inlined. The surrounding code already exposes `BUBBLE_RADIUS_MIN`, `BUBBLE_RADIUS_MAX`, `BUBBLE_VY`, `BUBBLE_MAX_LIFE_S`, `MAX_CONCURRENT_BUBBLES`, `BUBBLE_SPAWN_RATE_HZ` — extracting the fill colour matches the style.
+- Proposed fix: Add `const BUBBLE_FILL_COLOR = 'rgba(255,255,255,0.85)';` to the constants block. Use it in `createElementNS` setAttribute call.
+
+### [nice-to-have] N6 — Sign-safe modulo for `_wavePhase`
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~108`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `this._wavePhase = this._wavePhase % PHASE_WRAP;` works because `_wavePhase` is monotonically non-decreasing (positive `_currentSpeed * dt`), but a few lines below `scrollOffset` uses the sign-safe `((x % m) + m) % m` pattern. Consistency.
+- Proposed fix: Change to `this._wavePhase = ((this._wavePhase % PHASE_WRAP) + PHASE_WRAP) % PHASE_WRAP;`.
+
+### [nice-to-have] N7 — Disciplined `_currentColorMix` lerp
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~106` (the lerp line in `step()`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `this._currentColorMix += (targetColorMix - (this._currentColorMix ?? 0)) * lerpFactor;` defends the RHS with `?? 0` but the LHS `undefined +=` would yield `NaN`. The lazy-init at line 126 guarantees `_currentColorMix` is `0` before this line runs, so the `?? 0` is redundant — but the inconsistent defensiveness is confusing.
+- Proposed fix: Either (a) drop the `?? 0` since the lazy-init guarantees a number; OR (b) write it as `const cur = this._currentColorMix ?? 0; this._currentColorMix = cur + (targetColorMix - cur) * lerpFactor;` for explicit safety. Pick one and apply consistently with how `_currentAmplitude` / `_currentSpeed` are handled in the same function.
+
+### [nice-to-have] N8 — Skip bubble DOM update when effectively invisible
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~223` (bubble per-frame opacity setAttribute)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Bubbles continue calling `b.el.setAttribute('opacity', '0.000')` while `_currentColorMix` is mid-transition from boiling→calm. Cheap, but a tiny perf win to skip when both `opacity < epsilon` AND `_currentColorMix < epsilon`.
+- Proposed fix: Optional. Add a guard `if (opacity > 0.001) b.el.setAttribute(...)` else skip — but be careful not to leave stale `0.85` attribute values from spawn time. Probably cleaner to early-retire bubbles when `running === false` AND `_currentColorMix < epsilon` (drains the bubble layer during cool-down).
+
+### [nice-to-have] N9 — Assert DOM z-order of water `<g>` (AC-3)
+
+- File: `tests/test_dashboard_rendering.py` — extend `test_water_boiler_card_renders_water_layer`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: AC-3 mandates the clipped water `<g>` appears BEFORE `<path d="${bgPath}">` in source order (so the ring/handle render on top). Implementation is correct, but the test asserts presence only, not order. A refactor could swap them.
+- Proposed fix: Add an assertion that `source.index("</g>")` (closing tag of the water group) is less than `source.index("${bgPath}")` — or use a single-span regex that requires the water group block to appear before the bgPath interpolation.
+
+### [nice-to-have] N10 — Document `last_verified` adjustment
+
+- File: `docs/agents/concepts/dashboard-and-cards.md:15`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `last_verified` went `2026-05-23 → 2026-05-21`. Today's system date is `2026-05-21`, so this is internally consistent (the prior `2026-05-23` was a future-dated typo from QS-195's edit). Strictly speaking `last_verified` should monotonically increase. Either accept the correction or add a short note so a future reviewer doesn't bump it back.
+- Proposed fix: Either (a) leave `last_verified: 2026-05-21` as-is (today's date, current edit) and accept the implicit "correcting prior typo" semantics; OR (b) add an inline HTML comment `<!-- 2026-05-23 in prior QS-195 was a future-dated typo; corrected to today -->` next to the front-matter; OR (c) re-set to `2026-05-23` as the highest historic value. Pick whichever matches project convention.
+
+## How to apply
+
+Run `/implement-task` (or `claude --agent qs-implement-task`) against this fix plan. The implementer should:
+
+1. Tackle should-fix S1–S6 first (story metadata, test fragility, regression pinning, dt cap).
+2. Tackle nice-to-haves N1–N10 in logical order (N4 + N5 first since they introduce new constants that S5 will need to pin).
+3. Ensure the quality gate stays green (pytest 100% cov + ruff + mypy + translations).
+4. Return and run `/review-task` again to re-verify.
+
+If any nice-to-have item conflicts with project convention or is judged not worth the churn, the implementer may skip it with a one-line justification in the implementation summary.

--- a/docs/stories/QS-200.story_review_fix_#01.md
+++ b/docs/stories/QS-200.story_review_fix_#01.md
@@ -176,7 +176,7 @@ Run `/implement-task` (or `claude --agent qs-implement-task`) against this fix p
 
 1. Tackle should-fix S1–S6 first (story metadata, test fragility, regression pinning, dt cap).
 2. Tackle nice-to-haves N1–N10 in logical order (N4 + N5 first since they introduce new constants that S5 will need to pin).
-3. Ensure the quality gate stays green (pytest 100% cov + ruff + mypy + translations).
+3. Ensure the quality gate stays green: `python scripts/qs/quality_gate.py` (pytest 100% cov + ruff + mypy + translations).
 4. Return and run `/review-task` again to re-verify.
 
 If any nice-to-have item conflicts with project convention or is judged not worth the churn, the implementer may skip it with a one-line justification in the implementation summary.

--- a/docs/stories/QS-200.story_review_fix_#02.md
+++ b/docs/stories/QS-200.story_review_fix_#02.md
@@ -1,0 +1,168 @@
+---
+title: QS-200 — Review fix plan #02
+slug: QS-200-review-fix-02
+kind: review-fix
+parent_story: docs/stories/QS-200.story.md
+prior_fix: docs/stories/QS-200.story_review_fix_#01.md
+pr_number: 202
+next_phase: implement-task
+last_verified: 2026-05-21
+---
+
+# QS-200 — Review fix plan #02
+
+## Summary
+
+- Source PR: [#202](https://github.com/tmenguy/quiet-solar/pull/202)
+- Source story: `docs/stories/QS-200.story.md`
+- Prior fix plan: `docs/stories/QS-200.story_review_fix_#01.md` (commit `8b1ecf1` — 6 should-fix + 8 nice-to-have applied)
+- Findings to fix: **16** (3 should-fix + 13 nice-to-have)
+- Next implement phase: `implement-task` (touches `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js` and `tests/test_dashboard_rendering.py`)
+- CI on PR #202: all green (Tests 100% cov, Ruff, MyPy, HACS)
+
+Second adversarial review pass after the implementer applied fix plan #01. All previously-flagged regression-pinning gaps and the `dt`-cap edge case are resolved. The remaining items are smaller in scope:
+
+1. One **concrete miss** from the N4 migration: the arc/handle/progress-ring center literal `{cx: 160, cy: 160}` at line 680 was not migrated to `CENTER_CX/CENTER_CY` even though bubble spawn and clipPath markup were.
+2. One **maintainability hazard**: the post-`innerHTML` cleanup block hand-rolls the same field list as `_invalidateWaveCache()` — future memo keys can silently miss it.
+3. One **process miss**: story `next_phase` was bumped to `review-task` but review is now closing.
+4. 13 polish items split across blind-hunter, edge-case-hunter, and CodeRabbit.
+
+## Findings to fix
+
+### [should-fix] S1 — Migrate arc/handle/progress-ring center to `CENTER_CX/CENTER_CY`
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:680`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The N4 fix added `const CENTER_CX = 160; const CENTER_CY = 160;` to the module constants block and migrated bubble spawn (line 286: `cx = CENTER_CX - CLIP_R + 8 + …`) and clipPath SVG markup (line 897: `<circle cx="${CENTER_CX}" cy="${CENTER_CY}" r="${CLIP_R}" />`). However, line 680 still hard-codes `const center = {cx: 160, cy: 160};` for the arc / handle / progress-ring geometry. If `CENTER_CX` is ever tweaked (the constants exist precisely to allow this), the water clip circle would move but the ring, handle, and progress arc would stay at 160 — visible misalignment. The N4 migration is therefore incomplete.
+- Proposed fix: Replace `const center = {cx: 160, cy: 160};` with `const center = {cx: CENTER_CX, cy: CENTER_CY};`. Optionally also drop the `center` object entirely and inline `CENTER_CX`/`CENTER_CY` at use sites (lines 695, 696, 697, 1309, 1310, 1330) — but the lightweight rename is sufficient and lower-risk.
+
+### [should-fix] S2 — Bump story `next_phase` past `review-task`
+
+- File: `docs/stories/QS-200.story.md:5-6`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The prior review-fix #01 S1 partially landed: `status: planned → implemented` ✓ but `next_phase: implement-task → review-task` only. Review pass #02 is now closing, so `review-task` is also no longer the next phase. The lifecycle metadata is one phase behind reality.
+- Proposed fix: Set `next_phase: release` (or `none` / `finish-task`, whichever matches the project's convention seen on QS-195 / QS-198 at the equivalent stage). If unsure, grep recent merged story files for the post-review convention.
+
+### [should-fix] S3 — Factor `_resetDomRefs()` helper to dedup post-innerHTML cleanup
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:103-108, 1002-1007`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `_invalidateWaveCache()` at lines 103-108 resets six fields (`_lastWaterBaseY`, `_lastAmplitude`, `_waveEls`, `_bubbleLayerEl`, `_surfaceGlowEl`, plus `_bubbles` reset elsewhere). The post-`innerHTML` cleanup at lines 1002-1007 resets the SAME six fields but with diverging values: `_lastWaterBaseY` and `_lastAmplitude` are SET to the current `_waterBaseY`/`initialAmp` (sync), while `_waveEls`/`_bubbleLayerEl`/`_surfaceGlowEl`/`_bubbles` are cleared. If a future feature adds a seventh memo key to `_invalidateWaveCache()`, the post-render block will silently miss it — the next frame would see stale memo state until the new key happens to mutate.
+- Proposed fix: Extract a `_resetDomRefs()` (or `_clearDomCache()`) helper that clears `_waveEls`/`_bubbleLayerEl`/`_surfaceGlowEl` and resets `_bubbles = []`. Call it from BOTH `_invalidateWaveCache()` AND the post-render block. Keep the divergent `_lastWaterBaseY`/`_lastAmplitude` handling explicit at each call site (null vs current). Add a comment explaining why those two diverge.
+
+### [nice-to-have] N1 — Document `_extract_js_function_body` brace-walker limitations
+
+- File: `tests/test_dashboard_rendering.py:57-88`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: The balanced-brace walker doesn't understand string literals, template literals, or regex literals containing `{`/`}`. If a future `connectedCallback` body adds `const s = "{...}"` or `` `${...}` `` with literal `{` chars, the walker will miscount and the test will fail with a misleading "must call _startAnimation directly" message.
+- Proposed fix: Either (a) add a docstring note on `_extract_js_function_body` calling out the limitation, OR (b) harden the walker to skip braces inside `'…'`, `"…"`, `` `…` `` (respecting escapes and `${…}` nesting). Option (a) is sufficient given current scope.
+
+### [nice-to-have] N2 — Comment-stripper clobbers URL string literals
+
+- File: `tests/test_dashboard_rendering.py` (the helper that does `re.sub(r"//[^\n]*", "", body)`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The comment-stripping regex eats `//` followed by anything to end-of-line — including URL string literals like `"http://www.w3.org/2000/svg"`, turning them into `"http:`. No current test asserts that URL, but if a future test wants to pin the SVG namespace literal (e.g. to verify `createElementNS` correctness), it'll silently fail.
+- Proposed fix: Either (a) extract a proper JS comment-stripper that respects string literals, OR (b) leave as-is and add a docstring note on the helper warning that URL literals get clobbered. Option (b) is sufficient — option (a) is overengineering for one helper.
+
+### [nice-to-have] N3 — Document pool-card dt-cap behavior change
+
+- File: `custom_components/quiet_solar/ui/resources/qs-pool-card.js:~127`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: S6 from fix plan #01 applied the `dt = Math.min(dt, 0.1)` cap to both `qs-water-boiler-card.js` AND `qs-pool-card.js`. The pool card's prior behavior intentionally let wave phase accumulate raw `dt` "so scroll catches up" after a hidden tab — that semantic is now removed. Both behaviors are defensible (catch-up snap vs. one-frame freeze), and the cap is consistent with the boiler card. No regression test exists for the prior catch-up behavior.
+- Proposed fix: Add a one-line code comment near the pool-card `dt` cap explaining the trade-off: "Cap dt at 100ms to bound bubble life and phase advance on hidden-tab return; trades wave 'catch up' for a single-frame freeze." Optional: confirm visually that the pool card still looks correct after extended tab-hide.
+
+### [nice-to-have] N4 — Document `surface_glow` first-frame `d` invariant
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~918` (SVG markup) and `:230-238` (RAF regen block)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter (originally flagged as should-fix; downgraded after verification)
+- Description: The SVG markup sets `<path id="surface_glow" d="${initialWavePaths[0]}" .../>`. The RAF regen block only re-assigns `surfaceGlow`'s `d` when `regenerated === true`, which requires `ampDelta > 0` or `levelChanged === true`. On the first frame after `_render()`, `_lastAmplitude` and `_lastWaterBaseY` are synced to `initialAmp`/`_waterBaseY` (post-innerHTML cleanup, lines 1002-1003), so neither condition fires. The glow's `d` stays at `initialWavePaths[0]` for the first frame — which is exactly what wave 0's `d` is (also `initialWavePaths[0]`). They cannot desync by construction, but the invariant is implicit. A future refactor that changes how `initialWavePaths` is computed could break it silently.
+- Proposed fix: Add a code comment near the SVG markup: `<!-- surface_glow.d MUST equal wave 0's d on every frame; first frame is anchored to initialWavePaths[0] which wave 0 also uses. -->` and a matching comment in the RAF regen block: `// Glow d syncs to wave 0 only on regen; first-frame parity is anchored by the shared initialWavePaths[0] in the SVG markup.`
+
+### [nice-to-have] N5 — Drop unreachable `?? 0` fallback for `_waterBaseY`
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~373` (bubble retire surfaceY)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `surfaceY = (this._waterBaseY ?? 0) + 4` — the `?? 0` is unreachable because `_waterBaseY` is set in `_render()` before any RAF frame runs (the bubble retire loop only fires when bubbles exist, which requires at least one spawn, which requires `_running === true`, which requires `_render()` to have set it).
+- Proposed fix: Drop the `?? 0` (use `surfaceY = this._waterBaseY + 4`) OR replace with the same fallback used in `_render()`: `(CENTER_CY + CLIP_R - 0.2 * 2 * CLIP_R)`. Pick whichever matches the implementer's defensive style preference.
+
+### [nice-to-have] N6 — Drop `?? 0` on `_nextBubbleAt` for consistency
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~344` (bubble spawn cadence)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `this._nextBubbleAt = (this._nextBubbleAt ?? 0) - dt;` defends against undefined, but the lazy-init in `_startAnimation` guarantees `_nextBubbleAt = 0`. N7 from the prior plan removed the equivalent `?? 0` from `_currentColorMix`; consistency would extend that simplification here.
+- Proposed fix: Drop the `?? 0`: `this._nextBubbleAt -= dt;` (since lazy-init guarantees a number).
+
+### [nice-to-have] N7 — Reuse `boiling` const for bubble spawn gate
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~232, ~282`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `const boiling = this._running === true;` is computed near line 232 for the lerp target, but the bubble spawn block (line ~282) re-evaluates `if (this._running === true)` instead of reusing `boiling`. Minor consistency.
+- Proposed fix: Hoist `const boiling = this._running === true;` higher in the step function and reuse it in the bubble spawn check.
+
+### [nice-to-have] N8 — Accept `.toFixed(3)` trailing zeros (cosmetic)
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js` (multiple `.toFixed(3)` call sites)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `(1 - 0).toFixed(3) === "1.000"`, set as opacity attribute. SVG accepts this fine. Purely cosmetic — DOM inspector shows `opacity="1.000"` instead of `"1"`.
+- Proposed fix: No action required, OR use `(v === 0 || v === 1) ? String(v) : v.toFixed(3)` if cleanliness in DOM inspector matters. Recommend: skip with justification.
+
+### [nice-to-have] N9 — Reorganize `test_card_raf_idle_gated` comment placement
+
+- File: `tests/test_dashboard_rendering.py:~1409` (the parametrize block)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The QS-200 rationale for excluding boiler from `test_card_raf_idle_gated` is currently a multi-line comment inside the parametrize argument list. A future reviewer scanning the parametrize might miss the boiler-was-removed history.
+- Proposed fix: Move the comment to ABOVE the `@pytest.mark.parametrize` decorator OR include it as a docstring on the test function citing why the boiler is excluded. Keep the parametrize list clean.
+
+### [nice-to-have] N10 — Align `COOL_WATER_COLORS` comment with actual values
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~85` (header comment) and the `COOL_WATER_COLORS` constant
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The header comment says "cool blue when not running" but `COOL_WATER_COLORS` are `hsla(185, 60%, 18-22%, …)` — saturation 60% at hue 185 is a dark teal/cyan, not "cool blue" in the conventional sense. The description doesn't match the rendered color.
+- Proposed fix: Either (a) update the comment to say "cool teal" / "deep cyan", OR (b) tweak the constants to `hsla(210, 60%, …)` for actual blue. Option (a) is zero visual risk.
+
+### [nice-to-have] N11 — Smooth mass bubble retire on `_waterBaseY` jump
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~302` (bubble retire condition)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: When the user changes `displayTargetHours` (e.g. lowering the target so the water level drops sharply), `_waterBaseY` jumps higher between frames. All bubbles whose `cy < (new _waterBaseY) + 4` retire on the same frame, producing a visible "all bubbles vanish" moment. The 6Hz spawn cadence rebuilds the population over ~2s. The retire condition conflates "bubble rose past surface" with "surface dropped past bubble" — physically different events.
+- Proposed fix: Track each bubble's spawn-time `_waterBaseY` on the bubble object (`b._spawnBaseY`) and use `b.cy < (b._spawnBaseY + 4)` for retire, anchoring the retire-line to the bubble's spawn level. OR accept as-is since target-hours changes are rare deliberate user actions. Recommend: implement the per-bubble anchor — it's cheap and visually smoother.
+
+### [nice-to-have] N12 — Re-prime on reconnect if `_running` changed during disconnect
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:116-133` (`_startAnimation` lazy-init guard)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: On disconnect, `_currentAmplitude`/`_currentSpeed`/`_wavePhase`/`_currentColorMix` are preserved so wave state survives re-attach. But if `_running` flipped during the detached window (e.g. boiler turned off), the reattach RAF will lerp from the preserved (high) `_currentColorMix` toward the new (low) target over ~1.5s — user sees "boiling that calms down" even though the boiler was off for the entire detach.
+- Proposed fix: In `_startAnimation` (after the lazy-init guard), compare `_running` against the value at last `_stopAnimation` (stash on `this._runningAtStop` during `_stopAnimation`). If they differ, set `_needsAnimationPrime = true` so the next `_render` re-primes to current target. OR accept as-is — 1.5s transient is short and visually plausible.
+
+### [nice-to-have] N13 — Initialize `wave0Tx` to a safe default
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~211` (RAF step transform loop)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `let wave0Tx = ''` initializes to empty string. The 3-iter loop is pure arithmetic so it always reaches `i === 0` and assigns a valid `translateX(...)`, but a future edit introducing early-return or throw before that iteration would leave `wave0Tx = ''`. `surfaceGlow.style.transform = ''` resets the transform to `none` — glow snaps to SVG origin (cx=0) while waves stay at their previous translation.
+- Proposed fix: Initialize `let wave0Tx = 'translateX(0px)';` OR compute layer-0's `tx` once before the loop and reuse: `const tx0 = ...; wave0Tx = `translateX(${tx0}px)`;`. Lightweight forward-compatibility hardening.
+
+## How to apply
+
+Run `/implement-task` (or `claude --agent qs-implement-task`) against this fix plan. The implementer should:
+
+1. **Should-fix first**: S1 (CENTER_CX migration), S2 (story `next_phase`), S3 (refactor `_resetDomRefs()` helper).
+2. **Nice-to-haves**: apply N1–N13 in any order. N5/N6 are trivial; N11/N12 are slightly more involved (per-bubble field / disconnect-state stash); N4 is just comments.
+3. **Skip with justification allowed**: N8 (cosmetic `.toFixed(3)`), N10 (cool blue vs teal — subjective), N11 (target-hours-change visual) per the same rule as fix plan #01.
+4. **Quality gate**: pytest 100% cov + ruff + mypy + translations. Add regression tests for S1 (assert no inlined `160` for `center.cx`/`center.cy` in the source — or pin that `center.cx === CENTER_CX`).
+5. Return and run `/review-task` again to verify (or `/finish-task` if confident the third pass will be clean).

--- a/docs/stories/QS-200.story_review_fix_#02.md
+++ b/docs/stories/QS-200.story_review_fix_#02.md
@@ -164,5 +164,5 @@ Run `/implement-task` (or `claude --agent qs-implement-task`) against this fix p
 1. **Should-fix first**: S1 (CENTER_CX migration), S2 (story `next_phase`), S3 (refactor `_resetDomRefs()` helper).
 2. **Nice-to-haves**: apply N1–N13 in any order. N5/N6 are trivial; N11/N12 are slightly more involved (per-bubble field / disconnect-state stash); N4 is just comments.
 3. **Skip with justification allowed**: N8 (cosmetic `.toFixed(3)`), N10 (cool blue vs teal — subjective), N11 (target-hours-change visual) per the same rule as fix plan #01.
-4. **Quality gate**: pytest 100% cov + ruff + mypy + translations. Add regression tests for S1 (assert no inlined `160` for `center.cx`/`center.cy` in the source — or pin that `center.cx === CENTER_CX`).
+4. **Quality gate**: `python scripts/qs/quality_gate.py` (pytest 100% cov + ruff + mypy + translations). Add regression tests for S1 (assert no inlined `160` for `center.cx`/`center.cy` in the source — or pin that `center.cx === CENTER_CX`).
 5. Return and run `/review-task` again to verify (or `/finish-task` if confident the third pass will be clean).

--- a/docs/stories/QS-200.story_review_fix_#03.md
+++ b/docs/stories/QS-200.story_review_fix_#03.md
@@ -1,0 +1,96 @@
+---
+title: QS-200 — Review fix plan #03
+slug: QS-200-review-fix-03
+kind: review-fix
+parent_story: docs/stories/QS-200.story.md
+prior_fix: docs/stories/QS-200.story_review_fix_#02.md
+pr_number: 202
+next_phase: implement-task
+last_verified: 2026-05-21
+---
+
+# QS-200 — Review fix plan #03
+
+## Summary
+
+- Source PR: [#202](https://github.com/tmenguy/quiet-solar/pull/202)
+- Source story: `docs/stories/QS-200.story.md`
+- Prior fix plans: `#01` (commit `8b1ecf1`), `#02` (commit `8b446dc`)
+- Findings to fix: **4** (1 should-fix + 3 nice-to-have)
+- Next implement phase: `implement-task` (touches `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js` and `tests/test_dashboard_rendering.py`)
+- CI on PR #202: all green (Tests 100% cov, Ruff, MyPy, HACS)
+
+Third adversarial review pass. Blind-hunter and acceptance-auditor returned no findings. Edge-case-hunter found one concrete should-fix in the N12 implementation: the `_runningAtStop` stash is consumed too eagerly. CodeRabbit + edge-case-hunter contributed three small polish items.
+
+## Findings to fix
+
+### [should-fix] S1 — Defer `_runningAtStop` clear into the matching `if` block
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:765-768`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: N12 from fix plan #02 introduced a `_runningAtStop` stash to detect a `_running` state change that happened while the card was detached, so the reattach can prime to the new target instead of lerping over 1.5s. The current implementation consumes the stash on **every** `_render()`:
+  ```js
+  if (this._runningAtStop !== undefined && this._runningAtStop !== running) {
+    this._needsAnimationPrime = true;
+  }
+  this._runningAtStop = undefined;   // ← cleared regardless of whether the if-block fired
+  this._running = running;
+  ```
+  But `set hass` (line 451-457) does not gate on `this.isConnected`, and the code's own comment at line 401 acknowledges that hass-pushes happen during dashboard rearranges while detached. Concrete 4-step regression scenario:
+  1. Card mounted, boiler running, `_running = true`.
+  2. `disconnectedCallback()` fires → `_stopAnimation()` sets `_runningAtStop = true`.
+  3. HA pushes `set hass` while still detached, `running` unchanged (still true) → `_render()` runs → guard fails (`_runningAtStop === running`) → no prime → **but line 768 still clears `_runningAtStop = undefined`**.
+  4. HA pushes `set hass` again while still detached, `running` flipped to false → `_render()` runs → guard fails (`_runningAtStop === undefined`) → no prime.
+  5. Card reconnects → `_currentColorMix` is still ~1 (preserved by the lazy-init guard in `_startAnimation`) → wave visibly lerps from boiling to calm over ~1.5s.
+
+  This reintroduces the exact "visibly calming down on reattach" regression N12 was meant to prevent.
+- Proposed fix: Move the clear **inside** the matching `if` block so the stash survives subsequent unrelated `_render` calls until the comparison actually fires:
+  ```js
+  if (this._runningAtStop !== undefined && this._runningAtStop !== running) {
+    this._needsAnimationPrime = true;
+    this._runningAtStop = undefined;
+  }
+  this._running = running;
+  ```
+  
+  **Alternative** (slightly more invasive but more semantically correct): clear `_runningAtStop` in `connectedCallback` after consuming it, never in `_render`. The orchestration becomes: `_stopAnimation` sets it → `connectedCallback` reads it once → either sets `_needsAnimationPrime` or doesn't → clears it. This is robust against any number of hass-pushes during the detached window.
+  
+  Prefer the alternative if the lifecycle is easy to express; otherwise the inside-if move is sufficient.
+  
+  **Regression test**: add a test in `tests/test_dashboard_rendering.py` that pins the inside-if structure with a regex like `re.search(r"if\s*\(\s*this\._runningAtStop\s*!==\s*undefined[^{}]*?\{[^}]*?this\._runningAtStop\s*=\s*undefined", source)`. Match the existing `_extract_js_function_body`-style helpers for the test.
+
+### [nice-to-have] N1 — Rename `_resetDomRefs()` to surface bubble-reset behavior
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:105-110` (or wherever the helper is defined)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The S3 refactor from fix plan #02 extracted `_resetDomRefs()` to dedup the field-reset between `_invalidateWaveCache()` and the post-`innerHTML` cleanup. The helper resets DOM refs (`_waveEls`, `_bubbleLayerEl`, `_surfaceGlowEl`) **and** `this._bubbles = []`. Prior to the refactor, `_invalidateWaveCache()` did NOT touch `_bubbles` — the bubbles were cleared elsewhere (`disconnectedCallback`, or the post-render block separately). Today this is a no-op because every call to `_invalidateWaveCache` happens after `disconnectedCallback` already cleared bubbles. But a future caller invoking `_invalidateWaveCache()` to force a wave-only redraw would unexpectedly wipe active bubbles.
+- Proposed fix: Either (a) rename helper to `_clearDomAndBubbleState()` (or similar) to make the bubble reset visible at call sites; OR (b) split into two helpers — `_resetDomRefs()` for DOM-only and a separate explicit `this._bubbles = []` at the two current call sites; OR (c) add a single-line code comment on the helper noting that it intentionally resets bubbles too. Option (c) is the lightest fix.
+
+### [nice-to-have] N2 — Route existing tests through `_strip_js_comments`
+
+- File: `tests/test_dashboard_rendering.py` — 9 sites: lines 333-334, 949-950, 1033-1034, 1073-1074, 1551-1552, 1594-1595, 1669-1670, 1717-1718, 1746-1747, 1827-1828, 1876-1877, 1923-1924, 1958-1959
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: Plan #02 N2 extracted a `_strip_js_comments` helper with a docstring noting the `//`-inside-URL limitation. The new water-boiler tests use it, but 9 pre-existing tests still inline the same two-line `re.sub(...)` pair. Refactoring them through the helper makes the documented caveat a single point of truth and removes nine copies of the same idiom.
+- Proposed fix: Replace each `no_block = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL); executable = re.sub(r"//[^\n]*", "", no_block)` pair with `executable = _strip_js_comments(source)`. Keep the variable name `executable` consistent across sites. Quality gate run will confirm no test regresses.
+
+### [nice-to-have] N3 — Reference `scripts/qs/quality_gate.py` by name in fix-plan docs
+
+- File: `docs/stories/QS-200.story_review_fix_#02.md:167-168` (and forward — this plan #03)
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: CodeRabbit flagged that the fix-plan "How to apply" section lists "pytest 100% cov + ruff + mypy + translations" descriptively rather than referencing the canonical entrypoint `python scripts/qs/quality_gate.py`. The descriptive form mirrors `CLAUDE.md`'s own usage, so this is borderline. Updating for consistency makes the doc copy-paste-runnable.
+- Proposed fix: Update the "How to apply" section in fix plan #02 (and adopt the convention going forward) to read: "Quality gate: `python scripts/qs/quality_gate.py` (pytest 100% cov + ruff + mypy + translations)". Optionally backport the same wording to plan #01's "How to apply" for symmetry.
+
+## How to apply
+
+Run `/implement-task` (or `claude --agent qs-implement-task`) against this fix plan. The implementer should:
+
+1. **S1 first** (real bug): apply the inside-if move OR the connectedCallback-based alternative. Add a regression test pinning the chosen structure. Verify by mentally walking the 4-step scenario from the description.
+2. **N1**: simplest is option (c) — add a code comment. If the implementer prefers a rename or split, choose one and update all call sites.
+3. **N2**: mechanical refactor across 9 sites. The quality gate will confirm no regression.
+4. **N3**: cosmetic doc update.
+5. **Quality gate**: `python scripts/qs/quality_gate.py` (pytest 100% cov + ruff + mypy + translations).
+6. After this pass, fix plan #03 should be the final review-fix. Return and run `/review-task` once more to confirm a clean pass, then `/finish-task`.

--- a/docs/stories/QS-200.story_review_fix_#04.md
+++ b/docs/stories/QS-200.story_review_fix_#04.md
@@ -1,0 +1,94 @@
+---
+title: QS-200 — Review fix plan #04
+slug: QS-200-review-fix-04
+kind: review-fix
+parent_story: docs/stories/QS-200.story.md
+prior_fix: docs/stories/QS-200.story_review_fix_#03.md
+pr_number: 202
+next_phase: implement-task
+last_verified: 2026-05-21
+---
+
+# QS-200 — Review fix plan #04
+
+## Summary
+
+- Source PR: [#202](https://github.com/tmenguy/quiet-solar/pull/202)
+- Source story: `docs/stories/QS-200.story.md`
+- Prior fix plans: `#01` (commit `8b1ecf1`), `#02` (commit `8b446dc`), `#03` (commit `f4235b0`)
+- Findings to fix: **1** (1 must-fix)
+- Next implement phase: `implement-task` (touches `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js` and `tests/test_dashboard_rendering.py`)
+- CI on PR #202: green at last check
+- CodeRabbit: rate-limited at pass 4; the three independent reviewers (blind-hunter, acceptance-auditor, edge-case-hunter) cover the diff
+
+Fourth adversarial review pass. Blind-hunter and acceptance-auditor returned "no findings". Edge-case-hunter found one **must-fix** regression introduced by pass-3 S1: the `_runningAtStop` stash is now leaked across the first post-reattach `_render` (when running was unchanged at reattach), and the next in-place state flip falsely fires the prime — causing a visible "snap" instead of the designed ~1.5s lerp.
+
+This is the **third revision** of the N12 logic. The pattern needs to thread the needle: the stash must be consumed **exactly once** on the first post-reattach `_render`, regardless of guard outcome.
+
+## Findings to fix
+
+### [must-fix] M1 — Consume `_runningAtStop` exactly once on first post-reattach `_render`
+
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:780-783` (the guard) + `:382-394` (`_stopAnimation`) + `:396-403` (`connectedCallback`)
+- Severity: **must-fix**
+- Source: qs-review-edge-case-hunter
+- Description: Pass-3 S1 moved the `_runningAtStop = undefined;` clear **inside** the matching if-block to fix the prior "stash consumed too eagerly by intervening hass-pushes during detached window" hole. That fix correctly closes the original 4-step scenario, but introduces a **new** regression: the stash is now cleared **only** when the guard fires, so after any detach/reattach cycle where `running` was unchanged, `_runningAtStop` stays set indefinitely. The very next in-place state flip (running→stopped or stopped→running, hours later, no further detach involved) then fires the prime and snaps `_currentAmplitude/Speed/ColorMix` to the new targets in one frame — skipping the ~1.5s lerp envelope that was explicitly designed for in-place transitions (lerp logic at lines 197-200; prime-flag intent comments at lines 153-156, 813-816).
+
+  Concrete 5-step regression scenario (confirmed against code):
+  1. Boiler running, card attached: `_running = true`, `_runningAtStop = undefined`.
+  2. Detach (HA dashboard rearrange) → `_stopAnimation()` sets `_runningAtStop = true`.
+  3. Reattach with `running` still `true` → `_render()` runs → guard `_runningAtStop(true) !== running(true)` is **false** → **stash NOT cleared** (this is the intended pass-3 S1 behavior) → `_runningAtStop` remains `true` indefinitely.
+  4. Card stays attached for minutes/hours. Boiler finishes naturally; hass-push delivers `running = false`.
+  5. Next `_render()`: guard `_runningAtStop(true) !== running(false)` is **true** → `_needsAnimationPrime = true` → consume block at lines 817-822 snaps amplitude/speed/colorMix straight to CALM targets in the same render frame.
+
+  Net visual: every normal running→stopped (or stopped→running) transition that follows **any** prior detach/reattach cycle where `running` was unchanged at reattach will visibly snap instead of lerping. Symmetric in both directions.
+
+  The pass-3 regression test (`test_water_boiler_card_running_at_stop_clear_inside_if`) pins the textual shape of the inside-if clear but does NOT cover this stale-stash scenario.
+
+  **Root cause of the oscillation**: `_runningAtStop` semantically represents "state at the last `_stopAnimation`" but the guard runs on **every** `_render`, conflating "first post-reattach render" with "any subsequent render". The original (pre-pass-3) "always clear after if" was wrong because mid-detach hass-pushes ate the stash. The current (pass-3) "clear only when guard fires" is wrong because the stash leaks across the first post-reattach render. The right shape is **"clear once, on the first post-reattach render, regardless of guard outcome"**.
+
+- Proposed fix: Introduce a `_pendingReattachCheck` flag set in `connectedCallback` (or `_startAnimation`), consumed exactly once on the first post-reattach `_render`:
+
+  ```js
+  // In connectedCallback (after this._startAnimation();):
+  this._pendingReattachCheck = true;
+  
+  // In _render, replacing lines 780-783:
+  if (this._pendingReattachCheck) {
+    if (this._runningAtStop !== undefined && this._runningAtStop !== running) {
+      this._needsAnimationPrime = true;
+    }
+    this._runningAtStop = undefined;
+    this._pendingReattachCheck = false;
+  }
+  this._running = running;
+  ```
+
+  This handles all three scenarios:
+  - **Reattach with `running` unchanged** → flag is set in `connectedCallback`; first post-reattach `_render` consumes flag → guard fails → no prime → stash cleared → flag cleared. Next in-place transitions lerp normally.
+  - **Reattach with `running` flipped** → flag is set in `connectedCallback`; first post-reattach `_render` consumes flag → guard fires → prime → stash cleared → flag cleared. Wave snaps to new target on reattach.
+  - **Mid-detach hass-pushes** → flag was NOT set (we only set it in `connectedCallback`, not in `_stopAnimation`) → consume block is skipped entirely → stash preserved for the eventual first post-reattach `_render`.
+
+  Initialize `this._pendingReattachCheck = false` in the constructor (or at the top of `setConfig`) so the very first mount doesn't trigger a phantom consume on its initial `_render`.
+
+  Alternative considered: clear `_runningAtStop` on **both** branches of the guard (`if/else`). Rejected because it has the same bug — any subsequent `_render` after the first post-reattach one would also enter the else branch on a stable running value, defeating the purpose of preserving the stash through mid-detach hass-pushes. The flag-gated approach is the only way to truly bound the consume to "first post-reattach render".
+
+  **Regression test**: add a new test in `tests/test_dashboard_rendering.py` pinning the flag-gated structure. Minimum assertions:
+  - `re.search(r"_pendingReattachCheck\s*=\s*true", source)` — flag is set somewhere (`connectedCallback`)
+  - `re.search(r"if\s*\(\s*this\._pendingReattachCheck\s*\)\s*\{[\s\S]*?this\._runningAtStop\s*=\s*undefined[\s\S]*?this\._pendingReattachCheck\s*=\s*false", source)` — flag-gated block with both clears
+  - **Negative**: the clear `_runningAtStop = undefined` should NOT appear outside the flag-gated block (use a balanced-brace walk to extract `_render`'s body, then assert exactly one occurrence inside the flag-gated subblock).
+  
+  Also add a docstring on the test reproducing the 5-step scenario above so a future contributor understands what the structural assertion protects against.
+
+## How to apply
+
+Run `/implement-task` (or `claude --agent qs-implement-task`) against this fix plan. The implementer should:
+
+1. Initialize `this._pendingReattachCheck = false` in the constructor / `setConfig` (verify wherever other per-instance fields are initialized).
+2. In `connectedCallback`, set `this._pendingReattachCheck = true` after `this._startAnimation();`.
+3. Replace the current guard at lines 780-783 with the flag-gated block from the proposed fix.
+4. Add the regression test pinning the flag-gated structure + a docstring reproducing the 5-step scenario.
+5. Mentally walk all three scenarios (mid-detach hass-pushes, reattach with running unchanged + later in-place flip, reattach with running flipped) and confirm the new code handles each correctly.
+6. Update the inline comment block at lines 765-779 to reflect the third revision: "consume exactly once on first post-reattach render, regardless of guard outcome".
+7. Quality gate: `python scripts/qs/quality_gate.py` (pytest 100% cov + ruff + mypy + translations).
+8. After this pass, run `/review-task` once more to confirm a clean pass, then `/finish-task`. The N12 logic has now had 4 revisions — a final reviewer eyeballing the third revision is warranted before merge.

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -1959,33 +1959,55 @@ def test_water_boiler_card_factors_reset_dom_refs_helper():
     )
 
 
-def test_water_boiler_card_running_at_stop_clear_inside_if():
-    """Review-fix #03 S1: the `_runningAtStop = undefined;` clear must
-    live INSIDE the `if (...)` block that detected a state flip, not
-    unconditionally after. Otherwise a hass push during the detached
-    window (which fires `set hass → _render()` regardless of
-    connection state) consumes the stash WITHOUT the comparison ever
-    firing — and a subsequent push that does flip `running` sees
-    `_runningAtStop === undefined` and misses the prime, reintroducing
-    the exact "visibly calming down on reattach" regression that fix
-    plan #02 N12 was meant to prevent.
+def test_water_boiler_card_running_at_stop_consume_is_flag_gated():
+    """Review-fix #04 M1: the `_runningAtStop` stash must be consumed
+    EXACTLY ONCE on the first post-reattach `_render`, regardless of
+    whether the running-state guard fires.
 
-    Reproduction (without this guard):
+    This is the third revision of the N12 (fix-plan #02) reconnect
+    re-prime logic. The history:
 
-    1. Card mounted, boiler running, `_running = true`.
-    2. Detach → `_stopAnimation()` sets `_runningAtStop = true`.
-    3. Hass push while detached, `running` unchanged → `_render()`
-       runs, guard is false, BUT unconditional clear wipes
-       `_runningAtStop`.
-    4. Hass push while detached, `running` flipped to false →
-       `_render()` runs, but `_runningAtStop === undefined` so the
-       guard fails — no prime queued.
-    5. Reattach → wave lerps from `_currentColorMix ≈ 1` toward `0`
-       over ~1.5s. User sees "calming down" despite the boiler
-       having been off for the whole detach.
+    - Plan #02 N12 introduced `_runningAtStop` set in
+      `_stopAnimation` and consumed in `_render` (cleared
+      unconditionally after the guard).
+    - Plan #03 S1 moved the clear INSIDE the guard's if-body to fix
+      a "mid-detach hass-pushes consume the stash too early" hole.
+    - Plan #04 M1 (this) gates the entire consume on a
+      `_pendingReattachCheck` flag set in `connectedCallback`,
+      because the pass-3 fix introduced a complementary hole: a
+      stash that's only cleared when the inner guard fires LEAKS
+      across renders when reattach happens with `running` unchanged,
+      and the next in-place state flip (hours later, no detach
+      involved) then falsely triggers the prime → wave snaps to
+      target in one frame instead of lerping.
 
-    The fix is to keep the stash alive until the comparison actually
-    fires, by moving the clear inside the if-body.
+    5-step regression scenario this test pins against (the pass-3
+    inside-if structure alone misses it):
+
+    1. Boiler running, card attached: `_running = true`,
+       `_runningAtStop = undefined`.
+    2. Detach (HA dashboard rearrange) → `_stopAnimation()` sets
+       `_runningAtStop = true`.
+    3. Reattach with `running` still `true` → guard
+       `_runningAtStop(true) !== running(true)` is false → with
+       pass-3 inside-if, stash NOT cleared → `_runningAtStop = true`
+       indefinitely.
+    4. Card stays attached for hours. Boiler finishes naturally;
+       hass-push delivers `running = false`.
+    5. Next `_render`: guard `_runningAtStop(true) !== running(false)`
+       is true → prime fires → wave snaps. ← BUG.
+
+    The fix shape that handles all three patterns:
+
+    - Mid-detach hass-pushes: flag is false (only set in
+      `connectedCallback`), consume block is skipped, stash
+      preserved.
+    - Reattach with `running` unchanged: flag is true → consume
+      runs → guard fails → no prime → stash cleared → flag cleared
+      → subsequent in-place flips lerp normally.
+    - Reattach with `running` flipped: flag is true → consume runs
+      → guard fires → prime → stash cleared → flag cleared → wave
+      snaps to new target on reattach (the original N12 intent).
     """
     import re
 
@@ -1993,41 +2015,64 @@ def test_water_boiler_card_running_at_stop_clear_inside_if():
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
     executable = _strip_js_comments(content)
-    # The clear must appear inside the if block. Match
-    # `if (this._runningAtStop !== undefined ...) { ... this._runningAtStop = undefined ... }`
-    # in a single-block regex so a stray unconditional clear outside
-    # the block still trips the test (we'd see the inside-if clear AND
-    # the unconditional one — but the assert is on PRESENCE of the
-    # inside-if form, so a refactor that introduces the inside-if
-    # without removing the outside-if would pass; the negative case
-    # below catches that drift).
-    inside_if = re.compile(
-        r"if\s*\(\s*this\._runningAtStop\s*!==\s*undefined[^{}]*?\{[^{}]*?this\._runningAtStop\s*=\s*undefined",
-        re.DOTALL,
+    # The flag must be set somewhere — typically in connectedCallback
+    # after `_startAnimation()`.
+    assert re.search(
+        r"this\._pendingReattachCheck\s*=\s*true",
+        executable,
+    ), (
+        "qs-water-boiler-card.js (review-fix #04 M1): expected "
+        "`this._pendingReattachCheck = true` (set in "
+        "`connectedCallback` after `_startAnimation()`) so the next "
+        "`_render` knows to consume the `_runningAtStop` stash "
+        "exactly once per reattach."
     )
-    assert inside_if.search(executable), (
-        "qs-water-boiler-card.js (review-fix #03 S1): the "
-        "`this._runningAtStop = undefined;` clear must live INSIDE "
-        "the `if (this._runningAtStop !== undefined && ...) { ... }` "
-        "block. An unconditional clear after the if lets a hass-push "
-        "during disconnect consume the stash, leaving the next "
-        "state-flip push undetected and reintroducing the N12 "
-        "regression."
+    # The flag-gated consume block must exist in `_render` and contain
+    # the inner guard, the stash clear, AND the flag's own clear.
+    # Use a balanced-brace walk (not a regex) so the inner `if (...)`
+    # nested block doesn't truncate the captured body at the inner `}`.
+    body = _extract_js_function_body(
+        executable, r"if\s*\(\s*this\._pendingReattachCheck\s*\)\s*"
     )
-    # Negative form: there must NOT be a `this._runningAtStop = undefined;`
-    # immediately after the if-block's closing brace (= unconditional clear).
-    # Allow whitespace and a comment between `}` and the next statement.
-    outside_if = re.compile(
-        r"if\s*\(\s*this\._runningAtStop\s*!==\s*undefined[^{}]*?\{[^{}]*?\}\s*this\._runningAtStop\s*=\s*undefined",
-        re.DOTALL,
+    assert body is not None, (
+        "qs-water-boiler-card.js (review-fix #04 M1): missing "
+        "`if (this._pendingReattachCheck) { ... }` block in "
+        "`_render()`. The stash must be consumed inside this flag-"
+        "gated block so the consume fires exactly once per reattach "
+        "— independent of the inner running-state guard outcome."
     )
-    assert outside_if.search(executable) is None, (
-        "qs-water-boiler-card.js (review-fix #03 S1): a "
-        "`this._runningAtStop = undefined;` statement appears "
-        "immediately after the if-block's closing brace — that is "
-        "the unconditional-clear pattern that the inside-if move "
-        "must eliminate. Move the clear ENTIRELY inside the "
-        "if-body."
+    assert "this._runningAtStop !== undefined" in body, (
+        "qs-water-boiler-card.js (review-fix #04 M1): the flag-"
+        "gated block must contain the inner guard "
+        "`if (this._runningAtStop !== undefined && ...)` that "
+        "decides whether to set `_needsAnimationPrime`."
+    )
+    assert re.search(r"this\._runningAtStop\s*=\s*undefined", body), (
+        "qs-water-boiler-card.js (review-fix #04 M1): the flag-"
+        "gated block must clear `this._runningAtStop = undefined` "
+        "UNCONDITIONALLY (i.e. outside the inner guard's if-body, "
+        "but inside the outer flag-gated block) — runs regardless "
+        "of inner-guard outcome."
+    )
+    assert re.search(r"this\._pendingReattachCheck\s*=\s*false", body), (
+        "qs-water-boiler-card.js (review-fix #04 M1): the flag-"
+        "gated block must clear `this._pendingReattachCheck = "
+        "false` so the consume fires only on the first post-"
+        "reattach `_render`, not on every subsequent render."
+    )
+    # Negative: `_runningAtStop = undefined` must NOT appear outside
+    # the flag-gated block — exactly ONE total occurrence in the file.
+    clear_count = len(
+        re.findall(r"this\._runningAtStop\s*=\s*undefined", executable)
+    )
+    assert clear_count == 1, (
+        f"qs-water-boiler-card.js (review-fix #04 M1): expected "
+        f"exactly ONE `this._runningAtStop = undefined` clear "
+        f"(inside the flag-gated block); found {clear_count}. Any "
+        f"clear outside the flag gate would reintroduce either the "
+        f"pass-3 'mid-detach hass push consumes stash too early' "
+        f"hole OR the pass-4 'leaked stash → false prime on later "
+        f"in-place flip' hole."
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -1373,7 +1373,12 @@ def test_card_mode_change_wrapped_in_try_finally(card_filename):
 @pytest.mark.parametrize(
     "card_filename,gate",
     [
-        ("qs-water-boiler-card.js", "showAnimation"),
+        # QS-200: `qs-water-boiler-card.js` removed — the boiler now mirrors
+        # the pool's intrinsically-continuous RAF model (water always
+        # visible: cool when off, boiling when on). The
+        # `_startAnimation`/`_stopAnimation` helpers and the
+        # `connectedCallback → _startAnimation` direct call are pinned via
+        # `test_water_boiler_card_has_start_stop_helpers` below.
         ("qs-on-off-duration-card.js", "showAnimation"),
         ("qs-climate-card.js", "showAnimation"),
         ("qs-car-card.js", "charging"),
@@ -1381,11 +1386,12 @@ def test_card_mode_change_wrapped_in_try_finally(card_filename):
 )
 def test_card_raf_idle_gated(card_filename, gate):
     """M4: every card except pool gates `_startAnimation` on a
-    runtime condition (`showAnimation` for boiler/on-off-duration/
-    climate, `charging` for car). Pool's wave is intrinsically
+    runtime condition (`showAnimation` for on-off-duration/climate,
+    `charging` for car). Pool's wave is intrinsically
     continuous-while-connected and uses `_startAnimation` from
     `connectedCallback` directly — that file is covered by the
-    presence-of-helper check below.
+    presence-of-helper check below. QS-200 moved
+    `qs-water-boiler-card.js` to the same continuous-RAF model.
     """
     import re
 
@@ -1439,6 +1445,167 @@ def test_water_boiler_card_uses_safe_number_helper():
     assert not forbidden.search(content), (
         "S8: replace `Number(s*?.state || N)` for duration sensors with "
         "`this._safeNumber(s*, N)` to avoid NaN propagation."
+    )
+
+
+def test_water_boiler_card_has_start_stop_helpers():
+    """QS-200: water-boiler card mirrors the pool card — continuous RAF
+    while connected, no `showAnimation` gate.
+
+    Asserts:
+    - both `_startAnimation()` and `_stopAnimation()` helpers are defined.
+    - `connectedCallback()` calls `this._startAnimation()` DIRECTLY, with
+      no `if` between the brace and the call (continuous-RAF
+      architecture; the calm-vs-boiling distinction is amplitude / speed
+      / color-mix lerp, not RAF on/off).
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    # Strip comments first so the regex only matches executable code.
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    assert re.search(r"_startAnimation\s*\(\s*\)\s*\{", executable), (
+        "qs-water-boiler-card.js: missing _startAnimation method"
+    )
+    assert re.search(r"_stopAnimation\s*\(\s*\)\s*\{", executable), (
+        "qs-water-boiler-card.js: missing _stopAnimation method"
+    )
+    # `connectedCallback() { ... this._startAnimation() ... }` with NO
+    # `if` between the opening brace and the call — enforces the
+    # "no gate" architecture (mirror pool card).
+    cb_pat = re.compile(
+        r"connectedCallback\s*\(\s*\)\s*\{(?P<body>[^{}]*?this\._startAnimation\s*\(\s*\))",
+        re.DOTALL,
+    )
+    m = cb_pat.search(executable)
+    assert m is not None, (
+        "qs-water-boiler-card.js: connectedCallback must call "
+        "_startAnimation directly (continuous-RAF model, mirror pool)"
+    )
+    assert "if" not in m.group("body"), (
+        "qs-water-boiler-card.js: connectedCallback must call "
+        "_startAnimation() unconditionally — no `if` gate (continuous-RAF "
+        "model, mirror pool)"
+    )
+
+
+def test_water_boiler_card_uses_heat_palette():
+    """QS-200: boiler card adopts the climate-card heat palette.
+
+    The `const colors = { ... };` block at the top of `_render()`
+    MUST contain the heat hex codes and MUST NOT contain any of the
+    legacy cool-blue values. Cool-blue may still appear ELSEWHERE in
+    the file (e.g. `.power-btn.on` legitimately uses HA-blue
+    `#2196F3` as a semantic anchor) — the assertion is scoped to the
+    `colors` const only.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    block_match = re.search(
+        r"const\s+colors\s*=\s*\{(?P<body>.*?)\};",
+        content,
+        flags=re.DOTALL,
+    )
+    assert block_match is not None, (
+        "qs-water-boiler-card.js: expected `const colors = { ... };` block"
+    )
+    body = block_match.group("body")
+    for heat_hex in ("#FF5722", "#D32F2F", "#FF6E40", "#E64A19"):
+        assert heat_hex in body, (
+            f"qs-water-boiler-card.js: heat-palette color {heat_hex} "
+            f"missing from `const colors`"
+        )
+    for cool_hex in ("#2196F3", "#00bcd4", "#8bc34a", "#00e1ff", "#0066ff"):
+        assert cool_hex not in body, (
+            f"qs-water-boiler-card.js: legacy cool-blue color {cool_hex} "
+            f"still present in `const colors`"
+        )
+
+
+def test_water_boiler_card_renders_water_layer():
+    """QS-200: boiler card renders a circular clipPath wrapping the
+    six wave paths (3 cool + 3 boil cross-fade layers).
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    assert re.search(r"<clipPath\s+id=", executable), (
+        "qs-water-boiler-card.js: missing <clipPath> definition"
+    )
+    for layer in (
+        "wave0_cool",
+        "wave0_boil",
+        "wave1_cool",
+        "wave1_boil",
+        "wave2_cool",
+        "wave2_boil",
+    ):
+        assert re.search(rf'id="{layer}"', executable), (
+            f'qs-water-boiler-card.js: missing <path id="{layer}">'
+        )
+    assert re.search(r"_generateWavePath\s*\(", executable), (
+        "qs-water-boiler-card.js: missing _generateWavePath method"
+    )
+
+
+def test_water_boiler_card_has_bubble_system():
+    """QS-200: boiler card has a dynamic bubble system with a soft cap."""
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    assert re.search(r"MAX_CONCURRENT_BUBBLES\s*=\s*12", executable), (
+        "qs-water-boiler-card.js: missing `MAX_CONCURRENT_BUBBLES = 12` "
+        "constant"
+    )
+    assert re.search(r"BUBBLE_SPAWN_RATE_HZ\s*=", executable), (
+        "qs-water-boiler-card.js: missing BUBBLE_SPAWN_RATE_HZ constant"
+    )
+    assert re.search(r"this\._bubbles\s*=", executable), (
+        "qs-water-boiler-card.js: missing `this._bubbles` instance array"
+    )
+
+
+def test_water_boiler_card_has_surface_glow():
+    """QS-200: boiler card renders a red Gaussian-blurred surface glow
+    with mix-blend-mode: screen, locked to wave 0.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    assert re.search(r"<filter\s+id=", executable) and (
+        "feGaussianBlur" in executable
+    ), (
+        "qs-water-boiler-card.js: missing <filter>/<feGaussianBlur> in defs"
+    )
+    assert re.search(r'id="surface_glow"', executable), (
+        'qs-water-boiler-card.js: missing <path id="surface_glow">'
+    )
+    assert re.search(r"mix-blend-mode\s*:\s*screen", executable), (
+        "qs-water-boiler-card.js: surface_glow must use "
+        "`mix-blend-mode: screen`"
+    )
+    assert re.search(
+        r"SURFACE_GLOW_COLOR\s*=\s*['\"]#FF[0-9A-Fa-f]{4}['\"]", executable
+    ), (
+        "qs-water-boiler-card.js: missing SURFACE_GLOW_COLOR red constant"
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -54,17 +54,48 @@ from tests.ha_tests.const import (
 COMPONENT_ROOT = Path(__file__).parent.parent / "custom_components" / "quiet_solar"
 
 
+def _strip_js_comments(source: str) -> str:
+    """Strip ``/* ... */`` block comments and ``// ...`` line comments
+    from a JS source string.
+
+    **Review-fix #02 N2 — known limitation:** the ``//`` line-comment
+    pattern eats anything from ``//`` to end-of-line, INCLUDING ``//``
+    inside string literals — most notably URL literals like
+    ``"http://www.w3.org/2000/svg"`` become ``"http:`` after stripping.
+    No current test asserts an http URL literal, but any future regex
+    that does (e.g. pinning ``createElementNS('http://...')``) must
+    operate on the pre-stripped ``source`` directly, not the stripped
+    output of this helper.
+    """
+    import re
+
+    no_block = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    no_line = re.sub(r"//[^\n]*", "", no_block)
+    return no_line
+
+
 def _extract_js_function_body(source: str, signature_regex: str) -> str | None:
     """Return the body between matching braces for a JS function whose
     signature matches `signature_regex`. Walks balanced braces so nested
-    template literals, object literals, and arrow function bodies are
-    all handled cleanly. Returns ``None`` if the signature isn't found
-    or the braces don't balance.
+    object literals, arrow function bodies, and most template-literal
+    interpolations are handled cleanly. Returns ``None`` if the
+    signature isn't found or the braces don't balance.
 
     This avoids the brittle ``[^{}]*?`` pattern used by earlier
     per-card body checks — that pattern silently mis-matches the moment
     any nested brace lands in the body, producing misleading "X must
     do Y" failures even when the code is correct.
+
+    **Review-fix #02 N1 — known limitation:** the walker doesn't
+    understand string-literal quoting. A ``const s = "{ ... }"`` or
+    ```const s = `${...}` ``` containing a stray ``{`` / ``}`` inside
+    the quoted span will mis-count the balanced-brace depth. Today's
+    `connectedCallback` body is plain code with no string literals, so
+    the walker is safe — but a future addition of a template literal
+    with stray braces inside its quoted span could throw the walker
+    off. If that happens, harden the walker to skip braces inside
+    ``'…'`` / ``"…"`` / `` `…` `` spans (respecting escapes and
+    ``${…}`` nesting) or extract the body manually for that test.
     """
     import re
 
@@ -1404,28 +1435,34 @@ def test_card_mode_change_wrapped_in_try_finally(card_filename):
     )
 
 
+# Cards covered by `test_card_raf_idle_gated` — the idle-gated set.
+#
+# QS-200 (review-fix #02 N9): `qs-water-boiler-card.js` was previously
+# in this list with gate ``showAnimation``. The boiler now mirrors the
+# pool's intrinsically-continuous RAF model (water always visible —
+# cool when off, boiling when on), so it's covered separately by
+# `test_water_boiler_card_has_start_stop_helpers` below. Keeping this
+# history above the decorator (instead of inline in the parametrize
+# list) means a future reviewer scanning the parametrize entries can
+# read them as a clean enumeration without losing the removed-card
+# rationale.
 @pytest.mark.parametrize(
     "card_filename,gate",
     [
-        # QS-200: `qs-water-boiler-card.js` removed — the boiler now mirrors
-        # the pool's intrinsically-continuous RAF model (water always
-        # visible: cool when off, boiling when on). The
-        # `_startAnimation`/`_stopAnimation` helpers and the
-        # `connectedCallback → _startAnimation` direct call are pinned via
-        # `test_water_boiler_card_has_start_stop_helpers` below.
         ("qs-on-off-duration-card.js", "showAnimation"),
         ("qs-climate-card.js", "showAnimation"),
         ("qs-car-card.js", "charging"),
     ],
 )
 def test_card_raf_idle_gated(card_filename, gate):
-    """M4: every card except pool gates `_startAnimation` on a
-    runtime condition (`showAnimation` for on-off-duration/climate,
-    `charging` for car). Pool's wave is intrinsically
+    """M4: every card except pool / water boiler gates `_startAnimation`
+    on a runtime condition (`showAnimation` for on-off-duration/
+    climate, `charging` for car). The pool card's wave is intrinsically
     continuous-while-connected and uses `_startAnimation` from
     `connectedCallback` directly — that file is covered by the
     presence-of-helper check below. QS-200 moved
-    `qs-water-boiler-card.js` to the same continuous-RAF model.
+    `qs-water-boiler-card.js` to the same continuous-RAF model, also
+    covered separately.
     """
     import re
 
@@ -1867,6 +1904,71 @@ def test_water_boiler_card_pins_opacity_cross_fade():
         "qs-water-boiler-card.js (AC-6): expected the colorMix lerp "
         "target to be `targetColorMix = <cond> ? 1 : 0`, mirroring "
         "amplitude/speed."
+    )
+
+
+def test_water_boiler_card_center_uses_named_constants():
+    """Review-fix #02 S1: the arc / handle / progress-ring `center`
+    object in `_render()` must use the named `CENTER_CX` / `CENTER_CY`
+    constants, not inlined `160` literals. The water clip circle
+    moved to `CENTER_CX` / `CENTER_CY` with fix #01 N4; the ring
+    geometry must follow so a future tweak to either constant keeps
+    the ring, handle, and progress arc aligned with the water layer.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    positive = re.compile(
+        r"const\s+center\s*=\s*\{\s*cx\s*:\s*CENTER_CX\s*,\s*cy\s*:\s*CENTER_CY\s*\}"
+    )
+    assert positive.search(executable), (
+        "qs-water-boiler-card.js: the `const center = {...}` literal "
+        "must use `CENTER_CX` / `CENTER_CY`, not inlined `160` values. "
+        "A future tweak to either constant must keep the ring, handle, "
+        "and progress arc aligned with the water clip circle."
+    )
+    forbidden = re.compile(r"center\s*=\s*\{\s*cx\s*:\s*160\b")
+    assert forbidden.search(executable) is None, (
+        "qs-water-boiler-card.js: inlined `center = {cx: 160, ...}` "
+        "literal found; replace the raw 160 values with "
+        "`CENTER_CX` / `CENTER_CY`."
+    )
+
+
+def test_water_boiler_card_factors_reset_dom_refs_helper():
+    """Review-fix #02 S3: a `_resetDomRefs()` helper is defined and
+    called from BOTH `_invalidateWaveCache()` AND the
+    post-`innerHTML` cleanup block — so a future memo-key addition
+    inside the helper is automatically picked up at both call sites.
+
+    Without the shared helper, the two cleanup paths drift: a new
+    `this._fooEl = null` line added to `_invalidateWaveCache()` is
+    silently missed by the post-innerHTML block, and the next frame
+    sees stale memo state until the field happens to mutate.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    helper_def = re.search(r"_resetDomRefs\s*\(\s*\)\s*\{", executable)
+    assert helper_def, (
+        "qs-water-boiler-card.js: missing `_resetDomRefs()` helper "
+        "method. Extract the shared DOM-ref / bubble-array reset from "
+        "`_invalidateWaveCache()` and the post-innerHTML cleanup block "
+        "so a future memo-key addition is picked up at both sites."
+    )
+    calls = re.findall(r"this\._resetDomRefs\s*\(\s*\)", executable)
+    assert len(calls) >= 2, (
+        "qs-water-boiler-card.js: `_resetDomRefs()` must be called "
+        "from BOTH `_invalidateWaveCache()` AND the post-innerHTML "
+        f"cleanup block; found {len(calls)} call site(s)."
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -330,12 +330,11 @@ class TestDashboardTemplateRendering:
 
         # Strip `//` line comments AND `/* ... */` block comments before
         # the regex scan so we only match executable code.
-        no_block_comments = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-        no_line_comments = re.sub(r"//[^\n]*", "", no_block_comments)
+        executable = _strip_js_comments(content)
 
         # Raw `Number(state || fallback)` is the anti-pattern.
         raw_pattern = re.compile(r"Number\(\s*[^()]+\|\|[^()]+\)")
-        assert raw_pattern.search(no_line_comments) is None, (
+        assert raw_pattern.search(executable) is None, (
             "Found a raw `Number(... || ...)` pattern in executable code "
             "— should use `_safeNumber(...)`"
         )
@@ -946,8 +945,7 @@ class TestDashboardSectionMapping:
         for card_filename in ("qs-radiator-card.js", "qs-water-boiler-card.js"):
             content = (COMPONENT_ROOT / "ui" / "resources" / card_filename).read_text()
             # Strip comments so the regex only matches executable code.
-            no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-            executable = re.sub(r"//[^\n]*", "", no_block)
+            executable = _strip_js_comments(content)
 
             # The non-default branch MUST guard against zero (or NaN)
             # `targetHours` before assigning to `maxHours`. Acceptable
@@ -1030,8 +1028,7 @@ class TestDashboardSectionMapping:
         import re
 
         content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
-        no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-        executable = re.sub(r"//[^\n]*", "", no_block)
+        executable = _strip_js_comments(content)
 
         # Every reference to `e.climate_hvac_mode_on` that feeds into a
         # chained `.toLowerCase()` MUST be wrapped in `String(...)`
@@ -1070,8 +1067,7 @@ class TestDashboardSectionMapping:
 
         for card_filename in ("qs-radiator-card.js", "qs-water-boiler-card.js"):
             content = (COMPONENT_ROOT / "ui" / "resources" / card_filename).read_text()
-            no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-            executable = re.sub(r"//[^\n]*", "", no_block)
+            executable = _strip_js_comments(content)
 
             # The arcPath helper definition must include a finiteness
             # check on its angle inputs. Accept either `Number.isFinite`
@@ -1548,8 +1544,7 @@ def test_card_caps_raf_dt_against_hidden_tab(card_filename):
     content = (
         COMPONENT_ROOT / "ui" / "resources" / card_filename
     ).read_text()
-    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-    executable = re.sub(r"//[^\n]*", "", no_block)
+    executable = _strip_js_comments(content)
     # Accept either the literal `0.1` or the named `LERP_DT_CEIL` form
     # (both cards expose the same constant; pool's value is the same).
     pattern = re.compile(
@@ -1591,8 +1586,7 @@ def test_water_boiler_card_has_start_stop_helpers():
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
     # Strip comments first so the regex only matches executable code.
-    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-    executable = re.sub(r"//[^\n]*", "", no_block)
+    executable = _strip_js_comments(content)
     assert re.search(r"_startAnimation\s*\(\s*\)\s*\{", executable), (
         "qs-water-boiler-card.js: missing _startAnimation method"
     )
@@ -1666,8 +1660,7 @@ def test_water_boiler_card_renders_water_layer():
     content = (
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
-    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-    executable = re.sub(r"//[^\n]*", "", no_block)
+    executable = _strip_js_comments(content)
     assert re.search(r"<clipPath\s+id=", executable), (
         "qs-water-boiler-card.js: missing <clipPath> definition"
     )
@@ -1714,8 +1707,7 @@ def test_water_boiler_card_has_bubble_system():
     content = (
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
-    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-    executable = re.sub(r"//[^\n]*", "", no_block)
+    executable = _strip_js_comments(content)
     assert re.search(r"MAX_CONCURRENT_BUBBLES\s*=\s*12", executable), (
         "qs-water-boiler-card.js: missing `MAX_CONCURRENT_BUBBLES = 12` "
         "constant"
@@ -1743,8 +1735,7 @@ def test_water_boiler_card_has_surface_glow():
     content = (
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
-    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-    executable = re.sub(r"//[^\n]*", "", no_block)
+    executable = _strip_js_comments(content)
     assert re.search(r"<filter\s+id=", executable) and (
         "feGaussianBlur" in executable
     ), (
@@ -1824,8 +1815,7 @@ def test_water_boiler_card_pins_water_level_formula():
     content = (
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
-    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-    executable = re.sub(r"//[^\n]*", "", no_block)
+    executable = _strip_js_comments(content)
     assert re.search(
         r"Number\.isFinite\s*\(\s*displayTargetHours\s*\)\s*&&\s*displayTargetHours\s*>\s*0",
         executable,
@@ -1873,8 +1863,7 @@ def test_water_boiler_card_pins_opacity_cross_fade():
     content = (
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
-    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-    executable = re.sub(r"//[^\n]*", "", no_block)
+    executable = _strip_js_comments(content)
     # Cool-layer opacity literal — allow either `(1 - this._currentColorMix).toFixed(N)`
     # or `1 - this._currentColorMix` direct.
     assert re.search(
@@ -1920,8 +1909,7 @@ def test_water_boiler_card_center_uses_named_constants():
     content = (
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
-    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-    executable = re.sub(r"//[^\n]*", "", no_block)
+    executable = _strip_js_comments(content)
     positive = re.compile(
         r"const\s+center\s*=\s*\{\s*cx\s*:\s*CENTER_CX\s*,\s*cy\s*:\s*CENTER_CY\s*\}"
     )
@@ -1955,8 +1943,7 @@ def test_water_boiler_card_factors_reset_dom_refs_helper():
     content = (
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
-    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-    executable = re.sub(r"//[^\n]*", "", no_block)
+    executable = _strip_js_comments(content)
     helper_def = re.search(r"_resetDomRefs\s*\(\s*\)\s*\{", executable)
     assert helper_def, (
         "qs-water-boiler-card.js: missing `_resetDomRefs()` helper "
@@ -1969,6 +1956,78 @@ def test_water_boiler_card_factors_reset_dom_refs_helper():
         "qs-water-boiler-card.js: `_resetDomRefs()` must be called "
         "from BOTH `_invalidateWaveCache()` AND the post-innerHTML "
         f"cleanup block; found {len(calls)} call site(s)."
+    )
+
+
+def test_water_boiler_card_running_at_stop_clear_inside_if():
+    """Review-fix #03 S1: the `_runningAtStop = undefined;` clear must
+    live INSIDE the `if (...)` block that detected a state flip, not
+    unconditionally after. Otherwise a hass push during the detached
+    window (which fires `set hass → _render()` regardless of
+    connection state) consumes the stash WITHOUT the comparison ever
+    firing — and a subsequent push that does flip `running` sees
+    `_runningAtStop === undefined` and misses the prime, reintroducing
+    the exact "visibly calming down on reattach" regression that fix
+    plan #02 N12 was meant to prevent.
+
+    Reproduction (without this guard):
+
+    1. Card mounted, boiler running, `_running = true`.
+    2. Detach → `_stopAnimation()` sets `_runningAtStop = true`.
+    3. Hass push while detached, `running` unchanged → `_render()`
+       runs, guard is false, BUT unconditional clear wipes
+       `_runningAtStop`.
+    4. Hass push while detached, `running` flipped to false →
+       `_render()` runs, but `_runningAtStop === undefined` so the
+       guard fails — no prime queued.
+    5. Reattach → wave lerps from `_currentColorMix ≈ 1` toward `0`
+       over ~1.5s. User sees "calming down" despite the boiler
+       having been off for the whole detach.
+
+    The fix is to keep the stash alive until the comparison actually
+    fires, by moving the clear inside the if-body.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    # The clear must appear inside the if block. Match
+    # `if (this._runningAtStop !== undefined ...) { ... this._runningAtStop = undefined ... }`
+    # in a single-block regex so a stray unconditional clear outside
+    # the block still trips the test (we'd see the inside-if clear AND
+    # the unconditional one — but the assert is on PRESENCE of the
+    # inside-if form, so a refactor that introduces the inside-if
+    # without removing the outside-if would pass; the negative case
+    # below catches that drift).
+    inside_if = re.compile(
+        r"if\s*\(\s*this\._runningAtStop\s*!==\s*undefined[^{}]*?\{[^{}]*?this\._runningAtStop\s*=\s*undefined",
+        re.DOTALL,
+    )
+    assert inside_if.search(executable), (
+        "qs-water-boiler-card.js (review-fix #03 S1): the "
+        "`this._runningAtStop = undefined;` clear must live INSIDE "
+        "the `if (this._runningAtStop !== undefined && ...) { ... }` "
+        "block. An unconditional clear after the if lets a hass-push "
+        "during disconnect consume the stash, leaving the next "
+        "state-flip push undetected and reintroducing the N12 "
+        "regression."
+    )
+    # Negative form: there must NOT be a `this._runningAtStop = undefined;`
+    # immediately after the if-block's closing brace (= unconditional clear).
+    # Allow whitespace and a comment between `}` and the next statement.
+    outside_if = re.compile(
+        r"if\s*\(\s*this\._runningAtStop\s*!==\s*undefined[^{}]*?\{[^{}]*?\}\s*this\._runningAtStop\s*=\s*undefined",
+        re.DOTALL,
+    )
+    assert outside_if.search(executable) is None, (
+        "qs-water-boiler-card.js (review-fix #03 S1): a "
+        "`this._runningAtStop = undefined;` statement appears "
+        "immediately after the if-block's closing brace — that is "
+        "the unconditional-clear pattern that the inside-if move "
+        "must eliminate. Move the clear ENTIRELY inside the "
+        "if-body."
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -53,6 +53,40 @@ from tests.ha_tests.const import (
 
 COMPONENT_ROOT = Path(__file__).parent.parent / "custom_components" / "quiet_solar"
 
+
+def _extract_js_function_body(source: str, signature_regex: str) -> str | None:
+    """Return the body between matching braces for a JS function whose
+    signature matches `signature_regex`. Walks balanced braces so nested
+    template literals, object literals, and arrow function bodies are
+    all handled cleanly. Returns ``None`` if the signature isn't found
+    or the braces don't balance.
+
+    This avoids the brittle ``[^{}]*?`` pattern used by earlier
+    per-card body checks — that pattern silently mis-matches the moment
+    any nested brace lands in the body, producing misleading "X must
+    do Y" failures even when the code is correct.
+    """
+    import re
+
+    m = re.search(signature_regex, source)
+    if m is None:
+        return None
+    brace_idx = source.find("{", m.end() - 1)
+    if brace_idx == -1:
+        return None
+    depth = 1
+    i = brace_idx + 1
+    while i < len(source) and depth > 0:
+        c = source[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return None
+    return source[brace_idx + 1 : i - 1]
+
 # Pool config (not in ha_tests/const.py)
 MOCK_POOL_CONFIG = {
     "name": "Test Pool",
@@ -1448,6 +1482,51 @@ def test_water_boiler_card_uses_safe_number_helper():
     )
 
 
+@pytest.mark.parametrize(
+    "card_filename",
+    [
+        "qs-water-boiler-card.js",
+        "qs-pool-card.js",
+    ],
+)
+def test_card_caps_raf_dt_against_hidden_tab(card_filename):
+    """QS-200 review-fix S6: cap RAF `dt` against hidden-tab return.
+
+    Without a cap, the first frame after a tab returns from a hidden
+    state can produce a `dt` of many seconds (or more). Effects on
+    the pool-pattern step loop:
+
+    - `_wavePhase += _currentSpeed * dt` advances by a huge amount in
+      one frame → visible wave jump (modulo wrap saves correctness,
+      but the visual snaps).
+    - Bubble `b.life += dt` can exceed `BUBBLE_MAX_LIFE_S` in a single
+      frame → entire bubble layer retires at once on tab return.
+
+    The lerp factor already has its own `lerpDt = Math.min(dt,
+    LERP_DT_CEIL)` clamp; this test pins a TOP-level `dt` clamp so the
+    phase advance and bubble life increment are also bounded.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / card_filename
+    ).read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    # Accept either the literal `0.1` or the named `LERP_DT_CEIL` form
+    # (both cards expose the same constant; pool's value is the same).
+    pattern = re.compile(
+        r"dt\s*=\s*Math\.min\s*\(\s*dt\s*,\s*(?:0\.1|LERP_DT_CEIL)\s*\)"
+    )
+    assert pattern.search(executable), (
+        f"S6: {card_filename} must clamp the RAF step `dt` with "
+        f"`dt = Math.min(dt, LERP_DT_CEIL)` (or `Math.min(dt, 0.1)`) "
+        f"after the initial computation, so a hidden-tab return "
+        f"doesn't trigger a one-frame wave-scroll burst or mass "
+        f"bubble-life expiry."
+    )
+
+
 def test_water_boiler_card_has_start_stop_helpers():
     """QS-200: water-boiler card mirrors the pool card — continuous RAF
     while connected, no `showAnimation` gate.
@@ -1455,9 +1534,19 @@ def test_water_boiler_card_has_start_stop_helpers():
     Asserts:
     - both `_startAnimation()` and `_stopAnimation()` helpers are defined.
     - `connectedCallback()` calls `this._startAnimation()` DIRECTLY, with
-      no `if` between the brace and the call (continuous-RAF
+      no `if` statement between the brace and the call (continuous-RAF
       architecture; the calm-vs-boiling distinction is amplitude / speed
       / color-mix lerp, not RAF on/off).
+
+    Review-fix #01 S2: the `connectedCallback` body is extracted via a
+    balanced-brace walk instead of a `[^{}]*?` regex, so a future
+    template literal or arrow function inside the body doesn't trip
+    a misleading false negative.
+
+    Review-fix #01 N1: the `if`-gate guard is a tokenized
+    ``\\bif\\s*\\(`` regex, not a substring search — identifiers like
+    ``verify`` / ``modifier`` / ``lifecycle`` can't trigger a false
+    positive.
     """
     import re
 
@@ -1473,22 +1562,20 @@ def test_water_boiler_card_has_start_stop_helpers():
     assert re.search(r"_stopAnimation\s*\(\s*\)\s*\{", executable), (
         "qs-water-boiler-card.js: missing _stopAnimation method"
     )
-    # `connectedCallback() { ... this._startAnimation() ... }` with NO
-    # `if` between the opening brace and the call — enforces the
-    # "no gate" architecture (mirror pool card).
-    cb_pat = re.compile(
-        r"connectedCallback\s*\(\s*\)\s*\{(?P<body>[^{}]*?this\._startAnimation\s*\(\s*\))",
-        re.DOTALL,
+    cb_body = _extract_js_function_body(
+        executable, r"connectedCallback\s*\(\s*\)\s*"
     )
-    m = cb_pat.search(executable)
-    assert m is not None, (
+    assert cb_body is not None, (
+        "qs-water-boiler-card.js: connectedCallback() not found"
+    )
+    assert re.search(r"this\._startAnimation\s*\(\s*\)", cb_body), (
         "qs-water-boiler-card.js: connectedCallback must call "
         "_startAnimation directly (continuous-RAF model, mirror pool)"
     )
-    assert "if" not in m.group("body"), (
+    assert re.search(r"\bif\s*\(", cb_body) is None, (
         "qs-water-boiler-card.js: connectedCallback must call "
-        "_startAnimation() unconditionally — no `if` gate (continuous-RAF "
-        "model, mirror pool)"
+        "_startAnimation() unconditionally — no `if (...)` gate "
+        "(continuous-RAF model, mirror pool)"
     )
 
 
@@ -1531,6 +1618,11 @@ def test_water_boiler_card_uses_heat_palette():
 def test_water_boiler_card_renders_water_layer():
     """QS-200: boiler card renders a circular clipPath wrapping the
     six wave paths (3 cool + 3 boil cross-fade layers).
+
+    Review-fix #01 N9: also pins the DOM z-order of the clipped water
+    group — it MUST appear before ``<path d="${bgPath}">`` in source
+    order so the ring, progress arc, and handle render ON TOP of the
+    water (not under it).
     """
     import re
 
@@ -1555,6 +1647,26 @@ def test_water_boiler_card_renders_water_layer():
         )
     assert re.search(r"_generateWavePath\s*\(", executable), (
         "qs-water-boiler-card.js: missing _generateWavePath method"
+    )
+    # N9: z-order — the clipped water <g> must precede the bgPath <path>
+    # in source order. Pin via index comparison on stable anchor strings
+    # that appear exactly once in `_render()`'s SVG template literal.
+    g_anchor = '<g clip-path="url(#${waterClipId})">'
+    bg_anchor = '<path d="${bgPath}"'
+    g_idx = executable.find(g_anchor)
+    bg_idx = executable.find(bg_anchor)
+    assert g_idx != -1, (
+        f"qs-water-boiler-card.js: missing clipped water group anchor "
+        f"{g_anchor!r}"
+    )
+    assert bg_idx != -1, (
+        f"qs-water-boiler-card.js: missing bgPath anchor {bg_anchor!r}"
+    )
+    assert g_idx < bg_idx, (
+        "qs-water-boiler-card.js: the clipped water <g> must appear "
+        "BEFORE the bgPath <path> in DOM order so the dashed ring, "
+        "progress arc, and target handle render on top of the water. "
+        f"Got g_idx={g_idx}, bg_idx={bg_idx}."
     )
 
 
@@ -1582,6 +1694,12 @@ def test_water_boiler_card_has_bubble_system():
 def test_water_boiler_card_has_surface_glow():
     """QS-200: boiler card renders a red Gaussian-blurred surface glow
     with mix-blend-mode: screen, locked to wave 0.
+
+    Review-fix #01 N2: pins the exact ``SURFACE_GLOW_COLOR`` literal
+    (``'#FF3D00'`` — the canonical Material "Deep Orange A400"). The
+    prior ``#FF[0-9A-Fa-f]{4}`` regex was inconsistently restrictive
+    (rejected 3-digit / 8-digit forms, accepted unrelated reds).
+    Pinning the literal makes any drift instantly visible.
     """
     import re
 
@@ -1603,9 +1721,152 @@ def test_water_boiler_card_has_surface_glow():
         "`mix-blend-mode: screen`"
     )
     assert re.search(
-        r"SURFACE_GLOW_COLOR\s*=\s*['\"]#FF[0-9A-Fa-f]{4}['\"]", executable
+        r"SURFACE_GLOW_COLOR\s*=\s*['\"]#FF3D00['\"]", executable
     ), (
-        "qs-water-boiler-card.js: missing SURFACE_GLOW_COLOR red constant"
+        "qs-water-boiler-card.js: SURFACE_GLOW_COLOR must be the "
+        "canonical `'#FF3D00'` (Material Deep Orange A400). Any drift "
+        "should be deliberate — update this assertion in lock-step."
+    )
+
+
+def test_water_boiler_card_pins_geometry_constants():
+    """Review-fix #01 S5: pin the module-level geometry constants
+    (AC-2). The SVG layout depends on `CLIP_R`, `CENTER_CX`, `CENTER_CY`,
+    and `WAVE_WIDTH` matching specific values that the clipPath
+    ``<circle cx cy r>`` markup interpolates. A future tweak that
+    changes any of them without re-checking the SVG would silently
+    misalign the water animation, so we pin each here.
+
+    `CENTER_CX` is review-fix #01 N4's new constant (was inlined as
+    `160` in two places). `CENTER_CY` and `CLIP_R` and `WAVE_WIDTH`
+    pre-date this fix but the original test suite never pinned them.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    expected = {
+        "CENTER_CX": "160",
+        "CENTER_CY": "160",
+        "CLIP_R": "120",
+        "WAVE_WIDTH": "480",
+    }
+    for name, value in expected.items():
+        pat = re.compile(rf"const\s+{name}\s*=\s*{re.escape(value)}\b")
+        assert pat.search(content), (
+            f"qs-water-boiler-card.js: expected module-level "
+            f"`const {name} = {value};` declaration"
+        )
+    # N5: pin BUBBLE_FILL_COLOR as a named constant too (was inlined
+    # as `'rgba(255,255,255,0.85)'` in the bubble createElementNS call).
+    assert re.search(
+        r"const\s+BUBBLE_FILL_COLOR\s*=\s*['\"]rgba\(\s*255\s*,\s*255\s*,\s*255\s*,\s*0\.85\s*\)['\"]",
+        content,
+    ), (
+        "qs-water-boiler-card.js: expected module-level "
+        "`const BUBBLE_FILL_COLOR = 'rgba(255,255,255,0.85)';`"
+    )
+
+
+def test_water_boiler_card_pins_water_level_formula():
+    """Review-fix #01 S3: pin the AC-4 water-level mapping literals so
+    a refactor can't silently change ``progressRatio`` clamping or the
+    1/5..4/5 fill window.
+
+    AC-4 requires:
+    - guarded predicate ``Number.isFinite(displayTargetHours) && displayTargetHours > 0``
+    - fill window literal ``0.2 + progressRatio * 0.6`` (= 1/5..4/5 of clip)
+    - geometry literal ``* 2 * CLIP_R`` in the ``rawWaterBaseY`` expression
+
+    Each is asserted independently so a failure message tells you
+    which knob was touched.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    assert re.search(
+        r"Number\.isFinite\s*\(\s*displayTargetHours\s*\)\s*&&\s*displayTargetHours\s*>\s*0",
+        executable,
+    ), (
+        "qs-water-boiler-card.js (AC-4): the progress-ratio guard must "
+        "be `Number.isFinite(displayTargetHours) && displayTargetHours "
+        "> 0` so a null / NaN / negative / zero target falls cleanly "
+        "to a 0 ratio."
+    )
+    assert re.search(r"0\.2\s*\+\s*progressRatio\s*\*\s*0\.6", executable), (
+        "qs-water-boiler-card.js (AC-4): the fill-window literal "
+        "`0.2 + progressRatio * 0.6` (= 1/5..4/5 of clip diameter) "
+        "must appear in the rawWaterBaseY expression."
+    )
+    # Scope the `* 2 * CLIP_R` literal to the rawWaterBaseY expression
+    # so we don't match unrelated `2 * CLIP_R` arithmetic elsewhere.
+    assert re.search(
+        r"rawWaterBaseY\s*=\s*CENTER_CY\s*\+\s*CLIP_R\s*-\s*\([^)]*\)\s*\*\s*2\s*\*\s*CLIP_R",
+        executable,
+    ), (
+        "qs-water-boiler-card.js (AC-4): the rawWaterBaseY expression "
+        "must match `CENTER_CY + CLIP_R - (...) * 2 * CLIP_R` — any "
+        "deviation breaks the 1/5..4/5 fill mapping."
+    )
+
+
+def test_water_boiler_card_pins_opacity_cross_fade():
+    """Review-fix #01 S4: pin the AC-5/AC-6 dual-layer opacity cross-fade
+    formulae so a refactor can't accidentally introduce an HSL hue lerp
+    (which would pass through yellow-green at the midpoint) or a
+    staircase regen threshold.
+
+    AC-5/AC-6 require:
+    - cool-layer opacity = ``1 - this._currentColorMix`` (with
+      ``.toFixed(3)`` rounding before ``setAttribute``)
+    - boil-layer opacity = ``this._currentColorMix`` (same rounding)
+    - lerp target form ``running ? 1 : 0`` (or equivalent ternary on
+      ``boiling`` / ``this._running``)
+
+    These are scoped to ``executable`` (comments stripped) so a
+    comment quoting the formula doesn't accidentally pass.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    executable = re.sub(r"//[^\n]*", "", no_block)
+    # Cool-layer opacity literal — allow either `(1 - this._currentColorMix).toFixed(N)`
+    # or `1 - this._currentColorMix` direct.
+    assert re.search(
+        r"\(\s*1\s*-\s*this\._currentColorMix\s*\)\s*\.toFixed\s*\(",
+        executable,
+    ), (
+        "qs-water-boiler-card.js (AC-5): expected the cool-layer "
+        "opacity literal `(1 - this._currentColorMix).toFixed(N)` in "
+        "the RAF step body."
+    )
+    # Boil-layer opacity literal.
+    assert re.search(
+        r"this\._currentColorMix\s*\.toFixed\s*\(",
+        executable,
+    ), (
+        "qs-water-boiler-card.js (AC-6): expected the boil-layer "
+        "opacity literal `this._currentColorMix.toFixed(N)`."
+    )
+    # Lerp target: `targetColorMix = ... ? 1 : 0` — accept any condition
+    # token (e.g. `boiling`, `this._running === true`, etc.) so future
+    # readability tweaks don't break the test, but pin the `: 0` tail
+    # AND the `1` numerator.
+    assert re.search(
+        r"targetColorMix\s*=\s*[^;]*\?\s*1\s*:\s*0",
+        executable,
+    ), (
+        "qs-water-boiler-card.js (AC-6): expected the colorMix lerp "
+        "target to be `targetColorMix = <cond> ? 1 : 0`, mirroring "
+        "amplitude/speed."
     )
 
 


### PR DESCRIPTION
## Summary
Three layered visual upgrades to qs-water-boiler-card.js: heat-palette adoption (mirrors climate card's heat scheme), continuous-RAF water animation inside the ring with three sine-wave layers (pool-card pattern), and a boiling state when running with dual-layer opacity cross-fade + dynamic bubbles + red surface glow locked to wave 0.

Fixes #200

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boiler card: heat-color palette, continuous in-ring water animation, dual calm/boil wave cross‑fade, boiling bubbles, and red surface glow; per-instance SVG ids to prevent DOM collisions.

* **Bug Fixes**
  * Improved animation stability after background/tab returns and reconnection; safer DOM reset after template updates.

* **Documentation**
  * Added detailed QS-200 story, review-fix plans, and dashboard/card docs (updated verification date).

* **Tests**
  * Expanded regression tests covering continuous animation behavior, palette, SVG/wave structure, bubbles, and animation dt handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->