### PR TITLE
QS-217: Carve-out arc in card animations behind override hand button

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -57,6 +57,28 @@ const CLIP_R = 120;                 // backdrop clip circle radius
 const OVERRIDE_BTN_CARVE_CY = 277;
 const OVERRIDE_BTN_CARVE_R  = 35;
 
+// QS-217 review-fix #01: Crescent-cancel subpath intersection geometry.
+// The full carve disc extends 32 SVG units below the outer clip disc
+// (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R = 312 vs. CENTER_CY +
+// CLIP_R = 280). Under `clip-rule="evenodd"`, that crescent region
+// (inside the carve disc, OUTSIDE the outer clip disc) has winding
+// count 1 → "inside the clip" → the backdrop animation (flame /
+// snow / wind) would leak through below the override-hand button.
+// We bump the count to 2 by adding a third subpath shaped like the
+// crescent, bordered by the small outer-disc arc and the large
+// carve-disc arc that meet at the two circle intersections.
+// Two circles intersect when:
+//   y_int = (CLIP_R² − OVERRIDE_BTN_CARVE_R² + OVERRIDE_BTN_CARVE_CY²
+//            − CENTER_CY²) / (2 × (OVERRIDE_BTN_CARVE_CY − CENTER_CY))
+//         = 64304 / 234 ≈ 274.80 → rounded to 275
+//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²) ≈ 34.94 → 35
+// Integer rounding keeps the SVG path string short; the residual
+// (≤ 0.2 SVG units) is well below 1 CSS pixel and invisible. Swap
+// for floats (`274.80` / `34.94`) if a future visual review needs
+// exact alignment — the path string accepts decimals.
+const OVERRIDE_BTN_CARVE_INT_X = 35;
+const OVERRIDE_BTN_CARVE_INT_Y = 275;
+
 // --- Flame engine constants (QS-204 verbatim from qs-radiator-card.js) ---
 const FLAME_WIDTH = 480;            // single layer width in SVG px (2× clip diameter)
 const FLAME_BOTTOM_Y = 400;         // ≥ SVG viewBox max-y (320) so the closing rect is clipped
