### PR TITLE
QS-216: preserve in-flight snowflakes across _render() innerHTML rewrites

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -1316,6 +1316,25 @@ class QsClimateCard extends HTMLElement {
       const finishTimeStr = sDefaultOnFinishTime?.state || '07:00:00';
       const finishTimeMins = this._localFinishTimeMins != null ? this._localFinishTimeMins : parseTimeToMinutes(finishTimeStr);
 
+      // QS-216: snapshot the in-flight snowflakes BEFORE the
+      // innerHTML rewrite below. The rewrite detaches every DOM node
+      // under `this._root`, including the snow layer's children.
+      // Without this snapshot, every HA state push (which fires
+      // `set hass → _render`) wipes the entire snowflake array via
+      // the post-innerHTML `_invalidateSnowCache()` call (~once per
+      // second). Mirror of QS-214's boiler steam-puff + bubble
+      // preservation. The `b.el` references survive detachment (JS
+      // still holds them); we re-attach them to the new snow layer
+      // after `_invalidateSnowCache()` below. `_nextSnowflakeAt` is
+      // also preserved so the next spawn doesn't reset to 0 (which
+      // would burst-spawn on every push). On a cold render before
+      // `_startAnimation` or the snow backdrop-transition block has
+      // run, `this._snowflakes` and `this._nextSnowflakeAt` may be
+      // `undefined`; the restore-block's `?.length` guard handles
+      // that safely.
+      const preservedSnowflakes = this._snowflakes;
+      const preservedNextSnowflakeAt = this._nextSnowflakeAt;
+
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
         <style>${css}</style>
@@ -1461,6 +1480,56 @@ class QsClimateCard extends HTMLElement {
       this._invalidateFlameCache();
       this._invalidateSnowCache();
       this._invalidateWindCache();
+
+      // QS-216: restore the preserved snowflakes into the FRESH snow
+      // layer (its DOM identity changed via innerHTML — same `id`,
+      // new element). For each preserved flake, re-attach its
+      // detached `el` to the new layer; the per-flake state (cx, cy,
+      // r, vy, life, maxLife) survived in the JS array, so the RAF
+      // advance loop in `_stepSnow` picks up exactly where it left
+      // off with no visual blink. `_nextSnowflakeAt` is restored so
+      // spawn cadence is continuous.
+      //
+      // Ordering invariant (AC-4): this restore runs AFTER both the
+      // innerHTML rewrite and `_invalidateSnowCache()`. The snapshot
+      // captured the array reference before any mutation; the
+      // innerHTML rewrite + `_invalidateSnowCache()` performed their
+      // normal cleanup against the *instance* fields (reassigning
+      // `this._snowflakes = []`, nulling `this._snowLayerEl`,
+      // zeroing `this._nextSnowflakeAt`). The local
+      // `preservedSnowflakes` const still holds the original array
+      // reference; `_invalidateSnowCache()` calls `b.el?.remove?.()`
+      // (does NOT null `b.el`), so each preserved entry's DOM ref
+      // survives intact for re-attachment via `appendChild`.
+      if (preservedSnowflakes?.length) {
+        const newSnowLayer = this._snowLayerId
+          ? this._root.getElementById(this._snowLayerId)
+          : null;
+        if (newSnowLayer) {
+          for (const b of preservedSnowflakes) {
+            if (b?.el) newSnowLayer.appendChild(b.el);
+          }
+          // .filter aligns the array with the truthy set we just
+          // re-attached, so the advance loop never has to defensively
+          // null-check b.el (mirror of boiler steam-puff pattern).
+          this._snowflakes = preservedSnowflakes.filter(b => b?.el);
+          this._snowLayerEl = newSnowLayer;
+          this._nextSnowflakeAt = preservedNextSnowflakeAt;
+        } else {
+          // Unlike the boiler (which ALWAYS renders the steam layer),
+          // the climate card emits the snow <g> only when
+          // `_backdrop === 'snow'`. This branch is therefore a real
+          // backdrop-transition path (flakes from a 'snow' render
+          // arriving at a 'flame'/'wind'/'none' render), not just
+          // defensive belt-and-braces. Explicitly remove each preserved
+          // flake's DOM and reset the logical array so detached nodes
+          // don't leak. `_snowLayerEl` was already nulled by
+          // `_invalidateSnowCache()` above, so no extra cleanup needed
+          // there (mirror of boiler's `_resetDomRefs()` semantics).
+          for (const b of preservedSnowflakes) { b?.el?.remove(); }
+          this._snowflakes = [];
+        }
+      }
 
       // Wire events
       const root = this._root;

--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -389,17 +389,13 @@ class QsClimateCard extends HTMLElement {
 
       // Advance + retire active snowflakes regardless of running state.
       //
-      // Pass-#2 S2 note — this is an in-render graceful exit ONLY: a
-      // running→off transition that doesn't trigger a re-render lets
-      // active flakes finish their fall naturally. But the M1 (pass
-      // #1) post-innerHTML `_invalidateSnowCache()` wipes
-      // `_snowflakes = []` on every hass push (~once per second), so
-      // cross-render flakes do NOT survive in practice. The visual
-      // effect is acceptable because the wipe coincides with an
-      // innerHTML rewrite that also detaches the parent `<g>` —
-      // the user would have seen the flakes blink in either case.
-      // Re-parenting live `<circle>` nodes into the new `<g>` is a
-      // valid stretch goal but out of scope (deferred to a follow-up).
+      // QS-216 — cross-render flakes NOW survive same-backdrop
+      // re-renders: `_render()` snapshots `_snowflakes` BEFORE the
+      // innerHTML rewrite and re-attaches each `<circle>` to the
+      // fresh snow layer AFTER `_invalidateSnowCache()` (see AC-2).
+      // Flakes are still cleared on `disconnectedCallback` and on
+      // real backdrop transitions away from 'snow' (restore-block
+      // null-layer branch).
       // Pass-#3 N2 — when `_snowBaseY` is null (no valid pile base
       // computed yet, e.g. cold-start before the first render finishes
       // populating snow geometry), fall back to the BOTTOM of the
@@ -528,14 +524,16 @@ class QsClimateCard extends HTMLElement {
     this._snowLayerEl = null;
     this._lastSnowBaseY = null;
     this._lastSnowAmp = null;
-    // Review-fix N7 — defensive: the upcoming innerHTML rewrite (or
-    // post-disconnect cleanup) wipes the parent `<g>` anyway, so the
-    // explicit `.remove()` calls are redundant in the rewrite path.
-    // They DO matter on the `disconnectedCallback` path where there is
-    // no rewrite, and they keep `_snowflakes.length` from drifting up
-    // toward MAX_CONCURRENT_SNOWFLAKES across re-renders.
-    if (this._snowflakes && this._snowflakes.length) {
-      this._snowflakes.forEach(b => b.el?.remove?.());
+    // QS-216 — same-backdrop re-renders preserve flakes via
+    // _render()'s snapshot/restore block (AC-2); this reset only
+    // governs `disconnectedCallback` and real backdrop transitions
+    // away from 'snow'. Critical invariant (AC-3): do NOT null
+    // `b.el` — the truthy-branch restore filter `(b => b?.el)`
+    // would silently drop anything we null here.
+    if (this._snowflakes) {
+      for (const b of this._snowflakes) {
+        b?.el?.remove?.();
+      }
       this._snowflakes = [];
     }
     this._nextSnowflakeAt = 0;
@@ -1316,22 +1314,11 @@ class QsClimateCard extends HTMLElement {
       const finishTimeStr = sDefaultOnFinishTime?.state || '07:00:00';
       const finishTimeMins = this._localFinishTimeMins != null ? this._localFinishTimeMins : parseTimeToMinutes(finishTimeStr);
 
-      // QS-216: snapshot the in-flight snowflakes BEFORE the
-      // innerHTML rewrite below. The rewrite detaches every DOM node
-      // under `this._root`, including the snow layer's children.
-      // Without this snapshot, every HA state push (which fires
-      // `set hass → _render`) wipes the entire snowflake array via
-      // the post-innerHTML `_invalidateSnowCache()` call (~once per
-      // second). Mirror of QS-214's boiler steam-puff + bubble
-      // preservation. The `b.el` references survive detachment (JS
-      // still holds them); we re-attach them to the new snow layer
-      // after `_invalidateSnowCache()` below. `_nextSnowflakeAt` is
-      // also preserved so the next spawn doesn't reset to 0 (which
-      // would burst-spawn on every push). On a cold render before
-      // `_startAnimation` or the snow backdrop-transition block has
-      // run, `this._snowflakes` and `this._nextSnowflakeAt` may be
-      // `undefined`; the restore-block's `?.length` guard handles
-      // that safely.
+      // QS-216 AC-1 — snapshot in-flight snowflakes before the
+      // innerHTML rewrite (mirror of QS-214 boiler precedent). Both
+      // locals may capture `undefined` on a cold render; the restore
+      // block's `?.length` guard handles that. See AC-2 + AC-4 for
+      // the restore + ordering invariant.
       const preservedSnowflakes = this._snowflakes;
       const preservedNextSnowflakeAt = this._nextSnowflakeAt;
 
@@ -1481,26 +1468,11 @@ class QsClimateCard extends HTMLElement {
       this._invalidateSnowCache();
       this._invalidateWindCache();
 
-      // QS-216: restore the preserved snowflakes into the FRESH snow
-      // layer (its DOM identity changed via innerHTML — same `id`,
-      // new element). For each preserved flake, re-attach its
-      // detached `el` to the new layer; the per-flake state (cx, cy,
-      // r, vy, life, maxLife) survived in the JS array, so the RAF
-      // advance loop in `_stepSnow` picks up exactly where it left
-      // off with no visual blink. `_nextSnowflakeAt` is restored so
-      // spawn cadence is continuous.
-      //
-      // Ordering invariant (AC-4): this restore runs AFTER both the
-      // innerHTML rewrite and `_invalidateSnowCache()`. The snapshot
-      // captured the array reference before any mutation; the
-      // innerHTML rewrite + `_invalidateSnowCache()` performed their
-      // normal cleanup against the *instance* fields (reassigning
-      // `this._snowflakes = []`, nulling `this._snowLayerEl`,
-      // zeroing `this._nextSnowflakeAt`). The local
-      // `preservedSnowflakes` const still holds the original array
-      // reference; `_invalidateSnowCache()` calls `b.el?.remove?.()`
-      // (does NOT null `b.el`), so each preserved entry's DOM ref
-      // survives intact for re-attachment via `appendChild`.
+      // QS-216 AC-2/AC-4 — restore snapshot into the fresh snow
+      // layer AFTER the _invalidate*Cache() triplet (mirror of QS-214
+      // boiler). The null-layer else is the real backdrop-transition
+      // path (snow `<g>` is emitted only when `_backdrop === 'snow'`),
+      // not just defensive belt-and-braces.
       if (preservedSnowflakes?.length) {
         const newSnowLayer = this._snowLayerId
           ? this._root.getElementById(this._snowLayerId)
@@ -1509,24 +1481,17 @@ class QsClimateCard extends HTMLElement {
           for (const b of preservedSnowflakes) {
             if (b?.el) newSnowLayer.appendChild(b.el);
           }
-          // .filter aligns the array with the truthy set we just
-          // re-attached, so the advance loop never has to defensively
-          // null-check b.el (mirror of boiler steam-puff pattern).
+          // N8 — `.filter` builds a fresh array. All hot-path code
+          // (`_stepSnow`, `_invalidateSnowCache`) reads `this._snowflakes`
+          // each call, so the new reference is safe; do not pass the
+          // original `preservedSnowflakes` const to any closure.
           this._snowflakes = preservedSnowflakes.filter(b => b?.el);
           this._snowLayerEl = newSnowLayer;
           this._nextSnowflakeAt = preservedNextSnowflakeAt;
         } else {
-          // Unlike the boiler (which ALWAYS renders the steam layer),
-          // the climate card emits the snow <g> only when
-          // `_backdrop === 'snow'`. This branch is therefore a real
-          // backdrop-transition path (flakes from a 'snow' render
-          // arriving at a 'flame'/'wind'/'none' render), not just
-          // defensive belt-and-braces. Explicitly remove each preserved
-          // flake's DOM and reset the logical array so detached nodes
-          // don't leak. `_snowLayerEl` was already nulled by
-          // `_invalidateSnowCache()` above, so no extra cleanup needed
-          // there (mirror of boiler's `_resetDomRefs()` semantics).
-          for (const b of preservedSnowflakes) { b?.el?.remove(); }
+          for (const b of preservedSnowflakes) {
+            b?.el?.remove();
+          }
           this._snowflakes = [];
         }
       }

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -464,8 +464,13 @@ accumulators (`_currentFlameAmp`, `_currentSnowAmp`,
 deliberately survive both `_stopAnimation` and the post-rewrite
 invalidation so re-attach picks up where it left off without a
 visible snap. QS-216 — snowflake array now survives innerHTML via a
-snapshot/restore block bracketing the `_invalidate*Cache()` triplet;
-`_invalidateSnowCache` itself is unchanged.
+snapshot/restore block bracketing the `_invalidate*Cache()` triplet.
+`_invalidateSnowCache` itself still calls `.remove()` on each flake
+and clears `_snowflakes = []` (it governs the
+`disconnectedCallback` + real-backdrop-transition paths) but the
+body MUST NOT null `b.el` — the truthy-branch restore filter
+`(b => b?.el)` silently drops anything nulled there. Pinned by
+`test_invalidate_snow_cache_does_not_null_el` (review-fix #01 S2).
 
 **Snow-mode cold-start defence.** A cold start straight into
 `'snow'` mode (e.g. `climate_state_on === 'cool'` on first paint)

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -463,7 +463,9 @@ accumulators (`_currentFlameAmp`, `_currentSnowAmp`,
 `_currentSnowSpeed`, `_snowWavePhase`, `_windPhase`, `_tipPhases`)
 deliberately survive both `_stopAnimation` and the post-rewrite
 invalidation so re-attach picks up where it left off without a
-visible snap.
+visible snap. QS-216 — snowflake array now survives innerHTML via a
+snapshot/restore block bracketing the `_invalidate*Cache()` triplet;
+`_invalidateSnowCache` itself is unchanged.
 
 **Snow-mode cold-start defence.** A cold start straight into
 `'snow'` mode (e.g. `climate_state_on === 'cool'` on first paint)
@@ -476,6 +478,21 @@ the four sibling fields still initialise correctly. The N5 block
 also defensively initialises `_snowflakes`, `_snowWavePhase`, and
 `_nextSnowflakeAt` itself — belt + braces, robust to either
 init-order.
+
+**QS-216 — snowflake preservation across `innerHTML`.** Mirror of
+the QS-214 boiler steam-puff and bubble preservation. `_render()`
+snapshots `_snowflakes` and `_nextSnowflakeAt` BEFORE the
+innerHTML rewrite, then re-attaches each preserved `<circle>` to
+the freshly-rendered snow layer AFTER the three
+`_invalidate*Cache()` calls. Without this, every HA state push
+wiped every in-flight snowflake simultaneously (`_invalidateSnowCache`
+calls `b.el.remove()` on each then sets `_snowflakes = []`) — the
+same systemic wipe pathology QS-214 fixed for boiler steam. Unlike
+the boiler, which always renders the steam layer, the climate
+card emits the snow `<g>` only when `_backdrop === 'snow'`; the
+restore's null-layer branch is therefore a real backdrop-transition
+path (not just defensive) and explicitly removes the preserved
+flakes' detached DOM so they don't leak.
 
 ## Hardened JS-card patterns (QS-194 review-fix #03)
 

--- a/docs/stories/QS-216.story.md
+++ b/docs/stories/QS-216.story.md
@@ -165,20 +165,29 @@ case — `undefined?.length` is `undefined`, falsy.
   }
   ```
 
-- **AC-3 — `_invalidateSnowCache()` is left unchanged.**
-  The function continues to clear `_snowflakes = []` + call `.remove()`
-  on each existing flake + zero `_nextSnowflakeAt`. The boiler's
-  symmetric helper (`_resetDomRefs()`) follows the same pattern. Why
-  it's safe: `_invalidateSnowCache()` mutates the *instance* field
+- **AC-3 — `_invalidateSnowCache()` MUST NOT null `b.el`.**
+  Review-fix #01 N7 expanded scope beyond the original "left
+  unchanged" wording: the function body may be simplified (e.g.
+  `forEach` → `for…of`, drop redundant `.length` guard) provided the
+  hard invariant holds — **no assignment to `b.el`** anywhere in the
+  function. The function still calls `.remove()` on each existing
+  flake's `el`, clears `_snowflakes = []`, and zeroes
+  `_nextSnowflakeAt`. Why the invariant matters:
+  `_invalidateSnowCache()` mutates the *instance* field
   `this._snowflakes` (reassigns to `[]`) but does NOT touch the local
   `const preservedSnowflakes` (which still holds the original array
   reference). The `.remove()` calls on each `b.el` detach the DOM
   nodes from any parent (a no-op at this point because the innerHTML
   rewrite already orphaned them) but do NOT null `b.el` — so
   `appendChild(b.el)` in the restore block successfully re-attaches
-  them to the new snow layer. The disconnect path
-  (`disconnectedCallback → _invalidateSnowCache`) is unaffected — full
-  cleanup remains.
+  them to the new snow layer. The truthy-branch restore filter
+  `(b => b?.el)` silently drops anything we null here; pinning the
+  no-null invariant is what makes the filter safe. The disconnect
+  path (`disconnectedCallback → _invalidateSnowCache`) is unaffected
+  — full cleanup remains. Tests
+  `test_invalidate_snow_cache_does_not_null_el` (review-fix #01 S2)
+  pin both the positive `.remove()` call and the negative
+  no-`b.el = …` assignment.
 
 - **AC-4 — Ordering invariant.**
   The restore block MUST run AFTER `_invalidateSnowCache()` and AFTER
@@ -189,28 +198,38 @@ case — `undefined?.length` is `undefined`, falsy.
   cleanup against the *instance* fields, then the restore reassigns
   the instance fields from the snapshot.
 
-- **AC-5 — Tests pin the snapshot/restore pattern.**
+- **AC-5 — Tests pin the snapshot/restore pattern + ordering +
+  invariant.**
   A new test in `tests/test_dashboard_rendering.py`, named
   `test_climate_card_render_preserves_snowflakes_across_innerhtml`,
   mirrors the boiler test
-  `test_water_boiler_card_render_preserves_steam_puffs_across_innerhtml`
-  (currently at lines 2438-2530). It uses the existing
-  `_strip_js_comments` helper and asserts seven regex patterns against
-  `qs-climate-card.js`:
+  `test_water_boiler_card_render_preserves_steam_puffs_across_innerhtml`.
+  It uses the existing `_strip_js_comments` helper and asserts six
+  content regex patterns against `qs-climate-card.js` (review-fix
+  #01 N2 dropped a seventh regex that was a strict subset of the
+  `.filter(...)` form):
   1. `r"const\s+preservedSnowflakes\s*=\s*this\._snowflakes"`
   2. `r"const\s+preservedNextSnowflakeAt\s*=\s*this\._nextSnowflakeAt"`
   3. `r"newSnowLayer\.appendChild\s*\(\s*b\.el\s*\)"`
-  4. `r"this\._snowflakes\s*=\s*preservedSnowflakes"` (matches both
-     the bare restore AND the `.filter(...)` variant — same pattern
-     the boiler test uses)
-  5. `r"this\._nextSnowflakeAt\s*=\s*preservedNextSnowflakeAt"`
-  6. `r"this\._snowflakes\s*=\s*preservedSnowflakes\.filter\(\s*b\s*=>\s*b\?\.el\s*\)"`
-  7. `r"for\s*\(\s*const\s+b\s+of\s+preservedSnowflakes\s*\)\s*\{\s*b\?\.el\?\.remove\s*\(\s*\)\s*;?\s*\}"`
+  4. `r"this\._nextSnowflakeAt\s*=\s*preservedNextSnowflakeAt"`
+  5. `r"this\._snowflakes\s*=\s*preservedSnowflakes\.filter\(\s*b\s*=>\s*b\?\.el\s*\)"`
+  6. `r"for\s*\(\s*const\s+b\s+of\s+preservedSnowflakes\s*\)\s*\{\s*b\?\.el\?\.remove\s*\(\s*\)\s*;?\s*\}"`
 
-  Failure messages cite `qs-climate-card.js` and `_render()` per the
-  boiler test style. The variable name `b` (not `p`) matches the
-  existing `_stepSnow` advance-loop convention (line 416) and the
-  boiler **bubble** preservation test's variable choice.
+  A follow-on block (review-fix #01 S1) pins the AC-4 ordering
+  invariant via character-offset comparisons on the stripped source:
+  `preservedSnowflakes` / `preservedNextSnowflakeAt` MUST appear
+  BEFORE `this._root.innerHTML`, and `newSnowLayer.appendChild(b.el)`
+  MUST appear AFTER each of the three `_invalidate*Cache()` calls.
+
+  A sibling test `test_invalidate_snow_cache_does_not_null_el`
+  (review-fix #01 S2) extracts the `_invalidateSnowCache()` body via
+  `_extract_js_function_body` and pins the AC-3 invariant
+  (positive `.remove()` call, negative no-`b.el = …` assignment).
+
+  Failure messages cite `qs-climate-card.js` per the boiler test
+  style. The variable name `b` (not `p`) matches the existing
+  `_stepSnow` advance-loop convention and the boiler **bubble**
+  preservation test's variable choice.
 
 - **AC-6 — Doc updated.**
   `docs/agents/concepts/dashboard-and-cards.md` gains a paragraph
@@ -370,78 +389,27 @@ gh PR template.
 
 ## Adversarial review notes
 
-Four plan-reviewer sub-agents ran in parallel
-(`qs-plan-critic`, `qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
-`qs-plan-scope-guardian`). Synthesised findings + decisions:
+Four plan-reviewer sub-agents ran in parallel (`qs-plan-critic`,
+`qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
+`qs-plan-scope-guardian`). Decisions are encoded directly in the AC
+text; this section retains only the routing-by-reviewer summary:
 
-### Critical (3)
+- **critic** — pinned ordering (AC-4) + no-`b.el =` invariant
+  (AC-3); inlined AC-5 regex patterns; pinned `const` (AC-1);
+  syntactic anchors in Tasks. Rejected: redundant
+  `_snowLayerEl = null` in null-layer else.
+- **concrete-planner** — confirmed `_invalidateSnowCache` doesn't
+  null `b.el`; flagged undefined-at-snapshot (handled by `?.length`);
+  confirmed null-layer else is a real backdrop-transition path;
+  `last_verified` already today's date.
+- **dev-proxy** — required self-contained story (AC-2/AC-5/Task 2
+  inline all code); pinned UI-only fast-path (AC-7); quoted user
+  authorization in "Why".
+- **scope-guardian** — documented radiator exclusion in per-card
+  audit + "Out of scope" item 5; defended test-depth parity.
 
-- **critic — pin snapshot/clear ordering.** Risk: if
-  `_invalidateSnowCache` nulled `b.el` (rather than just calling
-  `.remove()`), the restore would silently drop everything via the
-  `.filter(b => b?.el)`. **Verified by concrete-planner**: the function
-  calls `b.el?.remove?.()` (no nulling). **Resolution**: comment in
-  AC-3 explicitly pins the ordering invariant and the no-nulling
-  contract.
-- **dev-proxy — inline boiler JS + regex patterns.** The story must
-  be self-contained enough that `implement-task` doesn't have to
-  re-discover the boiler pattern. **Resolution**: AC-2 inlines the
-  full restore block; AC-5 inlines all seven regex patterns; the
-  snapshot block is also inlined in Task 2.
-
-### Redesign (proposed → rejected: 1)
-
-- **critic — add `this._snowLayerEl = null` to null-layer else
-  branch.** Proposed because the success branch reassigns it to
-  `newSnowLayer`. **Rejected**: `_invalidateSnowCache()` already nulls
-  `_snowLayerEl` (line 528) before the restore runs. The boiler's
-  `_resetDomRefs()` does the same for `_steamLayerEl` /
-  `_bubbleLayerEl`, and the boiler's null-layer branch also leaves
-  them null. Adding the extra `= null` would diverge from the boiler
-  pattern. AC-2's null-layer comment explicitly calls this out so
-  future readers don't re-raise.
-
-### Improve (8)
-
-- **critic — AC5 says "6" but lists 7 assertions.** Fixed: AC-5 now
-  pins seven regexes.
-- **critic — `_nextSnowflakeAt` preservation rationale missing.**
-  Added to the snapshot-block comment in Task 2 ("so the next spawn
-  doesn't reset to 0, which would burst-spawn on every push").
-- **concrete-planner — `_snowflakes`/`_nextSnowflakeAt` may be
-  `undefined` at snapshot time.** Added a sentence to the snapshot
-  block's comment + to the "Existing-identifier contract" section
-  explaining that the restore's `?.length` guard handles undefined.
-- **concrete-planner — null-layer branch IS reachable on backdrop
-  change (not just defensive).** AC-2's null-layer comment is
-  strengthened to call this out: "this branch is therefore a real
-  backdrop-transition path (not just defensive)".
-- **concrete-planner — `last_verified` already today's date.**
-  Dropped the bump sub-step from AC-6.
-- **dev-proxy — UI-only fast-path certainty.** AC-7 now states
-  definitively that the fast path applies, citing project-rules.md.
-- **dev-proxy — doc paragraph content.** Drafted verbatim in AC-6.
-- **scope-guardian — document radiator exclusion in story.** Added
-  to the per-card audit table in "Why" and as item 5 in "Out of
-  scope".
-
-### Clarify (4)
-
-- **critic — use syntactic anchors, not line numbers.** Each task
-  states "locate by grep, not literal line number" with the
-  exact-string anchor.
-- **critic — reference boiler test by name + inline patterns.**
-  Task 1 references the boiler test by function name; AC-5 inlines
-  all seven regex patterns.
-- **dev-proxy — quote user authorization.** Quoted in "Why" ("yes
-  climate card only, follow boiler pattern exactly") and as the
-  "Explicit instruction granted" sentence.
-- **dev-proxy — pin `const` vs `let`.** AC-1 specifies `const` for
-  both locals.
-
-### Defended (no change)
-
-- **scope-guardian — test-depth parity.** The seven regex patterns
-  target the snowflake-specific lines (snapshot×2, appendChild,
-  restore×2, filter, null-layer remove loop), not just an assertion
-  count parity. Already covered by AC-5's inlined patterns.
+Review-fix #01 (2 should-fix + 8 nice-to-have findings) added the
+AC-4 ordering pin (S1) and AC-3 invariant pin (S2), trimmed comment
+/ regex / story bloat, and expanded AC-3 from "left unchanged" to
+"must not null `b.el`" (N7). See
+`docs/stories/QS-216.story_review_fix_#01.md`.

--- a/docs/stories/QS-216.story.md
+++ b/docs/stories/QS-216.story.md
@@ -1,0 +1,447 @@
+---
+issue: 216
+title: Check potential fix for radiator and climate card (render called by hass state change)
+branch: QS_216
+status: ready-for-dev
+next_phase: implement-task
+labels: [area:ui, area:dashboard, area:docs]
+---
+
+# QS-216 — Climate card: preserve in-flight snowflakes across `_render()` innerHTML rewrites
+
+## Why
+
+Issue [#216](https://github.com/tmenguy/quiet-solar/issues/216) asks
+us to verify whether the QS-214 root-cause (`set hass → _render →
+innerHTML` wipes in-flight DOM particles every HA state push) also
+affects the radiator and climate cards, and to apply the boiler card's
+fix where it does.
+
+**User clarification on scope (verbatim):** _"yes climate card only,
+follow boiler pattern exactly"_.
+
+### Per-card audit
+
+I read all six cards under `custom_components/quiet_solar/ui/resources/`.
+The QS-214 wipe pathology requires **spawned in-flight DOM particles**
+(circles/paths that are created via `createElementNS` + `appendChild`
+inside the animation step, then advanced/retired across multiple frames).
+Cards whose animation is just `setAttribute('d', …)` on static template
+paths or `setAttribute('stroke-dashoffset', …)` on a single static
+`<path>` are NOT vulnerable — their elements live inside the SVG
+fragment that `innerHTML` writes back fresh each render.
+
+| Card | Animation kind | In-flight particles? | Has the QS-214 bug? |
+|------|----------------|----------------------|----------------------|
+| `qs-car-card.js` | `stroke-dashoffset` on static `#charge_anim` path | No | No |
+| `qs-on-off-duration-card.js` | `stroke-dashoffset` on static `#running_anim` path | No | No |
+| `qs-pool-card.js` | 3 wave `<path>` elements with `d`-attr regen | No | No |
+| `qs-radiator-card.js` | 3 flame `<path>` elements with per-tooth `d`-attr regen | **No** | **No** |
+| `qs-climate-card.js` | flame OR **snow** OR wind backdrops | **Yes — `_snowflakes`** | **Yes** |
+| `qs-water-boiler-card.js` | waves + bubbles + steam | Yes | Already fixed in QS-214 |
+
+The radiator card was named in the issue title but its flame backdrop is
+**static `<path>` elements** (`flame0`, `flame1`, `flame2`) whose `d`
+attribute is regenerated per frame — no `createElementNS`/spawn loop.
+Out of scope.
+
+### The climate card has the same bug
+
+In `qs-climate-card.js`:
+
+- `set hass(hass)` (line 587 `_render()` call site / line 636 in the
+  same setter, with both also dispatching `_render`) fires on every
+  HA state push of any watched entity.
+- `_render()` writes `this._root.innerHTML = \`…\`` at the first such
+  assignment in the function (the SVG fragment plus the `<g
+  id="${snowLayerId}">` snow layer is part of that template). The
+  rewrite detaches every child of the shadow root.
+- Immediately after the rewrite, `_render()` calls
+  `this._invalidateFlameCache(); this._invalidateSnowCache();
+  this._invalidateWindCache();`. `_invalidateSnowCache()` iterates
+  `this._snowflakes` (still the array from the previous frame), calls
+  `.remove()` on each detached `<circle>`, and assigns
+  `this._snowflakes = []` plus `this._nextSnowflakeAt = 0`.
+
+Result: **every HA state push wipes every in-flight snowflake
+simultaneously** — the same pathology QS-214 fixed for steam puffs and
+bubbles. The code already acknowledges this explicitly in `_stepSnow`:
+
+> "the M1 (pass #1) post-innerHTML `_invalidateSnowCache()` wipes
+> `_snowflakes = []` on every hass push (~once per second), so
+> cross-render flakes do NOT survive in practice. … Re-parenting live
+> `<circle>` nodes into the new `<g>` is a valid stretch goal but out
+> of scope (deferred to a follow-up)."
+
+QS-216 IS that follow-up.
+
+**Explicit instruction granted by issue #216 + user clarification** —
+this story overrides the
+[project-context.md](../workflow/project-context.md) rule "Custom JS
+card code should not be modified without explicit instruction".
+
+## Inputs
+
+- `custom_components/quiet_solar/ui/resources/qs-climate-card.js` —
+  add a 2-line snapshot block immediately before the first
+  `this._root.innerHTML = \`` assignment in `_render()`, and a ~17-line
+  restore block immediately after the
+  `this._invalidateFlameCache(); this._invalidateSnowCache();
+  this._invalidateWindCache();` triplet.
+- `tests/test_dashboard_rendering.py` — add a single new test
+  `test_climate_card_render_preserves_snowflakes_across_innerhtml`,
+  mirroring `test_water_boiler_card_render_preserves_steam_puffs_across_innerhtml`
+  with the same seven regex assertions.
+- `docs/agents/concepts/dashboard-and-cards.md` — append a QS-216
+  paragraph below the "Snow-mode cold-start defence" section. The
+  `last_verified` field is already today's date (`2026-05-23`); no
+  bump needed.
+
+### Existing-identifier contract (read-only)
+
+| Identifier | Where (today) | Meaning |
+|---|---|---|
+| `this._snowflakes` | instance state, populated in `_stepSnow` spawn loop | Per-flake array `{el, cx, cy, r, vy, life, maxLife}` |
+| `this._nextSnowflakeAt` | instance state, decremented in `_stepSnow` | Spawn-cadence counter (seconds until next spawn) |
+| `this._snowLayerId` | instance state, set once in `_render` at first paint (`cSnowLayer-<uid>`) | Per-instance stable id for the snow `<g>` |
+| `this._snowLayerEl` | instance state cache | Cached `getElementById(this._snowLayerId)` result; nulled by `_invalidateSnowCache` |
+| `this._root` | shadow root (set in `setConfig`) | Shadow DOM root; `getElementById` against it works the same as on document |
+| `_invalidateSnowCache()` | method | Nulls cache refs, calls `b.el.remove()` on each existing flake, sets `_snowflakes = []` and `_nextSnowflakeAt = 0` |
+
+`this._snowflakes` and `this._nextSnowflakeAt` are lazily initialised
+either by `_startAnimation` (per-field guards at lines 171-172) or by
+the backdrop-transition block (lines 1155-1156). On a cold render
+before either runs, they may still be `undefined`. The restore-block
+guard `if (preservedSnowflakes?.length)` short-circuits safely in that
+case — `undefined?.length` is `undefined`, falsy.
+
+## Acceptance criteria
+
+- **AC-1 — Snapshot before innerHTML rewrite.**
+  Immediately BEFORE the first `this._root.innerHTML = \`` assignment
+  in `_render()`, two `const`-declared locals capture the current
+  snowflake state:
+  ```js
+  const preservedSnowflakes = this._snowflakes;
+  const preservedNextSnowflakeAt = this._nextSnowflakeAt;
+  ```
+  Followed by a comment explaining the mirror of QS-214 and that the
+  spawn-cadence counter must survive so the next spawn doesn't reset
+  to 0 (which would burst-spawn on every push).
+
+- **AC-2 — Restore after the three `_invalidate*Cache()` calls.**
+  Immediately AFTER the `_invalidateFlameCache(); _invalidateSnowCache();
+  _invalidateWindCache();` triplet, the preserved snowflakes are
+  restored into the freshly-rendered snow layer:
+  ```js
+  if (preservedSnowflakes?.length) {
+    const newSnowLayer = this._snowLayerId
+      ? this._root.getElementById(this._snowLayerId)
+      : null;
+    if (newSnowLayer) {
+      for (const b of preservedSnowflakes) {
+        if (b?.el) newSnowLayer.appendChild(b.el);
+      }
+      // .filter aligns the array with the truthy set we just
+      // re-attached, so the advance loop never has to defensively
+      // null-check b.el (mirror of boiler steam-puff pattern).
+      this._snowflakes = preservedSnowflakes.filter(b => b?.el);
+      this._snowLayerEl = newSnowLayer;
+      this._nextSnowflakeAt = preservedNextSnowflakeAt;
+    } else {
+      // Unlike the boiler (which ALWAYS renders the steam layer),
+      // the climate card emits the snow <g> only when
+      // `_backdrop === 'snow'`. This branch is therefore a real
+      // backdrop-transition path (flakes from a 'snow' render
+      // arriving at a 'flame'/'wind'/'none' render), not just
+      // defensive belt-and-braces. Explicitly remove each preserved
+      // flake's DOM and reset the logical array so detached nodes
+      // don't leak. `_snowLayerEl` was already nulled by
+      // `_invalidateSnowCache()` above, so no extra cleanup needed
+      // there (mirror of boiler's `_resetDomRefs()` semantics).
+      for (const b of preservedSnowflakes) { b?.el?.remove(); }
+      this._snowflakes = [];
+    }
+  }
+  ```
+
+- **AC-3 — `_invalidateSnowCache()` is left unchanged.**
+  The function continues to clear `_snowflakes = []` + call `.remove()`
+  on each existing flake + zero `_nextSnowflakeAt`. The boiler's
+  symmetric helper (`_resetDomRefs()`) follows the same pattern. Why
+  it's safe: `_invalidateSnowCache()` mutates the *instance* field
+  `this._snowflakes` (reassigns to `[]`) but does NOT touch the local
+  `const preservedSnowflakes` (which still holds the original array
+  reference). The `.remove()` calls on each `b.el` detach the DOM
+  nodes from any parent (a no-op at this point because the innerHTML
+  rewrite already orphaned them) but do NOT null `b.el` — so
+  `appendChild(b.el)` in the restore block successfully re-attaches
+  them to the new snow layer. The disconnect path
+  (`disconnectedCallback → _invalidateSnowCache`) is unaffected — full
+  cleanup remains.
+
+- **AC-4 — Ordering invariant.**
+  The restore block MUST run AFTER `_invalidateSnowCache()` and AFTER
+  the innerHTML rewrite. The ordering snapshot → innerHTML →
+  `_invalidate*Cache()` → restore is what makes the pattern correct:
+  the snapshot captures the array reference before any mutation, the
+  innerHTML rewrite + `_invalidateSnowCache()` perform their normal
+  cleanup against the *instance* fields, then the restore reassigns
+  the instance fields from the snapshot.
+
+- **AC-5 — Tests pin the snapshot/restore pattern.**
+  A new test in `tests/test_dashboard_rendering.py`, named
+  `test_climate_card_render_preserves_snowflakes_across_innerhtml`,
+  mirrors the boiler test
+  `test_water_boiler_card_render_preserves_steam_puffs_across_innerhtml`
+  (currently at lines 2438-2530). It uses the existing
+  `_strip_js_comments` helper and asserts seven regex patterns against
+  `qs-climate-card.js`:
+  1. `r"const\s+preservedSnowflakes\s*=\s*this\._snowflakes"`
+  2. `r"const\s+preservedNextSnowflakeAt\s*=\s*this\._nextSnowflakeAt"`
+  3. `r"newSnowLayer\.appendChild\s*\(\s*b\.el\s*\)"`
+  4. `r"this\._snowflakes\s*=\s*preservedSnowflakes"` (matches both
+     the bare restore AND the `.filter(...)` variant — same pattern
+     the boiler test uses)
+  5. `r"this\._nextSnowflakeAt\s*=\s*preservedNextSnowflakeAt"`
+  6. `r"this\._snowflakes\s*=\s*preservedSnowflakes\.filter\(\s*b\s*=>\s*b\?\.el\s*\)"`
+  7. `r"for\s*\(\s*const\s+b\s+of\s+preservedSnowflakes\s*\)\s*\{\s*b\?\.el\?\.remove\s*\(\s*\)\s*;?\s*\}"`
+
+  Failure messages cite `qs-climate-card.js` and `_render()` per the
+  boiler test style. The variable name `b` (not `p`) matches the
+  existing `_stepSnow` advance-loop convention (line 416) and the
+  boiler **bubble** preservation test's variable choice.
+
+- **AC-6 — Doc updated.**
+  `docs/agents/concepts/dashboard-and-cards.md` gains a paragraph
+  below the "Snow-mode cold-start defence" paragraph (around line 478):
+
+  > **QS-216 — snowflake preservation across `innerHTML`.** Mirror of
+  > the QS-214 boiler steam-puff and bubble preservation. `_render()`
+  > snapshots `_snowflakes` and `_nextSnowflakeAt` BEFORE the
+  > innerHTML rewrite, then re-attaches each preserved `<circle>` to
+  > the freshly-rendered snow layer AFTER the three
+  > `_invalidate*Cache()` calls. Without this, every HA state push
+  > wiped every in-flight snowflake simultaneously (`_invalidateSnowCache`
+  > calls `b.el.remove()` on each then sets `_snowflakes = []`) — the
+  > same systemic wipe pathology QS-214 fixed for boiler steam. Unlike
+  > the boiler, which always renders the steam layer, the climate
+  > card emits the snow `<g>` only when `_backdrop === 'snow'`; the
+  > restore's null-layer branch is therefore a real backdrop-transition
+  > path (not just defensive) and explicitly removes the preserved
+  > flakes' detached DOM so they don't leak.
+
+  Also amend the existing "Cache invalidation contract" paragraph
+  (around lines 455-466) with a one-line addendum: "QS-216 — snowflake
+  array now survives innerHTML via a snapshot/restore block bracketing
+  the `_invalidate*Cache()` triplet; `_invalidateSnowCache` itself is
+  unchanged."
+
+  `last_verified` is already `2026-05-23` — no bump needed.
+
+- **AC-7 — Quality gate passes.**
+  `python scripts/qs/quality_gate.py` runs the UI-only fast path
+  (changes are confined to `ui/resources/qs-climate-card.js` +
+  `tests/test_dashboard_rendering.py` + `docs/agents/`; per
+  [project-rules.md](../workflow/project-rules.md) §UI-only fast
+  path the trigger is `ui/*.j2` + `ui/resources/**` mixed with
+  dev-only paths including changed test files — qualifying here). The
+  new test goes RED first (no snapshot/restore yet), GREEN after the
+  snapshot + restore blocks land.
+
+## Tasks (TDD order)
+
+### Task 1 — Add the test (RED)
+
+- File: `tests/test_dashboard_rendering.py`.
+- Anchor: insert immediately AFTER
+  `test_water_boiler_card_render_preserves_bubbles_across_innerhtml`
+  (currently at line 2533-2609; the new test goes after its closing
+  blank line ~line 2610).
+- Function name:
+  `test_climate_card_render_preserves_snowflakes_across_innerhtml`.
+- Body: copy `test_water_boiler_card_render_preserves_steam_puffs_across_innerhtml`
+  verbatim and substitute:
+  - `qs-water-boiler-card.js` → `qs-climate-card.js`
+  - `preservedSteamPuffs` → `preservedSnowflakes`
+  - `preservedNextSteamAt` → `preservedNextSnowflakeAt`
+  - `this._steamPuffs` → `this._snowflakes`
+  - `this._nextSteamAt` → `this._nextSnowflakeAt`
+  - `newSteamLayer` → `newSnowLayer`
+  - regex variable name `p` → `b`
+  - failure-message file references: `qs-water-boiler-card.js` →
+    `qs-climate-card.js`; "puff" → "snowflake" semantically; "steam
+    layer" → "snow layer".
+- Docstring: open with one sentence stating this is a mirror of the
+  QS-214 boiler preservation, applied to climate snowflakes per QS-216.
+- Verify RED:
+  ```bash
+  python scripts/qs/quality_gate.py --quick tests/test_dashboard_rendering.py
+  ```
+
+### Task 2 — Snapshot block (GREEN, partial)
+
+- File: `custom_components/quiet_solar/ui/resources/qs-climate-card.js`.
+- Anchor: immediately before the FIRST `this._root.innerHTML = \``
+  assignment in `_render()` (today line 1319; locate by grep, not
+  literal line number, in case other commits land first).
+- Insert:
+  ```js
+  // QS-216: snapshot the in-flight snowflakes BEFORE the
+  // innerHTML rewrite below. The rewrite detaches every DOM node
+  // under `this._root`, including the snow layer's children.
+  // Without this snapshot, every HA state push (which fires
+  // `set hass → _render`) wipes the entire snowflake array via
+  // the post-innerHTML `_invalidateSnowCache()` call (~once per
+  // second). Mirror of QS-214's boiler steam-puff + bubble
+  // preservation. The `b.el` references survive detachment (JS
+  // still holds them); we re-attach them to the new snow layer
+  // after `_invalidateSnowCache()` below. `_nextSnowflakeAt` is
+  // also preserved so the next spawn doesn't reset to 0 (which
+  // would burst-spawn on every push). On a cold render before
+  // `_startAnimation` or the snow backdrop-transition block has
+  // run, `this._snowflakes` and `this._nextSnowflakeAt` may be
+  // `undefined`; the restore-block's `?.length` guard handles
+  // that safely.
+  const preservedSnowflakes = this._snowflakes;
+  const preservedNextSnowflakeAt = this._nextSnowflakeAt;
+  ```
+
+### Task 3 — Restore block (GREEN)
+
+- Same file.
+- Anchor: immediately after `this._invalidateWindCache();` (today
+  line 1463; locate by the triplet
+  `this._invalidateFlameCache(); this._invalidateSnowCache();
+  this._invalidateWindCache();`).
+- Insert the code block shown in AC-2 verbatim.
+- Verify GREEN:
+  ```bash
+  python scripts/qs/quality_gate.py --quick tests/test_dashboard_rendering.py
+  ```
+
+### Task 4 — Doc update
+
+- File: `docs/agents/concepts/dashboard-and-cards.md`.
+- Append the QS-216 paragraph from AC-6 below the "Snow-mode
+  cold-start defence" paragraph.
+- Add the one-line addendum to the "Cache invalidation contract"
+  paragraph.
+- `last_verified` is already `2026-05-23`; no bump.
+
+### Task 5 — Full quality gate
+
+```bash
+python scripts/qs/quality_gate.py
+```
+UI-only fast path expected (changes are `ui/resources/*.js` + test +
+doc). If the gate runs the full suite for any reason, that's also
+fine — neither path should regress.
+
+### Task 6 — Open PR
+
+`implement-task` opens the PR with the standard commit message and
+gh PR template.
+
+## Out of scope (deliberately)
+
+1. **No refactor of `_invalidateSnowCache()`.** It keeps its current
+   destructive behavior. The boiler's symmetric helper does the same;
+   keeping symmetry is the whole point of "follow the boiler pattern
+   exactly".
+2. **No changes to the snowflake spawn / advance logic** in
+   `_stepSnow` (lines 356-431). The fix is purely a render-flow
+   change.
+3. **No special-case for backdrop transitions** beyond the existing
+   null-layer fallback in the restore block. Backdrop transitions
+   that drop the snow `<g>` are handled by the null-layer else
+   branch.
+4. **No changes to wind or flame backdrops.** Flame uses
+   regenerated-`d` static paths; wind uses static stroked wisps with
+   translateX scroll. Neither spawns DOM particles, so neither has
+   the QS-214 wipe pathology.
+5. **No changes to the other five cards.** Per-card audit (table in
+   "Why") shows only `qs-climate-card.js` carries the bug. The
+   radiator card uses regenerated-`d` static paths only — it is
+   named in the issue title but, per the audit, not vulnerable.
+6. **No new constants.** The fix uses only existing instance state
+   (`_snowflakes`, `_nextSnowflakeAt`, `_snowLayerId`,
+   `_snowLayerEl`) and existing DOM APIs.
+
+## Adversarial review notes
+
+Four plan-reviewer sub-agents ran in parallel
+(`qs-plan-critic`, `qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
+`qs-plan-scope-guardian`). Synthesised findings + decisions:
+
+### Critical (3)
+
+- **critic — pin snapshot/clear ordering.** Risk: if
+  `_invalidateSnowCache` nulled `b.el` (rather than just calling
+  `.remove()`), the restore would silently drop everything via the
+  `.filter(b => b?.el)`. **Verified by concrete-planner**: the function
+  calls `b.el?.remove?.()` (no nulling). **Resolution**: comment in
+  AC-3 explicitly pins the ordering invariant and the no-nulling
+  contract.
+- **dev-proxy — inline boiler JS + regex patterns.** The story must
+  be self-contained enough that `implement-task` doesn't have to
+  re-discover the boiler pattern. **Resolution**: AC-2 inlines the
+  full restore block; AC-5 inlines all seven regex patterns; the
+  snapshot block is also inlined in Task 2.
+
+### Redesign (proposed → rejected: 1)
+
+- **critic — add `this._snowLayerEl = null` to null-layer else
+  branch.** Proposed because the success branch reassigns it to
+  `newSnowLayer`. **Rejected**: `_invalidateSnowCache()` already nulls
+  `_snowLayerEl` (line 528) before the restore runs. The boiler's
+  `_resetDomRefs()` does the same for `_steamLayerEl` /
+  `_bubbleLayerEl`, and the boiler's null-layer branch also leaves
+  them null. Adding the extra `= null` would diverge from the boiler
+  pattern. AC-2's null-layer comment explicitly calls this out so
+  future readers don't re-raise.
+
+### Improve (8)
+
+- **critic — AC5 says "6" but lists 7 assertions.** Fixed: AC-5 now
+  pins seven regexes.
+- **critic — `_nextSnowflakeAt` preservation rationale missing.**
+  Added to the snapshot-block comment in Task 2 ("so the next spawn
+  doesn't reset to 0, which would burst-spawn on every push").
+- **concrete-planner — `_snowflakes`/`_nextSnowflakeAt` may be
+  `undefined` at snapshot time.** Added a sentence to the snapshot
+  block's comment + to the "Existing-identifier contract" section
+  explaining that the restore's `?.length` guard handles undefined.
+- **concrete-planner — null-layer branch IS reachable on backdrop
+  change (not just defensive).** AC-2's null-layer comment is
+  strengthened to call this out: "this branch is therefore a real
+  backdrop-transition path (not just defensive)".
+- **concrete-planner — `last_verified` already today's date.**
+  Dropped the bump sub-step from AC-6.
+- **dev-proxy — UI-only fast-path certainty.** AC-7 now states
+  definitively that the fast path applies, citing project-rules.md.
+- **dev-proxy — doc paragraph content.** Drafted verbatim in AC-6.
+- **scope-guardian — document radiator exclusion in story.** Added
+  to the per-card audit table in "Why" and as item 5 in "Out of
+  scope".
+
+### Clarify (4)
+
+- **critic — use syntactic anchors, not line numbers.** Each task
+  states "locate by grep, not literal line number" with the
+  exact-string anchor.
+- **critic — reference boiler test by name + inline patterns.**
+  Task 1 references the boiler test by function name; AC-5 inlines
+  all seven regex patterns.
+- **dev-proxy — quote user authorization.** Quoted in "Why" ("yes
+  climate card only, follow boiler pattern exactly") and as the
+  "Explicit instruction granted" sentence.
+- **dev-proxy — pin `const` vs `let`.** AC-1 specifies `const` for
+  both locals.
+
+### Defended (no change)
+
+- **scope-guardian — test-depth parity.** The seven regex patterns
+  target the snowflake-specific lines (snapshot×2, appendChild,
+  restore×2, filter, null-layer remove loop), not just an assertion
+  count parity. Already covered by AC-5's inlined patterns.

--- a/docs/stories/QS-216.story_review_fix_#01.md
+++ b/docs/stories/QS-216.story_review_fix_#01.md
@@ -1,0 +1,264 @@
+# QS-216 — Review fix plan #01
+
+## Summary
+
+- Source PR: #218
+- Source story: `docs/stories/QS-216.story.md`
+- Findings to fix: 10 (2 should-fix + 8 nice-to-have)
+- Next implement phase: `implement-task`
+
+This round closes test-gap regressions (ordering + AC-3 invariant),
+cleans up stale comments left over from the QS-214/pre-216 design that
+explicitly deferred cross-render survival, and trims comment / story /
+helper bloat. **N7 expands scope beyond the original AC-3 boundary**
+("`_invalidateSnowCache()` is left unchanged") by allowing a no-op
+short-circuit on the rewrite path; the implement phase must update the
+AC-3 wording in `docs/stories/QS-216.story.md` accordingly (still no
+nulling of `b.el`; the contract that protects the truthy-branch filter
+remains intact).
+
+## Findings to fix
+
+### [should-fix] S1 — Test does not enforce snapshot/restore ordering (AC-4 gap)
+- File: `tests/test_dashboard_rendering.py:2612-2701`
+- Severity: should-fix
+- Source: qs-review-coderabbit (Major), qs-review-acceptance-auditor, qs-review-edge-case-hunter
+- Description: The seven regex assertions in
+  `test_climate_card_render_preserves_snowflakes_across_innerhtml`
+  verify *presence* but not *relative position*. A refactor that moves
+  the snapshot block AFTER `this._root.innerHTML = …`, or moves the
+  restore block BEFORE the `_invalidate*Cache()` triplet, would still
+  pass all seven assertions but silently re-introduce the original
+  wipe bug. AC-4 explicitly defines this ordering invariant; the test
+  does not pin it.
+- Proposed fix:
+  1. Use the existing `_extract_js_function_body` helper (the boiler
+     QS-214 test in the same module uses it — copy its idiom) to
+     extract the body of `_render()` from the stripped JS source.
+  2. After the existing seven `re.search(...)` assertions, compute
+     character offsets via `body.find(...)`:
+     - `snap_idx = body.find("const preservedSnowflakes")`
+     - `next_idx = body.find("const preservedNextSnowflakeAt")`
+     - `innerhtml_idx = body.find("this._root.innerHTML")`
+     - `inv_flame_idx = body.find("_invalidateFlameCache()")`
+     - `inv_snow_idx = body.find("_invalidateSnowCache()")`
+     - `inv_wind_idx = body.find("_invalidateWindCache()")`
+     - `attach_idx = body.find("newSnowLayer.appendChild(b.el)")`
+  3. Assert all indices are `>= 0` first (each with a named failure
+     message so a missing token reports clearly), then assert:
+     - `snap_idx < innerhtml_idx`
+     - `next_idx < innerhtml_idx`
+     - `attach_idx > inv_flame_idx`
+     - `attach_idx > inv_snow_idx`
+     - `attach_idx > inv_wind_idx`
+  4. Each ordering assertion gets a descriptive failure message
+     naming `_render()` and the AC-4 invariant.
+
+### [should-fix] S2 — AC-3 invariant not regression-tested
+- File: `tests/test_dashboard_rendering.py` (extend existing test or
+  add a sibling)
+- Severity: should-fix
+- Source: qs-review-blind-hunter, qs-review-acceptance-auditor
+- Description: AC-3's "Why it's safe" reasoning relies on the
+  invariant that `_invalidateSnowCache()` calls `b.el?.remove?.()` but
+  does NOT null `b.el`. If a future refactor adds `b.el = null` (or
+  any morally equivalent reassignment) to that helper, the
+  truthy-branch `.filter(b => b?.el)` silently drops every preserved
+  flake — the wipe bug returns invisibly and the seven content
+  regexes in S1's test all still pass.
+- Proposed fix:
+  1. In the same test module, extract the body of
+     `_invalidateSnowCache()` via `_extract_js_function_body`.
+  2. Assert the body contains the `.remove?.()` call (positive pin —
+     `re.search(r"b\??\.el\??\.remove\??\(\)", body)`).
+  3. Assert the body does NOT contain any `b.el = …` assignment
+     (negative pin — `assert not re.search(r"b\.el\s*=\s*", body)`).
+  4. Test name: `test_invalidate_snow_cache_does_not_null_el` (or
+     extend `test_climate_card_render_preserves_snowflakes_across_innerhtml`
+     with an additional block — implementer's choice, but a separate
+     test is cleaner since the contract is on a different function).
+  5. Failure messages must explicitly cite "AC-3 invariant" so a
+     future maintainer sees the linkage.
+
+### [nice-to-have] N1 — Trim snapshot/restore comment bloat
+- File: `custom_components/quiet_solar/ui/resources/qs-climate-card.js`
+  (snapshot block at the first added hunk; restore block at the
+  second added hunk)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The two added comment blocks total ~40 lines for ~17
+  lines of code. The same rationale (boiler precedent, ordering,
+  cache invalidation contract) is already captured in
+  `docs/agents/concepts/dashboard-and-cards.md` and the story.
+- Proposed fix: Reduce each comment block to ≤ 4 lines pointing to
+  AC-1 / AC-2 / AC-4 and the QS-214 boiler precedent. Keep enough
+  context for a reader to understand *why* the block exists; delete
+  prose that restates the AC verbatim.
+
+### [nice-to-have] N2 — Regex #4 is redundant with regex #6
+- File: `tests/test_dashboard_rendering.py` (the seven-regex assertion
+  list inside
+  `test_climate_card_render_preserves_snowflakes_across_innerhtml`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Regex #4 (`r"this\._snowflakes\s*=\s*preservedSnowflakes"`)
+  is a strict prefix-match subset of regex #6 (the `.filter(...)`
+  form). Regex #4 always passes when #6 does — zero added signal.
+- Proposed fix: Tighten regex #4 to anchor on the `.filter` form
+  (`r"this\._snowflakes\s*=\s*preservedSnowflakes\.filter\("`) so
+  it pins the same line as #6 with an explicit name, **or** delete
+  regex #4 entirely and renumber. Implementer's choice; prefer the
+  delete-and-renumber path for simplicity. Update the test's
+  docstring count from "seven regex assertions" to whatever the new
+  count is, and update the story's AC-5 wording (see below).
+- Cross-reference: AC-5 in `docs/stories/QS-216.story.md` enumerates
+  seven assertions. If N2's fix drops regex #4, AC-5 must be updated
+  to the new count in the same PR.
+
+### [nice-to-have] N3 — Trim story bloat
+- File: `docs/stories/QS-216.story.md`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: 447 lines for a ~50-line code change. The adversarial-
+  review notes section restates plan-critic decisions already encoded
+  in the AC text.
+- Proposed fix: Shrink the "Adversarial review notes" section to
+  ≤ 30 lines: a brief bulleted summary of which decisions came from
+  which reviewer, with file paths back to any superseded drafts. No
+  prose re-statement of the AC content. **Do not touch any AC
+  text** except for the AC-5 update required by N2 and the AC-3
+  update required by N7. Leave `last_verified` alone.
+
+### [nice-to-have] N4 — For-loop style consistency
+- File: `custom_components/quiet_solar/ui/resources/qs-climate-card.js`
+  (truthy-branch `for` block vs null-layer `for` block in the new
+  restore section)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The truthy branch uses a multi-line `for (const b of
+  …) { … }` block; the null-layer else branch uses a single-line
+  body. Inconsistent within the same function. Pure style.
+- Proposed fix: Make both `for` loops use the multi-line block style
+  for consistency with the rest of the file (the file uses multi-line
+  blocks throughout per `_stepSnow` / `_stepBubbles` precedent).
+
+### [nice-to-have] N5 — Stale `_stepSnow` comment about cross-render survival
+- File: `custom_components/quiet_solar/ui/resources/qs-climate-card.js:392-402`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The "Pass-#2 S2 note" still asserts "cross-render
+  flakes do NOT survive in practice" and that "re-parenting live
+  `<circle>` nodes into the new `<g>` is a valid stretch goal but out
+  of scope (deferred to a follow-up)." QS-216 IS that follow-up; the
+  comment now lies to future readers.
+- Proposed fix: Rewrite the stale comment to ≤ 6 lines describing
+  the post-QS-216 reality: cross-render flakes survive same-backdrop
+  re-renders via the snapshot/restore block in `_render()`; flakes
+  are still wiped on real backdrop transitions away from `'snow'`
+  (null-layer branch) and on `disconnectedCallback`. Cite QS-216 by
+  number.
+
+### [nice-to-have] N6 — Stale `_invalidateSnowCache` "drift-up" comment
+- File: `custom_components/quiet_solar/ui/resources/qs-climate-card.js:534-536`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The comment claims the `.forEach(b.el?.remove?.())`
+  + `_snowflakes = []` reset "keeps `_snowflakes.length` from
+  drifting up toward `MAX_CONCURRENT_SNOWFLAKES` across re-renders."
+  Post-QS-216 same-backdrop re-renders PRESERVE the array (which is
+  the desired behavior); the cache reset only governs real backdrop
+  transitions away from `'snow'` and `disconnectedCallback`.
+- Proposed fix: Rewrite the comment to ≤ 4 lines: this reset clears
+  flakes on real backdrop transitions and `disconnectedCallback`
+  only; same-backdrop re-renders preserve via the snapshot/restore
+  block in `_render()` (cite AC-2 + AC-3).
+
+### [nice-to-have] N7 — Short-circuit `_invalidateSnowCache` double-walk on rewrite path
+- File: `custom_components/quiet_solar/ui/resources/qs-climate-card.js`
+  (`_invalidateSnowCache` body)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- **Scope note:** This expands beyond original AC-3 ("`_invalidate
+  SnowCache()` is left unchanged"). The user explicitly accepted the
+  scope expansion when triaging this review round.
+- Description: On the rewrite path, the snapshot/restore block
+  already preserves the `_snowflakes` array. `_invalidateSnowCache`
+  then walks the same array, calls `.remove()` on each `el` (no-op
+  DOM-wise because `this._root.innerHTML = ...` already orphaned the
+  parent `<g>`), and reassigns `this._snowflakes = []`. The full
+  loop only matters on `disconnectedCallback` and on real backdrop
+  transitions (where the null-layer else of the restore block runs
+  its own `b?.el?.remove()` loop — itself a different no-op for the
+  same reason). Hot-path cost is negligible (≤ 14 entries) but the
+  redundancy adds reader friction.
+- Proposed fix: Replace the body of `_invalidateSnowCache` with the
+  minimal form that preserves the AC-3 invariant (must NOT null
+  `b.el` — this is what S2 pins). Suggested body:
+  ```js
+  _invalidateSnowCache() {
+    // QS-216 — same-backdrop re-renders preserve flakes via
+    // _render()'s snapshot/restore block. We still call .remove()
+    // on each surviving <circle> so the disconnectedCallback /
+    // real-backdrop-transition paths leave no orphaned DOM.
+    // Critical invariant: do NOT null b.el — the truthy-branch
+    // restore filter (b => b?.el) silently drops anything we
+    // null here.
+    for (const b of this._snowflakes) {
+      b?.el?.remove?.();
+    }
+    this._snowflakes = [];
+    this._nextSnowflakeAt = 0;
+    this._snowLayerId = null;
+    this._snowLayerEl = null;
+  }
+  ```
+  (Adjust the field list to match the actual current body — the
+  proposed form may already match line-for-line; if so, only the
+  comment changes.) Then update **AC-3** in
+  `docs/stories/QS-216.story.md` to reflect that the body is no
+  longer required to be *unchanged*; the new contract is "must NOT
+  null `b.el`". S2's test pins the contract.
+
+### [nice-to-have] N8 — Document the filter-creates-new-array intent
+- File: `custom_components/quiet_solar/ui/resources/qs-climate-card.js`
+  (truthy branch of the restore block, line containing
+  `this._snowflakes = preservedSnowflakes.filter(b => b?.el)`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The `.filter(...)` creates a new array; the local
+  `preservedSnowflakes` const still points at the original. Likely
+  benign because `_stepSnow` reads `this._snowflakes` each call,
+  but undocumented and easy to break by future refactors that hand
+  the original array to a closure.
+- Proposed fix: Add a ≤ 3-line inline comment next to the filter
+  call: "creates a fresh array — all hot-path code (`_stepSnow`,
+  `_invalidateSnowCache`) reads `this._snowflakes` each call, so
+  the new reference is safe; do not pass the original
+  `preservedSnowflakes` const to any closure."
+
+## How to apply
+
+Run `/implement-task` against this fix plan. The implement-task
+agent must:
+
+1. Apply S1 + S2 first (failing tests → green) under TDD.
+2. Apply N7 (which touches `_invalidateSnowCache` body) BEFORE the
+   AC-3 wording update in `docs/stories/QS-216.story.md` (N3 / N7).
+3. Apply N2 + N5 + N6 (comment / regex churn).
+4. Apply N1 + N3 + N4 + N8 (style / docs / comments).
+5. Re-run `python scripts/qs/quality_gate.py` — must stay green.
+6. Push to `QS_216`.
+
+When done, return and run `/review-task` again to re-verify.
+
+## Out-of-scope reminders
+
+- AC-7 (CI quality gate) was deferred from the diff-only review; the
+  implement agent must run `quality_gate.py` and confirm it stays
+  green after the fixes.
+- The doc-drift check on the PR's changed files passed (EXIT=0); no
+  doc-maintenance finding was needed.
+- No production behavior change is expected from any of the 10 fixes
+  except N7's `_invalidateSnowCache` short-circuit, which is
+  observably a no-op (the `.remove()` calls were already no-ops on
+  the rewrite path).

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2609,6 +2609,98 @@ def test_water_boiler_card_render_preserves_bubbles_across_innerhtml():
     )
 
 
+def test_climate_card_render_preserves_snowflakes_across_innerhtml():
+    """Mirror of the QS-214 boiler steam-puff and bubble preservation,
+    applied to climate snowflakes per QS-216.
+
+    The climate card's `_render()` rewrites `this._root.innerHTML` on
+    every HA state push (`set hass → _render → innerHTML`). Before
+    QS-216 the rewrite + subsequent `_invalidateSnowCache()` call wiped
+    every in-flight snowflake simultaneously — the same systemic wipe
+    pathology QS-214 fixed for steam puffs and bubbles. This test pins
+    the snapshot-and-restore pattern: `_render()` must capture
+    `_snowflakes` / `_nextSnowflakeAt` BEFORE the innerHTML rewrite,
+    then re-attach each preserved `<circle>` to the freshly-rendered
+    snow layer AFTER the three `_invalidate*Cache()` calls and restore
+    the array + cadence counter.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-climate-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Pre-innerHTML snapshot.
+    assert re.search(
+        r"const\s+preservedSnowflakes\s*=\s*this\._snowflakes",
+        executable,
+    ), (
+        "qs-climate-card.js: `_render()` must snapshot "
+        "`this._snowflakes` into `preservedSnowflakes` BEFORE the "
+        "innerHTML rewrite, so the snowflake DOM nodes survive."
+    )
+    assert re.search(
+        r"const\s+preservedNextSnowflakeAt\s*=\s*this\._nextSnowflakeAt",
+        executable,
+    ), (
+        "qs-climate-card.js: `_render()` must snapshot "
+        "`this._nextSnowflakeAt` so the spawn cadence counter doesn't "
+        "reset to 0 on every render (which would cause a spawn-burst "
+        "after every HA state push)."
+    )
+
+    # Post-innerHTML restore: re-attach each preserved snowflake's DOM
+    # node to the new snow layer, then restore the array + counter.
+    assert re.search(
+        r"newSnowLayer\.appendChild\s*\(\s*b\.el\s*\)",
+        executable,
+    ), (
+        "qs-climate-card.js: `_render()` must re-attach each "
+        "preserved snowflake's DOM node to the new snow layer via "
+        "`newSnowLayer.appendChild(b.el)`."
+    )
+    assert re.search(
+        r"this\._snowflakes\s*=\s*preservedSnowflakes",
+        executable,
+    ), (
+        "qs-climate-card.js: `_render()` must restore "
+        "`this._snowflakes = preservedSnowflakes` after the innerHTML "
+        "rewrite + _invalidateSnowCache() cleanup."
+    )
+    assert re.search(
+        r"this\._nextSnowflakeAt\s*=\s*preservedNextSnowflakeAt",
+        executable,
+    ), (
+        "qs-climate-card.js: `_render()` must restore "
+        "`this._nextSnowflakeAt = preservedNextSnowflakeAt` so the "
+        "spawn cadence picks up where it left off."
+    )
+    # Truthy-branch array semantics: `_snowflakes` is assigned the
+    # filtered set (drop entries whose `el` was missing) so the array
+    # is the canonical "preserved AND truthy" view (mirror of boiler
+    # steam-puff pattern).
+    assert re.search(
+        r"this\._snowflakes\s*=\s*preservedSnowflakes\.filter\(\s*b\s*=>\s*b\?\.el\s*\)",
+        executable,
+    ), (
+        "qs-climate-card.js: the snowflake preserve truthy branch "
+        "must align array semantics with the null-layer drop via "
+        "`this._snowflakes = preservedSnowflakes.filter(b => b?.el)`."
+    )
+    # Null-layer else branch: explicit DOM removal of preserved
+    # snowflakes so detached nodes don't leak (mirror of boiler).
+    assert re.search(
+        r"for\s*\(\s*const\s+b\s+of\s+preservedSnowflakes\s*\)\s*\{\s*"
+        r"b\?\.el\?\.remove\s*\(\s*\)\s*;?\s*\}",
+        executable,
+    ), (
+        "qs-climate-card.js: the snowflake preserve null-layer "
+        "else branch must iterate `preservedSnowflakes` and explicitly "
+        "call `b?.el?.remove()` so detached DOM nodes don't leak."
+    )
+
+
 def test_water_boiler_card_steam_spawn_defers_on_zero_budget():
     """Review fix #01 finding #5: the spawn-loop `riseBudget <= 0`
     branch must genuinely defer the spawn slot by advancing the

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2623,6 +2623,11 @@ def test_climate_card_render_preserves_snowflakes_across_innerhtml():
     then re-attach each preserved `<circle>` to the freshly-rendered
     snow layer AFTER the three `_invalidate*Cache()` calls and restore
     the array + cadence counter.
+
+    Six content regexes pin the presence of each clause; a follow-on
+    block (review fix #01 S1) extracts the `_render()` body via
+    `_extract_js_function_body` and pins the AC-4 ordering invariant
+    via character-offset comparisons.
     """
     import re
 
@@ -2661,14 +2666,6 @@ def test_climate_card_render_preserves_snowflakes_across_innerhtml():
         "`newSnowLayer.appendChild(b.el)`."
     )
     assert re.search(
-        r"this\._snowflakes\s*=\s*preservedSnowflakes",
-        executable,
-    ), (
-        "qs-climate-card.js: `_render()` must restore "
-        "`this._snowflakes = preservedSnowflakes` after the innerHTML "
-        "rewrite + _invalidateSnowCache() cleanup."
-    )
-    assert re.search(
         r"this\._nextSnowflakeAt\s*=\s*preservedNextSnowflakeAt",
         executable,
     ), (
@@ -2679,7 +2676,9 @@ def test_climate_card_render_preserves_snowflakes_across_innerhtml():
     # Truthy-branch array semantics: `_snowflakes` is assigned the
     # filtered set (drop entries whose `el` was missing) so the array
     # is the canonical "preserved AND truthy" view (mirror of boiler
-    # steam-puff pattern).
+    # steam-puff pattern). Review fix #01 N2: this filter assertion
+    # supersedes a previously-redundant bare-assignment regex; the
+    # filter form is a strict subset, so a single pin is sufficient.
     assert re.search(
         r"this\._snowflakes\s*=\s*preservedSnowflakes\.filter\(\s*b\s*=>\s*b\?\.el\s*\)",
         executable,
@@ -2698,6 +2697,149 @@ def test_climate_card_render_preserves_snowflakes_across_innerhtml():
         "qs-climate-card.js: the snowflake preserve null-layer "
         "else branch must iterate `preservedSnowflakes` and explicitly "
         "call `b?.el?.remove()` so detached DOM nodes don't leak."
+    )
+
+    # Review fix #01 S1 — AC-4 ordering invariant. Presence regexes
+    # above don't enforce *position*; a refactor that moved the
+    # snapshot AFTER innerHTML, or the restore BEFORE the
+    # _invalidate*Cache() triplet, would silently re-introduce the
+    # original wipe bug. Pin the ordering via character offsets on
+    # the stripped source.
+    #
+    # We deliberately don't use `_extract_js_function_body` here:
+    # (a) `r"_render\s*\(\s*\)"` would match a call site before the
+    #     declaration; and (b) the giant `this._root.innerHTML = \`…\``
+    #     template literal contains many `${…}` interpolation braces
+    #     that throw off the helper's balanced-brace walker (this is
+    #     the known limitation called out in the helper's docstring).
+    #
+    # Anchoring from `snap_idx` is sufficient: the snapshot string is
+    # unique, and every "after snap" needle below either occurs only
+    # in `_render()` (innerHTML, newSnowLayer.appendChild) or has its
+    # *other* occurrences strictly before `snap_idx` (the
+    # `_invalidate*Cache()` declarations + the `disconnectedCallback`
+    # call site, all earlier in the file).
+    snap_idx = executable.find("const preservedSnowflakes")
+    next_idx = executable.find("const preservedNextSnowflakeAt")
+    innerhtml_idx = executable.find("this._root.innerHTML")
+    assert snap_idx >= 0, (
+        "qs-climate-card.js: file must contain "
+        "`const preservedSnowflakes` (review fix #01 S1)."
+    )
+    assert next_idx >= 0, (
+        "qs-climate-card.js: file must contain "
+        "`const preservedNextSnowflakeAt` (review fix #01 S1)."
+    )
+    assert innerhtml_idx >= 0, (
+        "qs-climate-card.js: file must contain "
+        "`this._root.innerHTML` rewrite (review fix #01 S1)."
+    )
+    # All `_invalidate*Cache()` and `newSnowLayer.appendChild` lookups
+    # start AT `snap_idx` to skip the pre-_render() declaration and
+    # disconnectedCallback call-site occurrences.
+    inv_flame_idx = executable.find("_invalidateFlameCache()", snap_idx)
+    inv_snow_idx = executable.find("_invalidateSnowCache()", snap_idx)
+    inv_wind_idx = executable.find("_invalidateWindCache()", snap_idx)
+    attach_idx = executable.find("newSnowLayer.appendChild(b.el)", snap_idx)
+    assert inv_flame_idx >= 0, (
+        "qs-climate-card.js: `_render()` (after the snapshot) must "
+        "call `_invalidateFlameCache()` (review fix #01 S1)."
+    )
+    assert inv_snow_idx >= 0, (
+        "qs-climate-card.js: `_render()` (after the snapshot) must "
+        "call `_invalidateSnowCache()` (review fix #01 S1)."
+    )
+    assert inv_wind_idx >= 0, (
+        "qs-climate-card.js: `_render()` (after the snapshot) must "
+        "call `_invalidateWindCache()` (review fix #01 S1)."
+    )
+    assert attach_idx >= 0, (
+        "qs-climate-card.js: `_render()` (after the snapshot) must "
+        "call `newSnowLayer.appendChild(b.el)` (review fix #01 S1)."
+    )
+    assert snap_idx < innerhtml_idx, (
+        "qs-climate-card.js: AC-4 ordering invariant — "
+        "`const preservedSnowflakes` snapshot MUST appear BEFORE the "
+        "`this._root.innerHTML` rewrite in `_render()`. The snapshot "
+        "captures the array reference that the rewrite would otherwise "
+        "wipe (review fix #01 S1)."
+    )
+    assert next_idx < innerhtml_idx, (
+        "qs-climate-card.js: AC-4 ordering invariant — "
+        "`const preservedNextSnowflakeAt` snapshot MUST appear BEFORE "
+        "the `this._root.innerHTML` rewrite in `_render()` "
+        "(review fix #01 S1)."
+    )
+    assert attach_idx > inv_flame_idx, (
+        "qs-climate-card.js: AC-4 ordering invariant — the restore "
+        "block's `newSnowLayer.appendChild(b.el)` MUST appear AFTER "
+        "`_invalidateFlameCache()` in `_render()` (review fix #01 S1)."
+    )
+    assert attach_idx > inv_snow_idx, (
+        "qs-climate-card.js: AC-4 ordering invariant — the restore "
+        "block's `newSnowLayer.appendChild(b.el)` MUST appear AFTER "
+        "`_invalidateSnowCache()` in `_render()`. Calling it before "
+        "would let the invalidate-cache wipe the array we just "
+        "restored (review fix #01 S1)."
+    )
+    assert attach_idx > inv_wind_idx, (
+        "qs-climate-card.js: AC-4 ordering invariant — the restore "
+        "block's `newSnowLayer.appendChild(b.el)` MUST appear AFTER "
+        "`_invalidateWindCache()` in `_render()` (review fix #01 S1)."
+    )
+
+
+def test_invalidate_snow_cache_does_not_null_el():
+    """Review fix #01 S2 — pin the AC-3 invariant that
+    `_invalidateSnowCache()` calls `b.el.remove()` (or any safe-nav
+    variant thereof) but MUST NOT null `b.el`. If a future refactor
+    adds `b.el = null` (or any morally equivalent reassignment), the
+    truthy-branch `.filter(b => b?.el)` in `_render()`'s restore block
+    silently drops every preserved flake — the wipe bug returns
+    invisibly and the content regexes in
+    `test_climate_card_render_preserves_snowflakes_across_innerhtml`
+    all still pass.
+
+    This test extracts the `_invalidateSnowCache()` body and asserts:
+    1. A `.remove()` call on `b.el` is present (positive pin).
+    2. No `b.el = …` assignment is present (negative pin).
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-climate-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    body = _extract_js_function_body(
+        executable, r"_invalidateSnowCache\s*\(\s*\)"
+    )
+    assert body is not None, (
+        "qs-climate-card.js: `_invalidateSnowCache()` body must be "
+        "extractable for the AC-3 invariant pin (review fix #01 S2)."
+    )
+    # Positive pin: some `b.el.remove()` or `b?.el?.remove?.()` form
+    # must be present so the disconnect path still tears down DOM.
+    # `(?:\?\.)?` permits the JS optional-chained call syntax
+    # `remove?.()` as well as the plain `remove()` form.
+    assert re.search(
+        r"b\??\.el\??\.remove(?:\?\.)?\(\s*\)", body
+    ), (
+        "qs-climate-card.js: AC-3 invariant — `_invalidateSnowCache()` "
+        "must call `.remove()` on each flake's `el` (e.g. "
+        "`b?.el?.remove?.()`) so the disconnectedCallback / real "
+        "backdrop-transition paths leave no orphaned DOM "
+        "(review fix #01 S2)."
+    )
+    # Negative pin: no `b.el = …` assignment. The boiler's symmetric
+    # helper avoids nulling `p.el`; matching that contract is what
+    # makes the truthy-branch filter `(b => b?.el)` safe.
+    assert not re.search(r"b\.el\s*=\s*", body), (
+        "qs-climate-card.js: AC-3 invariant — `_invalidateSnowCache()` "
+        "must NOT assign to `b.el` (e.g. `b.el = null`). The "
+        "truthy-branch restore filter `(b => b?.el)` in `_render()` "
+        "silently drops any entry whose `el` was nulled, which would "
+        "silently re-introduce the wipe pathology QS-216 fixed "
+        "(review fix #01 S2)."
     )
 
 


### PR DESCRIPTION
## Summary
- Snapshot _snowflakes + _nextSnowflakeAt BEFORE innerHTML rewrite in qs-climate-card.js _render()
- Restore by re-attaching each preserved <circle> to the fresh snow layer AFTER the _invalidate*Cache() triplet (truthy-branch .filter for array alignment; null-layer else handles real backdrop transitions away from 'snow')
- Mirrors QS-214 boiler steam-puff/bubble preservation; pinned by a new test test_climate_card_render_preserves_snowflakes_across_innerhtml with seven regex assertions

Fixes #216

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snow animation no longer flickers or loses in-flight flakes during rapid climate card updates.

* **Documentation**
  * Expanded climate card docs and a new story describing the snow backdrop behavior and expected update ordering.

* **Tests**
  * Added tests validating snowflake preservation and cache-invalidation behavior to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->