### PR TITLE
QS-220: UI: make water boiler boiling water bluer and more transparent (like pool)

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -109,7 +109,7 @@ const LAYER_PHASE_OFFSET = 2.1;
 const LAYER_SCROLL_OFFSET = 1.2;
 const SNOW_BACK_COLOR  = 'hsla(220, 60%, 82%, 0.55)';
 const SNOW_MID_COLOR   = 'hsla(210, 50%, 88%, 0.45)';
-const SNOW_FRONT_COLOR = 'hsla(0, 0%, 95%, 0.65)';
+const SNOW_FRONT_COLOR = 'hsla(210, 30%, 92%, 0.45)';
 const SNOW_PILE_COLORS = [SNOW_BACK_COLOR, SNOW_MID_COLOR, SNOW_FRONT_COLOR];
 // Snow doesn't agitate like boiling water — smaller deltas than pool's
 // CALM_AMP=2 / PUMP_AMP=6.

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -73,9 +73,9 @@ const COOL_WATER_COLORS = [
   'hsla(185, 60%, 18%, 0.35)',
 ];
 const BOIL_WATER_COLORS = [
-  'hsla(0, 0%, 95%, 0.65)',
-  'hsla(0, 0%, 90%, 0.55)',
-  'hsla(0, 0%, 85%, 0.45)',
+  'hsla(185, 60%, 28%, 0.40)',
+  'hsla(185, 60%, 26%, 0.32)',
+  'hsla(185, 60%, 24%, 0.24)',
 ];
 
 // --- Animation tuning (lerp envelope; mirror pool) ---

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -12,7 +12,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
   - custom_components/quiet_solar/ui/resources/qs-radiator-card.js
   - custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
-last_verified: 2026-05-23
+last_verified: 2026-05-24
 ---
 
 # Dashboard generation and JS Lovelace cards
@@ -233,8 +233,8 @@ instruction" rule via direct issue-#200 authorisation:
 - **Continuous RAF, mirroring the pool card.** `connectedCallback()`
   calls `_startAnimation()` directly with no `showAnimation` gate;
   `disconnectedCallback()` stops it. The wave is intrinsically
-  visible at all times (cool blue when not running, near-white
-  translucent when boiling) so the RAF loop itself is no longer
+  visible at all times (cool blue when not running, translucent
+  pool-blue when boiling) so the RAF loop itself is no longer
   conditional. `showAnimation` survives only as a render-time switch
   for the existing dashed-arc `<path id="running_anim">`. The
   boiler is therefore removed from `test_card_raf_idle_gated`'s
@@ -243,7 +243,7 @@ instruction" rule via direct issue-#200 authorisation:
 - **Dual-layer water cross-fade + bubbles + surface glow.** Inside
   a circular `clipPath` (radius `CLIP_R = 120`), the card renders
   six wave paths in pairs: `wave{0,1,2}_cool` (cool-blue HSLA) and
-  `wave{0,1,2}_boil` (near-white HSLA). Each pair shares geometry;
+  `wave{0,1,2}_boil` (translucent pool-blue HSLA). Each pair shares geometry;
   only `fill` and `opacity` differ. The RAF loop lerps
   `_currentColorMix` toward `running ? 1 : 0` with the standard
   `LERP_RATE` envelope and updates per-frame opacity: cool layer
@@ -503,7 +503,7 @@ flakes' detached DOM so they don't leak.
 
 The semi-transparent bottom-center override "hand" button
 (`<div id="override_btn">`) was hard to read against the coloured
-animations (orange flames, white snow, blue water) painted by the
+animations (orange flames, pale-blue snow, blue water) painted by the
 clipPath group below it. QS-217 fixes the legibility by drawing a
 small **`<circle>` cover** with `fill="var(--card-background-color)"`
 on top of the clipped animation group, visually erasing the

