### PR TITLE
QS-208: add ui-only fast path to quality gate

### DIFF
--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -170,8 +170,14 @@ to grep the entire tree to figure out what an `ack` is.
 - **HA** — Home Assistant. The host platform.
 - **FakeHass** — the lightweight test double for the HA layer
   (`tests/conftest.py` + `tests/factories.py`).
-- **Quality gate** — `scripts/qs/quality_gate.py`. Runs pytest 100%
-  cov + ruff + mypy + translations. Required before every commit.
+- **Quality gate** — `scripts/qs/quality_gate.py`. Runs pytest 100% cov
+  + ruff + mypy + translations on full scope. Smart scope detection
+  picks one of three modes: **full** (default), **dev-only** (only
+  dev-infra paths changed → skip ruff/mypy/translations/coverage, run
+  only changed tests), **ui-only** (only `ui/*.j2` and `ui/resources/**`
+  changed → skip lint/coverage, run `tests/test_dashboard_rendering.py`
+  plus any changed tests). Required before every commit; `--full`
+  forces the full suite.
 - **Static agents** — agents whose body is committed to the repo
   (`.claude/agents/`, `.cursor/agents/`, `.opencode/agents/`),
   versus per-task rendering (legacy approach in `legacy/`).

--- a/docs/stories/QS-208.story.md
+++ b/docs/stories/QS-208.story.md
@@ -1,0 +1,543 @@
+# QS-208 — Optimize quality gate for UI-only changes
+
+issue: 208
+branch: "QS_208"
+Status: ready-for-dev
+
+## Story
+
+As a developer iterating on Jinja dashboard templates or JS Lovelace cards,
+I want the quality gate to skip the full lint/mypy/coverage suite when only UI assets changed,
+so that small UI tweaks pay only the cost of the dashboard-rendering tests
+(~few seconds) instead of the full gate (~60s+ for ruff + mypy + translations + pytest with 100% coverage).
+
+## Background
+
+`scripts/qs/quality_gate.py` already has a smart scope detector (`_detect_scope`)
+with two modes:
+
+- **`dev-only`** — when only `tests/`, `legacy/`, `scripts/`, `docs/`, `.claude/`,
+  `.cursor/`, `.opencode/`, `.github/` paths or top-level config changed → skips
+  ruff / mypy / translations / full-coverage pytest; runs only changed test files.
+- **`full`** — otherwise → runs the full suite.
+
+Today, changing a `.j2` template or a JS card under `ui/resources/` lands in
+the **`full`** bucket because those files live under
+`custom_components/quiet_solar/` (production source). This story adds a
+third scope **`"ui-only"`**, triggered when changes touch only
+`custom_components/quiet_solar/ui/*.j2` (or nested) and
+`custom_components/quiet_solar/ui/resources/**` (optionally combined with
+dev-only paths). The ui-only branch runs only
+`tests/test_dashboard_rendering.py` (which already exercises both J2
+templates and every JS card via regex assertions on the file contents)
+plus any test files that themselves changed in the diff.
+
+### Current state (verified line numbers in `scripts/qs/quality_gate.py`)
+
+- `_DEV_ONLY_PATTERNS` tuple at lines 70-79; `_is_dev_only(filepath)` at lines 200-221.
+- `_detect_scope(changed_files)` at lines 224-248 returns
+  `{"scope": "full" | "dev-only", "changed_test_files": [...], "reason": "..."}`.
+- `main()` at lines 744-891 contains:
+  - `--full` override at lines 826-827 forces `scope = "full"`.
+  - The scope dispatch at lines 829-840 is `if scope == "dev-only": … else: …`
+    (the `else` is the full branch).
+  - Cache write at lines 885-888 fires only when `scope == "full"`.
+  - `_output_results` call at line 890 already passes `scope=scope`.
+
+The plan extends `_detect_scope` to a 3-way return and rewrites the scope
+dispatch to `if dev-only … elif ui-only … else (full) …`. The `--full` override,
+the cache-write guard, and the `_output_results` plumbing already do the right
+thing for the new scope value — no changes needed at those sites.
+
+## Acceptance criteria
+
+**AC-1 — UI-only scope detection.**
+**Given** the worktree has changes (committed-not-pushed + staged + unstaged
+per the existing `_get_changed_files()`),
+**And** every changed file is classified as either dev-only (per the existing
+`_is_dev_only()`) or a UI asset (per the new `_is_ui_asset()`),
+**And** at least one changed file is a UI asset,
+**When** `python scripts/qs/quality_gate.py` runs (no `--full`),
+**Then** the detected scope is `"ui-only"`,
+**And** stderr begins with the banner
+`"  scope: UI-ONLY (<reason>)\n  skipping ruff, mypy, translations, full coverage\n"`,
+**And** the `--json` output object contains `"scope": "ui-only"`.
+
+**AC-2 — UI-only runs only dashboard rendering tests (plus changed tests).**
+**Given** the gate detects ui-only scope,
+**When** the test phase runs,
+**Then** it invokes `check_pytest_files()` with
+`sorted({"tests/test_dashboard_rendering.py", *changed_test_files})`,
+**And** ruff (lint + format), mypy, translations, and the full-coverage pytest
+(`check_pytest()`) are NOT invoked,
+**And** coverage is naturally absent — `check_pytest_files()` does not pass
+`--cov` or `--cov-fail-under`, so no new code is needed to disable coverage.
+
+**AC-3 — Python production changes force full gate.**
+**Given** the diff includes any `.py` file under `custom_components/quiet_solar/`
+(including `ui/dashboard.py`, `ui/__init__.py`, or any other module under `ui/`
+that ends in `.py`),
+**When** the gate runs,
+**Then** the detected scope is `"full"` (because `.py` files under
+`custom_components/quiet_solar/` match neither `_is_dev_only` nor
+`_is_ui_asset` and therefore land in `non_dev_non_ui`, which triggers
+the full-scope return).
+
+**AC-4 — `--full` overrides ui-only.**
+**Given** ui-only scope would be detected,
+**When** the user passes `--full`,
+**Then** the gate runs the full suite (ruff + mypy + translations + full
+`check_pytest()` with 100% coverage).
+The existing `--full` override at lines 826-827 already handles this
+without modification — pinned by AC-test.
+
+**AC-5 — Mixed UI + dev-only stays ui-only and dedupes test list.**
+**Given** the diff contains both a UI asset and a dev-only file
+(e.g. `ui/quiet_solar_dashboard_template.yaml.j2` + `docs/stories/QS-208.story.md`),
+**When** scope is detected,
+**Then** scope is `"ui-only"` (not `"dev-only"` or `"full"`).
+**And given** a dev-only test file is also in the diff
+(e.g. `tests/test_dashboard_rendering.py` itself),
+**When** the ui-only branch builds the test-file list,
+**Then** the canonical UI test appears exactly once (deduplication via
+`set(...)`).
+
+**AC-6 — UI assets include nested templates and all of `ui/resources/`.**
+**Given** a path under `custom_components/quiet_solar/ui/`,
+**Then** `_is_ui_asset(path)` returns True iff
+`path.endswith(".j2")` (top-level or nested) OR
+`path.startswith("custom_components/quiet_solar/ui/resources/")` (any extension,
+including hypothetical future `.css`, image files, etc.),
+**And** returns False for any `.py` file under `ui/` (including
+`ui/dashboard.py`, `ui/__init__.py`).
+
+## AC → Task traceability
+
+| AC | Implementation tasks | Test tasks |
+|----|----------------------|------------|
+| AC-1 | T3.1, T3.2, T3.3 | T1.3a (banner), T1.3b (JSON scope), T1.3c (no lint gates called) |
+| AC-2 | T3.2, T3.3 | T1.3a, T1.3b (check_pytest_files called with sorted set) |
+| AC-3 | T2.2 | T1.2c (`.py` under ui/ → full), T1.2d (non-UI .py → full) |
+| AC-4 | (existing code) | T1.4 (`test_full_flag_overrides_ui_only_scope`) |
+| AC-5 | T2.3, T3.2 | T1.2e (mixed + dedup) |
+| AC-6 | T1.1, T2.1 | T1.1a-T1.1d (detector unit tests) |
+
+## Tasks
+
+TDD order is **tests first** for every implementation step. Red → green → refactor.
+
+### T1 — Write failing tests in `tests/test_quality_gate.py`
+
+(Mirror the existing dev-only precedent at line 445: patch `_detect_scope`,
+patch `_patch_all_gates` from line 52, assert `mocks[:4].not_called()` for
+lint gates and `mocks[4].not_called()` for the full `check_pytest`.)
+
+- **T1.1 — `TestIsUIAsset` class (4 unit tests).**
+  - 1.1a `test_recognizes_j2_template_anywhere_under_ui` — both
+    `custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2`
+    and a hypothetical
+    `custom_components/quiet_solar/ui/subdir/partial.j2` → True.
+  - 1.1b `test_recognizes_any_file_under_resources` — `ui/resources/qs-car-card.js`,
+    `ui/resources/sub/nested.css`, and (per convention-documenting test)
+    `ui/resources/hypothetical.py` → True.
+  - 1.1c `test_rejects_python_at_ui_root` — `ui/dashboard.py` and
+    `ui/__init__.py` → False.
+  - 1.1d `test_rejects_paths_outside_ui` — `home_model/foo.py`,
+    `ha_model/bar.py`, `tests/test_baz.py`, `scripts/qs/quality_gate.py` → False.
+
+- **T1.2 — `TestDetectScopeUIOnly` class (5 tests).**
+  - 1.2a `test_returns_ui_only_when_only_j2_changed` — diff = one `.j2` →
+    scope `"ui-only"`, `changed_test_files` empty.
+  - 1.2b `test_returns_ui_only_when_only_resources_changed` — diff = two `.js`
+    under `ui/resources/` → scope `"ui-only"`.
+  - 1.2c `test_returns_full_when_dashboard_py_also_changed` — diff = `.j2` +
+    `ui/dashboard.py` → scope `"full"` (reason cites the `.py`).
+  - 1.2d `test_returns_full_when_init_py_also_changed` — diff = `.j2` +
+    `ui/__init__.py` → scope `"full"`.
+  - 1.2e `test_returns_ui_only_when_mixed_with_dev_only_and_dedupes` — diff =
+    `.j2` + `docs/stories/QS-208.story.md` + `tests/test_dashboard_rendering.py`
+    → scope `"ui-only"`, `changed_test_files = ["tests/test_dashboard_rendering.py"]`.
+
+- **T1.3 — `TestUIOnlyMainBranch` class (2 variants).**
+  - 1.3a `test_ui_only_scope_skips_lint_gates_and_runs_only_dashboard_rendering`
+    — patch `_detect_scope` to return ui-only with empty `changed_test_files`;
+    assert `check_pytest_files` called once with
+    `["tests/test_dashboard_rendering.py"]`; assert all four lint-gate mocks
+    NOT called; assert `mocks[4]` (full `check_pytest`) NOT called; assert
+    JSON output `scope == "ui-only"`; assert stderr contains the exact banner
+    `"scope: UI-ONLY"` and `"skipping ruff, mypy, translations, full coverage"`.
+  - 1.3b `test_ui_only_scope_dedupes_when_canonical_test_in_changed_set` —
+    `changed_test_files = ["tests/test_dashboard_rendering.py", "tests/test_other.py"]`;
+    assert `check_pytest_files` called once with sorted set
+    `["tests/test_dashboard_rendering.py", "tests/test_other.py"]` (canonical
+    appears exactly once).
+
+- **T1.4 — `test_full_flag_overrides_ui_only_scope`** — patch `_detect_scope`
+  to return ui-only; invoke `main()` with `--full`; assert all four lint-gate
+  mocks called AND full `check_pytest` mock called; assert ui-only `check_pytest_files`
+  NOT called.
+
+**Total**: 4 + 5 + 2 + 1 = **12 new tests.**
+
+Run `python scripts/qs/quality_gate.py --quick tests/test_quality_gate.py` to
+confirm all 12 are red. Then proceed to T2/T3.
+
+### T2 — Implement `_is_ui_asset` and constants in `scripts/qs/quality_gate.py`
+
+Located near `_DEV_ONLY_PATTERNS` (lines 70-80) and `_is_dev_only` (lines 200-221).
+
+- **T2.1 — Add the constants.**
+
+  ```python
+  _UI_FAST_PATH_TESTS: tuple[str, ...] = ("tests/test_dashboard_rendering.py",)
+  # Why a tuple of one element (not a string): the ui-only branch builds
+  # `sorted({*_UI_FAST_PATH_TESTS, *changed_test_files})`, and unpacking a
+  # tuple keeps that call-site readable whether the list grows to 2+ files
+  # or stays at one. Adding a second UI test file is a one-line PR.
+  #
+  # tests/test_ui_dashboard.py is intentionally NOT here — it covers
+  # ui/dashboard.py (Python module). If dashboard.py is in the diff,
+  # scope becomes "full" and test_ui_dashboard.py runs via the full
+  # pytest. If only .j2 / resources/ changed, that file is not needed.
+  ```
+
+- **T2.2 — Add the detector.**
+
+  ```python
+  _UI_PREFIX = "custom_components/quiet_solar/ui/"
+  _UI_RESOURCES_PREFIX = "custom_components/quiet_solar/ui/resources/"
+
+  def _is_ui_asset(filepath: str) -> bool:
+      """Classify a repo-root-relative POSIX path (as produced by
+      ``git diff --name-only``) as a non-Python UI asset.
+
+      True iff the path is under ``custom_components/quiet_solar/ui/`` AND
+      either ends with ``.j2`` (top-level or nested) OR sits under
+      ``resources/`` (any extension, any depth).
+
+      Crucially returns False for any ``.py`` file — including
+      ``ui/dashboard.py`` and ``ui/__init__.py`` — so Python edits route
+      to the full gate. Convention: nothing under ``ui/resources/`` is
+      Python; if a ``.py`` ever lands there, that's a category error and
+      should be moved out of ``resources/`` rather than handled by a
+      narrower extension allowlist here.
+
+      Examples:
+          ui/quiet_solar_dashboard_template.yaml.j2  → True
+          ui/subdir/partial.j2                       → True  (nested .j2)
+          ui/resources/qs-car-card.js                → True
+          ui/resources/sub/foo.css                   → True
+          ui/dashboard.py                            → False (Python)
+          ui/__init__.py                             → False (Python)
+          ui/something.py                            → False (Python)
+          home_model/load.py                         → False (not under ui/)
+      """
+      if not filepath.startswith(_UI_PREFIX):
+          return False
+      if filepath.startswith(_UI_RESOURCES_PREFIX):
+          return True
+      return filepath.endswith(".j2")
+  ```
+
+- **T2.3 — Extend `_detect_scope()` to the 3-way return.**
+
+  After the existing empty-changes early-return, replace the body with:
+
+  ```python
+  non_dev_non_ui = [
+      f for f in changed_files
+      if not _is_dev_only(f) and not _is_ui_asset(f)
+  ]
+  if non_dev_non_ui:
+      return {
+          "scope": "full",
+          "changed_test_files": [],
+          "reason": f"production files changed: {', '.join(non_dev_non_ui[:5])}",
+      }
+
+  test_files = [
+      f for f in changed_files
+      if f.startswith("tests/") and f.endswith(".py")
+  ]
+  ui_assets = [f for f in changed_files if _is_ui_asset(f)]
+  if ui_assets:
+      return {
+          "scope": "ui-only",
+          "changed_test_files": test_files,
+          "reason": (
+              f"only UI assets and dev files changed "
+              f"({len(ui_assets)} UI asset(s), {len(changed_files)} total)"
+          ),
+      }
+
+  return {
+      "scope": "dev-only",
+      "changed_test_files": test_files,
+      "reason": f"only dev/test files changed ({len(changed_files)} files)",
+  }
+  ```
+
+### T3 — Wire ui-only into `main()`
+
+At lines 829-840 of `scripts/qs/quality_gate.py`, the current dispatch is:
+
+```python
+if scope == "dev-only":
+    ...
+else:
+    ...   # full
+```
+
+- **T3.1 — Convert to `if / elif / else`.** Insert the `ui-only` branch
+  between dev-only and full:
+
+  ```python
+  if scope == "dev-only":
+      # (unchanged)
+      sys.stderr.write(f"  scope: DEV-ONLY ({scope_info['reason']})\n")
+      sys.stderr.write("  skipping ruff, mypy, translations, full coverage\n")
+      sys.stderr.flush()
+      results = []
+      test_files = scope_info["changed_test_files"]
+      result = check_pytest_files(test_files)
+      if test_files:
+          result["name"] = f"pytest ({len(test_files)} changed test files)"
+      results.append(result)
+  elif scope == "ui-only":
+      sys.stderr.write(f"  scope: UI-ONLY ({scope_info['reason']})\n")
+      sys.stderr.write("  skipping ruff, mypy, translations, full coverage\n")
+      sys.stderr.flush()
+      results = []
+      test_files = sorted({*_UI_FAST_PATH_TESTS, *scope_info["changed_test_files"]})
+      result = check_pytest_files(test_files)
+      result["name"] = f"pytest (UI fast path, {len(test_files)} file(s))"
+      results.append(result)
+  else:
+      # (full — unchanged)
+      ...
+  ```
+
+- **T3.2 — Banner and JSON.** The two stderr writes above produce the exact
+  banner AC-1 requires. The existing `_output_results(..., scope=scope, ...)`
+  call at line 890 already threads the new `"ui-only"` value through to the
+  JSON output — no change needed there.
+
+- **T3.3 — Cache write.** The existing condition
+  `if use_cache and all_passed and scope == "full"` at lines 885-888
+  already excludes ui-only from cache writes (and ui-only never causes a
+  cache hit either, because any UI file change either dirties the tree or
+  changes the commit hash, both invalidating the existing cache-validity
+  check at `_is_cache_valid`). **No change needed.**
+
+### T4 — Workflow doc updates
+
+- **T4.1 — `docs/workflow/project-rules.md`.** Under the "Commands" section
+  (around line 14-46), the existing text introduces the quality gate as the
+  single test entry point and mentions scope detection. Add one sentence to
+  the appropriate paragraph:
+
+  > **UI-only fast path.** When only `custom_components/quiet_solar/ui/*.j2`
+  > templates and `custom_components/quiet_solar/ui/resources/**` assets
+  > change (optionally mixed with dev-only paths), the gate runs only
+  > `tests/test_dashboard_rendering.py` plus any changed test files —
+  > skipping ruff, mypy, translations, and full coverage. Use `--full` to
+  > force the full suite.
+
+- **T4.2 — `docs/workflow/overview.md`.** At line 137-139, the current text reads:
+
+  > `python scripts/qs/quality_gate.py` — pytest 100% coverage + ruff + mypy
+  > + translations. Smart scope detection skips the full suite when only
+  > dev-infrastructure files changed.
+
+  Extend to:
+
+  > `python scripts/qs/quality_gate.py` — pytest 100% coverage + ruff + mypy
+  > + translations. Smart scope detection skips the full suite when only
+  > dev-infrastructure files changed (**dev-only fast path**), or only
+  > UI assets under `custom_components/quiet_solar/ui/` changed (**ui-only
+  > fast path** — runs only `tests/test_dashboard_rendering.py`).
+
+- **T4.3 — `docs/agents/glossary.md`.** The current "Quality gate" entry at
+  lines 173-174 reads:
+
+  > **Quality gate** — `scripts/qs/quality_gate.py`. Runs pytest 100% cov +
+  > ruff + mypy + translations. Required before every commit.
+
+  Extend to:
+
+  > **Quality gate** — `scripts/qs/quality_gate.py`. Runs pytest 100% cov +
+  > ruff + mypy + translations on full scope. Smart scope detection picks
+  > one of three modes: **full** (default), **dev-only** (only dev-infra
+  > paths changed → skip ruff/mypy/translations/coverage, run only changed
+  > tests), **ui-only** (only `ui/*.j2` and `ui/resources/**` changed →
+  > skip lint/coverage, run `tests/test_dashboard_rendering.py` plus any
+  > changed tests). Required before every commit; `--full` forces the
+  > full suite.
+
+### T5 — Pre-commit `--full` verification
+
+After the dev-only fast path passes on the implementer's diff, run
+
+```bash
+python scripts/qs/quality_gate.py --full
+```
+
+once locally before committing. **Why:** the implementer's diff (`scripts/qs/`,
+`tests/`, `docs/`) classifies as dev-only, so the implementer's `quality_gate.py`
+invocation runs only the changed test files — coverage of the new
+`_is_ui_asset` and `_detect_scope` branches inside `quality_gate.py` is not
+measured. The `--full` pass closes that gap before merge, catches any
+collateral coverage regression in `custom_components/quiet_solar/`, and runs
+ruff + mypy on the whole tree.
+
+## Out of scope
+
+- **Modifying `tests/test_dashboard_rendering.py` assertions** — the existing
+  J2 and JS coverage there is exactly what the ui-only fast path delegates to.
+- **Adding new JS cards, J2 templates, or refactoring existing ones.**
+- **Refactoring `check_pytest_files`, `_stream_pytest`, `_get_changed_files`,
+  or any other quality-gate internals.**
+- **Adding a `--ui-only` CLI flag** — there is no `--dev-only` either; scope
+  is inferred from the diff.
+- **Changing the behavior of the existing `dev-only` or `full` scopes** —
+  this change is purely additive.
+- **Changes to `.claude/agents/`, `.cursor/agents/`, `.opencode/agents/`** —
+  no agent file is affected; the harness-sync rule does not apply.
+- **Fixing the pre-existing `except json.JSONDecodeError, OSError:`
+  Python-2-style syntax at `scripts/qs/quality_gate.py:257`** — flagged by
+  the concrete-planner reviewer but unrelated to QS-208. File a separate
+  issue if it ever matters in practice.
+- **Detecting untracked `.j2` or JS files that have not been `git add`-ed** —
+  the existing `_get_changed_files()` already misses untracked files for the
+  dev-only path; this story preserves that limitation rather than fixing it
+  here. Workaround: `git add` before running the gate.
+- **Discovering UI tests by directory convention (e.g. `tests/ui/**`)** —
+  the canonical UI test file is one file today; a tuple constant is enough.
+  Re-open if/when a second UI test file appears.
+
+## Doc-OK
+
+`docs/agents/concepts/dashboard-and-cards.md` covers the j2 templates and
+JS cards in its `covers:` frontmatter. **No edit required for this story** — the
+concept doc describes the file layout (`ui/*.j2` + `ui/resources/*.js`), the
+runtime rendering pipeline (`dashboard.py` reads each template + registers
+each JS resource), and the per-device-type card mapping. This story changes
+only the *testing scope* applied to those files; the dashboard layout, the
+rendering pipeline, and the card mapping are all unchanged.
+
+The implement agent should still run `scripts/qs/check_doc_drift.py` after
+staging — if it flags the doc (because `quality_gate.py` modifications can
+theoretically affect how those covered files are tested), include a
+`## Doc maintenance` paragraph in the PR body pointing to this Doc-OK note,
+or bump the doc's `last_verified:` date.
+
+## Adversarial Review Notes
+
+Four reviewers ran in parallel before this story was finalised
+(plan-critic, concrete-planner, dev-proxy, scope-guardian). 24 unique
+findings consolidated; resolutions:
+
+### Accepted and applied to this plan
+
+- **Nested `.j2` rejected by the original "no further `/`" rule**
+  (critic C2, concrete-planner I1). Resolution: relaxed `_is_ui_asset`
+  to `endswith(".j2")` regardless of nesting depth, so a hypothetical
+  `ui/subdir/partial.j2` qualifies. T1.1a pins this.
+- **Misleading "elif before if" wording for the dispatch change**
+  (concrete-planner I4). Resolution: T3.1 spells out the full
+  `if dev-only / elif ui-only / else` block verbatim, matching the
+  existing code at lines 829-840.
+- **Redundant note about `scope=scope` already being passed**
+  (concrete-planner I5). Resolution: T3.2 explicitly notes the existing
+  `_output_results(..., scope=scope, ...)` at line 890 already threads
+  the new value through — no change needed.
+- **Justify excluding `tests/test_ui_dashboard.py`** (concrete-planner I3).
+  Resolution: comment in T2.1 above `_UI_FAST_PATH_TESTS` explains the
+  rationale.
+- **17 tests is excessive** (scope-guardian IMP-2 / IMP-3). Resolution:
+  collapsed to 12 tests: 4 detector unit tests + 5 scope tests + 2
+  end-to-end main() tests + 1 `--full` override test. Dropped the
+  redundant cache-write test (existing code already gates cache by
+  full-scope) and the third dedup variant.
+- **Drop AC-5 / cache-write test** (scope-guardian IMP-4). Resolution:
+  removed. The existing code at line 885 already conditions cache write
+  on `scope == "full"` — no new behavior to test. T3.3 explicitly
+  documents the no-op.
+- **Drop Task 6 ("Doc-OK note" was a non-action)** (dev-proxy R1,
+  scope-guardian IMP-5). Resolution: folded the Doc-OK rationale into
+  a dedicated `## Doc-OK` section above (not a task).
+- **Add `docs/agents/glossary.md` to doc updates** (dev-proxy I3).
+  Resolution: T4.3 added with the exact replacement text.
+- **AC → Task traceability missing** (scope-guardian CLR-1). Resolution:
+  table added between ACs and Tasks.
+- **Exact text for doc additions** (concrete-planner C1, scope-guardian
+  CLR-3). Resolution: T4.1, T4.2, T4.3 quote the current sentence and
+  show the exact delta.
+- **Spell out the stderr banner and JSON field** (critic I2). Resolution:
+  AC-1 specifies the exact banner and JSON field name; T1.3a asserts on
+  both.
+- **Enumerate each test method** (concrete-planner I6, dev-proxy I4).
+  Resolution: T1 lists every test by name with one-line shape.
+- **Document untracked-file limitation** (concrete-planner I8). Resolution:
+  added to "Out of scope" as a documented known limitation, matches the
+  existing dev-only path.
+- **Out-of-scope additions** (scope-guardian CLR-2). Resolution: explicit
+  bullet forbidding changes to existing `dev-only` / `full` scope behavior.
+- **Coverage gap for new `quality_gate.py` paths** (dev-proxy C1).
+  Resolution: T5 adds a one-time `--full` verification step before commit,
+  ensuring CI's next full run would not surface uncovered new lines.
+- **Current-state subsection** (dev-proxy Q1). Resolution: "Current state"
+  subsection added in Background with verified line numbers.
+- **Convention note for `ui/resources/`** (concrete-planner I2). Resolution:
+  docstring in T2.2 documents the "no `.py` under `resources/`" convention;
+  T1.1b pins the choice with a hypothetical `resources/foo.py` test case.
+
+### Rejected (with rationale)
+
+- **"Skipping translations is risky for `.j2` changes"** (critic C1).
+  Rejected: the translations gate checks `strings.json` ↔ `translations/en.json`
+  parity. `.j2` templates render Jinja against `home.devices`/`ha_entities`
+  data; they do not source from `strings.json`. Modifying a `.j2` file
+  cannot cause a translation drift.
+- **"JS gets no real verification"** (critic R3, I4). Rejected: lines 287-1546
+  of `tests/test_dashboard_rendering.py` read every JS card file
+  (`qs-radiator-card.js`, `qs-water-boiler-card.js`, etc.) and assert on
+  patterns (S14 NaN guards, escapeHTML, keyboard accessibility, flame
+  palette, animation invariants). JS files are heavily exercised by the
+  fast-path test.
+- **"`ui-only` and `dev-only` are redundant scopes"** (critic R2). Rejected:
+  they differ in the test list. `dev-only` runs only the changed test files;
+  `ui-only` forces `tests/test_dashboard_rendering.py` even when no test
+  file is in the diff (which is the common case for a pure `.j2` or `.js`
+  edit). Without this distinction, a UI edit with no co-changed test would
+  run zero tests under dev-only.
+- **"Frozen `_UI_FAST_PATH_TESTS` won't scale; discover tests dynamically"**
+  (critic R1). Rejected: YAGNI. One UI test file today; adding a second is
+  a trivial future PR.
+- **"Tuple → string"** (scope-guardian IMP-1). Rejected: tuple keeps the
+  `sorted({*_UI_FAST_PATH_TESTS, *changed_test_files})` syntax uniform and
+  cheap to extend. One-element tuples are idiomatic.
+- **"This is `implement-setup-task` territory, not `implement-task`"**
+  (dev-proxy I2). Rejected: per the routing rule in `qs-create-plan.md`
+  step 6, `tests/` is NOT in the `implement-setup-task` edit-scope list.
+  Touching `tests/test_quality_gate.py` therefore routes to
+  `implement-task`. The quality gate itself will still run the dev-only
+  fast path on the diff because `tests/` and `scripts/` are dev-only at
+  the gate level — the two scope concepts (agent edit-scope vs.
+  quality-gate scope detection) are deliberately independent.
+- **"CI vs dev-machine differentiation"** (dev-proxy Q5). Rejected: no
+  precedent for environment-aware behavior in the gate. CI runs the same
+  script and benefits from the same fast paths.
+- **"Cache READ semantics undefined"** (critic C3, dev-proxy R2). Rejected
+  as a code change. The cache-validity check is `(branch, commit, is_clean)`;
+  any UI file change either dirties the tree or moves the commit, so the
+  cache never validates against a stale full-scope pass. Documented in
+  T3.3 above.
+- **"Symlinks, Windows separators, case-sensitivity"** (dev-proxy Q2).
+  Rejected: `git diff` produces POSIX paths regardless of host; the
+  detector's `startswith`/`endswith` checks are platform-neutral.
+- **"`--cov-fail-under=100` must be explicitly disabled in the new path"**
+  (critic phrasing of AC-2). Rejected as new code. `check_pytest_files()`
+  at line 563 already builds its `pytest` command without `--cov`, so
+  coverage is inherently absent on the fast path. AC-2 is reworded to
+  reflect this.