@@ -1336,35 +1358,54 @@ class QsClimateCard extends HTMLElement {
       const finishTimeStr = sDefaultOnFinishTime?.state || '07:00:00';
       const finishTimeMins = this._localFinishTimeMins != null ? this._localFinishTimeMins : parseTimeToMinutes(finishTimeStr);
 
-      // QS-217 — clipPath path builder. Outer circle subpath = full
-      // ring clip; inner circle subpath = the override-button
-      // carve-out hole (when the button is rendered). The two subpaths
-      // are concatenated with `clip-rule="evenodd"` on the parent
-      // <path>, so the inner subpath becomes a hole — the backdrop
-      // animation (flame / snow / wind) is clipped OUT of that disc,
-      // exposing the card background around the semi-transparent
-      // button. The carve is gated on `e.override_reset`, byte-
-      // identical to the existing `<div id="override_btn">` render
-      // gate, so the clipPath is visually equivalent to the original
-      // full-circle clip when there is no override button.
-      // DN-3 — the carve applies uniformly to ALL backdrops (including
-      // wind) by design. Wind wisps live at y = 130..190 (well above
-      // the carve top at y = 242 = 277 − 35), so the carve has no
-      // visible effect today; but a future wind redesign that extends
-      // toward the bottom inherits the carve automatically.
+      // QS-217 — clipPath path builder. Three subpaths concatenated
+      // with `clip-rule="evenodd"` on the parent <path>:
+      //   1. Outer circle subpath — full ring clip (always present).
+      //   2. Inner circle subpath (`carveSubpath`) — the override-
+      //      button carve-out hole. Winding flip: inside outer +
+      //      inside carve = winding 2 = outside clip (hole), so the
+      //      backdrop animation (flame / snow / wind) is clipped OUT
+      //      of that disc, exposing the card background around the
+      //      semi-transparent button.
+      //   3. Crescent-cancel subpath (`cancelSubpath`, review-fix #01
+      //      must-fix #1) — covers the region where the carve disc
+      //      protrudes below the outer clip disc. Without it the
+      //      crescent has winding 1 → backdrop leaks below the
+      //      button. The cancel subpath bumps that crescent's
+      //      winding from 1 → 2 → outside clip → leak hidden.
+      // Both inner subpaths are gated on
+      // `(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` — review-fix
+      // #01 nice-to-have #4 guards against degenerate `rx=ry=0` arc
+      // commands when the user iterates the radius down to 0.
+      // DN-3 — the carve + cancel apply uniformly to ALL backdrops
+      // (including wind) by design. Wind wisps live at y = 130..190
+      // (well above the carve top at y = 242 = 277 − 35), so the
+      // carve has no visible effect today; but a future wind
+      // redesign that extends toward the bottom inherits the carve
+      // (and the leak fix) automatically.
       // SVG path semantics: each subpath needs its own M move-to so
-      // evenodd treats them as independent regions — the explicit
-      // ` M …` prefix on `carveSubpath` provides that separator.
-      const carveSubpath = e.override_reset
+      // evenodd treats them as independent regions.
+      const carveSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
         ? ` M ${CENTER_X - OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_CY}` +
           ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${2 * OVERRIDE_BTN_CARVE_R},0` +
           ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${-2 * OVERRIDE_BTN_CARVE_R},0`
+        : '';
+      // Cancel subpath: triangle-like region bordered by the
+      // outer-disc small arc (large-arc-flag = 0, sweep-flag = 1)
+      // and the carve-disc large arc through the carve bottom
+      // (large-arc-flag = 1, sweep-flag = 1). See the radiator card
+      // arc-flag rationale comment for the derivation.
+      const cancelSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
+        ? ` M ${CENTER_X - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
+          ` A ${CLIP_R},${CLIP_R} 0 0 1 ${CENTER_X + OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
+          ` A ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1 1 ${CENTER_X - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y} Z`
         : '';
       const clipPathD =
         `M ${CENTER_X - CLIP_R},${CENTER_CY}` +
         ` a ${CLIP_R},${CLIP_R} 0 1,0 ${2 * CLIP_R},0` +
         ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0` +
-        carveSubpath;
+        carveSubpath +
+        cancelSubpath;
 
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">

--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -54,30 +54,52 @@ const CLIP_R = 120;                 // backdrop clip circle radius
 // pin the constant NAME, not the value, so a later tweak stays green.
 // The carve applies uniformly across all backdrops (flame / snow /
 // wind / none) — see DN-3 for the wind-backdrop preemptive rationale.
+// QS-217 review-fix #02 — radius bumped from 35 → 45 after user
+// visual iteration: at R = 35 the carve disc was just barely wider
+// than the button at the carve centre y but NARROWER than the
+// button at the button-top y, leaving thin slivers of animation
+// visible at the top corners of the visible button area AND a
+// visible "lens" curve where the outer-clip-disc bottom (y = 280)
+// cut through the button area. At R = 45 the carve x range at the
+// button top y ≈ 250 is 160 ± √(45² − 26.33²) ≈ 160 ± 36.5,
+// comfortably wider than the button x range (133.33–186.67), with
+// ~10 SVG ≈ ~9 CSS px of padding at the tightest spot.
 const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 35;
+const OVERRIDE_BTN_CARVE_R  = 45;
 
-// QS-217 review-fix #01: Crescent-cancel subpath intersection geometry.
-// The full carve disc extends 32 SVG units below the outer clip disc
-// (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R = 312 vs. CENTER_CY +
-// CLIP_R = 280). Under `clip-rule="evenodd"`, that crescent region
-// (inside the carve disc, OUTSIDE the outer clip disc) has winding
-// count 1 → "inside the clip" → the backdrop animation (flame /
-// snow / wind) would leak through below the override-hand button.
-// We bump the count to 2 by adding a third subpath shaped like the
-// crescent, bordered by the small outer-disc arc and the large
-// carve-disc arc that meet at the two circle intersections.
-// Two circles intersect when:
-//   y_int = (CLIP_R² − OVERRIDE_BTN_CARVE_R² + OVERRIDE_BTN_CARVE_CY²
-//            − CENTER_CY²) / (2 × (OVERRIDE_BTN_CARVE_CY − CENTER_CY))
-//         = 64304 / 234 ≈ 274.80 → rounded to 275
-//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²) ≈ 34.94 → 35
-// Integer rounding keeps the SVG path string short; the residual
-// (≤ 0.2 SVG units) is well below 1 CSS pixel and invisible. Swap
-// for floats (`274.80` / `34.94`) if a future visual review needs
-// exact alignment — the path string accepts decimals.
-const OVERRIDE_BTN_CARVE_INT_X = 35;
-const OVERRIDE_BTN_CARVE_INT_Y = 275;
+// QS-217 review-fix #02: Crescent-cancel subpath intersection
+// geometry, now DERIVED at module load instead of integer-rounded.
+// Under `clip-rule="evenodd"`, the full carve disc extends below
+// the outer clip disc (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R
+// > CENTER_CY + CLIP_R); that crescent region has winding count 1
+// → "inside the clip" → the backdrop animation (flame / snow /
+// wind) would leak through below the override-hand button. The
+// cancel subpath traces the leak crescent and bumps its winding to
+// 2 → outside clip → leak hidden. The cancel subpath's two arcs
+// MUST meet at the exact circle intersection points so each arc
+// segment actually lies on its respective circle. Integer-rounded
+// endpoints (review-fix #01) caused SVG to fit the arcs to
+// slightly-OFFSET circles (centre shifted ≈ 0.22 SVG units for
+// the outer-disc arc), producing a thin sub-pixel gap at chord
+// level — visible on high-DPI displays as a faint circle of
+// backdrop colour just below the button. Runtime derivation
+// eliminates the rounding artifact AND auto-tracks future
+// iterations on `OVERRIDE_BTN_CARVE_R`.
+// Subtracting the two circle equations (both centres on x =
+// CENTER_X, so x cancels) gives:
+//   y_int = (CLIP_R² − R² + CARVE_CY² − CENTER_CY²)
+//           / (2 × (CARVE_CY − CENTER_CY))
+//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²)  ← from outer disc
+const OVERRIDE_BTN_CARVE_INT_Y = (
+  CLIP_R * CLIP_R
+  - OVERRIDE_BTN_CARVE_R * OVERRIDE_BTN_CARVE_R
+  + OVERRIDE_BTN_CARVE_CY * OVERRIDE_BTN_CARVE_CY
+  - CENTER_CY * CENTER_CY
+) / (2 * (OVERRIDE_BTN_CARVE_CY - CENTER_CY));
+const OVERRIDE_BTN_CARVE_INT_X = Math.sqrt(
+  CLIP_R * CLIP_R
+  - (OVERRIDE_BTN_CARVE_INT_Y - CENTER_CY) ** 2
+);
 
 // --- Flame engine constants (QS-204 verbatim from qs-radiator-card.js) ---
 const FLAME_WIDTH = 480;            // single layer width in SVG px (2× clip diameter)

--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -37,71 +37,25 @@ const CENTER_CY = 160;              // SVG y-centre of the ring / clip circle
 const CENTER_X = 160;               // SVG x-centre of the ring / clip circle
 const CLIP_R = 120;                 // backdrop clip circle radius
 
-// QS-217: Override-button carve-out geometry.
+// QS-217 — Override-button cover overlay geometry.
+// Review-fix #03 abandons the earlier clipPath carve approach
+// (which created a geometric lens-shape hole — intersection of the
+// carve disc and the outer clip disc). Instead, a simple `<circle>`
+// cover with `fill="var(--card-background-color)"` is drawn ON TOP
+// of the clipped animation group, visually erasing the animation
+// in a clean circular patch behind the button.
 // Anchored to the CSS `.override-btn` at `position: absolute;
 // bottom: 15px; left: 50%; transform: translateX(-50%); width: 50px;
 // height: 50px;` inside `.ring` (300×300 CSS px). The SVG viewBox
-// (320×320) is rendered at 300×300 → uniform scale 320/300 ≈ 1.0667.
-//   Button center CSS px (within .ring):  (150, 260)
-//                                          = (.ring.w/2, .ring.h − 15 − 50/2)
-//   Button center SVG units:               (160, 277.33)  ← x = CENTER_X
-//   Button outer radius CSS px:            25
-//   Button outer radius SVG units:         26.67
-//   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
-// Both rounded to integers (snap to SVG grid; sub-pixel residual
-// is < 0.4 CSS px, invisible). `OVERRIDE_BTN_CARVE_R = 35` is a
-// deliberate test placeholder — the user iterates visually; tests
-// pin the constant NAME, not the value, so a later tweak stays green.
-// The carve applies uniformly across all backdrops (flame / snow /
-// wind / none) — see DN-3 for the wind-backdrop preemptive rationale.
-// QS-217 review-fix #02b — radius bumped 35 → 45 → 60 across two
-// visual-iteration rounds after the user reported a persistent
-// "lens" inside the button outline. At R = 35 the carve was
-// clearly too small; at R = 45 the math says the carve fully
-// contains the 50 CSS-px button outline, but the user-visible
-// button (the .override-btn 2px border + 4 % white background)
-// renders larger than the strict 50-px box on retina/high-DPI
-// displays — the user's empirical observation showed the visible
-// button at ≈ 92 SVG diameter (46 SVG radius), so R = 45 was just
-// barely too small. R = 60 covers any reasonable visible-button
-// radius with ~13 SVG ≈ ~12 CSS px of padding even at the
-// tightest button y values.
+// (320×320) renders at 300×300 → scale 320/300 ≈ 1.0667.
+// Button centre CSS px (within .ring): (150, 260). Button centre
+// SVG units: (160, 277.33) → rounded to (CENTER_X, 277). Cover
+// radius R = 35 SVG ≈ 33 CSS px ⇒ ~8 CSS px padding around the
+// 25 CSS-px-radius button outline. User-tunable.
+// The cover applies uniformly across all backdrops (flame / snow /
+// wind / none) — same DN-3 rationale as the original carve.
 const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 60;
-
-// QS-217 review-fix #02: Crescent-cancel subpath intersection
-// geometry, now DERIVED at module load instead of integer-rounded.
-// Under `clip-rule="evenodd"`, the full carve disc extends below
-// the outer clip disc (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R
-// > CENTER_CY + CLIP_R); that crescent region has winding count 1
-// → "inside the clip" → the backdrop animation (flame / snow /
-// wind) would leak through below the override-hand button. The
-// cancel subpath traces the leak crescent and bumps its winding to
-// 2 → outside clip → leak hidden. The cancel subpath's two arcs
-// MUST meet at the exact circle intersection points so each arc
-// segment actually lies on its respective circle. Integer-rounded
-// endpoints (review-fix #01) caused SVG to fit the arcs to
-// slightly-OFFSET circles (centre shifted ≈ 0.22 SVG units for
-// the outer-disc arc), producing a thin sub-pixel gap at chord
-// level — visible on high-DPI displays as a faint circle of
-// backdrop colour just below the button. Runtime derivation
-// eliminates the rounding artifact AND auto-tracks future
-// iterations on `OVERRIDE_BTN_CARVE_R`.
-// Subtracting the two circle equations (both centres on x =
-// CENTER_X, so x cancels) gives:
-//   y_int = (CLIP_R² − R² + CARVE_CY² − CENTER_CY²)
-//           / (2 × (CARVE_CY − CENTER_CY))
-//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²)  ← from outer disc
-const OVERRIDE_BTN_CARVE_INT_Y = (
-  CLIP_R * CLIP_R
-  - OVERRIDE_BTN_CARVE_R * OVERRIDE_BTN_CARVE_R
-  + OVERRIDE_BTN_CARVE_CY * OVERRIDE_BTN_CARVE_CY
-  - CENTER_CY * CENTER_CY
-) / (2 * (OVERRIDE_BTN_CARVE_CY - CENTER_CY));
-const OVERRIDE_BTN_CARVE_INT_X = Math.sqrt(
-  CLIP_R * CLIP_R
-  - (OVERRIDE_BTN_CARVE_INT_Y - CENTER_CY) ** 2
-);
+const OVERRIDE_BTN_CARVE_R  = 35;
 
 // --- Flame engine constants (QS-204 verbatim from qs-radiator-card.js) ---
 const FLAME_WIDTH = 480;            // single layer width in SVG px (2× clip diameter)
@@ -1388,54 +1342,17 @@ class QsClimateCard extends HTMLElement {
       const preservedSnowflakes = this._snowflakes;
       const preservedNextSnowflakeAt = this._nextSnowflakeAt;
 
-      // QS-217 — clipPath path builder. Three subpaths concatenated
-      // with `clip-rule="evenodd"` on the parent <path>:
-      //   1. Outer circle subpath — full ring clip (always present).
-      //   2. Inner circle subpath (`carveSubpath`) — the override-
-      //      button carve-out hole. Winding flip: inside outer +
-      //      inside carve = winding 2 = outside clip (hole), so the
-      //      backdrop animation (flame / snow / wind) is clipped OUT
-      //      of that disc, exposing the card background around the
-      //      semi-transparent button.
-      //   3. Crescent-cancel subpath (`cancelSubpath`, review-fix #01
-      //      must-fix #1) — covers the region where the carve disc
-      //      protrudes below the outer clip disc. Without it the
-      //      crescent has winding 1 → backdrop leaks below the
-      //      button. The cancel subpath bumps that crescent's
-      //      winding from 1 → 2 → outside clip → leak hidden.
-      // Both inner subpaths are gated on
-      // `(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` — review-fix
-      // #01 nice-to-have #4 guards against degenerate `rx=ry=0` arc
-      // commands when the user iterates the radius down to 0.
-      // DN-3 — the carve + cancel apply uniformly to ALL backdrops
-      // (including wind) by design. Wind wisps live at y = 130..190
-      // (well above the carve top at y = 242 = 277 − 35), so the
-      // carve has no visible effect today; but a future wind
-      // redesign that extends toward the bottom inherits the carve
-      // (and the leak fix) automatically.
-      // SVG path semantics: each subpath needs its own M move-to so
-      // evenodd treats them as independent regions.
-      const carveSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
-        ? ` M ${CENTER_X - OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_CY}` +
-          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${2 * OVERRIDE_BTN_CARVE_R},0` +
-          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${-2 * OVERRIDE_BTN_CARVE_R},0`
-        : '';
-      // Cancel subpath: triangle-like region bordered by the
-      // outer-disc small arc (large-arc-flag = 0, sweep-flag = 1)
-      // and the carve-disc large arc through the carve bottom
-      // (large-arc-flag = 1, sweep-flag = 1). See the radiator card
-      // arc-flag rationale comment for the derivation.
-      const cancelSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
-        ? ` M ${CENTER_X - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
-          ` A ${CLIP_R},${CLIP_R} 0 0 1 ${CENTER_X + OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
-          ` A ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1 1 ${CENTER_X - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y} Z`
-        : '';
+      // QS-217 review-fix #03 — clipPath is just the outer disc;
+      // the override-button area is hidden by a separate `<circle>`
+      // cover drawn AFTER the clipped animation group (see the SVG
+      // markup below). This replaces the earlier carve+cancel
+      // clipPath approach, which produced a geometric lens-shape
+      // hole. The cover applies uniformly to all four backdrops
+      // (flame / snow / wind / none) per DN-3.
       const clipPathD =
         `M ${CENTER_X - CLIP_R},${CENTER_CY}` +
         ` a ${CLIP_R},${CLIP_R} 0 1,0 ${2 * CLIP_R},0` +
-        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0` +
-        carveSubpath +
-        cancelSubpath;
+        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0`;
 
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
@@ -1485,6 +1402,7 @@ class QsClimateCard extends HTMLElement {
                 </g>
                 ` : ''}
               </g>
+              ${e.override_reset ? `<circle id="override_btn_cover" cx="${CENTER_X}" cy="${OVERRIDE_BTN_CARVE_CY}" r="${OVERRIDE_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${ringDashActive ? 'stroke-opacity="0.35"' : ''} />
               ${ringDashActive ? `

--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -37,6 +37,26 @@ const CENTER_CY = 160;              // SVG y-centre of the ring / clip circle
 const CENTER_X = 160;               // SVG x-centre of the ring / clip circle
 const CLIP_R = 120;                 // backdrop clip circle radius
 
+// QS-217: Override-button carve-out geometry.
+// Anchored to the CSS `.override-btn` at `position: absolute;
+// bottom: 15px; left: 50%; transform: translateX(-50%); width: 50px;
+// height: 50px;` inside `.ring` (300×300 CSS px). The SVG viewBox
+// (320×320) is rendered at 300×300 → uniform scale 320/300 ≈ 1.0667.
+//   Button center CSS px (within .ring):  (150, 260)
+//                                          = (.ring.w/2, .ring.h − 15 − 50/2)
+//   Button center SVG units:               (160, 277.33)  ← x = CENTER_X
+//   Button outer radius CSS px:            25
+//   Button outer radius SVG units:         26.67
+//   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
+// Both rounded to integers (snap to SVG grid; sub-pixel residual
+// is < 0.4 CSS px, invisible). `OVERRIDE_BTN_CARVE_R = 35` is a
+// deliberate test placeholder — the user iterates visually; tests
+// pin the constant NAME, not the value, so a later tweak stays green.
+// The carve applies uniformly across all backdrops (flame / snow /
+// wind / none) — see DN-3 for the wind-backdrop preemptive rationale.
+const OVERRIDE_BTN_CARVE_CY = 277;
+const OVERRIDE_BTN_CARVE_R  = 35;
+
 // --- Flame engine constants (QS-204 verbatim from qs-radiator-card.js) ---
 const FLAME_WIDTH = 480;            // single layer width in SVG px (2× clip diameter)
 const FLAME_BOTTOM_Y = 400;         // ≥ SVG viewBox max-y (320) so the closing rect is clipped
@@ -1316,6 +1336,36 @@ class QsClimateCard extends HTMLElement {
       const finishTimeStr = sDefaultOnFinishTime?.state || '07:00:00';
       const finishTimeMins = this._localFinishTimeMins != null ? this._localFinishTimeMins : parseTimeToMinutes(finishTimeStr);
 
+      // QS-217 — clipPath path builder. Outer circle subpath = full
+      // ring clip; inner circle subpath = the override-button
+      // carve-out hole (when the button is rendered). The two subpaths
+      // are concatenated with `clip-rule="evenodd"` on the parent
+      // <path>, so the inner subpath becomes a hole — the backdrop
+      // animation (flame / snow / wind) is clipped OUT of that disc,
+      // exposing the card background around the semi-transparent
+      // button. The carve is gated on `e.override_reset`, byte-
+      // identical to the existing `<div id="override_btn">` render
+      // gate, so the clipPath is visually equivalent to the original
+      // full-circle clip when there is no override button.
+      // DN-3 — the carve applies uniformly to ALL backdrops (including
+      // wind) by design. Wind wisps live at y = 130..190 (well above
+      // the carve top at y = 242 = 277 − 35), so the carve has no
+      // visible effect today; but a future wind redesign that extends
+      // toward the bottom inherits the carve automatically.
+      // SVG path semantics: each subpath needs its own M move-to so
+      // evenodd treats them as independent regions — the explicit
+      // ` M …` prefix on `carveSubpath` provides that separator.
+      const carveSubpath = e.override_reset
+        ? ` M ${CENTER_X - OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_CY}` +
+          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${2 * OVERRIDE_BTN_CARVE_R},0` +
+          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${-2 * OVERRIDE_BTN_CARVE_R},0`
+        : '';
+      const clipPathD =
+        `M ${CENTER_X - CLIP_R},${CENTER_CY}` +
+        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${2 * CLIP_R},0` +
+        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0` +
+        carveSubpath;
+
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
         <style>${css}</style>
@@ -1343,7 +1393,7 @@ class QsClimateCard extends HTMLElement {
                   </feMerge>
                 </filter>
                 <clipPath id="${climateClipId}">
-                  <circle cx="${CENTER_X}" cy="${CENTER_CY}" r="${CLIP_R}" />
+                  <path clip-rule="evenodd" d="${clipPathD}" />
                 </clipPath>
               </defs>
               <g clip-path="url(#${climateClipId})">

--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -54,18 +54,20 @@ const CLIP_R = 120;                 // backdrop clip circle radius
 // pin the constant NAME, not the value, so a later tweak stays green.
 // The carve applies uniformly across all backdrops (flame / snow /
 // wind / none) — see DN-3 for the wind-backdrop preemptive rationale.
-// QS-217 review-fix #02 — radius bumped from 35 → 45 after user
-// visual iteration: at R = 35 the carve disc was just barely wider
-// than the button at the carve centre y but NARROWER than the
-// button at the button-top y, leaving thin slivers of animation
-// visible at the top corners of the visible button area AND a
-// visible "lens" curve where the outer-clip-disc bottom (y = 280)
-// cut through the button area. At R = 45 the carve x range at the
-// button top y ≈ 250 is 160 ± √(45² − 26.33²) ≈ 160 ± 36.5,
-// comfortably wider than the button x range (133.33–186.67), with
-// ~10 SVG ≈ ~9 CSS px of padding at the tightest spot.
+// QS-217 review-fix #02b — radius bumped 35 → 45 → 60 across two
+// visual-iteration rounds after the user reported a persistent
+// "lens" inside the button outline. At R = 35 the carve was
+// clearly too small; at R = 45 the math says the carve fully
+// contains the 50 CSS-px button outline, but the user-visible
+// button (the .override-btn 2px border + 4 % white background)
+// renders larger than the strict 50-px box on retina/high-DPI
+// displays — the user's empirical observation showed the visible
+// button at ≈ 92 SVG diameter (46 SVG radius), so R = 45 was just
+// barely too small. R = 60 covers any reasonable visible-button
+// radius with ~13 SVG ≈ ~12 CSS px of padding even at the
+// tightest button y values.
 const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 45;
+const OVERRIDE_BTN_CARVE_R  = 60;
 
 // QS-217 review-fix #02: Crescent-cancel subpath intersection
 // geometry, now DERIVED at module load instead of integer-rounded.

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -38,69 +38,23 @@ const CLIP_R = 120;                 // flame clip circle radius
 const FLAME_WIDTH = 480;            // single layer width in SVG px (2× clip diameter)
 const FLAME_BOTTOM_Y = 400;         // ≥ SVG viewBox max-y (320) so the closing rect is clipped
 
-// QS-217: Override-button carve-out geometry.
+// QS-217 — Override-button cover overlay geometry.
+// Review-fix #03 abandons the earlier clipPath carve approach
+// (which created a geometric lens-shape hole — intersection of the
+// carve disc and the outer clip disc). Instead, a simple `<circle>`
+// cover with `fill="var(--card-background-color)"` is drawn ON TOP
+// of the clipped animation group, visually erasing the animation
+// in a clean circular patch behind the button.
 // Anchored to the CSS `.override-btn` at `position: absolute;
 // bottom: 15px; left: 50%; transform: translateX(-50%); width: 50px;
 // height: 50px;` inside `.ring` (300×300 CSS px). The SVG viewBox
-// (320×320) is rendered at 300×300 → uniform scale 320/300 ≈ 1.0667.
-//   Button center CSS px (within .ring):  (150, 260)
-//                                          = (.ring.w/2, .ring.h − 15 − 50/2)
-//   Button center SVG units:               (160, 277.33)  ← x = CENTER_CY
-//   Button outer radius CSS px:            25
-//   Button outer radius SVG units:         26.67
-//   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
-// QS-217 review-fix #02b — radius bumped 35 → 45 → 60 across two
-// visual-iteration rounds after the user reported a persistent
-// "lens" inside the button outline. At R = 35 the carve was clearly
-// too small; at R = 45 the math says the carve fully contains the
-// 50 CSS-px button outline, but the user-visible button (the
-// .override-btn 2px border + 4 % white background) renders larger
-// than the strict 50-px box on retina/high-DPI displays — empirical
-// measurement on the user's screenshot put the visible button at
-// ≈ 92 SVG diameter (46 SVG radius), so R = 45 was just barely too
-// small. R = 60 covers any reasonable visible-button radius with
-// ~13 SVG ≈ ~12 CSS px of padding even at the tightest button y
-// values. The constant remains user-tunable — tests pin the NAME
-// for builder-block references, and the integer value is pinned
-// at the current visual-iteration choice; bump both together on
-// future iterations.
+// (320×320) renders at 300×300 → scale 320/300 ≈ 1.0667.
+// Button centre CSS px (within .ring): (150, 260). Button centre
+// SVG units: (160, 277.33) → rounded to (CENTER_CY, 277). Cover
+// radius R = 35 SVG ≈ 33 CSS px ⇒ ~8 CSS px padding around the
+// 25 CSS-px-radius button outline. User-tunable.
 const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 60;
-
-// QS-217 review-fix #02: Crescent-cancel subpath intersection
-// geometry, now DERIVED at module load instead of integer-rounded.
-// Under `clip-rule="evenodd"`, the full carve disc extends below
-// the outer clip disc (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R
-// > CENTER_CY + CLIP_R); that crescent region has winding count 1
-// → "inside the clip" → the animation would leak through below the
-// override-hand button. The cancel subpath (a third subpath
-// concatenated into `clipPathD`) traces the leak crescent and
-// bumps its winding to 2 → outside clip → leak hidden.
-// The cancel subpath's two arcs MUST meet at the exact circle
-// intersection points so each arc segment actually lies on its
-// respective circle (outer-disc arc + carve-disc arc). Integer-
-// rounded endpoints (review-fix #01) caused SVG to fit the arcs
-// to slightly-OFFSET circles (centre shifted ≈ 0.22 SVG units
-// for the outer-disc arc), producing a thin sub-pixel gap at
-// chord level — visible on high-DPI displays as a faint circle
-// of animation colour just below the button. Runtime derivation
-// from the other constants eliminates the rounding artifact AND
-// auto-tracks future iterations on `OVERRIDE_BTN_CARVE_R`.
-// Subtracting the two circle equations (both centres on x =
-// CENTER_X, so x cancels) gives:
-//   y_int = (CLIP_R² − R² + CARVE_CY² − CENTER_CY²)
-//           / (2 × (CARVE_CY − CENTER_CY))
-//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²)  ← from outer disc
-const OVERRIDE_BTN_CARVE_INT_Y = (
-  CLIP_R * CLIP_R
-  - OVERRIDE_BTN_CARVE_R * OVERRIDE_BTN_CARVE_R
-  + OVERRIDE_BTN_CARVE_CY * OVERRIDE_BTN_CARVE_CY
-  - CENTER_CY * CENTER_CY
-) / (2 * (OVERRIDE_BTN_CARVE_CY - CENTER_CY));
-const OVERRIDE_BTN_CARVE_INT_X = Math.sqrt(
-  CLIP_R * CLIP_R
-  - (OVERRIDE_BTN_CARVE_INT_Y - CENTER_CY) ** 2
-);
+const OVERRIDE_BTN_CARVE_R  = 35;
 
 // --- Animation tuning ---
 const LERP_RATE = 2;                // exp time-constant; ~95% of lerp in ~1.5s
@@ -921,61 +875,16 @@ class QsRadiatorCard extends HTMLElement {
       // so keyboard-only users can tab to and activate them. The Enter/
       // Space handlers are wired in the event-binding loops below.
 
-      // QS-217 — clipPath path builder. Three subpaths concatenated
-      // with `clip-rule="evenodd"` on the parent <path>:
-      //   1. Outer circle subpath — full ring clip (always present).
-      //   2. Inner circle subpath (`carveSubpath`) — the override-
-      //      button carve-out hole. Winding flip: inside outer +
-      //      inside carve = winding 2 = outside clip (hole), so the
-      //      animation is clipped OUT of that disc, exposing the
-      //      card background around the semi-transparent button.
-      //   3. Crescent-cancel subpath (`cancelSubpath`, review-fix #01
-      //      must-fix #1) — covers the region where the carve disc
-      //      protrudes below the outer clip disc (carve bottom y =
-      //      312 vs. outer disc bottom y = 280). Without it the
-      //      crescent has winding 1 = inside clip → animation leaks
-      //      below the button. The cancel subpath bumps that
-      //      crescent's winding from 1 → 2 → outside clip → leak
-      //      hidden, with no change to the visible carve footprint.
-      // Both inner subpaths are gated on
-      // `(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` — review-fix
-      // #01 nice-to-have #4 guards against degenerate `rx=ry=0` arc
-      // commands when the user iterates the radius down to 0 (which
-      // some browsers reject with a console warning). When the
-      // override-reset entity isn't wired the clipPath is byte-
-      // identical to the pre-QS-217 full-disc circle clip.
-      // SVG path semantics: each subpath needs its own M move-to so
-      // evenodd treats them as independent regions — both
-      // `carveSubpath` and `cancelSubpath` start with an explicit
-      // ` M …` separator.
-      const carveSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
-        ? ` M ${CENTER_CY - OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_CY}` +
-          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${2 * OVERRIDE_BTN_CARVE_R},0` +
-          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${-2 * OVERRIDE_BTN_CARVE_R},0`
-        : '';
-      // Cancel subpath: triangle-like region bordered by
-      //   (a) outer-disc small arc from left intersection
-      //       (CENTER_CY − OVERRIDE_BTN_CARVE_INT_X,
-      //        OVERRIDE_BTN_CARVE_INT_Y) to right intersection
-      //       (CENTER_CY + OVERRIDE_BTN_CARVE_INT_X,
-      //        OVERRIDE_BTN_CARVE_INT_Y) — large-arc-flag = 0
-      //       (small arc through outer-disc bottom y = 280),
-      //       sweep-flag = 1 (clockwise in SVG y-down coords);
-      //   (b) carve-disc large arc back through the carve-disc
-      //       bottom (y = 312) — large-arc-flag = 1 (chord at
-      //       y = 275 is only 2 units above carve centre y = 277,
-      //       so most of the carve disc lies below), sweep-flag = 1.
-      const cancelSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
-        ? ` M ${CENTER_CY - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
-          ` A ${CLIP_R},${CLIP_R} 0 0 1 ${CENTER_CY + OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
-          ` A ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1 1 ${CENTER_CY - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y} Z`
-        : '';
+      // QS-217 review-fix #03 — clipPath is just the outer disc;
+      // the override-button area is hidden by a separate `<circle>`
+      // cover drawn AFTER the clipped animation group (see the SVG
+      // markup below). This replaces the earlier carve+cancel
+      // clipPath approach, which produced a geometric lens-shape
+      // hole.
       const clipPathD =
         `M ${CENTER_CY - CLIP_R},${CENTER_CY}` +
         ` a ${CLIP_R},${CLIP_R} 0 1,0 ${2 * CLIP_R},0` +
-        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0` +
-        carveSubpath +
-        cancelSubpath;
+        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0`;
 
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
@@ -1012,6 +921,7 @@ class QsRadiatorCard extends HTMLElement {
                   `<path id="flame${i}" d="${d}" fill="${initialFlameColors[i]}" opacity="1" pointer-events="none" style="will-change: transform;" />`
                 ).join("\n                ")}
               </g>
+              ${e.override_reset ? `<circle id="override_btn_cover" cx="${CENTER_CY}" cy="${OVERRIDE_BTN_CARVE_CY}" r="${OVERRIDE_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${ringDashActive ? 'stroke-opacity="0.35"' : ''} />
               ${ringDashActive ? `

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -49,22 +49,23 @@ const FLAME_BOTTOM_Y = 400;         // ≥ SVG viewBox max-y (320) so the closin
 //   Button outer radius CSS px:            25
 //   Button outer radius SVG units:         26.67
 //   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
-// QS-217 review-fix #02 — radius bumped from 35 → 45 after user
-// visual iteration: at R = 35 the carve disc was just barely wider
-// than the button at the carve centre y but NARROWER than the
-// button at the button-top y (the carve circle pinches inward as
-// you move away from its centre), leaving thin slivers of animation
-// visible at the top corners of the visible button area AND a
-// visible "lens" curve where the outer-clip-disc bottom (y = 280)
-// cut through the button area (carve too small to cover it). At
-// R = 45 the carve x range at the button top y ≈ 250 is
-// 160 ± √(45² − 26.33²) ≈ 160 ± 36.5, comfortably wider than the
-// button x range (133.33–186.67), with ~10 SVG ≈ ~9 CSS px of
-// padding at the tightest spot. The constant remains user-tunable
-// — tests pin the NAME, the integer value is the current visual-
-// iteration choice.
+// QS-217 review-fix #02b — radius bumped 35 → 45 → 60 across two
+// visual-iteration rounds after the user reported a persistent
+// "lens" inside the button outline. At R = 35 the carve was clearly
+// too small; at R = 45 the math says the carve fully contains the
+// 50 CSS-px button outline, but the user-visible button (the
+// .override-btn 2px border + 4 % white background) renders larger
+// than the strict 50-px box on retina/high-DPI displays — empirical
+// measurement on the user's screenshot put the visible button at
+// ≈ 92 SVG diameter (46 SVG radius), so R = 45 was just barely too
+// small. R = 60 covers any reasonable visible-button radius with
+// ~13 SVG ≈ ~12 CSS px of padding even at the tightest button y
+// values. The constant remains user-tunable — tests pin the NAME
+// for builder-block references, and the integer value is pinned
+// at the current visual-iteration choice; bump both together on
+// future iterations.
 const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 45;
+const OVERRIDE_BTN_CARVE_R  = 60;
 
 // QS-217 review-fix #02: Crescent-cancel subpath intersection
 // geometry, now DERIVED at module load instead of integer-rounded.

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -56,6 +56,29 @@ const FLAME_BOTTOM_Y = 400;         // ≥ SVG viewBox max-y (320) so the closin
 const OVERRIDE_BTN_CARVE_CY = 277;
 const OVERRIDE_BTN_CARVE_R  = 35;
 
+// QS-217 review-fix #01: Crescent-cancel subpath intersection geometry.
+// The full carve disc extends 32 SVG units below the outer clip disc
+// (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R = 312 vs. CENTER_CY +
+// CLIP_R = 280). Under `clip-rule="evenodd"`, that crescent region
+// (inside the carve disc, OUTSIDE the outer clip disc) has winding
+// count 1 → "inside the clip" → the animation leaks through below
+// the override-hand button. We bump the count to 2 by adding a third
+// subpath shaped like the crescent, bordered by the small outer-disc
+// arc and the large carve-disc arc that meet at the two circle
+// intersections. Two circles intersect when:
+//   y_int = (CLIP_R² − OVERRIDE_BTN_CARVE_R² + OVERRIDE_BTN_CARVE_CY²
+//            − CENTER_CY²) / (2 × (OVERRIDE_BTN_CARVE_CY − CENTER_CY))
+//         = (14400 − 1225 + 76729 − 25600) / (2 × 117)
+//         = 64304 / 234
+//         ≈ 274.80 → rounded to 275 (|Δ| = 0.2 SVG ≈ 0.19 CSS px)
+//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²) = √1221.0 ≈ 34.94 → 35
+// Integer rounding keeps the SVG path string short; the residual
+// (≤ 0.2 SVG units) is well below 1 CSS pixel and invisible. If a
+// future visual review needs exact alignment, swap both constants
+// for floats (`274.80` / `34.94`); the path string accepts decimals.
+const OVERRIDE_BTN_CARVE_INT_X = 35;
+const OVERRIDE_BTN_CARVE_INT_Y = 275;
+
 // --- Animation tuning ---
 const LERP_RATE = 2;                // exp time-constant; ~95% of lerp in ~1.5s
 const LERP_DT_CEIL = 0.1;           // s; clamp lerp dt to avoid snap-to after tab hidden
@@ -875,30 +898,61 @@ class QsRadiatorCard extends HTMLElement {
       // so keyboard-only users can tab to and activate them. The Enter/
       // Space handlers are wired in the event-binding loops below.
 
-      // QS-217 — clipPath path builder. Outer circle subpath = full
-      // ring clip; inner circle subpath = the override-button
-      // carve-out hole (when the button is rendered). The two subpaths
-      // are concatenated with `clip-rule="evenodd"` on the parent
-      // <path>, so the inner subpath becomes a hole — the animation
-      // is clipped OUT of that disc, exposing the card background
-      // around the semi-transparent button. The carve is gated on
-      // `e.override_reset`, byte-identical to the existing
-      // `<div id="override_btn">` render gate, so the clipPath is
-      // visually equivalent to the original full-circle clip when
-      // there is no override button.
+      // QS-217 — clipPath path builder. Three subpaths concatenated
+      // with `clip-rule="evenodd"` on the parent <path>:
+      //   1. Outer circle subpath — full ring clip (always present).
+      //   2. Inner circle subpath (`carveSubpath`) — the override-
+      //      button carve-out hole. Winding flip: inside outer +
+      //      inside carve = winding 2 = outside clip (hole), so the
+      //      animation is clipped OUT of that disc, exposing the
+      //      card background around the semi-transparent button.
+      //   3. Crescent-cancel subpath (`cancelSubpath`, review-fix #01
+      //      must-fix #1) — covers the region where the carve disc
+      //      protrudes below the outer clip disc (carve bottom y =
+      //      312 vs. outer disc bottom y = 280). Without it the
+      //      crescent has winding 1 = inside clip → animation leaks
+      //      below the button. The cancel subpath bumps that
+      //      crescent's winding from 1 → 2 → outside clip → leak
+      //      hidden, with no change to the visible carve footprint.
+      // Both inner subpaths are gated on
+      // `(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` — review-fix
+      // #01 nice-to-have #4 guards against degenerate `rx=ry=0` arc
+      // commands when the user iterates the radius down to 0 (which
+      // some browsers reject with a console warning). When the
+      // override-reset entity isn't wired the clipPath is byte-
+      // identical to the pre-QS-217 full-disc circle clip.
       // SVG path semantics: each subpath needs its own M move-to so
-      // evenodd treats them as independent regions — the explicit
-      // ` M …` prefix on `carveSubpath` provides that separator.
-      const carveSubpath = e.override_reset
+      // evenodd treats them as independent regions — both
+      // `carveSubpath` and `cancelSubpath` start with an explicit
+      // ` M …` separator.
+      const carveSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
         ? ` M ${CENTER_CY - OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_CY}` +
           ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${2 * OVERRIDE_BTN_CARVE_R},0` +
           ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${-2 * OVERRIDE_BTN_CARVE_R},0`
+        : '';
+      // Cancel subpath: triangle-like region bordered by
+      //   (a) outer-disc small arc from left intersection
+      //       (CENTER_CY − OVERRIDE_BTN_CARVE_INT_X,
+      //        OVERRIDE_BTN_CARVE_INT_Y) to right intersection
+      //       (CENTER_CY + OVERRIDE_BTN_CARVE_INT_X,
+      //        OVERRIDE_BTN_CARVE_INT_Y) — large-arc-flag = 0
+      //       (small arc through outer-disc bottom y = 280),
+      //       sweep-flag = 1 (clockwise in SVG y-down coords);
+      //   (b) carve-disc large arc back through the carve-disc
+      //       bottom (y = 312) — large-arc-flag = 1 (chord at
+      //       y = 275 is only 2 units above carve centre y = 277,
+      //       so most of the carve disc lies below), sweep-flag = 1.
+      const cancelSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
+        ? ` M ${CENTER_CY - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
+          ` A ${CLIP_R},${CLIP_R} 0 0 1 ${CENTER_CY + OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
+          ` A ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1 1 ${CENTER_CY - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y} Z`
         : '';
       const clipPathD =
         `M ${CENTER_CY - CLIP_R},${CENTER_CY}` +
         ` a ${CLIP_R},${CLIP_R} 0 1,0 ${2 * CLIP_R},0` +
         ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0` +
-        carveSubpath;
+        carveSubpath +
+        cancelSubpath;
 
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -38,6 +38,24 @@ const CLIP_R = 120;                 // flame clip circle radius
 const FLAME_WIDTH = 480;            // single layer width in SVG px (2× clip diameter)
 const FLAME_BOTTOM_Y = 400;         // ≥ SVG viewBox max-y (320) so the closing rect is clipped
 
+// QS-217: Override-button carve-out geometry.
+// Anchored to the CSS `.override-btn` at `position: absolute;
+// bottom: 15px; left: 50%; transform: translateX(-50%); width: 50px;
+// height: 50px;` inside `.ring` (300×300 CSS px). The SVG viewBox
+// (320×320) is rendered at 300×300 → uniform scale 320/300 ≈ 1.0667.
+//   Button center CSS px (within .ring):  (150, 260)
+//                                          = (.ring.w/2, .ring.h − 15 − 50/2)
+//   Button center SVG units:               (160, 277.33)  ← x = CENTER_CY
+//   Button outer radius CSS px:            25
+//   Button outer radius SVG units:         26.67
+//   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
+// Both rounded to integers (snap to SVG grid; sub-pixel residual
+// is < 0.4 CSS px, invisible). `OVERRIDE_BTN_CARVE_R = 35` is a
+// deliberate test placeholder — the user iterates visually; tests
+// pin the constant NAME, not the value, so a later tweak stays green.
+const OVERRIDE_BTN_CARVE_CY = 277;
+const OVERRIDE_BTN_CARVE_R  = 35;
+
 // --- Animation tuning ---
 const LERP_RATE = 2;                // exp time-constant; ~95% of lerp in ~1.5s
 const LERP_DT_CEIL = 0.1;           // s; clamp lerp dt to avoid snap-to after tab hidden
@@ -856,6 +874,32 @@ class QsRadiatorCard extends HTMLElement {
       // S16 — primary action `<div>`s get `role="button"` + `tabindex="0"`
       // so keyboard-only users can tab to and activate them. The Enter/
       // Space handlers are wired in the event-binding loops below.
+
+      // QS-217 — clipPath path builder. Outer circle subpath = full
+      // ring clip; inner circle subpath = the override-button
+      // carve-out hole (when the button is rendered). The two subpaths
+      // are concatenated with `clip-rule="evenodd"` on the parent
+      // <path>, so the inner subpath becomes a hole — the animation
+      // is clipped OUT of that disc, exposing the card background
+      // around the semi-transparent button. The carve is gated on
+      // `e.override_reset`, byte-identical to the existing
+      // `<div id="override_btn">` render gate, so the clipPath is
+      // visually equivalent to the original full-circle clip when
+      // there is no override button.
+      // SVG path semantics: each subpath needs its own M move-to so
+      // evenodd treats them as independent regions — the explicit
+      // ` M …` prefix on `carveSubpath` provides that separator.
+      const carveSubpath = e.override_reset
+        ? ` M ${CENTER_CY - OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_CY}` +
+          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${2 * OVERRIDE_BTN_CARVE_R},0` +
+          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${-2 * OVERRIDE_BTN_CARVE_R},0`
+        : '';
+      const clipPathD =
+        `M ${CENTER_CY - CLIP_R},${CENTER_CY}` +
+        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${2 * CLIP_R},0` +
+        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0` +
+        carveSubpath;
+
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
         <style>${css}</style>
@@ -883,7 +927,7 @@ class QsRadiatorCard extends HTMLElement {
                   </feMerge>
                 </filter>
                 <clipPath id="${flameClipId}">
-                  <circle cx="${CENTER_CY}" cy="${CENTER_CY}" r="${CLIP_R}" />
+                  <path clip-rule="evenodd" d="${clipPathD}" />
                 </clipPath>
               </defs>
               <g clip-path="url(#${flameClipId})">

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -49,35 +49,57 @@ const FLAME_BOTTOM_Y = 400;         // ≥ SVG viewBox max-y (320) so the closin
 //   Button outer radius CSS px:            25
 //   Button outer radius SVG units:         26.67
 //   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
-// Both rounded to integers (snap to SVG grid; sub-pixel residual
-// is < 0.4 CSS px, invisible). `OVERRIDE_BTN_CARVE_R = 35` is a
-// deliberate test placeholder — the user iterates visually; tests
-// pin the constant NAME, not the value, so a later tweak stays green.
+// QS-217 review-fix #02 — radius bumped from 35 → 45 after user
+// visual iteration: at R = 35 the carve disc was just barely wider
+// than the button at the carve centre y but NARROWER than the
+// button at the button-top y (the carve circle pinches inward as
+// you move away from its centre), leaving thin slivers of animation
+// visible at the top corners of the visible button area AND a
+// visible "lens" curve where the outer-clip-disc bottom (y = 280)
+// cut through the button area (carve too small to cover it). At
+// R = 45 the carve x range at the button top y ≈ 250 is
+// 160 ± √(45² − 26.33²) ≈ 160 ± 36.5, comfortably wider than the
+// button x range (133.33–186.67), with ~10 SVG ≈ ~9 CSS px of
+// padding at the tightest spot. The constant remains user-tunable
+// — tests pin the NAME, the integer value is the current visual-
+// iteration choice.
 const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 35;
+const OVERRIDE_BTN_CARVE_R  = 45;
 
-// QS-217 review-fix #01: Crescent-cancel subpath intersection geometry.
-// The full carve disc extends 32 SVG units below the outer clip disc
-// (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R = 312 vs. CENTER_CY +
-// CLIP_R = 280). Under `clip-rule="evenodd"`, that crescent region
-// (inside the carve disc, OUTSIDE the outer clip disc) has winding
-// count 1 → "inside the clip" → the animation leaks through below
-// the override-hand button. We bump the count to 2 by adding a third
-// subpath shaped like the crescent, bordered by the small outer-disc
-// arc and the large carve-disc arc that meet at the two circle
-// intersections. Two circles intersect when:
-//   y_int = (CLIP_R² − OVERRIDE_BTN_CARVE_R² + OVERRIDE_BTN_CARVE_CY²
-//            − CENTER_CY²) / (2 × (OVERRIDE_BTN_CARVE_CY − CENTER_CY))
-//         = (14400 − 1225 + 76729 − 25600) / (2 × 117)
-//         = 64304 / 234
-//         ≈ 274.80 → rounded to 275 (|Δ| = 0.2 SVG ≈ 0.19 CSS px)
-//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²) = √1221.0 ≈ 34.94 → 35
-// Integer rounding keeps the SVG path string short; the residual
-// (≤ 0.2 SVG units) is well below 1 CSS pixel and invisible. If a
-// future visual review needs exact alignment, swap both constants
-// for floats (`274.80` / `34.94`); the path string accepts decimals.
-const OVERRIDE_BTN_CARVE_INT_X = 35;
-const OVERRIDE_BTN_CARVE_INT_Y = 275;
+// QS-217 review-fix #02: Crescent-cancel subpath intersection
+// geometry, now DERIVED at module load instead of integer-rounded.
+// Under `clip-rule="evenodd"`, the full carve disc extends below
+// the outer clip disc (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R
+// > CENTER_CY + CLIP_R); that crescent region has winding count 1
+// → "inside the clip" → the animation would leak through below the
+// override-hand button. The cancel subpath (a third subpath
+// concatenated into `clipPathD`) traces the leak crescent and
+// bumps its winding to 2 → outside clip → leak hidden.
+// The cancel subpath's two arcs MUST meet at the exact circle
+// intersection points so each arc segment actually lies on its
+// respective circle (outer-disc arc + carve-disc arc). Integer-
+// rounded endpoints (review-fix #01) caused SVG to fit the arcs
+// to slightly-OFFSET circles (centre shifted ≈ 0.22 SVG units
+// for the outer-disc arc), producing a thin sub-pixel gap at
+// chord level — visible on high-DPI displays as a faint circle
+// of animation colour just below the button. Runtime derivation
+// from the other constants eliminates the rounding artifact AND
+// auto-tracks future iterations on `OVERRIDE_BTN_CARVE_R`.
+// Subtracting the two circle equations (both centres on x =
+// CENTER_X, so x cancels) gives:
+//   y_int = (CLIP_R² − R² + CARVE_CY² − CENTER_CY²)
+//           / (2 × (CARVE_CY − CENTER_CY))
+//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²)  ← from outer disc
+const OVERRIDE_BTN_CARVE_INT_Y = (
+  CLIP_R * CLIP_R
+  - OVERRIDE_BTN_CARVE_R * OVERRIDE_BTN_CARVE_R
+  + OVERRIDE_BTN_CARVE_CY * OVERRIDE_BTN_CARVE_CY
+  - CENTER_CY * CENTER_CY
+) / (2 * (OVERRIDE_BTN_CARVE_CY - CENTER_CY));
+const OVERRIDE_BTN_CARVE_INT_X = Math.sqrt(
+  CLIP_R * CLIP_R
+  - (OVERRIDE_BTN_CARVE_INT_Y - CENTER_CY) ** 2
+);
 
 // --- Animation tuning ---
 const LERP_RATE = 2;                // exp time-constant; ~95% of lerp in ~1.5s

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -48,20 +48,21 @@ const WAVE_BOTTOM_Y = 400;          // closing rectangle y; clipped by circle
 //   Button outer radius CSS px:            25
 //   Button outer radius SVG units:         26.67
 //   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
-// QS-217 review-fix #02 — radius bumped from 35 → 45 after user
-// visual iteration: at R = 35 the carve disc was just barely wider
-// than the button at the carve centre y but NARROWER than the
-// button at the button-top y, leaving thin slivers of animation
-// visible at the top corners of the visible button area AND a
-// visible "lens" curve where the outer-clip-disc bottom (y = 280)
-// cut through the button area. At R = 45 the carve x range at the
-// button top y ≈ 250 is 160 ± √(45² − 26.33²) ≈ 160 ± 36.5,
-// comfortably wider than the button x range (133.33–186.67), with
-// ~10 SVG ≈ ~9 CSS px of padding at the tightest spot. The
-// constant remains user-tunable — tests pin the NAME, the integer
-// value is the current visual-iteration choice.
+// QS-217 review-fix #02b — radius bumped 35 → 45 → 60 across two
+// visual-iteration rounds after the user (testing on this boiler
+// card) reported a persistent "lens" inside the button outline.
+// At R = 35 the carve was clearly too small; at R = 45 the math
+// says the carve fully contains the 50 CSS-px button outline, but
+// the user-visible button (the .override-btn 2px border + 4 %
+// white background) renders larger than the strict 50-px box on
+// retina/high-DPI displays — empirical measurement on the user's
+// screenshot put the visible button at ≈ 92 SVG diameter (46 SVG
+// radius), so R = 45 was just barely too small. R = 60 covers any
+// reasonable visible-button radius with ~13 SVG ≈ ~12 CSS px of
+// padding even at the tightest button y values. The constant
+// remains user-tunable.
 const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 45;
+const OVERRIDE_BTN_CARVE_R  = 60;
 
 // QS-217 review-fix #02: Crescent-cancel subpath intersection
 // geometry, now DERIVED at module load instead of integer-rounded.

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -37,6 +37,24 @@ const CLIP_R = 120;                 // water clip circle radius (10px inside rin
 const WAVE_WIDTH = 480;             // single wave period (2× clip diameter)
 const WAVE_BOTTOM_Y = 400;          // closing rectangle y; clipped by circle
 
+// QS-217: Override-button carve-out geometry.
+// Anchored to the CSS `.override-btn` at `position: absolute;
+// bottom: 15px; left: 50%; transform: translateX(-50%); width: 50px;
+// height: 50px;` inside `.ring` (300×300 CSS px). The SVG viewBox
+// (320×320) is rendered at 300×300 → uniform scale 320/300 ≈ 1.0667.
+//   Button center CSS px (within .ring):  (150, 260)
+//                                          = (.ring.w/2, .ring.h − 15 − 50/2)
+//   Button center SVG units:               (160, 277.33)  ← x = CENTER_CX
+//   Button outer radius CSS px:            25
+//   Button outer radius SVG units:         26.67
+//   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
+// Both rounded to integers (snap to SVG grid; sub-pixel residual
+// is < 0.4 CSS px, invisible). `OVERRIDE_BTN_CARVE_R = 35` is a
+// deliberate test placeholder — the user iterates visually; tests
+// pin the constant NAME, not the value, so a later tweak stays green.
+const OVERRIDE_BTN_CARVE_CY = 277;
+const OVERRIDE_BTN_CARVE_R  = 35;
+
 // --- Per-layer wave offsets ---
 const LAYER_SCROLL_OFFSET = 1.2;
 const LAYER_PHASE_OFFSET = 2.1;
@@ -1193,6 +1211,31 @@ class QsWaterBoilerCard extends HTMLElement {
       const preservedBubbles = this._bubbles;
       const preservedNextBubbleAt = this._nextBubbleAt;
 
+      // QS-217 — clipPath path builder. Outer circle subpath = full
+      // ring clip; inner circle subpath = the override-button
+      // carve-out hole (when the button is rendered). The two subpaths
+      // are concatenated with `clip-rule="evenodd"` on the parent
+      // <path>, so the inner subpath becomes a hole — the water
+      // animation is clipped OUT of that disc, exposing the card
+      // background around the semi-transparent button. The carve is
+      // gated on `e.override_reset`, byte-identical to the existing
+      // `<div id="override_btn">` render gate, so the clipPath is
+      // visually equivalent to the original full-circle clip when
+      // there is no override button.
+      // SVG path semantics: each subpath needs its own M move-to so
+      // evenodd treats them as independent regions — the explicit
+      // ` M …` prefix on `carveSubpath` provides that separator.
+      const carveSubpath = e.override_reset
+        ? ` M ${CENTER_CX - OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_CY}` +
+          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${2 * OVERRIDE_BTN_CARVE_R},0` +
+          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${-2 * OVERRIDE_BTN_CARVE_R},0`
+        : '';
+      const clipPathD =
+        `M ${CENTER_CX - CLIP_R},${CENTER_CY}` +
+        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${2 * CLIP_R},0` +
+        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0` +
+        carveSubpath;
+
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
         <style>${css}</style>
@@ -1221,7 +1264,7 @@ class QsWaterBoilerCard extends HTMLElement {
                   </feMerge>
                 </filter>
                 <clipPath id="${waterClipId}">
-                  <circle cx="${CENTER_CX}" cy="${CENTER_CY}" r="${CLIP_R}" />
+                  <path clip-rule="evenodd" d="${clipPathD}" />
                 </clipPath>
                 <filter id="${surfaceGlowFilterId}" x="-50%" y="-50%" width="200%" height="200%">
                   <feGaussianBlur stdDeviation="${SURFACE_GLOW_BLUR_STDDEV}" result="blur" />

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -48,34 +48,53 @@ const WAVE_BOTTOM_Y = 400;          // closing rectangle y; clipped by circle
 //   Button outer radius CSS px:            25
 //   Button outer radius SVG units:         26.67
 //   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
-// Both rounded to integers (snap to SVG grid; sub-pixel residual
-// is < 0.4 CSS px, invisible). `OVERRIDE_BTN_CARVE_R = 35` is a
-// deliberate test placeholder — the user iterates visually; tests
-// pin the constant NAME, not the value, so a later tweak stays green.
+// QS-217 review-fix #02 — radius bumped from 35 → 45 after user
+// visual iteration: at R = 35 the carve disc was just barely wider
+// than the button at the carve centre y but NARROWER than the
+// button at the button-top y, leaving thin slivers of animation
+// visible at the top corners of the visible button area AND a
+// visible "lens" curve where the outer-clip-disc bottom (y = 280)
+// cut through the button area. At R = 45 the carve x range at the
+// button top y ≈ 250 is 160 ± √(45² − 26.33²) ≈ 160 ± 36.5,
+// comfortably wider than the button x range (133.33–186.67), with
+// ~10 SVG ≈ ~9 CSS px of padding at the tightest spot. The
+// constant remains user-tunable — tests pin the NAME, the integer
+// value is the current visual-iteration choice.
 const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 35;
+const OVERRIDE_BTN_CARVE_R  = 45;
 
-// QS-217 review-fix #01: Crescent-cancel subpath intersection geometry.
-// The full carve disc extends 32 SVG units below the outer clip disc
-// (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R = 312 vs. CENTER_CY +
-// CLIP_R = 280). Under `clip-rule="evenodd"`, that crescent region
-// (inside the carve disc, OUTSIDE the outer clip disc) has winding
-// count 1 → "inside the clip" → the water animation leaks through
-// below the override-hand button (user screenshot confirmed). We
-// bump the count to 2 by adding a third subpath shaped like the
-// crescent, bordered by the small outer-disc arc and the large
-// carve-disc arc that meet at the two circle intersections.
-// Two circles intersect when:
-//   y_int = (CLIP_R² − OVERRIDE_BTN_CARVE_R² + OVERRIDE_BTN_CARVE_CY²
-//            − CENTER_CY²) / (2 × (OVERRIDE_BTN_CARVE_CY − CENTER_CY))
-//         = 64304 / 234 ≈ 274.80 → rounded to 275
-//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²) ≈ 34.94 → 35
-// Integer rounding keeps the SVG path string short; the residual
-// (≤ 0.2 SVG units) is well below 1 CSS pixel and invisible. Swap
-// for floats (`274.80` / `34.94`) if a future visual review needs
-// exact alignment — the path string accepts decimals.
-const OVERRIDE_BTN_CARVE_INT_X = 35;
-const OVERRIDE_BTN_CARVE_INT_Y = 275;
+// QS-217 review-fix #02: Crescent-cancel subpath intersection
+// geometry, now DERIVED at module load instead of integer-rounded.
+// Under `clip-rule="evenodd"`, the full carve disc extends below
+// the outer clip disc (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R
+// > CENTER_CY + CLIP_R); that crescent region has winding count 1
+// → "inside the clip" → the water animation would leak through
+// below the override-hand button. The cancel subpath traces the
+// leak crescent and bumps its winding to 2 → outside clip → leak
+// hidden. The cancel subpath's two arcs MUST meet at the exact
+// circle intersection points so each arc segment actually lies on
+// its respective circle. Integer-rounded endpoints (review-fix
+// #01) caused SVG to fit the arcs to slightly-OFFSET circles
+// (centre shifted ≈ 0.22 SVG units for the outer-disc arc),
+// producing a thin sub-pixel gap at chord level — visible on
+// high-DPI displays as a faint circle of water colour just below
+// the button. Runtime derivation eliminates the rounding artifact
+// AND auto-tracks future iterations on `OVERRIDE_BTN_CARVE_R`.
+// Subtracting the two circle equations (both centres on x =
+// CENTER_CX, so x cancels) gives:
+//   y_int = (CLIP_R² − R² + CARVE_CY² − CENTER_CY²)
+//           / (2 × (CARVE_CY − CENTER_CY))
+//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²)  ← from outer disc
+const OVERRIDE_BTN_CARVE_INT_Y = (
+  CLIP_R * CLIP_R
+  - OVERRIDE_BTN_CARVE_R * OVERRIDE_BTN_CARVE_R
+  + OVERRIDE_BTN_CARVE_CY * OVERRIDE_BTN_CARVE_CY
+  - CENTER_CY * CENTER_CY
+) / (2 * (OVERRIDE_BTN_CARVE_CY - CENTER_CY));
+const OVERRIDE_BTN_CARVE_INT_X = Math.sqrt(
+  CLIP_R * CLIP_R
+  - (OVERRIDE_BTN_CARVE_INT_Y - CENTER_CY) ** 2
+);
 
 // --- Per-layer wave offsets ---
 const LAYER_SCROLL_OFFSET = 1.2;

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -55,6 +55,28 @@ const WAVE_BOTTOM_Y = 400;          // closing rectangle y; clipped by circle
 const OVERRIDE_BTN_CARVE_CY = 277;
 const OVERRIDE_BTN_CARVE_R  = 35;
 
+// QS-217 review-fix #01: Crescent-cancel subpath intersection geometry.
+// The full carve disc extends 32 SVG units below the outer clip disc
+// (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R = 312 vs. CENTER_CY +
+// CLIP_R = 280). Under `clip-rule="evenodd"`, that crescent region
+// (inside the carve disc, OUTSIDE the outer clip disc) has winding
+// count 1 → "inside the clip" → the water animation leaks through
+// below the override-hand button (user screenshot confirmed). We
+// bump the count to 2 by adding a third subpath shaped like the
+// crescent, bordered by the small outer-disc arc and the large
+// carve-disc arc that meet at the two circle intersections.
+// Two circles intersect when:
+//   y_int = (CLIP_R² − OVERRIDE_BTN_CARVE_R² + OVERRIDE_BTN_CARVE_CY²
+//            − CENTER_CY²) / (2 × (OVERRIDE_BTN_CARVE_CY − CENTER_CY))
+//         = 64304 / 234 ≈ 274.80 → rounded to 275
+//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²) ≈ 34.94 → 35
+// Integer rounding keeps the SVG path string short; the residual
+// (≤ 0.2 SVG units) is well below 1 CSS pixel and invisible. Swap
+// for floats (`274.80` / `34.94`) if a future visual review needs
+// exact alignment — the path string accepts decimals.
+const OVERRIDE_BTN_CARVE_INT_X = 35;
+const OVERRIDE_BTN_CARVE_INT_Y = 275;
+
 // --- Per-layer wave offsets ---
 const LAYER_SCROLL_OFFSET = 1.2;
 const LAYER_PHASE_OFFSET = 2.1;
@@ -1211,30 +1233,48 @@ class QsWaterBoilerCard extends HTMLElement {
       const preservedBubbles = this._bubbles;
       const preservedNextBubbleAt = this._nextBubbleAt;
 
-      // QS-217 — clipPath path builder. Outer circle subpath = full
-      // ring clip; inner circle subpath = the override-button
-      // carve-out hole (when the button is rendered). The two subpaths
-      // are concatenated with `clip-rule="evenodd"` on the parent
-      // <path>, so the inner subpath becomes a hole — the water
-      // animation is clipped OUT of that disc, exposing the card
-      // background around the semi-transparent button. The carve is
-      // gated on `e.override_reset`, byte-identical to the existing
-      // `<div id="override_btn">` render gate, so the clipPath is
-      // visually equivalent to the original full-circle clip when
-      // there is no override button.
+      // QS-217 — clipPath path builder. Three subpaths concatenated
+      // with `clip-rule="evenodd"` on the parent <path>:
+      //   1. Outer circle subpath — full ring clip (always present).
+      //   2. Inner circle subpath (`carveSubpath`) — the override-
+      //      button carve-out hole. Winding flip: inside outer +
+      //      inside carve = winding 2 = outside clip (hole), so the
+      //      water animation is clipped OUT of that disc, exposing
+      //      the card background around the semi-transparent button.
+      //   3. Crescent-cancel subpath (`cancelSubpath`, review-fix #01
+      //      must-fix #1) — covers the region where the carve disc
+      //      protrudes below the outer clip disc. Without it the
+      //      crescent shows the wave animation as a coloured arc
+      //      below the override button (user-confirmed by
+      //      screenshot). The cancel subpath bumps that crescent's
+      //      winding from 1 → 2 → outside clip → leak hidden.
+      // Both inner subpaths are gated on
+      // `(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` — review-fix
+      // #01 nice-to-have #4 guards against degenerate `rx=ry=0` arc
+      // commands when the user iterates the radius down to 0.
       // SVG path semantics: each subpath needs its own M move-to so
-      // evenodd treats them as independent regions — the explicit
-      // ` M …` prefix on `carveSubpath` provides that separator.
-      const carveSubpath = e.override_reset
+      // evenodd treats them as independent regions.
+      const carveSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
         ? ` M ${CENTER_CX - OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_CY}` +
           ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${2 * OVERRIDE_BTN_CARVE_R},0` +
           ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${-2 * OVERRIDE_BTN_CARVE_R},0`
+        : '';
+      // Cancel subpath: triangle-like region bordered by the
+      // outer-disc small arc (large-arc-flag = 0, sweep-flag = 1)
+      // and the carve-disc large arc through the carve bottom
+      // (large-arc-flag = 1, sweep-flag = 1). See the radiator card
+      // arc-flag rationale comment for the derivation.
+      const cancelSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
+        ? ` M ${CENTER_CX - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
+          ` A ${CLIP_R},${CLIP_R} 0 0 1 ${CENTER_CX + OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
+          ` A ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1 1 ${CENTER_CX - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y} Z`
         : '';
       const clipPathD =
         `M ${CENTER_CX - CLIP_R},${CENTER_CY}` +
         ` a ${CLIP_R},${CLIP_R} 0 1,0 ${2 * CLIP_R},0` +
         ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0` +
-        carveSubpath;
+        carveSubpath +
+        cancelSubpath;
 
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -37,65 +37,30 @@ const CLIP_R = 120;                 // water clip circle radius (10px inside rin
 const WAVE_WIDTH = 480;             // single wave period (2× clip diameter)
 const WAVE_BOTTOM_Y = 400;          // closing rectangle y; clipped by circle
 
-// QS-217: Override-button carve-out geometry.
+// QS-217 — Override-button cover overlay geometry.
+// Iteration history: the original PR #219 used a CLIPPATH carve
+// (outer disc + carve disc + cancel subpath, evenodd). That created
+// a hole in the water animation via the SVG clip-path mechanism.
+// Across three review-fix rounds (R=35 → 45 → 60) the user
+// consistently reported a visible "lens" inside the button — the
+// intersection of the carve disc and the outer clip disc is
+// geometrically a lens (vesica piscis) shape, so the visible HOLE
+// took on that shape regardless of R; bigger R just produced a
+// bigger lens. Review-fix #03 abandons the clipPath approach
+// entirely and uses a SIMPLE `<circle>` cover drawn ON TOP of the
+// clipped animation group, with `fill="var(--card-background-color)"`
+// so it visually erases the animation in a circular patch. The
+// patch IS a circle by construction — no lens shape possible.
 // Anchored to the CSS `.override-btn` at `position: absolute;
 // bottom: 15px; left: 50%; transform: translateX(-50%); width: 50px;
 // height: 50px;` inside `.ring` (300×300 CSS px). The SVG viewBox
-// (320×320) is rendered at 300×300 → uniform scale 320/300 ≈ 1.0667.
-//   Button center CSS px (within .ring):  (150, 260)
-//                                          = (.ring.w/2, .ring.h − 15 − 50/2)
-//   Button center SVG units:               (160, 277.33)  ← x = CENTER_CX
-//   Button outer radius CSS px:            25
-//   Button outer radius SVG units:         26.67
-//   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
-// QS-217 review-fix #02b — radius bumped 35 → 45 → 60 across two
-// visual-iteration rounds after the user (testing on this boiler
-// card) reported a persistent "lens" inside the button outline.
-// At R = 35 the carve was clearly too small; at R = 45 the math
-// says the carve fully contains the 50 CSS-px button outline, but
-// the user-visible button (the .override-btn 2px border + 4 %
-// white background) renders larger than the strict 50-px box on
-// retina/high-DPI displays — empirical measurement on the user's
-// screenshot put the visible button at ≈ 92 SVG diameter (46 SVG
-// radius), so R = 45 was just barely too small. R = 60 covers any
-// reasonable visible-button radius with ~13 SVG ≈ ~12 CSS px of
-// padding even at the tightest button y values. The constant
-// remains user-tunable.
+// (320×320) renders at 300×300 → scale 320/300 ≈ 1.0667.
+// Button centre CSS px (within .ring): (150, 260). Button centre
+// SVG units: (160, 277.33) → rounded to (CENTER_CX, 277).
+// Cover radius R = 35 SVG ≈ 33 CSS px ⇒ ~8 CSS px padding around
+// the 25 CSS-px-radius button outline. User-tunable.
 const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 60;
-
-// QS-217 review-fix #02: Crescent-cancel subpath intersection
-// geometry, now DERIVED at module load instead of integer-rounded.
-// Under `clip-rule="evenodd"`, the full carve disc extends below
-// the outer clip disc (OVERRIDE_BTN_CARVE_CY + OVERRIDE_BTN_CARVE_R
-// > CENTER_CY + CLIP_R); that crescent region has winding count 1
-// → "inside the clip" → the water animation would leak through
-// below the override-hand button. The cancel subpath traces the
-// leak crescent and bumps its winding to 2 → outside clip → leak
-// hidden. The cancel subpath's two arcs MUST meet at the exact
-// circle intersection points so each arc segment actually lies on
-// its respective circle. Integer-rounded endpoints (review-fix
-// #01) caused SVG to fit the arcs to slightly-OFFSET circles
-// (centre shifted ≈ 0.22 SVG units for the outer-disc arc),
-// producing a thin sub-pixel gap at chord level — visible on
-// high-DPI displays as a faint circle of water colour just below
-// the button. Runtime derivation eliminates the rounding artifact
-// AND auto-tracks future iterations on `OVERRIDE_BTN_CARVE_R`.
-// Subtracting the two circle equations (both centres on x =
-// CENTER_CX, so x cancels) gives:
-//   y_int = (CLIP_R² − R² + CARVE_CY² − CENTER_CY²)
-//           / (2 × (CARVE_CY − CENTER_CY))
-//   x_off = √(CLIP_R² − (y_int − CENTER_CY)²)  ← from outer disc
-const OVERRIDE_BTN_CARVE_INT_Y = (
-  CLIP_R * CLIP_R
-  - OVERRIDE_BTN_CARVE_R * OVERRIDE_BTN_CARVE_R
-  + OVERRIDE_BTN_CARVE_CY * OVERRIDE_BTN_CARVE_CY
-  - CENTER_CY * CENTER_CY
-) / (2 * (OVERRIDE_BTN_CARVE_CY - CENTER_CY));
-const OVERRIDE_BTN_CARVE_INT_X = Math.sqrt(
-  CLIP_R * CLIP_R
-  - (OVERRIDE_BTN_CARVE_INT_Y - CENTER_CY) ** 2
-);
+const OVERRIDE_BTN_CARVE_R  = 35;
 
 // --- Per-layer wave offsets ---
 const LAYER_SCROLL_OFFSET = 1.2;
@@ -1253,48 +1218,16 @@ class QsWaterBoilerCard extends HTMLElement {
       const preservedBubbles = this._bubbles;
       const preservedNextBubbleAt = this._nextBubbleAt;
 
-      // QS-217 — clipPath path builder. Three subpaths concatenated
-      // with `clip-rule="evenodd"` on the parent <path>:
-      //   1. Outer circle subpath — full ring clip (always present).
-      //   2. Inner circle subpath (`carveSubpath`) — the override-
-      //      button carve-out hole. Winding flip: inside outer +
-      //      inside carve = winding 2 = outside clip (hole), so the
-      //      water animation is clipped OUT of that disc, exposing
-      //      the card background around the semi-transparent button.
-      //   3. Crescent-cancel subpath (`cancelSubpath`, review-fix #01
-      //      must-fix #1) — covers the region where the carve disc
-      //      protrudes below the outer clip disc. Without it the
-      //      crescent shows the wave animation as a coloured arc
-      //      below the override button (user-confirmed by
-      //      screenshot). The cancel subpath bumps that crescent's
-      //      winding from 1 → 2 → outside clip → leak hidden.
-      // Both inner subpaths are gated on
-      // `(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` — review-fix
-      // #01 nice-to-have #4 guards against degenerate `rx=ry=0` arc
-      // commands when the user iterates the radius down to 0.
-      // SVG path semantics: each subpath needs its own M move-to so
-      // evenodd treats them as independent regions.
-      const carveSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
-        ? ` M ${CENTER_CX - OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_CY}` +
-          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${2 * OVERRIDE_BTN_CARVE_R},0` +
-          ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${-2 * OVERRIDE_BTN_CARVE_R},0`
-        : '';
-      // Cancel subpath: triangle-like region bordered by the
-      // outer-disc small arc (large-arc-flag = 0, sweep-flag = 1)
-      // and the carve-disc large arc through the carve bottom
-      // (large-arc-flag = 1, sweep-flag = 1). See the radiator card
-      // arc-flag rationale comment for the derivation.
-      const cancelSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0)
-        ? ` M ${CENTER_CX - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
-          ` A ${CLIP_R},${CLIP_R} 0 0 1 ${CENTER_CX + OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}` +
-          ` A ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1 1 ${CENTER_CX - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y} Z`
-        : '';
+      // QS-217 review-fix #03 — clipPath is just the outer disc;
+      // the override-button area is hidden by a separate `<circle>`
+      // cover drawn AFTER the clipped animation group (see the SVG
+      // markup below). This replaces the earlier carve+cancel
+      // clipPath approach, which produced a geometric lens-shape
+      // hole that the user repeatedly flagged.
       const clipPathD =
         `M ${CENTER_CX - CLIP_R},${CENTER_CY}` +
         ` a ${CLIP_R},${CLIP_R} 0 1,0 ${2 * CLIP_R},0` +
-        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0` +
-        carveSubpath +
-        cancelSubpath;
+        ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0`;
 
       this._root.innerHTML = `
       <ha-card class="card ${!isEnabled ? 'disabled' : ''} ${isOffGrid ? 'off-grid' : ''}">
@@ -1354,6 +1287,7 @@ class QsWaterBoilerCard extends HTMLElement {
                 <path id="surface_glow" d="${initialWavePaths[0]}" stroke="${SURFACE_GLOW_COLOR}" stroke-width="${SURFACE_GLOW_STROKE_WIDTH}" fill="none" filter="url(#${surfaceGlowFilterId})" opacity="${initialBoilOpacity}" pointer-events="none" style="mix-blend-mode: screen; will-change: transform, opacity, d;" />
                 <g id="${steamLayerId}" filter="url(#${steamFilterId})" pointer-events="none"></g>
               </g>
+              ${e.override_reset ? `<circle id="override_btn_cover" cx="${CENTER_CX}" cy="${OVERRIDE_BTN_CARVE_CY}" r="${OVERRIDE_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
               ${showAnimation ? `

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -514,19 +514,19 @@ builder concatenates two circular subpaths: the outer full-disc
 clip (radius `CLIP_R = 120`) and, when the override button is
 rendered, an inner carve disc at
 `(CENTER_*, OVERRIDE_BTN_CARVE_CY = 277)` with
-`OVERRIDE_BTN_CARVE_R = 35`. The `277`/`35` values derive from the
-CSS `.override-btn` geometry (button center `(150, 260)` CSS px,
-outer radius 25, plus ≈ 8 CSS px of padding so the card background
-is visible between the button outline and the carve edge) scaled
-by the SVG viewBox factor `320/300` and rounded to integers (the
-sub-pixel residual is invisible). The carve subpath is gated on
-`e.override_reset` — the same truthy gate that already controls
-the button DOM render — so cards without an override-reset entity
-render a visually identical full-disc clip.
+`OVERRIDE_BTN_CARVE_R` (currently `45` after review-fix #02 visual
+iteration — see below). The button-centre `277` value derives from
+the CSS `.override-btn` geometry (button center `(150, 260)` CSS
+px, outer radius 25) scaled by the SVG viewBox factor `320/300`
+and rounded to an integer (sub-pixel residual invisible). The
+carve subpath is gated on `e.override_reset` — the same truthy
+gate that already controls the button DOM render — so cards
+without an override-reset entity render a visually identical
+full-disc clip.
 
 Review-fix #01 added a **third "crescent-cancel" subpath**
 (`cancelSubpath`) on top of the carve. The full carve disc extends
-32 SVG units below the outer clip disc (carve bottom at y = 312
+below the outer clip disc (carve bottom at y ≈ 322 with R = 45
 vs. outer disc bottom at y = 280); under `clip-rule="evenodd"`
 that crescent of the carve disc lying outside the outer disc has
 winding count 1 → "inside the clip" → the underlying animation
@@ -536,12 +536,31 @@ outer-disc small arc and the carve-disc large arc that meet at
 the two circle intersections — so it raises the winding from 1 →
 2 → "outside the clip" → leak suppressed, with **no change** to
 the visible carve footprint. Two further module-level constants
-(`OVERRIDE_BTN_CARVE_INT_X = 35`, `OVERRIDE_BTN_CARVE_INT_Y = 275`)
-encode the rounded circle intersection point
-(y_int ≈ 274.80, x_off ≈ 34.94). Both inner subpaths share a
-hardened gate `(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` so
-a visual-iteration tweak that sets the radius to 0 cannot emit
-degenerate `rx = ry = 0` arc commands.
+`OVERRIDE_BTN_CARVE_INT_X` and `OVERRIDE_BTN_CARVE_INT_Y` encode
+the circle-intersection point; review-fix #02 switched them from
+integer-rounded literals to RUNTIME-DERIVED expressions
+(`y_int = (CLIP_R² − R² + CARVE_CY² − CENTER_CY²) / (2·(CARVE_CY −
+CENTER_CY))`, `x_off = √(CLIP_R² − (y_int − CENTER_CY)²)`) so the
+cancel-subpath arc endpoints lie EXACTLY on the relevant circles
+— no sub-pixel chord-level gap — AND so a future iteration on
+`OVERRIDE_BTN_CARVE_R` automatically updates the cancel boundary.
+Both inner subpaths share a hardened gate
+`(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` so a visual-
+iteration tweak that sets the radius to 0 cannot emit degenerate
+`rx = ry = 0` arc commands.
+
+Review-fix #02 also **bumped `OVERRIDE_BTN_CARVE_R` from 35 → 45**
+after a user-visual confirmation that the original radius was too
+small: at R = 35 the carve circle pinched too tightly near its
+top, leaving thin slivers of animation visible at the corners of
+the visible button area AND a "lens" curve where the outer-clip-
+disc bottom (y = 280) cut through the button area itself. At
+R = 45 the carve x range at the button top y ≈ 250 is
+`160 ± √(45² − 26.33²) ≈ 160 ± 36.5`, comfortably wider than the
+button x range (`133.33–186.67`), with ~10 SVG ≈ ~9 CSS px of
+padding at the tightest spot. The value remains user-tunable —
+tests pin the constant NAME, the integer is the current
+visual-iteration choice.
 
 ## Hardened JS-card patterns (QS-194 review-fix #03)
 

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -477,6 +477,31 @@ also defensively initialises `_snowflakes`, `_snowWavePhase`, and
 `_nextSnowflakeAt` itself — belt + braces, robust to either
 init-order.
 
+### QS-217 — Override-button carve-out
+
+The semi-transparent bottom-center override "hand" button
+(`<div id="override_btn">`) was hard to read against the colored
+animations (orange flames, white snow, blue water) painted by the
+clipPath group below it. QS-217 fixes the legibility by carving an
+arc out of the animation behind the button, exposing the card
+background ring. The three affected cards — `qs-radiator-card.js`,
+`qs-water-boiler-card.js`, and `qs-climate-card.js` — each replace
+the single `<circle>` inside their `<clipPath>` with a single
+`<path clip-rule="evenodd" d="${clipPathD}">`. The `clipPathD`
+builder concatenates two circular subpaths: the outer full-disc
+clip (radius `CLIP_R = 120`) and, when the override button is
+rendered, an inner carve disc at
+`(CENTER_*, OVERRIDE_BTN_CARVE_CY = 277)` with
+`OVERRIDE_BTN_CARVE_R = 35`. The `277`/`35` values derive from the
+CSS `.override-btn` geometry (button center `(150, 260)` CSS px,
+outer radius 25, plus ≈ 8 CSS px of padding so the card background
+is visible between the button outline and the carve edge) scaled
+by the SVG viewBox factor `320/300` and rounded to integers (the
+sub-pixel residual is invisible). The carve subpath is gated on
+`e.override_reset` — the same truthy gate that already controls
+the button DOM render — so cards without an override-reset entity
+render a visually identical full-disc clip.
+
 ## Hardened JS-card patterns (QS-194 review-fix #03)
 
 Every JS card in `ui/resources/` follows the same defensive

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -502,6 +502,25 @@ sub-pixel residual is invisible). The carve subpath is gated on
 the button DOM render — so cards without an override-reset entity
 render a visually identical full-disc clip.
 
+Review-fix #01 added a **third "crescent-cancel" subpath**
+(`cancelSubpath`) on top of the carve. The full carve disc extends
+32 SVG units below the outer clip disc (carve bottom at y = 312
+vs. outer disc bottom at y = 280); under `clip-rule="evenodd"`
+that crescent of the carve disc lying outside the outer disc has
+winding count 1 → "inside the clip" → the underlying animation
+leaks through as a coloured arc just below the override button.
+The cancel subpath is shaped like that crescent — bordered by the
+outer-disc small arc and the carve-disc large arc that meet at
+the two circle intersections — so it raises the winding from 1 →
+2 → "outside the clip" → leak suppressed, with **no change** to
+the visible carve footprint. Two further module-level constants
+(`OVERRIDE_BTN_CARVE_INT_X = 35`, `OVERRIDE_BTN_CARVE_INT_Y = 275`)
+encode the rounded circle intersection point
+(y_int ≈ 274.80, x_off ≈ 34.94). Both inner subpaths share a
+hardened gate `(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` so
+a visual-iteration tweak that sets the radius to 0 cannot emit
+degenerate `rx = ry = 0` arc commands.
+
 ## Hardened JS-card patterns (QS-194 review-fix #03)
 
 Every JS card in `ui/resources/` follows the same defensive

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -549,18 +549,23 @@ Both inner subpaths share a hardened gate
 iteration tweak that sets the radius to 0 cannot emit degenerate
 `rx = ry = 0` arc commands.
 
-Review-fix #02 also **bumped `OVERRIDE_BTN_CARVE_R` from 35 → 45**
-after a user-visual confirmation that the original radius was too
-small: at R = 35 the carve circle pinched too tightly near its
-top, leaving thin slivers of animation visible at the corners of
-the visible button area AND a "lens" curve where the outer-clip-
-disc bottom (y = 280) cut through the button area itself. At
-R = 45 the carve x range at the button top y ≈ 250 is
-`160 ± √(45² − 26.33²) ≈ 160 ± 36.5`, comfortably wider than the
-button x range (`133.33–186.67`), with ~10 SVG ≈ ~9 CSS px of
+Review-fix #02 also **bumped `OVERRIDE_BTN_CARVE_R` 35 → 45 → 60**
+across two visual-iteration rounds: at R = 35 the carve circle
+pinched too tightly near its top, leaving thin slivers of
+animation visible at the top corners of the visible button area
+AND a "lens" curve where the outer-clip-disc bottom (y = 280)
+cut through the button area; at R = 45 the math said the carve
+fully contained the 50 CSS-px button outline, but the user-
+visible button (the `.override-btn` 2 px border + 4 % white
+background) renders larger than the strict 50-px box on retina /
+high-DPI displays (empirical: ≈ 92 SVG diameter / 46 SVG radius on
+the user's screen), so R = 45 was still just barely too small. At
+R = 60 the carve x range at the button top y ≈ 250 is
+`160 ± √(60² − 26.33²) ≈ 160 ± 53.9`, comfortably wider than any
+reasonable visible-button x range, with ~13 SVG ≈ ~12 CSS px of
 padding at the tightest spot. The value remains user-tunable —
-tests pin the constant NAME, the integer is the current
-visual-iteration choice.
+tests pin the constant NAME for builder-block references, the
+integer value is the current visual-iteration choice.
 
 ## Hardened JS-card patterns (QS-194 review-fix #03)
 

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -499,73 +499,53 @@ restore's null-layer branch is therefore a real backdrop-transition
 path (not just defensive) and explicitly removes the preserved
 flakes' detached DOM so they don't leak.
 
-### QS-217 — Override-button carve-out
+### QS-217 — Override-button cover overlay
 
 The semi-transparent bottom-center override "hand" button
-(`<div id="override_btn">`) was hard to read against the colored
+(`<div id="override_btn">`) was hard to read against the coloured
 animations (orange flames, white snow, blue water) painted by the
-clipPath group below it. QS-217 fixes the legibility by carving an
-arc out of the animation behind the button, exposing the card
-background ring. The three affected cards — `qs-radiator-card.js`,
-`qs-water-boiler-card.js`, and `qs-climate-card.js` — each replace
-the single `<circle>` inside their `<clipPath>` with a single
-`<path clip-rule="evenodd" d="${clipPathD}">`. The `clipPathD`
-builder concatenates two circular subpaths: the outer full-disc
-clip (radius `CLIP_R = 120`) and, when the override button is
-rendered, an inner carve disc at
-`(CENTER_*, OVERRIDE_BTN_CARVE_CY = 277)` with
-`OVERRIDE_BTN_CARVE_R` (currently `45` after review-fix #02 visual
-iteration — see below). The button-centre `277` value derives from
-the CSS `.override-btn` geometry (button center `(150, 260)` CSS
-px, outer radius 25) scaled by the SVG viewBox factor `320/300`
-and rounded to an integer (sub-pixel residual invisible). The
-carve subpath is gated on `e.override_reset` — the same truthy
-gate that already controls the button DOM render — so cards
-without an override-reset entity render a visually identical
-full-disc clip.
+clipPath group below it. QS-217 fixes the legibility by drawing a
+small **`<circle>` cover** with `fill="var(--card-background-color)"`
+on top of the clipped animation group, visually erasing the
+animation in a clean circular patch behind the button. The three
+affected cards — `qs-radiator-card.js`, `qs-water-boiler-card.js`,
+and `qs-climate-card.js` — each render the cover element
+immediately after their `<g clip-path="url(#…ClipId)">` group and
+before the outer-ring stroke, gated on `e.override_reset` (the same
+truthy check that already controls the button DOM render):
 
-Review-fix #01 added a **third "crescent-cancel" subpath**
-(`cancelSubpath`) on top of the carve. The full carve disc extends
-below the outer clip disc (carve bottom at y ≈ 322 with R = 45
-vs. outer disc bottom at y = 280); under `clip-rule="evenodd"`
-that crescent of the carve disc lying outside the outer disc has
-winding count 1 → "inside the clip" → the underlying animation
-leaks through as a coloured arc just below the override button.
-The cancel subpath is shaped like that crescent — bordered by the
-outer-disc small arc and the carve-disc large arc that meet at
-the two circle intersections — so it raises the winding from 1 →
-2 → "outside the clip" → leak suppressed, with **no change** to
-the visible carve footprint. Two further module-level constants
-`OVERRIDE_BTN_CARVE_INT_X` and `OVERRIDE_BTN_CARVE_INT_Y` encode
-the circle-intersection point; review-fix #02 switched them from
-integer-rounded literals to RUNTIME-DERIVED expressions
-(`y_int = (CLIP_R² − R² + CARVE_CY² − CENTER_CY²) / (2·(CARVE_CY −
-CENTER_CY))`, `x_off = √(CLIP_R² − (y_int − CENTER_CY)²)`) so the
-cancel-subpath arc endpoints lie EXACTLY on the relevant circles
-— no sub-pixel chord-level gap — AND so a future iteration on
-`OVERRIDE_BTN_CARVE_R` automatically updates the cancel boundary.
-Both inner subpaths share a hardened gate
-`(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` so a visual-
-iteration tweak that sets the radius to 0 cannot emit degenerate
-`rx = ry = 0` arc commands.
+```html
+<g clip-path="url(#…ClipId)"> … animation paths … </g>
+${e.override_reset ? `<circle id="override_btn_cover"
+  cx="${CENTER_*}"
+  cy="${OVERRIDE_BTN_CARVE_CY}"
+  r="${OVERRIDE_BTN_CARVE_R}"
+  fill="var(--card-background-color)"
+  pointer-events="none" />` : ''}
+<path d="${bgPath}" … />  <!-- outer ring stroke -->
+```
 
-Review-fix #02 also **bumped `OVERRIDE_BTN_CARVE_R` 35 → 45 → 60**
-across two visual-iteration rounds: at R = 35 the carve circle
-pinched too tightly near its top, leaving thin slivers of
-animation visible at the top corners of the visible button area
-AND a "lens" curve where the outer-clip-disc bottom (y = 280)
-cut through the button area; at R = 45 the math said the carve
-fully contained the 50 CSS-px button outline, but the user-
-visible button (the `.override-btn` 2 px border + 4 % white
-background) renders larger than the strict 50-px box on retina /
-high-DPI displays (empirical: ≈ 92 SVG diameter / 46 SVG radius on
-the user's screen), so R = 45 was still just barely too small. At
-R = 60 the carve x range at the button top y ≈ 250 is
-`160 ± √(60² − 26.33²) ≈ 160 ± 53.9`, comfortably wider than any
-reasonable visible-button x range, with ~13 SVG ≈ ~12 CSS px of
-padding at the tightest spot. The value remains user-tunable —
-tests pin the constant NAME for builder-block references, the
-integer value is the current visual-iteration choice.
+Two module-level constants control the cover geometry:
+`OVERRIDE_BTN_CARVE_CY = 277` is the button centre y in SVG units
+(derived from the CSS `.override-btn` position: button centre
+`(150, 260)` CSS px, scaled by the SVG viewBox factor `320/300` →
+`(160, 277.33)`, rounded to integer). `OVERRIDE_BTN_CARVE_R` is
+the cover radius in SVG units; the integer is intentionally user-
+tunable for visual iteration (tests pin the constant NAME only,
+not the value). The cover applies uniformly across all backdrops
+(including the climate card's flame / snow / wind / none).
+
+**Why a cover overlay instead of a clipPath carve?** The first two
+implementation rounds used an `<clipPath>` with three subpaths
+(outer disc + carve disc + cancel subpath, evenodd fill rule) to
+create a hole in the animation. Across two visual-iteration rounds
+(R = 35 → 45 → 60) the user consistently reported a "lens" inside
+the button: the intersection of the carve disc with the outer
+clip disc is geometrically a lens (vesica piscis) shape, so the
+visible HOLE always took on that shape regardless of R. The cover
+overlay sidesteps the issue entirely — the patch is a `<circle>`
+by construction, so the user sees a circle on screen. No lens
+shape possible.
 
 ## Hardened JS-card patterns (QS-194 review-fix #03)
 

--- a/docs/stories/QS-217.story.md
+++ b/docs/stories/QS-217.story.md
@@ -1,0 +1,398 @@
+---
+issue: 217
+title: Carve-out arc in card animations behind override hand button
+branch: QS_217
+status: ready-for-dev
+next_phase: implement-task
+labels: [area:ui, area:dashboard, area:docs]
+---
+
+# QS-217 — Override-button carve-out in card animations
+
+## Why
+
+Issue [#217](https://github.com/tmenguy/quiet-solar/issues/217) reads
+verbatim:
+
+> A lot of cards have a bottom central round button (the user override
+> hand button for on-off/climate/boiler/radiator for ex). The issue is
+> that this button being semi transparent, it appears on top of the
+> new animations (flames, snow, water for the boiler etc) and so is
+> not super legible.
+>
+> I would like to "carveout" an arc of disc in the animation (flame,
+> snow, water) when there is such a button so we see the card
+> background and the button appears better surrounded by the
+> animation color. The carved disc should obviously be carved bigger
+> than the button so there is some padding to see the background
+> between the outer circle of the button and the animation color.
+
+The radiator, climate, and water-boiler cards each render their
+animation inside a circular `<clipPath>`. A semi-transparent
+bottom-center override "hand" button (`<div id="override_btn">`) sits
+ON TOP of that animation via absolute CSS positioning. Color from the
+animation (orange flames, white snow, blue water) bleeds through the
+semi-transparent button background, making the button hard to read.
+
+The fix: swap the single `<circle>` inside each card's `<clipPath>`
+for a `<path clip-rule="evenodd">` whose `d` attribute always contains
+the outer circle subpath, plus an inner "carve" subpath when the
+override button is rendered (gated on `e.override_reset`, the same
+truthy check that already gates the button DOM). With `evenodd` fill
+rule, the inner circle becomes a HOLE in the clip — the animation is
+clipped OUT of that disc, exposing the card background ring around
+the button.
+
+**Explicit instruction granted by issue #217** — this story overrides
+the [project-context.md](../workflow/project-context.md) rule "Custom
+JS card code should not be modified without explicit instruction" for
+the three target cards.
+
+## Inputs
+
+- `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`
+  — 2 new constants near the existing `CENTER_CX` / `CENTER_CY` /
+  `CLIP_R` block (lines 33-36) + clipPath payload swap at lines
+  1223-1225 + a `const clipPathD = …` builder declared immediately
+  above the `<svg viewBox="0 0 320 320" …>` template literal at line
+  1206.
+- `custom_components/quiet_solar/ui/resources/qs-radiator-card.js` —
+  same pattern. Constants block at lines 35-37, clipPath at 885-887,
+  builder above the svg at line ~868.
+- `custom_components/quiet_solar/ui/resources/qs-climate-card.js` —
+  same pattern. Constants block at lines 31-38, clipPath at
+  1345-1347, builder above the svg at line ~1310.
+- `tests/test_dashboard_rendering.py` — update **one** existing pin
+  inside `test_radiator_card_flame_layers_present` (lines 581-595) +
+  add **three** new test functions (one per card).
+- `docs/agents/concepts/dashboard-and-cards.md` — add a 4–6 sentence
+  "QS-217 override-button carve-out" sub-section + bump
+  `last_verified: 2026-05-23`.
+
+### Existing-identifier contract (read-only)
+
+| Identifier | Where | Meaning |
+|---|---|---|
+| `CENTER_CX` | water-boiler-card.js:34 | SVG x-center 160 (pre-existing). |
+| `CENTER_X` | climate-card.js:37 | SVG x-center 160 (pre-existing; sibling of `CENTER_CY`). |
+| `CENTER_CY` | all three cards | SVG y-center 160 (pre-existing). Radiator uses it for BOTH axes (no separate x-name). |
+| `CLIP_R` | all three cards | Full-disc clip radius 120 (pre-existing). |
+| `e.override_reset` | all three cards | Truthy ⇔ override-button entity wired ⇔ `<div id="override_btn">` rendered. Existing gate used verbatim. The existing render expressions are:<br/>- radiator: `` `${e.override_reset ? `<div id="override_btn" …>` : ''}` `` (line 944)<br/>- water-boiler: same idiom (line 1304)<br/>- climate: same idiom (line 1417) |
+| `<g clip-path="url(#…)">` wrapper | all three cards | Wraps every animation subsystem (waves, bubbles, steam, surface-glow, flames, snowflakes, snow waves, wind wisps). The carve effect propagates to every child — no per-subsystem changes needed. |
+
+### Cross-card invariants (verified during planning — pinned by AC-1)
+
+All three cards share **identical** values for the carve-relevant
+constants and CSS, which is why a SINGLE pair of carve constants
+(`OVERRIDE_BTN_CARVE_CY = 277`, `OVERRIDE_BTN_CARVE_R = 35`) is
+correct for all three:
+
+| Invariant | All three cards |
+|---|---|
+| `CENTER_*` (both axes) | `= 160` |
+| `CLIP_R` | `= 120` |
+| `.ring` CSS dimensions | `width: 300px; height: 300px;` |
+| SVG viewBox | `0 0 320 320` rendered at `width="300" height="300"` |
+| `.override-btn` CSS | `position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); width: 50px; height: 50px;` |
+
+If any future card needs a per-card override, the constants would
+move from module-level to a per-card derivation. Out of scope for
+QS-217.
+
+## New constants (per card)
+
+Added at the top of each card file, in the same constants block as
+`CENTER_*` / `CLIP_R`:
+
+```js
+// QS-217: Override-button carve-out geometry.
+// Anchored to the CSS `.override-btn` at `position: absolute;
+// bottom: 15px; left: 50%; transform: translateX(-50%); width: 50px;
+// height: 50px;` inside `.ring` (300×300 CSS px). The SVG viewBox
+// (320×320) is rendered at 300×300 → uniform scale 320/300 ≈ 1.0667.
+//   Button center CSS px (within .ring):  (150, 260)
+//                                          = (.ring.w/2, .ring.h − 15 − 50/2)
+//   Button center SVG units:               (160, 277.33)  ← x = CENTER_*
+//   Button outer radius CSS px:            25
+//   Button outer radius SVG units:         26.67
+//   Carve adds ≈ 8 CSS px padding:         (25 + 8) × 320/300 ≈ 35.2
+// Both rounded to integers (snap to SVG grid; sub-pixel residual
+// is < 0.4 CSS px, invisible).
+const OVERRIDE_BTN_CARVE_CY = 277;
+const OVERRIDE_BTN_CARVE_R  = 35;
+```
+
+Naming follows the file-local precedent set by `CENTER_CX` /
+`CENTER_CY` / `CLIP_R` (SCREAMING_SNAKE, module-scope, integer SVG
+units).
+
+`OVERRIDE_BTN_CARVE_R = 35` is a **deliberate-test placeholder**.
+The user said _"difficult to see, pick something we will test it
+and I'll decide seeing the result"_. Tests pin the constant by
+**name** (`OVERRIDE_BTN_CARVE_R`), NOT by value `35`, so a later
+visual iteration on the radius leaves the tests green. See DN-2.
+
+## Acceptance criteria
+
+- **AC-1** — Constants present & integer (× 3 cards). Each of the
+  three target card files declares **both** of these as top-level
+  module constants in the same block as `CLIP_R`:
+  ```js
+  const OVERRIDE_BTN_CARVE_CY = 277;
+  const OVERRIDE_BTN_CARVE_R  = 35;
+  ```
+  Cross-card invariants from the Inputs table (`CENTER_* = 160`,
+  `CLIP_R = 120`, identical `.ring` + `.override-btn` CSS) MUST hold
+  on all three cards. The invariant check is implicit (the JS-source
+  regex pins assert the constants and the structural use of `CLIP_R`
+  / `CENTER_*` in the clipPath builder; if any card silently
+  diverges, its test fails).
+
+- **AC-2** — ClipPath is `<path clip-rule="evenodd" d="${clipPathD}" />`.
+  In each target card, the `<clipPath id="…">` block contains
+  **exactly** one `<path>` element with attributes
+  `clip-rule="evenodd"` and `d="${clipPathD}"`. The bare `<circle>`
+  form is removed entirely.
+
+- **AC-3** — `clipPathD` builder shape. Each card declares
+  `const clipPathD = …` **immediately above** the `<svg viewBox="0 0
+  320 320" …>` template literal in its `_render()` body (so the
+  template can interpolate `${clipPathD}`). The builder is:
+  ```js
+  const carveSubpath = e.override_reset
+    ? ` M ${<X> - OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_CY}` +
+      ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${2 * OVERRIDE_BTN_CARVE_R},0` +
+      ` a ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1,0 ${-2 * OVERRIDE_BTN_CARVE_R},0`
+    : '';
+  const clipPathD =
+    `M ${<X> - CLIP_R},${CENTER_CY}` +
+    ` a ${CLIP_R},${CLIP_R} 0 1,0 ${2 * CLIP_R},0` +
+    ` a ${CLIP_R},${CLIP_R} 0 1,0 ${-2 * CLIP_R},0` +
+    carveSubpath;
+  ```
+  Where `<X>` is the **file-local x-center constant**:
+  - water-boiler-card.js → `CENTER_CX`
+  - climate-card.js → `CENTER_X`
+  - radiator-card.js → `CENTER_CY` (radiator has no separate x-name
+    — it uses `CENTER_CY` for both axes; existing pattern preserved
+    per DN-4)
+  
+  The two subpaths are separated by an explicit `M` move-to command
+  (within `carveSubpath`'s leading ` M …`), so each subpath has its
+  own start point — required by SVG path semantics for the evenodd
+  fill rule to treat them as independent regions.
+
+- **AC-4** — Carve gated on `e.override_reset` (identical to the
+  existing button gate). `carveSubpath` is `''` when `e.override_reset`
+  is falsy. The `e.override_reset ? … : ''` ternary syntax matches the
+  in-file precedent for the `<div id="override_btn">` render (see
+  Existing-identifier contract). When the carve is absent, the
+  resulting `clipPathD` describes a closed circle and is **visually
+  equivalent** to the original `<circle>` clipPath form (same area
+  clipped in, no hole).
+
+- **AC-5** — `<g clip-path="url(#…)">` wrapper unchanged. The wrapper
+  group still wraps every animation subsystem. No per-backdrop
+  branching in `clipPathD` (so the climate-card wind backdrop also
+  gets the carve uniformly — preemptively safe per DN-3 even though
+  wind wisps live at y = 130..190, above the carve top at y = 242).
+
+- **AC-6** — Existing test pin updated:
+  `test_radiator_card_flame_layers_present`. The strict regex at
+  `tests/test_dashboard_rendering.py` lines 585-592 currently pins
+  ```
+  r"<clipPath\s+id=\"\$\{flameClipId\}\">\s*<circle\s+cx=\"\$\{CENTER_CY\}\"\s+cy=\"\$\{CENTER_CY\}\"\s+r=\"\$\{CLIP_R\}\""
+  ```
+  is replaced with the equivalent for the new `<path>` form:
+  ```
+  r"<clipPath\s+id=\"\$\{flameClipId\}\">\s*<path\s+clip-rule=\"evenodd\"\s+d=\"\$\{clipPathD\}\"\s*/>\s*</clipPath>"
+  ```
+  PLUS a separate assertion (kept on its own line in the same test
+  body, immediately AFTER the replaced regex) verifying the
+  `clipPathD` builder source references all four constants by name
+  (interpolated, not hard-coded): regex pins for `CENTER_CY`,
+  `CLIP_R`, `OVERRIDE_BTN_CARVE_CY`, `OVERRIDE_BTN_CARVE_R` each
+  appearing inside the builder block. The existing standalone
+  `const CENTER_CY = 160` and `const CLIP_R = 120` pins (lines 594,
+  595) are kept verbatim — they pin the geometric values.
+
+- **AC-7** — New tests added: **three** new functions in
+  `tests/test_dashboard_rendering.py` (one per card). Each new test
+  is a single function that asserts three invariants in one body:
+  
+  | Function name | Pins (all three in one body) |
+  |---|---|
+  | `test_radiator_card_override_btn_carve_out` | (a) clipPath uses `<path clip-rule="evenodd" d="${clipPathD}">` form; (b) `OVERRIDE_BTN_CARVE_CY = 277` and `OVERRIDE_BTN_CARVE_R = 35` are declared as top-level consts AND referenced (by name) in the `clipPathD` builder block; (c) the carve subpath is gated on `e.override_reset` (regex `r"e\.override_reset\s*\?"` appears in the builder block). |
+  | `test_water_boiler_card_override_btn_carve_out` | Same three invariants, anchored to `qs-water-boiler-card.js`. |
+  | `test_climate_card_override_btn_carve_out` | Same three invariants, anchored to `qs-climate-card.js`. |
+  
+  Test bodies use the existing `(COMPONENT_ROOT / "ui" / "resources" /
+  …).read_text()` idiom (see the existing
+  `test_water_boiler_card_renders_water_layer` at line 1911 for the
+  pattern). All three pin the constant **name**, not the value `35`
+  / `277`, in the builder-block reference checks — so visual
+  iteration on the radius leaves the tests green.
+
+- **AC-8** — Doc paragraph added to
+  `docs/agents/concepts/dashboard-and-cards.md`. A new 4–6 sentence
+  sub-section "QS-217 — Override-button carve-out" is added near the
+  existing per-card sub-sections. It must mention: (a) the
+  legibility motivation, (b) the three affected cards, (c) the
+  `<path clip-rule="evenodd">` clipPath idiom (replacing the bare
+  `<circle>`), (d) the `OVERRIDE_BTN_CARVE_CY = 277` /
+  `OVERRIDE_BTN_CARVE_R = 35` constants and their CSS-to-SVG
+  derivation, (e) the `e.override_reset` gate. `last_verified:` in
+  the frontmatter is bumped to `2026-05-23`. Drift checker exits 0.
+
+- **AC-9** — Quality gate green via the UI-only fast path. Verified
+  scope: all five changed files match `_DEV_ONLY_PATTERNS` /
+  `_DEV_ONLY_EXTENSIONS` (the three `.js` files match
+  `_UI_RESOURCES_PREFIX`, `tests/test_dashboard_rendering.py` matches
+  `tests/`, `docs/agents/concepts/dashboard-and-cards.md` matches
+  `docs/` AND `.md`). Scope detection in
+  `scripts/qs/quality_gate.py:276-308` yields `scope = "ui-only"` →
+  runs only `tests/test_dashboard_rendering.py` + skips ruff / mypy
+  / translations / full-coverage. The full gate command stays
+  `python scripts/qs/quality_gate.py` (no flag; auto-detects).
+
+## Design notes (not testable as ACs)
+
+### DN-1 — Existing test pins survey (only line 586 needs updating)
+
+A grep of `tests/test_dashboard_rendering.py` for `clipPath` /
+`clip-path` / `<circle.*cx.*cy.*r` returned six matches; only ONE is
+a structural pin that breaks with the new form:
+
+| Line | Site | Action |
+|---|---|---|
+| 586 | `test_radiator_card_flame_layers_present` strict regex `<clipPath><circle …>` | **UPDATE** (AC-6). |
+| 598 | `'clip-path="url(#${flameClipId})"'` wrapper anchor | **KEEP** — wrapper unchanged. |
+| 1926 | `re.search(r"<clipPath\s+id=", executable)` lax existence check | **KEEP** — still matches the `<path>` form. |
+| 2026 | docstring comment _"`<circle cx cy r>` markup"_ in `test_water_boiler_card_pins_geometry_constants` | **REVIEW** — the test body itself pins the GEOMETRY CONSTANTS (`CENTER_CX/CY`, `CLIP_R`, `WAVE_WIDTH` values), not the clipPath markup. The comment is descriptive prose, slightly stale but technically still accurate for the outer-circle subpath. Update the comment to read _"`<clipPath>` markup interpolates `CENTER_CX/CY` and `CLIP_R` via the `clipPathD` builder"_ to track the new form. No assert changes. |
+| 2231 | `'<g clip-path="url(#${waterClipId})">'` wrapper anchor | **KEEP** — wrapper unchanged. |
+| 1946 | same wrapper anchor (boiler steam test) | **KEEP** — wrapper unchanged. |
+
+No other test files in `tests/` reference the clipPath markup
+internals.
+
+### DN-2 — Why integer constants, and why tests pin names not values
+
+Exact derivation gives `cy = 277.33` and `r ≈ 35.2`. Rounding to
+integers (277, 35):
+- Snaps to the SVG grid (no sub-pixel anti-aliasing fuzz on the
+  carve edge).
+- Residual: 0.33 SVG units (≈ 0.31 CSS px) on cy, 0.2 SVG units (≈
+  0.19 CSS px) on r — both well below pixel resolution.
+- Matches the existing convention (`CLIP_R = 120`, `CENTER_* = 160`
+  are all integers).
+
+`r = 35` is a placeholder. The user will visually iterate. Tests
+therefore pin the constant **name** (regex `OVERRIDE_BTN_CARVE_R`)
+appearing in the `clipPathD` builder block — NOT the value `35`. A
+follow-up tweak (e.g. `r = 33` or `r = 40`) leaves all pins green
+because the builder still references the same identifier.
+
+### DN-3 — Wind backdrop carve is preemptive (user-approved)
+
+The climate card has four backdrops (flame / snow / wind / none).
+Wind wisps live at y = CENTER_CY ± 30 = 130 / 160 / 190 — **all far
+above the carve top at y = 242** (= 277 − 35). The carve has zero
+visible interaction with wind today.
+
+The user explicitly approved carving uniformly anyway:
+> "yes still apply (so if we change the wind, it will be properly
+> carved out)"
+
+This is preemptive future-proofing for a possible wind-backdrop
+redesign. The cost is zero — `clipPathD` is built once per render,
+not per backdrop. The benefit is that any future wind visual that
+DOES extend toward the bottom of the clip automatically inherits
+the carve. Flagged here so a future scope-reviewer doesn't read it
+as scope creep.
+
+## Doc maintenance
+
+- `docs/agents/concepts/dashboard-and-cards.md` — `covers:`
+  frontmatter lists all three target card files (lines 11-14 of the
+  doc). Modifying the cards without updating this doc would trip the
+  drift checker. AC-8 covers the doc update and the `last_verified`
+  bump.
+- No other doc surfaces the clipPath internals. No agent files
+  touched (no harness-sync co-modification required).
+
+## Adversarial Review Notes
+
+Four plan-reviewer sub-agents (critic, concrete-planner, dev-proxy,
+scope-guardian) reviewed the plan draft in parallel. Twenty-one
+findings consolidated. Acted on:
+
+- **ARN-1 (critic critical, dev-proxy clarify).** SVG path
+  concatenation safety: the two subpaths are separated by an
+  explicit `M` move-to (via `carveSubpath`'s leading ` M …`),
+  required by SVG path semantics for evenodd to treat them as
+  independent regions. AC-3 spells out the explicit `M` separator.
+- **ARN-2 (critic critical).** Audit of existing test pins for
+  clipPath-shape assumptions. Verified by grep: only line 586 needs
+  a structural update; everything else is a wrapper-group anchor or
+  a lax existence check that survives. DN-1 documents the survey.
+- **ARN-3 (critic redesign).** Carve constants are uniform across
+  cards because all three share identical `CLIP_R`, `CENTER_*`,
+  `.ring` dimensions, and `.override-btn` CSS. Inputs section adds
+  a cross-card invariants table; AC-1 pins the use of the constants.
+- **ARN-4 (critic improve, scope-guardian improve).** Tests pin
+  constant **names**, not values. Visual iteration on `r` leaves
+  the tests green. DN-2 documents the rationale; AC-7 is structured
+  to reference `OVERRIDE_BTN_CARVE_R` by identifier in regex pins.
+- **ARN-5 (critic improve, dev-proxy clarify).** Gate idiom is
+  byte-identical to existing button render: `e.override_reset ? …
+  : ''`. Existing-identifier contract quotes the in-file expression
+  for all three cards.
+- **ARN-6 (concrete-planner improve).** Replacement regex for the
+  line-586 pin spelled out explicitly in AC-6, plus the four
+  constant-reference assertions that preserve the pre-existing
+  "constants-not-hardcoded" invariant.
+- **ARN-7 (concrete-planner improve).** JS file comments: only the
+  test-body comment at line 2026 needs a minor prose tweak; in-file
+  card comments referencing "circular clipPath" are still accurate
+  for the outer-circle subpath. DN-1 row for line 2026 documents
+  the comment update.
+- **ARN-8 (dev-proxy improve).** New-constants naming follows the
+  same SCREAMING_SNAKE module-scope integer convention as the
+  existing `CENTER_CX` / `CENTER_CY` / `CLIP_R` in the same files.
+  Cited in the "New constants" section.
+- **ARN-9 (scope-guardian improve).** Test gold-plating reduced
+  from 9 functions to 3 (one per card, three invariants in one
+  body). AC-7 documents the consolidated form.
+- **ARN-10 (scope-guardian improve, clarify).** Design notes
+  trimmed from 6 to 3. AC count reduced from 10 to 9 (one AC per
+  meaningful invariant; the original "AC-3 carve gated" and
+  "AC-6 wind uniform" both folded into the natural shape of AC-3
+  builder + AC-5 wrapper-unchanged).
+- **ARN-11 (scope-guardian improve).** Wind backdrop carve is
+  preemptive — flagged in DN-3 with the user's verbatim approval.
+- **ARN-12 (concrete-planner clarify).** Per-card x-center constant
+  names spelled out literally in AC-3 (water-boiler `CENTER_CX`,
+  climate `CENTER_X`, radiator `CENTER_CY`).
+- **ARN-13 (concrete-planner clarify).** `clipPathD` builder
+  location: "immediately above the `<svg viewBox=…>` template
+  literal" — pinned in AC-3.
+- **ARN-14 (dev-proxy improve).** UI-only fast-path scope verified
+  against `scripts/qs/quality_gate.py:_DEV_ONLY_PATTERNS` —
+  `docs/agents/*.md` qualifies via both the `docs/` prefix and the
+  `.md` extension. AC-9 cites the source.
+- **ARN-15 (critic clarify).** Line 586 reference disambiguated by
+  test function name `test_radiator_card_flame_layers_present` (AC-6).
+
+Rejected:
+- **scope-guardian I3 (two constants over-abstracted).** User wants
+  to iterate on `r` independently of `cy`; collapsing to a single
+  constant + inline arithmetic obscures that intent.
+- **critic R1 reframed (per-card carve geometry).** Verified that
+  all three cards share the relevant invariants; no per-card
+  derivation needed today. If a future card breaks the invariants,
+  promoting the constants to per-card derivations is a one-line
+  change.
+- **concrete-planner Cl3 (preserveAspectRatio note).** Out of scope
+  — the derivation chain already shows the uniform 320/300 scale
+  without invoking aspect-ratio details. Implementer can derive
+  from the values given.

--- a/docs/stories/QS-217.story_review_fix_#01.md
+++ b/docs/stories/QS-217.story_review_fix_#01.md
@@ -1,0 +1,479 @@
+---
+issue: QS-217
+source_pr: 219
+source_story: docs/stories/QS-217.story.md
+next_implement_phase: /implement-task
+---
+
+# QS-217 — Review fix plan #01
+
+## Summary
+
+- Source PR: [#219](https://github.com/tmenguy/quiet-solar/pull/219)
+- Source story: `docs/stories/QS-217.story.md`
+- Findings to fix: 7 (3 should-fix + 4 nice-to-have)
+- Invalid (by design): 1 (nice-to-have #5 — uniform carve across backdrops is
+  explicitly user-approved in DN-3)
+- Next implement phase: `/implement-task` (touches
+  `custom_components/quiet_solar/ui/resources/*.js` — product code, not the
+  dev-env carve-out)
+
+## Visual context (the bug that motivates fix #1)
+
+User screenshot during /review-task confirmed the predicted evenodd leak:
+the water-wave animation is visible as a coloured crescent **below the
+outer ring outline** on the water-boiler card, plus a faint side-tint
+where the carve disc bulges past the outer disc at y ∈ [274.8, 280].
+
+**Why** (geometry): the full carve disc at centre `(CENTER_X, OVERRIDE_BTN_CARVE_CY)
+= (160, 277)` with radius `OVERRIDE_BTN_CARVE_R = 35` extends to y = 312,
+which is 32 SVG units **below** the outer clip disc bottom at y = 280.
+Under `clip-rule="evenodd"`:
+
+| Region | outer disc winding | carve disc winding | total | inside clip? |
+| ------ | ------------------ | ------------------ | ----- | ------------ |
+| Inside outer, outside carve (normal ring) | 1 | 0 | 1 | ✅ animation renders (intended) |
+| Inside both (button area) | 1 | 1 | 2 | ❌ carved hole (intended) |
+| **Outside outer, inside carve (the crescent)** | **0** | **1** | **1** | **✅ animation renders — BUG** |
+
+The user picked **Option 2** from the review discussion: keep the full
+carve disc (preserves "carve everything behind the semi-transparent
+button" intent — the only choice that fully covers the button cap at
+y ≈ 278–280) and add a third "cancel" subpath shaped like the crescent.
+Under evenodd, the cancel subpath bumps the crescent's winding count
+from 1 → 2 → outside clip → animation hidden. Net effect: identical
+visible carve footprint to the current PR, plus the leak goes away.
+
+## Findings to fix
+
+### [must-fix → upgraded from should-fix #1] Crescent-cancel subpath
+
+- Files:
+  - `custom_components/quiet_solar/ui/resources/qs-radiator-card.js`
+    (lines ~889–895, the `carveSubpath` / `clipPathD` builder block)
+  - `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`
+    (lines ~1225–1231, same block)
+  - `custom_components/quiet_solar/ui/resources/qs-climate-card.js`
+    (lines ~1357–1363, same block)
+- Severity: was should-fix, upgraded after user-visual confirmation in
+  the screenshot — wave colour clearly bleeds below the ring on the
+  water-boiler card. Treat as **must-fix**.
+- Source: qs-review-edge-case-hunter should-fix #1, user-confirmed.
+- Description: the carve disc protrudes 32 SVG units below the outer
+  clip disc; evenodd flips that crescent into "inside clip" and the
+  underlying water/flame/snow animation becomes visible below the
+  override-hand button.
+
+#### Proposed fix — option 2 (crescent-cancel subpath)
+
+Add a **cancelSubpath** const next to the existing `carveSubpath`,
+gated on the same `e.override_reset` condition. Then concatenate it into
+`clipPathD` after the carve subpath.
+
+**Mathematical derivation of intersection points (worked once, hard-coded
+in module-level constants per card to keep the runtime template simple).**
+Two circles:
+
+- Outer: centre `(CENTER_X, CENTER_Y)` = `(160, 160)`, radius `CLIP_R` = `120`
+- Carve: centre `(CENTER_X, OVERRIDE_BTN_CARVE_CY)` = `(160, 277)`,
+  radius `OVERRIDE_BTN_CARVE_R` = `35`
+
+Subtracting circle equations gives the intersection y:
+
+```
+y_int = (CLIP_R² − OVERRIDE_BTN_CARVE_R² + OVERRIDE_BTN_CARVE_CY² − CENTER_Y²)
+        / (2 × (OVERRIDE_BTN_CARVE_CY − CENTER_Y))
+      = (14400 − 1225 + 76729 − 25600) / (2 × 117)
+      = 64304 / 234
+      ≈ 274.80
+```
+
+And the x-offset from `CENTER_X` at that y:
+
+```
+x_off = √(CLIP_R² − (y_int − CENTER_Y)²)
+      = √(14400 − 114.80²)
+      = √(14400 − 13179.0)
+      = √1221.0
+      ≈ 34.94
+```
+
+Intersection points: `(125.06, 274.80)` and `(194.94, 274.80)`.
+
+**Two new module-level constants per card.** Same pattern as the existing
+`OVERRIDE_BTN_CARVE_*` consts — derived once, hard-coded, with a comment
+showing the formula. Place these immediately below the existing
+`OVERRIDE_BTN_CARVE_CY` / `OVERRIDE_BTN_CARVE_R` block in each file.
+
+```js
+// QS-217 review-fix-01: Crescent-cancel subpath intersection geometry.
+// The full carve disc extends 32 SVG units below the outer clip disc
+// (CARVE_CY + CARVE_R = 312, CLIP_R + CENTER_Y = 280). Under evenodd
+// clip-rule, that crescent region (inside carve disc, outside outer
+// clip disc) has winding count 1 → INSIDE clip → animation leaks
+// through. We bump the count to 2 with a third subpath shaped like
+// the crescent, bordered by:
+//   - outer-disc arc from (CENTER_X − OVERRIDE_BTN_CARVE_INT_X, OVERRIDE_BTN_CARVE_INT_Y)
+//     to (CENTER_X + OVERRIDE_BTN_CARVE_INT_X, OVERRIDE_BTN_CARVE_INT_Y), small arc
+//     through the bottom of the outer disc;
+//   - carve-disc large arc returning through the bottom of the carve disc.
+// Derivation (see story_review_fix_#01.md):
+//   y_int = (CLIP_R² − OVERRIDE_BTN_CARVE_R² + OVERRIDE_BTN_CARVE_CY² − CENTER_Y²)
+//           / (2 × (OVERRIDE_BTN_CARVE_CY − CENTER_Y))
+//         = 274.80 → rounded to 275 (sub-pixel snap, |Δ| = 0.2 SVG ≈ 0.19 CSS px)
+//   x_off = √(CLIP_R² − (y_int − CENTER_Y)²) ≈ 34.94 → 35
+// Integer rounding keeps the SVG path string short; the residual is
+// well below 1 CSS pixel and invisible.
+const OVERRIDE_BTN_CARVE_INT_X = 35;
+const OVERRIDE_BTN_CARVE_INT_Y = 275;
+```
+
+NOTE: rounding y_int = 274.8 → 275 introduces a 0.2-unit gap between
+the cancel subpath and the actual intersection point. Under evenodd
+this is harmless (the carve subpath and cancel subpath winding counts
+sum correctly at every pixel that's clearly inside or clearly outside
+each circle); the 0.2-unit transition strip is sub-pixel.
+
+If the implementer prefers exactness over integer-rounding, swap both
+constants for floats (`274.80`, `34.94`) — the SVG path string accepts
+decimal coordinates. Either choice is acceptable; integer is preferred
+for consistency with the existing `OVERRIDE_BTN_CARVE_*` constants and
+brevity.
+
+**New `cancelSubpath` const, immediately below `carveSubpath`, in each
+of the three card files.** Use the same x-centre naming convention each
+file already uses (`CENTER_CY` for radiator-card, `CENTER_X` for
+climate-card, `CENTER_CX` for water-boiler-card).
+
+Radiator (`qs-radiator-card.js`):
+
+```js
+const cancelSubpath = e.override_reset
+    ? ` M ${CENTER_CY - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}`
+      + ` A ${CLIP_R},${CLIP_R} 0 0 1 ${CENTER_CY + OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}`
+      + ` A ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1 1 ${CENTER_CY - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y} Z`
+    : '';
+```
+
+Water-boiler (`qs-water-boiler-card.js`):
+
+```js
+const cancelSubpath = e.override_reset
+    ? ` M ${CENTER_CX - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}`
+      + ` A ${CLIP_R},${CLIP_R} 0 0 1 ${CENTER_CX + OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}`
+      + ` A ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1 1 ${CENTER_CX - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y} Z`
+    : '';
+```
+
+Climate (`qs-climate-card.js`):
+
+```js
+const cancelSubpath = e.override_reset
+    ? ` M ${CENTER_X - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}`
+      + ` A ${CLIP_R},${CLIP_R} 0 0 1 ${CENTER_X + OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y}`
+      + ` A ${OVERRIDE_BTN_CARVE_R},${OVERRIDE_BTN_CARVE_R} 0 1 1 ${CENTER_X - OVERRIDE_BTN_CARVE_INT_X},${OVERRIDE_BTN_CARVE_INT_Y} Z`
+    : '';
+```
+
+**Arc-flag rationale (in case the implementer needs to debug).** First
+arc (outer disc, `CLIP_R`): chord at `OVERRIDE_BTN_CARVE_INT_Y = 275`,
+outer disc centre at `CENTER_Y = 160` — the chord is 115 units below
+the centre, near the bottom of the disc, so the **small** arc passes
+through the bottom of the outer disc → `large-arc-flag = 0`. Going from
+the left intersection to the right intersection through that small arc
+moves clockwise in SVG screen coords (y-axis down) → `sweep-flag = 1`.
+Second arc (carve disc, `OVERRIDE_BTN_CARVE_R`): chord at the same
+`OVERRIDE_BTN_CARVE_INT_Y = 275`, carve disc centre at
+`OVERRIDE_BTN_CARVE_CY = 277` — the chord is only 2 units above centre,
+so most of the carve disc is below the chord. The arc returning from
+right intersection to left intersection through the bottom of the carve
+disc (y = 312) is the **large** arc → `large-arc-flag = 1`. Going right
+→ down → left is also clockwise → `sweep-flag = 1`.
+
+**`clipPathD` builder update** in each card: append `cancelSubpath`
+after `carveSubpath`:
+
+```js
+const clipPathD = `M ${CENTER_*_X - CLIP_R},${CENTER_CY} `
+                + `a ${CLIP_R},${CLIP_R} 0 1 0 ${CLIP_R * 2},0 `
+                + `a ${CLIP_R},${CLIP_R} 0 1 0 -${CLIP_R * 2},0`
+                + carveSubpath
+                + cancelSubpath;
+```
+
+(`CENTER_*_X` = the file-local x-centre constant — `CENTER_CY` for
+radiator, `CENTER_X` for climate, `CENTER_CX` for water-boiler.)
+
+#### Tests for fix #1
+
+Extend the existing `_qs217_assert_card_carve_out` helper in
+`tests/test_dashboard_rendering.py` to also pin:
+
+1. `OVERRIDE_BTN_CARVE_INT_X` and `OVERRIDE_BTN_CARVE_INT_Y` module
+   constants are declared in each card file (regex by name, no value
+   pinning — same iteration-friendly pattern as the existing
+   `OVERRIDE_BTN_CARVE_*` consts).
+2. `const cancelSubpath = e.override_reset ? … : ''` exists in each
+   card file's builder block.
+3. `cancelSubpath` is concatenated into `clipPathD` after
+   `carveSubpath` (e.g., regex `r"clipPathD\s*=[\s\S]+?carveSubpath[\s\S]+?cancelSubpath"`).
+4. The cancel subpath body references the new constants
+   `OVERRIDE_BTN_CARVE_INT_X` and `OVERRIDE_BTN_CARVE_INT_Y` and the
+   pre-existing `CLIP_R`, `OVERRIDE_BTN_CARVE_R`, and the file-local
+   x-centre (`CENTER_CY` / `CENTER_X` / `CENTER_CX`) — all by NAME,
+   not by value, to preserve the "user iterates visually on R"
+   contract.
+
+---
+
+### [should-fix #2] Pin the QS-217 doc paragraph content
+
+- File: `tests/test_dashboard_rendering.py` (add new test)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor.
+- Description: AC-8 mandates the new "QS-217 — Override-button carve-out"
+  paragraph in `docs/agents/concepts/dashboard-and-cards.md` mentions
+  five specific items (a–e: legibility motivation, the three affected
+  cards, the `<path clip-rule="evenodd">` idiom, the constants + CSS-to-
+  SVG derivation, the `e.override_reset` gate). QS-211 has the
+  precedent `test_dashboard_and_cards_doc_pins_qs_211_steam_paragraph`;
+  QS-217 needs the analogous test pin.
+
+#### Proposed fix
+
+Add `test_dashboard_and_cards_doc_pins_qs_217_carve_paragraph` in
+`tests/test_dashboard_rendering.py`, mirroring the QS-211 test. Read
+`docs/agents/concepts/dashboard-and-cards.md` and assert (case-
+insensitively, with adjacent-section tolerance — let the implementer
+find the QS-211 precedent and copy its exact style) that the QS-217
+section contains:
+
+- (a) the words `legibility` or `legible` AND `override` AND `button`
+- (b) all three card file names: `qs-radiator-card.js`,
+  `qs-water-boiler-card.js`, `qs-climate-card.js`
+- (c) the literal string `clip-rule="evenodd"` (with quotes)
+- (d) both constant names `OVERRIDE_BTN_CARVE_CY` and
+  `OVERRIDE_BTN_CARVE_R`, AND a reference to the CSS-to-SVG scale
+  (any of `320/300`, `320×320`, `300×300`, or `1.0667`)
+- (e) the literal `e.override_reset`
+
+Discovery hint: search `tests/test_dashboard_rendering.py` for
+`test_dashboard_and_cards_doc_pins_qs_211_steam_paragraph` and use it
+as a template — the structural shape (file open, find heading anchor,
+assert substrings) is what we want to mirror.
+
+---
+
+### [should-fix #3] Pin the `<g clip-path="url(#…)">` wrapper invariant
+
+- Files: `tests/test_dashboard_rendering.py` (extend three new tests)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor.
+- Description: AC-5 requires the `<g clip-path="url(#…)">` wrapper to
+  remain byte-identical (no per-backdrop branching, no rewrite). The
+  PR relies on pre-existing pins at lines 598 / 1926 / 2026 / 2231 /
+  1946 to enforce this implicitly; auditor admits risk is low. Adding
+  a one-line explicit assertion in each new carve-out test makes the
+  invariant directly testable.
+
+#### Proposed fix
+
+In `_qs217_assert_card_carve_out` (or inline in each of
+`test_radiator_card_override_btn_carve_out`,
+`test_water_boiler_card_override_btn_carve_out`,
+`test_climate_card_override_btn_carve_out`), add:
+
+```python
+# AC-5: <g clip-path="url(#…)"> wrapper unchanged (no per-backdrop branching).
+assert re.search(r'<g\s+clip-path="url\(#\$\{[a-zA-Z]+ClipId\}\)">', content), (
+    f"{card_filename}: expected unchanged <g clip-path=\"url(#${{…}})\"> wrapper"
+)
+```
+
+Use the correct `clipId` variable name per card (radiator:
+`flameClipId`; water-boiler: `waveClipId` or whatever the existing
+name is — discoverable by `grep -n "ClipId" custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`;
+climate: `flameClipId` or similar — same grep approach).
+
+---
+
+### [nice-to-have #1] Fix the climate-test comment/assertion mismatch
+
+- File: `tests/test_dashboard_rendering.py`, in
+  `test_climate_card_snowflake_spawn_uses_halfchord_geometry`
+  (around line ~4360 per the diff, near the `CENTER_CY - CLIP_R`
+  assertion).
+- Severity: nice-to-have.
+- Source: qs-review-blind-hunter.
+- Description: comment claims to assert absence of BOTH
+  `CENTER_CY - CLIP_R` AND `CENTER_CY - OVERRIDE_BTN_CARVE_R` in the
+  builder block, but the actual code only checks the first one. A
+  regression that emits `${CENTER_CY - OVERRIDE_BTN_CARVE_R}` instead
+  of `${CENTER_X - OVERRIDE_BTN_CARVE_R}` for the carve's x-coordinate
+  would still pass.
+
+#### Proposed fix
+
+Add the missing assertion (one line) directly below the existing
+`CENTER_CY - CLIP_R` absence check:
+
+```python
+assert "CENTER_CY - OVERRIDE_BTN_CARVE_R" not in builder_block, (
+    "qs-climate-card.js: carve x-coordinate should use CENTER_X, not CENTER_CY"
+)
+```
+
+The comment can stay as-is; this assertion makes it true.
+
+---
+
+### [nice-to-have #2] Factor the builder-block regex into a single helper
+
+- File: `tests/test_dashboard_rendering.py`
+- Severity: nice-to-have.
+- Source: qs-review-blind-hunter.
+- Description: the regex
+  `r"const\s+carveSubpath\s*=([\s\S]*?const\s+clipPathD\s*=[\s\S]*?);"`
+  is duplicated across three call sites
+  (`_qs217_assert_card_carve_out` ~line 700,
+  `test_radiator_card_flame_layers_present` ~line 700,
+  `test_climate_card_snowflake_spawn_uses_halfchord_geometry` ~line 900).
+
+#### Proposed fix
+
+Introduce a module-level constant at the top of
+`tests/test_dashboard_rendering.py` (near other test regex constants,
+or alongside `_qs217_assert_card_carve_out`):
+
+```python
+_QS217_BUILDER_BLOCK_RE = re.compile(
+    r"const\s+carveSubpath\s*=([\s\S]*?const\s+clipPathD\s*=[\s\S]*?);",
+)
+```
+
+Replace the three inline `re.search(...)` calls with
+`_QS217_BUILDER_BLOCK_RE.search(content)`.
+
+Note: this finding interacts with **fix #1's** test changes (the
+helper will also need to pin `cancelSubpath`, which lives inside the
+same builder block). The implementer should land **fix #1 first**,
+which forces re-writing the helper to also check `cancelSubpath`, and
+**at the same time** factor out the regex constant. Don't do these as
+two separate diffs to the same helper.
+
+Also interacts with **nice-to-have #3** (regex anchoring) — both edit
+the same regex, so coalesce them. See #3 below.
+
+---
+
+### [nice-to-have #3] Anchor the builder-block regex more strictly
+
+- File: `tests/test_dashboard_rendering.py`, the
+  `_QS217_BUILDER_BLOCK_RE` introduced by #2.
+- Severity: nice-to-have.
+- Source: qs-review-edge-case-hunter.
+- Description: the lazy-match `[\s\S]*?` terminating at the first `;`
+  after `const clipPathD = …` is brittle. If a future refactor
+  computes `clipPathD` in multiple statements (e.g., `let clipPathD = …;
+  if (…) clipPathD += …;`), or inserts another `const clipPathD = …`
+  somewhere, the regex captures the wrong span.
+
+#### Proposed fix
+
+Coalesce with #2's helper. After factoring out
+`_QS217_BUILDER_BLOCK_RE`, update its pattern to also require
+`cancelSubpath` (introduced by fix #1) and `clipPathD` to both appear
+inside the captured block, AND anchor the start at the carveSubpath
+opening:
+
+```python
+_QS217_BUILDER_BLOCK_RE = re.compile(
+    r"(const\s+carveSubpath\s*=[\s\S]+?"
+    r"const\s+cancelSubpath\s*=[\s\S]+?"
+    r"const\s+clipPathD\s*=[\s\S]+?);",
+)
+```
+
+This pins all three consts in order inside one block, fails fast if a
+future refactor renames any of them, and the lazy `?` after each `[\s\S]+`
+keeps it from over-greedy spanning into unrelated `;` characters.
+
+---
+
+### [nice-to-have #4] Gate `carveSubpath` and `cancelSubpath` on `OVERRIDE_BTN_CARVE_R > 0`
+
+- Files:
+  - `custom_components/quiet_solar/ui/resources/qs-radiator-card.js`
+  - `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`
+  - `custom_components/quiet_solar/ui/resources/qs-climate-card.js`
+- Severity: nice-to-have.
+- Source: qs-review-edge-case-hunter.
+- Description: if the user accidentally sets `OVERRIDE_BTN_CARVE_R = 0`
+  during visual iteration, the emitted carve subpath becomes
+  `M 160,277 a 0,0 0 1,0 0,0 a 0,0 0 1,0 0,0` — SVG arc commands with
+  rx = ry = 0 are spec-degenerate; browsers may render no-op (safe) or
+  log warnings (annoying). The cancel subpath would similarly degenerate
+  with `rx = ry = 0` on the second arc. Cheap defense.
+
+#### Proposed fix
+
+Change the gate on both `carveSubpath` and `cancelSubpath` in all three
+card files from:
+
+```js
+const carveSubpath = e.override_reset ? `...` : '';
+const cancelSubpath = e.override_reset ? `...` : '';
+```
+
+to:
+
+```js
+const carveSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0) ? `...` : '';
+const cancelSubpath = (e.override_reset && OVERRIDE_BTN_CARVE_R > 0) ? `...` : '';
+```
+
+Tests: extend `_qs217_assert_card_carve_out` to pin the gate pattern
+`e.override_reset && OVERRIDE_BTN_CARVE_R > 0` (or equivalent —
+regex `r"e\.override_reset\s*&&\s*OVERRIDE_BTN_CARVE_R\s*>\s*0"`).
+
+---
+
+## Invalid (explicitly not fixed)
+
+### [nice-to-have #5] Climate `'none'` backdrop emits unused carve markup
+
+- Status: **invalid — by design.**
+- Source: qs-review-edge-case-hunter.
+- Rationale: DN-3 in the story file explicitly documents the user
+  pre-approval for uniform carve across all four climate backdrops
+  (`flame` / `snow` / `wind` / `none`) as preemptive future-proofing.
+  AC-5 also forbids per-backdrop branching in `clipPathD`. "Fixing"
+  this would directly violate both. No change.
+
+---
+
+## How to apply
+
+1. Run `/implement-task` (preferred: open a fresh `claude --agent
+   qs-implement-task` session) against this fix plan.
+2. Implementation order:
+   - Apply must-fix #1 first (the geometry change with new constants
+     and `cancelSubpath`). Coalesce with nice-to-have #2 and #3 since
+     all three rewrite the same test helper.
+   - Then nice-to-have #4 (gate change) — touches the same three JS
+     files but is a tiny localized diff.
+   - Then should-fix #2 (new doc-pin test).
+   - Then should-fix #3 (wrapper invariant pin — small extension to
+     `_qs217_assert_card_carve_out`).
+   - Then nice-to-have #1 (one-line missing assertion).
+3. Quality gate: `python scripts/qs/quality_gate.py` (UI-only fast
+   path applies — `custom_components/quiet_solar/ui/resources/*.js`
+   and `tests/test_dashboard_rendering.py`).
+4. Visually verify the fix on the same screen as the original
+   screenshot: the wave-coloured crescent below the override-hand
+   button should be gone; the side-tint at the ring rim near the
+   button should also be gone. The button itself should remain
+   carved out exactly as before (no regression on the original
+   behaviour).
+5. Push, then run `/review-task` again to re-verify (the
+   re-review loop should converge with zero must-fix/should-fix).

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -3344,14 +3344,16 @@ def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None
         f"OVERRIDE_BTN_CARVE_CY = 277;` declaration (QS-217 AC-1)."
     )
     assert re.search(
-        r"const\s+OVERRIDE_BTN_CARVE_R\s*=\s*45\b",
+        r"const\s+OVERRIDE_BTN_CARVE_R\s*=\s*60\b",
         content,
     ) is not None, (
         f"{card_filename}: missing module-level `const "
-        f"OVERRIDE_BTN_CARVE_R = 45;` declaration (QS-217 AC-1; R "
-        f"bumped from 35 → 45 during review-fix #02 visual iteration "
-        f"so the carve generously covers the visible button area + "
-        f"~9 CSS px padding at the tightest spot, the top corners)."
+        f"OVERRIDE_BTN_CARVE_R = 60;` declaration (QS-217 AC-1; R "
+        f"bumped 35 → 45 → 60 across two visual-iteration rounds — "
+        f"the user's rendered button is ~46 SVG radius after retina "
+        f"scaling, so R=45 was just barely too small; R=60 covers it "
+        f"with ~13 SVG ≈ ~12 CSS px of padding even at the tightest "
+        f"button y values)."
     )
     assert re.search(
         r"const\s+OVERRIDE_BTN_CARVE_INT_X\s*=",

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -578,18 +578,53 @@ class TestDashboardTemplateRendering:
             "test bump should follow."
         )
 
-        # AC-2: clipPath circle at the ring centre. Geometry must be wired
-        # through the module-top `CENTER_CY` / `CLIP_R` constants so the
-        # SVG cannot silently drift if those constants are tweaked
-        # (review fix S2).
+        # AC-2 / QS-217 AC-6: clipPath uses `<path clip-rule="evenodd"
+        # d="${clipPathD}" />`. The bare `<circle>` form was replaced
+        # by QS-217 to enable the override-button carve-out hole via
+        # the SVG evenodd fill rule. Geometry is still wired through
+        # the module-top `CENTER_CY` / `CLIP_R` constants — now via the
+        # `clipPathD` builder (the next assertion block) — so the SVG
+        # cannot silently drift if those constants are tweaked
+        # (review fix S2 preserved).
         assert re.search(
-            r"<clipPath\s+id=\"\$\{flameClipId\}\">\s*<circle\s+cx=\"\$\{CENTER_CY\}\"\s+cy=\"\$\{CENTER_CY\}\"\s+r=\"\$\{CLIP_R\}\"",
+            r"<clipPath\s+id=\"\$\{flameClipId\}\">\s*<path\s+clip-rule=\"evenodd\"\s+d=\"\$\{clipPathD\}\"\s*/>\s*</clipPath>",
             content,
             re.DOTALL,
         ) is not None, (
-            "Missing clipPath circle interpolating CENTER_CY / CLIP_R "
-            "(must use ${CENTER_CY} / ${CLIP_R}, not hard-coded 160 / 120)"
+            "Missing clipPath <path clip-rule=\"evenodd\" "
+            "d=\"${clipPathD}\" /> form — QS-217 replaced the bare "
+            "<circle> with this evenodd-rule path so the override "
+            "button gets a carve-out hole."
         )
+        # QS-217 AC-6: the `clipPathD` builder block must reference all
+        # four constants by NAME (not hard-coded values) — the original
+        # "constants-not-hardcoded" invariant from review-fix S2 carries
+        # over to the new builder. Capture BOTH the `carveSubpath` and
+        # `clipPathD` declarations as one contiguous span so the
+        # constants referenced from either statement count toward the
+        # invariant.
+        builder_match = re.search(
+            r"const\s+carveSubpath\s*=([\s\S]*?const\s+clipPathD\s*=[\s\S]*?);",
+            content,
+        )
+        assert builder_match is not None, (
+            "Missing `const carveSubpath = …;\\nconst clipPathD = …;` "
+            "builder block — QS-217 AC-3 requires both declarations "
+            "be present, in that order, above the innerHTML template "
+            "literal so the SVG clipPath can interpolate `${clipPathD}`."
+        )
+        builder_block = builder_match.group(1)
+        for ident in (
+            "CENTER_CY",
+            "CLIP_R",
+            "OVERRIDE_BTN_CARVE_CY",
+            "OVERRIDE_BTN_CARVE_R",
+        ):
+            assert re.search(rf"\b{ident}\b", builder_block) is not None, (
+                f"qs-radiator-card.js: clipPathD builder must "
+                f"reference `{ident}` by name (not hard-coded). QS-217 "
+                f"AC-6 preserves the constants-not-hardcoded invariant."
+            )
         # The constants themselves carry the correct geometric values.
         assert re.search(r"const\s+CENTER_CY\s*=\s*160\b", content) is not None
         assert re.search(r"const\s+CLIP_R\s*=\s*120\b", content) is not None
@@ -2022,10 +2057,12 @@ def test_water_boiler_card_has_surface_glow():
 def test_water_boiler_card_pins_geometry_constants():
     """Review-fix #01 S5: pin the module-level geometry constants
     (AC-2). The SVG layout depends on `CLIP_R`, `CENTER_CX`, `CENTER_CY`,
-    and `WAVE_WIDTH` matching specific values that the clipPath
-    ``<circle cx cy r>`` markup interpolates. A future tweak that
-    changes any of them without re-checking the SVG would silently
-    misalign the water animation, so we pin each here.
+    and `WAVE_WIDTH` matching specific values that the ``<clipPath>``
+    markup interpolates via the `clipPathD` builder (QS-217 swapped the
+    bare ``<circle cx cy r>`` form for a ``<path>`` with evenodd
+    fill-rule so the override button can be carved out as a hole). A
+    future tweak that changes any of them without re-checking the SVG
+    would silently misalign the water animation, so we pin each here.
 
     `CENTER_CX` is review-fix #01 N4's new constant (was inlined as
     `160` in two places). `CENTER_CY` and `CLIP_R` and `WAVE_WIDTH`
@@ -2973,6 +3010,163 @@ def test_water_boiler_card_steam_filter_region_attributes():
     ), (
         "qs-water-boiler-card.js: steam filter must contain "
         "`<feGaussianBlur stdDeviation=\"${STEAM_BLUR_STDDEV}\" />`."
+    )
+
+
+# ============================================================================
+# QS-217 — Override-button carve-out across radiator / water-boiler / climate
+# cards. Each card now wraps a `<path clip-rule="evenodd" d="${clipPathD}" />`
+# in its `<clipPath>` so the semi-transparent bottom-center override "hand"
+# button is no longer painted over by the animation (orange flames, white
+# snow, blue water). The carve is gated on `e.override_reset`, identical to
+# the existing button-render gate, and pins the constant *names* — not
+# values — so the user can iterate visually on the radius.
+# ============================================================================
+
+
+def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None:
+    """Shared QS-217 invariant check used by the three carve-out tests.
+
+    Pinned invariants (AC-1, AC-2, AC-3, AC-4, AC-7):
+
+    - (a) the ``<clipPath>`` block contains ``<path clip-rule="evenodd"
+      d="${clipPathD}" />`` (the bare ``<circle>`` form was removed).
+    - (b) the two new module-level constants
+      ``OVERRIDE_BTN_CARVE_CY = 277`` and ``OVERRIDE_BTN_CARVE_R = 35``
+      are declared at file scope; both are referenced by *name* in the
+      ``clipPathD`` builder block (so a later visual tweak to the radius
+      value leaves the test green — see DN-2).
+    - (c) the carve subpath is gated on ``e.override_reset`` — i.e. the
+      regex ``e\\.override_reset\\s*\\?`` appears inside the builder block,
+      matching the existing in-file gate for the
+      ``<div id="override_btn">`` render.
+
+    ``x_center_name`` is the file-local x-centre constant name (radiator
+    uses ``CENTER_CY`` for both axes; water-boiler uses ``CENTER_CX``;
+    climate uses ``CENTER_X``).
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / card_filename
+    ).read_text()
+
+    # (a) clipPath uses `<path clip-rule="evenodd" d="${clipPathD}" />`.
+    assert re.search(
+        r"<clipPath\s+id=\"\$\{[^}]+\}\">\s*<path\s+clip-rule=\"evenodd\"\s+d=\"\$\{clipPathD\}\"\s*/>\s*</clipPath>",
+        content,
+        re.DOTALL,
+    ) is not None, (
+        f"{card_filename}: missing `<clipPath …><path clip-rule="
+        f"\"evenodd\" d=\"${{clipPathD}}\" /></clipPath>` form. QS-217 "
+        f"AC-2 replaces the bare `<circle>` with the evenodd path so "
+        f"the override button is carved out as a hole."
+    )
+
+    # (b) Top-level const declarations for the two new carve constants.
+    assert re.search(
+        r"const\s+OVERRIDE_BTN_CARVE_CY\s*=\s*277\b",
+        content,
+    ) is not None, (
+        f"{card_filename}: missing module-level `const "
+        f"OVERRIDE_BTN_CARVE_CY = 277;` declaration (QS-217 AC-1)."
+    )
+    assert re.search(
+        r"const\s+OVERRIDE_BTN_CARVE_R\s*=\s*35\b",
+        content,
+    ) is not None, (
+        f"{card_filename}: missing module-level `const "
+        f"OVERRIDE_BTN_CARVE_R = 35;` declaration (QS-217 AC-1)."
+    )
+
+    # (b) The `clipPathD` builder must reference the carve constants by
+    # NAME (not by value) so a later iteration on the radius leaves this
+    # test green. Scope the regex to BOTH declarations — `carveSubpath`
+    # (which holds the override gate + carve geometry) AND `clipPathD`
+    # (the final concatenated path). AC-3 requires `carveSubpath` to be
+    # declared immediately above `clipPathD`, so capturing the contiguous
+    # span is safe and pins the in-file ordering.
+    builder_match = re.search(
+        r"const\s+carveSubpath\s*=([\s\S]*?const\s+clipPathD\s*=[\s\S]*?);",
+        content,
+    )
+    assert builder_match is not None, (
+        f"{card_filename}: missing `const carveSubpath = …;\\n"
+        f"const clipPathD = …;` builder block. QS-217 AC-3 requires "
+        f"both declarations be present, in that order, immediately "
+        f"above the innerHTML template literal so the SVG clipPath "
+        f"can interpolate `${{clipPathD}}`."
+    )
+    builder_block = builder_match.group(1)
+    # The full-disc subpath references CLIP_R and the y-centre const.
+    # The radiator's `CENTER_CY` doubles as the x-centre name, while
+    # water-boiler uses `CENTER_CX` and climate uses `CENTER_X`. Pin
+    # the per-card x-centre name plus the shared invariants.
+    for ident in (
+        "CLIP_R",
+        "CENTER_CY",
+        x_center_name,
+        "OVERRIDE_BTN_CARVE_CY",
+        "OVERRIDE_BTN_CARVE_R",
+    ):
+        assert re.search(rf"\b{ident}\b", builder_block) is not None, (
+            f"{card_filename}: clipPathD builder must reference "
+            f"`{ident}` by name (not hard-coded). QS-217 AC-3/AC-7 "
+            f"preserves the constants-not-hardcoded invariant."
+        )
+
+    # (c) Carve subpath gated on `e.override_reset` — identical idiom to
+    # the existing `<div id="override_btn">` render gate (AC-4).
+    assert re.search(
+        r"e\.override_reset\s*\?",
+        builder_block,
+    ) is not None, (
+        f"{card_filename}: clipPathD builder must gate the carve "
+        f"subpath on `e.override_reset ? … : ''` — same truthy gate "
+        f"as the existing override-button render. QS-217 AC-4."
+    )
+
+
+def test_radiator_card_override_btn_carve_out():
+    """QS-217 AC-7 — radiator card: clipPath swaps `<circle>` for
+    `<path clip-rule="evenodd" d="${clipPathD}" />`, adds the two
+    `OVERRIDE_BTN_CARVE_*` constants at module scope, and gates the
+    carve subpath on `e.override_reset`.
+
+    See the helper docstring for invariant (a)/(b)/(c) details.
+    """
+    _qs217_assert_card_carve_out(
+        "qs-radiator-card.js",
+        x_center_name="CENTER_CY",
+    )
+
+
+def test_water_boiler_card_override_btn_carve_out():
+    """QS-217 AC-7 — water-boiler card carve-out invariants.
+
+    Same three pins as the radiator card (AC-7 helper), anchored to
+    `qs-water-boiler-card.js`. The water-boiler card uses `CENTER_CX`
+    (not `CENTER_CY`) for the x-centre — review-fix #01 N4 introduced
+    that explicit constant, and QS-217's `clipPathD` builder must
+    reference it.
+    """
+    _qs217_assert_card_carve_out(
+        "qs-water-boiler-card.js",
+        x_center_name="CENTER_CX",
+    )
+
+
+def test_climate_card_override_btn_carve_out():
+    """QS-217 AC-7 — climate card carve-out invariants.
+
+    Same three pins as the radiator card (AC-7 helper), anchored to
+    `qs-climate-card.js`. The climate card uses `CENTER_X` (QS-210
+    review-fix S5 introduced that explicit x-centre constant), and
+    QS-217's `clipPathD` builder must reference it.
+    """
+    _qs217_assert_card_carve_out(
+        "qs-climate-card.js",
+        x_center_name="CENTER_X",
     )
 
 
@@ -4120,22 +4314,58 @@ class TestClimateCardReviewFix01Hardening:
             "chord at the spawn-y."
         )
 
-        # Pass-#2 S1 / N3 — the clip `<circle cx>` must use `CENTER_X`,
-        # not `CENTER_CY`. Numerically equivalent today (square
-        # viewBox) but the `CENTER_X` comment block claims
+        # Pass-#2 S1 / N3 — the clipPath x-coordinate must use
+        # `CENTER_X`, not `CENTER_CY`. Numerically equivalent today
+        # (square viewBox) but the `CENTER_X` comment block claims
         # future-proofing for a non-square viewBox; that claim only
-        # holds if EVERY x-coordinate reference uses `CENTER_X`. Pass-#1
-        # missed updating the clip-circle attribute; this is the
-        # finisher.
-        assert re.search(
-            r'<circle\s+cx="\$\{CENTER_X\}"\s+cy="\$\{CENTER_CY\}"\s+'
-            r'r="\$\{CLIP_R\}"',
+        # holds if EVERY x-coordinate reference uses `CENTER_X`.
+        # QS-217 replaced the bare `<circle>` clipPath with a
+        # `<path d="${clipPathD}" />` whose builder concatenates an
+        # outer-disc and (optional) inner-carve subpath. The pass-#2
+        # S1 invariant carries over: the builder's x-coordinate
+        # expression must be `CENTER_X - …`, not `CENTER_CY - …`.
+        builder_match = re.search(
+            r"const\s+carveSubpath\s*=([\s\S]*?const\s+clipPathD\s*=[\s\S]*?);",
             content,
+        )
+        assert builder_match is not None, (
+            "Pass-#2 S1: `clipPathD` builder block missing — "
+            "QS-217 AC-3 requires `const carveSubpath = …; const "
+            "clipPathD = …;` above the innerHTML template literal."
+        )
+        builder_block = builder_match.group(1)
+        # Outer disc subpath uses `CENTER_X - CLIP_R`.
+        assert re.search(
+            r"\$\{\s*CENTER_X\s*-\s*CLIP_R\s*\}",
+            builder_block,
         ) is not None, (
-            "Pass-#2 S1: the climate card's clip `<circle>` must read "
-            "`cx=\"${CENTER_X}\" cy=\"${CENTER_CY}\" r=\"${CLIP_R}\"` "
-            "(not `cx=\"${CENTER_CY}\"`) so the `CENTER_X` constant's "
+            "Pass-#2 S1: the climate card's clipPathD outer-disc "
+            "subpath must use `${CENTER_X - CLIP_R}` (not "
+            "`${CENTER_CY - CLIP_R}`) so the `CENTER_X` constant's "
             "future-proofing comment is accurate."
+        )
+        # Inner-carve subpath uses `CENTER_X - OVERRIDE_BTN_CARVE_R`.
+        assert re.search(
+            r"\$\{\s*CENTER_X\s*-\s*OVERRIDE_BTN_CARVE_R\s*\}",
+            builder_block,
+        ) is not None, (
+            "Pass-#2 S1 (QS-217 extension): the climate card's "
+            "clipPathD inner-carve subpath must use `${CENTER_X - "
+            "OVERRIDE_BTN_CARVE_R}` so the x-centre is sourced from "
+            "`CENTER_X`, preserving the future-proofing invariant."
+        )
+        # And the builder must NOT use `CENTER_CY` for any x-coordinate
+        # arithmetic (the pass-#2 anti-pattern). We can pin this by
+        # asserting the absence of `CENTER_CY - CLIP_R` and
+        # `CENTER_CY - OVERRIDE_BTN_CARVE_R` in the builder block;
+        # `CENTER_CY` still appears legitimately as a y-coordinate.
+        assert re.search(
+            r"\$\{\s*CENTER_CY\s*-\s*CLIP_R\s*\}",
+            builder_block,
+        ) is None, (
+            "Pass-#2 S1: the climate card's clipPathD must NOT use "
+            "`${CENTER_CY - CLIP_R}` as an x-coordinate. That was "
+            "the pre-pass-#2 anti-pattern; use `CENTER_X - CLIP_R`."
         )
 
     def test_climate_card_safe_number_filters_whitespace_and_infinity(self):

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -3344,11 +3344,14 @@ def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None
         f"OVERRIDE_BTN_CARVE_CY = 277;` declaration (QS-217 AC-1)."
     )
     assert re.search(
-        r"const\s+OVERRIDE_BTN_CARVE_R\s*=\s*35\b",
+        r"const\s+OVERRIDE_BTN_CARVE_R\s*=\s*45\b",
         content,
     ) is not None, (
         f"{card_filename}: missing module-level `const "
-        f"OVERRIDE_BTN_CARVE_R = 35;` declaration (QS-217 AC-1)."
+        f"OVERRIDE_BTN_CARVE_R = 45;` declaration (QS-217 AC-1; R "
+        f"bumped from 35 → 45 during review-fix #02 visual iteration "
+        f"so the carve generously covers the visible button area + "
+        f"~9 CSS px padding at the tightest spot, the top corners)."
     )
     assert re.search(
         r"const\s+OVERRIDE_BTN_CARVE_INT_X\s*=",

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -581,53 +581,36 @@ class TestDashboardTemplateRendering:
 
         # AC-2 / QS-217 AC-6: clipPath uses `<path clip-rule="evenodd"
         # d="${clipPathD}" />`. The bare `<circle>` form was replaced
-        # by QS-217 to enable the override-button carve-out hole via
-        # the SVG evenodd fill rule. Geometry is still wired through
-        # the module-top `CENTER_CY` / `CLIP_R` constants — now via the
-        # `clipPathD` builder (the next assertion block) — so the SVG
-        # cannot silently drift if those constants are tweaked
-        # (review fix S2 preserved).
+        # by QS-217 to enable the override-button hole — review-fix
+        # #03 simplifies clipPathD back to just an outer-disc circle
+        # path (the lens-shape carve was dropped in favour of a cover
+        # overlay drawn ON TOP of the animation; see the
+        # test_radiator_card_override_btn_carve_out test for the cover
+        # invariants).
         assert re.search(
             r"<clipPath\s+id=\"\$\{flameClipId\}\">\s*<path\s+clip-rule=\"evenodd\"\s+d=\"\$\{clipPathD\}\"\s*/>\s*</clipPath>",
             content,
             re.DOTALL,
         ) is not None, (
             "Missing clipPath <path clip-rule=\"evenodd\" "
-            "d=\"${clipPathD}\" /> form — QS-217 replaced the bare "
-            "<circle> with this evenodd-rule path so the override "
-            "button gets a carve-out hole."
+            "d=\"${clipPathD}\" /> form."
         )
-        # QS-217 AC-6: the `clipPathD` builder block must reference all
-        # six constants by NAME (not hard-coded values) — the original
-        # "constants-not-hardcoded" invariant from review-fix S2 carries
-        # over to the new builder. Review-fix #01 must-fix #1 added two
-        # more (OVERRIDE_BTN_CARVE_INT_X / OVERRIDE_BTN_CARVE_INT_Y) for
-        # the crescent-cancel subpath. Use the shared
-        # _QS217_BUILDER_BLOCK_RE (review-fix #01 nice-to-have #2 + #3)
-        # which anchors the three-const order strictly.
-        builder_match = _QS217_BUILDER_BLOCK_RE.search(content)
+        # The clipPathD builder must still reference `CENTER_CY` and
+        # `CLIP_R` (the outer-disc geometry). QS-217 review-fix #03
+        # drops the carve+cancel constants (no longer in the builder).
+        builder_match = re.search(
+            r"const\s+clipPathD\s*=([\s\S]*?);",
+            content,
+        )
         assert builder_match is not None, (
-            "Missing the QS-217 three-const builder block "
-            "(`const carveSubpath = …;\\nconst cancelSubpath = …;"
-            "\\nconst clipPathD = …;`). QS-217 AC-3 + review-fix #01 "
-            "must-fix #1 require all three declarations in that order "
-            "above the innerHTML template literal."
+            "Missing `const clipPathD = …;` builder declaration — "
+            "must be present above the innerHTML template literal."
         )
         builder_block = builder_match.group(1)
-        for ident in (
-            "CENTER_CY",
-            "CLIP_R",
-            "OVERRIDE_BTN_CARVE_CY",
-            "OVERRIDE_BTN_CARVE_R",
-            "OVERRIDE_BTN_CARVE_INT_X",
-            "OVERRIDE_BTN_CARVE_INT_Y",
-        ):
+        for ident in ("CENTER_CY", "CLIP_R"):
             assert re.search(rf"\b{ident}\b", builder_block) is not None, (
                 f"qs-radiator-card.js: clipPathD builder must "
-                f"reference `{ident}` by name (not hard-coded). QS-217 "
-                f"AC-6 + review-fix #01 must-fix #1 preserve the "
-                f"constants-not-hardcoded invariant for both the carve "
-                f"and the crescent-cancel subpaths."
+                f"reference `{ident}` by name (not hard-coded)."
             )
         # The constants themselves carry the correct geometric values.
         assert re.search(r"const\s+CENTER_CY\s*=\s*160\b", content) is not None
@@ -3262,52 +3245,38 @@ def test_water_boiler_card_steam_filter_region_attributes():
 # ============================================================================
 
 
-# QS-217 review-fix #01 (nice-to-have #2 + #3): factored builder-block
-# regex shared by the three call sites (_qs217_assert_card_carve_out,
-# test_radiator_card_flame_layers_present, and
-# test_climate_card_snowflake_spawn_uses_halfchord_geometry). The
-# pattern requires ALL THREE consts (`carveSubpath`, `cancelSubpath`,
-# `clipPathD`) to appear in that order inside the captured block, so
-# any future refactor that renames / drops / reorders them fails fast.
-# Each `[\s\S]+?` lazy-matches across statement terminators (a single
-# `;` lives at the end of each const declaration) so the captured span
-# stays anchored to the three-statement builder block.
-_QS217_BUILDER_BLOCK_RE = re.compile(
-    r"(const\s+carveSubpath\s*=[\s\S]+?"
-    r"const\s+cancelSubpath\s*=[\s\S]+?"
-    r"const\s+clipPathD\s*=[\s\S]+?);",
-)
-
-
 def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None:
     """Shared QS-217 invariant check used by the three carve-out tests.
 
-    Pinned invariants (AC-1, AC-2, AC-3, AC-4, AC-5, AC-7 + review-fix
-    #01 must-fix #1, nice-to-have #4, should-fix #3):
+    Review-fix #03 abandoned the original clipPath carve-out approach
+    (outer disc + carve disc + cancel subpath under evenodd, which
+    produced a geometric lens-shape hole that the user repeatedly
+    flagged) in favour of a much simpler COVER OVERLAY: a single
+    ``<circle>`` element with ``fill="var(--card-background-color)"``
+    drawn ON TOP of the clipped animation group. The cover IS a
+    circle by construction — no lens shape possible.
 
-    - (a) the ``<clipPath>`` block contains ``<path clip-rule="evenodd"
-      d="${clipPathD}" />`` (the bare ``<circle>`` form was removed).
-    - (b) the four module-level constants
-      ``OVERRIDE_BTN_CARVE_CY = 277``, ``OVERRIDE_BTN_CARVE_R = 35``,
-      ``OVERRIDE_BTN_CARVE_INT_X``, and ``OVERRIDE_BTN_CARVE_INT_Y`` are
-      declared at file scope (the first two by value, the last two by
-      name only — review-fix #01 must-fix #1 + iteration-friendly
-      contract). Each is referenced by *name* in the ``clipPathD``
-      builder block so a later visual tweak to the radius value leaves
-      the test green — see DN-2 in the story.
-    - (c) BOTH ``carveSubpath`` and ``cancelSubpath`` are gated on the
-      review-fix #01 nice-to-have #4 hardened predicate
-      ``e.override_reset && OVERRIDE_BTN_CARVE_R > 0`` — same truthy
-      check as the existing ``<div id="override_btn">`` render plus a
-      degenerate-arc guard for the ``OVERRIDE_BTN_CARVE_R = 0`` visual-
-      iteration edge case.
-    - (d) The ``clipPathD`` concatenation appends ``cancelSubpath``
-      AFTER ``carveSubpath`` so the evenodd winding-count math works
-      (must-fix #1 — the cancel subpath bumps the leak-crescent winding
-      from 1 → 2 → outside clip → animation hidden).
-    - (e) ``<g clip-path="url(#${…ClipId})">`` wrapper present (AC-5 +
-      review-fix #01 should-fix #3) — explicit per-card pin replaces
-      the pre-existing implicit anchor checks.
+    Pinned invariants (review-fix #03):
+
+    - (a) the ``<clipPath>`` is just the outer disc (no carve, no
+      cancel subpath in ``clipPathD``).
+    - (b) the two module-level constants ``OVERRIDE_BTN_CARVE_CY = 277``
+      and ``OVERRIDE_BTN_CARVE_R`` (integer) are declared at file
+      scope. The radius value is intentionally NOT pinned by tests so
+      visual-iteration tweaks (e.g. 35 → 40 → 30) leave the suite
+      green — only the constant NAME is required.
+    - (c) the ``<circle id="override_btn_cover" …>`` cover element
+      is present in the SVG markup, gated on ``e.override_reset``
+      (same truthy check as the existing button render), and uses the
+      file-local x-centre constant for ``cx``, ``OVERRIDE_BTN_CARVE_CY``
+      for ``cy``, ``OVERRIDE_BTN_CARVE_R`` for ``r``, and
+      ``fill="var(--card-background-color)"`` so it visually erases
+      the animation in a clean circular patch.
+    - (d) ``<g clip-path="url(#${…ClipId})">`` wrapper unchanged.
+    - (e) the obsolete carve-out artifacts (carveSubpath, cancelSubpath,
+      OVERRIDE_BTN_CARVE_INT_X, OVERRIDE_BTN_CARVE_INT_Y) MUST be
+      absent — pinned as negative assertions so a regression can't
+      silently reintroduce the lens-shape approach.
 
     ``x_center_name`` is the file-local x-centre constant name (radiator
     uses ``CENTER_CY`` for both axes; water-boiler uses ``CENTER_CX``;
@@ -3317,148 +3286,88 @@ def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None
         COMPONENT_ROOT / "ui" / "resources" / card_filename
     ).read_text()
 
-    # (a) clipPath uses `<path clip-rule="evenodd" d="${clipPathD}" />`.
+    # (a) clipPath has the simple outer disc (no carve, no cancel). The
+    # SVG markup uses the `<path clip-rule="evenodd" d="${clipPathD}">`
+    # form for backward-compatibility with other tests, but `clipPathD`
+    # is just an outer-disc circle path now.
     assert re.search(
         r"<clipPath\s+id=\"\$\{[^}]+\}\">\s*<path\s+clip-rule=\"evenodd\"\s+d=\"\$\{clipPathD\}\"\s*/>\s*</clipPath>",
         content,
         re.DOTALL,
     ) is not None, (
-        f"{card_filename}: missing `<clipPath …><path clip-rule="
-        f"\"evenodd\" d=\"${{clipPathD}}\" /></clipPath>` form. QS-217 "
-        f"AC-2 replaces the bare `<circle>` with the evenodd path so "
-        f"the override button is carved out as a hole."
+        f"{card_filename}: missing `<clipPath …><path "
+        f"clip-rule=\"evenodd\" d=\"${{clipPathD}}\" /></clipPath>` "
+        f"form. The clipPath wraps the simple outer-disc circle now "
+        f"(review-fix #03 dropped the carve+cancel subpaths)."
     )
 
-    # (b) Top-level const declarations for the two value-pinned carve
-    # constants. The two intersection constants
-    # (OVERRIDE_BTN_CARVE_INT_X / OVERRIDE_BTN_CARVE_INT_Y, introduced
-    # by review-fix #01 must-fix #1) are pinned by NAME only — they
-    # follow the same iteration-friendly contract as
-    # OVERRIDE_BTN_CARVE_R (the user can swap integers for floats or
-    # tweak the rounded value during visual iteration).
+    # (b) The two module-level constants are declared. CY pinned by
+    # value (geometry-fixed, derives from CSS button position). R
+    # pinned by NAME only — visual-iteration friendly.
     assert re.search(
         r"const\s+OVERRIDE_BTN_CARVE_CY\s*=\s*277\b",
         content,
     ) is not None, (
         f"{card_filename}: missing module-level `const "
-        f"OVERRIDE_BTN_CARVE_CY = 277;` declaration (QS-217 AC-1)."
+        f"OVERRIDE_BTN_CARVE_CY = 277;` declaration (button-centre y "
+        f"in SVG units, derived from CSS .override-btn position)."
     )
     assert re.search(
-        r"const\s+OVERRIDE_BTN_CARVE_R\s*=\s*60\b",
+        r"const\s+OVERRIDE_BTN_CARVE_R\s*=\s*\d+\b",
         content,
     ) is not None, (
         f"{card_filename}: missing module-level `const "
-        f"OVERRIDE_BTN_CARVE_R = 60;` declaration (QS-217 AC-1; R "
-        f"bumped 35 → 45 → 60 across two visual-iteration rounds — "
-        f"the user's rendered button is ~46 SVG radius after retina "
-        f"scaling, so R=45 was just barely too small; R=60 covers it "
-        f"with ~13 SVG ≈ ~12 CSS px of padding even at the tightest "
-        f"button y values)."
-    )
-    assert re.search(
-        r"const\s+OVERRIDE_BTN_CARVE_INT_X\s*=",
-        content,
-    ) is not None, (
-        f"{card_filename}: missing module-level `const "
-        f"OVERRIDE_BTN_CARVE_INT_X = …;` declaration (QS-217 review-"
-        f"fix #01 must-fix #1: crescent-cancel x-intersection)."
-    )
-    assert re.search(
-        r"const\s+OVERRIDE_BTN_CARVE_INT_Y\s*=",
-        content,
-    ) is not None, (
-        f"{card_filename}: missing module-level `const "
-        f"OVERRIDE_BTN_CARVE_INT_Y = …;` declaration (QS-217 review-"
-        f"fix #01 must-fix #1: crescent-cancel y-intersection)."
+        f"OVERRIDE_BTN_CARVE_R = <integer>;` declaration. The integer "
+        f"value is user-tunable; tests pin the NAME only so visual-"
+        f"iteration tweaks leave the suite green."
     )
 
-    # (b cont.) The builder block must contain `carveSubpath`,
-    # `cancelSubpath`, and `clipPathD` in that order — pinned by the
-    # shared regex (nice-to-have #2 + #3).
-    builder_match = _QS217_BUILDER_BLOCK_RE.search(content)
-    assert builder_match is not None, (
-        f"{card_filename}: missing the three-const builder block "
-        f"(`const carveSubpath = …;\\nconst cancelSubpath = …;\\n"
-        f"const clipPathD = …;`). QS-217 review-fix #01 must-fix #1 "
-        f"requires the cancel subpath between carveSubpath and "
-        f"clipPathD; nice-to-have #3 anchors the order strictly."
+    # (c) The `<circle id="override_btn_cover" …>` cover element is
+    # present, gated on `e.override_reset`, and uses the correct
+    # constants for its geometry + the card-background-color fill.
+    cover_re = re.compile(
+        r"e\.override_reset\s*\?\s*`?\s*<circle\s+id=\"override_btn_cover\""
+        r"\s+cx=\"\$\{" + x_center_name + r"\}\""
+        r"\s+cy=\"\$\{OVERRIDE_BTN_CARVE_CY\}\""
+        r"\s+r=\"\$\{OVERRIDE_BTN_CARVE_R\}\""
+        r"\s+fill=\"var\(--card-background-color\)\""
+        r"\s+pointer-events=\"none\"\s*/>",
     )
-    builder_block = builder_match.group(1)
-    # The builder must reference every relevant constant by NAME so a
-    # later value tweak (e.g. iteration on R or the intersection
-    # coords) leaves these pins green.
-    for ident in (
-        "CLIP_R",
-        "CENTER_CY",
-        x_center_name,
-        "OVERRIDE_BTN_CARVE_CY",
-        "OVERRIDE_BTN_CARVE_R",
-        "OVERRIDE_BTN_CARVE_INT_X",
-        "OVERRIDE_BTN_CARVE_INT_Y",
-    ):
-        assert re.search(rf"\b{ident}\b", builder_block) is not None, (
-            f"{card_filename}: clipPathD builder must reference "
-            f"`{ident}` by name (not hard-coded). QS-217 AC-3/AC-7 + "
-            f"review-fix #01 must-fix #1 preserve the "
-            f"constants-not-hardcoded invariant for the crescent-"
-            f"cancel subpath."
-        )
-
-    # (c) Both `carveSubpath` and `cancelSubpath` are gated on the
-    # hardened predicate `e.override_reset && OVERRIDE_BTN_CARVE_R > 0`
-    # (review-fix #01 nice-to-have #4). Pin BOTH declarations
-    # separately so dropping the gate from either degrades the test.
-    assert re.search(
-        r"const\s+carveSubpath\s*=\s*\(?\s*e\.override_reset\s*&&\s*OVERRIDE_BTN_CARVE_R\s*>\s*0",
-        builder_block,
-    ) is not None, (
-        f"{card_filename}: `carveSubpath` must be gated on "
-        f"`(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` — review-"
-        f"fix #01 nice-to-have #4 guards against degenerate arc "
-        f"commands when the radius is set to 0 during visual "
-        f"iteration."
-    )
-    assert re.search(
-        r"const\s+cancelSubpath\s*=\s*\(?\s*e\.override_reset\s*&&\s*OVERRIDE_BTN_CARVE_R\s*>\s*0",
-        builder_block,
-    ) is not None, (
-        f"{card_filename}: `cancelSubpath` must be gated on "
-        f"`(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` — review-"
-        f"fix #01 must-fix #1 + nice-to-have #4: the cancel subpath "
-        f"shares the carve gate (so absent-button cards render an "
-        f"unchanged full-disc clip) AND the degenerate-arc guard."
+    assert cover_re.search(content) is not None, (
+        f"{card_filename}: missing the override-button cover element "
+        f"`<circle id=\"override_btn_cover\" cx=\"${{{x_center_name}}}\" "
+        f"cy=\"${{OVERRIDE_BTN_CARVE_CY}}\" r=\"${{OVERRIDE_BTN_CARVE_R}}\" "
+        f"fill=\"var(--card-background-color)\" pointer-events=\"none\" />` "
+        f"gated on `e.override_reset`. Review-fix #03 replaces the "
+        f"clipPath carve approach with a simple cover overlay drawn on "
+        f"top of the animation."
     )
 
-    # (d) `clipPathD` concatenates `cancelSubpath` AFTER `carveSubpath`
-    # — the winding-count math under evenodd only suppresses the leak
-    # if the cancel subpath increments the winding *in addition to*
-    # the carve subpath. Order matters semantically (paths add winding
-    # commutatively under evenodd, so order is actually free) but
-    # pinning the source order matches the documented intent of
-    # review-fix #01 must-fix #1 and makes the builder visually
-    # readable.
-    assert re.search(
-        r"clipPathD\s*=[\s\S]+?carveSubpath[\s\S]+?cancelSubpath",
-        builder_block,
-    ) is not None, (
-        f"{card_filename}: `clipPathD` must concatenate `carveSubpath` "
-        f"then `cancelSubpath`. Review-fix #01 must-fix #1 requires "
-        f"the cancel subpath be present in the final path string."
-    )
-
-    # (e) `<g clip-path="url(#${…ClipId})">` wrapper unchanged (AC-5 +
-    # review-fix #01 should-fix #3). The wrapper variable name differs
-    # per card (`flameClipId` / `waterClipId` / `climateClipId`) — the
-    # `[a-zA-Z]+ClipId` segment matches any of them.
+    # (d) `<g clip-path="url(#${…ClipId})">` wrapper unchanged.
     assert re.search(
         r'<g\s+clip-path="url\(#\$\{[a-zA-Z]+ClipId\}\)">',
         content,
     ) is not None, (
         f"{card_filename}: expected unchanged "
-        f"`<g clip-path=\"url(#${{…ClipId}})\">` wrapper. AC-5 + "
-        f"review-fix #01 should-fix #3 require the wrapper be "
-        f"byte-identical (no per-backdrop branching)."
+        f"`<g clip-path=\"url(#${{…ClipId}})\">` wrapper."
     )
+
+    # (e) Negative pins — the obsolete carve+cancel artifacts MUST be
+    # absent so a regression cannot silently reintroduce the lens-
+    # shape approach.
+    for artifact in (
+        "carveSubpath",
+        "cancelSubpath",
+        "OVERRIDE_BTN_CARVE_INT_X",
+        "OVERRIDE_BTN_CARVE_INT_Y",
+    ):
+        assert artifact not in content, (
+            f"{card_filename}: review-fix #03 dropped the carve+cancel "
+            f"clipPath approach, but `{artifact}` is still present in "
+            f"the source. Removing the cover-overlay approach requires "
+            f"an explicit design discussion — don't silently reintroduce "
+            f"the lens-shape geometry."
+        )
 
 
 def test_radiator_card_override_btn_carve_out():
@@ -3539,6 +3448,12 @@ def test_dashboard_and_cards_doc_pins_qs_217_carve_paragraph():
           AND a CSS-to-SVG scale reference (any of `320/300`,
           `320×320`, `300×300`, `1.0667`);
       (e) the literal `e.override_reset`.
+
+    Review-fix #03 dropped the original `clip-rule="evenodd"` pin
+    in (c) — the implementation no longer uses the evenodd carve
+    approach. The (c) pin now anchors on `override_btn_cover` and
+    `var(--card-background-color)`, the two new identifiers for
+    the cover-overlay approach.
     """
     doc_path = (
         Path(__file__).parent.parent
@@ -3549,13 +3464,13 @@ def test_dashboard_and_cards_doc_pins_qs_217_carve_paragraph():
     )
     doc = doc_path.read_text(encoding="utf-8")
 
-    headline = "### QS-217 — Override-button carve-out"
+    headline = "### QS-217 — Override-button cover overlay"
     headline_idx = doc.find(headline)
     assert headline_idx != -1, (
         f"dashboard-and-cards.md: missing the literal QS-217 H3 "
-        f"headline `{headline}`. AC-8 + review-fix #01 should-fix #2 "
-        f"require this exact wording so the section is discoverable "
-        f"from a substring search."
+        f"headline `{headline}`. Review-fix #03 changed the wording "
+        f"from `carve-out` to `cover overlay` to match the simpler "
+        f"implementation (cover overlay instead of clipPath carve)."
     )
 
     # Anchor the section between the QS-210 H3 above and the next H2
@@ -3631,11 +3546,22 @@ def test_dashboard_and_cards_doc_pins_qs_217_carve_paragraph():
             f"three affected cards be named explicitly."
         )
 
-    # (c) Literal `clip-rule="evenodd"` (with quotes).
-    assert 'clip-rule="evenodd"' in section, (
+    # (c) Literal `<circle ... fill="var(--card-background-color)"`
+    # describing the cover-overlay approach (review-fix #03 replaced
+    # the earlier `clip-rule="evenodd"` clipPath idiom). The cover
+    # element name `override_btn_cover` is also pinned so a doc
+    # rewrite can't silently drop the implementation anchor.
+    assert "override_btn_cover" in section, (
         "dashboard-and-cards.md (QS-217 section): missing the literal "
-        "`clip-rule=\"evenodd\"` (with quotes) — AC-8 (c) requires the "
-        "exact clipPath idiom be named."
+        "`override_btn_cover` element id — pin requires the doc "
+        "name the cover element so a reader can grep it back to the "
+        "source."
+    )
+    assert "var(--card-background-color)" in section, (
+        "dashboard-and-cards.md (QS-217 section): missing the literal "
+        "`var(--card-background-color)` — the cover overlay's fill "
+        "value must be documented so the visual behaviour is "
+        "reproducible from the doc alone."
     )
 
     # (d) Both constant names + a CSS-to-SVG scale reference.
@@ -4812,22 +4738,20 @@ class TestClimateCardReviewFix01Hardening:
         # (square viewBox) but the `CENTER_X` comment block claims
         # future-proofing for a non-square viewBox; that claim only
         # holds if EVERY x-coordinate reference uses `CENTER_X`.
-        # QS-217 replaced the bare `<circle>` clipPath with a
-        # `<path d="${clipPathD}" />` whose builder concatenates an
-        # outer-disc, an (optional) inner-carve subpath, and (review-
-        # fix #01 must-fix #1) an (optional) crescent-cancel subpath.
-        # The pass-#2 S1 invariant carries over: every x-coordinate
-        # expression in the builder must be `CENTER_X - …`, not
-        # `CENTER_CY - …`. Use the shared _QS217_BUILDER_BLOCK_RE
-        # (review-fix #01 nice-to-have #2 + #3) to anchor the three-
-        # const order.
-        builder_match = _QS217_BUILDER_BLOCK_RE.search(content)
+        # Review-fix #03 dropped the carve+cancel clipPath approach;
+        # the clipPathD is now just the outer-disc circle. The
+        # invariant carries over: outer-disc subpath must use
+        # `CENTER_X - CLIP_R`. The cover overlay (drawn after the
+        # clip group) ALSO uses `CENTER_X` for its `cx` (verified by
+        # test_climate_card_override_btn_carve_out via the shared
+        # helper).
+        builder_match = re.search(
+            r"const\s+clipPathD\s*=([\s\S]*?);",
+            content,
+        )
         assert builder_match is not None, (
-            "Pass-#2 S1: `clipPathD` builder block missing — "
-            "QS-217 AC-3 + review-fix #01 must-fix #1 require "
-            "`const carveSubpath = …;\\nconst cancelSubpath = …;"
-            "\\nconst clipPathD = …;` above the innerHTML template "
-            "literal."
+            "`clipPathD` builder declaration missing — must be "
+            "present above the innerHTML template literal."
         )
         builder_block = builder_match.group(1)
         # Outer disc subpath uses `CENTER_X - CLIP_R`.
@@ -4840,37 +4764,13 @@ class TestClimateCardReviewFix01Hardening:
             "`${CENTER_CY - CLIP_R}`) so the `CENTER_X` constant's "
             "future-proofing comment is accurate."
         )
-        # Inner-carve subpath uses `CENTER_X - OVERRIDE_BTN_CARVE_R`.
-        assert re.search(
-            r"\$\{\s*CENTER_X\s*-\s*OVERRIDE_BTN_CARVE_R\s*\}",
-            builder_block,
-        ) is not None, (
-            "Pass-#2 S1 (QS-217 extension): the climate card's "
-            "clipPathD inner-carve subpath must use `${CENTER_X - "
-            "OVERRIDE_BTN_CARVE_R}` so the x-centre is sourced from "
-            "`CENTER_X`, preserving the future-proofing invariant."
-        )
-        # And the builder must NOT use `CENTER_CY` for any x-coordinate
-        # arithmetic (the pass-#2 anti-pattern). Pin by asserting the
-        # absence of EACH x-arithmetic anti-pattern in the builder
-        # block; `CENTER_CY` still appears legitimately as a y-
-        # coordinate. Review-fix #01 nice-to-have #1: the comment
-        # previously claimed BOTH `CENTER_CY - CLIP_R` and
-        # `CENTER_CY - OVERRIDE_BTN_CARVE_R` were asserted absent;
-        # only the first was. This block now matches the comment.
+        # And the builder must NOT use `CENTER_CY - CLIP_R` for the
+        # x-coordinate (the pass-#2 anti-pattern). `CENTER_CY` still
+        # appears legitimately as a y-coordinate.
         assert "CENTER_CY - CLIP_R" not in builder_block, (
             "Pass-#2 S1: the climate card's clipPathD must NOT use "
             "`CENTER_CY - CLIP_R` as an x-coordinate. That was the "
             "pre-pass-#2 anti-pattern; use `CENTER_X - CLIP_R`."
-        )
-        assert "CENTER_CY - OVERRIDE_BTN_CARVE_R" not in builder_block, (
-            "Pass-#2 S1 (review-fix #01 nice-to-have #1): the climate "
-            "card's clipPathD must NOT use `CENTER_CY - "
-            "OVERRIDE_BTN_CARVE_R` as an x-coordinate. A regression "
-            "that emitted `${CENTER_CY - OVERRIDE_BTN_CARVE_R}` for "
-            "the carve's x-coordinate would still produce a valid "
-            "render today (numerically equivalent) but defeat the "
-            "`CENTER_X` future-proofing intent."
         )
 
     def test_climate_card_safe_number_filters_whitespace_and_infinity(self):

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -10,6 +10,7 @@ These tests catch bugs where:
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -597,21 +598,20 @@ class TestDashboardTemplateRendering:
             "button gets a carve-out hole."
         )
         # QS-217 AC-6: the `clipPathD` builder block must reference all
-        # four constants by NAME (not hard-coded values) — the original
+        # six constants by NAME (not hard-coded values) — the original
         # "constants-not-hardcoded" invariant from review-fix S2 carries
-        # over to the new builder. Capture BOTH the `carveSubpath` and
-        # `clipPathD` declarations as one contiguous span so the
-        # constants referenced from either statement count toward the
-        # invariant.
-        builder_match = re.search(
-            r"const\s+carveSubpath\s*=([\s\S]*?const\s+clipPathD\s*=[\s\S]*?);",
-            content,
-        )
+        # over to the new builder. Review-fix #01 must-fix #1 added two
+        # more (OVERRIDE_BTN_CARVE_INT_X / OVERRIDE_BTN_CARVE_INT_Y) for
+        # the crescent-cancel subpath. Use the shared
+        # _QS217_BUILDER_BLOCK_RE (review-fix #01 nice-to-have #2 + #3)
+        # which anchors the three-const order strictly.
+        builder_match = _QS217_BUILDER_BLOCK_RE.search(content)
         assert builder_match is not None, (
-            "Missing `const carveSubpath = …;\\nconst clipPathD = …;` "
-            "builder block — QS-217 AC-3 requires both declarations "
-            "be present, in that order, above the innerHTML template "
-            "literal so the SVG clipPath can interpolate `${clipPathD}`."
+            "Missing the QS-217 three-const builder block "
+            "(`const carveSubpath = …;\\nconst cancelSubpath = …;"
+            "\\nconst clipPathD = …;`). QS-217 AC-3 + review-fix #01 "
+            "must-fix #1 require all three declarations in that order "
+            "above the innerHTML template literal."
         )
         builder_block = builder_match.group(1)
         for ident in (
@@ -619,11 +619,15 @@ class TestDashboardTemplateRendering:
             "CLIP_R",
             "OVERRIDE_BTN_CARVE_CY",
             "OVERRIDE_BTN_CARVE_R",
+            "OVERRIDE_BTN_CARVE_INT_X",
+            "OVERRIDE_BTN_CARVE_INT_Y",
         ):
             assert re.search(rf"\b{ident}\b", builder_block) is not None, (
                 f"qs-radiator-card.js: clipPathD builder must "
                 f"reference `{ident}` by name (not hard-coded). QS-217 "
-                f"AC-6 preserves the constants-not-hardcoded invariant."
+                f"AC-6 + review-fix #01 must-fix #1 preserve the "
+                f"constants-not-hardcoded invariant for both the carve "
+                f"and the crescent-cancel subpaths."
             )
         # The constants themselves carry the correct geometric values.
         assert re.search(r"const\s+CENTER_CY\s*=\s*160\b", content) is not None
@@ -3024,29 +3028,57 @@ def test_water_boiler_card_steam_filter_region_attributes():
 # ============================================================================
 
 
+# QS-217 review-fix #01 (nice-to-have #2 + #3): factored builder-block
+# regex shared by the three call sites (_qs217_assert_card_carve_out,
+# test_radiator_card_flame_layers_present, and
+# test_climate_card_snowflake_spawn_uses_halfchord_geometry). The
+# pattern requires ALL THREE consts (`carveSubpath`, `cancelSubpath`,
+# `clipPathD`) to appear in that order inside the captured block, so
+# any future refactor that renames / drops / reorders them fails fast.
+# Each `[\s\S]+?` lazy-matches across statement terminators (a single
+# `;` lives at the end of each const declaration) so the captured span
+# stays anchored to the three-statement builder block.
+_QS217_BUILDER_BLOCK_RE = re.compile(
+    r"(const\s+carveSubpath\s*=[\s\S]+?"
+    r"const\s+cancelSubpath\s*=[\s\S]+?"
+    r"const\s+clipPathD\s*=[\s\S]+?);",
+)
+
+
 def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None:
     """Shared QS-217 invariant check used by the three carve-out tests.
 
-    Pinned invariants (AC-1, AC-2, AC-3, AC-4, AC-7):
+    Pinned invariants (AC-1, AC-2, AC-3, AC-4, AC-5, AC-7 + review-fix
+    #01 must-fix #1, nice-to-have #4, should-fix #3):
 
     - (a) the ``<clipPath>`` block contains ``<path clip-rule="evenodd"
       d="${clipPathD}" />`` (the bare ``<circle>`` form was removed).
-    - (b) the two new module-level constants
-      ``OVERRIDE_BTN_CARVE_CY = 277`` and ``OVERRIDE_BTN_CARVE_R = 35``
-      are declared at file scope; both are referenced by *name* in the
-      ``clipPathD`` builder block (so a later visual tweak to the radius
-      value leaves the test green — see DN-2).
-    - (c) the carve subpath is gated on ``e.override_reset`` — i.e. the
-      regex ``e\\.override_reset\\s*\\?`` appears inside the builder block,
-      matching the existing in-file gate for the
-      ``<div id="override_btn">`` render.
+    - (b) the four module-level constants
+      ``OVERRIDE_BTN_CARVE_CY = 277``, ``OVERRIDE_BTN_CARVE_R = 35``,
+      ``OVERRIDE_BTN_CARVE_INT_X``, and ``OVERRIDE_BTN_CARVE_INT_Y`` are
+      declared at file scope (the first two by value, the last two by
+      name only — review-fix #01 must-fix #1 + iteration-friendly
+      contract). Each is referenced by *name* in the ``clipPathD``
+      builder block so a later visual tweak to the radius value leaves
+      the test green — see DN-2 in the story.
+    - (c) BOTH ``carveSubpath`` and ``cancelSubpath`` are gated on the
+      review-fix #01 nice-to-have #4 hardened predicate
+      ``e.override_reset && OVERRIDE_BTN_CARVE_R > 0`` — same truthy
+      check as the existing ``<div id="override_btn">`` render plus a
+      degenerate-arc guard for the ``OVERRIDE_BTN_CARVE_R = 0`` visual-
+      iteration edge case.
+    - (d) The ``clipPathD`` concatenation appends ``cancelSubpath``
+      AFTER ``carveSubpath`` so the evenodd winding-count math works
+      (must-fix #1 — the cancel subpath bumps the leak-crescent winding
+      from 1 → 2 → outside clip → animation hidden).
+    - (e) ``<g clip-path="url(#${…ClipId})">`` wrapper present (AC-5 +
+      review-fix #01 should-fix #3) — explicit per-card pin replaces
+      the pre-existing implicit anchor checks.
 
     ``x_center_name`` is the file-local x-centre constant name (radiator
     uses ``CENTER_CY`` for both axes; water-boiler uses ``CENTER_CX``;
     climate uses ``CENTER_X``).
     """
-    import re
-
     content = (
         COMPONENT_ROOT / "ui" / "resources" / card_filename
     ).read_text()
@@ -3063,7 +3095,13 @@ def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None
         f"the override button is carved out as a hole."
     )
 
-    # (b) Top-level const declarations for the two new carve constants.
+    # (b) Top-level const declarations for the two value-pinned carve
+    # constants. The two intersection constants
+    # (OVERRIDE_BTN_CARVE_INT_X / OVERRIDE_BTN_CARVE_INT_Y, introduced
+    # by review-fix #01 must-fix #1) are pinned by NAME only — they
+    # follow the same iteration-friendly contract as
+    # OVERRIDE_BTN_CARVE_R (the user can swap integers for floats or
+    # tweak the rounded value during visual iteration).
     assert re.search(
         r"const\s+OVERRIDE_BTN_CARVE_CY\s*=\s*277\b",
         content,
@@ -3078,52 +3116,109 @@ def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None
         f"{card_filename}: missing module-level `const "
         f"OVERRIDE_BTN_CARVE_R = 35;` declaration (QS-217 AC-1)."
     )
-
-    # (b) The `clipPathD` builder must reference the carve constants by
-    # NAME (not by value) so a later iteration on the radius leaves this
-    # test green. Scope the regex to BOTH declarations — `carveSubpath`
-    # (which holds the override gate + carve geometry) AND `clipPathD`
-    # (the final concatenated path). AC-3 requires `carveSubpath` to be
-    # declared immediately above `clipPathD`, so capturing the contiguous
-    # span is safe and pins the in-file ordering.
-    builder_match = re.search(
-        r"const\s+carveSubpath\s*=([\s\S]*?const\s+clipPathD\s*=[\s\S]*?);",
+    assert re.search(
+        r"const\s+OVERRIDE_BTN_CARVE_INT_X\s*=",
         content,
+    ) is not None, (
+        f"{card_filename}: missing module-level `const "
+        f"OVERRIDE_BTN_CARVE_INT_X = …;` declaration (QS-217 review-"
+        f"fix #01 must-fix #1: crescent-cancel x-intersection)."
     )
+    assert re.search(
+        r"const\s+OVERRIDE_BTN_CARVE_INT_Y\s*=",
+        content,
+    ) is not None, (
+        f"{card_filename}: missing module-level `const "
+        f"OVERRIDE_BTN_CARVE_INT_Y = …;` declaration (QS-217 review-"
+        f"fix #01 must-fix #1: crescent-cancel y-intersection)."
+    )
+
+    # (b cont.) The builder block must contain `carveSubpath`,
+    # `cancelSubpath`, and `clipPathD` in that order — pinned by the
+    # shared regex (nice-to-have #2 + #3).
+    builder_match = _QS217_BUILDER_BLOCK_RE.search(content)
     assert builder_match is not None, (
-        f"{card_filename}: missing `const carveSubpath = …;\\n"
-        f"const clipPathD = …;` builder block. QS-217 AC-3 requires "
-        f"both declarations be present, in that order, immediately "
-        f"above the innerHTML template literal so the SVG clipPath "
-        f"can interpolate `${{clipPathD}}`."
+        f"{card_filename}: missing the three-const builder block "
+        f"(`const carveSubpath = …;\\nconst cancelSubpath = …;\\n"
+        f"const clipPathD = …;`). QS-217 review-fix #01 must-fix #1 "
+        f"requires the cancel subpath between carveSubpath and "
+        f"clipPathD; nice-to-have #3 anchors the order strictly."
     )
     builder_block = builder_match.group(1)
-    # The full-disc subpath references CLIP_R and the y-centre const.
-    # The radiator's `CENTER_CY` doubles as the x-centre name, while
-    # water-boiler uses `CENTER_CX` and climate uses `CENTER_X`. Pin
-    # the per-card x-centre name plus the shared invariants.
+    # The builder must reference every relevant constant by NAME so a
+    # later value tweak (e.g. iteration on R or the intersection
+    # coords) leaves these pins green.
     for ident in (
         "CLIP_R",
         "CENTER_CY",
         x_center_name,
         "OVERRIDE_BTN_CARVE_CY",
         "OVERRIDE_BTN_CARVE_R",
+        "OVERRIDE_BTN_CARVE_INT_X",
+        "OVERRIDE_BTN_CARVE_INT_Y",
     ):
         assert re.search(rf"\b{ident}\b", builder_block) is not None, (
             f"{card_filename}: clipPathD builder must reference "
-            f"`{ident}` by name (not hard-coded). QS-217 AC-3/AC-7 "
-            f"preserves the constants-not-hardcoded invariant."
+            f"`{ident}` by name (not hard-coded). QS-217 AC-3/AC-7 + "
+            f"review-fix #01 must-fix #1 preserve the "
+            f"constants-not-hardcoded invariant for the crescent-"
+            f"cancel subpath."
         )
 
-    # (c) Carve subpath gated on `e.override_reset` — identical idiom to
-    # the existing `<div id="override_btn">` render gate (AC-4).
+    # (c) Both `carveSubpath` and `cancelSubpath` are gated on the
+    # hardened predicate `e.override_reset && OVERRIDE_BTN_CARVE_R > 0`
+    # (review-fix #01 nice-to-have #4). Pin BOTH declarations
+    # separately so dropping the gate from either degrades the test.
     assert re.search(
-        r"e\.override_reset\s*\?",
+        r"const\s+carveSubpath\s*=\s*\(?\s*e\.override_reset\s*&&\s*OVERRIDE_BTN_CARVE_R\s*>\s*0",
         builder_block,
     ) is not None, (
-        f"{card_filename}: clipPathD builder must gate the carve "
-        f"subpath on `e.override_reset ? … : ''` — same truthy gate "
-        f"as the existing override-button render. QS-217 AC-4."
+        f"{card_filename}: `carveSubpath` must be gated on "
+        f"`(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` — review-"
+        f"fix #01 nice-to-have #4 guards against degenerate arc "
+        f"commands when the radius is set to 0 during visual "
+        f"iteration."
+    )
+    assert re.search(
+        r"const\s+cancelSubpath\s*=\s*\(?\s*e\.override_reset\s*&&\s*OVERRIDE_BTN_CARVE_R\s*>\s*0",
+        builder_block,
+    ) is not None, (
+        f"{card_filename}: `cancelSubpath` must be gated on "
+        f"`(e.override_reset && OVERRIDE_BTN_CARVE_R > 0)` — review-"
+        f"fix #01 must-fix #1 + nice-to-have #4: the cancel subpath "
+        f"shares the carve gate (so absent-button cards render an "
+        f"unchanged full-disc clip) AND the degenerate-arc guard."
+    )
+
+    # (d) `clipPathD` concatenates `cancelSubpath` AFTER `carveSubpath`
+    # — the winding-count math under evenodd only suppresses the leak
+    # if the cancel subpath increments the winding *in addition to*
+    # the carve subpath. Order matters semantically (paths add winding
+    # commutatively under evenodd, so order is actually free) but
+    # pinning the source order matches the documented intent of
+    # review-fix #01 must-fix #1 and makes the builder visually
+    # readable.
+    assert re.search(
+        r"clipPathD\s*=[\s\S]+?carveSubpath[\s\S]+?cancelSubpath",
+        builder_block,
+    ) is not None, (
+        f"{card_filename}: `clipPathD` must concatenate `carveSubpath` "
+        f"then `cancelSubpath`. Review-fix #01 must-fix #1 requires "
+        f"the cancel subpath be present in the final path string."
+    )
+
+    # (e) `<g clip-path="url(#${…ClipId})">` wrapper unchanged (AC-5 +
+    # review-fix #01 should-fix #3). The wrapper variable name differs
+    # per card (`flameClipId` / `waterClipId` / `climateClipId`) — the
+    # `[a-zA-Z]+ClipId` segment matches any of them.
+    assert re.search(
+        r'<g\s+clip-path="url\(#\$\{[a-zA-Z]+ClipId\}\)">',
+        content,
+    ) is not None, (
+        f"{card_filename}: expected unchanged "
+        f"`<g clip-path=\"url(#${{…ClipId}})\">` wrapper. AC-5 + "
+        f"review-fix #01 should-fix #3 require the wrapper be "
+        f"byte-identical (no per-backdrop branching)."
     )
 
 
@@ -3167,6 +3262,165 @@ def test_climate_card_override_btn_carve_out():
     _qs217_assert_card_carve_out(
         "qs-climate-card.js",
         x_center_name="CENTER_X",
+    )
+
+
+def test_dashboard_and_cards_doc_pins_qs_217_carve_paragraph():
+    """QS-217 review-fix #01 should-fix #2: pin the QS-217 doc
+    paragraph in `docs/agents/concepts/dashboard-and-cards.md` so a
+    future edit can't silently strip the AC-8-required content.
+
+    AC-8 mandates the new "QS-217 — Override-button carve-out" section
+    mentions five specific items (a–e: legibility motivation, the
+    three affected cards, the `<path clip-rule="evenodd">` idiom, the
+    `OVERRIDE_BTN_CARVE_*` constants plus the CSS-to-SVG derivation,
+    the `e.override_reset` gate). The QS-211 precedent
+    (`test_dashboard_and_cards_doc_pins_qs_211_steam_paragraph`)
+    pins QS-211 the same way; QS-217 needs the analogous test.
+
+    Pinned invariants (mirror of the QS-211 test pattern):
+
+    - The literal H3 headline `### QS-217 — Override-button carve-out`
+      is present.
+    - Headline position is GREATER than the `### QS-210` headline
+      (which immediately precedes it per the in-doc order) AND LESS
+      than the `## Hardened JS-card patterns` H2 (which immediately
+      follows). This anchors the section between climate-backdrops
+      and the hardened-patterns history.
+    - Front-matter contains a `last_verified: YYYY-MM-DD` field — the
+      regex deliberately does NOT pin a specific date so the test
+      doesn't go red every day.
+    - The section body satisfies AC-8 (a)–(e):
+      (a) "legibility" OR "legible" AND "override" AND "button" —
+          the human-readable motivation;
+      (b) all three card filenames (`qs-radiator-card.js`,
+          `qs-water-boiler-card.js`, `qs-climate-card.js`);
+      (c) the literal string `clip-rule="evenodd"` (with quotes);
+      (d) both `OVERRIDE_BTN_CARVE_CY` and `OVERRIDE_BTN_CARVE_R`,
+          AND a CSS-to-SVG scale reference (any of `320/300`,
+          `320×320`, `300×300`, `1.0667`);
+      (e) the literal `e.override_reset`.
+    """
+    doc_path = (
+        Path(__file__).parent.parent
+        / "docs"
+        / "agents"
+        / "concepts"
+        / "dashboard-and-cards.md"
+    )
+    doc = doc_path.read_text(encoding="utf-8")
+
+    headline = "### QS-217 — Override-button carve-out"
+    headline_idx = doc.find(headline)
+    assert headline_idx != -1, (
+        f"dashboard-and-cards.md: missing the literal QS-217 H3 "
+        f"headline `{headline}`. AC-8 + review-fix #01 should-fix #2 "
+        f"require this exact wording so the section is discoverable "
+        f"from a substring search."
+    )
+
+    # Anchor the section between the QS-210 H3 above and the next H2
+    # below (`## Hardened JS-card patterns`). The next-H2 search uses
+    # `\n## ` (with trailing space + capital H) so it doesn't match
+    # arbitrary `##` substrings or the front-matter delimiters.
+    qs210_idx = doc.find("### QS-210")
+    assert qs210_idx != -1, (
+        "dashboard-and-cards.md: missing the `### QS-210` headline — "
+        "AC-8 + review-fix #01 should-fix #2 anchor QS-217 AFTER "
+        "the climate-card backdrop section."
+    )
+    hardened_idx = doc.find("## Hardened JS-card patterns")
+    assert hardened_idx != -1, (
+        "dashboard-and-cards.md: missing `## Hardened JS-card patterns` "
+        "H2 — review-fix #01 should-fix #2 anchors QS-217 BEFORE that "
+        "section."
+    )
+    assert qs210_idx < headline_idx < hardened_idx, (
+        f"dashboard-and-cards.md: the QS-217 headline must appear "
+        f"AFTER `### QS-210` AND BEFORE `## Hardened JS-card "
+        f"patterns`. Current order: QS-210 at {qs210_idx}, QS-217 "
+        f"at {headline_idx}, Hardened at {hardened_idx}."
+    )
+
+    # Front-matter `last_verified: YYYY-MM-DD` shape — same deliberate-
+    # vagueness as the QS-211 test.
+    front_matter_match = re.search(
+        r"^last_verified:\s*(\d{4}-\d{2}-\d{2})\s*$",
+        doc,
+        re.MULTILINE,
+    )
+    assert front_matter_match, (
+        "dashboard-and-cards.md: front-matter must contain a "
+        "`last_verified: YYYY-MM-DD` field per AC-8."
+    )
+
+    # Slice the section body — from the QS-217 headline to the next H2
+    # (or H3) boundary. Use `\n## ` for the H2 sentinel (more reliable
+    # than `\n\n` because the body itself contains blank lines between
+    # paragraphs). Fall back to `hardened_idx` since we already
+    # asserted that exists above.
+    section = doc[headline_idx:hardened_idx]
+    section_lower = section.lower()
+
+    # (a) Legibility motivation: "legibility" or "legible" + "override"
+    # + "button".
+    assert "legibility" in section_lower or "legible" in section_lower, (
+        "dashboard-and-cards.md (QS-217 section): missing legibility-"
+        "motivation language. AC-8 (a) requires a human-readable "
+        "explanation of why the carve-out exists."
+    )
+    assert "override" in section_lower, (
+        "dashboard-and-cards.md (QS-217 section): missing `override` "
+        "reference — AC-8 (a) requires mentioning the override "
+        "button as the motivating element."
+    )
+    assert "button" in section_lower, (
+        "dashboard-and-cards.md (QS-217 section): missing `button` "
+        "reference — AC-8 (a) requires mentioning the override "
+        "button as the motivating element."
+    )
+
+    # (b) All three card filenames mentioned in the section.
+    for card_filename in (
+        "qs-radiator-card.js",
+        "qs-water-boiler-card.js",
+        "qs-climate-card.js",
+    ):
+        assert card_filename in section, (
+            f"dashboard-and-cards.md (QS-217 section): missing card "
+            f"filename `{card_filename}` — AC-8 (b) requires all "
+            f"three affected cards be named explicitly."
+        )
+
+    # (c) Literal `clip-rule="evenodd"` (with quotes).
+    assert 'clip-rule="evenodd"' in section, (
+        "dashboard-and-cards.md (QS-217 section): missing the literal "
+        "`clip-rule=\"evenodd\"` (with quotes) — AC-8 (c) requires the "
+        "exact clipPath idiom be named."
+    )
+
+    # (d) Both constant names + a CSS-to-SVG scale reference.
+    for const_name in ("OVERRIDE_BTN_CARVE_CY", "OVERRIDE_BTN_CARVE_R"):
+        assert const_name in section, (
+            f"dashboard-and-cards.md (QS-217 section): missing "
+            f"`{const_name}` — AC-8 (d) requires both carve constants "
+            f"be named (so the doc reader can grep them back to the "
+            f"source)."
+        )
+    scale_patterns = ("320/300", "320×320", "300×300", "1.0667")
+    assert any(pat in section for pat in scale_patterns), (
+        f"dashboard-and-cards.md (QS-217 section): missing a CSS-to-"
+        f"SVG scale reference. AC-8 (d) requires one of "
+        f"{scale_patterns!r} so the derivation chain is reproducible "
+        f"from the doc alone."
+    )
+
+    # (e) Literal `e.override_reset`.
+    assert "e.override_reset" in section, (
+        "dashboard-and-cards.md (QS-217 section): missing the literal "
+        "`e.override_reset` — AC-8 (e) requires the gate idiom be "
+        "named so the reader knows which truthy check controls the "
+        "carve."
     )
 
 
@@ -4321,17 +4575,20 @@ class TestClimateCardReviewFix01Hardening:
         # holds if EVERY x-coordinate reference uses `CENTER_X`.
         # QS-217 replaced the bare `<circle>` clipPath with a
         # `<path d="${clipPathD}" />` whose builder concatenates an
-        # outer-disc and (optional) inner-carve subpath. The pass-#2
-        # S1 invariant carries over: the builder's x-coordinate
-        # expression must be `CENTER_X - …`, not `CENTER_CY - …`.
-        builder_match = re.search(
-            r"const\s+carveSubpath\s*=([\s\S]*?const\s+clipPathD\s*=[\s\S]*?);",
-            content,
-        )
+        # outer-disc, an (optional) inner-carve subpath, and (review-
+        # fix #01 must-fix #1) an (optional) crescent-cancel subpath.
+        # The pass-#2 S1 invariant carries over: every x-coordinate
+        # expression in the builder must be `CENTER_X - …`, not
+        # `CENTER_CY - …`. Use the shared _QS217_BUILDER_BLOCK_RE
+        # (review-fix #01 nice-to-have #2 + #3) to anchor the three-
+        # const order.
+        builder_match = _QS217_BUILDER_BLOCK_RE.search(content)
         assert builder_match is not None, (
             "Pass-#2 S1: `clipPathD` builder block missing — "
-            "QS-217 AC-3 requires `const carveSubpath = …; const "
-            "clipPathD = …;` above the innerHTML template literal."
+            "QS-217 AC-3 + review-fix #01 must-fix #1 require "
+            "`const carveSubpath = …;\\nconst cancelSubpath = …;"
+            "\\nconst clipPathD = …;` above the innerHTML template "
+            "literal."
         )
         builder_block = builder_match.group(1)
         # Outer disc subpath uses `CENTER_X - CLIP_R`.
@@ -4355,17 +4612,26 @@ class TestClimateCardReviewFix01Hardening:
             "`CENTER_X`, preserving the future-proofing invariant."
         )
         # And the builder must NOT use `CENTER_CY` for any x-coordinate
-        # arithmetic (the pass-#2 anti-pattern). We can pin this by
-        # asserting the absence of `CENTER_CY - CLIP_R` and
-        # `CENTER_CY - OVERRIDE_BTN_CARVE_R` in the builder block;
-        # `CENTER_CY` still appears legitimately as a y-coordinate.
-        assert re.search(
-            r"\$\{\s*CENTER_CY\s*-\s*CLIP_R\s*\}",
-            builder_block,
-        ) is None, (
+        # arithmetic (the pass-#2 anti-pattern). Pin by asserting the
+        # absence of EACH x-arithmetic anti-pattern in the builder
+        # block; `CENTER_CY` still appears legitimately as a y-
+        # coordinate. Review-fix #01 nice-to-have #1: the comment
+        # previously claimed BOTH `CENTER_CY - CLIP_R` and
+        # `CENTER_CY - OVERRIDE_BTN_CARVE_R` were asserted absent;
+        # only the first was. This block now matches the comment.
+        assert "CENTER_CY - CLIP_R" not in builder_block, (
             "Pass-#2 S1: the climate card's clipPathD must NOT use "
-            "`${CENTER_CY - CLIP_R}` as an x-coordinate. That was "
-            "the pre-pass-#2 anti-pattern; use `CENTER_X - CLIP_R`."
+            "`CENTER_CY - CLIP_R` as an x-coordinate. That was the "
+            "pre-pass-#2 anti-pattern; use `CENTER_X - CLIP_R`."
+        )
+        assert "CENTER_CY - OVERRIDE_BTN_CARVE_R" not in builder_block, (
+            "Pass-#2 S1 (review-fix #01 nice-to-have #1): the climate "
+            "card's clipPathD must NOT use `CENTER_CY - "
+            "OVERRIDE_BTN_CARVE_R` as an x-coordinate. A regression "
+            "that emitted `${CENTER_CY - OVERRIDE_BTN_CARVE_R}` for "
+            "the carve's x-coordinate would still produce a valid "
+            "render today (numerically equivalent) but defeat the "
+            "`CENTER_X` future-proofing intent."
         )
 
     def test_climate_card_safe_number_filters_whitespace_and_infinity(self):


### PR DESCRIPTION
## Summary
Swap the bare <circle> inside the radiator / water-boiler / climate card <clipPath> for a <path clip-rule="evenodd" d="${clipPathD}" /> with a builder that concatenates the full ring-clip subpath plus an optional carve-out disc gated on e.override_reset. The evenodd hole exposes the card background ring behind the semi-transparent override-hand button so the colored animations (flames / snow / water) stop bleeding through and the button becomes legible. Two new module-level constants per card (OVERRIDE_BTN_CARVE_CY = 277, OVERRIDE_BTN_CARVE_R = 35) derived from the CSS .override-btn geometry × the SVG 320/300 scale; tests pin the constant names so the user can iterate visually on the radius value without flipping the suite red.

Fixes #217

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced fragile clip-path carve logic with a simple background cover so animated visuals no longer leak beneath the override button on radiator, water‑boiler and climate cards.

* **Documentation**
  * Added/updated guidance describing the new override-button cover overlay and its expected behavior across cards.

* **Tests**
  * Added/updated tests to assert the new overlay rendering and to pin the related documentation section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->