### PR TITLE
QS-214: Steam not shown when boiler is on (regression after #211 fix)

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -1159,6 +1159,20 @@ class QsWaterBoilerCard extends HTMLElement {
         }
       }
 
+      // QS-214: snapshot the in-flight steam puffs BEFORE the
+      // innerHTML rewrite below. The rewrite detaches every DOM node
+      // under `this._root`, including the steam layer's children.
+      // Without this snapshot, every HA state push (which fires
+      // `set hass → _render`) wipes the entire puff array
+      // simultaneously — the user-visible "3-4 puffs all disappear at
+      // the exact same time" symptom. The `p.el` references survive
+      // detachment (JS still holds them); we re-attach them to the
+      // new steam layer after `_resetDomRefs()` below. Spawn-cadence
+      // counter is also preserved so the next spawn doesn't reset to
+      // 0 (which would burst-spawn on every push).
+      const preservedSteamPuffs = this._steamPuffs;
+      const preservedNextSteamAt = this._nextSteamAt;
+
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
         <style>${css}</style>
@@ -1307,6 +1321,30 @@ class QsWaterBoilerCard extends HTMLElement {
       this._lastWaterBaseY = this._waterBaseY;
       this._lastAmplitude = initialAmp;
       this._resetDomRefs();
+
+      // QS-214: restore the preserved steam puffs into the FRESH
+      // steam layer (its DOM identity changed via innerHTML — same
+      // `id`, new element). For each preserved puff, re-attach its
+      // detached `el` to the new layer; the puff's per-frame state
+      // (cy, life, fadeBand, …) survived in the JS array, so the RAF
+      // advance loop picks up exactly where it left off, with no
+      // visual blink. Counter is restored so spawn cadence is
+      // continuous. If the new layer isn't found (defensive — e.g.
+      // template change removed it), drop the preserved puffs so they
+      // don't leak DOM nodes.
+      if (preservedSteamPuffs?.length) {
+        const newSteamLayer = this._steamLayerId
+          ? this._root.getElementById(this._steamLayerId)
+          : null;
+        if (newSteamLayer) {
+          for (const p of preservedSteamPuffs) {
+            if (p?.el) newSteamLayer.appendChild(p.el);
+          }
+          this._steamPuffs = preservedSteamPuffs;
+          this._steamLayerEl = newSteamLayer;
+          this._nextSteamAt = preservedNextSteamAt;
+        }
+      }
 
       // Wire events
       const root = this._root;

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -89,13 +89,13 @@ const MAX_CONCURRENT_STEAM = 8;
 const STEAM_SPAWN_RATE_HZ = 1.5;
 const STEAM_RADIUS_MIN = 4;
 const STEAM_RADIUS_MAX = 10;
-const STEAM_RISE_PX_PER_S_MIN = 10;
-const STEAM_RISE_PX_PER_S_MAX = 22;
+const STEAM_RISE_PX_PER_S_MIN = 18;
+const STEAM_RISE_PX_PER_S_MAX = 32;
 const STEAM_DRIFT_PX_PER_S = 6;
 const STEAM_DRIFT_FREQ_HZ = 0.4;
 const STEAM_RADIUS_GROW_PX_PER_S = 4;
-const STEAM_MAX_LIFE_S = 4.5;
-const STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)';
+const STEAM_MAX_LIFE_S = 8.0;
+const STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)';
 const STEAM_BLUR_STDDEV = 3.5;
 const STEAM_TOP_MARGIN_PX = 4;
 
@@ -459,24 +459,35 @@ class QsWaterBoilerCard extends HTMLElement {
         // Advance + retire active puffs regardless of boiling state.
         // Graceful exit: in-flight puffs keep rising; opacity fades to
         // 0 via `_currentColorMix` over ~1.5s when running→false.
-        const topY = CENTER_CY - CLIP_R + STEAM_TOP_MARGIN_PX;
         const aliveSteam = [];
         for (const p of this._steamPuffs) {
           p.life += dt;
           p.cy -= p.vy * dt;
           p.cx += STEAM_DRIFT_PX_PER_S * Math.sin(2 * Math.PI * STEAM_DRIFT_FREQ_HZ * p.life + p.phase) * dt;
           p.r = Math.min(p.r + STEAM_RADIUS_GROW_PX_PER_S * dt, STEAM_RADIUS_MAX + 4);
-          if (p.cy < topY || p.life >= p.maxLife) {
+          // QS-214 retire predicate: per-puff circle-aware geometry.
+          // SVG convention: smaller y = visually higher. Retire when
+          // the puff rises above the local clip-circle top at this x,
+          // minus the STEAM_TOP_MARGIN_PX guard. Mirrors the spawn-side
+          // chord-half formula (`chordHalf = sqrt(max(0, CLIP_R² - dy²))`)
+          // a few lines above, so puffs drifting toward the rim retire
+          // at the local clip top rather than continuing invisibly
+          // toward the global apex.
+          const dx = p.cx - CENTER_CX;
+          const localChordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dx * dx));
+          const localTopY = CENTER_CY - localChordHalf + STEAM_TOP_MARGIN_PX;
+          if (p.cy < localTopY || p.life >= p.maxLife) {
             p.el.remove();
             continue;
           }
           // Life curve: piecewise linear — fade-in [0, 0.15], hold
-          // [0.15, 0.7], fade-out [0.7, 1].
+          // [0.15, 0.85], fade-out [0.85, 1]. QS-214 widened the hold
+          // band so fast puffs reach the rim before the fade kicks in.
           const lifeT = p.life / p.maxLife;
           let lifeOpacity;
           if (lifeT < 0.15) lifeOpacity = lifeT / 0.15;
-          else if (lifeT < 0.7) lifeOpacity = 1;
-          else lifeOpacity = Math.max(0, 1 - (lifeT - 0.7) / 0.3);
+          else if (lifeT < 0.85) lifeOpacity = 1;
+          else lifeOpacity = Math.max(0, 1 - (lifeT - 0.85) / 0.15);
           const opacity = lifeOpacity * this._currentColorMix;
           p.el.setAttribute('cx', p.cx.toFixed(2));
           p.el.setAttribute('cy', p.cy.toFixed(2));

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -89,26 +89,31 @@ const MAX_CONCURRENT_STEAM = 8;
 const STEAM_SPAWN_RATE_HZ = 1.5;
 const STEAM_RADIUS_MIN = 4;
 const STEAM_RADIUS_MAX = 10;
-// Uniform vy (MIN == MAX): all puffs rise at the same rate so they
-// all reach the local clip-circle top within their life budget.
-// Organic variance still comes from spawn x, spawn time, drift phase,
-// and radius — not from vy. The 32 px/s value gives a 188 px worst-
-// case rise (empty tank, center column) in 5.88 s — well under
-// 0.7 × STEAM_MAX_LIFE_S = 8.4 s, leaving ~2.5 s of full-opacity hold
-// at the rim before the life-curve fade-out engages.
-const STEAM_RISE_PX_PER_S_MIN = 32;
-const STEAM_RISE_PX_PER_S_MAX = 32;
+// Uniform vy (MIN == MAX): all puffs rise at the same gentle rate.
+// Organic variance comes from spawn x/time, drift phase, radius.
+const STEAM_RISE_PX_PER_S_MIN = 24;
+const STEAM_RISE_PX_PER_S_MAX = 24;
 const STEAM_DRIFT_PX_PER_S = 6;
 const STEAM_DRIFT_FREQ_HZ = 0.4;
 const STEAM_RADIUS_GROW_PX_PER_S = 4;
-// Long enough for the worst-case rise (5.88 s) PLUS the hold band
-// PLUS the life-curve fade-out [0.7, 1.0] (3.6 s). Total puff
-// lifespan exceeds the rise time by 6.12 s — that's the visible
-// "reaches the top and dissipates" time at the rim.
-const STEAM_MAX_LIFE_S = 12.0;
+const STEAM_MAX_LIFE_S = 8.0;
 const STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)';
 const STEAM_BLUR_STDDEV = 3.5;
 const STEAM_TOP_MARGIN_PX = 4;
+// Narrow the spawn cx band to ±STEAM_SPAWN_CX_HALF_PX around
+// CENTER_CX, regardless of water level. Without this clamp, edge-
+// spawned puffs at partial water levels had only 12–80 px of rise
+// before hitting their local rim — perceived as "stops just above the
+// surface". The narrow central band guarantees every puff has a
+// substantial visible rise (≥ 39 px even at near-full tank; > 110 px
+// for half-empty).
+const STEAM_SPAWN_CX_HALF_PX = 35;
+// Per-puff rim-fade band is `STEAM_RIM_FADE_FRACTION × riseBudget`,
+// computed at spawn time and stored on the puff. Geometry-aware:
+// center puffs (long rise) get a long fade band; side puffs (short
+// local rise) get a proportionally shorter band so the fade fits the
+// available space. The fade is the upper 60 % of each puff's rise.
+const STEAM_RIM_FADE_FRACTION = 0.6;
 
 // --- Surface glow ---
 const SURFACE_GLOW_COLOR = '#FF3D00';
@@ -447,7 +452,29 @@ class QsWaterBoilerCard extends HTMLElement {
             const cySpawn = this._waterBaseY + jitter;
             const dy = cySpawn - CENTER_CY;
             const chordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dy * dy));
-            const cxSpawn = CENTER_CX + (Math.random() * 2 - 1) * chordHalf * 0.85;
+            // QS-214: clamp spawn cx to a narrow central band so every
+            // puff has a substantial vertical rise budget regardless
+            // of water level. The water-surface chord at edge cx
+            // would otherwise let puffs spawn near the side rim with
+            // < 80 px of rise — perceived as "stops above the surface".
+            const spawnHalfWidth = Math.min(chordHalf * 0.85, STEAM_SPAWN_CX_HALF_PX);
+            const cxSpawn = CENTER_CX + (Math.random() * 2 - 1) * spawnHalfWidth;
+            // Per-puff rim-fade band: STEAM_RIM_FADE_FRACTION times
+            // the puff's actual rise budget (waterBaseY → localTopY at
+            // spawn cx). Stored on the puff so drift doesn't shift the
+            // fade band mid-flight. The clamp `riseBudget > 0` guards
+            // against very full tanks where the spawn could land
+            // inside the rim (skip those spawns entirely).
+            const spawnDx = cxSpawn - CENTER_CX;
+            const spawnLocalChordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - spawnDx * spawnDx));
+            const spawnLocalTopY = CENTER_CY - spawnLocalChordHalf + STEAM_TOP_MARGIN_PX;
+            const riseBudget = cySpawn - spawnLocalTopY;
+            if (riseBudget <= 0) {
+              // No vertical room above this spawn point — defer.
+              this._nextSteamAt = Math.max(this._nextSteamAt, 0);
+              break;
+            }
+            const fadeBand = riseBudget * STEAM_RIM_FADE_FRACTION;
             const r = STEAM_RADIUS_MIN + Math.random() * (STEAM_RADIUS_MAX - STEAM_RADIUS_MIN);
             const vy = STEAM_RISE_PX_PER_S_MIN + Math.random() * (STEAM_RISE_PX_PER_S_MAX - STEAM_RISE_PX_PER_S_MIN);
             const phase = Math.random() * Math.PI * 2;
@@ -460,7 +487,7 @@ class QsWaterBoilerCard extends HTMLElement {
             el.setAttribute('pointer-events', 'none');
             el.setAttribute('opacity', '0');
             steamLayer.appendChild(el);
-            this._steamPuffs.push({el, cx: cxSpawn, cy: cySpawn, r, vy, phase, life: 0, maxLife: STEAM_MAX_LIFE_S});
+            this._steamPuffs.push({el, cx: cxSpawn, cy: cySpawn, r, vy, phase, life: 0, maxLife: STEAM_MAX_LIFE_S, fadeBand});
             this._nextSteamAt += 1 / STEAM_SPAWN_RATE_HZ;
           }
           // Clamp to 0 to avoid a spawn-backlog burst when capacity recovers.
@@ -485,32 +512,33 @@ class QsWaterBoilerCard extends HTMLElement {
           const dx = p.cx - CENTER_CX;
           const localChordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dx * dx));
           const localTopY = CENTER_CY - localChordHalf + STEAM_TOP_MARGIN_PX;
-          // Pin-at-rim: when the puff rises past localTopY, clamp its
-          // cy back down so it sits at the local clip-circle top
-          // instead of being removed. The life-curve fade-out then
-          // dissolves it gracefully in place over the last 30% of its
-          // life budget — replaces the previous abrupt geometric
-          // retire that blinked puffs out at the rim.
-          if (p.cy < localTopY) p.cy = localTopY;
-          // Sole remove() branch: time-based retire. The geometric
-          // retire was demoted to a position pin (above); only
-          // maxLife removes the DOM node now.
-          if (p.life >= p.maxLife) {
+          // Disjunctive retire: geometric (reached the local rim) OR
+          // time (life expired). The per-puff rim-fade below means the
+          // puff is already at opacity 0 by the time geometric retire
+          // fires — so the remove is invisible, no abrupt blink.
+          if (p.cy < localTopY || p.life >= p.maxLife) {
             p.el.remove();
             continue;
           }
+          // Per-puff rim-proximity fade. `p.fadeBand` was stored at
+          // spawn time as `STEAM_RIM_FADE_FRACTION × riseBudget`, so
+          // each puff fades over the upper 60 % of ITS OWN rise
+          // distance. Center puffs (long rise) get a long fade; side
+          // puffs (short local rise) get a proportionally shorter one
+          // — geometry-aware, never larger than the available space.
+          const rimDistance = p.cy - localTopY;
+          const rimOpacity = Math.max(0, Math.min(1, rimDistance / p.fadeBand));
           // Life curve: piecewise linear — fade-in [0, 0.15], hold
-          // [0.15, 0.7], fade-out [0.7, 1]. The 30%-of-life fade-out
-          // band gives a smooth ~3.6 s dissolve at maxLife = 12 s; the
-          // worst-case rise (5.88 s = 0.49 lifeT) lands the puff at
-          // the rim with ~2.5 s of full-opacity hold before the fade
-          // engages.
+          // [0.15, 0.85], fade-out [0.85, 1]. The fade-out is the
+          // safety branch for puffs that hit maxLife before geometric
+          // retire (stalled / very-full-tank puffs); the rim-fade
+          // handles the normal "rises and fades at the rim" case.
           const lifeT = p.life / p.maxLife;
           let lifeOpacity;
           if (lifeT < 0.15) lifeOpacity = lifeT / 0.15;
-          else if (lifeT < 0.7) lifeOpacity = 1;
-          else lifeOpacity = Math.max(0, 1 - (lifeT - 0.7) / 0.3);
-          const opacity = lifeOpacity * this._currentColorMix;
+          else if (lifeT < 0.85) lifeOpacity = 1;
+          else lifeOpacity = Math.max(0, 1 - (lifeT - 0.85) / 0.15);
+          const opacity = lifeOpacity * rimOpacity * this._currentColorMix;
           p.el.setAttribute('cx', p.cx.toFixed(2));
           p.el.setAttribute('cy', p.cy.toFixed(2));
           p.el.setAttribute('r', p.r.toFixed(2));

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -89,15 +89,29 @@ const MAX_CONCURRENT_STEAM = 8;
 const STEAM_SPAWN_RATE_HZ = 1.5;
 const STEAM_RADIUS_MIN = 4;
 const STEAM_RADIUS_MAX = 10;
-const STEAM_RISE_PX_PER_S_MIN = 18;
-const STEAM_RISE_PX_PER_S_MAX = 32;
+// Uniform vy (MIN == MAX): all puffs rise at the same rate so they
+// all reach the local clip-circle top within their life budget. The
+// rim-proximity fade (STEAM_RIM_FADE_PX) provides the graceful
+// dissolve at the rim; without uniform vy, slow puffs ran out of
+// life mid-tank and never reached the rim, looking inconsistent.
+// Organic variance still comes from spawn x, spawn time, drift phase,
+// and radius — not from vy.
+const STEAM_RISE_PX_PER_S_MIN = 24;
+const STEAM_RISE_PX_PER_S_MAX = 24;
 const STEAM_DRIFT_PX_PER_S = 6;
 const STEAM_DRIFT_FREQ_HZ = 0.4;
 const STEAM_RADIUS_GROW_PX_PER_S = 4;
-const STEAM_MAX_LIFE_S = 8.0;
+const STEAM_MAX_LIFE_S = 10.0;
 const STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)';
 const STEAM_BLUR_STDDEV = 3.5;
 const STEAM_TOP_MARGIN_PX = 4;
+// Rim-proximity fade band (in px). The puff's opacity ramps 1→0 over
+// the last STEAM_RIM_FADE_PX pixels below localTopY, so it dissolves
+// at the local clip-circle top instead of blinking out on the
+// geometric retire. At vy=24 the fade lasts STEAM_RIM_FADE_PX/24 s
+// (1.25s at 30px) — gentle, visible "reaches the top and dissipates"
+// reading without ever crossing the clip-path arc.
+const STEAM_RIM_FADE_PX = 30;
 
 // --- Surface glow ---
 const SURFACE_GLOW_COLOR = '#FF3D00';
@@ -480,15 +494,27 @@ class QsWaterBoilerCard extends HTMLElement {
             p.el.remove();
             continue;
           }
+          // Rim-proximity fade: opacity ramps 1 → 0 over the last
+          // STEAM_RIM_FADE_PX pixels below localTopY so the puff
+          // dissolves at the rim rather than blinking out on the
+          // geometric retire. `rimDistance` is positive while the puff
+          // is below the local top; it shrinks toward 0 as the puff
+          // approaches. Clamped to [0, 1] so puffs further below the
+          // rim render at full opacity.
+          const rimDistance = p.cy - localTopY;
+          const rimOpacity = Math.max(0, Math.min(1, rimDistance / STEAM_RIM_FADE_PX));
           // Life curve: piecewise linear — fade-in [0, 0.15], hold
-          // [0.15, 0.85], fade-out [0.85, 1]. QS-214 widened the hold
-          // band so fast puffs reach the rim before the fade kicks in.
+          // [0.15, 0.85], fade-out [0.85, 1]. With uniform vy and the
+          // longer maxLife, fast trajectories retire at the rim via
+          // the rim-fade well before the life-curve fade-out engages;
+          // the life-curve fade-out remains as the slow-puff / stalled-
+          // puff safety branch.
           const lifeT = p.life / p.maxLife;
           let lifeOpacity;
           if (lifeT < 0.15) lifeOpacity = lifeT / 0.15;
           else if (lifeT < 0.85) lifeOpacity = 1;
           else lifeOpacity = Math.max(0, 1 - (lifeT - 0.85) / 0.15);
-          const opacity = lifeOpacity * this._currentColorMix;
+          const opacity = lifeOpacity * rimOpacity * this._currentColorMix;
           p.el.setAttribute('cx', p.cx.toFixed(2));
           p.el.setAttribute('cy', p.cy.toFixed(2));
           p.el.setAttribute('r', p.r.toFixed(2));

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -90,28 +90,25 @@ const STEAM_SPAWN_RATE_HZ = 1.5;
 const STEAM_RADIUS_MIN = 4;
 const STEAM_RADIUS_MAX = 10;
 // Uniform vy (MIN == MAX): all puffs rise at the same rate so they
-// all reach the local clip-circle top within their life budget. The
-// rim-proximity fade (STEAM_RIM_FADE_PX) provides the graceful
-// dissolve at the rim; without uniform vy, slow puffs ran out of
-// life mid-tank and never reached the rim, looking inconsistent.
+// all reach the local clip-circle top within their life budget.
 // Organic variance still comes from spawn x, spawn time, drift phase,