--- a/docs/workflow/overview.md
+++ b/docs/workflow/overview.md
@@ -136,4 +136,6 @@ See [project-rules.md](project-rules.md) § "Harness sync" for the cross-harness
 
 `python scripts/qs/quality_gate.py` — pytest 100% coverage + ruff + mypy
 + translations. Smart scope detection skips the full suite when only
-dev-infrastructure files changed.
+dev-infrastructure files changed (**dev-only fast path**), or only
+UI assets under `custom_components/quiet_solar/ui/` changed (**ui-only
+fast path** — runs only `tests/test_dashboard_rendering.py`).

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -52,6 +52,13 @@ command: any `pytest` invocation whose positional argument lacks
 `pytest tests/test_foo.py`. Use `--quick` on the enclosing file or
 directory instead.
 
+**UI-only fast path.** When only `custom_components/quiet_solar/ui/*.j2`
+templates and `custom_components/quiet_solar/ui/resources/**` assets
+change (optionally mixed with dev-only paths), the gate runs only
+`tests/test_dashboard_rendering.py` plus any changed test files —
+skipping ruff, mypy, translations, and full coverage. Use `--full` to
+force the full suite.
+
 ## Architecture constraints
 
 - **Two-layer boundary**: `home_model/` NEVER imports `homeassistant.*`. `ha_model/` bridges both.

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -79,6 +79,26 @@ _DEV_ONLY_PATTERNS = (
 )
 _DEV_ONLY_EXTENSIONS = (".md",)
 
