### PR TITLE
QS-228: apply uniform ring text shadow across all 6 QS Lovelace cards

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -298,7 +298,7 @@ class QsCarCard extends HTMLElement {
       const nextTimeMins = this._localNextTimeMins != null ? this._localNextTimeMins : parseTimeToMinutes(nextTimeStr);
 
       const css = `
-      :host { --pad: 18px; display:block; }
+      :host { --pad: 18px; --ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); display:block; }
       .card { padding: var(--pad); }
       .card.stale { border: 3px solid var(--error-color, #db4437); }
       .card.off-grid { background: rgba(244, 67, 54, 0.08); }
@@ -327,10 +327,10 @@ class QsCarCard extends HTMLElement {
       .hero .side .value { display:block; font-size:1.2rem; color: var(--primary-text-color); }
       .ring { position: relative; width:300px; height:300px; margin: 0 auto; }
       .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center; pointer-events: none; transform: translateY(16px); }
-      .ring .pct { font-size: 4rem; font-weight:800; letter-spacing:-1px; line-height:1; }
+      .ring .pct { font-size: 4rem; font-weight:800; letter-spacing:-1px; line-height:1; text-shadow: var(--ring-text-shadow); }
       .ring ha-icon { --mdc-icon-size: 32px; color: var(--secondary-text-color); margin-bottom: 6px; }
-      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .target-value { color: var(--primary-color); font-weight:800; font-size: 1.5rem; line-height: 1; }
+      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .target-value { color: var(--primary-color); font-weight:800; font-size: 1.5rem; line-height: 1; text-shadow: var(--ring-text-shadow); }
       .ring .stack { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:4px; text-align:center; width: 180px; margin: 0 auto; }
       .ring .soc-block { display:flex; flex-direction:column; align-items:center; gap:2px; margin-top:4px; margin-bottom:8px; }
       .ring .soc-block .charge-type-icon { --mdc-icon-size: 20px; color: var(--secondary-text-color); margin-bottom: 2px; }
@@ -339,12 +339,12 @@ class QsCarCard extends HTMLElement {
       .ring .mini-grid.extra { row-gap:0; margin-top:2px; margin-bottom:6px; }
       .ring .target-block { display:flex; flex-direction:column; align-items:center; gap:0; }
       .ring .target-cell { display:flex; flex-direction:column; align-items:center; gap:2px; }
-      .ring .mini-title { color: var(--secondary-text-color); font-weight:700; font-size: .7rem; letter-spacing:.2px; white-space: nowrap; }
-      .ring .mini-value { color: var(--primary-text-color); font-weight:800; font-size: .95rem; line-height: 1.1; white-space: pre-line; }
+      .ring .mini-title { color: var(--secondary-text-color); font-weight:700; font-size: .7rem; letter-spacing:.2px; white-space: nowrap; text-shadow: var(--ring-text-shadow); }
+      .ring .mini-value { color: var(--primary-text-color); font-weight:800; font-size: .95rem; line-height: 1.1; white-space: pre-line; text-shadow: var(--ring-text-shadow); }
       .ring .mini-icon { --mdc-icon-size: 18px; color: var(--primary-text-color); }
-      .ring .mini-range { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .mini-range-now { color: var(--primary-text-color); font-weight:700; font-size: .95rem; line-height: 1; margin-top:0; transform: translateY(-8px); }
-      .ring .mini-range-target { color: var(--primary-color); font-weight:700; font-size: .95rem; line-height: 1; margin-top:0; margin-bottom:0; }
+      .ring .mini-range { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .mini-range-now { color: var(--primary-text-color); font-weight:700; font-size: .95rem; line-height: 1; margin-top:0; transform: translateY(-8px); text-shadow: var(--ring-text-shadow); }
+      .ring .mini-range-target { color: var(--primary-color); font-weight:700; font-size: .95rem; line-height: 1; margin-top:0; margin-bottom:0; text-shadow: var(--ring-text-shadow); }
       .disabled .ring .mini-range-target { color: var(--secondary-text-color); }
       .ring .mini-range:empty, .ring .mini-range-now:empty, .ring .mini-range-target:empty { display:none; }
       .ring .center-controls { display:flex; align-items:center; justify-content:center; margin-top: 6px; }

--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -916,7 +916,7 @@ class QsClimateCard extends HTMLElement {
       const colors = colorSchemes[climateStateOn] || colorSchemes.cool;
       
       const css = `
-      :host { --pad: 18px; display:block; }
+      :host { --pad: 18px; --ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); display:block; }
       .card { padding: var(--pad); position: relative; }
       .card.off-grid { background: rgba(244, 67, 54, 0.08); }
       .card-title { text-align:center; font-weight:800; font-size: 1.6rem; margin: 0px 0 0px; }