-// and radius — not from vy.
-const STEAM_RISE_PX_PER_S_MIN = 24;
-const STEAM_RISE_PX_PER_S_MAX = 24;
+// and radius — not from vy. The 32 px/s value gives a 188 px worst-
+// case rise (empty tank, center column) in 5.88 s — well under
+// 0.7 × STEAM_MAX_LIFE_S = 8.4 s, leaving ~2.5 s of full-opacity hold
+// at the rim before the life-curve fade-out engages.
+const STEAM_RISE_PX_PER_S_MIN = 32;
+const STEAM_RISE_PX_PER_S_MAX = 32;
 const STEAM_DRIFT_PX_PER_S = 6;
 const STEAM_DRIFT_FREQ_HZ = 0.4;
 const STEAM_RADIUS_GROW_PX_PER_S = 4;
-const STEAM_MAX_LIFE_S = 10.0;
+// Long enough for the worst-case rise (5.88 s) PLUS the hold band
+// PLUS the life-curve fade-out [0.7, 1.0] (3.6 s). Total puff
+// lifespan exceeds the rise time by 6.12 s — that's the visible
+// "reaches the top and dissipates" time at the rim.
+const STEAM_MAX_LIFE_S = 12.0;
 const STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)';
 const STEAM_BLUR_STDDEV = 3.5;
 const STEAM_TOP_MARGIN_PX = 4;
-// Rim-proximity fade band (in px). The puff's opacity ramps 1→0 over
-// the last STEAM_RIM_FADE_PX pixels below localTopY, so it dissolves
-// at the local clip-circle top instead of blinking out on the
-// geometric retire. At vy=24 the fade lasts STEAM_RIM_FADE_PX/24 s
-// (1.25s at 30px) — gentle, visible "reaches the top and dissipates"
-// reading without ever crossing the clip-path arc.
-const STEAM_RIM_FADE_PX = 30;
 
 // --- Surface glow ---
 const SURFACE_GLOW_COLOR = '#FF3D00';
@@ -479,42 +476,41 @@ class QsWaterBoilerCard extends HTMLElement {
           p.cy -= p.vy * dt;
           p.cx += STEAM_DRIFT_PX_PER_S * Math.sin(2 * Math.PI * STEAM_DRIFT_FREQ_HZ * p.life + p.phase) * dt;
           p.r = Math.min(p.r + STEAM_RADIUS_GROW_PX_PER_S * dt, STEAM_RADIUS_MAX + 4);
-          // QS-214 retire predicate: per-puff circle-aware geometry.
-          // SVG convention: smaller y = visually higher. Retire when
-          // the puff rises above the local clip-circle top at this x,
-          // minus the STEAM_TOP_MARGIN_PX guard. Mirrors the spawn-side
-          // chord-half formula (`chordHalf = sqrt(max(0, CLIP_R² - dy²))`)
-          // a few lines above, so puffs drifting toward the rim retire
-          // at the local clip top rather than continuing invisibly
-          // toward the global apex.
+          // Per-puff circle-aware geometry (SVG convention: smaller y =
+          // visually higher). `localTopY` is the local clip-circle top
+          // at the puff's current x, minus the STEAM_TOP_MARGIN_PX
+          // guard. Mirrors the spawn-side chord-half formula
+          // (`chordHalf = sqrt(max(0, CLIP_R² - dy²))`) a few lines
+          // above.
           const dx = p.cx - CENTER_CX;
           const localChordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dx * dx));
           const localTopY = CENTER_CY - localChordHalf + STEAM_TOP_MARGIN_PX;
-          if (p.cy < localTopY || p.life >= p.maxLife) {
+          // Pin-at-rim: when the puff rises past localTopY, clamp its
+          // cy back down so it sits at the local clip-circle top
+          // instead of being removed. The life-curve fade-out then
+          // dissolves it gracefully in place over the last 30% of its
+          // life budget — replaces the previous abrupt geometric
+          // retire that blinked puffs out at the rim.
+          if (p.cy < localTopY) p.cy = localTopY;
+          // Sole remove() branch: time-based retire. The geometric
+          // retire was demoted to a position pin (above); only
+          // maxLife removes the DOM node now.
+          if (p.life >= p.maxLife) {
             p.el.remove();
             continue;
           }
-          // Rim-proximity fade: opacity ramps 1 → 0 over the last
-          // STEAM_RIM_FADE_PX pixels below localTopY so the puff
-          // dissolves at the rim rather than blinking out on the
-          // geometric retire. `rimDistance` is positive while the puff
-          // is below the local top; it shrinks toward 0 as the puff
-          // approaches. Clamped to [0, 1] so puffs further below the
-          // rim render at full opacity.
-          const rimDistance = p.cy - localTopY;
-          const rimOpacity = Math.max(0, Math.min(1, rimDistance / STEAM_RIM_FADE_PX));
           // Life curve: piecewise linear — fade-in [0, 0.15], hold
-          // [0.15, 0.85], fade-out [0.85, 1]. With uniform vy and the
-          // longer maxLife, fast trajectories retire at the rim via
-          // the rim-fade well before the life-curve fade-out engages;
-          // the life-curve fade-out remains as the slow-puff / stalled-
-          // puff safety branch.
+          // [0.15, 0.7], fade-out [0.7, 1]. The 30%-of-life fade-out
+          // band gives a smooth ~3.6 s dissolve at maxLife = 12 s; the
+          // worst-case rise (5.88 s = 0.49 lifeT) lands the puff at
+          // the rim with ~2.5 s of full-opacity hold before the fade
+          // engages.
           const lifeT = p.life / p.maxLife;
           let lifeOpacity;
           if (lifeT < 0.15) lifeOpacity = lifeT / 0.15;
-          else if (lifeT < 0.85) lifeOpacity = 1;
-          else lifeOpacity = Math.max(0, 1 - (lifeT - 0.85) / 0.15);
-          const opacity = lifeOpacity * rimOpacity * this._currentColorMix;
+          else if (lifeT < 0.7) lifeOpacity = 1;
+          else lifeOpacity = Math.max(0, 1 - (lifeT - 0.7) / 0.3);
+          const opacity = lifeOpacity * this._currentColorMix;
           p.el.setAttribute('cx', p.cx.toFixed(2));
           p.el.setAttribute('cy', p.cy.toFixed(2));
           p.el.setAttribute('r', p.r.toFixed(2));

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -470,9 +470,18 @@ class QsWaterBoilerCard extends HTMLElement {
             const spawnLocalTopY = CENTER_CY - spawnLocalChordHalf + STEAM_TOP_MARGIN_PX;
             const riseBudget = cySpawn - spawnLocalTopY;
             if (riseBudget <= 0) {
-              // No vertical room above this spawn point — defer.
-              this._nextSteamAt = Math.max(this._nextSteamAt, 0);
-              break;
+              // Genuinely defer: advance the cadence counter by one
+              // full spawn slot so the next attempt waits a real
+              // interval. `continue` re-checks the while condition
+              // (which will be false after the +=) so we exit this
+              // frame cleanly. Previously this branch did
+              //   `_nextSteamAt = Math.max(_nextSteamAt, 0); break;`
+              // — a no-op (the while guarantees `_nextSteamAt <= 0`
+              // on entry, so the clamp collapses to 0) that spin-
+              // looped the spawn check every frame for near-full
+              // tanks (review fix #01 #5).
+              this._nextSteamAt += 1 / STEAM_SPAWN_RATE_HZ;
+              continue;
             }
             const fadeBand = riseBudget * STEAM_RIM_FADE_FRACTION;
             const r = STEAM_RADIUS_MIN + Math.random() * (STEAM_RADIUS_MAX - STEAM_RADIUS_MIN);
@@ -1348,9 +1357,22 @@ class QsWaterBoilerCard extends HTMLElement {
           for (const p of preservedSteamPuffs) {
             if (p?.el) newSteamLayer.appendChild(p.el);
           }
-          this._steamPuffs = preservedSteamPuffs;
+          // .filter aligns the array with the truthy set we just
+          // re-attached, so the advance loop never has to defensively
+          // null-check `p.el` (review fix #01 #6).
+          this._steamPuffs = preservedSteamPuffs.filter(p => p?.el);
           this._steamLayerEl = newSteamLayer;
           this._nextSteamAt = preservedNextSteamAt;
+        } else {
+          // Defensive: the freshly-rendered template doesn't contain
+          // a steam layer (e.g. a future template variant elides it).
+          // Without this branch the detached `p.el` references would
+          // be GC'd silently while their DOM nodes remained orphaned.
+          // Honour the docstring contract: explicitly remove each
+          // preserved puff's DOM and reset the logical array
+          // (review fix #01 #6).
+          for (const p of preservedSteamPuffs) { p?.el?.remove(); }
+          this._steamPuffs = [];
         }
       }
       if (preservedBubbles?.length) {
@@ -1361,9 +1383,16 @@ class QsWaterBoilerCard extends HTMLElement {
           for (const b of preservedBubbles) {
             if (b?.el) newBubbleLayer.appendChild(b.el);
           }
-          this._bubbles = preservedBubbles;
+          // Symmetric with the steam path: filter aligns the array
+          // with the truthy set we just re-attached.
+          this._bubbles = preservedBubbles.filter(b => b?.el);
           this._bubbleLayerEl = newBubbleLayer;
           this._nextBubbleAt = preservedNextBubbleAt;
+        } else {
+          // Symmetric with the steam null-layer branch (review fix
+          // #01 #6).
+          for (const b of preservedBubbles) { b?.el?.remove(); }
+          this._bubbles = [];
         }
       }
 

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -64,8 +64,11 @@ const PHASE_TO_PX = 60;
 // --- Calm vs boil targets ---
 const CALM_AMP = 1.5;
 const BOIL_AMP = 8;
-const CALM_SPEED = 0.2;
-const BOIL_SPEED = 1.6;
+// QS-214 user iteration: wave speeds slowed from the pool-card-
+// inherited values (CALM 0.2 / BOIL 1.6) to read as a gentle boiler-
+// tank simmer rather than pumped flow. ~4× slower while boiling.
+const CALM_SPEED = 0.1;
+const BOIL_SPEED = 0.4;
 
 // --- Bubbles ---
 const MAX_CONCURRENT_BUBBLES = 12;

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -1159,19 +1159,27 @@ class QsWaterBoilerCard extends HTMLElement {
         }
       }
 
-      // QS-214: snapshot the in-flight steam puffs BEFORE the
-      // innerHTML rewrite below. The rewrite detaches every DOM node
-      // under `this._root`, including the steam layer's children.
-      // Without this snapshot, every HA state push (which fires
-      // `set hass → _render`) wipes the entire puff array
-      // simultaneously — the user-visible "3-4 puffs all disappear at
-      // the exact same time" symptom. The `p.el` references survive
-      // detachment (JS still holds them); we re-attach them to the
-      // new steam layer after `_resetDomRefs()` below. Spawn-cadence
-      // counter is also preserved so the next spawn doesn't reset to
-      // 0 (which would burst-spawn on every push).
+      // QS-214: snapshot the in-flight steam puffs AND bubbles BEFORE
+      // the innerHTML rewrite below. The rewrite detaches every DOM
+      // node under `this._root`, including the steam and bubble
+      // layers' children. Without this snapshot, every HA state push
+      // (which fires `set hass → _render`) wipes the entire particle
+      // arrays simultaneously — the user-visible "3-4 puffs all
+      // disappear at the exact same time" symptom for steam. Bubbles
+      // had the same wipe but it was previously accepted as a
+      // "barely-perceptible blip" (1.5s life, 167ms respawn); the
+      // symmetric preservation removes that blip too and eliminates a
+      // per-push DOM-thrash spike.
+      //
+      // The `p.el` / `b.el` references survive detachment (JS still
+      // holds them); we re-attach them to the new layers after
+      // `_resetDomRefs()` below. Spawn-cadence counters are also
+      // preserved so the next spawn doesn't reset to 0 (which would
+      // burst-spawn on every push).
       const preservedSteamPuffs = this._steamPuffs;
       const preservedNextSteamAt = this._nextSteamAt;
+      const preservedBubbles = this._bubbles;
+      const preservedNextBubbleAt = this._nextBubbleAt;
 
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
@@ -1322,16 +1330,16 @@ class QsWaterBoilerCard extends HTMLElement {
       this._lastAmplitude = initialAmp;
       this._resetDomRefs();
 
-      // QS-214: restore the preserved steam puffs into the FRESH
-      // steam layer (its DOM identity changed via innerHTML — same
-      // `id`, new element). For each preserved puff, re-attach its
-      // detached `el` to the new layer; the puff's per-frame state
-      // (cy, life, fadeBand, …) survived in the JS array, so the RAF
-      // advance loop picks up exactly where it left off, with no
-      // visual blink. Counter is restored so spawn cadence is
-      // continuous. If the new layer isn't found (defensive — e.g.
-      // template change removed it), drop the preserved puffs so they
-      // don't leak DOM nodes.
+      // QS-214: restore the preserved steam puffs AND bubbles into
+      // the FRESH layers (their DOM identity changed via innerHTML —
+      // same `id`, new element). For each preserved particle,
+      // re-attach its detached `el` to the new layer; the per-frame
+      // state (cy, life, fadeBand, …) survived in the JS array, so
+      // the RAF advance loop picks up exactly where it left off, with
+      // no visual blink. Counters are restored so spawn cadence is
+      // continuous. If a new layer isn't found (defensive — e.g.
+      // template change removed it), the preserved particles are
+      // dropped to avoid leaking detached DOM nodes.
       if (preservedSteamPuffs?.length) {
         const newSteamLayer = this._steamLayerId
           ? this._root.getElementById(this._steamLayerId)
@@ -1343,6 +1351,19 @@ class QsWaterBoilerCard extends HTMLElement {
           this._steamPuffs = preservedSteamPuffs;
           this._steamLayerEl = newSteamLayer;
           this._nextSteamAt = preservedNextSteamAt;
+        }
+      }
+      if (preservedBubbles?.length) {
+        const newBubbleLayer = this._bubbleLayerId
+          ? this._root.getElementById(this._bubbleLayerId)
+          : null;
+        if (newBubbleLayer) {
+          for (const b of preservedBubbles) {
+            if (b?.el) newBubbleLayer.appendChild(b.el);
+          }
+          this._bubbles = preservedBubbles;
+          this._bubbleLayerEl = newBubbleLayer;
+          this._nextBubbleAt = preservedNextBubbleAt;
         }
       }
 

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -320,13 +320,18 @@ of their rise budget at full opacity, then fade smoothly over the
 upper 60 % as they approach the local rim". The disjunctive retire
 (`p.cy < localTopY || p.life >= p.maxLife`) is preserved: by the time
 geometric retire fires, opacity is already 0, so the remove is
-invisible. **Steam puffs survive `_render()` innerHTML rewrites** —
-`_render()` snapshots `_steamPuffs` and `_nextSteamAt` before the
-rewrite, then re-attaches each preserved puff's detached DOM node to
-the freshly-rendered steam layer after `_resetDomRefs()`. Without
-this preservation, every HA state push wiped all in-flight puffs
-simultaneously (the "3-4 puffs all disappear at the exact same time"
-symptom), making the per-puff lifecycle invisible.
+invisible. **Steam puffs AND bubbles survive `_render()` innerHTML rewrites** —
+`_render()` snapshots `_steamPuffs` / `_nextSteamAt` and `_bubbles` /
+`_nextBubbleAt` before the rewrite, then re-attaches each preserved
+particle's detached DOM node to the freshly-rendered steam / bubble
+layer after `_resetDomRefs()`. Without this preservation, every HA
+state push wiped all in-flight particles simultaneously: the "3-4
+puffs all disappear at the exact same time" symptom for steam
+(visible because puffs now live ~8 s with a long fade) and the
+previously-accepted "barely-perceptible blip" for bubbles (which
+respawned in ~167 ms because their life is only ~1.5 s). The
+symmetric snapshot/restore for both subsystems also removes a
+per-push DOM-thrash spike.
 
 Review-fix #01 also caps the RAF step `dt` at `LERP_DT_CEIL` (`0.1s`)
 in BOTH `qs-water-boiler-card.js` AND `qs-pool-card.js`. Without the

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -12,7 +12,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
   - custom_components/quiet_solar/ui/resources/qs-radiator-card.js
   - custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
-last_verified: 2026-05-22
+last_verified: 2026-05-23
 ---
 
 # Dashboard generation and JS Lovelace cards

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -298,14 +298,20 @@ running→false: existing puffs continue rising while their opacity
 ramps to 0 over the same ~1.5s envelope as bubbles. `_resetDomRefs()`
 extends to null `_steamLayerEl` and clear `_steamPuffs`;
 `disconnectedCallback` mirrors the bubble teardown to eagerly remove
-puff DOM nodes. **QS-214** widened the rise budget
-(`STEAM_MAX_LIFE_S = 8.0`, `STEAM_RISE_PX_PER_S_*` bumped to
-`[18, 32]`), tinted the puff color to a cool blue-gray for visibility
-against dark HA themes, and replaced the global-apex retire with a
-per-puff circle-aware predicate (`localTopY = CENTER_CY -
-sqrt(CLIP_R² - dx²) + STEAM_TOP_MARGIN_PX`) so puffs drifting toward
-the rim retire at the local clip top rather than continuing
-invisibly toward the global apex.
+puff DOM nodes. **QS-214** tinted the puff color to a cool blue-gray for visibility
+against dark HA themes; unified the rise rate (`STEAM_RISE_PX_PER_S_MIN
+= STEAM_RISE_PX_PER_S_MAX = 24`, with `STEAM_MAX_LIFE_S = 10.0`) so
+every puff reaches the local clip-circle top within its life budget
+rather than slow puffs stalling mid-tank; replaced the global-apex
+retire with a per-puff circle-aware predicate (`localTopY = CENTER_CY
+- sqrt(CLIP_R² - dx²) + STEAM_TOP_MARGIN_PX`); and added a
+rim-proximity fade (`rimOpacity = clamp((p.cy - localTopY) /
+STEAM_RIM_FADE_PX, 0, 1)`, multiplied into the per-frame opacity
+alongside `lifeOpacity` and `_currentColorMix`) so each puff
+gracefully dissolves over the last `STEAM_RIM_FADE_PX = 30` pixels
+below `localTopY` instead of blinking out on the geometric retire.
+The visible result reads as "puffs rise, reach the rim, and dissipate
+into it" with no abrupt removals.
 
 Review-fix #01 also caps the RAF step `dt` at `LERP_DT_CEIL` (`0.1s`)
 in BOTH `qs-water-boiler-card.js` AND `qs-pool-card.js`. Without the

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -320,7 +320,13 @@ of their rise budget at full opacity, then fade smoothly over the
 upper 60 % as they approach the local rim". The disjunctive retire
 (`p.cy < localTopY || p.life >= p.maxLife`) is preserved: by the time
 geometric retire fires, opacity is already 0, so the remove is
-invisible.
+invisible. **Steam puffs survive `_render()` innerHTML rewrites** —
+`_render()` snapshots `_steamPuffs` and `_nextSteamAt` before the
+rewrite, then re-attaches each preserved puff's detached DOM node to
+the freshly-rendered steam layer after `_resetDomRefs()`. Without
+this preservation, every HA state push wiped all in-flight puffs
+simultaneously (the "3-4 puffs all disappear at the exact same time"
+symptom), making the per-puff lifecycle invisible.
 
 Review-fix #01 also caps the RAF step `dt` at `LERP_DT_CEIL` (`0.1s`)
 in BOTH `qs-water-boiler-card.js` AND `qs-pool-card.js`. Without the

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -289,29 +289,29 @@ baked into the SVG fill literal — there is no separate
 `STEAM_FILL_ALPHA` JS constant); the runtime per-frame `opacity`
 attribute is `lifeOpacity * _currentColorMix` — assignment, not
 compound — where `lifeOpacity` is the piecewise-linear lifeCurve(t)