+# QS-208: UI fast-path classification.
+#
+# The canonical UI test exercises every J2 template and every JS card via
+# regex assertions on the file contents — it is the right one-stop pytest
+# target when only UI assets changed.
+#
+# Kept as a tuple (not a string) so the ui-only branch can build
+# `sorted({*_UI_FAST_PATH_TESTS, *changed_test_files})` uniformly whether
+# the list grows to 2+ files or stays at one. Adding a second UI test
+# file is a one-line PR.
+#
+# tests/test_ui_dashboard.py is intentionally NOT here — it covers
+# ui/dashboard.py (Python module). If dashboard.py is in the diff,
+# scope becomes "full" and test_ui_dashboard.py runs via the full
+# pytest. If only .j2 / resources/ changed, that file is not needed.
+_UI_FAST_PATH_TESTS: tuple[str, ...] = ("tests/test_dashboard_rendering.py",)
+
+_UI_PREFIX = "custom_components/quiet_solar/ui/"
+_UI_RESOURCES_PREFIX = "custom_components/quiet_solar/ui/resources/"
+
 
 def _venv_tool(name: str) -> str:
     """Return the absolute path to a tool inside the venv."""
@@ -221,26 +241,69 @@ def _is_dev_only(filepath: str) -> bool:
     return False
 
 