@@ -954,14 +954,14 @@ class QsClimateCard extends HTMLElement {
       .card.disabled { opacity: 0.5; pointer-events: none; filter: grayscale(0.8); }
       .card.disabled .power-btn { pointer-events: auto; opacity: 1; filter: grayscale(0); }
       .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center; pointer-events: none; transform: translateY(-5px); }
-      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .target-value { font-weight:800; font-size: 2.5rem; line-height: 1.1; }
+      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .target-value { font-weight:800; font-size: 2.5rem; line-height: 1.1; text-shadow: var(--ring-text-shadow); }
       .ring .stack { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; text-align:center; width: 220px; margin: 0 auto; }
       .ring .target-block { display:flex; flex-direction:column; align-items:center; gap:6px; }
       .ring .from-to-row { display:flex; justify-content:space-between; width:140px; margin-top: 8px; gap:20px; }
       .ring .from-to-item { display:flex; flex-direction:column; align-items:center; gap:2px; }
-      .ring .from-to-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .from-to-value { color: var(--primary-text-color); font-weight:800; font-size: 1.4rem; }
+      .ring .from-to-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .from-to-value { color: var(--primary-text-color); font-weight:800; font-size: 1.4rem; text-shadow: var(--ring-text-shadow); }
       .ring .center-controls { display:flex; align-items:center; justify-content:center; margin-top: 6px; }
       .ring .override-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
       .ring .override-btn ha-icon { --mdc-icon-size: 26px; color: var(--secondary-text-color); display:block; line-height:1; }

--- a/custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
@@ -207,7 +207,7 @@ class QsOnOffDurationCard extends HTMLElement {
       };
       
       const css = `
-      :host { --pad: 18px; display:block; }
+      :host { --pad: 18px; --ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); display:block; }
       .card { padding: var(--pad); position: relative; }
       .card.off-grid { background: rgba(244, 67, 54, 0.08); }
       .card-title { text-align:center; font-weight:800; font-size: 1.6rem; margin: 0px 0 0px; }
@@ -245,14 +245,14 @@ class QsOnOffDurationCard extends HTMLElement {
       .card.disabled { opacity: 0.5; pointer-events: none; filter: grayscale(0.8); }
       .card.disabled .power-btn { pointer-events: auto; opacity: 1; filter: grayscale(0); }
       .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center; pointer-events: none; transform: translateY(-5px); }
-      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .target-value { font-weight:800; font-size: 2.5rem; line-height: 1.1; }
+      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .target-value { font-weight:800; font-size: 2.5rem; line-height: 1.1; text-shadow: var(--ring-text-shadow); }
       .ring .stack { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; text-align:center; width: 220px; margin: 0 auto; }
       .ring .target-block { display:flex; flex-direction:column; align-items:center; gap:6px; }
       .ring .from-to-row { display:flex; justify-content:space-between; width:140px; margin-top: 8px; gap:20px; }
       .ring .from-to-item { display:flex; flex-direction:column; align-items:center; gap:2px; }
-      .ring .from-to-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .from-to-value { color: var(--primary-text-color); font-weight:800; font-size: 1.4rem; }
+      .ring .from-to-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .from-to-value { color: var(--primary-text-color); font-weight:800; font-size: 1.4rem; text-shadow: var(--ring-text-shadow); }
       .ring .center-controls { display:flex; align-items:center; justify-content:center; margin-top: 6px; }
       .ring .override-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
       .ring .override-btn ha-icon { --mdc-icon-size: 26px; color: var(--secondary-text-color); display:block; line-height:1; }

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -814,7 +814,7 @@ class QsWaterBoilerCard extends HTMLElement {
       };
       
       const css = `
