### PR TITLE
QS-221: enrich OVERRIDE BY USER diagnostic log line

### DIFF
--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -626,14 +626,27 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                             override_constraint = None
                             do_force_next_solve = True
                         else:
-                            _LOGGER.info(
-                                "check_load_activity_and_constraints: bistate "
-                                "OVERRIDE BY USER %s for load %s instead of %s %s",
-                                state.state,
-                                self.name,
-                                expected_state,
-                                expected_state_running,
-                            )
+                            if self.external_user_initiated_state is not None:
+                                _LOGGER.info(
+                                    "check_load_activity_and_constraints: bistate "
+                                    "OVERRIDE BY USER on %s for load %s "
+                                    "(previous override: %s, current state: %s)",
+                                    self.bistate_entity,
+                                    self.name,
+                                    self.external_user_initiated_state,
+                                    current_state,
+                                )
+                            else:
+                                _LOGGER.info(
+                                    "check_load_activity_and_constraints: bistate "
+                                    "OVERRIDE BY USER on %s for load %s "
+                                    "(current state: %s, expected: %s, running expected: %s)",
+                                    self.bistate_entity,
+                                    self.name,
+                                    current_state,
+                                    expected_state,
+                                    expected_state_running,
+                                )
 
                             # the user did something different ... just OVERRIDE the automation for a given time
                             self.external_user_initiated_state = current_state

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -10,7 +10,7 @@ covers:
   - custom_components/quiet_solar/ha_model/radiator.py
   - custom_components/quiet_solar/ha_model/bistate_transport.py
   - custom_components/quiet_solar/ha_model/water_boiler.py
-last_verified: 2026-05-22
+last_verified: 2026-05-24
 ---
 
 # Bistate-duration devices (pool, on/off duration, water boiler, climate, radiator)