-with breakpoints at 0.15 (fade-in end) and 0.85 (fade-out start). The
+with breakpoints at 0.15 (fade-in end) and 0.7 (fade-out start). The
 effective rendered alpha multiplies through the SVG: `0.45 ×
-_currentColorMix × lifeOpacity`, peaking at 0.45 across the wider
-0.15–0.85 hold band with a fully-ramped colorMix. Steam therefore
+_currentColorMix × lifeOpacity`, peaking at 0.45 during the hold band
+with a fully-ramped colorMix. Steam therefore
 cross-fades with `_currentColorMix` and gracefully exits on
 running→false: existing puffs continue rising while their opacity
 ramps to 0 over the same ~1.5s envelope as bubbles. `_resetDomRefs()`
 extends to null `_steamLayerEl` and clear `_steamPuffs`;
 `disconnectedCallback` mirrors the bubble teardown to eagerly remove
 puff DOM nodes. **QS-214** tinted the puff color to a cool blue-gray for visibility
-against dark HA themes; unified the rise rate (`STEAM_RISE_PX_PER_S_MIN
-= STEAM_RISE_PX_PER_S_MAX = 24`, with `STEAM_MAX_LIFE_S = 10.0`) so
-every puff reaches the local clip-circle top within its life budget
-rather than slow puffs stalling mid-tank; replaced the global-apex
-retire with a per-puff circle-aware predicate (`localTopY = CENTER_CY
-- sqrt(CLIP_R² - dx²) + STEAM_TOP_MARGIN_PX`); and added a
-rim-proximity fade (`rimOpacity = clamp((p.cy - localTopY) /
-STEAM_RIM_FADE_PX, 0, 1)`, multiplied into the per-frame opacity
-alongside `lifeOpacity` and `_currentColorMix`) so each puff
-gracefully dissolves over the last `STEAM_RIM_FADE_PX = 30` pixels
-below `localTopY` instead of blinking out on the geometric retire.
-The visible result reads as "puffs rise, reach the rim, and dissipate
-into it" with no abrupt removals.
+against dark HA themes; unified the rise rate
+(`STEAM_RISE_PX_PER_S_MIN = STEAM_RISE_PX_PER_S_MAX = 32`, with
+`STEAM_MAX_LIFE_S = 12.0`) so every puff reaches the local
+clip-circle top within its life budget; introduced the per-puff
+circle-aware geometry (`localTopY = CENTER_CY - sqrt(CLIP_R² - dx²) +
+STEAM_TOP_MARGIN_PX`) so puffs follow the arc shape rather than the
+global apex; and replaced the abrupt geometric retire with a position
+pin (`if (p.cy < localTopY) p.cy = localTopY`) so each puff sits at
+the local clip-circle top once it arrives, dissolving in place via
+the `[0.7, 1.0]` life-curve fade-out band (~3.6 s at maxLife=12). The
+visible result reads as "puffs rise to the rim, linger, and fade out
+there" — no abrupt removals, no fading during rise. The sole DOM
+remove path is now `p.life >= p.maxLife`.
 
 Review-fix #01 also caps the RAF step `dt` at `LERP_DT_CEIL` (`0.1s`)
 in BOTH `qs-water-boiler-card.js` AND `qs-pool-card.js`. Without the

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -289,10 +289,10 @@ baked into the SVG fill literal — there is no separate
 `STEAM_FILL_ALPHA` JS constant); the runtime per-frame `opacity`
 attribute is `lifeOpacity * _currentColorMix` — assignment, not
 compound — where `lifeOpacity` is the piecewise-linear lifeCurve(t)
-with breakpoints at 0.15 (fade-in end) and 0.7 (fade-out start). The
+with breakpoints at 0.15 (fade-in end) and 0.85 (fade-out start). The
 effective rendered alpha multiplies through the SVG: `0.45 ×
-_currentColorMix × lifeOpacity`, peaking at 0.45 during the hold band
-with a fully-ramped colorMix. Steam therefore
+_currentColorMix × lifeOpacity × rimOpacity`, peaking at 0.45 during
+the hold band with a fully-ramped colorMix. Steam therefore
 cross-fades with `_currentColorMix` and gracefully exits on
 running→false: existing puffs continue rising while their opacity
 ramps to 0 over the same ~1.5s envelope as bubbles. `_resetDomRefs()`
@@ -300,18 +300,27 @@ extends to null `_steamLayerEl` and clear `_steamPuffs`;
 `disconnectedCallback` mirrors the bubble teardown to eagerly remove
 puff DOM nodes. **QS-214** tinted the puff color to a cool blue-gray for visibility
 against dark HA themes; unified the rise rate