-      :host { --pad: 18px; display:block; }
+      :host { --pad: 18px; --ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5); display:block; }
       .card { padding: var(--pad); position: relative; }
       .card.off-grid { background: rgba(244, 67, 54, 0.08); }
       .card-title { text-align:center; font-weight:800; font-size: 1.6rem; margin: 0px 0 0px; }
@@ -857,14 +857,14 @@ class QsWaterBoilerCard extends HTMLElement {
       .card.disabled { opacity: 0.5; pointer-events: none; filter: grayscale(0.8); }
       .card.disabled .power-btn { pointer-events: auto; opacity: 1; filter: grayscale(0); }
       .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center; pointer-events: none; transform: translateY(-5px); }
-      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .target-value { font-weight:800; font-size: 2.5rem; line-height: 1.1; }
+      .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .target-value { font-weight:800; font-size: 2.5rem; line-height: 1.1; text-shadow: var(--ring-text-shadow); }
       .ring .stack { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; text-align:center; width: 220px; margin: 0 auto; }
       .ring .target-block { display:flex; flex-direction:column; align-items:center; gap:6px; }
       .ring .from-to-row { display:flex; justify-content:space-between; width:140px; margin-top: 8px; gap:20px; }
       .ring .from-to-item { display:flex; flex-direction:column; align-items:center; gap:2px; }
-      .ring .from-to-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; }
-      .ring .from-to-value { color: var(--primary-text-color); font-weight:800; font-size: 1.4rem; }
+      .ring .from-to-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
+      .ring .from-to-value { color: var(--primary-text-color); font-weight:800; font-size: 1.4rem; text-shadow: var(--ring-text-shadow); }
       .ring .center-controls { display:flex; align-items:center; justify-content:center; margin-top: 6px; }
       .ring .override-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
       .ring .override-btn ha-icon { --mdc-icon-size: 26px; color: var(--secondary-text-color); display:block; line-height:1; }

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -12,7 +12,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js
   - custom_components/quiet_solar/ui/resources/qs-radiator-card.js
   - custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
-last_verified: 2026-05-24
+last_verified: 2026-05-25
 ---
 
 # Dashboard generation and JS Lovelace cards
@@ -599,6 +599,21 @@ patterns after the cross-card audit:
   `buttons` is empty, and the per-button `activate` closure wraps
   `b.onClick?.()` in `try/finally` so a synchronous throw can't
   leave the modal locked open.
+
+### Ring text readability — uniform shadow (QS-228)
+
+Every QS Lovelace card declares
+`--ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5)`
+on `:host` and applies `text-shadow: var(--ring-text-shadow)` to every
+inside-the-ring text class across all six cards (`qs-car-card`,
+`qs-climate-card`, `qs-on-off-duration-card`, `qs-pool-card`,
+`qs-radiator-card`, `qs-water-boiler-card`). The shadow originated in
+QS-201 for the radiator's warm flame and the pool's animated water;
+QS-228 extends it to the remaining cards for visual consistency. The
+contract is pinned by
+`tests/test_dashboard_rendering.py::TestDashboardTemplateRendering::test_all_qs_cards_apply_ring_text_shadow_for_readability`
+(the per-card `CARDS_TO_RING_TEXT_CLASSES` mapping enumerates which
+classes each card must shadow).
 
 Follow these patterns when adding new JS cards. 
 

