### PR TITLE
QS-224: car-card animated battery backdrop (green idle, blue charging with lightning)

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -12,6 +12,96 @@ const ANIM_MAX_POWER_W = 22000;
 const ANIM_SPEED_RANGE = ANIM_MAX_SPEED - ANIM_MIN_SPEED;
 const ANIM_POWER_RANGE = ANIM_MAX_POWER_W - ANIM_MIN_POWER_W;
 
+// --- QS-224 battery animation constants -----------------------------------
+// Battery shape derived from mdi:battery-outline (24×24 mdi viewBox).
+// The icon is body 12×18 at (6,4)..(18,22) plus terminal nub 6×2 at
+// (9,2)..(15,4), with corner radius 2 mdi-units (~2/24 ≈ 8.3% of side).
+// The user pins vertical span at "+1/5 / −1/5 of diameter" = 60% of
+// the ring's visible diameter (ringCirc * 2 = 260 SVG-px) — total
+// height 156 SVG-px split 18:2 between body and terminal nub.
+
+const CENTER_CX = 160;                                       // SVG x-center
+const CENTER_CY = 160;                                       // SVG y-center
+const BATTERY_TOTAL_HEIGHT = 156;                            // = 0.6 × 2 × ringCirc (130), per issue's "+1/5 / −1/5" rule
+const MDI_UNIT_PX = BATTERY_TOTAL_HEIGHT / 20;               // = 7.8 (20 mdi-units total height: body 18 + terminal 2)
+const BATTERY_BODY_HEIGHT = 18 * MDI_UNIT_PX;                // = 140.4
+const BATTERY_BODY_WIDTH  = 12 * MDI_UNIT_PX;                // = 93.6   (body 12:18 ratio preserved)
+const BATTERY_TERMINAL_WIDTH  = 6 * MDI_UNIT_PX;             // = 46.8
+const BATTERY_TERMINAL_HEIGHT = 2 * MDI_UNIT_PX;             // = 15.6
+const BATTERY_CORNER_R = 2 * MDI_UNIT_PX;                    // = 15.6
+const BATTERY_TOP_Y       = CENTER_CY - BATTERY_TOTAL_HEIGHT / 2;       // = 82
+const BATTERY_BOTTOM_Y    = CENTER_CY + BATTERY_TOTAL_HEIGHT / 2;       // = 238
+const BATTERY_BODY_TOP_Y  = BATTERY_TOP_Y + BATTERY_TERMINAL_HEIGHT;    // = 97.6
+const BATTERY_BODY_LEFT_X  = CENTER_CX - BATTERY_BODY_WIDTH / 2;        // = 113.2
+const BATTERY_BODY_RIGHT_X = CENTER_CX + BATTERY_BODY_WIDTH / 2;        // = 206.8
+const BATTERY_TERMINAL_LEFT_X  = CENTER_CX - BATTERY_TERMINAL_WIDTH / 2; // = 136.6
+const BATTERY_TERMINAL_RIGHT_X = CENTER_CX + BATTERY_TERMINAL_WIDTH / 2; // = 183.4
+
+// Wave geometry — reuse the pool/boiler defaults verbatim. The wave path
+// is rendered with extent [0, 2*WAVE_WIDTH] and translated; absolute
+// width is decoupled from battery body width.
+const WAVE_WIDTH = 480;                                      // single wave period; same as pool/boiler
+const WAVE_BOTTOM_Y = 400;                                   // closing rect y; below viewBox (320)
+const LAYER_SCROLL_OFFSET = 1.2;                             // per-layer extra scroll phase
+const LAYER_PHASE_OFFSET  = 2.1;                             // per-layer static sine phase
+
+// Water palettes — opacity cross-fade between idle/green and charging/blue.
+// IDLE family: hue 150 (green; matches the gradGreenId cyan→green
+// gradient direction). CHARGING family: hue 205 (blue; matches the
+// gradChargeId cyan→deep-blue gradient direction). Lightness/alpha
+// step down per layer for depth.
+const IDLE_WATER_COLORS = [
+  'hsla(150, 60%, 35%, 0.55)',
+  'hsla(150, 60%, 30%, 0.45)',
+  'hsla(150, 60%, 25%, 0.35)',
+];
+const CHARGING_WATER_COLORS = [
+  'hsla(205, 80%, 40%, 0.60)',
+  'hsla(205, 80%, 35%, 0.50)',
+  'hsla(205, 80%, 30%, 0.40)',
+];
+
+// Animation tuning — mirror the boiler exactly (gentle calm, more
+// pronounced when active). Documented at QS-200 in
+// docs/agents/concepts/dashboard-and-cards.md.
+const LERP_RATE = 2;                                         // exp lerp time-constant (~95% in ~1.5s)
+const LERP_DT_CEIL = 0.1;                                    // s; clamp dt against hidden-tab return
+const AMP_REGEN_THRESHOLD = 0.25;                            // amp delta for path regen
+const LEVEL_REGEN_THRESHOLD = 0.01;                          // px; water level delta for path regen
+const PHASE_WRAP = 1e6;                                      // wrap _wavePhase to preserve float precision
+const PHASE_TO_PX = 60;                                      // scroll px per phase-unit
+const CALM_AMP = 1.5;                                        // = boiler CALM_AMP
+const CHARGING_AMP = 8;                                      // = boiler BOIL_AMP
+const CALM_SPEED = 0.1;                                      // = boiler CALM_SPEED
+const CHARGING_SPEED = 0.4;                                  // = boiler BOIL_SPEED
+
+// Lightning subsystem — charging-only particle system, HARD CAP at
+// MAX_CONCURRENT_LIGHTNING (spawn rejected when len >= cap, no overflow).
+// Architecture mirrors the boiler bubble/steam subsystems: create/destroy
+// (NOT pool/reuse) — matches project precedent at qs-water-boiler-card.js
+// :413-461. Spawn rate × life ≈ 1.5 avg, occasional 3-cap.
+const MAX_CONCURRENT_LIGHTNING = 3;
+const LIGHTNING_SPAWN_RATE_HZ = 3;
+const LIGHTNING_LIFE_S = 0.5;
+const LIGHTNING_HEIGHT_MIN_PX = 18;
+const LIGHTNING_HEIGHT_MAX_PX = 30;
+const LIGHTNING_ZIGZAG_AMPLITUDE_PX = 6;                     // horizontal jitter per segment
+const LIGHTNING_SEGMENTS = 4;                                // zigzag segments per bolt (5 vertices)
+const LIGHTNING_STROKE_WIDTH = 1.5;
+const LIGHTNING_STROKE_COLOR = '#FFFFFF';                    // white core
+const LIGHTNING_GLOW_COLOR = '#80D4FF';                      // blue-white halo
+const LIGHTNING_GLOW_STDDEV = 2.5;
+// Life curve breakpoints (piecewise linear). Mirrors boiler steam at
+// qs-water-boiler-card.js:573-577 (0.15/0.85 → here 0.2/0.7).
+const LIGHTNING_FADE_IN_FRACTION = 0.2;                      // 0 → 0.2 fade-in
+const LIGHTNING_FADE_OUT_FRACTION = 0.7;                     // 0.2 → 0.7 hold, 0.7 → 1.0 fade-out
+
+// Battery outline appearance — alpha lerped between idle/charging via
+// JS rgba interpolation (NOT CSS color-mix, for browser compat).
+const BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.30;
+const BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.55;
+const BATTERY_OUTLINE_STROKE_WIDTH = 2;
+
 class QsCarCard extends HTMLElement {
   constructor() {
     super();
@@ -19,35 +109,313 @@ class QsCarCard extends HTMLElement {
     this._charging = false;
   }
 
-  // M4: gate the requestAnimationFrame loop on `_charging`. The loop
-  // is started lazily by `_render()` only when the car is actually
-  // charging, and stopped in `disconnectedCallback` AND whenever
-  // `_charging` becomes false. Avoids constant per-card repaint
-  // overhead when the car isn't drawing any current.
+  // QS-224: SVG path `d` for the body-only rounded-rectangle (terminal
+  // NOT included). Used as the <clipPath> contents — water and
+  // lightning are clipped to the body interior so the terminal nub
+  // never shows water bleed or stray bolts. Trace the rounded-rect
+  // clockwise from top-left-after-corner.
+  _generateBatteryBodyClipPath() {
+    const r = BATTERY_CORNER_R;
+    const left = BATTERY_BODY_LEFT_X;
+    const right = BATTERY_BODY_RIGHT_X;
+    const top = BATTERY_BODY_TOP_Y;
+    const bottom = BATTERY_BOTTOM_Y;
+    return (
+      `M ${(left + r).toFixed(2)} ${top.toFixed(2)} ` +
+      `H ${(right - r).toFixed(2)} ` +
+      `Q ${right.toFixed(2)} ${top.toFixed(2)} ${right.toFixed(2)} ${(top + r).toFixed(2)} ` +
+      `V ${(bottom - r).toFixed(2)} ` +
+      `Q ${right.toFixed(2)} ${bottom.toFixed(2)} ${(right - r).toFixed(2)} ${bottom.toFixed(2)} ` +
+      `H ${(left + r).toFixed(2)} ` +
+      `Q ${left.toFixed(2)} ${bottom.toFixed(2)} ${left.toFixed(2)} ${(bottom - r).toFixed(2)} ` +
+      `V ${(top + r).toFixed(2)} ` +
+      `Q ${left.toFixed(2)} ${top.toFixed(2)} ${(left + r).toFixed(2)} ${top.toFixed(2)} Z`
+    );
+  }
+
+  // QS-224: SVG path `d` for the COMBINED body+terminal silhouette
+  // (single closed path, no seam). Drawn as a stroked outline only
+  // (fill="none"). The path traces the mdi:battery-outline shape:
+  // terminal-nub on top (small rectangle) seamlessly joined to the
+  // rounded-rect body below.
+  _generateBatteryOutlinePath() {
+    const r = BATTERY_CORNER_R;
+    const left = BATTERY_BODY_LEFT_X;
+    const right = BATTERY_BODY_RIGHT_X;
+    const top = BATTERY_BODY_TOP_Y;
+    const bottom = BATTERY_BOTTOM_Y;
+    const termLeft = BATTERY_TERMINAL_LEFT_X;
+    const termRight = BATTERY_TERMINAL_RIGHT_X;
+    const termTop = BATTERY_TOP_Y;
+    // Trace clockwise from body-top-left-after-corner:
+    //   1. across body top to where the terminal joins (termLeft)
+    //   2. up the terminal left edge
+    //   3. across the terminal top
+    //   4. down the terminal right edge
+    //   5. across body top from termRight back to body-top-right-before-corner
+    //   6. arc the top-right body corner
+    //   7. down the right body edge
+    //   8. arc the bottom-right corner
+    //   9. across the body bottom
+    //  10. arc the bottom-left corner
+    //  11. up the left body edge
+    //  12. arc the top-left body corner, close
+    return (
+      `M ${(left + r).toFixed(2)} ${top.toFixed(2)} ` +
+      `H ${termLeft.toFixed(2)} ` +
+      `V ${termTop.toFixed(2)} ` +
+      `H ${termRight.toFixed(2)} ` +
+      `V ${top.toFixed(2)} ` +
+      `H ${(right - r).toFixed(2)} ` +
+      `Q ${right.toFixed(2)} ${top.toFixed(2)} ${right.toFixed(2)} ${(top + r).toFixed(2)} ` +
+      `V ${(bottom - r).toFixed(2)} ` +
+      `Q ${right.toFixed(2)} ${bottom.toFixed(2)} ${(right - r).toFixed(2)} ${bottom.toFixed(2)} ` +
+      `H ${(left + r).toFixed(2)} ` +
+      `Q ${left.toFixed(2)} ${bottom.toFixed(2)} ${left.toFixed(2)} ${(bottom - r).toFixed(2)} ` +
+      `V ${(top + r).toFixed(2)} ` +
+      `Q ${left.toFixed(2)} ${top.toFixed(2)} ${(left + r).toFixed(2)} ${top.toFixed(2)} Z`
+    );
+  }
+
+  // QS-224: ported verbatim from qs-pool-card.js:49-62. Emits TWO
+  // repetitions of the wave (path extent = [0, 2*width]) so the
+  // translated path always covers the clip region regardless of
+  // scroll offset.
+  _generateWavePath(width, amplitude, frequency, phase, yOffset) {
+    const points = [];
+    const stepsPerPeriod = 60;
+    const totalSteps = stepsPerPeriod * 2;
+    const totalWidth = 2 * width;
+    for (let i = 0; i <= totalSteps; i++) {
+      const x = (i / stepsPerPeriod) * width;
+      const y = yOffset + amplitude * Math.sin((x / width) * frequency * 2 * Math.PI + phase);
+      points.push(`${x.toFixed(2)} ${y.toFixed(2)}`);
+    }
+    return `M ${points[0]} ` +
+           points.slice(1).map(p => `L ${p}`).join(' ') +
+           ` L ${totalWidth.toFixed(2)} ${WAVE_BOTTOM_Y} L 0 ${WAVE_BOTTOM_Y} Z`;
+  }
+
+  // QS-224: reset cached DOM refs and the logical lightning array.
+  // Shared between `_invalidateWaveCache()` (full memo reset on
+  // (re-)connect) and the post-`innerHTML` cleanup block in
+  // `_render()`. Mirrors qs-water-boiler-card.js:192-199.
+  _resetDomRefs() {
+    this._waveEls = null;
+    this._lightningLayerEl = null;
+    this._batteryOutlineEl = null;
+    this._lightning = [];
+  }
+
+  // QS-224: clear the wave-path memoization keys and cached DOM refs.
+  // Called on every (re-)connect and after each _render() innerHTML
+  // rewrite. Mirrors qs-water-boiler-card.js:209-213.
+  _invalidateWaveCache() {
+    this._lastWaterBaseY = null;
+    this._lastAmplitude = null;
+    this._resetDomRefs();
+  }
+
+  // QS-224: continuous RAF while connected, mirroring qs-water-boiler-card.js.
+  // The battery+water animation is intrinsically visible at all times
+  // (calm green when not charging, electric blue with lightning when
+  // charging) so RAF is no longer gated on `_charging`. Calm vs charging
+  // is amplitude / speed / color-mix lerp, not RAF on/off.
   _startAnimation() {
     if (this._animRaf != null) return;
+    // Initialize wave animation state ONLY on the first-ever connect
+    // so that detach/re-attach preserves _currentAmplitude /
+    // _currentSpeed / _wavePhase. Without this guard, a charging wave
+    // would visibly snap back to CALM on each reconnect and re-lerp
+    // up over ~1.5s. Mirrors qs-water-boiler-card.js:227-242.
+    if (this._currentAmplitude == null) {
+      this._currentAmplitude = CALM_AMP;
+      this._currentSpeed = CALM_SPEED;
+      this._wavePhase = 0;
+      this._currentColorMix = 0;
+      this._lightning = [];
+      this._nextLightningAt = 0;
+      this._needsAnimationPrime = true;
+    }
     this._lastAnimTs = null;
+    this._invalidateWaveCache();
+
     const step = (ts) => {
       if (!this.isConnected) { this._animRaf = null; return; }
-      if (!this._charging) {
-        // _charging went false between renders — stop the loop entirely
-        // rather than spin idle.
-        this._animOffset = 0;
-        this._lastAnimTs = null;
-        this._animRaf = null;
-        return;
-      }
       if (this._lastAnimTs == null) this._lastAnimTs = ts;
-      const dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
+      // Cap dt against hidden-tab return (S6 pattern from boiler /
+      // pool — bounds phase advance, lerp envelope, and lightning life
+      // by the same upper envelope).
+      let dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
+      dt = Math.min(dt, LERP_DT_CEIL);
       this._lastAnimTs = ts;
+
+      // --- Existing dashed-arc animation (preserved verbatim).
+      // The charging-progress dash still drives off `showAnimation`
+      // (applied as a render-time switch on `<path id="charge_anim">`).
+      // The RAF loop itself no longer gates on `_charging`.
       const patternLen = Math.max(8, this._animPatternLen || 64);
       const cp = this._chargePower || 0;
       const speed = Math.min(ANIM_MAX_SPEED, Math.max(ANIM_MIN_SPEED, ANIM_MIN_SPEED + (cp - ANIM_MIN_POWER_W) * ANIM_SPEED_RANGE / ANIM_POWER_RANGE));
       this._animOffset = ((this._animOffset || 0) + speed * dt) % patternLen;
-      const p = this._root?.getElementById('charge_anim');
-      if (p) {
-        p.setAttribute('stroke-dashoffset', String(-this._animOffset));
+      const dashEl = this._root?.getElementById('charge_anim');
+      if (dashEl) {
+        dashEl.setAttribute('stroke-dashoffset', String(-this._animOffset));
       }
+
+      // --- Lerp amplitude / speed / colorMix toward charging targets.
+      const charging = this._charging === true;
+      const targetAmplitude = charging ? CHARGING_AMP : CALM_AMP;
+      const targetSpeed     = charging ? CHARGING_SPEED : CALM_SPEED;
+      const targetColorMix  = charging ? 1 : 0;
+      const lerpFactor = 1 - Math.exp(-LERP_RATE * dt);
+      this._currentAmplitude += (targetAmplitude - this._currentAmplitude) * lerpFactor;
+      this._currentSpeed     += (targetSpeed     - this._currentSpeed)     * lerpFactor;
+      this._currentColorMix  += (targetColorMix  - this._currentColorMix)  * lerpFactor;
+      this._wavePhase += this._currentSpeed * dt;
+      this._wavePhase = ((this._wavePhase % PHASE_WRAP) + PHASE_WRAP) % PHASE_WRAP;
+
+      // Lazy-resolve wave / lightning layer / outline DOM refs once
+      // per innerHTML rewrite. Six wave nodes (3 idle + 3 charge pairs);
+      // the pair shares geometry, only `fill` differs.
+      if (!this._waveEls) {
+        const idle0   = this._root?.getElementById('wave0_idle') ?? null;
+        const charge0 = this._root?.getElementById('wave0_charge') ?? null;
+        const idle1   = this._root?.getElementById('wave1_idle') ?? null;
+        const charge1 = this._root?.getElementById('wave1_charge') ?? null;
+        const idle2   = this._root?.getElementById('wave2_idle') ?? null;
+        const charge2 = this._root?.getElementById('wave2_charge') ?? null;
+        this._waveEls = [idle0, charge0, idle1, charge1, idle2, charge2];
+      }
+      const lightningLayer = this._lightningLayerEl
+        ?? (this._lightningLayerEl = this._lightningLayerId
+              ? (this._root?.getElementById(this._lightningLayerId) ?? null)
+              : null);
+      const outlineEl = this._batteryOutlineEl
+        ?? (this._batteryOutlineEl = this._root?.getElementById('battery_outline') ?? null);
+
+      // --- Wave transforms (per-layer translateX).
+      for (let i = 0; i < 3; i++) {
+        const phaseOffset = i * LAYER_SCROLL_OFFSET;
+        const raw = (this._wavePhase + phaseOffset) * PHASE_TO_PX;
+        const scrollOffset = ((raw % WAVE_WIDTH) + WAVE_WIDTH) % WAVE_WIDTH;
+        // Align path start with the battery body left edge, then
+        // scroll within one period. The path extent is [0, 2*WAVE_WIDTH]
+        // so any scroll value still covers the visible body.
+        const tx = BATTERY_BODY_LEFT_X - WAVE_WIDTH - scrollOffset;
+        const txStr = `translateX(${tx.toFixed(1)}px)`;
+        const idleEl   = this._waveEls[i * 2];
+        const chargeEl = this._waveEls[i * 2 + 1];
+        if (idleEl)   idleEl.style.transform = txStr;
+        if (chargeEl) chargeEl.style.transform = txStr;
+      }
+
+      // --- Wave path regen (throttled by amplitude / water-level delta).
+      const waterBaseY = this._waterBaseY;
+      const hasValidBase = waterBaseY != null && !Number.isNaN(waterBaseY);
+      const ampDelta = this._lastAmplitude == null
+          ? Infinity
+          : Math.abs(this._currentAmplitude - this._lastAmplitude);
+      const levelChanged = hasValidBase &&
+          Math.abs(waterBaseY - (this._lastWaterBaseY ?? Number.NEGATIVE_INFINITY)) > LEVEL_REGEN_THRESHOLD;
+      if (hasValidBase && (levelChanged || ampDelta > AMP_REGEN_THRESHOLD)) {
+        this._lastWaterBaseY = waterBaseY;
+        this._lastAmplitude = this._currentAmplitude;
+        for (let i = 0; i < 3; i++) {
+          const phaseOffset = i * LAYER_PHASE_OFFSET;
+          const freq = 2 + i;
+          const d = this._generateWavePath(WAVE_WIDTH, this._currentAmplitude, freq, phaseOffset, waterBaseY);
+          const idleEl   = this._waveEls[i * 2];
+          const chargeEl = this._waveEls[i * 2 + 1];
+          if (idleEl)   idleEl.setAttribute('d', d);
+          if (chargeEl) chargeEl.setAttribute('d', d);
+        }
+      }
+
+      // --- Per-frame wave opacity update (idle ↔ charge cross-fade).
+      // Per-PATH opacity (NOT group opacity on parent <g>) per AC-3.
+      const idleOpacity   = (1 - this._currentColorMix).toFixed(3);
+      const chargeOpacity = this._currentColorMix.toFixed(3);
+      for (let i = 0; i < 3; i++) {
+        const idleEl   = this._waveEls[i * 2];
+        const chargeEl = this._waveEls[i * 2 + 1];
+        if (idleEl)   idleEl.setAttribute('opacity', idleOpacity);
+        if (chargeEl) chargeEl.setAttribute('opacity', chargeOpacity);
+      }
+
+      // --- Battery outline alpha lerp (idle 0.30 → charging 0.55).
+      // JS rgba interpolation (NOT CSS color-mix, for browser compat).
+      if (outlineEl) {
+        const outlineAlpha = BATTERY_OUTLINE_STROKE_IDLE_ALPHA
+          + this._currentColorMix
+            * (BATTERY_OUTLINE_STROKE_CHARGING_ALPHA - BATTERY_OUTLINE_STROKE_IDLE_ALPHA);
+        outlineEl.setAttribute('stroke', `rgba(255,255,255,${outlineAlpha.toFixed(3)})`);
+      }
+
+      // === QS-224 lightning particle system: charging-only spawn,
+      // HARD CAP at MAX_CONCURRENT_LIGHTNING. Advance + retire runs
+      // unconditionally so bolts in flight when charging→false
+      // continue their life curve and retire naturally.
+      if (lightningLayer) {
+        if (charging) {
+          this._nextLightningAt -= dt;
+          while (this._nextLightningAt <= 0
+                 && this._lightning.length < MAX_CONCURRENT_LIGHTNING) {
+            const h = LIGHTNING_HEIGHT_MIN_PX
+                    + Math.random() * (LIGHTNING_HEIGHT_MAX_PX - LIGHTNING_HEIGHT_MIN_PX);
+            const cxStart = BATTERY_BODY_LEFT_X + 10
+                          + Math.random() * (BATTERY_BODY_WIDTH - 20);
+            const cyStart = BATTERY_BODY_TOP_Y + 5
+                          + Math.random() * (BATTERY_BODY_HEIGHT - h - 10);
+            // Build zigzag points: 5 vertices, alternating
+            // ±LIGHTNING_ZIGZAG_AMPLITUDE_PX.
+            const points = [];
+            for (let i = 0; i <= LIGHTNING_SEGMENTS; i++) {
+              const t = i / LIGHTNING_SEGMENTS;
+              const dx = (i % 2 === 0 ? 1 : -1) * LIGHTNING_ZIGZAG_AMPLITUDE_PX;
+              points.push(`${(cxStart + dx).toFixed(2)},${(cyStart + t * h).toFixed(2)}`);
+            }
+            // createElementNS REQUIRED for SVG inside a Shadow DOM
+            // (matches boiler bubble/steam precedent).
+            const el = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+            el.setAttribute('points', points.join(' '));
+            el.setAttribute('fill', 'none');
+            el.setAttribute('stroke', LIGHTNING_STROKE_COLOR);
+            el.setAttribute('stroke-width', String(LIGHTNING_STROKE_WIDTH));
+            el.setAttribute('stroke-linejoin', 'round');
+            el.setAttribute('stroke-linecap', 'round');
+            el.setAttribute('pointer-events', 'none');
+            el.setAttribute('opacity', '0');
+            lightningLayer.appendChild(el);
+            this._lightning.push({ el, life: 0, maxLife: LIGHTNING_LIFE_S });
+            this._nextLightningAt += 1 / LIGHTNING_SPAWN_RATE_HZ;
+          }
+          if (this._nextLightningAt < 0) this._nextLightningAt = 0;
+        }
+
+        // Advance + retire — graceful exit on charging→false.
+        const aliveLightning = [];
+        for (const b of this._lightning) {
+          b.life += dt;
+          if (b.life >= b.maxLife) { b.el.remove(); continue; }
+          const lifeT = b.life / b.maxLife;
+          let lifeOpacity;
+          if (lifeT < LIGHTNING_FADE_IN_FRACTION) {
+            lifeOpacity = lifeT / LIGHTNING_FADE_IN_FRACTION;
+          } else if (lifeT < LIGHTNING_FADE_OUT_FRACTION) {
+            lifeOpacity = 1;
+          } else {
+            lifeOpacity = Math.max(
+              0,
+              1 - (lifeT - LIGHTNING_FADE_OUT_FRACTION) / (1 - LIGHTNING_FADE_OUT_FRACTION),
+            );
+          }
+          b.el.setAttribute('opacity', (lifeOpacity * this._currentColorMix).toFixed(3));
+          aliveLightning.push(b);
+        }
+        this._lightning = aliveLightning;
+      }
+
       this._animRaf = requestAnimationFrame(step);
     };
     this._animRaf = requestAnimationFrame(step);
@@ -60,8 +428,14 @@ class QsCarCard extends HTMLElement {
   }
 
   connectedCallback() {
-    // RAF intentionally NOT started here — _render() calls
-    // _startAnimation() when `_charging` is true.
+    // QS-224: continuous RAF while connected, mirroring
+    // qs-water-boiler-card.js / qs-pool-card.js. The battery+water
+    // animation is intrinsically visible at all times (calm green when
+    // not charging, electric blue with lightning when charging) so RAF
+    // is no longer gated on `_charging`. See AC-7 in
+    // docs/stories/QS-224.story.md and the QS-224 paragraph in
+    // docs/agents/concepts/dashboard-and-cards.md.
+    this._startAnimation();
   }
 
   disconnectedCallback() {
@@ -73,6 +447,10 @@ class QsCarCard extends HTMLElement {
     this._isInteractingPerson = false;
     this._isInteractingTarget = false;
     this._modalOpen = false;
+    // QS-224: eagerly tear down lightning DOM nodes. Mirrors
+    // qs-water-boiler-card.js:637-644.
+    this._lightning?.forEach(b => b.el?.remove?.());
+    this._lightning = [];
   }
   static getStubConfig() {
     return { name: "QS Car", entities: {} };
@@ -166,13 +544,11 @@ class QsCarCard extends HTMLElement {
       const target = selLimit?.state || "";
       const charging = (Number(power) > 50);
       this._charging = charging;
-      // M4: start/stop the RAF loop based on whether the car is actually
-      // charging. Idle cards consume zero per-frame work.
-      if (charging) {
-        this._startAnimation();
-      } else {
-        this._stopAnimation();
-      }
+      // QS-224: continuous RAF while connected — the battery+water
+      // animation must keep ticking gently (calm green waves) even
+      // when idle, and the charging state is reflected via
+      // amplitude/speed/colorMix lerp inside the RAF step function.
+      // The RAF loop is started in `connectedCallback()`.
       const carChargeTypeIcons = {
           "Unknown": "mdi:help-circle-outline",
           "Not Plugged": "mdi:power-plug-off",
@@ -547,6 +923,53 @@ class QsCarCard extends HTMLElement {
       //const displayTitle = showForecastedPerson ? `${title} (${forecastedPersonStr})` : title;
       const displayTitle = title;
 
+      // === QS-224 battery+water layer ============================
+      // Water level from SOC (same value the SOC arc uses — no
+      // raw-SOC bypass of the stale-percent override). The issue's
+      // literal "+1/5 / −1/5 of diameter" rule maps to the pool's
+      // `(0.2 + ratio × 0.6)` formula applied to the battery body.
+      const progressRatio = Math.max(0, Math.min(1, soc / 100));
+      const waterBaseY = BATTERY_BOTTOM_Y
+                       - (0.2 + progressRatio * 0.6) * BATTERY_BODY_HEIGHT;
+      this._waterBaseY = waterBaseY;
+
+      // QS-224: prime the wave animation state to the actual charging
+      // targets on the first render after connect, avoiding the
+      // ~1.5s boot transient. Mirror qs-water-boiler-card.js:1072-1077.
+      if (this._needsAnimationPrime) {
+        this._currentAmplitude = charging ? CHARGING_AMP : CALM_AMP;
+        this._currentSpeed     = charging ? CHARGING_SPEED : CALM_SPEED;
+        this._currentColorMix  = charging ? 1 : 0;
+        this._needsAnimationPrime = false;
+      }
+
+      // QS-224: pre-generate the 3 initial wave path `d` strings so
+      // the SVG renders with water immediately, avoiding an empty-`d`
+      // flash between the innerHTML rewrite and the first RAF tick.
+      // The idle/charge siblings of each layer share the same `d`.
+      const initialAmp = this._currentAmplitude ?? CALM_AMP;
+      const initialColorMix = this._currentColorMix ?? 0;
+      const initialWavePaths = [0, 1, 2].map(i => {
+        const freq = 2 + i;
+        const phaseOffset = i * LAYER_PHASE_OFFSET;
+        return this._generateWavePath(WAVE_WIDTH, initialAmp, freq, phaseOffset, waterBaseY);
+      });
+      const initialIdleOpacity   = (1 - initialColorMix).toFixed(3);
+      const initialChargeOpacity = initialColorMix.toFixed(3);
+      const initialOutlineStrokeAlpha = BATTERY_OUTLINE_STROKE_IDLE_ALPHA
+        + initialColorMix
+          * (BATTERY_OUTLINE_STROKE_CHARGING_ALPHA - BATTERY_OUTLINE_STROKE_IDLE_ALPHA);
+
+      // Per-instance unique SVG ids (mirror gradGreenId / gradChargeId
+      // pattern at lines 884-888) so two car cards on the same
+      // dashboard don't collide on clipPath / filter / layer ids.
+      const batteryClipId    = `batClip-${Math.floor(Math.random() * 1e6)}`;
+      const lightningGlowId  = `lightG-${Math.floor(Math.random() * 1e6)}`;
+      const lightningLayerId = `lightL-${Math.floor(Math.random() * 1e6)}`;
+      this._lightningLayerId = lightningLayerId;
+      const batteryBodyClipD = this._generateBatteryBodyClipPath();
+      const batteryOutlineD  = this._generateBatteryOutlinePath();
+
       this._root.innerHTML = `
       <ha-card class="card ${isDisconnected ? 'disabled' : ''} ${isFaulted ? 'fault' : ''} ${isOffGrid ? 'off-grid' : ''} ${isStale ? 'stale' : ''}">
         <style>${css}</style>
@@ -584,7 +1007,32 @@ class QsCarCard extends HTMLElement {
                     <feMergeNode in="SourceGraphic" />
                   </feMerge>
                 </filter>
+                <clipPath id="${batteryClipId}">
+                  <path d="${batteryBodyClipD}" />
+                </clipPath>
+                <filter id="${lightningGlowId}" x="-50%" y="-50%" width="200%" height="200%">
+                  <feGaussianBlur stdDeviation="${LIGHTNING_GLOW_STDDEV}" result="blur" />
+                  <feFlood flood-color="${LIGHTNING_GLOW_COLOR}" flood-opacity="1" />
+                  <feComposite in2="blur" operator="in" result="glow" />
+                  <feMerge>
+                    <feMergeNode in="glow" />
+                    <feMergeNode in="SourceGraphic" />
+                  </feMerge>
+                </filter>
               </defs>
+              <g clip-path="url(#${batteryClipId})">
+                <path id="wave0_idle"   d="${initialWavePaths[0]}" fill="${IDLE_WATER_COLORS[0]}"     opacity="${initialIdleOpacity}"   pointer-events="none" style="will-change: transform;" />
+                <path id="wave0_charge" d="${initialWavePaths[0]}" fill="${CHARGING_WATER_COLORS[0]}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
+                <path id="wave1_idle"   d="${initialWavePaths[1]}" fill="${IDLE_WATER_COLORS[1]}"     opacity="${initialIdleOpacity}"   pointer-events="none" style="will-change: transform;" />
+                <path id="wave1_charge" d="${initialWavePaths[1]}" fill="${CHARGING_WATER_COLORS[1]}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
+                <path id="wave2_idle"   d="${initialWavePaths[2]}" fill="${IDLE_WATER_COLORS[2]}"     opacity="${initialIdleOpacity}"   pointer-events="none" style="will-change: transform;" />
+                <path id="wave2_charge" d="${initialWavePaths[2]}" fill="${CHARGING_WATER_COLORS[2]}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
+                <g id="${lightningLayerId}" filter="url(#${lightningGlowId})" pointer-events="none"></g>
+              </g>
+              <path id="battery_outline" d="${batteryOutlineD}" fill="none"
+                    stroke="rgba(255,255,255,${initialOutlineStrokeAlpha.toFixed(3)})"
+                    stroke-width="${BATTERY_OUTLINE_STROKE_WIDTH}"
+                    stroke-linejoin="round" pointer-events="none" />
               <path d="${bgPath}" stroke="${isFaulted ? 'rgba(244,67,54,0.35)' : 'var(--divider-color)'}" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${socPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
               ${showAnimation ? `
@@ -655,6 +1103,24 @@ class QsCarCard extends HTMLElement {
         </div>
       </ha-card>
     `;
+
+      // QS-224: innerHTML rewrite detached the previous wave / outline
+      // / lightning DOM nodes. Sync RAF's memo keys to the rendered
+      // state (prevents a redundant regen on the next frame) and null
+      // the cached DOM refs so RAF re-resolves them lazily. The new
+      // wave nodes already carry the freshly-generated `d`
+      // (initialWavePaths) and the correct `fill`
+      // (IDLE_/CHARGING_WATER_COLORS), so the next RAF tick can
+      // proceed without an extra regen.
+      this._lastWaterBaseY = this._waterBaseY;
+      this._lastAmplitude  = initialAmp;
+      this._waveEls = null;
+      this._lightningLayerEl = null;
+      this._batteryOutlineEl = null;
+      // Lightning nodes from the previous render were detached; clear
+      // the logical array so the next spawn cycle starts clean (mirrors
+      // the boiler bubble-array reset on innerHTML rewrite).
+      this._lightning = [];
 
       // old buttons:
 /*      <div className="below-line">

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -46,19 +46,21 @@ const LAYER_SCROLL_OFFSET = 1.2;                             // per-layer extra 
 const LAYER_PHASE_OFFSET  = 2.1;                             // per-layer static sine phase
 
 // Water palettes — opacity cross-fade between idle/green and charging/blue.
-// IDLE family: hue 150 (green; matches the gradGreenId cyan→green
-// gradient direction). CHARGING family: hue 205 (blue; matches the
-// gradChargeId cyan→deep-blue gradient direction). Lightness/alpha
-// step down per layer for depth.
+// Review-fix #01 FX-01 + FX-02: collapsed from 3 layers to 1 with a
+// BRIGHT (lightness ≥ 85%) + VERY TRANSLUCENT (alpha ≤ 0.35) palette.
+// The original mid-saturation mid-lightness 3-layer stack read as a
+// dark muddy green and obscured the SOC arc; the user wants the
+// water to read as "fresh / lively" and the existing ring + SOC
+// arc to remain clearly visible THROUGH the water. The single-layer
+// design avoids the multi-path overlay density that defeated the
+// "very translucent" goal. Loop counts in `_render()` and
+// `_startAnimation()` are driven by `IDLE_WATER_COLORS.length` so
+// adding entries back later is a one-line change.
 const IDLE_WATER_COLORS = [
-  'hsla(150, 60%, 35%, 0.55)',
-  'hsla(150, 60%, 30%, 0.45)',
-  'hsla(150, 60%, 25%, 0.35)',
+  'hsla(135, 95%, 88%, 0.30)',   // bright vibrant green, very translucent
 ];
 const CHARGING_WATER_COLORS = [
-  'hsla(205, 80%, 40%, 0.60)',
-  'hsla(205, 80%, 35%, 0.50)',
-  'hsla(205, 80%, 30%, 0.40)',
+  'hsla(205, 95%, 88%, 0.32)',   // bright sky-blue, slightly more present while charging
 ];
 
 // Animation tuning — mirror the boiler exactly (gentle calm, more
@@ -98,9 +100,20 @@ const LIGHTNING_FADE_OUT_FRACTION = 0.7;                     // 0.2 → 0.7 hold
 
 // Battery outline appearance — alpha lerped between idle/charging via
 // JS rgba interpolation (NOT CSS color-mix, for browser compat).
-const BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.30;
-const BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.55;
-const BATTERY_OUTLINE_STROKE_WIDTH = 2;
+// Review-fix #01 FX-03: the user reported the outline was invisible
+// against the ring and the (post-FX-01 brighter) water. Three knobs
+// were tuned together:
+//   1. STROKE color swapped from near-white `rgba(255,255,255,…)` to
+//      a neutral grey `rgba(180,180,180,…)` so the silhouette reads
+//      against both the ring and the bright translucent water.
+//   2. STROKE_WIDTH widened from a literal `2` to `MDI_UNIT_PX`
+//      (= 1 mdi-unit ≈ 7.8 px) — the canonical mdi:battery-outline
+//      stroke ratio (1/12 of body width).
+//   3. ALPHA range bumped from `0.30 / 0.55` to `0.55 / 0.80` so the
+//      wider grey stroke reads at idle and pops while charging.
+const BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.55;
+const BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.80;
+const BATTERY_OUTLINE_STROKE_WIDTH = MDI_UNIT_PX;
 
 class QsCarCard extends HTMLElement {
   constructor() {
@@ -275,27 +288,45 @@ class QsCarCard extends HTMLElement {
       this._wavePhase += this._currentSpeed * dt;
       this._wavePhase = ((this._wavePhase % PHASE_WRAP) + PHASE_WRAP) % PHASE_WRAP;
 
-      // Lazy-resolve wave / lightning layer / outline DOM refs once
-      // per innerHTML rewrite. Six wave nodes (3 idle + 3 charge pairs);
-      // the pair shares geometry, only `fill` differs.
-      if (!this._waveEls) {
-        const idle0   = this._root?.getElementById('wave0_idle') ?? null;
-        const charge0 = this._root?.getElementById('wave0_charge') ?? null;
-        const idle1   = this._root?.getElementById('wave1_idle') ?? null;
-        const charge1 = this._root?.getElementById('wave1_charge') ?? null;
-        const idle2   = this._root?.getElementById('wave2_idle') ?? null;
-        const charge2 = this._root?.getElementById('wave2_charge') ?? null;
-        this._waveEls = [idle0, charge0, idle1, charge1, idle2, charge2];
+      // Lazy-resolve wave / lightning layer / outline DOM refs.
+      // Review-fix #01 FX-07: the resolve guard checks `null` on
+      // EACH cached entry (not just the array's existence) — if the
+      // first RAF tick lands before `_render()` populates the
+      // shadow root, every `getElementById` returns `null` and the
+      // resulting all-nulls array is truthy, which would lock the
+      // cache permanently. Re-querying when any entry is null
+      // covers the eager-RAF case (and is idempotent once the refs
+      // are populated). The layer-count loop is driven by
+      // `IDLE_WATER_COLORS.length` per FX-02.
+      const waveLayerCount = IDLE_WATER_COLORS.length;
+      if (!this._waveEls || this._waveEls.some(el => el == null)) {
+        const refs = [];
+        for (let i = 0; i < waveLayerCount; i++) {
+          refs.push(this._root?.getElementById(`wave${i}_idle`) ?? null);
+          refs.push(this._root?.getElementById(`wave${i}_charge`) ?? null);
+        }
+        this._waveEls = refs;
       }
-      const lightningLayer = this._lightningLayerEl
-        ?? (this._lightningLayerEl = this._lightningLayerId
-              ? (this._root?.getElementById(this._lightningLayerId) ?? null)
-              : null);
-      const outlineEl = this._batteryOutlineEl
-        ?? (this._batteryOutlineEl = this._root?.getElementById('battery_outline') ?? null);
+      // Same null-recheck idiom for `_lightningLayerEl` and
+      // `_batteryOutlineEl` — the prior `el ?? (el = …)` pattern
+      // re-ran `getElementById` every frame when the result was
+      // `null` (assignment-as-cache short-circuits to the truthy
+      // result only). The explicit null check is clearer.
+      if (this._lightningLayerEl == null && this._lightningLayerId) {
+        this._lightningLayerEl =
+          this._root?.getElementById(this._lightningLayerId) ?? null;
+      }
+      const lightningLayer = this._lightningLayerEl;
+      if (this._batteryOutlineEl == null) {
+        this._batteryOutlineEl =
+          this._root?.getElementById('battery_outline') ?? null;
+      }
+      const outlineEl = this._batteryOutlineEl;
 
       // --- Wave transforms (per-layer translateX).
-      for (let i = 0; i < 3; i++) {
+      // Loop bound from `waveLayerCount = IDLE_WATER_COLORS.length`
+      // (FX-02) — same idiom for the regen and opacity loops below.
+      for (let i = 0; i < waveLayerCount; i++) {
         const phaseOffset = i * LAYER_SCROLL_OFFSET;
         const raw = (this._wavePhase + phaseOffset) * PHASE_TO_PX;
         const scrollOffset = ((raw % WAVE_WIDTH) + WAVE_WIDTH) % WAVE_WIDTH;
@@ -321,7 +352,7 @@ class QsCarCard extends HTMLElement {
       if (hasValidBase && (levelChanged || ampDelta > AMP_REGEN_THRESHOLD)) {
         this._lastWaterBaseY = waterBaseY;
         this._lastAmplitude = this._currentAmplitude;
-        for (let i = 0; i < 3; i++) {
+        for (let i = 0; i < waveLayerCount; i++) {
           const phaseOffset = i * LAYER_PHASE_OFFSET;
           const freq = 2 + i;
           const d = this._generateWavePath(WAVE_WIDTH, this._currentAmplitude, freq, phaseOffset, waterBaseY);
@@ -336,20 +367,23 @@ class QsCarCard extends HTMLElement {
       // Per-PATH opacity (NOT group opacity on parent <g>) per AC-3.
       const idleOpacity   = (1 - this._currentColorMix).toFixed(3);
       const chargeOpacity = this._currentColorMix.toFixed(3);
-      for (let i = 0; i < 3; i++) {
+      for (let i = 0; i < waveLayerCount; i++) {
         const idleEl   = this._waveEls[i * 2];
         const chargeEl = this._waveEls[i * 2 + 1];
         if (idleEl)   idleEl.setAttribute('opacity', idleOpacity);
         if (chargeEl) chargeEl.setAttribute('opacity', chargeOpacity);
       }
 
-      // --- Battery outline alpha lerp (idle 0.30 → charging 0.55).
+      // --- Battery outline alpha lerp (idle 0.55 → charging 0.80).
+      // Review-fix #01 FX-03: stroke RGB is `180,180,180` (neutral
+      // grey) — was `255,255,255` (white) — and the alpha range is
+      // wider so the (also-widened) stroke is always readable.
       // JS rgba interpolation (NOT CSS color-mix, for browser compat).
       if (outlineEl) {
         const outlineAlpha = BATTERY_OUTLINE_STROKE_IDLE_ALPHA
           + this._currentColorMix
             * (BATTERY_OUTLINE_STROKE_CHARGING_ALPHA - BATTERY_OUTLINE_STROKE_IDLE_ALPHA);
-        outlineEl.setAttribute('stroke', `rgba(255,255,255,${outlineAlpha.toFixed(3)})`);
+        outlineEl.setAttribute('stroke', `rgba(180,180,180,${outlineAlpha.toFixed(3)})`);
       }
 
       // === QS-224 lightning particle system: charging-only spawn,
@@ -390,7 +424,16 @@ class QsCarCard extends HTMLElement {
             this._lightning.push({ el, life: 0, maxLife: LIGHTNING_LIFE_S });
             this._nextLightningAt += 1 / LIGHTNING_SPAWN_RATE_HZ;
           }
-          if (this._nextLightningAt < 0) this._nextLightningAt = 0;
+          // Review-fix #01 FX-06: ONLY clamp when not capped, so the
+          // accumulated spawn debt is preserved across cap-blocked
+          // frames and a freed slot is filled immediately. Previously
+          // the unconditional clamp discarded the debt when the cap
+          // was hit, making the next post-retire spawn wait the full
+          // `1/SPAWN_RATE_HZ` window.
+          if (this._lightning.length < MAX_CONCURRENT_LIGHTNING
+              && this._nextLightningAt < 0) {
+            this._nextLightningAt = 0;
+          }
         }
 
         // Advance + retire — graceful exit on charging→false.
@@ -936,20 +979,31 @@ class QsCarCard extends HTMLElement {
       // QS-224: prime the wave animation state to the actual charging
       // targets on the first render after connect, avoiding the
       // ~1.5s boot transient. Mirror qs-water-boiler-card.js:1072-1077.
-      if (this._needsAnimationPrime) {
+      // Review-fix #01 FX-05: also prime when `_currentAmplitude` is
+      // still uninitialised — the very first `_render` is called by
+      // `setConfig` BEFORE `connectedCallback → _startAnimation`
+      // initialises any animation state, so `_needsAnimationPrime`
+      // is still `undefined` on that path. Without the
+      // `|| _currentAmplitude == null` clause, an actively-charging
+      // car shows calm green on its very first paint and only the
+      // second `_render` snaps to charging.
+      if (this._needsAnimationPrime || this._currentAmplitude == null) {
         this._currentAmplitude = charging ? CHARGING_AMP : CALM_AMP;
         this._currentSpeed     = charging ? CHARGING_SPEED : CALM_SPEED;
         this._currentColorMix  = charging ? 1 : 0;
         this._needsAnimationPrime = false;
       }
 
-      // QS-224: pre-generate the 3 initial wave path `d` strings so
+      // QS-224: pre-generate the initial wave path `d` strings so
       // the SVG renders with water immediately, avoiding an empty-`d`
       // flash between the innerHTML rewrite and the first RAF tick.
       // The idle/charge siblings of each layer share the same `d`.
+      // Review-fix #01 FX-02: layer count driven by
+      // `IDLE_WATER_COLORS.length` (= 1 today) so a future palette
+      // tweak that re-adds layers doesn't require touching the loop.
       const initialAmp = this._currentAmplitude ?? CALM_AMP;
       const initialColorMix = this._currentColorMix ?? 0;
-      const initialWavePaths = [0, 1, 2].map(i => {
+      const initialWavePaths = IDLE_WATER_COLORS.map((_color, i) => {
         const freq = 2 + i;
         const phaseOffset = i * LAYER_PHASE_OFFSET;
         return this._generateWavePath(WAVE_WIDTH, initialAmp, freq, phaseOffset, waterBaseY);
@@ -969,6 +1023,20 @@ class QsCarCard extends HTMLElement {
       this._lightningLayerId = lightningLayerId;
       const batteryBodyClipD = this._generateBatteryBodyClipPath();
       const batteryOutlineD  = this._generateBatteryOutlinePath();
+
+      // Review-fix #01 FX-04: snapshot in-flight lightning bolts AND
+      // the spawn cadence counter BEFORE the innerHTML rewrite below.
+      // The rewrite detaches every DOM node under `this._root`,
+      // including the `<polyline>`s appended to the lightning layer.
+      // Without this snapshot, every HA state push during charging
+      // wiped all in-flight bolts simultaneously (the "particles all
+      // disappear at the exact same time" symptom QS-214 fixed on
+      // the boiler card). The `b.el` references survive detachment
+      // (JS still holds them); they get re-attached to the new
+      // layer below. Mirrors qs-water-boiler-card.js:1216-1219 for
+      // the snapshot side and 1418-1437 for the restore side.
+      const preservedLightning = this._lightning;
+      const preservedNextLightningAt = this._nextLightningAt;
 
       this._root.innerHTML = `
       <ha-card class="card ${isDisconnected ? 'disabled' : ''} ${isFaulted ? 'fault' : ''} ${isOffGrid ? 'off-grid' : ''} ${isStale ? 'stale' : ''}">
@@ -1023,10 +1091,6 @@ class QsCarCard extends HTMLElement {
               <g clip-path="url(#${batteryClipId})">
                 <path id="wave0_idle"   d="${initialWavePaths[0]}" fill="${IDLE_WATER_COLORS[0]}"     opacity="${initialIdleOpacity}"   pointer-events="none" style="will-change: transform;" />
                 <path id="wave0_charge" d="${initialWavePaths[0]}" fill="${CHARGING_WATER_COLORS[0]}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
-                <path id="wave1_idle"   d="${initialWavePaths[1]}" fill="${IDLE_WATER_COLORS[1]}"     opacity="${initialIdleOpacity}"   pointer-events="none" style="will-change: transform;" />
-                <path id="wave1_charge" d="${initialWavePaths[1]}" fill="${CHARGING_WATER_COLORS[1]}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
-                <path id="wave2_idle"   d="${initialWavePaths[2]}" fill="${IDLE_WATER_COLORS[2]}"     opacity="${initialIdleOpacity}"   pointer-events="none" style="will-change: transform;" />
-                <path id="wave2_charge" d="${initialWavePaths[2]}" fill="${CHARGING_WATER_COLORS[2]}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
                 <g id="${lightningLayerId}" filter="url(#${lightningGlowId})" pointer-events="none"></g>
               </g>
               <path id="battery_outline" d="${batteryOutlineD}" fill="none"
@@ -1117,10 +1181,37 @@ class QsCarCard extends HTMLElement {
       this._waveEls = null;
       this._lightningLayerEl = null;
       this._batteryOutlineEl = null;
-      // Lightning nodes from the previous render were detached; clear
-      // the logical array so the next spawn cycle starts clean (mirrors
-      // the boiler bubble-array reset on innerHTML rewrite).
-      this._lightning = [];
+
+      // Review-fix #01 FX-04: restore the preserved lightning bolts
+      // into the FRESH lightning layer. Their DOM identity changed
+      // via innerHTML (same `id`, new element); for each preserved
+      // bolt, re-attach its detached `el` to the new layer. The
+      // per-frame state (life, maxLife) survived in the JS array, so
+      // the RAF advance loop picks up exactly where it left off with
+      // no visual blink. The spawn cadence counter is also restored
+      // so the next spawn doesn't reset to 0 (which would burst-
+      // spawn up to the cap on every HA state push). If no layer
+      // exists in the fresh markup (defensive — e.g. a future
+      // template change removed it), drop the preserved bolts via
+      // explicit `el.remove()` so detached DOM nodes don't leak.
+      if (preservedLightning?.length) {
+        const newLightningLayer = this._lightningLayerId
+          ? this._root.getElementById(this._lightningLayerId)
+          : null;
+        if (newLightningLayer) {
+          for (const b of preservedLightning) {
+            if (b?.el) newLightningLayer.appendChild(b.el);
+          }
+          this._lightning = preservedLightning.filter(b => b?.el);
+          this._lightningLayerEl = newLightningLayer;
+          this._nextLightningAt = preservedNextLightningAt;
+        } else {
+          for (const b of preservedLightning) { b?.el?.remove(); }
+          this._lightning = [];
+        }
+      } else {
+        this._lightning = [];
+      }
 
       // old buttons:
 /*      <div className="below-line">

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -403,24 +403,42 @@ boiler card's continuous-RAF model and renders an
 300×300 ring. The battery vertically spans the user-anchored "+1/5 /
 −1/5 of diameter" rule (`BATTERY_TOTAL_HEIGHT = 156` SVG-px, body
 12:18 mdi proportions preserved). The battery body interior is a
-rounded-rect `<clipPath>` containing three sine-wave layers as in
-the pool card: two siblings per layer (`wave{0,1,2}_idle` in
-green-family hsla, `wave{0,1,2}_charge` in blue-family hsla),
-cross-faded via per-path opacity from `_currentColorMix`
-(`1 − colorMix` for idle, `colorMix` for charging) — the same
-opacity cross-fade mechanism QS-200 introduced on the boiler. The
-amplitude/speed lerp mirrors the boiler (`CALM_AMP=1.5`,
-`CHARGING_AMP=8`, `CALM_SPEED=0.1`, `CHARGING_SPEED=0.4`). A
-combined body+terminal `<path id="battery_outline">` is drawn after
-the clipped water group with `fill="none"` and stroke alpha lerped
-from 0.30 (idle) to 0.55 (charging) so the silhouette is always
-visible. A charging-only lightning particle system (hard cap
+rounded-rect `<clipPath>` containing a single sine-wave layer
+(two `<path>` siblings — `wave0_idle` in green-family hsla,
+`wave0_charge` in blue-family hsla, cross-faded via per-path
+opacity from `_currentColorMix`). The single-layer design (driven
+off `IDLE_WATER_COLORS.length`) is a review-fix #01 collapse from
+the original 3-layer stack: with the bright translucent palette
+(lightness ≥ 85 %, alpha ≤ 0.35) the user reported the multi-layer
+stack as dark / muddy and obscuring the SOC arc; the single layer
+preserves the cross-fade machinery while keeping the water "very
+translucent" so the ring and arc read through it cleanly. The
+amplitude / speed / colorMix lerp envelope mirrors the boiler
+(`CALM_AMP=1.5`, `CHARGING_AMP=8`, `CALM_SPEED=0.1`,
+`CHARGING_SPEED=0.4`). A combined body+terminal
+`<path id="battery_outline">` is drawn after the clipped water
+group; its stroke is a wide neutral grey
+(`rgba(180,180,180,${alpha})`, `BATTERY_OUTLINE_STROKE_WIDTH =
+MDI_UNIT_PX ≈ 7.8 px`, the canonical mdi:battery-outline 1/12 of
+body-width ratio) with alpha lerped from 0.55 (idle) to 0.80
+(charging) so the silhouette reads against both the ring and the
+bright translucent water — a review-fix #01 retune from the
+original 2-px near-white outline that the user reported as
+invisible. A charging-only lightning particle system (hard cap
 `MAX_CONCURRENT_LIGHTNING=3`, spawn `LIGHTNING_SPAWN_RATE_HZ=3`,
 life 0.5 s with a piecewise-linear 0/0.2/0.7/1.0 opacity curve)
 spawns `<polyline>` zigzag bolts inside the same clipPath as the
 water — white core with a blue Gaussian-blur glow filter applied to
 the layer group (NOT per polyline), mirroring the boiler steam
-subsystem. Per-instance unique SVG ids
+subsystem. The post-spawn-loop debt clamp is guarded by the cap
+check (`if (length < cap && _nextLightningAt < 0)`) so accumulated
+spawn debt is preserved across cap-blocked frames and a freed slot
+fills immediately — review-fix #01 fix for the original
+unconditional clamp that desynced the spawn rhythm. Lightning bolts
+ALSO survive `_render()` innerHTML rewrites via a snapshot/restore
+pattern (mirror of QS-214's boiler bubble/steam preservation): each
+HA state push during charging would otherwise wipe every in-flight
+bolt simultaneously. Per-instance unique SVG ids
 (`batteryClipId`/`lightningGlowId`/`lightningLayerId`) use the
 existing `Math.floor(Math.random() * 1e6)` pattern. The new layer
 slots between `</defs>` and the gauge background `<path

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -397,6 +397,37 @@ several internal refactors:
   `qs-pool-card.js`'s `dt` cap documents the trade-off: cross-card
   consistency over the prior "catch up after hidden tab" behavior.
 
+**QS-224 — car card battery backdrop.** The car card adopts the
+boiler card's continuous-RAF model and renders an
+`mdi:battery-outline`-shaped translucent overlay inside the existing
+300×300 ring. The battery vertically spans the user-anchored "+1/5 /
+−1/5 of diameter" rule (`BATTERY_TOTAL_HEIGHT = 156` SVG-px, body
+12:18 mdi proportions preserved). The battery body interior is a
+rounded-rect `<clipPath>` containing three sine-wave layers as in
+the pool card: two siblings per layer (`wave{0,1,2}_idle` in
+green-family hsla, `wave{0,1,2}_charge` in blue-family hsla),
+cross-faded via per-path opacity from `_currentColorMix`
+(`1 − colorMix` for idle, `colorMix` for charging) — the same
+opacity cross-fade mechanism QS-200 introduced on the boiler. The
+amplitude/speed lerp mirrors the boiler (`CALM_AMP=1.5`,
+`CHARGING_AMP=8`, `CALM_SPEED=0.1`, `CHARGING_SPEED=0.4`). A
+combined body+terminal `<path id="battery_outline">` is drawn after
+the clipped water group with `fill="none"` and stroke alpha lerped
+from 0.30 (idle) to 0.55 (charging) so the silhouette is always
+visible. A charging-only lightning particle system (hard cap
+`MAX_CONCURRENT_LIGHTNING=3`, spawn `LIGHTNING_SPAWN_RATE_HZ=3`,
+life 0.5 s with a piecewise-linear 0/0.2/0.7/1.0 opacity curve)
+spawns `<polyline>` zigzag bolts inside the same clipPath as the
+water — white core with a blue Gaussian-blur glow filter applied to
+the layer group (NOT per polyline), mirroring the boiler steam
+subsystem. Per-instance unique SVG ids
+(`batteryClipId`/`lightningGlowId`/`lightningLayerId`) use the
+existing `Math.floor(Math.random() * 1e6)` pattern. The new layer
+slots between `</defs>` and the gauge background `<path
+d="${bgPath}">` so the ring, SOC arc, charging-dash animation,
+target handle, and the HTML `<div class="center">` overlay all
+render on top — none of those existing elements were touched.
+
 ### QS-210 — Climate card backdrops
 
 The climate card (`qs-climate-card.js`) renders one of four backdrop

--- a/docs/stories/QS-224.story.md
+++ b/docs/stories/QS-224.story.md
@@ -1,0 +1,860 @@
+# QS-224 — Car card: animated battery background (green idle, blue charging with lightning)
+
+## Issue
+
+GitHub #224 (`area:battery`, `area:car`). Body verbatim:
+
+> Now I would like to add also to the car card a kind of nice background
+> animation as we did for the boiler/climate/radiator but a bit different
+> I would like to have an empty battery (mdi:battery-outline) in the
+> middle of the circle (but transparent and backward to all text, button
+> etc) going from bottom + 1/5 of the circle Diameter and top - 1/5 of
+> the circle diameter. And this will be filled like the water for a pool
+> but (same kind of animation) but when not charging the color will be
+> green (same bright green already used in the circle not running) and
+> when charging I want it to move more (like the pool) but be blue (same
+> electric blue as the one used in the charging circle) ... and with
+> litle lightning / thunder inside the battery frame
+
+Session clarifications (in priority order):
+
+1. **State coverage**: water animation visible in ALL states including
+   disconnected/faulted/stale. When not charging (including those
+   states), water is calm green at the current SOC value the existing
+   arc uses (no override-bypass). Lightning only when actively charging.
+2. **Battery dimensions**: preserve `mdi:battery-outline` proportions
+   (body 12:18 ratio, terminal 6:2 nub on top, corner radius 2 — all in
+   the mdi 24×24 viewBox). Vertical span = 60% of ring diameter, per the
+   issue's literal "+1/5 / −1/5" rule.
+3. **Battery frame outline**: always visible — faint translucent white
+   stroke when idle, brighter when charging.
+4. **Lightning style**: small, frequent flashes. 1–3 concurrent, ~3/sec
+   spawn, ~500ms life each. Zigzag `<polyline>` with 5 vertices, white
+   core (`#FFFFFF`) + blue Gaussian-blur glow (`#80D4FF`).
+5. **Wave dynamics**: use the boiler's amplitude/speed values
+   (`CALM_AMP=1.5`, `CHARGING_AMP=8` for amp; `CALM_SPEED=0.1`,
+   `CHARGING_SPEED=0.4` for speed).
+
+## Scope (single sentence)
+
+In `qs-car-card.js` add a battery-shaped translucent overlay inside the
+existing 300×300 ring, fill the body interior with the pool/boiler's
+3-layer sine-wave water animation (green when idle, blue when charging
+via per-path opacity cross-fade on dual-layer siblings), draw the
+combined battery body+terminal outline as a stroked SVG path overlay
+whose alpha lerps with `_currentColorMix`, and add a charging-only
+lightning particle system (zigzag `<polyline>`s, hard-capped at 3
+concurrent, clipped to the battery body interior) — mirroring the
+boiler card's continuous-RAF + opacity-cross-fade + particle-subsystem
+architecture.
+
+## Files touched
+
+| Path                                                                  | Change |
+| --------------------------------------------------------------------- | --- |
+| `custom_components/quiet_solar/ui/resources/qs-car-card.js`           | New module-level constants (geometry, palettes, animation tuning, lightning) ~80 LOC; `_generateWavePath` + `_generateBatteryOutlinePath` + `_generateBatteryBodyClipPath` + `_invalidateWaveCache` + `_resetDomRefs` helpers ~50 LOC; refactor `_startAnimation`/`_stopAnimation` to continuous-while-connected with calm↔charging lerp ~150 LOC; inject `<defs>` (clipPath + lightning filter) and clipped water/lightning `<g>` + battery outline `<path>` into the SVG markup ~80 LOC; lightning particle subsystem (spawn cadence, life curve, retire, cleanup) ~120 LOC; teardown / interaction-flag reset ~30 LOC. **Total ~510 LOC.** |
+| `tests/test_dashboard_rendering.py`                                   | Nine new module-level sentinel tests + one MODIFY (remove `("qs-car-card.js", "charging")` entry from `test_card_raf_idle_gated`'s parametrize list; add a removal-comment block mirroring the QS-200 pattern at lines 1719-1727). ~+220 LOC. |
+| `docs/agents/concepts/dashboard-and-cards.md`                         | One new paragraph under "The five JS Lovelace cards" section (anchor: insert after the QS-211 steam-puffs paragraph that ends "single Gaussian blur applied to the steam layer group"). `last_verified` is already `2026-05-24` (today) — no bump needed. No `covers:` change (the JS file is already listed). |
+
+No `dashboard.py`, no template, no Python source, no `strings.json`, no
+harness-sync (`.claude/agents/` / `.cursor/agents/` / `.opencode/agents/`)
+changes. UI-only.
+
+## Initial constants (iterate visually after first paint — pin every value in tests)
+
+Inserted in `qs-car-card.js` after line 13 (after the existing
+`ANIM_*` block), wrapped in a labeled section header:
+
+```js
+// --- QS-224 battery animation constants -----------------------------------
+// Battery shape derived from mdi:battery-outline (24×24 mdi viewBox).
+// The icon is body 12×18 at (6,4)..(18,22) plus terminal nub 6×2 at
+// (9,2)..(15,4), with corner radius 2 mdi-units (~2/24 ≈ 8.3% of side).
+// The user pins vertical span at "+1/5 / −1/5 of diameter" = 60% of
+// the ring's visible diameter (ringCirc * 2 = 260 SVG-px) — total
+// height 156 SVG-px split 18:2 between body and terminal nub.
+
+const CENTER_CX = 160;                                       // SVG x-center
+const CENTER_CY = 160;                                       // SVG y-center
+const BATTERY_TOTAL_HEIGHT = 156;                            // = 0.6 × 2 × ringCirc (130), per issue's "+1/5 / −1/5" rule
+const MDI_UNIT_PX = BATTERY_TOTAL_HEIGHT / 20;               // = 7.8 (20 mdi-units total height)
+const BATTERY_BODY_HEIGHT = 18 * MDI_UNIT_PX;                // = 140.4
+const BATTERY_BODY_WIDTH  = 12 * MDI_UNIT_PX;                // = 93.6   (body 12:18 ratio preserved)
+const BATTERY_TERMINAL_WIDTH  = 6 * MDI_UNIT_PX;             // = 46.8
+const BATTERY_TERMINAL_HEIGHT = 2 * MDI_UNIT_PX;             // = 15.6
+const BATTERY_CORNER_R = 2 * MDI_UNIT_PX;                    // = 15.6
+const BATTERY_TOP_Y       = CENTER_CY - BATTERY_TOTAL_HEIGHT / 2;       // = 82
+const BATTERY_BOTTOM_Y    = CENTER_CY + BATTERY_TOTAL_HEIGHT / 2;       // = 238
+const BATTERY_BODY_TOP_Y  = BATTERY_TOP_Y + BATTERY_TERMINAL_HEIGHT;    // = 97.6
+const BATTERY_BODY_LEFT_X  = CENTER_CX - BATTERY_BODY_WIDTH / 2;        // = 113.2
+const BATTERY_BODY_RIGHT_X = CENTER_CX + BATTERY_BODY_WIDTH / 2;        // = 206.8
+
+// Wave geometry — reuse the pool/boiler defaults verbatim. The wave path
+// is rendered with extent [0, 2*WAVE_WIDTH] and translated; absolute
+// width is decoupled from battery body width.
+const WAVE_WIDTH = 480;                                      // single wave period; same as pool/boiler
+const WAVE_BOTTOM_Y = 400;                                   // closing rect y; below viewBox (320)
+const LAYER_SCROLL_OFFSET = 1.2;                             // per-layer extra scroll phase
+const LAYER_PHASE_OFFSET  = 2.1;                             // per-layer static sine phase
+
+// Water palettes — opacity cross-fade between idle/green and charging/blue.
+// IDLE family: hue 150 (green; matches the gradGreenId cyan→green
+// gradient direction). CHARGING family: hue 205 (blue; matches the
+// gradChargeId cyan→deep-blue gradient direction). Lightness/alpha
+// step down per layer for depth.
+const IDLE_WATER_COLORS = [
+  'hsla(150, 60%, 35%, 0.55)',
+  'hsla(150, 60%, 30%, 0.45)',
+  'hsla(150, 60%, 25%, 0.35)',
+];
+const CHARGING_WATER_COLORS = [
+  'hsla(205, 80%, 40%, 0.60)',
+  'hsla(205, 80%, 35%, 0.50)',
+  'hsla(205, 80%, 30%, 0.40)',
+];
+
+// Animation tuning — mirror the boiler exactly (gentle calm, more
+// pronounced when active). Documented at QS-200 in
+// docs/agents/concepts/dashboard-and-cards.md.
+const LERP_RATE = 2;                                         // exp lerp time-constant (~95% in ~1.5s)
+const LERP_DT_CEIL = 0.1;                                    // s; clamp dt against hidden-tab return
+const AMP_REGEN_THRESHOLD = 0.25;                            // amp delta for path regen
+const LEVEL_REGEN_THRESHOLD = 0.01;                          // px; water level delta for path regen
+const PHASE_WRAP = 1e6;                                      // wrap _wavePhase to preserve float precision
+const PHASE_TO_PX = 60;                                      // scroll px per phase-unit
+const CALM_AMP = 1.5;                                        // = boiler CALM_AMP
+const CHARGING_AMP = 8;                                      // = boiler BOIL_AMP
+const CALM_SPEED = 0.1;                                      // = boiler CALM_SPEED
+const CHARGING_SPEED = 0.4;                                  // = boiler BOIL_SPEED
+
+// Lightning subsystem — charging-only particle system, HARD CAP at
+// MAX_CONCURRENT_LIGHTNING (spawn rejected when len >= cap, no overflow).
+// Architecture mirrors the boiler bubble/steam subsystems: create/destroy
+// (NOT pool/reuse) — matches project precedent at qs-water-boiler-card.js
+// :413-461. Spawn rate × life ≈ 1.5 avg, occasional 3-cap.
+const MAX_CONCURRENT_LIGHTNING = 3;
+const LIGHTNING_SPAWN_RATE_HZ = 3;
+const LIGHTNING_LIFE_S = 0.5;
+const LIGHTNING_HEIGHT_MIN_PX = 18;
+const LIGHTNING_HEIGHT_MAX_PX = 30;
+const LIGHTNING_ZIGZAG_AMPLITUDE_PX = 6;                     // horizontal jitter per segment
+const LIGHTNING_SEGMENTS = 4;                                // zigzag segments per bolt (5 vertices)
+const LIGHTNING_STROKE_WIDTH = 1.5;
+const LIGHTNING_STROKE_COLOR = '#FFFFFF';                    // white core
+const LIGHTNING_GLOW_COLOR = '#80D4FF';                      // blue-white halo
+const LIGHTNING_GLOW_STDDEV = 2.5;
+// Life curve breakpoints (piecewise linear). Mirrors boiler steam at
+// qs-water-boiler-card.js:573-577 (0.15/0.85 → here 0.2/0.7).
+const LIGHTNING_FADE_IN_FRACTION = 0.2;                      // 0 → 0.2 fade-in
+const LIGHTNING_FADE_OUT_FRACTION = 0.7;                     // 0.2 → 0.7 hold, 0.7 → 1.0 fade-out
+
+// Battery outline appearance — alpha lerped between idle/charging via
+// JS rgba interpolation (NOT CSS color-mix, for browser compat).
+const BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.30;
+const BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.55;
+const BATTERY_OUTLINE_STROKE_WIDTH = 2;
+```
+
+## Behavior contracts (inlined — plan stands alone)
+
+These are project precedents from `qs-water-boiler-card.js` and
+`qs-pool-card.js`, inlined here so reviewers don't need cross-file
+context.
+
+### Continuous RAF + lerp envelope (mirror boiler `_startAnimation`)
+
+```js
+// In _startAnimation step(ts):
+let dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
+dt = Math.min(dt, LERP_DT_CEIL);
+this._lastAnimTs = ts;
+
+const charging = this._charging === true;
+const targetAmplitude = charging ? CHARGING_AMP : CALM_AMP;
+const targetSpeed     = charging ? CHARGING_SPEED : CALM_SPEED;
+const targetColorMix  = charging ? 1 : 0;
+
+const lerpFactor = 1 - Math.exp(-LERP_RATE * dt);
+this._currentAmplitude += (targetAmplitude - this._currentAmplitude) * lerpFactor;
+this._currentSpeed     += (targetSpeed     - this._currentSpeed)     * lerpFactor;
+this._currentColorMix  += (targetColorMix  - this._currentColorMix)  * lerpFactor;
+
+this._wavePhase += this._currentSpeed * dt;
+this._wavePhase = ((this._wavePhase % PHASE_WRAP) + PHASE_WRAP) % PHASE_WRAP;
+```
+
+`_currentColorMix` ∈ [0, 1]. **0 = pure idle (green visible, blue
+invisible); 1 = pure charging (blue visible, green invisible)**. Per-path
+opacity attribute is updated every frame (NOT group opacity — see AC-3).
+
+### Per-path opacity cross-fade
+
+```js
+const idleOpacity   = (1 - this._currentColorMix).toFixed(3);
+const chargeOpacity = this._currentColorMix.toFixed(3);
+for (let i = 0; i < 3; i++) {
+  this._waveEls[i * 2    ]?.setAttribute('opacity', idleOpacity);   // wave{i}_idle
+  this._waveEls[i * 2 + 1]?.setAttribute('opacity', chargeOpacity); // wave{i}_charge
+}
+```
+
+### Helper signatures (concrete)
+
+```js
+// Returns the SVG path `d` for the BODY ONLY (rounded-rect, terminal
+// NOT included). Used as the <clipPath> contents — water + lightning
+// are clipped to the body interior so the terminal nub never shows
+// water bleed or stray bolts.
+_generateBatteryBodyClipPath() {
+  // M (left+r, top) H (right−r) Q (right, top, right, top+r) V (bottom−r)
+  // Q (right, bottom, right−r, bottom) H (left+r) Q (left, bottom, left, bottom−r)
+  // V (top+r) Q (left, top, left+r, top) Z
+  // Coordinates from BATTERY_BODY_{TOP_Y,LEFT_X,RIGHT_X} + BATTERY_BOTTOM_Y, BATTERY_CORNER_R.
+}
+
+// Returns ONE SVG path `d` for the COMBINED body+terminal silhouette
+// (single closed path, no seam). Drawn as a stroked outline only
+// (fill="none"). Used by <path id="battery_outline">.
+_generateBatteryOutlinePath() {
+  // Trace counter-clockwise from body-top-left-after-corner around the
+  // body bottom, up the right side to top-right-of-body, RIGHT across
+  // to the terminal-right-bottom, UP the terminal right edge, LEFT
+  // across the terminal top (rounded corners), DOWN the terminal left
+  // edge, LEFT back across the body top to body-top-left-after-corner,
+  // close with the top-left body corner arc.
+}
+```
+
+### Lightning bolt spawn + life
+
+```js
+// Spawn (only while charging, HARD CAP)
+if (charging) {
+  this._nextLightningAt -= dt;
+  while (this._nextLightningAt <= 0
+         && this._lightning.length < MAX_CONCURRENT_LIGHTNING) {
+    const h = LIGHTNING_HEIGHT_MIN_PX
+            + Math.random() * (LIGHTNING_HEIGHT_MAX_PX - LIGHTNING_HEIGHT_MIN_PX);
+    const cxStart = BATTERY_BODY_LEFT_X + 10
+                  + Math.random() * (BATTERY_BODY_WIDTH - 20);
+    const cyStart = BATTERY_BODY_TOP_Y + 5
+                  + Math.random() * (BATTERY_BODY_HEIGHT - h - 10);
+    // Build zigzag points: 5 vertices, alternating ±LIGHTNING_ZIGZAG_AMPLITUDE_PX
+    const points = [];
+    for (let i = 0; i <= LIGHTNING_SEGMENTS; i++) {
+      const t = i / LIGHTNING_SEGMENTS;
+      const dx = (i % 2 === 0 ? 1 : -1) * LIGHTNING_ZIGZAG_AMPLITUDE_PX;
+      points.push(`${(cxStart + dx).toFixed(2)},${(cyStart + t * h).toFixed(2)}`);
+    }
+    const el = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+    el.setAttribute('points', points.join(' '));
+    el.setAttribute('fill', 'none');
+    el.setAttribute('stroke', LIGHTNING_STROKE_COLOR);
+    el.setAttribute('stroke-width', String(LIGHTNING_STROKE_WIDTH));
+    el.setAttribute('pointer-events', 'none');
+    el.setAttribute('opacity', '0');
+    lightningLayer.appendChild(el);
+    this._lightning.push({ el, life: 0, maxLife: LIGHTNING_LIFE_S });
+    this._nextLightningAt += 1 / LIGHTNING_SPAWN_RATE_HZ;
+  }
+  if (this._nextLightningAt < 0) this._nextLightningAt = 0;
+}
+
+// Advance + retire (unconditional — graceful exit on charging→false)
+const aliveLightning = [];
+for (const b of this._lightning) {
+  b.life += dt;
+  if (b.life >= b.maxLife) { b.el.remove(); continue; }
+  const lifeT = b.life / b.maxLife;
+  let lifeOpacity;
+  if      (lifeT < LIGHTNING_FADE_IN_FRACTION)
+       lifeOpacity = lifeT / LIGHTNING_FADE_IN_FRACTION;
+  else if (lifeT < LIGHTNING_FADE_OUT_FRACTION)
+       lifeOpacity = 1;
+  else lifeOpacity = Math.max(0, 1 - (lifeT - LIGHTNING_FADE_OUT_FRACTION)
+                                     / (1 - LIGHTNING_FADE_OUT_FRACTION));
+  b.el.setAttribute('opacity', (lifeOpacity * this._currentColorMix).toFixed(3));
+  aliveLightning.push(b);
+}
+this._lightning = aliveLightning;
+```
+
+### Water-level mapping (issue's literal rule)
+
+```js
+const progressRatio = Math.max(0, Math.min(1, soc / 100));
+// Issue says "going from bottom + 1/5 of the circle Diameter and top - 1/5".
+// Translated to battery body: 1/5 floor + 1/5 ceiling = pool's formula:
+const waterBaseY = BATTERY_BOTTOM_Y
+                 - (0.2 + progressRatio * 0.6) * BATTERY_BODY_HEIGHT;
+this._waterBaseY = waterBaseY;
+```
+
+`soc` is the existing variable as set by the card's downstream branches
+(stale-percent override, energy-mode override, normal) — same value the
+SOC arc uses. No bypass.
+
+### Per-instance unique SVG ids
+
+Reuse the existing `Math.floor(Math.random() * 1e6)` pattern the card
+already uses for `gradGreenId`/`gradChargeId` (line 508-512). New ids:
+`batteryClipId`, `lightningGlowId`, `lightningLayerId`. No class-level
+counter introduced.
+
+## Acceptance criteria
+
+### AC-1 — Battery clipPath geometry (body-only)
+
+- **Given** the car card source,
+- **When** the SVG `<defs>` are inspected,
+- **Then** there is exactly one `<clipPath id="${batteryClipId}">` whose
+  content is a SINGLE `<path>` child describing the rounded-rectangle
+  battery body interior — the terminal nub is NOT part of the clip
+  (water and lightning never bleed into the terminal),
+- **And** module-level numeric constants `BATTERY_TOTAL_HEIGHT === 156`,
+  `MDI_UNIT_PX === BATTERY_TOTAL_HEIGHT / 20`, `BATTERY_BODY_HEIGHT
+  === 18 * MDI_UNIT_PX`, `BATTERY_BODY_WIDTH === 12 * MDI_UNIT_PX`
+  exist, encoding the 12:18 mdi body aspect ratio and the issue's
+  "+1/5 / −1/5" rule.
+
+### AC-2 — Three-layer wave animation inside the body clipPath
+
+- **Given** the car card source,
+- **When** the rendered SVG is inspected,
+- **Then** the SVG contains six `<path>` elements with stable ids
+  `wave0_idle`, `wave0_charge`, `wave1_idle`, `wave1_charge`,
+  `wave2_idle`, `wave2_charge`, ALL nested inside a single
+  `<g clip-path="url(#${batteryClipId})">`,
+- **And** a `_generateWavePath(width, amplitude, frequency, phase,
+  yOffset)` method exists with the verbatim body of
+  `qs-pool-card.js:49-62` (emits two periods of a sine wave closed
+  with `WAVE_BOTTOM_Y`),
+- **And** module-level constants `WAVE_WIDTH === 480` and
+  `WAVE_BOTTOM_Y === 400` are pinned (reuse pool/boiler values for the
+  "same kind of animation" the issue asks for).
+
+### AC-3 — Idle green / charging blue palette, per-path opacity cross-fade
+
+- **Given** the module-level constants,
+- **When** inspected,
+- **Then** `IDLE_WATER_COLORS` is a 3-element array of `'hsla(...)'`
+  strings whose hue token is in `[100, 180]` (green family — sentinel
+  rules out the blue/red/yellow/grey palettes),
+- **And** `CHARGING_WATER_COLORS` is a 3-element array of `'hsla(...)'`
+  strings whose hue token is in `[190, 230]` (blue family — sentinel
+  rules out green/red/grey),
+- **And** the RAF loop sets `opacity` PER PATH every frame (not via a
+  group `opacity` attribute on the parent `<g>`) — the wave 6
+  `setAttribute('opacity', ...)` calls or equivalent per-element
+  opacity updates appear in source.
+
+### AC-4 — Wave amplitude/speed lerp mirrors the boiler
+
+- **Given** the module-level constants in `qs-car-card.js`,
+- **When** inspected,
+- **Then** `CALM_AMP === 1.5`, `CHARGING_AMP === 8`, `CALM_SPEED === 0.1`,
+  `CHARGING_SPEED === 0.4`, `LERP_RATE === 2`, `LERP_DT_CEIL === 0.1`
+  — i.e. byte-identical to the boiler's tuning.
+
+### AC-5 — Battery outline (body+terminal) always visible, alpha lerps with `_currentColorMix`
+
+- **Given** the rendered SVG,
+- **When** inspected,
+- **Then** there is exactly one `<path id="battery_outline">` drawn
+  IMMEDIATELY AFTER the clipped water/lightning group, with
+  `fill="none"` and a non-empty `stroke` attribute,
+- **And** the outline `d` covers BOTH the body rounded-rect AND the
+  terminal nub in ONE single combined path (no seam at the join),
+- **And** module-level constants `BATTERY_OUTLINE_STROKE_IDLE_ALPHA
+  === 0.30` and `BATTERY_OUTLINE_STROKE_CHARGING_ALPHA === 0.55` exist
+  with distinct values,
+- **And** the RAF loop updates the `stroke` attribute every frame via
+  JS rgba interpolation (NOT CSS `color-mix` — for browser compat):
+  `alpha = IDLE + colorMix * (CHARGING - IDLE)`, format
+  `rgba(255,255,255,${alpha.toFixed(3)})`.
+
+### AC-6 — Lightning particle system: charging-only spawn, hard cap, life curve
+
+- **Given** the module-level constants,
+- **When** inspected,
+- **Then** `MAX_CONCURRENT_LIGHTNING === 3`, `LIGHTNING_SPAWN_RATE_HZ
+  === 3`, `LIGHTNING_LIFE_S === 0.5`, `LIGHTNING_SEGMENTS === 4`,
+  `LIGHTNING_FADE_IN_FRACTION === 0.2`, `LIGHTNING_FADE_OUT_FRACTION
+  === 0.7` are pinned numeric constants,
+- **And** the spawn block in the RAF step function is guarded by
+  `if (charging)` (NO spawns when calm),
+- **And** the spawn loop uses the HARD-CAP form `while (... <
+  MAX_CONCURRENT_LIGHTNING)` (spawn rejected at cap, NO overflow),
+- **And** retire (advance + remove) runs unconditionally — bolts that
+  are already in flight when `charging` flips to false continue their
+  life curve and retire naturally,
+- **And** each bolt is a `<polyline>` element appended to
+  `<g id="${lightningLayerId}">` (which is itself inside the same
+  `batteryClipId` clip group as the water — bolts are body-clipped),
+- **And** the `<g id="${lightningLayerId}">` group has a `filter`
+  attribute referencing `<filter id="${lightningGlowId}">` (single
+  filter applied to the group, NOT per polyline — mirrors boiler steam
+  pattern),
+- **And** each polyline's `points` attribute contains exactly
+  `LIGHTNING_SEGMENTS + 1` (= 5) whitespace-separated `x,y` pairs.
+
+### AC-7 — Continuous RAF while connected
+
+- **Given** the car card source,
+- **When** `connectedCallback()` and `_render()` are inspected,
+- **Then** `connectedCallback()` calls `this._startAnimation()`
+  UNCONDITIONALLY (no surrounding `if`),
+- **And** the `_render()` method NO LONGER calls
+  `this._startAnimation()` or `this._stopAnimation()` based on the
+  per-frame `charging` boolean (today's lines 171-175 are removed),
+- **And** the step function's old `if (!this._charging) { ...
+  return; }` early-return is REPLACED by the lerp-toward-calm block
+  inlined above (waves keep animating gently when idle),
+- **And** `disconnectedCallback()` still calls `this._stopAnimation()`
+  AND removes all live lightning bolt DOM nodes (eager teardown —
+  mirrors `qs-water-boiler-card.js:637-644`).
+
+### AC-8 — Z-order: water + outline below the gauge ring, HTML overlay on top
+
+- **Given** the rendered SVG source,
+- **When** source order is inspected (string-find on stable anchors),
+- **Then** `<g clip-path="url(#${batteryClipId})">` appears BEFORE
+  `<path d="${bgPath}"` (= the gauge ring background),
+- **And** `<path id="battery_outline"` appears AFTER the
+  `<g clip-path="...">` group but BEFORE `<path d="${bgPath}"`,
+- **And** the existing `<path d="${socPath}"` (SOC arc),
+  `<path id="charge_anim"` (charging dash),
+  `<circle id="target_handle"`, and
+  `<text id="target_handle_text"` all appear AFTER `<path d="${bgPath}"`
+  in source order (= they render on top of the new layer),
+- **And** the HTML `<div class="center">` overlay remains in its
+  current position (after `</svg>`, no z-index changes).
+
+### AC-9 — Existing arc / dash / handle code paths unchanged
+
+- **Given** the diff against `main`,
+- **When** inspected,
+- **Then** the `<path d="${bgPath}"` line, the
+  `<path d="${socPath}"` line, the `<path id="charge_anim"` block
+  (whole conditional), the `<circle id="target_handle"` line, and the
+  `<text id="target_handle_text"` line are byte-identical between
+  pre- and post-change versions (the diff is purely additive in the
+  SVG markup; no rearrangement of existing elements).
+
+Existing tests around lines 1576-2200 and 1719-1750 of
+`test_dashboard_rendering.py` that pin charging-anim presence and other
+car-card invariants pass without modification.
+
+## Task breakdown
+
+### 1. TDD red — sentinel tests + parametrize fix
+
+In `tests/test_dashboard_rendering.py`:
+
+a. **MODIFY `test_card_raf_idle_gated`'s parametrize list.** Find the
+   decorator currently at lines ~1728-1734 that lists
+   `("qs-car-card.js", "charging")` (alongside other duration-card
+   entries). REMOVE the `("qs-car-card.js", "charging")` tuple. Above
+   the decorator, add a comment block mirroring the QS-200 pattern at
+   lines 1719-1727:
+
+   ```python
+   # QS-224: `qs-car-card.js` was previously in the idle-gated cluster
+   # (the `if (charging) { _startAnimation() }` form in _render). QS-224
+   # moves the car card to the same continuous-RAF model the pool and
+   # boiler cards already use, because the new battery+water animation
+   # must keep animating gently (calm green waves) even when idle. See
+   # AC-7 of docs/stories/QS-224.story.md.
+   ```
+
+b. **Nine new module-level tests**, inserted as a contiguous block
+   below the existing boiler/pool test cluster. Each ≤30 LOC. All read
+   the car card source via `(COMPONENT_ROOT / "ui" / "resources" /
+   "qs-car-card.js").read_text()` (existing project pattern).
+   Test names + intent:
+
+   1. `test_car_card_pins_battery_geometry_constants` — pins
+      `BATTERY_TOTAL_HEIGHT = 156`, `MDI_UNIT_PX` derivation, and the
+      12:18 body ratio via regex on the constant declarations.
+   2. `test_car_card_battery_clippath_in_defs` — pins
+      `<clipPath id="${batteryClipId}">` presence + single `<path>`
+      child + helper `_generateBatteryBodyClipPath` method exists.
+   3. `test_car_card_renders_water_layer` — pins six
+      `<path id="waveX_{idle,charge}">` elements inside
+      `<g clip-path="url(#${batteryClipId})">` + `_generateWavePath`
+      method + `WAVE_WIDTH = 480` + `WAVE_BOTTOM_Y = 400`.
+   4. `test_car_card_pins_water_palette_triplets` — pins each
+      `IDLE_WATER_COLORS` entry has hue in `[100, 180]` AND pins each
+      `CHARGING_WATER_COLORS` entry has hue in `[190, 230]`, plus the
+      stepped lightness/alpha pattern (each layer ≤ prior in
+      lightness AND alpha).
+   5. `test_car_card_pins_amplitude_speed_constants` — pins
+      `CALM_AMP=1.5`, `CHARGING_AMP=8`, `CALM_SPEED=0.1`,
+      `CHARGING_SPEED=0.4`, `LERP_RATE=2`, `LERP_DT_CEIL=0.1`.
+   6. `test_car_card_battery_outline_present_with_distinct_strokes` —
+      pins `<path id="battery_outline">` + `fill="none"` +
+      `BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.30` and
+      `BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.55` (distinct) +
+      `_generateBatteryOutlinePath` helper exists.
+   7. `test_car_card_has_lightning_system` — pins
+      `MAX_CONCURRENT_LIGHTNING=3`, `LIGHTNING_SPAWN_RATE_HZ=3`,
+      `LIGHTNING_LIFE_S=0.5`, `LIGHTNING_SEGMENTS=4`,
+      `LIGHTNING_FADE_IN_FRACTION=0.2`,
+      `LIGHTNING_FADE_OUT_FRACTION=0.7`, presence of
+      `<filter id="${lightningGlowId}">` in defs and
+      `<g id="${lightningLayerId}" filter=` inside the clipped group.
+   8. `test_car_card_continuous_raf_refactor` — pins
+      `connectedCallback() { this._startAnimation()` (no `if`
+      guard before the call), AND asserts `_render()` no longer
+      contains the prior `if (charging) { this._startAnimation();
+      } else { this._stopAnimation(); }` block (current lines
+      171-175 must be gone).
+   9. `test_car_card_z_order_battery_group_before_bgpath` — string-find
+      with three anchors: `<g clip-path="url(#${batteryClipId})">`,
+      `<path id="battery_outline"`, `<path d="${bgPath}"`. Assert
+      `idx(g) < idx(outline) < idx(bgPath)`. Mirror the boiler's
+      `test_water_boiler_card_renders_water_layer` z-order assertion
+      pattern (lines 1979-1984).
+
+c. Run `python scripts/qs/quality_gate.py --quick
+   tests/test_dashboard_rendering.py` and confirm:
+   - The 9 new tests fail (red — symbols don't exist yet).
+   - `test_card_raf_idle_gated` for `qs-car-card.js` does NOT appear
+     in the parametrize list (so it can't fail on the still-gated
+     pre-change source).
+
+### 2. Add module-level constants — `qs-car-card.js`, after line 13
+
+Append the full constant block from "Initial constants" (above) after
+the existing `ANIM_*` block at line 13, wrapped in the comment header
+`// --- QS-224 battery animation constants ---`. **~80 LOC.**
+
+### 3. Add geometry helpers
+
+Inside the class, between `constructor` and `_startAnimation` (so they
+sit near the other helpers), add:
+
+- `_generateBatteryBodyClipPath()` — returns the body rounded-rect `d`
+  string. ~15 LOC.
+- `_generateBatteryOutlinePath()` — returns the combined body+terminal
+  outline `d` string. ~35 LOC.
+- `_generateWavePath(width, amplitude, frequency, phase, yOffset)` —
+  ported verbatim from `qs-pool-card.js:49-62`. ~15 LOC.
+- `_invalidateWaveCache()` — clears `_lastWaterBaseY`, `_lastAmplitude`,
+  and `_resetDomRefs()`. ~5 LOC.
+- `_resetDomRefs()` — clears `_waveEls`, `_lightningLayerEl`, and
+  `this._lightning = []`. ~8 LOC.
+
+**Total ~50 LOC.**
+
+### 4. Refactor RAF lifecycle
+
+- In `connectedCallback()` (currently line 62-65), REPLACE the
+  no-op body with `this._startAnimation();` (unconditional).
+- In `disconnectedCallback()` (currently line 67-76), keep existing
+  body AND add eager teardown of live lightning bolts (mirror
+  `qs-water-boiler-card.js:637-644`):
+  ```js
+  this._lightning?.forEach(b => b.el?.remove?.());
+  this._lightning = [];
+  ```
+- In `_startAnimation()` (currently line 27-54), REWRITE the function:
+  - Lazy-init guard: if `this._currentAmplitude == null`, set
+    `_currentAmplitude = CALM_AMP`, `_currentSpeed = CALM_SPEED`,
+    `_currentColorMix = 0`, `_wavePhase = 0`, `_lightning = []`,
+    `_nextLightningAt = 0`. Set `_needsAnimationPrime = true`.
+  - `step(ts)` body: implement the continuous RAF + lerp envelope
+    inlined above. Drop the old `if (!this._charging) { return; }`
+    early-return entirely.
+  - Add the existing dashed-arc animation (current behavior at lines
+    43-50) AS-IS within the step function. The wave/colorMix/outline/
+    lightning updates run AFTER the dashed-arc update each frame.
+- In `_stopAnimation()` (currently line 56-60), keep existing body.
+- In `_render()` (currently lines 168-175), DELETE the
+  `if (charging) { this._startAnimation(); } else { this._stopAnimation(); }`
+  block entirely. Keep `this._charging = charging;` assignment.
+- In `_render()`, near the bottom of the function before the SVG
+  innerHTML rewrite, add the QS-200-style "prime on first paint"
+  block:
+  ```js
+  if (this._needsAnimationPrime) {
+    this._currentAmplitude = charging ? CHARGING_AMP : CALM_AMP;
+    this._currentSpeed     = charging ? CHARGING_SPEED : CALM_SPEED;
+    this._currentColorMix  = charging ? 1 : 0;
+    this._needsAnimationPrime = false;
+  }
+  ```
+
+**Total ~150 LOC.**
+
+### 5. Water level + initial-wave-paths in `_render()`
+
+After the existing `soc` computation (which finishes by line ~282),
+add:
+
+```js
+const progressRatio = Math.max(0, Math.min(1, soc / 100));
+const waterBaseY = BATTERY_BOTTOM_Y
+                 - (0.2 + progressRatio * 0.6) * BATTERY_BODY_HEIGHT;
+this._waterBaseY = waterBaseY;
+
+const initialAmp = this._currentAmplitude ?? CALM_AMP;
+const initialColorMix = this._currentColorMix ?? 0;
+const initialWavePaths = [0, 1, 2].map(i => {
+  const freq = 2 + i;
+  const phaseOffset = i * LAYER_PHASE_OFFSET;
+  return this._generateWavePath(WAVE_WIDTH, initialAmp, freq, phaseOffset, waterBaseY);
+});
+const initialIdleOpacity   = (1 - initialColorMix).toFixed(3);
+const initialChargeOpacity = initialColorMix.toFixed(3);
+const initialOutlineStrokeAlpha = BATTERY_OUTLINE_STROKE_IDLE_ALPHA
+  + initialColorMix * (BATTERY_OUTLINE_STROKE_CHARGING_ALPHA
+                       - BATTERY_OUTLINE_STROKE_IDLE_ALPHA);
+const batteryClipId     = `batClip-${Math.floor(Math.random() * 1e6)}`;
+const lightningGlowId   = `lightG-${Math.floor(Math.random() * 1e6)}`;
+const lightningLayerId  = `lightL-${Math.floor(Math.random() * 1e6)}`;
+const batteryBodyClipD  = this._generateBatteryBodyClipPath();
+const batteryOutlineD   = this._generateBatteryOutlinePath();
+```
+
+### 6. SVG markup injection — `qs-car-card.js` lines 559-589
+
+a. **Append to `<defs>`** (after `chargeGlow` filter, line 586;
+   before `</defs>`, line 587):
+
+   ```html
+   <clipPath id="${batteryClipId}">
+     <path d="${batteryBodyClipD}" />
+   </clipPath>
+   <filter id="${lightningGlowId}" x="-50%" y="-50%" width="200%" height="200%">
+     <feGaussianBlur stdDeviation="${LIGHTNING_GLOW_STDDEV}" result="blur" />
+     <feFlood flood-color="${LIGHTNING_GLOW_COLOR}" flood-opacity="1" />
+     <feComposite in2="blur" operator="in" result="glow" />
+     <feMerge>
+       <feMergeNode in="glow" />
+       <feMergeNode in="SourceGraphic" />
+     </feMerge>
+   </filter>
+   ```
+
+b. **Insert between `</defs>` (line 587) and `<path d="${bgPath}">`
+   (line 588)**:
+
+   ```html
+   <g clip-path="url(#${batteryClipId})">
+     <path id="wave0_idle"   d="${initialWavePaths[0]}" fill="${IDLE_WATER_COLORS[0]}"     opacity="${initialIdleOpacity}"   pointer-events="none" style="will-change: transform;" />
+     <path id="wave0_charge" d="${initialWavePaths[0]}" fill="${CHARGING_WATER_COLORS[0]}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
+     <path id="wave1_idle"   d="${initialWavePaths[1]}" fill="${IDLE_WATER_COLORS[1]}"     opacity="${initialIdleOpacity}"   pointer-events="none" style="will-change: transform;" />
+     <path id="wave1_charge" d="${initialWavePaths[1]}" fill="${CHARGING_WATER_COLORS[1]}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
+     <path id="wave2_idle"   d="${initialWavePaths[2]}" fill="${IDLE_WATER_COLORS[2]}"     opacity="${initialIdleOpacity}"   pointer-events="none" style="will-change: transform;" />
+     <path id="wave2_charge" d="${initialWavePaths[2]}" fill="${CHARGING_WATER_COLORS[2]}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
+     <g id="${lightningLayerId}" filter="url(#${lightningGlowId})" pointer-events="none"></g>
+   </g>
+   <path id="battery_outline" d="${batteryOutlineD}" fill="none"
+         stroke="rgba(255,255,255,${initialOutlineStrokeAlpha.toFixed(3)})"
+         stroke-width="${BATTERY_OUTLINE_STROKE_WIDTH}"
+         stroke-linejoin="round" pointer-events="none" />
+   ```
+
+   DO NOT move/rearrange `<path d="${bgPath}">`, `<path d="${socPath}">`,
+   the `${showAnimation ? ...` charging-dash conditional, `<circle
+   id="target_handle">`, or `<text id="target_handle_text">`. The
+   change is purely additive between `</defs>` and `<path d="${bgPath}">`.
+
+**~80 LOC.**
+
+### 7. Lightning particle subsystem — inside `_startAnimation` step
+
+After the wave update block in the step function, add:
+
+- Lazy DOM ref resolution: `this._lightningLayerEl ??= this._root?.
+  getElementById(this._lightningLayerId) ?? null`.
+- Cache `this._lightningLayerId` from `_render()` (set just after
+  generating the random id, alongside `this._waterClipId` style).
+- Spawn block (charging-only, hard cap) + advance/retire block per the
+  inlined contract above.
+
+In `_render()`, set `this._lightningLayerId = lightningLayerId` so the
+RAF loop can resolve the layer DOM ref after the innerHTML rewrite.
+
+**~120 LOC.**
+
+### 8. Post-innerHTML memo-key sync
+
+After the `this._root.innerHTML = ...` rewrite in `_render()` (current
+line ~657), add the boiler-style post-rewrite block:
+
+```js
+this._lastWaterBaseY = this._waterBaseY;
+this._lastAmplitude  = this._currentAmplitude;
+this._waveEls = null;            // lazy-resolve on next RAF tick
+this._lightningLayerEl = null;   // ditto
+```
+
+(The wave-path memo keys are already aligned to the post-render state,
+matching the boiler/pool precedent — see
+`qs-water-boiler-card.js:1364-1383`.)
+
+### 9. Doc paragraph — `docs/agents/concepts/dashboard-and-cards.md`
+
+Anchor: insert ONE new paragraph after the QS-211 paragraph (which
+ends `"...without the per-circle filter cost."` around line 290), and
+before the QS-210 backdrop section (around line 400). Suggested wording:
+
+> **QS-224 — car card battery backdrop.** The car card adopts the
+> boiler card's continuous-RAF model and renders an
+> `mdi:battery-outline`-shaped translucent overlay inside the existing
+> 300×300 ring. The battery vertically spans the user-anchored "+1/5 /
+> −1/5 of diameter" rule (`BATTERY_TOTAL_HEIGHT = 156` SVG-px, body
+> 12:18 mdi proportions preserved). The battery body interior is a
+> rounded-rect `<clipPath>` containing three sine-wave layers as in
+> the pool card: two siblings per layer (`wave{0,1,2}_idle` in
+> green-family hsla, `wave{0,1,2}_charge` in blue-family hsla),
+> cross-faded via per-path opacity from `_currentColorMix`
+> (`1 − colorMix` for idle, `colorMix` for charging) — the same
+> opacity cross-fade mechanism QS-200 introduced on the boiler. The
+> amplitude/speed lerp mirrors the boiler (`CALM_AMP=1.5`,
+> `CHARGING_AMP=8`, `CALM_SPEED=0.1`, `CHARGING_SPEED=0.4`). A
+> combined body+terminal `<path id="battery_outline">` is drawn after
+> the clipped water group with `fill="none"` and stroke alpha lerped
+> from 0.30 (idle) to 0.55 (charging) so the silhouette is always
+> visible. A charging-only lightning particle system (hard cap
+> `MAX_CONCURRENT_LIGHTNING=3`, spawn `LIGHTNING_SPAWN_RATE_HZ=3`,
+> life 0.5 s with a piecewise-linear 0/0.2/0.7/1.0 opacity curve)
+> spawns `<polyline>` zigzag bolts inside the same clipPath as the
+> water — white core with a blue Gaussian-blur glow filter applied to
+> the layer group (NOT per polyline), mirroring the boiler steam
+> subsystem. Per-instance unique SVG ids
+> (`batteryClipId`/`lightningGlowId`/`lightningLayerId`) use the
+> existing `Math.floor(Math.random() * 1e6)` pattern. The new layer
+> slots between `</defs>` and the gauge background `<path
+> d="${bgPath}">` so the ring, SOC arc, charging-dash animation,
+> target handle, and the HTML `<div class="center">` overlay all
+> render on top — none of those existing elements were touched.
+
+`last_verified` is already `2026-05-24` (today). No bump needed. No
+`covers:` block change (the JS file is already listed).
+
+### 10. Quality gate
+
+Run `python scripts/qs/quality_gate.py`.
+
+**UI-only fast path scope.** Per `docs/workflow/project-rules.md`:
+*"When only `custom_components/quiet_solar/ui/*.j2` templates and
+`custom_components/quiet_solar/ui/resources/**` assets change
+(optionally mixed with dev-only paths), the gate runs only
+`tests/test_dashboard_rendering.py` plus any changed test files."*
+This story touches `ui/resources/*.js` (1 file), `tests/` (1 file),
+and `docs/` (1 file). If `docs/` is treated as dev-only by the scope
+detector, the fast path applies (only `tests/test_dashboard_rendering.py`).
+If not, the full gate runs. Either is acceptable; check the gate
+output for which path was taken.
+
+### 11. Commit + push + open PR via the standard implement-task flow.
+
+## Out of scope (explicit)
+
+- **No visual snapshot test.** The card's runtime SVG depends on the HA
+  card-helper environment; literal regex sentinels are the right gate
+  for a UI animation feature (mirrors QS-200/QS-210/QS-211/QS-220
+  precedent).
+- **No JS runtime tests.** Boundary tests (colorMix=0/0.5/1,
+  SOC=0/50/100, life-curve thirds) would require a JS execution
+  environment the project doesn't have. We pin behavior via Python
+  regex sentinels on the source, matching the project's existing
+  testing model.
+- **No backend / domain logic / Python changes.** Pure JS + tests + doc.
+- **No changes to other cards** (pool, boiler, climate, radiator,
+  on-off-duration). All new symbols live in `qs-car-card.js` only —
+  no shared module extraction.
+- **No SOC arc / target-handle / charging-dash / control-button
+  changes.** The new layer slots in BEFORE bgPath; existing code paths
+  are untouched per AC-9.
+- **No raw-SOC bypass of the stale-percent override.** Water level uses
+  the same `soc` value the existing arc uses — whatever override the
+  card's downstream branches apply applies to the water too. (Dropped
+  during adversarial review as invented scope; see Adversarial Review
+  Notes.)
+- **No state-specific water palettes.** Per session-Q1=(c): the water
+  always uses idle-green when not actively charging, regardless of
+  disconnected/faulted/stale state. The existing `charging` boolean
+  (`Number(power) > 50`) already excludes those states from triggering
+  the blue palette.
+- **No off-screen / visibility gating for the RAF loop** (`IntersectionObserver`,
+  `document.visibilityState`). The pool and boiler cards run continuous
+  RAF without such gating; that's project precedent. If perf becomes
+  an issue on dashboards with many cards, file a separate issue
+  covering all four continuous-RAF cards uniformly.
+- **No `--ring-text-shadow` CSS variable.** Issue says "transparent
+  and backward to all text" — the new layer being behind text and
+  buttons is the contract; legibility was not flagged by the user. If
+  text legibility regresses post-paint, file separately.
+- **No card-config option to disable the animation.** YAGNI until
+  users ask.
+- **No DOM reuse / object pool for lightning bolts.** Boiler bubbles
+  and steam use create/destroy; we follow that precedent.
+
+## NEXT_PHASE
+
+`implement-task` — all touched product paths are under
+`custom_components/quiet_solar/ui/` (product code). The
+`docs/agents/concepts/dashboard-and-cards.md` co-modification is a
+required doc-maintenance touch per the drift-checker rule (the JS
+file is already listed in that doc's `covers:` frontmatter), not the
+primary edit, so it does not shift routing to `implement-setup-task`.
+
+## Doc maintenance
+
+`scripts/qs/check_doc_drift.py --paths
+custom_components/quiet_solar/ui/resources/qs-car-card.js
+tests/test_dashboard_rendering.py
+docs/agents/concepts/dashboard-and-cards.md` — returns clean during
+planning (no `stale:` lines; pre-existing warnings about
+`testing-layers.md` covering test files outside
+`custom_components/` are unrelated to QS-224).
+
+## Adversarial Review Notes
+
+Four reviewers (`qs-plan-critic`, `qs-plan-concrete-planner`,
+`qs-plan-dev-proxy`, `qs-plan-scope-guardian`) ran in parallel against
+the first draft. 27 deduped findings; all triaged per the table below.
+
+| Finding | Sources | Disposition |
+| --- | --- | --- |
+| F1 — Original AC-9 "water level uses raw SOC bypassing stale-percent override" was invented; not in issue body; no test feasibility; `soc` is mutated downstream so the "raw" name is ambiguous | scope-guardian (critical), critic (critical), concrete-planner (critical), dev-proxy (improve) | **DROPPED**. Water level now uses the same `soc` variable the existing arc uses — no bypass. Listed in "Out of scope". |
+| F2 — Water-level mapping `(0.1 + ratio × 0.8)` invented; the issue literally says "+1/5 / −1/5" = pool's `(0.2 + ratio × 0.6)` | scope-guardian (critical), critic (clarify) | **APPLIED**. Mapping is now the issue's literal rule, identical to the pool card. |
+| F3 — Continuous RAF refactor conflicts with the existing `test_card_raf_idle_gated` parametrize row `("qs-car-card.js", "charging")` at `test_dashboard_rendering.py:1733`; gate would go red without an explicit removal step | concrete-planner (critical), critic (critical), scope-guardian (redesign) | **APPLIED**. Task 1a now explicitly removes that parametrize row and mirrors the QS-200 removal-comment pattern at lines 1719-1727. |
+| F4 — Lightning math inconsistent: spawn 2 Hz × life 0.25 s = 0.5 steady state, so cap=3 was dead code | critic (critical) | **APPLIED**. Rebalanced to `LIGHTNING_SPAWN_RATE_HZ=3`, `LIGHTNING_LIFE_S=0.5` → ~1.5 average, occasional 3-cap. |
+| F5 — "Mirror boiler" hand-wave violates plan-stands-alone | critic (redesign), dev-proxy (clarify) | **APPLIED**. The lerp envelope, opacity cross-fade, lightning spawn/retire loop, water-level mapping, and post-innerHTML memo-key sync are all inlined as code snippets in "Behavior contracts". |
+| F6 — AC-8 z-order ambiguity / hidden-under-bgPath risk; needs explicit insertion-point text | critic (redesign), concrete-planner (improve) | **APPLIED**. Task 6 now specifies "insert between `</defs>` (line 587) and `<path d=\"${bgPath}\">` (line 588)" and explains bgPath is a stroke ring at radius 130 while the water region's max radius is ~78, so there is no overlap. |
+| F7 — Body-only clip (water/lightning) vs body+terminal outline (silhouette) implicit | critic (clarify) | **APPLIED**. Explicit statement in AC-1 ("terminal NOT part of the clip — water and lightning never bleed into the terminal") and AC-5 ("outline `d` covers BOTH the body rounded-rect AND the terminal nub in ONE single combined path"). |
+| F8 — `_currentColorMix` undefined / lerp rate not pinned | critic (clarify), dev-proxy (clarify) | **APPLIED**. Defined: ∈ [0, 1], driven by `charging`, lerped via the boiler's `LERP_RATE=2` envelope. Code snippet inlined in "Continuous RAF + lerp envelope". |
+| F9 — Cross-fade: per-path vs group opacity ambiguity | critic (redesign) | **APPLIED**. AC-3 explicitly says "per PATH every frame (not via a group `opacity` attribute on the parent `<g>`)". Code snippet "Per-path opacity cross-fade" inlined. |
+| F10 — `--ring-text-shadow` is gold-plating / not requested by issue / undefined origin | critic (clarify), scope-guardian (improve), dev-proxy (clarify), concrete-planner (clarify) | **DROPPED**. Listed in "Out of scope". If legibility regresses, file separately. |
+| F11 — AC-10 (per-instance unique ids) is hygiene, not issue-derived | scope-guardian (improve), dev-proxy (clarify) | **DROPPED as AC**. Kept as implementation requirement in Task 5 ("Reuse the existing `Math.floor(Math.random() * 1e6)` pattern"). No dedicated test. |
+| F12 — AC-11 (existing arc unchanged) was paranoia | scope-guardian (improve), dev-proxy (improve) | **SIMPLIFIED**. AC-9 (renumbered) now reads "purely additive in the SVG markup; no rearrangement of existing elements" with explicit list of byte-identical lines. |
+| F13 — Lightning life curve breakpoints unspecified | dev-proxy (improve), critic (clarify) | **APPLIED**. `LIGHTNING_FADE_IN_FRACTION = 0.2`, `LIGHTNING_FADE_OUT_FRACTION = 0.7` pinned as constants; AC-6 pins them; spawn+life code snippet inlined. |
+| F14 — Boundary tests (colorMix=0/0.5/1, SOC=0/50/100, life thirds) need JS runtime | dev-proxy (improve ×3) | **NOT APPLICABLE**. Project tests JS via Python regex sentinels (boiler/pool precedent). The 9 new tests pin the source-level invariants those boundaries would manifest. |
+| F15 — ~+550 LOC budget too large to track | critic (critical) | **APPLIED**. Decomposed per sub-system in "Files touched" — constants ~80, helpers ~50, RAF refactor ~150, lightning ~120, SVG markup ~80, cleanup ~30 = ~510 total. |
+| F16 — Doc paragraph not requested by issue | scope-guardian (improve), concrete-planner (clarify) | **KEPT**. Workflow-required co-modification per the drift-checker rule; `dashboard-and-cards.md` already lists `qs-car-card.js` in `covers:`. |
+| F17 — `last_verified` already at `2026-05-24` (today) — no bump needed | concrete-planner (clarify) | **APPLIED**. Task 9 no longer bumps `last_verified`. |
+| F18 — `WAVE_WIDTH = 200` was invented; pool/boiler use 480 | scope-guardian (improve) | **APPLIED**. `WAVE_WIDTH = 480`, same as pool/boiler — "same kind of animation" per the issue. |
+| F19 — Combined body+terminal outline path "no seam" justification was speculative | scope-guardian (improve), concrete-planner (redesign) | **KEPT** the combined path approach (project precedent: boiler uses a single combined path for its override-button-carve clipPath), but **APPLIED** concrete helper signatures with line-by-line tracing in "Helper signatures". |
+| F20 — `RING_DIAMETER = 260` was invented; existing code uses `ringCirc = 130` (radius) | concrete-planner (clarify) | **APPLIED**. `BATTERY_TOTAL_HEIGHT = 156` is now declared directly as a numeric literal with comment `// = 0.6 × 2 × ringCirc (130), per issue's "+1/5 / −1/5" rule`. No `RING_DIAMETER` constant introduced. |
+| F21 — New-constants insertion point ambiguous | concrete-planner (clarify) | **APPLIED**. Task 2 specifies "after line 13 (after the existing `ANIM_*` block), wrapped in `// --- QS-224 battery animation constants ---`". |
+| F22 — New clipPath / filter insertion point in `<defs>` | concrete-planner (improve) | **APPLIED**. Task 6a specifies "after `chargeGlow` filter, line 586; before `</defs>`, line 587". |
+| F23 — New SVG markup insertion point | concrete-planner (improve) | **APPLIED**. Task 6b specifies "between `</defs>` (line 587) and `<path d=\"${bgPath}\">` (line 588)". |
+| F24 — Triplet hue/lightness/alpha pattern not fully pinned | concrete-planner (clarify) | **APPLIED**. Full 3-element triplets pinned in the constants block (lightness/alpha step down per layer, mirror boiler's pattern at `qs-water-boiler-card.js:70-79`). |
+| F25 — DOM reuse vs create/destroy for lightning bolts | critic (improve) | **APPLIED**. Explicit "create/destroy (NOT pool/reuse) — matches project precedent at `qs-water-boiler-card.js:413-461`" in the constants block comment. |
+| F26 — Soft cap vs hard cap on particles | critic (clarify) | **APPLIED**. Explicit "HARD CAP" in the constants block comment and AC-6. The spawn loop uses `while (... < MAX_CONCURRENT_LIGHTNING)`. |
+| F27 — Lightning palette confirmed by user (session Q4) | scope-guardian (clarify) | **NO CHANGE**. White core (`#FFFFFF`) + blue glow (`#80D4FF`) per session clarification. |
+
+Net effect of triage:
+- 11 ACs → **9 ACs** (dropped raw-SOC bypass + per-instance-ids, simplified existing-arc-unchanged).
+- 9 tests → **9 tests** (1 parametrize MODIFY + 9 new sentinels — none dropped; precision tightened: each triplet element pinned, breakpoints pinned, helper signatures pinned).
+- `--ring-text-shadow` gold-plating removed.
+- Continuous-RAF refactor's test-conflict now has an explicit fix step (mirror QS-200 pattern).
+- All "mirror boiler" hand-waves replaced with inlined code snippets and line-number anchors.
+- Wave width unified with pool/boiler at 480.
+- Lightning timing rebalanced from dead-code cap to a meaningful 3-cap.
+- LOC budget decomposed per sub-system.

--- a/docs/stories/QS-224.story.md
+++ b/docs/stories/QS-224.story.md
@@ -317,14 +317,22 @@ counter introduced.
   exist, encoding the 12:18 mdi body aspect ratio and the issue's
   "+1/5 / −1/5" rule.
 
-### AC-2 — Three-layer wave animation inside the body clipPath
+### AC-2 — Single-layer wave animation inside the body clipPath
+
+> Review-fix #01 FX-02 collapsed the original 3-layer wave stack to a
+> single layer driven by `IDLE_WATER_COLORS.length`. With the bright
+> translucent palette from FX-01 the 3-layer stack produced too much
+> visual density and defeated the "very translucent" goal. Loop
+> counts in `_render()` and `_startAnimation()` are driven by the
+> palette length so adding entries back later is a one-line change.
 
 - **Given** the car card source,
 - **When** the rendered SVG is inspected,
-- **Then** the SVG contains six `<path>` elements with stable ids
-  `wave0_idle`, `wave0_charge`, `wave1_idle`, `wave1_charge`,
-  `wave2_idle`, `wave2_charge`, ALL nested inside a single
+- **Then** the SVG contains TWO `<path>` elements with stable ids
+  `wave0_idle` and `wave0_charge`, nested inside a single
   `<g clip-path="url(#${batteryClipId})">`,
+- **And** the obsolete `wave1_*` / `wave2_*` ids are NOT present
+  (negative pin against regression),
 - **And** a `_generateWavePath(width, amplitude, frequency, phase,
   yOffset)` method exists with the verbatim body of
   `qs-pool-card.js:49-62` (emits two periods of a sine wave closed
@@ -333,20 +341,27 @@ counter introduced.
   `WAVE_BOTTOM_Y === 400` are pinned (reuse pool/boiler values for the
   "same kind of animation" the issue asks for).
 
-### AC-3 — Idle green / charging blue palette, per-path opacity cross-fade
+### AC-3 — Bright translucent palettes, per-path opacity cross-fade
+
+> Review-fix #01 FX-01: the original 3-layer mid-saturation
+> mid-lightness palette read as dark and muddy. The new palette is
+> SINGLE-ELEMENT (FX-02 collapse), with hue still in the green/blue
+> families but lightness ≥ 85% and alpha ≤ 0.35 so the existing ring
+> + SOC arc + background remain clearly visible through the water.
+> Per-path opacity cross-fade is preserved.
 
 - **Given** the module-level constants,
 - **When** inspected,
-- **Then** `IDLE_WATER_COLORS` is a 3-element array of `'hsla(...)'`
-  strings whose hue token is in `[100, 180]` (green family — sentinel
-  rules out the blue/red/yellow/grey palettes),
-- **And** `CHARGING_WATER_COLORS` is a 3-element array of `'hsla(...)'`
-  strings whose hue token is in `[190, 230]` (blue family — sentinel
-  rules out green/red/grey),
+- **Then** `IDLE_WATER_COLORS` is a SINGLE-element array of
+  `'hsla(...)'` strings whose hue is in `[100, 180]` (green family),
+  lightness ≥ 85%, alpha ≤ 0.35,
+- **And** `CHARGING_WATER_COLORS` is a SINGLE-element array of
+  `'hsla(...)'` strings whose hue is in `[190, 230]` (blue family),
+  same lightness floor and alpha ceiling as the idle palette,
 - **And** the RAF loop sets `opacity` PER PATH every frame (not via a
-  group `opacity` attribute on the parent `<g>`) — the wave 6
-  `setAttribute('opacity', ...)` calls or equivalent per-element
-  opacity updates appear in source.
+  group `opacity` attribute on the parent `<g>`) — the
+  `setAttribute('opacity', idleOpacity)` and
+  `setAttribute('opacity', chargeOpacity)` calls appear in source.
 
 ### AC-4 — Wave amplitude/speed lerp mirrors the boiler
 
@@ -358,6 +373,14 @@ counter introduced.
 
 ### AC-5 — Battery outline (body+terminal) always visible, alpha lerps with `_currentColorMix`
 
+> Review-fix #01 FX-03: the user reported the outline was invisible
+> against the ring + bright water. Three knobs were tuned together:
+> stroke color swapped to a neutral grey (`rgba(180,180,180,…)`),
+> width widened to `MDI_UNIT_PX` (1 mdi-unit ≈ 7.8 px, matching the
+> mdi:battery-outline 1/12 body-width stroke ratio), and alpha range
+> bumped from `0.30 → 0.55` to `0.55 → 0.80`. AC-9's RAF
+> rgba-interpolation contract (not CSS `color-mix`) is preserved.
+
 - **Given** the rendered SVG,
 - **When** inspected,
 - **Then** there is exactly one `<path id="battery_outline">` drawn
@@ -366,12 +389,15 @@ counter introduced.
 - **And** the outline `d` covers BOTH the body rounded-rect AND the
   terminal nub in ONE single combined path (no seam at the join),
 - **And** module-level constants `BATTERY_OUTLINE_STROKE_IDLE_ALPHA
-  === 0.30` and `BATTERY_OUTLINE_STROKE_CHARGING_ALPHA === 0.55` exist
-  with distinct values,
+  === 0.55` and `BATTERY_OUTLINE_STROKE_CHARGING_ALPHA === 0.80`
+  exist with distinct values,
+- **And** `BATTERY_OUTLINE_STROKE_WIDTH === MDI_UNIT_PX` (= 1
+  mdi-unit ≈ 7.8 SVG-px, the mdi:battery-outline 1/12 body-width
+  stroke ratio),
 - **And** the RAF loop updates the `stroke` attribute every frame via
   JS rgba interpolation (NOT CSS `color-mix` — for browser compat):
   `alpha = IDLE + colorMix * (CHARGING - IDLE)`, format
-  `rgba(255,255,255,${alpha.toFixed(3)})`.
+  `rgba(180,180,180,${alpha.toFixed(3)})`.
 
 ### AC-6 — Lightning particle system: charging-only spawn, hard cap, life curve
 

--- a/docs/stories/QS-224.story_review_fix_#01.md
+++ b/docs/stories/QS-224.story_review_fix_#01.md
@@ -4,20 +4,23 @@
 
 - Source PR: #227
 - Source story: `docs/stories/QS-224.story.md`
-- Findings to fix: 3 (user visual feedback after seeing the rendered card)
+- Findings to fix: 13 (3 user visual rejections + 10 adversarial-review should-fix)
 - Next implement phase: `/implement-task`
 
-The user has reviewed the rendered card and rejected the current visual
-parameters. The three items below replace the relevant choices made in
-QS-224 plan §§ "Water palettes" and "Battery outline appearance" and
-collapse the 3-layer wave stack to 1.
+**FX-01 — FX-03** are user visual rejections after seeing the rendered
+card. They replace the relevant choices in QS-224 plan §§ "Water
+palettes" and "Battery outline appearance" and collapse the 3-layer
+wave stack to 1.
 
-The 10 should-fix items from the adversarial review (lightning wipe on
-`set hass`, first-paint prime miss, spawn-debt clamp, `_waveEls` null
-cache, water-level formula, 5 test-coverage gaps) are NOT included in
-this fix plan — the user opted to focus on visual feedback first. Those
-items remain visible in the PR review history and can be addressed in
-a follow-up `/review-task` → `/implement-task` cycle.
+**FX-04 — FX-13** are the should-fix findings from the four-reviewer
+adversarial review: 2 from edge-case-hunter, 3 from blind-hunter, 5
+test-coverage gaps from acceptance-auditor.
+
+The 8 nice-to-haves from the review (misleading comment, terminal-nub
+square corners, hardcoded theme colors, random id collisions,
+`_resetDomRefs` no-DOM-cleanup, `_lightningLayerId` not cleared on
+detach, lightning `cyStart` future-negative clamp, RAF `null ??` cache
+loop) are NOT included — they can wait for a future polish pass.
 
 ## Findings to fix
 
@@ -184,24 +187,275 @@ a follow-up `/review-task` → `/implement-task` cycle.
   QS-224 paragraph: update the alpha lerp range and the stroke-width
   rationale (mdi:battery-outline ratio).
 
+### [should-fix] FX-04 — lightning bolts blink out on every `set hass` push (regresses QS-214 fix)
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js` post-innerHTML cleanup block in `_render()` (the `this._lightning = []` direct reset after `_root.innerHTML = …`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: while a car is actively charging, HA pushes multi-Hz
+  state updates (`power`, `current_inputed_energy`, etc.), each of
+  which calls `_render()`. The current cleanup wipes
+  `this._lightning = []` and detaches every previously-appended
+  `<polyline>` DOM node, so any bolt mid-life-curve pops out
+  instantly with no fade-out — the exact "particles all disappear
+  simultaneously" symptom QS-214 fixed in the boiler card. Visible
+  on any normal charging dashboard.
+- Proposed fix: mirror `qs-water-boiler-card.js:1216-1219, 1382-1432`.
+  Snapshot `this._lightning` and `this._nextLightningAt` BEFORE the
+  `_root.innerHTML = …` rewrite. After the rewrite, resolve the
+  freshly-rendered lightning layer via the new `_lightningLayerId`,
+  `appendChild(p.el)` each preserved bolt back into the new layer,
+  restore the array (filter on `p?.el` truthy), and restore the
+  cadence counter. RAF picks up exactly where it left off; no
+  visible blink. Add a test mirroring
+  `test_water_boiler_card_render_preserves_steam_puffs_across_innerHTML`
+  (or whichever boiler test enforces the same invariant).
+
+### [should-fix] FX-05 — first `_render` from `setConfig` doesn't prime, so first paint is calm even when charging
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:939-944, 950-956`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: lifecycle order is `setConfig → _render → connectedCallback
+  → _startAnimation (sets _needsAnimationPrime=true) → set hass →
+  _render → prime fires`. On the very first `_render` (from
+  `setConfig`), `_needsAnimationPrime` is `undefined`, the prime
+  block is skipped, `_currentAmplitude` is still `undefined`, and
+  `initialAmp = _currentAmplitude ?? CALM_AMP = CALM_AMP` regardless
+  of `charging`. First SVG paint of an actively-charging car shows
+  calm green; only the second `_render` snaps to charging blue.
+  Visible on slow first-page loads.
+- Proposed fix: extend the prime condition so it also fires when the
+  state has not yet been initialised:
+
+  ```js
+  if (this._needsAnimationPrime || this._currentAmplitude == null) {
+    this._currentAmplitude = charging ? CHARGING_AMP : CALM_AMP;
+    this._currentSpeed     = charging ? CHARGING_SPEED : CALM_SPEED;
+    this._currentColorMix  = charging ? 1 : 0;
+    this._needsAnimationPrime = false;
+  }
+  ```
+
+  Add a test that sets `charging=true` then renders once and asserts
+  the resulting SVG `d` attribute corresponds to `CHARGING_AMP`
+  geometry, not `CALM_AMP`. (Sentinel can be a regex on the
+  amplitude-dependent extremum of the wave path; the easier
+  alternative is to inspect `_currentAmplitude` directly after a
+  simulated first render in JSDOM.)
+
+### [should-fix] FX-06 — lightning spawn-debt clamp discards accumulated debt when cap is hit
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:404`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `if (this._nextLightningAt < 0) this._nextLightningAt = 0;`
+  runs unconditionally after the cap-blocked while-loop. When the
+  hard cap is hit, `_nextLightningAt` stops decrementing inside the
+  loop, then the clamp silently zeros any accumulated negative debt.
+  Net effect: when a slot frees, the next spawn waits the full
+  `1/SPAWN_RATE_HZ` window instead of firing immediately — minor
+  desync vs. the documented "spawn rate × life ≈ 1.5 avg" target.
+- Proposed fix: only clamp when NOT capped, e.g.
+
+  ```js
+  if (this._lightning.length < MAX_CONCURRENT_LIGHTNING
+      && this._nextLightningAt < 0) {
+    this._nextLightningAt = 0;
+  }
+  ```
+
+  so the debt is preserved across cap-blocked frames and a freed slot
+  is filled immediately. Add a unit test that drives RAF with the
+  hard cap saturated, retires one bolt, and asserts the next spawn
+  fires within the same `dt` rather than after the full `1/SPAWN_RATE_HZ`.
+
+### [should-fix] FX-07 — `_waveEls` lazy cache locks in `[null, null, …]` if RAF fires before first `_render`
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:293-301`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `connectedCallback()` eagerly calls `_startAnimation()`,
+  which schedules a RAF tick. If that tick lands before the first
+  `_render()` (no SVG markup yet), `getElementById` returns `null`
+  for all 6 wave nodes; the resulting `_waveEls = [null, …, null]`
+  array is truthy, so the lazy-resolution guard `if (!this._waveEls)`
+  never re-queries. The cache stays stuck at all-nulls until the
+  next innerHTML rewrite invalidates it via `_resetDomRefs`.
+- Proposed fix: re-query when ANY cached ref is null, e.g.
+
+  ```js
+  if (!this._waveEls || this._waveEls.some(el => el == null)) {
+    // …resolve all six (post-FX-02: all two) refs…
+  }
+  ```
+
+  Same idiom for `_lightningLayerEl` and `_batteryOutlineEl` — the
+  current `el ?? (el = getElementById(…) ?? null)` pattern also
+  short-circuits assignment-as-cache when the result is `null` (it
+  re-runs `getElementById` every frame). Use an explicit boolean
+  flag (e.g. `_domRefsResolved`) set once `_render` finished, and
+  read refs lazily once that flag flips true. Add a sentinel test
+  asserting the cache survives a "RAF-before-render" sequence
+  (simulated by stepping the animation before calling `_render`).
+
+### [should-fix] FX-08 — water-level formula deviates from the issue's "+1/5 / −1/5 of ring diameter" rule
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js` (`waterBaseY` calculation in `_render()`, ~line 491 of the post-PR file)
+- Severity: should-fix (documented re-interpretation, but worth confirming intent)
+- Source: qs-review-blind-hunter
+- Description: the issue text literally specifies "+1/5 / −1/5 of the
+  circle Diameter" (ring diameter = 260 SVG-px → 1/5 = 52 px), but
+  the implementation applies the `0.2 + ratio × 0.6` fraction to
+  `BATTERY_BODY_HEIGHT` (140.4 px → 1/5 = 28 px). The plan
+  documented this re-interpretation as "translated to battery body"
+  but the literal mapping was never confirmed with the user.
+- Proposed fix: confirm intent with a low-cost decision in
+  `/implement-task`:
+  - **Option A** (keep current): leave the formula as-is and add a
+    block-comment citing the plan's re-interpretation rationale so
+    future readers don't flag the drift.
+  - **Option B** (literal): switch to ring-diameter-based bounds:
+    `waterBaseY = CENTER_CY + ringCirc - (0.2 + ratio × 0.6) * (2 × ringCirc)`
+    (i.e., bottom-at-ring-bottom, top-at-ring-top × 60% band). The
+    waves then potentially extend beyond `BATTERY_BODY_TOP_Y`
+    (clipped by the clipPath; effectively means the water can fully
+    fill the body at 100% SOC and only the corner radii of the body
+    bottom clip the floor at 0% SOC).
+  - Recommend Option A unless the user, on the next visual eyeball,
+    sees the water hitting the body floor at low SOC. Pin whichever
+    is chosen with a comment + test sentinel.
+
+### [should-fix] FX-09 — AC-5 test missing: no sentinel for the RAF rgba interpolation contract
+
+- File: `tests/test_dashboard_rendering.py` (extend `test_car_card_battery_outline_present_with_distinct_strokes`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor (AC-5)
+- Description: AC-5 explicitly says "the RAF loop updates the
+  `stroke` attribute every frame via JS rgba interpolation (NOT CSS
+  `color-mix`)" with format
+  `rgba(255,255,255,${alpha.toFixed(3)})`. After FX-03 the format
+  becomes `rgba(180,180,180,${alpha.toFixed(3)})`. The existing test
+  only pins the two alpha constants and a static markup regex; it
+  does not assert the RAF setter exists or that `color-mix` is
+  forbidden. A regression that swapped to CSS `color-mix` would
+  pass.
+- Proposed fix: extend
+  `test_car_card_battery_outline_present_with_distinct_strokes`:
+  1. `assert re.search(r"setAttribute\(\s*['\"]stroke['\"][^;]*rgba\(180,180,180,", _strip_js_comments(content))`
+     — pins the RAF rgba setter and the grey RGB triple.
+  2. `assert "color-mix" not in _strip_js_comments(content)` — bans
+     the CSS path.
+
+### [should-fix] FX-10 — AC-6 test missing: no sentinel for polyline 5-vertex count
+
+- File: `tests/test_dashboard_rendering.py` (extend `test_car_card_has_lightning_system`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor (AC-6)
+- Description: AC-6 pins "each polyline's `points` attribute contains
+  exactly `LIGHTNING_SEGMENTS + 1` (= 5) whitespace-separated `x,y`
+  pairs". The current test pins `LIGHTNING_SEGMENTS = 4` but does
+  not assert the spawn loop bound is `i <= LIGHTNING_SEGMENTS`.
+  Off-by-one drift (`i < LIGHTNING_SEGMENTS` → 4 vertices, or
+  `i <= LIGHTNING_SEGMENTS + 1` → 6 vertices) would silently pass.
+- Proposed fix: add
+  `assert re.search(r"for\s*\([^)]*i\s*<=\s*LIGHTNING_SEGMENTS\b",
+  _strip_js_comments(executable))` to the existing test.
+
+### [should-fix] FX-11 — AC-7 test missing: `disconnectedCallback` lightning teardown not asserted
+
+- File: `tests/test_dashboard_rendering.py` (extend `test_car_card_continuous_raf_refactor` or add a dedicated sentinel)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor (AC-7)
+- Description: AC-7 says "`disconnectedCallback()` still calls
+  `this._stopAnimation()` AND removes all live lightning bolt DOM
+  nodes (eager teardown — mirrors `qs-water-boiler-card.js:637-644`)".
+  The existing test only asserts `connectedCallback` calls
+  `_startAnimation` directly and the legacy `if(charging)` gate is
+  gone in `_render`; it does not walk `disconnectedCallback` for
+  the lightning forEach-remove pattern. The boiler card has
+  precedent
+  `test_water_boiler_card_disconnected_callback_clears_steam` (line
+  ~3227) doing exactly this.
+- Proposed fix: add a sentinel that extracts the
+  `disconnectedCallback` body and asserts both
+  `re.search(r"this\._lightning\?\.forEach\(b\s*=>\s*b\.el\?\.remove\?\.\(\)\)", body)`
+  and `re.search(r"this\._lightning\s*=\s*\[\]", body)` are present.
+
+### [should-fix] FX-12 — AC-8 test missing: z-order coverage is incomplete
+
+- File: `tests/test_dashboard_rendering.py` (extend `test_car_card_z_order_battery_group_before_bgpath`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor (AC-8)
+- Description: AC-8 has 4 sub-clauses; the existing test covers only
+  (a) clipped `<g>` before `bgPath` and (b) `battery_outline`
+  between. Sub-clauses (c) — SOC arc / `charge_anim` /
+  `target_handle` / `target_handle_text` all appear AFTER `bgPath`
+  — and (d) — HTML `<div class="center">` overlay unchanged — are
+  not asserted. A regression that moved `charge_anim` above
+  `bgPath` would not be caught.
+- Proposed fix: extend the test to locate each existing element
+  (`<path d="${socPath}"`, `<path id="charge_anim"`,
+  `<circle id="target_handle"`, `<text id="target_handle_text"`)
+  and assert each `find()` returns an index `> bg_idx`. For (d),
+  assert the HTML `<div class="center">` string literal still
+  appears exactly once in the source.
+
+### [should-fix] FX-13 — AC-9 test missing: no sentinel for "existing elements byte-identical"
+
+- File: `tests/test_dashboard_rendering.py` (add `test_car_card_existing_svg_elements_unchanged`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor (AC-9)
+- Description: AC-9 explicitly lists 5 elements/blocks that must be
+  byte-identical between pre- and post-change source: `<path
+  d="${bgPath}"`, `<path d="${socPath}"`, `<path id="charge_anim"`,
+  `<circle id="target_handle"`, `<text id="target_handle_text"`.
+  The 9 new tests cover none of this AC. The story only claims
+  "existing tests pass without modification", which is a *negative*
+  assertion (they don't break), not a sentinel that the
+  additive-only contract holds.
+- Proposed fix: add a new test
+  `test_car_card_existing_svg_elements_unchanged` that, for each of
+  the 5 marker substrings, asserts it appears exactly once in
+  `_strip_js_comments(content)` — protecting against accidental
+  duplication or rearrangement. (Note: FX-12 sub-clause (c) covers
+  position; this AC covers count.)
+
 ## How to apply
 
 Run `/implement-task` against this fix plan. The implementation must:
 
-1. Apply the three source changes to
-   `custom_components/quiet_solar/ui/resources/qs-car-card.js`.
-2. Update the affected tests in `tests/test_dashboard_rendering.py`
-   so they pin the new invariants (single-layer waves, bright/
-   translucent palettes, grey/wider outline).
-3. Update the story file
-   (`docs/stories/QS-224.story.md`) so the ACs match the new
-   visuals — otherwise the acceptance-auditor will rightly flag the
-   drift on the next `/review-task` pass.
-4. Update the concept doc
-   (`docs/agents/concepts/dashboard-and-cards.md`) QS-224 paragraph
-   to match.
-5. Pass the full quality gate (pytest 100% cov + ruff + mypy +
-   translations).
+1. **Visual fixes (FX-01 — FX-03)** — apply the source changes to
+   `custom_components/quiet_solar/ui/resources/qs-car-card.js`:
+   bright/translucent palettes, single-layer wave stack,
+   grey/wider/higher-alpha battery outline.
+2. **Behavior fixes (FX-04 — FX-08)** — apply the source changes:
+   - FX-04: snapshot lightning state across `_render()` innerHTML
+     rewrite (mirror boiler QS-214 pattern).
+   - FX-05: extend prime condition to also fire on
+     `_currentAmplitude == null`.
+   - FX-06: only clamp spawn debt when not capped.
+   - FX-07: re-resolve DOM ref cache when any entry is null.
+   - FX-08: confirm water-level interpretation (default to Option A —
+     keep current + add comment).
+3. **Test fixes (FX-09 — FX-13)** — extend / add tests in
+   `tests/test_dashboard_rendering.py` so each acceptance criterion
+   has a load-bearing sentinel: RAF rgba setter, polyline vertex
+   count, `disconnectedCallback` teardown, full z-order coverage,
+   byte-identical existing elements.
+4. **Story sync** — update `docs/stories/QS-224.story.md` so the ACs
+   match the new visuals (FX-01/02/03 alter AC-2, AC-3, AC-5) and
+   any FX-04/FX-08 design decisions are reflected.
+5. **Concept doc sync** — update the QS-224 paragraph in
+   `docs/agents/concepts/dashboard-and-cards.md` (single-layer
+   water, grey outline rationale, lightning preservation note).
+6. **Quality gate** — pass full `python scripts/qs/quality_gate.py`
+   (pytest 100% cov + ruff + mypy + translations).
+
+Suggested commit shape: one TDD commit per FX item, OR group
+FX-01/02/03 (user-visual), FX-04/05/06/07/08 (behavior), and
+FX-09–13 (test coverage) into three coherent commits. Implementer's
+call.
 
 When done, return and run `/review-task` again to re-verify, and
 expect the user to eyeball the new render before signing off.

--- a/docs/stories/QS-224.story_review_fix_#01.md
+++ b/docs/stories/QS-224.story_review_fix_#01.md
@@ -1,0 +1,207 @@
+# QS-224 — Review fix plan #01
+
+## Summary
+
+- Source PR: #227
+- Source story: `docs/stories/QS-224.story.md`
+- Findings to fix: 3 (user visual feedback after seeing the rendered card)
+- Next implement phase: `/implement-task`
+
+The user has reviewed the rendered card and rejected the current visual
+parameters. The three items below replace the relevant choices made in
+QS-224 plan §§ "Water palettes" and "Battery outline appearance" and
+collapse the 3-layer wave stack to 1.
+
+The 10 should-fix items from the adversarial review (lightning wipe on
+`set hass`, first-paint prime miss, spawn-debt clamp, `_waveEls` null
+cache, water-level formula, 5 test-coverage gaps) are NOT included in
+this fix plan — the user opted to focus on visual feedback first. Those
+items remain visible in the PR review history and can be addressed in
+a follow-up `/review-task` → `/implement-task` cycle.
+
+## Findings to fix
+
+### [must-fix] FX-01 — water palette is too dark and dull; want bright + very translucent
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:47-56`
+- Severity: must-fix (direct user visual rejection)
+- Source: user feedback on rendered card
+- Description: the current palette uses moderate-saturation mid-lightness
+  green (`hsla(150, 60%, 35%, 0.55)` and friends) and shows as a dark,
+  muddy green inside the battery. The user wants a **very bright,
+  vibrant** green that reads as "fresh / lively" and **very
+  translucent** so the existing ring + SOC arc + background remain
+  clearly visible through the water. The charging blue follows the same
+  brightness/transparency principle for visual coherence.
+- Proposed fix:
+
+  Replace the two palettes with single-element, high-lightness,
+  low-alpha entries:
+
+  ```js
+  // Bright, very translucent: lets the SOC arc and ring read clearly
+  // through the water; reads as "fresh" rather than "muddy".
+  const IDLE_WATER_COLORS = [
+    'hsla(135, 95%, 60%, 0.22)',   // bright vibrant green, very translucent
+  ];
+  const CHARGING_WATER_COLORS = [
+    'hsla(205, 95%, 60%, 0.32)',   // bright sky-blue, slightly more present while charging
+  ];
+  ```
+
+  Final hue/lightness/alpha numbers may be tuned during implementation
+  (the implementer can dry-run two or three nearby values), but the
+  shape of the change is fixed: hue stays in the green family for idle
+  / blue family for charging, **lightness ≥ 85%** (currently ≤ 40% —
+  this is the load-bearing fix), **alpha ≤ 0.35** (currently up to
+  0.60), single entry per palette.
+
+### [must-fix] FX-02 — collapse the 3-layer wave stack to a single sin layer
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js` (multiple sites; see below)
+- Severity: must-fix (direct user visual rejection)
+- Source: user feedback on rendered card
+- Description: the current implementation renders 3 wave layers (each
+  with a pair of `<path>` nodes, idle + charge cross-fade — 6 paths
+  total). With the new bright translucent palette per FX-01, the
+  user says **a single sin layer is sufficient**; the 3-layer stack
+  produces too much visual density and defeats the "very translucent"
+  goal. This change pairs naturally with FX-01.
+- Proposed fix:
+
+  Collapse all 3-layer iteration to 1-layer in qs-car-card.js. Drive
+  the loop count from `IDLE_WATER_COLORS.length` rather than a
+  hard-coded `3` so the change is robust to future palette tweaks.
+  Concretely:
+
+  1. **Constants** (lines 39-40): keep `LAYER_SCROLL_OFFSET` and
+     `LAYER_PHASE_OFFSET` as-is (still used for `i = 0` they just
+     produce zero offset, which is correct).
+  2. **Markup generation** in `_render()` — currently emits six paths
+     `wave{0,1,2}_{idle,charge}` inside the clipped `<g>`. Drive the
+     emission via `IDLE_WATER_COLORS.map((color, i) => ...)` so it
+     emits 2 paths total (`wave0_idle`, `wave0_charge`) when the
+     palette length is 1.
+  3. **`_waveEls` cache resolution** in `_startAnimation()` step
+     function (currently resolves 6 ids `wave0_idle` ... `wave2_charge`):
+     resolve via a loop driven by `IDLE_WATER_COLORS.length`. The
+     cache shape becomes `[idle0, charge0]` of length 2 (instead of
+     length 6).
+  4. **Wave transform loop** (currently `for (let i = 0; i < 3; i++)`):
+     bound by `IDLE_WATER_COLORS.length`. Same idiom for the path
+     regen loop and the per-frame opacity update loop.
+  5. **`_generateWavePath` arguments**: the call site already uses
+     `phaseOffset = i * LAYER_PHASE_OFFSET` and `freq = 2 + i`. With
+     `i ∈ {0}` only, `phaseOffset = 0` and `freq = 2`. That is the
+     intended single-layer behavior — preserve the call shape.
+  6. **Tests** in `tests/test_dashboard_rendering.py`:
+     - `test_car_card_renders_water_layer` (lines 3650-3697 of the
+       post-PR file): update the count assertion from 6 paths to 2
+       (or, better, assert `count == 2 * IDLE_WATER_COLORS.length`
+       so the test stays in sync with future palette changes — but
+       the simpler `count == 2` is acceptable).
+     - `test_car_card_pins_water_palette_triplets` (lines 3700-3796):
+       rename to `..._pins_water_palette_singletons` and update the
+       array-length assertion to `== 1`. Hue ranges, lightness
+       floor, and alpha ceiling assertions stay (with updated
+       thresholds per FX-01: lightness ≥ 85, alpha ≤ 0.35).
+  7. **Story doc** `docs/stories/QS-224.story.md`:
+     - AC-2 currently lists "six `<path id="waveX_{idle,charge}">`"
+       (one per layer × idle/charge). Update to "two `<path
+       id="wave0_{idle,charge}">`" and note the single-layer design.
+     - AC-3 currently mentions stepped lightness/alpha across the 3
+       layers. Drop the "stepped" wording and pin the single
+       lightness/alpha pair per palette per FX-01.
+  8. **Concept doc** `docs/agents/concepts/dashboard-and-cards.md` —
+     the QS-224 paragraph mentions "3-layer sine-wave water". Update
+     to "single-layer sine-wave water" and note the rationale
+     (translucency goal).
+
+### [must-fix] FX-03 — battery outline is invisible; make it grey + wider per mdi ratio
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:95-97, 359-364`
+- Severity: must-fix (direct user visual rejection)
+- Source: user feedback on rendered card
+- Description: the current outline draws a thin (`stroke-width=2`)
+  near-white (`rgba(255,255,255,alpha)`) stroke with alphas
+  `0.30 → 0.55`. On the user's dashboard the outline disappears
+  against the ring and the water — the silhouette goal of AC-5 is not
+  achieved. The user wants (a) a **neutral grey** stroke (not white)
+  and (b) a **wider** stroke matching the mdi:battery-outline
+  thickness ratio.
+- Proposed fix:
+
+  **Width:** mdi:battery-outline draws its silhouette with a stroke of
+  ~1 mdi-unit (the outer-to-inner edge thickness of the drawn body
+  outline). Body interior is 12 mdi-units wide. Ratio = 1/12 ≈ 8.3%.
+  Apply the same ratio to our scaled battery: stroke width =
+  `MDI_UNIT_PX` (= 7.8 SVG-px). That is roughly 4× the current
+  `BATTERY_OUTLINE_STROKE_WIDTH = 2`. If 7.8 px reads too dominant
+  during implementation, half-unit (`MDI_UNIT_PX * 0.5` ≈ 3.9 px) is
+  the fallback — but the literal 1-unit mdi-ratio is what the user
+  asked for and is the canonical interpretation.
+
+  **Color:** swap the per-frame `setAttribute('stroke', ...)` value
+  from `rgba(255,255,255,${alpha})` to a soft neutral grey, e.g.
+  `rgba(180,180,180,${alpha})` (≈ 70% lightness). Keep the JS rgba
+  interpolation contract (NOT CSS `color-mix`) per the existing AC-5.
+
+  **Alpha:** the wider stroke means alpha can stay moderate, but the
+  current `0.30 → 0.55` is too low against a grey RGB. Bump to
+  `0.55 → 0.80`:
+
+  ```js
+  const BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.55;       // was 0.30
+  const BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.80;   // was 0.55
+  const BATTERY_OUTLINE_STROKE_WIDTH = MDI_UNIT_PX;     // was 2 (literal); ≈ 7.8 px now
+  ```
+
+  In the RAF step function:
+
+  ```js
+  outlineEl.setAttribute('stroke', `rgba(180,180,180,${outlineAlpha.toFixed(3)})`);
+  ```
+
+  **Tests** in `tests/test_dashboard_rendering.py`
+  (`test_car_card_battery_outline_present_with_distinct_strokes` at
+  lines 3576-3633 of post-PR file):
+  - Update the pinned alpha constants from `0.30 / 0.55` to
+    `0.55 / 0.80`.
+  - Update the pinned stroke-width assertion: it should no longer
+    pin literal `2`. Pin `BATTERY_OUTLINE_STROKE_WIDTH = MDI_UNIT_PX`
+    in source (regex match of the source line), which is the
+    load-bearing invariant — the literal pixel value is computed.
+  - Add a regex sentinel that asserts the RAF stroke setter uses
+    `rgba(180,180,180,` (not `rgba(255,255,255,`) — protecting the
+    color contract.
+
+  **Story doc** `docs/stories/QS-224.story.md` AC-5 currently says
+  "stroke alpha lerps from 0.30 (idle) to 0.55 (charging)" and
+  describes the stroke-width as `2`. Update to the new values and
+  note the mdi-ratio derivation (1/12 of body width).
+
+  **Concept doc** `docs/agents/concepts/dashboard-and-cards.md`
+  QS-224 paragraph: update the alpha lerp range and the stroke-width
+  rationale (mdi:battery-outline ratio).
+
+## How to apply
+
+Run `/implement-task` against this fix plan. The implementation must:
+
+1. Apply the three source changes to
+   `custom_components/quiet_solar/ui/resources/qs-car-card.js`.
+2. Update the affected tests in `tests/test_dashboard_rendering.py`
+   so they pin the new invariants (single-layer waves, bright/
+   translucent palettes, grey/wider outline).
+3. Update the story file
+   (`docs/stories/QS-224.story.md`) so the ACs match the new
+   visuals — otherwise the acceptance-auditor will rightly flag the
+   drift on the next `/review-task` pass.
+4. Update the concept doc
+   (`docs/agents/concepts/dashboard-and-cards.md`) QS-224 paragraph
+   to match.
+5. Pass the full quality gate (pytest 100% cov + ruff + mypy +
+   translations).
+
+When done, return and run `/review-task` again to re-verify, and
+expect the user to eyeball the new render before signing off.

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -1725,24 +1725,32 @@ def test_card_mode_change_wrapped_in_try_finally(card_filename):
 # list) means a future reviewer scanning the parametrize entries can
 # read them as a clean enumeration without losing the removed-card
 # rationale.
+#
+# QS-224: `qs-car-card.js` was previously in the idle-gated cluster
+# (the `if (charging) { _startAnimation() }` form in _render). QS-224
+# moves the car card to the same continuous-RAF model the pool and
+# boiler cards already use, because the new battery+water animation
+# must keep animating gently (calm green waves) even when idle. See
+# AC-7 of docs/stories/QS-224.story.md. Coverage moves to
+# `test_car_card_continuous_raf_refactor` below.
 @pytest.mark.parametrize(
     "card_filename,gate",
     [
         ("qs-on-off-duration-card.js", "showAnimation"),
         ("qs-climate-card.js", "showAnimation"),
-        ("qs-car-card.js", "charging"),
         ("qs-radiator-card.js", "showAnimation"),
     ],
 )
 def test_card_raf_idle_gated(card_filename, gate):
-    """M4: every card except pool / water boiler gates `_startAnimation`
-    on a runtime condition (`showAnimation` for on-off-duration/
-    climate, `charging` for car). The pool card's wave is intrinsically
-    continuous-while-connected and uses `_startAnimation` from
-    `connectedCallback` directly — that file is covered by the
-    presence-of-helper check below. QS-200 moved
-    `qs-water-boiler-card.js` to the same continuous-RAF model, also
-    covered separately.
+    """M4: every card except pool / water-boiler / car gates
+    `_startAnimation` on a runtime condition (`showAnimation` for
+    on-off-duration / climate / radiator). The pool card's wave is
+    intrinsically continuous-while-connected and uses
+    `_startAnimation` from `connectedCallback` directly — that file is
+    covered by the presence-of-helper check below. QS-200 moved
+    `qs-water-boiler-card.js` to the same continuous-RAF model, and
+    QS-224 moved `qs-car-card.js` to it as well; both are covered
+    separately.
     """
     import re
 
@@ -3268,6 +3276,536 @@ def test_water_boiler_card_steam_filter_region_attributes():
     ), (
         "qs-water-boiler-card.js: steam filter must contain "
         "`<feGaussianBlur stdDeviation=\"${STEAM_BLUR_STDDEV}\" />`."
+    )
+
+
+# ============================================================================
+# QS-224 — Car card battery backdrop (water + lightning + outline).
+# Sentinel tests pin the source-level invariants of the new animation:
+# battery geometry, three-layer water palette + cross-fade, amplitude /
+# speed lerp mirroring the boiler, body+terminal outline, lightning
+# particle system, continuous-RAF refactor, z-order vs the gauge ring.
+# All assertions read `qs-car-card.js` and walk the source — no JS
+# runtime required (boiler/pool precedent).
+# ============================================================================
+
+
+def test_car_card_pins_battery_geometry_constants():
+    """QS-224 AC-1: pin the module-level battery geometry constants
+    derived from the mdi:battery-outline 24×24 viewBox.
+
+    - `BATTERY_TOTAL_HEIGHT = 156` — vertical span of the battery
+      inside the 300×300 ring, per the issue's literal "+1/5 / −1/5
+      of diameter" rule (= 0.6 × 2 × ringCirc(130)).
+    - `MDI_UNIT_PX = BATTERY_TOTAL_HEIGHT / 20` — one mdi-unit in SVG
+      pixels (20 mdi-units = body 18 + terminal 2).
+    - `BATTERY_BODY_HEIGHT = 18 * MDI_UNIT_PX` and
+      `BATTERY_BODY_WIDTH = 12 * MDI_UNIT_PX` encode the 12:18 body
+      aspect ratio of the mdi icon (NOT 1:1, NOT square — drift here
+      breaks the silhouette).
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    assert re.search(
+        r"const\s+BATTERY_TOTAL_HEIGHT\s*=\s*156\b", content
+    ), (
+        "qs-car-card.js: missing module-level "
+        "`const BATTERY_TOTAL_HEIGHT = 156;` (vertical span derived "
+        "from issue's `+1/5 / −1/5 of diameter` rule = 0.6 × 2 × 130)."
+    )
+    assert re.search(
+        r"const\s+MDI_UNIT_PX\s*=\s*BATTERY_TOTAL_HEIGHT\s*/\s*20\b",
+        content,
+    ), (
+        "qs-car-card.js: missing module-level "
+        "`const MDI_UNIT_PX = BATTERY_TOTAL_HEIGHT / 20;` "
+        "(one mdi-unit in SVG pixels — body 18 + terminal 2 = 20)."
+    )
+    assert re.search(
+        r"const\s+BATTERY_BODY_HEIGHT\s*=\s*18\s*\*\s*MDI_UNIT_PX\b",
+        content,
+    ), (
+        "qs-car-card.js: missing "
+        "`const BATTERY_BODY_HEIGHT = 18 * MDI_UNIT_PX;` "
+        "(18 mdi-units = mdi body height)."
+    )
+    assert re.search(
+        r"const\s+BATTERY_BODY_WIDTH\s*=\s*12\s*\*\s*MDI_UNIT_PX\b",
+        content,
+    ), (
+        "qs-car-card.js: missing "
+        "`const BATTERY_BODY_WIDTH = 12 * MDI_UNIT_PX;` "
+        "(12 mdi-units = mdi body width — preserves the 12:18 ratio)."
+    )
+
+
+def test_car_card_battery_clippath_in_defs():
+    """QS-224 AC-1: exactly one `<clipPath id="${batteryClipId}">`
+    in defs whose content is a SINGLE `<path>` child describing the
+    rounded-rect battery BODY interior. The terminal nub is NOT part
+    of the clip — water and lightning never bleed into it.
+
+    Also pins the existence of the `_generateBatteryBodyClipPath()`
+    helper method (the body's `d` builder)."""
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    # The clipPath element with stable id substitution + single <path>
+    # child (the body rounded-rect d string).
+    clip_re = re.compile(
+        r'<clipPath\s+id="\$\{batteryClipId\}">\s*'
+        r'<path\s+d="\$\{batteryBodyClipD\}"\s*/>\s*'
+        r'</clipPath>',
+        re.DOTALL,
+    )
+    assert clip_re.search(executable), (
+        "qs-car-card.js: expected exactly one "
+        '`<clipPath id="${batteryClipId}"><path d="${batteryBodyClipD}" />'
+        "</clipPath>` element in <defs>. The clip is body-only — the "
+        "terminal nub is drawn only on the outline path, never in the "
+        "clip (per AC-1)."
+    )
+    assert re.search(
+        r"_generateBatteryBodyClipPath\s*\(\s*\)\s*\{", executable
+    ), (
+        "qs-car-card.js: missing `_generateBatteryBodyClipPath()` "
+        "method (helper that returns the body rounded-rect `d` string "
+        "used by the clipPath child <path>)."
+    )
+
+
+def test_car_card_renders_water_layer():
+    """QS-224 AC-2: six `<path>` elements with stable ids
+    `wave{0,1,2}_{idle,charge}` are nested inside a single
+    `<g clip-path="url(#${batteryClipId})">`. The two siblings per
+    layer share `d` (same wave geometry) and differ only in `fill`
+    + per-frame `opacity` (cross-fade contract — AC-3).
+
+    Also pins `_generateWavePath` method (ported from
+    `qs-pool-card.js`), `WAVE_WIDTH = 480`, `WAVE_BOTTOM_Y = 400` —
+    the "same kind of animation" the issue asked for (pool/boiler
+    values reused verbatim)."""
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    # The wrapper <g> presence (anchor used by z-order test below).
+    g_anchor = '<g clip-path="url(#${batteryClipId})">'
+    assert g_anchor in executable, (
+        f"qs-car-card.js: missing clipped water-group anchor `{g_anchor}` "
+        f"(the parent <g> wrapping all six waveX_{{idle,charge}} <path>s)."
+    )
+    for layer in (
+        "wave0_idle",
+        "wave0_charge",
+        "wave1_idle",
+        "wave1_charge",
+        "wave2_idle",
+        "wave2_charge",
+    ):
+        assert re.search(rf'id="{layer}"', executable), (
+            f'qs-car-card.js: missing <path id="{layer}"> — AC-2 '
+            f"requires three layers × two palette siblings each."
+        )
+    assert re.search(r"_generateWavePath\s*\(", executable), (
+        "qs-car-card.js: missing `_generateWavePath(...)` method "
+        "(ported verbatim from qs-pool-card.js — the issue asked for "
+        "the `same kind of animation` as the pool card)."
+    )
+    assert re.search(r"const\s+WAVE_WIDTH\s*=\s*480\b", content), (
+        "qs-car-card.js: missing `const WAVE_WIDTH = 480;` (matches "
+        "pool/boiler — the issue's `same kind of animation` clause)."
+    )
+    assert re.search(r"const\s+WAVE_BOTTOM_Y\s*=\s*400\b", content), (
+        "qs-car-card.js: missing `const WAVE_BOTTOM_Y = 400;` "
+        "(matches pool/boiler — closing rectangle y below viewBox)."
+    )
+
+
+def test_car_card_pins_water_palette_triplets():
+    """QS-224 AC-3: `IDLE_WATER_COLORS` is a 3-element `hsla(...)`
+    array whose hue token is in `[100, 180]` (green family — rules
+    out blue/red/yellow/grey); `CHARGING_WATER_COLORS` is a 3-element
+    `hsla(...)` array whose hue token is in `[190, 230]` (blue family
+    — rules out green/red/grey).
+
+    Lightness and alpha step down per layer for depth (mirror the
+    boiler's `COOL_WATER_COLORS` triplet pattern at
+    qs-water-boiler-card.js:70-79).
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+
+    def extract_triplet(name: str) -> list[tuple[int, int, int, float]]:
+        match = re.search(
+            rf"const\s+{name}\s*=\s*\[(?P<body>[^\]]+)\]",
+            content,
+            re.DOTALL,
+        )
+        assert match is not None, (
+            f"qs-car-card.js: missing module-level `const {name} = [...]`"
+        )
+        body = match.group("body")
+        entries = re.findall(
+            r"'hsla\(\s*(\d+)\s*,\s*(\d+)\s*%\s*,\s*(\d+)\s*%\s*,\s*"
+            r"([\d.]+)\s*\)'",
+            body,
+        )
+        assert len(entries) == 3, (
+            f"qs-car-card.js: {name} must have exactly 3 hsla entries "
+            f"(one per wave layer); got {len(entries)}."
+        )
+        return [
+            (int(h), int(s), int(lt), float(a)) for h, s, lt, a in entries
+        ]
+
+    idle = extract_triplet("IDLE_WATER_COLORS")
+    for h, _s, _lt, _a in idle:
+        assert 100 <= h <= 180, (
+            f"qs-car-card.js: IDLE_WATER_COLORS hue must be in the "
+            f"green family [100, 180]; got hue={h}. The issue says "
+            f"`when not charging the color will be green (same bright "
+            f"green already used in the circle not running)`."
+        )
+    # Stepped lightness AND alpha per layer (deeper = lower).
+    for i in range(1, 3):
+        assert idle[i][2] <= idle[i - 1][2], (
+            f"qs-car-card.js: IDLE_WATER_COLORS lightness must step "
+            f"DOWN (or stay equal) per layer for depth; got "
+            f"{[c[2] for c in idle]}."
+        )
+        assert idle[i][3] <= idle[i - 1][3], (
+            f"qs-car-card.js: IDLE_WATER_COLORS alpha must step DOWN "
+            f"(or stay equal) per layer for depth; got "
+            f"{[c[3] for c in idle]}."
+        )
+
+    charging = extract_triplet("CHARGING_WATER_COLORS")
+    for h, _s, _lt, _a in charging:
+        assert 190 <= h <= 230, (
+            f"qs-car-card.js: CHARGING_WATER_COLORS hue must be in "
+            f"the blue family [190, 230]; got hue={h}. The issue says "
+            f"`when charging ... be blue (same electric blue as the one "
+            f"used in the charging circle)`."
+        )
+    for i in range(1, 3):
+        assert charging[i][2] <= charging[i - 1][2], (
+            f"qs-car-card.js: CHARGING_WATER_COLORS lightness must "
+            f"step DOWN per layer; got {[c[2] for c in charging]}."
+        )
+        assert charging[i][3] <= charging[i - 1][3], (
+            f"qs-car-card.js: CHARGING_WATER_COLORS alpha must step "
+            f"DOWN per layer; got {[c[3] for c in charging]}."
+        )
+
+    # AC-3 (cont.) — per-path opacity cross-fade is applied to the
+    # waveX_idle / waveX_charge <path> elements (NOT a group opacity
+    # on the parent <g>). Verify the RAF loop calls `setAttribute(
+    # 'opacity', ...)` on the six wave elements. The boiler precedent
+    # uses `for (let i = 0; i < 3; i++) { ... setAttribute('opacity',
+    # ...) }` — the same idiom is the canonical "per-path" form here.
+    executable = _strip_js_comments(content)
+    assert re.search(
+        r"setAttribute\s*\(\s*['\"]opacity['\"]\s*,\s*idleOpacity",
+        executable,
+    ), (
+        "qs-car-card.js (AC-3): the RAF loop must set per-path "
+        "opacity on each wave element via "
+        "`setAttribute('opacity', idleOpacity)` (and the charging "
+        "sibling with `chargeOpacity`). Group-level opacity on the "
+        "parent <g> is forbidden — the cross-fade is per-path."
+    )
+    assert re.search(
+        r"setAttribute\s*\(\s*['\"]opacity['\"]\s*,\s*chargeOpacity",
+        executable,
+    ), (
+        "qs-car-card.js (AC-3): the RAF loop must set per-path "
+        "opacity on each charging-sibling wave element via "
+        "`setAttribute('opacity', chargeOpacity)`."
+    )
+
+
+def test_car_card_pins_amplitude_speed_constants():
+    """QS-224 AC-4: the calm vs charging amp/speed targets and the
+    lerp envelope are byte-identical to the boiler's tuning (which
+    QS-214 already iterated for a gentle simmer). Drift here would
+    desync the visual rhythm across the boiler and car cards — both
+    intentionally read as "gentle calm, more pronounced when active".
+
+    Pins:
+    - `CALM_AMP = 1.5`, `CHARGING_AMP = 8` (= boiler CALM_AMP /
+      BOIL_AMP)
+    - `CALM_SPEED = 0.1`, `CHARGING_SPEED = 0.4` (= boiler CALM_SPEED /
+      BOIL_SPEED — QS-214-slowed values)
+    - `LERP_RATE = 2`, `LERP_DT_CEIL = 0.1` (= boiler envelope)
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    expected = {
+        "CALM_AMP": "1.5",
+        "CHARGING_AMP": "8",
+        "CALM_SPEED": "0.1",
+        "CHARGING_SPEED": "0.4",
+        "LERP_RATE": "2",
+        "LERP_DT_CEIL": "0.1",
+    }
+    for name, value in expected.items():
+        pat = re.compile(rf"const\s+{name}\s*=\s*{re.escape(value)}\b")
+        assert pat.search(content), (
+            f"qs-car-card.js: expected module-level "
+            f"`const {name} = {value};` declaration. Drift from the "
+            f"boiler's amp/speed/lerp tuning desyncs the visual "
+            f"rhythm across cards."
+        )
+
+
+def test_car_card_battery_outline_present_with_distinct_strokes():
+    """QS-224 AC-5: a single `<path id="battery_outline">` is drawn
+    AFTER the clipped water/lightning group, with `fill="none"` and
+    a non-empty `stroke` attribute. The `d` covers BOTH the body
+    rounded-rect AND the terminal nub in ONE combined path (no seam
+    at the join).
+
+    Module-level `BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.30` and
+    `BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.55` exist and are
+    distinct — the alpha lerps with `_currentColorMix` so the
+    silhouette is brighter when charging.
+
+    Also pins the existence of the `_generateBatteryOutlinePath()`
+    helper (the combined body+terminal `d` builder)."""
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    # The outline element: id, d binding, fill="none", non-empty stroke.
+    outline_re = re.compile(
+        r'<path\s+id="battery_outline"\s+d="\$\{batteryOutlineD\}"\s+'
+        r'fill="none"\s+stroke="[^"]+"',
+        re.DOTALL,
+    )
+    assert outline_re.search(executable), (
+        "qs-car-card.js (AC-5): expected "
+        '`<path id="battery_outline" d="${batteryOutlineD}" fill="none" '
+        'stroke="...">` after the clipped water/lightning group. The '
+        "outline is fill=none — body+terminal silhouette only."
+    )
+    # Module-level alpha constants, distinct values.
+    idle_match = re.search(
+        r"const\s+BATTERY_OUTLINE_STROKE_IDLE_ALPHA\s*=\s*0\.30\b", content
+    )
+    charge_match = re.search(
+        r"const\s+BATTERY_OUTLINE_STROKE_CHARGING_ALPHA\s*=\s*0\.55\b",
+        content,
+    )
+    assert idle_match is not None, (
+        "qs-car-card.js (AC-5): missing "
+        "`const BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.30;` — idle "
+        "outline alpha must be a pinned constant."
+    )
+    assert charge_match is not None, (
+        "qs-car-card.js (AC-5): missing "
+        "`const BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.55;` — "
+        "charging outline alpha must be a pinned constant."
+    )
+    assert re.search(
+        r"_generateBatteryOutlinePath\s*\(\s*\)\s*\{", executable
+    ), (
+        "qs-car-card.js (AC-5): missing "
+        "`_generateBatteryOutlinePath()` method (helper that returns "
+        "the combined body+terminal `d` string used by "
+        '<path id="battery_outline">).'
+    )
+
+
+def test_car_card_has_lightning_system():
+    """QS-224 AC-6: charging-only lightning particle system with
+    a HARD CAP. Pins the six tuning constants, the `<filter>` decl
+    in defs, and the `<g id="${lightningLayerId}" filter=` group
+    inside the clipped wrapper.
+
+    - `MAX_CONCURRENT_LIGHTNING = 3` — hard cap; spawn rejected when
+      `_lightning.length >= cap`.
+    - `LIGHTNING_SPAWN_RATE_HZ = 3` × `LIGHTNING_LIFE_S = 0.5` =
+      ~1.5 avg, occasional 3-cap (review-fix rebalance).
+    - `LIGHTNING_SEGMENTS = 4` — zigzag polyline has 5 vertices.
+    - `LIGHTNING_FADE_IN_FRACTION = 0.2`,
+      `LIGHTNING_FADE_OUT_FRACTION = 0.7` — piecewise-linear life
+      curve breakpoints.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    expected = {
+        "MAX_CONCURRENT_LIGHTNING": "3",
+        "LIGHTNING_SPAWN_RATE_HZ": "3",
+        "LIGHTNING_LIFE_S": "0.5",
+        "LIGHTNING_SEGMENTS": "4",
+        "LIGHTNING_FADE_IN_FRACTION": "0.2",
+        "LIGHTNING_FADE_OUT_FRACTION": "0.7",
+    }
+    for name, value in expected.items():
+        pat = re.compile(rf"const\s+{name}\s*=\s*{re.escape(value)}\b")
+        assert pat.search(content), (
+            f"qs-car-card.js (AC-6): expected module-level "
+            f"`const {name} = {value};` declaration."
+        )
+    # The <filter id="${lightningGlowId}"> must exist in defs.
+    assert re.search(
+        r'<filter\s+id="\$\{lightningGlowId\}"', content
+    ), (
+        "qs-car-card.js (AC-6): missing "
+        '`<filter id="${lightningGlowId}" ...>` in <defs>. The glow '
+        "is one filter applied to the layer group, NOT per-polyline "
+        "(mirrors boiler steam pattern)."
+    )
+    # The lightning layer <g>, with filter attribute, inside the
+    # clipped wrapper.
+    assert re.search(
+        r'<g\s+id="\$\{lightningLayerId\}"\s+filter=', content
+    ), (
+        "qs-car-card.js (AC-6): missing "
+        '`<g id="${lightningLayerId}" filter="...">` inside the '
+        "clipped water-group wrapper. The lightning layer must be "
+        "body-clipped (same `batteryClipId` as the water)."
+    )
+    # Spawn guarded on `charging` (no spawns when calm).
+    executable = _strip_js_comments(content)
+    spawn_re = re.compile(
+        r"if\s*\(\s*charging\s*\)\s*\{[^{}]*?"
+        r"while\s*\([^)]*?this\._lightning\.length\s*<\s*MAX_CONCURRENT_LIGHTNING",
+        re.DOTALL,
+    )
+    assert spawn_re.search(executable), (
+        "qs-car-card.js (AC-6): expected the lightning spawn block to "
+        "be `if (charging) { ... while (... this._lightning.length < "
+        "MAX_CONCURRENT_LIGHTNING) { ... } }` — hard cap (NO overflow), "
+        "calm has NO spawns."
+    )
+
+
+def test_car_card_continuous_raf_refactor():
+    """QS-224 AC-7: continuous RAF while connected.
+
+    - `connectedCallback()` calls `this._startAnimation()` directly,
+      with no `if`-gate in the body (mirror boiler/pool).
+    - `_render()` no longer contains the prior
+      `if (charging) { _startAnimation } else { _stopAnimation }`
+      block — that toggle is gone; the RAF runs continuously and the
+      calm↔charging difference is amp/speed/colorMix lerp.
+
+    The body extraction uses the balanced-brace walker so future
+    template literals or arrow functions inside `connectedCallback`
+    don't trip a false negative (mirrors the boiler test pattern).
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    # AC-7 (a) — connectedCallback calls _startAnimation directly,
+    # no if-gate.
+    cb_body = _extract_js_function_body(
+        executable, r"connectedCallback\s*\(\s*\)\s*"
+    )
+    assert cb_body is not None, (
+        "qs-car-card.js: connectedCallback() not found"
+    )
+    assert re.search(r"this\._startAnimation\s*\(\s*\)", cb_body), (
+        "qs-car-card.js (AC-7): connectedCallback must call "
+        "`this._startAnimation()` directly (continuous-RAF model, "
+        "mirror boiler/pool)."
+    )
+    assert re.search(r"\bif\s*\(", cb_body) is None, (
+        "qs-car-card.js (AC-7): connectedCallback must call "
+        "`_startAnimation()` UNCONDITIONALLY — no `if (...)` gate. "
+        "QS-224 moved the car card to the continuous-RAF model the "
+        "pool and boiler cards already use."
+    )
+    # AC-7 (b) — the legacy charging-gated `_render` block is GONE.
+    # Reject the canonical `if (charging) { this._startAnimation() }
+    # else { this._stopAnimation() }` form. The replacement is
+    # purely amp/speed/colorMix lerp — no RAF on/off based on the
+    # per-frame `charging` boolean.
+    legacy_gate = re.compile(
+        r"if\s*\(\s*charging\s*\)\s*\{\s*this\._startAnimation\s*\(\s*\)\s*;\s*\}"
+        r"\s*else\s*\{\s*this\._stopAnimation",
+        re.DOTALL,
+    )
+    assert legacy_gate.search(executable) is None, (
+        "qs-car-card.js (AC-7): the legacy "
+        "`if (charging) { this._startAnimation(); } else { "
+        "this._stopAnimation(); }` block in `_render()` must be "
+        "removed. The car card now runs continuous RAF while "
+        "connected; calm waves animate gently when idle (per "
+        "the issue's `when not charging the color will be green` "
+        "clause)."
+    )
+
+
+def test_car_card_z_order_battery_group_before_bgpath():
+    """QS-224 AC-8: source order for the new battery layer.
+
+    The clipped water/lightning group MUST appear BEFORE the gauge
+    background `<path d="${bgPath}">` in source order. The battery
+    outline MUST appear BETWEEN the clipped group and bgPath. Anchor:
+
+      g_anchor < outline_anchor < bg_anchor
+
+    Mirrors the boiler's
+    `test_water_boiler_card_renders_water_layer` z-order assertion
+    pattern (lines 1979-1984). This pins the issue's "transparent and
+    backward to all text, button etc" requirement at the SVG source
+    level: the ring, SOC arc, charging-dash anim, target handle, and
+    HTML overlay all sit AFTER bgPath, so they render on top of the
+    new battery layer.
+    """
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    g_anchor = '<g clip-path="url(#${batteryClipId})">'
+    outline_anchor = '<path id="battery_outline"'
+    bg_anchor = '<path d="${bgPath}"'
+    g_idx = executable.find(g_anchor)
+    outline_idx = executable.find(outline_anchor)
+    bg_idx = executable.find(bg_anchor)
+    assert g_idx != -1, (
+        f"qs-car-card.js (AC-8): missing clipped water-group anchor "
+        f"{g_anchor!r}."
+    )
+    assert outline_idx != -1, (
+        f"qs-car-card.js (AC-8): missing battery-outline anchor "
+        f"{outline_anchor!r}."
+    )
+    assert bg_idx != -1, (
+        f"qs-car-card.js (AC-8): missing bgPath anchor {bg_anchor!r}."
+    )
+    assert g_idx < outline_idx < bg_idx, (
+        "qs-car-card.js (AC-8): source order must be "
+        "`<g clip-path=...> ... <path id=\"battery_outline\"> ... "
+        "<path d=\"${bgPath}\">` so the gauge ring renders ON TOP of "
+        "the new battery+water layer (per the issue's `transparent "
+        "and backward to all text, button etc` clause). "
+        f"Got g_idx={g_idx}, outline_idx={outline_idx}, bg_idx={bg_idx}."
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -3381,16 +3381,23 @@ def test_car_card_battery_clippath_in_defs():
 
 
 def test_car_card_renders_water_layer():
-    """QS-224 AC-2: six `<path>` elements with stable ids
-    `wave{0,1,2}_{idle,charge}` are nested inside a single
-    `<g clip-path="url(#${batteryClipId})">`. The two siblings per
-    layer share `d` (same wave geometry) and differ only in `fill`
-    + per-frame `opacity` (cross-fade contract — AC-3).
+    """QS-224 AC-2 (post-FX-02): TWO `<path>` elements with stable ids
+    `wave0_{idle,charge}` are nested inside a single
+    `<g clip-path="url(#${batteryClipId})">`. The two siblings share
+    `d` (same wave geometry) and differ only in `fill` + per-frame
+    `opacity` (cross-fade contract — AC-3).
 
-    Also pins `_generateWavePath` method (ported from
-    `qs-pool-card.js`), `WAVE_WIDTH = 480`, `WAVE_BOTTOM_Y = 400` —
-    the "same kind of animation" the issue asked for (pool/boiler
-    values reused verbatim)."""
+    Review-fix #01 FX-02 collapsed the 3-layer wave stack to 1
+    layer: with the bright translucent palette from FX-01, the
+    3-layer stack produced too much visual density. The single
+    layer keeps the cross-fade machinery (idle/charge sibling) but
+    avoids the muddy overlay.
+
+    Pins `_generateWavePath` method (ported from `qs-pool-card.js`),
+    `WAVE_WIDTH = 480`, `WAVE_BOTTOM_Y = 400` — the "same kind of
+    animation" the issue asked for (pool/boiler values reused
+    verbatim).
+    """
     import re
 
     content = (
@@ -3400,20 +3407,30 @@ def test_car_card_renders_water_layer():
     # The wrapper <g> presence (anchor used by z-order test below).
     g_anchor = '<g clip-path="url(#${batteryClipId})">'
     assert g_anchor in executable, (
-        f"qs-car-card.js: missing clipped water-group anchor `{g_anchor}` "
-        f"(the parent <g> wrapping all six waveX_{{idle,charge}} <path>s)."
+        f"qs-car-card.js: missing clipped water-group anchor "
+        f"`{g_anchor}` (the parent <g> wrapping the wave0_{{idle,charge}} "
+        f"<path>s)."
     )
-    for layer in (
-        "wave0_idle",
-        "wave0_charge",
+    # Post-FX-02: the two surviving wave ids are wave0_idle / wave0_charge.
+    for layer in ("wave0_idle", "wave0_charge"):
+        assert re.search(rf'id="{layer}"', executable), (
+            f'qs-car-card.js (FX-02): missing <path id="{layer}"> — '
+            f"AC-2 (single-layer) requires the idle/charge cross-fade "
+            f"pair on the single wave layer."
+        )
+    # Negative pins: the obsolete 3-layer ids must be GONE so a
+    # regression can't silently reintroduce the muddy multi-layer stack.
+    for stale in (
         "wave1_idle",
         "wave1_charge",
         "wave2_idle",
         "wave2_charge",
     ):
-        assert re.search(rf'id="{layer}"', executable), (
-            f'qs-car-card.js: missing <path id="{layer}"> — AC-2 '
-            f"requires three layers × two palette siblings each."
+        assert re.search(rf'id="{stale}"', executable) is None, (
+            f'qs-car-card.js (FX-02): obsolete <path id="{stale}"> '
+            f"must be removed. Review-fix #01 collapsed the 3-layer "
+            f"wave stack to a single layer driven by "
+            f"IDLE_WATER_COLORS.length."
         )
     assert re.search(r"_generateWavePath\s*\(", executable), (
         "qs-car-card.js: missing `_generateWavePath(...)` method "
@@ -3430,16 +3447,21 @@ def test_car_card_renders_water_layer():
     )
 
 
-def test_car_card_pins_water_palette_triplets():
-    """QS-224 AC-3: `IDLE_WATER_COLORS` is a 3-element `hsla(...)`
-    array whose hue token is in `[100, 180]` (green family — rules
-    out blue/red/yellow/grey); `CHARGING_WATER_COLORS` is a 3-element
-    `hsla(...)` array whose hue token is in `[190, 230]` (blue family
-    — rules out green/red/grey).
+def test_car_card_pins_water_palette_singletons():
+    """QS-224 AC-3 (post-FX-01 + FX-02): `IDLE_WATER_COLORS` and
+    `CHARGING_WATER_COLORS` are BOTH single-element `hsla(...)` arrays
+    after review-fix #01.
 
-    Lightness and alpha step down per layer for depth (mirror the
-    boiler's `COOL_WATER_COLORS` triplet pattern at
-    qs-water-boiler-card.js:70-79).
+    - Hue: idle in `[100, 180]` (green family); charging in
+      `[190, 230]` (blue family).
+    - **Lightness ≥ 85%** (FX-01): the original 25–35% was too dark
+      and muddy; the user wants bright/vibrant tones.
+    - **Alpha ≤ 0.35** (FX-01): the original 0.35–0.60 obscured the
+      SOC arc and ring through the water; very translucent reads
+      better against the bright lightness.
+
+    AC-3 also still requires per-path opacity (NOT group opacity on
+    the parent <g>) for the idle↔charge cross-fade.
     """
     import re
 
@@ -3447,14 +3469,15 @@ def test_car_card_pins_water_palette_triplets():
         COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
     ).read_text()
 
-    def extract_triplet(name: str) -> list[tuple[int, int, int, float]]:
+    def extract_palette(name: str) -> list[tuple[int, int, int, float]]:
         match = re.search(
             rf"const\s+{name}\s*=\s*\[(?P<body>[^\]]+)\]",
             content,
             re.DOTALL,
         )
         assert match is not None, (
-            f"qs-car-card.js: missing module-level `const {name} = [...]`"
+            f"qs-car-card.js (FX-01): missing module-level "
+            f"`const {name} = [...]`."
         )
         body = match.group("body")
         entries = re.findall(
@@ -3462,59 +3485,58 @@ def test_car_card_pins_water_palette_triplets():
             r"([\d.]+)\s*\)'",
             body,
         )
-        assert len(entries) == 3, (
-            f"qs-car-card.js: {name} must have exactly 3 hsla entries "
-            f"(one per wave layer); got {len(entries)}."
+        assert len(entries) == 1, (
+            f"qs-car-card.js (FX-02): {name} must have exactly 1 hsla "
+            f"entry (review-fix #01 collapsed the 3-layer wave stack "
+            f"to a single layer); got {len(entries)}."
         )
         return [
             (int(h), int(s), int(lt), float(a)) for h, s, lt, a in entries
         ]
 
-    idle = extract_triplet("IDLE_WATER_COLORS")
-    for h, _s, _lt, _a in idle:
+    idle = extract_palette("IDLE_WATER_COLORS")
+    for h, _s, lt, a in idle:
         assert 100 <= h <= 180, (
-            f"qs-car-card.js: IDLE_WATER_COLORS hue must be in the "
-            f"green family [100, 180]; got hue={h}. The issue says "
-            f"`when not charging the color will be green (same bright "
-            f"green already used in the circle not running)`."
+            f"qs-car-card.js (FX-01): IDLE_WATER_COLORS hue must be "
+            f"in the green family [100, 180]; got hue={h}. The issue "
+            f"says `when not charging the color will be green`."
         )
-    # Stepped lightness AND alpha per layer (deeper = lower).
-    for i in range(1, 3):
-        assert idle[i][2] <= idle[i - 1][2], (
-            f"qs-car-card.js: IDLE_WATER_COLORS lightness must step "
-            f"DOWN (or stay equal) per layer for depth; got "
-            f"{[c[2] for c in idle]}."
+        assert lt >= 85, (
+            f"qs-car-card.js (FX-01): IDLE_WATER_COLORS lightness "
+            f"must be ≥ 85% — the user rejected the previous "
+            f"≤ 40% as `dark and muddy` and asked for a `very "
+            f"bright, vibrant` green. Got lightness={lt}%."
         )
-        assert idle[i][3] <= idle[i - 1][3], (
-            f"qs-car-card.js: IDLE_WATER_COLORS alpha must step DOWN "
-            f"(or stay equal) per layer for depth; got "
-            f"{[c[3] for c in idle]}."
+        assert a <= 0.35, (
+            f"qs-car-card.js (FX-01): IDLE_WATER_COLORS alpha must "
+            f"be ≤ 0.35 — the user asked for `very translucent` so "
+            f"the existing ring + SOC arc remain clearly visible. "
+            f"Got alpha={a}."
         )
 
-    charging = extract_triplet("CHARGING_WATER_COLORS")
-    for h, _s, _lt, _a in charging:
+    charging = extract_palette("CHARGING_WATER_COLORS")
+    for h, _s, lt, a in charging:
         assert 190 <= h <= 230, (
-            f"qs-car-card.js: CHARGING_WATER_COLORS hue must be in "
-            f"the blue family [190, 230]; got hue={h}. The issue says "
-            f"`when charging ... be blue (same electric blue as the one "
-            f"used in the charging circle)`."
+            f"qs-car-card.js (FX-01): CHARGING_WATER_COLORS hue must "
+            f"be in the blue family [190, 230]; got hue={h}. The "
+            f"issue says `when charging ... be blue (same electric "
+            f"blue as the one used in the charging circle)`."
         )
-    for i in range(1, 3):
-        assert charging[i][2] <= charging[i - 1][2], (
-            f"qs-car-card.js: CHARGING_WATER_COLORS lightness must "
-            f"step DOWN per layer; got {[c[2] for c in charging]}."
+        assert lt >= 85, (
+            f"qs-car-card.js (FX-01): CHARGING_WATER_COLORS lightness "
+            f"must be ≥ 85% — matching the brightness floor of the "
+            f"idle palette so the cross-fade reads as a hue shift, "
+            f"not a brightness change. Got lightness={lt}%."
         )
-        assert charging[i][3] <= charging[i - 1][3], (
-            f"qs-car-card.js: CHARGING_WATER_COLORS alpha must step "
-            f"DOWN per layer; got {[c[3] for c in charging]}."
+        assert a <= 0.35, (
+            f"qs-car-card.js (FX-01): CHARGING_WATER_COLORS alpha "
+            f"must be ≤ 0.35 — same translucency contract as the "
+            f"idle palette. Got alpha={a}."
         )
 
     # AC-3 (cont.) — per-path opacity cross-fade is applied to the
-    # waveX_idle / waveX_charge <path> elements (NOT a group opacity
-    # on the parent <g>). Verify the RAF loop calls `setAttribute(
-    # 'opacity', ...)` on the six wave elements. The boiler precedent
-    # uses `for (let i = 0; i < 3; i++) { ... setAttribute('opacity',
-    # ...) }` — the same idiom is the canonical "per-path" form here.
+    # wave0_idle / wave0_charge <path> elements (NOT a group opacity
+    # on the parent <g>).
     executable = _strip_js_comments(content)
     assert re.search(
         r"setAttribute\s*\(\s*['\"]opacity['\"]\s*,\s*idleOpacity",
@@ -3574,19 +3596,27 @@ def test_car_card_pins_amplitude_speed_constants():
 
 
 def test_car_card_battery_outline_present_with_distinct_strokes():
-    """QS-224 AC-5: a single `<path id="battery_outline">` is drawn
-    AFTER the clipped water/lightning group, with `fill="none"` and
-    a non-empty `stroke` attribute. The `d` covers BOTH the body
-    rounded-rect AND the terminal nub in ONE combined path (no seam
-    at the join).
+    """QS-224 AC-5 (post-FX-03 + FX-09): a single
+    `<path id="battery_outline">` is drawn AFTER the clipped
+    water/lightning group, with `fill="none"` and a non-empty
+    `stroke` attribute. The `d` covers BOTH the body rounded-rect AND
+    the terminal nub in ONE combined path (no seam at the join).
 
-    Module-level `BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.30` and
-    `BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.55` exist and are
-    distinct — the alpha lerps with `_currentColorMix` so the
-    silhouette is brighter when charging.
+    Review-fix #01 FX-03 (user visual rejection — outline was
+    invisible against the ring + bright water):
+    - alpha lerp range widened from `0.30 → 0.55` to `0.55 → 0.80`
+    - stroke color swapped from near-white `rgba(255,255,255,…)` to
+      a neutral grey `rgba(180,180,180,…)` so the silhouette reads
+      against both the ring and the bright translucent water
+    - stroke width pinned to `MDI_UNIT_PX` (= 1 mdi-unit ≈ 7.8 px),
+      matching the mdi:battery-outline 1/12 body-width stroke ratio
+      (was a hard-coded `2` literal — too thin)
 
-    Also pins the existence of the `_generateBatteryOutlinePath()`
-    helper (the combined body+terminal `d` builder)."""
+    FX-09: also pins the RAF rgba interpolation contract — the
+    per-frame `setAttribute('stroke', ...)` call must format
+    `rgba(180,180,180,${alpha.toFixed(3)})` and CSS `color-mix` is
+    forbidden (browser-compat contract from the original AC-5).
+    """
     import re
 
     content = (
@@ -3605,23 +3635,38 @@ def test_car_card_battery_outline_present_with_distinct_strokes():
         'stroke="...">` after the clipped water/lightning group. The '
         "outline is fill=none — body+terminal silhouette only."
     )
-    # Module-level alpha constants, distinct values.
+    # Module-level alpha constants, post-FX-03 values, distinct.
     idle_match = re.search(
-        r"const\s+BATTERY_OUTLINE_STROKE_IDLE_ALPHA\s*=\s*0\.30\b", content
+        r"const\s+BATTERY_OUTLINE_STROKE_IDLE_ALPHA\s*=\s*0\.55\b", content
     )
     charge_match = re.search(
-        r"const\s+BATTERY_OUTLINE_STROKE_CHARGING_ALPHA\s*=\s*0\.55\b",
+        r"const\s+BATTERY_OUTLINE_STROKE_CHARGING_ALPHA\s*=\s*0\.80\b",
         content,
     )
     assert idle_match is not None, (
-        "qs-car-card.js (AC-5): missing "
-        "`const BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.30;` — idle "
-        "outline alpha must be a pinned constant."
+        "qs-car-card.js (FX-03): missing "
+        "`const BATTERY_OUTLINE_STROKE_IDLE_ALPHA = 0.55;` — review-"
+        "fix #01 bumped the idle alpha from 0.30 to 0.55 to make the "
+        "wider grey outline visible against the ring + bright water."
     )
     assert charge_match is not None, (
-        "qs-car-card.js (AC-5): missing "
-        "`const BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.55;` — "
-        "charging outline alpha must be a pinned constant."
+        "qs-car-card.js (FX-03): missing "
+        "`const BATTERY_OUTLINE_STROKE_CHARGING_ALPHA = 0.80;` — "
+        "review-fix #01 bumped the charging alpha from 0.55 to 0.80 "
+        "so the silhouette pops while charging."
+    )
+    # Stroke width pinned by NAME (= MDI_UNIT_PX), not literal pixel
+    # value — preserves the mdi 1/12 ratio derivation even if the
+    # vertical-span constant is retuned.
+    assert re.search(
+        r"const\s+BATTERY_OUTLINE_STROKE_WIDTH\s*=\s*MDI_UNIT_PX\b",
+        content,
+    ), (
+        "qs-car-card.js (FX-03): expected "
+        "`const BATTERY_OUTLINE_STROKE_WIDTH = MDI_UNIT_PX;` — review-"
+        "fix #01 widens the stroke from a literal `2` to one mdi-unit "
+        "(= MDI_UNIT_PX ≈ 7.8 px), the canonical mdi:battery-outline "
+        "stroke ratio (1/12 of body width)."
     )
     assert re.search(
         r"_generateBatteryOutlinePath\s*\(\s*\)\s*\{", executable
@@ -3630,6 +3675,32 @@ def test_car_card_battery_outline_present_with_distinct_strokes():
         "`_generateBatteryOutlinePath()` method (helper that returns "
         "the combined body+terminal `d` string used by "
         '<path id="battery_outline">).'
+    )
+    # FX-09 — pin the RAF rgba(180,180,180,…) setter (the grey RGB
+    # contract from FX-03) so a regression to white can't slip
+    # through, and ban CSS color-mix (browser-compat contract).
+    assert re.search(
+        r"setAttribute\s*\(\s*['\"]stroke['\"]\s*,[^;]*rgba\(\s*180\s*,\s*180\s*,\s*180\s*,",
+        executable,
+    ), (
+        "qs-car-card.js (FX-09 / AC-5): the RAF loop must set the "
+        "outline stroke via `setAttribute('stroke', "
+        "`rgba(180,180,180,${alpha.toFixed(3)})`)` — the grey RGB "
+        "triple is the FX-03 contract."
+    )
+    # FX-09 — CSS `color-mix(...)` may legitimately appear in the
+    # card's `<style>` block (e.g. `select:focus` border glow) but
+    # must NOT appear in any `setAttribute('stroke', ...)` RAF call.
+    # The positive `rgba(180,180,180,…)` assertion above pins the
+    # outline path; this negative scopes the ban to the stroke-setter
+    # context only (regex window of ~120 chars after the setter).
+    forbidden_color_mix_in_stroke = re.compile(
+        r"setAttribute\s*\(\s*['\"]stroke['\"][^;]{0,200}color-mix",
+    )
+    assert not forbidden_color_mix_in_stroke.search(executable), (
+        "qs-car-card.js (FX-09 / AC-5): no `setAttribute('stroke', "
+        "...)` call may interpolate via CSS `color-mix(...)` — AC-5 "
+        "requires JS rgba interpolation for browser compatibility."
     )
 
 
@@ -3699,6 +3770,22 @@ def test_car_card_has_lightning_system():
         "MAX_CONCURRENT_LIGHTNING) { ... } }` — hard cap (NO overflow), "
         "calm has NO spawns."
     )
+    # FX-10 — pin the polyline vertex loop bound. The zigzag builder
+    # must iterate `for (let i = 0; i <= LIGHTNING_SEGMENTS; i++)` so
+    # the emitted polyline has exactly LIGHTNING_SEGMENTS + 1 (= 5)
+    # vertices. Off-by-one drift (`i < LIGHTNING_SEGMENTS` → 4
+    # vertices, `i <= LIGHTNING_SEGMENTS + 1` → 6 vertices) would
+    # silently break AC-6's "exactly 5 whitespace-separated x,y pairs"
+    # contract.
+    assert re.search(
+        r"for\s*\(\s*let\s+i\s*=\s*0\s*;\s*i\s*<=\s*LIGHTNING_SEGMENTS\b",
+        executable,
+    ), (
+        "qs-car-card.js (FX-10 / AC-6): the lightning zigzag vertex "
+        "loop must be bounded by `i <= LIGHTNING_SEGMENTS` (inclusive) "
+        "so the resulting polyline carries exactly "
+        "`LIGHTNING_SEGMENTS + 1` (= 5) vertices."
+    )
 
 
 def test_car_card_continuous_raf_refactor():
@@ -3762,21 +3849,19 @@ def test_car_card_continuous_raf_refactor():
 
 
 def test_car_card_z_order_battery_group_before_bgpath():
-    """QS-224 AC-8: source order for the new battery layer.
+    """QS-224 AC-8 (post-FX-12): full source-order coverage for the
+    new battery layer + the existing ring elements.
 
-    The clipped water/lightning group MUST appear BEFORE the gauge
-    background `<path d="${bgPath}">` in source order. The battery
-    outline MUST appear BETWEEN the clipped group and bgPath. Anchor:
-
-      g_anchor < outline_anchor < bg_anchor
+    Required order: clipped water/lightning group < battery outline <
+    `bgPath` < (`socPath`, `charge_anim`, `target_handle`,
+    `target_handle_text`). The HTML `<div class="center">` overlay
+    remains in the markup unchanged.
 
     Mirrors the boiler's
-    `test_water_boiler_card_renders_water_layer` z-order assertion
-    pattern (lines 1979-1984). This pins the issue's "transparent and
-    backward to all text, button etc" requirement at the SVG source
-    level: the ring, SOC arc, charging-dash anim, target handle, and
-    HTML overlay all sit AFTER bgPath, so they render on top of the
-    new battery layer.
+    `test_water_boiler_card_renders_water_layer` z-order pattern but
+    extended per FX-12 to cover sub-clauses (c) and (d) of AC-8 — a
+    regression that moved any existing element ABOVE `bgPath` (or
+    removed the HTML overlay) would now be caught.
     """
     content = (
         COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
@@ -3806,6 +3891,360 @@ def test_car_card_z_order_battery_group_before_bgpath():
         "the new battery+water layer (per the issue's `transparent "
         "and backward to all text, button etc` clause). "
         f"Got g_idx={g_idx}, outline_idx={outline_idx}, bg_idx={bg_idx}."
+    )
+
+    # FX-12 sub-clause (c) — every existing ring-and-handle element
+    # must appear AFTER `bgPath` in source order. A regression that
+    # moved (say) `charge_anim` above `bgPath` would make the dashed
+    # animation render UNDER the gauge ring and disappear behind the
+    # new water layer.
+    for anchor in (
+        '<path d="${socPath}"',
+        '<path id="charge_anim"',
+        '<circle id="target_handle"',
+        '<text id="target_handle_text"',
+    ):
+        idx = executable.find(anchor)
+        assert idx != -1, (
+            f"qs-car-card.js (FX-12 / AC-8): missing source anchor "
+            f"{anchor!r}. AC-9 requires these elements to remain in "
+            f"the markup byte-identical to the pre-QS-224 state."
+        )
+        assert idx > bg_idx, (
+            f"qs-car-card.js (FX-12 / AC-8): {anchor!r} must appear "
+            f"AFTER `<path d=\"${{bgPath}}\">` in source order so it "
+            f"renders ON TOP of the gauge background. "
+            f"Got idx={idx}, bg_idx={bg_idx}."
+        )
+
+    # FX-12 sub-clause (d) — the HTML overlay anchor still exists in
+    # the post-`</svg>` markup. Pin presence (not position relative to
+    # the SVG, which spans the rest of the template literal).
+    assert '<div class="center">' in executable, (
+        "qs-car-card.js (FX-12 / AC-8): the HTML overlay anchor "
+        "`<div class=\"center\">` must remain in the markup — it "
+        "carries the SOC text, target value, and control buttons "
+        "that the issue says must stay `on top` of the new layer."
+    )
+
+
+def test_car_card_render_preserves_lightning_across_innerhtml():
+    """QS-224 FX-04: `_render()` must snapshot `_lightning` and
+    `_nextLightningAt` BEFORE the innerHTML rewrite and restore them
+    AFTER `_resetDomRefs()` / equivalent cleanup, re-attaching each
+    preserved bolt's detached DOM node to the freshly-rendered
+    lightning layer.
+
+    Without preservation, every HA state push during charging (multi-
+    Hz on `power` / `current_inputed_energy` updates) wipes every
+    in-flight bolt's `<polyline>` simultaneously — the same "particles
+    all disappear at the exact same time" symptom QS-214 fixed for
+    the boiler steam+bubble subsystems. Mirror that pattern.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    assert re.search(
+        r"const\s+preservedLightning\s*=\s*this\._lightning",
+        executable,
+    ), (
+        "qs-car-card.js (FX-04): `_render()` must snapshot "
+        "`this._lightning` into `preservedLightning` BEFORE the "
+        "innerHTML rewrite."
+    )
+    assert re.search(
+        r"const\s+preservedNextLightningAt\s*=\s*this\._nextLightningAt",
+        executable,
+    ), (
+        "qs-car-card.js (FX-04): `_render()` must snapshot "
+        "`this._nextLightningAt` so the lightning spawn cadence "
+        "doesn't reset to 0 on every push (which would burst-spawn "
+        "up to the cap on every HA state push)."
+    )
+    assert re.search(
+        r"newLightningLayer\.appendChild\s*\(\s*b\.el\s*\)",
+        executable,
+    ), (
+        "qs-car-card.js (FX-04): `_render()` must re-attach each "
+        "preserved bolt's DOM node to the freshly-rendered lightning "
+        "layer via `newLightningLayer.appendChild(b.el)`."
+    )
+    assert re.search(
+        r"this\._lightning\s*=\s*preservedLightning\.filter\(\s*b\s*=>\s*b\?\.el\s*\)",
+        executable,
+    ), (
+        "qs-car-card.js (FX-04): the lightning-preserve truthy branch "
+        "must align array semantics with the null-layer drop via "
+        "`this._lightning = preservedLightning.filter(b => b?.el)` "
+        "(mirrors the boiler bubble/steam preserve pattern)."
+    )
+    assert re.search(
+        r"this\._nextLightningAt\s*=\s*preservedNextLightningAt",
+        executable,
+    ), (
+        "qs-car-card.js (FX-04): `_render()` must restore "
+        "`this._nextLightningAt = preservedNextLightningAt`."
+    )
+    # Null-layer else branch: defensive DOM removal (no leak).
+    assert re.search(
+        r"for\s*\(\s*const\s+b\s+of\s+preservedLightning\s*\)\s*\{\s*"
+        r"b\?\.el\?\.remove\s*\(\s*\)\s*;?\s*\}",
+        executable,
+    ), (
+        "qs-car-card.js (FX-04): the lightning-preserve null-layer "
+        "else branch must iterate `preservedLightning` and explicitly "
+        "call `b?.el?.remove()` so detached DOM nodes don't leak."
+    )
+
+
+def test_car_card_disconnected_callback_clears_lightning():
+    """QS-224 AC-7 / FX-11: `disconnectedCallback()` eagerly removes
+    live lightning `<polyline>` DOM nodes and resets `_lightning` to
+    `[]`. Mirrors the boiler bubble/steam teardown
+    (qs-water-boiler-card.js:637-644).
+
+    Without this teardown, a rapid detach/re-attach (HA dashboard
+    rearrangement, tab navigation) would leave the previously-spawned
+    bolt nodes attached to a detached SVG and never garbage-collected
+    until the next attach overwrote `_lightning` — a small but
+    avoidable memory leak.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    body = _extract_js_function_body(
+        executable, r"disconnectedCallback\s*\(\s*\)"
+    )
+    assert body is not None, (
+        "qs-car-card.js: missing `disconnectedCallback()`."
+    )
+    assert re.search(
+        r"this\._lightning\?\.forEach\s*\(\s*b\s*=>\s*b\.el\?\.remove\?\.\(\)\s*\)",
+        body,
+    ), (
+        "qs-car-card.js (FX-11 / AC-7): `disconnectedCallback` must "
+        "eagerly tear down lightning DOM with "
+        "`this._lightning?.forEach(b => b.el?.remove?.())` (mirror of "
+        "the boiler bubble/steam teardown shape)."
+    )
+    assert re.search(r"this\._lightning\s*=\s*\[\s*\]", body), (
+        "qs-car-card.js (FX-11 / AC-7): `disconnectedCallback` must "
+        "clear `this._lightning = []` after removing nodes."
+    )
+
+
+def test_car_card_existing_svg_elements_unchanged():
+    """QS-224 AC-9 / FX-13: each of the 5 existing SVG elements
+    listed in AC-9 must appear EXACTLY ONCE in the source.
+
+    Pins:
+    - `<path d="${bgPath}"` — gauge background ring
+    - `<path d="${socPath}"` — SOC arc
+    - `<path id="charge_anim"` — charging-dash animation (gated on
+      `showAnimation`)
+    - `<circle id="target_handle"` — draggable target handle
+    - `<text id="target_handle_text"` — target value text
+
+    A regression that accidentally duplicated or rearranged any of
+    these would silently break AC-9's "purely additive in the SVG
+    markup; no rearrangement of existing elements" contract. FX-12
+    sub-clause (c) covers position; this test covers count.
+    """
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    for marker in (
+        '<path d="${bgPath}"',
+        '<path d="${socPath}"',
+        '<path id="charge_anim"',
+        '<circle id="target_handle"',
+        '<text id="target_handle_text"',
+    ):
+        count = executable.count(marker)
+        assert count == 1, (
+            f"qs-car-card.js (FX-13 / AC-9): {marker!r} must appear "
+            f"EXACTLY ONCE in the source — got {count} occurrence(s). "
+            f"AC-9 pins the existing SVG markup as additive-only — "
+            f"duplicates or rearrangement break the contract."
+        )
+
+
+def test_car_card_prime_fires_on_uninitialised_amplitude():
+    """QS-224 FX-05: the prime block must fire ALSO when
+    `_currentAmplitude` is still `null`/`undefined`, not only when
+    `_needsAnimationPrime` is true.
+
+    Lifecycle order is `setConfig → _render → connectedCallback →
+    _startAnimation (sets _needsAnimationPrime=true) → set hass →
+    _render`. The first `_render` (from `setConfig`) runs BEFORE
+    `_startAnimation` initialises any state, so
+    `_needsAnimationPrime` is still undefined and the prime block is
+    skipped. Result: an actively-charging car renders its first SVG
+    with calm-green geometry; only the second `_render` snaps to
+    charging. Extending the guard to also fire on
+    `_currentAmplitude == null` covers the first-render case
+    cleanly.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    # The prime guard must be a logical-OR covering both conditions.
+    # Accept either `|| this._currentAmplitude == null` or
+    # `|| this._currentAmplitude === null` or the `==/===` against
+    # `undefined` variants.
+    pat = re.compile(
+        r"if\s*\(\s*this\._needsAnimationPrime\s*\|\|\s*"
+        r"this\._currentAmplitude\s*==\s*null\b"
+    )
+    assert pat.search(executable), (
+        "qs-car-card.js (FX-05): the prime guard must be "
+        "`if (this._needsAnimationPrime || this._currentAmplitude == "
+        "null)` so the first-render-from-setConfig case (no RAF "
+        "init yet) also primes amplitude/speed/colorMix to the actual "
+        "`charging` targets — without this, an actively-charging car "
+        "shows calm green on its very first paint."
+    )
+
+
+def test_car_card_lightning_spawn_debt_preserved_at_cap():
+    """QS-224 FX-06: the post-spawn-loop clamp
+    `if (this._nextLightningAt < 0) this._nextLightningAt = 0;` must
+    be guarded by the not-capped check so accumulated spawn debt is
+    preserved across cap-blocked frames.
+
+    Without the guard: when the hard cap is hit, the while-loop
+    doesn't enter, `_nextLightningAt` stops decrementing inside the
+    loop, then the clamp silently zeros any accumulated negative
+    debt. Net effect: when a slot frees, the next spawn waits the
+    full `1/SPAWN_RATE_HZ` window instead of firing immediately —
+    minor desync vs. the documented "spawn rate × life ≈ 1.5 avg"
+    target.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    # The corrected form puts the cap check on the same `if`:
+    #   if (this._lightning.length < MAX_CONCURRENT_LIGHTNING
+    #       && this._nextLightningAt < 0) {
+    #     this._nextLightningAt = 0;
+    #   }
+    pat = re.compile(
+        r"if\s*\(\s*this\._lightning\.length\s*<\s*MAX_CONCURRENT_LIGHTNING"
+        r"\s*&&\s*this\._nextLightningAt\s*<\s*0\s*\)\s*"
+        r"\{[^}]*this\._nextLightningAt\s*=\s*0",
+        re.DOTALL,
+    )
+    assert pat.search(executable), (
+        "qs-car-card.js (FX-06): the post-spawn-loop clamp must be "
+        "guarded by the not-capped check, e.g. "
+        "`if (this._lightning.length < MAX_CONCURRENT_LIGHTNING && "
+        "this._nextLightningAt < 0) { this._nextLightningAt = 0; }`. "
+        "Without the guard, accumulated spawn debt is discarded "
+        "whenever the cap is hit, and a freed slot waits the full "
+        "spawn-rate window instead of firing immediately."
+    )
+
+
+def test_car_card_wave_els_cache_rechecks_null():
+    """QS-224 FX-07: the lazy DOM-ref cache (`_waveEls`) must
+    re-resolve when ANY cached entry is `null`.
+
+    `connectedCallback()` eagerly schedules a RAF tick before the
+    first `_render()` runs. If that tick lands first (no SVG markup
+    in the shadow root yet), `getElementById` returns `null` for
+    every wave id; the resulting `_waveEls = [null, null]` is
+    truthy, so the next-frame `if (!this._waveEls)` guard never
+    re-queries. The cache locks in `[null, null]` until the next
+    innerHTML rewrite invalidates it via `_resetDomRefs`. Result:
+    the wave animation visibly freezes for the first ~1s of every
+    fresh attach.
+
+    The fix re-queries when any entry is null:
+      if (!this._waveEls || this._waveEls.some(el => el == null)) {
+        ...resolve...
+      }
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    pat = re.compile(
+        r"if\s*\(\s*!this\._waveEls\s*\|\|\s*"
+        r"this\._waveEls\.some\s*\(\s*el\s*=>\s*el\s*==\s*null\s*\)\s*\)",
+    )
+    assert pat.search(executable), (
+        "qs-car-card.js (FX-07): the wave-DOM-ref cache resolution "
+        "guard must be `if (!this._waveEls || "
+        "this._waveEls.some(el => el == null)) { … }` so a "
+        "RAF-before-render sequence (eager `_startAnimation` schedules "
+        "a tick before the first `_render` has populated the shadow "
+        "root) doesn't lock the cache to `[null, null]` until the "
+        "next innerHTML rewrite."
+    )
+
+
+def test_car_card_water_level_uses_battery_body_height():
+    """QS-224 FX-08 (Option A — keep current; pin with comment).
+
+    The water-level formula `BATTERY_BOTTOM_Y - (0.2 + ratio × 0.6)
+    × BATTERY_BODY_HEIGHT` maps the issue's literal "+1/5 / −1/5 of
+    diameter" rule into the battery body's height (= 140.4 px), NOT
+    the literal ring diameter (= 260 px). The re-interpretation
+    keeps the water visually bounded inside the battery silhouette
+    at all SOC values (0% never floods the body interior; 100%
+    leaves the top 1/5 of the body empty as headroom).
+
+    This sentinel pins the formula's exact shape AND requires an
+    inline source comment citing the FX-08 design decision so future
+    readers don't flag the deviation from the literal issue text as
+    drift.
+    """
+    import re
+
+    content = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(content)
+    assert re.search(
+        r"waterBaseY\s*=\s*BATTERY_BOTTOM_Y\s*-\s*\(\s*0\.2\s*\+\s*"
+        r"progressRatio\s*\*\s*0\.6\s*\)\s*\*\s*BATTERY_BODY_HEIGHT",
+        executable,
+    ), (
+        "qs-car-card.js (FX-08): the water-level formula must be "
+        "`waterBaseY = BATTERY_BOTTOM_Y - (0.2 + progressRatio * "
+        "0.6) * BATTERY_BODY_HEIGHT` (the issue's `+1/5 / −1/5` rule "
+        "re-interpreted relative to the battery body height — see "
+        "the FX-08 design-decision comment that should accompany "
+        "this line)."
+    )
+    # The FX-08 comment must be present in the source (not the
+    # stripped executable). Mention either `FX-08` or the literal
+    # `+1/5 / −1/5` phrase from the issue + a justification for the
+    # body-height denominator.
+    assert ("FX-08" in content) or (
+        "+1/5" in content and "BATTERY_BODY_HEIGHT" in content
+    ), (
+        "qs-car-card.js (FX-08): expected a source comment near the "
+        "water-level formula citing review-fix #01 FX-08 (or the "
+        "literal `+1/5` issue phrase + `BATTERY_BODY_HEIGHT` "
+        "justification) so future readers don't re-question the "
+        "deviation from the literal ring-diameter interpretation."
     )
 
 


### PR DESCRIPTION
## Summary
- Adds an mdi:battery-outline-shaped translucent overlay inside the car card's existing ring; 3-layer sine-wave water animation cross-fades from green (idle) to electric blue (charging) via per-path opacity, with white-core/blue-glow zigzag lightning bolts (hard cap 3) while charging
- Stroked body+terminal outline drawn over the clipped water/lightning group; stroke alpha lerps from 0.30 (idle) to 0.55 (charging) so the silhouette is always visible
- Mirrors the boiler card's continuous-RAF + lerp envelope (CALM_AMP=1.5 / CHARGING_AMP=8, CALM_SPEED=0.1 / CHARGING_SPEED=0.4); removes the legacy charging-gated start/stop block from _render — the car card now runs continuous RAF while connected, and the calm-vs-charging distinction is amp/speed/colorMix lerp

Fixes #224

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)