### PR TITLE
QS-211: add gentle steam effect to boiler card when boiling

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -16,6 +16,14 @@
     bubbles rise bottom→top, and a red Gaussian-blurred glow with
     `mix-blend-mode: screen` traces the water surface.
 
+  QS-211 added a 4th boiling-state visual on top of QS-200:
+  - "Steam" layer above the water — soft white-translucent puffs
+    spawn at the surface, rise to the top of the clip circle with a
+    gentle sin-wobble, grow and fade with a piecewise-linear life
+    curve. Single Gaussian-blur filter applied to the layer group
+    (NOT per particle). Cross-fades with `_currentColorMix` like the
+    other boiling visuals; graceful exit on running→false.
+
   Other lit features:
   - Optional `temperature_sensor` entity row, rendered at the top of
     the card when configured (the QS-194 customisation).
@@ -69,6 +77,28 @@ const BUBBLE_SPEED_PX_PER_S_MAX = 80;
 const BUBBLE_MAX_LIFE_S = 2.5;
 const BUBBLE_FILL_COLOR = 'rgba(255,255,255,0.85)';
 
+// --- Steam (QS-211) ---
+// Wispy puffs rising from the water surface (_waterBaseY) to the top
+// of the clip circle (CENTER_CY - CLIP_R) while the boiler is running.
+// Architecture mirrors the bubble subsystem above: spawn-gated on
+// `boiling`, capped at MAX_CONCURRENT_STEAM, advance/retire outside
+// the gate for graceful exit. A single feGaussianBlur is applied to
+// the layer <g> (NOT per particle) for the soft wispy look without
+// per-circle filter cost.
+const MAX_CONCURRENT_STEAM = 8;
+const STEAM_SPAWN_RATE_HZ = 1.5;
+const STEAM_RADIUS_MIN = 4;
+const STEAM_RADIUS_MAX = 10;
+const STEAM_RISE_PX_PER_S_MIN = 10;
+const STEAM_RISE_PX_PER_S_MAX = 22;
+const STEAM_DRIFT_PX_PER_S = 6;
+const STEAM_DRIFT_FREQ_HZ = 0.4;
+const STEAM_RADIUS_GROW_PX_PER_S = 4;
+const STEAM_MAX_LIFE_S = 4.5;
+const STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)';
+const STEAM_BLUR_STDDEV = 3.5;
+const STEAM_TOP_MARGIN_PX = 4;
+
 // --- Surface glow ---
 const SURFACE_GLOW_COLOR = '#FF3D00';
 const SURFACE_GLOW_STROKE_WIDTH = 4;
@@ -110,11 +140,18 @@ class QsWaterBoilerCard extends HTMLElement {
   // If a future caller needs DOM-only reset WITHOUT touching bubbles,
   // split this into `_resetWaveDomRefs()` + explicit
   // `this._bubbles = []` at the call sites.
+  // QS-211: the same pattern is extended for the steam subsystem —
+  // `this._steamLayerEl` (cached DOM ref) and `this._steamPuffs`
+  // (logical particle array) are both reset here so the next RAF
+  // tick after an innerHTML rewrite or full memo invalidation starts
+  // with a clean slate (mirrors the QS-200 N1 note for bubbles).
   _resetDomRefs() {
     this._waveEls = null;
     this._bubbleLayerEl = null;
     this._surfaceGlowEl = null;
     this._bubbles = [];
+    this._steamLayerEl = null;
+    this._steamPuffs = [];
   }
 
   // Clear the wave-path memoization keys and cached DOM refs. Called on
@@ -153,6 +190,11 @@ class QsWaterBoilerCard extends HTMLElement {
       // Tell the next _render() to prime amp/speed/colorMix directly to
       // the actual running-state targets, skipping the 1.5s lerp envelope.
       this._needsAnimationPrime = true;
+      // QS-211: steam particle array + spawn cadence counter. Mirrors
+      // the bubble lazy-init above; runs once on first connect and is
+      // preserved across detach/re-attach.
+      this._steamPuffs = [];
+      this._nextSteamAt = 0;
     }
     this._lastAnimTs = null;
     this._invalidateWaveCache();
@@ -374,6 +416,77 @@ class QsWaterBoilerCard extends HTMLElement {
         this._bubbles = alive;
       }
 
+      // === QS-211 steam system: dynamic spawn, soft-capped at MAX_CONCURRENT_STEAM.
+      // Mirrors the bubble subsystem above. Spawn gated on `boiling`;
+      // advance/retire runs unconditionally (graceful exit on running→false
+      // via `_currentColorMix` opacity multiplier — see D15 in QS-211 story).
+      const steamLayer = this._steamLayerEl
+        ?? (this._steamLayerEl = this._steamLayerId
+              ? (this._root?.getElementById(this._steamLayerId) ?? null)
+              : null);
+      if (steamLayer) {
+        if (boiling) {
+          this._nextSteamAt -= dt;
+          while (this._nextSteamAt <= 0 && this._steamPuffs.length < MAX_CONCURRENT_STEAM) {
+            // Spawn at the water surface, within the chord of the clip
+            // circle at that Y (so puffs originate inside the visible
+            // water surface — degenerate chord → cluster near CENTER_CX,
+            // visually inconspicuous for an empty tank).
+            const jitter = Math.random() * 4 - 2;
+            const cySpawn = this._waterBaseY + jitter;
+            const dy = cySpawn - CENTER_CY;
+            const chordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dy * dy));
+            const cxSpawn = CENTER_CX + (Math.random() * 2 - 1) * chordHalf * 0.85;
+            const r = STEAM_RADIUS_MIN + Math.random() * (STEAM_RADIUS_MAX - STEAM_RADIUS_MIN);
+            const vy = STEAM_RISE_PX_PER_S_MIN + Math.random() * (STEAM_RISE_PX_PER_S_MAX - STEAM_RISE_PX_PER_S_MIN);
+            const phase = Math.random() * Math.PI * 2;
+            // createElementNS is REQUIRED for SVG inside a Shadow DOM.
+            const el = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            el.setAttribute('cx', cxSpawn.toFixed(2));
+            el.setAttribute('cy', cySpawn.toFixed(2));
+            el.setAttribute('r', r.toFixed(2));
+            el.setAttribute('fill', STEAM_FILL_COLOR);
+            el.setAttribute('pointer-events', 'none');
+            el.setAttribute('opacity', '0');
+            steamLayer.appendChild(el);
+            this._steamPuffs.push({el, cx: cxSpawn, cy: cySpawn, r, vy, phase, life: 0, maxLife: STEAM_MAX_LIFE_S});
+            this._nextSteamAt += 1 / STEAM_SPAWN_RATE_HZ;
+          }
+          // Clamp to 0 to avoid a spawn-backlog burst when capacity recovers.
+          if (this._nextSteamAt < 0) this._nextSteamAt = 0;
+        }
+
+        // Advance + retire active puffs regardless of boiling state.
+        // Graceful exit: in-flight puffs keep rising; opacity fades to
+        // 0 via `_currentColorMix` over ~1.5s when running→false.
+        const topY = CENTER_CY - CLIP_R + STEAM_TOP_MARGIN_PX;
+        const aliveSteam = [];
+        for (const p of this._steamPuffs) {
+          p.life += dt;
+          p.cy -= p.vy * dt;
+          p.cx += STEAM_DRIFT_PX_PER_S * Math.sin(2 * Math.PI * STEAM_DRIFT_FREQ_HZ * p.life + p.phase) * dt;
+          p.r = Math.min(p.r + STEAM_RADIUS_GROW_PX_PER_S * dt, STEAM_RADIUS_MAX + 4);
+          if (p.cy < topY || p.life >= p.maxLife) {
+            p.el.remove();
+            continue;
+          }
+          // Life curve: piecewise linear — fade-in [0, 0.15], hold
+          // [0.15, 0.7], fade-out [0.7, 1].
+          const lifeT = p.life / p.maxLife;
+          let lifeOpacity;
+          if (lifeT < 0.15) lifeOpacity = lifeT / 0.15;
+          else if (lifeT < 0.7) lifeOpacity = 1;
+          else lifeOpacity = Math.max(0, 1 - (lifeT - 0.7) / 0.3);
+          const opacity = lifeOpacity * this._currentColorMix;
+          p.el.setAttribute('cx', p.cx.toFixed(2));
+          p.el.setAttribute('cy', p.cy.toFixed(2));
+          p.el.setAttribute('r', p.r.toFixed(2));
+          p.el.setAttribute('opacity', opacity.toFixed(3));
+          aliveSteam.push(p);
+        }
+        this._steamPuffs = aliveSteam;
+      }
+
       this._animRaf = requestAnimationFrame(step);
     };
     this._animRaf = requestAnimationFrame(step);