--- a/docs/stories/QS-228.story.md
+++ b/docs/stories/QS-228.story.md
@@ -1,0 +1,316 @@
+# QS-228 — Apply uniform ring text shadow to all QS Lovelace cards
+
+## Issue
+
+GitHub #228 — "Apply text shadow to all cards for better readability"
+
+> The pool and radiator texts inside of the circle has a kind of shadow
+> (black-ish) I would like to do the same for all the other cards as it
+> makes stuff more readable.
+
+## Summary
+
+QS-201 introduced a `--ring-text-shadow` CSS variable on `qs-radiator-card.js`
+(value `0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5)`) and applied
+it to four inside-the-ring text classes to keep them legible over the
+warm orange flame backdrop. The same pattern shipped on `qs-pool-card.js`
+for legibility over the animated water. The four remaining QS custom
+Lovelace cards (`qs-car-card`, `qs-climate-card`,
+`qs-on-off-duration-card`, `qs-water-boiler-card`) do NOT carry the
+shadow. The climate card has an animated flame/snow/wind backdrop
+(QS-210) and the water-boiler card has the bubble/steam/wave backdrop
+(QS-200/211/214) — both clearly need it. The car and on-off-duration
+cards lack an animated backdrop but get the shadow anyway, per the
+issue ("apply to all other cards") and a maintainer call for visual
+consistency (Q2 in clarifying-question round).
+
+## Authorization (JS-card edits)
+
+`project-context.md` and `project-rules.md` warn: "Custom JS card code
+should not be modified without explicit instruction." Issue #228 is
+that explicit instruction — the body asks directly for the shadow to
+be applied to the remaining cards. This story logs the authorization
+so reviewers don't false-flag the JS edits.
+
+## Harness sync
+
+N/A — no agent files under `.claude/agents/`, `.cursor/agents/`, or
+`.opencode/agents/` are touched.
+
+## Acceptance criteria
+
+- **AC-1: `--ring-text-shadow` variable declared on every QS card.**
+  Given each of the six QS Lovelace cards (`qs-car-card.js`,
+  `qs-climate-card.js`, `qs-on-off-duration-card.js`, `qs-pool-card.js`,
+  `qs-radiator-card.js`, `qs-water-boiler-card.js`), when its `:host`
+  block is parsed, then it declares
+  `--ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5)`.
+  The pool and radiator cards already match this verbatim — no
+  re-normalization needed.
+
+- **AC-2: `text-shadow: var(--ring-text-shadow)` on every inside-the-ring
+  text class.** Given a card and the enumerated ring-text classes (see
+  the table below), when each `.ring .<class>` rule in the card's CSS is
+  parsed (the selector appears literally in this form — see the
+  existing pool/radiator cards as the canonical reference pattern),
+  then it contains `text-shadow: var(--ring-text-shadow)`. The
+  declaration is appended as the last declaration before the closing
+  `}`, mirroring the single-line form used at
+  `custom_components/quiet_solar/ui/resources/qs-pool-card.js:409`.
+
+- **AC-3: Regression-proof tests covering all 6 cards.** A new test
+  method `test_all_qs_cards_apply_ring_text_shadow_for_readability` in
+  `tests/test_dashboard_rendering.py` iterates a single
+  `CARDS_TO_RING_TEXT_CLASSES` mapping (the table below) and asserts
+  AC-1 + AC-2 for each card. The implementation matches the existing
+  `test_radiator_card_text_shadow_for_flame_readability`
+  (file:line `tests/test_dashboard_rendering.py:720`) idiom — a plain
+  class method that loops via Python `for`, not `pytest.mark.parametrize`
+  (the existing class lacks parametrize precedent). The existing
+  radiator-only AC-9 test is preserved (additive change).
+
+- **AC-4: Doc maintenance.** `docs/agents/concepts/dashboard-and-cards.md`
+  gains a short subsection titled `### Ring text readability — uniform
+  shadow (QS-228)` under "Hardened JS-card patterns", 2-3 sentences
+  naming the variable, listing the 6 cards, and cross-referencing the
+  test path. `last_verified` is bumped to the implementation date
+  (today, as set by the implement-task agent during commit).
+
+## Ring-text class mapping
+
+| Card | Ring text classes (selectors are `.ring .<class>` literally) | Status |
+|---|---|---|
+| `qs-pool-card.js` | `pct`, `target-label`, `target-value` | already shipping (QS-201) — verify-only |
+| `qs-radiator-card.js` | `target-label`, `target-value`, `from-to-label`, `from-to-value` | already shipping (QS-201) — verify-only |
+| `qs-car-card.js` | `pct`, `target-label`, `target-value`, `mini-title`, `mini-value`, `mini-range`, `mini-range-now`, `mini-range-target` | source edit required |
+| `qs-climate-card.js` | `target-label`, `target-value`, `from-to-label`, `from-to-value` | source edit required |
+| `qs-on-off-duration-card.js` | `target-label`, `target-value`, `from-to-label`, `from-to-value` | source edit required |
+| `qs-water-boiler-card.js` | `target-label`, `target-value`, `from-to-label`, `from-to-value` | source edit required |
+
+## Task breakdown
+
+Line numbers below are approximate orientation hints — the real anchor
+is the existing `:host { ... }` block / selector match. Use the existing
+`qs-pool-card.js` and `qs-radiator-card.js` patterns as the canonical
+reference for both the `:host` declaration form and the per-rule
+single-line append.
+
+### Verify-only (no JS source edit)
+
+0a. **`custom_components/quiet_solar/ui/resources/qs-pool-card.js`** —
+    NO source edit required. Variable declared at L371 and shadows
+    applied at L409-411 already match AC-1/AC-2 verbatim. AC-3 test
+    asserts these classes to lock the pattern in.
+
+0b. **`custom_components/quiet_solar/ui/resources/qs-radiator-card.js`** —
+    NO source edit required. Variable declared at L617 and shadows
+    applied at L657-664 already match AC-1/AC-2 verbatim. AC-3 test
+    asserts these classes (already pinned by
+    `test_radiator_card_text_shadow_for_flame_readability` — both tests
+    coexist).
+
+### Source edits required
+
+1. **`custom_components/quiet_solar/ui/resources/qs-car-card.js`**
+   - Inside the `:host { --pad: 18px; display:block; }` block (~L301),
+     add `--ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5);`.
+     Mirror the multi-line form already used in `qs-radiator-card.js:615-619`
+     for readability, or keep single-line — either is fine.
+   - Append `text-shadow: var(--ring-text-shadow);` as the last
+     declaration before `}` on these 8 rules (approximate line numbers):
+     - `.ring .pct` (~L330)
+     - `.ring .target-label` (~L332)
+     - `.ring .target-value` (~L333)
+     - `.ring .mini-title` (~L342)
+     - `.ring .mini-value` (~L343)
+     - `.ring .mini-range` (~L345)
+     - `.ring .mini-range-now` (~L346)
+     - `.ring .mini-range-target` (~L347)
+
+2. **`custom_components/quiet_solar/ui/resources/qs-climate-card.js`**
+   - Inside the `:host { --pad: 18px; display:block; }` block (~L919),
+     add the variable.
+   - Append `text-shadow: var(--ring-text-shadow);` to these 4 rules:
+     - `.ring .target-label` (~L957)
+     - `.ring .target-value` (~L958)
+     - `.ring .from-to-label` (~L963)
+     - `.ring .from-to-value` (~L964)
+
+3. **`custom_components/quiet_solar/ui/resources/qs-on-off-duration-card.js`**
+   - Inside the `:host { --pad: 18px; display:block; }` block (~L210),
+     add the variable.
+   - Append `text-shadow: var(--ring-text-shadow);` to these 4 rules:
+     - `.ring .target-label` (~L248)
+     - `.ring .target-value` (~L249)
+     - `.ring .from-to-label` (~L254)
+     - `.ring .from-to-value` (~L255)
+
+4. **`custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js`**
+   - Inside the `:host { --pad: 18px; display:block; }` block (~L817),
+     add the variable.
+   - Append `text-shadow: var(--ring-text-shadow);` to these 4 rules:
+     - `.ring .target-label` (~L860)
+     - `.ring .target-value` (~L861)
+     - `.ring .from-to-label` (~L866)
+     - `.ring .from-to-value` (~L867)
+
+### Test
+
+5. **`tests/test_dashboard_rendering.py`**
+   - Add a module-level (or class-level — match the location of
+     `test_radiator_card_text_shadow_for_flame_readability`)
+     constant `CARDS_TO_RING_TEXT_CLASSES` mapping each card file to
+     its expected ring-text class list (the table above).
+   - Add `test_all_qs_cards_apply_ring_text_shadow_for_readability` as
+     a class method that iterates the mapping. For each card:
+     - Assert the variable declaration via the regex
+       `r"--ring-text-shadow:\s*0 0 12px rgba\(0,0,0,0\.8\),\s*0 2px 4px rgba\(0,0,0,0\.5\)"`.
+     - For each expected class, assert
+       `rf"\.ring\s+\.{cls}\s*\{{[^}}]*text-shadow:\s*var\(--ring-text-shadow\)"`.
+   - These are the same regex patterns used by the existing radiator
+     AC-9 test, lifted verbatim. The `\{[^}]*` block-scoped match
+     prevents commented-out CSS from passing.
+   - Keep `test_radiator_card_text_shadow_for_flame_readability`
+     intact — purely additive change. The two tests overlap on radiator
+     by design (the AC-9 pin is its own contract).
+
+### Doc
+
+6. **`docs/agents/concepts/dashboard-and-cards.md`**
+   - Add a subsection under "Hardened JS-card patterns" titled
+     `### Ring text readability — uniform shadow (QS-228)`. Body
+     (2-3 sentences): name the CSS variable verbatim
+     (`--ring-text-shadow: 0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5)`),
+     state that it is declared on `:host` and applied to every
+     inside-the-ring text class across all 6 cards (`qs-car-card`,
+     `qs-climate-card`, `qs-on-off-duration-card`, `qs-pool-card`,
+     `qs-radiator-card`, `qs-water-boiler-card`), and cross-reference
+     the pin at `tests/test_dashboard_rendering.py` /
+     `test_all_qs_cards_apply_ring_text_shadow_for_readability`.
+   - Bump `last_verified` from `2026-05-24` to the implementation
+     date (the implement-task agent sets this when committing).
+
+## Out of scope (explicit)
+
+- `.card-title` outside the ring on every card — the issue scope is
+  "texts inside of the circle".
+- `qs-water-boiler-card.js` `.tank-temp` row above the card — outside
+  the ring.
+- `qs-car-card.js` `.hero .side` side-text columns — outside the ring.
+- Buttons, pill text, dialog text, select text — no readability
+  concern flagged in the issue.
+- Theme-aware shadow variants (light vs dark) — the variable uses
+  fixed `rgba(0,0,0,...)` by design; this matches the existing
+  shipping pool/radiator behavior. Out of scope as a follow-up.
+
+## Dev notes / scope-add disclosures
+
+For the PR description:
+
+- **Deliberate scope adds beyond literal issue, user-authorized:**
+  - The shadow is applied to `qs-car-card.js` and `qs-on-off-duration-card.js`
+    even though they have no animated backdrop. Maintainer call for
+    visual consistency.
+  - AC-3 covers all 6 cards (not just the 4 newly-shadowed), giving the
+    pool card a parallel pin alongside the existing radiator AC-9.
+  - AC-4 doc update is downstream of the JS edits (`covers:` includes
+    all 6 cards, so the drift checker would flag it anyway).
+
+- **Visual verification is manual**. The new test pins the CSS
+  contract (variable declared + applied to enumerated classes), not
+  the rendered output. The shadow value is a verbatim copy of the
+  already-shipping pool/radiator value, so any pre-merge HA install
+  rendering should match QS-201's known-good visual.
+
+- **No coverage / lint regressions expected**. The change is CSS-only
+  inside JS template-string literals + one pure-regex pytest. JS cards
+  are explicitly outside the quality pipeline; the gate's UI-only
+  fast-path (`project-rules.md` §"UI-only fast path") covers this
+  exact change pattern.
+
+## Adversarial Review Notes
+
+Four reviewers ran in parallel on the plan draft before commit:
+
+### plan-critic
+
+- **critical**: pool + radiator listed in AC table but absent from
+  task breakdown → **fixed** by adding explicit verify-only tasks 0a/0b
+  citing existing line ranges.
+- **critical**: AC-1 normalization ambiguity (must existing
+  declarations be re-normalized?) → **fixed** by stating "pool +
+  radiator already match verbatim — no edit needed" in AC-1.
+- **redesign**: hard-coded line numbers brittle → **partial fix**;
+  keeping line numbers as approximate orientation hints, with the
+  real anchor being the `:host` block / selector match. Implementer
+  uses pool/radiator as canonical reference.
+- **redesign**: pytest string-matching fragile → **acknowledged**;
+  the `\{[^}]*` block-scoped regex prevents commented-out CSS from
+  passing. Documented in AC-3.
+- **improve**: visual regression safeguard → **acknowledged as
+  manual**; JS cards outside the quality pipeline. Documented in dev
+  notes.
+- **improve**: asymmetric out-of-scope list → **rejected** as
+  sufficient (covers every non-ring text class category).
+- **improve**: theme-aware shadow variants → **explicit out of scope**.
+- **clarify**: AC-3 test data location → **fixed** by naming
+  `CARDS_TO_RING_TEXT_CLASSES` and stating "class method loops via
+  Python for, not parametrize".
+- **clarify**: AC-2 selector form ambiguity → **fixed** by stating
+  selectors are `.ring .<class>` literally and citing pool/radiator
+  as canonical reference.
+- **clarify**: `last_verified: 2026-05-25` hard-codes today →
+  **fixed** by replacing with "implementation date, set by the
+  implement-task agent during commit".
+- **clarify**: tilde line numbers → **fixed** by labeling them
+  "approximate orientation hints".
+
+### concrete-planner
+
+- **improve**: pool + radiator skipped in task list → **fixed**
+  (same as plan-critic critical #1) with explicit verify-only tasks.
+- **clarify**: insert position inside each ring-class rule → **fixed**
+  by specifying "append as last declaration before `}`, mirroring
+  `qs-pool-card.js:409` single-line form".
+- **clarify**: pytest test shape vs file's existing class-method style
+  → **fixed** by picking class method + Python for-loop iteration
+  (matches existing radiator test idiom).
+- **improve**: doc subsection content unspecified → **fixed** by
+  specifying title, 2-3 sentence body, and required content (variable
+  + 6 cards + test cross-reference).
+
+### dev-proxy
+
+- **critical**: exact CSS rule structure unspecified → **fixed** by
+  citing existing pool/radiator cards as the canonical reference
+  pattern, confirming selectors are `.ring .<class>` literally.
+- **clarify**: JS-card-modification authorization → **fixed** by
+  adding "Authorization" section quoting the issue body.
+- **improve**: AC-1 ambiguity (add to 4 vs verify all 6) → **fixed**
+  by reworded AC-1 ("ensure declared") + the verify-only / source-edit
+  split in the task breakdown.
+- **clarify**: test name + assertions unspecified → **fixed** with
+  full name (`test_all_qs_cards_apply_ring_text_shadow_for_readability`)
+  and explicit regex strings in AC-3.
+- **improve**: doc subsection content unspecified → **fixed** (same
+  as concrete-planner finding).
+- **clarify**: harness-sync rule → **fixed** with explicit
+  "Harness sync: N/A" line.
+
+### scope-guardian
+
+- **improve**: AC-1 phrasing implies touching all 6 cards including
+  the already-correct pool/radiator → **fixed** by reworded AC-1
+  ("ensure declared") + verify-only tasks for pool/radiator.
+- **improve**: AC-4 doc update downstream of over-broad AC-1 →
+  **partial fix**; doc update narrowed to a small subsection +
+  `last_verified` bump. The covers: list still includes all 6 cards
+  so the drift checker would flag the doc regardless.
+- **improve**: AC-3 broader than issue → **acknowledged**;
+  user-authorized in clarifying-question round, flagged in dev notes
+  as a deliberate scope add.
+- **clarify**: car-card class list against flat background →
+  **acknowledged**; user-authorized in clarifying-question round,
+  flagged in dev notes as a deliberate scope add.
+- **clarify**: out-of-scope list completeness → **kept as-is**;
+  reviewer agreed list is appropriately conservative.

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -743,6 +743,93 @@ class TestDashboardTemplateRendering:
                 f"AC-9: .ring .{cls} must apply text-shadow: var(--ring-text-shadow)"
             )
 