+def _is_ui_asset(filepath: str) -> bool:
+    """Classify a repo-root-relative POSIX path (as produced by
+    ``git diff --name-only``) as a non-Python UI asset.
+
+    True iff the path is under ``custom_components/quiet_solar/ui/`` AND
+    either ends with ``.j2`` (top-level or nested) OR sits under
+    ``resources/`` (any extension, any depth).
+
+    Crucially returns False for any ``.py`` file directly under ``ui/``
+    — including ``ui/dashboard.py`` and ``ui/__init__.py`` — so Python
+    edits route to the full gate. Convention: nothing under
+    ``ui/resources/`` is Python; if a ``.py`` ever lands there, that's a
+    category error and should be moved out of ``resources/`` rather
+    than handled by a narrower extension allowlist here.
+
+    Examples:
+        ui/quiet_solar_dashboard_template.yaml.j2  → True
+        ui/subdir/partial.j2                       → True  (nested .j2)
+        ui/resources/qs-car-card.js                → True
+        ui/resources/sub/foo.css                   → True
+        ui/dashboard.py                            → False (Python)
+        ui/__init__.py                             → False (Python)
+        ui/something.py                            → False (Python)
+        home_model/load.py                         → False (not under ui/)
+    """
+    if not filepath.startswith(_UI_PREFIX):
+        return False
+    if filepath.startswith(_UI_RESOURCES_PREFIX):
+        return True
+    return filepath.endswith(".j2")
+
+
 def _detect_scope(changed_files: list[str]) -> dict:
     """Determine which gates to run based on changed files.
 
     Returns dict with:
-        scope: "full" | "dev-only"
-        changed_test_files: list of test files that changed (if dev-only)
+        scope: "full" | "dev-only" | "ui-only"
+        changed_test_files: list of test files that changed (dev-only / ui-only)
         reason: human-readable explanation
     """
     if not changed_files:
         return {"scope": "full", "changed_test_files": [], "reason": "no changes detected, running full"}
 