-(`STEAM_RISE_PX_PER_S_MIN = STEAM_RISE_PX_PER_S_MAX = 32`, with
-`STEAM_MAX_LIFE_S = 12.0`) so every puff reaches the local
-clip-circle top within its life budget; introduced the per-puff
-circle-aware geometry (`localTopY = CENTER_CY - sqrt(CLIP_R² - dx²) +
+(`STEAM_RISE_PX_PER_S_MIN = STEAM_RISE_PX_PER_S_MAX = 24`, with
+`STEAM_MAX_LIFE_S = 8.0`); introduced the per-puff circle-aware
+geometry (`localTopY = CENTER_CY - sqrt(CLIP_R² - dx²) +
 STEAM_TOP_MARGIN_PX`) so puffs follow the arc shape rather than the
-global apex; and replaced the abrupt geometric retire with a position
-pin (`if (p.cy < localTopY) p.cy = localTopY`) so each puff sits at
-the local clip-circle top once it arrives, dissolving in place via
-the `[0.7, 1.0]` life-curve fade-out band (~3.6 s at maxLife=12). The
-visible result reads as "puffs rise to the rim, linger, and fade out
-there" — no abrupt removals, no fading during rise. The sole DOM
-remove path is now `p.life >= p.maxLife`.
+global apex; narrowed the spawn cx to a central band
+(`±STEAM_SPAWN_CX_HALF_PX = ±35`) so every puff has a substantial
+vertical rise regardless of water level (avoiding the "stops just
+above the surface" edge-spawn artefact); and added a geometry-aware
+per-puff fade — each puff stores `fadeBand = STEAM_RIM_FADE_FRACTION ×
+riseBudget` at spawn time (where `riseBudget = cySpawn -
+spawnLocalTopY`), then the per-frame factor `rimOpacity = clamp((p.cy
+- localTopY) / p.fadeBand, 0, 1)` is multiplied into the opacity
+alongside `lifeOpacity` and `_currentColorMix`. Center-spawned puffs
+(long rise) get a long fade band; side puffs (short local rise) get
+a proportionally shorter one, so the fade always fits the available
+space. The visible result reads as "puffs rise visibly through ~40 %
+of their rise budget at full opacity, then fade smoothly over the
+upper 60 % as they approach the local rim". The disjunctive retire
+(`p.cy < localTopY || p.life >= p.maxLife`) is preserved: by the time
+geometric retire fires, opacity is already 0, so the remove is
+invisible.
 
 Review-fix #01 also caps the RAF step `dt` at `LERP_DT_CEIL` (`0.1s`)
 in BOTH `qs-water-boiler-card.js` AND `qs-pool-card.js`. Without the

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -284,20 +284,28 @@ wispy look at constant per-frame cost. Per-instance unique IDs
 (`_steamLayerId`, `_steamFilterId`) derived from
 `QsWaterBoilerCard._nextClipId` so two boiler cards on the same
 dashboard never collide. The `<circle>` fill is
-`STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'` (the 0.45 alpha is
+`STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)'` (the 0.45 alpha is
 baked into the SVG fill literal — there is no separate
 `STEAM_FILL_ALPHA` JS constant); the runtime per-frame `opacity`
 attribute is `lifeOpacity * _currentColorMix` — assignment, not
 compound — where `lifeOpacity` is the piecewise-linear lifeCurve(t)
-with breakpoints at 0.15 (fade-in end) and 0.7 (fade-out start). The
+with breakpoints at 0.15 (fade-in end) and 0.85 (fade-out start). The
 effective rendered alpha multiplies through the SVG: `0.45 ×
-_currentColorMix × lifeOpacity`, peaking at 0.45 only during hold
-phase with a fully-ramped colorMix. Steam therefore cross-fades with
-`_currentColorMix` and gracefully exits on running→false: existing
-puffs continue rising while their opacity ramps to 0 over the same
-~1.5s envelope as bubbles. `_resetDomRefs()` extends to null
-`_steamLayerEl` and clear `_steamPuffs`; `disconnectedCallback`
-mirrors the bubble teardown to eagerly remove puff DOM nodes.
+_currentColorMix × lifeOpacity`, peaking at 0.45 across the wider
+0.15–0.85 hold band with a fully-ramped colorMix. Steam therefore
+cross-fades with `_currentColorMix` and gracefully exits on
+running→false: existing puffs continue rising while their opacity
+ramps to 0 over the same ~1.5s envelope as bubbles. `_resetDomRefs()`
+extends to null `_steamLayerEl` and clear `_steamPuffs`;
+`disconnectedCallback` mirrors the bubble teardown to eagerly remove
+puff DOM nodes. **QS-214** widened the rise budget
+(`STEAM_MAX_LIFE_S = 8.0`, `STEAM_RISE_PX_PER_S_*` bumped to
+`[18, 32]`), tinted the puff color to a cool blue-gray for visibility
+against dark HA themes, and replaced the global-apex retire with a
+per-puff circle-aware predicate (`localTopY = CENTER_CY -
+sqrt(CLIP_R² - dx²) + STEAM_TOP_MARGIN_PX`) so puffs drifting toward
+the rim retire at the local clip top rather than continuing
+invisibly toward the global apex.
 
 Review-fix #01 also caps the RAF step `dt` at `LERP_DT_CEIL` (`0.1s`)
 in BOTH `qs-water-boiler-card.js` AND `qs-pool-card.js`. Without the

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -320,7 +320,15 @@ of their rise budget at full opacity, then fade smoothly over the
 upper 60 % as they approach the local rim". The disjunctive retire
 (`p.cy < localTopY || p.life >= p.maxLife`) is preserved: by the time
 geometric retire fires, opacity is already 0, so the remove is
-invisible. **Steam puffs AND bubbles survive `_render()` innerHTML rewrites** —
+invisible. **QS-214 also slows the wave speed.** The pool-card-inherited
+`CALM_SPEED = 0.2` and `BOIL_SPEED = 1.6` read as pumped flow on the
+boiler card, which the user flagged as "too fast — it's the speed
+from the pool pump running". Slowed to `CALM_SPEED = 0.1` /
+`BOIL_SPEED = 0.4` (~4× slower while boiling) so the surface reads
+as a gentle simmer rather than pumped circulation. Bubble and steam
+constants are unaffected.
+
+**Steam puffs AND bubbles survive `_render()` innerHTML rewrites** —
 `_render()` snapshots `_steamPuffs` / `_nextSteamAt` and `_bubbles` /
 `_nextBubbleAt` before the rewrite, then re-attaches each preserved
 particle's detached DOM node to the freshly-rendered steam / bubble

--- a/docs/stories/QS-214.story.md
+++ b/docs/stories/QS-214.story.md
@@ -1,0 +1,638 @@
+---
+issue: 214
+title: Steam not shown when boiler is on (regression after #211 fix)
+branch: QS_214
+status: ready-for-dev
+next_phase: implement-task
+labels: [area:ui, area:dashboard, area:docs]
+---
+
+# QS-214 — Boiler card: steam visibility on dark themes + reach the clip-circle top
+
+## Why
+
+Issue [#214](https://github.com/tmenguy/quiet-solar/issues/214) reads
+verbatim: _"the so colled fixed issue 211 is not working: I see no
+steam when the boiler is on...."_
+
+Root cause was straightforward — PR #212 (QS-211 "add gentle steam
+effect to boiler card when boiling") was never merged into `main`.
+After merging it (merge commit `ad70e727`, fast-forwarded into this
+worktree), the user redeployed and confirmed _"ok I see the setam now!"_
+
+The merge alone resolves "no steam visible". QS-214 ships two follow-up
+user-requested visual tweaks observed against the freshly-merged code
+on a dark HA theme:
+
+1. _"please tint it more grey/bluewish as you proposed to make it
+   more visible perhaps"_ — switch `STEAM_FILL_COLOR` from pure white
+   to a cool blue-gray.
+2. _"today the steam is stoping too low I would like it to go higher
+   up to the circle up limit"_ — bump the rise budget so puffs reach
+   the clip-circle rim. Plus the user's own follow-up clarification —
+   _"I want the puff to go as close as possible to teh circle limit
+   on top of it, but never cross the cricle"_ — which forces a
+   per-puff circle-aware retire predicate (not just a faster apex
+   ceiling).
+
+**Explicit instruction granted by issue #214 + user clarifications** —
+this story overrides the
+[project-context.md](../workflow/project-context.md) rule "Custom JS
+card code should not be modified without explicit instruction".
+
+## Inputs
+
+- `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`
+  — four constants + one life-curve breakpoint + one retire-predicate
+  refactor. No new constants introduced. All referenced identifiers
+  (`STEAM_TOP_MARGIN_PX`, `CENTER_CX`, `CENTER_CY`, `CLIP_R`,
+  `STEAM_RADIUS_GROW_PX_PER_S`, `STEAM_RADIUS_MAX`,
+  `STEAM_DRIFT_PX_PER_S`, `_steamPuffs`, …) already exist from QS-211.
+- `tests/test_dashboard_rendering.py` — two existing tests updated;
+  no new test functions.
+- `docs/agents/concepts/dashboard-and-cards.md` — rewrite the QS-211
+  paragraph's color / breakpoint / hold-phase sentences and add 1–2
+  sentences about the QS-214 circle-aware retire. Bump
+  `last_verified:` frontmatter to `2026-05-22` (today).
+
+### Existing-identifier contract (read-only, mirrors QS-211)
+
+| Identifier | Where (today) | Meaning |
+|---|---|---|
+| `CENTER_CX` / `CENTER_CY` | constants block | SVG center of the ring / clip circle (160, 160) |
+| `CLIP_R` | constants block | Water clip-circle radius (120) |
+| `STEAM_TOP_MARGIN_PX` | constants block | Margin below the local clip-circle top before retire (`+4`; positive = retire `STEAM_TOP_MARGIN_PX` below the chord, so puffs visibly approach but never touch the arc) |
+| `_steamPuffs` | instance state | Per-puff array `{el, cx, cy, r, vy, phase, life, maxLife}` |
+| Steam advance loop | `for (const p of this._steamPuffs)` in the RAF step | Anchor for the retire-predicate edit and breakpoint edit |
+
+## Acceptance criteria
+
+- **AC-1** — `STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)'`. Cool
+  blue-gray (R=195, G=215, B=235). Alpha unchanged at `0.45`.
+
+- **AC-2** — Speed/life constants updated:
+  ```js
+  const STEAM_MAX_LIFE_S        = 8.0;   // was 4.5
+  const STEAM_RISE_PX_PER_S_MIN = 18;    // was 10
+  const STEAM_RISE_PX_PER_S_MAX = 32;    // was 22
+  ```
+
+- **AC-3** — Life-curve fade-out breakpoint moved from `0.7` to `0.85`
+  in the steam advance block. Fade-in breakpoint `0.15` unchanged.
+  The new piecewise-linear curve is:
+  ```js
+  if      (lifeT < 0.15) lifeOpacity = lifeT / 0.15;
+  else if (lifeT < 0.85) lifeOpacity = 1;
+  else                   lifeOpacity = Math.max(0, 1 - (lifeT - 0.85) / 0.15);
+  ```
+  Hold phase widens from 55% of life (`[0.15, 0.7]`) to 70%
+  (`[0.15, 0.85]`); fade-out window shrinks from 30% to 15%.
+
+- **AC-4** — Retire predicate is circle-aware. Inside the per-puff
+  advance loop, drop the outer `const topY = CENTER_CY - CLIP_R +
+  STEAM_TOP_MARGIN_PX` declaration entirely and replace with per-puff
+  geometry:
+  ```js
+  // SVG convention: smaller y = visually higher. Retire when the puff
+  // rises above the local clip-circle top at this x, minus the
+  // STEAM_TOP_MARGIN_PX guard. Mirrors the spawn-side chord-half
+  // formula (see Inputs / spawn quote below).
+  const dx = p.cx - CENTER_CX;
+  const localChordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dx * dx));
+  const localTopY = CENTER_CY - localChordHalf + STEAM_TOP_MARGIN_PX;
+  if (p.cy < localTopY || p.life >= p.maxLife) { p.el.remove(); continue; }
+  ```
+  Both retire branches survive (geometry AND time ceiling). After the
+  edit, `Grep topY qs-water-boiler-card.js` returns zero matches.
+
+- **AC-5** — The outer wrapper `<g clip-path="url(#${waterClipId})">`
+  still wraps the steam group. The clip path is the hard "never cross
+  the circle" safety net — independent of AC-4. Existing test
+  `test_water_boiler_card_steam_layer_after_surface_glow_in_clip`
+  continues to pass with no edits.
+
+- **AC-6** — Existing test updates (no new test functions):
+  - `test_water_boiler_card_steam_opacity_formula`:
+    - Update the RGB-triplet regex from
+      `r"STEAM_FILL_COLOR\s*=\s*['\"]rgba\(255,\s*255,\s*255,\s*0\.45\)['\"]"`
+      to
+      `r"STEAM_FILL_COLOR\s*=\s*['\"]rgba\(195,\s*215,\s*235,\s*0\.45\)['\"]"`.
+    - Update the docstring at lines 2361–2363 to reference the new
+      color literal AND the new `0.85` fade-out breakpoint
+      (currently mentions `'rgba(255,255,255,0.45)'` and `0.7`).
+    - Replace the loose substring pin
+      `assert "0.7" in advance_block` with two **precise** regexes:
+      `r"lifeT\s*<\s*0\.85"` AND
+      `r"\(\s*lifeT\s*-\s*0\.85\s*\)\s*/\s*0\.15"`.
+      Keep the existing `assert "0.15" in advance_block` fade-in pin.
+      (Reviewer-induced tightening — see ARN-A1.)
+
+  - `test_water_boiler_card_steam_retire_both_branches`:
+    - Remove the existing `const topY = …` pin block in its entirety
+      (the `assert re.search(r"const\s+topY\s*=\s*CENTER_CY\s*-\s*CLIP_R\s*\+\s*STEAM_TOP_MARGIN_PX", advance_block)`
+      + its multi-line failure message, currently 7 lines at the test
+      module's lines 2348–2354).
+    - **Add a window extraction first** — the retire test does NOT
+      currently extract an `advance_block` window (it does raw
+      `re.search` against the full `executable`). Mirror lines
+      2387–2392 of the opacity test to define `advance_block` before
+      asserting the three new pins.
+    - Add three new pins inside `advance_block`:
+      - `r"const\s+dx\s*=\s*p\.cx\s*-\s*CENTER_CX"`
+      - `r"const\s+localChordHalf\s*=\s*Math\.sqrt\(\s*Math\.max\(\s*0\s*,\s*CLIP_R\s*\*\s*CLIP_R\s*-\s*dx\s*\*\s*dx\s*\)\s*\)"`
+      - `r"const\s+localTopY\s*=\s*CENTER_CY\s*-\s*localChordHalf\s*\+\s*STEAM_TOP_MARGIN_PX"`
+    - Update the existing retire-predicate pin from
+      `p\.cy\s*<\s*topY` to `p\.cy\s*<\s*localTopY`.
+
+- **AC-7** — Quality gate green via the UI-only fast path. The
+  changed-file set is:
+  - `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`
+    → UI asset under `_UI_RESOURCES_PREFIX`.
+  - `tests/test_dashboard_rendering.py` → dev-only (`tests/` prefix).
+  - `docs/agents/concepts/dashboard-and-cards.md` → dev-only (`docs/`
+    prefix; `.md` extension also matches `_DEV_ONLY_EXTENSIONS`).
+
+  Scope detection (`scripts/qs/quality_gate.py`): `non_dev_non_ui` is
+  empty → scope = `ui-only`. The full gate command stays
+  `python scripts/qs/quality_gate.py` (no flag; auto-detects). Fast
+  path runs only `tests/test_dashboard_rendering.py` and skips ruff,
+  mypy, translations, and full-coverage pytest.
+
+- **AC-8** — Doc paragraph in `docs/agents/concepts/dashboard-and-cards.md`
+  reflects the new color, the new speed/life constants, the new
+  fade-out breakpoint, and a one-sentence note about the circle-aware
+  retire. `last_verified:` bumped to `2026-05-22`. Doc-drift checker
+  exits 0 (executed transitively via T6).
+
+## Design notes (not testable as ACs — kept here for traceability)
+
+### DN-1 — Geometry budget for "reach the circle top"
+
+Worst-case spawn-to-apex distance (empty tank, center column):
+```text
+waterBaseY @ progressRatio = 0   = CENTER_CY + CLIP_R - (0.2 + 0) × 2 × CLIP_R
+                                  = 160 + 120 - 48
+                                  = 232
+global apex y                    = CENTER_CY - CLIP_R + STEAM_TOP_MARGIN_PX
+                                  = 160 - 120 + 4
+                                  = 44
+worst-case rise needed           = 232 - 44 = 188 px (matches the user's
+                                  perception of "stops too low" today)
+
+Hmm — that's 188. Let me redo with the symbolic form a reviewer used:
+                                 = 2 × CLIP_R × (1 - 0.2)
+                                 = 2 × 120 × 0.8
+                                 = 192 px (modulo the 4-px STEAM_TOP_MARGIN_PX)
+The two derivations differ by exactly `STEAM_TOP_MARGIN_PX` (4 px).
+The user-perceived "reach the top" target is the 188 figure (puffs
+retire at `topY = 44`, NOT at `40` = the geometric arc). 192 is the
+strictly-geometric distance; 188 is the operationally-meaningful one.
+We use 188 below.
+```
+
+Max-velocity puff hold-phase reach with the new constants:
+```text
+0.85 × STEAM_MAX_LIFE_S × STEAM_RISE_PX_PER_S_MAX
+  = 0.85 × 8.0 × 32
+  = 217.6 px
+  ≥ 188 px  ✓ (fast puffs visibly reach the apex with 16 % margin)
+```
+
+Min-velocity puff full-life reach:
+```text
+STEAM_MAX_LIFE_S × STEAM_RISE_PX_PER_S_MIN
+  = 8.0 × 18
+  = 144 px
+```
+
+That's deliberately shorter than 188 px. Slow puffs retire on
+`p.life >= p.maxLife` partway up; only fast puffs reach the rim. This
+per-puff variance is intentional — uniform reach would look mechanical;
+real steam plumes have wisps that thin out at varying heights. The
+range `[18, 32]` is tuned so the worst plumes still rise ~145 px
+(visible across most of the tank).
+
+### DN-2 — Why the circle-aware retire is not gold-plating
+
+Without the per-puff `localTopY` refactor, a puff that drifts to
+e.g. `cx ≈ 240` (just inside the rim) keeps rising invisibly past
+the local clip-circle top (`y ≈ 70`) all the way to the global apex
+`y = 44` — 26 px of fully-clipped life budget wasted. With QS-214's
+longer life budget (8.0 s vs 4.5 s) that gap grows worse, so the
+per-puff retire isn't merely a polish — it's a precondition for
+"reaches the top" reading naturally at any drift position.
+
+The user surfaced this themselves after re-reading the previous
+agent message: _"are you sure that when a steam puff for example on
+the right will stop before it crosses the circle limit on top that
+is not the apex … I want the puff to go as close as possible to
+teh circle limit on top of it, but never cross the cricle."_ Not
+agent-induced scope — see ARN-B3.
+
+### DN-3 — Spawn-side mirror (read-only context)
+
+The retire-side chord-half formula mirrors the existing spawn-side
+formula already in the file (used to confine spawn x within the
+chord at the water surface). Quoted here so the test's regex pin is
+auditable without leaving the story:
+
+```js
+// inside the steam spawn `while`:
+const dy = cySpawn - CENTER_CY;
+const chordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dy * dy));
+const cxSpawn = CENTER_CX + (Math.random() * 2 - 1) * chordHalf * 0.85;
+```
+
+Same `sqrt(max(0, CLIP_R² - d²))` shape. Not extracted into a helper
+in this story (would expand scope; see ARN-C7).
+
+### DN-4 — Drift cannot un-retire a puff
+
+`localTopY` depends on `dx = p.cx - CENTER_CX`. As a puff drifts
+toward the rim, `|dx|` grows, `localChordHalf` shrinks, and
+`localTopY` increases (= moves down). A retire that was about to fire
+on frame N could fail on frame N+1 if `p.cy` (which decreased due to
+rise) is now compared against an even-smaller `localTopY` (which also
+shrank). But the retire predicate is re-evaluated each frame from
+scratch — we don't carry "was about to retire" state, so there is no
+"un-trigger." Vertical motion (18–32 px/s) also dominates horizontal
+drift (±6 px/s peak), so the puff's `cy` monotonically decreases
+faster than `localTopY` shrinks. The `p.life >= p.maxLife` second
+branch is a hard upper bound that cannot be un-triggered.
+
+Inline comment will state SVG y-axis convention so a future reader
+can verify quickly.
+
+### DN-5 — Density vs. visibility trade-off
+
+`MAX_CONCURRENT_STEAM = 8` and `STEAM_SPAWN_RATE_HZ = 1.5` are
+unchanged. With the doubled life, theoretical steady-state
+(`1.5 × 8 = 12`) still caps at 8 — actual puff count unchanged.
+But each puff travels further before retire, so the per-px density
+of the visible steam drops (~3× sparser). Visual call: iterate if
+the user reports "too sparse"; do not pre-emptively change the cap.
+Noted in Risk.
+
+### DN-6 — Light-theme contrast
+
+The new color `rgb(195, 215, 235)` sacrifices some contrast against
+a hypothetical white background (`Δluminance ≈ 0.20` vs. the old
+white's `Δ = 0`). The user's reported theme is dark; the boiler card
+does not have a "light theme" variant; HA themes typically render
+cards on muted backgrounds. If a user later reports invisibility on
+a true-white theme, iterate.
+
+## Task breakdown
+
+### T0 — Doc-drift sanity check
+
+```bash
+python scripts/qs/check_doc_drift.py \
+    --paths custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js \
+            tests/test_dashboard_rendering.py \
+            docs/agents/concepts/dashboard-and-cards.md
+```
+
+Must exit `0`. Confirms the JS / test / doc trio is co-modification-coherent
+before touching any file. (Already verified during planning; documented
+here as a precondition the implement agent re-runs after the worktree
+is updated.)
+
+### T1 — Update the two existing pinned tests (TDD red)
+
+Edit `tests/test_dashboard_rendering.py`. Apply the test changes spelled
+out in AC-6 (RGB-triplet regex, docstring values, breakpoint regex
+tightening, `topY` pin removal, `advance_block` window extraction, three
+new pins, retire-predicate pin update).
+
+Run the test file:
+```bash
+python scripts/qs/quality_gate.py --quick tests/test_dashboard_rendering.py
+```
+
+Expect `test_water_boiler_card_steam_opacity_formula` and
+`test_water_boiler_card_steam_retire_both_branches` to FAIL (red) —
+the JS still has the old constants and the old `topY` predicate.
+This confirms the tests are wired to the new expectations.
+
+### T2 — Update the JS card (TDD green)
+
+Edit `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`:
+
+1. **Four constants** (constants block, currently lines 88–100):
+   - `STEAM_FILL_COLOR` → `'rgba(195,215,235,0.45)'`
+   - `STEAM_MAX_LIFE_S` → `8.0`
+   - `STEAM_RISE_PX_PER_S_MIN` → `18`
+   - `STEAM_RISE_PX_PER_S_MAX` → `32`
+
+2. **Life-curve breakpoint** (inside the steam advance loop): replace
+   the `0.7` literal with `0.85` in **both** places — the `if (lifeT <
+   0.7)` guard AND the `(lifeT - 0.7) / 0.3` fade-out expression. The
+   `0.3` divisor changes to `0.15` because the fade-out window now
+   spans `[0.85, 1.0]` (width 0.15) instead of `[0.7, 1.0]` (width
+   0.3).
+
+3. **Retire predicate refactor** (inside the steam advance loop):
+   - **Remove** the outer `const topY = CENTER_CY - CLIP_R +
+     STEAM_TOP_MARGIN_PX;` declaration (currently a single line just
+     before the `for (const p of this._steamPuffs)` loop).
+   - **Inside** the loop, after `p.r = Math.min(p.r +
+     STEAM_RADIUS_GROW_PX_PER_S * dt, STEAM_RADIUS_MAX + 4);` and
+     **before** the retire `if`, insert the three lines spelled out
+     in AC-4.
+   - **Change** `if (p.cy < topY || …)` to `if (p.cy < localTopY ||
+     …)`.
+
+Post-edit grep check: `grep -n "topY" qs-water-boiler-card.js`
+returns zero matches.
+
+Re-run the quick gate:
+```bash
+python scripts/qs/quality_gate.py --quick tests/test_dashboard_rendering.py
+```
+
+Expect all `test_water_boiler_card_*` tests green.
+
+### T3 — Update the agent-concept doc paragraph
+
+Edit `docs/agents/concepts/dashboard-and-cards.md`:
+
+1. Bump frontmatter `last_verified:` to `2026-05-22`.
+
+2. Rewrite the QS-211 paragraph (currently lines 274–300). Apply the
+   following substitutions inline (no structural reordering, but the
+   sentence about "peaks at 0.45 only during hold phase with a
+   fully-ramped colorMix" must reflect the wider hold band):
+   - `STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'` →
+     `STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)'` (note: 0.45 alpha
+     baked into SVG fill literal unchanged).
+   - "fade-out start" breakpoint `0.7` → `0.85`.
+   - "peaks at 0.45 only during hold phase" → "peaks at 0.45 across
+     the wider 0.15–0.85 hold band".
+
+3. Append the following sentence at the end of the paragraph (one
+   sentence, ~40 words):
+
+   > **QS-214** widened the rise budget (`STEAM_MAX_LIFE_S = 8.0`,
+   > `STEAM_RISE_PX_PER_S_*` bumped to `[18, 32]`), tinted the puff
+   > color to a cool blue-gray for visibility against dark HA themes,
+   > and replaced the global-apex retire with a per-puff circle-aware
+   > predicate (`localTopY = CENTER_CY - sqrt(CLIP_R² - dx²) +
+   > STEAM_TOP_MARGIN_PX`) so puffs drifting toward the rim retire at
+   > the local clip top rather than continuing invisibly toward the
+   > global apex.
+
+### T4 — Full UI-only fast-path quality gate
+
+```bash
+python scripts/qs/quality_gate.py
+```
+
+Auto-detects `scope = "ui-only"` from the changed files (verified in
+AC-7). Runs only `tests/test_dashboard_rendering.py`, skipping ruff,
+mypy, translations, and the full coverage suite. Doc-drift is invoked
+transitively (no separate `check_doc_drift.py` invocation needed —
+that's why T0's separate run is a fast pre-flight, not a gate step).
+
+Expect exit `0`. If the scope detector resolves to anything other than
+`ui-only`, halt and inspect — that indicates a missed dev-only-pattern
+match.
+
+### T5 — Commit and push
+
+```bash
+git add custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js \
+        tests/test_dashboard_rendering.py \
+        docs/agents/concepts/dashboard-and-cards.md \
+        docs/stories/QS-214.story.md
+git commit -m "QS-214: steam tint + reach top of clip circle"
+git push origin QS_214
+```
+
+(Story file is staged alongside the implementation in the same commit —
+the create-plan commit only stages this story; T5 is the
+implement-task agent's commit and will include any review-fix story
+files spawned during phase 3.)
+
+### T6 — Open the PR
+
+`gh pr create` with the title `QS-214: steam tint + reach top of clip
+circle` and a body referencing issue #214 with the user's verbatim
+asks.
+
+## Non-impacts
+
+The following are explicitly **not** affected by this story:
+
+- No agent files in `.claude/agents/`, `.cursor/agents/`, or
+  `.opencode/agents/` — harness-sync co-modification rule does not
+  apply.
+- No `const.py`, no Python production source, no translations
+  (`strings.json` / `translations/en.json`).
+- No new device types, no platform files (`sensor.py` / `switch.py` /
+  …).
+- No domain logic in `home_model/` and no HA-bridge logic in
+  `ha_model/` — the boundary stays intact.
+- No solver, no constraint, no QSDataHandler cycle.
+- No changes to `MAX_CONCURRENT_STEAM`, `STEAM_SPAWN_RATE_HZ`,
+  `STEAM_RADIUS_*`, `STEAM_DRIFT_*`, or `STEAM_BLUR_STDDEV`. The
+  steam subsystem's structural facts (per-instance unique IDs, lazy
+  DOM-ref resolution, `disconnectedCallback` teardown, clip-path
+  wrapping, layer ordering after `surface_glow`) are unchanged from
+  QS-211 — every QS-211 structural test continues to pass without
+  edits.
+
+## Risk
+
+- **Visual density may decrease** (~3× sparser puff count per visible
+  rise pixel) — see DN-5. Iterate if user reports "too sparse"; do
+  not pre-emptively bump `MAX_CONCURRENT_STEAM`.
+- **Light-theme contrast** reduced — see DN-6. Acceptable given the
+  user's theme is dark; no card has a "light theme" variant today.
+- **Coverage**: pin-style structural tests do not execute the new
+  per-puff geometry. Coverage is preserved because nothing new lives
+  outside the existing `for (const p of this._steamPuffs)` block,
+  which is already exercised by the structural assertions in
+  `test_water_boiler_card_steam_retire_both_branches` and
+  `test_water_boiler_card_steam_opacity_formula`.
+
+Overall: very low risk. Tiny diff. Single-file behavioural change.
+UI-only fast-path quality gate.
+
+---
+
+## Adversarial Review Notes
+
+Round 1 of the qs-plan-* reviewer pass returned 38 findings across
+the four agents. Deduplicated and triaged below.
+
+### A — Must-fix findings (applied to this story)
+
+- **ARN-A1** (Critic + ConcretePlanner + Scope-Guardian, all
+  critical) — _Pin tightening on the `0.85` breakpoint._ Substring
+  pin `"0.85" in advance_block` would false-positive on unrelated
+  literals (e.g. the spawn-side `chordHalf * 0.85` jitter scalar that
+  already lives in the file). Replaced with two precise regexes
+  matching the exact `lifeT < 0.85` and `(lifeT - 0.85) / 0.15`
+  expressions; dropped the symmetric "literal `0.7` must NOT survive"
+  sentinel idea. Codified in AC-6.
+
+- **ARN-A2** (Critic, critical) — _AC-6's geometry budget used MAX
+  velocity, hiding min-velocity under-reach._ Reframed: max-vy puffs
+  reach the rim with 16 % margin (217.6 ≥ 188 px); slow puffs (MIN =
+  18 px/s) reach only 144 px and retire on `life >= maxLife`. This
+  per-vy variance is intentional realism — captured in DN-1 and
+  DN-5.
+
+- **ARN-A3** (Dev-Proxy, critical) — _TDD ordering inverted._ Tasks
+  reordered: T1 = tests (red), T2 = JS (green), T4 = full gate.
+
+- **ARN-A4** (ConcretePlanner, critical) — _Stale docstring in
+  `test_water_boiler_card_steam_opacity_formula`._ Lines 2361–2363
+  still mention `'rgba(255,255,255,0.45)'` and `0.7`. AC-6 now
+  explicitly requires the docstring to be updated as well, not just
+  the regex / pin.
+
+- **ARN-A5** (ConcretePlanner, critical) — _Atomic `topY` removal._
+  The test file's existing pin block spans 7 lines (regex line +
+  multi-line failure message), and the JS edit must remove both the
+  outer `const topY = …` declaration AND switch the retire-`if`'s
+  variable name in the same change. AC-6 + T2 spell out both edits
+  with the post-edit grep verification.
+
+- **ARN-A6** (Dev-Proxy, redesign) — _JS-card edit authorization
+  rule not surfaced._ The "Why" section now opens with both verbatim
+  user requests and an explicit "Explicit instruction granted by
+  issue #214" disclaimer mirroring the QS-200 / QS-211 convention.
+
+- **ARN-A7** (ConcretePlanner, improve) — _AC-6 conflated max-vy
+  reach with the spawn-to-apex distance figure._ Reworked in DN-1
+  with both derivations (operational 188 px vs. strictly-geometric
+  192 px) and the variance note.
+
+- **ARN-A8** (ConcretePlanner, improve) — _Doc paragraph needed
+  broader rewrite than "1–2 sentences"._ T3 now spells out the
+  exact substitutions inline (color, breakpoint, "hold phase"
+  rationale) plus the appended QS-214 sentence verbatim.
+
+- **ARN-A9** (ConcretePlanner, clarify) — _`last_verified:`
+  frontmatter date bump._ Added as T3 step 1.
+
+- **ARN-A10** (ConcretePlanner, clarify) — _Retire-branches test
+  lacks an `advance_block` window._ AC-6 now requires the
+  implement agent to mirror the opacity test's window-extraction
+  snippet (lines 2387–2392) into the retire test before adding the
+  three new pins.
+
+- **ARN-A11** (Dev-Proxy, improve) — _AC-6 was arithmetic, not
+  executable._ Demoted the geometry budget to DN-1 (design note).
+  No story-level AC depends on a derivation; the AC suite is now
+  fully test-pinnable.
+
+- **ARN-A12** (Dev-Proxy, clarify) — _T6 lacked an explicit
+  command._ T4 now states `python scripts/qs/quality_gate.py`
+  (auto-detects ui-only scope).
+
+- **ARN-A13** (Dev-Proxy, clarify) — _T5 (`check_doc_drift.py`)
+  was redundant with T6._ Reorganised: doc-drift sanity check
+  lifted into T0 as a pre-flight; T4 (full gate) invokes it
+  transitively. No separate `check_doc_drift.py` step survives in
+  the main flow.
+
+### B — Should-fix findings (applied)
+
+- **ARN-B1** (Critic, clarify) — _Spawn-side code not quoted._
+  Added DN-3 quoting the spawn-side `chordHalf` formula so the
+  AC-4 retire-side mirror claim is auditable inline.
+
+- **ARN-B2** (Critic, clarify) — _Line numbers drift._ The story
+  uses test-function names and exact text anchors for every edit;
+  line numbers appear only as "currently around line X" hints,
+  never as the sole anchor.
+
+- **ARN-B3** (Scope-Guardian, redesign) — _Circle-aware retire
+  characterised as gold-plating._ Rejected — DN-2 documents that
+  the user surfaced the rim-vs-apex distinction in their own words
+  after reading the agent's prior message; this is not
+  agent-induced scope.
+
+- **ARN-B4** (Critic, clarify) — _SVG y-axis convention._ Inline
+  code comment in AC-4 states "smaller y = visually higher."
+
+- **ARN-B5** (Critic, improve) — _Light-theme contrast risk._
+  Documented in DN-6 + Risk; deferred to iteration.
+
+- **ARN-B6** (Critic, improve) — _T3 (`--quick`) redundant before
+  T6._ Kept as fast-feedback iteration step, labelled as such in
+  T1 / T2 (each task closes with the quick-gate command).
+
+- **ARN-B7** (ConcretePlanner, clarify) — _"Five edits" prose was
+  off-by-one._ Inputs section now says "four constants + one
+  life-curve breakpoint + one retire-predicate refactor".
+
+- **ARN-B8** (Dev-Proxy, clarify) — _Constants source not
+  specified._ Inputs section explicitly states no new constants;
+  all referenced identifiers are QS-211-shipped.
+
+- **ARN-B9** (Dev-Proxy, clarify) — _Harness sync non-impact not
+  stated._ Non-impacts section calls it out explicitly.
+
+- **ARN-B10** (Critic, clarify) — _UI-only fast-path criteria not
+  restated._ AC-7 now spells out the scope detection (changed-file
+  → `_DEV_ONLY_PATTERNS` / `_UI_RESOURCES_PREFIX` classification)
+  with the relevant `scripts/qs/quality_gate.py` symbols quoted.
+
+- **ARN-B11** (Scope-Guardian, improve) — _Color/motion shipping
+  in same PR._ Both asks came in the same user turn; the user did
+  not ask for staged delivery. Note added to Why.
+
+### C — Skipped findings (documented with reasoning)
+
+- **ARN-C1** (Critic, redesign) — _"Drift could un-trigger
+  retire."_ Skipped — DN-4 explains why this is impossible:
+  retire is re-evaluated each frame independently, no state is
+  carried across frames, and vertical motion dominates drift.
+
+- **ARN-C2** (Critic, redesign) — _Doubling MAX_LIFE doubles
+  steady-state puff count._ Skipped — `MAX_CONCURRENT_STEAM = 8`
+  cap is unchanged; actual puff count stays bounded. Density
+  trade-off documented in DN-5 and Risk.
+
+- **ARN-C3** (Scope-Guardian, redesign) — _Speed/life constants
+  overshoot; smaller tuple suffices._ Skipped — the chosen tuple
+  is justified by the worst-case 188 px budget plus margin (DN-1).
+  Smaller bumps either fail the budget (e.g. `MAX_LIFE = 6.5`,
+  `RISE_MAX = 28`: `0.85 × 6.5 × 28 = 154.7 < 188`) or push the
+  breakpoint into territory that crowds the fade-in start.
+
+- **ARN-C4** (Scope-Guardian, improve) — _Doc edit is bureaucratic
+  compliance._ Skipped — `dashboard-and-cards.md` has
+  `covers: [custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js]`
+  in its frontmatter, so any JS edit triggers doc-drift unless
+  the doc co-modifies. Compliance is mandatory, not optional.
+
+- **ARN-C5** (Scope-Guardian, improve) — _Magic triplet
+  `rgb(195,215,235)`._ Skipped — the user specified direction
+  ("blue/gray"), not an exact hex. The triplet is a defensible
+  starting point with R<G<B ordering for a cool tint; iteration
+  is cheap if the user wants a different value.
+
+- **ARN-C6** (Critic, improve) — _No luminance/contrast test for
+  new color._ Skipped — visual tuning is not test-pinnable at
+  the unit-test layer; the regex literal is the right
+  granularity.
+
+- **ARN-C7** (ConcretePlanner, clarify) — _Brittle regex if
+  formula extracted into a helper._ Skipped — extracting
+  `_chordHalfAt(d)` would deduplicate the spawn-side and
+  retire-side formulas (~4 lines saved) but expand scope. DN-3
+  documents the parallel without enforcing DRY in this story.
+
+- **ARN-C8** (Critic, improve) — _No AC for not-boiling state
+  regression._ Skipped — the existing test
+  `test_water_boiler_card_steam_spawn_is_boiling_gated`
+  (untouched by QS-214) already pins "spawn only when boiling."
+
+- **ARN-C9** (Scope-Guardian, clarify) — _AC-6 pinned a user-not-
+  requested numerical floor._ Addressed by demoting AC-6 to DN-1
+  (already covered by ARN-A11).

--- a/docs/stories/QS-214.story.md
+++ b/docs/stories/QS-214.story.md
@@ -43,8 +43,12 @@ card code should not be modified without explicit instruction".
 ## Inputs
 
 - `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`
-  — four constants + one life-curve breakpoint + one retire-predicate
-  refactor. No new constants introduced. All referenced identifiers
+  — six constants + one life-curve breakpoint + one retire-predicate
+  refactor + a per-puff rim-fade derivation + a `_render()`
+  preservation block. **Post-merge correction:** two new constants
+  were introduced during user iteration (initially the story claimed
+  "no new constants"): `STEAM_SPAWN_CX_HALF_PX` (AC-9) and
+  `STEAM_RIM_FADE_FRACTION` (AC-10). All other referenced identifiers
   (`STEAM_TOP_MARGIN_PX`, `CENTER_CX`, `CENTER_CY`, `CLIP_R`,
   `STEAM_RADIUS_GROW_PX_PER_S`, `STEAM_RADIUS_MAX`,
   `STEAM_DRIFT_PX_PER_S`, `_steamPuffs`, …) already exist from QS-211.
@@ -73,9 +77,13 @@ card code should not be modified without explicit instruction".
 - **AC-2** — Speed/life constants updated:
   ```js
   const STEAM_MAX_LIFE_S        = 8.0;   // was 4.5
-  const STEAM_RISE_PX_PER_S_MIN = 18;    // was 10
-  const STEAM_RISE_PX_PER_S_MAX = 32;    // was 22
+  const STEAM_RISE_PX_PER_S_MIN = 24;    // uniform vy; was 10
+  const STEAM_RISE_PX_PER_S_MAX = 24;    // uniform vy; was 22
   ```
+  **Post-merge correction:** uniform `vy = 24` (organic variance comes
+  from spawn x/time, drift phase, and radius — not from `vy`). The
+  asymmetric `[18, 32]` band initially planned was retracted during
+  user iteration — see ARN-D1.
 
 - **AC-3** — Life-curve fade-out breakpoint moved from `0.7` to `0.85`
   in the steam advance block. Fade-in breakpoint `0.15` unchanged.
@@ -164,6 +172,41 @@ card code should not be modified without explicit instruction".
   retire. `last_verified:` bumped to `2026-05-22`. Doc-drift checker
   exits 0 (executed transitively via T6).
 
+- **AC-9** — Narrow spawn cx band. `STEAM_SPAWN_CX_HALF_PX = 35`
+  caps the maximum |dx| at spawn regardless of water-surface chord
+  width. The spawn loop draws `cxSpawn` from
+  `CENTER_CX ± Math.min(chordHalf * 0.85, STEAM_SPAWN_CX_HALF_PX)`
+  so every puff's per-puff `riseBudget = cySpawn − spawnLocalTopY`
+  is substantial even when the tank is near-full. Without this clamp,
+  edge-spawned puffs at partial water levels had only 12–80 px of
+  rise before hitting their local rim, perceived as "stops just above
+  the surface". See ARN-D2.
+
+- **AC-10** — Per-puff rim-fade. Each puff stores
+  `fadeBand = riseBudget × STEAM_RIM_FADE_FRACTION` at spawn time,
+  where `STEAM_RIM_FADE_FRACTION = 0.6`. The advance loop computes
+  `rimDistance = p.cy − localTopY` and
+  `rimOpacity = Math.max(0, Math.min(1, rimDistance / p.fadeBand))`,
+  multiplied into the per-frame opacity alongside `lifeOpacity` and
+  `_currentColorMix`. Geometry-aware: center puffs (long rise) get a
+  long fade band; side puffs (short local rise) get a proportionally
+  shorter one. The fade always fits the available space — a fixed
+  pixel band would either be too short for center puffs or exceed
+  the rise budget for side / high-water puffs. See ARN-D2.
+
+- **AC-11** — `_render()` preserves in-flight steam puffs and bubbles
+  across `innerHTML` rewrites. Snapshot `_steamPuffs` / `_nextSteamAt`
+  and `_bubbles` / `_nextBubbleAt` before the rewrite; re-attach each
+  preserved particle's detached DOM node to the freshly-rendered
+  layer after `_resetDomRefs()`; restore the cadence counters. If a
+  new layer is absent (defensive — e.g. a future template variant
+  elides it), preserved particle DOM is explicitly removed via
+  `p?.el?.remove()` / `b?.el?.remove()` and the array is reset to
+  `[]` so no detached nodes leak. Without this preservation, every
+  HA state push wiped all in-flight particles simultaneously (the
+  user-reported "3-4 puffs all disappear at the exact same time"
+  symptom), making the per-puff lifecycle invisible. See ARN-D3.
+
 ## Design notes (not testable as ACs — kept here for traceability)
 
 ### DN-1 — Geometry budget for "reach the circle top"
@@ -190,27 +233,35 @@ strictly-geometric distance; 188 is the operationally-meaningful one.
 We use 188 below.
 ```
 
-Max-velocity puff hold-phase reach with the new constants:
+**Post-merge correction (uniform vy=24):** hold-phase reach is
 ```text
-0.85 × STEAM_MAX_LIFE_S × STEAM_RISE_PX_PER_S_MAX
-  = 0.85 × 8.0 × 32
-  = 217.6 px
-  ≥ 188 px  ✓ (fast puffs visibly reach the apex with 16 % margin)
+0.85 × STEAM_MAX_LIFE_S × STEAM_RISE_PX_PER_S
+  = 0.85 × 8.0 × 24
+  = 163.2 px
+  < 188 px (the geometric worst case)
 ```
 
-Min-velocity puff full-life reach:
-```text
-STEAM_MAX_LIFE_S × STEAM_RISE_PX_PER_S_MIN
-  = 8.0 × 18
-  = 144 px
-```
+The hold-phase reach falls short of the geometric worst case by ~25
+px. Two complementary mechanisms cover the gap:
 
-That's deliberately shorter than 188 px. Slow puffs retire on
-`p.life >= p.maxLife` partway up; only fast puffs reach the rim. This
-per-puff variance is intentional — uniform reach would look mechanical;
-real steam plumes have wisps that thin out at varying heights. The
-range `[18, 32]` is tuned so the worst plumes still rise ~145 px
-(visible across most of the tank).
+1. **Geometric retire fires before `lifeT = 1`**: the puff is removed
+   when `p.cy < localTopY`, typically at `t ≈ 7.83 s` (= 188/24) for
+   a center-column empty-tank puff. `lifeT` at that point is ≈ 0.98,
+   well into the life-curve fade-out window `[0.85, 1.0]`.
+2. **Per-puff rim-fade** (AC-10) ramps opacity to 0 over the upper
+   60 % of each puff's `riseBudget` (`STEAM_RIM_FADE_FRACTION ×
+   riseBudget`), so the visible puff dissolves at the LOCAL rim, not
+   at the global apex. For a center-column empty-tank puff
+   (`riseBudget = 188`), the fade band is `0.6 × 188 = 112.8 px` —
+   ample to give a smooth ~4.7 s fade from full opacity to invisible.
+
+Slow-puff under-reach is no longer a concern with uniform `vy`. The
+asymmetric `[18, 32]` band originally planned introduced visible
+speed-sorting near the rim; see ARN-D1.
+
+(cross-reference: AC-9 narrows the spawn cx band so every puff has a
+substantial `riseBudget`; AC-10 specifies the per-puff rim-fade;
+AC-11 protects in-flight puffs from `_render()` wipes.)
 
 ### DN-2 — Why the circle-aware retire is not gold-plating
 
@@ -636,3 +687,65 @@ the four agents. Deduplicated and triaged below.
 - **ARN-C9** (Scope-Guardian, clarify) — _AC-6 pinned a user-not-
   requested numerical floor._ Addressed by demoting AC-6 to DN-1
   (already covered by ARN-A11).
+
+### D — Post-merge revisions (validated by user iteration on PR #215)
+
+- **ARN-D1** (post-merge) — _Asymmetric vy band `[18, 32]` retracted
+  in favour of uniform `vy = 24`._ The asymmetric band produced
+  visible speed-sorting near the rim that user-facing iteration read
+  as a "two-stream" steam effect ("some are going up few pixels,
+  other higher"). Uniform `vy` with the per-puff rim-fade tail looks
+  more homogeneous and lets every puff reach near the local rim
+  within its life budget. The under-reach implied by the new
+  arithmetic (`0.85 × 8.0 × 24 = 163.2 < 188 px`) is covered by the
+  geometric retire firing at `lifeT ≈ 0.98` plus the per-puff
+  rim-fade (AC-10). Recorded in commit `8fd50636`.
+
+- **ARN-D2** (post-merge) — _Spawn cx narrowed; per-puff rim-fade
+  introduced (AC-9 + AC-10)._ Without the spawn-cx clamp
+  (`STEAM_SPAWN_CX_HALF_PX = 35`), edge-spawned puffs at partial
+  water levels had only 12–80 px of rise before hitting their local
+  rim — perceived as "stops just above the surface". A FIXED-PX
+  rim-fade band was tried first (`STEAM_RIM_FADE_PX = 60`) and was
+  user-flagged as "true at center, but wrong on the sides (and 60 px
+  may be too small)". Replaced with the per-puff proportional band
+  (`STEAM_RIM_FADE_FRACTION × riseBudget`) so the fade is
+  geometry-aware and always fits the available space. Recorded in
+  commits `50530b8f` (narrow spawn + per-puff fade) and the
+  intermediate-experiment trail in `8399c010` (pin-at-rim, also
+  reverted).
+
+- **ARN-D3** (post-merge) — _Render preservation across `innerHTML`
+  rewrites (AC-11)._ Root cause for the user-reported "3-4 puffs all
+  disappear at the exact same time": every HA state push fires
+  `set hass → _render → this._root.innerHTML = …`, which detaches
+  every DOM node under root including the steam and bubble layers'
+  children. `_resetDomRefs()` then sets `_steamPuffs = []` and
+  `_bubbles = []`. Snapshot/restore pattern lands in commits
+  `f0a91bf2` (steam) and `3eae265e` (bubbles). The bubbles wipe was
+  previously documented in-code as "barely-perceptible — 167 ms
+  respawn, accepted per pool precedent" — that comment is now stale
+  (bubbles also survive renders).
+
+- **ARN-D4** (post-merge) — _Spawn-loop no-op defer + premature
+  break._ The `if (riseBudget <= 0)` branch in the spawn loop set
+  `_nextSteamAt = Math.max(_nextSteamAt, 0)` (collapses to `0` since
+  the while condition guarantees `_nextSteamAt <= 0` on entry) and
+  `break`. Next frame `_nextSteamAt -= dt` immediately re-enters the
+  loop, burns CPU on the random `cxSpawn` + two `Math.sqrt` calls,
+  hits the same branch, breaks — a per-frame spin. Replaced with a
+  proper defer (`_nextSteamAt += 1 / STEAM_SPAWN_RATE_HZ; continue;`)
+  that genuinely advances the cadence.
+
+- **ARN-D5** (post-merge) — _`_render()` preserve path's null-layer
+  branch leaked detached DOM._ Docstring said "drop the preserved
+  puffs so they don't leak DOM nodes" but the code only re-attached
+  when `newSteamLayer` was truthy; the null-layer path left the
+  detached `p.el` references in the function-local
+  `preservedSteamPuffs` to be GC'd silently — relying on the GC to
+  clean up DOM nodes that were never re-attached. Fixed by adding an
+  explicit `else` branch that calls `p?.el?.remove()` on each
+  preserved puff and resets `this._steamPuffs = []`. Same applied
+  symmetrically to bubbles. Aligned the truthy-branch array
+  semantics with `.filter(p => p?.el)` so the preserved-and-truthy
+  set is the source of truth.

--- a/docs/stories/QS-214.story.md
+++ b/docs/stories/QS-214.story.md
@@ -125,6 +125,12 @@ card code should not be modified without explicit instruction".
       `r"STEAM_FILL_COLOR\s*=\s*['\"]rgba\(255,\s*255,\s*255,\s*0\.45\)['\"]"`
       to
       `r"STEAM_FILL_COLOR\s*=\s*['\"]rgba\(195,\s*215,\s*235,\s*0\.45\)['\"]"`.
+    - **Post-merge addition (review fix #01 #2):** pin the uniform
+      `vy` constants with `r"STEAM_RISE_PX_PER_S_MIN\s*=\s*24\b"`
+      and `r"STEAM_RISE_PX_PER_S_MAX\s*=\s*24\b"`. Without these
+      pins, a future edit could silently drift either constant and
+      reintroduce the "two-stream" speed-sorting near the rim
+      retracted by ARN-D1.
     - Update the docstring at lines 2361–2363 to reference the new
       color literal AND the new `0.85` fade-out breakpoint
       (currently mentions `'rgba(255,255,255,0.45)'` and `0.7`).

--- a/docs/stories/QS-214.story_review_fix_#01.md
+++ b/docs/stories/QS-214.story_review_fix_#01.md
@@ -1,0 +1,217 @@
+# QS-214 — Review fix plan #01
+
+## Summary
+- Source PR: #215
+- Source story: `docs/stories/QS-214.story.md`
+- Findings to fix: 7 (2 must-fix + 5 should-fix)
+- Next implement phase: `/implement-task`
+
+The PR's product behavior (steam tint, life curve, circle-aware retire) is
+sound and adversarial review found no must-fix bugs in the visible code.
+The blocking findings are alignment problems: the implementation drifted
+from the story's stated AC-2 constants and added unmodeled design surface
+(spawn-cx narrowing, per-puff rim-fade, render preservation) without
+backfilling acceptance criteria or test pins. Fix plan #01 reconciles
+the story-vs-code gap, adds the missing test pin for the rise constants,
+hardens the two real correctness smells in the spawn/preserve paths, and
+re-runs the CodeRabbit second-opinion now that the hourly limit has
+refilled.
+
+## Findings to fix
+
+### [must-fix] Reconcile AC-2 speed constants with code
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:91-98`
+  and `docs/stories/QS-214.story.md` (AC-2 + DN-1)
+- Severity: must-fix
+- Source: qs-review-acceptance-auditor
+- Description: Story specifies `STEAM_RISE_PX_PER_S_MIN = 18` and
+  `STEAM_RISE_PX_PER_S_MAX = 32` (asymmetric band derived in DN-1). PR
+  ships uniform `STEAM_RISE_PX_PER_S_MIN = STEAM_RISE_PX_PER_S_MAX = 24`
+  with an inline comment "Uniform vy (MIN == MAX): all puffs rise at
+  the same gentle rate. Organic variance comes from spawn x/time, drift
+  phase, radius." Commit `8fd50636` records the iteration ("uniform
+  rise rate + rim-proximity fade"). The uniform design is the validated
+  one; the story is stale.
+- Proposed fix: **adopt the uniform design as the source of truth.**
+  Amend the story (do NOT revert the JS):
+  1. In AC-2: change "`STEAM_RISE_PX_PER_S_MIN = 18` and
+     `STEAM_RISE_PX_PER_S_MAX = 32`" to "`STEAM_RISE_PX_PER_S_MIN =
+     STEAM_RISE_PX_PER_S_MAX = 24` (uniform; organic variance comes
+     from spawn x/time, drift phase, and radius)".
+  2. In DN-1: drop the `0.85 × 8.0 × 32 = 217.6 px ≥ 188 px` arithmetic
+     and replace with the actual operating budget: hold-phase reach is
+     `0.85 × 8.0 × 24 = 163.2 px`; the final 24-30 px to the rim is
+     covered by the per-puff rim-fade band (STEAM_RIM_FADE_FRACTION ×
+     riseBudget at spawn), so puffs visually retire near the local rim
+     rather than at the global apex. Update the supporting paragraph
+     accordingly.
+  3. Update ARN-C3 (or add ARN-C4) to record why the asymmetric band
+     was retracted in favor of uniform vy + rim-fade: "asymmetric
+     [18, 32] band produced visible speed sorting near the rim that
+     reviewers read as 'two-stream' steam; uniform vy with the rim-fade
+     tail looks more homogeneous."
+
+### [must-fix] Add test pin for `STEAM_RISE_PX_PER_S_MIN/MAX`
+- File: `tests/test_dashboard_rendering.py` (the existing constants test
+  or a sibling pin in
+  `test_water_boiler_card_steam_opacity_formula` — whichever already
+  pins other steam constants)
+- Severity: must-fix
+- Source: qs-review-acceptance-auditor
+- Description: No regex pin enforces `STEAM_RISE_PX_PER_S_MIN` or
+  `STEAM_RISE_PX_PER_S_MAX`. Future edits can silently drift either
+  constant.
+- Proposed fix: add a single regex pin asserting both constants equal
+  `24`, e.g.
+  `assert re.search(r"STEAM_RISE_PX_PER_S_MIN\s*=\s*24\b", executable)`
+  and
+  `assert re.search(r"STEAM_RISE_PX_PER_S_MAX\s*=\s*24\b", executable)`,
+  in the same test that already pins
+  `STEAM_FILL_COLOR`/`STEAM_MAX_LIFE_S`. Also extend AC-6 in the story
+  to require these pins (one-line addition).
+
+### [should-fix] Backfill ACs for the unmodeled design surface
+- File: `docs/stories/QS-214.story.md` (Inputs + AC list + DN/ARN
+  sections)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: PR introduced two new constants
+  (`STEAM_SPAWN_CX_HALF_PX`, `STEAM_RIM_FADE_FRACTION`), one new puff
+  field (`fadeBand`), a per-puff rim-fade computation, and a
+  `_render()` snapshot/restore block. None appear in any AC. The
+  story's Inputs section currently says "No new constants introduced"
+  — factually wrong as of merge.
+- Proposed fix: extend the story with three new ACs (keep them
+  surgical — describe what shipped, not a redesign):
+  - AC-9 (spawn-cx narrowing): "`STEAM_SPAWN_CX_HALF_PX = 18` defines a
+    narrow band around `CENTER_CX` from which puff `cxSpawn` is drawn,
+    so the per-puff `riseBudget` (cySpawn − spawnLocalTopY) stays
+    positive even when the tank is near-full."
+  - AC-10 (per-puff rim-fade): "Each puff stores `fadeBand =
+    riseBudget × STEAM_RIM_FADE_FRACTION` at spawn; `rimOpacity` ramps
+    linearly over `fadeBand` so puffs fade into the local rim rather
+    than at the global apex. `STEAM_RIM_FADE_FRACTION = 0.5`."
+  - AC-11 (render preservation): "`_render()` snapshots in-flight
+    puffs before innerHTML rewrite and re-attaches them to the new
+    steam layer; if the new layer is absent, preserved puff DOM is
+    explicitly removed (see fix #4 below) so no detached nodes leak."
+  - Update Inputs to read "Six constants" and list the new pair.
+  - Add a one-line note in DN-1 cross-referencing AC-9/10/11.
+  - Add ARN-D recording why narrow spawn band + per-puff rim-fade was
+    chosen over wider spawn + global apex retire.
+
+### [should-fix] Update DN-1 geometry derivation
+- File: `docs/stories/QS-214.story.md` (DN-1)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: DN-1 still derives reach from `vy_max = 32`. With
+  uniform `vy = 24`, the math no longer holds. Folded into the AC-2
+  amendment above but called out separately so the implementer doesn't
+  miss it.
+- Proposed fix: as described in must-fix #1 step 2.
+
+### [should-fix] Fix the spawn loop's no-op defer + premature break
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~471`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (merged)
+- Description: The spawn loop currently does
+  ```
+  if (riseBudget <= 0) {
+      this._nextSteamAt = Math.max(this._nextSteamAt, 0);
+      break;
+  }
+  ```
+  To enter the `while`, `_nextSteamAt <= 0` already, so
+  `Math.max(_nextSteamAt, 0)` collapses to `0`. The comment "defer"
+  is false — nothing is deferred. Worse, next frame `_nextSteamAt -=
+  dt` immediately re-enters the loop. Combined with the `break`, a
+  near-full tank (`progressRatio == 1.0`,
+  `_waterBaseY ∈ [40, 42]`, `spawnLocalTopY = 44`) spin-loops the
+  spawn check every frame: random `cxSpawn`, two `Math.sqrt`, one
+  miss, break. Burns CPU while producing no spawn.
+- Proposed fix: replace with a real defer + `continue`-style retry:
+  ```
+  if (riseBudget <= 0) {
+      // Genuinely defer: consume this spawn slot so the cadence
+      // counter advances. Future frames may pick a different cx
+      // with positive budget.
+      this._nextSteamAt += 1 / STEAM_SPAWN_RATE_HZ;
+      continue;
+  }
+  ```
+  Alternative (cleaner): short-circuit before the loop when the
+  whole-tank apex is unreachable:
+  ```
+  const globalTopY = CENTER_CY - CLIP_R + STEAM_TOP_MARGIN_PX;
+  if (this._waterBaseY < globalTopY) {
+      // Tank too full for any spawn cx to have positive budget.
+      this._nextSteamAt = Math.max(this._nextSteamAt, 0);
+      return;
+  }
+  ```
+  Add a unit test (in `test_dashboard_rendering.py`) that pins the
+  chosen branch — regex for either `_nextSteamAt += 1 /
+  STEAM_SPAWN_RATE_HZ` inside the riseBudget guard, or for the
+  short-circuit comparison against `globalTopY`. Decide which during
+  implementation; document the choice in commit message.
+
+### [should-fix] Honor the docstring contract in `_render()` preserve path
+- File: `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js:~1335-1346`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (merged)
+- Description: Docstring at line ~1331-1334 says "drop the preserved
+  puffs so they don't leak DOM nodes" but the code only re-attaches
+  when `newSteamLayer` truthy; the null-layer path leaves the detached
+  `p.el` references in `preservedSteamPuffs` (function-local) to be
+  GC'd silently. Today this works because there is no template variant
+  that elides `<g id="${steamLayerId}">`, but the contract is silently
+  broken.
+- Proposed fix: add the missing else branch and align the array
+  semantics:
+  ```
+  if (newSteamLayer) {
+      for (const p of preservedSteamPuffs) {
+          if (p?.el) newSteamLayer.appendChild(p.el);
+      }
+      this._steamPuffs = preservedSteamPuffs.filter(p => p?.el);
+      this._steamLayerEl = newSteamLayer;
+  } else {
+      for (const p of preservedSteamPuffs) {
+          p?.el?.remove();
+      }
+      this._steamPuffs = [];
+  }
+  ```
+  Add (or extend) the existing render-preservation test in
+  `test_dashboard_rendering.py` to pin the else branch — a regex
+  asserting `p\?.el\?.remove\(\)` appears inside the no-newSteamLayer
+  branch is sufficient.
+
+### [should-fix] Re-run CodeRabbit (hourly limit has refilled)
+- File: n/a — process action
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: CodeRabbit's automated review hit the 1-review/hour
+  limit during this round (PR comment refill ETA was ~8 min from
+  trigger time). No second-opinion signal was collected.
+- Proposed fix: during the next implement-task → review-task cycle,
+  the next `qs-review-coderabbit` invocation will hit a fresh quota.
+  No code change required here; this entry exists to ensure the
+  follow-up review re-collects CodeRabbit findings before merge.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. The implementer should
+group the work into three commits to keep the diff reviewable:
+
+1. **Story amendment** — AC-2 + DN-1 + new AC-9/10/11 + ARN-C3 (or
+   ARN-C4) + Inputs section ("Six constants"). Doc-only.
+2. **JS hardening** — spawn-loop defer fix (#5) + `_render()` else
+   branch + symmetric `filter(p => p?.el)` (#6). Includes new test
+   pins for both branches.
+3. **Test pins for rise constants** — `STEAM_RISE_PX_PER_S_MIN/MAX =
+   24` regex pins (#2). Update AC-6 in the story to require them.
+
+When `/implement-task` finishes and re-opens the PR (push to existing
+PR #215), return and run `/review-task` again to re-verify — that
+re-review will also re-collect CodeRabbit's findings.

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2328,39 +2328,70 @@ def test_water_boiler_card_steam_spawn_is_boiling_gated():
 
 
 def test_water_boiler_card_steam_retire_both_branches():
-    """QS-211 AC-3: the steam retire predicate covers BOTH branches —
-    `p.cy < topY` (reached top of clip) AND `p.life >= p.maxLife`
-    (hard upper-bound). Either condition retires the puff."""
+    """QS-214 AC-4: the steam retire predicate covers BOTH branches —
+    `p.cy < localTopY` (reached the local clip-circle top at the
+    puff's current x) AND `p.life >= p.maxLife` (hard upper-bound).
+    Either condition retires the puff. The per-puff `localTopY`
+    derivation replaces QS-211's global `topY = CENTER_CY - CLIP_R +
+    STEAM_TOP_MARGIN_PX` so puffs drifting toward the rim retire at
+    the local clip top rather than continuing invisibly toward the
+    global apex."""
     import re
 
     source = (
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
     executable = _strip_js_comments(source)
+    # Find the steam advance block and assert the per-puff geometry
+    # appears inside it (mirrors the opacity test's window extraction).
+    advance_start = executable.find("for (const p of this._steamPuffs)")
+    assert advance_start != -1, (
+        "qs-water-boiler-card.js: missing steam advance loop."
+    )
+    advance_block = executable[advance_start : advance_start + 1500]
     assert re.search(
-        r"p\.cy\s*<\s*topY\s*\|\|\s*p\.life\s*>=\s*p\.maxLife",
-        executable,
+        r"p\.cy\s*<\s*localTopY\s*\|\|\s*p\.life\s*>=\s*p\.maxLife",
+        advance_block,
     ), (
         "qs-water-boiler-card.js: the steam retire predicate must be "
-        "exactly `p.cy < topY || p.life >= p.maxLife` — both branches "
-        "are required (top-of-clip + maxLife)."
+        "exactly `p.cy < localTopY || p.life >= p.maxLife` — both "
+        "branches are required (local clip-top + maxLife)."
     )
     assert re.search(
-        r"const\s+topY\s*=\s*CENTER_CY\s*-\s*CLIP_R\s*\+\s*STEAM_TOP_MARGIN_PX",
-        executable,
+        r"const\s+dx\s*=\s*p\.cx\s*-\s*CENTER_CX",
+        advance_block,
     ), (
-        "qs-water-boiler-card.js: `topY` must be derived as "
-        "`CENTER_CY - CLIP_R + STEAM_TOP_MARGIN_PX`."
+        "qs-water-boiler-card.js: the per-puff retire geometry must "
+        "derive `dx = p.cx - CENTER_CX` inside the advance loop."
+    )
+    assert re.search(
+        r"const\s+localChordHalf\s*=\s*Math\.sqrt\(\s*Math\.max\(\s*0\s*,\s*"
+        r"CLIP_R\s*\*\s*CLIP_R\s*-\s*dx\s*\*\s*dx\s*\)\s*\)",
+        advance_block,
+    ), (
+        "qs-water-boiler-card.js: the per-puff retire geometry must "
+        "derive `localChordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R "
+        "- dx * dx))` inside the advance loop (mirrors the spawn-side "
+        "chord-half formula)."
+    )
+    assert re.search(
+        r"const\s+localTopY\s*=\s*CENTER_CY\s*-\s*localChordHalf\s*\+\s*"
+        r"STEAM_TOP_MARGIN_PX",
+        advance_block,
+    ), (
+        "qs-water-boiler-card.js: the per-puff retire geometry must "
+        "derive `localTopY = CENTER_CY - localChordHalf + "
+        "STEAM_TOP_MARGIN_PX` inside the advance loop."
     )
 
 
 def test_water_boiler_card_steam_opacity_formula():
-    """QS-211 AC-4: per-frame opacity is the assignment
+    """QS-214 AC-1/AC-3: per-frame opacity is the assignment
     `lifeOpacity * this._currentColorMix` (not a compound `*=`), and
-    the life-curve breakpoints `0.15` (fade-in) and `0.7` (fade-out)
+    the life-curve breakpoints `0.15` (fade-in) and `0.85` (fade-out)
     appear literally in the steam advance block. The `<circle>` fill
-    is the literal `STEAM_FILL_COLOR = 'rgba(255,255,255,0.45)'` so the
-    SVG alpha 0.45 is baked in."""
+    is the literal `STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)'` (cool
+    blue-gray tint, alpha 0.45 baked into the SVG fill literal)."""
     import re
 
     source = (
@@ -2368,11 +2399,11 @@ def test_water_boiler_card_steam_opacity_formula():
     ).read_text()
     executable = _strip_js_comments(source)
     assert re.search(
-        r"STEAM_FILL_COLOR\s*=\s*['\"]rgba\(255,\s*255,\s*255,\s*0\.45\)['\"]",
+        r"STEAM_FILL_COLOR\s*=\s*['\"]rgba\(195,\s*215,\s*235,\s*0\.45\)['\"]",
         executable,
     ), (
         "qs-water-boiler-card.js: STEAM_FILL_COLOR must be the literal "
-        "`'rgba(255,255,255,0.45)'` so SVG alpha 0.45 is baked in."
+        "`'rgba(195,215,235,0.45)'` (cool blue-gray, alpha 0.45 baked in)."
     )
     assert re.search(
         r"const\s+opacity\s*=\s*lifeOpacity\s*\*\s*this\._currentColorMix",
@@ -2394,9 +2425,15 @@ def test_water_boiler_card_steam_opacity_formula():
         "qs-water-boiler-card.js: missing the `0.15` fade-in breakpoint "
         "in the steam life-curve."
     )
-    assert "0.7" in advance_block, (
-        "qs-water-boiler-card.js: missing the `0.7` fade-out breakpoint "
-        "in the steam life-curve."
+    assert re.search(r"lifeT\s*<\s*0\.85", advance_block), (
+        "qs-water-boiler-card.js: missing the `lifeT < 0.85` fade-out "
+        "guard in the steam life-curve."
+    )
+    assert re.search(
+        r"\(\s*lifeT\s*-\s*0\.85\s*\)\s*/\s*0\.15", advance_block
+    ), (
+        "qs-water-boiler-card.js: missing the `(lifeT - 0.85) / 0.15` "
+        "fade-out ramp in the steam life-curve."
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2718,6 +2718,23 @@ def test_water_boiler_card_steam_opacity_formula():
         "qs-water-boiler-card.js: STEAM_RISE_PX_PER_S_MAX must be `24` "
         "(uniform vy with STEAM_RISE_PX_PER_S_MIN — see ARN-D1)."
     )
+    # User iteration on PR #215: the wave speed inherited from the
+    # pool card (`BOIL_SPEED = 1.6`, `CALM_SPEED = 0.2`) read as a
+    # pumped-flow pace — wrong for a heated boiler tank where the
+    # visible motion should be a gentle bubbling drift. Slowed to
+    # `CALM_SPEED = 0.1`, `BOIL_SPEED = 0.4` (~ 4× slower while
+    # boiling). Pinned so a future pool-card sync doesn't silently
+    # restore the pumped-flow speeds.
+    assert re.search(r"CALM_SPEED\s*=\s*0\.1\b", executable), (
+        "qs-water-boiler-card.js: CALM_SPEED must be `0.1` (slowed "
+        "from the pool-card-inherited 0.2 — gentle drift when not "
+        "boiling)."
+    )
+    assert re.search(r"BOIL_SPEED\s*=\s*0\.4\b", executable), (
+        "qs-water-boiler-card.js: BOIL_SPEED must be `0.4` (slowed "
+        "from the pool-card-inherited 1.6 — gentle bubbling pace, "
+        "not pumped flow)."
+    )
     assert re.search(
         r"const\s+opacity\s*=\s*lifeOpacity\s*\*\s*rimOpacity\s*\*\s*"
         r"this\._currentColorMix",

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2705,6 +2705,19 @@ def test_water_boiler_card_steam_opacity_formula():
         "qs-water-boiler-card.js: STEAM_FILL_COLOR must be the literal "
         "`'rgba(195,215,235,0.45)'` (cool blue-gray, alpha 0.45 baked in)."
     )
+    # Review fix #01 finding #2: pin the uniform vy. The asymmetric
+    # [18, 32] band initially planned was retracted in favour of
+    # `MIN == MAX == 24` (see ARN-D1); without these pins a future
+    # edit could silently drift either constant and reintroduce the
+    # "two-stream" speed-sorting near the rim.
+    assert re.search(r"STEAM_RISE_PX_PER_S_MIN\s*=\s*24\b", executable), (
+        "qs-water-boiler-card.js: STEAM_RISE_PX_PER_S_MIN must be `24` "
+        "(uniform vy with STEAM_RISE_PX_PER_S_MAX — see ARN-D1)."
+    )
+    assert re.search(r"STEAM_RISE_PX_PER_S_MAX\s*=\s*24\b", executable), (
+        "qs-water-boiler-card.js: STEAM_RISE_PX_PER_S_MAX must be `24` "
+        "(uniform vy with STEAM_RISE_PX_PER_S_MIN — see ARN-D1)."
+    )
     assert re.search(
         r"const\s+opacity\s*=\s*lifeOpacity\s*\*\s*rimOpacity\s*\*\s*"
         r"this\._currentColorMix",

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2506,6 +2506,66 @@ def test_water_boiler_card_render_preserves_steam_puffs_across_innerhtml():
     )
 
 
+def test_water_boiler_card_render_preserves_bubbles_across_innerhtml():
+    """Symmetric to the steam-puff preservation: `_render()` must also
+    snapshot `_bubbles` and `_nextBubbleAt` BEFORE the innerHTML
+    rewrite and restore them AFTER `_resetDomRefs()`, re-attaching
+    each preserved bubble's detached DOM node to the freshly-rendered
+    bubble layer.
+
+    The bubble blip on hass push was previously documented as
+    "barely-perceptible (167 ms respawn)" — accepted at the time
+    because bubbles live ~1.5 s. Now that we have the snapshot/
+    restore pattern in place for steam puffs, applying it
+    symmetrically to bubbles eliminates the blip entirely and removes
+    a per-push DOM-thrash spike."""
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    assert re.search(
+        r"const\s+preservedBubbles\s*=\s*this\._bubbles",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `_render()` must snapshot "
+        "`this._bubbles` into `preservedBubbles` BEFORE the innerHTML "
+        "rewrite."
+    )
+    assert re.search(
+        r"const\s+preservedNextBubbleAt\s*=\s*this\._nextBubbleAt",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `_render()` must snapshot "
+        "`this._nextBubbleAt` so the bubble spawn cadence doesn't "
+        "reset to 0 (which would burst-spawn on every push)."
+    )
+    assert re.search(
+        r"newBubbleLayer\.appendChild\s*\(\s*b\.el\s*\)",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `_render()` must re-attach each "
+        "preserved bubble's DOM node to the new bubble layer via "
+        "`newBubbleLayer.appendChild(b.el)`."
+    )
+    assert re.search(
+        r"this\._bubbles\s*=\s*preservedBubbles",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `_render()` must restore "
+        "`this._bubbles = preservedBubbles` after _resetDomRefs()."
+    )
+    assert re.search(
+        r"this\._nextBubbleAt\s*=\s*preservedNextBubbleAt",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `_render()` must restore "
+        "`this._nextBubbleAt = preservedNextBubbleAt`."
+    )
+
+
 def test_water_boiler_card_steam_opacity_formula():
     """QS-214 per-puff proportional rim-fade iteration: per-frame
     opacity is `lifeOpacity * rimOpacity * this._currentColorMix`,

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2386,12 +2386,16 @@ def test_water_boiler_card_steam_retire_both_branches():
 
 
 def test_water_boiler_card_steam_opacity_formula():
-    """QS-214 AC-1/AC-3: per-frame opacity is the assignment
-    `lifeOpacity * this._currentColorMix` (not a compound `*=`), and
-    the life-curve breakpoints `0.15` (fade-in) and `0.85` (fade-out)
-    appear literally in the steam advance block. The `<circle>` fill
-    is the literal `STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)'` (cool
-    blue-gray tint, alpha 0.45 baked into the SVG fill literal)."""
+    """QS-214 AC-1/AC-3 + rim-fade iteration: per-frame opacity is the
+    assignment `lifeOpacity * rimOpacity * this._currentColorMix` (not
+    a compound `*=`), and the life-curve breakpoints `0.15` (fade-in)
+    and `0.85` (fade-out) appear literally in the steam advance block.
+    The `<circle>` fill is the literal `STEAM_FILL_COLOR =
+    'rgba(195,215,235,0.45)'` (cool blue-gray tint, alpha 0.45 baked
+    into the SVG fill literal). The rim-fade factor (`rimOpacity`)
+    fades each puff out gracefully as it approaches `localTopY`, so
+    puffs dissolve at the local clip-circle top instead of blinking
+    out on the geometric retire."""
     import re
 
     source = (
@@ -2406,15 +2410,18 @@ def test_water_boiler_card_steam_opacity_formula():
         "`'rgba(195,215,235,0.45)'` (cool blue-gray, alpha 0.45 baked in)."
     )
     assert re.search(
-        r"const\s+opacity\s*=\s*lifeOpacity\s*\*\s*this\._currentColorMix",
+        r"const\s+opacity\s*=\s*lifeOpacity\s*\*\s*rimOpacity\s*\*\s*"
+        r"this\._currentColorMix",
         executable,
     ), (
         "qs-water-boiler-card.js: the per-frame opacity must be an "
-        "ASSIGNMENT `const opacity = lifeOpacity * this._currentColorMix` "
-        "(NOT a compound `*=`, which would decay exponentially over "
-        "frames)."
+        "ASSIGNMENT `const opacity = lifeOpacity * rimOpacity * "
+        "this._currentColorMix` — both `lifeOpacity` (life-curve fade) "
+        "AND `rimOpacity` (rim-proximity fade) multiply through with "
+        "the colorMix cross-fade. Compound `*=` would decay exponentially."
     )
-    # Find the steam advance block and assert breakpoints appear inside it.
+    # Find the steam advance block and assert breakpoints + rim-fade
+    # derivations appear inside it.
     advance_start = executable.find("for (const p of this._steamPuffs)")
     assert advance_start != -1, (
         "qs-water-boiler-card.js: missing steam advance loop."
@@ -2434,6 +2441,27 @@ def test_water_boiler_card_steam_opacity_formula():
     ), (
         "qs-water-boiler-card.js: missing the `(lifeT - 0.85) / 0.15` "
         "fade-out ramp in the steam life-curve."
+    )
+    # Rim-proximity fade derivation. The puff fades to 0 over the last
+    # `STEAM_RIM_FADE_PX` pixels below `localTopY`, so it dissolves at
+    # the local clip-circle top instead of vanishing in one frame.
+    assert re.search(
+        r"const\s+rimDistance\s*=\s*p\.cy\s*-\s*localTopY",
+        advance_block,
+    ), (
+        "qs-water-boiler-card.js: missing `rimDistance = p.cy - "
+        "localTopY` derivation inside the steam advance loop — this is "
+        "the input to the rim-proximity fade."
+    )
+    assert re.search(
+        r"const\s+rimOpacity\s*=\s*Math\.max\(\s*0\s*,\s*Math\.min\(\s*1\s*,"
+        r"\s*rimDistance\s*/\s*STEAM_RIM_FADE_PX\s*\)\s*\)",
+        advance_block,
+    ), (
+        "qs-water-boiler-card.js: missing `rimOpacity = "
+        "Math.max(0, Math.min(1, rimDistance / STEAM_RIM_FADE_PX))` "
+        "derivation inside the steam advance loop — this is the "
+        "rim-proximity fade factor."
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2435,6 +2435,77 @@ def test_water_boiler_card_steam_spawn_cx_narrowed_to_central_band():
     )
 
 
+def test_water_boiler_card_render_preserves_steam_puffs_across_innerhtml():
+    """`_render()` rewrites `this._root.innerHTML` on every HA state
+    push, which previously wiped the entire SVG including every
+    in-flight steam puff. That caused the user-visible "3-4 puffs
+    rising and all disappearing at the exact same time" symptom —
+    puffs were being nuked by `set hass → _render → innerHTML`
+    every few seconds (whenever any watched entity state changed),
+    long before their individual lifecycles ended.
+
+    This test pins the snapshot-and-restore preservation pattern:
+    `_render()` must capture `_steamPuffs` / `_steamLayerEl` /
+    `_nextSteamAt` BEFORE the innerHTML rewrite, then re-attach the
+    preserved DOM nodes to the new steam layer AFTER `_resetDomRefs()`
+    and restore the array + cadence counter. Without this pattern, no
+    other steam-visual tuning can be perceived correctly — puffs get
+    wiped before the user sees the lifecycle.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Pre-innerHTML snapshot.
+    assert re.search(
+        r"const\s+preservedSteamPuffs\s*=\s*this\._steamPuffs",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `_render()` must snapshot "
+        "`this._steamPuffs` into `preservedSteamPuffs` BEFORE the "
+        "innerHTML rewrite, so the puff DOM nodes survive."
+    )
+    assert re.search(
+        r"const\s+preservedNextSteamAt\s*=\s*this\._nextSteamAt",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `_render()` must snapshot "
+        "`this._nextSteamAt` so the spawn cadence counter doesn't "
+        "reset to 0 on every render (which would cause a spawn-burst "
+        "after every HA state push)."
+    )
+
+    # Post-innerHTML restore: re-attach each preserved puff's DOM node
+    # to the new steam layer, then restore the array + counter.
+    assert re.search(
+        r"newSteamLayer\.appendChild\s*\(\s*p\.el\s*\)",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `_render()` must re-attach each "
+        "preserved puff's DOM node to the new steam layer via "
+        "`newSteamLayer.appendChild(p.el)`."
+    )
+    assert re.search(
+        r"this\._steamPuffs\s*=\s*preservedSteamPuffs",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `_render()` must restore "
+        "`this._steamPuffs = preservedSteamPuffs` after the innerHTML "
+        "rewrite + _resetDomRefs() cleanup."
+    )
+    assert re.search(
+        r"this\._nextSteamAt\s*=\s*preservedNextSteamAt",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: `_render()` must restore "
+        "`this._nextSteamAt = preservedNextSteamAt` so the spawn "
+        "cadence picks up where it left off."
+    )
+
+
 def test_water_boiler_card_steam_opacity_formula():
     """QS-214 per-puff proportional rim-fade iteration: per-frame
     opacity is `lifeOpacity * rimOpacity * this._currentColorMix`,

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2504,6 +2504,30 @@ def test_water_boiler_card_render_preserves_steam_puffs_across_innerhtml():
         "`this._nextSteamAt = preservedNextSteamAt` so the spawn "
         "cadence picks up where it left off."
     )
+    # Truthy-branch array semantics: `_steamPuffs` is assigned the
+    # filtered set (drop entries whose `el` was missing) so the array
+    # is the canonical "preserved AND truthy" view (review fix #01
+    # finding #6, alignment with the null-layer drop).
+    assert re.search(
+        r"this\._steamPuffs\s*=\s*preservedSteamPuffs\.filter\(\s*p\s*=>\s*p\?\.el\s*\)",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: the steam puff preserve truthy "
+        "branch must align array semantics with the null-layer drop "
+        "via `this._steamPuffs = preservedSteamPuffs.filter(p => p?.el)`."
+    )
+    # Null-layer else branch: explicit DOM removal of preserved puffs
+    # so detached nodes don't leak (honours the docstring contract;
+    # review fix #01 finding #6).
+    assert re.search(
+        r"for\s*\(\s*const\s+p\s+of\s+preservedSteamPuffs\s*\)\s*\{\s*"
+        r"p\?\.el\?\.remove\s*\(\s*\)\s*;?\s*\}",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: the steam puff preserve null-layer "
+        "else branch must iterate `preservedSteamPuffs` and explicitly "
+        "call `p?.el?.remove()` so detached DOM nodes don't leak."
+    )
 
 
 def test_water_boiler_card_render_preserves_bubbles_across_innerhtml():
@@ -2563,6 +2587,95 @@ def test_water_boiler_card_render_preserves_bubbles_across_innerhtml():
     ), (
         "qs-water-boiler-card.js: `_render()` must restore "
         "`this._nextBubbleAt = preservedNextBubbleAt`."
+    )
+    # Truthy-branch filter for symmetry with the steam path.
+    assert re.search(
+        r"this\._bubbles\s*=\s*preservedBubbles\.filter\(\s*b\s*=>\s*b\?\.el\s*\)",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: the bubble preserve truthy branch "
+        "must align array semantics with the null-layer drop via "
+        "`this._bubbles = preservedBubbles.filter(b => b?.el)`."
+    )
+    # Null-layer else branch: explicit DOM removal for bubbles.
+    assert re.search(
+        r"for\s*\(\s*const\s+b\s+of\s+preservedBubbles\s*\)\s*\{\s*"
+        r"b\?\.el\?\.remove\s*\(\s*\)\s*;?\s*\}",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: the bubble preserve null-layer else "
+        "branch must iterate `preservedBubbles` and explicitly call "
+        "`b?.el?.remove()` so detached DOM nodes don't leak."
+    )
+
+
+def test_water_boiler_card_steam_spawn_defers_on_zero_budget():
+    """Review fix #01 finding #5: the spawn-loop `riseBudget <= 0`
+    branch must genuinely defer the spawn slot by advancing the
+    cadence counter (`_nextSteamAt += 1 / STEAM_SPAWN_RATE_HZ`) and
+    `continue`-ing the while loop, NOT clamp `_nextSteamAt` to 0 and
+    `break`.
+
+    The old form (`_nextSteamAt = Math.max(_nextSteamAt, 0); break;`)
+    was a no-op: the while condition `_nextSteamAt <= 0` already
+    guarantees `_nextSteamAt <= 0` on entry, so `Math.max(_, 0)`
+    collapses to `0`. Next frame `_nextSteamAt -= dt` immediately
+    re-enters the loop, runs the random `cxSpawn` + two `Math.sqrt`
+    computations, hits the same branch, breaks — a per-frame CPU spin
+    when the tank is too full for any spawn cx to have positive
+    riseBudget.
+
+    The fix advances the cadence by a real spawn-slot duration so the
+    next attempt waits a full slot."""
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    # Locate the steam spawn while-loop.
+    spawn_idx = executable.find("while (this._nextSteamAt <= 0")
+    assert spawn_idx != -1, (
+        "qs-water-boiler-card.js: missing the steam spawn while loop."
+    )
+    spawn_block = executable[spawn_idx : spawn_idx + 3000]
+    # Pin the riseBudget guard exists in the spawn loop.
+    assert re.search(
+        r"if\s*\(\s*riseBudget\s*<=\s*0\s*\)",
+        spawn_block,
+    ), (
+        "qs-water-boiler-card.js: missing the `if (riseBudget <= 0)` "
+        "guard in the steam spawn loop."
+    )
+    # Pin the proper cadence advance.
+    assert re.search(
+        r"this\._nextSteamAt\s*\+=\s*1\s*/\s*STEAM_SPAWN_RATE_HZ",
+        spawn_block,
+    ), (
+        "qs-water-boiler-card.js: the `if (riseBudget <= 0)` branch "
+        "must advance the cadence with "
+        "`this._nextSteamAt += 1 / STEAM_SPAWN_RATE_HZ` so the spawn "
+        "is genuinely deferred (not no-op-clamped)."
+    )
+    # Pin the `continue` (NOT `break`).
+    assert re.search(
+        r"if\s*\(\s*riseBudget\s*<=\s*0\s*\)\s*\{[^}]*continue\s*;",
+        spawn_block,
+    ), (
+        "qs-water-boiler-card.js: the `if (riseBudget <= 0)` branch "
+        "must use `continue` (re-check the while condition) rather "
+        "than `break` (which would exit the loop with no retry)."
+    )
+    # Negative guard: the old no-op clamp form must NOT appear inside
+    # the riseBudget block.
+    assert not re.search(
+        r"if\s*\(\s*riseBudget\s*<=\s*0\s*\)\s*\{[^}]*Math\.max\s*\(\s*this\._nextSteamAt",
+        spawn_block,
+    ), (
+        "qs-water-boiler-card.js: the no-op clamp "
+        "`Math.max(this._nextSteamAt, 0)` must NOT appear inside the "
+        "riseBudget guard (was the dead-code form before the review "
+        "fix)."
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2327,18 +2327,16 @@ def test_water_boiler_card_steam_spawn_is_boiling_gated():
     )
 
 
-def test_water_boiler_card_steam_pin_at_rim_and_life_retire():
-    """QS-214 pin-at-rim iteration: the per-puff geometry (`dx`,
-    `localChordHalf`, `localTopY`) is unchanged from the AC-4 design,
-    but the abrupt geometric retire `if (p.cy < localTopY) {...remove}`
-    has been replaced by a position pin
-    `if (p.cy < localTopY) p.cy = localTopY` so the puff sits at the
-    local clip-circle top once it arrives. The sole `remove()` branch
-    is now the time-based `p.life >= p.maxLife`, allowing the
-    life-curve fade-out to dissolve the puff in place over the last
-    30% of its life budget. This addresses the user feedback that
-    puffs were "disappearing too abruptly" instead of fading at the
-    rim."""
+def test_water_boiler_card_steam_retire_both_branches():
+    """QS-214 rim-fade iteration: the steam retire predicate covers
+    BOTH branches — `p.cy < localTopY` (reached the local clip-circle
+    top) AND `p.life >= p.maxLife` (hard upper-bound). Either retires.
+    The pin-at-rim experiment was reverted because it left puffs
+    statically pinned for several seconds, which read as "stuck above
+    the surface" rather than "rising and dissipating at the rim". The
+    rim-fade (re-added to the opacity test) makes the geometric retire
+    smooth — by the time the puff's cy reaches localTopY, its opacity
+    is already 0, so the remove is invisible."""
     import re
 
     source = (
@@ -2350,7 +2348,7 @@ def test_water_boiler_card_steam_pin_at_rim_and_life_retire():
         "qs-water-boiler-card.js: missing steam advance loop."
     )
     advance_block = executable[advance_start : advance_start + 1500]
-    # Per-puff geometry (unchanged from AC-4).
+    # Per-puff geometry (unchanged).
     assert re.search(
         r"const\s+dx\s*=\s*p\.cx\s*-\s*CENTER_CX",
         advance_block,
@@ -2377,49 +2375,79 @@ def test_water_boiler_card_steam_pin_at_rim_and_life_retire():
         "`localTopY = CENTER_CY - localChordHalf + STEAM_TOP_MARGIN_PX`"
         " inside the advance loop."
     )
-    # Pin-at-rim: when the puff rises past localTopY, clamp its cy back
-    # down so it sits at the rim instead of being removed.
+    # Disjunctive retire (geometric + time). With the rim-fade in
+    # place the puff is already at opacity 0 by the time `p.cy <
+    # localTopY` fires, so the remove is invisible — no abrupt blink.
     assert re.search(
-        r"if\s*\(\s*p\.cy\s*<\s*localTopY\s*\)\s*p\.cy\s*=\s*localTopY",
+        r"p\.cy\s*<\s*localTopY\s*\|\|\s*p\.life\s*>=\s*p\.maxLife",
         advance_block,
     ), (
-        "qs-water-boiler-card.js: the steam advance loop must pin the "
-        "puff at the local clip-circle top with "
-        "`if (p.cy < localTopY) p.cy = localTopY` — the geometric "
-        "retire was replaced by a position pin so the life-curve fade "
-        "dissolves the puff in place at the rim rather than blinking "
-        "it out."
+        "qs-water-boiler-card.js: the steam retire predicate must be "
+        "exactly `p.cy < localTopY || p.life >= p.maxLife` — both "
+        "branches are required (local clip-top + maxLife)."
     )
-    # Sole remove() branch: time-based retire only. The negative
-    # assertion guards against a future regression that re-introduces
-    # the abrupt `p.cy < localTopY || ...` retire.
-    assert re.search(
-        r"if\s*\(\s*p\.life\s*>=\s*p\.maxLife\s*\)",
-        advance_block,
-    ), (
-        "qs-water-boiler-card.js: the steam advance loop must retire "
-        "on `if (p.life >= p.maxLife)` as the sole time-based remove "
-        "branch."
-    )
+    # Negative guard: the pin-at-rim assignment must NOT appear (it
+    # caused the "stuck above the surface" perception and has been
+    # superseded by the rim-fade design).
     assert not re.search(
-        r"p\.cy\s*<\s*localTopY\s*\|\|", advance_block
+        r"p\.cy\s*=\s*localTopY", advance_block
     ), (
-        "qs-water-boiler-card.js: the abrupt geometric retire "
-        "`p.cy < localTopY || ...` must NOT appear — it was replaced "
-        "by the position pin so the puff fades gracefully at the rim."
+        "qs-water-boiler-card.js: the pin-at-rim assignment "
+        "`p.cy = localTopY` must NOT appear — it was reverted in "
+        "favour of the rim-fade approach."
+    )
+
+
+def test_water_boiler_card_steam_spawn_cx_narrowed_to_central_band():
+    """QS-214 rim-fade iteration: spawn cx is constrained to a narrow
+    central band (CENTER_CX ± STEAM_SPAWN_CX_HALF_PX) regardless of
+    water level, so every spawned puff has a substantial vertical
+    rise budget before hitting the local rim. Previously the spawn
+    range was `chordHalf * 0.85` of the water-surface chord, which
+    let edge-spawned puffs land within 12 px of the local rim for
+    partial water levels — the "stops just above the surface"
+    complaint. The narrow central band guarantees ≥ 110 px of rise
+    for any water level above ≈ y=160 (mid-tank or lower).
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    assert re.search(
+        r"const\s+STEAM_SPAWN_CX_HALF_PX\s*=\s*\d+",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: missing the `STEAM_SPAWN_CX_HALF_PX` "
+        "constant that bounds the spawn cx band around CENTER_CX."
+    )
+    # The spawn formula must clamp the chord-half by
+    # STEAM_SPAWN_CX_HALF_PX so every puff lands in the narrow central
+    # band even when the water-surface chord is wider.
+    assert re.search(
+        r"Math\.min\(\s*[^,]*chordHalf[^,]*,\s*STEAM_SPAWN_CX_HALF_PX\s*\)",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: the steam spawn must clamp the "
+        "spawn-cx half-width to STEAM_SPAWN_CX_HALF_PX, e.g. "
+        "`Math.min(chordHalf * 0.85, STEAM_SPAWN_CX_HALF_PX)`."
     )
 
 
 def test_water_boiler_card_steam_opacity_formula():
-    """QS-214 pin-at-rim iteration: per-frame opacity is the assignment
-    `lifeOpacity * this._currentColorMix` (not a compound `*=`), and
-    the life-curve breakpoints `0.15` (fade-in) and `0.7` (fade-out)
-    appear literally in the steam advance block. The `<circle>` fill
-    is the literal `STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)'` (cool
-    blue-gray tint, alpha 0.45 baked into the SVG fill literal). The
-    rim-fade factor has been removed — the puff is now pinned at
-    `localTopY` and the wider `[0.7, 1.0]` life-curve fade-out band
-    (30% of life) dissolves it gracefully in place at the rim."""
+    """QS-214 per-puff proportional rim-fade iteration: per-frame
+    opacity is `lifeOpacity * rimOpacity * this._currentColorMix`,
+    where `rimOpacity` is the puff's distance below its local rim
+    divided by its STORED `p.fadeBand` (computed at spawn time as
+    `STEAM_RIM_FADE_FRACTION` of the rise budget at that spawn cx).
+    This makes the fade band geometry-aware: center puffs (long rise)
+    get a long fade band; side puffs (short local rise) get a
+    proportionally shorter one. The life-curve breakpoints `0.15`
+    (fade-in) and `0.85` (fade-out — safety branch for puffs that
+    stall via maxLife rather than geometric retire) remain literal in
+    the advance block. The `<circle>` fill is
+    `STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)'`."""
     import re
 
     source = (
@@ -2434,16 +2462,16 @@ def test_water_boiler_card_steam_opacity_formula():
         "`'rgba(195,215,235,0.45)'` (cool blue-gray, alpha 0.45 baked in)."
     )
     assert re.search(
-        r"const\s+opacity\s*=\s*lifeOpacity\s*\*\s*this\._currentColorMix",
+        r"const\s+opacity\s*=\s*lifeOpacity\s*\*\s*rimOpacity\s*\*\s*"
+        r"this\._currentColorMix",
         executable,
     ), (
-        "qs-water-boiler-card.js: the per-frame opacity must be an "
-        "ASSIGNMENT `const opacity = lifeOpacity * this._currentColorMix` "
-        "— the rim-fade factor was removed in favour of pin-at-rim + "
-        "wider life-curve fade-out. Compound `*=` would decay "
-        "exponentially."
+        "qs-water-boiler-card.js: the per-frame opacity must be the "
+        "three-factor product `lifeOpacity * rimOpacity * "
+        "this._currentColorMix` — the rim-fade factor is back, this "
+        "time as a per-puff proportional fade band."
     )
-    # Find the steam advance block and assert breakpoints appear inside it.
+    # Find the steam advance block and assert per-puff fade derivations.
     advance_start = executable.find("for (const p of this._steamPuffs)")
     assert advance_start != -1, (
         "qs-water-boiler-card.js: missing steam advance loop."
@@ -2453,28 +2481,61 @@ def test_water_boiler_card_steam_opacity_formula():
         "qs-water-boiler-card.js: missing the `0.15` fade-in breakpoint "
         "in the steam life-curve."
     )
-    assert re.search(r"lifeT\s*<\s*0\.7\b", advance_block), (
-        "qs-water-boiler-card.js: missing the `lifeT < 0.7` fade-out "
-        "guard in the steam life-curve (widened from 0.85 so the "
-        "fade-out band spans 30% of life)."
+    assert re.search(r"lifeT\s*<\s*0\.85\b", advance_block), (
+        "qs-water-boiler-card.js: missing the `lifeT < 0.85` fade-out "
+        "guard in the steam life-curve (safety branch for puffs that "
+        "stall via maxLife rather than geometric retire)."
     )
     assert re.search(
-        r"\(\s*lifeT\s*-\s*0\.7\s*\)\s*/\s*0\.3", advance_block
+        r"\(\s*lifeT\s*-\s*0\.85\s*\)\s*/\s*0\.15", advance_block
     ), (
-        "qs-water-boiler-card.js: missing the `(lifeT - 0.7) / 0.3` "
+        "qs-water-boiler-card.js: missing the `(lifeT - 0.85) / 0.15` "
         "fade-out ramp in the steam life-curve."
     )
-    # Negative guard: the rim-fade factor (rimDistance / rimOpacity /
-    # STEAM_RIM_FADE_PX) must NOT appear — it was removed in favour of
-    # the pin-at-rim design.
-    assert "rimOpacity" not in advance_block, (
-        "qs-water-boiler-card.js: `rimOpacity` must NOT appear — the "
-        "rim-proximity fade was removed in favour of pin-at-rim + "
-        "life-curve fade-out."
+    # Per-puff rim-fade derivation: rimDistance from p.cy to localTopY,
+    # divided by the STORED p.fadeBand (set at spawn).
+    assert re.search(
+        r"const\s+rimDistance\s*=\s*p\.cy\s*-\s*localTopY",
+        advance_block,
+    ), (
+        "qs-water-boiler-card.js: missing `rimDistance = p.cy - "
+        "localTopY` derivation in the advance loop."
     )
+    assert re.search(
+        r"const\s+rimOpacity\s*=\s*Math\.max\(\s*0\s*,\s*Math\.min\(\s*1\s*,"
+        r"\s*rimDistance\s*/\s*p\.fadeBand\s*\)\s*\)",
+        advance_block,
+    ), (
+        "qs-water-boiler-card.js: missing `rimOpacity = Math.max(0, "
+        "Math.min(1, rimDistance / p.fadeBand))` in the advance loop — "
+        "the fade band is per-puff (stored on the puff at spawn time) "
+        "rather than a global pixel constant."
+    )
+    # The fade band must be assigned at spawn time as a fraction of the
+    # puff's spawn-side rise budget. Pin the constant and the spawn-side
+    # derivation.
+    assert re.search(
+        r"const\s+STEAM_RIM_FADE_FRACTION\s*=\s*0\.\d+",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: missing the STEAM_RIM_FADE_FRACTION "
+        "constant — controls the per-puff fade band as a fraction of "
+        "the puff's rise budget."
+    )
+    assert re.search(
+        r"fadeBand\s*[:=]\s*[^,;\n]*STEAM_RIM_FADE_FRACTION",
+        executable,
+    ), (
+        "qs-water-boiler-card.js: the spawn loop must store a per-puff "
+        "`fadeBand` computed from `STEAM_RIM_FADE_FRACTION` times the "
+        "puff's rise budget."
+    )
+    # Negative guard: the global STEAM_RIM_FADE_PX constant must NOT
+    # appear (replaced by the per-puff fadeBand).
     assert "STEAM_RIM_FADE_PX" not in executable, (
         "qs-water-boiler-card.js: `STEAM_RIM_FADE_PX` constant must "
-        "NOT appear — removed in the pin-at-rim iteration."
+        "NOT appear — replaced by the per-puff `STEAM_RIM_FADE_FRACTION` "
+        "scaled by the per-puff rise budget."
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2327,75 +2327,99 @@ def test_water_boiler_card_steam_spawn_is_boiling_gated():
     )
 
 
-def test_water_boiler_card_steam_retire_both_branches():
-    """QS-214 AC-4: the steam retire predicate covers BOTH branches —
-    `p.cy < localTopY` (reached the local clip-circle top at the
-    puff's current x) AND `p.life >= p.maxLife` (hard upper-bound).
-    Either condition retires the puff. The per-puff `localTopY`
-    derivation replaces QS-211's global `topY = CENTER_CY - CLIP_R +
-    STEAM_TOP_MARGIN_PX` so puffs drifting toward the rim retire at
-    the local clip top rather than continuing invisibly toward the
-    global apex."""
+def test_water_boiler_card_steam_pin_at_rim_and_life_retire():
+    """QS-214 pin-at-rim iteration: the per-puff geometry (`dx`,
+    `localChordHalf`, `localTopY`) is unchanged from the AC-4 design,
+    but the abrupt geometric retire `if (p.cy < localTopY) {...remove}`
+    has been replaced by a position pin
+    `if (p.cy < localTopY) p.cy = localTopY` so the puff sits at the
+    local clip-circle top once it arrives. The sole `remove()` branch
+    is now the time-based `p.life >= p.maxLife`, allowing the
+    life-curve fade-out to dissolve the puff in place over the last
+    30% of its life budget. This addresses the user feedback that
+    puffs were "disappearing too abruptly" instead of fading at the
+    rim."""
     import re
 
     source = (
         COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
     ).read_text()
     executable = _strip_js_comments(source)
-    # Find the steam advance block and assert the per-puff geometry
-    # appears inside it (mirrors the opacity test's window extraction).
     advance_start = executable.find("for (const p of this._steamPuffs)")
     assert advance_start != -1, (
         "qs-water-boiler-card.js: missing steam advance loop."
     )
     advance_block = executable[advance_start : advance_start + 1500]
-    assert re.search(
-        r"p\.cy\s*<\s*localTopY\s*\|\|\s*p\.life\s*>=\s*p\.maxLife",
-        advance_block,
-    ), (
-        "qs-water-boiler-card.js: the steam retire predicate must be "
-        "exactly `p.cy < localTopY || p.life >= p.maxLife` — both "
-        "branches are required (local clip-top + maxLife)."
-    )
+    # Per-puff geometry (unchanged from AC-4).
     assert re.search(
         r"const\s+dx\s*=\s*p\.cx\s*-\s*CENTER_CX",
         advance_block,
     ), (
-        "qs-water-boiler-card.js: the per-puff retire geometry must "
-        "derive `dx = p.cx - CENTER_CX` inside the advance loop."
+        "qs-water-boiler-card.js: the per-puff geometry must derive "
+        "`dx = p.cx - CENTER_CX` inside the advance loop."
     )
     assert re.search(
         r"const\s+localChordHalf\s*=\s*Math\.sqrt\(\s*Math\.max\(\s*0\s*,\s*"
         r"CLIP_R\s*\*\s*CLIP_R\s*-\s*dx\s*\*\s*dx\s*\)\s*\)",
         advance_block,
     ), (
-        "qs-water-boiler-card.js: the per-puff retire geometry must "
-        "derive `localChordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R "
-        "- dx * dx))` inside the advance loop (mirrors the spawn-side "
-        "chord-half formula)."
+        "qs-water-boiler-card.js: the per-puff geometry must derive "
+        "`localChordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dx * "
+        "dx))` inside the advance loop (mirrors the spawn-side chord-"
+        "half formula)."
     )
     assert re.search(
         r"const\s+localTopY\s*=\s*CENTER_CY\s*-\s*localChordHalf\s*\+\s*"
         r"STEAM_TOP_MARGIN_PX",
         advance_block,
     ), (
-        "qs-water-boiler-card.js: the per-puff retire geometry must "
-        "derive `localTopY = CENTER_CY - localChordHalf + "
-        "STEAM_TOP_MARGIN_PX` inside the advance loop."
+        "qs-water-boiler-card.js: the per-puff geometry must derive "
+        "`localTopY = CENTER_CY - localChordHalf + STEAM_TOP_MARGIN_PX`"
+        " inside the advance loop."
+    )
+    # Pin-at-rim: when the puff rises past localTopY, clamp its cy back
+    # down so it sits at the rim instead of being removed.
+    assert re.search(
+        r"if\s*\(\s*p\.cy\s*<\s*localTopY\s*\)\s*p\.cy\s*=\s*localTopY",
+        advance_block,
+    ), (
+        "qs-water-boiler-card.js: the steam advance loop must pin the "
+        "puff at the local clip-circle top with "
+        "`if (p.cy < localTopY) p.cy = localTopY` — the geometric "
+        "retire was replaced by a position pin so the life-curve fade "
+        "dissolves the puff in place at the rim rather than blinking "
+        "it out."
+    )
+    # Sole remove() branch: time-based retire only. The negative
+    # assertion guards against a future regression that re-introduces
+    # the abrupt `p.cy < localTopY || ...` retire.
+    assert re.search(
+        r"if\s*\(\s*p\.life\s*>=\s*p\.maxLife\s*\)",
+        advance_block,
+    ), (
+        "qs-water-boiler-card.js: the steam advance loop must retire "
+        "on `if (p.life >= p.maxLife)` as the sole time-based remove "
+        "branch."
+    )
+    assert not re.search(
+        r"p\.cy\s*<\s*localTopY\s*\|\|", advance_block
+    ), (
+        "qs-water-boiler-card.js: the abrupt geometric retire "
+        "`p.cy < localTopY || ...` must NOT appear — it was replaced "
+        "by the position pin so the puff fades gracefully at the rim."
     )
 
 
 def test_water_boiler_card_steam_opacity_formula():
-    """QS-214 AC-1/AC-3 + rim-fade iteration: per-frame opacity is the
-    assignment `lifeOpacity * rimOpacity * this._currentColorMix` (not
-    a compound `*=`), and the life-curve breakpoints `0.15` (fade-in)
-    and `0.85` (fade-out) appear literally in the steam advance block.
-    The `<circle>` fill is the literal `STEAM_FILL_COLOR =
-    'rgba(195,215,235,0.45)'` (cool blue-gray tint, alpha 0.45 baked
-    into the SVG fill literal). The rim-fade factor (`rimOpacity`)
-    fades each puff out gracefully as it approaches `localTopY`, so
-    puffs dissolve at the local clip-circle top instead of blinking
-    out on the geometric retire."""
+    """QS-214 pin-at-rim iteration: per-frame opacity is the assignment
+    `lifeOpacity * this._currentColorMix` (not a compound `*=`), and
+    the life-curve breakpoints `0.15` (fade-in) and `0.7` (fade-out)
+    appear literally in the steam advance block. The `<circle>` fill
+    is the literal `STEAM_FILL_COLOR = 'rgba(195,215,235,0.45)'` (cool
+    blue-gray tint, alpha 0.45 baked into the SVG fill literal). The
+    rim-fade factor has been removed — the puff is now pinned at
+    `localTopY` and the wider `[0.7, 1.0]` life-curve fade-out band
+    (30% of life) dissolves it gracefully in place at the rim."""
     import re
 
     source = (
@@ -2410,58 +2434,47 @@ def test_water_boiler_card_steam_opacity_formula():
         "`'rgba(195,215,235,0.45)'` (cool blue-gray, alpha 0.45 baked in)."
     )
     assert re.search(
-        r"const\s+opacity\s*=\s*lifeOpacity\s*\*\s*rimOpacity\s*\*\s*"
-        r"this\._currentColorMix",
+        r"const\s+opacity\s*=\s*lifeOpacity\s*\*\s*this\._currentColorMix",
         executable,
     ), (
         "qs-water-boiler-card.js: the per-frame opacity must be an "
-        "ASSIGNMENT `const opacity = lifeOpacity * rimOpacity * "
-        "this._currentColorMix` — both `lifeOpacity` (life-curve fade) "
-        "AND `rimOpacity` (rim-proximity fade) multiply through with "
-        "the colorMix cross-fade. Compound `*=` would decay exponentially."
+        "ASSIGNMENT `const opacity = lifeOpacity * this._currentColorMix` "
+        "— the rim-fade factor was removed in favour of pin-at-rim + "
+        "wider life-curve fade-out. Compound `*=` would decay "
+        "exponentially."
     )
-    # Find the steam advance block and assert breakpoints + rim-fade
-    # derivations appear inside it.
+    # Find the steam advance block and assert breakpoints appear inside it.
     advance_start = executable.find("for (const p of this._steamPuffs)")
     assert advance_start != -1, (
         "qs-water-boiler-card.js: missing steam advance loop."
     )
-    # Take a window large enough to cover the life-curve branches.
     advance_block = executable[advance_start : advance_start + 1500]
     assert "0.15" in advance_block, (
         "qs-water-boiler-card.js: missing the `0.15` fade-in breakpoint "
         "in the steam life-curve."
     )
-    assert re.search(r"lifeT\s*<\s*0\.85", advance_block), (
-        "qs-water-boiler-card.js: missing the `lifeT < 0.85` fade-out "
-        "guard in the steam life-curve."
+    assert re.search(r"lifeT\s*<\s*0\.7\b", advance_block), (
+        "qs-water-boiler-card.js: missing the `lifeT < 0.7` fade-out "
+        "guard in the steam life-curve (widened from 0.85 so the "
+        "fade-out band spans 30% of life)."
     )
     assert re.search(
-        r"\(\s*lifeT\s*-\s*0\.85\s*\)\s*/\s*0\.15", advance_block
+        r"\(\s*lifeT\s*-\s*0\.7\s*\)\s*/\s*0\.3", advance_block
     ), (
-        "qs-water-boiler-card.js: missing the `(lifeT - 0.85) / 0.15` "
+        "qs-water-boiler-card.js: missing the `(lifeT - 0.7) / 0.3` "
         "fade-out ramp in the steam life-curve."
     )
-    # Rim-proximity fade derivation. The puff fades to 0 over the last
-    # `STEAM_RIM_FADE_PX` pixels below `localTopY`, so it dissolves at
-    # the local clip-circle top instead of vanishing in one frame.
-    assert re.search(
-        r"const\s+rimDistance\s*=\s*p\.cy\s*-\s*localTopY",
-        advance_block,
-    ), (
-        "qs-water-boiler-card.js: missing `rimDistance = p.cy - "
-        "localTopY` derivation inside the steam advance loop — this is "
-        "the input to the rim-proximity fade."
+    # Negative guard: the rim-fade factor (rimDistance / rimOpacity /
+    # STEAM_RIM_FADE_PX) must NOT appear — it was removed in favour of
+    # the pin-at-rim design.
+    assert "rimOpacity" not in advance_block, (
+        "qs-water-boiler-card.js: `rimOpacity` must NOT appear — the "
+        "rim-proximity fade was removed in favour of pin-at-rim + "
+        "life-curve fade-out."
     )
-    assert re.search(
-        r"const\s+rimOpacity\s*=\s*Math\.max\(\s*0\s*,\s*Math\.min\(\s*1\s*,"
-        r"\s*rimDistance\s*/\s*STEAM_RIM_FADE_PX\s*\)\s*\)",
-        advance_block,
-    ), (
-        "qs-water-boiler-card.js: missing `rimOpacity = "
-        "Math.max(0, Math.min(1, rimDistance / STEAM_RIM_FADE_PX))` "
-        "derivation inside the steam advance loop — this is the "
-        "rim-proximity fade factor."
+    assert "STEAM_RIM_FADE_PX" not in executable, (
+        "qs-water-boiler-card.js: `STEAM_RIM_FADE_PX` constant must "
+        "NOT appear — removed in the pin-at-rim iteration."
     )
 
 


### PR DESCRIPTION
## Summary
- STEAM_FILL_COLOR tinted cool blue-gray rgba(195,215,235,0.45) for visibility against dark HA themes (user ask: 'tint it more grey/bluewish').
- Rise budget widened (STEAM_MAX_LIFE_S 4.5->8.0, STEAM_RISE_PX_PER_S_* [10,22]->[18,32]) so fast puffs reach the rim (user ask: 'goes higher up to the circle up limit').
- Retire predicate refactored to a per-puff circle-aware localTopY (= CENTER_CY - sqrt(CLIP_R^2 - dx^2) + STEAM_TOP_MARGIN_PX) so puffs drifting toward the rim retire at the local clip top, not the global apex (user ask: 'never cross the cricle').

Fixes #214

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Water boiler card steam visuals updated with a new blue-gray color and refined particle opacity curves.
  * Steam particle rise and retirement behavior enhanced for smoother motion transitions.

* **Documentation**
  * Updated reference documentation for water boiler steam mechanics and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->