+    # QS-228 — uniform ring text shadow across all 6 QS Lovelace cards.
+    # Map each card to its enumerated ring-text classes. The test method
+    # below loops via Python `for` (matches the radiator AC-9 idiom — the
+    # surrounding class lacks parametrize precedent).
+    CARDS_TO_RING_TEXT_CLASSES = {
+        "qs-pool-card.js": ("pct", "target-label", "target-value"),
+        "qs-radiator-card.js": (
+            "target-label",
+            "target-value",
+            "from-to-label",
+            "from-to-value",
+        ),
+        "qs-car-card.js": (
+            "pct",
+            "target-label",
+            "target-value",
+            "mini-title",
+            "mini-value",
+            "mini-range",
+            "mini-range-now",
+            "mini-range-target",
+        ),
+        "qs-climate-card.js": (
+            "target-label",
+            "target-value",
+            "from-to-label",
+            "from-to-value",
+        ),
+        "qs-on-off-duration-card.js": (
+            "target-label",
+            "target-value",
+            "from-to-label",
+            "from-to-value",
+        ),
+        "qs-water-boiler-card.js": (
+            "target-label",
+            "target-value",
+            "from-to-label",
+            "from-to-value",
+        ),
+    }
+
+    def test_all_qs_cards_apply_ring_text_shadow_for_readability(self):  # CR2 — sync (no hass)
+        """QS-228 — uniform ring text shadow across all 6 QS Lovelace cards.
+
+        The pool and radiator cards already shipped this in QS-201 to keep
+        inside-the-ring text legible over their animated backdrops. QS-228
+        extends the same `--ring-text-shadow` variable and `text-shadow:
+        var(--ring-text-shadow)` per-rule application to the four remaining
+        cards (car, climate, on-off-duration, water-boiler). Some of these
+        cards have animated backdrops (climate flame/snow/wind,
+        water-boiler bubble/steam/wave) and some don't (car, on-off-duration)
+        — the maintainer asked for visual consistency across the set.
+
+        Block-scoped regex (`\\{[^}]*`) prevents a commented-out CSS rule
+        from satisfying the assertion. Pattern matches the existing
+        `test_radiator_card_text_shadow_for_flame_readability` idiom
+        verbatim — the radiator test is kept intact and the two tests
+        overlap on radiator by design (AC-9's own pin is its contract).
+        """
+        import re
+
+        for card_filename, classes in self.CARDS_TO_RING_TEXT_CLASSES.items():
+            content = (
+                COMPONENT_ROOT / "ui" / "resources" / card_filename
+            ).read_text()
+
+            # AC-1: --ring-text-shadow declared on :host (whitespace-tolerant).
+            assert re.search(
+                r"--ring-text-shadow:\s*0 0 12px rgba\(0,0,0,0\.8\),\s*0 2px 4px rgba\(0,0,0,0\.5\)",
+                content,
+            ) is not None, (
+                f"AC-1 ({card_filename}): --ring-text-shadow variable must "
+                "be declared on :host with the verbatim value "
+                "`0 0 12px rgba(0,0,0,0.8), 0 2px 4px rgba(0,0,0,0.5)`"
+            )
+
+            # AC-2: every enumerated ring-text class applies the variable.
+            for cls in classes:
+                assert re.search(
+                    rf"\.ring\s+\.{cls}\s*\{{[^}}]*text-shadow:\s*var\(--ring-text-shadow\)",
+                    content,
+                ) is not None, (
+                    f"AC-2 ({card_filename}): .ring .{cls} must apply "
+                    "text-shadow: var(--ring-text-shadow)"
+                )
+
     def test_radiator_card_flame_dancing_dynamic_proxy(self):  # CR2 — sync (no hass)
         """QS-204 AC-4 — structural proxy for "flames flicker when running".
 


### PR DESCRIPTION
## Summary
Extend QS-201's --ring-text-shadow pattern from pool/radiator to the remaining four QS cards (car, climate, on-off-duration, water-boiler) for inside-the-ring text readability. The shadow value is verbatim-copied from QS-201's already-shipping pool/radiator declarations.
Add test_all_qs_cards_apply_ring_text_shadow_for_readability pinning the contract for all 6 cards (variable declaration on :host + text-shadow application on each enumerated ring-text class). Existing radiator-only AC-9 test left intact — additive change.
Doc update: dashboard-and-cards.md gains a 'Ring text readability — uniform shadow (QS-228)' subsection under 'Hardened JS-card patterns'; last_verified bumped to 2026-05-25.

Fixes #228

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced readability of ring percentage labels, charge targets, and range indicators across car, climate, on-off-duration, and water-boiler cards through uniform text shadow styling.

* **Documentation**
  * Added story and updated concept documentation detailing ring text readability improvements and implementation guidelines.

* **Tests**
  * Added comprehensive test coverage to verify uniform text shadow application across all Quiet Solar Lovelace cards and prevent future regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->