--- a/docs/stories/QS-221.story.md
+++ b/docs/stories/QS-221.story.md
@@ -1,0 +1,298 @@
+# QS-221 — Enrich `OVERRIDE BY USER` diagnostic log line
+
+## Why
+
+While debugging issue #221 ("Radiator in switch mode: user override is not
+respected") the existing INFO log emitted from
+`QSBiStateDuration.check_load_activity_and_constraints` was actively
+misleading:
+
+```
+OVERRIDE BY USER off for load Serviette Parents instead of UNKNOWN UNKNOWN
+OVERRIDE BY USER on  for load Serviette Parents instead of UNKNOWN UNKNOWN
+… (alternating every 7 s for many minutes)
+```
+
+Two problems hid the real root cause:
+
+1. **Stale placeholder leak.** `expected_state` and
+   `expected_state_running` are seeded to the literal string `"UNKNOWN"`
+   at the top of the override-detection block. In the
+   `external_user_initiated_state is not None` elif (a state alternation
+   while a prior override is still active) those variables are never
+   reassigned, so the seed leaked into the log as the misleading
+   "instead of UNKNOWN UNKNOWN" — sending the operator to look at the
+   command-state machine instead of the entity-binding layer.
+2. **Watched entity missing.** The log line carries the *load name* but
+   not the `bistate_entity` id that QS is actually polling. The actual
+   root cause of #221 was a stored-config error: the `Serviette Parents`
+   radiator's persisted `CONF_SWITCH` pointed at
+   `switch.lhk_seche_serviette_enfants_facade` (the Enfants switch).
+   The Parents radiator therefore re-detected an "override" on every
+   cycle where Enfants flipped its own switch, and never observed the
+   real parents switch the user had toggled. Surfacing
+   `self.bistate_entity` in the log makes this collision visible at a
+   glance.
+
+The user has already resolved the production incident by reconfiguring
+the radiator to point at the correct switch — **no code fix is needed
+for the misconfiguration itself**. The remaining work is purely
+diagnostic: make sure the next operator who hits an
+override-misbehaviour finds the root cause in one log read rather than
+three.
+
+Out of scope (explicitly declined): config-flow entity-collision
+validation, startup multi-load-on-same-entity warning, runtime
+self-healing on oscillation, audit of the radiator pass-2 save path.
+
+## Acceptance criteria
+
+### AC1 — Prior-override branch surfaces the entity and the previous override state
+
+**GIVEN** a `QSBiStateDuration` load has `external_user_initiated_state`
+set to `"on"` (a previous user override is active)
+**AND** `self.bistate_entity` is `"switch.test_device"`
+**AND** the HA state of `switch.test_device` reads `"off"` (differs
+from the prior override)
+**AND** the device is in `bistate_mode_auto`
+**WHEN** `check_load_activity_and_constraints(time)` runs and reaches
+the `is_command_overridden_state_changed = True` branch with
+`external_user_initiated_state is not None`
+**THEN** exactly one INFO log record is emitted on the
+`custom_components.quiet_solar.ha_model.bistate_duration` logger that:
+- contains the literal substring `"OVERRIDE BY USER"`
+- contains the literal substring `"switch.test_device"`
+- contains the literal substring `"previous override: on"`
+- contains the literal substring `"current state: off"`
+- does NOT contain the literal substring `"UNKNOWN UNKNOWN"`
+- does NOT contain the literal substring `"expected:"` (the prior-override branch
+  does not compute an expected command state, so the field is omitted entirely)
+
+### AC2 — No-prior-override branch surfaces the entity and the expected command state
+
+**GIVEN** a `QSBiStateDuration` load has
+`external_user_initiated_state is None` (no previous override)
+**AND** `self.bistate_entity` is `"switch.test_device"`
+**AND** `self.current_command` and `self.running_command` are both `CMD_OFF`
+**AND** the HA state of `switch.test_device` reads `"on"` (differs
+from the expected `"off"`)
+**AND** the device is in `bistate_mode_auto`
+**WHEN** `check_load_activity_and_constraints(time)` runs and reaches
+the `is_command_overridden_state_changed = True` branch with
+`external_user_initiated_state is None`
+**THEN** exactly one INFO log record is emitted on the
+`custom_components.quiet_solar.ha_model.bistate_duration` logger that:
+- contains the literal substring `"OVERRIDE BY USER"`
+- contains the literal substring `"switch.test_device"`
+- contains the literal substring `"current state: on"`
+- contains the literal substring `"expected: off"` (the resolved
+  expected_state from `expected_state_from_command(CMD_OFF)` = `_state_off`)
+- does NOT contain the literal substring `"UNKNOWN UNKNOWN"`
+
+### AC3 — No production behaviour change
+
+**WHEN** the implementation is complete
+**THEN** the diff in `custom_components/quiet_solar/` consists exclusively
+of changes to the two `_LOGGER.info(...)` calls inside the
+`is_command_overridden_state_changed` branch of
+`QSBiStateDuration.check_load_activity_and_constraints` — no other source
+lines change, no constraint-state logic, no transport calls, no
+attribute reads/writes outside the log statements
+(verifiable via `git diff custom_components/`).
+**AND** `python scripts/qs/quality_gate.py` passes (100% coverage, ruff,
+mypy, translations, doc drift).
+
+### AC4 — Coverage of both new log branches
+
+**GIVEN** the two new INFO log statements live on distinct source lines
+**WHEN** the new tests run
+**THEN** the prior-override test (AC1) executes the prior-override log
+line at least once
+**AND** the no-prior-override test (AC2) executes the no-prior-override
+log line at least once
+**AND** the 100%-coverage gate in `quality_gate.py` is satisfied with no
+`# pragma: no cover` additions to the new code.
+
+## Task breakdown
+
+### T1 — Pre-verified: no existing tests assert on the old log text
+
+Already confirmed during planning: `grep "OVERRIDE BY USER" tests/`
+returns no matches in this branch. No existing test pins the old format
+string, so changing it is safe. Recorded here so the implementer does
+not re-grep.
+
+### T2 — Branch the `_LOGGER.info(...)` call inside `QSBiStateDuration.check_load_activity_and_constraints`
+
+File: `custom_components/quiet_solar/ha_model/bistate_duration.py`.
+
+Anchor: inside the `else` arm of `if is_command_overridden_state_changed:`
+(currently a single `_LOGGER.info` call followed by the
+`# the user did something different ...` comment, sitting between the
+`BACK TO NORMAL` `if` arm and the `self.external_user_initiated_state =
+current_state` assignment).
+
+Replace the single `_LOGGER.info` call with a conditional split keyed
+on `self.external_user_initiated_state is not None`. Two separate calls
+keep each format string carrying only the fields that are meaningful in
+its branch — this is the structural change that addresses the original
+"UNKNOWN UNKNOWN" leak (the prior-override branch never reassigns
+`expected_state`/`expected_state_running`, so its log must not reference
+them):
+
+```python
+if self.external_user_initiated_state is not None:
+    _LOGGER.info(
+        "check_load_activity_and_constraints: bistate "
+        "OVERRIDE BY USER on %s for load %s "
+        "(previous override: %s, current state: %s)",
+        self.bistate_entity,
+        self.name,
+        self.external_user_initiated_state,
+        current_state,
+    )
+else:
+    _LOGGER.info(
+        "check_load_activity_and_constraints: bistate "
+        "OVERRIDE BY USER on %s for load %s "
+        "(current state: %s, expected: %s, running expected: %s)",
+        self.bistate_entity,
+        self.name,
+        current_state,
+        expected_state,
+        expected_state_running,
+    )
+```
+
+Constraints (enforced by project-context.md):
+
+- Lazy `%s` formatting only — no f-strings inside log calls.
+- No trailing period on the message.
+- Logger name unchanged (`_LOGGER = logging.getLogger(__name__)` already
+  resolves to `custom_components.quiet_solar.ha_model.bistate_duration`).
+- INFO level preserved (matches the existing `BACK TO NORMAL` sibling
+  log immediately above).
+- No other code in the surrounding method changes — the rest of the
+  override state-machine logic is untouched.
+
+### T3 — Add two tests in `tests/test_ha_bistate_duration.py`
+
+Place both tests in the same group as `test_user_override_detected`
+(file `tests/test_ha_bistate_duration.py`, around line 739 — uses the
+`bistate_check_load_device: ConcreteBiStateDevice` fixture).
+
+Both tests must call
+`caplog.set_level(logging.INFO, logger="custom_components.quiet_solar.ha_model.bistate_duration")`
+before invoking `check_load_activity_and_constraints` — pytest's
+`caplog` defaults to WARNING and would silently drop the new INFO
+records otherwise.
+
+#### T3a — `test_user_override_log_includes_entity_and_previous_state_when_override_already_active`
+
+Mirrors `test_user_override_detected`'s setup. Differences:
+- Seed `external_user_initiated_state = "on"`,
+  `external_user_initiated_state_time = time - timedelta(minutes=1)`
+  (short enough to stay inside the override window).
+- Seed the HA state via `hass.states.async_set("switch.test_device", "off")`
+  (mismatch vs. the prior override → triggers the alternation branch).
+- After awaiting `check_load_activity_and_constraints(time)`, assert
+  on `caplog.records` filtered for INFO records containing
+  `"OVERRIDE BY USER"`:
+  - exactly one matching record exists
+  - its `getMessage()` contains `"switch.test_device"`
+  - its `getMessage()` contains `"previous override: on"`
+  - its `getMessage()` contains `"current state: off"`
+  - its `getMessage()` does NOT contain `"UNKNOWN UNKNOWN"`
+  - its `getMessage()` does NOT contain `"expected:"`
+
+#### T3b — `test_user_override_log_includes_entity_and_expected_state_when_no_prior_override`
+
+Mirrors `test_user_override_detected` exactly (`external_user_initiated_state = None`,
+`current_command = running_command = CMD_OFF`,
+`hass.states.async_set("switch.test_device", "on")`). After awaiting
+`check_load_activity_and_constraints(time)`, assert on `caplog.records`
+filtered for INFO records containing `"OVERRIDE BY USER"`:
+- exactly one matching record exists
+- its `getMessage()` contains `"switch.test_device"`
+- its `getMessage()` contains `"current state: on"`
+- its `getMessage()` contains `"expected: off"`
+- its `getMessage()` does NOT contain `"UNKNOWN UNKNOWN"`
+
+The existing `test_user_override_detected` continues to pass unchanged
+— it asserts on `external_user_initiated_state` / `_time` mutations
+only, never on log text.
+
+### T4 — Bump `last_verified` in `docs/agents/concepts/bistate-duration-devices.md`
+
+The drift checker (`scripts/qs/check_doc_drift.py`) flags this doc as
+stale on this branch because `bistate_duration.py` is being modified:
+
+```
+$ python scripts/qs/check_doc_drift.py --paths \
+    custom_components/quiet_solar/ha_model/bistate_duration.py \
+    tests/test_ha_bistate_duration.py
+stale: docs/agents/concepts/bistate-duration-devices.md (...)
+```
+
+Exit 1 → quality gate fails. **Doc-OK**: the doc body describes the
+override state machine at a high level and does NOT quote any log text,
+so the body is genuinely unchanged. Only the `last_verified` field
+needs to advance from `2026-05-22` to today (`2026-05-24`).
+
+Verification command after the bump:
+
+```
+python scripts/qs/check_doc_drift.py --paths \
+    custom_components/quiet_solar/ha_model/bistate_duration.py \
+    tests/test_ha_bistate_duration.py \
+    docs/agents/concepts/bistate-duration-devices.md
+```
+
+Must exit 0.
+
+### T5 — Run the quality gate
+
+TDD loop during development:
+
+```
+python scripts/qs/quality_gate.py --quick tests/test_ha_bistate_duration.py
+```
+
+Final pass before commit (full gate, 100% coverage, ruff, mypy,
+translations, doc drift):
+
+```
+python scripts/qs/quality_gate.py
+```
+
+## Adversarial Review Notes
+
+Four reviewers ran in parallel against the plan draft. Summary of the
+12 findings raised and how each was resolved:
+
+| # | Severity | Source | Finding (abridged) | Resolution |
+|---|----------|--------|--------------------|------------|
+| F1 | redesign | Critic | T2's new single format still surfaces the stale `expected_state`/`expected_state_running` ("UNKNOWN") in the prior-override branch — bug not fully fixed. | **Accepted.** T2 redesigned: branch the `_LOGGER.info` call into two paths, each carrying only the fields relevant to that branch. Documented under "Constraints" in T2. |
+| F2 | clarify | Critic | Asserting absence of `"UNKNOWN"` substring will false-positive on HA's `STATE_UNKNOWN`. | **Accepted.** AC1/AC2/T3 assert absence of the specific pair `"UNKNOWN UNKNOWN"`. |
+| F3 | clarify | Critic / Dev-proxy | Line-number anchors (629-636) are fragile. | **Accepted.** T2 anchors by function name + branch description (`else` arm of `if is_command_overridden_state_changed`) and the existing surrounding comment. |
+| F4 | improve | Critic / Guardian | T1 ("grep tests for old log text") is exploratory, not a deliverable. | **Accepted.** T1 reframed as "pre-verified during planning" — recorded that no existing tests assert on the old text, so implementer can skip the grep. |
+| F5 | critical | Critic / Dev-proxy | Coverage of both branches needs an explicit AC. | **Accepted.** Added AC4 ("Coverage of both new log branches"). |
+| F6 | clarify | Concrete-planner | `caplog` defaults to WARNING; INFO records will silently drop. | **Accepted.** T3 explicitly requires `caplog.set_level(logging.INFO, logger="...")` in both tests. |
+| F7 | clarify | Concrete-planner | T3 ambiguous on sub-case structure (one test vs two). | **Accepted.** Split into T3a / T3b — two separate `def test_...` functions. |
+| F8 | improve | Critic / Dev-proxy | AC1 lacked an exact-substring assertion for the rendered previous-override value. | **Accepted.** AC1 pins literal `"previous override: on"` matching the fixture seed. |
+| F9 | improve | Scope-Guardian | T4 (doc `last_verified` bump) is gold-plating. | **Overridden.** Scope-Guardian did not have access to `scripts/qs/check_doc_drift.py`. The drift checker already exits 1 on this branch flagging the doc as stale; without T4 the full `quality_gate.py` fails. T4 is mechanical doc-maintenance, NOT gold-plating. The verification command is now embedded in T4. |
+| F10 | improve | Concrete-planner | Claims `test_user_override_detected` does not exist. | **Rejected.** False negative — the test exists at line 739 of `tests/test_ha_bistate_duration.py`. Confirmed by direct file read during planning. |
+| F11 | improve / redesign | Concrete-planner / Dev-proxy | `bistate_entity` could be a wrapper object, not a string — `%s` may render `<Object ...>`. | **Rejected.** Both assignment sites in the codebase set `self.bistate_entity` to a plain entity_id string (`= self.switch_entity` in the base, `= self._transport.entity` in `QSRadiator` where `transport.entity` is the string passed to the transport constructor). Existing call `self.hass.states.get(self.bistate_entity)` at line 540 already relies on it being a string. |
+| F12 | clarify | Scope-Guardian | AC1/AC2 asymmetry on the `expected_state` pair was unmotivated. | **Resolved by F1.** Branching the log call makes each path carry exactly the fields meaningful to its branch; the asymmetry is now intentional and visible in the format strings. |
+
+## NEXT_PHASE: implement-task
+
+The edit set is:
+- `custom_components/quiet_solar/ha_model/bistate_duration.py` — product code
+- `tests/test_ha_bistate_duration.py` — tests
+- `docs/agents/concepts/bistate-duration-devices.md` — doc maintenance
+
+None of these are in setup-only paths
+(`scripts/`, `.claude/`, `.cursor/`, `.opencode/`, `legacy/`, `docs/workflow/`,
+`.github/`, top-level config). Routes to `qs-implement-task` (not
+`qs-implement-setup-task`).