-    non_dev = [f for f in changed_files if not _is_dev_only(f)]
-    if non_dev:
+    non_dev_non_ui = [f for f in changed_files if not _is_dev_only(f) and not _is_ui_asset(f)]
+    if non_dev_non_ui:
         return {
             "scope": "full",
             "changed_test_files": [],
-            "reason": f"production files changed: {', '.join(non_dev[:5])}",
+            "reason": f"production files changed: {', '.join(non_dev_non_ui[:5])}",
         }
 
     test_files = [f for f in changed_files if f.startswith("tests/") and f.endswith(".py")]
+    ui_assets = [f for f in changed_files if _is_ui_asset(f)]
+    if ui_assets:
+        return {
+            "scope": "ui-only",
+            "changed_test_files": test_files,
+            "reason": (
+                f"only UI assets and dev files changed "
+                f"({len(ui_assets)} UI asset(s), {len(changed_files)} total)"
+            ),
+        }
+
     return {
         "scope": "dev-only",
         "changed_test_files": test_files,
@@ -837,6 +900,18 @@ def main() -> None:
         # Rename for clarity
         if test_files:
             result["name"] = f"pytest ({len(test_files)} changed test files)"
+        results.append(result)
+    elif scope == "ui-only":
+        sys.stderr.write(f"  scope: UI-ONLY ({scope_info['reason']})\n")
+        sys.stderr.write("  skipping ruff, mypy, translations, full coverage\n")
+        sys.stderr.flush()
+
+        results = []
+        # Always run the canonical dashboard-rendering test; dedupe against
+        # any test files that also appear in the diff via set semantics.
+        test_files = sorted({*_UI_FAST_PATH_TESTS, *scope_info["changed_test_files"]})
+        result = check_pytest_files(test_files)
+        result["name"] = f"pytest (UI fast path, {len(test_files)} file(s))"
         results.append(result)
     else:
         sys.stderr.write(f"  scope: FULL ({scope_info['reason']})\n")

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -1854,3 +1854,255 @@ class TestQuickMode:
         assert "must be non-empty" in err, (
             f"empty-path message missing/changed: {err!r}"
         )
+
+
+# --- QS-208 T1.1: _is_ui_asset detector ---
+
+
+class TestIsUIAsset:
+    """Tests for the `_is_ui_asset` UI-asset classifier (AC-6)."""
+
+    def test_recognizes_j2_template_anywhere_under_ui(self) -> None:
+        """Both top-level and nested `.j2` files under `ui/` count as UI assets."""
+        assert (
+            quality_gate._is_ui_asset(
+                "custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2"
+            )
+            is True
+        )
+        assert (
+            quality_gate._is_ui_asset(
+                "custom_components/quiet_solar/ui/subdir/partial.j2"
+            )
+            is True
+        )
+
+    def test_recognizes_any_file_under_resources(self) -> None:
+        """Any file under `ui/resources/` is a UI asset, regardless of extension.
+
+        Convention: nothing under `ui/resources/` is Python. Even a hypothetical
+        `.py` file there is treated as a UI asset (and would be a category error
+        — Python code belongs outside `resources/`).
+        """
+        assert (
+            quality_gate._is_ui_asset(
+                "custom_components/quiet_solar/ui/resources/qs-car-card.js"
+            )
+            is True
+        )
+        assert (
+            quality_gate._is_ui_asset(
+                "custom_components/quiet_solar/ui/resources/sub/nested.css"
+            )
+            is True
+        )
+        # Convention-documenting test: nothing should be .py here, but if it
+        # is, it still routes through the UI fast path. Users should move it.
+        assert (
+            quality_gate._is_ui_asset(
+                "custom_components/quiet_solar/ui/resources/hypothetical.py"
+            )
+            is True
+        )
+
+    def test_rejects_python_at_ui_root(self) -> None:
+        """`.py` files directly under `ui/` are Python production code, not UI assets."""
+        assert (
+            quality_gate._is_ui_asset("custom_components/quiet_solar/ui/dashboard.py")
+            is False
+        )
+        assert (
+            quality_gate._is_ui_asset("custom_components/quiet_solar/ui/__init__.py")
+            is False
+        )
+
+    def test_rejects_paths_outside_ui(self) -> None:
+        """Files outside `custom_components/quiet_solar/ui/` are never UI assets."""
+        assert (
+            quality_gate._is_ui_asset("custom_components/quiet_solar/home_model/foo.py")
+            is False
+        )
+        assert (
+            quality_gate._is_ui_asset("custom_components/quiet_solar/ha_model/bar.py")
+            is False
+        )
+        assert quality_gate._is_ui_asset("tests/test_baz.py") is False
+        assert quality_gate._is_ui_asset("scripts/qs/quality_gate.py") is False
+
+
+# --- QS-208 T1.2: _detect_scope returns "ui-only" ---
+
+
+class TestDetectScopeUIOnly:
+    """Tests for the new `"ui-only"` branch in `_detect_scope` (AC-1, AC-3, AC-5)."""
+
+    def test_returns_ui_only_when_only_j2_changed(self) -> None:
+        """Diff of one `.j2` template → scope is `"ui-only"`."""
+        info = quality_gate._detect_scope(
+            ["custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2"]
+        )
+        assert info["scope"] == "ui-only"
+        assert info["changed_test_files"] == []
+
+    def test_returns_ui_only_when_only_resources_changed(self) -> None:
+        """Diff of multiple files under `ui/resources/` → scope is `"ui-only"`."""
+        info = quality_gate._detect_scope(
+            [
+                "custom_components/quiet_solar/ui/resources/qs-car-card.js",
+                "custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js",
+            ]
+        )
+        assert info["scope"] == "ui-only"
+
+    def test_returns_full_when_dashboard_py_also_changed(self) -> None:
+        """Diff containing `ui/dashboard.py` plus a `.j2` → scope is `"full"`.
+
+        The Python module is production code under `quiet_solar/`; it doesn't
+        match `_is_dev_only` or `_is_ui_asset` and must force the full gate.
+        """
+        info = quality_gate._detect_scope(
+            [
+                "custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2",
+                "custom_components/quiet_solar/ui/dashboard.py",
+            ]
+        )
+        assert info["scope"] == "full"
+        assert "dashboard.py" in info["reason"]
+
+    def test_returns_full_when_init_py_also_changed(self) -> None:
+        """Diff containing `ui/__init__.py` plus a `.j2` → scope is `"full"`."""
+        info = quality_gate._detect_scope(
+            [
+                "custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2",
+                "custom_components/quiet_solar/ui/__init__.py",
+            ]
+        )
+        assert info["scope"] == "full"
+        assert "__init__.py" in info["reason"]
+
+    def test_returns_ui_only_when_mixed_with_dev_only_and_dedupes(self) -> None:
+        """UI assets mixed with dev-only paths still resolve to `"ui-only"`,
+        and changed test files surface in `changed_test_files`.
+        """
+        info = quality_gate._detect_scope(
+            [
+                "custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2",
+                "docs/stories/QS-208.story.md",
+                "tests/test_dashboard_rendering.py",
+            ]
+        )
+        assert info["scope"] == "ui-only"
+        assert info["changed_test_files"] == ["tests/test_dashboard_rendering.py"]
+
+
+# --- QS-208 T1.3 + T1.4: main() dispatches ui-only branch correctly ---
+
+
+class TestUIOnlyMainBranch:
+    """End-to-end tests for the ui-only branch in `main()` (AC-1, AC-2, AC-4, AC-5)."""
+
+    def test_ui_only_scope_skips_lint_gates_and_runs_only_dashboard_rendering(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """ui-only scope: skips all lint gates + full pytest; runs only the
+        canonical dashboard-rendering test; emits the UI-ONLY banner; JSON
+        scope field is `"ui-only"`."""
+        cache_path = tmp_path / ".quality_gate_cache"
+        ui_only_scope = {
+            "scope": "ui-only",
+            "changed_test_files": [],
+            "reason": "only UI assets and dev files changed (1 UI asset(s), 1 total)",
+        }
+        pytest_result = {"name": "pytest", "passed": True, "detail": ""}
+
+        with (
+            patch("sys.argv", ["quality_gate.py", "--json"]),
+            _patch_git_state("QS_208", "abc123", True),
+            patch.object(quality_gate, "_detect_scope", return_value=ui_only_scope),
+            patch.object(quality_gate, "CACHE_FILE", cache_path),
+            patch.object(quality_gate, "check_pytest_files", return_value=pytest_result) as mock_pytest_files,
+            _patch_all_gates() as mocks,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+
+        assert exc_info.value.code == 0
+        # mocks order: [ruff_format, ruff_lint, mypy, translations, pytest]
+        for m in mocks[:4]:
+            m.assert_not_called()
+        # Full pytest must NOT run either.
+        mocks[4].assert_not_called()
+        # Only the UI fast-path pytest invocation runs, on the canonical file.
+        mock_pytest_files.assert_called_once_with(["tests/test_dashboard_rendering.py"])
+
+        captured = capsys.readouterr()
+        # JSON output: scope is "ui-only".
+        output = json.loads(captured.out)
+        assert output["scope"] == "ui-only"
+        assert output["all_passed"] is True
+        # Stderr banner: exact text per AC-1.
+        assert "scope: UI-ONLY" in captured.err
+        assert "skipping ruff, mypy, translations, full coverage" in captured.err
+
+    def test_ui_only_scope_dedupes_when_canonical_test_in_changed_set(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """When the canonical test file is itself in the diff, the merged
+        list still contains it exactly once (set semantics)."""
+        cache_path = tmp_path / ".quality_gate_cache"
+        ui_only_scope = {
+            "scope": "ui-only",
+            "changed_test_files": [
+                "tests/test_dashboard_rendering.py",
+                "tests/test_other.py",
+            ],
+            "reason": "only UI assets and dev files changed",
+        }
+        pytest_result = {"name": "pytest", "passed": True, "detail": ""}
+
+        with (
+            patch("sys.argv", ["quality_gate.py", "--json"]),
+            _patch_git_state("QS_208", "abc123", True),
+            patch.object(quality_gate, "_detect_scope", return_value=ui_only_scope),
+            patch.object(quality_gate, "CACHE_FILE", cache_path),
+            patch.object(quality_gate, "check_pytest_files", return_value=pytest_result) as mock_pytest_files,
+            _patch_all_gates(),
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+
+        mock_pytest_files.assert_called_once_with(
+            ["tests/test_dashboard_rendering.py", "tests/test_other.py"]
+        )
+
+    def test_full_flag_overrides_ui_only_scope(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`--full` forces the full gate even when ui-only would be detected."""
+        cache_path = tmp_path / ".quality_gate_cache"
+        ui_only_scope = {
+            "scope": "ui-only",
+            "changed_test_files": [],
+            "reason": "only UI assets and dev files changed",
+        }
+
+        with (
+            patch("sys.argv", ["quality_gate.py", "--json", "--full"]),
+            _patch_git_state("QS_208", "abc123", True),
+            patch.object(quality_gate, "_detect_scope", return_value=ui_only_scope),
+            patch.object(quality_gate, "CACHE_FILE", cache_path),
+            patch.object(quality_gate, "check_pytest_files") as mock_pytest_files,
+            _patch_all_gates() as mocks,
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+
+        # All four lint gates + full pytest must have been called.
+        for m in mocks:
+            m.assert_called()
+        # The UI fast-path pytest must NOT have been called.
+        mock_pytest_files.assert_not_called()


### PR DESCRIPTION
## Summary
- Add _is_ui_asset detector and 3-way _detect_scope (full / ui-only / dev-only).
- main() dispatches the new ui-only branch to tests/test_dashboard_rendering.py plus any changed test files (deduped).
- 12 new tests pin the detector, scope dispatch, and --full override; docs updated (project-rules, overview, glossary).

Fixes #208

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "ui-only" fast-path for quality gate that skips lint and full coverage checks when only UI assets change, running only UI-specific tests instead.

* **Documentation**
  * Updated quality gate documentation to detail smart scope detection and ui-only fast-path behavior.

* **Tests**
  * Added test coverage for UI asset classification and ui-only scope detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->