### PR TITLE
QS-201: Radiator card design: heat-mode color shift + stylized animated fire background

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -83,16 +83,27 @@ class QsRadiatorCard extends HTMLElement {
   _startAnimation() {
     // QS-201: first-connect prime — initialize flame anim state if null so
     // the next _render() can read sane defaults. Set _needsFlamePrime so
-    // _render() skips the 1.5s lerp from defaults at boot.
+    // _render() skips the 1.5s lerp from defaults at boot. The prime block
+    // must run BEFORE the early-return so the very first _render() after
+    // construction sees primed amp/speed values; it's idempotent on every
+    // subsequent call (guarded by the null check).
     if (this._currentFlameAmp == null) {
       this._currentFlameAmp = STILL_AMP;
       this._currentFlameSpeed = STILL_SPEED;
       this._flamePhase = 0;
       this._needsFlamePrime = true;
     }
-    this._invalidateFlameCache();
 
+    // QS-201 review fix S1: the cache-invalidate MUST live behind the
+    // early-return guard. `_startAnimation()` is called on every _render()
+    // via the umbrella RAF gate, but nulling `_lastFlameAmp` /
+    // `_lastFlameBaseY` on every render would defeat the path-regen
+    // throttle (ampDelta becomes Infinity, forcing unconditional path
+    // regeneration on the next RAF tick). The cache only needs clearing
+    // when RAF is actually being (re)started; the post-innerHTML reset in
+    // `_render()` already handles the rewrite case.
     if (this._animRaf != null) return;
+    this._invalidateFlameCache();
     this._lastAnimTs = null;
     const step = (ts) => {
       if (!this.isConnected) { this._animRaf = null; return; }
@@ -751,7 +762,7 @@ class QsRadiatorCard extends HTMLElement {
                   </feMerge>
                 </filter>
                 <clipPath id="${flameClipId}">
-                  <circle cx="160" cy="160" r="120" />
+                  <circle cx="${CENTER_CY}" cy="${CENTER_CY}" r="${CLIP_R}" />
                 </clipPath>
               </defs>
               <g clip-path="url(#${flameClipId})">

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -23,6 +23,56 @@
   (A1 review-fix #02).
 */
 
+// QS-201: 3-layer animated flame backdrop. Geometry, layer offsets,
+// and animation tuning mirror qs-pool-card.js's water-wave pattern.
+// Constants are duplicated (not imported) so a future pool-card refactor
+// cannot silently break this card.
+
+// --- Geometry (must match the <clipPath> circle attributes below) ---
+const CENTER_CY = 160;              // SVG y-centre of the ring / clip circle
+const CLIP_R = 120;                 // flame clip circle radius
+const FLAME_WIDTH = 480;            // single flame period in SVG px (2× clip diameter)
+const FLAME_BOTTOM_Y = 400;         // ≥ SVG viewBox max-y (320) so the closing rect is clipped
+
+// --- Per-layer offsets (parallax-tongue effect; different magic numbers, different purposes) ---
+const LAYER_SCROLL_OFFSET = 1.2;    // per-layer extra scroll phase (visual depth)
+const LAYER_PHASE_OFFSET = 2.1;     // per-layer static sine phase (shape variety)
+const LAYER_TIP_FREQS = [2, 3, 4];  // tongues per width — integer freqs so paths wrap seamlessly
+
+// --- Animation tuning ---
+const LERP_RATE = 2;                // exp time-constant; ~95% of lerp in ~1.5s
+const LERP_DT_CEIL = 0.1;           // s; clamp lerp dt to avoid snap-to after tab hidden
+const AMP_REGEN_THRESHOLD = 0.25;   // amplitude delta threshold for path regen (throttle)
+const LEVEL_REGEN_THRESHOLD = 0.01; // px; threshold for base-Y path regen (jitter-proof)
+const PHASE_WRAP = 1e6;             // wrap _flamePhase to preserve float precision
+const PHASE_TO_PX = 60;             // scroll px per phase-unit
+
+// --- Flame dynamics targets (still vs dancing) ---
+const STILL_AMP = 1;                // tip wobble when off — minimal, near-frozen
+const DANCE_AMP = 5;                // tip wobble when on — visibly dancing
+const STILL_SPEED = 0;              // phase-units/s when off — no scroll
+const DANCE_SPEED = 1.0;            // phase-units/s when on
+
+// --- Flame height envelope (1/5..4/5 of clip diameter; mirrors pool) ---
+const FLAME_BASE_MIN_PCT = 0.2;     // hoursRun=0 → flame base low
+const FLAME_BASE_MAX_PCT = 0.8;     // hoursRun=maxHours → flame base high
+
+// --- Fills (warm when running, greys when off) ---
+const FLAME_FILLS = [
+    'rgba(255, 87, 34, 0.55)',      // back layer (tallest tongues) — primary
+    'rgba(255, 110, 64, 0.45)',     // mid layer — animStart
+    'rgba(255, 193,  7, 0.35)',     // front layer (shortest tips) — amber
+];
+const FLAME_GREY_FILLS = [
+    'rgba(160, 160, 160, 0.40)',    // back layer
+    'rgba(140, 140, 140, 0.30)',    // mid layer
+    'rgba(120, 120, 120, 0.22)',    // front layer
+];
+
+// --- Per-layer base heights (px) — back is tallest, front is shortest ---
+const LAYER_BASE_HEIGHTS = [80, 65, 55];
+const LAYER_TIP_AMP_MULTS = [1.2, 1.0, 0.8];  // multiplies _currentFlameAmp per layer
+
 class QsRadiatorCard extends HTMLElement {
   // M4: gate the requestAnimationFrame loop on `showAnimation`.
     // condition (`showAnimation`). The loop is started lazily by
@@ -31,6 +81,17 @@ class QsRadiatorCard extends HTMLElement {
   // becomes false. Avoids constant per-card repaint overhead when no
   // visible animation is in progress.
   _startAnimation() {
+    // QS-201: first-connect prime — initialize flame anim state if null so
+    // the next _render() can read sane defaults. Set _needsFlamePrime so
+    // _render() skips the 1.5s lerp from defaults at boot.
+    if (this._currentFlameAmp == null) {
+      this._currentFlameAmp = STILL_AMP;
+      this._currentFlameSpeed = STILL_SPEED;
+      this._flamePhase = 0;
+      this._needsFlamePrime = true;
+    }
+    this._invalidateFlameCache();
+
     if (this._animRaf != null) return;
     this._lastAnimTs = null;
     const step = (ts) => {
@@ -45,6 +106,78 @@ class QsRadiatorCard extends HTMLElement {
       if (p) {
         p.setAttribute('stroke-dashoffset', String(-this._animOffset));
       }
+
+      // --- QS-201: flame animation update ---
+      const fireOn = this._fireRunning === true;
+      const targetAmp = fireOn ? DANCE_AMP : STILL_AMP;
+      const targetSpeed = fireOn ? DANCE_SPEED : STILL_SPEED;
+      // Clamp the lerp dt: after a tab is hidden for several seconds, the
+      // first frame back has huge dt and lerpFactor ≈ 1, which would snap
+      // amp/speed to target. Wave phase keeps using raw dt so scroll catches up.
+      const lerpDt = Math.min(dt, LERP_DT_CEIL);
+      const lerpFactor = 1 - Math.exp(-LERP_RATE * lerpDt);
+      this._currentFlameAmp += (targetAmp - this._currentFlameAmp) * lerpFactor;
+      this._currentFlameSpeed += (targetSpeed - this._currentFlameSpeed) * lerpFactor;
+      this._flamePhase += this._currentFlameSpeed * dt;
+      // Modulo wrap is robust to any sign / magnitude of accumulated phase.
+      this._flamePhase = this._flamePhase % PHASE_WRAP;
+
+      // Lazy-resolve flame DOM refs once per innerHTML rewrite.
+      if (!this._flameEls) {
+        this._flameEls = [
+          this._root?.getElementById('flame0') ?? null,
+          this._root?.getElementById('flame1') ?? null,
+          this._root?.getElementById('flame2') ?? null,
+        ];
+      }
+
+      // Per-layer translateX scroll (cheap GPU compositing).
+      // Path extent is [0, 2*FLAME_WIDTH] so the translated path always
+      // covers the clip region. We offset by -CLIP_R to align the path
+      // start with the clip's left edge, then scroll within one period.
+      for (let i = 0; i < 3; i++) {
+        const fEl = this._flameEls[i];
+        if (fEl) {
+          const phaseOffset = i * LAYER_SCROLL_OFFSET;
+          const raw = (this._flamePhase + phaseOffset) * PHASE_TO_PX;
+          const scrollOffset = ((raw % FLAME_WIDTH) + FLAME_WIDTH) % FLAME_WIDTH;
+          const tx = -CLIP_R - scrollOffset;
+          fEl.style.transform = `translateX(${tx.toFixed(1)}px)`;
+        }
+      }
+
+      // Regenerate paths only when base-Y or amp changes appreciably (throttle).
+      // Guard against undefined/NaN base — the RAF loop can fire before
+      // _render() populates _flameBaseY on cold start.
+      const flameBaseY = this._flameBaseY;
+      const hasValidBase = flameBaseY != null && !Number.isNaN(flameBaseY);
+      const ampDelta = this._lastFlameAmp == null
+          ? Infinity
+          : Math.abs(this._currentFlameAmp - this._lastFlameAmp);
+      // Threshold compare for float-jitter robustness vs strict !==.
+      const levelChanged = hasValidBase &&
+          Math.abs(flameBaseY - (this._lastFlameBaseY ?? Number.NEGATIVE_INFINITY)) > LEVEL_REGEN_THRESHOLD;
+      if (hasValidBase && (levelChanged || ampDelta > AMP_REGEN_THRESHOLD)) {
+        this._lastFlameBaseY = flameBaseY;
+        this._lastFlameAmp = this._currentFlameAmp;
+        const flameColors = this._flameColors || FLAME_GREY_FILLS;
+        for (let i = 0; i < 3; i++) {
+          const fEl = this._flameEls[i];
+          if (fEl) {
+            const d = this._generateFlamePath(
+              FLAME_WIDTH,
+              flameBaseY,
+              LAYER_BASE_HEIGHTS[i],
+              this._currentFlameAmp * LAYER_TIP_AMP_MULTS[i],
+              LAYER_TIP_FREQS[i],
+              i * LAYER_PHASE_OFFSET,
+            );
+            fEl.setAttribute('d', d);
+            fEl.setAttribute('fill', flameColors[i]);
+          }
+        }
+      }
+
       this._animRaf = requestAnimationFrame(step);
     };
     this._animRaf = requestAnimationFrame(step);
@@ -63,6 +196,10 @@ class QsRadiatorCard extends HTMLElement {
 
   disconnectedCallback() {
     this._stopAnimation();
+    // QS-201: clear flame DOM cache and memoization keys. _currentFlameAmp /
+    // _currentFlameSpeed / _flamePhase deliberately survive so re-attach
+    // resumes the dance without a visible jump.
+    this._invalidateFlameCache();
     // S7: reset interaction flags so a re-attach after mid-interaction
     // (e.g. dragging the ring or processing a mode change when the
     // dashboard rearranges) doesn't silently short-circuit `set hass`
@@ -108,6 +245,42 @@ class QsRadiatorCard extends HTMLElement {
     if (s === '' || s === 'unknown' || s === 'unavailable') return defaultValue;
     const n = Number(s);
     return Number.isNaN(n) ? defaultValue : n;
+  }
+
+  // QS-201: SVG path for a single flame layer. Two periods of a sine-wave
+  // top edge bounded by a vertical baseline at FLAME_BOTTOM_Y. The path
+  // is drawn wider than the clip circle so translateX scrolling can
+  // reveal new tongues without seam.
+  //   width      — single period in SVG px (FLAME_WIDTH)
+  //   baseY      — y-coord of the flame base (lower = taller flame)
+  //   baseHeight — average flame height above baseY (positive number)
+  //   tipAmp     — sine amplitude for tip wobble
+  //   tipFreq    — sine frequency (tongues per width); integer for seamless wrap
+  //   phase      — radians; static per-layer phase offset
+  _generateFlamePath(width, baseY, baseHeight, tipAmp, tipFreq, phase) {
+    const points = [];
+    const stepsPerPeriod = 60;
+    const totalSteps = stepsPerPeriod * 2;
+    const totalWidth = 2 * width;
+    for (let i = 0; i <= totalSteps; i++) {
+      const x = (i / stepsPerPeriod) * width;  // 0 .. 2*width
+      // y goes UP from baseY (smaller y in SVG). tipAmp wobbles tip.
+      const y = baseY - baseHeight - tipAmp * Math.sin((x / width) * tipFreq * 2 * Math.PI + phase);
+      points.push(`${x.toFixed(2)} ${y.toFixed(2)}`);
+    }
+    return `M ${points[0]} ` +
+           points.slice(1).map(p => `L ${p}`).join(' ') +
+           ` L ${totalWidth.toFixed(2)} ${FLAME_BOTTOM_Y} L 0 ${FLAME_BOTTOM_Y} Z`;
+  }
+
+  // QS-201: clear the memoization keys and cached DOM refs after each
+  // _render() innerHTML rewrite. Does NOT touch _currentFlameAmp /
+  // _currentFlameSpeed / _flamePhase — those survive disconnect so
+  // re-attach resumes the dance without a visible jump.
+  _invalidateFlameCache() {
+    this._flameEls = null;
+    this._lastFlameBaseY = null;
+    this._lastFlameAmp = null;
   }
 
   set hass(hass) {
@@ -222,6 +395,22 @@ class QsRadiatorCard extends HTMLElement {
         displayTargetHours = targetHours;
       }
       
+      // QS-201: flame backdrop — height tracks hoursRun/maxHours (mirrors pool).
+      const progressRatio = maxHours > 0
+          ? Math.max(0, Math.min(1, hoursRun / maxHours))
+          : 0;
+      const flameBaseY = CENTER_CY + CLIP_R - (FLAME_BASE_MIN_PCT + progressRatio * (FLAME_BASE_MAX_PCT - FLAME_BASE_MIN_PCT)) * 2 * CLIP_R;
+      this._fireRunning = running;          // consumed by _startAnimation's step() closure
+      this._flameBaseY = Number.isNaN(flameBaseY) ? null : flameBaseY;
+      this._flameColors = running ? FLAME_FILLS : FLAME_GREY_FILLS;
+
+      // Honor first-connect prime: skip the 1.5s boot lerp.
+      if (this._needsFlamePrime) {
+        this._currentFlameAmp = running ? DANCE_AMP : STILL_AMP;
+        this._currentFlameSpeed = running ? DANCE_SPEED : STILL_SPEED;
+        this._needsFlamePrime = false;
+      }
+
       // Determine if we should show from/to times
       const showFromTo = !isDefaultMode || isOverridden;
       
@@ -236,17 +425,48 @@ class QsRadiatorCard extends HTMLElement {
       const startTime = (sStartTime && isValidState(sStartTime.state)) ? sStartTime.state : '--:--';
       const endTime = (sEndTime && isValidState(sEndTime.state)) ? sEndTime.state : '--:--';
       
-      // Color schemes - MUST BE DEFINED BEFORE CSS
+      // QS-201: heat-mode palette — borrowed verbatim from qs-climate-card.js's
+      // `heat` colorScheme block. The radiator is heating-only so a fixed warm
+      // palette is appropriate (no per-state branching like the climate card).
       const colors = {
-        primary: '#2196F3',
-        gradStart: '#00bcd4',
-        gradEnd: '#8bc34a',
-        animStart: '#00e1ff',
-        animEnd: '#0066ff'
+        primary: '#FF5722',
+        gradStart: '#FF5722',
+        gradEnd: '#D32F2F',
+        animStart: '#FF6E40',
+        animEnd: '#E64A19'
       };
-      
+
+      // QS-201: per-instance clip id so multiple radiator cards on one
+      // dashboard don't collide. Shadow DOM scopes the id anyway, but a
+      // stable per-instance id makes diff/inspection easier.
+      if (!this._flameClipId) {
+        QsRadiatorCard._nextClipId = (QsRadiatorCard._nextClipId || 0) + 1;
+        this._flameClipId = 'fClip-' + QsRadiatorCard._nextClipId;
+      }
+      const flameClipId = this._flameClipId;
+
+      // QS-201: pre-generate paths so the SVG renders with flames immediately,
+      // avoiding the empty-d="" flash between innerHTML rewrite and the first
+      // RAF tick. The RAF loop continues animating from these initial shapes
+      // seamlessly (memo keys synced after the innerHTML write).
+      const initialAmp = this._currentFlameAmp ?? STILL_AMP;
+      const initialBaseY = this._flameBaseY ?? CENTER_CY;
+      const initialFlameColors = this._flameColors ?? FLAME_GREY_FILLS;
+      const initialFlamePaths = [0, 1, 2].map(i => this._generateFlamePath(
+        FLAME_WIDTH,
+        initialBaseY,
+        LAYER_BASE_HEIGHTS[i],
+        initialAmp * LAYER_TIP_AMP_MULTS[i],
+        LAYER_TIP_FREQS[i],
+        i * LAYER_PHASE_OFFSET,
+      ));
+
       const css = `
-      :host { --pad: 18px; display:block; }
+      :host {
+        --pad: 18px;
+        --ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5);
+        display: block;
+      }
       .card { padding: var(--pad); position: relative; }
       .card.off-grid { background: rgba(244, 67, 54, 0.08); }
       .card-title { text-align:center; font-weight:800; font-size: 1.6rem; margin: 0px 0 0px; }
@@ -284,14 +504,14 @@ class QsRadiatorCard extends HTMLElement {
       .card.disabled { opacity: 0.5; pointer-events: none; filter: grayscale(0.8); }
       .card.disabled .power-btn { pointer-events: auto; opacity: 1; filter: grayscale(0); }
       .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center; pointer-events: none; transform: translateY(-5px); }
-      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .target-value { font-weight:800; font-size: 2.5rem; line-height: 1.1; }
+      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .target-value { font-weight:800; font-size: 2.5rem; line-height: 1.1; text-shadow: var(--ring-text-shadow); }
       .ring .stack { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; text-align:center; width: 220px; margin: 0 auto; }
       .ring .target-block { display:flex; flex-direction:column; align-items:center; gap:6px; }
       .ring .from-to-row { display:flex; justify-content:space-between; width:140px; margin-top: 8px; gap:20px; }
       .ring .from-to-item { display:flex; flex-direction:column; align-items:center; gap:2px; }
-      .ring .from-to-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .from-to-value { color: var(--primary-text-color); font-weight:800; font-size: 1.4rem; }
+      .ring .from-to-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .from-to-value { color: var(--primary-text-color); font-weight:800; font-size: 1.4rem; text-shadow: var(--ring-text-shadow); }
       .ring .center-controls { display:flex; align-items:center; justify-content:center; margin-top: 6px; }
       .ring .override-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
       .ring .override-btn ha-icon { --mdc-icon-size: 26px; color: var(--secondary-text-color); display:block; line-height:1; }
@@ -410,7 +630,13 @@ class QsRadiatorCard extends HTMLElement {
       const gradGreenId = `gradG-${Math.floor(Math.random() * 1e6)}`;
       const gradRunningId = `gradR-${Math.floor(Math.random() * 1e6)}`;
       const activeGradId = running ? gradRunningId : gradGreenId;
-      const showAnimation = (running && segLen > 6);
+      // QS-201: gate split. The ring-dash animation only needs RAF when
+      // there is enough progress to dash through (segLen > 6). The flame
+      // backdrop wants RAF as soon as the radiator is running, even with
+      // zero progress yet. The umbrella `showAnimation` is the OR.
+      const ringDashActive = running && segLen > 6;
+      const fireActive = running;
+      const showAnimation = ringDashActive || fireActive;
 
       // M4: start/stop the RAF loop based on whether the dash animation
       // is actually needed. Idle cards consume zero per-frame work.
@@ -524,10 +750,18 @@ class QsRadiatorCard extends HTMLElement {
                     <feMergeNode in="SourceGraphic" />
                   </feMerge>
                 </filter>
+                <clipPath id="${flameClipId}">
+                  <circle cx="160" cy="160" r="120" />
+                </clipPath>
               </defs>
+              <g clip-path="url(#${flameClipId})">
+                <path id="flame0" d="${initialFlamePaths[0]}" fill="${initialFlameColors[0]}" opacity="1" pointer-events="none" style="will-change: transform;" />
+                <path id="flame1" d="${initialFlamePaths[1]}" fill="${initialFlameColors[1]}" opacity="1" pointer-events="none" style="will-change: transform;" />
+                <path id="flame2" d="${initialFlamePaths[2]}" fill="${initialFlameColors[2]}" opacity="1" pointer-events="none" style="will-change: transform;" />
+              </g>
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
-              <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
-              ${showAnimation ? `
+              <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${ringDashActive ? 'stroke-opacity="0.35"' : ''} />
+              ${ringDashActive ? `
               <path id="running_anim"
                     d="${progressPath}"
                     stroke="url(#${gradRunningId})"
@@ -597,6 +831,10 @@ class QsRadiatorCard extends HTMLElement {
         ` : ''}
       </ha-card>
     `;
+
+      // QS-201: invalidate cached flame DOM refs after innerHTML rewrite so
+      // the next RAF tick re-queries fresh elements.
+      this._invalidateFlameCache();
 
       // Wire events
       const root = this._root;

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -192,7 +192,7 @@ Subsequent HA starts:
 | Pool | `custom:qs-pool-card` | `QSPool` | `ui/resources/qs-pool-card.js` |
 | Climate | `custom:qs-climate-card` | `QSClimateDuration`, `QSHeatPump` | `ui/resources/qs-climate-card.js` |
 | On-off duration | `custom:qs-on-off-duration-card` | `QSOnOffDuration` | `ui/resources/qs-on-off-duration-card.js` |
-| Radiator | `custom:qs-radiator-card` | `QSRadiator` | `ui/resources/qs-radiator-card.js` (cloned from `qs-on-off-duration-card.js`; UX redesign deferred via [#199](https://github.com/tmenguy/quiet-solar/issues/199); has S14-S17/N7 safety hardening the on/off card has not yet adopted) |
+| Radiator | `custom:qs-radiator-card` | `QSRadiator` | `ui/resources/qs-radiator-card.js` (cloned from `qs-on-off-duration-card.js`; has S14-S17/N7 safety hardening the on/off card has not yet adopted; QS-201 added the heat-mode warm palette and a stylized 3-layer flame backdrop that grows with `hoursRun/maxHours` and goes grey-still when off, mirroring pool's water-wave pattern. Animation constants are duplicated in-file rather than shared, so a future pool-card refactor cannot silently break this card.) |
 | Water boiler | `custom:qs-water-boiler-card` | `QSWaterBoiler` | `ui/resources/qs-water-boiler-card.js` |
 
 The radiator template wires `backing_entity` (the underlying

--- a/docs/stories/QS-201.story.md
+++ b/docs/stories/QS-201.story.md
@@ -1,0 +1,1073 @@
+---
+issue: 201
+title: Radiator card design — heat-mode color shift + animated 3-layer flame backdrop
+branch: QS_201
+status: planned
+next_phase: implement-task
+labels: [area:ui, area:dashboard]
+---
+
+# QS-201 — Radiator card design: heat-mode color shift + animated 3-layer flame backdrop
+
+## Why
+
+The radiator card (`custom_components/quiet_solar/ui/resources/qs-radiator-card.js`)
+currently inherits the on/off-duration card's **cool** palette (`#2196F3`,
+`#00bcd4`, `#8bc34a`). That's appropriate for an air conditioner — wrong for
+something whose job is to make heat. The card needs to **feel like heat**:
+warm colours, plus a visible affordance that the radiator is actually warming
+the room.
+
+Issue [#201](https://github.com/tmenguy/quiet-solar/issues/201) asks for two
+things:
+
+1. **Heat-mode palette**: shift the card's accent colours to match the climate
+   card's existing `heat` block (warm orange / red).
+2. **Stylized animated flame backdrop**: a subtle 3-layer flame in the
+   background of the ring — growing in height with progress (mirroring how
+   the pool card's water rises with progress), dancing when the radiator is
+   running, grey and still when it's off.
+
+The user explicitly chose **Option B** in the orchestrator's design round:
+a 3-layer flame mirroring the pool card's 3-wave water pattern. Same RAF
+model, same path-regen throttle, same level-tracks-progress envelope —
+different fill colours, different gate, vertical flame shape instead of
+horizontal water wave.
+
+## Inputs
+
+### Files to edit
+
+- `custom_components/quiet_solar/ui/resources/qs-radiator-card.js` (1030 lines today, current state lines 1-1030).
+- `tests/test_dashboard_rendering.py` (new regex pins added inside
+  `class TestDashboardTemplateRendering:` starting at line 168, parametrize
+  extension at module-level line ~1373).
+- `docs/agents/concepts/dashboard-and-cards.md` (radiator-card row at line
+  195 gets a new parenthetical describing the flame backdrop).
+
+### Reference files (DO NOT edit — copy patterns from)
+
+- `custom_components/quiet_solar/ui/resources/qs-pool-card.js` — the
+  canonical 3-layer animated-background pattern. Read in particular:
+  - Lines 6-41: module-top `const` block (geometry, layer offsets, animation
+    tuning, dynamics).
+  - Lines 49-62: `_generateWavePath(width, amplitude, frequency, phase, yOffset)`.
+  - Lines 92-204: `connectedCallback` → `_startAnimation` with first-connect
+    prime logic + per-frame lerp + transform/regen split.
+  - Lines 327-356: `_render()` water-level computation + `_waterClipId`
+    static-counter + pre-generated initial paths.
+  - Lines 359-436: CSS (note the `--ring-text-shadow` variable at line 359
+    and its application on `.pct`, `.target-label`, `.target-value`).
+  - Lines 548-556: `<defs>` block with the clipPath + the three `<path>`
+    layers inside `<g clip-path="url(...)">`.
+- `custom_components/quiet_solar/ui/resources/qs-climate-card.js` lines
+  214-220 — source of the `heat` palette to copy verbatim.
+
+### Existing test pins that MUST stay green
+
+These pin the radiator card's hardening contract. Every one of them must
+keep passing after the change.
+
+| Pin                                                       | Source line   | Asserts                                            |
+| --------------------------------------------------------- | ------------- | -------------------------------------------------- |
+| `test_radiator_card_resource_file_present`                | 221           | File exists; custom-element + display name        |
+| `test_radiator_card_s14_safe_number_guards_against_nan`   | 242           | `_safeNumber` helper; no raw `Number(... \|\| ...)` |
+| `test_radiator_card_s15_escape_html_before_innerHTML`     | 278           | `_escapeHtml` wraps card-title + bistate labels   |
+| `test_radiator_card_s16_keyboard_accessibility`           | 300           | `role="button"` + `tabindex="0"` on action divs   |
+| `test_radiator_card_s17_async_calls_wrapped_in_try_finally` | 322         | `try/finally` around `_select` + `_setNumber`     |
+| `test_radiator_card_b5_show_dialog_escapes_interpolations`| 362           | `showDialog` escapes title/message                |
+| `test_radiator_card_n7_running_includes_live_backing_state`| 413          | `running = commandReportsOn \|\| liveBackingOn`    |
+| `test_radiator_card_bh10_configured_hvac_on_compared`     | 435           | `liveBackingState === configuredHvacOn`           |
+| `test_radiator_card_tolerates_non_string_hvac_mode_on`    | 958           | `String(e.climate_hvac_mode_on \|\| 'heat')`       |
+| `test_card_mode_change_wrapped_in_try_finally` (M2)       | 1340 (param)  | `_isProcessing*` flag in `try/finally`            |
+| `test_card_raf_idle_gated` (M4)                           | 1382 (param)  | `if (showAnimation) { ... _startAnimation`        |
+
+The QS-195 hardening surface (S14-S17, N7, M2, M4, B5, BH10) is non-negotiable.
+
+## Out of scope
+
+- **Design-proposal document with mockup images** — the user explicitly
+  de-scoped this in clarification (orchestrator Q1 answer: "go directly to
+  implementation of Option B"; Q6 answer: "don't care for now"). No
+  `docs/design/QS-201-*.md` deliverable.
+- **`prefers-reduced-motion` honoring** — not asked for. Defer to a
+  follow-up. Note in PR description as known limitation.
+- **Multi-octave noise on the flame top edge** — Option B uses pool's
+  single-sine path with per-layer frequencies (`[2, 3, 4]`) and phase
+  offsets to give the parallax-tongue effect. If manual verification
+  reveals the result reads as "wave painted orange" rather than "flame",
+  a follow-up can add a higher-frequency overlay (`+ sin(x * tipFreq*3)`).
+- **Feature-flag / kill switch on the flame backdrop** — YAGNI; the card
+  is shadow-DOM-isolated so a perf regression only affects one card.
+- **Extracting a shared `_AnimatedBackgroundMixin`** between pool and
+  radiator. The two cards stay independent — this story decouples by
+  copying constants, not by sharing a module. A future refactor can
+  extract a shared base if/when a third animated-backdrop card lands.
+- **Re-skinning the on/off-duration or water-boiler cards** — radiator
+  only.
+- **Configuration toggle to disable the flame** — YAGNI.
+
+## Acceptance criteria
+
+All criteria are framed Given / When / Then. Each pins to a concrete
+regex pattern in the new test pins (see "Test plan" below).
+
+### AC-1 — Heat palette applied verbatim
+
+- **Given** the radiator card source `qs-radiator-card.js`.
+- **When** inspecting the module-level `colors` constant inside `_render()`.
+- **Then** the constant matches the climate card's `heat` palette literally:
+  ```js
+  const colors = {
+    primary: '#FF5722',
+    gradStart: '#FF5722',
+    gradEnd: '#D32F2F',
+    animStart: '#FF6E40',
+    animEnd: '#E64A19'
+  };
+  ```
+- **And** none of the cool-palette literals (`#2196F3`, `#00bcd4`,
+  `#8bc34a`, `#00e1ff`, `#0066ff`) appears in executable code (comments
+  stripped per the existing helper at lines 268-269 of the test file).
+
+### AC-2 — Three flame layers inside a circular clip
+
+- **Given** the rendered shadow DOM of one radiator card.
+- **When** inspecting the SVG.
+- **Then** `<defs>` contains a `<clipPath id="${flameClipId}">` whose child
+  is `<circle cx="160" cy="160" r="120"/>` (clip radius matches the ring's
+  inner area; centre matches the SVG `viewBox` centre).
+- **And** the SVG body contains a `<g clip-path="url(#${flameClipId})">`
+  wrapping exactly three `<path>` elements with ids `flame0`, `flame1`,
+  `flame2`, each with a non-empty `d` attribute at first render (pre-RAF —
+  no empty `d=""` flash).
+- **And** because each card uses its own shadow root
+  (`attachShadow({ mode: 'open' })`), `getElementById('flame0')` is shadow-
+  scoped — multiple radiator cards on one dashboard do NOT collide on the
+  `flame*` ids.
+
+### AC-3 — Flame height tracks progress (1/5 .. 4/5 of clip)
+
+- **Given** a radiator with `hoursRun` ranging from `0` to `maxHours`.
+- **When** `_render()` computes
+  `progressRatio = maxHours > 0 ? Math.max(0, Math.min(1, hoursRun / maxHours)) : 0`.
+- **Then**
+  `flameBaseY = CENTER_CY + CLIP_R - (FLAME_BASE_MIN_PCT + progressRatio * (FLAME_BASE_MAX_PCT - FLAME_BASE_MIN_PCT)) * 2 * CLIP_R`
+  with `FLAME_BASE_MIN_PCT = 0.2`, `FLAME_BASE_MAX_PCT = 0.8`
+  (= `1/5..4/5` of the clip-circle diameter — identical envelope to
+  `qs-pool-card.js:332`).
+- **And** `hoursRun = 0` puts the flame base at 1/5 (`y ≈ 232`).
+- **And** `hoursRun = maxHours` puts the flame base at 4/5 (`y ≈ 88`).
+- **And** the user's Q3 answer (option (i): "mirrors pool exactly") is the
+  trade-off justification — "more run-time = taller flame" is intentional
+  visual semantics, not infinite fuel.
+
+### AC-4 — Dancing when running (structural proxy)
+
+- **Given** `running === true`.
+- **When** the RAF `step()` closure executes.
+- **Then** the closure contains a `this._flamePhase +=` accumulator that
+  advances per frame.
+- **And** each of the three layers gets a per-frame `style.transform`
+  update of the form
+  `translateX(${(-CLIP_R - scrollOffset).toFixed(1)}px)`.
+- **And** layer indices `[0, 1, 2]` produce three distinct
+  `scrollOffset` values via `LAYER_SCROLL_OFFSET` (a "parallax" effect
+  — slower / faster scroll per layer mirrors pool's pattern).
+- **Note** (known limitation): per-frame runtime behaviour is verified
+  via STRUCTURAL pins (regex over the JS source) — no JS runtime tests
+  exist in this repo. Behavioural AC is verified manually (see "Manual
+  verification" below).
+
+### AC-5 — Grey and still when off
+
+- **Given** `running === false`.
+- **When** the card renders.
+- **Then** the three flame layers' `fill` attributes are drawn from the
+  `FLAME_GREY_FILLS` constant (e.g. `'rgba(160,160,160,0.40)'`), NOT
+  from `FLAME_FILLS` (the orange palette).
+- **And** the umbrella RAF gate `showAnimation` evaluates to `false`
+  (since `ringDashActive === false` AND `fireActive === false`).
+- **And** `_stopAnimation()` is called from `_render()` via the existing
+  `if (showAnimation) ... else _stopAnimation()` branch (line 417
+  currently).
+- **And** because RAF has stopped, the flame layers' last-drawn `translateX`
+  values FREEZE — no further movement until `running` flips true again.
+- **No lerp-to-still** is attempted; the off transition is a snap
+  (fills swap immediately, RAF stops, position freezes). This is
+  intentional — a lerp would require keeping RAF alive briefly past the
+  state change, complicating the gate and adding a code path with no
+  user-visible benefit.
+
+### AC-6 — Existing hardening pins stay green
+
+- **Given** the modified card.
+- **When** running the full quality gate.
+- **Then** every test in the "Existing test pins" table above stays green.
+- **Specifically** the M4 pin `test_card_raf_idle_gated` continues to
+  match because the variable NAME `showAnimation` is preserved (only its
+  RHS changes from `running && segLen > 6` to
+  `ringDashActive || fireActive`).
+
+### AC-7 — Cache cleanup on disconnect; animation state survives
+
+- **Given** the card is disconnected mid-dance (e.g. dashboard
+  rearrangement; modal navigation).
+- **When** `disconnectedCallback()` runs.
+- **Then** `_stopAnimation()` is called (existing behaviour).
+- **And** `_invalidateFlameCache()` is called — which assigns
+  EXACTLY these three fields to `null`: `this._flameEls`,
+  `this._lastFlameBaseY`, `this._lastFlameAmp`. No other fields.
+- **And** `this._currentFlameAmp`, `this._currentFlameSpeed`,
+  `this._flamePhase` are NOT touched by either `disconnectedCallback` or
+  `_invalidateFlameCache` — they survive disconnect, mirroring pool's
+  pattern. A re-attach therefore resumes the dance without a visible
+  jump.
+
+### AC-8 — Umbrella RAF gate widened cleanly
+
+- **Given** the existing M4 gate at line 417 (`if (showAnimation) {
+  this._startAnimation(); } else { this._stopAnimation(); }`).
+- **When** code review the new `_render()`.
+- **Then** the gate's call site (line 417 — `if (showAnimation)`) is
+  unchanged.
+- **And** the variable `showAnimation` is now defined as the OR of two
+  named sub-conditions:
+  ```js
+  const ringDashActive = running && segLen > 6;  // existing semantics, preserved
+  const fireActive = running;                     // new
+  const showAnimation = ringDashActive || fireActive;
+  ```
+- **And** the SVG emission of `<path id="running_anim" ...>` (line 530-541
+  today, gated on `showAnimation`) MIGRATES to gate on `ringDashActive`
+  instead — this preserves its current semantics (the ring's running
+  dash only emits when there's some progress to dash through).
+- **Justification** (user Q5 answered: "(i) RAF gated on `running === true`")
+  — the existing `running && segLen > 6` gate would NOT start RAF in the
+  moment `running === true && segLen === 0` (user just enabled the
+  radiator, no progress accumulated yet). The umbrella widens the gate
+  so the fire dances from the first frame after switch-on.
+
+### AC-9 — Center-text readability over flames
+
+- **Given** the warm flame layers render orange behind the centre text.
+- **When** the user reads `Actual / Target Hours`, the from/to row, and
+  the time-button label.
+- **Then** the CSS includes a `--ring-text-shadow` variable on `:host`
+  with the value `0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5)`
+  (verbatim from pool's `:host` rule at line 359).
+- **And** the text-shadow is applied to all four text classes in the
+  ring's centre area:
+  - `.ring .target-value`
+  - `.ring .target-label`
+  - `.ring .from-to-value`
+  - `.ring .from-to-label`
+- **Justification** — the target-value span currently uses
+  `color: ${colors.primary}` which becomes `#FF5722` orange. With orange
+  flames behind it, contrast collapses. Without the shadow, the centre
+  text becomes unreadable when the flame layer scrolls behind it. This
+  is required-for-correctness, not gold-plating.
+
+### AC-10 — Doc updated
+
+- **Given** `docs/agents/concepts/dashboard-and-cards.md`.
+- **When** the radiator-card table row (currently line 195) is read.
+- **Then** the row's "Source" cell is extended with a parenthetical
+  describing the heat palette + 3-layer flame backdrop (e.g.
+  "QS-201 adds a heat-mode warm palette and a stylized 3-layer flame
+  backdrop that grows with progress and goes grey-still when off,
+  mirroring pool's water-wave pattern").
+- **And** `last_verified` is NOT bumped. The doc is currently
+  `2026-05-23`, today is `2026-05-21` per current-date context — bumping
+  would move the date backwards. The content update suffices.
+- **And** `docs/agents/glossary.md` is NOT modified — its mention of
+  `qs-radiator-card` is prose only (not in any `covers:` frontmatter).
+
+## Test plan
+
+**TDD discipline**: all new test pins are added FIRST and verified red
+before the JS code lands. The implement-task agent should follow this
+red→green→refactor flow.
+
+Place all four new pins as **class methods inside
+`class TestDashboardTemplateRendering:`** (the class starts at line 168;
+the existing radiator pins are methods at lines 221, 242, 278, 300, 322,
+362, 413, 435, 958). Each follows the existing pattern:
+
+- Sync `def` (no `@pytest.mark.asyncio`, no `hass` fixture).
+- Reads `(COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()`.
+- Strips block comments (`/* ... */`) and line comments (`// ...`)
+  before regex scans for executable code (existing pattern at lines
+  268-269).
+- Has a sentence-case docstring naming the AC it pins.
+
+### New pin 1: `test_radiator_card_heat_palette` (pins AC-1)
+
+```python
+def test_radiator_card_heat_palette(self):  # CR2 — sync (no hass)
+    """QS-201 AC-1 — heat palette is applied verbatim, cool palette gone."""
+    import re
+
+    content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+    # Strip comments first.
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    no_comments = re.sub(r"//[^\n]*", "", no_block)
+
+    # Required heat-palette literals (all five keys).
+    for literal in ("'#FF5722'", "'#D32F2F'", "'#FF6E40'", "'#E64A19'"):
+        assert literal in no_comments, f"Missing heat-palette literal {literal}"
+
+    # The `colors` const must use these literals (not just appear somewhere).
+    assert re.search(
+        r"const\s+colors\s*=\s*\{[^}]*primary:\s*'#FF5722'", no_comments
+    ) is not None
+
+    # Cool-palette literals must NOT appear in executable code.
+    for forbidden in ("'#2196F3'", "'#00bcd4'", "'#8bc34a'", "'#00e1ff'", "'#0066ff'"):
+        assert forbidden not in no_comments, (
+            f"Stale cool-palette literal {forbidden} still present"
+        )
+```
+
+### New pin 2: `test_radiator_card_flame_layers_present` (pins AC-2 + AC-7's positive whitelist)
+
+```python
+def test_radiator_card_flame_layers_present(self):  # CR2 — sync (no hass)
+    """QS-201 AC-2 + AC-7 — three flame paths, circular clip, cache-clear whitelist."""
+    import re
+
+    content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+    # AC-2: three flame paths with ids flame0/1/2.
+    for fid in ("flame0", "flame1", "flame2"):
+        assert re.search(rf'id="{fid}"', content) is not None, (
+            f"Missing <path id=\"{fid}\">"
+        )
+
+    # AC-2: clipPath circle at the ring centre.
+    assert re.search(
+        r"<clipPath\s+id=\"\$\{flameClipId\}\">\s*<circle\s+cx=\"160\"\s+cy=\"160\"\s+r=\"120\"",
+        content,
+        re.DOTALL,
+    ) is not None, "Missing clipPath circle (cx=160 cy=160 r=120)"
+
+    # AC-2: <g clip-path="url(#${flameClipId})"> wraps the three paths.
+    assert 'clip-path="url(#${flameClipId})"' in content
+
+    # AC-7: _invalidateFlameCache body whitelist — EXACTLY three fields cleared.
+    inv_match = re.search(
+        r"_invalidateFlameCache\s*\(\s*\)\s*\{([^}]+)\}",
+        content,
+        re.DOTALL,
+    )
+    assert inv_match is not None, "Missing _invalidateFlameCache method"
+    body = inv_match.group(1)
+    # Required positive whitelist.
+    for required in ("_flameEls", "_lastFlameBaseY", "_lastFlameAmp"):
+        assert required in body, (
+            f"_invalidateFlameCache must clear `this.{required}`"
+        )
+    # Forbidden: fields that must SURVIVE disconnect.
+    for forbidden in ("_currentFlameAmp", "_currentFlameSpeed", "_flamePhase"):
+        assert forbidden not in body, (
+            f"_invalidateFlameCache must NOT touch `this.{forbidden}` "
+            f"(animation state survives disconnect — mirror pool)"
+        )
+
+    # AC-7: disconnectedCallback calls _invalidateFlameCache.
+    disc_match = re.search(
+        r"disconnectedCallback\s*\(\s*\)\s*\{([^}]+)\}",
+        content,
+        re.DOTALL,
+    )
+    assert disc_match is not None
+    assert "_invalidateFlameCache" in disc_match.group(1)
+```
+
+### New pin 3: `test_radiator_card_flame_height_envelope_uses_progress` (pins AC-3 + AC-8)
+
+```python
+def test_radiator_card_flame_height_envelope_uses_progress(self):  # CR2 — sync (no hass)
+    """QS-201 AC-3 + AC-8 — flame base tracks progress; gate split into named sub-conditions."""
+    import re
+
+    content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    no_comments = re.sub(r"//[^\n]*", "", no_block)
+
+    # AC-3: progressRatio is clamped against maxHours.
+    assert re.search(
+        r"progressRatio\s*=\s*maxHours\s*>\s*0\s*\?\s*Math\.max\(\s*0\s*,\s*Math\.min\(\s*1\s*,\s*hoursRun\s*/\s*maxHours",
+        no_comments,
+    ) is not None, "Missing progressRatio clamp"
+
+    # AC-3: flameBaseY formula uses the 1/5..4/5 envelope.
+    assert "FLAME_BASE_MIN_PCT" in no_comments
+    assert "FLAME_BASE_MAX_PCT" in no_comments
+    assert re.search(
+        r"flameBaseY\s*=\s*CENTER_CY\s*\+\s*CLIP_R\s*-\s*\(\s*FLAME_BASE_MIN_PCT\s*\+\s*progressRatio\s*\*\s*\(\s*FLAME_BASE_MAX_PCT\s*-\s*FLAME_BASE_MIN_PCT\s*\)\s*\)\s*\*\s*2\s*\*\s*CLIP_R",
+        no_comments,
+    ) is not None, "flameBaseY formula does not mirror pool's water-level envelope"
+
+    # AC-8: gate split.
+    assert re.search(
+        r"const\s+ringDashActive\s*=\s*running\s*&&\s*segLen\s*>\s*6", no_comments
+    ) is not None
+    assert re.search(
+        r"const\s+fireActive\s*=\s*running", no_comments
+    ) is not None
+    assert re.search(
+        r"const\s+showAnimation\s*=\s*ringDashActive\s*\|\|\s*fireActive", no_comments
+    ) is not None
+
+    # AC-8: <path id="running_anim"> emission is gated on ringDashActive,
+    # not the umbrella showAnimation.
+    assert re.search(
+        r"\$\{\s*ringDashActive\s*\?\s*`[^`]*?id=\"running_anim\"",
+        content,
+        re.DOTALL,
+    ) is not None, (
+        "<path id=\"running_anim\"> must be gated on ringDashActive, not showAnimation"
+    )
+```
+
+### New pin 4: `test_radiator_card_flame_off_grey` (pins AC-5)
+
+```python
+def test_radiator_card_flame_off_grey(self):  # CR2 — sync (no hass)
+    """QS-201 AC-5 — grey fills when !running; FLAME_GREY_FILLS constant exists."""
+    import re
+
+    content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+    no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    no_comments = re.sub(r"//[^\n]*", "", no_block)
+
+    # FLAME_GREY_FILLS constant present.
+    assert "FLAME_GREY_FILLS" in no_comments
+    # Constant is an array of at least three grey values (rgba with all
+    # three channels equal or near-equal — accept the simple form).
+    grey_array = re.search(
+        r"FLAME_GREY_FILLS\s*=\s*\[([^\]]+)\]", no_comments
+    )
+    assert grey_array is not None
+    # FLAME_FILLS (warm) also present — both constants required.
+    assert "FLAME_FILLS" in no_comments
+
+    # Selection between the two constants is gated on `running`.
+    assert re.search(
+        r"running\s*\?\s*FLAME_FILLS\s*:\s*FLAME_GREY_FILLS", no_comments
+    ) is not None, (
+        "Fill-selection must branch on `running` — `running ? FLAME_FILLS : FLAME_GREY_FILLS`"
+    )
+```
+
+### Parametrize extension
+
+Modify the existing `test_card_raf_idle_gated` parametrize (currently
+lines 1373-1381) to ADD `("qs-radiator-card.js", "showAnimation")` as a
+fifth tuple. The umbrella `showAnimation` variable name is preserved
+(per AC-8), so the existing regex
+`if\s*\(\s*showAnimation\s*\)\s*\{[^}]*?_startAnimation` matches the
+unchanged call site at line 417.
+
+### Quality gate
+
+- Iteration: `python scripts/qs/quality_gate.py --quick tests/test_dashboard_rendering.py`.
+- Pre-PR: `python scripts/qs/quality_gate.py` (full pytest 100% cov +
+  ruff + mypy + translations).
+- Smart-scope concern: even though the executable change is JS-only,
+  `tests/test_dashboard_rendering.py` IS modified — that's a Python
+  change and triggers the full gate. Confirm by inspecting the gate's
+  scope-detection log; if it skips, force full via the gate's flag.
+
+## Task breakdown
+
+### Task 1 — Add the 4 new test pins (RED)
+
+File: `tests/test_dashboard_rendering.py`.
+
+- Add `test_radiator_card_heat_palette` as a class method inside
+  `class TestDashboardTemplateRendering:`, near the existing
+  `test_radiator_card_bh10_*` (around line 458, before the
+  `@pytest.mark.asyncio` test at line 460).
+- Add `test_radiator_card_flame_layers_present` immediately after it.
+- Add `test_radiator_card_flame_height_envelope_uses_progress` after that.
+- Add `test_radiator_card_flame_off_grey` after that.
+
+Each uses the exact regex shown under "Test plan" above. Each carries a
+QS-201 docstring naming the AC it pins.
+
+Then modify the module-level parametrize on `test_card_raf_idle_gated`
+(currently lines 1373-1381) — add `("qs-radiator-card.js", "showAnimation")`
+as the fifth tuple.
+
+**Verify red**: `python scripts/qs/quality_gate.py --quick
+tests/test_dashboard_rendering.py` — the four new pins fail, the
+parametrize extension also fails (because the radiator card's existing
+`showAnimation = running && segLen > 6` doesn't match the
+broader-context regex for the gate; actually it DOES match — the
+parametrize extension may pass immediately because the existing gate
+call site is already `if (showAnimation) { ... _startAnimation`).
+Document the actual red/green status when verifying.
+
+### Task 2 — Module-top constants block
+
+File: `custom_components/quiet_solar/ui/resources/qs-radiator-card.js`,
+insert AFTER the file header comment (line 24) and BEFORE
+`class QsRadiatorCard extends HTMLElement {` (line 26). Insert as
+module-top `const` declarations (mirror pool's pattern at lines 6-41 —
+NOT class statics).
+
+```js
+// QS-201: 3-layer animated flame backdrop. Geometry, layer offsets,
+// and animation tuning mirror qs-pool-card.js's water-wave pattern.
+// Constants are duplicated (not imported) so a future pool-card refactor
+// cannot silently break this card.
+
+// --- Geometry (must match the <clipPath> circle attributes below) ---
+const CENTER_CY = 160;              // SVG y-centre of the ring / clip circle
+const CLIP_R = 120;                 // flame clip circle radius
+const FLAME_WIDTH = 480;            // single flame period in SVG px (2× clip diameter)
+const FLAME_BOTTOM_Y = 400;         // ≥ SVG viewBox max-y (320) so the closing rect is clipped
+
+// --- Per-layer offsets (parallax-tongue effect; different magic numbers, different purposes) ---
+const LAYER_SCROLL_OFFSET = 1.2;    // per-layer extra scroll phase (visual depth)
+const LAYER_PHASE_OFFSET = 2.1;     // per-layer static sine phase (shape variety)
+const LAYER_TIP_FREQS = [2, 3, 4];  // tongues per width — integer freqs so paths wrap seamlessly
+
+// --- Animation tuning ---
+const LERP_RATE = 2;                // exp time-constant; ~95% of lerp in ~1.5s
+const LERP_DT_CEIL = 0.1;           // s; clamp lerp dt to avoid snap-to after tab hidden
+const AMP_REGEN_THRESHOLD = 0.25;   // amplitude delta threshold for path regen (throttle)
+const LEVEL_REGEN_THRESHOLD = 0.01; // px; threshold for base-Y path regen (jitter-proof)
+const PHASE_WRAP = 1e6;             // wrap _flamePhase to preserve float precision
+const PHASE_TO_PX = 60;             // scroll px per phase-unit
+
+// --- Flame dynamics targets (still vs dancing) ---
+const STILL_AMP = 1;                // tip wobble when off — minimal, near-frozen
+const DANCE_AMP = 5;                // tip wobble when on — visibly dancing
+const STILL_SPEED = 0;              // phase-units/s when off — no scroll
+const DANCE_SPEED = 1.0;            // phase-units/s when on
+
+// --- Flame height envelope (1/5..4/5 of clip diameter; mirrors pool) ---
+const FLAME_BASE_MIN_PCT = 0.2;     // hoursRun=0 → flame base low
+const FLAME_BASE_MAX_PCT = 0.8;     // hoursRun=maxHours → flame base high
+
+// --- Fills (warm when running, greys when off) ---
+const FLAME_FILLS = [
+    'rgba(255, 87, 34, 0.55)',      // back layer (tallest tongues) — primary
+    'rgba(255, 110, 64, 0.45)',     // mid layer — animStart
+    'rgba(255, 193,  7, 0.35)',     // front layer (shortest tips) — amber
+];
+const FLAME_GREY_FILLS = [
+    'rgba(160, 160, 160, 0.40)',    // back layer
+    'rgba(140, 140, 140, 0.30)',    // mid layer
+    'rgba(120, 120, 120, 0.22)',    // front layer
+];
+
+// --- Per-layer base heights (px) — back is tallest, front is shortest ---
+const LAYER_BASE_HEIGHTS = [80, 65, 55];
+const LAYER_TIP_AMP_MULTS = [1.2, 1.0, 0.8];  // multiplies _currentFlameAmp per layer
+```
+
+Naming convention: `FLAME_*` prefix for all flame-specific constants;
+`CENTER_CY`, `CLIP_R`, `LAYER_*` mirror pool's shared-geometry names
+verbatim. `LERP_*`, `AMP_*`, `LEVEL_*`, `PHASE_*` mirror pool's
+animation-tuning names verbatim.
+
+### Task 3 — `_generateFlamePath` method
+
+File: `qs-radiator-card.js`, insert after `_safeNumber` (currently
+closes at line 111) and before `set hass(hass)` (line 113).
+
+```js
+// QS-201: SVG path for a single flame layer. Two periods of a sine-wave
+// top edge bounded by a vertical baseline at FLAME_BOTTOM_Y. The path
+// is drawn wider than the clip circle so translateX scrolling can
+// reveal new tongues without seam.
+//   width      — single period in SVG px (FLAME_WIDTH)
+//   baseY      — y-coord of the flame base (lower = taller flame)
+//   baseHeight — average flame height above baseY (positive number)
+//   tipAmp     — sine amplitude for tip wobble
+//   tipFreq    — sine frequency (tongues per width); integer for seamless wrap
+//   phase      — radians; static per-layer phase offset
+_generateFlamePath(width, baseY, baseHeight, tipAmp, tipFreq, phase) {
+    const points = [];
+    const stepsPerPeriod = 60;
+    const totalSteps = stepsPerPeriod * 2;
+    const totalWidth = 2 * width;
+    for (let i = 0; i <= totalSteps; i++) {
+        const x = (i / stepsPerPeriod) * width;  // 0 .. 2*width
+        // y goes UP from baseY (smaller y in SVG). tipAmp wobbles tip.
+        const y = baseY - baseHeight - tipAmp * Math.sin((x / width) * tipFreq * 2 * Math.PI + phase);
+        points.push(`${x.toFixed(2)} ${y.toFixed(2)}`);
+    }
+    return `M ${points[0]} ` +
+           points.slice(1).map(p => `L ${p}`).join(' ') +
+           ` L ${totalWidth.toFixed(2)} ${FLAME_BOTTOM_Y} L 0 ${FLAME_BOTTOM_Y} Z`;
+}
+```
+
+### Task 4 — `_invalidateFlameCache` method
+
+Insert after `_generateFlamePath`. Body whitelist matches AC-7's pin.
+
+```js
+// QS-201: clear the memoization keys and cached DOM refs after each
+// _render() innerHTML rewrite. Does NOT touch _currentFlameAmp /
+// _currentFlameSpeed / _flamePhase — those survive disconnect so
+// re-attach resumes the dance without a visible jump.
+_invalidateFlameCache() {
+    this._flameEls = null;
+    this._lastFlameBaseY = null;
+    this._lastFlameAmp = null;
+}
+```
+
+### Task 5 — Replace the `colors` constant
+
+File: `qs-radiator-card.js`, lines 240-246 currently:
+
+```js
+const colors = {
+    primary: '#2196F3',
+    gradStart: '#00bcd4',
+    gradEnd: '#8bc34a',
+    animStart: '#00e1ff',
+    animEnd: '#0066ff'
+};
+```
+
+Replace with the climate heat palette (verbatim from
+`qs-climate-card.js:214-220`):
+
+```js
+// QS-201: heat-mode palette — borrowed verbatim from qs-climate-card.js's
+// `heat` colorScheme block. The radiator is heating-only so a fixed warm
+// palette is appropriate (no per-state branching like the climate card).
+const colors = {
+    primary: '#FF5722',
+    gradStart: '#FF5722',
+    gradEnd: '#D32F2F',
+    animStart: '#FF6E40',
+    animEnd: '#E64A19'
+};
+```
+
+### Task 6 — `_render()` extensions
+
+File: `qs-radiator-card.js`, inside `_render()` (currently lines
+142-1016). All extensions documented as discrete bullets — each lands
+at an anchor location specified by neighbouring code.
+
+6a. **Compute progressRatio and flameBaseY**. Insert after
+`maxHours, displayTargetHours` block (around line 223) and before
+`const showFromTo` (line 226):
+
+```js
+// QS-201: flame backdrop — height tracks hoursRun/maxHours (mirrors pool).
+const progressRatio = maxHours > 0
+    ? Math.max(0, Math.min(1, hoursRun / maxHours))
+    : 0;
+const flameBaseY = CENTER_CY + CLIP_R - (FLAME_BASE_MIN_PCT + progressRatio * (FLAME_BASE_MAX_PCT - FLAME_BASE_MIN_PCT)) * 2 * CLIP_R;
+this._fireRunning = running;          // consumed by _startAnimation's step() closure
+this._flameBaseY = Number.isNaN(flameBaseY) ? null : flameBaseY;
+this._flameColors = running ? FLAME_FILLS : FLAME_GREY_FILLS;
+
+// Honor first-connect prime: skip the 1.5s boot lerp.
+if (this._needsFlamePrime) {
+    this._currentFlameAmp = running ? DANCE_AMP : STILL_AMP;
+    this._currentFlameSpeed = running ? DANCE_SPEED : STILL_SPEED;
+    this._needsFlamePrime = false;
+}
+```
+
+6b. **Per-instance `flameClipId`** — insert just before the `const css = ` declaration (currently line 248), mirroring pool's pattern at lines 351-355 (lines confirmed by concrete-planner reviewer):
+
+```js
+// QS-201: per-instance clip id so multiple radiator cards on one
+// dashboard don't collide. Shadow DOM scopes the id anyway, but a
+// stable per-instance id makes diff/inspection easier.
+if (!this._flameClipId) {
+    QsRadiatorCard._nextClipId = (QsRadiatorCard._nextClipId || 0) + 1;
+    this._flameClipId = 'fClip-' + QsRadiatorCard._nextClipId;
+}
+const flameClipId = this._flameClipId;
+```
+
+6c. **Pre-generate initial flame paths** (no empty `d=""` flash). Insert
+immediately after the `_flameClipId` block:
+
+```js
+// QS-201: pre-generate paths so the SVG renders with flames immediately,
+// avoiding the empty-d="" flash between innerHTML rewrite and the first
+// RAF tick. The RAF loop continues animating from these initial shapes
+// seamlessly (memo keys synced after the innerHTML write).
+const initialAmp = this._currentFlameAmp ?? STILL_AMP;
+const initialBaseY = this._flameBaseY ?? CENTER_CY;
+const initialFlameColors = this._flameColors ?? FLAME_GREY_FILLS;
+const initialFlamePaths = [0, 1, 2].map(i => this._generateFlamePath(
+    FLAME_WIDTH,
+    initialBaseY,
+    LAYER_BASE_HEIGHTS[i],
+    initialAmp * LAYER_TIP_AMP_MULTS[i],
+    LAYER_TIP_FREQS[i],
+    i * LAYER_PHASE_OFFSET,
+));
+```
+
+6d. **CSS additions** — at the top of the existing `const css = ` template
+literal (line 248), extend the `:host` rule and add text-shadow on the
+four ring text classes. Existing rule:
+
+```js
+:host { --pad: 18px; display:block; }
+```
+
+Becomes:
+
+```js
+:host {
+    --pad: 18px;
+    --ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5);
+    display: block;
+}
+```
+
+And add text-shadow to the four classes (extend existing rules at
+lines 287, 288, 293, 294):
+
+```js
+.ring .target-label { ...; text-shadow: var(--ring-text-shadow); }
+.ring .target-value { ...; text-shadow: var(--ring-text-shadow); }
+.ring .from-to-label { ...; text-shadow: var(--ring-text-shadow); }
+.ring .from-to-value { ...; text-shadow: var(--ring-text-shadow); }
+```
+
+6e. **Gate split** — replace the existing `const showAnimation = (running
+&& segLen > 6);` (line 413) with the three-variable form:
+
+```js
+const ringDashActive = (running && segLen > 6);
+const fireActive = running;
+const showAnimation = ringDashActive || fireActive;
+```
+
+The call site at line 417 (`if (showAnimation) { this._startAnimation(); }
+else { this._stopAnimation(); }`) is UNCHANGED.
+
+6f. **`<path id="running_anim">` gate migration** — line 530-541 today
+emits the dash element conditionally on `showAnimation`. Change the
+gate at that emission point from `showAnimation` to `ringDashActive`.
+The intent: the ring dash only renders when there's progress to dash
+through, but the fire RAF should run as long as `running===true`.
+
+6g. **Flame SVG markup** — inside the `_root.innerHTML` template:
+
+- In `<defs>` (currently lines 511-527), add the clipPath INSIDE the
+  `<defs>` block, after the `<filter id="runningGlow">` (line 520-526):
+
+  ```jsx
+  <clipPath id="${flameClipId}">
+      <circle cx="160" cy="160" r="120" />
+  </clipPath>
+  ```
+
+- Between the closing `</defs>` and the existing
+  `<path d="${bgPath}" stroke="var(--divider-color)" ...>` (line 528),
+  insert the flame layer group:
+
+  ```jsx
+  <g clip-path="url(#${flameClipId})">
+      <path id="flame0" d="${initialFlamePaths[0]}" fill="${initialFlameColors[0]}" opacity="1" pointer-events="none" style="will-change: transform;" />
+      <path id="flame1" d="${initialFlamePaths[1]}" fill="${initialFlameColors[1]}" opacity="1" pointer-events="none" style="will-change: transform;" />
+      <path id="flame2" d="${initialFlamePaths[2]}" fill="${initialFlameColors[2]}" opacity="1" pointer-events="none" style="will-change: transform;" />
+  </g>
+  ```
+
+6h. **Cache invalidation post-innerHTML** — immediately after the
+`this._root.innerHTML = \`...\`;` assignment (currently ends around line
+599) and BEFORE the `// Wire events` comment (line 601), insert:
+
+```js
+// QS-201: invalidate cached flame DOM refs after innerHTML rewrite so
+// the next RAF tick re-queries fresh elements.
+this._invalidateFlameCache();
+```
+
+### Task 7 — `_startAnimation()` extension
+
+File: `qs-radiator-card.js`, `_startAnimation()` currently lines 33-51.
+
+Add first-init prime logic at the top of the function (before
+`if (this._animRaf != null) return;` at line 34):
+
+```js
+// QS-201: first-connect prime — initialize flame anim state if null so
+// the next _render() can read sane defaults. Set _needsFlamePrime so
+// _render() skips the 1.5s lerp from defaults at boot.
+if (this._currentFlameAmp == null) {
+    this._currentFlameAmp = STILL_AMP;
+    this._currentFlameSpeed = STILL_SPEED;
+    this._flamePhase = 0;
+    this._needsFlamePrime = true;
+}
+this._invalidateFlameCache();
+```
+
+Then inside the existing `step(ts)` closure (line 36-49), AFTER the
+existing ring-dash update (`p.setAttribute('stroke-dashoffset', ...)`)
+and BEFORE the `this._animRaf = requestAnimationFrame(step);` line at
+the end, insert the flame update logic. Mirror pool's
+`_startAnimation` body lines 132-199 exactly, adapted to flame names:
+
+```js
+// --- QS-201: flame animation update ---
+const fireOn = this._fireRunning === true;
+const targetAmp = fireOn ? DANCE_AMP : STILL_AMP;
+const targetSpeed = fireOn ? DANCE_SPEED : STILL_SPEED;
+const lerpDt = Math.min(dt, LERP_DT_CEIL);
+const lerpFactor = 1 - Math.exp(-LERP_RATE * lerpDt);
+this._currentFlameAmp += (targetAmp - this._currentFlameAmp) * lerpFactor;
+this._currentFlameSpeed += (targetSpeed - this._currentFlameSpeed) * lerpFactor;
+this._flamePhase += this._currentFlameSpeed * dt;
+this._flamePhase = this._flamePhase % PHASE_WRAP;
+
+// Lazy-resolve flame DOM refs once per innerHTML rewrite.
+if (!this._flameEls) {
+    this._flameEls = [
+        this._root?.getElementById('flame0') ?? null,
+        this._root?.getElementById('flame1') ?? null,
+        this._root?.getElementById('flame2') ?? null,
+    ];
+}
+
+// Per-layer translateX scroll (cheap GPU compositing).
+for (let i = 0; i < 3; i++) {
+    const fEl = this._flameEls[i];
+    if (fEl) {
+        const phaseOffset = i * LAYER_SCROLL_OFFSET;
+        const raw = (this._flamePhase + phaseOffset) * PHASE_TO_PX;
+        const scrollOffset = ((raw % FLAME_WIDTH) + FLAME_WIDTH) % FLAME_WIDTH;
+        const tx = -CLIP_R - scrollOffset;
+        fEl.style.transform = `translateX(${tx.toFixed(1)}px)`;
+    }
+}
+
+// Regenerate paths only when base-Y or amp changes appreciably (throttle).
+const flameBaseY = this._flameBaseY;
+const hasValidBase = flameBaseY != null && !Number.isNaN(flameBaseY);
+const ampDelta = this._lastFlameAmp == null
+    ? Infinity
+    : Math.abs(this._currentFlameAmp - this._lastFlameAmp);
+const levelChanged = hasValidBase &&
+    Math.abs(flameBaseY - (this._lastFlameBaseY ?? Number.NEGATIVE_INFINITY)) > LEVEL_REGEN_THRESHOLD;
+if (hasValidBase && (levelChanged || ampDelta > AMP_REGEN_THRESHOLD)) {
+    this._lastFlameBaseY = flameBaseY;
+    this._lastFlameAmp = this._currentFlameAmp;
+    const colors = this._flameColors || FLAME_GREY_FILLS;
+    for (let i = 0; i < 3; i++) {
+        const fEl = this._flameEls[i];
+        if (fEl) {
+            const d = this._generateFlamePath(
+                FLAME_WIDTH,
+                flameBaseY,
+                LAYER_BASE_HEIGHTS[i],
+                this._currentFlameAmp * LAYER_TIP_AMP_MULTS[i],
+                LAYER_TIP_FREQS[i],
+                i * LAYER_PHASE_OFFSET,
+            );
+            fEl.setAttribute('d', d);
+            fEl.setAttribute('fill', colors[i]);
+        }
+    }
+}
+```
+
+### Task 8 — `disconnectedCallback` extension
+
+File: `qs-radiator-card.js`, `disconnectedCallback()` currently lines
+64-74. After the existing `this._stopAnimation();` call (line 65),
+insert:
+
+```js
+// QS-201: clear flame DOM cache and memoization keys. _currentFlameAmp /
+// _currentFlameSpeed / _flamePhase deliberately survive so re-attach
+// resumes the dance without a visible jump.
+this._invalidateFlameCache();
+```
+
+The existing flag resets (lines 70-74) stay unchanged.
+
+### Task 9 — Update `dashboard-and-cards.md`
+
+File: `docs/agents/concepts/dashboard-and-cards.md`, line 195 (radiator
+card row in the JS Lovelace cards table):
+
+Change from:
+
+```md
+| Radiator | `custom:qs-radiator-card` | `QSRadiator` | `ui/resources/qs-radiator-card.js` (cloned from `qs-on-off-duration-card.js`; UX redesign deferred via [#199](https://github.com/tmenguy/quiet-solar/issues/199); has S14-S17/N7 safety hardening the on/off card has not yet adopted) |
+```
+
+To (extend the parenthetical):
+
+```md
+| Radiator | `custom:qs-radiator-card` | `QSRadiator` | `ui/resources/qs-radiator-card.js` (cloned from `qs-on-off-duration-card.js`; has S14-S17/N7 safety hardening the on/off card has not yet adopted; QS-201 added the heat-mode warm palette and a stylized 3-layer flame backdrop that grows with `hoursRun/maxHours` and goes grey-still when off, mirroring pool's water-wave pattern. Animation constants are duplicated in-file rather than shared, so a future pool-card refactor cannot silently break this card.) |
+```
+
+`last_verified: 2026-05-23` is INTENTIONALLY untouched — today's date is
+`2026-05-21` per current-date context; bumping would move the date
+backwards.
+
+### Task 10 — Quality gate
+
+- Iterate during TDD: `python scripts/qs/quality_gate.py --quick
+  tests/test_dashboard_rendering.py`.
+- Verify red (after Task 1, before Task 2): four new pins fail, the
+  parametrize extension status documented (likely passes immediately —
+  the existing `if (showAnimation)` line matches the regex; flag if
+  not).
+- Verify green (after Tasks 2-9 land in order): all radiator + cross-
+  card tests green.
+- Pre-PR: full gate `python scripts/qs/quality_gate.py` — pytest 100%
+  coverage + ruff + mypy + translations.
+
+### Task 11 — Manual visual verification (PR description)
+
+Spell out the checklist in the PR description so the human reviewer
+has a concrete reproduction recipe. The cards are outside the quality
+pipeline (KNOWN GAP — see "Known limitations" below) — manual
+verification is the only safety net for AC-4 and parts of AC-5.
+
+**Manual verification states** to walk through on a real HA install
+with the worktree branch:
+
+1. **Off (`enable_device: off`)** — card is greyscale via the existing
+   `.card.disabled` CSS. Flame layers are grey AND still. No
+   "Configuration error" SVG warnings.
+2. **Enabled, not running (`enable_device: on`, `running: false`)** —
+   ring + buttons are warm orange-red. Flame layers are grey, low
+   (base ≈ 1/5), and not moving (RAF stopped).
+3. **Enabled, just turned on (`running: true`, `hoursRun: 0`)** — flame
+   layers are warm orange, low (base ≈ 1/5), and dancing (RAF active,
+   `_flamePhase` advancing). The dance starts in the first frame —
+   NOT after `hoursRun` accumulates past 6 minutes (that's the AC-8
+   widening, verified manually here).
+4. **Enabled, running mid-progress (`hoursRun ≈ maxHours/2`)** — flame
+   base ≈ 1/2 of clip diameter. Dancing.
+5. **Enabled, running at target (`hoursRun ≈ maxHours`)** — flame base
+   ≈ 4/5. Dancing.
+6. **Running, then disabled mid-dance** — flame layers immediately go
+   grey and freeze at whatever scroll offset they had. Re-enabling
+   resumes the dance from a similar position (`_flamePhase` survived).
+
+Read the centre text in every state — `Actual / Target Hours`, the
+from/to row, the finish-time button. All four text classes should be
+legible against the flame backdrop thanks to the `--ring-text-shadow`.
+
+## Known limitations
+
+This story does NOT change the fact that **JS cards live outside the
+quality pipeline**:
+
+- No JS unit tests, no JS linter, no build step.
+- The new test pins in `test_dashboard_rendering.py` are **STRUCTURAL
+  proxies** — they assert source-code shape (presence of identifiers,
+  formula literals, gate splits), not runtime behaviour.
+- AC-4 (dance per frame) and parts of AC-5 (RAF stopped on transition)
+  rest on manual verification, not automated tests.
+- A flame-path geometry regression (e.g. tongues end up pointing down
+  instead of up) WOULD pass all four new pins. Visual regressions are
+  the developer's responsibility.
+
+This is consistent with the project-context.md "UI Stack KNOWN GAP" call-out.
+
+## Adversarial review notes
+
+The qs-create-plan phase ran four reviewers in parallel:
+**critic**, **concrete-planner**, **dev-proxy**, **scope-guardian**.
+~30 raw findings consolidated to 18 unique issues. All `critical` and
+`redesign` findings were resolved into the AC / task structure above.
+Material decisions:
+
+- **Off-state semantics (Critic critical C1)** — AC5 originally specified
+  "lerp to STILL_AMP" but said RAF stops on `!running`. Contradiction
+  resolved by dropping the lerp entirely: snap-to-grey fills, RAF stops,
+  flame positions freeze. Simpler and matches user intent.
+- **TDD ordering (Dev-proxy critical)** — Task 1 (test pins) now lands
+  before any production task. Original draft had production first.
+- **Test placement (Concrete-planner critical)** — new pins are CLASS
+  METHODS inside `class TestDashboardTemplateRendering:`, not module-level.
+  The parametrize extension stays module-level where it already is.
+- **`last_verified` (Concrete-planner critical)** — left UNTOUCHED at
+  `2026-05-23`. Today is `2026-05-21`. Bumping would move the date
+  backwards. Only the radiator-row content is updated.
+- **AC-7 positive whitelist (Critic + Dev-proxy critical)** — instead of
+  asserting `disconnectedCallback` does NOT contain `_currentFlameAmp =
+  null`, the new pin asserts `_invalidateFlameCache` body whitelist
+  contains exactly `_flameEls`, `_lastFlameBaseY`, `_lastFlameAmp` AND
+  does NOT contain `_currentFlameAmp` / `_currentFlameSpeed` /
+  `_flamePhase`. Tighter, less bypass-able.
+- **Test pin count (Scope-guardian improve)** — reduced from 6 to 4 by
+  folding `flame_state_preserved_on_disconnect` into the
+  `flame_layers_present` test's `_invalidateFlameCache` body assertions,
+  and merging `flame_clip_circle` into `flame_layers_present`.
+- **Multi-card DOM-id collision on `flame0/1/2` (Critic clarify)** —
+  resolved as NON-ISSUE via shadow DOM scoping. Documented in AC-2.
+- **`tests/` doc-drift (Dev-proxy critical)** — resolved as NON-ISSUE.
+  The drift checker only tracks paths inside `custom_components/quiet_solar/`
+  (verified empirically: the warning we saw says "outside, ignored").
+- **Text-shadow scope (Concrete + Scope clarify)** — extended from
+  `.target-value` (AC9 original) to all four ring centre text classes,
+  with explicit required-for-correctness justification (orange-on-orange
+  contrast collapse).
+- **Pool-as-source-of-truth fragility (Critic redesign)** — accepted
+  trade-off: constants are duplicated in the radiator card. No runtime
+  reference to pool. Documented as an "Out of scope" item (shared base
+  extraction is a follow-up if a third animated-backdrop card lands).
+- **AC-3 height semantic (Critic redesign)** — kept "more run-time =
+  taller flame" because the user explicitly chose option (i) in
+  clarifying Q3 ("matches pool's water level exactly"). Trade-off
+  documented inline.
+- **`prefers-reduced-motion` (Critic redesign)** — deferred to follow-up.
+  Not in user's clarifying answers. Flagged in "Out of scope".
+- **Wave-painted-orange visual risk (Concrete clarify)** — accepted
+  trade-off: per-layer `tipFreq=[2,3,4]` + per-layer base heights +
+  amp multipliers should give the parallax-tongue effect. If manual
+  verification reveals it reads as "wave painted orange", a follow-up
+  can add a higher-frequency overlay. Flagged in "Out of scope".
+- **`_needsFlamePrime` lifecycle (Critic clarify)** — fully specified:
+  set in `_startAnimation` first-init; consumed in `_render()`; cleared
+  immediately after consumption. Lifecycle pinned in Task 7.
+- **All other `clarify` findings** (LAYER_SCROLL_OFFSET use,
+  per-layer tipFreq values, PHASE_TO_PX formula, throttle interval,
+  text-shadow CSS string, manual verification pass criteria) — resolved
+  inline in the constants block (Task 2) + the `_startAnimation` code
+  (Task 7) + the manual verification checklist (Task 11).
+
+## Approach summary
+
+In one paragraph: the implement-task agent will (1) land four new
+regex-pin tests in `class TestDashboardTemplateRendering` and extend
+the M4 parametrize, verifying red. Then (2) add module-top fire-geometry
+constants to `qs-radiator-card.js` mirroring pool's pattern; (3) add a
+`_generateFlamePath` method; (4) add an `_invalidateFlameCache` method
+whose body whitelist matches the AC-7 pin; (5) swap the cool `colors`
+constant for the climate-card heat palette verbatim; (6) extend
+`_render()` with progressRatio + flameBaseY + per-instance clip id +
+pre-generated initial paths + the gate split + text-shadow CSS + flame
+SVG markup + post-innerHTML cache invalidation; (7) extend
+`_startAnimation()` with first-init prime + per-frame flame lerp +
+translateX scroll + throttled path regen, all mirroring pool's
+proven body; (8) extend `disconnectedCallback` with a single
+`_invalidateFlameCache()` call (preserves animation state); (9) extend
+the radiator-card row in `dashboard-and-cards.md`. Run the full
+quality gate. Manual visual verification per the six-state checklist
+goes into the PR description.
+
+Doc maintenance: only `docs/agents/concepts/dashboard-and-cards.md`
+needs a content edit (the radiator-row sentence). `last_verified`
+deliberately stays at `2026-05-23` (already ahead of today's
+`2026-05-21`). `docs/agents/glossary.md`'s prose mention is not in
+any `covers:` frontmatter — no edit needed.

--- a/docs/stories/QS-201.story_review_fix_#01.md
+++ b/docs/stories/QS-201.story_review_fix_#01.md
@@ -1,0 +1,227 @@
+---
+issue: 201
+title: QS-201 review fix plan #01
+branch: QS_201
+status: planned
+next_phase: implement-task
+source_pr: 203
+source_story: docs/stories/QS-201.story.md
+labels: [area:ui, area:tests]
+---
+
+# QS-201 — Review fix plan #01
+
+## Summary
+- Source PR: [#203](https://github.com/tmenguy/quiet-solar/pull/203)
+- Source story: [docs/stories/QS-201.story.md](QS-201.story.md)
+- Findings to fix: 4 (0 must-fix, 4 should-fix)
+- Next implement phase: `/implement-task`
+- Reviewers: blind-hunter, edge-case-hunter, acceptance-auditor (CodeRabbit
+  unavailable — rate-limited + out of credits, manual review covered the
+  same surfaces)
+
+The four fixes break into two correctness/quality issues in the radiator
+card source and two test-pin gaps for ACs whose implementation landed but
+whose structural assertion was missing from the test plan.
+
+## Findings to fix
+
+### [should-fix] S1 — `_invalidateFlameCache()` defeats path-regen throttle on every render
+
+- **File:** `custom_components/quiet_solar/ui/resources/qs-radiator-card.js`
+  (`_startAnimation`, ~line 93)
+- **Severity:** should-fix
+- **Source:** blind-hunter + edge-case-hunter (deduped)
+- **Description:** `this._invalidateFlameCache()` is called at the top of
+  `_startAnimation()` BEFORE the `if (this._animRaf != null) return;`
+  early-return. Since `_startAnimation` is called on every `_render()`
+  (via the gate at ~line 644), this nulls `_lastFlameAmp` and
+  `_lastFlameBaseY` on every HA state push — even when RAF is already
+  running. On the next RAF tick, `_lastFlameAmp == null` makes
+  `ampDelta = Infinity` (>`AMP_REGEN_THRESHOLD = 0.25`), forcing
+  unconditional regeneration of all three flame `<path d="...">`
+  attributes. The intended throttle (`AMP_REGEN_THRESHOLD`,
+  `LEVEL_REGEN_THRESHOLD`) is effectively defeated.
+- **Proposed fix:** Move the `this._invalidateFlameCache()` call AFTER the
+  `if (this._animRaf != null) return;` guard, so it only runs when RAF is
+  actually being (re)started. The `_render()`-end invalidate at ~line 837
+  already handles the post-innerHTML-rewrite case.
+
+```diff
+   _startAnimation() {
+-    // QS-201: first-connect prime — initialize flame anim state if null so
+-    // the next _render() can read sane defaults. Set _needsFlamePrime so
+-    // _render() skips the 1.5s lerp from defaults at boot.
++    if (this._animRaf != null) return;
++    // QS-201: first-connect prime — initialize flame anim state if null so
++    // the next _render() can read sane defaults. Set _needsFlamePrime so
++    // _render() skips the 1.5s lerp from defaults at boot.
+     if (this._currentFlameAmp == null) {
+       this._currentFlameAmp = STILL_AMP;
+       this._currentFlameSpeed = STILL_SPEED;
+       this._flamePhase = 0;
+       this._needsFlamePrime = true;
+     }
+     this._invalidateFlameCache();
+-
+-    if (this._animRaf != null) return;
+     this._lastAnimTs = null;
+```
+
+### [should-fix] S2 — ClipPath hard-codes geometry that already exists as constants
+
+- **File:** `custom_components/quiet_solar/ui/resources/qs-radiator-card.js`
+  (clipPath defs, ~line 754 in `_render`)
+- **Severity:** should-fix
+- **Source:** blind-hunter
+- **Description:** The `<clipPath id="${flameClipId}"><circle cx="160"
+  cy="160" r="120" /></clipPath>` SVG block hard-codes the same
+  `CENTER_CY = 160` and `CLIP_R = 120` values that are declared at the
+  module top. If a future tweak to the constants is made, the clipPath
+  silently drifts and the flame layers spill outside the ring (or get
+  clipped too tightly). The top-of-file comment already says geometry
+  "must match the `<clipPath> circle attributes below`" — close that gap.
+- **Proposed fix:** Interpolate the constants into the SVG template
+  string:
+
+```diff
+-                <clipPath id="${flameClipId}">
+-                  <circle cx="160" cy="160" r="120" />
+-                </clipPath>
++                <clipPath id="${flameClipId}">
++                  <circle cx="${CENTER_CY}" cy="${CENTER_CY}" r="${CLIP_R}" />
++                </clipPath>
+```
+
+(Note: in the radiator card the ring is centred on the same point in both
+axes, so `cx` and `cy` both use `CENTER_CY`. If you'd prefer a separate
+`CENTER_CX` constant for symmetry/clarity, that's a nice-to-have on top.)
+
+### [should-fix] S3 — AC-9 (centre-text readability) lacks a structural test pin
+
+- **File:** `tests/test_dashboard_rendering.py` (new test method inside
+  `class TestDashboardTemplateRendering:` — append after the existing
+  `test_radiator_card_flame_off_grey`)
+- **Severity:** should-fix
+- **Source:** acceptance-auditor
+- **Description:** AC-9 is implemented (`--ring-text-shadow` CSS variable
+  on `:host`, applied to `.ring .target-label`, `.ring .target-value`,
+  `.ring .from-to-label`, `.ring .from-to-value`) but no test pin asserts
+  it. A future CSS-only regression that drops the shadow would not be
+  caught.
+- **Proposed fix:** Add a test method that:
+  1. Reads `custom_components/quiet_solar/ui/resources/qs-radiator-card.js`.
+  2. Asserts the literal CSS-variable declaration on `:host`:
+     ```
+     --ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5);
+     ```
+     (regex, tolerant of whitespace).
+  3. Asserts the variable is applied via `text-shadow: var(--ring-text-shadow)`
+     on each of the four ring text classes, by regex-matching each class
+     block individually.
+
+Skeleton:
+
+```python
+def test_radiator_card_text_shadow_for_flame_readability(self):
+    """AC-9: --ring-text-shadow on :host + applied to 4 ring text classes."""
+    src = (RESOURCE_DIR / "qs-radiator-card.js").read_text()
+    assert re.search(
+        r"--ring-text-shadow:\s*0 0 12px rgba\(0,0,0,0\.8\),\s*0 2px 4px rgba\(0,0,0,0\.5\)",
+        src,
+    ), "AC-9: --ring-text-shadow variable must be declared on :host"
+    for cls in ("target-label", "target-value", "from-to-label", "from-to-value"):
+        assert re.search(
+            rf"\.ring\s+\.{cls}\s*\{{[^}}]*text-shadow:\s*var\(--ring-text-shadow\)",
+            src,
+        ), f"AC-9: .ring .{cls} must apply text-shadow: var(--ring-text-shadow)"
+```
+
+### [should-fix] S4 — AC-4 (dancing dynamic proxy) lacks structural test pins
+
+- **File:** `tests/test_dashboard_rendering.py` (new test method inside
+  `class TestDashboardTemplateRendering:` — append alongside S3)
+- **Severity:** should-fix
+- **Source:** acceptance-auditor
+- **Description:** AC-4 promises a structural proxy for "dancing when
+  running" via three patterns: the `_flamePhase +=` accumulator, the
+  per-layer `translateX(${tx.toFixed(1)}px)` template, and the use of
+  `LAYER_SCROLL_OFFSET` inside the step closure for parallax-tongue
+  effect. Implementation is present (~lines 96, 113-122) but no test pin
+  asserts any of these. A refactor that drops one of the three would not
+  be caught.
+- **Proposed fix:** Add a test method asserting all three regex patterns:
+
+```python
+def test_radiator_card_flame_dancing_dynamic_proxy(self):
+    """AC-4: phase accumulator + translateX scroll + LAYER_SCROLL_OFFSET."""
+    src = (RESOURCE_DIR / "qs-radiator-card.js").read_text()
+    # Phase accumulator
+    assert re.search(
+        r"this\._flamePhase\s*\+=\s*this\._currentFlameSpeed\s*\*\s*dt",
+        src,
+    ), "AC-4: _flamePhase += _currentFlameSpeed * dt must be present"
+    # Per-frame transform template — tx is toFixed(1)
+    assert re.search(
+        r"translateX\(\$\{tx\.toFixed\(1\)\}px\)",
+        src,
+    ), "AC-4: per-layer translateX(${tx.toFixed(1)}px) template required"
+    # LAYER_SCROLL_OFFSET used inside the step closure for parallax depth
+    assert re.search(
+        r"i\s*\*\s*LAYER_SCROLL_OFFSET",
+        src,
+    ), "AC-4: LAYER_SCROLL_OFFSET must drive per-layer scroll phase"
+```
+
+## Verification
+
+After applying S1-S4, the implementation phase must:
+
+- Re-run the quality gate (`python scripts/qs/quality_gate.py`) — pytest
+  100% cov + ruff + mypy + translations.
+- Confirm the four existing radiator-card hardening pins (S14, S15, S16,
+  S17, N7, M2, M4, B5, BH10) still pass.
+- Confirm the four pre-existing AC pins (`test_radiator_card_heat_palette`,
+  `test_radiator_card_flame_layers_present`,
+  `test_radiator_card_flame_height_envelope_uses_progress`,
+  `test_radiator_card_flame_off_grey`) still pass.
+
+## Deferred (not in this fix plan)
+
+The following nice-to-have findings from the review were intentionally
+NOT included in this round. Re-raise in a follow-up if they bite:
+
+- **N1** — `initialBaseY` cold-start fallback uses SVG y-centre (`CENTER_CY`)
+  instead of clip bottom (`CENTER_CY + CLIP_R`). Only affects the very first
+  frame before state arrives.
+- **N2** — `_needsFlamePrime` could leak across a narrow disconnect/reconnect
+  window and overwrite preserved animation state. Window is synchronous and
+  unlikely in practice.
+- **N3** — `_lastAnimTs` not reset on `document.visibilitychange`; single-frame
+  scroll jump after multi-hour tab hide (modulo masks within one period).
+- **N4** — `_safeNumber` doesn't filter `Infinity`. Safe in current callers
+  (Math.min/max clamps catch it).
+- **N5** — Local `flameColors` const shadows the broader `colors` palette name
+  in `_render`'s outer scope. Cosmetic.
+- **N6** — `_currentFlameAmp == null` loose-equality is intentional but
+  inconsistent with the file's general strict-equality style.
+- **N7** — AC-3 envelope endpoint numerical values (`y≈232`, `y≈88`) not
+  asserted by the regex pin (formula is pinned).
+- **N8** — `else _stopAnimation()` branch of the umbrella RAF gate not pinned.
+- **N9** — 1073-line story file in the repo (meta concern, not a code defect).
+
+## How to apply
+
+Run `/implement-task` (or `claude --agent qs-implement-task`) against this
+fix plan. The implementer should:
+
+1. Apply S1 (cache-invalidation reorder) and S2 (clipPath constant
+   interpolation) to `qs-radiator-card.js`.
+2. Add the two new test methods for S3 and S4 to
+   `tests/test_dashboard_rendering.py` (alongside the existing four AC
+   pins).
+3. Run the quality gate, push, and let the existing PR #203 pick up the
+   fix commit.
+
+When done, return and run `/review-task` (or
+`claude --agent qs-review-task`) again to re-verify.

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -493,12 +493,21 @@ class TestDashboardTemplateRendering:
                 f"Missing <path id=\"{fid}\">"
             )
 
-        # AC-2: clipPath circle at the ring centre.
+        # AC-2: clipPath circle at the ring centre. Geometry must be wired
+        # through the module-top `CENTER_CY` / `CLIP_R` constants so the
+        # SVG cannot silently drift if those constants are tweaked
+        # (review fix S2).
         assert re.search(
-            r"<clipPath\s+id=\"\$\{flameClipId\}\">\s*<circle\s+cx=\"160\"\s+cy=\"160\"\s+r=\"120\"",
+            r"<clipPath\s+id=\"\$\{flameClipId\}\">\s*<circle\s+cx=\"\$\{CENTER_CY\}\"\s+cy=\"\$\{CENTER_CY\}\"\s+r=\"\$\{CLIP_R\}\"",
             content,
             re.DOTALL,
-        ) is not None, "Missing clipPath circle (cx=160 cy=160 r=120)"
+        ) is not None, (
+            "Missing clipPath circle interpolating CENTER_CY / CLIP_R "
+            "(must use ${CENTER_CY} / ${CLIP_R}, not hard-coded 160 / 120)"
+        )
+        # The constants themselves carry the correct geometric values.
+        assert re.search(r"const\s+CENTER_CY\s*=\s*160\b", content) is not None
+        assert re.search(r"const\s+CLIP_R\s*=\s*120\b", content) is not None
 
         # AC-2: <g clip-path="url(#${flameClipId})"> wraps the three paths.
         assert 'clip-path="url(#${flameClipId})"' in content
@@ -600,6 +609,63 @@ class TestDashboardTemplateRendering:
         ) is not None, (
             "Fill-selection must branch on `running` — `running ? FLAME_FILLS : FLAME_GREY_FILLS`"
         )
+
+    def test_radiator_card_text_shadow_for_flame_readability(self):  # CR2 — sync (no hass)
+        """QS-201 AC-9 — --ring-text-shadow on :host + applied to 4 ring text classes.
+
+        Without the text-shadow, the centre text collapses in contrast over the
+        warm orange flame backdrop. AC-9 is required-for-correctness — pin it
+        so a CSS-only regression that drops the shadow can't slip past review.
+        """
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+        # CSS variable declaration on :host (whitespace-tolerant).
+        assert re.search(
+            r"--ring-text-shadow:\s*0 0 12px rgba\(0,0,0,0\.8\),\s*0 2px 4px rgba\(0,0,0,0\.5\)",
+            content,
+        ) is not None, "AC-9: --ring-text-shadow variable must be declared on :host"
+
+        # Each of the four ring text classes applies the variable.
+        for cls in ("target-label", "target-value", "from-to-label", "from-to-value"):
+            assert re.search(
+                rf"\.ring\s+\.{cls}\s*\{{[^}}]*text-shadow:\s*var\(--ring-text-shadow\)",
+                content,
+            ) is not None, (
+                f"AC-9: .ring .{cls} must apply text-shadow: var(--ring-text-shadow)"
+            )
+
+    def test_radiator_card_flame_dancing_dynamic_proxy(self):  # CR2 — sync (no hass)
+        """QS-201 AC-4 — structural proxy for "dancing when running".
+
+        No JS runtime tests exist; AC-4 is verified manually plus via these
+        three structural patterns: a `_flamePhase` accumulator that advances
+        per frame, a per-layer `translateX(${tx.toFixed(1)}px)` template, and
+        the use of `LAYER_SCROLL_OFFSET` inside the step closure for the
+        parallax-tongue effect.
+        """
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+        # Phase accumulator inside the RAF step closure.
+        assert re.search(
+            r"this\._flamePhase\s*\+=\s*this\._currentFlameSpeed\s*\*\s*dt",
+            content,
+        ) is not None, "AC-4: _flamePhase += _currentFlameSpeed * dt must be present"
+
+        # Per-frame translateX template — tx is toFixed(1) for sub-pixel snap.
+        assert re.search(
+            r"translateX\(\$\{tx\.toFixed\(1\)\}px\)",
+            content,
+        ) is not None, "AC-4: per-layer translateX(${tx.toFixed(1)}px) template required"
+
+        # LAYER_SCROLL_OFFSET drives per-layer scroll phase for parallax.
+        assert re.search(
+            r"i\s*\*\s*LAYER_SCROLL_OFFSET",
+            content,
+        ) is not None, "AC-4: LAYER_SCROLL_OFFSET must drive per-layer scroll phase"
 
     @pytest.mark.asyncio
     async def test_radiator_dashboard_passes_climate_hvac_mode_on(

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -457,6 +457,150 @@ class TestDashboardTemplateRendering:
             "configured HVAC ON mode — non-default HVAC modes won't be recognised"
         )
 
+    def test_radiator_card_heat_palette(self):  # CR2 — sync (no hass)
+        """QS-201 AC-1 — heat palette is applied verbatim, cool palette gone."""
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+        # Strip comments first.
+        no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+        no_comments = re.sub(r"//[^\n]*", "", no_block)
+
+        # Required heat-palette literals (all five keys).
+        for literal in ("'#FF5722'", "'#D32F2F'", "'#FF6E40'", "'#E64A19'"):
+            assert literal in no_comments, f"Missing heat-palette literal {literal}"
+
+        # The `colors` const must use these literals (not just appear somewhere).
+        assert re.search(
+            r"const\s+colors\s*=\s*\{[^}]*primary:\s*'#FF5722'", no_comments
+        ) is not None
+
+        # Cool-palette literals must NOT appear in executable code.
+        for forbidden in ("'#2196F3'", "'#00bcd4'", "'#8bc34a'", "'#00e1ff'", "'#0066ff'"):
+            assert forbidden not in no_comments, (
+                f"Stale cool-palette literal {forbidden} still present"
+            )
+
+    def test_radiator_card_flame_layers_present(self):  # CR2 — sync (no hass)
+        """QS-201 AC-2 + AC-7 — three flame paths, circular clip, cache-clear whitelist."""
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+
+        # AC-2: three flame paths with ids flame0/1/2.
+        for fid in ("flame0", "flame1", "flame2"):
+            assert re.search(rf'id="{fid}"', content) is not None, (
+                f"Missing <path id=\"{fid}\">"
+            )
+
+        # AC-2: clipPath circle at the ring centre.
+        assert re.search(
+            r"<clipPath\s+id=\"\$\{flameClipId\}\">\s*<circle\s+cx=\"160\"\s+cy=\"160\"\s+r=\"120\"",
+            content,
+            re.DOTALL,
+        ) is not None, "Missing clipPath circle (cx=160 cy=160 r=120)"
+
+        # AC-2: <g clip-path="url(#${flameClipId})"> wraps the three paths.
+        assert 'clip-path="url(#${flameClipId})"' in content
+
+        # AC-7: _invalidateFlameCache body whitelist — EXACTLY three fields cleared.
+        inv_match = re.search(
+            r"_invalidateFlameCache\s*\(\s*\)\s*\{([^}]+)\}",
+            content,
+            re.DOTALL,
+        )
+        assert inv_match is not None, "Missing _invalidateFlameCache method"
+        body = inv_match.group(1)
+        # Required positive whitelist.
+        for required in ("_flameEls", "_lastFlameBaseY", "_lastFlameAmp"):
+            assert required in body, (
+                f"_invalidateFlameCache must clear `this.{required}`"
+            )
+        # Forbidden: fields that must SURVIVE disconnect.
+        for forbidden in ("_currentFlameAmp", "_currentFlameSpeed", "_flamePhase"):
+            assert forbidden not in body, (
+                f"_invalidateFlameCache must NOT touch `this.{forbidden}` "
+                f"(animation state survives disconnect — mirror pool)"
+            )
+
+        # AC-7: disconnectedCallback calls _invalidateFlameCache.
+        disc_match = re.search(
+            r"disconnectedCallback\s*\(\s*\)\s*\{([^}]+)\}",
+            content,
+            re.DOTALL,
+        )
+        assert disc_match is not None
+        assert "_invalidateFlameCache" in disc_match.group(1)
+
+    def test_radiator_card_flame_height_envelope_uses_progress(self):  # CR2 — sync (no hass)
+        """QS-201 AC-3 + AC-8 — flame base tracks progress; gate split into named sub-conditions."""
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+        no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+        no_comments = re.sub(r"//[^\n]*", "", no_block)
+
+        # AC-3: progressRatio is clamped against maxHours.
+        assert re.search(
+            r"progressRatio\s*=\s*maxHours\s*>\s*0\s*\?\s*Math\.max\(\s*0\s*,\s*Math\.min\(\s*1\s*,\s*hoursRun\s*/\s*maxHours",
+            no_comments,
+        ) is not None, "Missing progressRatio clamp"
+
+        # AC-3: flameBaseY formula uses the 1/5..4/5 envelope.
+        assert "FLAME_BASE_MIN_PCT" in no_comments
+        assert "FLAME_BASE_MAX_PCT" in no_comments
+        assert re.search(
+            r"flameBaseY\s*=\s*CENTER_CY\s*\+\s*CLIP_R\s*-\s*\(\s*FLAME_BASE_MIN_PCT\s*\+\s*progressRatio\s*\*\s*\(\s*FLAME_BASE_MAX_PCT\s*-\s*FLAME_BASE_MIN_PCT\s*\)\s*\)\s*\*\s*2\s*\*\s*CLIP_R",
+            no_comments,
+        ) is not None, "flameBaseY formula does not mirror pool's water-level envelope"
+
+        # AC-8: gate split.
+        assert re.search(
+            r"const\s+ringDashActive\s*=\s*running\s*&&\s*segLen\s*>\s*6", no_comments
+        ) is not None
+        assert re.search(
+            r"const\s+fireActive\s*=\s*running", no_comments
+        ) is not None
+        assert re.search(
+            r"const\s+showAnimation\s*=\s*ringDashActive\s*\|\|\s*fireActive", no_comments
+        ) is not None
+
+        # AC-8: <path id="running_anim"> emission is gated on ringDashActive,
+        # not the umbrella showAnimation.
+        assert re.search(
+            r"\$\{\s*ringDashActive\s*\?\s*`[^`]*?id=\"running_anim\"",
+            content,
+            re.DOTALL,
+        ) is not None, (
+            "<path id=\"running_anim\"> must be gated on ringDashActive, not showAnimation"
+        )
+
+    def test_radiator_card_flame_off_grey(self):  # CR2 — sync (no hass)
+        """QS-201 AC-5 — grey fills when !running; FLAME_GREY_FILLS constant exists."""
+        import re
+
+        content = (COMPONENT_ROOT / "ui" / "resources" / "qs-radiator-card.js").read_text()
+        no_block = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+        no_comments = re.sub(r"//[^\n]*", "", no_block)
+
+        # FLAME_GREY_FILLS constant present.
+        assert "FLAME_GREY_FILLS" in no_comments
+        # Constant is an array of at least three grey values (rgba with all
+        # three channels equal or near-equal — accept the simple form).
+        grey_array = re.search(
+            r"FLAME_GREY_FILLS\s*=\s*\[([^\]]+)\]", no_comments
+        )
+        assert grey_array is not None
+        # FLAME_FILLS (warm) also present — both constants required.
+        assert "FLAME_FILLS" in no_comments
+
+        # Selection between the two constants is gated on `running`.
+        assert re.search(
+            r"running\s*\?\s*FLAME_FILLS\s*:\s*FLAME_GREY_FILLS", no_comments
+        ) is not None, (
+            "Fill-selection must branch on `running` — `running ? FLAME_FILLS : FLAME_GREY_FILLS`"
+        )
+
     @pytest.mark.asyncio
     async def test_radiator_dashboard_passes_climate_hvac_mode_on(
         self, hass, full_dashboard_home
@@ -1377,6 +1521,7 @@ def test_card_mode_change_wrapped_in_try_finally(card_filename):
         ("qs-on-off-duration-card.js", "showAnimation"),
         ("qs-climate-card.js", "showAnimation"),
         ("qs-car-card.js", "charging"),
+        ("qs-radiator-card.js", "showAnimation"),
     ],
 )
 def test_card_raf_idle_gated(card_filename, gate):


### PR DESCRIPTION
## Summary
- Swap the radiator card's cool blue/teal/green palette for the climate-card heat palette (#FF5722 / #D32F2F / #FF6E40 / #E64A19).
- Add a 3-layer animated flame backdrop inside a circular clip on the ring: layer height tracks hoursRun/maxHours (1/5..4/5 of clip diameter, mirroring pool's water-level envelope), layers dance via per-frame translateX scroll + sine-wave tip wobble when running, snap to grey-still fills when off.
- Add a text-shadow CSS variable on the four ring centre text classes so the actual/target hours, from-to row, and finish-time button stay legible over the warm flame backdrop.

Fixes #201

## Review fix #01 (commit `23d913b`)
- **S1** — `_invalidateFlameCache()` moved behind the early-return guard in `_startAnimation()` so the path-regen throttle isn't defeated on every `_render()` call.
- **S2** — `<clipPath>` circle interpolates `${CENTER_CY}` / `${CLIP_R}` instead of hard-coded `160` / `120`, closing the constant-drift gap.
- **S3** — new test pin `test_radiator_card_text_shadow_for_flame_readability` covers AC-9 (`--ring-text-shadow` variable + application on the four ring text classes).
- **S4** — new test pin `test_radiator_card_flame_dancing_dynamic_proxy` covers AC-4 (phase accumulator, per-layer translateX, `LAYER_SCROLL_OFFSET` parallax).

## Doc maintenance
`docs/agents/concepts/dashboard-and-cards.md` was already updated in the original implementation commit (`1c471a1`) with the heat-palette + 3-layer flame backdrop entry on the radiator-card row. The review-fix commit changes only `qs-radiator-card.js` internals (S1 throttle reorder, S2 constant interpolation) and `tests/test_dashboard_rendering.py` (S3 + S4 structural pins) — none of these alter user-visible behaviour or invalidate the existing doc copy. `last_verified` is intentionally left at `2026-05-23` (the current date is `2026-05-21`; bumping would move the date backwards).

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)