--- a/tests/test_ha_bistate_duration.py
+++ b/tests/test_ha_bistate_duration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 from datetime import time as dt_time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -762,6 +763,96 @@ class TestQSBiStateDurationCheckLoadActivityUserOverride:
 
         assert bistate_check_load_device.external_user_initiated_state == "on"
         assert bistate_check_load_device.external_user_initiated_state_time == time
+
+    @pytest.mark.asyncio
+    async def test_user_override_log_includes_entity_and_previous_state_when_override_already_active(
+        self, hass: HomeAssistant, bistate_check_load_device: ConcreteBiStateDevice, caplog
+    ):
+        """AC1: prior-override branch logs entity + previous override + current state, no UNKNOWN UNKNOWN, no expected:."""
+        caplog.set_level(
+            logging.INFO,
+            logger="custom_components.quiet_solar.ha_model.bistate_duration",
+        )
+
+        bistate_check_load_device.current_command = None
+        bistate_check_load_device.running_command = None
+        bistate_check_load_device.bistate_mode = "bistate_mode_auto"
+        bistate_check_load_device.is_load_command_set = MagicMock(return_value=True)
+        time = datetime.datetime.now(pytz.UTC)
+        bistate_check_load_device.external_user_initiated_state = "on"
+        bistate_check_load_device.external_user_initiated_state_time = time - datetime.timedelta(minutes=1)
+        bistate_check_load_device.asked_for_reset_user_initiated_state_time = None
+        bistate_check_load_device.asked_for_reset_user_initiated_state_time_first_cmd_reset_done = None
+
+        hass.states.async_set("switch.test_device", "off")
+
+        bistate_check_load_device.set_live_constraints = MagicMock()
+        bistate_check_load_device.push_live_constraint = MagicMock(return_value=(True, False))
+        bistate_check_load_device.get_next_scheduled_event = AsyncMock(return_value=(None, None))
+
+        await bistate_check_load_device.check_load_activity_and_constraints(time)
+
+        override_records = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.INFO and "OVERRIDE BY USER" in record.getMessage()
+        ]
+        assert len(override_records) == 1, (
+            f"expected exactly one OVERRIDE BY USER INFO record, got {len(override_records)}: "
+            f"{[r.getMessage() for r in override_records]}"
+        )
+        message = override_records[0].getMessage()
+        assert "switch.test_device" in message
+        assert "previous override: on" in message
+        assert "current state: off" in message
+        assert "UNKNOWN UNKNOWN" not in message
+        assert "expected:" not in message
+
+    @pytest.mark.asyncio
+    async def test_user_override_log_includes_entity_and_expected_state_when_no_prior_override(
+        self, hass: HomeAssistant, bistate_check_load_device: ConcreteBiStateDevice, caplog
+    ):
+        """AC2: no-prior-override branch logs entity + current state + expected state, no UNKNOWN UNKNOWN."""
+        caplog.set_level(
+            logging.INFO,
+            logger="custom_components.quiet_solar.ha_model.bistate_duration",
+        )
+
+        bistate_check_load_device.current_command = None
+        bistate_check_load_device.running_command = None
+        bistate_check_load_device.bistate_mode = "bistate_mode_auto"
+        bistate_check_load_device.is_load_command_set = MagicMock(return_value=True)
+        bistate_check_load_device.external_user_initiated_state = None
+        bistate_check_load_device.external_user_initiated_state_time = None
+        bistate_check_load_device.asked_for_reset_user_initiated_state_time = None
+        bistate_check_load_device.asked_for_reset_user_initiated_state_time_first_cmd_reset_done = None
+
+        bistate_check_load_device.current_command = CMD_OFF
+        bistate_check_load_device.running_command = CMD_OFF
+        hass.states.async_set("switch.test_device", "on")
+
+        bistate_check_load_device.set_live_constraints = MagicMock()
+        bistate_check_load_device.push_live_constraint = MagicMock(return_value=(True, False))
+        bistate_check_load_device.get_next_scheduled_event = AsyncMock(return_value=(None, None))
+
+        time = datetime.datetime.now(pytz.UTC)
+
+        await bistate_check_load_device.check_load_activity_and_constraints(time)
+
+        override_records = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.INFO and "OVERRIDE BY USER" in record.getMessage()
+        ]
+        assert len(override_records) == 1, (
+            f"expected exactly one OVERRIDE BY USER INFO record, got {len(override_records)}: "
+            f"{[r.getMessage() for r in override_records]}"
+        )
+        message = override_records[0].getMessage()
+        assert "switch.test_device" in message
+        assert "current state: on" in message
+        assert "expected: off" in message
+        assert "UNKNOWN UNKNOWN" not in message
 
     @pytest.mark.asyncio
     async def test_user_override_idle_resets_constraints(


### PR DESCRIPTION
## Summary
- Split the OVERRIDE BY USER _LOGGER.info call into two branches so the prior-override path no longer leaks the stale UNKNOWN UNKNOWN seeds.
- Both branches now surface self.bistate_entity (the actual watched entity id) — the missing diagnostic that hid the #221 root cause.
- No production behaviour change: edit is confined to the two _LOGGER.info statements; covered by two new tests in test_ha_bistate_duration.py.

Fixes #221

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)