@@ -425,6 +538,12 @@ class QsWaterBoilerCard extends HTMLElement {
     // cheap and avoids dangling SVG nodes during a rapid detach/attach.
     this._bubbles?.forEach(b => b.el?.remove?.());
     this._bubbles = [];
+    // QS-211: same eager teardown for the steam <circle> nodes.
+    // Optional-chaining matches the bubble shape so a partially-
+    // constructed puff (e.g. from a mid-spawn throw) doesn't crash
+    // teardown.
+    this._steamPuffs?.forEach(p => p.el?.remove?.());
+    this._steamPuffs = [];
   }
 
   static getStubConfig() {
@@ -824,10 +943,17 @@ class QsWaterBoilerCard extends HTMLElement {
         this._waterClipId = `wb_wClip_${uid}`;
         this._surfaceGlowFilterId = `wb_surfGlow_${uid}`;
         this._bubbleLayerId = `wb_bubbleLayer_${uid}`;
+        // QS-211: per-instance unique IDs for the steam layer + filter.
+        // Derived from the same `uid` source as the other IDs so two
+        // boiler cards on the same dashboard never collide.
+        this._steamLayerId = `wb_steamLayer_${uid}`;
+        this._steamFilterId = `wb_steamFilter_${uid}`;
       }
       const waterClipId = this._waterClipId;
       const surfaceGlowFilterId = this._surfaceGlowFilterId;
       const bubbleLayerId = this._bubbleLayerId;
+      const steamLayerId = this._steamLayerId;
+      const steamFilterId = this._steamFilterId;
 
       // QS-200: water level from progress fill (same mapping as pool).
       // Treat null / NaN / negative / zero `displayTargetHours` as "no
@@ -1011,6 +1137,9 @@ class QsWaterBoilerCard extends HTMLElement {
                     <feMergeNode in="SourceGraphic" />
                   </feMerge>
                 </filter>
+                <filter id="${steamFilterId}" x="-50%" y="-50%" width="200%" height="200%">
+                  <feGaussianBlur stdDeviation="${STEAM_BLUR_STDDEV}" />
+                </filter>
               </defs>
               <g clip-path="url(#${waterClipId})">
                 <path id="wave0_cool" d="${initialWavePaths[0]}" fill="${COOL_WATER_COLORS[0]}" opacity="${initialCoolOpacity}" pointer-events="none" style="will-change: transform; mix-blend-mode: normal;" />
@@ -1025,6 +1154,7 @@ class QsWaterBoilerCard extends HTMLElement {
                      below and on wave0_cool/wave0_boil above; the RAF regen block then
                      resyncs d only when wave 0's geometry changes. -->
                 <path id="surface_glow" d="${initialWavePaths[0]}" stroke="${SURFACE_GLOW_COLOR}" stroke-width="${SURFACE_GLOW_STROKE_WIDTH}" fill="none" filter="url(#${surfaceGlowFilterId})" opacity="${initialBoilOpacity}" pointer-events="none" style="mix-blend-mode: screen; will-change: transform, opacity, d;" />
+                <g id="${steamLayerId}" filter="url(#${steamFilterId})" pointer-events="none"></g>
               </g>
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -284,15 +284,20 @@ wispy look at constant per-frame cost. Per-instance unique IDs
 (`_steamLayerId`, `_steamFilterId`) derived from
 `QsWaterBoilerCard._nextClipId` so two boiler cards on the same
 dashboard never collide. The `<circle>` fill is
-`STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'` (alpha 0.45 baked in
-via the SVG color literal); opacity each frame is
-`STEAM_FILL_ALPHA × _currentColorMix × lifeCurve(t)` — assignment,
-not compound — so steam cross-fades with `_currentColorMix` and
-gracefully exits on running→false: existing puffs continue rising
-while their opacity ramps to 0 over the same ~1.5s envelope as
-bubbles. `_resetDomRefs()` extends to null `_steamLayerEl` and clear
-`_steamPuffs`; `disconnectedCallback` mirrors the bubble teardown to
-eagerly remove puff DOM nodes.
+`STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'` (the 0.45 alpha is
+baked into the SVG fill literal — there is no separate
+`STEAM_FILL_ALPHA` JS constant); the runtime per-frame `opacity`
+attribute is `lifeOpacity * _currentColorMix` — assignment, not
+compound — where `lifeOpacity` is the piecewise-linear lifeCurve(t)
+with breakpoints at 0.15 (fade-in end) and 0.7 (fade-out start). The
+effective rendered alpha multiplies through the SVG: `0.45 ×
+_currentColorMix × lifeOpacity`, peaking at 0.45 only during hold
+phase with a fully-ramped colorMix. Steam therefore cross-fades with
+`_currentColorMix` and gracefully exits on running→false: existing
+puffs continue rising while their opacity ramps to 0 over the same
+~1.5s envelope as bubbles. `_resetDomRefs()` extends to null
+`_steamLayerEl` and clear `_steamPuffs`; `disconnectedCallback`
+mirrors the bubble teardown to eagerly remove puff DOM nodes.
 
 Review-fix #01 also caps the RAF step `dt` at `LERP_DT_CEIL` (`0.1s`)
 in BOTH `qs-water-boiler-card.js` AND `qs-pool-card.js`. Without the

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -271,6 +271,27 @@ order (= lowest z), so the controls sit on top. The QS-194 optional
 bubble rate, and surface-glow opacity are all independent of the
 temperature sensor (boiling is binary, driven by `running === true`).
 
+**QS-211 — boiling steam puffs.** A 4th boiling-state visual on top
+of QS-200's waves + bubbles + surface-glow. When `running === true`:
+soft white-translucent `<circle>` puffs spawn from the water surface
+(`_waterBaseY`) at `STEAM_SPAWN_RATE_HZ = 1.5` (capped at
+`MAX_CONCURRENT_STEAM = 8`), rise toward the top of the water clip
+circle with a small sin-wobble, grow with `STEAM_RADIUS_GROW_PX_PER_S
+= 4`, and fade in/hold/fade-out via a piecewise-linear life curve. A
+single `<filter>` (`feGaussianBlur stdDeviation = 3.5`) is applied to
+the `<g id="${steamLayerId}">` group (NOT per circle) for the soft
+wispy look at constant per-frame cost. Per-instance unique IDs
+(`_steamLayerId`, `_steamFilterId`) derived from
+`QsWaterBoilerCard._nextClipId` so two boiler cards on the same
+dashboard never collide. Opacity each frame is `STEAM_FILL_ALPHA ×
+_currentColorMix × lifeCurve(t)` — assignment, not compound — so
+steam cross-fades with `_currentColorMix` and gracefully exits on
+running→false: existing puffs continue rising while their opacity
+ramps to 0 over the same ~1.5s envelope as bubbles. `_resetDomRefs()`
+extends to null `_steamLayerEl` and clear `_steamPuffs`;
+`disconnectedCallback` mirrors the bubble teardown to eagerly remove
+puff DOM nodes.
+
 Review-fix #01 also caps the RAF step `dt` at `LERP_DT_CEIL` (`0.1s`)
 in BOTH `qs-water-boiler-card.js` AND `qs-pool-card.js`. Without the
 cap, the first frame after a multi-second hidden-tab window

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -283,14 +283,16 @@ the `<g id="${steamLayerId}">` group (NOT per circle) for the soft
 wispy look at constant per-frame cost. Per-instance unique IDs
 (`_steamLayerId`, `_steamFilterId`) derived from
 `QsWaterBoilerCard._nextClipId` so two boiler cards on the same
-dashboard never collide. Opacity each frame is `STEAM_FILL_ALPHA ×
-_currentColorMix × lifeCurve(t)` — assignment, not compound — so
-steam cross-fades with `_currentColorMix` and gracefully exits on
-running→false: existing puffs continue rising while their opacity
-ramps to 0 over the same ~1.5s envelope as bubbles. `_resetDomRefs()`
-extends to null `_steamLayerEl` and clear `_steamPuffs`;
-`disconnectedCallback` mirrors the bubble teardown to eagerly remove
-puff DOM nodes.
+dashboard never collide. The `<circle>` fill is
+`STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'` (alpha 0.45 baked in
+via the SVG color literal); opacity each frame is
+`STEAM_FILL_ALPHA × _currentColorMix × lifeCurve(t)` — assignment,
+not compound — so steam cross-fades with `_currentColorMix` and
+gracefully exits on running→false: existing puffs continue rising
+while their opacity ramps to 0 over the same ~1.5s envelope as
+bubbles. `_resetDomRefs()` extends to null `_steamLayerEl` and clear
+`_steamPuffs`; `disconnectedCallback` mirrors the bubble teardown to
+eagerly remove puff DOM nodes.
 
 Review-fix #01 also caps the RAF step `dt` at `LERP_DT_CEIL` (`0.1s`)
 in BOTH `qs-water-boiler-card.js` AND `qs-pool-card.js`. Without the

--- a/docs/stories/QS-211.story.md
+++ b/docs/stories/QS-211.story.md
@@ -1,0 +1,779 @@
+---
+issue: 211
+title: Boiler card — gentle steam rising from water when boiling
+branch: QS_211
+status: ready-for-dev
+next_phase: implement-task
+labels: [area:ui, area:dashboard, area:docs]
+---
+
+# QS-211 — Boiler card: gentle steam rising from water when boiling
+
+## Why
+
+Issue [#211](https://github.com/tmenguy/quiet-solar/issues/211) asks for
+a "steam" visual on `qs-water-boiler-card.js` when the boiler is
+working (`running === true`). Steam must be very gentle and rise from
+the top of the water surface to the top of the clipped circle.
+
+This continues the QS-200 visual-upgrade arc. The boiling state today
+has three visual signals — dual-layer wave cross-fade, rising bubbles,
+red surface glow — but nothing above the water. QS-211 fills that gap
+with a steam layer above the surface, mirroring the QS-200 bubble
+subsystem's architecture (per-instance unique IDs, lazy-resolved DOM
+refs, RAF-driven spawn/advance/retire, `_currentColorMix` cross-fade,
+clean `disconnectedCallback` teardown).
+
+**Explicit instruction granted by issue #211** — this story overrides
+the [project-context.md](../workflow/project-context.md) rule "Custom
+JS card code should not be modified without explicit instruction"
+(mirrors the QS-200 grant).
+
+## Inputs
+
+- `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js` —
+  the only file with behavioural changes (~1550 LOC today → ~1700 LOC).
+- `tests/test_dashboard_rendering.py` — new module-level structural
+  tests appended to the existing cluster of `test_water_boiler_card_*`
+  module-level functions (insertion anchor pinned in T0 below).
+- `docs/agents/concepts/dashboard-and-cards.md` — append a new
+  **top-level** "QS-211 — boiling steam puffs" paragraph after the
+  QS-200 block; verify `last_verified` field is current (2026-05-22 —
+  today; no bump if already correct).
+
+### Existing identifiers reused (read-only contract)
+
+These identifiers already live in `qs-water-boiler-card.js`. The steam
+subsystem consumes them without modification.
+
+| Identifier | Where | Meaning / range |
+|---|---|---|
+| `CENTER_CX = 160`, `CENTER_CY = 160` | module constants (lines 26-27) | SVG center of ring / clip circle |
+| `CLIP_R = 120` | module constant (line 28) | Water clip circle radius |
+| `LERP_DT_CEIL = 0.1` | module constant (line 50) | dt clamp shared by all per-frame subsystems |
+| `_running` | instance field set in `_render()` | Boolean: command sensor state === "on" |
+| `_currentColorMix` | instance field, lerped per frame (line 200) | 0→1; ramps toward `running ? 1 : 0` with `LERP_RATE = 2` (≈ 0.5s time constant; effectively saturated in ~1.5s) |
+| `_waterBaseY` | instance field, set in `_render()` (line 840) | Y-coordinate of the visible water surface; smaller Y = higher water level |
+| `_resetDomRefs()` | instance method (~lines 113-118) | Resets cached DOM refs + logical particle arrays; called from `_invalidateWaveCache()` and post-innerHTML |
+| `_startAnimation()` lazy-init guard | `if (this._currentAmplitude == null)` (~lines 146-156) | Runs ONCE on first connect; preserved across detach/re-attach |
+| `QsWaterBoilerCard._nextClipId` | static counter (~line 822) | Bumped on first render of each instance; source of per-instance unique IDs |
+| QS-200 bubble subsystem | spawn/advance/retire block at lines 315-375 inside `step()` | Direct precedent for the steam loop architecture |
+| `_invalidateWaveCache()` | instance method (~lines 128-132) | Calls `_resetDomRefs()`; ensures every reconnect starts with clean memo |
+| `bubble teardown` in `disconnectedCallback` | (~lines 426-428) | Direct precedent for the steam teardown shape |
+
+### Reference snippets
+
+- QS-200 bubble spawn cadence + cap-hit clamping
+  (`qs-water-boiler-card.js` lines 324-347) — same pattern adopted for
+  steam in T4.
+- QS-200 bubble advance + retire (lines 357-374) — direct shape used
+  by the steam advance/retire block.
+- Existing surface-glow filter declaration
+  (`<filter id="${surfaceGlowFilterId}" x="-50%" y="-50%" width="200%" height="200%">`)
+  at lines 1005-1013 — the steam filter mirrors the filter-region
+  attributes exactly to avoid edge-clip of the Gaussian blur.
+
+## Out of scope
+
+- Other cards (`qs-pool-card.js`, `qs-radiator-card.js`,
+  `qs-climate-card.js`, `qs-on-off-duration-card.js`).
+- Sound effects, click/tap interactivity, configurable density via card
+  YAML.
+- Steam intensity tied to the optional `temperature_sensor`.
+- Backend / `ha_model/water_boiler.py` changes — purely visual, driven
+  by the existing `command` sensor.
+- `prefers-reduced-motion` accessibility fallback (matches QS-200
+  deferral).
+- Refactoring the existing wave / bubble / surface-glow code paths.
+- Any change to `dashboard.py`, the Jinja templates, `const.py`,
+  `strings.json`.
+
+## Design decisions
+
+- **D1 — Intensity.** `MAX_CONCURRENT_STEAM = 8`,
+  `STEAM_SPAWN_RATE_HZ = 1.5`. Peak rendered opacity is
+  `STEAM_FILL_ALPHA × _currentColorMix × max(lifeCurve) = 0.45 × 1 × 1
+  = 0.45` only when the boiler is fully ramped AND a puff is in its
+  hold phase — otherwise strictly lower. "Gentle" by construction.
+- **D2 — Color.** Pure white-translucent fill:
+  `STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'`. No warm tint, no
+  heat-palette mix.
+- **D3 — Motion.** Rise rate `STEAM_RISE_PX_PER_S_MIN = 10`,
+  `STEAM_RISE_PX_PER_S_MAX = 22` (per-puff random in this range).
+  Sin-wobble lateral: `STEAM_DRIFT_PX_PER_S = 6` amplitude,
+  `STEAM_DRIFT_FREQ_HZ = 0.4`. Per-puff random `phase ∈ [0, 2π)` so
+  puffs aren't synchronised. Vertical span over a full `maxLife` is
+  ~45-99 px; lateral wobble integrates to ≤ 6 px total — upward
+  motion dominates by ~10×, matching the issue's "in this direction".
+- **D4 — Stacking.** Steam `<g>` placed INSIDE the existing
+  `<g clip-path="url(#${waterClipId})">`, AFTER `<path id="surface_glow">`.
+  Bubbles sit BELOW surface_glow (water-resident); steam sits ABOVE
+  surface_glow (escapes water surface). Both share the water
+  clipPath.
+- **D5 — Filter.** Single `<filter id="${steamFilterId}" x="-50%"
+  y="-50%" width="200%" height="200%"><feGaussianBlur
+  stdDeviation="${STEAM_BLUR_STDDEV}" /></filter>` in `<defs>`. The
+  expanded filter region prevents the blur from being clipped at the
+  puff bounding box (mirrors `surfaceGlowFilterId` precedent). The
+  filter is applied to the `<g>` once, NOT per `<circle>` — one
+  filter evaluation per frame regardless of puff count.
+- **D6 — Opacity formula (per frame, ASSIGNMENT not compound).**
+  ```
+  opacity = STEAM_FILL_ALPHA × _currentColorMix × lifeCurve(life/maxLife)
+  ```
+  where `STEAM_FILL_ALPHA = 0.45` (alpha channel of `STEAM_FILL_COLOR`),
+  and `lifeCurve(t)` is the piecewise LINEAR ramp:
+  - `t ∈ [0, 0.15]` → `t / 0.15` (fade-in)
+  - `t ∈ [0.15, 0.7]` → `1` (hold)
+  - `t ∈ [0.7, 1]` → `max(0, 1 − (t − 0.7) / 0.3)` (fade-out)
+
+  The `<circle>` `fill` attribute carries the raw `STEAM_FILL_COLOR`
+  (so the SVG alpha = 0.45); each frame sets `opacity = _currentColorMix
+  × lifeCurve(t)`. SVG multiplies them, yielding the rendered alpha
+  above. **Important:** assignment, not `*=` — compound multiplication
+  every frame is exponential decay.
+- **D7 — Spawn position.** Random X within the water-surface chord at
+  `cy = _waterBaseY + jitter`:
+  ```
+  jitter   = (Math.random() * 4) - 2          // ±2 px Y jitter
+  cySpawn  = _waterBaseY + jitter
+  dy       = cySpawn - CENTER_CY
+  chordHalf = Math.sqrt(Math.max(0, CLIP_R*CLIP_R - dy*dy))
+  cx       = CENTER_CX + (Math.random()*2 - 1) * chordHalf * 0.85
+  ```
+  When the tank is empty (`_waterBaseY` near the circle bottom or
+  outside the circle), `chordHalf` collapses toward 0 and puffs spawn
+  near `CENTER_CX` — visually inconspicuous, which matches reality
+  (no water → no steam to speak of). The 0.85 inset keeps puffs from
+  spawning right at the clip-boundary chord edges where the SVG clip
+  would harshly cut them.
+- **D8 — Retire conditions.** A puff is removed when EITHER:
+  - `cy < CENTER_CY - CLIP_R + STEAM_TOP_MARGIN_PX` (reached top of
+    clip, with `STEAM_TOP_MARGIN_PX = 4`), OR
+  - `life >= STEAM_MAX_LIFE_S` (= 4.5s, hard upper bound).
+
+  Both branches are explicitly tested (AC-3, AC-4).
+- **D9 — Per-instance unique IDs.** `_steamLayerId =
+  \`wb_steamLayer_${uid}\`` and `_steamFilterId =
+  \`wb_steamFilter_${uid}\``, where `uid` is the existing
+  `QsWaterBoilerCard._nextClipId` counter — same source as
+  `_waterClipId` / `_surfaceGlowFilterId` / `_bubbleLayerId`. Two
+  boiler cards on the same dashboard never collide.
+- **D10 — Lazy init.** `_nextSteamAt = 0` and `_steamPuffs = []`
+  initialised in the same `if (this._currentAmplitude == null) {…}`
+  block that initialises `_nextBubbleAt = 0` and `_bubbles = []`
+  (~line 151-152). Runs once on first connect; preserved across
+  detach/re-attach (matches bubble/wave behaviour).
+- **D11 — dt cap.** Reuses the existing `LERP_DT_CEIL`-clamped `dt`
+  from the top of `step()` (line 170). No new local clamp. Hidden-tab
+  return → spawn cadence drains exactly one tick of `1/SPAWN_RATE`
+  per `LERP_DT_CEIL`-sized super-frame, no burst (mirrors QS-200
+  fix #02 S6).
+- **D12 — Reset symmetry.** `_resetDomRefs()` is extended to null
+  `this._steamLayerEl` and clear `this._steamPuffs = []`. Single
+  helper, both call sites (`_invalidateWaveCache` + post-innerHTML)
+  automatically covered (matches QS-200 fix #03 N1 design).
+- **D13 — Cap-hit behaviour.** When `_steamPuffs.length >=
+  MAX_CONCURRENT_STEAM`, the spawn `while` loop's second condition
+  fails → no spawn that tick. After the spawn loop:
+  `if (this._nextSteamAt < 0) this._nextSteamAt = 0;` clamps the
+  cadence counter so capacity-recovery doesn't trigger a backlog
+  burst (mirrors bubble code at line 347).
+- **D14 — Re-render vs detach.** A normal hass-push `_render()`
+  rewrites `innerHTML`, destroying the steam `<g>` and all puff
+  `<circle>` children. Post-innerHTML the existing
+  `_resetDomRefs()` call clears `_steamLayerEl` and `_steamPuffs`;
+  next RAF tick lazy-resolves the new `<g>`. `_nextSteamAt`,
+  `_currentColorMix`, and `_running` are preserved across the
+  rewrite (they're not in `_resetDomRefs()`), so cadence and
+  cross-fade continue smoothly. On detach → `disconnectedCallback`
+  tears down DOM nodes (T5); on re-attach → `_startAnimation` lazy
+  init guard is skipped (state preserved); first render after
+  re-attach replays the rewrite flow.
+- **D15 — Graceful exit on running → false.** Steam does NOT have
+  an opacity-driven retirement path. When boiling flips off:
+  - `_currentColorMix` lerps 1 → 0 over ~1.5s.
+  - The spawn `while` loop is gated on `if (boiling)` — no new
+    puffs spawn.
+  - The advance loop continues to run on existing puffs
+    regardless of `boiling`. Each in-flight puff continues to
+    rise, sin-wobble, and grow until it hits AC-3a or AC-3b.
+  - Its rendered opacity is `STEAM_FILL_ALPHA × _currentColorMix ×
+    lifeCurve(t)`, which fades to 0 over the same ~1.5s envelope.
+
+  Net behaviour: at running→false, steam visibly fades over ~1.5s
+  while in-flight puffs continue rising — no abrupt vanish, no
+  immediate retirement. Mirrors QS-200 bubble graceful-exit
+  behaviour (line 350-352 comment).
+
+## Acceptance criteria
+
+### AC-1 — Steam markup present and correctly stacked
+**Given** the card has rendered
+**When** the resulting SVG markup is inspected
+**Then** the source contains, in order, inside the
+`<g clip-path="url(#${waterClipId})">`:
+1. The six wave `<path>` nodes (existing).
+2. The bubble `<g id="${bubbleLayerId}">` (existing, AFTER waves).
+3. The `<path id="surface_glow">` (existing, AFTER bubbles).
+4. The new `<g id="${steamLayerId}" filter="url(#${steamFilterId})"
+   pointer-events="none">` (AFTER surface_glow).
+
+The steam `<g>` index in the source string is strictly greater than
+the `surface_glow` path index, and both indices live within the
+clipped group (verified by the `</g>` closer appearing AFTER both).
+
+### AC-2 — Spawn is boiling-gated
+**Given** the source of `_startAnimation()`'s step closure
+**When** the steam spawn block is read
+**Then** the spawn `while` loop is inside an `if (boiling) {…}` guard
+(reusing the existing `boiling` const from the bubble block). The
+spawn loop's outer condition is also `this._steamPuffs.length <
+MAX_CONCURRENT_STEAM`. The advance/retire loop sits OUTSIDE the
+`if (boiling)` guard (graceful-exit behaviour per D15).
+
+### AC-3 — Retirement uses BOTH top-of-clip AND maxLife conditions
+**Given** the source of the steam advance loop
+**When** the retire `if` predicate is read
+**Then** the predicate is exactly `if (p.cy < topY || p.life >=
+p.maxLife)`, where `topY = CENTER_CY - CLIP_R + STEAM_TOP_MARGIN_PX`.
+Both branches must be present (covers AC-3a top-reached and AC-3b
+maxLife-reached).
+
+### AC-4 — Opacity formula is correct (structural)
+**Given** the source of the steam advance loop
+**When** the opacity assignment is read
+**Then** the line is shaped:
+```
+const opacity = lifeOpacity * this._currentColorMix;
+p.el.setAttribute('opacity', opacity.toFixed(3));
+```
+…where `lifeOpacity` is computed via a piecewise linear ramp using
+the breakpoint constants `0.15` and `0.7`. The `<circle>` element's
+`fill` attribute is `STEAM_FILL_COLOR` (raw alpha 0.45 baked in via
+`rgba(...)`). `peak rendered alpha = 0.45 × 1 × 1 = 0.45` only when
+the puff is in hold phase AND `_currentColorMix === 1`. The
+breakpoints `0.15` and `0.7` appear literally in the source.
+
+### AC-5 — Steam IDs are per-instance unique
+**Given** the source of the per-instance ID initialiser block
+**When** the `this._steamLayerId` and `this._steamFilterId`
+assignments are read
+**Then** both derive from the same `uid` variable as the existing
+`_waterClipId` / `_surfaceGlowFilterId` / `_bubbleLayerId`
+(specifically: the `uid = (QsWaterBoilerCard._nextClipId =
+(QsWaterBoilerCard._nextClipId || 0) + 1)` block). Literal naming
+convention: `wb_steamLayer_${uid}` and `wb_steamFilter_${uid}`.
+
+### AC-6 — Reset / re-attach hygiene
+**Given** the source of `_resetDomRefs()`
+**When** the body is read
+**Then** the body contains both `this._steamLayerEl = null` AND
+`this._steamPuffs = []`. The helper has exactly two call sites in
+the file (`_invalidateWaveCache()` and the post-innerHTML block in
+`_render()`), both pre-existing, both unchanged.
+
+### AC-7 — Cap-hit clamps cadence counter
+**Given** the source of the steam spawn block
+**When** the cap-recovery line is read
+**Then** the source contains `if (this._nextSteamAt < 0)
+this._nextSteamAt = 0;` AFTER the spawn `while` loop, mirroring the
+bubble code at line 347. The `dt` used for `_nextSteamAt -= dt` is
+the existing top-of-step clamped `dt` (D11).
+
+### AC-8 — Disconnect tears down steam DOM
+**Given** the source of `disconnectedCallback()`
+**When** the body is read AFTER the existing bubble teardown lines
+**Then** the body contains
+`this._steamPuffs?.forEach(p => p.el?.remove?.()); this._steamPuffs
+= [];`. Optional-chaining matches the bubble teardown shape
+(line 426).
+
+### AC-9 — Steam filter declared in `<defs>` with safe region
+**Given** the source of the SVG `<defs>` block
+**When** the steam filter is read
+**Then** it is exactly:
+```
+<filter id="${steamFilterId}" x="-50%" y="-50%" width="200%" height="200%">
+  <feGaussianBlur stdDeviation="${STEAM_BLUR_STDDEV}" />
+</filter>
+```
+The filter-region attributes (`x="-50%"` etc.) MUST be present so
+the blur doesn't clip at the puff bounding box (mirrors
+`surfaceGlowFilterId` precedent at lines 1005-1013).
+
+### AC-10 — Doc maintenance
+**Given** `docs/agents/concepts/dashboard-and-cards.md` after the
+change
+**When** read
+**Then**:
+- A new **top-level** paragraph titled `**QS-211 — boiling steam
+  puffs.**` appears AFTER the QS-200 block (around line 272+) and
+  BEFORE the "Review-fix #01" / "Review-fix #02" / … blocks.
+- The paragraph describes: the steam constants, the new `<filter>` +
+  `<g>` markup, spawn/retire rules, the `_currentColorMix`
+  cross-fade reuse, and the `disconnectedCallback` cleanup.
+- `last_verified:` field value is the current date
+  (`2026-05-22`). If it is already `2026-05-22`, leave unchanged.
+- `python scripts/qs/check_doc_drift.py` returns clean (no drift
+  flagged for any of the touched files).
+
+## Tasks / file-level diff
+
+> **TDD ordering.** T0 writes the structural tests first (red). T1–T6
+> turn them green. T7 finishes the doc. T8 runs the quality gate.
+
+### T0 — Write structural tests (RED phase)
+**File:** `tests/test_dashboard_rendering.py`
+**Insertion anchor:** AFTER the existing module-level
+`test_water_boiler_card_factors_reset_dom_refs_helper` function
+(~line 2192; module-level scope, NOT inside a class). New tests are
+also module-level `def test_…(): …` functions, no `self`.
+
+**Pinned regex / substring assertions** (one test per AC, mostly):
+
+1. `test_water_boiler_card_steam_layer_after_surface_glow_in_clip` (AC-1)
+   - Reads card source from `ui/resources/qs-water-boiler-card.js`.
+   - Locates the substring opening the clipped group:
+     `'<g clip-path="url(#${waterClipId})">'`.
+   - Locates the next `'</g>'` closer.
+   - Within that span, asserts both `'id="surface_glow"'` and
+     `'id="${steamLayerId}"'` are present, AND
+     `source.find('id="surface_glow"') < source.find('id="${steamLayerId}"')`.
+   - Also asserts the steam group carries
+     `'filter="url(#${steamFilterId})"'` and
+     `'pointer-events="none"'`.
+
+2. `test_water_boiler_card_steam_spawn_is_boiling_gated` (AC-2)
+   - `re.search(r"if \(boiling\)\s*\{[^}]*while\s*\(\s*this\._nextSteamAt\s*<=\s*0[^}]*MAX_CONCURRENT_STEAM", source, re.DOTALL)`
+   - And: the advance loop (`for (const p of this._steamPuffs)`)
+     appears OUTSIDE / AFTER the `if (boiling)` closing brace —
+     verified by index comparison.
+
+3. `test_water_boiler_card_steam_retire_both_branches` (AC-3)
+   - `re.search(r"p\.cy\s*<\s*topY\s*\|\|\s*p\.life\s*>=\s*p\.maxLife", source)`
+
+4. `test_water_boiler_card_steam_opacity_formula` (AC-4)
+   - `re.search(r"lifeOpacity\s*\*\s*this\._currentColorMix", source)`
+   - `re.search(r"0\.15", source_steam_block)` (the fade-in
+     breakpoint inside the steam advance closure)
+   - `re.search(r"0\.7", source_steam_block)` (the fade-out
+     breakpoint)
+   - Source contains `STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'`.
+
+5. `test_water_boiler_card_steam_ids_derive_from_next_clip_id` (AC-5)
+   - `re.search(r"this\._steamLayerId\s*=\s*`wb_steamLayer_\$\{uid\}`", source)`
+   - `re.search(r"this\._steamFilterId\s*=\s*`wb_steamFilter_\$\{uid\}`", source)`
+   - Both must appear inside the same `if (!this._waterClipId)`
+     block as the existing IDs.
+
+6. `test_water_boiler_card_reset_dom_refs_includes_steam` (AC-6)
+   - `re.search(r"_resetDomRefs\s*\(\s*\)\s*\{[^}]*this\._steamLayerEl\s*=\s*null[^}]*this\._steamPuffs\s*=\s*\[\]", source, re.DOTALL)`
+
+7. `test_water_boiler_card_steam_cap_hit_clamps_next_steam_at` (AC-7)
+   - `re.search(r"if\s*\(\s*this\._nextSteamAt\s*<\s*0\s*\)\s*this\._nextSteamAt\s*=\s*0\s*;", source)`
+
+8. `test_water_boiler_card_disconnected_callback_clears_steam` (AC-8)
+   - `re.search(r"disconnectedCallback\s*\(\s*\)\s*\{[^}]*this\._steamPuffs\?\.forEach\(\s*p\s*=>\s*p\.el\?\.remove\?\.\(\)[^}]*this\._steamPuffs\s*=\s*\[\]", source, re.DOTALL)`
+
+9. `test_water_boiler_card_steam_filter_region_attributes` (AC-9)
+   - Source contains the literal substring
+     `'<filter id="${steamFilterId}" x="-50%" y="-50%" width="200%" height="200%">'`.
+   - Source contains
+     `'<feGaussianBlur stdDeviation="${STEAM_BLUR_STDDEV}" />'`.
+
+After writing: `pytest tests/test_dashboard_rendering.py -k steam` —
+9 failures expected (RED).
+
+### T1 — Constants block, per-instance IDs, header comment
+**File:** `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`
+
+**Edit 1 (constants).** Insert AFTER the existing bubble constants
+(line 70 — `const BUBBLE_FILL_COLOR = …;`) and BEFORE
+`// --- Surface glow ---` (line 72):
+```js
+// --- Steam (QS-211) ---
+// Wispy puffs rising from the water surface (_waterBaseY) to the top
+// of the clip circle (CENTER_CY - CLIP_R) while the boiler is running.
+// Architecture mirrors the bubble subsystem above: spawn-gated on
+// `boiling`, capped at MAX_CONCURRENT_STEAM, advance/retire outside
+// the gate for graceful exit. A single feGaussianBlur is applied to
+// the layer <g> (NOT per particle) for the soft wispy look without
+// per-circle filter cost.
+const MAX_CONCURRENT_STEAM = 8;
+const STEAM_SPAWN_RATE_HZ = 1.5;
+const STEAM_RADIUS_MIN = 4;
+const STEAM_RADIUS_MAX = 10;
+const STEAM_RISE_PX_PER_S_MIN = 10;
+const STEAM_RISE_PX_PER_S_MAX = 22;
+const STEAM_DRIFT_PX_PER_S = 6;
+const STEAM_DRIFT_FREQ_HZ = 0.4;
+const STEAM_RADIUS_GROW_PX_PER_S = 4;
+const STEAM_MAX_LIFE_S = 4.5;
+const STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)';
+const STEAM_BLUR_STDDEV = 3.5;
+const STEAM_TOP_MARGIN_PX = 4;
+```
+
+**Edit 2 (per-instance IDs).** Inside the `if (!this._waterClipId)`
+block (~lines 821-827), AFTER the existing `this._bubbleLayerId =
+…;` line and BEFORE the closing `}`:
+```js
+this._steamLayerId = `wb_steamLayer_${uid}`;
+this._steamFilterId = `wb_steamFilter_${uid}`;
+```
+Then, immediately after the existing `const bubbleLayerId =
+this._bubbleLayerId;` line, add:
+```js
+const steamLayerId = this._steamLayerId;
+const steamFilterId = this._steamFilterId;
+```
+
+**Edit 3 (header comment).** In the top-of-file block (lines 1-23),
+insert a new paragraph BETWEEN line 18 (`mix-blend-mode: screen.`)
+and line 19 (`Other lit features:`):
+```
+  QS-211 added a 4th boiling-state visual on top of QS-200:
+  - "Steam" layer above the water — soft white-translucent puffs
+    spawn at the surface, rise to the top of the clip circle with a
+    gentle sin-wobble, grow and fade with a piecewise-linear life
+    curve. Single Gaussian-blur filter applied to the layer group
+    (NOT per particle). Cross-fades with `_currentColorMix` like the
+    other boiling visuals; graceful exit on running→false.
+```
+
+### T2 — SVG `<filter>` + steam layer markup
+**File:** Same.
+
+**Edit 1 (filter in `<defs>`).** Insert AFTER the existing
+`<filter id="${surfaceGlowFilterId}">…</filter>` block
+(~lines 1005-1013) and BEFORE the closing `</defs>` (line 1014):
+```html
+<filter id="${steamFilterId}" x="-50%" y="-50%" width="200%" height="200%">
+  <feGaussianBlur stdDeviation="${STEAM_BLUR_STDDEV}" />
+</filter>
+```
+
+**Edit 2 (steam layer inside the clipped group).** Insert AFTER the
+`<path id="surface_glow" …/>` line (~line 1027) and BEFORE the
+closing `</g>` of the clipped group (~line 1028):
+```html
+<g id="${steamLayerId}" filter="url(#${steamFilterId})" pointer-events="none"></g>
+```
+Stacking confirmed: steam group is the new last child of the
+clipped `<g>`, sitting on top of `surface_glow`.
+
+### T3 — `_resetDomRefs()` extension
+**File:** Same.
+**Location:** Inside `_resetDomRefs()` body (~lines 113-118). Append
+two lines BEFORE the closing `}`:
+```js
+this._steamLayerEl = null;
+this._steamPuffs = [];
+```
+Update the head-of-function comment (lines 99-112) to add a third
+"this helper also resets…" bullet for the steam state, mirroring
+the QS-200 N1 note about bubbles.
+
+### T4 — Lazy-init alongside bubble state
+**File:** Same.
+**Location:** Inside the `if (this._currentAmplitude == null) {…}`
+guard in `_startAnimation` (~lines 146-156). Insert AFTER
+`this._needsAnimationPrime = true;` (line 155) and BEFORE the
+closing `}` (line 156):
+```js
+this._steamPuffs = [];
+this._nextSteamAt = 0;
+```
+Ordering matches the bubble fields at lines 151-152.
+
+### T5 — Per-frame spawn + advance + retire
+**File:** Same.
+**Insertion anchor:** Pin to literal substrings to eliminate
+brace-nesting ambiguity. Insert BETWEEN these two lines inside the
+`step()` closure of `_startAnimation`:
+
+- AFTER the line that ends the bubble block:
+  `this._bubbles = alive;` (line 374, followed by the bubble's
+  outer `}` closer at line 375).
+- BEFORE the line:
+  `this._animRaf = requestAnimationFrame(step);` (line 377).
+
+Specifically, find the lines:
+```js
+        this._bubbles = alive;
+      }
+
+      this._animRaf = requestAnimationFrame(step);
+```
+…and replace with:
+```js
+        this._bubbles = alive;
+      }
+
+      // === QS-211 steam system: dynamic spawn, soft-capped at MAX_CONCURRENT_STEAM.
+      // Mirrors the bubble subsystem above. Spawn gated on `boiling`;
+      // advance/retire runs unconditionally (graceful exit on running→false
+      // via `_currentColorMix` opacity multiplier — see D15 in QS-211 story).
+      const steamLayer = this._steamLayerEl
+        ?? (this._steamLayerEl = this._steamLayerId
+              ? (this._root?.getElementById(this._steamLayerId) ?? null)
+              : null);
+      if (steamLayer) {
+        if (boiling) {
+          this._nextSteamAt -= dt;
+          while (this._nextSteamAt <= 0 && this._steamPuffs.length < MAX_CONCURRENT_STEAM) {
+            // Spawn at the water surface, within the chord of the clip
+            // circle at that Y (so puffs originate inside the visible
+            // water surface — degenerate chord → cluster near CENTER_CX,
+            // visually inconspicuous for an empty tank).
+            const jitter = Math.random() * 4 - 2;
+            const cySpawn = this._waterBaseY + jitter;
+            const dy = cySpawn - CENTER_CY;
+            const chordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dy * dy));
+            const cxSpawn = CENTER_CX + (Math.random() * 2 - 1) * chordHalf * 0.85;
+            const r = STEAM_RADIUS_MIN + Math.random() * (STEAM_RADIUS_MAX - STEAM_RADIUS_MIN);
+            const vy = STEAM_RISE_PX_PER_S_MIN + Math.random() * (STEAM_RISE_PX_PER_S_MAX - STEAM_RISE_PX_PER_S_MIN);
+            const phase = Math.random() * Math.PI * 2;
+            // createElementNS is REQUIRED for SVG inside a Shadow DOM.
+            const el = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            el.setAttribute('cx', cxSpawn.toFixed(2));
+            el.setAttribute('cy', cySpawn.toFixed(2));
+            el.setAttribute('r', r.toFixed(2));
+            el.setAttribute('fill', STEAM_FILL_COLOR);
+            el.setAttribute('pointer-events', 'none');
+            el.setAttribute('opacity', '0');
+            steamLayer.appendChild(el);
+            this._steamPuffs.push({el, cx: cxSpawn, cy: cySpawn, r, vy, phase, life: 0, maxLife: STEAM_MAX_LIFE_S});
+            this._nextSteamAt += 1 / STEAM_SPAWN_RATE_HZ;
+          }
+          // Clamp to 0 to avoid a spawn-backlog burst when capacity recovers.
+          if (this._nextSteamAt < 0) this._nextSteamAt = 0;
+        }
+
+        // Advance + retire active puffs regardless of boiling state.
+        // Graceful exit: in-flight puffs keep rising; opacity fades to
+        // 0 via `_currentColorMix` over ~1.5s when running→false.
+        const topY = CENTER_CY - CLIP_R + STEAM_TOP_MARGIN_PX;
+        const aliveSteam = [];
+        for (const p of this._steamPuffs) {
+          p.life += dt;
+          p.cy -= p.vy * dt;
+          p.cx += STEAM_DRIFT_PX_PER_S * Math.sin(2 * Math.PI * STEAM_DRIFT_FREQ_HZ * p.life + p.phase) * dt;
+          p.r = Math.min(p.r + STEAM_RADIUS_GROW_PX_PER_S * dt, STEAM_RADIUS_MAX + 4);
+          if (p.cy < topY || p.life >= p.maxLife) {
+            p.el.remove();
+            continue;
+          }
+          // Life curve: piecewise linear — fade-in [0, 0.15], hold
+          // [0.15, 0.7], fade-out [0.7, 1].
+          const lifeT = p.life / p.maxLife;
+          let lifeOpacity;
+          if (lifeT < 0.15) lifeOpacity = lifeT / 0.15;
+          else if (lifeT < 0.7) lifeOpacity = 1;
+          else lifeOpacity = Math.max(0, 1 - (lifeT - 0.7) / 0.3);
+          const opacity = lifeOpacity * this._currentColorMix;
+          p.el.setAttribute('cx', p.cx.toFixed(2));
+          p.el.setAttribute('cy', p.cy.toFixed(2));
+          p.el.setAttribute('r', p.r.toFixed(2));
+          p.el.setAttribute('opacity', opacity.toFixed(3));
+          aliveSteam.push(p);
+        }
+        this._steamPuffs = aliveSteam;
+      }
+
+      this._animRaf = requestAnimationFrame(step);
+```
+
+### T6 — `disconnectedCallback` teardown
+**File:** Same.
+**Location:** Inside `disconnectedCallback()` (~lines 413-428).
+AFTER the existing bubble teardown lines:
+```js
+this._bubbles?.forEach(b => b.el?.remove?.());
+this._bubbles = [];
+```
+…append:
+```js
+this._steamPuffs?.forEach(p => p.el?.remove?.());
+this._steamPuffs = [];
+```
+Same optional-chaining shape as bubbles, so a partially-constructed
+puff (e.g. from a mid-spawn throw) doesn't crash teardown.
+
+### T7 — Doc update
+**File:** `docs/agents/concepts/dashboard-and-cards.md`
+
+**Edit 1 (paragraph).** Insert a NEW top-level paragraph AFTER the
+QS-200 block (after line 272) and BEFORE the existing "Review-fix
+#01" / "Review-fix #02" sections (line 274+):
+
+```markdown
+**QS-211 — boiling steam puffs.** A 4th boiling-state visual on top
+of QS-200's waves + bubbles + surface-glow. When `running === true`:
+soft white-translucent `<circle>` puffs spawn from the water surface
+(`_waterBaseY`) at `STEAM_SPAWN_RATE_HZ = 1.5` (capped at
+`MAX_CONCURRENT_STEAM = 8`), rise toward the top of the water clip
+circle with a small sin-wobble, grow with `STEAM_RADIUS_GROW_PX_PER_S
+= 4`, and fade in/hold/fade-out via a piecewise-linear life curve. A
+single `<filter>` (`feGaussianBlur stdDeviation = 3.5`) is applied to
+the `<g id="${steamLayerId}">` group (NOT per circle) for the soft
+wispy look at constant per-frame cost. Per-instance unique IDs
+(`_steamLayerId`, `_steamFilterId`) derived from
+`QsWaterBoilerCard._nextClipId` so two boiler cards on the same
+dashboard never collide. Opacity each frame is `STEAM_FILL_ALPHA ×
+_currentColorMix × lifeCurve(t)` — assignment, not compound — so
+steam cross-fades with `_currentColorMix` and gracefully exits on
+running→false: existing puffs continue rising while their opacity
+ramps to 0 over the same ~1.5s envelope as bubbles. `_resetDomRefs()`
+extends to null `_steamLayerEl` and clear `_steamPuffs`;
+`disconnectedCallback` mirrors the bubble teardown to eagerly remove
+puff DOM nodes.
+```
+
+**Edit 2 (verify `last_verified`).** Check the front-matter
+`last_verified:` value. If already `2026-05-22`, leave unchanged. If
+older, set to `2026-05-22`.
+
+**Edit 3 (drift check).** Run
+`python scripts/qs/check_doc_drift.py` and confirm green.
+
+### T8 — Quality gate
+**File:** (none — just run.)
+Run `python scripts/qs/quality_gate.py`. **Expected scope:**
+UI-only fast path (per QS-208), since the only `.py` change is in
+`tests/`. The fast path runs `tests/test_dashboard_rendering.py` +
+the changed test file, skipping full ruff/mypy/translations/cov.
+Expected: green.
+
+If the `.md` change happens to break scope-detection and the full
+gate runs: no `.py` non-test files change, so 100% coverage is
+preserved by construction.
+
+## Test plan
+
+**Structural tests** (T0; 9 tests in
+`tests/test_dashboard_rendering.py`):
+
+| Test name | AC | Assertion summary |
+|---|---|---|
+| `test_water_boiler_card_steam_layer_after_surface_glow_in_clip` | AC-1 | Steam `<g>` inside clipped group, AFTER surface_glow |
+| `test_water_boiler_card_steam_spawn_is_boiling_gated` | AC-2 | Spawn `while` wrapped in `if (boiling)`; advance loop OUTSIDE that guard |
+| `test_water_boiler_card_steam_retire_both_branches` | AC-3 | Retire predicate has both `p.cy < topY` AND `p.life >= p.maxLife` |
+| `test_water_boiler_card_steam_opacity_formula` | AC-4 | `lifeOpacity * this._currentColorMix`; breakpoints `0.15` and `0.7` present; `STEAM_FILL_COLOR` rgba alpha 0.45 |
+| `test_water_boiler_card_steam_ids_derive_from_next_clip_id` | AC-5 | `_steamLayerId` / `_steamFilterId` derive from `uid` |
+| `test_water_boiler_card_reset_dom_refs_includes_steam` | AC-6 | `_resetDomRefs` body nulls `_steamLayerEl` and clears `_steamPuffs` |
+| `test_water_boiler_card_steam_cap_hit_clamps_next_steam_at` | AC-7 | `if (this._nextSteamAt < 0) this._nextSteamAt = 0;` present |
+| `test_water_boiler_card_disconnected_callback_clears_steam` | AC-8 | `disconnectedCallback` tears down puffs + clears array |
+| `test_water_boiler_card_steam_filter_region_attributes` | AC-9 | Steam filter has `x="-50%" y="-50%" width="200%" height="200%"` |
+
+**Quality gate** (T8): `python scripts/qs/quality_gate.py`; expected
+UI-only fast path.
+
+**Doc drift** (T7): `python scripts/qs/check_doc_drift.py`; expected
+green.
+
+**Manual smoke** (out of CI; visual-only; runtime ACs not regex-testable):
+
+1. **Steam appears when boiler turns on.** Mount card with `command
+   === "off"`, observe no steam. Flip `command` to `"on"`; within
+   ~1.5s see soft white puffs rising from water surface to top of
+   ring. Pass: visible puffs spawning at roughly the expected
+   cadence. Fail: no puffs / burst of many at once / puffs not
+   rising.
+
+2. **Steam fades when boiler turns off.** From running state, flip
+   `command` to `"off"`. Within ~1.5s, no new spawns; existing puffs
+   continue rising while fading to invisible. Pass: graceful exit.
+   Fail: abrupt vanish / puffs frozen / new spawns continue.
+
+3. **Steam does not escape the ring.** At maximum water level
+   (`progressRatio = 1`, `_waterBaseY ≈ 80`), confirm puffs are
+   clipped at the top of the ring (no white haze outside the
+   circle's top arc).
+
+4. **Two boiler cards on one dashboard.** Add two
+   `qs-water-boiler-card` instances to one dashboard view. Both
+   render steam independently (no cross-card interference, no
+   missing puffs).
+
+5. **Hidden-tab return.** Open card while boiling; switch to another
+   tab for ≥ 5s; switch back. No burst-spawn of many puffs at once;
+   spawn rate resumes normally.
+
+## Adversarial Review Notes
+
+Four reviewers ran in parallel against the initial draft. **All
+critical and redesign findings were accepted and folded into the
+plan above. Most improve / clarify findings were also accepted; two
+scope-guardian "trim" suggestions were partially accepted.**
+
+### Critical (11 findings; all fixed)
+
+| # | Reviewer | Finding | Resolution in plan |
+|---|---|---|---|
+| 1 | Critic + Dev | AC-2 self-contradiction (mount vs. flip retire path) | Reframed via D15 + AC-2 + AC-3 split semantics; retirement is position/time-based, colorMix only multiplies opacity. |
+| 2 | Critic + Dev | AC-4 vs. D1 inconsistency, runtime-untestable | Reframed AC-4 as structural (breakpoints + STEAM_FILL_COLOR alpha); peak = 0.45 only at hold + fully ramped. |
+| 3 | Critic | AC-7 cap-hit behaviour undefined | Added D13 explicit cap-hit semantics; AC-7 + dedicated test pin the `Math.max(0, …)` clamp. |
+| 4 | Critic | AC-3 missing maxLife branch | AC-3 now covers BOTH `cy < topY` AND `life >= maxLife`; tested by `test_water_boiler_card_steam_retire_both_branches`. |
+| 5 | Critic | D6 "opacity *= colorMix every frame" exponential decay | Rewrote D6 with ASSIGNMENT semantics; D6 now states formula explicitly. |
+| 6 | Critic | D7 chord math undefined | D7 spells out the formula; degenerate-chord edge case noted. |
+| 7 | Critic + Concrete | Steam filter region attributes missing | D5 + AC-9 + T2 now pin `x="-50%" y="-50%" width="200%" height="200%"`. |
+| 8 | Concrete | T8 insertion point inside a class scope | T0 re-anchored to module-level (AFTER `test_water_boiler_card_factors_reset_dom_refs_helper` ~line 2192). |
+| 9 | Concrete | Clip envelope intent for steam ambiguous | D4 + T2 explicitly state clip is the intended envelope; `STEAM_TOP_MARGIN_PX` retires puffs before the visual cut. |
+| 10 | Dev | TDD ordering — tests came last | Reordered: T0 (tests) is now first, then T1-T6 (behavior), T7 (doc), T8 (gate). |
+| 11 | Dev | Test assertion shapes undefined | Each of the 9 tests now has a pinned regex / substring in T0. |
+
+### Redesign (4 findings; all fixed)
+
+| # | Reviewer | Finding | Resolution |
+|---|---|---|---|
+| 12 | Dev | Runtime ACs (AC-1, AC-2, AC-3, AC-7, AC-10) not regex-testable | Each AC has a paired structural assertion; genuine runtime behaviours moved to manual-smoke checklist (5 items). |
+| 13 | Concrete | T9 sub-paragraph inside QS-200 dilutes history | T7 now adds a new **top-level** paragraph AFTER the QS-200 block (before "Review-fix" entries). |
+| 14 | Dev | AC-5 lacked a corresponding test | Added `test_water_boiler_card_steam_ids_derive_from_next_clip_id`. |
+| 15 | Dev | AC-11 missing `check_doc_drift` step | T7 includes explicit `python scripts/qs/check_doc_drift.py` invocation. |
+
+### Improvements (selected highlights; all accepted unless noted)
+
+- T5 brace-nesting risk → T5 anchors pinned to literal substrings
+  `this._bubbles = alive;` and `this._animRaf = requestAnimationFrame(step);`.
+- T1 ID literals pinned to `wb_steamLayer_${uid}` /
+  `wb_steamFilter_${uid}` matching `wb_wClip_${uid}` precedent.
+- T4 ordering specified: AFTER `_needsAnimationPrime = true;`,
+  BEFORE closing `}`.
+- Quality-gate scope expectation stated (UI-only fast path; full
+  gate harmless since no non-test `.py` changes).
+- Commit message pinned (see "Commit" section below).
+- T7 (header comment) folded into T1 Edit 3 — no longer a standalone
+  task, satisfying scope-guardian's "trim task count" suggestion.
+- Manual smoke checklist added with 5 explicit pass/fail criteria.
+
+### Clarifications (folded inline)
+
+- "Existing identifiers reused" table added to Inputs with explicit
+  range/meaning for `_currentColorMix`, `_waterBaseY`, `CENTER_CY`,
+  `CLIP_R`, `LERP_DT_CEIL`, `_resetDomRefs`, `_nextClipId`, and the
+  bubble-subsystem precedent.
+- `lifeCurve` type pinned in D6: piecewise LINEAR ramp.
+- Re-render vs. detach behaviour documented in D14.
+- Header-comment text fully pinned in T1 Edit 3.
+
+### Scope-guardian partial accepts
+
+- "Trim 11 ACs → 6-7": **partial**. Final AC count is 10 (AC-1
+  through AC-10) — AC-3 absorbs the previous 3a/3b split into a
+  single condition with both branches tested; AC-5/AC-6 stay
+  distinct because they test different invariants (ID uniqueness vs.
+  reset hygiene). QS-200 precedent supports this density.
+- "Trim 6 tests → 3-4": **rejected with reason**. Dropping below 5
+  leaves AC-2, AC-3, AC-6, AC-7, AC-8 only manually verifiable —
+  which the dev-proxy reviewer flagged as critical. Final count is
+  9 tests (one per AC except AC-1 absorbs the filter-region check).
+
+## Commit
+
+When implement-task ships this, the commit subject should be:
+```
+QS-211: add gentle steam effect to boiler card when boiling
+```
+Mirrors the project's `QS-<N>: <subject>` convention.

--- a/docs/stories/QS-211.story.md
+++ b/docs/stories/QS-211.story.md
@@ -118,7 +118,8 @@ subsystem consumes them without modification.
   filter is applied to the `<g>` once, NOT per `<circle>` — one
   filter evaluation per frame regardless of puff count.
 - **D6 — Opacity formula (per frame, ASSIGNMENT not compound).**
-  ```
+
+  ```text
   opacity = STEAM_FILL_ALPHA × _currentColorMix × lifeCurve(life/maxLife)
   ```
   where `STEAM_FILL_ALPHA = 0.45` (alpha channel of `STEAM_FILL_COLOR`),
@@ -134,7 +135,8 @@ subsystem consumes them without modification.
   every frame is exponential decay.
 - **D7 — Spawn position.** Random X within the water-surface chord at
   `cy = _waterBaseY + jitter`:
-  ```
+
+  ```js
   jitter   = (Math.random() * 4) - 2          // ±2 px Y jitter
   cySpawn  = _waterBaseY + jitter
   dy       = cySpawn - CENTER_CY
@@ -153,9 +155,9 @@ subsystem consumes them without modification.
   - `life >= STEAM_MAX_LIFE_S` (= 4.5s, hard upper bound).
 
   Both branches are explicitly tested (AC-3, AC-4).
-- **D9 — Per-instance unique IDs.** `_steamLayerId =
-  \`wb_steamLayer_${uid}\`` and `_steamFilterId =
-  \`wb_steamFilter_${uid}\``, where `uid` is the existing
+- **D9 — Per-instance unique IDs.** `_steamLayerId` is assigned to the
+  template-literal `` `wb_steamLayer_${uid}` `` and `_steamFilterId`
+  to `` `wb_steamFilter_${uid}` ``, where `uid` is the existing
   `QsWaterBoilerCard._nextClipId` counter — same source as
   `_waterClipId` / `_surfaceGlowFilterId` / `_bubbleLayerId`. Two
   boiler cards on the same dashboard never collide.
@@ -244,7 +246,8 @@ maxLife-reached).
 **Given** the source of the steam advance loop
 **When** the opacity assignment is read
 **Then** the line is shaped:
-```
+
+```js
 const opacity = lifeOpacity * this._currentColorMix;
 p.el.setAttribute('opacity', opacity.toFixed(3));
 ```
@@ -293,7 +296,8 @@ the existing top-of-step clamped `dt` (D11).
 **Given** the source of the SVG `<defs>` block
 **When** the steam filter is read
 **Then** it is exactly:
-```
+
+```html
 <filter id="${steamFilterId}" x="-50%" y="-50%" width="200%" height="200%">
   <feGaussianBlur stdDeviation="${STEAM_BLUR_STDDEV}" />
 </filter>
@@ -432,7 +436,8 @@ const steamFilterId = this._steamFilterId;
 **Edit 3 (header comment).** In the top-of-file block (lines 1-23),
 insert a new paragraph BETWEEN line 18 (`mix-blend-mode: screen.`)
 and line 19 (`Other lit features:`):
-```
+
+```text
   QS-211 added a 4th boiling-state visual on top of QS-200:
   - "Steam" layer above the water — soft white-translucent puffs
     spawn at the surface, rise to the top of the clip circle with a
@@ -605,8 +610,8 @@ puff (e.g. from a mid-spawn throw) doesn't crash teardown.
 **File:** `docs/agents/concepts/dashboard-and-cards.md`
 
 **Edit 1 (paragraph).** Insert a NEW top-level paragraph AFTER the
-QS-200 block (after line 272) and BEFORE the existing "Review-fix
-#01" / "Review-fix #02" sections (line 274+):
+QS-200 block (after line 272) and BEFORE the existing
+"Review-fix \#01" / "Review-fix \#02" sections (line 274+):
 
 ```markdown
 **QS-211 — boiling steam puffs.** A 4th boiling-state visual on top
@@ -773,7 +778,9 @@ scope-guardian "trim" suggestions were partially accepted.**
 ## Commit
 
 When implement-task ships this, the commit subject should be:
-```
+
+```text
 QS-211: add gentle steam effect to boiler card when boiling
 ```
+
 Mirrors the project's `QS-<N>: <subject>` convention.

--- a/docs/stories/QS-211.story_review_fix_#01.md
+++ b/docs/stories/QS-211.story_review_fix_#01.md
@@ -1,0 +1,93 @@
+# QS-211 — Review fix plan #01
+
+## Summary
+- Source PR: #212
+- Source story: docs/stories/QS-211.story.md
+- Findings to fix: 3
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [should-fix] Clip-group containment test is indirect
+- File: `tests/test_dashboard_rendering.py:2260-2266`
+- Severity: should-fix
+- Source: qs-review-coderabbit (also flagged as nice-to-have by qs-review-acceptance-auditor — AC-1)
+- Description: In `test_water_boiler_card_steam_layer_after_surface_glow_in_clip`,
+  `outer_close = source.find("</g>", steam_idx)` resolves to the steam
+  group's OWN closing tag rather than the outer water-clip group's
+  closer. The current assertion `assert outer_close != -1` therefore
+  does not actually prove the steam layer is nested inside the clip
+  `<g>` — it only proves a `</g>` exists somewhere after the steam
+  open tag (which is the steam group's own self-close on the same
+  line). AC-1 explicitly states "both indices live within the clipped
+  group"; the test does not pin this.
+- Proposed fix: Locate the literal steam-group block (`steam_group =
+  '<g id="..." filter="url(#...)" pointer-events="none"></g>'` or the
+  pattern actually emitted), then compute
+  `outer_close = source.find("</g>", steam_idx + len(steam_group))`
+  and assert it is `!= -1`. This guarantees a `</g>` exists AFTER the
+  steam group's self-close, which can only be the outer water-clip
+  group's closer.
+
+### [should-fix] Markdownlint warnings in story file
+- File: `docs/stories/QS-211.story.md` (lines 121, 137, 158, 247, 296, 435, 609, 776)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The story file accumulates markdownlint hits across
+  several locations:
+  - Missing fenced-code language tags on triple-backtick blocks.
+  - Code-span spacing issues (e.g. `` ` text ` `` instead of `` `text` ``).
+  - The bare `#01` token in headings (e.g. "Review-fix #01") being
+    parsed as Markdown heading syntax by some linters.
+- Proposed fix: Walk each of lines 121, 137, 158, 247, 296, 435, 609,
+  776; for each:
+  - Add an explicit language tag to any bare ```` ``` ```` fence
+    (e.g. ` ```text `, ` ```js `, ` ```python `, ` ```markdown ` as
+    appropriate).
+  - Normalise code-span whitespace (no leading/trailing space inside
+    backticks).
+  - Escape the `#` in `#01` heading-adjacent tokens (e.g. `\#01`) OR
+    rewrap the line so `#01` is not at the start of a fragment that a
+    linter could misread as a heading. Apply consistent escaping
+    across the file. Verify with the markdown linter the project
+    uses (or a dry run of `python scripts/qs/quality_gate.py`).
+
+### [should-fix] AC-10 doc paragraph not pinned by automated test
+- File: `tests/test_dashboard_rendering.py` (new test alongside the
+  other QS-211 steam tests, after
+  `test_water_boiler_card_steam_filter_region_attributes`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC-10 requires a new top-level "QS-211 — boiling steam
+  puffs" paragraph in `docs/agents/concepts/dashboard-and-cards.md`,
+  positioned AFTER the QS-200 block and BEFORE the "Review-fix"
+  entries, plus a current `last_verified` value in the file's
+  front-matter. The story routes verification of this AC to
+  `python scripts/qs/check_doc_drift.py`, leaving the paragraph and
+  its placement unprotected by a regression test. If a future edit
+  silently moves the paragraph, strips the headline, or stales the
+  `last_verified`, drift detection alone may not catch it.
+- Proposed fix: Add a new pytest function in
+  `tests/test_dashboard_rendering.py` (e.g.
+  `test_dashboard_and_cards_doc_pins_qs_211_steam_paragraph`) that:
+  - Reads `docs/agents/concepts/dashboard-and-cards.md` from the
+    repo root.
+  - Asserts the literal headline `**QS-211 — boiling steam puffs.**`
+    is present.
+  - Asserts the headline's index is GREATER than the index of the
+    QS-200 block marker (e.g. `**QS-200`) AND LESS than the index
+    of the first `Review-fix #01` (or equivalent) marker — pinning
+    placement.
+  - Asserts the front-matter contains a `last_verified:` field with
+    a YYYY-MM-DD value (use a regex; do not hardcode the current
+    date — the goal is to guarantee the field exists and is
+    well-formed, not to fail every day).
+  - Optionally: asserts the paragraph body mentions the key
+    QS-211 elements (`MAX_CONCURRENT_STEAM`, `STEAM_FILL_COLOR`,
+    `_currentColorMix`, `disconnectedCallback`) so future doc
+    rewrites can't silently strip the substantive content.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify.

--- a/docs/stories/QS-211.story_review_fix_#02.md
+++ b/docs/stories/QS-211.story_review_fix_#02.md
@@ -1,0 +1,127 @@
+# QS-211 — Review fix plan #02
+
+## Summary
+- Source PR: #212
+- Source story: docs/stories/QS-211.story.md
+- Prior fix plan: docs/stories/QS-211.story_review_fix_#01.md
+- Findings to fix: 3
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [should-fix] Doc-paragraph test's slice over-reads (regression in fix-plan #01 item #3)
+- File: `tests/test_dashboard_rendering.py` — the
+  `test_dashboard_and_cards_doc_pins_qs_211_steam_paragraph` function
+  added by fix-plan #01.
+- Severity: should-fix
+- Source: qs-review-blind-hunter (also confirmed by qs-review-edge-case-hunter)
+- Description: The test currently does:
+  ```python
+  paragraph_end = doc.find("\n\n", headline_idx)
+  if paragraph_end == -1:
+      paragraph_end = len(doc)
+  paragraph = doc[headline_idx:paragraph_end + 2000]
+  ```
+  The slice extends 2000 characters past the QS-211 paragraph's
+  blank-line terminator. The four anchor assertions
+  (`MAX_CONCURRENT_STEAM`, `STEAM_FILL_COLOR`, `_currentColorMix`,
+  `disconnectedCallback`) are therefore searched not only within
+  the QS-211 paragraph but also into the next ~2000 chars of doc
+  (which include the Review-fix #01 / #02 sections). A future edit
+  that moves any of the four anchors OUT of the QS-211 paragraph
+  but into a nearby section would still pass this test, defeating
+  the entire point of fix-plan #01 item #3 ("pin the substantive
+  content of the QS-211 paragraph").
+- Proposed fix: Drop the `+ 2000` widening. Slice exactly to the
+  detected paragraph end:
+  ```python
+  paragraph_end = doc.find("\n\n", headline_idx)
+  if paragraph_end == -1:
+      paragraph_end = len(doc)
+  paragraph = doc[headline_idx:paragraph_end]
+  ```
+  Verify the test still passes with the QS-211 paragraph as
+  currently written (it already contains all four anchors —
+  `MAX_CONCURRENT_STEAM` ~line 278, `STEAM_FILL_COLOR` ~line 287,
+  `_currentColorMix` ~line 290, `disconnectedCallback` ~line 294 of
+  `docs/agents/concepts/dashboard-and-cards.md`). If any anchor is
+  outside the paragraph today, the failure is genuine — relocate
+  the anchor into the paragraph rather than re-widen the slice.
+
+### [should-fix] Doc references undefined JS constant `STEAM_FILL_ALPHA`
+- File: `docs/agents/concepts/dashboard-and-cards.md` — the new
+  QS-211 paragraph (between the QS-200 block and Review-fix #01).
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The paragraph states per-frame opacity is
+  `STEAM_FILL_ALPHA × _currentColorMix × lifeCurve(t)`. The JS
+  source (`custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`)
+  has no `STEAM_FILL_ALPHA` constant; alpha 0.45 is baked into
+  `STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'`, and the runtime
+  opacity assignment is literally
+  `const opacity = lifeOpacity * this._currentColorMix;`
+  Readers grepping the source for `STEAM_FILL_ALPHA` find nothing,
+  which is misleading.
+- Proposed fix: Pick ONE of the following two paths (cheapest
+  wins — both are acceptable):
+
+  **Path A — fix the doc** (recommended; minimal blast radius):
+  - Rewrite the formula sentence in
+    `docs/agents/concepts/dashboard-and-cards.md` to clarify that
+    alpha 0.45 is baked into the SVG fill literal and the runtime
+    multiplier is `lifeOpacity * _currentColorMix`. Something like:
+    "The `<circle>` fill is
+    `STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'` (the 0.45 alpha
+    is baked into the SVG fill); the runtime per-frame opacity
+    attribute is `lifeOpacity * _currentColorMix`, where
+    `lifeOpacity` is the piecewise-linear lifeCurve(t) with
+    breakpoints at 0.15 and 0.7."
+  - No JS change.
+
+  **Path B — extract the constant** (only if doc parity matters
+  more than diff size):
+  - Add `const STEAM_FILL_ALPHA = 0.45;` to the steam constants
+    block in `qs-water-boiler-card.js`.
+  - Change `STEAM_FILL_COLOR` to be derived from it (e.g.
+    `\`rgba(255,255,255,${STEAM_FILL_ALPHA})\``).
+  - Leave the doc formula as-is.
+  - Update / add a test asserting both constants exist and the
+    color string is derived from the alpha.
+
+  Default to Path A unless there is a strong reason to expose
+  the alpha as a JS-level constant. Whichever path is taken,
+  also update the `test_dashboard_and_cards_doc_pins_qs_211_steam_paragraph`
+  test (from the first should-fix above) so its anchor list still
+  matches reality.
+
+### [should-fix] `Path` import not visible in test file for new test
+- File: `tests/test_dashboard_rendering.py` — the
+  `test_dashboard_and_cards_doc_pins_qs_211_steam_paragraph` function
+  added by fix-plan #01.
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The new test uses
+  `Path(__file__).parent.parent / "docs" / "agents" / "concepts" / "dashboard-and-cards.md"`,
+  but the `Path` import is not present in the diff. If the top of
+  `tests/test_dashboard_rendering.py` doesn't already import
+  `Path` from `pathlib`, the test raises `NameError` on first run.
+  The quality gate may have masked this if the test happened to be
+  skipped, parametrised away, or if a fixture provided `Path` via
+  another mechanism — verify directly.
+- Proposed fix:
+  - Open `tests/test_dashboard_rendering.py`. Check the top-of-file
+    imports.
+  - If `Path` is not imported, add `from pathlib import Path` to the
+    imports block (alphabetical order if the file uses one;
+    otherwise grouped with stdlib imports).
+  - If `Path` is already imported, simply confirm and leave the
+    file alone — no change required. Record the confirmation in
+    the commit message ("confirmed Path import already present").
+  - Either way, run `python scripts/qs/quality_gate.py` (or at
+    minimum the test module) to prove the test executes without
+    NameError.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify.

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2257,12 +2257,24 @@ def test_water_boiler_card_steam_layer_after_surface_glow_in_clip():
         "qs-water-boiler-card.js: steam group markup must be exactly "
         f"`{steam_group}` (filter + pointer-events both required)."
     )
-    # Outer </g> of the clip group must close AFTER the steam group, so
-    # the steam layer is still inside the clipped envelope.
-    outer_close = source.find("</g>", steam_idx)
+    # Review-fix #01 finding #1: the previous assertion
+    # `source.find("</g>", steam_idx)` resolved to the steam group's OWN
+    # self-closing tag — trivially `!= -1` even if the steam layer were
+    # OUTSIDE the clip group. To prove containment, advance the search
+    # past the steam group's own `</g>` so the next `</g>` we find must
+    # be a sibling/ancestor closer — specifically the outer water-clip
+    # group's `</g>`. AC-1: "both indices live within the clipped
+    # group".
+    steam_group_idx = source.find(steam_group, clip_open)
+    assert steam_group_idx != -1, (
+        "qs-water-boiler-card.js: literal steam group block must appear "
+        "inside the water clip group."
+    )
+    outer_close = source.find("</g>", steam_group_idx + len(steam_group))
     assert outer_close != -1, (
-        "qs-water-boiler-card.js: no `</g>` after the steam layer — "
-        "the clip group never closes."
+        "qs-water-boiler-card.js: no `</g>` AFTER the steam group's "
+        "self-close — the steam layer must be nested inside the outer "
+        "water-clip `<g>` so puffs are clipped at the ring."
     )
 
 
@@ -2549,6 +2561,110 @@ def test_water_boiler_card_steam_filter_region_attributes():
         "qs-water-boiler-card.js: steam filter must contain "
         "`<feGaussianBlur stdDeviation=\"${STEAM_BLUR_STDDEV}\" />`."
     )
+
+
+def test_dashboard_and_cards_doc_pins_qs_211_steam_paragraph():
+    """Review-fix #01 finding #3: pin the QS-211 doc paragraph in
+    `docs/agents/concepts/dashboard-and-cards.md` so a future edit
+    can't silently strip the headline, move it, or stale the
+    `last_verified` field without flipping this test red.
+
+    AC-10 already routes verification through
+    `python scripts/qs/check_doc_drift.py`, but drift detection only
+    fires on co-modification mismatches — it does not enforce
+    placement, headline literal, or front-matter field shape. This
+    regression-test complements the drift checker on those three
+    dimensions.
+
+    Pinned invariants:
+
+    - The literal headline `**QS-211 — boiling steam puffs.**` is
+      present.
+    - Headline index is GREATER than the QS-200 block marker
+      (`**QS-200`) AND LESS than the first `Review-fix #01` marker —
+      i.e. the paragraph sits between the QS-200 block and the
+      review-fix history, per AC-10.
+    - The front-matter contains a `last_verified:` field with a
+      `YYYY-MM-DD` value. The regex deliberately does NOT pin a
+      specific date so the test doesn't go red every day; the goal
+      is that the field exists and is well-formed.
+    - The paragraph body mentions the four QS-211 anchors
+      (`MAX_CONCURRENT_STEAM`, `STEAM_FILL_COLOR`,
+      `_currentColorMix`, `disconnectedCallback`) so a future doc
+      rewrite can't silently strip the substantive content.
+    """
+    import re
+
+    doc_path = (
+        Path(__file__).parent.parent
+        / "docs"
+        / "agents"
+        / "concepts"
+        / "dashboard-and-cards.md"
+    )
+    doc = doc_path.read_text(encoding="utf-8")
+
+    headline = "**QS-211 — boiling steam puffs.**"
+    headline_idx = doc.find(headline)
+    assert headline_idx != -1, (
+        f"dashboard-and-cards.md: missing the literal QS-211 headline "
+        f"`{headline}`. AC-10 requires this exact wording so the "
+        "paragraph is discoverable from a substring search."
+    )
+
+    qs200_idx = doc.find("**QS-200")
+    assert qs200_idx != -1, (
+        "dashboard-and-cards.md: missing the `**QS-200` block marker — "
+        "AC-10 anchors the QS-211 paragraph relative to that block."
+    )
+    review_fix_idx = doc.find("Review-fix #01")
+    assert review_fix_idx != -1, (
+        "dashboard-and-cards.md: missing the `Review-fix #01` marker — "
+        "AC-10 anchors the QS-211 paragraph BEFORE that marker."
+    )
+    assert qs200_idx < headline_idx < review_fix_idx, (
+        "dashboard-and-cards.md: the QS-211 headline must appear AFTER "
+        "the `**QS-200` block AND BEFORE `Review-fix #01`. Current "
+        f"order: QS-200 at {qs200_idx}, QS-211 at {headline_idx}, "
+        f"Review-fix #01 at {review_fix_idx}."
+    )
+
+    # Front-matter `last_verified:` field must be present and shaped
+    # YYYY-MM-DD. We deliberately do NOT pin a specific date so this
+    # test doesn't go red every day — the field-exists + well-formed
+    # check is the right level for a regression test.
+    front_matter_match = re.search(
+        r"^last_verified:\s*(\d{4}-\d{2}-\d{2})\s*$",
+        doc,
+        re.MULTILINE,
+    )
+    assert front_matter_match, (
+        "dashboard-and-cards.md: front-matter must contain a "
+        "`last_verified: YYYY-MM-DD` field per AC-10."
+    )
+
+    # Body content guards: a future doc rewrite that strips these
+    # anchors leaves a paragraph without substance, defeating the
+    # AC-10 documentation intent. We pin the four most-load-bearing
+    # tokens (cap constant, fill-color constant, the colorMix
+    # cross-fade reference, the disconnectedCallback teardown
+    # reference).
+    paragraph_end = doc.find("\n\n", headline_idx)
+    if paragraph_end == -1:
+        paragraph_end = len(doc)
+    paragraph = doc[headline_idx:paragraph_end + 2000]  # widen for follow-on lines
+    for anchor in (
+        "MAX_CONCURRENT_STEAM",
+        "STEAM_FILL_COLOR",
+        "_currentColorMix",
+        "disconnectedCallback",
+    ):
+        assert anchor in paragraph, (
+            f"dashboard-and-cards.md: the QS-211 paragraph must "
+            f"mention `{anchor}` — it's one of the four load-bearing "
+            "anchors the AC-10 paragraph is required to cover. A "
+            "rewrite that drops it leaves the paragraph as a stub."
+        )
 
 
 def test_water_boiler_card_running_at_stop_consume_is_flag_gated():

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2649,10 +2649,17 @@ def test_dashboard_and_cards_doc_pins_qs_211_steam_paragraph():
     # tokens (cap constant, fill-color constant, the colorMix
     # cross-fade reference, the disconnectedCallback teardown
     # reference).
+    #
+    # Review-fix #02 finding #1: the slice is bounded EXACTLY to the
+    # paragraph (terminated by the next blank line) — no widening. A
+    # `+ 2000` reach-ahead would let any of the four anchors live in
+    # a NEIGHBOURING section (e.g. Review-fix #01/#02 below) and
+    # still satisfy this test, defeating the "pin the substantive
+    # content of the QS-211 paragraph" intent of fix-plan #01 #3.
     paragraph_end = doc.find("\n\n", headline_idx)
     if paragraph_end == -1:
         paragraph_end = len(doc)
-    paragraph = doc[headline_idx:paragraph_end + 2000]  # widen for follow-on lines
+    paragraph = doc[headline_idx:paragraph_end]
     for anchor in (
         "MAX_CONCURRENT_STEAM",
         "STEAM_FILL_COLOR",

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2221,6 +2221,336 @@ def test_water_boiler_card_factors_reset_dom_refs_helper():
     )
 
 
+def test_water_boiler_card_steam_layer_after_surface_glow_in_clip():
+    """QS-211 AC-1: the steam `<g>` is the new last child of the water
+    clip-path group, sitting AFTER `<path id="surface_glow">` in source
+    order. It carries the steam filter and `pointer-events="none"`."""
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    clip_open = source.find('<g clip-path="url(#${waterClipId})">')
+    assert clip_open != -1, (
+        "qs-water-boiler-card.js: missing the water clip-path group "
+        "opener `<g clip-path=\"url(#${waterClipId})\">` — has the "
+        "QS-200 markup been removed?"
+    )
+    surface_idx = source.find('id="surface_glow"', clip_open)
+    steam_idx = source.find('id="${steamLayerId}"', clip_open)
+    assert surface_idx != -1, (
+        "qs-water-boiler-card.js: missing `id=\"surface_glow\"` inside "
+        "the water clip group (QS-200 anchor)."
+    )
+    assert steam_idx != -1, (
+        "qs-water-boiler-card.js: missing the QS-211 steam layer "
+        "`<g id=\"${steamLayerId}\" ...>` inside the water clip group."
+    )
+    assert surface_idx < steam_idx, (
+        "qs-water-boiler-card.js: the steam `<g>` must appear AFTER "
+        "`<path id=\"surface_glow\">` in source order so it stacks "
+        "above the surface glow inside the clip group."
+    )
+    steam_group = (
+        '<g id="${steamLayerId}" filter="url(#${steamFilterId})" '
+        'pointer-events="none"></g>'
+    )
+    assert steam_group in source, (
+        "qs-water-boiler-card.js: steam group markup must be exactly "
+        f"`{steam_group}` (filter + pointer-events both required)."
+    )
+    # Outer </g> of the clip group must close AFTER the steam group, so
+    # the steam layer is still inside the clipped envelope.
+    outer_close = source.find("</g>", steam_idx)
+    assert outer_close != -1, (
+        "qs-water-boiler-card.js: no `</g>` after the steam layer — "
+        "the clip group never closes."
+    )
+
+
+def test_water_boiler_card_steam_spawn_is_boiling_gated():
+    """QS-211 AC-2: the steam spawn `while` loop is wrapped in
+    `if (boiling) { ... }`, while the advance/retire `for` loop sits
+    OUTSIDE that guard (graceful-exit per design decision D15)."""
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    spawn_gate = re.search(
+        r"if \(boiling\)\s*\{[^}]*while\s*\(\s*this\._nextSteamAt\s*<=\s*0"
+        r"[^}]*MAX_CONCURRENT_STEAM",
+        executable,
+        re.DOTALL,
+    )
+    assert spawn_gate, (
+        "qs-water-boiler-card.js: the steam spawn `while` must live "
+        "inside an `if (boiling) { ... }` guard (the same `boiling` "
+        "const reused from the bubble block)."
+    )
+    advance_match = re.search(
+        r"for\s*\(\s*const\s+p\s+of\s+this\._steamPuffs\s*\)",
+        executable,
+    )
+    assert advance_match, (
+        "qs-water-boiler-card.js: missing the steam advance loop "
+        "`for (const p of this._steamPuffs)`."
+    )
+    cap_clamp = re.search(
+        r"if\s*\(\s*this\._nextSteamAt\s*<\s*0\s*\)\s*"
+        r"this\._nextSteamAt\s*=\s*0\s*;",
+        executable,
+    )
+    assert cap_clamp, (
+        "qs-water-boiler-card.js: missing the cap-recovery clamp "
+        "`if (this._nextSteamAt < 0) this._nextSteamAt = 0;`."
+    )
+    # The advance loop must come AFTER the cap-clamp line (which is the
+    # last statement inside the `if (boiling)` block), proving the
+    # advance loop is outside the boiling-gate.
+    assert advance_match.start() > cap_clamp.start(), (
+        "qs-water-boiler-card.js: the steam advance/retire loop must "
+        "appear AFTER the cap-clamp line — that is, OUTSIDE the "
+        "`if (boiling)` guard — so in-flight puffs continue to rise "
+        "and fade gracefully when boiling flips off."
+    )
+
+
+def test_water_boiler_card_steam_retire_both_branches():
+    """QS-211 AC-3: the steam retire predicate covers BOTH branches —
+    `p.cy < topY` (reached top of clip) AND `p.life >= p.maxLife`
+    (hard upper-bound). Either condition retires the puff."""
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    assert re.search(
+        r"p\.cy\s*<\s*topY\s*\|\|\s*p\.life\s*>=\s*p\.maxLife",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: the steam retire predicate must be "
+        "exactly `p.cy < topY || p.life >= p.maxLife` — both branches "
+        "are required (top-of-clip + maxLife)."
+    )
+    assert re.search(
+        r"const\s+topY\s*=\s*CENTER_CY\s*-\s*CLIP_R\s*\+\s*STEAM_TOP_MARGIN_PX",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `topY` must be derived as "
+        "`CENTER_CY - CLIP_R + STEAM_TOP_MARGIN_PX`."
+    )
+
+
+def test_water_boiler_card_steam_opacity_formula():
+    """QS-211 AC-4: per-frame opacity is the assignment
+    `lifeOpacity * this._currentColorMix` (not a compound `*=`), and
+    the life-curve breakpoints `0.15` (fade-in) and `0.7` (fade-out)
+    appear literally in the steam advance block. The `<circle>` fill
+    is the literal `STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'` so the
+    SVG alpha 0.45 is baked in."""
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    assert re.search(
+        r"STEAM_FILL_COLOR\s*=\s*['\"]rgba\(255,\s*255,\s*255,\s*0\.45\)['\"]",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: STEAM_FILL_COLOR must be the literal "
+        "`'rgba(255,255,255,0.45)'` so SVG alpha 0.45 is baked in."
+    )
+    assert re.search(
+        r"const\s+opacity\s*=\s*lifeOpacity\s*\*\s*this\._currentColorMix",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: the per-frame opacity must be an "
+        "ASSIGNMENT `const opacity = lifeOpacity * this._currentColorMix` "
+        "(NOT a compound `*=`, which would decay exponentially over "
+        "frames)."
+    )
+    # Find the steam advance block and assert breakpoints appear inside it.
+    advance_start = executable.find("for (const p of this._steamPuffs)")
+    assert advance_start != -1, (
+        "qs-water-boiler-card.js: missing steam advance loop."
+    )
+    # Take a window large enough to cover the life-curve branches.
+    advance_block = executable[advance_start : advance_start + 1500]
+    assert "0.15" in advance_block, (
+        "qs-water-boiler-card.js: missing the `0.15` fade-in breakpoint "
+        "in the steam life-curve."
+    )
+    assert "0.7" in advance_block, (
+        "qs-water-boiler-card.js: missing the `0.7` fade-out breakpoint "
+        "in the steam life-curve."
+    )
+
+
+def test_water_boiler_card_steam_ids_derive_from_next_clip_id():
+    """QS-211 AC-5: `_steamLayerId` and `_steamFilterId` are assigned
+    inside the same `if (!this._waterClipId)` block that owns the other
+    per-instance IDs, and derive from the same `uid` variable sourced
+    from `QsWaterBoilerCard._nextClipId`. Naming convention:
+    `wb_steamLayer_${uid}` / `wb_steamFilter_${uid}`."""
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    assert re.search(
+        r"this\._steamLayerId\s*=\s*`wb_steamLayer_\$\{uid\}`",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: missing "
+        "`this._steamLayerId = \\`wb_steamLayer_${uid}\\`` assignment."
+    )
+    assert re.search(
+        r"this\._steamFilterId\s*=\s*`wb_steamFilter_\$\{uid\}`",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: missing "
+        "`this._steamFilterId = \\`wb_steamFilter_${uid}\\`` assignment."
+    )
+    # Both must live inside the per-instance ID guard, i.e. after the
+    # `_nextClipId` bump and before the next consumer (`const waterClipId
+    # = this._waterClipId;`).
+    guard_open = re.search(
+        r"if\s*\(\s*!this\._waterClipId\s*\)\s*\{",
+        executable,
+    )
+    assert guard_open, (
+        "qs-water-boiler-card.js: missing the "
+        "`if (!this._waterClipId) { ... }` per-instance ID guard."
+    )
+    consumer = executable.find(
+        "const waterClipId = this._waterClipId;",
+        guard_open.end(),
+    )
+    assert consumer != -1, (
+        "qs-water-boiler-card.js: missing the "
+        "`const waterClipId = this._waterClipId;` consumer line."
+    )
+    steam_layer_idx = executable.find("this._steamLayerId", guard_open.end())
+    steam_filter_idx = executable.find("this._steamFilterId", guard_open.end())
+    assert guard_open.end() < steam_layer_idx < consumer, (
+        "qs-water-boiler-card.js: `this._steamLayerId` must be assigned "
+        "inside the `if (!this._waterClipId)` block, alongside the "
+        "other per-instance IDs."
+    )
+    assert guard_open.end() < steam_filter_idx < consumer, (
+        "qs-water-boiler-card.js: `this._steamFilterId` must be "
+        "assigned inside the `if (!this._waterClipId)` block, alongside "
+        "the other per-instance IDs."
+    )
+
+
+def test_water_boiler_card_reset_dom_refs_includes_steam():
+    """QS-211 AC-6: `_resetDomRefs()` body nulls `_steamLayerEl` AND
+    clears `_steamPuffs`. Both call sites (`_invalidateWaveCache()`
+    and the post-innerHTML cleanup block) inherit the steam reset
+    automatically — no per-site duplication."""
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    body = _extract_js_function_body(executable, r"_resetDomRefs\s*\(\s*\)")
+    assert body is not None, (
+        "qs-water-boiler-card.js: missing `_resetDomRefs()` method."
+    )
+    assert re.search(r"this\._steamLayerEl\s*=\s*null", body), (
+        "qs-water-boiler-card.js: `_resetDomRefs()` must null "
+        "`this._steamLayerEl` so a stale ref doesn't survive into the "
+        "next RAF tick after an innerHTML rewrite."
+    )
+    assert re.search(r"this\._steamPuffs\s*=\s*\[\s*\]", body), (
+        "qs-water-boiler-card.js: `_resetDomRefs()` must clear "
+        "`this._steamPuffs = []` so a re-render starts with a fresh "
+        "particle array (matches the QS-200 bubble precedent)."
+    )
+
+
+def test_water_boiler_card_steam_cap_hit_clamps_next_steam_at():
+    """QS-211 AC-7: after the steam spawn `while` loop,
+    `if (this._nextSteamAt < 0) this._nextSteamAt = 0;` clamps the
+    cadence counter so capacity-recovery doesn't fire a backlog
+    burst. Mirrors the QS-200 bubble pattern (line 347)."""
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    assert re.search(
+        r"if\s*\(\s*this\._nextSteamAt\s*<\s*0\s*\)\s*"
+        r"this\._nextSteamAt\s*=\s*0\s*;",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: missing cap-recovery clamp "
+        "`if (this._nextSteamAt < 0) this._nextSteamAt = 0;` after the "
+        "steam spawn `while` loop."
+    )
+
+
+def test_water_boiler_card_disconnected_callback_clears_steam():
+    """QS-211 AC-8: `disconnectedCallback()` eagerly removes steam
+    `<circle>` DOM nodes and resets `_steamPuffs` to `[]`. Mirrors the
+    bubble teardown shape (line ~426)."""
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    body = _extract_js_function_body(
+        executable, r"disconnectedCallback\s*\(\s*\)"
+    )
+    assert body is not None, (
+        "qs-water-boiler-card.js: missing `disconnectedCallback()`."
+    )
+    assert re.search(
+        r"this\._steamPuffs\?\.forEach\s*\(\s*p\s*=>\s*p\.el\?\.remove\?\.\(\)\s*\)",
+        body,
+    ), (
+        "qs-water-boiler-card.js: `disconnectedCallback` must eagerly "
+        "tear down steam DOM with "
+        "`this._steamPuffs?.forEach(p => p.el?.remove?.())`."
+    )
+    assert re.search(r"this\._steamPuffs\s*=\s*\[\s*\]", body), (
+        "qs-water-boiler-card.js: `disconnectedCallback` must clear "
+        "`this._steamPuffs = []` after removing nodes."
+    )
+
+
+def test_water_boiler_card_steam_filter_region_attributes():
+    """QS-211 AC-9: the steam `<filter>` is declared in `<defs>` with
+    the safe-region attributes (`x="-50%" y="-50%" width="200%"
+    height="200%"`) so the Gaussian blur isn't clipped at the puff
+    bounding box. Mirrors the surface_glow filter precedent."""
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    filter_decl = (
+        '<filter id="${steamFilterId}" x="-50%" y="-50%" '
+        'width="200%" height="200%">'
+    )
+    assert filter_decl in source, (
+        "qs-water-boiler-card.js: steam filter declaration must include "
+        "the safe-region attributes — expected literal substring "
+        f"`{filter_decl}` (mirrors the surface_glow filter precedent)."
+    )
+    assert (
+        '<feGaussianBlur stdDeviation="${STEAM_BLUR_STDDEV}" />' in source
+    ), (
+        "qs-water-boiler-card.js: steam filter must contain "
+        "`<feGaussianBlur stdDeviation=\"${STEAM_BLUR_STDDEV}\" />`."
+    )
+
+
 def test_water_boiler_card_running_at_stop_consume_is_flag_gated():
     """Review-fix #04 M1: the `_runningAtStop` stash must be consumed
     EXACTLY ONCE on the first post-reattach `_render`, regardless of


### PR DESCRIPTION
## Summary
- Add 4th boiling-state visual to qs-water-boiler-card: white-translucent puffs that rise from the water surface to the top of the clip circle with a sin-wobble.
- Mirror the QS-200 bubble subsystem architecture: per-instance unique IDs, lazy-resolved DOM refs, RAF-driven spawn/advance/retire, single feGaussianBlur applied to the layer <g> (constant per-frame cost), graceful exit via _currentColorMix opacity multiplier.
- Pin behaviour with 9 structural tests (AC-1 through AC-9); document subsystem in dashboard-and-cards.md.

Fixes #211

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Water boiler card now displays gentle animated steam puffs when actively boiling, with realistic spawn rates, vertical rise behavior, growth scaling, and smooth opacity fade transitions.

* **Tests**
  * Added regression tests to verify steam layer structure, spawn behavior, retire logic, and lifecycle management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->