--- a/docs/stories/QS-220.story.md
+++ b/docs/stories/QS-220.story.md
@@ -1,0 +1,301 @@
+# QS-220 — UI: boiler boil palette to translucent pool-blue; climate snow-front bluer + more transparent
+
+## Issue
+
+GitHub #220 (`area:ui`). Body verbatim:
+
+> ui only : make the water part of the boiling water animation of the
+> water boiler less white, more blueish (more like the pool but more
+> transparent), keep the steam, bubbles and the red water frontier the
+> same, simply change the water colors.
+
+Session clarifications added (in priority order):
+
+1. Pick the best starting values — "we will run it to see" → empirical
+   iteration expected; the story pins direction, not exact literals.
+2. Boil state should read brighter than cool (lightness bump).
+3. Drop the legacy near-white palette entirely; no reason to keep it.
+4. Bonus: also nudge the climate card's snow front layer to be slightly
+   bluer + more transparent so white numbers/text on top stay legible.
+
+## Scope (single sentence)
+
+Swap one JS literal triplet (`BOIL_WATER_COLORS` in the water-boiler
+card) and one JS literal (`SNOW_FRONT_COLOR` in the climate card), with
+matching test sentinels and three prose-line fixes in the
+`dashboard-and-cards` agent doc. No domain logic, no architecture, no
+Python.
+
+## Files touched
+
+| Path                                                                                  | Change                                                                                                                                                              |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`                  | Replace `BOIL_WATER_COLORS` triplet (currently `hsla(0, 0%, 95/90/85%, 0.65/0.55/0.45)`) with a translucent pool-blue triplet anchored by symbol `BOIL_WATER_COLORS`.|
+| `custom_components/quiet_solar/ui/resources/qs-climate-card.js`                       | Replace the single literal assigned to `SNOW_FRONT_COLOR` (currently `'hsla(0, 0%, 95%, 0.65)'`) with a translucent pale-blue literal. `SNOW_BACK_COLOR` and `SNOW_MID_COLOR` untouched. |
+| `tests/test_dashboard_rendering.py`                                                   | Add 1 module-level sentinel test for the boiler boil palette; relax the existing snow-pile palette test's strict literal pin to a direction-only sentinel.          |
+| `docs/agents/concepts/dashboard-and-cards.md`                                         | Three prose-line fixes (boiler boil-state phrasing × 2, snow color word × 1) + bump `last_verified` to `2026-05-24`.                                                |
+
+**Initial values (starting points — expected to iterate):**
+
+```js
+// qs-water-boiler-card.js
+const BOIL_WATER_COLORS = [
+  'hsla(185, 60%, 28%, 0.40)',
+  'hsla(185, 60%, 26%, 0.32)',
+  'hsla(185, 60%, 24%, 0.24)',
+];
+
+// qs-climate-card.js
+const SNOW_FRONT_COLOR = 'hsla(210, 30%, 92%, 0.45)';
+```
+
+These satisfy the directional ACs below. The implementer may tweak
+them by 1–2 percentage points / 0.01–0.05 alpha during visual review
+without amending this story; they remain "in the pool-blue family"
+and "not pure white".
+
+## Acceptance criteria
+
+### AC-1 — Boiler boil palette is in the pool-blue family, not white
+
+- **Given** the water-boiler card source,
+- **When** `BOIL_WATER_COLORS` is inspected,
+- **Then** every triplet entry starts with the hue token `185,` (i.e.
+  the pool-blue family — same hue family used by the existing
+  `COOL_WATER_COLORS` and the pool card's `DEFAULT_WATER_COLORS`),
+  AND the legacy near-white pattern `hsla(0, 0%, …)` does NOT appear
+  anywhere in `BOIL_WATER_COLORS`.
+
+Rationale: a "hue == 185" sentinel rules out the old `hsla(0, 0%,
+…)` triplet AND the climate-card `SNOW_*` hues (220 / 210 / 0 in
+prior state). It does not pin saturation/lightness/alpha — those
+remain iterable.
+
+### AC-2 — Climate snow-front is no longer pure white
+
+- **Given** the climate card source,
+- **When** `SNOW_FRONT_COLOR` is inspected,
+- **Then** the legacy literal `'hsla(0, 0%, 95%, 0.65)'` does NOT
+  appear in the source, AND the new value uses a non-zero hue token
+  (i.e. a blue tint, however slight).
+
+Rationale: directionally enforces "less white, slightly bluer" without
+freezing the exact hue/sat/light/alpha — the implementer can iterate.
+
+### AC-3 — All untouched constants stay untouched
+
+The diff against `main` must not alter the literal values of:
+
+- `BUBBLE_FILL_COLOR`, `STEAM_FILL_COLOR`, `SURFACE_GLOW_COLOR` in
+  `qs-water-boiler-card.js`,
+- each entry of `COOL_WATER_COLORS` in `qs-water-boiler-card.js`,
+- `CALM_AMP`, `BOIL_AMP`, `CALM_SPEED`, `BOIL_SPEED`, `LERP_RATE` in
+  `qs-water-boiler-card.js`,
+- `SNOW_BACK_COLOR` (`'hsla(220, 60%, 82%, 0.55)'`) and
+  `SNOW_MID_COLOR` (`'hsla(210, 50%, 88%, 0.45)'`) in
+  `qs-climate-card.js`,
+- `SNOW_PILE_COLORS = [SNOW_BACK_COLOR, SNOW_MID_COLOR, SNOW_FRONT_COLOR]`
+  ordering in `qs-climate-card.js`.
+
+Rationale: phrasing is **literals unchanged**, not "visually identical"
+— compositing the unchanged red `SURFACE_GLOW_COLOR` over the new
+darker translucent water will of course look different to the eye.
+That's the point of the issue.
+
+**Existing tests that pin these (the regression net for AC-3):**
+
+- `test_water_boiler_card_pins_geometry_constants` pins
+  `BUBBLE_FILL_COLOR = 'rgba(255,255,255,0.85)'` exactly.
+- `test_water_boiler_card_has_surface_glow` pins
+  `SURFACE_GLOW_COLOR = '#FF3D00'` exactly.
+- `test_water_boiler_card_pins_opacity_cross_fade` pins the cross-fade
+  formula (so wave kinematics + colorMix lerp shape stay intact).
+- `test_climate_card_snow_pile_three_waves_with_palette` (after the
+  relaxation in AC-2) still asserts ≥1 blue-ish layer via
+  `hsla\(\s*2[0-3]\d\s*,` — keeps the back/mid layers in band.
+
+No new "negative pin" tests are needed; the diff is the source of
+truth for what stays unchanged.
+
+## Task breakdown
+
+1. **TDD red — write the sentinel tests first.**
+   In `tests/test_dashboard_rendering.py`:
+
+   a. **NEW** module-level (column 0, no class wrapper) test
+      `test_water_boiler_card_pins_boil_water_palette`, inserted
+      between the existing `test_water_boiler_card_pins_opacity_cross_fade`
+      and `test_water_boiler_card_center_uses_named_constants`
+      (currently at lines ~2131 and ~2185 — line numbers advisory).
+      Body (≤25 LOC):
+
+      ```python
+      def test_water_boiler_card_pins_boil_water_palette():
+          """QS-220: BOIL_WATER_COLORS is in the pool-blue family
+          (hue 185, same as cool/pool default), not the legacy
+          near-white triplet. Saturation/lightness/alpha are
+          intentionally unpinned — they are iterable knobs."""
+          import re
+          content = (
+              COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+          ).read_text()
+          # Extract the array body so the regex isn't tricked by
+          # unrelated literals elsewhere in the file.
+          match = re.search(
+              r"const\s+BOIL_WATER_COLORS\s*=\s*\[(?P<body>[^\]]+)\]",
+              content,
+          )
+          assert match, (
+              "qs-water-boiler-card.js: BOIL_WATER_COLORS declaration "
+              "must remain a literal array."
+          )
+          body = match.group("body")
+          entries = re.findall(r"'hsla\(([^']+)\)'", body)
+          assert len(entries) >= 1, (
+              "qs-water-boiler-card.js: BOIL_WATER_COLORS must have "
+              "at least one hsla literal."
+          )
+          for entry in entries:
+              assert entry.lstrip().startswith("185,"), (
+                  "QS-220 AC-1: every BOIL_WATER_COLORS entry must "
+                  f"use the pool-blue hue (185); got `{entry}`."
+              )
+          # Sentinel: legacy near-white pattern is gone.
+          assert "hsla(0, 0%" not in body, (
+              "QS-220 AC-1: the legacy near-white pattern "
+              "`hsla(0, 0%, …)` must not appear in BOIL_WATER_COLORS."
+          )
+      ```
+
+   b. **MODIFY** `test_climate_card_snow_pile_three_waves_with_palette`
+      (anchor: the function whose docstring starts "3 snow-pile wave
+      paths plus the documented palette…"). Replace the strict
+      `assert "hsla(0, 0%, 95%, 0.65)" in executable` line with:
+
+      ```python
+      # QS-220 AC-2: the front layer is no longer pure white.
+      assert "hsla(0, 0%, 95%, 0.65)" not in executable, (
+          "QS-220 AC-2: the legacy pure-white SNOW_FRONT_COLOR "
+          "literal `hsla(0, 0%, 95%, 0.65)` must be replaced "
+          "with a translucent pale-blue value."
+      )
+      # SNOW_FRONT_COLOR constant must still exist and reference an
+      # hsla literal — direction-only, no hue/sat/light/alpha pin.
+      assert re.search(
+          r"const\s+SNOW_FRONT_COLOR\s*=\s*'hsla\([^']+\)'",
+          executable,
+      ), (
+          "QS-220 AC-2: SNOW_FRONT_COLOR must remain a module-level "
+          "const assigned to an hsla literal."
+      )
+      ```
+
+      Also update the surviving `r"hsla\(\s*2[0-3]\d\s*,"` assertion's
+      message string from "back snow-pile layer(s)" to "≥1 blue-ish
+      pile layer (back/mid/front)" — it now legitimately matches the
+      new front color too, and a misleading message is worse than no
+      message.
+
+   c. Run `python scripts/qs/quality_gate.py --quick tests/test_dashboard_rendering.py`
+      to confirm both tests are RED on the pre-change source.
+
+2. **Implement the boiler change.** In
+   `custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`,
+   anchor on `const BOIL_WATER_COLORS = [` and replace the three
+   `hsla(0, 0%, 9?%, 0.??)` strings with the initial values listed
+   above. No other line in the file is touched.
+
+3. **Implement the climate change.** In
+   `custom_components/quiet_solar/ui/resources/qs-climate-card.js`,
+   anchor on `const SNOW_FRONT_COLOR =` and replace the single string
+   `'hsla(0, 0%, 95%, 0.65)'` with the initial value listed above.
+   No other line in the file is touched.
+
+4. **Doc update.** In `docs/agents/concepts/dashboard-and-cards.md`:
+
+   - Anchor the boiler prose by the phrase **"near-white translucent
+     when boiling"** → "translucent pool-blue when boiling".
+   - Anchor the boiler prose by the phrase **"(near-white HSLA)"** →
+     "(translucent pool-blue HSLA)".
+   - Anchor the snow phrase **"orange flames, white snow, blue water"**
+     → "orange flames, pale-blue snow, blue water".
+   - Frontmatter: `last_verified: 2026-05-23` → `last_verified: 2026-05-24`.
+
+   No new paragraphs. No `covers:` block change (both modified JS
+   files are already listed). Story files under `docs/stories/QS-200`,
+   `QS-210`, `QS-217` contain the same legacy literals/phrases —
+   intentionally NOT touched (they are historical artefacts of
+   their respective releases).
+
+5. **Quality gate.** Run `python scripts/qs/quality_gate.py`.
+
+   **UI-only fast path applies.** Per `docs/workflow/project-rules.md`
+   §"UI-only fast path": *"When only
+   `custom_components/quiet_solar/ui/*.j2` templates and
+   `custom_components/quiet_solar/ui/resources/**` assets change
+   (optionally mixed with dev-only paths), the gate runs only
+   `tests/test_dashboard_rendering.py` plus any changed test files."*
+   This story touches `ui/resources/*.js` (2 files), `tests/` (1
+   file), and `docs/` (1 file) — `tests/` and `docs/` qualify as
+   dev-only paths, so the gate restricts to
+   `tests/test_dashboard_rendering.py`.
+
+6. **Commit + push + open PR via the standard implement-task flow.**
+
+## Out of scope (explicit)
+
+- The system reminder during planning referenced
+  `ha_model/bistate_duration.py:555` (`external_user_initiated_state`).
+  Unrelated to this UI color change; not addressed.
+- No tightening / loosening of saturation, lightness, or alpha bands
+  beyond the direction-only sentinels in AC-1/AC-2. The user will
+  iterate the literals visually after first paint.
+- No visual snapshot test. The card's runtime SVG depends on the HA
+  card-helper environment; a literal sentinel is the right gate for a
+  one-line color swap.
+- No JS file other than `qs-water-boiler-card.js` and
+  `qs-climate-card.js` is touched. No Python source touched. No
+  templates touched.
+
+## NEXT_PHASE
+
+`implement-task` — all touched product paths are under
+`custom_components/quiet_solar/ui/`, which is product code, not the
+dev-env list (`scripts/`, `.claude/`, `.cursor/`, `.opencode/`,
+`legacy/`, `docs/`, `.github/`, top-level config).
+
+## Doc maintenance
+
+`scripts/qs/check_doc_drift.py --paths
+custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+custom_components/quiet_solar/ui/resources/qs-climate-card.js
+tests/test_dashboard_rendering.py
+docs/agents/concepts/dashboard-and-cards.md` returns clean (no `stale:`
+lines) when the doc is co-modified with the JS sources — verified
+during planning.
+
+## Adversarial Review Notes
+
+Four reviewers (`qs-plan-critic`, `qs-plan-concrete-planner`,
+`qs-plan-dev-proxy`, `qs-plan-scope-guardian`) ran in parallel against
+an earlier draft. Twelve deduped findings; all addressed:
+
+| Finding                                                                                  | Source             | Disposition                                                                                                       |
+| ---------------------------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| QS-220 narrative paragraph in doc is gold-plating                                        | scope-guardian     | Cut. Doc edit reduced to three prose-line fixes + `last_verified` bump.                                           |
+| Regex band ACs (hue/sat/light/alpha) too tight given "iterate visually" intent           | scope-guardian, plan-critic | Loosened to direction-only sentinels (hue == 185 for boil; non-zero hue + legacy literal absent for snow). |
+| TDD red is unimplementable — no test body spec                                           | dev-proxy          | Resolved by simplification + inlined the full test body in task step 1.                                           |
+| AC-3 "unchanged" needs negative pins to be testable                                      | dev-proxy          | Reframed: list existing tests that pin the unchanged literals; diff is the source of truth for the rest.          |
+| New `SNOW_FRONT_COLOR` (hue 210) collides with existing AC3 back-regex `hsla\(\s*2[0-3]\d`| concrete-planner   | Existing assertion stays; message updated from "back layer" to "≥1 blue-ish layer" since front now matches too.   |
+| Surface-glow composite WILL look different when water palette changes                    | plan-critic        | AC-3 reworded to "literals unchanged" (not "visually identical").                                                  |
+| QS-200/QS-210/QS-217 story files contain legacy literals/phrases                         | concrete-planner   | Acknowledged as historical artefacts in §"Doc update"; intentionally not touched.                                 |
+| Doc anchors by absolute line numbers will drift                                          | plan-critic, dev-proxy | Anchored by symbol name or quoted phrase. Line numbers retained as "advisory" only.                            |
+| `covers:` block doesn't need changes (both JS files already covered)                     | concrete-planner, dev-proxy | Verified during planning; noted in §"Doc maintenance".                                                       |
+| UI-only fast path applies — cite the rule                                                | dev-proxy          | Cited verbatim in task step 5.                                                                                    |
+| Visual smoke check undefined                                                             | plan-critic        | Step dropped.                                                                                                     |
+| AC-6 ("doc + test pins refreshed") was self-referential                                  | scope-guardian     | Collapsed into task list; not promoted to an AC.                                                                  |
+
+Net effect of triage: 6 ACs → 3; 2 new+modified tests with regex bands
+→ 1 new sentinel + 1 modified sentinel (~25 LOC total); narrative
+doc paragraph removed; numeric literals labeled "initial — iterate"
+rather than frozen contract.

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -2182,6 +2182,43 @@ def test_water_boiler_card_pins_opacity_cross_fade():
     )
 
 
+def test_water_boiler_card_pins_boil_water_palette():
+    """QS-220: BOIL_WATER_COLORS is in the pool-blue family
+    (hue 185, same as cool/pool default), not the legacy
+    near-white triplet. Saturation/lightness/alpha are
+    intentionally unpinned — they are iterable knobs."""
+    import re
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-water-boiler-card.js"
+    ).read_text()
+    # Extract the array body so the regex isn't tricked by
+    # unrelated literals elsewhere in the file.
+    match = re.search(
+        r"const\s+BOIL_WATER_COLORS\s*=\s*\[(?P<body>[^\]]+)\]",
+        content,
+    )
+    assert match, (
+        "qs-water-boiler-card.js: BOIL_WATER_COLORS declaration "
+        "must remain a literal array."
+    )
+    body = match.group("body")
+    entries = re.findall(r"'hsla\(([^']+)\)'", body)
+    assert len(entries) >= 1, (
+        "qs-water-boiler-card.js: BOIL_WATER_COLORS must have "
+        "at least one hsla literal."
+    )
+    for entry in entries:
+        assert entry.lstrip().startswith("185,"), (
+            "QS-220 AC-1: every BOIL_WATER_COLORS entry must "
+            f"use the pool-blue hue (185); got `{entry}`."
+        )
+    # Sentinel: legacy near-white pattern is gone.
+    assert "hsla(0, 0%" not in body, (
+        "QS-220 AC-1: the legacy near-white pattern "
+        "`hsla(0, 0%, …)` must not appear in BOIL_WATER_COLORS."
+    )
+
+
 def test_water_boiler_card_center_uses_named_constants():
     """Review-fix #02 S1: the arc / handle / progress-ring `center`
     object in `_render()` must use the named `CENTER_CX` / `CENTER_CY`
@@ -4140,19 +4177,30 @@ class TestClimateCardSnowBackdrop:
                     f"`id=\"snowWave{i}\"`."
                 )
 
-        # Front white-ish literal.
-        assert "hsla(0, 0%, 95%, 0.65)" in executable, (
-            "QS-210 AC3: front snow-pile layer must use the white-ish "
-            "literal `hsla(0, 0%, 95%, 0.65)`."
+        # QS-220 AC-2: the front layer is no longer pure white.
+        assert "hsla(0, 0%, 95%, 0.65)" not in executable, (
+            "QS-220 AC-2: the legacy pure-white SNOW_FRONT_COLOR "
+            "literal `hsla(0, 0%, 95%, 0.65)` must be replaced "
+            "with a translucent pale-blue value."
+        )
+        # SNOW_FRONT_COLOR constant must still exist and reference an
+        # hsla literal — direction-only, no hue/sat/light/alpha pin.
+        assert re.search(
+            r"const\s+SNOW_FRONT_COLOR\s*=\s*'hsla\([^']+\)'",
+            executable,
+        ), (
+            "QS-220 AC-2: SNOW_FRONT_COLOR must remain a module-level "
+            "const assigned to an hsla literal."
         )
 
-        # At least one blue-ish back literal (hue around 200-230).
+        # At least one blue-ish layer (hue around 200-230) — after
+        # QS-220 the front layer also matches; back/mid still do.
         assert re.search(
             r"hsla\(\s*2[0-3]\d\s*,",
             executable,
         ) is not None, (
-            "QS-210 AC3: back snow-pile layer(s) must use a blue-ish "
-            "hue (regex on `hsla(2[0-3]X, …)`)."
+            "QS-210 AC3: ≥1 blue-ish pile layer (back/mid/front) must "
+            "use a blue-ish hue (regex on `hsla(2[0-3]X, …)`)."
         )
 
     def test_climate_card_snowflakes_fall_down(self):


### PR DESCRIPTION
## Summary
- Boiler BOIL_WATER_COLORS swapped from near-white to translucent pool-blue (hue 185, same family as COOL_WATER_COLORS).
- Climate SNOW_FRONT_COLOR swapped from pure white to translucent pale-blue (hue 210) so white numbers/text on top stay legible.
- TDD: 1 new module-level boil-palette sentinel; 1 relaxed snow-pile sentinel; bubble/steam/glow/cross-fade pins untouched.

Fixes #220

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated climate card snow layer color scheme from neutral gray/white to blue-toned.
  * Updated water boiler card color palette to translucent blue/cyan for enhanced visuals.

* **Documentation**
  * Updated card visual descriptions to reflect new color schemes and refreshed verification date.

* **Tests**
  * Added validation for boiler card color palette consistency.
  * Updated climate card snow rendering test assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->