### PR TITLE
QS-232: Car SVG: electron soup SOC animation with sparkles and lightning bolts

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -877,11 +877,16 @@ class QsCarCard extends HTMLElement {
          positioning as override-btn on boiler/radiator/climate cards.
          Bottom: 15px from .ring bottom, centered horizontally. */
       .ring .sun-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:flex; align-items:center; justify-content:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
-      /* QS-232 review-fix #04: icon bumped 26 → 30 px and centered via
-         flex (instead of grid+place-items + the legacy translateY(3px)
-         hack) so the sun renders at the same visual size as the hand
-         on the override-btn in climate/radiator/boiler. */
-      .ring .sun-btn ha-icon { --mdc-icon-size: 30px; color: var(--secondary-text-color); display:flex; align-items:center; justify-content:center; line-height:1; }
+      /* QS-232 review-fix #04: icon bumped 26 → 30 px so the sun
+         renders at the same visual size as the hand on the
+         override-btn in climate/radiator/boiler.
+         Review-fix #07: kept 'transform: translateY(3px)' on the icon
+         (same as the rabbit-btn icon) — the mdi:weather-sunny glyph
+         has rays extending upward more than downward, so its bounding-
+         box center sits above its visual center. The 3 px nudge
+         pushes the icon down so it reads as centered in the 50×50
+         button shell. */
+      .ring .sun-btn ha-icon { --mdc-icon-size: 30px; color: var(--secondary-text-color); display:flex; align-items:center; justify-content:center; line-height:1; transform: translateY(3px); }
       .ring .sun-btn.on { border-color: rgba(255,202,40,.45); background: rgba(255,202,40,.14); box-shadow: 0 0 0 3px rgba(255,202,40,.20), 0 0 16px #FFCA28; }
       .ring .sun-btn.on ha-icon { color: #FFCA28; }
       /* QS-232 review-fix #04: invisible spacer that preserves the

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -140,9 +140,16 @@ const LIGHTNING_LATERAL_JITTER_PX = 18;
 // - Review-fix #02:    SUN=288, RABBIT/TIME=192,192  R=38 (R bump made things worse)
 // - Review-fix #03:    SUN=277 R=35, RABBIT/TIME=215 R=32 — sun matches
 //                      OVERRIDE_BTN_CARVE_CY/R from the other cards.
-// - Review-fix #05:    RABBIT/TIME=200 R=32 — user instruction "move the
-//                      holes UP by 15 pixels" from the 215 deployment.
-//                      Sun stays at 277 (matches override-btn position).
+// - Review-fix #05:    RABBIT/TIME=200 R=32 — user "move the holes
+//                      UP by 15 pixels" from the 215 deployment.
+// - Review-fix #06:    RABBIT/TIME=206 R=32 — user measured "hole
+//                      apex 22 image px above button apex, lower
+//                      by 11 image px to align". With a ~1.9× retina
+//                      screenshot scale (the user measured the
+//                      circle diameter at ~490 image px ÷ ~258 CSS
+//                      px ring-stroke diameter), 11 image px ≈
+//                      5.5 CSS px ≈ 6 SVG units → 200 + 6 = 206.
+//                      Sun stays at 277 (matches override-btn).
 // - The sun-btn DOM was restructured to a direct child of the
 //   .ring container (out of `.center > .stack > .center-controls`)
 //   so its CSS layout matches override-btn exactly.
@@ -150,10 +157,10 @@ const SUN_BTN_CARVE_CX = 160;       // bottom-center of ring
 const SUN_BTN_CARVE_CY = 277;       // matches OVERRIDE_BTN_CARVE_CY in other cards
 const SUN_BTN_CARVE_R  = 35;        // matches OVERRIDE_BTN_CARVE_R in other cards
 const RABBIT_BTN_CARVE_CX = 96;     // left column of mini-grid
-const RABBIT_BTN_CARVE_CY = 200;
+const RABBIT_BTN_CARVE_CY = 206;
 const RABBIT_BTN_CARVE_R  = 32;
 const TIME_BTN_CARVE_CX = 224;      // right column of mini-grid
-const TIME_BTN_CARVE_CY = 200;
+const TIME_BTN_CARVE_CY = 206;
 const TIME_BTN_CARVE_R  = 32;
 
 class QsCarCard extends HTMLElement {

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -110,18 +110,39 @@ const SPARKLE_LIFE_S = 0.45;
 // --- Lightning bolts ("thunder from the top to the soup surface") ---
 // Only spawn when `_charging === true && !degraded`. In-flight bolts
 // complete their fade-out naturally on charging → false.
+//
+// Each bolt is a FILLED tapered polygon (Zeus-thunderbolt shape):
+// wide at the top, zig-zags via two lateral kinks, narrows to a
+// point at the soup surface. The previous form used a uniform-width
+// stroked polyline (~1.8 px) and a near-white colour that bloomed
+// to grey through the glow filter — user feedback: "they should be
+// light and bright blue, wider at top and reducing to the bottom
+// … like the ones from Zeus".
 const MAX_CONCURRENT_LIGHTNING = 3;
 const LIGHTNING_SPAWN_MIN_S = 1.5;
 const LIGHTNING_SPAWN_MAX_S = 3.0;
 const LIGHTNING_LIFE_S = 0.25;
-const LIGHTNING_STROKE_COLOR = '#E0F7FF';
-const LIGHTNING_STROKE_WIDTH = 1.8;
+// Fill colour for the bolt polygon. The name `LIGHTNING_STROKE_COLOR`
+// is retained for backward-compat with the AC-6 test (which pins the
+// constant NAME); semantically it's now a fill colour. Value is the
+// "Light Blue A400" Material Design tone — saturated enough to read
+// as electric blue even after the Gaussian-blur glow softens edges.
+const LIGHTNING_STROKE_COLOR = '#33B5FF';
 const LIGHTNING_GLOW_STDDEV = 2.5;
 const LIGHTNING_TOP_MARGIN_PX = 4;
 const LIGHTNING_LATERAL_JITTER_PX = 18;
+// Tapering widths for the thunderbolt outline (in SVG units).
+// `LIGHTNING_TOP_WIDTH` is the width at the top of the bolt; the
+// path then narrows to a point at the soup surface via two
+// intermediate widths (~55% and ~25% of the top, computed inline).
+const LIGHTNING_TOP_WIDTH = 9;
 // Review-fix #01 #16: removed unused `LIGHTNING_SEGMENTS = 3` —
-// the lightning path hardcodes its three `L` segments inline rather
-// than driving an emission loop, so the constant served no purpose.
+// the lightning path hardcodes its skeleton inline rather than
+// driving an emission loop, so the constant served no purpose.
+// Review-fix #02 user follow-up: removed `LIGHTNING_STROKE_WIDTH`
+// — the new tapered-polygon shape has no uniform stroke; widths
+// vary along the skeleton via `LIGHTNING_TOP_WIDTH` and its
+// inline percentages.
 
 // --- Inside-disc button carve-out covers (QS-232 D17) ---
 // Mirror of QS-217 for THREE buttons that sit inside the clip disc.
@@ -518,7 +539,11 @@ class QsCarCard extends HTMLElement {
         if (charging && !degraded) {
           this._nextLightningAt -= dt;
           while (this._nextLightningAt <= 0 && this._lightningBolts.length < MAX_CONCURRENT_LIGHTNING) {
-            // 3-segment jagged path: top → mid (with lateral kink) → surface.
+            // Tapered Zeus-thunderbolt path. 4-node skeleton from
+            // top (wide) to soup tip (point), with lateral jitter at
+            // the two midpoints for the zig-zag. The outline is a
+            // closed polygon: left side top→bottom, tip, right side
+            // bottom→top.
             const topY = CENTER_CY - CLIP_R + LIGHTNING_TOP_MARGIN_PX;
             const startCx = CENTER_CX + (Math.random() * 2 - 1) * (CLIP_R * 0.4);
             const dy = this._waterBaseY - CENTER_CY;
@@ -529,16 +554,34 @@ class QsCarCard extends HTMLElement {
               continue;
             }
             const endCx = CENTER_CX + (Math.random() * 2 - 1) * chordHalf * 0.7;
-            const midY = (topY + this._waterBaseY) / 2;
-            const midCx = (startCx + endCx) / 2 +
-                          (Math.random() * 2 - 1) * LIGHTNING_LATERAL_JITTER_PX;
-            const d = `M ${startCx.toFixed(2)} ${topY.toFixed(2)} L ${midCx.toFixed(2)} ${midY.toFixed(2)} L ${endCx.toFixed(2)} ${this._waterBaseY.toFixed(2)}`;
+            const totalLen = this._waterBaseY - topY;
+            // Two lateral jitters at 33% and 67% down the bolt —
+            // smaller than the original mid-kink so the overall
+            // shape still reads as "going down" rather than
+            // "sideways squiggle".
+            const j1 = (Math.random() * 2 - 1) * LIGHTNING_LATERAL_JITTER_PX * 0.5;
+            const j2 = (Math.random() * 2 - 1) * LIGHTNING_LATERAL_JITTER_PX * 0.5;
+            const x1 = startCx + (endCx - startCx) * 0.33 + j1;
+            const x2 = startCx + (endCx - startCx) * 0.67 + j2;
+            const y1 = topY + totalLen * 0.33;
+            const y2 = topY + totalLen * 0.67;
+            // Half-widths along the skeleton. Top is the widest; the
+            // path narrows to a point at the tip (water surface).
+            const h0 = LIGHTNING_TOP_WIDTH * 0.50;
+            const h1 = LIGHTNING_TOP_WIDTH * 0.30;
+            const h2 = LIGHTNING_TOP_WIDTH * 0.15;
+            const d = `M ${(startCx - h0).toFixed(2)},${topY.toFixed(2)}`
+                    + ` L ${(x1 - h1).toFixed(2)},${y1.toFixed(2)}`
+                    + ` L ${(x2 - h2).toFixed(2)},${y2.toFixed(2)}`
+                    + ` L ${endCx.toFixed(2)},${this._waterBaseY.toFixed(2)}`
+                    + ` L ${(x2 + h2).toFixed(2)},${y2.toFixed(2)}`
+                    + ` L ${(x1 + h1).toFixed(2)},${y1.toFixed(2)}`
+                    + ` L ${(startCx + h0).toFixed(2)},${topY.toFixed(2)}`
+                    + ` Z`;
             const el = document.createElementNS('http://www.w3.org/2000/svg', 'path');
             el.setAttribute('d', d);
-            el.setAttribute('stroke', LIGHTNING_STROKE_COLOR);
-            el.setAttribute('stroke-width', String(LIGHTNING_STROKE_WIDTH));
-            el.setAttribute('fill', 'none');
-            el.setAttribute('stroke-linecap', 'round');
+            el.setAttribute('fill', LIGHTNING_STROKE_COLOR);
+            el.setAttribute('stroke', 'none');
             el.setAttribute('pointer-events', 'none');
             el.setAttribute('opacity', '0');
             lightningLayer.appendChild(el);

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -127,12 +127,13 @@ const LIGHTNING_LIFE_S = 0.25;
 // constant NAME); semantically it's now a fill colour.
 // Iteration history:
 // - Initial:                 `#E0F7FF` near-white (read as grey through glow)
-// - Review-fix #02 user #1:  `#33B5FF` electric blue (user: "too blue")
-// - Review-fix #02 user #2:  `#E580FF` very bright purple — matches
-//                            real lightning (white-violet plasma core)
-//                            and reads as "Zeus thunderbolt" rather
-//                            than a neon arc.
-const LIGHTNING_STROKE_COLOR = '#E580FF';
+// - Review-fix #02 user #1:  `#33B5FF` electric blue ("too blue")
+// - Review-fix #02 user #2:  `#E580FF` very bright purple ("purple is ugly")
+// - Review-fix #02 user #3:  `#00E5FF` — same `SPARKLE_CHARGE_COLOR`
+//                            electric-cyan as the charging sparkles,
+//                            so bolts + sparkles share one bright-
+//                            blue palette during charging discharge.
+const LIGHTNING_STROKE_COLOR = '#00E5FF';
 const LIGHTNING_TOP_MARGIN_PX = 4;
 const LIGHTNING_LATERAL_JITTER_PX = 18;
 // Tapering widths for the thunderbolt outline (in SVG units).

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -124,11 +124,15 @@ const LIGHTNING_SPAWN_MAX_S = 3.0;
 const LIGHTNING_LIFE_S = 0.25;
 // Fill colour for the bolt polygon. The name `LIGHTNING_STROKE_COLOR`
 // is retained for backward-compat with the AC-6 test (which pins the
-// constant NAME); semantically it's now a fill colour. Value is the
-// "Light Blue A400" Material Design tone — saturated enough to read
-// as electric blue even after the Gaussian-blur glow softens edges.
-const LIGHTNING_STROKE_COLOR = '#33B5FF';
-const LIGHTNING_GLOW_STDDEV = 2.5;
+// constant NAME); semantically it's now a fill colour.
+// Iteration history:
+// - Initial:                 `#E0F7FF` near-white (read as grey through glow)
+// - Review-fix #02 user #1:  `#33B5FF` electric blue (user: "too blue")
+// - Review-fix #02 user #2:  `#E580FF` very bright purple — matches
+//                            real lightning (white-violet plasma core)
+//                            and reads as "Zeus thunderbolt" rather
+//                            than a neon arc.
+const LIGHTNING_STROKE_COLOR = '#E580FF';
 const LIGHTNING_TOP_MARGIN_PX = 4;
 const LIGHTNING_LATERAL_JITTER_PX = 18;
 // Tapering widths for the thunderbolt outline (in SVG units).
@@ -136,13 +140,22 @@ const LIGHTNING_LATERAL_JITTER_PX = 18;
 // path then narrows to a point at the soup surface via two
 // intermediate widths (~55% and ~25% of the top, computed inline).
 const LIGHTNING_TOP_WIDTH = 9;
+// Branch (ramification) count per bolt. Real lightning has many
+// smaller forks off the main channel — these short tapered branches
+// give the bolt the characteristic "lightning tree" look.
+const LIGHTNING_BRANCH_MIN_COUNT = 3;
+const LIGHTNING_BRANCH_MAX_COUNT = 6;
+const LIGHTNING_BRANCH_MIN_LEN = 8;
+const LIGHTNING_BRANCH_MAX_LEN = 22;
 // Review-fix #01 #16: removed unused `LIGHTNING_SEGMENTS = 3` —
 // the lightning path hardcodes its skeleton inline rather than
 // driving an emission loop, so the constant served no purpose.
 // Review-fix #02 user follow-up: removed `LIGHTNING_STROKE_WIDTH`
-// — the new tapered-polygon shape has no uniform stroke; widths
-// vary along the skeleton via `LIGHTNING_TOP_WIDTH` and its
-// inline percentages.
+// — the new tapered-polygon shape has no uniform stroke.
+// Review-fix #02 user follow-up #2: removed `LIGHTNING_GLOW_STDDEV`
+// and the associated `<filter>` in `<defs>` — user said "no need of
+// the glow effect for the lightning bolts". The sharp filled
+// polygon now reads as bright-edged plasma without the soft blur.
 
 // --- Inside-disc button carve-out covers (QS-232 D17) ---
 // Mirror of QS-217 for THREE buttons that sit inside the clip disc.
@@ -539,11 +552,12 @@ class QsCarCard extends HTMLElement {
         if (charging && !degraded) {
           this._nextLightningAt -= dt;
           while (this._nextLightningAt <= 0 && this._lightningBolts.length < MAX_CONCURRENT_LIGHTNING) {
-            // Tapered Zeus-thunderbolt path. 4-node skeleton from
-            // top (wide) to soup tip (point), with lateral jitter at
-            // the two midpoints for the zig-zag. The outline is a
-            // closed polygon: left side top→bottom, tip, right side
-            // bottom→top.
+            // Tapered Zeus-thunderbolt with branching ramifications.
+            // 4-node main skeleton from top (wide) to soup tip
+            // (point), with lateral jitter at the two midpoints for
+            // the zig-zag. Plus N small tapered branches forking off
+            // the main spine — gives the bolt the characteristic
+            // "lightning tree" look of a real discharge.
             const topY = CENTER_CY - CLIP_R + LIGHTNING_TOP_MARGIN_PX;
             const startCx = CENTER_CX + (Math.random() * 2 - 1) * (CLIP_R * 0.4);
             const dy = this._waterBaseY - CENTER_CY;
@@ -555,33 +569,87 @@ class QsCarCard extends HTMLElement {
             }
             const endCx = CENTER_CX + (Math.random() * 2 - 1) * chordHalf * 0.7;
             const totalLen = this._waterBaseY - topY;
-            // Two lateral jitters at 33% and 67% down the bolt —
-            // smaller than the original mid-kink so the overall
-            // shape still reads as "going down" rather than
-            // "sideways squiggle".
             const j1 = (Math.random() * 2 - 1) * LIGHTNING_LATERAL_JITTER_PX * 0.5;
             const j2 = (Math.random() * 2 - 1) * LIGHTNING_LATERAL_JITTER_PX * 0.5;
             const x1 = startCx + (endCx - startCx) * 0.33 + j1;
             const x2 = startCx + (endCx - startCx) * 0.67 + j2;
             const y1 = topY + totalLen * 0.33;
             const y2 = topY + totalLen * 0.67;
-            // Half-widths along the skeleton. Top is the widest; the
-            // path narrows to a point at the tip (water surface).
+            // Half-widths along the main skeleton (50/30/15/0 of top).
             const h0 = LIGHTNING_TOP_WIDTH * 0.50;
             const h1 = LIGHTNING_TOP_WIDTH * 0.30;
             const h2 = LIGHTNING_TOP_WIDTH * 0.15;
-            const d = `M ${(startCx - h0).toFixed(2)},${topY.toFixed(2)}`
-                    + ` L ${(x1 - h1).toFixed(2)},${y1.toFixed(2)}`
-                    + ` L ${(x2 - h2).toFixed(2)},${y2.toFixed(2)}`
-                    + ` L ${endCx.toFixed(2)},${this._waterBaseY.toFixed(2)}`
-                    + ` L ${(x2 + h2).toFixed(2)},${y2.toFixed(2)}`
-                    + ` L ${(x1 + h1).toFixed(2)},${y1.toFixed(2)}`
-                    + ` L ${(startCx + h0).toFixed(2)},${topY.toFixed(2)}`
-                    + ` Z`;
+            // Main bolt outline — left edge top→bottom, tip, right
+            // edge bottom→top, closed.
+            let d = `M ${(startCx - h0).toFixed(2)},${topY.toFixed(2)}`
+                  + ` L ${(x1 - h1).toFixed(2)},${y1.toFixed(2)}`
+                  + ` L ${(x2 - h2).toFixed(2)},${y2.toFixed(2)}`
+                  + ` L ${endCx.toFixed(2)},${this._waterBaseY.toFixed(2)}`
+                  + ` L ${(x2 + h2).toFixed(2)},${y2.toFixed(2)}`
+                  + ` L ${(x1 + h1).toFixed(2)},${y1.toFixed(2)}`
+                  + ` L ${(startCx + h0).toFixed(2)},${topY.toFixed(2)}`
+                  + ` Z`;
+            // Branches: short tapered triangles forking from random
+            // positions along the main spine. Each branch is a
+            // separate sub-path appended to the compound `d`.
+            const branchCount = LIGHTNING_BRANCH_MIN_COUNT +
+              Math.floor(Math.random() * (LIGHTNING_BRANCH_MAX_COUNT - LIGHTNING_BRANCH_MIN_COUNT + 1));
+            for (let bi = 0; bi < branchCount; bi++) {
+              // Origin along the main spine — `t` in [0.15, 0.85].
+              const t = 0.15 + Math.random() * 0.70;
+              // Linear interp through the 4-node skeleton to find
+              // origin point + local main-bolt half-width.
+              let ox, oy, originHalfWidth;
+              if (t < 0.33) {
+                const u = t / 0.33;
+                ox = startCx + (x1 - startCx) * u;
+                oy = topY + (y1 - topY) * u;
+                originHalfWidth = h0 + (h1 - h0) * u;
+              } else if (t < 0.67) {
+                const u = (t - 0.33) / 0.34;
+                ox = x1 + (x2 - x1) * u;
+                oy = y1 + (y2 - y1) * u;
+                originHalfWidth = h1 + (h2 - h1) * u;
+              } else {
+                const u = (t - 0.67) / 0.33;
+                ox = x2 + (endCx - x2) * u;
+                oy = y2 + (this._waterBaseY - y2) * u;
+                originHalfWidth = h2 * (1 - u);
+              }
+              // Branch direction — biased outward+downward.
+              // dirAngle = 90° is straight down. Range covers down ±
+              // ~70° to give some near-horizontal forks too.
+              const angleDeg = -70 + Math.random() * 140;
+              const dirAngle = (90 + angleDeg) * Math.PI / 180;
+              const branchLen = LIGHTNING_BRANCH_MIN_LEN +
+                Math.random() * (LIGHTNING_BRANCH_MAX_LEN - LIGHTNING_BRANCH_MIN_LEN);
+              const tipX = ox + Math.cos(dirAngle) * branchLen;
+              const tipY = oy + Math.sin(dirAngle) * branchLen;
+              // Branch origin width — ~70% of the main bolt's local
+              // half-width, perpendicular to the branch direction.
+              const branchHalfW = Math.max(0.6, originHalfWidth * 0.7);
+              const blen = Math.sqrt(
+                (tipX - ox) * (tipX - ox) + (tipY - oy) * (tipY - oy)
+              );
+              if (blen < 0.5) continue;
+              // Perpendicular unit vector to the branch direction.
+              const px = -(tipY - oy) / blen;
+              const py = (tipX - ox) / blen;
+              const lx = ox + px * branchHalfW;
+              const ly = oy + py * branchHalfW;
+              const rx = ox - px * branchHalfW;
+              const ry = oy - py * branchHalfW;
+              // Tapered triangular branch: origin-left, tip, origin-right.
+              d += ` M ${lx.toFixed(2)},${ly.toFixed(2)}`
+                +  ` L ${tipX.toFixed(2)},${tipY.toFixed(2)}`
+                +  ` L ${rx.toFixed(2)},${ry.toFixed(2)}`
+                +  ` Z`;
+            }
             const el = document.createElementNS('http://www.w3.org/2000/svg', 'path');
             el.setAttribute('d', d);
             el.setAttribute('fill', LIGHTNING_STROKE_COLOR);
             el.setAttribute('stroke', 'none');
+            el.setAttribute('fill-rule', 'nonzero');
             el.setAttribute('pointer-events', 'none');
             el.setAttribute('opacity', '0');
             lightningLayer.appendChild(el);
@@ -800,17 +868,18 @@ class QsCarCard extends HTMLElement {
       if (!this._electronClipId) {
         QsCarCard._nextClipId = (QsCarCard._nextClipId || 0) + 1;
         const uid = QsCarCard._nextClipId;
-        this._electronClipId    = `car_eClip_${uid}`;
-        this._sparkleLayerId    = `car_sparkLayer_${uid}`;
-        this._lightningLayerId  = `car_lightningLayer_${uid}`;
-        this._grainFilterId     = `car_grainFilter_${uid}`;
-        this._lightningFilterId = `car_lightningFilter_${uid}`;
+        this._electronClipId   = `car_eClip_${uid}`;
+        this._sparkleLayerId   = `car_sparkLayer_${uid}`;
+        this._lightningLayerId = `car_lightningLayer_${uid}`;
+        this._grainFilterId    = `car_grainFilter_${uid}`;
+        // Review-fix #02 user follow-up #2: `_lightningFilterId`
+        // removed alongside the lightning glow filter — the new
+        // sharp purple bolt doesn't use a `<filter>`.
       }
-      const electronClipId    = this._electronClipId;
-      const sparkleLayerId    = this._sparkleLayerId;
-      const lightningLayerId  = this._lightningLayerId;
-      const grainFilterId     = this._grainFilterId;
-      const lightningFilterId = this._lightningFilterId;
+      const electronClipId   = this._electronClipId;
+      const sparkleLayerId   = this._sparkleLayerId;
+      const lightningLayerId = this._lightningLayerId;
+      const grainFilterId    = this._grainFilterId;
       const carChargeTypeIcons = {
           "Unknown": "mdi:help-circle-outline",
           "Not Plugged": "mdi:power-plug-off",
@@ -1342,9 +1411,6 @@ class QsCarCard extends HTMLElement {
                     <feMergeNode in="grain" />
                   </feMerge>
                 </filter>
-                <filter id="${lightningFilterId}" x="-50%" y="-50%" width="200%" height="200%">
-                  <feGaussianBlur stdDeviation="${LIGHTNING_GLOW_STDDEV}" />
-                </filter>
                 <clipPath id="${electronClipId}">
                   <circle cx="${CENTER_CX}" cy="${CENTER_CY}" r="${CLIP_R}" />
                 </clipPath>
@@ -1353,7 +1419,7 @@ class QsCarCard extends HTMLElement {
                 <path id="electron_wave_idle" d="${initialWavePath}" fill="${IDLE_SOUP_COLOR}" opacity="${initialIdleOpacity}" filter="url(#${grainFilterId})" pointer-events="none" style="will-change: transform;" />
                 <path id="electron_wave_charge" d="${initialWavePath}" fill="${CHARGE_SOUP_COLOR}" opacity="${initialChargeOpacity}" filter="url(#${grainFilterId})" pointer-events="none" style="will-change: transform;" />
                 <g id="${sparkleLayerId}" pointer-events="none"></g>
-                <g id="${lightningLayerId}" filter="url(#${lightningFilterId})" pointer-events="none" style="mix-blend-mode: screen; will-change: opacity;"></g>
+                <g id="${lightningLayerId}" pointer-events="none" style="mix-blend-mode: screen; will-change: opacity;"></g>
               </g>
               ${swPriority ? `<circle id="sun_btn_cover" cx="${SUN_BTN_CARVE_CX}" cy="${SUN_BTN_CARVE_CY}" r="${SUN_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
               ${e.force_now ? `<circle id="rabbit_btn_cover" cx="${RABBIT_BTN_CARVE_CX}" cy="${RABBIT_BTN_CARVE_CY}" r="${RABBIT_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -1,35 +1,21 @@
 /*
   QS Car Card - custom:qs-car-card
-  Zero-build single-file Lit-style web component compatible with Home Assistant
+  Zero-build single-file Lit-style web component compatible with Home
+  Assistant.
 
-  QS-232 layered an "electron soup" SOC animation inside the ring,
-  mirroring the QS-200/QS-211/QS-214 boiler architecture:
-  - A single sine wave inside a circular clipPath, with dual-opacity
-    cross-fade between an idle green palette and a charging blue
-    palette (binary `_currentColorMix` lerp, NOT HSL hue lerp).
-  - Lightning-blue "electron" sparkles popping randomly inside the
-    soup. Sparkle density / spawn-rate / radius scale linearly with
-    charge power on [1500W, 22000W]; below 1500W (but still
-    `_charging`) the visuals clamp to the 1500W MIN endpoint. Idle
-    uses a fixed low rate of greenish sparkles independent of power.
-  - Lightning bolts flashing from the top of the clip circle to the
-    soup surface when charging — 3-segment `<path>` with a glow
-    filter and `mix-blend-mode: screen`, life 0.25s, spawn interval
-    randomised on [1.5, 3.0]s.
-  - feTurbulence grain filter applied to the wave path's fill (NOT a
-    separate overlay rect) so the grain composites within the wave
-    shape via `feComposite operator="in"`.
-  - Degraded states (`isDisconnected || isFaulted || isStale`)
-    desaturate the entire clipped group via a CSS filter
-    (`saturate(0.3) brightness(0.7)`) and suppress lightning
-    entirely. `isOffGrid` is NOT folded in (the card-level pinkish
-    .off-grid tint already covers it).
-  - Continuous RAF while connected (no more `_charging`-gated
-    start/stop). Mirrors QS-200 / QS-211 pool & boiler precedent.
-  - QS-217 carve-cover pattern extended from one button (override-
-    reset on boiler/radiator/climate) to THREE inside-disc buttons
-    on the car card: sun-btn (Solar priority), rabbit-btn (Force
-    now), time-btn (Finish time).
+  QS-232 layers an "electron soup" SOC animation inside the ring,
+  mirroring the QS-200 / QS-211 / QS-214 boiler architecture. The
+  high-level design — single-layer sine wave inside a clipPath,
+  idle↔charge cross-fade, lightning-blue sparkle particles, lightning
+  bolts during charging, feTurbulence grain on the wave fill,
+  degraded-state CSS desaturate, continuous RAF, and QS-217 carve
+  covers extended to three inside-disc buttons — is documented in
+  `docs/agents/concepts/dashboard-and-cards.md` (search for
+  "QS-232 — Car-card electron-soup animation"). Tuning constants
+  (sparkle power-scaling range, lightning spawn interval, life
+  curves, palette colours) live in the constants block immediately
+  below this header — those values are the source of truth; the
+  docstring intentionally avoids duplicating them.
 
   Existing dashed-arc animation (`<path id="charge_anim">`) is
   preserved verbatim; `showAnimation` remains its render-time switch.
@@ -241,21 +227,34 @@ class QsCarCard extends HTMLElement {
     // call `_startAnimation` directly today) — for safety, we also
     // re-attempt from `connectedCallback` if it runs first.
     if (!this._root) return;
-    // Lazy-init: runs ONCE on first connect, preserved across
-    // detach/re-attach so `_currentAmplitude` / `_wavePhase` /
-    // `_currentColorMix` don't snap back on tab navigation.
-    if (this._currentAmplitude == null) {
-      this._currentAmplitude = CALM_AMP;
-      this._currentSpeed     = CALM_SPEED;
-      this._wavePhase        = 0;
-      this._currentColorMix  = 0;
-      this._sparkles         = [];
-      this._nextSparkleAt    = 0;
-      this._lightningBolts   = [];
-      this._nextLightningAt  = LIGHTNING_SPAWN_MIN_S +
-        Math.random() * (LIGHTNING_SPAWN_MAX_S - LIGHTNING_SPAWN_MIN_S);
-      this._needsAnimationPrime = true;
-    }
+    // Lazy-init: each RAF-state field guards itself individually.
+    // Review-fix #02 #1: the previous form bundled ALL five
+    // RAF-state fields (`_currentAmplitude`, `_wavePhase`,
+    // `_nextSparkleAt`, `_nextLightningAt`, `_sparkles`,
+    // `_lightningBolts`) inside `if (this._currentAmplitude == null)`,
+    // and review-fix #01 #4 added a `_needsAnimationPrime` consumer
+    // in `_render()` that pre-seeds `_currentAmplitude` / `_currentSpeed`
+    // / `_currentColorMix`. Combined effect: the lazy-init guard
+    // evaluated FALSE on first `_startAnimation()`, leaving
+    // `_wavePhase` / `_nextSparkleAt` / `_nextLightningAt` /
+    // `_sparkles` / `_lightningBolts` undefined. First RAF tick:
+    // `_wavePhase += dt` = NaN, sparkle/lightning spawn loops never
+    // enter (since `NaN <= 0 === false`). User-visible symptom:
+    // "no sparkles at all". Per-field guards eliminate the coupling.
+    if (this._currentAmplitude == null) this._currentAmplitude = CALM_AMP;
+    if (this._currentSpeed     == null) this._currentSpeed     = CALM_SPEED;
+    if (this._currentColorMix  == null) this._currentColorMix  = 0;
+    if (this._wavePhase        == null) this._wavePhase        = 0;
+    if (this._sparkles         == null) this._sparkles         = [];
+    if (this._nextSparkleAt    == null) this._nextSparkleAt    = 0;
+    if (this._lightningBolts   == null) this._lightningBolts   = [];
+    if (this._nextLightningAt  == null) this._nextLightningAt  = LIGHTNING_SPAWN_MIN_S +
+      Math.random() * (LIGHTNING_SPAWN_MAX_S - LIGHTNING_SPAWN_MIN_S);
+    // `_needsAnimationPrime` is armed by `setConfig` (review-fix #01 #4)
+    // and consumed by `_render`'s prime block; only set here on the
+    // very first lazy-init if neither `setConfig` nor `_render` has
+    // touched it yet.
+    if (this._needsAnimationPrime == null) this._needsAnimationPrime = true;
     this._lastAnimTs = null;
     this._invalidateAnimCache();
 
@@ -304,21 +303,35 @@ class QsCarCard extends HTMLElement {
 
       // --- Lazy-resolve wave / sparkle / lightning DOM refs once per
       //     innerHTML rewrite (two wave nodes — idle + charge).
-      //     Review-fix #01 #15: `getElementById` already returns
-      //     `null` on miss; the prior inner `?? null` was redundant.
-      if (!this._waveEls) {
+      //     The inner `?? null` is intentional: `_root?.getElementById`
+      //     can return `undefined` (when `_root` itself is null), and
+      //     the retry guard below distinguishes a successful cache
+      //     (truthy elements) from a stale `[null, null]` cache hit.
+      //     Review-fix #02 #10: retry the lookup if EITHER slot is
+      //     null (the previous form cached `[null, null]` — truthy —
+      //     permanently if both lookups missed during a transient
+      //     detach).
+      // Review-fix #02 #12: align all three DOM-ref lookups on the
+      // block-form (was: inline `?? (... = ...)` for sparkle/lightning
+      // and block-form for `_waveEls`). One shape across all layers
+      // makes the retry-on-null behaviour easier to reason about.
+      if (!this._waveEls || !this._waveEls[0] || !this._waveEls[1]) {
         const idleEl   = this._root?.getElementById('electron_wave_idle')   ?? null;
         const chargeEl = this._root?.getElementById('electron_wave_charge') ?? null;
         this._waveEls = [idleEl, chargeEl];
       }
-      const sparkleLayer = this._sparkleLayerEl
-        ?? (this._sparkleLayerEl = this._sparkleLayerId
-              ? this._root?.getElementById(this._sparkleLayerId)
-              : null);
-      const lightningLayer = this._lightningLayerEl
-        ?? (this._lightningLayerEl = this._lightningLayerId
-              ? this._root?.getElementById(this._lightningLayerId)
-              : null);
+      if (!this._sparkleLayerEl) {
+        this._sparkleLayerEl = this._sparkleLayerId
+          ? (this._root?.getElementById(this._sparkleLayerId) ?? null)
+          : null;
+      }
+      if (!this._lightningLayerEl) {
+        this._lightningLayerEl = this._lightningLayerId
+          ? (this._root?.getElementById(this._lightningLayerId) ?? null)
+          : null;
+      }
+      const sparkleLayer = this._sparkleLayerEl;
+      const lightningLayer = this._lightningLayerEl;
 
       // --- Wave transform (single layer translateX).
       // Path extent is [0, 2*WAVE_WIDTH] so the translated path always
@@ -334,15 +347,27 @@ class QsCarCard extends HTMLElement {
 
       // --- Wave path regen (throttled by amplitude / soup-level delta).
       const waterBaseY = this._waterBaseY;
-      const hasValidBase = waterBaseY != null && !Number.isNaN(waterBaseY);
-      const ampDelta = this._lastAmplitude == null
+      // Review-fix #02 #11: use `Number.isFinite(...)` instead of
+      // `!Number.isNaN(...)` so a spurious `Infinity` doesn't slip
+      // through the guard. Asymmetric otherwise with the
+      // `Number.isFinite(soc)` guard in `_render` (fix #01 #3) and
+      // the call-site guard on `initialWavePath` (fix #01 #5).
+      const hasValidBase = waterBaseY != null && Number.isFinite(waterBaseY);
+      // Review-fix #02 #5: the in-RAF read AND write must guard
+      // against non-finite `_lastAmplitude`. Fix-#01-#8 only patched
+      // the post-innerHTML write at the end of `_render`; if NaN
+      // ever lands in `_lastAmplitude` here mid-frame, all
+      // subsequent regen checks evaluate `Math.abs(_ - NaN) = NaN`
+      // (always `< threshold`), freezing the wave-path regen for
+      // the lifetime of the card.
+      const ampDelta = (this._lastAmplitude == null || !Number.isFinite(this._lastAmplitude))
           ? Infinity
           : Math.abs(this._currentAmplitude - this._lastAmplitude);
       const levelChanged = hasValidBase &&
           Math.abs(waterBaseY - (this._lastWaterBaseY ?? Number.NEGATIVE_INFINITY)) > LEVEL_REGEN_THRESHOLD;
       if (hasValidBase && (levelChanged || ampDelta > AMP_REGEN_THRESHOLD)) {
         this._lastWaterBaseY = waterBaseY;
-        this._lastAmplitude = this._currentAmplitude;
+        this._lastAmplitude = Number.isFinite(this._currentAmplitude) ? this._currentAmplitude : CALM_AMP;
         const d = this._generateWavePath(WAVE_WIDTH, this._currentAmplitude, 2, 0, waterBaseY);
         if (idleWave)   idleWave.setAttribute('d', d);
         if (chargeWave) chargeWave.setAttribute('d', d);
@@ -354,7 +379,12 @@ class QsCarCard extends HTMLElement {
       // clamp `_currentColorMix` to `[0, 1]` for opacity emission so
       // floating-point lerp drift (e.g., `1.0000000001`) doesn't
       // surface as ugly `"-0.000"` opacity tokens.
-      const mix = Math.max(0, Math.min(1, this._currentColorMix));
+      // Review-fix #02 #9: `Math.max(0, Math.min(1, NaN)) === NaN`,
+      // so the clamp alone doesn't trap NaN. Wrap with a
+      // `Number.isFinite` ternary so a poisoned lerp falls back to
+      // the idle palette (`mix = 0`).
+      const mix = Number.isFinite(this._currentColorMix)
+        ? Math.max(0, Math.min(1, this._currentColorMix)) : 0;
       const idleOpacity   = (1 - mix).toFixed(3);
       const chargeOpacity = mix.toFixed(3);
       if (idleWave)   idleWave.setAttribute('opacity', idleOpacity);
@@ -495,8 +525,14 @@ class QsCarCard extends HTMLElement {
             this._nextLightningAt += LIGHTNING_SPAWN_MIN_S +
               Math.random() * (LIGHTNING_SPAWN_MAX_S - LIGHTNING_SPAWN_MIN_S);
           }
-          if (this._nextLightningAt < 0) this._nextLightningAt = 0;
         }
+        // Review-fix #02 #8: hoist the cap-recovery clamp out of the
+        // `if (charging && !degraded)` spawn gate so the structure
+        // mirrors the sparkle subsystem above. Currently safe because
+        // the `-= dt` decrement is also gated, but a future refactor
+        // moving the decrement out would create a permanent
+        // negative-drift bug.
+        if (this._nextLightningAt < 0) this._nextLightningAt = 0;
 
         // Advance + retire (runs every frame, graceful exit).
         // Three-phase opacity curve: fade-in [0, 0.10], hold
@@ -546,9 +582,16 @@ class QsCarCard extends HTMLElement {
     // both _charging and _currentColorMix are still at their initial
     // values — the equation `(false ? 1 : 0) !== Math.round(0)`
     // evaluates `0 !== 0`, so no spurious prime fires.
+    //
+    // Review-fix #02 #4: arming the flag isn't enough — `_render`
+    // consumes it. Without an explicit `_render` call, the flag
+    // sits until the next hass push (which can be seconds away)
+    // and the RAF lerps visibly during the gap. Call `_render`
+    // immediately so the prime takes effect on the next paint.
     const impliedMix = Math.round(this._currentColorMix ?? 0);
     if ((this._charging ? 1 : 0) !== impliedMix) {
       this._needsAnimationPrime = true;
+      this._render();
     }
   }
 
@@ -590,6 +633,13 @@ class QsCarCard extends HTMLElement {
     // (green-to-blue flash).
     this._needsAnimationPrime = true;
     this._render();
+    // Review-fix #02 #3: complete the fix-#01-#22 fix. `_startAnimation`
+    // bails early on `!this._root`; if `connectedCallback` fires
+    // BEFORE `setConfig` (uncommon but valid lifecycle), the bail
+    // would never be retried. Re-invoke here once `_root` is set.
+    if (this.isConnected && this._animRaf == null) {
+      this._startAnimation();
+    }
   }
 
   // S6: defence-in-depth HTML escaping for user-/3rd-party-controlled
@@ -894,10 +944,16 @@ class QsCarCard extends HTMLElement {
          .center-controls to absolute positioning. Without this, the
          shorter stack gets grid-centered higher in .center, pushing
          the soc-block (89%, range) and the mini-grid buttons (rabbit,
-         time) visibly downward — the symptom the user flagged
-         ("you moved all the texts and stuff down"). The 74 px height
-         matches the former .center-controls outer footprint
-         (6 px margin + 14 px label + 4 px gap + 50 px button). */
+         time) visibly downward.
+         Review-fix #02 #17 — components of the 74 px height:
+           - 6 px margin-top on the original .center-controls block
+           - 14 px label ("Solar priority", font-size 0.7rem,
+             font-weight 700)
+           - 4 px gap between label and button (column-gap: 4)
+           - 50 px sun-btn button height
+         If any of those four numbers changes (icon-size, label
+         typography, button dimensions), this height MUST be updated
+         in lockstep, otherwise the layout drifts. */
       .ring .sun-btn-spacer { width: 50px; height: 74px; pointer-events: none; }
       .ring .rabbit-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
       .ring .rabbit-btn ha-icon { --mdc-icon-size: 26px; color: var(--secondary-text-color); display:block; line-height:1; transform: translateY(3px); }
@@ -1130,13 +1186,26 @@ class QsCarCard extends HTMLElement {
       // Wrapping the `_generateWavePath(...)` call with a
       // `Number.isFinite(this._waterBaseY)` ternary makes the empty-
       // string fallback explicit at the call site.
-      const initialAmp = this._currentAmplitude ?? CALM_AMP;
-      const initialColorMix = this._currentColorMix ?? 0;
+      // Review-fix #02 #2: `??` only traps null/undefined; a runtime
+      // NaN in either `_currentAmplitude` or `_currentColorMix` would
+      // propagate into the initial wave path's `d` attribute and the
+      // opacity attribute strings. Mirror the fix-#01-#8 finite-guard
+      // shape so NaN falls back to the calm/idle defaults.
+      const initialAmp = Number.isFinite(this._currentAmplitude)
+        ? this._currentAmplitude : CALM_AMP;
+      const initialColorMix = Number.isFinite(this._currentColorMix)
+        ? this._currentColorMix : 0;
       const initialWavePath = Number.isFinite(this._waterBaseY)
         ? this._generateWavePath(WAVE_WIDTH, initialAmp, 2, 0, this._waterBaseY)
         : '';
-      const initialIdleOpacity   = (1 - initialColorMix).toFixed(3);
-      const initialChargeOpacity = initialColorMix.toFixed(3);
+      // Review-fix #02 #6: clamp `initialColorMix` to [0, 1] before
+      // `.toFixed(3)` so floating-point lerp drift outside the
+      // envelope (e.g., `1.0000000001`) doesn't surface as an ugly
+      // `"-0.000"` opacity token at the initial-paint sites
+      // (review-fix #01 #18 clamped only the RAF-step emission).
+      const initialMix = Math.max(0, Math.min(1, initialColorMix));
+      const initialIdleOpacity   = (1 - initialMix).toFixed(3);
+      const initialChargeOpacity = initialMix.toFixed(3);
 
       // QS-232 review-fix #03: snapshot the in-flight sparkles AND
       // lightning bolts BEFORE the innerHTML rewrite below. The
@@ -1149,9 +1218,13 @@ class QsCarCard extends HTMLElement {
       // that 0.45 s lifetime made the wipe imperceptible, but in
       // practice with HA pushing every 100-500 ms the sparkles never
       // accumulate). Mirrors the QS-214 boiler snapshot/restore.
-      const preservedSparkles      = this._sparkles;
+      // Review-fix #02 #18: defensive `?? []` so a future caller
+      // that dereferences `.length` on the snapshot result can't
+      // crash when `_render` runs from `setConfig` BEFORE
+      // `_startAnimation` has lazy-init'd the particle arrays.
+      const preservedSparkles      = this._sparkles ?? [];
       const preservedNextSparkleAt = this._nextSparkleAt;
-      const preservedLightningBolts  = this._lightningBolts;
+      const preservedLightningBolts  = this._lightningBolts ?? [];
       const preservedNextLightningAt = this._nextLightningAt;
 
       this._root.innerHTML = `
@@ -1246,7 +1319,7 @@ class QsCarCard extends HTMLElement {
                   <div class="mini-title">${useEnergyMode ? 'Target Energy' : 'Target SOC'}</div>
                   <div class="mini-title">${chargeTimeLabel}</div>
 
-                  <div id="rabbit_btn" class="rabbit-btn ${sChargeType?.state === 'As Fast As Possible' ? 'on' : ''}"><ha-icon icon="mdi:rabbit"></ha-icon></div>
+                  ${e.force_now ? `<div id="rabbit_btn" class="rabbit-btn ${sChargeType?.state === 'As Fast As Possible' ? 'on' : ''}"><ha-icon icon="mdi:rabbit"></ha-icon></div>` : ''}
                   <div class="target-cell">
                     <div id="target_value" class="target-value">${displayTargetValue}</div>
                     ${useEnergyMode ? '' : `<div class="mini-range-target" aria-label="range at target">${rangeTargetStr}</div>`}
@@ -1312,12 +1385,19 @@ class QsCarCard extends HTMLElement {
       // preserved particle, re-attach its detached `el` to the new
       // layer; the per-frame state (cy, life, …) survived in the
       // JS array so the RAF advance loop picks up exactly where it
-      // left off, with no visual blink. Cadence counters are
-      // restored so spawn timing is continuous. If a new layer
-      // isn't found (defensive — e.g. shadow root was torn down
-      // mid-flight), preserved particles are dropped to avoid
-      // leaking detached DOM. Mirrors the QS-214 boiler steam/bubble
-      // snapshot/restore pattern.
+      // left off, with no visual blink. Cadence counters
+      // (`_nextSparkleAt`, `_nextLightningAt`) are restored
+      // INSIDE the `length > 0` branches below; when the snapshot
+      // arrays are empty (common — sparkles live ~0.45 s and
+      // hass-pushes fire every 100–500 ms, so most renders snapshot
+      // 0–3 sparkles), the cadence counters survive the rebuild
+      // because `_resetDomRefs` doesn't touch them. Net effect: a
+      // spawn cadence is continuous regardless of whether the
+      // particle arrays were populated at snapshot time. If a new
+      // layer isn't found (defensive — e.g. shadow root was torn
+      // down mid-flight), preserved particles are dropped to avoid
+      // leaking detached DOM. Mirrors the QS-214 boiler
+      // steam/bubble snapshot/restore pattern.
       if (preservedSparkles?.length) {
         const newSparkleLayer = this._sparkleLayerId
           ? this._root.getElementById(this._sparkleLayerId)
@@ -1326,7 +1406,21 @@ class QsCarCard extends HTMLElement {
           for (const s of preservedSparkles) {
             if (s?.el) newSparkleLayer.appendChild(s.el);
           }
-          this._sparkles = preservedSparkles.filter(s => s?.el);
+          // Review-fix #02 #16: drop preserved sparkles whose `cy`
+          // is now ABOVE the new `_waterBaseY` (i.e., the SOC dropped
+          // enough that the soup surface rose past the sparkle's
+          // frozen y-position). Otherwise the sparkle would visually
+          // float in the air above the soup for the remainder of its
+          // ~0.45s life. The DOM `<circle>` is removed too so it
+          // doesn't paint during the brief gap.
+          this._sparkles = preservedSparkles.filter(s => {
+            if (!s?.el) return false;
+            if (s.cy < this._waterBaseY) {
+              s.el.remove();
+              return false;
+            }
+            return true;
+          });
           this._sparkleLayerEl = newSparkleLayer;
           this._nextSparkleAt = preservedNextSparkleAt;
         } else {

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -139,20 +139,21 @@ const LIGHTNING_LATERAL_JITTER_PX = 18;
 // - Review-fix #01:    SUN=285, RABBIT/TIME=195,195  R=32 (still too high)
 // - Review-fix #02:    SUN=288, RABBIT/TIME=192,192  R=38 (R bump made things worse)
 // - Review-fix #03:    SUN=277 R=35, RABBIT/TIME=215 R=32 — sun matches
-//                      OVERRIDE_BTN_CARVE_CY/R from the other cards,
-//                      rabbit/time moved +20 SVG down per user instruction.
-//
-// The sun-btn DOM was also restructured to a direct child of the
-// .ring container (out of `.center > .stack > .center-controls`)
-// so its CSS layout matches override-btn exactly.
+//                      OVERRIDE_BTN_CARVE_CY/R from the other cards.
+// - Review-fix #05:    RABBIT/TIME=200 R=32 — user instruction "move the
+//                      holes UP by 15 pixels" from the 215 deployment.
+//                      Sun stays at 277 (matches override-btn position).
+// - The sun-btn DOM was restructured to a direct child of the
+//   .ring container (out of `.center > .stack > .center-controls`)
+//   so its CSS layout matches override-btn exactly.
 const SUN_BTN_CARVE_CX = 160;       // bottom-center of ring
 const SUN_BTN_CARVE_CY = 277;       // matches OVERRIDE_BTN_CARVE_CY in other cards
 const SUN_BTN_CARVE_R  = 35;        // matches OVERRIDE_BTN_CARVE_R in other cards
 const RABBIT_BTN_CARVE_CX = 96;     // left column of mini-grid
-const RABBIT_BTN_CARVE_CY = 215;
+const RABBIT_BTN_CARVE_CY = 200;
 const RABBIT_BTN_CARVE_R  = 32;
 const TIME_BTN_CARVE_CX = 224;      // right column of mini-grid
-const TIME_BTN_CARVE_CY = 215;
+const TIME_BTN_CARVE_CY = 200;
 const TIME_BTN_CARVE_R  = 32;
 
 class QsCarCard extends HTMLElement {

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -77,16 +77,19 @@ const CHARGE_AMP = 3.5;
 const CHARGE_SPEED = 0.15;          // still gentle
 
 // --- Sparkles ("electrons popping in the water") ---
-// Idle: always visible, very few, very small, green.
-// Review-fix #01 #2: radii roughly doubled from the initial QS-232
-// constants — user reported the electron pops barely read in the
-// rendered card. Final values pinned visually against the user's
-// reference car configuration.
-const SPARKLE_IDLE_MAX = 4;
-const SPARKLE_IDLE_RATE_HZ = 0.6;
-const SPARKLE_IDLE_RADIUS_MIN = 1.6;
-const SPARKLE_IDLE_RADIUS_MAX = 3.0;
-const SPARKLE_IDLE_COLOR = 'hsla(140, 90%, 70%, 0.9)';
+// Idle: always visible, low rate, small, near-white minty highlight.
+// Review-fix history:
+// - #01 #2: radii roughly doubled (0.8/1.6 → 1.6/3.0).
+// - #03:    bumped further — user reported sparkles became invisible
+//           against the brighter idle soup palette. Idle sparkles now
+//           use a near-white minty colour for high contrast vs the
+//           green soup, larger radius, and a higher spawn rate so
+//           there's always a visible sparkle at any moment.
+const SPARKLE_IDLE_MAX = 8;
+const SPARKLE_IDLE_RATE_HZ = 1.5;
+const SPARKLE_IDLE_RADIUS_MIN = 2.5;
+const SPARKLE_IDLE_RADIUS_MAX = 5.0;
+const SPARKLE_IDLE_COLOR = 'hsla(140, 100%, 92%, 0.95)';   // near-white mint, high contrast vs soup green
 // Charging endpoints — scale linearly on [SPARKLE_POWER_MIN_W, SPARKLE_POWER_MAX_W].
 // Below MIN (but still `_charging`) the values clamp to the MIN-power
 // endpoint per user intent (1500W = MIN charging density, NOT a ramp
@@ -122,30 +125,35 @@ const LIGHTNING_LATERAL_JITTER_PX = 18;
 // than driving an emission loop, so the constant served no purpose.
 
 // --- Inside-disc button carve-out covers (QS-232 D17) ---
-// Mirror of QS-217 for THREE buttons that sit inside the clip disc:
-// sun-btn (Solar priority, bottom-center), rabbit-btn (Force now,
-// left column of mini-grid), time-btn (Finish time, right column).
-// The CSS positions are pinned in the .ring layout; the SVG-unit
-// coordinates here track those positions. Integer values are
-// intentionally user-tunable for visual iteration — tests pin the
-// constant NAMES only (mirrors the QS-217 precedent).
+// Mirror of QS-217 for THREE buttons that sit inside the clip disc.
+// The sun-btn (Solar priority, bottom-center) now follows the EXACT
+// same pattern as `override-btn` on the boiler/radiator/climate
+// cards — absolute-positioned at `bottom: 15px; left: 50%;` in the
+// .ring container, carved with CY=277 / R=35 (matching
+// OVERRIDE_BTN_CARVE_* on those cards). Rabbit-btn (Force now, left
+// column of mini-grid) and time-btn (Finish time, right column) sit
+// inside the .stack flow and are carved with CY=215 / R=32.
 //
 // Review-fix iteration history:
-// - QS-232 initial:     267 / 180 / 180  (CY too high — holes above buttons)
-// - Review-fix #01:     285 / 195 / 195  (overshot — holes slightly below buttons)
-// - Review-fix #02:     288 / 192 / 192  (pixel-measured from user screenshot)
-// Plus all radii bumped 32 → 38 so any residual ±3 SVG offset
-// stays inside the cover area and never leaves a sliver of green
-// peeking around the button outline.
-const SUN_BTN_CARVE_CX = 160;       // bottom-center of stack
-const SUN_BTN_CARVE_CY = 288;
-const SUN_BTN_CARVE_R  = 38;
+// - QS-232 initial:    SUN=267, RABBIT/TIME=180,180  R=32
+// - Review-fix #01:    SUN=285, RABBIT/TIME=195,195  R=32 (still too high)
+// - Review-fix #02:    SUN=288, RABBIT/TIME=192,192  R=38 (R bump made things worse)
+// - Review-fix #03:    SUN=277 R=35, RABBIT/TIME=215 R=32 — sun matches
+//                      OVERRIDE_BTN_CARVE_CY/R from the other cards,
+//                      rabbit/time moved +20 SVG down per user instruction.
+//
+// The sun-btn DOM was also restructured to a direct child of the
+// .ring container (out of `.center > .stack > .center-controls`)
+// so its CSS layout matches override-btn exactly.
+const SUN_BTN_CARVE_CX = 160;       // bottom-center of ring
+const SUN_BTN_CARVE_CY = 277;       // matches OVERRIDE_BTN_CARVE_CY in other cards
+const SUN_BTN_CARVE_R  = 35;        // matches OVERRIDE_BTN_CARVE_R in other cards
 const RABBIT_BTN_CARVE_CX = 96;     // left column of mini-grid
-const RABBIT_BTN_CARVE_CY = 192;
-const RABBIT_BTN_CARVE_R  = 38;
+const RABBIT_BTN_CARVE_CY = 215;
+const RABBIT_BTN_CARVE_R  = 32;
 const TIME_BTN_CARVE_CX = 224;      // right column of mini-grid
-const TIME_BTN_CARVE_CY = 192;
-const TIME_BTN_CARVE_R  = 38;
+const TIME_BTN_CARVE_CY = 215;
+const TIME_BTN_CARVE_R  = 32;
 
 class QsCarCard extends HTMLElement {
   constructor() {
@@ -857,8 +865,11 @@ class QsCarCard extends HTMLElement {
       /* Mobile touch fix: touch-action:manipulation removes the 300ms tap delay that mobile
          browsers impose for double-tap detection, making button taps register immediately.
          Without this, a hass re-render can destroy the DOM node before the synthetic click fires. */
-      .ring .sun-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
-      .ring .sun-btn ha-icon { --mdc-icon-size: 26px; color: var(--secondary-text-color); display:block; line-height:1; transform: translateY(3px); }
+      /* QS-232 review-fix #03: sun-btn now uses the same absolute
+         positioning as override-btn on boiler/radiator/climate cards.
+         Bottom: 15px from .ring bottom, centered horizontally. */
+      .ring .sun-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
+      .ring .sun-btn ha-icon { --mdc-icon-size: 26px; color: var(--secondary-text-color); display:block; line-height:1; }
       .ring .sun-btn.on { border-color: rgba(255,202,40,.45); background: rgba(255,202,40,.14); box-shadow: 0 0 0 3px rgba(255,202,40,.20), 0 0 16px #FFCA28; }
       .ring .sun-btn.on ha-icon { color: #FFCA28; }
       .ring .rabbit-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
@@ -1100,6 +1111,22 @@ class QsCarCard extends HTMLElement {
       const initialIdleOpacity   = (1 - initialColorMix).toFixed(3);
       const initialChargeOpacity = initialColorMix.toFixed(3);
 
+      // QS-232 review-fix #03: snapshot the in-flight sparkles AND
+      // lightning bolts BEFORE the innerHTML rewrite below. The
+      // rewrite detaches every DOM node under `this._root`, including
+      // the sparkle and lightning layers' children. Without this
+      // snapshot, every HA state push (which fires `set hass →
+      // _render`) wipes the entire particle arrays — the user-
+      // visible "no sparkles at all" symptom on a fast-updating car
+      // (the original story dropped snapshot/restore on the theory
+      // that 0.45 s lifetime made the wipe imperceptible, but in
+      // practice with HA pushing every 100-500 ms the sparkles never
+      // accumulate). Mirrors the QS-214 boiler snapshot/restore.
+      const preservedSparkles      = this._sparkles;
+      const preservedNextSparkleAt = this._nextSparkleAt;
+      const preservedLightningBolts  = this._lightningBolts;
+      const preservedNextLightningAt = this._nextLightningAt;
+
       this._root.innerHTML = `
       <ha-card class="card ${isDisconnected ? 'disabled' : ''} ${isFaulted ? 'fault' : ''} ${isOffGrid ? 'off-grid' : ''} ${isStale ? 'stale' : ''}">
         <style>${css}</style>
@@ -1200,12 +1227,12 @@ class QsCarCard extends HTMLElement {
                   ${(tNext && e.schedule) ? `<div id="time_btn" class="time-btn ${chargeTime && chargeTime !== '--:--' ? 'on' : ''}">${chargeTime}</div>` : ''}
                 </div>
                 </div>
-                <div class="center-controls" style="flex-direction:column; gap:4px;">
-                  <div class="mini-title">Solar priority</div>
-                  <div id="sun_btn" class="sun-btn ${swPriority?.state === 'on' ? 'on' : ''}"><ha-icon icon="mdi:weather-sunny"></ha-icon></div>
-                </div>
               </div>
             </div>
+            <!-- QS-232 review-fix #03: sun-btn moved out of .center > .stack > .center-controls
+                 to a direct child of .ring, matching the override-btn placement pattern in
+                 boiler/radiator/climate cards (position: absolute; bottom: 15px;). -->
+            ${swPriority ? `<div id="sun_btn" class="sun-btn ${swPriority?.state === 'on' ? 'on' : ''}"><ha-icon icon="mdi:weather-sunny"></ha-icon></div>` : ''}
           </div>
         </div>
 
@@ -1237,8 +1264,7 @@ class QsCarCard extends HTMLElement {
       // the freshly-rendered state (prevents a redundant regen on the
       // next frame) and null cached DOM refs + clear the logical
       // particle arrays via _resetDomRefs() so subsequent spawns
-      // don't try to advance dead nodes. No snapshot/restore — short
-      // particle life (≤ 0.45s) makes nuke-and-respawn imperceptible.
+      // don't try to advance dead nodes.
       this._lastWaterBaseY = this._waterBaseY;
       // Review-fix #01 #8: `??` does NOT trap NaN — if
       // `_currentAmplitude` ever became NaN, the prior form would
@@ -1248,6 +1274,51 @@ class QsCarCard extends HTMLElement {
       // explicit `Number.isFinite` check instead.
       this._lastAmplitude  = Number.isFinite(this._currentAmplitude) ? this._currentAmplitude : CALM_AMP;
       this._resetDomRefs();
+
+      // QS-232 review-fix #03: restore the preserved sparkles AND
+      // lightning bolts into the FRESH layers (their DOM identity
+      // changed via innerHTML — same `id`, new element). For each
+      // preserved particle, re-attach its detached `el` to the new
+      // layer; the per-frame state (cy, life, …) survived in the
+      // JS array so the RAF advance loop picks up exactly where it
+      // left off, with no visual blink. Cadence counters are
+      // restored so spawn timing is continuous. If a new layer
+      // isn't found (defensive — e.g. shadow root was torn down
+      // mid-flight), preserved particles are dropped to avoid
+      // leaking detached DOM. Mirrors the QS-214 boiler steam/bubble
+      // snapshot/restore pattern.
+      if (preservedSparkles?.length) {
+        const newSparkleLayer = this._sparkleLayerId
+          ? this._root.getElementById(this._sparkleLayerId)
+          : null;
+        if (newSparkleLayer) {
+          for (const s of preservedSparkles) {
+            if (s?.el) newSparkleLayer.appendChild(s.el);
+          }
+          this._sparkles = preservedSparkles.filter(s => s?.el);
+          this._sparkleLayerEl = newSparkleLayer;
+          this._nextSparkleAt = preservedNextSparkleAt;
+        } else {
+          for (const s of preservedSparkles) { s?.el?.remove(); }
+          this._sparkles = [];
+        }
+      }
+      if (preservedLightningBolts?.length) {
+        const newLightningLayer = this._lightningLayerId
+          ? this._root.getElementById(this._lightningLayerId)
+          : null;
+        if (newLightningLayer) {
+          for (const b of preservedLightningBolts) {
+            if (b?.el) newLightningLayer.appendChild(b.el);
+          }
+          this._lightningBolts = preservedLightningBolts.filter(b => b?.el);
+          this._lightningLayerEl = newLightningLayer;
+          this._nextLightningAt = preservedNextLightningAt;
+        } else {
+          for (const b of preservedLightningBolts) { b?.el?.remove(); }
+          this._lightningBolts = [];
+        }
+      }
 
       // old buttons:
 /*      <div className="below-line">

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -54,8 +54,13 @@ const WAVE_WIDTH = 480;             // single wave period (2× clip diameter)
 const WAVE_BOTTOM_Y = 400;          // closing rectangle y; clipped by circle
 
 // --- Wave palette (dual-opacity cross-fade idle ↔ charge) ---
-const IDLE_SOUP_COLOR   = 'hsla(140, 80%, 50%, 0.12)';   // very translucent electric green
-const CHARGE_SOUP_COLOR = 'hsla(180, 90%, 55%, 0.25)';   // bluer, slightly less transparent
+// Review-fix #02: user reported the idle green was too dark / muddy
+// to read at a glance. Bumped from `hsla(140, 80%, 50%, 0.12)` →
+// `hsla(140, 85%, 60%, 0.30)` — slightly brighter, slightly more
+// saturated, 2.5× more opaque. Charging blue bumped in parallel
+// so the cross-fade contrast remains balanced.
+const IDLE_SOUP_COLOR   = 'hsla(140, 85%, 60%, 0.30)';   // electric green, clearly visible
+const CHARGE_SOUP_COLOR = 'hsla(180, 90%, 60%, 0.38)';   // bright cyan-blue, equally visible
 
 // --- Animation tuning (lerp envelope; mirror boiler) ---
 const LERP_RATE = 2;
@@ -124,18 +129,23 @@ const LIGHTNING_LATERAL_JITTER_PX = 18;
 // coordinates here track those positions. Integer values are
 // intentionally user-tunable for visual iteration — tests pin the
 // constant NAMES only (mirrors the QS-217 precedent).
-// Review-fix #01 #1: bumped all three CY values down from the
-// initial QS-232 estimates after a user screenshot showed the
-// holes drawn above the actual button centers.
+//
+// Review-fix iteration history:
+// - QS-232 initial:     267 / 180 / 180  (CY too high — holes above buttons)
+// - Review-fix #01:     285 / 195 / 195  (overshot — holes slightly below buttons)
+// - Review-fix #02:     288 / 192 / 192  (pixel-measured from user screenshot)
+// Plus all radii bumped 32 → 38 so any residual ±3 SVG offset
+// stays inside the cover area and never leaves a sliver of green
+// peeking around the button outline.
 const SUN_BTN_CARVE_CX = 160;       // bottom-center of stack
-const SUN_BTN_CARVE_CY = 285;
-const SUN_BTN_CARVE_R  = 32;
+const SUN_BTN_CARVE_CY = 288;
+const SUN_BTN_CARVE_R  = 38;
 const RABBIT_BTN_CARVE_CX = 96;     // left column of mini-grid
-const RABBIT_BTN_CARVE_CY = 195;
-const RABBIT_BTN_CARVE_R  = 32;
+const RABBIT_BTN_CARVE_CY = 192;
+const RABBIT_BTN_CARVE_R  = 38;
 const TIME_BTN_CARVE_CX = 224;      // right column of mini-grid
-const TIME_BTN_CARVE_CY = 195;
-const TIME_BTN_CARVE_R  = 32;
+const TIME_BTN_CARVE_CY = 192;
+const TIME_BTN_CARVE_R  = 38;
 
 class QsCarCard extends HTMLElement {
   constructor() {

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -63,19 +63,32 @@ const CHARGE_AMP = 3.5;
 const CHARGE_SPEED = 0.15;          // still gentle
 
 // --- Sparkles ("electrons popping in the water") ---
-// Idle: always visible, low rate, small, near-white minty highlight.
+// Idle: always visible, low rate, vivid yellow-green burst-shaped
+// "electron pops" rather than smooth discs. Each sparkle is an
+// 8-ray asterisk path (4 long rays in a cross + 4 short rays in
+// an X) drawn with stroke (no fill) — see the spawn code in
+// `_startAnimation` for the exact `d` builder. Mimics the
+// little-explosion mental model of an electron flashing in the
+// soup, vs. the smooth-disc look the previous `<circle>` form
+// gave.
+//
 // Review-fix history:
 // - #01 #2: radii roughly doubled (0.8/1.6 → 1.6/3.0).
 // - #03:    bumped further — user reported sparkles became invisible
-//           against the brighter idle soup palette. Idle sparkles now
-//           use a near-white minty colour for high contrast vs the
-//           green soup, larger radius, and a higher spawn rate so
-//           there's always a visible sparkle at any moment.
+//           against the brighter idle soup palette.
+// - #04:    shape changed `<circle>` → 8-ray `<path>` burst; colour
+//           changed near-white mint → vivid yellow-green (hue 80)
+//           per user feedback "they have to be green/yellow ... not
+//           a disc as today but should be more like a little
+//           explosion".
 const SPARKLE_IDLE_MAX = 8;
 const SPARKLE_IDLE_RATE_HZ = 1.5;
 const SPARKLE_IDLE_RADIUS_MIN = 2.5;
 const SPARKLE_IDLE_RADIUS_MAX = 5.0;
-const SPARKLE_IDLE_COLOR = 'hsla(140, 100%, 92%, 0.95)';   // near-white mint, high contrast vs soup green
+const SPARKLE_IDLE_COLOR = 'hsla(80, 100%, 65%, 0.95)';    // vivid yellow-green / lime, high contrast vs soup green
+// Stroke-width for the asterisk-style sparkle path. Tuned so a 5 px
+// sparkle still reads as a "spark" rather than a clump.
+const SPARKLE_STROKE_WIDTH = 1.4;
 // Charging endpoints — scale linearly on [SPARKLE_POWER_MIN_W, SPARKLE_POWER_MAX_W].
 // Below MIN (but still `_charging`) the values clamp to the MIN-power
 // endpoint per user intent (1500W = MIN charging density, NOT a ramp
@@ -446,11 +459,25 @@ class QsCarCard extends HTMLElement {
           const r = rMin + Math.random() * (rMax - rMin);
           // Fill decided ONCE at spawn — never re-assigned in advance.
           const fill = charging ? SPARKLE_CHARGE_COLOR : SPARKLE_IDLE_COLOR;
-          const el = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-          el.setAttribute('cx', cx.toFixed(2));
-          el.setAttribute('cy', cy.toFixed(2));
-          el.setAttribute('r', r.toFixed(2));
-          el.setAttribute('fill', fill);
+          // Review-fix #02 user follow-up: sparkles are now 8-ray
+          // asterisk bursts (4 long axial rays + 4 short diagonal
+          // rays) drawn with stroke, evoking a small electron-soup
+          // flash. The path origin is the spawn (cx, cy); ray length
+          // scales with `r` from the power-scaling formula.
+          const longR  = r;
+          const shortR = r * 0.6;
+          const cxs = cx.toFixed(2);
+          const cys = cy.toFixed(2);
+          const d = `M ${cxs},${(cy - longR).toFixed(2)} L ${cxs},${(cy + longR).toFixed(2)}`
+                  + ` M ${(cx - longR).toFixed(2)},${cys} L ${(cx + longR).toFixed(2)},${cys}`
+                  + ` M ${(cx - shortR).toFixed(2)},${(cy - shortR).toFixed(2)} L ${(cx + shortR).toFixed(2)},${(cy + shortR).toFixed(2)}`
+                  + ` M ${(cx - shortR).toFixed(2)},${(cy + shortR).toFixed(2)} L ${(cx + shortR).toFixed(2)},${(cy - shortR).toFixed(2)}`;
+          const el = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+          el.setAttribute('d', d);
+          el.setAttribute('stroke', fill);
+          el.setAttribute('stroke-width', String(SPARKLE_STROKE_WIDTH));
+          el.setAttribute('stroke-linecap', 'round');
+          el.setAttribute('fill', 'none');
           el.setAttribute('pointer-events', 'none');
           el.setAttribute('opacity', '0');
           sparkleLayer.appendChild(el);

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -868,10 +868,24 @@ class QsCarCard extends HTMLElement {
       /* QS-232 review-fix #03: sun-btn now uses the same absolute
          positioning as override-btn on boiler/radiator/climate cards.
          Bottom: 15px from .ring bottom, centered horizontally. */
-      .ring .sun-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
-      .ring .sun-btn ha-icon { --mdc-icon-size: 26px; color: var(--secondary-text-color); display:block; line-height:1; }
+      .ring .sun-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:flex; align-items:center; justify-content:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
+      /* QS-232 review-fix #04: icon bumped 26 → 30 px and centered via
+         flex (instead of grid+place-items + the legacy translateY(3px)
+         hack) so the sun renders at the same visual size as the hand
+         on the override-btn in climate/radiator/boiler. */
+      .ring .sun-btn ha-icon { --mdc-icon-size: 30px; color: var(--secondary-text-color); display:flex; align-items:center; justify-content:center; line-height:1; }
       .ring .sun-btn.on { border-color: rgba(255,202,40,.45); background: rgba(255,202,40,.14); box-shadow: 0 0 0 3px rgba(255,202,40,.20), 0 0 16px #FFCA28; }
       .ring .sun-btn.on ha-icon { color: #FFCA28; }
+      /* QS-232 review-fix #04: invisible spacer that preserves the
+         .stack's vertical balance after the sun-btn was moved out of
+         .center-controls to absolute positioning. Without this, the
+         shorter stack gets grid-centered higher in .center, pushing
+         the soc-block (89%, range) and the mini-grid buttons (rabbit,
+         time) visibly downward — the symptom the user flagged
+         ("you moved all the texts and stuff down"). The 74 px height
+         matches the former .center-controls outer footprint
+         (6 px margin + 14 px label + 4 px gap + 50 px button). */
+      .ring .sun-btn-spacer { width: 50px; height: 74px; pointer-events: none; }
       .ring .rabbit-btn { width: 50px; height: 50px; border-radius: 50%; border: 2px solid var(--divider-color); background: rgba(255,255,255,.04); display:grid; place-items:center; cursor:pointer; box-shadow: none; pointer-events: auto; box-sizing: border-box; touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
       .ring .rabbit-btn ha-icon { --mdc-icon-size: 26px; color: var(--secondary-text-color); display:block; line-height:1; transform: translateY(3px); }
       .ring .rabbit-btn.on { border-color: rgba(33,150,243,.45); background: rgba(33,150,243,.14); box-shadow: 0 0 0 3px rgba(33,150,243,.20), 0 0 16px #2196F3; }
@@ -1227,6 +1241,10 @@ class QsCarCard extends HTMLElement {
                   ${(tNext && e.schedule) ? `<div id="time_btn" class="time-btn ${chargeTime && chargeTime !== '--:--' ? 'on' : ''}">${chargeTime}</div>` : ''}
                 </div>
                 </div>
+                <!-- QS-232 review-fix #04: invisible spacer preserves .stack's vertical balance
+                     after sun-btn was moved to absolute positioning. Without this, the soc-block
+                     and mini-grid visibly shift downward. -->
+                <div class="sun-btn-spacer" aria-hidden="true"></div>
               </div>
             </div>
             <!-- QS-232 review-fix #03: sun-btn moved out of .center > .stack > .center-controls

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -1,6 +1,38 @@
 /*
   QS Car Card - custom:qs-car-card
   Zero-build single-file Lit-style web component compatible with Home Assistant
+
+  QS-232 layered an "electron soup" SOC animation inside the ring,
+  mirroring the QS-200/QS-211/QS-214 boiler architecture:
+  - A single sine wave inside a circular clipPath, with dual-opacity
+    cross-fade between an idle green palette and a charging blue
+    palette (binary `_currentColorMix` lerp, NOT HSL hue lerp).
+  - Lightning-blue "electron" sparkles popping randomly inside the
+    soup. Sparkle density / spawn-rate / radius scale linearly with
+    charge power on [1500W, 22000W]; below 1500W (but still
+    `_charging`) the visuals clamp to the 1500W MIN endpoint. Idle
+    uses a fixed low rate of greenish sparkles independent of power.
+  - Lightning bolts flashing from the top of the clip circle to the
+    soup surface when charging — 3-segment `<path>` with a glow
+    filter and `mix-blend-mode: screen`, life 0.25s, spawn interval
+    randomised on [1.5, 3.0]s.
+  - feTurbulence grain filter applied to the wave path's fill (NOT a
+    separate overlay rect) so the grain composites within the wave
+    shape via `feComposite operator="in"`.
+  - Degraded states (`isDisconnected || isFaulted || isStale`)
+    desaturate the entire clipped group via a CSS filter
+    (`saturate(0.3) brightness(0.7)`) and suppress lightning
+    entirely. `isOffGrid` is NOT folded in (the card-level pinkish
+    .off-grid tint already covers it).
+  - Continuous RAF while connected (no more `_charging`-gated
+    start/stop). Mirrors QS-200 / QS-211 pool & boiler precedent.
+  - QS-217 carve-cover pattern extended from one button (override-
+    reset on boiler/radiator/climate) to THREE inside-disc buttons
+    on the car card: sun-btn (Solar priority), rabbit-btn (Force
+    now), time-btn (Finish time).
+
+  Existing dashed-arc animation (`<path id="charge_anim">`) is
+  preserved verbatim; `showAnimation` remains its render-time switch.
 */
 
 const INVALID_STATES = ['unavailable', 'unknown', 'none'];
@@ -12,6 +44,90 @@ const ANIM_MAX_POWER_W = 22000;
 const ANIM_SPEED_RANGE = ANIM_MAX_SPEED - ANIM_MIN_SPEED;
 const ANIM_POWER_RANGE = ANIM_MAX_POWER_W - ANIM_MIN_POWER_W;
 
+// === QS-232 electron-soup constants ===
+
+// --- Geometry (must match the SVG <clipPath> circle attributes below) ---
+const CENTER_CX = 160;              // SVG x-center of the ring / clip circle
+const CENTER_CY = 160;              // SVG y-center of the ring / clip circle
+const CLIP_R = 120;                 // soup clip circle radius (10 px inside ringCirc=130, same as boiler)
+const WAVE_WIDTH = 480;             // single wave period (2× clip diameter)
+const WAVE_BOTTOM_Y = 400;          // closing rectangle y; clipped by circle
+
+// --- Wave palette (dual-opacity cross-fade idle ↔ charge) ---
+const IDLE_SOUP_COLOR   = 'hsla(140, 80%, 50%, 0.12)';   // very translucent electric green
+const CHARGE_SOUP_COLOR = 'hsla(180, 90%, 55%, 0.25)';   // bluer, slightly less transparent
+
+// --- Animation tuning (lerp envelope; mirror boiler) ---
+const LERP_RATE = 2;
+const LERP_DT_CEIL = 0.1;
+const AMP_REGEN_THRESHOLD = 0.25;
+const LEVEL_REGEN_THRESHOLD = 0.01;
+const PHASE_WRAP = 1e6;
+const PHASE_TO_PX = 60;
+
+// --- Calm vs charge targets (single layer, gentler than boiler) ---
+const CALM_AMP = 1.2;
+const CALM_SPEED = 0.03;            // very slow per issue brief
+const CHARGE_AMP = 3.5;
+const CHARGE_SPEED = 0.15;          // still gentle
+
+// --- Sparkles ("electrons popping in the water") ---
+// Idle: always visible, very few, very small, green.
+const SPARKLE_IDLE_MAX = 4;
+const SPARKLE_IDLE_RATE_HZ = 0.6;
+const SPARKLE_IDLE_RADIUS_MIN = 0.8;
+const SPARKLE_IDLE_RADIUS_MAX = 1.6;
+const SPARKLE_IDLE_COLOR = 'hsla(140, 90%, 70%, 0.9)';
+// Charging endpoints — scale linearly on [SPARKLE_POWER_MIN_W, SPARKLE_POWER_MAX_W].
+// Below MIN (but still `_charging`) the values clamp to the MIN-power
+// endpoint per user intent (1500W = MIN charging density, NOT a ramp
+// from 0W). The idle→charging boundary at 50W is a deliberate
+// visible step in density and colour.
+const SPARKLE_POWER_MIN_W = 1500;
+const SPARKLE_POWER_MAX_W = 22000;
+const SPARKLE_CHARGE_MAX_AT_MIN_POWER = 12;
+const SPARKLE_CHARGE_MAX_AT_MAX_POWER = 28;
+const SPARKLE_CHARGE_RATE_HZ_AT_MIN_POWER = 3;
+const SPARKLE_CHARGE_RATE_HZ_AT_MAX_POWER = 10;
+const SPARKLE_CHARGE_RADIUS_MIN_AT_MIN_POWER = 1.2;
+const SPARKLE_CHARGE_RADIUS_MAX_AT_MIN_POWER = 2.5;
+const SPARKLE_CHARGE_RADIUS_MIN_AT_MAX_POWER = 1.8;
+const SPARKLE_CHARGE_RADIUS_MAX_AT_MAX_POWER = 3.5;
+const SPARKLE_CHARGE_COLOR = '#00E5FF';   // electric "lightning blue"
+const SPARKLE_LIFE_S = 0.45;
+
+// --- Lightning bolts ("thunder from the top to the soup surface") ---
+// Only spawn when `_charging === true && !degraded`. In-flight bolts
+// complete their fade-out naturally on charging → false.
+const MAX_CONCURRENT_LIGHTNING = 3;
+const LIGHTNING_SPAWN_MIN_S = 1.5;
+const LIGHTNING_SPAWN_MAX_S = 3.0;
+const LIGHTNING_LIFE_S = 0.25;
+const LIGHTNING_STROKE_COLOR = '#E0F7FF';
+const LIGHTNING_STROKE_WIDTH = 1.8;
+const LIGHTNING_GLOW_STDDEV = 2.5;
+const LIGHTNING_TOP_MARGIN_PX = 4;
+const LIGHTNING_LATERAL_JITTER_PX = 18;
+const LIGHTNING_SEGMENTS = 3;
+
+// --- Inside-disc button carve-out covers (QS-232 D17) ---
+// Mirror of QS-217 for THREE buttons that sit inside the clip disc:
+// sun-btn (Solar priority, bottom-center), rabbit-btn (Force now,
+// left column of mini-grid), time-btn (Finish time, right column).
+// The CSS positions are pinned in the .ring layout; the SVG-unit
+// coordinates here track those positions. Integer values are
+// intentionally user-tunable for visual iteration — tests pin the
+// constant NAMES only (mirrors the QS-217 precedent).
+const SUN_BTN_CARVE_CX = 160;       // bottom-center of stack
+const SUN_BTN_CARVE_CY = 267;
+const SUN_BTN_CARVE_R  = 32;
+const RABBIT_BTN_CARVE_CX = 96;     // left column of mini-grid
+const RABBIT_BTN_CARVE_CY = 180;
+const RABBIT_BTN_CARVE_R  = 32;
+const TIME_BTN_CARVE_CX = 224;      // right column of mini-grid
+const TIME_BTN_CARVE_CY = 180;
+const TIME_BTN_CARVE_R  = 32;
+
 class QsCarCard extends HTMLElement {
   constructor() {
     super();
@@ -19,35 +135,321 @@ class QsCarCard extends HTMLElement {
     this._charging = false;
   }
 
-  // M4: gate the requestAnimationFrame loop on `_charging`. The loop
-  // is started lazily by `_render()` only when the car is actually
-  // charging, and stopped in `disconnectedCallback` AND whenever
-  // `_charging` becomes false. Avoids constant per-card repaint
-  // overhead when the car isn't drawing any current.
+  // QS-232: generate an SVG path for a sine-wave-based closed shape
+  // (ported verbatim from `qs-water-boiler-card.js` / `qs-pool-card.js`).
+  // Emits TWO repetitions of the wave (path extent = [0, 2*width]) so
+  // the translated path always covers the clip region regardless of
+  // scroll offset. The car uses ONE call site with `frequency = 2`
+  // (single layer per D1).
+  _generateWavePath(width, amplitude, frequency, phase, yOffset) {
+    const points = [];
+    const stepsPerPeriod = 60;
+    const totalSteps = stepsPerPeriod * 2;
+    const totalWidth = 2 * width;
+    for (let i = 0; i <= totalSteps; i++) {
+      const x = (i / stepsPerPeriod) * width;
+      const y = yOffset + amplitude * Math.sin((x / width) * frequency * 2 * Math.PI + phase);
+      points.push(`${x.toFixed(2)} ${y.toFixed(2)}`);
+    }
+    return `M ${points[0]} ` +
+           points.slice(1).map(p => `L ${p}`).join(' ') +
+           ` L ${totalWidth.toFixed(2)} ${WAVE_BOTTOM_Y} L 0 ${WAVE_BOTTOM_Y} Z`;
+  }
+
+  // QS-232: reset cached DOM refs and the logical sparkle / lightning
+  // arrays. Shared between `_invalidateAnimCache()` (full memo reset
+  // on (re-)connect) and the post-`innerHTML` cleanup block in
+  // `_render()`. Factored out so a future memo-key addition lands at
+  // BOTH call sites — without the helper, the two paths would drift
+  // silently and the post-render block would carry stale refs into
+  // the next RAF frame (boiler precedent —
+  // `test_water_boiler_card_factors_reset_dom_refs_helper`).
+  _resetDomRefs() {
+    this._waveEls = null;             // [idleWave, chargeWave]
+    this._grainFilterEl = null;
+    this._sparkleLayerEl = null;
+    this._lightningLayerEl = null;
+    this._sparkles = [];
+    this._lightningBolts = [];
+  }
+
+  // QS-232: clear wave-path memoization keys and cached DOM refs.
+  // Called on every (re-)connect and after each _render() innerHTML
+  // rewrite. Mirrors boiler `_invalidateWaveCache` (it nulls
+  // `_lastWaterBaseY` / `_lastAmplitude` for full invalidation; the
+  // post-innerHTML path syncs them to the current render state, so
+  // they stay outside `_resetDomRefs()`).
+  _invalidateAnimCache() {
+    this._lastWaterBaseY = null;
+    this._lastAmplitude = null;
+    this._resetDomRefs();
+  }
+
+  // QS-232: continuous RAF while connected, mirroring
+  // `qs-water-boiler-card.js`. The electron-soup wave is intrinsically
+  // visible at all times (idle green when not charging, charging blue
+  // when `_charging`, desaturated grey when `degraded`) so RAF is no
+  // longer gated on `_charging`. Calm vs. charging is amplitude /
+  // speed / color-mix lerp, not RAF on/off. The existing dashed-arc
+  // animation (`<path id="charge_anim">`) is preserved verbatim and
+  // continues to be driven by `_animOffset` inside the step closure
+  // below — `showAnimation` remains its render-time switch.
   _startAnimation() {
     if (this._animRaf != null) return;
+    // Lazy-init: runs ONCE on first connect, preserved across
+    // detach/re-attach so `_currentAmplitude` / `_wavePhase` /
+    // `_currentColorMix` don't snap back on tab navigation.
+    if (this._currentAmplitude == null) {
+      this._currentAmplitude = CALM_AMP;
+      this._currentSpeed     = CALM_SPEED;
+      this._wavePhase        = 0;
+      this._currentColorMix  = 0;
+      this._sparkles         = [];
+      this._nextSparkleAt    = 0;
+      this._lightningBolts   = [];
+      this._nextLightningAt  = LIGHTNING_SPAWN_MIN_S +
+        Math.random() * (LIGHTNING_SPAWN_MAX_S - LIGHTNING_SPAWN_MIN_S);
+      this._needsAnimationPrime = true;
+    }
     this._lastAnimTs = null;
+    this._invalidateAnimCache();
+
     const step = (ts) => {
       if (!this.isConnected) { this._animRaf = null; return; }
-      if (!this._charging) {
-        // _charging went false between renders — stop the loop entirely
-        // rather than spin idle.
-        this._animOffset = 0;
-        this._lastAnimTs = null;
-        this._animRaf = null;
-        return;
-      }
       if (this._lastAnimTs == null) this._lastAnimTs = ts;
-      const dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
+      // QS-232 (mirror QS-200 fix #02 S6): cap `dt` against hidden-tab
+      // return. Without this cap, the first frame after a multi-second
+      // tab-hidden window produces a huge dt, snapping wave phase by
+      // hundreds of pixels in one frame and aging every sparkle past
+      // SPARKLE_LIFE_S simultaneously. The cap matches LERP_DT_CEIL
+      // so every step-loop subsystem shares the same envelope.
+      let dt = Math.max(0, (ts - this._lastAnimTs) / 1000);
+      dt = Math.min(dt, LERP_DT_CEIL);
       this._lastAnimTs = ts;
+
+      // --- Existing dashed-arc animation (PRESERVED from M4).
+      // The dashed `<path id="charge_anim">` still drives off
+      // `showAnimation`, which is now applied as a render-time switch
+      // on the element. The RAF loop itself no longer gates on
+      // `_charging` (D9).
       const patternLen = Math.max(8, this._animPatternLen || 64);
       const cp = this._chargePower || 0;
-      const speed = Math.min(ANIM_MAX_SPEED, Math.max(ANIM_MIN_SPEED, ANIM_MIN_SPEED + (cp - ANIM_MIN_POWER_W) * ANIM_SPEED_RANGE / ANIM_POWER_RANGE));
-      this._animOffset = ((this._animOffset || 0) + speed * dt) % patternLen;
-      const p = this._root?.getElementById('charge_anim');
-      if (p) {
-        p.setAttribute('stroke-dashoffset', String(-this._animOffset));
+      const dashSpeed = Math.min(ANIM_MAX_SPEED, Math.max(ANIM_MIN_SPEED, ANIM_MIN_SPEED + (cp - ANIM_MIN_POWER_W) * ANIM_SPEED_RANGE / ANIM_POWER_RANGE));
+      this._animOffset = ((this._animOffset || 0) + dashSpeed * dt) % patternLen;
+      const dashEl = this._root?.getElementById('charge_anim');
+      if (dashEl) {
+        dashEl.setAttribute('stroke-dashoffset', String(-this._animOffset));
       }
+
+      // --- Lerp amplitude / speed / colorMix toward charge targets.
+      // The lerp is binary (idle ↔ charge); the degraded palette is
+      // a separate runtime path via CSS filter on the clip group (D8).
+      const charging = this._charging === true;
+      const degraded = this._degraded === true;
+      const targetAmplitude = charging ? CHARGE_AMP : CALM_AMP;
+      const targetSpeed     = charging ? CHARGE_SPEED : CALM_SPEED;
+      const targetColorMix  = charging ? 1 : 0;
+      const lerpFactor = 1 - Math.exp(-LERP_RATE * dt);
+      this._currentAmplitude += (targetAmplitude - this._currentAmplitude) * lerpFactor;
+      this._currentSpeed     += (targetSpeed - this._currentSpeed) * lerpFactor;
+      this._currentColorMix  += (targetColorMix - this._currentColorMix) * lerpFactor;
+      this._wavePhase += this._currentSpeed * dt;
+      this._wavePhase = ((this._wavePhase % PHASE_WRAP) + PHASE_WRAP) % PHASE_WRAP;
+
+      // --- Lazy-resolve wave / sparkle / lightning DOM refs once per
+      //     innerHTML rewrite (two wave nodes — idle + charge).
+      if (!this._waveEls) {
+        const idleEl   = this._root?.getElementById('electron_wave_idle')   ?? null;
+        const chargeEl = this._root?.getElementById('electron_wave_charge') ?? null;
+        this._waveEls = [idleEl, chargeEl];
+      }
+      const sparkleLayer = this._sparkleLayerEl
+        ?? (this._sparkleLayerEl = this._sparkleLayerId
+              ? (this._root?.getElementById(this._sparkleLayerId) ?? null)
+              : null);
+      const lightningLayer = this._lightningLayerEl
+        ?? (this._lightningLayerEl = this._lightningLayerId
+              ? (this._root?.getElementById(this._lightningLayerId) ?? null)
+              : null);
+
+      // --- Wave transform (single layer translateX).
+      // Path extent is [0, 2*WAVE_WIDTH] so the translated path always
+      // covers the clip region.
+      const raw = this._wavePhase * PHASE_TO_PX;
+      const scrollOffset = ((raw % WAVE_WIDTH) + WAVE_WIDTH) % WAVE_WIDTH;
+      const tx = -CLIP_R - scrollOffset;
+      const txStr = `translateX(${tx.toFixed(1)}px)`;
+      const idleWave   = this._waveEls[0];
+      const chargeWave = this._waveEls[1];
+      if (idleWave)   idleWave.style.transform   = txStr;
+      if (chargeWave) chargeWave.style.transform = txStr;
+
+      // --- Wave path regen (throttled by amplitude / soup-level delta).
+      const waterBaseY = this._waterBaseY;
+      const hasValidBase = waterBaseY != null && !Number.isNaN(waterBaseY);
+      const ampDelta = this._lastAmplitude == null
+          ? Infinity
+          : Math.abs(this._currentAmplitude - this._lastAmplitude);
+      const levelChanged = hasValidBase &&
+          Math.abs(waterBaseY - (this._lastWaterBaseY ?? Number.NEGATIVE_INFINITY)) > LEVEL_REGEN_THRESHOLD;
+      if (hasValidBase && (levelChanged || ampDelta > AMP_REGEN_THRESHOLD)) {
+        this._lastWaterBaseY = waterBaseY;
+        this._lastAmplitude = this._currentAmplitude;
+        const d = this._generateWavePath(WAVE_WIDTH, this._currentAmplitude, 2, 0, waterBaseY);
+        if (idleWave)   idleWave.setAttribute('d', d);
+        if (chargeWave) chargeWave.setAttribute('d', d);
+      }
+
+      // --- Per-frame wave opacity (idle ↔ charge cross-fade).
+      // Dual-layer opacity rather than HSL lerp — passing through
+      // yellow at the midpoint is artifact-prone.
+      const idleOpacity   = (1 - this._currentColorMix).toFixed(3);
+      const chargeOpacity = this._currentColorMix.toFixed(3);
+      if (idleWave)   idleWave.setAttribute('opacity', idleOpacity);
+      if (chargeWave) chargeWave.setAttribute('opacity', chargeOpacity);
+
+      // === QS-232 sparkle subsystem ===========================
+      // Always visible. Colour / density / spawn-rate / radius
+      // depend on `_charging` state. Spawns advance even when idle
+      // (low rate). The advance + retire loop runs every frame for
+      // graceful exit on `_charging` flips (in-flight sparkles
+      // complete their natural fade).
+      if (sparkleLayer && hasValidBase) {
+        // Power-scaling for the charging endpoints (clamped to
+        // [SPARKLE_POWER_MIN_W, SPARKLE_POWER_MAX_W]).
+        let sparkleMax, sparkleRateHz, rMin, rMax;
+        if (charging) {
+          const power = this._chargePower || 0;
+          const clamped = Math.max(SPARKLE_POWER_MIN_W, Math.min(SPARKLE_POWER_MAX_W, power));
+          const t = (clamped - SPARKLE_POWER_MIN_W) / (SPARKLE_POWER_MAX_W - SPARKLE_POWER_MIN_W);
+          sparkleMax = SPARKLE_CHARGE_MAX_AT_MIN_POWER + t * (SPARKLE_CHARGE_MAX_AT_MAX_POWER - SPARKLE_CHARGE_MAX_AT_MIN_POWER);
+          sparkleRateHz = SPARKLE_CHARGE_RATE_HZ_AT_MIN_POWER + t * (SPARKLE_CHARGE_RATE_HZ_AT_MAX_POWER - SPARKLE_CHARGE_RATE_HZ_AT_MIN_POWER);
+          rMin = SPARKLE_CHARGE_RADIUS_MIN_AT_MIN_POWER + t * (SPARKLE_CHARGE_RADIUS_MIN_AT_MAX_POWER - SPARKLE_CHARGE_RADIUS_MIN_AT_MIN_POWER);
+          rMax = SPARKLE_CHARGE_RADIUS_MAX_AT_MIN_POWER + t * (SPARKLE_CHARGE_RADIUS_MAX_AT_MAX_POWER - SPARKLE_CHARGE_RADIUS_MAX_AT_MIN_POWER);
+        } else {
+          sparkleMax = SPARKLE_IDLE_MAX;
+          sparkleRateHz = SPARKLE_IDLE_RATE_HZ;
+          rMin = SPARKLE_IDLE_RADIUS_MIN;
+          rMax = SPARKLE_IDLE_RADIUS_MAX;
+        }
+
+        this._nextSparkleAt -= dt;
+        while (this._nextSparkleAt <= 0 && this._sparkles.length < sparkleMax) {
+          // Spawn position: random inside the water portion of the
+          // clip circle. `continue`-with-cadence-advance pattern
+          // (no `break`) avoids a per-frame spin-loop on degenerate
+          // empty soup, mirroring QS-214 review-fix #01 #5.
+          const cyMin = this._waterBaseY + 2;
+          const cyMax = CENTER_CY + CLIP_R - 4;
+          if (cyMax <= cyMin) {
+            this._nextSparkleAt += 1 / sparkleRateHz;
+            continue;
+          }
+          const cy = cyMin + Math.random() * (cyMax - cyMin);
+          const dy = cy - CENTER_CY;
+          const chordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dy * dy));
+          if (chordHalf < 2) {
+            this._nextSparkleAt += 1 / sparkleRateHz;
+            continue;
+          }
+          const cx = CENTER_CX + (Math.random() * 2 - 1) * chordHalf * 0.9;
+          const r = rMin + Math.random() * (rMax - rMin);
+          // Fill decided ONCE at spawn — never re-assigned in advance.
+          const fill = charging ? SPARKLE_CHARGE_COLOR : SPARKLE_IDLE_COLOR;
+          const el = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          el.setAttribute('cx', cx.toFixed(2));
+          el.setAttribute('cy', cy.toFixed(2));
+          el.setAttribute('r', r.toFixed(2));
+          el.setAttribute('fill', fill);
+          el.setAttribute('pointer-events', 'none');
+          el.setAttribute('opacity', '0');
+          sparkleLayer.appendChild(el);
+          this._sparkles.push({el, cx, cy, r, life: 0, maxLife: SPARKLE_LIFE_S});
+          this._nextSparkleAt += 1 / sparkleRateHz;
+        }
+        if (this._nextSparkleAt < 0) this._nextSparkleAt = 0;
+
+        // Advance + retire active sparkles. Three-phase opacity
+        // curve: fade-in [0, 0.20], hold [0.20, 0.50], fade-out
+        // [0.50, 1.0]. No rising motion (unlike boiler bubbles).
+        const aliveSparkles = [];
+        for (const s of this._sparkles) {
+          s.life += dt;
+          if (s.life >= s.maxLife) {
+            s.el.remove();
+            continue;
+          }
+          const lifeT = s.life / s.maxLife;
+          let opacity;
+          if (lifeT < 0.20) opacity = lifeT / 0.20;
+          else if (lifeT < 0.50) opacity = 1;
+          else opacity = Math.max(0, 1 - (lifeT - 0.50) / 0.50);
+          s.el.setAttribute('opacity', opacity.toFixed(3));
+          aliveSparkles.push(s);
+        }
+        this._sparkles = aliveSparkles;
+      }
+
+      // === QS-232 lightning subsystem =========================
+      // Only spawn when `charging && !degraded`. The advance/retire
+      // loop runs unconditionally for graceful exit (in-flight bolts
+      // complete their fade-out ~0.25s).
+      if (lightningLayer && hasValidBase) {
+        if (charging && !degraded) {
+          this._nextLightningAt -= dt;
+          while (this._nextLightningAt <= 0 && this._lightningBolts.length < MAX_CONCURRENT_LIGHTNING) {
+            // 3-segment jagged path: top → mid (with lateral kink) → surface.
+            const topY = CENTER_CY - CLIP_R + LIGHTNING_TOP_MARGIN_PX;
+            const startCx = CENTER_CX + (Math.random() * 2 - 1) * (CLIP_R * 0.4);
+            const dy = this._waterBaseY - CENTER_CY;
+            const chordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dy * dy));
+            if (chordHalf < 2) {
+              this._nextLightningAt += LIGHTNING_SPAWN_MIN_S +
+                Math.random() * (LIGHTNING_SPAWN_MAX_S - LIGHTNING_SPAWN_MIN_S);
+              continue;
+            }
+            const endCx = CENTER_CX + (Math.random() * 2 - 1) * chordHalf * 0.7;
+            const midY = (topY + this._waterBaseY) / 2;
+            const midCx = (startCx + endCx) / 2 +
+                          (Math.random() * 2 - 1) * LIGHTNING_LATERAL_JITTER_PX;
+            const d = `M ${startCx.toFixed(2)} ${topY.toFixed(2)} L ${midCx.toFixed(2)} ${midY.toFixed(2)} L ${endCx.toFixed(2)} ${this._waterBaseY.toFixed(2)}`;
+            const el = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            el.setAttribute('d', d);
+            el.setAttribute('stroke', LIGHTNING_STROKE_COLOR);
+            el.setAttribute('stroke-width', String(LIGHTNING_STROKE_WIDTH));
+            el.setAttribute('fill', 'none');
+            el.setAttribute('stroke-linecap', 'round');
+            el.setAttribute('pointer-events', 'none');
+            el.setAttribute('opacity', '0');
+            lightningLayer.appendChild(el);
+            this._lightningBolts.push({el, life: 0, maxLife: LIGHTNING_LIFE_S});
+            this._nextLightningAt = LIGHTNING_SPAWN_MIN_S +
+              Math.random() * (LIGHTNING_SPAWN_MAX_S - LIGHTNING_SPAWN_MIN_S);
+          }
+          if (this._nextLightningAt < 0) this._nextLightningAt = 0;
+        }
+
+        // Advance + retire (runs every frame, graceful exit).
+        // Three-phase opacity curve: fade-in [0, 0.10], hold
+        // [0.10, 0.70], fade-out [0.70, 1.0].
+        const aliveBolts = [];
+        for (const b of this._lightningBolts) {
+          b.life += dt;
+          if (b.life >= b.maxLife) {
+            b.el.remove();
+            continue;
+          }
+          const lifeT = b.life / b.maxLife;
+          let opacity;
+          if (lifeT < 0.10) opacity = lifeT / 0.10;
+          else if (lifeT < 0.70) opacity = 1;
+          else opacity = Math.max(0, 1 - (lifeT - 0.70) / 0.30);
+          b.el.setAttribute('opacity', opacity.toFixed(3));
+          aliveBolts.push(b);
+        }
+        this._lightningBolts = aliveBolts;
+      }
+
       this._animRaf = requestAnimationFrame(step);
     };
     this._animRaf = requestAnimationFrame(step);
@@ -60,8 +462,11 @@ class QsCarCard extends HTMLElement {
   }
 
   connectedCallback() {
-    // RAF intentionally NOT started here — _render() calls
-    // _startAnimation() when `_charging` is true.
+    // QS-232: continuous RAF while connected, mirroring
+    // qs-water-boiler-card.js / qs-pool-card.js. The electron-soup
+    // wave is intrinsically visible at all times (idle green / charge
+    // blue / degraded grey) so RAF is no longer gated on `_charging`.
+    this._startAnimation();
   }
 
   disconnectedCallback() {
@@ -73,6 +478,15 @@ class QsCarCard extends HTMLElement {
     this._isInteractingPerson = false;
     this._isInteractingTarget = false;
     this._modalOpen = false;
+    // QS-232: eagerly tear down sparkle and lightning DOM nodes.
+    // Without this they would be GC'd along with the shadow root, but
+    // explicit cleanup is cheap and avoids dangling SVG nodes during
+    // a rapid detach/attach. Optional-chaining shape matches the
+    // boiler bubble / steam teardown pattern.
+    this._sparkles?.forEach(s => s.el?.remove?.());
+    this._sparkles = [];
+    this._lightningBolts?.forEach(b => b.el?.remove?.());
+    this._lightningBolts = [];
   }
   static getStubConfig() {
     return { name: "QS Car", entities: {} };
@@ -166,13 +580,24 @@ class QsCarCard extends HTMLElement {
       const target = selLimit?.state || "";
       const charging = (Number(power) > 50);
       this._charging = charging;
-      // M4: start/stop the RAF loop based on whether the car is actually
-      // charging. Idle cards consume zero per-frame work.
-      if (charging) {
-        this._startAnimation();
-      } else {
-        this._stopAnimation();
+      // QS-232: per-instance unique SVG IDs so two car cards on the
+      // same dashboard don't collide (cheap insurance — households
+      // can plausibly have ≥ 2 cars on one dashboard). Mirrors the
+      // boiler / pool _nextClipId pattern.
+      if (!this._electronClipId) {
+        QsCarCard._nextClipId = (QsCarCard._nextClipId || 0) + 1;
+        const uid = QsCarCard._nextClipId;
+        this._electronClipId    = `car_eClip_${uid}`;
+        this._sparkleLayerId    = `car_sparkLayer_${uid}`;
+        this._lightningLayerId  = `car_lightningLayer_${uid}`;
+        this._grainFilterId     = `car_grainFilter_${uid}`;
+        this._lightningFilterId = `car_lightningFilter_${uid}`;
       }
+      const electronClipId    = this._electronClipId;
+      const sparkleLayerId    = this._sparkleLayerId;
+      const lightningLayerId  = this._lightningLayerId;
+      const grainFilterId     = this._grainFilterId;
+      const lightningFilterId = this._lightningFilterId;
       const carChargeTypeIcons = {
           "Unknown": "mdi:help-circle-outline",
           "Not Plugged": "mdi:power-plug-off",
@@ -547,6 +972,43 @@ class QsCarCard extends HTMLElement {
       //const displayTitle = showForecastedPerson ? `${title} (${forecastedPersonStr})` : title;
       const displayTitle = title;
 
+      // QS-232 D8: degraded state combines disconnected / faulted /
+      // stale. `isOffGrid` is excluded — off-grid keeps the
+      // card-level pinkish tint already applied via the `.off-grid`
+      // CSS class; the soup is unaffected.
+      const degraded = isDisconnected || isFaulted || isStale;
+      // Stash on the instance so the RAF step closure can read it
+      // without re-deriving (and so degraded-state lightning
+      // suppression has a consistent value across the frame).
+      this._degraded = degraded;
+
+      // QS-232 D15: water surface y from SOC fill ratio. Matches the
+      // boiler envelope (`0.2 + ratio × 0.6`) so the visual character
+      // is consistent across the two water-style cards.
+      const progressRatio = Math.max(0, Math.min(1, soc / 100));
+      this._waterBaseY = CENTER_CY + CLIP_R - (0.2 + progressRatio * 0.6) * 2 * CLIP_R;
+
+      // QS-232: prime the wave animation state to the actual charging
+      // targets on the first render after connect, avoiding the
+      // ~1.5s boot transient. Without this, a card mounted while the
+      // car is already charging would visibly lerp up from CALM.
+      if (this._needsAnimationPrime) {
+        this._currentAmplitude = charging ? CHARGE_AMP : CALM_AMP;
+        this._currentSpeed     = charging ? CHARGE_SPEED : CALM_SPEED;
+        this._currentColorMix  = charging ? 1 : 0;
+        this._needsAnimationPrime = false;
+      }
+
+      // QS-232: pre-generate the initial wave path so the SVG renders
+      // with soup immediately, avoiding the empty-`d=""` flash between
+      // the innerHTML rewrite and the first RAF tick. Both idle/charge
+      // siblings share the same `d`; only fill + opacity differ.
+      const initialAmp = this._currentAmplitude ?? CALM_AMP;
+      const initialColorMix = this._currentColorMix ?? 0;
+      const initialWavePath = this._generateWavePath(WAVE_WIDTH, initialAmp, 2, 0, this._waterBaseY);
+      const initialIdleOpacity   = (1 - initialColorMix).toFixed(3);
+      const initialChargeOpacity = initialColorMix.toFixed(3);
+
       this._root.innerHTML = `
       <ha-card class="card ${isDisconnected ? 'disabled' : ''} ${isFaulted ? 'fault' : ''} ${isOffGrid ? 'off-grid' : ''} ${isStale ? 'stale' : ''}">
         <style>${css}</style>
@@ -584,7 +1046,30 @@ class QsCarCard extends HTMLElement {
                     <feMergeNode in="SourceGraphic" />
                   </feMerge>
                 </filter>
+                <filter id="${grainFilterId}" x="-20%" y="-20%" width="140%" height="140%">
+                  <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" seed="3" result="noise" />
+                  <feComposite in="noise" in2="SourceGraphic" operator="in" result="grain" />
+                  <feMerge>
+                    <feMergeNode in="SourceGraphic" />
+                    <feMergeNode in="grain" />
+                  </feMerge>
+                </filter>
+                <filter id="${lightningFilterId}" x="-50%" y="-50%" width="200%" height="200%">
+                  <feGaussianBlur stdDeviation="${LIGHTNING_GLOW_STDDEV}" />
+                </filter>
+                <clipPath id="${electronClipId}">
+                  <circle cx="${CENTER_CX}" cy="${CENTER_CY}" r="${CLIP_R}" />
+                </clipPath>
               </defs>
+              <g clip-path="url(#${electronClipId})" style="${degraded ? 'filter: saturate(0.3) brightness(0.7);' : ''}">
+                <path id="electron_wave_idle" d="${initialWavePath}" fill="${IDLE_SOUP_COLOR}" opacity="${initialIdleOpacity}" filter="url(#${grainFilterId})" pointer-events="none" style="will-change: transform;" />
+                <path id="electron_wave_charge" d="${initialWavePath}" fill="${CHARGE_SOUP_COLOR}" opacity="${initialChargeOpacity}" filter="url(#${grainFilterId})" pointer-events="none" style="will-change: transform;" />
+                <g id="${sparkleLayerId}" pointer-events="none"></g>
+                <g id="${lightningLayerId}" filter="url(#${lightningFilterId})" pointer-events="none" style="mix-blend-mode: screen; will-change: opacity;"></g>
+              </g>
+              ${swPriority ? `<circle id="sun_btn_cover" cx="${SUN_BTN_CARVE_CX}" cy="${SUN_BTN_CARVE_CY}" r="${SUN_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
+              ${e.force_now ? `<circle id="rabbit_btn_cover" cx="${RABBIT_BTN_CARVE_CX}" cy="${RABBIT_BTN_CARVE_CY}" r="${RABBIT_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
+              ${(tNext && e.schedule) ? `<circle id="time_btn_cover" cx="${TIME_BTN_CARVE_CX}" cy="${TIME_BTN_CARVE_CY}" r="${TIME_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
               <path d="${bgPath}" stroke="${isFaulted ? 'rgba(244,67,54,0.35)' : 'var(--divider-color)'}" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${socPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
               ${showAnimation ? `
@@ -655,6 +1140,17 @@ class QsCarCard extends HTMLElement {
         </div>
       </ha-card>
     `;
+
+      // QS-232: innerHTML rewrite just replaced the wave <path> nodes
+      // and the sparkle/lightning layer <g>s. Sync the memo keys to
+      // the freshly-rendered state (prevents a redundant regen on the
+      // next frame) and null cached DOM refs + clear the logical
+      // particle arrays via _resetDomRefs() so subsequent spawns
+      // don't try to advance dead nodes. No snapshot/restore — short
+      // particle life (≤ 0.45s) makes nuke-and-respawn imperceptible.
+      this._lastWaterBaseY = this._waterBaseY;
+      this._lastAmplitude  = this._currentAmplitude ?? CALM_AMP;
+      this._resetDomRefs();
 
       // old buttons:
 /*      <div className="below-line">

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -73,10 +73,14 @@ const CHARGE_SPEED = 0.15;          // still gentle
 
 // --- Sparkles ("electrons popping in the water") ---
 // Idle: always visible, very few, very small, green.
+// Review-fix #01 #2: radii roughly doubled from the initial QS-232
+// constants — user reported the electron pops barely read in the
+// rendered card. Final values pinned visually against the user's
+// reference car configuration.
 const SPARKLE_IDLE_MAX = 4;
 const SPARKLE_IDLE_RATE_HZ = 0.6;
-const SPARKLE_IDLE_RADIUS_MIN = 0.8;
-const SPARKLE_IDLE_RADIUS_MAX = 1.6;
+const SPARKLE_IDLE_RADIUS_MIN = 1.6;
+const SPARKLE_IDLE_RADIUS_MAX = 3.0;
 const SPARKLE_IDLE_COLOR = 'hsla(140, 90%, 70%, 0.9)';
 // Charging endpoints — scale linearly on [SPARKLE_POWER_MIN_W, SPARKLE_POWER_MAX_W].
 // Below MIN (but still `_charging`) the values clamp to the MIN-power
@@ -89,10 +93,10 @@ const SPARKLE_CHARGE_MAX_AT_MIN_POWER = 12;
 const SPARKLE_CHARGE_MAX_AT_MAX_POWER = 28;
 const SPARKLE_CHARGE_RATE_HZ_AT_MIN_POWER = 3;
 const SPARKLE_CHARGE_RATE_HZ_AT_MAX_POWER = 10;
-const SPARKLE_CHARGE_RADIUS_MIN_AT_MIN_POWER = 1.2;
-const SPARKLE_CHARGE_RADIUS_MAX_AT_MIN_POWER = 2.5;
-const SPARKLE_CHARGE_RADIUS_MIN_AT_MAX_POWER = 1.8;
-const SPARKLE_CHARGE_RADIUS_MAX_AT_MAX_POWER = 3.5;
+const SPARKLE_CHARGE_RADIUS_MIN_AT_MIN_POWER = 2.4;
+const SPARKLE_CHARGE_RADIUS_MAX_AT_MIN_POWER = 4.5;
+const SPARKLE_CHARGE_RADIUS_MIN_AT_MAX_POWER = 3.4;
+const SPARKLE_CHARGE_RADIUS_MAX_AT_MAX_POWER = 6.5;
 const SPARKLE_CHARGE_COLOR = '#00E5FF';   // electric "lightning blue"
 const SPARKLE_LIFE_S = 0.45;
 
@@ -108,7 +112,9 @@ const LIGHTNING_STROKE_WIDTH = 1.8;
 const LIGHTNING_GLOW_STDDEV = 2.5;
 const LIGHTNING_TOP_MARGIN_PX = 4;
 const LIGHTNING_LATERAL_JITTER_PX = 18;
-const LIGHTNING_SEGMENTS = 3;
+// Review-fix #01 #16: removed unused `LIGHTNING_SEGMENTS = 3` —
+// the lightning path hardcodes its three `L` segments inline rather
+// than driving an emission loop, so the constant served no purpose.
 
 // --- Inside-disc button carve-out covers (QS-232 D17) ---
 // Mirror of QS-217 for THREE buttons that sit inside the clip disc:
@@ -118,14 +124,17 @@ const LIGHTNING_SEGMENTS = 3;
 // coordinates here track those positions. Integer values are
 // intentionally user-tunable for visual iteration — tests pin the
 // constant NAMES only (mirrors the QS-217 precedent).
+// Review-fix #01 #1: bumped all three CY values down from the
+// initial QS-232 estimates after a user screenshot showed the
+// holes drawn above the actual button centers.
 const SUN_BTN_CARVE_CX = 160;       // bottom-center of stack
-const SUN_BTN_CARVE_CY = 267;
+const SUN_BTN_CARVE_CY = 285;
 const SUN_BTN_CARVE_R  = 32;
 const RABBIT_BTN_CARVE_CX = 96;     // left column of mini-grid
-const RABBIT_BTN_CARVE_CY = 180;
+const RABBIT_BTN_CARVE_CY = 195;
 const RABBIT_BTN_CARVE_R  = 32;
 const TIME_BTN_CARVE_CX = 224;      // right column of mini-grid
-const TIME_BTN_CARVE_CY = 180;
+const TIME_BTN_CARVE_CY = 195;
 const TIME_BTN_CARVE_R  = 32;
 
 class QsCarCard extends HTMLElement {
@@ -166,7 +175,10 @@ class QsCarCard extends HTMLElement {
   // `test_water_boiler_card_factors_reset_dom_refs_helper`).
   _resetDomRefs() {
     this._waveEls = null;             // [idleWave, chargeWave]
-    this._grainFilterEl = null;
+    // Review-fix #01 #14: removed `_grainFilterEl` — no code path
+    // ever read or lazily-resolved it. The grain filter is declared
+    // once in `<defs>` and referenced by the wave paths via
+    // `filter="url(#${grainFilterId})"`; no JS-side ref needed.
     this._sparkleLayerEl = null;
     this._lightningLayerEl = null;
     this._sparkles = [];
@@ -196,6 +208,13 @@ class QsCarCard extends HTMLElement {
   // below — `showAnimation` remains its render-time switch.
   _startAnimation() {
     if (this._animRaf != null) return;
+    // Review-fix #01 #22: bail if `_root` isn't yet attached. A
+    // `connectedCallback` that fires before `setConfig` would
+    // otherwise spin RAF with every DOM lookup returning null. The
+    // re-entry happens via `setConfig` → `_render` (which doesn't
+    // call `_startAnimation` directly today) — for safety, we also
+    // re-attempt from `connectedCallback` if it runs first.
+    if (!this._root) return;
     // Lazy-init: runs ONCE on first connect, preserved across
     // detach/re-attach so `_currentAmplitude` / `_wavePhase` /
     // `_currentColorMix` don't snap back on tab navigation.
@@ -227,11 +246,12 @@ class QsCarCard extends HTMLElement {
       dt = Math.min(dt, LERP_DT_CEIL);
       this._lastAnimTs = ts;
 
-      // --- Existing dashed-arc animation (PRESERVED from M4).
-      // The dashed `<path id="charge_anim">` still drives off
-      // `showAnimation`, which is now applied as a render-time switch
-      // on the element. The RAF loop itself no longer gates on
-      // `_charging` (D9).
+      // --- Existing dashed-arc animation (preserved from the prior
+      //     car-card revision). The dashed `<path id="charge_anim">`
+      //     still drives off `showAnimation`, which is applied as a
+      //     render-time switch on the element. The RAF loop itself
+      //     is no longer gated on `_charging` — QS-232 D9 migrated
+      //     the card to the continuous-RAF model.
       const patternLen = Math.max(8, this._animPatternLen || 64);
       const cp = this._chargePower || 0;
       const dashSpeed = Math.min(ANIM_MAX_SPEED, Math.max(ANIM_MIN_SPEED, ANIM_MIN_SPEED + (cp - ANIM_MIN_POWER_W) * ANIM_SPEED_RANGE / ANIM_POWER_RANGE));
@@ -258,6 +278,8 @@ class QsCarCard extends HTMLElement {
 
       // --- Lazy-resolve wave / sparkle / lightning DOM refs once per
       //     innerHTML rewrite (two wave nodes — idle + charge).
+      //     Review-fix #01 #15: `getElementById` already returns
+      //     `null` on miss; the prior inner `?? null` was redundant.
       if (!this._waveEls) {
         const idleEl   = this._root?.getElementById('electron_wave_idle')   ?? null;
         const chargeEl = this._root?.getElementById('electron_wave_charge') ?? null;
@@ -265,11 +287,11 @@ class QsCarCard extends HTMLElement {
       }
       const sparkleLayer = this._sparkleLayerEl
         ?? (this._sparkleLayerEl = this._sparkleLayerId
-              ? (this._root?.getElementById(this._sparkleLayerId) ?? null)
+              ? this._root?.getElementById(this._sparkleLayerId)
               : null);
       const lightningLayer = this._lightningLayerEl
         ?? (this._lightningLayerEl = this._lightningLayerId
-              ? (this._root?.getElementById(this._lightningLayerId) ?? null)
+              ? this._root?.getElementById(this._lightningLayerId)
               : null);
 
       // --- Wave transform (single layer translateX).
@@ -302,9 +324,13 @@ class QsCarCard extends HTMLElement {
 
       // --- Per-frame wave opacity (idle ↔ charge cross-fade).
       // Dual-layer opacity rather than HSL lerp — passing through
-      // yellow at the midpoint is artifact-prone.
-      const idleOpacity   = (1 - this._currentColorMix).toFixed(3);
-      const chargeOpacity = this._currentColorMix.toFixed(3);
+      // yellow at the midpoint is artifact-prone. Review-fix #01 #18:
+      // clamp `_currentColorMix` to `[0, 1]` for opacity emission so
+      // floating-point lerp drift (e.g., `1.0000000001`) doesn't
+      // surface as ugly `"-0.000"` opacity tokens.
+      const mix = Math.max(0, Math.min(1, this._currentColorMix));
+      const idleOpacity   = (1 - mix).toFixed(3);
+      const chargeOpacity = mix.toFixed(3);
       if (idleWave)   idleWave.setAttribute('opacity', idleOpacity);
       if (chargeWave) chargeWave.setAttribute('opacity', chargeOpacity);
 
@@ -317,9 +343,12 @@ class QsCarCard extends HTMLElement {
       if (sparkleLayer && hasValidBase) {
         // Power-scaling for the charging endpoints (clamped to
         // [SPARKLE_POWER_MIN_W, SPARKLE_POWER_MAX_W]).
+        // Review-fix #01 #20: defensively floor negative chargePower
+        // (V2L discharge / sensor glitch) to 0 at the source so
+        // downstream scaling never receives a negative `power`.
         let sparkleMax, sparkleRateHz, rMin, rMax;
         if (charging) {
-          const power = this._chargePower || 0;
+          const power = Math.max(0, this._chargePower || 0);
           const clamped = Math.max(SPARKLE_POWER_MIN_W, Math.min(SPARKLE_POWER_MAX_W, power));
           const t = (clamped - SPARKLE_POWER_MIN_W) / (SPARKLE_POWER_MAX_W - SPARKLE_POWER_MIN_W);
           sparkleMax = SPARKLE_CHARGE_MAX_AT_MIN_POWER + t * (SPARKLE_CHARGE_MAX_AT_MAX_POWER - SPARKLE_CHARGE_MAX_AT_MIN_POWER);
@@ -332,9 +361,14 @@ class QsCarCard extends HTMLElement {
           rMin = SPARKLE_IDLE_RADIUS_MIN;
           rMax = SPARKLE_IDLE_RADIUS_MAX;
         }
+        // Review-fix #01 #19: `Math.floor(sparkleMax)` for the
+        // concurrent-cap comparison so a fractional max (e.g. 18.5
+        // from linear interpolation between 12 and 28) doesn't read
+        // confusingly when compared against `length`.
+        const sparkleCap = Math.floor(sparkleMax);
 
         this._nextSparkleAt -= dt;
-        while (this._nextSparkleAt <= 0 && this._sparkles.length < sparkleMax) {
+        while (this._nextSparkleAt <= 0 && this._sparkles.length < sparkleCap) {
           // Spawn position: random inside the water portion of the
           // clip circle. `continue`-with-cadence-advance pattern
           // (no `break`) avoids a per-frame spin-loop on degenerate
@@ -372,10 +406,13 @@ class QsCarCard extends HTMLElement {
         // Advance + retire active sparkles. Three-phase opacity
         // curve: fade-in [0, 0.20], hold [0.20, 0.50], fade-out
         // [0.50, 1.0]. No rising motion (unlike boiler bubbles).
+        // Review-fix #01 #21: retire slightly before maxLife so a
+        // sparkle whose `lifeT` lands exactly on `1.0` doesn't
+        // linger one frame at opacity 0 before the next-tick retire.
         const aliveSparkles = [];
         for (const s of this._sparkles) {
           s.life += dt;
-          if (s.life >= s.maxLife) {
+          if (s.life >= s.maxLife * 0.999) {
             s.el.remove();
             continue;
           }
@@ -423,7 +460,13 @@ class QsCarCard extends HTMLElement {
             el.setAttribute('opacity', '0');
             lightningLayer.appendChild(el);
             this._lightningBolts.push({el, life: 0, maxLife: LIGHTNING_LIFE_S});
-            this._nextLightningAt = LIGHTNING_SPAWN_MIN_S +
+            // Review-fix #01 #12: use `+=` (cadence accumulation) for
+            // symmetry with the degenerate-chord `continue` branch
+            // above AND with the sparkle subsystem — both spawn
+            // paths advance the cadence counter identically, and the
+            // post-loop clamp `if (… < 0) … = 0` below absorbs any
+            // backlog drift.
+            this._nextLightningAt += LIGHTNING_SPAWN_MIN_S +
               Math.random() * (LIGHTNING_SPAWN_MAX_S - LIGHTNING_SPAWN_MIN_S);
           }
           if (this._nextLightningAt < 0) this._nextLightningAt = 0;
@@ -467,6 +510,20 @@ class QsCarCard extends HTMLElement {
     // wave is intrinsically visible at all times (idle green / charge
     // blue / degraded grey) so RAF is no longer gated on `_charging`.
     this._startAnimation();
+    // Review-fix #01 #7: re-prime on reconnect ONLY when the implied
+    // colorMix state diverged from the actual `_charging` during the
+    // detached interval. Without this, the lazy-init guard in
+    // `_startAnimation()` preserves the pre-detach `_currentColorMix`
+    // across reconnect, so a state-flip mid-detach causes the soup to
+    // visibly lerp on reattach rather than snap. The `?? 0` fallback
+    // covers the very first connect (before lazy-init has run), where
+    // both _charging and _currentColorMix are still at their initial
+    // values — the equation `(false ? 1 : 0) !== Math.round(0)`
+    // evaluates `0 !== 0`, so no spurious prime fires.
+    const impliedMix = Math.round(this._currentColorMix ?? 0);
+    if ((this._charging ? 1 : 0) !== impliedMix) {
+      this._needsAnimationPrime = true;
+    }
   }
 
   disconnectedCallback() {
@@ -496,6 +553,16 @@ class QsCarCard extends HTMLElement {
     if (!config || !config.entities) throw new Error("entities is required");
     this._config = config;
     this._root = this.attachShadow({ mode: "open" });
+    // Review-fix #01 #4: arm the priming flag so the FIRST `_render()`
+    // below — which runs from `setConfig`, BEFORE `connectedCallback`
+    // fires — primes `_currentAmplitude` / `_currentSpeed` /
+    // `_currentColorMix` against the about-to-be-computed `_charging`
+    // state. Without this, the first paint always uses
+    // `initialAmp = CALM_AMP` and `initialColorMix = 0` (idle palette)
+    // regardless of `_charging`, and either the RAF lerps visibly
+    // over ~1.5 s or a quick hass push snaps the values
+    // (green-to-blue flash).
+    this._needsAnimationPrime = true;
     this._render();
   }
 
@@ -985,7 +1052,13 @@ class QsCarCard extends HTMLElement {
       // QS-232 D15: water surface y from SOC fill ratio. Matches the
       // boiler envelope (`0.2 + ratio × 0.6`) so the visual character
       // is consistent across the two water-style cards.
-      const progressRatio = Math.max(0, Math.min(1, soc / 100));
+      // Review-fix #01 #3: guard `soc` against NaN (a non-numeric
+      // `current_inputed_energy` state in `useEnergyMode`, or a
+      // corrupted percent reading) so the resulting `_waterBaseY`
+      // never propagates `NaN` into the SVG `d` attribute. Mirrors
+      // the boiler's `Number.isFinite(displayTargetHours)` guard.
+      const safeSoc = Number.isFinite(soc) ? soc : 0;
+      const progressRatio = Math.max(0, Math.min(1, safeSoc / 100));
       this._waterBaseY = CENTER_CY + CLIP_R - (0.2 + progressRatio * 0.6) * 2 * CLIP_R;
 
       // QS-232: prime the wave animation state to the actual charging
@@ -1003,9 +1076,17 @@ class QsCarCard extends HTMLElement {
       // with soup immediately, avoiding the empty-`d=""` flash between
       // the innerHTML rewrite and the first RAF tick. Both idle/charge
       // siblings share the same `d`; only fill + opacity differ.
+      // Review-fix #01 #5: belt-and-braces guard at the call site —
+      // even with the upstream `safeSoc` guard, a regression that
+      // bypasses it would still poison the emitted `d` attribute.
+      // Wrapping the `_generateWavePath(...)` call with a
+      // `Number.isFinite(this._waterBaseY)` ternary makes the empty-
+      // string fallback explicit at the call site.
       const initialAmp = this._currentAmplitude ?? CALM_AMP;
       const initialColorMix = this._currentColorMix ?? 0;
-      const initialWavePath = this._generateWavePath(WAVE_WIDTH, initialAmp, 2, 0, this._waterBaseY);
+      const initialWavePath = Number.isFinite(this._waterBaseY)
+        ? this._generateWavePath(WAVE_WIDTH, initialAmp, 2, 0, this._waterBaseY)
+        : '';
       const initialIdleOpacity   = (1 - initialColorMix).toFixed(3);
       const initialChargeOpacity = initialColorMix.toFixed(3);
 
@@ -1106,7 +1187,7 @@ class QsCarCard extends HTMLElement {
                     <div id="target_value" class="target-value">${displayTargetValue}</div>
                     ${useEnergyMode ? '' : `<div class="mini-range-target" aria-label="range at target">${rangeTargetStr}</div>`}
                   </div>
-                  <div id="time_btn" class="time-btn ${chargeTime && chargeTime !== '--:--' ? 'on' : ''}">${chargeTime}</div>
+                  ${(tNext && e.schedule) ? `<div id="time_btn" class="time-btn ${chargeTime && chargeTime !== '--:--' ? 'on' : ''}">${chargeTime}</div>` : ''}
                 </div>
                 </div>
                 <div class="center-controls" style="flex-direction:column; gap:4px;">
@@ -1149,7 +1230,13 @@ class QsCarCard extends HTMLElement {
       // don't try to advance dead nodes. No snapshot/restore — short
       // particle life (≤ 0.45s) makes nuke-and-respawn imperceptible.
       this._lastWaterBaseY = this._waterBaseY;
-      this._lastAmplitude  = this._currentAmplitude ?? CALM_AMP;
+      // Review-fix #01 #8: `??` does NOT trap NaN — if
+      // `_currentAmplitude` ever became NaN, the prior form would
+      // assign NaN to `_lastAmplitude`, making `ampDelta` always NaN
+      // (i.e. always `< AMP_REGEN_THRESHOLD`), and the wave-path
+      // regen would freeze for the lifetime of the card. Use an
+      // explicit `Number.isFinite` check instead.
+      this._lastAmplitude  = Number.isFinite(this._currentAmplitude) ? this._currentAmplitude : CALM_AMP;
       this._resetDomRefs();
 
       // old buttons:

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -670,10 +670,14 @@ patterns after the cross-card audit:
 - **RAF idle-gating (M4).** Each card defines `_startAnimation()` and
   `_stopAnimation()` helpers. The render path starts/stops the
   animation conditionally — on `showAnimation` for the
-  duration-based cards, on `_charging` for the car card, and
-  continuously while connected for the pool wave (intrinsically
-  visible). `connectedCallback` no longer kicks off RAF
-  unconditionally; `disconnectedCallback` always stops it.
+  duration-based cards (`qs-on-off-duration-card`, `qs-radiator-card`,
+  `qs-climate-card`) — and continuously while connected for the
+  three water-style cards (`qs-pool-card`, `qs-water-boiler-card`,
+  and `qs-car-card` per QS-232) whose wave is intrinsically visible.
+  `disconnectedCallback` always stops the loop. The
+  `_charging`-gated form previously used by `qs-car-card.js` was
+  retired by QS-232 — see "QS-232 — Car-card electron-soup
+  animation" above.
 - **try/finally around service calls (M2).** Every
   `_isProcessing*` flag setter is wrapped in `try { await
   this._select(...) } finally { setTimeout(() => _isProcessing... =

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -547,6 +547,121 @@ overlay sidesteps the issue entirely — the patch is a `<circle>`
 by construction, so the user sees a circle on screen. No lens
 shape possible.
 
+### QS-232 — Car-card electron-soup animation
+
+QS-232 transplants the QS-200 / QS-211 / QS-214 boiler architecture
+onto `qs-car-card.js`. The car's SOC reads as a translucent
+"electron soup" inside the ring's clip circle: one slowly-moving
+sine layer, lightning-blue sparkle particles popping inside the
+soup ("electrons popping in the water"), and lightning bolts
+flashing from the top of the clip circle to the soup surface when
+the car is charging. The animation tracks the existing already-
+mode-normalised `soc` variable (0–100), and the wave-level
+mapping `0.2 + ratio × 0.6` matches the boiler envelope so the
+visual character is consistent across the two water-style cards.
+
+**Single-layer wave with dual-opacity cross-fade.** The issue
+explicitly asks "do not superpose 3 layer of sin". The clipped
+`<g clip-path="url(#${electronClipId})">` group contains ONE
+`_generateWavePath(...)`-derived `d` string applied to TWO stacked
+`<path>` siblings (`electron_wave_idle` and `electron_wave_charge`)
+that share geometry but differ in `fill` (`IDLE_SOUP_COLOR`
+`hsla(140, 80%, 50%, 0.12)` vs `CHARGE_SOUP_COLOR`
+`hsla(180, 90%, 55%, 0.25)`) and `opacity`. The cross-fade is
+binary: `_currentColorMix` lerps toward `_charging ? 1 : 0` with
+`LERP_RATE = 2` (≈ 0.5 s time constant). Idle opacity =
+`1 - colorMix`; charge opacity = `colorMix`. This is the same
+dual-opacity idiom as the boiler's cool/boil cross-fade, adapted
+to a single layer (boiler renders 6 paths; car renders 2).
+
+**Sparkle palette switch + power-scaling.** Sparkles are always
+visible. Idle: green (`SPARKLE_IDLE_COLOR` `hsla(140, 90%, 70%, 0.9)`),
+very few (max 4), very small (radius 0.8–1.6 px), fixed spawn
+rate `SPARKLE_IDLE_RATE_HZ = 0.6`. Charging: lightning blue
+(`SPARKLE_CHARGE_COLOR` `#00E5FF`), with density, spawn-rate and
+radius all scaling LINEARLY with charge power on the range
+`[SPARKLE_POWER_MIN_W, SPARKLE_POWER_MAX_W] = [1500, 22000]` W —
+12–28 max concurrent, 3–10 Hz spawn rate, 1.2–3.5 px radius. Below
+1500 W (but still `_charging`) the values clamp to the
+1500 W MIN endpoint per user intent (1500 W = MIN charging
+density, NOT a ramp from 0 W). The idle→charging boundary at 50 W
+is therefore a deliberate visible step in density and colour. Each
+sparkle's `fill` attribute is decided ONCE at spawn from the
+then-current `_charging` value and never re-assigned in the
+advance loop — when `_charging` flips, new sparkles spawn with
+the new colour while in-flight sparkles complete their natural
+~0.45 s fade (a brief mixed-palette tail).
+
+**Lightning bolts.** Only spawn when `charging && !degraded`. Each
+bolt is a 3-segment jagged `<path d="M start L mid L end">`
+(NOT polyline — `<path>` is consistent with the boiler precedent
+and lets tests pin the `d=` attribute), starting near the top of
+the clip circle, kinking laterally at the midpoint, and ending on
+the water surface within the chord. Life is
+`LIGHTNING_LIFE_S = 0.25` s with a three-phase opacity curve
+(fade-in `[0, 0.10]`, hold `[0.10, 0.70]`, fade-out `[0.70, 1.0]`).
+Spawn interval is randomised on
+`[LIGHTNING_SPAWN_MIN_S, LIGHTNING_SPAWN_MAX_S] = [1.5, 3.0]` s, capped at
+`MAX_CONCURRENT_LIGHTNING = 3` simultaneous bolts. The advance /
+retire loop sits OUTSIDE the spawn gate so in-flight bolts
+complete their fade naturally when charging stops. Glow is provided
+by a single `<filter id="${lightningFilterId}">` with
+`<feGaussianBlur stdDeviation="${LIGHTNING_GLOW_STDDEV}">` plus
+`mix-blend-mode: screen` on the layer `<g>`.
+
+**feTurbulence grain on wave fill.** The fuzzy granularity comes
+from a single `<filter id="${grainFilterId}">` declaring
+`<feTurbulence type="fractalNoise" baseFrequency="0.9"
+numOctaves="2" …>`, composited against `SourceGraphic` via
+`<feComposite operator="in">` so the grain is masked to the
+wave's filled shape (water region only). Both wave `<path>`
+elements carry `filter="url(#${grainFilterId})"`. There is NO
+separate overlay `<rect>` — the grain naturally ends at the wave
+surface and is automatically clipped to the soup boundary.
+
+**Degraded state CSS filter.** When `degraded === true` (computed
+as `isDisconnected || isFaulted || isStale` — `isOffGrid` is
+explicitly excluded; the card-level pinkish `.off-grid` CSS class
+already covers it), the clipped `<g>` carries the inline style
+`filter: saturate(0.3) brightness(0.7);`. This is a runtime CSS
+filter swap, NOT a third entry in the `_currentColorMix` lerp —
+the lerp stays binary idle↔charge. Sparkles still spawn at idle
+rate with idle-green colour (the CSS filter desaturates them);
+lightning is suppressed entirely (`if (charging && !degraded)`
+spawn gate), and in-flight bolts complete their natural fade.
+
+**Continuous-RAF model.** The car card was migrated out of the
+`_charging`-gated `test_card_raf_idle_gated` parametrize list
+(previously gated on `charging`) and into the
+`test_card_caps_raf_dt_against_hidden_tab` list (joining the
+pool and water-boiler cards). `connectedCallback()` now calls
+`this._startAnimation()` directly. The dt cap
+`LERP_DT_CEIL = 0.1` clamps the first frame after a hidden-tab
+return so phase advance and sparkle / lightning life increments
+don't burst. The existing dashed-arc animation
+(`<path id="charge_anim">`) is preserved verbatim, and
+`showAnimation` remains its render-time switch.
+
+**D17 — three carve-cover overlays.** Unlike the
+boiler / radiator / climate cards which carry only one
+`override_reset` button cover (QS-217), the car card has THREE
+buttons sitting inside the clip disc: the `sun-btn`
+(`<div id="sun_btn">`, Solar priority, bottom-center stack), the
+`rabbit-btn` (`<div id="rabbit_btn">`, Force now, left column of
+the mini-grid), and the `time-btn` (`<div id="time_btn">`,
+Finish time, right column of the mini-grid). Each gets a
+QS-217-style `<circle id="…_cover" fill="var(--card-background-color)"
+pointer-events="none" />` drawn AFTER the closing `</g>` of the
+clipped animation group and BEFORE the `<path d="${bgPath}"`
+outer-ring stroke, gated on its corresponding render predicate —
+`swPriority` for `sun_btn_cover`, `e.force_now` for
+`rabbit_btn_cover`, `(tNext && e.schedule)` for `time_btn_cover`.
+The CY/CX integer values are user-tunable; tests pin the constant
+NAMES only (mirrors the QS-217 R-tuning iteration). The
+`target_handle` circle (already on the ring stroke at radius
+`ringCirc = 130`) does NOT need a carve — it sits outside the
+clip disc by construction.
+
 ## Hardened JS-card patterns (QS-194 review-fix #03)
 
 Every JS card in `ui/resources/` follows the same defensive

--- a/docs/stories/QS-232.story.md
+++ b/docs/stories/QS-232.story.md
@@ -1,0 +1,1143 @@
+---
+issue: 232
+title: Car SVG — electron soup SOC animation with sparkles and lightning bolts
+branch: QS_232
+status: ready-for-dev
+next_phase: implement-task
+labels: [area:ui, area:car, area:docs]
+---
+
+# QS-232 — Car SVG: electron soup SOC animation with sparkles and lightning bolts
+
+## Why
+
+Issue [#232](https://github.com/tmenguy/quiet-solar/issues/232) asks
+for an animation on `qs-car-card.js` paralleling the QS-200/QS-211/
+QS-214 architecture on `qs-water-boiler-card.js`. The car's SOC level
+should read as an "electron soup" — translucent green water-like fill
+with **one** slowly-moving sine layer, lightning-blue sparkle particles
+inside the soup ("electrons popping"), and lightning bolts flashing
+from the top of the clip circle to the soup surface when charging.
+
+**User clarifications obtained during planning:**
+
+1. **Sparkles** are always visible. Idle: green (lightened, less
+   transparent than the soup), very few, very small. Charging: blue
+   ("lightning blue"). Charging spawn-rate + max-concurrent + radius
+   scale **linearly with charge power** on `[1500W, 22000W]`; below
+   1500W (but `_charging === true`) the charging visuals clamp to the
+   1500W MIN values. Idle uses a fixed low rate independent of power.
+2. **Lightning bolts** only when `_charging === true`.
+3. The single sine **always animates** — very slow when idle, slightly
+   more lively when charging.
+4. **Degraded states** (`isDisconnected || isFaulted || isStale`):
+   render the soup with a **greyscale tint** (CSS filter on the clip
+   group) and **suppress lightning entirely**.
+5. **Fuzzy granularity** implemented via `feTurbulence type="fractalNoise"`
+   applied to the wave path's fill (not a separate overlay rect).
+6. Soup level tracks the displayed arc — uses the existing already-
+   mode-normalised `soc` variable (0–100).
+
+**Override-button-cover scope correction (user follow-up):** unlike
+the boiler/radiator/climate which only carry one `override_reset`
+button at bottom-centre of the ring, the car card has **three**
+inside-the-clip-disc buttons whose legibility degrades when the soup
++ sparkles + lightning are painted underneath them. QS-217's
+`<circle>` cover-overlay pattern is extended to all three:
+`sun-btn` (Solar priority), `rabbit-btn` (Force now), `time-btn`
+(Finish time). See D17.
+
+**Explicit instruction granted by issue #232** — this story
+overrides the [project-context.md](../workflow/project-context.md)
+rule "Custom JS card code should not be modified without explicit
+instruction" (mirrors the QS-200 grant).
+
+## Inputs
+
+- `custom_components/quiet_solar/ui/resources/qs-car-card.js` — the
+  only file with behavioural changes (~1232 LOC today → ~1700 LOC).
+- `tests/test_dashboard_rendering.py` — append new module-level
+  structural tests in a `# === QS-232 …` section after the existing
+  QS-214 boiler steam test cluster (insertion anchor pinned in T0).
+  ALSO modify two existing parametrized tests (T6 / T0 side-effects):
+  remove the `("qs-car-card.js", "charging")` tuple from
+  `test_card_raf_idle_gated` (L1820), and ADD `"qs-car-card.js"` to
+  `test_card_caps_raf_dt_against_hidden_tab` (L1889-1894).
+- `docs/agents/concepts/dashboard-and-cards.md` — append a new
+  H3 section `### QS-232 — Car-card electron-soup animation` AFTER
+  the existing QS-217 H3 section and BEFORE the
+  "## Hardened JS-card patterns" H2 header. `covers:` already includes
+  `qs-car-card.js` (line 9) — no frontmatter change. Update
+  `last_verified` to `2026-05-25` if older.
+
+### Existing identifiers reused (read-only contract)
+
+These identifiers live in `qs-car-card.js` today. The new subsystem
+consumes them without renaming.
+
+| Identifier | Where | Meaning |
+|---|---|---|
+| `_charging` | instance field set in `_render()` (L168) | `Number(power) > 50` |
+| `_chargePower` | instance field set in `_render()` (L165) | raw W from power sensor |
+| `ANIM_MIN_POWER_W = 500`, `ANIM_MAX_POWER_W = 22000` | module constants (L10-11) | existing dash-speed scaling range — sparkle scaling uses **different** anchors (1500W not 500W) |
+| `_startAnimation()`, `_stopAnimation()` | instance methods (L27-60) | RAF lifecycle; currently `_charging`-gated, will become continuous |
+| `_animOffset`, `_animPatternLen`, `_lastAnimTs`, `_animRaf` | instance fields used by the dashed-arc loop | MUST be preserved (drive the existing `charge_anim` dashed arc) |
+| `connectedCallback()` | currently does NOT start RAF (L62-65) | will START RAF directly (D9) |
+| `disconnectedCallback()` | resets interaction flags (L67-76) | extended to tear down particle DOM |
+| `_render()` `soc` normalisation block | L222-282 | three display modes (`isStalePercentMode`, `useEnergyMode`, else) end with `soc` as a 0–100 fill ratio |
+| `center.cx = 160`, `center.cy = 160`, `ringCirc = 130` | L488-489 | ring geometry; new constants `CENTER_CX / CENTER_CY = 160` are introduced module-level for cross-reference with the clip circle |
+| `showAnimation` (L543) | render-time flag | PRESERVED for the existing dashed `<path id="charge_anim">` only; new soup/sparkles/lightning are NOT gated on `showAnimation` |
+| `isStale`, `isFaulted`, `isDisconnected`, `isOffGrid` | `_render()` locals (L160-162, L513-515) | source of the new `degraded` boolean |
+| `_modalOpen`, `_isInteracting*` | interaction flags (L100-105) | unchanged; new code does not touch them |
+| Boiler precedent | `qs-water-boiler-card.js` | QS-200 wave architecture (L33-99, 220-242, 1085-1094, 1199-1219, 1382-1437); QS-211 steam (L116-144, 463-586); QS-214 snapshot/restore (L1199-1219 / 1382-1437); QS-217 carve cover (L62-63, L1290) — all transplanted into the car card |
+
+## Out of scope
+
+- Other cards (`qs-water-boiler-card.js`, `qs-pool-card.js`,
+  `qs-climate-card.js`, `qs-radiator-card.js`,
+  `qs-on-off-duration-card.js`). No cross-card refactor.
+- Sound effects, click/tap interactivity, configurable density/colour
+  via card YAML.
+- Backend / `ha_model/car.py` changes.
+- `prefers-reduced-motion` accessibility fallback (matches QS-200/211
+  deferral).
+- Refactoring existing wave/RAF code on other cards.
+- Snapshot/restore of in-flight particles across `innerHTML`
+  rewrites (DROPPED by adversarial review — sparkle life 0.45s and
+  lightning life 0.25s are short enough that a wipe-and-respawn is
+  imperceptible; the QS-214 engineering effort is not justified
+  here).
+- Extracting shared modules between cards: animation constants and
+  helper blocks are **duplicated in-file** in `qs-car-card.js`,
+  matching the radiator-card precedent
+  ([dashboard-and-cards.md line ~195](../agents/concepts/dashboard-and-cards.md)).
+
+## Design decisions
+
+### D1 — Single sine wave
+Issue explicitly: "do not superpose 3 layer of sin, only one". The
+clipped group contains **one** `_generateWavePath(...)`-derived `d`
+string applied to **two stacked `<path>` siblings** that share
+geometry but differ in `fill` and `opacity` — the QS-200 dual-opacity
+cross-fade idiom adapted to a single layer. The boiler renders 6
+paths (3 layers × cool/boil pair); the car renders **2** (1 layer ×
+idle/charge pair).
+
+### D2 — Wave palette (dual-opacity cross-fade)
+- `IDLE_SOUP_COLOR = 'hsla(140, 80%, 50%, 0.12)'` — very translucent
+  electric green.
+- `CHARGE_SOUP_COLOR = 'hsla(180, 90%, 55%, 0.25)'` — bluer, slightly
+  less transparent.
+
+The cross-fade is binary: `_currentColorMix` lerps toward
+`_charging ? 1 : 0` with `LERP_RATE = 2` (≈ 0.5 s time constant). Idle
+layer opacity = `1 - colorMix`; charge layer opacity = `colorMix`.
+The **degraded** state is NOT folded into the cross-fade — it's a
+runtime CSS filter on the entire clipped `<g>` (D8). This keeps the
+lerp math binary and the palette logic free of three-way state.
+
+### D3 — Geometry constants
+Module-level `const`s mirroring the boiler:
+```js
+const CENTER_CX = 160;
+const CENTER_CY = 160;
+const CLIP_R = 120;        // 10 px inside ringCirc=130, same as boiler
+const WAVE_WIDTH = 480;    // 2 × CLIP_R × 2 — single period
+const WAVE_BOTTOM_Y = 400; // closing rectangle Y; clipped by the circle
+```
+Pinned by an AC (geometry test).
+
+### D4 — Wave amp / speed targets
+- `CALM_AMP = 1.2`, `CALM_SPEED = 0.03` (very slow per issue).
+- `CHARGE_AMP = 3.5`, `CHARGE_SPEED = 0.15` (still gentle).
+- `LERP_RATE = 2`. Same lerp envelope as boiler.
+- `PHASE_TO_PX = 60`, `PHASE_WRAP = 1e6` — mirror boiler.
+
+### D5 — Sparkles ("electrons popping in the water")
+**Always visible**, color and density depend on state.
+
+Constants (single naming scheme — pinned to avoid the C1 critic
+finding):
+```js
+const SPARKLE_IDLE_MAX = 4;
+const SPARKLE_IDLE_RATE_HZ = 0.6;
+const SPARKLE_IDLE_RADIUS_MIN = 0.8;
+const SPARKLE_IDLE_RADIUS_MAX = 1.6;
+const SPARKLE_IDLE_COLOR = 'hsla(140, 90%, 70%, 0.9)';
+// Charging endpoints — clamped on [SPARKLE_POWER_MIN_W, SPARKLE_POWER_MAX_W]
+const SPARKLE_POWER_MIN_W = 1500;
+const SPARKLE_POWER_MAX_W = 22000;
+const SPARKLE_CHARGE_MAX_AT_MIN_POWER = 12;
+const SPARKLE_CHARGE_MAX_AT_MAX_POWER = 28;
+const SPARKLE_CHARGE_RATE_HZ_AT_MIN_POWER = 3;
+const SPARKLE_CHARGE_RATE_HZ_AT_MAX_POWER = 10;
+const SPARKLE_CHARGE_RADIUS_MIN_AT_MIN_POWER = 1.2;
+const SPARKLE_CHARGE_RADIUS_MAX_AT_MIN_POWER = 2.5;
+const SPARKLE_CHARGE_RADIUS_MIN_AT_MAX_POWER = 1.8;
+const SPARKLE_CHARGE_RADIUS_MAX_AT_MAX_POWER = 3.5;
+const SPARKLE_CHARGE_COLOR = '#00E5FF';    // electric "lightning blue"
+const SPARKLE_LIFE_S = 0.45;
+```
+
+**Lifecycle:** "pop" — no rising motion (unlike boiler bubbles).
+Three-phase opacity curve: fade-in `[0, 0.20]`, hold `[0.20, 0.50]`,
+fade-out `[0.50, 1.0]`. Each sparkle is a `<circle>` whose `fill`
+attribute is set at spawn from the **then-current** state (idle vs
+charging) and never changes. Cross-fade is natural: when
+`_charging` flips, new sparkles spawn with the new colour while
+in-flight sparkles complete their life — a ~0.45 s mixed-palette
+tail is acceptable per scope-guardian's Q3 clarification.
+
+**Power-scaling formula** (clamped):
+```js
+const power = this._chargePower || 0;
+const clamped = Math.max(SPARKLE_POWER_MIN_W,
+                         Math.min(SPARKLE_POWER_MAX_W, power));
+const t = (clamped - SPARKLE_POWER_MIN_W) /
+          (SPARKLE_POWER_MAX_W - SPARKLE_POWER_MIN_W);
+const sparkleMax = SPARKLE_CHARGE_MAX_AT_MIN_POWER +
+                   t * (SPARKLE_CHARGE_MAX_AT_MAX_POWER -
+                        SPARKLE_CHARGE_MAX_AT_MIN_POWER);
+const sparkleRateHz = SPARKLE_CHARGE_RATE_HZ_AT_MIN_POWER +
+                      t * (SPARKLE_CHARGE_RATE_HZ_AT_MAX_POWER -
+                           SPARKLE_CHARGE_RATE_HZ_AT_MIN_POWER);
+const rMin = SPARKLE_CHARGE_RADIUS_MIN_AT_MIN_POWER +
+             t * (SPARKLE_CHARGE_RADIUS_MIN_AT_MAX_POWER -
+                  SPARKLE_CHARGE_RADIUS_MIN_AT_MIN_POWER);
+const rMax = SPARKLE_CHARGE_RADIUS_MAX_AT_MIN_POWER +
+             t * (SPARKLE_CHARGE_RADIUS_MAX_AT_MAX_POWER -
+                  SPARKLE_CHARGE_RADIUS_MAX_AT_MIN_POWER);
+```
+This is evaluated **per frame** when `_charging`; idle uses the
+fixed `SPARKLE_IDLE_*` constants. Below `SPARKLE_POWER_MIN_W` but
+still `_charging`, values clamp to the MIN-power endpoint (user
+intent: 1500W = MIN charging density, NOT a ramp from 0W). The
+idle→charging boundary at 50W is therefore a deliberate visible
+step in density and colour — matches the user's design intent
+(rejected scope-guardian I4).
+
+**Spawn position** (random inside the water portion of the clip
+circle):
+```js
+const cyMin = this._waterBaseY + 2;             // just below surface
+const cyMax = CENTER_CY + CLIP_R - 4;           // just above bottom rim
+if (cyMax <= cyMin) {                            // degenerate: empty soup
+  this._nextSparkleAt += 1 / sparkleRateHz;
+  continue;                                       // advance cadence; do not break
+}
+const cy = cyMin + Math.random() * (cyMax - cyMin);
+const dy = cy - CENTER_CY;
+const chordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dy * dy));
+if (chordHalf < 2) {                              // degenerate chord
+  this._nextSparkleAt += 1 / sparkleRateHz;
+  continue;
+}
+const cx = CENTER_CX + (Math.random() * 2 - 1) * chordHalf * 0.9;
+```
+The `continue`-with-cadence-advance pattern (no `break`) mirrors
+the QS-214 review-fix #01 #5 fix on the boiler — avoids a
+per-frame spin-loop when the soup is empty.
+
+### D6 — Lightning bolts ("thunder from the top to the soup surface")
+**Only when `_charging` AND `!degraded`.** Three-segment jagged
+`<path d="...">` (NOT polyline — `<path>` keeps the markup
+consistent with the boiler precedent and lets the implementer pin
+the `d=` attribute in tests). Scope-guardian I2 trim accepted:
+**3 segments + one lateral kink mid-path**, NOT 6 segments.
+
+```js
+const MAX_CONCURRENT_LIGHTNING = 3;
+const LIGHTNING_SPAWN_MIN_S = 1.5;
+const LIGHTNING_SPAWN_MAX_S = 3.0;
+const LIGHTNING_LIFE_S = 0.25;
+const LIGHTNING_STROKE_COLOR = '#E0F7FF';
+const LIGHTNING_STROKE_WIDTH = 1.8;
+const LIGHTNING_GLOW_STDDEV = 2.5;
+const LIGHTNING_TOP_MARGIN_PX = 4;
+const LIGHTNING_LATERAL_JITTER_PX = 18;
+const LIGHTNING_SEGMENTS = 3;
+```
+
+**Path construction at spawn:**
+```js
+// Start near the top of the clip circle, random cx in central band
+const topY = CENTER_CY - CLIP_R + LIGHTNING_TOP_MARGIN_PX;
+const startCx = CENTER_CX + (Math.random() * 2 - 1) * (CLIP_R * 0.4);
+// End on the water surface, random cx within the chord at _waterBaseY
+const dy = this._waterBaseY - CENTER_CY;
+const chordHalf = Math.sqrt(Math.max(0, CLIP_R * CLIP_R - dy * dy));
+const endCx = CENTER_CX + (Math.random() * 2 - 1) * chordHalf * 0.7;
+// Mid kink point: lateral jitter
+const midY = (topY + this._waterBaseY) / 2;
+const midCx = (startCx + endCx) / 2 +
+              (Math.random() * 2 - 1) * LIGHTNING_LATERAL_JITTER_PX;
+const d = `M ${startCx} ${topY} L ${midCx} ${midY} L ${endCx} ${this._waterBaseY}`;
+```
+
+**Lifecycle / opacity:** three-phase flash, life `0.25 s`:
+- fade-in `[0, 0.10]` → linear 0→1
+- hold `[0.10, 0.70]` → 1
+- fade-out `[0.70, 1.0]` → linear 1→0
+
+**Glow** via a per-instance `<filter id="${lightningFilterId}">`
+with `<feGaussianBlur stdDeviation="${LIGHTNING_GLOW_STDDEV}" />`
+plus `mix-blend-mode: screen` on the layer `<g>`. The filter sits
+in `<defs>` alongside the grain filter.
+
+**Spawn cadence:** when `_charging && !degraded`, on each frame
+decrement `_nextLightningAt` by `dt`. When ≤ 0 AND
+`_lightningBolts.length < MAX_CONCURRENT_LIGHTNING`, spawn one
+bolt, then `_nextLightningAt = LIGHTNING_SPAWN_MIN_S +
+Math.random() * (LIGHTNING_SPAWN_MAX_S - LIGHTNING_SPAWN_MIN_S);`.
+The advance/retire loop runs unconditionally (graceful exit per D15).
+
+### D7 — Granular noise on the wave
+Single `<filter id="${grainFilterId}" …>` in `<defs>`:
+```html
+<filter id="${grainFilterId}" x="-20%" y="-20%" width="140%" height="140%">
+  <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2"
+                seed="3" result="noise" />
+  <feComposite in="noise" in2="SourceGraphic" operator="in" result="grain" />
+  <feMerge>
+    <feMergeNode in="SourceGraphic" />
+    <feMergeNode in="grain" />
+  </feMerge>
+</filter>
+```
+Applied to **the wave `<path>`s' fill via `filter="url(#${grainFilterId})"`**
+(NOT a separate overlay `<rect>` — accepted scope-guardian I1). The
+`feComposite operator="in"` masks the turbulence to the wave's
+filled shape (water region only), so the grain naturally ends at
+the wave surface and is automatically clipped to the soup
+boundary — solves the C2 critic finding.
+
+### D8 — Degraded state (CSS filter on clip group)
+Accepted scope-guardian C2: no third palette. Instead, on the
+clipped `<g>` element, conditionally apply
+`style="filter: saturate(0.3) brightness(0.7);"` when
+`degraded === true`, where:
+```js
+const degraded = isDisconnected || isFaulted || isStale;
+```
+(`isOffGrid` is excluded — off-grid keeps the card-level pinkish
+tint already applied via the `.off-grid` CSS class; the soup is
+unaffected.)
+
+When `degraded`:
+- Soup wave still animates calmly (no behavioural change to wave).
+- Sparkles still spawn at idle rate **with idle-green colour** (the
+  CSS filter desaturates them).
+- Lightning bolts: **spawn is suppressed** (`if (charging && !degraded)`).
+  In-flight bolts complete their fade-out.
+
+This is **a runtime palette/filter swap**, not a lerp. `_currentColorMix`
+remains a binary idle↔charge lerp; the degraded layer is independent
+(C3 critic finding fixed).
+
+### D9 — Continuous RAF while connected
+Remove the `_charging`-gated `_startAnimation()` / `_stopAnimation()`
+toggle in `_render()`. `connectedCallback()` calls
+`_startAnimation()` directly (mirror QS-200 boiler). The new RAF
+loop is intrinsically continuous-while-connected: the soup is
+always visible (idle green or degraded grey) and the wave always
+animates (calmly when idle). `disconnectedCallback()` continues to
+call `_stopAnimation()`.
+
+**Existing dashed-arc** (`<path id="charge_anim">`) is preserved.
+`showAnimation` (L543) remains the render-time switch for it.
+The new step closure incorporates the existing `_animOffset`
+update (lines 43-50 of today's `_startAnimation`) and ADDS the
+new subsystem updates.
+
+**Perf rationale (dev-proxy I4):** per-frame cost is bounded by
+the dt-cap (D10) + idle counts (≤ 4 sparkles, no lightning when
+idle); estimated ≤ 0.5 ms/frame at 60 Hz. Mirrors QS-200 boiler
+trade-off. Acceptable for the typical 1-2 car cards per
+household dashboard.
+
+### D10 — `LERP_DT_CEIL = 0.1` dt cap
+`dt = Math.min(Math.max(0, (ts - this._lastAnimTs) / 1000),
+LERP_DT_CEIL);` at the top of `step()`. Mirrors QS-200 fix #02 S6.
+Pinned by an existing parametrized test that the car card joins
+(see "Existing tests modified" below).
+
+### D11 — `_resetDomRefs()` helper
+New helper, mirroring boiler. Resets DOM-ref memo keys AND logical
+particle arrays:
+```js
+_resetDomRefs() {
+  this._waveEls = null;          // [idleWave, chargeWave]
+  this._grainFilterEl = null;
+  this._sparkleLayerEl = null;
+  this._lightningLayerEl = null;
+  this._sparkles = [];
+  this._lightningBolts = [];
+}
+```
+Called from BOTH a new `_invalidateAnimCache()` (which also nulls
+`_lastWaterBaseY` / `_lastAmplitude`) AND the post-`innerHTML`
+cleanup block in `_render()`. Rejected scope-guardian R2: with 2
+call sites today AND ~5 reset fields, the helper saves real drift
+bugs (boiler precedent).
+
+### D12 — Per-instance unique SVG IDs
+Rejected scope-guardian C3: households can plausibly have two cars
+on one dashboard. Cheap insurance, matches the boiler/pool/climate
+precedent. Static counter on the class:
+```js
+if (!this._electronClipId) {
+  QsCarCard._nextClipId = (QsCarCard._nextClipId || 0) + 1;
+  const uid = QsCarCard._nextClipId;
+  this._electronClipId    = `car_eClip_${uid}`;
+  this._sparkleLayerId    = `car_sparkLayer_${uid}`;
+  this._lightningLayerId  = `car_lightningLayer_${uid}`;
+  this._grainFilterId     = `car_grainFilter_${uid}`;
+  this._lightningFilterId = `car_lightningFilter_${uid}`;
+}
+```
+Placed in `_render()` AFTER `_charging` is computed (L168) and
+BEFORE the SVG markup is interpolated (L550).
+
+### D13 — Lazy-init guard in `_startAnimation`
+Mirrors boiler L220-242. Runs ONCE on first connect; preserved
+across detach/re-attach so `_currentAmplitude` / `_wavePhase` /
+`_currentColorMix` don't snap back on tab navigation:
+```js
+if (this._currentAmplitude == null) {
+  this._currentAmplitude = CALM_AMP;
+  this._currentSpeed     = CALM_SPEED;
+  this._wavePhase        = 0;
+  this._currentColorMix  = 0;
+  this._sparkles         = [];
+  this._nextSparkleAt    = 0;
+  this._lightningBolts   = [];
+  this._nextLightningAt  = LIGHTNING_SPAWN_MIN_S +
+    Math.random() * (LIGHTNING_SPAWN_MAX_S - LIGHTNING_SPAWN_MIN_S);
+  this._needsAnimationPrime = true;
+}
+```
+
+### D14 — Graceful exit on `_charging → false`
+- No new charging-blue sparkles spawn — new spawns use idle-green at
+  idle rate.
+- No new lightning bolts spawn. In-flight bolts complete their
+  natural fade-out (~0.25s).
+- In-flight charging-blue sparkles complete their natural fade-out
+  (~0.45s). They visibly mix with new green sparkles for that
+  window — acceptable per dev-proxy Q3.
+
+### D15 — `_waterBaseY` formula
+```js
+const progressRatio = Math.max(0, Math.min(1, soc / 100));
+this._waterBaseY = CENTER_CY + CLIP_R - (0.2 + progressRatio * 0.6) * 2 * CLIP_R;
+```
+Matches the boiler envelope (`0.2 + ratio × 0.6`) so the visual
+character is consistent across the two water-style cards. At
+SOC = 0 the soup occupies the bottom 20% of the disc; at SOC =
+100 it reaches ~88 px down from the disc top. The expression sits
+in `_render()` AFTER the `soc` normalisation block ends (after
+L282), BEFORE the SVG markup is interpolated.
+
+### D16 — Sparkle / lightning DOM identity
+A sparkle is `<circle>` whose `fill` attribute encodes its colour
+(set at spawn). A lightning bolt is `<path d="..." stroke="..." />`
+inside a `<g>` carrying the glow filter. JS-side state arrays
+(`_sparkles`, `_lightningBolts`) store `{el, …}` references. The
+`<circle>` / `<path>` `fill` and `stroke` attributes persist on
+detached nodes (browser DOM contract), so a hypothetical future
+snapshot/restore would preserve colour without additional JS-side
+metadata (dev-proxy Q2). **No snapshot/restore is implemented
+this pass** — short particle life (≤0.45s) makes nuke-and-respawn
+imperceptible (accepted scope-guardian C1).
+
+### D17 — Inside-disc button carve-out covers (user follow-up)
+Mirror of QS-217 for THREE buttons that sit inside the clip disc:
+```js
+// Module constants (initial estimates; tunable in T2 visual iteration).
+const SUN_BTN_CARVE_CX = 160;       // bottom-center of stack
+const SUN_BTN_CARVE_CY = 267;
+const SUN_BTN_CARVE_R  = 32;
+const RABBIT_BTN_CARVE_CX = 96;     // left column of mini-grid
+const RABBIT_BTN_CARVE_CY = 180;
+const RABBIT_BTN_CARVE_R  = 32;
+const TIME_BTN_CARVE_CX = 224;      // right column of mini-grid
+const TIME_BTN_CARVE_CY = 180;
+const TIME_BTN_CARVE_R  = 32;
+```
+Three `<circle>` elements drawn AFTER the clipped `<g>` (closer `</g>`)
+and BEFORE the outer ring stroke `<path d="${bgPath}">`. Each is
+gated on the corresponding button's render predicate, mirroring
+the boiler `e.override_reset ? '<circle …/>' : ''` ternary:
+```html
+${swPriority ? `<circle id="sun_btn_cover" cx="${SUN_BTN_CARVE_CX}" cy="${SUN_BTN_CARVE_CY}" r="${SUN_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
+${e.force_now ? `<circle id="rabbit_btn_cover" cx="${RABBIT_BTN_CARVE_CX}" cy="${RABBIT_BTN_CARVE_CY}" r="${RABBIT_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
+${(tNext && e.schedule) ? `<circle id="time_btn_cover" cx="${TIME_BTN_CARVE_CX}" cy="${TIME_BTN_CARVE_CY}" r="${TIME_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
+```
+The `target_handle` circle (already on the ring stroke at radius
+`ringCirc = 130`) does NOT need a carve — it sits outside the
+clip disc by construction.
+
+The CY/CX integer values are user-tunable in T2; tests pin the
+constant NAMES only (not values) — mirrors QS-217 line ~62
+("integer is intentionally user-tunable for visual iteration").
+
+## Acceptance criteria
+
+### AC-1 — Single sine wave, two stacked paths, in clip group
+**Given** the rendered SVG source string
+**When** the clipped `<g clip-path="url(#${electronClipId})">` is
+located
+**Then** it contains, in source order:
+1. The grain filter is declared in `<defs>` with
+   `<feTurbulence type="fractalNoise" baseFrequency="0.9" …>`.
+2. Inside the clip group: exactly **two** `<path>` elements that
+   share an `id`-pair like `electron_wave_idle` / `electron_wave_charge`
+   and the same `d` attribute placeholder (`initialWavePath`),
+   differing only in `fill` (IDLE_SOUP_COLOR vs CHARGE_SOUP_COLOR)
+   and `opacity` (`initialIdleOpacity` vs `initialChargeOpacity`).
+3. Each wave `<path>` carries `filter="url(#${grainFilterId})"`.
+4. Then the sparkle `<g id="${sparkleLayerId}">` (after waves).
+5. Then the lightning `<g id="${lightningLayerId}" filter="url(#${lightningFilterId})">`
+   (after sparkles).
+6. The wave layer count is exactly 2 (no `wave1_*` or `wave2_*`
+   ids — the issue's "do not superpose 3 layer of sin").
+
+### AC-2 — Cross-fade lerp (idle ↔ charging, binary)
+**Given** the source of `_startAnimation()`'s `step()` closure
+**When** the lerp block is read
+**Then**:
+- A line shaped `const targetColorMix = boiling ? 1 : 0;` exists
+  (with `boiling` replaced by `charging` — the car-card analogue).
+- `this._currentColorMix +=` updates with `lerpFactor` derived from
+  `LERP_RATE = 2` and the clamped `dt`.
+- Per-frame opacity update for both wave siblings sets
+  `coolOpacity = (1 - _currentColorMix).toFixed(3)` and
+  `boilOpacity = _currentColorMix.toFixed(3)` (or analogous
+  idle/charge names — name pinned, exact wording pinned by the
+  test).
+- `_currentColorMix` is NEVER mutated by the `degraded` branch
+  (regex assert: no `if (degraded) { … _currentColorMix … }` ).
+
+### AC-3 — Sparkle power-scaling on [1500W, 22000W]
+**Given** the source of the sparkle spawn block
+**When** the power-clamping formula is read
+**Then**:
+- `SPARKLE_POWER_MIN_W = 1500` and `SPARKLE_POWER_MAX_W = 22000`
+  module constants exist.
+- A `clamped = Math.max(SPARKLE_POWER_MIN_W, Math.min(SPARKLE_POWER_MAX_W, power))`
+  expression exists.
+- Linear interpolation `(clamped - SPARKLE_POWER_MIN_W) /
+  (SPARKLE_POWER_MAX_W - SPARKLE_POWER_MIN_W)` appears.
+- `SPARKLE_CHARGE_MAX_AT_MIN_POWER = 12`,
+  `SPARKLE_CHARGE_MAX_AT_MAX_POWER = 28`,
+  `SPARKLE_CHARGE_RATE_HZ_AT_MIN_POWER = 3`,
+  `SPARKLE_CHARGE_RATE_HZ_AT_MAX_POWER = 10` constants exist.
+
+### AC-4 — Sparkle colour decided at spawn (idle vs charging)
+**Given** the source of the sparkle spawn block
+**When** the `<circle>` `fill` attribute is set
+**Then**:
+- A literal `SPARKLE_IDLE_COLOR = 'hsla(140, 90%, 70%, 0.9)'`
+  module constant exists.
+- A literal `SPARKLE_CHARGE_COLOR = '#00E5FF'` module constant
+  exists.
+- The spawn closure selects the fill via a ternary expression
+  resolving to one of the two based on `_charging` (regex assert).
+- The fill is set on the `<circle>` element ONCE at spawn time —
+  no re-assignment of `fill` in the advance loop (negative
+  regex: `el.setAttribute('fill'` appears at most once per
+  particle, AT spawn).
+
+### AC-5 — Lightning gate + spawn interval random in [1.5, 3.0] s
+**Given** the source of `_startAnimation()`'s `step()` closure
+**When** the lightning spawn block is read
+**Then**:
+- The spawn `while` (or single-shot `if`) is wrapped in
+  `if (charging && !degraded) { … }` (regex pins both conjuncts).
+- `LIGHTNING_SPAWN_MIN_S = 1.5` and `LIGHTNING_SPAWN_MAX_S = 3.0`
+  module constants exist.
+- The next-spawn re-arming line is shaped:
+  `this._nextLightningAt = LIGHTNING_SPAWN_MIN_S +
+   Math.random() * (LIGHTNING_SPAWN_MAX_S - LIGHTNING_SPAWN_MIN_S);`
+- `MAX_CONCURRENT_LIGHTNING = 3` exists.
+- The advance/retire `for` loop sits OUTSIDE the
+  `if (charging && !degraded)` guard (graceful exit per D14).
+
+### AC-6 — Lightning life + glow filter
+- `LIGHTNING_LIFE_S = 0.25` module constant.
+- Three-phase opacity curve breakpoints `0.10` and `0.70` appear
+  in the advance loop.
+- `<filter id="${lightningFilterId}" …><feGaussianBlur stdDeviation="${LIGHTNING_GLOW_STDDEV}" /></filter>`
+  is in `<defs>` with safe filter region (`x="-50%" y="-50%"
+  width="200%" height="200%"`).
+- The `<g id="${lightningLayerId}">` carries
+  `filter="url(#${lightningFilterId})"` AND
+  `style="mix-blend-mode: screen; …"`.
+- Lightning element type is `<path d="…" stroke="${LIGHTNING_STROKE_COLOR}"
+  stroke-width="${LIGHTNING_STROKE_WIDTH}" fill="none" />`
+  (path, not polyline).
+
+### AC-7 — feTurbulence grain on wave fill
+- `<filter id="${grainFilterId}" …>` contains exactly
+  `<feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2"`
+  attributes (substring assert; `seed` and `result` are also
+  present but not pinned).
+- BOTH wave `<path>` elements carry
+  `filter="url(#${grainFilterId})"`.
+- No separate `<rect>` overlay carries the grain filter (negative
+  regex: no `<rect>` immediately preceding a sparkle layer).
+
+### AC-8 — Degraded state CSS filter + lightning suppression
+- A `degraded` local boolean computed as
+  `isDisconnected || isFaulted || isStale` exists in `_render()`.
+- The clipped `<g>` carries an inline style ternary:
+  `style="${degraded ? 'filter: saturate(0.3) brightness(0.7);' : ''}"`
+  (or equivalent — exact CSS values pinned).
+- The lightning spawn gate is `if (charging && !degraded)`.
+- `isOffGrid` does NOT participate in `degraded` (negative regex:
+  `degraded =` line does not mention `isOffGrid`).
+
+### AC-9 — Continuous RAF from `connectedCallback`
+- `connectedCallback()` body contains `this._startAnimation();`.
+- `_render()` does NOT contain a conditional `_startAnimation()`
+  call gated on `charging` (negative regex:
+  no `if (charging) { … _startAnimation` or
+  `if (this._charging) { … _startAnimation`).
+- `_render()` does NOT contain `_stopAnimation()` (the only call
+  sites are `connectedCallback` → start and `disconnectedCallback`
+  → stop).
+- **Side-effect on existing tests** (T0 also touches these):
+  - `("qs-car-card.js", "charging")` is REMOVED from the
+    `test_card_raf_idle_gated` parametrize list at L1820.
+  - The history-comment block above the decorator (L1804-1814)
+    is EXTENDED with a QS-232 sentence explaining the migration
+    (mirror the QS-200 boiler precedent text).
+  - `"qs-car-card.js"` is ADDED to the
+    `test_card_caps_raf_dt_against_hidden_tab` parametrize list
+    at L1889-1894 (so the dt-cap is pinned for the car too).
+
+### AC-10 — `_resetDomRefs()` helper at two call sites; teardown
+- A `_resetDomRefs()` instance method exists.
+- It nulls `_waveEls`, `_grainFilterEl`, `_sparkleLayerEl`,
+  `_lightningLayerEl` AND clears `_sparkles = []` and
+  `_lightningBolts = []`.
+- It is called from BOTH a new `_invalidateAnimCache()` AND the
+  post-`innerHTML` cleanup block in `_render()` (regex: `>= 2`
+  `this._resetDomRefs()` call sites, matching the boiler
+  `test_water_boiler_card_factors_reset_dom_refs_helper`
+  precedent).
+- `disconnectedCallback()` calls `_stopAnimation()` AND tears
+  down DOM:
+  `this._sparkles?.forEach(s => s.el?.remove?.()); this._sparkles = [];`
+  AND the analogous lightning teardown — both with the boiler
+  optional-chaining shape.
+
+### AC-11 — Per-instance unique SVG IDs
+- A `QsCarCard._nextClipId` static counter is bumped inside a
+  `if (!this._electronClipId)` block.
+- Five per-instance ID fields are assigned from the same `uid`:
+  `_electronClipId`, `_sparkleLayerId`, `_lightningLayerId`,
+  `_grainFilterId`, `_lightningFilterId`. All follow the
+  `car_<role>_${uid}` naming convention (regex pins each).
+
+### AC-12 — `LERP_DT_CEIL = 0.1` dt cap
+- Module constant `const LERP_DT_CEIL = 0.1;` exists.
+- The step closure clamps `dt = Math.min(dt, LERP_DT_CEIL);` (or
+  `dt = Math.min(Math.max(0, …), LERP_DT_CEIL);`) at top of
+  closure (regex pin).
+- The car card is in the
+  `test_card_caps_raf_dt_against_hidden_tab` parametrize list
+  (assertion already implied by AC-9 side-effect).
+
+### AC-13 — Doc maintenance
+- A new H3 section `### QS-232 — Car-card electron-soup animation`
+  exists in `docs/agents/concepts/dashboard-and-cards.md` AFTER
+  the existing QS-217 section and BEFORE the
+  `## Hardened JS-card patterns` H2.
+- The section describes: the single-layer wave, dual-opacity
+  cross-fade, sparkle palette switch + power-scaling on [1500W,
+  22000W], lightning bolt 3-segment path + glow + spawn interval,
+  feTurbulence grain on wave fill, degraded CSS filter, continuous
+  RAF, and the three carve-out covers.
+- The section mentions D17 explicitly (carve covers extended from
+  one button to three on the car card).
+- `last_verified:` field reflects today (2026-05-25).
+- `python scripts/qs/check_doc_drift.py` exits clean for all
+  touched files.
+
+### AC-14 — Three inside-disc button carve-out covers (D17)
+- Six module-level constants are present:
+  `SUN_BTN_CARVE_CX`, `SUN_BTN_CARVE_CY`, `SUN_BTN_CARVE_R`,
+  `RABBIT_BTN_CARVE_CX`, `RABBIT_BTN_CARVE_CY`, `RABBIT_BTN_CARVE_R`,
+  `TIME_BTN_CARVE_CX`, `TIME_BTN_CARVE_CY`, `TIME_BTN_CARVE_R` (9
+  total). Test pins the NAMES only (not values — user-tunable per
+  QS-217).
+- Three `<circle id="…_cover" fill="var(--card-background-color)"
+  pointer-events="none" />` elements appear in source AFTER the
+  clipped `</g>` closer AND BEFORE the `<path d="${bgPath}"` line.
+- Each is gated on its corresponding button's render predicate
+  (`swPriority`, `e.force_now`, `(tNext && e.schedule)`).
+- The `<circle>` element IDs are exactly `sun_btn_cover`,
+  `rabbit_btn_cover`, `time_btn_cover`.
+
+## Tasks / file-level diff
+
+> **TDD ordering.** T0 writes structural tests first (RED). T1–T9
+> turn them green. T10 finishes the doc. T11 runs the quality gate.
+> Single commit per PR (squashed if multi-step landing is preferred
+> — implementer's call): subject `QS-232: add electron-soup SOC
+> animation to car card`.
+
+### T0 — Write structural tests (RED phase)
+**File:** `tests/test_dashboard_rendering.py`
+**Insertion anchor:** Insert the 14 new module-level tests AFTER
+`def test_water_boiler_card_steam_filter_region_attributes` (ends
+~L3585) and BEFORE the `# ==== QS-217 ====` (or equivalent) header
+comment at ~L3588. Wrap in a `# === QS-232 car-card electron-soup
+tests ===` header for parity with existing boiler-section style.
+
+**ALSO modify existing parametrize lists** (do this in T0 so AC-9
+side-effect lands RED):
+1. Remove the tuple `("qs-car-card.js", "charging"),` from
+   `test_card_raf_idle_gated` (currently L1820).
+2. Extend the comment block above the decorator (currently L1804-1814)
+   with: "QS-232 (this commit): `qs-car-card.js` was previously in
+   this list with gate `charging`. The car card now mirrors the
+   continuous-RAF model adopted by the pool and (per QS-200) the
+   water-boiler cards — RAF runs continuously while connected
+   because the electron-soup wave is intrinsically visible (idle
+   green or degraded grey). Covered separately by the new
+   `test_car_card_continuous_raf_from_connected_callback` below."
+3. Add `"qs-car-card.js",` to the
+   `test_card_caps_raf_dt_against_hidden_tab` parametrize list
+   (currently L1889-1894).
+
+**14 new tests** (one per AC):
+
+| Test name | AC |
+|---|---|
+| `test_car_card_electron_soup_clip_group_and_two_waves` | AC-1 |
+| `test_car_card_cross_fade_lerp_is_binary_idle_charge` | AC-2 |
+| `test_car_card_sparkle_power_scaling_constants` | AC-3 |
+| `test_car_card_sparkle_color_decided_at_spawn` | AC-4 |
+| `test_car_card_lightning_gated_and_spawn_interval` | AC-5 |
+| `test_car_card_lightning_life_and_glow_filter` | AC-6 |
+| `test_car_card_grain_filter_uses_feturbulence_on_wave_fill` | AC-7 |
+| `test_car_card_degraded_state_css_filter_and_lightning_suppression` | AC-8 |
+| `test_car_card_continuous_raf_from_connected_callback` | AC-9 |
+| `test_car_card_reset_dom_refs_helper_and_disconnect_teardown` | AC-10 |
+| `test_car_card_per_instance_unique_svg_ids` | AC-11 |
+| `test_car_card_caps_raf_dt_at_lerp_dt_ceil` | AC-12 |
+| `test_dashboard_and_cards_doc_pins_qs_232_paragraph` | AC-13 |
+| `test_car_card_inside_disc_button_carve_covers` | AC-14 |
+
+Each test follows the shape:
+```python
+def test_…():
+    source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
+    executable = _strip_js_comments(source)
+    # pinned regex / substring assertions per AC
+    ...
+```
+For AC-13, the test reads
+`docs/agents/concepts/dashboard-and-cards.md` and asserts the
+new H3 substring exists.
+
+**After writing:** `python scripts/qs/quality_gate.py --quick
+tests/test_dashboard_rendering.py` → 14 new failures expected
+(RED), plus the modified parametrize entries failing.
+
+### T1 — Constants block, per-instance IDs, header comment
+**File:** `custom_components/quiet_solar/ui/resources/qs-car-card.js`
+
+**Edit 1 (constants block).** Insert AFTER L13's `const
+ANIM_POWER_RANGE = …;` line and BEFORE the `class QsCarCard
+extends HTMLElement {` declaration at L15, separated by a blank
+line. Add ALL new module constants listed in D2-D6, D10, D17.
+
+**Edit 2 (header comment).** Update the file's header docstring
+(L1-4) to add a paragraph describing QS-232 (mirror the QS-200
+header update on the boiler).
+
+**Edit 3 (per-instance ID block).** Inside `_render()`, AFTER
+`charging` is computed (current L168) and BEFORE the
+`carChargeTypeIcons` literal at L176, insert:
+```js
+if (!this._electronClipId) {
+  QsCarCard._nextClipId = (QsCarCard._nextClipId || 0) + 1;
+  const uid = QsCarCard._nextClipId;
+  this._electronClipId    = `car_eClip_${uid}`;
+  this._sparkleLayerId    = `car_sparkLayer_${uid}`;
+  this._lightningLayerId  = `car_lightningLayer_${uid}`;
+  this._grainFilterId     = `car_grainFilter_${uid}`;
+  this._lightningFilterId = `car_lightningFilter_${uid}`;
+}
+const electronClipId    = this._electronClipId;
+const sparkleLayerId    = this._sparkleLayerId;
+const lightningLayerId  = this._lightningLayerId;
+const grainFilterId     = this._grainFilterId;
+const lightningFilterId = this._lightningFilterId;
+```
+
+### T2 — SVG `<defs>` + clipped group markup
+**File:** Same.
+
+**Edit 1 (`<defs>` additions).** Inside the existing `<defs>`
+block (currently L559-587), AFTER `<filter id="chargeGlow">…</filter>`
+(L580-586) and BEFORE the `</defs>` closer (L587), insert:
+
+1. The grain filter (`feTurbulence`) per D7.
+2. The lightning glow filter per D6.
+3. The clipPath:
+   ```html
+   <clipPath id="${electronClipId}">
+     <circle cx="${CENTER_CX}" cy="${CENTER_CY}" r="${CLIP_R}" />
+   </clipPath>
+   ```
+
+**Edit 2 (clipped group markup).** Insert BETWEEN `</defs>` (L587)
+and `<path d="${bgPath}" …>` (L588):
+
+```html
+<g clip-path="url(#${electronClipId})"
+   style="${degraded ? 'filter: saturate(0.3) brightness(0.7);' : ''}">
+  <path id="electron_wave_idle"
+        d="${initialWavePath}"
+        fill="${IDLE_SOUP_COLOR}"
+        opacity="${initialIdleOpacity}"
+        filter="url(#${grainFilterId})"
+        pointer-events="none"
+        style="will-change: transform;" />
+  <path id="electron_wave_charge"
+        d="${initialWavePath}"
+        fill="${CHARGE_SOUP_COLOR}"
+        opacity="${initialChargeOpacity}"
+        filter="url(#${grainFilterId})"
+        pointer-events="none"
+        style="will-change: transform;" />
+  <g id="${sparkleLayerId}" pointer-events="none"></g>
+  <g id="${lightningLayerId}" filter="url(#${lightningFilterId})"
+     pointer-events="none"
+     style="mix-blend-mode: screen; will-change: opacity;"></g>
+</g>
+```
+
+**Edit 3 (carve covers).** Immediately AFTER the closing `</g>` of
+the clipped group AND BEFORE `<path d="${bgPath}" …>`, insert the
+three `<circle>` carve covers per D17 (ternary-gated on each
+button's render predicate).
+
+**Edit 4 (initial wave path + opacities).** In `_render()`, AFTER
+the `_waterBaseY` computation (D15) and BEFORE `this._root.innerHTML
+= …`, compute:
+```js
+const initialAmp = this._currentAmplitude ?? CALM_AMP;
+const initialColorMix = this._currentColorMix ?? 0;
+const initialWavePath = this._generateWavePath(WAVE_WIDTH, initialAmp, 2, 0, this._waterBaseY);
+const initialIdleOpacity   = (1 - initialColorMix).toFixed(3);
+const initialChargeOpacity = initialColorMix.toFixed(3);
+```
+And `degraded` local:
+```js
+const degraded = isDisconnected || isFaulted || isStale;
+```
+
+### T3 — `_resetDomRefs()` + `_invalidateAnimCache()` helpers
+**File:** Same.
+**Location:** As new instance methods, BEFORE `_startAnimation()`
+(currently L27).
+
+```js
+_resetDomRefs() {
+  this._waveEls = null;
+  this._grainFilterEl = null;
+  this._sparkleLayerEl = null;
+  this._lightningLayerEl = null;
+  this._sparkles = [];
+  this._lightningBolts = [];
+}
+
+_invalidateAnimCache() {
+  this._lastWaterBaseY = null;
+  this._lastAmplitude = null;
+  this._resetDomRefs();
+}
+```
+
+### T4 — `_generateWavePath()` method (verbatim copy from boiler)
+**File:** Same.
+**Location:** As a new instance method, BEFORE `_resetDomRefs()`.
+**Content:** Copy verbatim from `qs-water-boiler-card.js` L157-170.
+The car uses ONE call site with `freq = 2`; no per-layer offset
+loop.
+
+### T5 — Lazy-init in `_startAnimation`
+**File:** Same.
+**Location:** Inside `_startAnimation()` (currently L27-54). REPLACE
+the entire method body. The new method:
+1. Returns early if `_animRaf != null` (preserved).
+2. Lazy-init guard per D13 (runs once).
+3. `_lastAnimTs = null`; `_invalidateAnimCache()`.
+4. Defines the new `step(ts)` closure (T6).
+5. Starts RAF.
+
+### T6 — Per-frame animation logic (single step closure)
+**File:** Same. Inside `_startAnimation()`'s `step(ts)` closure.
+
+Order of operations per frame (mirror boiler):
+1. Early-return if `!this.isConnected`.
+2. Compute dt, clamp to `LERP_DT_CEIL`.
+3. **Dashed-arc update** (PRESERVED from L43-50): update
+   `_animOffset`, set `stroke-dashoffset` on `#charge_anim`. This
+   block is unchanged in behaviour — only the `if (!this._charging)`
+   early-return at L32-39 is REMOVED.
+4. **Wave lerp.** Lerp `_currentAmplitude`, `_currentSpeed`,
+   `_currentColorMix` toward `_charging ? CHARGE_*` / 1 : 0`. Advance
+   `_wavePhase` by `_currentSpeed * dt` and wrap.
+5. **Wave DOM lookup / regen.** Mirror boiler L297-336.
+6. **Wave opacity per-frame** (idle / charge cross-fade).
+7. **Sparkle subsystem.** Spawn block (conditional on `_charging`
+   for charging-blue, ALWAYS for idle-green at idle rate). Advance
+   + retire (life-based, no rising motion).
+8. **Lightning subsystem.** Spawn block gated on `_charging &&
+   !degraded`. Advance + retire.
+9. `this._animRaf = requestAnimationFrame(step);`
+
+**Implementation reference:** boiler L246-589 — the entire `step()`
+closure body. Adapt names (`boiling` → `charging`; `bubbles`/`steam`
+→ `sparkles`/`lightningBolts`; remove the second-and-third wave
+layer iteration).
+
+### T7 — `connectedCallback` calls `_startAnimation` directly
+**File:** Same.
+**Location:** `connectedCallback()` (currently L62-65). REPLACE with:
+```js
+connectedCallback() {
+  this._startAnimation();
+}
+```
+
+### T8 — `_render()` integration
+**File:** Same.
+
+**Edit 1 (remove `_charging`-gated start/stop).** Inside `_render()`,
+DELETE the existing block (currently L169-175):
+```js
+if (charging) {
+  this._startAnimation();
+} else {
+  this._stopAnimation();
+}
+```
+
+**Edit 2 (post-`innerHTML` reset + memo sync).** Immediately AFTER
+`this._root.innerHTML = \`…\`;` (currently ends ~L657), and AFTER
+the doctstring-style comment block, insert:
+```js
+this._lastWaterBaseY = this._waterBaseY;
+this._lastAmplitude  = this._currentAmplitude ?? CALM_AMP;
+this._resetDomRefs();
+```
+
+(No snapshot/restore — accepted scope-guardian C1 / critic R2.)
+
+### T9 — `disconnectedCallback` teardown extension
+**File:** Same.
+**Location:** Inside `disconnectedCallback()` (currently L67-76).
+APPEND after the existing flag resets:
+```js
+this._sparkles?.forEach(s => s.el?.remove?.());
+this._sparkles = [];
+this._lightningBolts?.forEach(b => b.el?.remove?.());
+this._lightningBolts = [];
+```
+
+### T10 — Doc update
+**File:** `docs/agents/concepts/dashboard-and-cards.md`
+
+**Edit 1 (paragraph).** Insert a NEW H3 section
+`### QS-232 — Car-card electron-soup animation` AFTER the existing
+`### QS-217 — Override-button cover overlay` section (currently
+~L502-548) and BEFORE the `## Hardened JS-card patterns` H2 header
+(~L550).
+
+The paragraph covers (under 500 words):
+- The single-layer wave + dual-opacity idle↔charge cross-fade.
+- Sparkle palette switch (green idle / blue charging), power-
+  scaling formula on [1500W, 22000W], idle/charge density and
+  spawn-rate endpoints.
+- Lightning bolt 3-segment path, life 0.25s, glow filter +
+  `mix-blend-mode: screen`, spawn interval [1.5, 3.0]s.
+- feTurbulence grain filter applied to the wave path's fill
+  (NOT a separate overlay rect — composites within the wave shape).
+- Degraded state via CSS `filter: saturate(0.3) brightness(0.7)`
+  on the clip group; lightning suppressed; sparkles still spawn
+  (greenish, desaturated by the parent filter).
+- Continuous RAF model: the car card was migrated out of the
+  `_charging`-gated `test_card_raf_idle_gated` parametrize list
+  and into the `test_card_caps_raf_dt_against_hidden_tab` list.
+- D17 — carve-cover extended from one button (override-reset on
+  boiler/radiator/climate) to three (sun-btn, rabbit-btn, time-btn
+  on car), all using QS-217's simple `<circle fill="var(--card-
+  background-color)">` pattern.
+
+**Edit 2 (`last_verified`).** Frontmatter `last_verified` field
+to `2026-05-25` (today). Leave unchanged if already today.
+
+**Edit 3 (drift check).** Run
+`python scripts/qs/check_doc_drift.py`; expected clean.
+
+### T11 — Quality gate
+**File:** (none — just run.)
+**Command:** `python scripts/qs/quality_gate.py`.
+**Expected scope:** UI-only fast path (per QS-208), since the only
+non-test Python change is none (zero `.py` non-test files
+changed). The fast path runs `tests/test_dashboard_rendering.py`
++ changed test files, skipping full ruff/mypy/translations/cov.
+Expected: green.
+
+If the doc file `docs/agents/concepts/dashboard-and-cards.md`
+breaks the fast-path scope detection: the full gate runs; no `.py`
+non-test files change, so 100% coverage is preserved by construction.
+
+## Test plan
+
+**Structural tests** (T0; 14 new + 2 modified parametrize lists):
+
+| # | Test name | AC | Assertion summary |
+|---|---|---|---|
+| 1 | `test_car_card_electron_soup_clip_group_and_two_waves` | AC-1 | `<g clip-path="url(#${electronClipId})">` contains exactly 2 wave `<path>`s sharing one `d`, plus sparkle + lightning `<g>` layers in order. No `wave1_*`/`wave2_*` ids. |
+| 2 | `test_car_card_cross_fade_lerp_is_binary_idle_charge` | AC-2 | `targetColorMix = charging ? 1 : 0`; per-frame opacity uses `(1 - colorMix)` / `colorMix`; no degraded mutation of `_currentColorMix`. |
+| 3 | `test_car_card_sparkle_power_scaling_constants` | AC-3 | Six `SPARKLE_*` module constants; clamping + linear-interp formula present. |
+| 4 | `test_car_card_sparkle_color_decided_at_spawn` | AC-4 | Idle vs charge fill literals; ternary on `_charging` at spawn site only. |
+| 5 | `test_car_card_lightning_gated_and_spawn_interval` | AC-5 | `if (charging && !degraded)` gate; `LIGHTNING_SPAWN_MIN_S`/`MAX_S` constants; re-arm formula. |
+| 6 | `test_car_card_lightning_life_and_glow_filter` | AC-6 | `LIGHTNING_LIFE_S = 0.25`; 0.10 / 0.70 breakpoints; `<filter>` + Gaussian blur; `<path d` not `<polyline`. |
+| 7 | `test_car_card_grain_filter_uses_feturbulence_on_wave_fill` | AC-7 | `feTurbulence type="fractalNoise" baseFrequency="0.9"` in `<defs>`; both wave `<path>`s carry `filter=url(#${grainFilterId})`. |
+| 8 | `test_car_card_degraded_state_css_filter_and_lightning_suppression` | AC-8 | `degraded = isDisconnected \|\| isFaulted \|\| isStale`; clip group style ternary; lightning gate conjunct `!degraded`. |
+| 9 | `test_car_card_continuous_raf_from_connected_callback` | AC-9 | `connectedCallback` starts RAF; `_render` has no `_charging`-gated start. Also: car removed from `test_card_raf_idle_gated` list, added to dt-cap list. |
+| 10 | `test_car_card_reset_dom_refs_helper_and_disconnect_teardown` | AC-10 | `_resetDomRefs` body + ≥2 call sites; disconnect tears down sparkles + lightning. |
+| 11 | `test_car_card_per_instance_unique_svg_ids` | AC-11 | `QsCarCard._nextClipId` bump; 5 ID literals follow `car_<role>_${uid}` pattern. |
+| 12 | `test_car_card_caps_raf_dt_at_lerp_dt_ceil` | AC-12 | `const LERP_DT_CEIL = 0.1`; `Math.min(dt, LERP_DT_CEIL)` at top of step. |
+| 13 | `test_dashboard_and_cards_doc_pins_qs_232_paragraph` | AC-13 | H3 section literal present; references all key concepts; `last_verified` = today. |
+| 14 | `test_car_card_inside_disc_button_carve_covers` | AC-14 | 9 carve constants (3×{CX,CY,R}); 3 `<circle id="…_cover"` elements after `</g>` and before `bgPath`; gated on respective button predicates. |
+
+**Modified existing tests:**
+- `test_card_raf_idle_gated`: car-card tuple removed; history comment extended.
+- `test_card_caps_raf_dt_against_hidden_tab`: car-card added.
+
+**Quality gate** (T11): `python scripts/qs/quality_gate.py`;
+expected UI-only fast path.
+
+**Doc drift** (T10): `python scripts/qs/check_doc_drift.py`;
+expected green.
+
+**Manual smoke** (out of CI; visual-only; runtime ACs not regex-
+testable):
+
+1. **Soup always visible.** Open dashboard with a car card; verify a
+   translucent green water-level fill is visible at all SOC levels
+   (0%, 50%, 100%). Wave moves very slowly.
+2. **Charging transition.** Plug car in. Within ~0.5 s the soup
+   transitions from green to bluish; wave becomes slightly more
+   lively; sparkles increase in density + switch to lightning blue;
+   lightning bolts start flashing every ~1.5-3 s. Unplug: reverse
+   within ~0.5 s; in-flight blue sparkles complete naturally.
+3. **Power-scaled density.** Force charge at low power (e.g. 1500W
+   minimum charge) vs high power (22000W three-phase) and verify
+   sparkle density visibly differs. Below 1500W charging (e.g. solar
+   trickle 600W): density clamps to the 1500W minimum (no further
+   drop, but still visibly higher than idle).
+4. **Degraded states.** Disable car / disconnect charger / mark
+   car stale: soup desaturates to grey, sparkles still pop but
+   greyish, NO lightning bolts.
+5. **Carve covers.** Verify the three inside-disc buttons (sun,
+   rabbit, time) sit on a clean `--card-background-color` circular
+   patch with no soup/sparkle/lightning bleed-through. The buttons
+   themselves remain visually unchanged.
+6. **Two car cards on one dashboard.** Add two `qs-car-card`
+   entries to a single view (e.g. two cars in the same household).
+   Both render with distinct clipPath IDs; no visual cross-talk.
+7. **Hidden-tab return.** Open card; switch to another tab for
+   ≥ 5 s; switch back. No burst-spawn of sparkles, no wave snap.
+
+## Adversarial Review Notes
+
+Four reviewers ran in parallel against the initial draft:
+`qs-plan-critic`, `qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
+`qs-plan-scope-guardian`. The user-supplied follow-up
+("disc carving for the bump-priority button") was folded in
+as D17 / AC-14.
+
+### Critical (12 findings; all accepted and folded)
+
+| # | Reviewer | Finding | Resolution |
+|---|---|---|---|
+| 1 | Critic | Sparkle constant naming diverged between D5 and D16 (`MAX_SPARKLES_*` vs `SPARKLE_CHARGE_MAX_*`). | Unified single naming scheme in D5; all 13 sparkle constants explicitly listed. |
+| 2 | Critic | Grain filter overlay rect would cover entire disc (not just water). | D7 reframed: filter applied to wave `<path>`s' fill via `filter=url(#…)`; `feComposite operator="in"` confines grain to the wave shape — automatic clipping to soup boundary. |
+| 3 | Critic + Dev-Proxy | 3-palette cross-fade is undefined: `_currentColorMix` is binary but D2/D8 introduce a 3rd palette. | Resolved as Option A: `_currentColorMix` lerps **only** idle↔charge; degraded is a separate runtime path via CSS filter (D8). AC-2 explicitly forbids `_currentColorMix` mutation in the degraded branch. |
+| 4 | Critic | Multiple ACs declared but not pinnable as static-source assertions. | Every AC re-stated as structural (regex / substring). Runtime behaviours moved to the manual-smoke checklist (7 items). |
+| 5 | Concrete | Boiler line anchors in plan were wrong (claimed L147-156; actual is L220-242). | All boiler line anchors re-verified and rewritten in the Inputs table and individual D-blocks. |
+| 6 | Concrete | Existing `_startAnimation` at L27-54 must be REPLACED, not added alongside. | T5 explicitly states "REPLACE the entire method body". |
+| 7 | Concrete + Dev-Proxy | Removing the `_charging` gate breaks the existing `test_card_raf_idle_gated` parametrize entry at L1820. | T0 now explicitly: removes the tuple, extends the history-comment block (mirror QS-200 boiler precedent), adds car card to `test_card_caps_raf_dt_against_hidden_tab` list. AC-9 pins the side-effect. |
+| 8 | Concrete | Snapshot/restore anchors missing. | N/A — snapshot/restore is DROPPED (see Redesign #1). |
+| 9 | Dev-Proxy | T5 bundled wave + sparkles + lightning + lerp into one task. | Split into T5 (lazy-init) + T6 (step closure ordered into 9 numbered sub-steps). Each AC traces to a specific sub-step. |
+| 10 | Dev-Proxy | Lightning element type unpinned (`<polyline>` vs `<path>`). | Pinned `<path d="...">` per boiler precedent. AC-6 asserts. |
+| 11 | Critic | AC-1 wording said "single sine wave" but D2 said "two stacked wave paths". | AC-1 reworded: "two stacked paths sharing one sine geometry" — geometric singleness preserved. |
+| 12 | _User follow-up_ | Inside-disc buttons (sun/rabbit/time) need carve-out covers like boiler QS-217's override-btn. | Added D17 + AC-14. Three `<circle fill="var(--card-background-color)">` covers, ternary-gated on each button's render predicate. |
+
+### Redesign (5 findings; all accepted)
+
+| # | Reviewer | Finding | Resolution |
+|---|---|---|---|
+| 1 | Scope + Critic | Snapshot/restore (D12) is speculative for 0.45s/0.25s particles. | DROPPED. Particles turn over faster than the typical hass-push interval; wipe-and-respawn is imperceptible. AC removed. ~80 LOC saved. |
+| 2 | Scope | Degraded state full 3rd palette is over-engineered — user just said "greyscale tint". | D8 reframed: CSS `filter: saturate(0.3) brightness(0.7)` on the clip group. Zero state machinery; one-line inline style. |
+| 3 | Scope | D7 grain via separate `<rect>` overlay is heavier than filter on wave fill. | Accepted — D7 applies filter to wave path. (Also fixes Critical #2.) |
+| 4 | Scope | Lightning bolt 6 segments too elaborate; 3 segments suffice. | Accepted — `LIGHTNING_SEGMENTS = 3`, one mid kink. |
+| 5 | Dev-Proxy | T5 task ownership unclear; multiple ACs in one block. | Split per Critical #9. |
+
+### Scope-guardian partial accepts / rejects
+
+- **REJECTED — C3 "defer per-instance unique IDs (D12)":** households can plausibly have ≥ 2 cars on one dashboard (the data model supports it). The boiler/pool/climate all carry this — keeping the car aligned is cheap (5 lines) and avoids a future debugging session.
+- **REJECTED — R2 "inline `_resetDomRefs()`":** 2 call sites + 6 reset fields already justifies the helper. Boiler precedent (`test_water_boiler_card_factors_reset_dom_refs_helper`) shows this is a real drift trap.
+- **REJECTED — I4 "linear ramp 0W→1500W→22000W":** the user explicitly said "1500W being minimum speed and density (but way more than not charging)" — they WANT the visible step at the idle→charging boundary. Smoothing would contradict design intent.
+- **PARTIALLY ACCEPTED — R1 "trim ACs":** final AC count is 14 (down from 15 in the initial draft), and absorbing the snapshot/restore drop cut it further; AC-9 / AC-10 each cover two related invariants. Counting carve-out covers as AC-14 keeps the discoverability of the user-flagged scope addition.
+
+### Improvements (selected highlights; all accepted)
+
+- All file-level anchors (L13, L168, L176, L282, L488, L543, L588,
+  L657, L1804-1814, L1820, L1889-1894, L3585) cross-verified
+  against the current files.
+- T0 anchored to a literal insertion point (AFTER
+  `test_water_boiler_card_steam_filter_region_attributes`).
+- T5 spelled out as 9 numbered sub-steps inside `step()`.
+- Code-sharing policy stated: duplicate in-file, no shared module
+  (radiator-card precedent).
+- Perf rationale for continuous RAF stated (≤ 0.5 ms/frame).
+- Harness-sync exemption stated (no agent files touched).
+- Commit-count policy stated (single commit `QS-232: …`).
+- `_waterBaseY` formula pinned to the boiler-matching
+  `0.2 + ratio*0.6` envelope.
+
+### Clarifications (folded inline)
+
+- Sparkle position formula spelled out (cyMin/cyMax + chord half +
+  `continue` on degenerate).
+- Lightning path construction spelled out (3-segment math).
+- Sparkle cross-fade tail (~0.45 s mixed-palette window) explicitly
+  acceptable.
+- `showAnimation` preserved verbatim for the existing dashed
+  `charge_anim` only.
+- `generateWavePath` copied verbatim from boiler L157-170, called
+  with `freq = 2`.
+- Sparkle DOM identity: `fill` attribute persists on detached
+  `<circle>` (browser DOM contract).
+
+## Commit
+
+When implement-task ships this, the commit subject should be:
+
+```text
+QS-232: add electron-soup SOC animation to car card
+```
+
+Mirrors the project's `QS-<N>: <subject>` convention.

--- a/docs/stories/QS-232.story_review_fix_#01.md
+++ b/docs/stories/QS-232.story_review_fix_#01.md
@@ -1,0 +1,326 @@
+# QS-232 — Review fix plan #01
+
+## Summary
+- Source PR: #233
+- Source story: `docs/stories/QS-232.story.md`
+- Findings to fix: 22 (4 must-fix + 8 should-fix + 10 nice-to-have)
+- Next implement phase: `/implement-task`
+- Path scope: mixed product / tests / docs
+
+## Acceptance audit
+All 14 ACs of QS-232 (AC-1 through AC-14) are implemented and tested
+in the source PR. The acceptance auditor returned no must-fix or
+should-fix items. The fixes below address user-visual feedback, edge
+cases the auditor's structural lens did not exercise, internal-doc
+contradictions, and test-assertion tightening flagged by CodeRabbit.
+
+## Findings to fix
+
+### [must-fix] #1 Carve-cover Y-positions are too high (user-visual)
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:122-130`
+- Severity: must-fix
+- Source: user (screenshot)
+- Description: The three inside-disc carve covers (`SUN_BTN_CARVE_CY`
+  = 267, `RABBIT_BTN_CARVE_CY` = 180, `TIME_BTN_CARVE_CY` = 180) are
+  visibly above the actual button centers in the rendered card. The
+  dark holes don't line up with the rabbit / time / sun icons.
+- Proposed fix: bump all three carve `_CY` constants down so the
+  holes align with their buttons. The CSS layout pins the buttons via
+  their grid placement; the SVG-unit coordinates need to track those
+  positions. Iterate visually: try `SUN_BTN_CARVE_CY = 285`,
+  `RABBIT_BTN_CARVE_CY = 195`, `TIME_BTN_CARVE_CY = 195` as the first
+  cut, then verify in HA against the same `ID.buzz` card and adjust.
+  Existing structural tests (`test_car_card_inside_disc_button_carve_covers`)
+  pin the constant NAMES only, not their numeric values, so the
+  numbers are user-tunable per the QS-217 precedent.
+
+### [must-fix] #2 Sparkles are too small (user-visual)
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:81-95`
+- Severity: must-fix
+- Source: user (screenshot)
+- Description: The sparkle radii are too discrete; the electron pops
+  barely read in the rendered card.
+- Proposed fix: roughly double all six sparkle-radius constants so
+  the electrons read at a glance. First cut:
+  - `SPARKLE_IDLE_RADIUS_MIN`: 0.8 → 1.6
+  - `SPARKLE_IDLE_RADIUS_MAX`: 1.6 → 3.0
+  - `SPARKLE_CHARGE_RADIUS_MIN_AT_MIN_POWER`: 1.2 → 2.4
+  - `SPARKLE_CHARGE_RADIUS_MAX_AT_MIN_POWER`: 2.5 → 4.5
+  - `SPARKLE_CHARGE_RADIUS_MIN_AT_MAX_POWER`: 1.8 → 3.4
+  - `SPARKLE_CHARGE_RADIUS_MAX_AT_MAX_POWER`: 3.5 → 6.5
+  These are starting points; iterate visually. Existing structural
+  tests pin constant NAMES, not values.
+
+### [must-fix] #3 NaN `_waterBaseY` poisons initial paint
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:988-989`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: When `soc` is NaN (a non-numeric `current_inputed_energy`
+  state in `useEnergyMode`, or a corrupted percent reading),
+  `_waterBaseY` becomes NaN. The RAF loop guards via `hasValidBase`,
+  but the initial `_generateWavePath()` call at `_render()` time does
+  NOT, so the `d` attribute is emitted with literal `"NaN"` tokens
+  and no soup paints until the next valid hass push.
+- Proposed fix: in the `useEnergyMode` branch (and any other path
+  that produces `soc`), guard with `Number.isFinite()` and fall back
+  to a sensible default (0 or the last known SOC). Mirror the
+  `isStalePercentMode` `isNumberLike(energyRaw)` pattern. Add a unit
+  test `test_car_card_render_skips_nan_water_base_y` that constructs
+  the rendered HTML with a non-numeric energy state and asserts the
+  emitted SVG path contains no `"NaN"` token.
+
+### [must-fix] #4 `_needsAnimationPrime` never fires before first paint
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:202-213`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: `_needsAnimationPrime` is set in `_startAnimation()`'s
+  lazy-init guard, which only runs after `connectedCallback()`. But
+  `setConfig()` calls `_render()` BEFORE the element is appended
+  (which is when `connectedCallback` fires). So the first paint
+  always uses `initialAmp = CALM_AMP` and `initialColorMix = 0` (idle
+  palette), regardless of `_charging`. Then either the RAF lerps
+  visibly over ~1.5s, or a quick hass push snaps the values
+  (producing a green-to-blue flash). The boot-transient avoidance the
+  priming block was designed for does not work as intended.
+- Proposed fix: also set `this._needsAnimationPrime = true` at the
+  end of `setConfig()`, so the first `_render()` primes
+  `_currentAmplitude` / `_currentSpeed` / `_currentColorMix` against
+  `this._charging` before emitting the initial wave path. Add a unit
+  test `test_car_card_first_render_primes_against_charging_state`.
+
+### [should-fix] #5 Defensive `Number.isFinite` wrap at `initialWavePath` call site
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1008`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Belt-and-braces against #3 at the call site. Even with
+  the upstream guard, defensive code at the call site protects
+  against any future regression.
+- Proposed fix: wrap with
+  `const initialWavePath = Number.isFinite(this._waterBaseY) ? this._generateWavePath(WAVE_WIDTH, initialAmp, 2, 0, this._waterBaseY) : '';`
+  so the emitted `d` attribute is never poisoned.
+
+### [should-fix] #6 `time_btn` cover gate inconsistency
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1109` vs `:1072`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `time_btn` renders unconditionally in the mini-grid
+  (driven by `chargeTime`), but its `time_btn_cover` carve is gated
+  on `(tNext && e.schedule)`. When `chargeTime` is set but
+  `e.schedule` isn't, the button face draws over un-carved soup —
+  sparkles and lightning bleed through.
+- Proposed fix: align the two predicates. Either gate the button on
+  the same `(tNext && e.schedule)` condition, or relax the cover
+  gate to whatever drives `chargeTime` actually being present.
+  Verify in HA against a config that exercises this corner. Add a
+  unit test `test_car_card_time_btn_and_cover_gates_match` that
+  extracts both predicates and asserts string equality.
+
+### [should-fix] #7 Detach/reattach skips re-prime
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:472-490`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: On re-attach (HA panel switch), `_startAnimation()`'s
+  lazy-init guard skips because `_currentAmplitude != null`. If
+  `_charging` flipped during the detached interval, the soup will
+  visibly lerp on reconnect rather than snap. The "preserved across
+  detach/re-attach" comment intends this, but it conflicts with the
+  prime-on-mount goal of #4.
+- Proposed fix: in `connectedCallback()`, after `_startAnimation()`,
+  set `this._needsAnimationPrime = true` IF the current `_charging`
+  state differs from the implied state of `_currentColorMix` (i.e.,
+  `(charging ? 1 : 0) !== Math.round(this._currentColorMix)`). This
+  re-primes on reconnect only when the state actually flipped.
+
+### [should-fix] #8 `_lastAmplitude = NaN` permanently freezes regen
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1151-1153`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `this._lastAmplitude = this._currentAmplitude ?? CALM_AMP`
+  uses `??`, which does NOT trap NaN. If `_currentAmplitude` ever
+  becomes NaN, `_lastAmplitude` becomes NaN, the regen check
+  `ampDelta = Math.abs(_currentAmplitude - NaN) = NaN` is always
+  `< threshold`, and the wave-path attribute is never regenerated
+  for the lifetime of the card.
+- Proposed fix: replace `??` with an explicit finite check:
+  `this._lastAmplitude = Number.isFinite(this._currentAmplitude) ? this._currentAmplitude : CALM_AMP;`
+  Apply the same guard wherever the cached value is read.
+
+### [should-fix] #9 RAF-model contradiction in docs
+- File: `docs/agents/concepts/dashboard-and-cards.md:633-643` (later "Hardened JS-card patterns" section)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The new QS-232 H3 documents `qs-car-card.js` as
+  continuous-RAF, but the later "Hardened JS-card patterns" section
+  still describes the car card as `_charging`-gated. The two
+  sections contradict and will confuse future maintainers.
+- Proposed fix: update the later "Hardened JS-card patterns" section
+  to align with the QS-232 H3 — strike or rewrite the
+  "_charging-gated" claim for the car card, leaving the boiler and
+  pool as the documented `_charging`-gated → continuous-RAF
+  migration precedents.
+
+### [should-fix] #10 `0.10` breakpoint assertion is too loose
+- File: `tests/test_dashboard_rendering.py:3961-3967`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The lightning-fade breakpoint check currently passes
+  on ANY `0.1` literal in the file (e.g., `LERP_DT_CEIL = 0.1`), so
+  it won't catch a regression in the lightning fade-in breakpoint.
+- Proposed fix: tighten the regex to scope to the lightning fade
+  context:
+  `re.search(r"lifeT\s*<\s*0\.10\b|lifeT\s*<=\s*0\.10\b", executable)`
+
+### [should-fix] #11 Cover-order check uses `find` instead of `rfind`
+- File: `tests/test_dashboard_rendering.py:4614-4649`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: `source.find("</g>", clip_g_idx)` returns the FIRST
+  nested `</g>` after the electron-soup group opens, hitting a child
+  layer before the outer clipped group closes. A misplaced cover
+  inserted between inner layers would still satisfy this test.
+- Proposed fix: switch to
+  `source.rfind("</g>", clip_g_idx, bg_idx)` to locate the OUTER
+  close, or implement nested `<g>` / `</g>` depth tracking.
+
+### [should-fix] #12 Lightning spawn `+=` vs `=` asymmetry
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js` lightning spawn while-loop
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: Inside the lightning spawn while-loop, the
+  degenerate-chord `continue` branch uses
+  `this._nextLightningAt += ...` but the successful-spawn path uses
+  `this._nextLightningAt = ...`. The sparkle subsystem uses `+=` in
+  BOTH branches. Asymmetric semantics are a drift hazard for future
+  maintainers.
+- Proposed fix: change the successful-spawn path to use `+=` to
+  match the sparkle pattern, then clamp with `if (... < 0) ... = 0`
+  at the end of the while-loop (same as the sparkle path already
+  does).
+
+### [nice-to-have] #13 `connectedCallback` no-`if` assertion is too broad
+- File: `tests/test_dashboard_rendering.py:4186-4190`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: The current assertion rejects any `if` in
+  `connectedCallback()`, but the contract is "`_startAnimation()` is
+  unconditional", not "no `if` at all". Future harmless guards
+  unrelated to RAF startup would fail this assertion.
+- Proposed fix: tighten to
+  `re.search(r"if\s*\([^)]*\)\s*\{[^}]*this\._startAnimation", cb_body, re.DOTALL)`
+  so only `if`-blocks wrapping/preceding `_startAnimation` are
+  rejected.
+
+### [nice-to-have] #14 `_grainFilterEl` dead field
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:173-180`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `_resetDomRefs()` nulls `this._grainFilterEl`, but no
+  code in the codebase ever reads or lazily-resolves
+  `_grainFilterEl`. Dead initialisation.
+- Proposed fix: either remove the line from `_resetDomRefs()` (the
+  test pins the name, so update the test concurrently) or add a
+  comment explaining why the field exists for future use.
+
+### [nice-to-have] #15 Redundant `?? null` in lazy DOM lookup
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:286-293`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description:
+  `this._root?.getElementById(this._sparkleLayerId) ?? null` —
+  `getElementById` already returns `null` on miss, so the inner
+  `?? null` is redundant.
+- Proposed fix: drop the inner `?? null`. Same for `_lightningLayerEl`.
+
+### [nice-to-have] #16 `LIGHTNING_SEGMENTS = 3` declared but unused
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:112`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The constant is declared at module scope but never
+  referenced; the lightning path hardcodes 3 `L` segments rather
+  than looping driven by this constant.
+- Proposed fix: either remove the constant, or drive the lightning
+  path emission by a loop using `LIGHTNING_SEGMENTS`. Removal is the
+  smaller change.
+
+### [nice-to-have] #17 Stray "PRESERVED from M4" comment
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:258`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The dashed-arc inline comment still references "M4"
+  (the deleted `_charging`-gated milestone). Mention should be
+  updated to reflect the QS-232 continuous-RAF model.
+- Proposed fix: rewrite the comment to say "PRESERVED from prior
+  car-card revision; the dashed `<path id=\"charge_anim\">` still
+  drives off `showAnimation`, …".
+
+### [nice-to-have] #18 `_currentColorMix` floating-point drift outside [0,1]
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:255-257`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Floating-point lerp can leave `_currentColorMix`
+  slightly outside `[0, 1]` after many iterations (e.g.,
+  `1.0000000001`). Then `(1 - _currentColorMix).toFixed(3)` emits
+  `"-0.000"` — SVG accepts this but the negative sign is ugly.
+- Proposed fix: clamp explicitly when assigning opacity:
+  `const mix = Math.max(0, Math.min(1, this._currentColorMix));`
+  then use `mix` in both opacity emissions.
+
+### [nice-to-have] #19 `sparkleMax` non-integer comparison
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:337`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `while (this._nextSparkleAt <= 0 && this._sparkles.length < sparkleMax)`
+  with `sparkleMax = 18.5` (linear interpolation between 12 and 28)
+  works correctly but reads as if integer comparison were intended.
+- Proposed fix: apply `Math.floor(sparkleMax)` at the spawn-loop
+  guard, or document the intent inline.
+
+### [nice-to-have] #20 Negative `_chargePower` defensive coercion
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:323`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: A V2L discharge scenario or sensor glitch could
+  produce negative `_chargePower`. Downstream clamping handles it,
+  but a defensive `Math.max(0, this._chargePower)` at the source
+  would be cleaner.
+- Proposed fix: `const power = Math.max(0, this._chargePower || 0);`
+
+### [nice-to-have] #21 Sparkle opacity=0 at `lifeT=1.0` lingers one frame
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:386`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: When `lifeT` is exactly `1.0` (rounded into the
+  boundary), opacity = 0 and the sparkle persists at opacity 0 for
+  one frame before being retired the next tick. Cosmetic only.
+- Proposed fix: in the advance loop, retire when
+  `s.life >= s.maxLife * 0.999` (or use `>` instead of `>=` only if
+  the prior comparison already handles equality).
+
+### [nice-to-have] #22 `connectedCallback` before `setConfig` defensive bail
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:466-470`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: If `connectedCallback` runs before `setConfig`,
+  `_root` is null and the RAF loop spins with all DOM lookups
+  returning `undefined → null`. Harmless but wasteful.
+- Proposed fix: bail at the top of `_startAnimation` if `!this._root`,
+  and re-call `_startAnimation` from `setConfig` once `_root` exists.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. The implementation
+agent must:
+1. Land all 22 fixes in a single PR commit (or split into 2-3
+   thematic commits if the diff exceeds ~400 lines net).
+2. Honor the 100% test coverage gate — every new branch or NaN guard
+   needs a covering test.
+3. For the user-visual fixes (#1, #2), iterate the numeric constants
+   visually in HA against the same `ID.buzz` card the screenshot
+   captured, then pin the final values in the constants block.
+4. Re-run the structural tests in `tests/test_dashboard_rendering.py`
+   to confirm the existing assertions still pass (constant NAMES
+   only are pinned, not numeric values).
+
+When done, return here and run `/review-task` again to re-verify the
+PR. The four reviewer sub-agents will re-check the same lenses, plus
+the user can visually inspect the rendered card.

--- a/docs/stories/QS-232.story_review_fix_#02.md
+++ b/docs/stories/QS-232.story_review_fix_#02.md
@@ -1,0 +1,409 @@
+# QS-232 — Review fix plan #02
+
+## Summary
+- Source PR: #233
+- Source story: `docs/stories/QS-232.story.md`
+- Prior fix plan: `docs/stories/QS-232.story_review_fix_#01.md` (applied
+  in commit `9d7beab9` — assumed fully landed; not re-litigated here)
+- Branch HEAD at audit: `ec4cd49c`
+- Findings to fix: 18 (2 must-fix + 5 should-fix + 11 nice-to-have)
+- Next implement phase: `/implement-task`
+- Path scope: mixed product / tests / docs
+
+## Background — what changed between rounds
+
+After fix plan #01 was applied (commit `9d7beab9`), 6 additional
+commits landed (`93fb46bd`, `29645939`, `ad8ddf91`, `088769f2`,
+`a033ae92`, `ec4cd49c`) that addressed user-visual positioning
+(sun/rabbit/time carve geometry, idle soup brightness, sparkle
+snapshot/restore on `_render`, sun-btn override-pattern). Those
+commits resolved the carve-cover position issue for sun-btn and
+time-btn (gate-mismatch fixed for both), but **did NOT close the
+critical animation-blocking regression** that fix plan #01 introduced
+via fix #4 (`setConfig` arming `_needsAnimationPrime`).
+
+User has confirmed at runtime: **"I don't see any sparkles."** This
+matches the regression's predicted symptom exactly.
+
+## Findings to fix
+
+### [must-fix] #1 Lazy-init bypass → no sparkles, no lightning, no wave scroll
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js`
+- Severity: must-fix (animation-blocking regression)
+- Source: qs-review-edge-case-hunter (round 2)
+- Status: STILL APPLIES at HEAD `ec4cd49c`. Confirmed by user
+  ("I don't see any sparkles").
+- Description: `setConfig` (line ~591) arms
+  `_needsAnimationPrime = true`, then calls `_render()`. The
+  `_render()` prime block (lines ~1116-1121) consumes the flag and
+  sets `_currentAmplitude`, `_currentSpeed`, `_currentColorMix` —
+  BUT NOT `_wavePhase`, `_nextSparkleAt`, `_nextLightningAt`. Then
+  `connectedCallback` (line ~538) calls `_startAnimation()`, whose
+  lazy-init guard `if (this._currentAmplitude == null)` (line ~247)
+  is FALSE because the prime block already assigned it. The entire
+  lazy-init block at lines ~248-258 is SKIPPED, leaving
+  `_wavePhase` / `_nextSparkleAt` / `_nextLightningAt` permanently
+  `undefined`. First RAF tick: `_wavePhase += _currentSpeed * dt` =
+  `undefined + n = NaN`. Result: wave transform becomes
+  `translateX(NaNpx)` (browsers silently ignore), the sparkle spawn
+  while-loop reads `NaN <= 0 = false` (never enters), and lightning
+  ditto. **All particle systems are dead.**
+- Commit `29645939` (sparkle snapshot/restore) does NOT close this:
+  the restore path runs only when `preservedSparkles?.length` is
+  truthy, which is never the case on cold-start mount.
+- Proposed fix: **decouple the prime block from the lazy-init
+  block.** Two valid shapes:
+  - **Option A** (preferred — minimal change): in `_startAnimation`,
+    move the lines that initialise `_wavePhase`, `_nextSparkleAt`,
+    `_nextLightningAt`, `_sparkles`, `_lightningBolts` OUTSIDE the
+    `if (this._currentAmplitude == null)` guard. Guard each one
+    individually with `if (this._wavePhase == null) this._wavePhase = 0;`
+    etc. The `_currentAmplitude`-gated block keeps only the three
+    fields the prime block already seeds (so reattach doesn't double-
+    seed them).
+  - **Option B**: revert fix #04's `setConfig` arming and find a
+    different way to prime the first paint. The boiler card relies
+    on lazy-init to seed all RAF state and lets the next `_render`
+    consume the prime flag; the car card should mirror that pattern
+    exactly.
+- Test plan:
+  - Add `test_car_card_first_raf_tick_initialises_wave_phase` —
+    extract `_startAnimation()` body and assert that
+    `_wavePhase`, `_nextSparkleAt`, `_nextLightningAt` are each
+    seeded on a code path NOT gated by `_currentAmplitude == null`.
+  - Add `test_car_card_setConfig_render_does_not_strand_raf_state` —
+    simulate `setConfig` → `_render` → `connectedCallback` ordering
+    and assert that after `connectedCallback` returns, all three
+    counters are finite numbers.
+  - Add a smoke test that builds the rendered card and asserts the
+    sparkle layer is non-empty after a few simulated RAF ticks.
+
+### [must-fix] #2 `??` for `initialAmp` / `initialColorMix` lets NaN through
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1133-1134`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter + qs-review-blind-hunter (round 2)
+- Status: STILL APPLIES at HEAD `ec4cd49c`.
+- Description: `initialAmp = this._currentAmplitude ?? CALM_AMP` and
+  `initialColorMix = this._currentColorMix ?? 0` use `??`, which only
+  traps null/undefined — NaN passes through. If either runtime field
+  ever becomes NaN, the initial `_generateWavePath(...)` emits
+  `"NaN"` tokens into the `d` attribute and the opacity attributes
+  become literal `"NaN"`. Mirror the fix-#01-#8 finite-guard shape
+  here.
+- Proposed fix:
+  ```javascript
+  const initialAmp = Number.isFinite(this._currentAmplitude)
+      ? this._currentAmplitude : CALM_AMP;
+  const initialColorMix = Number.isFinite(this._currentColorMix)
+      ? this._currentColorMix : 0;
+  ```
+- Test plan: extend
+  `test_car_card_last_amplitude_uses_finite_guard_not_nullish` to
+  also pin the initial-paint sites — extract the lines and assert
+  they use `Number.isFinite(...)` rather than `??`.
+
+### [should-fix] #3 `_startAnimation` early-bail without re-entry path
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:243` + `setConfig`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter + qs-review-blind-hunter +
+  qs-review-acceptance-auditor (round 2; carried from fix plan #01 #22)
+- Status: STILL APPLIES at HEAD. Fix #01 added the bail but never
+  completed the second clause.
+- Description: `_startAnimation` bails when `!this._root`, but
+  nothing re-invokes it from `setConfig` once `_root` is assigned.
+  `_render` doesn't call `_startAnimation`. In the (uncommon)
+  lifecycle ordering where `connectedCallback` fires before
+  `setConfig`, RAF never starts.
+- Proposed fix: at the tail of `setConfig()`, after the initial
+  `_render()`, add:
+  ```javascript
+  if (this.isConnected && this._animRaf == null) {
+      this._startAnimation();
+  }
+  ```
+- Test plan: add `test_car_card_setConfig_restarts_animation_when_connected`
+  — assert the `setConfig` body contains a guarded `_startAnimation()`
+  re-entry call.
+
+### [should-fix] #4 `connectedCallback` reprime arms flag but doesn't trigger consumption
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:549-552`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter + qs-review-blind-hunter (round 2;
+  carried from fix plan #01 #7)
+- Status: STILL APPLIES at HEAD.
+- Description: On reconnect after a state-flip, `connectedCallback`
+  sets `_needsAnimationPrime = true` but never calls `_render()`.
+  The flag is consumed only by the next `_render` (triggered by the
+  next hass push, which may be seconds away). Between reconnect and
+  that next push, the RAF lerps visibly from the stale
+  `_currentColorMix` toward the new target — the exact behaviour
+  fix #07 was designed to suppress.
+- Proposed fix: after setting the flag, explicitly call
+  `this._render()` (or `this._invalidateAnimCache()` plus a manual
+  prime evaluation). The most direct shape:
+  ```javascript
+  if (charging !== (Math.round(this._currentColorMix) === 1)) {
+      this._needsAnimationPrime = true;
+      this._render();   // consume the flag immediately
+  }
+  ```
+- Test plan: add
+  `test_car_card_connectedCallback_reprime_calls_render` — verify
+  the reprime branch calls `this._render()` within the same block.
+
+### [should-fix] #5 Fix #01-#8 incomplete — in-RAF `_lastAmplitude` write/read still unguarded
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:338` (read) + `:345` (write)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter + qs-review-acceptance-auditor (round 2)
+- Status: STILL APPLIES at HEAD. Fix #01-#8 only patched the
+  post-innerHTML site (`:1306`).
+- Description: The in-RAF write `this._lastAmplitude = this._currentAmplitude`
+  at line ~345 is unguarded; the read at line ~338 uses `== null`
+  which doesn't trap NaN. If `_currentAmplitude` ever becomes NaN
+  mid-frame, line 345 propagates NaN into `_lastAmplitude`,
+  subsequent reads stay NaN, `Math.abs(... - NaN) = NaN`,
+  `NaN > threshold = false` — wave-path regen freezes for the
+  lifetime of the card.
+- Proposed fix: change the read condition to
+  `this._lastAmplitude == null || !Number.isFinite(this._lastAmplitude)`,
+  and mirror the post-innerHTML guard at the in-RAF write:
+  ```javascript
+  this._lastAmplitude = Number.isFinite(this._currentAmplitude)
+      ? this._currentAmplitude : CALM_AMP;
+  ```
+- Test plan: extend
+  `test_car_card_last_amplitude_uses_finite_guard_not_nullish` to
+  pin both the in-RAF read AND write sites.
+
+### [should-fix] #6 `initialIdleOpacity` / `initialChargeOpacity` not clamped (fix #01-#18 scope gap)
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1138-1139`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter (round 2)
+- Status: STILL APPLIES at HEAD. Fix #01-#18 clamped the RAF-step
+  opacity emission (`:357`) but not the initial-paint emission.
+- Description: Lines 1138-1139 emit
+  `(1 - initialColorMix).toFixed(3)` and `initialColorMix.toFixed(3)`
+  with no clamp. After RAF has run long enough for `_currentColorMix`
+  to drift outside `[0, 1]` (any session >a few seconds), the next
+  `_render` emits `"-0.000"` as the opacity attribute. SVG accepts
+  it visually but the attribute string is ugly.
+- Proposed fix: mirror the RAF-step clamp at the initial-paint site:
+  ```javascript
+  const mix = Math.max(0, Math.min(1, initialColorMix));
+  // …emit (1 - mix).toFixed(3) and mix.toFixed(3)…
+  ```
+- Test plan: extend the existing AC-2 opacity test to also pin the
+  initial-paint clamp.
+
+### [should-fix] #7 rabbit-btn cover gate mismatch (fix #01-#06 partial scope)
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1216` (cover) vs `:1249` (button)
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (round 2)
+- Status: STILL APPLIES at HEAD. Recent commits aligned sun-btn and
+  time-btn gates but rabbit-btn was left in the partial-fix state.
+- Description: `<div id="rabbit_btn">` renders UNCONDITIONALLY, but
+  `<circle id="rabbit_btn_cover">` is gated on `e.force_now`. When
+  `force_now` is undefined for the car entity, the rabbit button
+  draws over un-carved soup and sparkles bleed through behind it.
+- Proposed fix: gate the button on the same predicate as the cover:
+  `${e.force_now ? `<div id="rabbit_btn" …>…</div>` : ''}`. Verify
+  no downstream code depends on `#rabbit_btn` always existing in the
+  DOM; if it does, instead relax the cover gate.
+- Test plan: add `test_car_card_rabbit_btn_render_and_cover_gates_match`
+  — extract both predicates and assert string equality (mirror the
+  existing `test_car_card_time_btn_render_and_cover_gates_match`).
+
+### [nice-to-have] #8 Lightning post-loop clamp inside spawn gate
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:498` vs `:430` (sparkle)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter (round 2)
+- Status: STILL APPLIES at HEAD.
+- Description: Lightning clamp sits inside `if (charging && !degraded)`
+  (line ~461); sparkle clamp sits outside. Currently fine because
+  the `-= dt` decrement is also inside the same gate, but a future
+  refactor that moves the decrement out would create a permanent
+  negative-drift bug.
+- Proposed fix: hoist the lightning clamp out of the spawn gate to
+  mirror the sparkle structure.
+
+### [nice-to-have] #9 `mix` clamp doesn't trap NaN
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:357`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter (round 2)
+- Status: STILL APPLIES at HEAD.
+- Description: `Math.max(0, Math.min(1, NaN)) = NaN`. The fix-#01-#18
+  clamp doesn't trap NaN.
+- Proposed fix:
+  ```javascript
+  const mix = Number.isFinite(this._currentColorMix)
+      ? Math.max(0, Math.min(1, this._currentColorMix)) : 0;
+  ```
+
+### [nice-to-have] #10 `_waveEls` lazy-resolve caches `null` permanently
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:309-313`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter (round 2)
+- Status: STILL APPLIES at HEAD (only `_waveEls`; sparkle/lightning
+  use `??` so they retry).
+- Description: `if (!this._waveEls) { this._waveEls = [idleEl, chargeEl]; }`
+  — if both lookups return null (e.g., transient detach), the array
+  `[null, null]` is truthy, so the guard never retries.
+- Proposed fix: retry if either slot is null:
+  ```javascript
+  if (!this._waveEls || !this._waveEls[0] || !this._waveEls[1]) {
+      const idleEl   = this._root?.getElementById('electron_wave_idle');
+      const chargeEl = this._root?.getElementById('electron_wave_charge');
+      this._waveEls = [idleEl ?? null, chargeEl ?? null];
+  }
+  ```
+
+### [nice-to-have] #11 `hasValidBase` uses `!Number.isNaN(...)` not `Number.isFinite(...)`
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:337`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter (round 2)
+- Status: STILL APPLIES at HEAD.
+- Description: `!Number.isNaN(Infinity) === true`, so an `Infinity`
+  `_waterBaseY` would pass the guard. Currently unreachable but
+  asymmetric with the fix-#01-#3 / fix-#01-#5 guards.
+- Proposed fix: `const hasValidBase = waterBaseY != null && Number.isFinite(waterBaseY);`
+
+### [nice-to-have] #12 Asymmetric DOM-ref caching style
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:309-321`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter + qs-review-blind-hunter (round 2)
+- Status: STILL APPLIES at HEAD.
+- Description: `_waveEls` uses `if (!this._waveEls)` block-form;
+  sparkle/lightning layers use inline `?? (this._x = …)` form.
+  Future-maintainer drift hazard.
+- Proposed fix: align both to one form. The block-form is clearer;
+  the inline form is shorter. Pick one and apply to all three.
+
+### [nice-to-have] #13 Wave-element comment drift
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:307-308`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter (round 2; carried from fix
+  plan #01 #15 partial)
+- Status: STILL APPLIES at HEAD.
+- Description: Comment lines 307-308 claim "the prior inner `?? null`
+  was redundant" but lines 310-311 still carry `?? null`. The wave-
+  element lookups need `?? null` (different semantics from the layer
+  lookups). Either update the comment or remove the redundant
+  qualifier from the comment.
+- Proposed fix: rewrite the comment to clarify that the wave-element
+  `?? null` is intentional (because `_root?.getElementById(...)` can
+  return `undefined`, and the lazy-resolve must distinguish `null`
+  cache hits from `undefined` for the retry check in fix #10 above).
+
+### [nice-to-have] #14 Header docstring duplicates in-code comments
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1-36`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter (round 2)
+- Status: STILL APPLIES at HEAD.
+- Description: Header lines 1-36 redundantly describe sparkle
+  behaviour (`[1500W, 22000W]` range, `[1.5, 3.0]s` spawn interval)
+  that the in-code constants block (lines 93-97, 115-116) already
+  documents.
+- Proposed fix: trim the header to design intent only; cite the
+  constants block by line range for specifics.
+
+### [nice-to-have] #15 New regression — sparkle snapshot cadence-restore is gated
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1331, 1347`
+- Severity: nice-to-have (comment drift, not functional)
+- Source: qs-review-edge-case-hunter (round 2; introduced by commit `29645939`)
+- Status: NEW at HEAD.
+- Description: Commit `29645939` added a sparkle snapshot/restore
+  block in `_render()`. The comment at line 1330 says "Cadence
+  counters are restored so spawn timing is continuous", but the
+  restoration of `_nextSparkleAt` / `_nextLightningAt` is gated on
+  `if (preservedSparkles?.length)` / `if (preservedLightningBolts?.length)`.
+  When the arrays are empty at snapshot time (common — sparkles live
+  ~0.45s, lightning ~0.25s, `set hass` ~10/s), cadence counters are
+  NOT restored. In practice this is benign because `_resetDomRefs`
+  doesn't touch them, so they survive the rebuild via the unchanged-
+  instance-state path. Comment drift only.
+- Proposed fix: either move the cadence-counter restore lines outside
+  the array-truthy branches (so the comment matches), or rewrite the
+  comment to clarify the actual gating.
+
+### [nice-to-have] #16 New regression — sparkle `cy` becomes stale on large SOC shifts
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js` sparkle-restore block
+- Severity: nice-to-have (visible ≤0.45s)
+- Source: qs-review-edge-case-hunter (round 2; introduced by commit `29645939`)
+- Status: NEW at HEAD.
+- Description: A sparkle spawned at `cy ≈ _waterBaseY + 2` is
+  preserved across a `_render` even if SOC has changed enough that
+  the new `_waterBaseY` is now ABOVE the sparkle's frozen `cy`. The
+  sparkle appears in the air above the soup surface during its
+  remaining lifetime.
+- Proposed fix: in the restore loop, drop any preserved sparkle whose
+  `cy < (new _waterBaseY)` — let it fade rather than appearing above
+  the soup. Cheap: one comparison per restored sparkle.
+
+### [nice-to-have] #17 New regression — `sun-btn-spacer` height hardcoded
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js` style block (~line 901)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter (round 2; introduced by commit `ad8ddf91`)
+- Status: NEW at HEAD.
+- Description: `.ring .sun-btn-spacer { height: 74px; … }` hardcodes
+  the spacer height that compensates for the absolute-positioned
+  sun-btn. The 74px figure assumes the current sun-btn icon size and
+  label height. A future tweak to `--qs-sun-btn-icon-size` or the
+  label typography will silently get out of sync.
+- Proposed fix: either derive the spacer height from a CSS custom
+  property (`height: calc(var(--qs-sun-btn-icon-size) + var(--qs-sun-btn-label-height) + 24px)`),
+  or add an inline comment block specifying the components of the
+  74px figure so future maintainers update both numbers in lockstep.
+
+### [nice-to-have] #18 New coupling — `_render` snapshot reads `this._sparkles` before lazy-init
+
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js` `_render()` start
+- Severity: nice-to-have (currently safe, fragile coupling)
+- Source: qs-review-edge-case-hunter (round 2; introduced by commit `29645939`)
+- Status: NEW at HEAD.
+- Description: On the very first `_render` (called from `setConfig`,
+  BEFORE `connectedCallback`), `this._sparkles` is `undefined` and
+  the snapshot captures `undefined`. The restore block is skipped,
+  and `_resetDomRefs()` later sets `_sparkles = []`. End state is
+  correct, but if `_resetDomRefs` ever stops setting `_sparkles = []`,
+  the first RAF tick would deref `undefined.length` in the spawn
+  loop.
+- Proposed fix: defensively coerce at snapshot time:
+  `const preservedSparkles = this._sparkles ?? [];`. This eliminates
+  the hidden coupling.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. The implementation
+agent MUST:
+1. **Land must-fix #1 first** — verify in HA that sparkles + lightning
+   spawn after a cold-start mount BEFORE moving on. This is the only
+   way to confirm the critical regression is closed.
+2. Apply remaining must-fix (#2) and should-fix (#3-#7) in any
+   order; they're independent.
+3. Apply nice-to-have items in batches; the comment drift items
+   (#13, #14, #15) can be a single commit.
+4. Maintain the 100% test-coverage gate. Each new branch / NaN guard
+   needs a covering test (see per-finding "Test plan" sections).
+5. Do NOT regress any of the 22 fix-plan-#01 items — re-run the
+   existing acceptance-auditor's traceability tests.
+
+When done, return here and run `/review-task` again. The four
+reviewer sub-agents will re-check the same lenses; the user will
+visually verify sparkles + lightning are alive at runtime.

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -3743,22 +3743,42 @@ def test_car_card_cross_fade_lerp_is_binary_idle_charge():
         "? 1 : 0` lerp target (mirrors boiler precedent)."
     )
 
-    # Per-frame opacity: `(1 - this._currentColorMix).toFixed(3)` and
-    # `this._currentColorMix.toFixed(3)`.
-    assert re.search(
-        r"\(\s*1\s*-\s*this\._currentColorMix\s*\)\s*\.toFixed\s*\(\s*3\s*\)",
-        executable,
-    ), (
+    # Per-frame opacity: `(1 - <colorMix>).toFixed(3)` and
+    # `<colorMix>.toFixed(3)`. The `<colorMix>` token may be either
+    # `this._currentColorMix` directly OR a clamped local derived
+    # from it (review-fix #01 #18 introduced a `mix = Math.max(0,
+    # Math.min(1, this._currentColorMix))` clamp). Either form
+    # satisfies the semantic AC-2 contract.
+    idle_re = re.compile(
+        r"\(\s*1\s*-\s*(?:this\._currentColorMix|mix)\s*\)"
+        r"\s*\.toFixed\s*\(\s*3\s*\)",
+    )
+    assert idle_re.search(executable), (
         "qs-car-card.js (AC-2): missing idle-opacity expression "
-        "`(1 - this._currentColorMix).toFixed(3)`."
+        "`(1 - <colorMix>).toFixed(3)` where <colorMix> is either "
+        "`this._currentColorMix` or a clamped local derived from it."
     )
-    assert re.search(
-        r"this\._currentColorMix\s*\.toFixed\s*\(\s*3\s*\)",
-        executable,
-    ), (
+    charge_re = re.compile(
+        r"(?:this\._currentColorMix|mix)\s*\.toFixed\s*\(\s*3\s*\)",
+    )
+    assert charge_re.search(executable), (
         "qs-car-card.js (AC-2): missing charge-opacity expression "
-        "`this._currentColorMix.toFixed(3)`."
+        "`<colorMix>.toFixed(3)` where <colorMix> is either "
+        "`this._currentColorMix` or a clamped local derived from it."
     )
+    # If a `mix` local is used for opacity, it must be derived from
+    # `this._currentColorMix` (NOT a fresh independent variable
+    # that bypasses the binary lerp).
+    if re.search(r"\(\s*1\s*-\s*mix\s*\)\s*\.toFixed", executable):
+        assert re.search(
+            r"const\s+mix\s*=\s*[^;]*this\._currentColorMix",
+            executable,
+        ), (
+            "qs-car-card.js (AC-2): the local `mix` used for opacity "
+            "must be derived from `this._currentColorMix` "
+            "(typically `const mix = Math.max(0, Math.min(1, "
+            "this._currentColorMix));`)."
+        )
 
     # LERP_RATE constant.
     assert re.search(r"const\s+LERP_RATE\s*=\s*2\b", executable), (
@@ -3957,14 +3977,22 @@ def test_car_card_lightning_life_and_glow_filter():
         "qs-car-card.js (AC-6): missing `const LIGHTNING_LIFE_S = "
         "0.25;`"
     )
-    # Three-phase opacity breakpoints.
-    assert "0.10" in executable or "0.1 " in executable or "0.1\n" in executable, (
-        "qs-car-card.js (AC-6): missing fade-in breakpoint `0.10` "
-        "in the lightning advance loop."
+    # Three-phase opacity breakpoints. Review-fix #01 #10: scope the
+    # `0.10` check to the `lifeT < …` lightning-fade context so a
+    # regression on the actual breakpoint can't be masked by an
+    # unrelated `0.1` literal elsewhere in the file (e.g.,
+    # `LERP_DT_CEIL = 0.1`).
+    assert re.search(
+        r"lifeT\s*<\s*0\.10\b", executable
+    ), (
+        "qs-car-card.js (AC-6): missing fade-in breakpoint "
+        "`lifeT < 0.10` in the lightning advance loop."
     )
-    assert "0.70" in executable, (
-        "qs-car-card.js (AC-6): missing fade-out breakpoint `0.70` "
-        "in the lightning advance loop."
+    assert re.search(
+        r"lifeT\s*<\s*0\.70\b", executable
+    ), (
+        "qs-car-card.js (AC-6): missing fade-out breakpoint "
+        "`lifeT < 0.70` in the lightning advance loop."
     )
 
     # Glow filter with safe-region attrs.
@@ -4183,9 +4211,19 @@ def test_car_card_continuous_raf_from_connected_callback():
         "qs-car-card.js (AC-9): `connectedCallback` must call "
         "`this._startAnimation()` directly (continuous-RAF model)."
     )
-    assert re.search(r"\bif\s*\(", cb_body) is None, (
+    # Review-fix #01 #13: the contract is "`_startAnimation()` is
+    # unconditional", not "no `if` at all". Future harmless guards
+    # unrelated to RAF startup (e.g., the QS-232 #7 fix that
+    # re-primes on state-flip after reconnect) are legitimate. Pin
+    # only `if`-blocks that wrap or precede `_startAnimation`.
+    raf_gate_re = re.compile(
+        r"if\s*\([^)]*\)\s*\{[^}]*this\._startAnimation",
+        re.DOTALL,
+    )
+    assert raf_gate_re.search(cb_body) is None, (
         "qs-car-card.js (AC-9): `connectedCallback` must call "
-        "`_startAnimation()` unconditionally — no `if (...)` gate "
+        "`_startAnimation()` unconditionally — no `if (...)` block "
+        "wrapping or preceding the `_startAnimation` call "
         "(continuous-RAF model, mirror boiler/pool)."
     )
 
@@ -4282,9 +4320,11 @@ def test_car_card_reset_dom_refs_helper_and_disconnect_teardown():
         "qs-car-card.js (AC-10): `_resetDomRefs()` method not found."
     )
 
+    # Review-fix #01 #14: `_grainFilterEl` was a dead field — no
+    # code path ever read or lazily-resolved it. Removed from
+    # `_resetDomRefs()` to match the actual DOM-ref surface area.
     for assignment_re in (
         r"this\._waveEls\s*=\s*null",
-        r"this\._grainFilterEl\s*=\s*null",
         r"this\._sparkleLayerEl\s*=\s*null",
         r"this\._lightningLayerEl\s*=\s*null",
         r"this\._sparkles\s*=\s*\[\s*\]",
@@ -4618,18 +4658,22 @@ def test_car_card_inside_disc_button_carve_covers():
     rabbit_idx = source.find('id="rabbit_btn_cover"')
     time_idx = source.find('id="time_btn_cover"')
     bg_idx = source.find('<path d="${bgPath}"')
-    # Find the closing </g> of the clipped group: look for the
-    # `<g clip-path="url(#${electronClipId})"` anchor and then the
-    # FIRST </g> that follows it.
+    # Find the OUTER closing </g> of the clipped group. Review-fix
+    # #01 #11: the original `find("</g>", clip_g_idx)` returned the
+    # FIRST nested `</g>` (sparkle layer or lightning layer), so a
+    # misplaced cover inserted between inner layers would falsely
+    # satisfy the ordering check. Use `rfind` scoped to the
+    # [clip_g_idx, bg_idx] window to locate the OUTER close.
     clip_g_idx = source.find('<g clip-path="url(#${electronClipId})"')
     assert clip_g_idx != -1, (
         "qs-car-card.js (AC-14): missing the electron-soup clipped "
         "group anchor."
     )
-    clip_g_close_idx = source.find("</g>", clip_g_idx)
+    clip_g_close_idx = source.rfind("</g>", clip_g_idx, bg_idx)
     assert clip_g_close_idx != -1, (
-        "qs-car-card.js (AC-14): cannot find the closing `</g>` of "
-        "the electron-soup clipped group."
+        "qs-car-card.js (AC-14): cannot find the outer closing "
+        "`</g>` of the electron-soup clipped group within the "
+        "expected [clip_g_idx, bg_idx] window."
     )
 
     for cover_name, cover_idx in (
@@ -4647,6 +4691,312 @@ def test_car_card_inside_disc_button_carve_covers():
             f"BEFORE the `<path d=\"${{bgPath}}\"` line "
             f"(idx {bg_idx}). Got cover idx {cover_idx}."
         )
+
+
+# ============================================================================
+# === QS-232 review-fix #01 tests ===
+# Additional regression pins from the post-PR review pass. Each
+# guards a specific edge case or bugfix from
+# `docs/stories/QS-232.story_review_fix_#01.md`.
+# ============================================================================
+
+
+def test_car_card_render_guards_water_base_y_against_nan():
+    """QS-232 review-fix #01 #3: `_waterBaseY` must NOT become NaN
+    if `soc` is NaN (a non-numeric `current_inputed_energy` state
+    in `useEnergyMode`, or a corrupted percent reading). Without a
+    guard, the initial `_generateWavePath()` call at `_render()` time
+    emits literal `"NaN"` tokens in the `d` attribute and no soup
+    paints until the next valid hass push. Pinned via a structural
+    `Number.isFinite` check on either `soc` or `progressRatio`
+    before the `_waterBaseY` assignment.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # The `_waterBaseY` assignment must be preceded by (or wrap with)
+    # a `Number.isFinite` guard against NaN soc. Accept either:
+    # - `Number.isFinite(soc)` ternary in the progressRatio
+    #   computation, OR
+    # - `Number.isFinite(progressRatio)` guard, OR
+    # - `Number.isFinite(this._waterBaseY)` post-assignment guard.
+    waterbase_guard_re = re.compile(
+        r"Number\.isFinite\s*\(\s*"
+        r"(?:soc|progressRatio|this\._waterBaseY|rawWaterBaseY)\s*\)",
+    )
+    assert waterbase_guard_re.search(executable), (
+        "qs-car-card.js (review-fix #01 #3): `_waterBaseY` "
+        "assignment must be guarded by `Number.isFinite(...)` against "
+        "NaN `soc`. Without this, a non-numeric energy/percent state "
+        "poisons the initial wave path's `d` attribute with literal "
+        "`NaN` tokens."
+    )
+
+
+def test_car_card_initial_wave_path_skips_nan_water_base_y():
+    """QS-232 review-fix #01 #5: belt-and-braces guard at the
+    `initialWavePath` call site. Even with the upstream
+    `_waterBaseY` guard, the call-site itself must check
+    `Number.isFinite(this._waterBaseY)` before invoking
+    `_generateWavePath(...)`, so a future regression to the upstream
+    guard can't silently poison the emitted SVG `d` attribute.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # The `initialWavePath = ...` line must use a ternary on
+    # `Number.isFinite(this._waterBaseY)` so the empty-string
+    # fallback path exists.
+    call_site_guard_re = re.compile(
+        r"const\s+initialWavePath\s*=\s*"
+        r"Number\.isFinite\s*\(\s*this\._waterBaseY\s*\)\s*\?\s*"
+        r"this\._generateWavePath\s*\(",
+        re.DOTALL,
+    )
+    assert call_site_guard_re.search(executable), (
+        "qs-car-card.js (review-fix #01 #5): the `initialWavePath` "
+        "call site must wrap `_generateWavePath(...)` in "
+        "`Number.isFinite(this._waterBaseY) ? ... : ''` so the "
+        "emitted `d` attribute is never poisoned by a regression "
+        "upstream."
+    )
+
+
+def test_car_card_setConfig_primes_animation_state():
+    """QS-232 review-fix #01 #4: `_needsAnimationPrime` must be set
+    in `setConfig()` so the FIRST `_render()` (which runs from
+    `setConfig`, BEFORE `connectedCallback`) primes
+    `_currentAmplitude` / `_currentSpeed` / `_currentColorMix`
+    against the current `_charging` state. Without this, the first
+    paint always uses the idle palette regardless of `_charging`,
+    and a subsequent RAF lerp visibly transitions over ~1.5 s
+    (the boot-transient avoidance is moot).
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    set_config_body = _extract_js_function_body(
+        executable, r"setConfig\s*\(\s*config\s*\)\s*"
+    )
+    assert set_config_body is not None, (
+        "qs-car-card.js (review-fix #01 #4): `setConfig(config)` "
+        "method not found — the test file structure has drifted."
+    )
+    assert re.search(
+        r"this\._needsAnimationPrime\s*=\s*true",
+        set_config_body,
+    ), (
+        "qs-car-card.js (review-fix #01 #4): `setConfig()` must set "
+        "`this._needsAnimationPrime = true` so the first render "
+        "(which fires from `setConfig` BEFORE `connectedCallback`) "
+        "primes the wave animation state against `_charging`."
+    )
+
+
+def test_car_card_time_btn_render_and_cover_gates_match():
+    """QS-232 review-fix #01 #6: `time_btn` and `time_btn_cover`
+    must share the same render gate. The original implementation
+    had the button render unconditionally inside the mini-grid while
+    the cover was gated on `(tNext && e.schedule)` — when
+    `chargeTime` was set but `e.schedule` wasn't, the button face
+    drew over un-carved soup. This pin extracts both predicates
+    and asserts string equality.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+
+    # Extract the time_btn render gate. The fix gates the button on
+    # the same `(tNext && e.schedule)` predicate as the cover.
+    # Accept either form:
+    # - `(tNext && e.schedule) ? \`<div id="time_btn"…>\` : ''`
+    # - or any equivalent predicate that matches the cover's gate.
+    btn_gate_re = re.compile(
+        r"(\([^)]*\))\s*\?\s*`?\s*<div\s+id=\"time_btn\"",
+    )
+    btn_m = btn_gate_re.search(source)
+    assert btn_m is not None, (
+        "qs-car-card.js (review-fix #01 #6): the `time_btn` <div> "
+        "must now be wrapped in a `(predicate) ? `<div id=\"time_btn\""
+        " …>` : ''` ternary so its render gate aligns with the "
+        "`time_btn_cover` gate."
+    )
+
+    cover_gate_re = re.compile(
+        r"(\([^)]*\))\s*\?\s*`?\s*<circle\s+id=\"time_btn_cover\"",
+    )
+    cover_m = cover_gate_re.search(source)
+    assert cover_m is not None, (
+        "qs-car-card.js (review-fix #01 #6): missing the "
+        "`time_btn_cover` <circle> element with a gating ternary."
+    )
+
+    # Whitespace-normalise both predicates and compare.
+    def _normalise(s: str) -> str:
+        return re.sub(r"\s+", "", s)
+
+    btn_predicate = _normalise(btn_m.group(1))
+    cover_predicate = _normalise(cover_m.group(1))
+    assert btn_predicate == cover_predicate, (
+        f"qs-car-card.js (review-fix #01 #6): the `time_btn` render "
+        f"gate `{btn_m.group(1)}` and the `time_btn_cover` gate "
+        f"`{cover_m.group(1)}` must be equal (whitespace-normalised). "
+        f"Asymmetric gates allow the button face to draw over "
+        f"un-covered soup."
+    )
+
+
+def test_car_card_connectedCallback_reprimes_on_state_flip():
+    """QS-232 review-fix #01 #7: `connectedCallback()` must
+    re-prime `_needsAnimationPrime` when the `_charging` state
+    flipped during a detached interval. Otherwise, the
+    lazy-init guard in `_startAnimation()` (which preserves
+    `_currentAmplitude` etc. across detach/re-attach) skips the
+    prime block and the soup visibly lerps on reconnect rather
+    than snapping. Pinned structurally: the `connectedCallback`
+    body must reference both `_charging` and `_currentColorMix`
+    inside a re-prime guard.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    cb_body = _extract_js_function_body(
+        executable, r"connectedCallback\s*\(\s*\)\s*"
+    )
+    assert cb_body is not None, (
+        "qs-car-card.js (review-fix #01 #7): `connectedCallback()` "
+        "not found."
+    )
+    # The re-prime guard must reference `this._charging` AND
+    # `this._currentColorMix` (the implied state derivation).
+    assert re.search(r"this\._charging", cb_body), (
+        "qs-car-card.js (review-fix #01 #7): `connectedCallback` "
+        "must reference `this._charging` to compute the implied "
+        "state for re-prime."
+    )
+    assert re.search(r"this\._currentColorMix", cb_body), (
+        "qs-car-card.js (review-fix #01 #7): `connectedCallback` "
+        "must reference `this._currentColorMix` to detect a "
+        "state-flip during the detached interval."
+    )
+    assert re.search(
+        r"this\._needsAnimationPrime\s*=\s*true",
+        cb_body,
+    ), (
+        "qs-car-card.js (review-fix #01 #7): `connectedCallback` "
+        "must conditionally set `this._needsAnimationPrime = true` "
+        "when `_charging` flipped during detach."
+    )
+
+
+def test_car_card_last_amplitude_uses_finite_guard_not_nullish():
+    """QS-232 review-fix #01 #8: `this._lastAmplitude` must be
+    assigned via `Number.isFinite(this._currentAmplitude) ? ... :
+    CALM_AMP` instead of `this._currentAmplitude ?? CALM_AMP`. The
+    nullish coalescing operator does NOT trap NaN: if
+    `_currentAmplitude` ever becomes NaN, `_lastAmplitude` becomes
+    NaN, the regen check `ampDelta = Math.abs(_ - NaN) = NaN` is
+    always `< threshold`, and the wave-path attribute is never
+    regenerated for the lifetime of the card.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Positive pin: the explicit finite-check form.
+    finite_form_re = re.compile(
+        r"this\._lastAmplitude\s*=\s*"
+        r"Number\.isFinite\s*\(\s*this\._currentAmplitude\s*\)\s*\?\s*"
+        r"this\._currentAmplitude\s*:\s*CALM_AMP",
+    )
+    assert finite_form_re.search(executable), (
+        "qs-car-card.js (review-fix #01 #8): `_lastAmplitude` must "
+        "be assigned via `Number.isFinite(this._currentAmplitude) ? "
+        "this._currentAmplitude : CALM_AMP` so a NaN amplitude can't "
+        "permanently freeze the wave-path regen."
+    )
+
+    # Negative pin: the old `??` form must not be present for
+    # `_lastAmplitude`. Pinned narrowly so unrelated `??` usages
+    # (e.g., `_currentColorMix ?? 0`) are not flagged.
+    forbidden_re = re.compile(
+        r"this\._lastAmplitude\s*=\s*this\._currentAmplitude\s*\?\?",
+    )
+    assert not forbidden_re.search(executable), (
+        "qs-car-card.js (review-fix #01 #8): the old "
+        "`this._lastAmplitude = this._currentAmplitude ?? CALM_AMP` "
+        "form must be replaced — `??` does not trap NaN."
+    )
+
+
+def test_car_card_lightning_segments_constant_removed():
+    """QS-232 review-fix #01 #16: `LIGHTNING_SEGMENTS = 3` was
+    declared at module scope but never referenced; the lightning
+    path hardcoded 3 `L` segments rather than looping driven by
+    the constant. Dead code; removed. The pin is scoped to
+    EXECUTABLE code (comments stripped) so a `// removed …`
+    historical comment is allowed.
+    """
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+    assert "LIGHTNING_SEGMENTS" not in executable, (
+        "qs-car-card.js (review-fix #01 #16): `LIGHTNING_SEGMENTS` "
+        "must be removed from EXECUTABLE code — declared at module "
+        "scope but never referenced (the lightning path hardcodes "
+        "its 3 `L` segments). Historical references in comments "
+        "are allowed."
+    )
+
+
+def test_car_card_dashed_arc_comment_no_stale_m4_reference():
+    """QS-232 review-fix #01 #17: the dashed-arc inline comment
+    used to reference "M4" (the deleted `_charging`-gated
+    milestone). Should be updated to reflect the QS-232
+    continuous-RAF model. Pinned narrowly to the dashed-arc block,
+    not to all M4 references in the file.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+
+    # Find the dashed-arc comment block (it precedes the
+    # `_animOffset = ...` / `charge_anim` block).
+    dashed_arc_re = re.compile(
+        r"^\s*//[^\n]*PRESERVED\s+from\s+M4[^\n]*$",
+        re.MULTILINE,
+    )
+    assert dashed_arc_re.search(source) is None, (
+        "qs-car-card.js (review-fix #01 #17): the stale "
+        "\"PRESERVED from M4\" comment in the dashed-arc block "
+        "must be rewritten to reflect the QS-232 continuous-RAF "
+        "model. The M4 milestone is no longer the controlling "
+        "lifecycle anchor."
+    )
 
 
 # ============================================================================

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -3867,19 +3867,31 @@ def test_car_card_sparkle_color_decided_at_spawn():
     ).read_text()
     executable = _strip_js_comments(source)
 
-    # Palette constants. SPARKLE_IDLE_COLOR is a `hsla(140, …, …, …)`
-    # expression — hue MUST be 140 (green family) so the idle palette
-    # is recognisable as "electron green", but saturation / lightness /
-    # alpha are user-tunable per the QS-217 visual-iteration precedent
-    # (review-fix #03 retuned to near-white mint for higher contrast
-    # against the brighter soup palette).
-    assert re.search(
-        r"const\s+SPARKLE_IDLE_COLOR\s*=\s*['\"]hsla\(\s*140\s*,",
-        executable,
-    ), (
+    # Palette constants. `SPARKLE_IDLE_COLOR` is an `hsla(...)`
+    # expression with a hue in the yellow-green-to-green family
+    # `[60, 160]`. The exact hue is user-tunable per the QS-217
+    # visual-iteration precedent:
+    # - QS-232 initial:   hue 140 (pure green, light)
+    # - Review-fix #03:   hue 140, near-white mint (saturation drop)
+    # - Review-fix #02
+    #   user follow-up:   hue 80 (vivid yellow-green / lime) — user
+    #                     said "they have to be green/yellow … not a
+    #                     disc … little explosion".
+    idle_color_re = re.compile(
+        r"const\s+SPARKLE_IDLE_COLOR\s*=\s*"
+        r"['\"]hsla\(\s*(\d+)\s*,",
+    )
+    idle_color_m = idle_color_re.search(executable)
+    assert idle_color_m is not None, (
         "qs-car-card.js (AC-4): expected `const SPARKLE_IDLE_COLOR = "
-        "'hsla(140, …, …, …)';` — hue must be 140 (green family); "
-        "saturation/lightness/alpha are user-tunable."
+        "'hsla(<hue>, …, …, …)';` — value user-tunable."
+    )
+    idle_hue = int(idle_color_m.group(1))
+    assert 60 <= idle_hue <= 160, (
+        f"qs-car-card.js (AC-4): `SPARKLE_IDLE_COLOR` hue must be in "
+        f"the yellow-green-to-green family `[60, 160]` so the idle "
+        f"palette reads as \"electron green / yellow\". Got hue "
+        f"{idle_hue}."
     )
     # SPARKLE_CHARGE_COLOR — pinned by name only (value is the
     # electric-blue family but the user is free to retune the exact

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -1812,12 +1812,19 @@ def test_card_mode_change_wrapped_in_try_finally(card_filename):
 # list) means a future reviewer scanning the parametrize entries can
 # read them as a clean enumeration without losing the removed-card
 # rationale.
+#
+# QS-232 (this commit): `qs-car-card.js` was previously in this list
+# with gate `charging`. The car card now mirrors the continuous-RAF
+# model adopted by the pool and (per QS-200) the water-boiler cards
+# — RAF runs continuously while connected because the electron-soup
+# wave is intrinsically visible (idle green or degraded grey).
+# Covered separately by the new
+# `test_car_card_continuous_raf_from_connected_callback` below.
 @pytest.mark.parametrize(
     "card_filename,gate",
     [
         ("qs-on-off-duration-card.js", "showAnimation"),
         ("qs-climate-card.js", "showAnimation"),
-        ("qs-car-card.js", "charging"),
         ("qs-radiator-card.js", "showAnimation"),
     ],
 )
@@ -1891,6 +1898,7 @@ def test_water_boiler_card_uses_safe_number_helper():
     [
         "qs-water-boiler-card.js",
         "qs-pool-card.js",
+        "qs-car-card.js",
     ],
 )
 def test_card_caps_raf_dt_against_hidden_tab(card_filename):
@@ -3583,6 +3591,1062 @@ def test_water_boiler_card_steam_filter_region_attributes():
         "qs-water-boiler-card.js: steam filter must contain "
         "`<feGaussianBlur stdDeviation=\"${STEAM_BLUR_STDDEV}\" />`."
     )
+
+
+# ============================================================================
+# === QS-232 car-card electron-soup tests ===
+# QS-232 transplants the QS-200 / QS-211 boiler architecture onto
+# `qs-car-card.js`: a single sine wave inside a circular clipPath
+# (idle vs charging cross-fade), lightning-blue "electron" sparkles
+# that pop randomly inside the soup, lightning bolts flashing from the
+# top of the clip circle to the soup surface only while charging, and
+# a feTurbulence grain filter applied to the wave fill for fuzzy
+# granularity. Degraded states (disconnected / faulted / stale)
+# desaturate the entire clipped group via a CSS filter and suppress
+# lightning. Three inside-disc buttons (sun / rabbit / time) get
+# QS-217-style `<circle>` cover overlays. RAF is continuous while
+# connected (no more `_charging`-gated start/stop).
+# ============================================================================
+
+
+def test_car_card_electron_soup_clip_group_and_two_waves():
+    """QS-232 AC-1: the clipped `<g clip-path="url(#${electronClipId})">`
+    group contains exactly two wave `<path>` elements sharing one `d`
+    placeholder, differing only in fill (IDLE_SOUP_COLOR vs
+    CHARGE_SOUP_COLOR) and opacity. Sparkle and lightning layers
+    follow the waves in source order. The grain filter is declared in
+    `<defs>` with `<feTurbulence type="fractalNoise" …>` and BOTH
+    waves carry `filter="url(#${grainFilterId})"`. The issue's
+    "do not superpose 3 layer of sin" is pinned negatively: NO
+    `wave1_*` / `wave2_*` ids.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Grain filter in <defs> declares feTurbulence type="fractalNoise".
+    assert re.search(
+        r'<filter\s+id="\$\{grainFilterId\}"', source
+    ), (
+        "qs-car-card.js: missing `<filter id=\"${grainFilterId}\">` "
+        "declaration in <defs>."
+    )
+    assert (
+        '<feTurbulence type="fractalNoise"' in source
+    ), (
+        "qs-car-card.js: grain filter must use "
+        "`<feTurbulence type=\"fractalNoise\" …>` (AC-1 #1)."
+    )
+
+    # The two wave paths share the clip group anchor.
+    clip_g_anchor = '<g clip-path="url(#${electronClipId})"'
+    assert clip_g_anchor in source, (
+        "qs-car-card.js: missing the electron-soup clipped group "
+        f"`{clip_g_anchor}…>` (AC-1)."
+    )
+
+    assert 'id="electron_wave_idle"' in source, (
+        "qs-car-card.js: missing `<path id=\"electron_wave_idle\">` "
+        "(AC-1 #2)."
+    )
+    assert 'id="electron_wave_charge"' in source, (
+        "qs-car-card.js: missing `<path id=\"electron_wave_charge\">` "
+        "(AC-1 #2)."
+    )
+
+    # Both waves share the same `d` placeholder (initialWavePath) and
+    # carry filter="url(#${grainFilterId})".
+    idle_wave_re = re.compile(
+        r'<path\s+id="electron_wave_idle"\s+'
+        r'd="\$\{initialWavePath\}"\s+'
+        r'fill="\$\{IDLE_SOUP_COLOR\}"\s+'
+        r'opacity="\$\{initialIdleOpacity\}"\s+'
+        r'filter="url\(#\$\{grainFilterId\}\)"',
+    )
+    assert idle_wave_re.search(source), (
+        "qs-car-card.js: `electron_wave_idle` <path> must carry "
+        "`d=\"${initialWavePath}\" fill=\"${IDLE_SOUP_COLOR}\" "
+        "opacity=\"${initialIdleOpacity}\" "
+        "filter=\"url(#${grainFilterId})\"` (AC-1 #2/#3)."
+    )
+    charge_wave_re = re.compile(
+        r'<path\s+id="electron_wave_charge"\s+'
+        r'd="\$\{initialWavePath\}"\s+'
+        r'fill="\$\{CHARGE_SOUP_COLOR\}"\s+'
+        r'opacity="\$\{initialChargeOpacity\}"\s+'
+        r'filter="url\(#\$\{grainFilterId\}\)"',
+    )
+    assert charge_wave_re.search(source), (
+        "qs-car-card.js: `electron_wave_charge` <path> must carry "
+        "`d=\"${initialWavePath}\" fill=\"${CHARGE_SOUP_COLOR}\" "
+        "opacity=\"${initialChargeOpacity}\" "
+        "filter=\"url(#${grainFilterId})\"` (AC-1 #2/#3)."
+    )
+
+    # Sparkle layer follows waves; lightning layer follows sparkles.
+    idle_idx = source.find('id="electron_wave_idle"')
+    charge_idx = source.find('id="electron_wave_charge"')
+    sparkle_idx = source.find('id="${sparkleLayerId}"')
+    lightning_idx = source.find('id="${lightningLayerId}"')
+    assert idle_idx != -1 and charge_idx != -1, (
+        "qs-car-card.js: missing wave anchors for source-order check."
+    )
+    assert sparkle_idx != -1, (
+        "qs-car-card.js: missing `<g id=\"${sparkleLayerId}\">` after "
+        "the waves (AC-1 #4)."
+    )
+    assert lightning_idx != -1, (
+        "qs-car-card.js: missing `<g id=\"${lightningLayerId}\" …>` "
+        "after the sparkle layer (AC-1 #5)."
+    )
+    assert idle_idx < charge_idx < sparkle_idx < lightning_idx, (
+        "qs-car-card.js: source order must be wave_idle → wave_charge "
+        f"→ sparkleLayer → lightningLayer. Got idle={idle_idx}, "
+        f"charge={charge_idx}, sparkle={sparkle_idx}, "
+        f"lightning={lightning_idx}."
+    )
+
+    # Negative pins — single sine, not three layers.
+    for forbidden in ("wave1_idle", "wave1_charge", "wave2_idle", "wave2_charge"):
+        assert forbidden not in executable, (
+            f"qs-car-card.js: forbidden id `{forbidden}` present — the "
+            "issue explicitly says \"do not superpose 3 layer of sin\" "
+            "(AC-1 #6)."
+        )
+
+
+def test_car_card_cross_fade_lerp_is_binary_idle_charge():
+    """QS-232 AC-2: the wave cross-fade is a binary idle↔charge lerp.
+    `targetColorMix = charging ? 1 : 0` exists; per-frame opacity uses
+    `(1 - _currentColorMix)` and `_currentColorMix` with `.toFixed(3)`.
+    Critically, `_currentColorMix` is NEVER mutated inside the
+    `degraded` branch — the third (degraded) palette is handled via a
+    CSS filter on the clip group, not via the lerp envelope.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # `targetColorMix = charging ? 1 : 0` (the car-card analogue of
+    # boiler `boiling ? 1 : 0`).
+    assert re.search(
+        r"targetColorMix\s*=\s*charging\s*\?\s*1\s*:\s*0",
+        executable,
+    ), (
+        "qs-car-card.js (AC-2): missing `targetColorMix = charging "
+        "? 1 : 0` lerp target (mirrors boiler precedent)."
+    )
+
+    # Per-frame opacity: `(1 - this._currentColorMix).toFixed(3)` and
+    # `this._currentColorMix.toFixed(3)`.
+    assert re.search(
+        r"\(\s*1\s*-\s*this\._currentColorMix\s*\)\s*\.toFixed\s*\(\s*3\s*\)",
+        executable,
+    ), (
+        "qs-car-card.js (AC-2): missing idle-opacity expression "
+        "`(1 - this._currentColorMix).toFixed(3)`."
+    )
+    assert re.search(
+        r"this\._currentColorMix\s*\.toFixed\s*\(\s*3\s*\)",
+        executable,
+    ), (
+        "qs-car-card.js (AC-2): missing charge-opacity expression "
+        "`this._currentColorMix.toFixed(3)`."
+    )
+
+    # LERP_RATE constant.
+    assert re.search(r"const\s+LERP_RATE\s*=\s*2\b", executable), (
+        "qs-car-card.js (AC-2): missing `const LERP_RATE = 2;` "
+        "(mirror boiler envelope)."
+    )
+
+    # Negative: `_currentColorMix` is NOT mutated under a `degraded`
+    # branch. Pin: no `if (degraded)` block that touches
+    # `_currentColorMix`.
+    forbidden = re.compile(
+        r"if\s*\(\s*degraded\s*\)\s*\{[^}]*_currentColorMix",
+        re.DOTALL,
+    )
+    assert not forbidden.search(executable), (
+        "qs-car-card.js (AC-2): `_currentColorMix` must not be mutated "
+        "inside a `if (degraded)` branch — the degraded palette is a "
+        "runtime CSS filter on the clip group (D8), independent of "
+        "the binary idle↔charge lerp."
+    )
+
+
+def test_car_card_sparkle_power_scaling_constants():
+    """QS-232 AC-3: sparkle density / spawn-rate / radius scale
+    linearly with charge power on `[SPARKLE_POWER_MIN_W,
+    SPARKLE_POWER_MAX_W] = [1500W, 22000W]`. Below MIN, values clamp
+    to the MIN-power endpoint. Pin all six scaling constants + the
+    clamping + linear-interp formula.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    expected = {
+        "SPARKLE_POWER_MIN_W": "1500",
+        "SPARKLE_POWER_MAX_W": "22000",
+        "SPARKLE_CHARGE_MAX_AT_MIN_POWER": "12",
+        "SPARKLE_CHARGE_MAX_AT_MAX_POWER": "28",
+        "SPARKLE_CHARGE_RATE_HZ_AT_MIN_POWER": "3",
+        "SPARKLE_CHARGE_RATE_HZ_AT_MAX_POWER": "10",
+    }
+    for name, value in expected.items():
+        pat = re.compile(rf"const\s+{name}\s*=\s*{re.escape(value)}\b")
+        assert pat.search(executable), (
+            f"qs-car-card.js (AC-3): expected module-level "
+            f"`const {name} = {value};`"
+        )
+
+    # Clamping formula.
+    assert re.search(
+        r"Math\.max\s*\(\s*SPARKLE_POWER_MIN_W\s*,\s*"
+        r"Math\.min\s*\(\s*SPARKLE_POWER_MAX_W\s*,",
+        executable,
+    ), (
+        "qs-car-card.js (AC-3): missing the clamping expression "
+        "`Math.max(SPARKLE_POWER_MIN_W, Math.min(SPARKLE_POWER_MAX_W, "
+        "power))`."
+    )
+
+    # Linear interp denominator.
+    assert re.search(
+        r"\(\s*SPARKLE_POWER_MAX_W\s*-\s*SPARKLE_POWER_MIN_W\s*\)",
+        executable,
+    ), (
+        "qs-car-card.js (AC-3): missing the linear-interp denominator "
+        "`(SPARKLE_POWER_MAX_W - SPARKLE_POWER_MIN_W)` in the "
+        "power-scaling formula."
+    )
+
+
+def test_car_card_sparkle_color_decided_at_spawn():
+    """QS-232 AC-4: each sparkle's `fill` attribute is decided at
+    spawn time via a ternary on `_charging`, resolving to
+    `SPARKLE_IDLE_COLOR` (greenish) or `SPARKLE_CHARGE_COLOR`
+    (electric lightning blue, `#00E5FF`). The fill is set on the
+    `<circle>` element only at spawn — it is not re-assigned per
+    frame in the advance loop.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Literal palette constants.
+    assert re.search(
+        r"const\s+SPARKLE_IDLE_COLOR\s*=\s*['\"]hsla\(\s*140\s*,\s*90%\s*,\s*70%\s*,\s*0\.9\s*\)['\"]",
+        executable,
+    ), (
+        "qs-car-card.js (AC-4): expected `const SPARKLE_IDLE_COLOR = "
+        "'hsla(140, 90%, 70%, 0.9)';`"
+    )
+    assert re.search(
+        r"const\s+SPARKLE_CHARGE_COLOR\s*=\s*['\"]#00E5FF['\"]",
+        executable,
+    ), (
+        "qs-car-card.js (AC-4): expected `const SPARKLE_CHARGE_COLOR = "
+        "'#00E5FF';` (electric lightning blue)."
+    )
+
+    # Ternary selecting fill at spawn (mention both constants in a
+    # ternary on `_charging` or `charging`).
+    spawn_fill_re = re.compile(
+        r"(?:this\._charging|charging)\s*\?\s*"
+        r"SPARKLE_CHARGE_COLOR\s*:\s*SPARKLE_IDLE_COLOR",
+    )
+    assert spawn_fill_re.search(executable), (
+        "qs-car-card.js (AC-4): expected a `_charging ? "
+        "SPARKLE_CHARGE_COLOR : SPARKLE_IDLE_COLOR` ternary at the "
+        "spawn site so the fill is decided once and never re-assigned."
+    )
+
+
+def test_car_card_lightning_gated_and_spawn_interval():
+    """QS-232 AC-5: lightning bolts only spawn when `charging &&
+    !degraded`. Spawn interval is randomised on
+    `[LIGHTNING_SPAWN_MIN_S, LIGHTNING_SPAWN_MAX_S] = [1.5, 3.0]`s.
+    `MAX_CONCURRENT_LIGHTNING = 3`. The advance/retire loop runs
+    OUTSIDE the gate (graceful exit for in-flight bolts).
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Constants.
+    assert re.search(
+        r"const\s+LIGHTNING_SPAWN_MIN_S\s*=\s*1\.5\b", executable
+    ), (
+        "qs-car-card.js (AC-5): missing `const LIGHTNING_SPAWN_MIN_S "
+        "= 1.5;`"
+    )
+    assert re.search(
+        r"const\s+LIGHTNING_SPAWN_MAX_S\s*=\s*3(\.0)?\b", executable
+    ), (
+        "qs-car-card.js (AC-5): missing `const LIGHTNING_SPAWN_MAX_S "
+        "= 3.0;`"
+    )
+    assert re.search(
+        r"const\s+MAX_CONCURRENT_LIGHTNING\s*=\s*3\b", executable
+    ), (
+        "qs-car-card.js (AC-5): missing `const MAX_CONCURRENT_LIGHTNING "
+        "= 3;`"
+    )
+
+    # Spawn gate: `if (charging && !degraded)`.
+    gate_re = re.compile(
+        r"if\s*\(\s*charging\s*&&\s*!\s*degraded\s*\)",
+    )
+    assert gate_re.search(executable), (
+        "qs-car-card.js (AC-5): missing the lightning spawn gate "
+        "`if (charging && !degraded) { … }`."
+    )
+
+    # Re-arm formula uses MIN_S + Math.random() * (MAX_S - MIN_S).
+    rearm_re = re.compile(
+        r"this\._nextLightningAt\s*=\s*LIGHTNING_SPAWN_MIN_S\s*\+\s*"
+        r"Math\.random\s*\(\s*\)\s*\*\s*"
+        r"\(\s*LIGHTNING_SPAWN_MAX_S\s*-\s*LIGHTNING_SPAWN_MIN_S\s*\)",
+    )
+    assert rearm_re.search(executable), (
+        "qs-car-card.js (AC-5): missing the lightning re-arm formula "
+        "`this._nextLightningAt = LIGHTNING_SPAWN_MIN_S + "
+        "Math.random() * (LIGHTNING_SPAWN_MAX_S - "
+        "LIGHTNING_SPAWN_MIN_S);`"
+    )
+
+
+def test_car_card_lightning_life_and_glow_filter():
+    """QS-232 AC-6: lightning life is `LIGHTNING_LIFE_S = 0.25`s.
+    Three-phase opacity curve breakpoints `0.10` and `0.70` appear in
+    the advance loop. The `<filter id="${lightningFilterId}" …>`
+    carries safe-region attributes and a `<feGaussianBlur
+    stdDeviation="${LIGHTNING_GLOW_STDDEV}" />`. The lightning layer
+    `<g>` carries `filter="url(#${lightningFilterId})"` AND
+    `mix-blend-mode: screen`. Lightning elements are `<path>`s, not
+    `<polyline>`s.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Life constant.
+    assert re.search(
+        r"const\s+LIGHTNING_LIFE_S\s*=\s*0\.25\b", executable
+    ), (
+        "qs-car-card.js (AC-6): missing `const LIGHTNING_LIFE_S = "
+        "0.25;`"
+    )
+    # Three-phase opacity breakpoints.
+    assert "0.10" in executable or "0.1 " in executable or "0.1\n" in executable, (
+        "qs-car-card.js (AC-6): missing fade-in breakpoint `0.10` "
+        "in the lightning advance loop."
+    )
+    assert "0.70" in executable, (
+        "qs-car-card.js (AC-6): missing fade-out breakpoint `0.70` "
+        "in the lightning advance loop."
+    )
+
+    # Glow filter with safe-region attrs.
+    filter_decl = (
+        '<filter id="${lightningFilterId}" x="-50%" y="-50%" '
+        'width="200%" height="200%">'
+    )
+    assert filter_decl in source, (
+        "qs-car-card.js (AC-6): lightning filter declaration must "
+        f"include safe-region attributes — expected `{filter_decl}`."
+    )
+    assert (
+        '<feGaussianBlur stdDeviation="${LIGHTNING_GLOW_STDDEV}" />'
+        in source
+    ), (
+        "qs-car-card.js (AC-6): lightning filter must contain "
+        "`<feGaussianBlur stdDeviation=\"${LIGHTNING_GLOW_STDDEV}\" />`."
+    )
+
+    # Layer carries filter + mix-blend-mode.
+    layer_re = re.compile(
+        r'<g\s+id="\$\{lightningLayerId\}"\s+'
+        r'filter="url\(#\$\{lightningFilterId\}\)"',
+    )
+    assert layer_re.search(source), (
+        "qs-car-card.js (AC-6): `<g id=\"${lightningLayerId}\">` must "
+        "carry `filter=\"url(#${lightningFilterId})\"`."
+    )
+    assert "mix-blend-mode: screen" in source, (
+        "qs-car-card.js (AC-6): lightning layer must use "
+        "`mix-blend-mode: screen` so the glow composites against the "
+        "soup."
+    )
+
+    # Lightning element type: <path>, not <polyline>. Pin negatively:
+    # the spawn code must construct a `path` SVG element (not
+    # `polyline`).
+    assert re.search(
+        r"createElementNS\(\s*['\"]http://www\.w3\.org/2000/svg['\"]"
+        r"\s*,\s*['\"]path['\"]",
+        source,
+    ), (
+        "qs-car-card.js (AC-6): lightning bolts must be `<path>` "
+        "elements created via `createElementNS(SVG_NS, 'path')` — "
+        "not `polyline`."
+    )
+    assert "createElementNS('http://www.w3.org/2000/svg', 'polyline'" not in source, (
+        "qs-car-card.js (AC-6): forbidden `<polyline>` creation — "
+        "lightning must be `<path>` per boiler-precedent shape."
+    )
+
+    # Stroke / stroke-width constants.
+    assert re.search(
+        r"const\s+LIGHTNING_STROKE_COLOR\s*=\s*['\"]#E0F7FF['\"]",
+        executable,
+    ), (
+        "qs-car-card.js (AC-6): missing `const LIGHTNING_STROKE_COLOR "
+        "= '#E0F7FF';`"
+    )
+    assert re.search(
+        r"const\s+LIGHTNING_STROKE_WIDTH\s*=\s*1\.8\b",
+        executable,
+    ), (
+        "qs-car-card.js (AC-6): missing `const LIGHTNING_STROKE_WIDTH "
+        "= 1.8;`"
+    )
+
+
+def test_car_card_grain_filter_uses_feturbulence_on_wave_fill():
+    """QS-232 AC-7: the grain filter declares `<feTurbulence
+    type="fractalNoise" baseFrequency="0.9" numOctaves="2" …>` in
+    `<defs>` and BOTH wave `<path>` elements carry
+    `filter="url(#${grainFilterId})"`. No separate overlay `<rect>`
+    carries the grain filter — the grain composites within the wave
+    shape via `feComposite operator="in"`.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Grain filter declaration substring.
+    assert (
+        '<feTurbulence type="fractalNoise" baseFrequency="0.9" '
+        'numOctaves="2"'
+    ) in source, (
+        "qs-car-card.js (AC-7): grain filter must declare "
+        "`<feTurbulence type=\"fractalNoise\" baseFrequency=\"0.9\" "
+        "numOctaves=\"2\" …>` (substring assert; `seed`/`result` not "
+        "pinned)."
+    )
+
+    # The composite step that masks turbulence to the wave fill.
+    assert (
+        '<feComposite' in source
+        and 'operator="in"' in source
+    ), (
+        "qs-car-card.js (AC-7): grain filter must contain a "
+        "`<feComposite … operator=\"in\" …>` step so the grain is "
+        "masked to the wave's filled shape (water region only)."
+    )
+
+    # Both waves reference filter="url(#${grainFilterId})".
+    idle_filter = re.compile(
+        r'id="electron_wave_idle"[^>]*filter="url\(#\$\{grainFilterId\}\)"',
+        re.DOTALL,
+    )
+    charge_filter = re.compile(
+        r'id="electron_wave_charge"[^>]*filter="url\(#\$\{grainFilterId\}\)"',
+        re.DOTALL,
+    )
+    assert idle_filter.search(source), (
+        "qs-car-card.js (AC-7): `electron_wave_idle` must carry "
+        "`filter=\"url(#${grainFilterId})\"`."
+    )
+    assert charge_filter.search(source), (
+        "qs-car-card.js (AC-7): `electron_wave_charge` must carry "
+        "`filter=\"url(#${grainFilterId})\"`."
+    )
+
+    # Negative: no <rect> immediately preceding the sparkle layer
+    # carries the grain filter.
+    forbidden = re.compile(
+        r'<rect[^>]*filter="url\(#\$\{grainFilterId\}\)"[^>]*/?>\s*'
+        r'<g\s+id="\$\{sparkleLayerId\}"',
+        re.DOTALL,
+    )
+    assert not forbidden.search(source), (
+        "qs-car-card.js (AC-7): no separate `<rect>` overlay should "
+        "carry the grain filter — grain composites within the wave "
+        "shape via `feComposite operator=\"in\"` (D7)."
+    )
+
+
+def test_car_card_degraded_state_css_filter_and_lightning_suppression():
+    """QS-232 AC-8: `degraded = isDisconnected || isFaulted ||
+    isStale` is computed in `_render()`. The clipped `<g>` carries a
+    conditional inline style `style="${degraded ? 'filter:
+    saturate(0.3) brightness(0.7);' : ''}"`. Lightning is suppressed
+    via the `if (charging && !degraded)` gate. `isOffGrid` is
+    explicitly NOT part of `degraded`.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # `degraded` boolean.
+    degraded_re = re.compile(
+        r"const\s+degraded\s*=\s*isDisconnected\s*\|\|\s*"
+        r"isFaulted\s*\|\|\s*isStale\b",
+    )
+    m = degraded_re.search(executable)
+    assert m, (
+        "qs-car-card.js (AC-8): missing `const degraded = isDisconnected "
+        "|| isFaulted || isStale;`"
+    )
+    # Negative: `isOffGrid` is NOT part of `degraded`.
+    matched_line = m.group(0)
+    assert "isOffGrid" not in matched_line, (
+        "qs-car-card.js (AC-8): the `degraded =` expression must NOT "
+        "mention `isOffGrid` — off-grid keeps the card-level tint via "
+        "the `.off-grid` CSS class; the soup is unaffected (D8)."
+    )
+
+    # Inline style ternary on the clip group.
+    assert (
+        "${degraded ? 'filter: saturate(0.3) brightness(0.7);' : ''}"
+        in source
+    ), (
+        "qs-car-card.js (AC-8): the clipped `<g>` must carry the "
+        "inline style ternary "
+        "`style=\"${degraded ? 'filter: saturate(0.3) "
+        "brightness(0.7);' : ''}\"`."
+    )
+
+    # Lightning gate already pinned in AC-5 — re-assert here for
+    # locality.
+    assert re.search(
+        r"if\s*\(\s*charging\s*&&\s*!\s*degraded\s*\)", executable
+    ), (
+        "qs-car-card.js (AC-8): lightning spawn must be gated on "
+        "`charging && !degraded`."
+    )
+
+
+def test_car_card_continuous_raf_from_connected_callback():
+    """QS-232 AC-9: `connectedCallback()` calls `this._startAnimation()`
+    directly (continuous-RAF model). `_render()` does NOT contain a
+    conditional `_startAnimation()` gated on `charging`, nor any
+    `_stopAnimation()` call (the only `_stopAnimation` call site is
+    `disconnectedCallback`). The car card has been removed from the
+    `test_card_raf_idle_gated` parametrize list (and added to the
+    `test_card_caps_raf_dt_against_hidden_tab` list) — both side-
+    effects are pinned here by re-reading this test file.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # connectedCallback calls _startAnimation directly, no `if` gate.
+    cb_body = _extract_js_function_body(
+        executable, r"connectedCallback\s*\(\s*\)\s*"
+    )
+    assert cb_body is not None, (
+        "qs-car-card.js (AC-9): `connectedCallback()` not found."
+    )
+    assert re.search(r"this\._startAnimation\s*\(\s*\)", cb_body), (
+        "qs-car-card.js (AC-9): `connectedCallback` must call "
+        "`this._startAnimation()` directly (continuous-RAF model)."
+    )
+    assert re.search(r"\bif\s*\(", cb_body) is None, (
+        "qs-car-card.js (AC-9): `connectedCallback` must call "
+        "`_startAnimation()` unconditionally — no `if (...)` gate "
+        "(continuous-RAF model, mirror boiler/pool)."
+    )
+
+    # `_render()` body must NOT contain `_stopAnimation` or a
+    # conditional `_startAnimation` gated on charging.
+    render_body = _extract_js_function_body(
+        executable, r"_render\s*\(\s*\)\s*"
+    )
+    assert render_body is not None, (
+        "qs-car-card.js (AC-9): `_render()` body not found."
+    )
+    assert "_stopAnimation" not in render_body, (
+        "qs-car-card.js (AC-9): `_render()` must not call "
+        "`_stopAnimation()` — the only call site is "
+        "`disconnectedCallback` (continuous-RAF model)."
+    )
+    forbidden_gated = re.compile(
+        r"if\s*\(\s*(?:this\._)?charging\s*\)\s*\{[^}]*_startAnimation",
+        re.DOTALL,
+    )
+    assert not forbidden_gated.search(render_body), (
+        "qs-car-card.js (AC-9): `_render()` must not start RAF "
+        "conditionally on `charging` — `connectedCallback` starts it "
+        "continuously."
+    )
+
+    # Verify the parametrize migration by inspecting the parametrize
+    # decorator of `test_card_raf_idle_gated` — the car-card tuple
+    # must be absent from its list.
+    #
+    # NB: we deliberately avoid hard-coding the forbidden tuple as a
+    # bare literal in this file (that would itself be a substring
+    # match and trip the assertion). Instead we extract the parametrize
+    # body via regex and inspect its contents structurally.
+    test_file = Path(__file__).read_text(encoding="utf-8")
+    idle_gated_block = re.search(
+        r"@pytest\.mark\.parametrize\s*\(\s*\"card_filename\s*,\s*gate\""
+        r".*?def\s+test_card_raf_idle_gated",
+        test_file,
+        re.DOTALL,
+    )
+    assert idle_gated_block is not None, (
+        "AC-9: `test_card_raf_idle_gated` parametrize decorator not "
+        "found — the test file structure has drifted."
+    )
+    block_text = idle_gated_block.group(0)
+    assert "qs-car-card.js" not in block_text, (
+        "tests/test_dashboard_rendering.py (AC-9): the car-card entry "
+        "must be removed from the `test_card_raf_idle_gated` "
+        "parametrize list — the car card now uses continuous RAF."
+    )
+    # The dt-cap list must include qs-car-card.js (AC-12 side-effect).
+    cap_list_block = re.search(
+        r"@pytest\.mark\.parametrize\s*\(\s*\"card_filename\"\s*,\s*\["
+        r"(.*?)\]\s*,?\s*\)\s*def\s+test_card_caps_raf_dt_against_hidden_tab",
+        test_file,
+        re.DOTALL,
+    )
+    assert cap_list_block is not None, (
+        "AC-9: `test_card_caps_raf_dt_against_hidden_tab` parametrize "
+        "decorator not found — the test file structure has drifted."
+    )
+    assert "qs-car-card.js" in cap_list_block.group(1), (
+        "AC-9 side-effect: `qs-car-card.js` must be present in the "
+        "`test_card_caps_raf_dt_against_hidden_tab` parametrize list."
+    )
+    # We can't easily check the parametrize list contents from inside
+    # one of its tests without circular complexity; this test merely
+    # pins the removal from the idle-gated list. The dt-cap test
+    # itself (test_car_card_caps_raf_dt_at_lerp_dt_ceil below) covers
+    # the additive side.
+
+
+def test_car_card_reset_dom_refs_helper_and_disconnect_teardown():
+    """QS-232 AC-10: `_resetDomRefs()` instance method exists. It
+    nulls `_waveEls`, `_grainFilterEl`, `_sparkleLayerEl`,
+    `_lightningLayerEl` AND clears `_sparkles = []` and
+    `_lightningBolts = []`. It is called from `_invalidateAnimCache()`
+    AND from the post-`innerHTML` cleanup in `_render()` (≥ 2 call
+    sites). `disconnectedCallback()` tears down sparkle AND lightning
+    DOM with optional-chaining shape.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    body = _extract_js_function_body(
+        executable, r"_resetDomRefs\s*\(\s*\)\s*"
+    )
+    assert body is not None, (
+        "qs-car-card.js (AC-10): `_resetDomRefs()` method not found."
+    )
+
+    for assignment_re in (
+        r"this\._waveEls\s*=\s*null",
+        r"this\._grainFilterEl\s*=\s*null",
+        r"this\._sparkleLayerEl\s*=\s*null",
+        r"this\._lightningLayerEl\s*=\s*null",
+        r"this\._sparkles\s*=\s*\[\s*\]",
+        r"this\._lightningBolts\s*=\s*\[\s*\]",
+    ):
+        assert re.search(assignment_re, body), (
+            f"qs-car-card.js (AC-10): `_resetDomRefs()` must assign "
+            f"`{assignment_re}` so all DOM-ref memos and particle "
+            f"arrays reset together."
+        )
+
+    # ≥ 2 `this._resetDomRefs()` call sites in the file.
+    call_sites = re.findall(
+        r"this\._resetDomRefs\s*\(\s*\)", executable
+    )
+    assert len(call_sites) >= 2, (
+        f"qs-car-card.js (AC-10): expected ≥ 2 `this._resetDomRefs()` "
+        f"call sites (one from `_invalidateAnimCache`, one post-"
+        f"`innerHTML` in `_render`). Found {len(call_sites)}."
+    )
+
+    # `_invalidateAnimCache` exists and calls `_resetDomRefs`.
+    inv_body = _extract_js_function_body(
+        executable, r"_invalidateAnimCache\s*\(\s*\)\s*"
+    )
+    assert inv_body is not None, (
+        "qs-car-card.js (AC-10): missing `_invalidateAnimCache()` "
+        "method."
+    )
+    assert "this._resetDomRefs()" in inv_body, (
+        "qs-car-card.js (AC-10): `_invalidateAnimCache()` must call "
+        "`this._resetDomRefs()`."
+    )
+
+    # disconnectedCallback teardown.
+    dc_body = _extract_js_function_body(
+        executable, r"disconnectedCallback\s*\(\s*\)\s*"
+    )
+    assert dc_body is not None, (
+        "qs-car-card.js (AC-10): `disconnectedCallback()` not found."
+    )
+    assert re.search(
+        r"this\._sparkles\?\.forEach\s*\(\s*s\s*=>\s*s\.el\?\.remove\?\.\(\)\s*\)",
+        dc_body,
+    ), (
+        "qs-car-card.js (AC-10): `disconnectedCallback` must eagerly "
+        "tear down sparkle DOM with "
+        "`this._sparkles?.forEach(s => s.el?.remove?.())`."
+    )
+    assert re.search(r"this\._sparkles\s*=\s*\[\s*\]", dc_body), (
+        "qs-car-card.js (AC-10): `disconnectedCallback` must clear "
+        "`this._sparkles = []` after the teardown."
+    )
+    assert re.search(
+        r"this\._lightningBolts\?\.forEach\s*\(\s*b\s*=>\s*b\.el\?\.remove\?\.\(\)\s*\)",
+        dc_body,
+    ), (
+        "qs-car-card.js (AC-10): `disconnectedCallback` must eagerly "
+        "tear down lightning DOM with "
+        "`this._lightningBolts?.forEach(b => b.el?.remove?.())`."
+    )
+    assert re.search(r"this\._lightningBolts\s*=\s*\[\s*\]", dc_body), (
+        "qs-car-card.js (AC-10): `disconnectedCallback` must clear "
+        "`this._lightningBolts = []` after the teardown."
+    )
+
+
+def test_car_card_per_instance_unique_svg_ids():
+    """QS-232 AC-11: `QsCarCard._nextClipId` static counter is bumped
+    inside `if (!this._electronClipId)`. Five per-instance ID fields
+    are derived from the same `uid`: `_electronClipId`,
+    `_sparkleLayerId`, `_lightningLayerId`, `_grainFilterId`,
+    `_lightningFilterId`. All follow the `car_<role>_${uid}` naming
+    convention.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Static counter bump.
+    assert re.search(
+        r"QsCarCard\._nextClipId\s*=\s*\(\s*QsCarCard\._nextClipId\s*\|\|\s*0\s*\)\s*\+\s*1",
+        executable,
+    ), (
+        "qs-car-card.js (AC-11): missing the `QsCarCard._nextClipId "
+        "= (QsCarCard._nextClipId || 0) + 1` static-counter bump."
+    )
+    # Guard.
+    assert re.search(
+        r"if\s*\(\s*!\s*this\._electronClipId\s*\)", executable
+    ), (
+        "qs-car-card.js (AC-11): the counter bump must be wrapped in "
+        "`if (!this._electronClipId) { … }` so the IDs are assigned "
+        "once."
+    )
+
+    # Five ID fields, all `car_<role>_${uid}`-shaped.
+    id_assignments = {
+        "_electronClipId":    "car_eClip_",
+        "_sparkleLayerId":    "car_sparkLayer_",
+        "_lightningLayerId":  "car_lightningLayer_",
+        "_grainFilterId":     "car_grainFilter_",
+        "_lightningFilterId": "car_lightningFilter_",
+    }
+    for field, prefix in id_assignments.items():
+        pat = re.compile(
+            rf"this\.{field}\s*=\s*`{re.escape(prefix)}\$\{{uid\}}`",
+        )
+        assert pat.search(executable), (
+            f"qs-car-card.js (AC-11): expected "
+            f"`this.{field} = \\`{prefix}${{uid}}\\``"
+        )
+
+
+def test_car_card_caps_raf_dt_at_lerp_dt_ceil():
+    """QS-232 AC-12: module constant `const LERP_DT_CEIL = 0.1;` and
+    the RAF step closure clamps `dt = Math.min(dt, LERP_DT_CEIL)` at
+    the top. The car card joins
+    `test_card_caps_raf_dt_against_hidden_tab` for the same hidden-
+    tab guard the boiler / pool cards carry.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    assert re.search(
+        r"const\s+LERP_DT_CEIL\s*=\s*0\.1\b", executable
+    ), (
+        "qs-car-card.js (AC-12): missing `const LERP_DT_CEIL = 0.1;` "
+        "module constant."
+    )
+    assert re.search(
+        r"dt\s*=\s*Math\.min\s*\(\s*dt\s*,\s*LERP_DT_CEIL\s*\)",
+        executable,
+    ), (
+        "qs-car-card.js (AC-12): expected `dt = Math.min(dt, "
+        "LERP_DT_CEIL);` at the top of the RAF step closure."
+    )
+
+
+def test_dashboard_and_cards_doc_pins_qs_232_paragraph():
+    """QS-232 AC-13: a new H3 section
+    `### QS-232 — Car-card electron-soup animation` exists in
+    `docs/agents/concepts/dashboard-and-cards.md` AFTER the existing
+    `### QS-217` section and BEFORE the `## Hardened JS-card patterns`
+    H2 header. The section body mentions the key concepts:
+    single-layer wave, dual-opacity cross-fade, sparkle palette switch
+    + [1500W, 22000W] power-scaling, lightning bolt 3-segment path +
+    glow + spawn interval, feTurbulence grain on wave fill, degraded
+    CSS filter, continuous RAF, three carve covers (D17). The
+    `last_verified` field is present and well-formed.
+    """
+    doc_path = (
+        Path(__file__).parent.parent
+        / "docs"
+        / "agents"
+        / "concepts"
+        / "dashboard-and-cards.md"
+    )
+    doc = doc_path.read_text(encoding="utf-8")
+
+    headline = "### QS-232 — Car-card electron-soup animation"
+    headline_idx = doc.find(headline)
+    assert headline_idx != -1, (
+        f"dashboard-and-cards.md: missing the literal QS-232 H3 "
+        f"headline `{headline}` (AC-13)."
+    )
+
+    qs217_idx = doc.find("### QS-217")
+    assert qs217_idx != -1, (
+        "dashboard-and-cards.md: missing `### QS-217` headline — "
+        "AC-13 anchors QS-232 AFTER it."
+    )
+    hardened_idx = doc.find("## Hardened JS-card patterns")
+    assert hardened_idx != -1, (
+        "dashboard-and-cards.md: missing `## Hardened JS-card "
+        "patterns` H2 — AC-13 anchors QS-232 BEFORE it."
+    )
+    assert qs217_idx < headline_idx < hardened_idx, (
+        f"dashboard-and-cards.md: QS-232 headline must appear AFTER "
+        f"`### QS-217` AND BEFORE `## Hardened JS-card patterns`. "
+        f"Current order: QS-217 at {qs217_idx}, QS-232 at "
+        f"{headline_idx}, Hardened at {hardened_idx}."
+    )
+
+    # Front-matter `last_verified` field shape.
+    front_matter_match = re.search(
+        r"^last_verified:\s*(\d{4}-\d{2}-\d{2})\s*$",
+        doc,
+        re.MULTILINE,
+    )
+    assert front_matter_match, (
+        "dashboard-and-cards.md: front-matter must contain a "
+        "`last_verified: YYYY-MM-DD` field (AC-13)."
+    )
+
+    # Slice the section body — from the QS-232 headline to the next
+    # H2 (or H3) boundary.
+    section = doc[headline_idx:hardened_idx]
+    section_lower = section.lower()
+
+    # AC-13 key-concept pins.
+    expected_substrings = [
+        ("electron", "soup electron-soup concept"),
+        ("sparkle", "sparkle palette switch"),
+        ("lightning", "lightning bolt subsystem"),
+        ("feturbulence", "feTurbulence grain filter"),
+        ("grain", "grain on wave fill"),
+        ("degraded", "degraded CSS filter"),
+        ("continuous", "continuous-RAF model"),
+        ("1500", "[1500W, 22000W] power-scaling range (lower)"),
+        ("22000", "[1500W, 22000W] power-scaling range (upper)"),
+        ("3-segment", "3-segment lightning path"),
+        ("0.25", "lightning life 0.25 s"),
+        ("[1.5", "lightning spawn interval lower bound"),
+        ("3.0", "lightning spawn interval upper bound"),
+        ("d17", "D17 explicit reference"),
+        ("sun-btn", "sun-btn carve cover"),
+        ("rabbit-btn", "rabbit-btn carve cover"),
+        ("time-btn", "time-btn carve cover"),
+    ]
+    for token, description in expected_substrings:
+        assert token in section_lower, (
+            f"dashboard-and-cards.md (QS-232 section): missing "
+            f"`{token}` — {description} (AC-13)."
+        )
+
+    # All three carve-cover element ids named in the section.
+    for cover_id in (
+        "sun_btn_cover",
+        "rabbit_btn_cover",
+        "time_btn_cover",
+    ):
+        assert cover_id in section, (
+            f"dashboard-and-cards.md (QS-232 section): missing the "
+            f"carve-cover element id `{cover_id}` (AC-13/AC-14)."
+        )
+
+
+def test_car_card_inside_disc_button_carve_covers():
+    """QS-232 AC-14: three inside-disc button carve-out covers
+    (sun-btn, rabbit-btn, time-btn) extend QS-217's `<circle>` cover
+    pattern from one button to three on the car card. Nine module-
+    level constants (3 × {CX, CY, R}) are present (NAMES pinned, not
+    values — user-tunable per QS-217 precedent). Three `<circle
+    id="…_cover" fill="var(--card-background-color)"
+    pointer-events="none" />` elements appear in source AFTER the
+    clipped `</g>` AND BEFORE the `<path d="${bgPath}"` line. Each is
+    gated on its corresponding render predicate (`swPriority`,
+    `e.force_now`, `(tNext && e.schedule)`).
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Nine constants — NAMES only (values are user-tunable).
+    for const_name in (
+        "SUN_BTN_CARVE_CX",
+        "SUN_BTN_CARVE_CY",
+        "SUN_BTN_CARVE_R",
+        "RABBIT_BTN_CARVE_CX",
+        "RABBIT_BTN_CARVE_CY",
+        "RABBIT_BTN_CARVE_R",
+        "TIME_BTN_CARVE_CX",
+        "TIME_BTN_CARVE_CY",
+        "TIME_BTN_CARVE_R",
+    ):
+        assert re.search(
+            rf"const\s+{const_name}\s*=\s*\d+\b", executable
+        ), (
+            f"qs-car-card.js (AC-14): missing module-level "
+            f"`const {const_name} = <integer>;` declaration. Values "
+            f"are user-tunable per QS-217 precedent — only the NAME "
+            f"is pinned."
+        )
+
+    # The three cover circles, each gated on its render predicate.
+    sun_cover_re = re.compile(
+        r"swPriority\s*\?\s*`?\s*"
+        r'<circle\s+id="sun_btn_cover"\s+'
+        r'cx="\$\{SUN_BTN_CARVE_CX\}"\s+'
+        r'cy="\$\{SUN_BTN_CARVE_CY\}"\s+'
+        r'r="\$\{SUN_BTN_CARVE_R\}"\s+'
+        r'fill="var\(--card-background-color\)"\s+'
+        r'pointer-events="none"\s*/>',
+    )
+    assert sun_cover_re.search(source), (
+        "qs-car-card.js (AC-14): missing the `sun_btn_cover` "
+        "<circle> element gated on `swPriority`."
+    )
+    rabbit_cover_re = re.compile(
+        r"e\.force_now\s*\?\s*`?\s*"
+        r'<circle\s+id="rabbit_btn_cover"\s+'
+        r'cx="\$\{RABBIT_BTN_CARVE_CX\}"\s+'
+        r'cy="\$\{RABBIT_BTN_CARVE_CY\}"\s+'
+        r'r="\$\{RABBIT_BTN_CARVE_R\}"\s+'
+        r'fill="var\(--card-background-color\)"\s+'
+        r'pointer-events="none"\s*/>',
+    )
+    assert rabbit_cover_re.search(source), (
+        "qs-car-card.js (AC-14): missing the `rabbit_btn_cover` "
+        "<circle> element gated on `e.force_now`."
+    )
+    time_cover_re = re.compile(
+        r"\(\s*tNext\s*&&\s*e\.schedule\s*\)\s*\?\s*`?\s*"
+        r'<circle\s+id="time_btn_cover"\s+'
+        r'cx="\$\{TIME_BTN_CARVE_CX\}"\s+'
+        r'cy="\$\{TIME_BTN_CARVE_CY\}"\s+'
+        r'r="\$\{TIME_BTN_CARVE_R\}"\s+'
+        r'fill="var\(--card-background-color\)"\s+'
+        r'pointer-events="none"\s*/>',
+    )
+    assert time_cover_re.search(source), (
+        "qs-car-card.js (AC-14): missing the `time_btn_cover` "
+        "<circle> element gated on `(tNext && e.schedule)`."
+    )
+
+    # Source order: covers must appear AFTER the clipped </g> AND
+    # BEFORE `<path d="${bgPath}"` so they paint on top of the soup
+    # and under the outer ring.
+    sun_idx = source.find('id="sun_btn_cover"')
+    rabbit_idx = source.find('id="rabbit_btn_cover"')
+    time_idx = source.find('id="time_btn_cover"')
+    bg_idx = source.find('<path d="${bgPath}"')
+    # Find the closing </g> of the clipped group: look for the
+    # `<g clip-path="url(#${electronClipId})"` anchor and then the
+    # FIRST </g> that follows it.
+    clip_g_idx = source.find('<g clip-path="url(#${electronClipId})"')
+    assert clip_g_idx != -1, (
+        "qs-car-card.js (AC-14): missing the electron-soup clipped "
+        "group anchor."
+    )
+    clip_g_close_idx = source.find("</g>", clip_g_idx)
+    assert clip_g_close_idx != -1, (
+        "qs-car-card.js (AC-14): cannot find the closing `</g>` of "
+        "the electron-soup clipped group."
+    )
+
+    for cover_name, cover_idx in (
+        ("sun_btn_cover", sun_idx),
+        ("rabbit_btn_cover", rabbit_idx),
+        ("time_btn_cover", time_idx),
+    ):
+        assert cover_idx != -1, (
+            f"qs-car-card.js (AC-14): missing the `{cover_name}` "
+            f"element in source."
+        )
+        assert clip_g_close_idx < cover_idx < bg_idx, (
+            f"qs-car-card.js (AC-14): `{cover_name}` must appear "
+            f"AFTER the clipped `</g>` (idx {clip_g_close_idx}) AND "
+            f"BEFORE the `<path d=\"${{bgPath}}\"` line "
+            f"(idx {bg_idx}). Got cover idx {cover_idx}."
+        )
 
 
 # ============================================================================

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -4065,20 +4065,31 @@ def test_car_card_lightning_life_and_glow_filter():
         "lightning must be `<path>` per boiler-precedent shape."
     )
 
-    # Stroke / stroke-width constants.
+    # Lightning palette + shape constants.
+    # `LIGHTNING_STROKE_COLOR` is the bolt's fill colour. The value
+    # is user-tunable per the QS-217 visual-iteration precedent
+    # (initial `#E0F7FF` pale-white → review-fix #02 user follow-up
+    # `#33B5FF` electric blue, per user "they should be light and
+    # bright blue, like Zeus thunderbolts").
     assert re.search(
-        r"const\s+LIGHTNING_STROKE_COLOR\s*=\s*['\"]#E0F7FF['\"]",
+        r"const\s+LIGHTNING_STROKE_COLOR\s*=\s*['\"]#[0-9A-Fa-f]{3,8}['\"]",
         executable,
     ), (
-        "qs-car-card.js (AC-6): missing `const LIGHTNING_STROKE_COLOR "
-        "= '#E0F7FF';`"
+        "qs-car-card.js (AC-6): expected `const LIGHTNING_STROKE_COLOR "
+        "= '#<hex>';` — value user-tunable."
     )
+    # `LIGHTNING_TOP_WIDTH` is the width at the top of the tapered
+    # bolt outline (pixel value user-tunable; pinned by NAME only).
+    # The previous `LIGHTNING_STROKE_WIDTH` was removed when the
+    # shape changed from uniform-stroke polyline to filled-polygon
+    # taper (user feedback: "wider from the top and reducing to the
+    # bottom").
     assert re.search(
-        r"const\s+LIGHTNING_STROKE_WIDTH\s*=\s*1\.8\b",
+        r"const\s+LIGHTNING_TOP_WIDTH\s*=\s*\d+(?:\.\d+)?\b",
         executable,
     ), (
-        "qs-car-card.js (AC-6): missing `const LIGHTNING_STROKE_WIDTH "
-        "= 1.8;`"
+        "qs-car-card.js (AC-6): expected `const LIGHTNING_TOP_WIDTH "
+        "= <number>;` (value user-tunable; pinned by NAME only)."
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -4016,36 +4016,31 @@ def test_car_card_lightning_life_and_glow_filter():
         "`lifeT < 0.70` in the lightning advance loop."
     )
 
-    # Glow filter with safe-region attrs.
-    filter_decl = (
-        '<filter id="${lightningFilterId}" x="-50%" y="-50%" '
-        'width="200%" height="200%">'
+    # Review-fix #02 user follow-up #2: the Gaussian-blur glow filter
+    # was removed per user "no need of the glow effect for the
+    # lightning bolts". Both the filter declaration AND its
+    # application on the lightning layer must now be absent. The
+    # `mix-blend-mode: screen` is kept for the electric "Screen"
+    # composite against the soup.
+    # Scope these "must-not-exist" checks to EXECUTABLE code only —
+    # historical comments referencing the removed identifiers are
+    # allowed (helpful for `git log` archaeology).
+    assert "${lightningFilterId}" not in executable, (
+        "qs-car-card.js (AC-6): the lightning Gaussian-blur glow "
+        "filter has been removed; no `${lightningFilterId}` "
+        "reference should remain in executable code. User: \"no need "
+        "of the glow effect for the lightning bolts\"."
     )
-    assert filter_decl in source, (
-        "qs-car-card.js (AC-6): lightning filter declaration must "
-        f"include safe-region attributes — expected `{filter_decl}`."
+    assert "LIGHTNING_GLOW_STDDEV" not in executable, (
+        "qs-car-card.js (AC-6): the `LIGHTNING_GLOW_STDDEV` "
+        "constant was removed alongside the glow filter — "
+        "no reference should remain in executable code."
     )
-    assert (
-        '<feGaussianBlur stdDeviation="${LIGHTNING_GLOW_STDDEV}" />'
-        in source
-    ), (
-        "qs-car-card.js (AC-6): lightning filter must contain "
-        "`<feGaussianBlur stdDeviation=\"${LIGHTNING_GLOW_STDDEV}\" />`."
-    )
-
-    # Layer carries filter + mix-blend-mode.
-    layer_re = re.compile(
-        r'<g\s+id="\$\{lightningLayerId\}"\s+'
-        r'filter="url\(#\$\{lightningFilterId\}\)"',
-    )
-    assert layer_re.search(source), (
-        "qs-car-card.js (AC-6): `<g id=\"${lightningLayerId}\">` must "
-        "carry `filter=\"url(#${lightningFilterId})\"`."
-    )
+    # Layer keeps `mix-blend-mode: screen` (composite, not blur).
     assert "mix-blend-mode: screen" in source, (
-        "qs-car-card.js (AC-6): lightning layer must use "
-        "`mix-blend-mode: screen` so the glow composites against the "
-        "soup."
+        "qs-car-card.js (AC-6): lightning layer must still use "
+        "`mix-blend-mode: screen` so the bolt composites brightly "
+        "against the soup even without the glow filter."
     )
 
     # Lightning element type: <path>, not <polyline>. Pin negatively:
@@ -4431,11 +4426,15 @@ def test_car_card_reset_dom_refs_helper_and_disconnect_teardown():
 
 def test_car_card_per_instance_unique_svg_ids():
     """QS-232 AC-11: `QsCarCard._nextClipId` static counter is bumped
-    inside `if (!this._electronClipId)`. Five per-instance ID fields
+    inside `if (!this._electronClipId)`. Four per-instance ID fields
     are derived from the same `uid`: `_electronClipId`,
-    `_sparkleLayerId`, `_lightningLayerId`, `_grainFilterId`,
-    `_lightningFilterId`. All follow the `car_<role>_${uid}` naming
-    convention.
+    `_sparkleLayerId`, `_lightningLayerId`, `_grainFilterId`. All
+    follow the `car_<role>_${uid}` naming convention.
+
+    Review-fix #02 user follow-up #2: `_lightningFilterId` was
+    removed alongside the lightning glow filter — the new sharp
+    purple bolt has no `<filter>` element, so the per-instance
+    filter ID is unused.
     """
     import re
 
@@ -4461,13 +4460,14 @@ def test_car_card_per_instance_unique_svg_ids():
         "once."
     )
 
-    # Five ID fields, all `car_<role>_${uid}`-shaped.
+    # Four ID fields, all `car_<role>_${uid}`-shaped. The
+    # `_lightningFilterId` was removed in review-fix #02 follow-up
+    # alongside the lightning glow filter.
     id_assignments = {
-        "_electronClipId":    "car_eClip_",
-        "_sparkleLayerId":    "car_sparkLayer_",
-        "_lightningLayerId":  "car_lightningLayer_",
-        "_grainFilterId":     "car_grainFilter_",
-        "_lightningFilterId": "car_lightningFilter_",
+        "_electronClipId":   "car_eClip_",
+        "_sparkleLayerId":   "car_sparkLayer_",
+        "_lightningLayerId": "car_lightningLayer_",
+        "_grainFilterId":    "car_grainFilter_",
     }
     for field, prefix in id_assignments.items():
         pat = re.compile(

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -3867,20 +3867,29 @@ def test_car_card_sparkle_color_decided_at_spawn():
     ).read_text()
     executable = _strip_js_comments(source)
 
-    # Literal palette constants.
+    # Palette constants. SPARKLE_IDLE_COLOR is a `hsla(140, …, …, …)`
+    # expression — hue MUST be 140 (green family) so the idle palette
+    # is recognisable as "electron green", but saturation / lightness /
+    # alpha are user-tunable per the QS-217 visual-iteration precedent
+    # (review-fix #03 retuned to near-white mint for higher contrast
+    # against the brighter soup palette).
     assert re.search(
-        r"const\s+SPARKLE_IDLE_COLOR\s*=\s*['\"]hsla\(\s*140\s*,\s*90%\s*,\s*70%\s*,\s*0\.9\s*\)['\"]",
+        r"const\s+SPARKLE_IDLE_COLOR\s*=\s*['\"]hsla\(\s*140\s*,",
         executable,
     ), (
         "qs-car-card.js (AC-4): expected `const SPARKLE_IDLE_COLOR = "
-        "'hsla(140, 90%, 70%, 0.9)';`"
+        "'hsla(140, …, …, …)';` — hue must be 140 (green family); "
+        "saturation/lightness/alpha are user-tunable."
     )
+    # SPARKLE_CHARGE_COLOR — pinned by name only (value is the
+    # electric-blue family but the user is free to retune the exact
+    # hex code).
     assert re.search(
-        r"const\s+SPARKLE_CHARGE_COLOR\s*=\s*['\"]#00E5FF['\"]",
+        r"const\s+SPARKLE_CHARGE_COLOR\s*=\s*['\"]#[0-9A-Fa-f]{3,8}['\"]",
         executable,
     ), (
         "qs-car-card.js (AC-4): expected `const SPARKLE_CHARGE_COLOR = "
-        "'#00E5FF';` (electric lightning blue)."
+        "'#<hex>';` (electric lightning blue — value user-tunable)."
     )
 
     # Ternary selecting fill at spawn (mention both constants in a

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -4238,8 +4238,13 @@ def test_car_card_continuous_raf_from_connected_callback():
 
     # `_render()` body must NOT contain `_stopAnimation` or a
     # conditional `_startAnimation` gated on charging.
+    # NB: the signature regex includes the opening `{` so that
+    # `_extract_js_function_body` matches the METHOD DEFINITION
+    # (not the various `this._render()` CALL sites in
+    # `connectedCallback` / `setConfig` / event handlers, which
+    # appear before the definition in source order).
     render_body = _extract_js_function_body(
-        executable, r"_render\s*\(\s*\)\s*"
+        executable, r"_render\s*\(\s*\)\s*\{"
     )
     assert render_body is not None, (
         "qs-car-card.js (AC-9): `_render()` body not found."
@@ -5005,6 +5010,523 @@ def test_car_card_dashed_arc_comment_no_stale_m4_reference():
         "must be rewritten to reflect the QS-232 continuous-RAF "
         "model. The M4 milestone is no longer the controlling "
         "lifecycle anchor."
+    )
+
+
+# ============================================================================
+# === QS-232 review-fix #02 tests ===
+# Round-2 follow-ups. The headline regression: review-fix #01 #4 armed
+# `_needsAnimationPrime = true` in `setConfig`, then `_render`
+# consumed the flag (setting `_currentAmplitude`/`_currentSpeed`/
+# `_currentColorMix`) BEFORE `connectedCallback` fired. The lazy-init
+# guard in `_startAnimation()` is `if (this._currentAmplitude == null)`
+# — which is now FALSE — so the rest of the lazy-init block
+# (`_wavePhase`, `_nextSparkleAt`, `_nextLightningAt`, `_sparkles`,
+# `_lightningBolts`) is skipped, leaving them undefined. First RAF
+# tick poisons `_wavePhase` with NaN; the sparkle / lightning spawn
+# loops never enter. User-visible symptom: "no sparkles at all".
+# Fix: each RAF-state field guards itself individually.
+# ============================================================================
+
+
+def test_car_card_first_raf_tick_initialises_wave_phase_unconditionally():
+    """QS-232 review-fix #02 #1: `_wavePhase`, `_nextSparkleAt`,
+    `_nextLightningAt`, `_sparkles`, `_lightningBolts` must each be
+    seeded by `_startAnimation()` regardless of whether
+    `_currentAmplitude` has already been primed by `_render()`.
+    The previous form bundled all five inside
+    `if (this._currentAmplitude == null) { ... }`, which the
+    prime-block-in-`_render` consumed — leaving the other five
+    undefined and poisoning the first RAF tick with NaN.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    body = _extract_js_function_body(
+        executable, r"_startAnimation\s*\(\s*\)\s*"
+    )
+    assert body is not None, (
+        "qs-car-card.js (review-fix #02 #1): `_startAnimation()` "
+        "body not found."
+    )
+
+    # The five RAF-state fields must each have their OWN
+    # `if (this.X == null) this.X = ...` guard so that consumption
+    # of `_currentAmplitude` by the prime block doesn't strand them.
+    for field, default_pattern in [
+        ("_wavePhase",       r"=\s*0"),
+        ("_nextSparkleAt",   r"=\s*0"),
+        ("_nextLightningAt", r"=\s*LIGHTNING_SPAWN_MIN_S"),
+        ("_sparkles",        r"=\s*\[\s*\]"),
+        ("_lightningBolts",  r"=\s*\[\s*\]"),
+    ]:
+        per_field_guard = re.compile(
+            rf"if\s*\(\s*this\.{field}\s*==\s*null\s*\)\s*"
+            rf"this\.{field}\s*{default_pattern}",
+        )
+        assert per_field_guard.search(body), (
+            f"qs-car-card.js (review-fix #02 #1): `_startAnimation` "
+            f"must seed `this.{field}` under its OWN `== null` guard "
+            f"(not bundled inside the `_currentAmplitude == null` "
+            f"block) so the prime path can't strand it."
+        )
+
+
+def test_car_card_initial_paint_uses_finite_guards_not_nullish():
+    """QS-232 review-fix #02 #2: `initialAmp` / `initialColorMix`
+    must be derived via `Number.isFinite(...)` checks rather than
+    `??`. `??` only traps null/undefined, so a runtime NaN (from a
+    poisoned lerp accumulator) propagates into the initial wave path
+    `d` attribute and opacity attribute strings. Mirrors the fix-#01-#8
+    finite-guard shape for `_lastAmplitude`.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Positive: explicit finite check for initialAmp.
+    initial_amp_re = re.compile(
+        r"const\s+initialAmp\s*=\s*"
+        r"Number\.isFinite\s*\(\s*this\._currentAmplitude\s*\)\s*\?\s*"
+        r"this\._currentAmplitude\s*:\s*CALM_AMP",
+    )
+    assert initial_amp_re.search(executable), (
+        "qs-car-card.js (review-fix #02 #2): `initialAmp` must be "
+        "computed via `Number.isFinite(this._currentAmplitude) ? "
+        "this._currentAmplitude : CALM_AMP` — `??` does not trap "
+        "NaN."
+    )
+
+    # Positive: explicit finite check for initialColorMix.
+    initial_mix_re = re.compile(
+        r"const\s+initialColorMix\s*=\s*"
+        r"Number\.isFinite\s*\(\s*this\._currentColorMix\s*\)\s*\?\s*"
+        r"this\._currentColorMix\s*:\s*0",
+    )
+    assert initial_mix_re.search(executable), (
+        "qs-car-card.js (review-fix #02 #2): `initialColorMix` must "
+        "be computed via `Number.isFinite(this._currentColorMix) ? "
+        "this._currentColorMix : 0` — `??` does not trap NaN."
+    )
+
+    # Negative pins: the old `??` shapes for the same identifiers
+    # must not be present.
+    for old_form in (
+        r"const\s+initialAmp\s*=\s*this\._currentAmplitude\s*\?\?",
+        r"const\s+initialColorMix\s*=\s*this\._currentColorMix\s*\?\?",
+    ):
+        assert not re.search(old_form, executable), (
+            "qs-car-card.js (review-fix #02 #2): the old `??` form "
+            f"matching /{old_form}/ must be replaced with a "
+            "`Number.isFinite(...)` ternary."
+        )
+
+
+def test_car_card_setConfig_restarts_animation_when_connected():
+    """QS-232 review-fix #02 #3: `setConfig()` must re-invoke
+    `_startAnimation()` at its tail if the element is already
+    connected and RAF hasn't started yet. Otherwise — in the
+    (uncommon) lifecycle where `connectedCallback` fires before
+    `setConfig` — RAF never starts because `_startAnimation` bails
+    early on `!_root` and nothing re-calls it once `_root` is set.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    set_config_body = _extract_js_function_body(
+        executable, r"setConfig\s*\(\s*config\s*\)\s*"
+    )
+    assert set_config_body is not None, (
+        "qs-car-card.js (review-fix #02 #3): `setConfig(config)` "
+        "method not found."
+    )
+    # Re-entry guard: must reference both `isConnected` and call
+    # `_startAnimation()` inside a guarded block.
+    reentry_re = re.compile(
+        r"if\s*\(\s*this\.isConnected[^)]*_animRaf[^)]*\)\s*\{[^}]*"
+        r"this\._startAnimation\s*\(\s*\)",
+        re.DOTALL,
+    )
+    assert reentry_re.search(set_config_body), (
+        "qs-car-card.js (review-fix #02 #3): `setConfig` must "
+        "contain a tail guard "
+        "`if (this.isConnected && this._animRaf == null) "
+        "this._startAnimation();` so RAF starts even when "
+        "`connectedCallback` fired before `setConfig`."
+    )
+
+
+def test_car_card_connectedCallback_reprime_calls_render():
+    """QS-232 review-fix #02 #4: the reprime branch in
+    `connectedCallback()` (which sets `_needsAnimationPrime = true`
+    when `_charging` flipped during a detached interval) must also
+    call `this._render()` so the flag is consumed immediately. The
+    previous form left the flag set until the next `set hass` push,
+    during which the RAF lerps visibly from the stale `_currentColorMix`
+    toward the new target.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    cb_body = _extract_js_function_body(
+        executable, r"connectedCallback\s*\(\s*\)\s*"
+    )
+    assert cb_body is not None, (
+        "qs-car-card.js (review-fix #02 #4): `connectedCallback()` "
+        "not found."
+    )
+    # The reprime block must contain BOTH the flag set AND the
+    # `_render()` call, adjacent or with whitespace between them.
+    # NB: we don't use an `if (... _charging ...)` regex anchor here
+    # because `_charging` may live in a `const targetMix = ...`
+    # statement BEFORE the `if`, not inside the `if` predicate.
+    # Adjacency check is sufficient: prime + render in the same
+    # block.
+    adjacent_re = re.compile(
+        r"this\._needsAnimationPrime\s*=\s*true\s*;\s*"
+        r"this\._render\s*\(\s*\)",
+    )
+    assert adjacent_re.search(cb_body), (
+        "qs-car-card.js (review-fix #02 #4): `connectedCallback` "
+        "must call `this._render()` immediately after setting "
+        "`this._needsAnimationPrime = true` (adjacent statements) "
+        "so the flag is consumed on the next paint, not on the "
+        "next hass push."
+    )
+
+
+def test_car_card_last_amplitude_in_raf_uses_finite_guard():
+    """QS-232 review-fix #02 #5: review-fix #01 #8 patched only the
+    POST-innerHTML write to `_lastAmplitude` (at the end of
+    `_render`). The IN-RAF write at the wave-regen block was left
+    unguarded — if `_currentAmplitude` ever becomes NaN mid-frame,
+    NaN propagates into `_lastAmplitude`, the regen check freezes,
+    and the wave path is never regenerated. Both the in-RAF read
+    AND the in-RAF write must guard against NaN.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    raf_body = _extract_js_function_body(
+        executable, r"_startAnimation\s*\(\s*\)\s*"
+    )
+    assert raf_body is not None, (
+        "qs-car-card.js (review-fix #02 #5): `_startAnimation()` "
+        "body not found."
+    )
+
+    # In-RAF read: the `ampDelta = ...` ternary must treat both null
+    # AND non-finite as "first frame". The source uses a parenthesised
+    # disjunction `(this._lastAmplitude == null || !Number.isFinite(
+    # this._lastAmplitude))` so the regex allows an optional leading
+    # `(`.
+    ampdelta_finite_re = re.compile(
+        r"ampDelta\s*=\s*\(?\s*"
+        r"(?:!?\s*Number\.isFinite\s*\(\s*this\._lastAmplitude\s*\)"
+        r"|this\._lastAmplitude\s*==\s*null\s*\|\|\s*!\s*Number\.isFinite)",
+    )
+    assert ampdelta_finite_re.search(raf_body), (
+        "qs-car-card.js (review-fix #02 #5): the in-RAF "
+        "`ampDelta = …` computation must guard against non-finite "
+        "`_lastAmplitude` (use `Number.isFinite(...)` rather than "
+        "`== null` alone, since NaN can be stored)."
+    )
+
+    # In-RAF write: count `_lastAmplitude = ` occurrences. The shape
+    # with the finite guard must appear AT LEAST TWICE (in-RAF write
+    # at line ~345, post-innerHTML write at the end of _render).
+    finite_writes = re.findall(
+        r"this\._lastAmplitude\s*=\s*"
+        r"Number\.isFinite\s*\(\s*this\._currentAmplitude\s*\)\s*\?\s*"
+        r"this\._currentAmplitude\s*:\s*CALM_AMP",
+        executable,
+    )
+    assert len(finite_writes) >= 2, (
+        f"qs-car-card.js (review-fix #02 #5): expected at least 2 "
+        f"`_lastAmplitude = Number.isFinite(this._currentAmplitude) ? "
+        f"this._currentAmplitude : CALM_AMP` assignments (one in-RAF "
+        f"at the wave-regen block, one post-innerHTML in `_render`). "
+        f"Found {len(finite_writes)}."
+    )
+
+
+def test_car_card_initial_paint_opacity_is_clamped():
+    """QS-232 review-fix #02 #6: review-fix #01 #18 clamped the
+    RAF-step opacity emission via a local `mix` variable, but the
+    INITIAL-PAINT opacity emission (`initialIdleOpacity` /
+    `initialChargeOpacity`) was left unclamped. After RAF has run
+    long enough for `_currentColorMix` to drift slightly outside
+    `[0, 1]`, the next `_render` emits `"-0.000"` opacity tokens.
+    The initial-paint sites must clamp too.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # Either form is acceptable:
+    # (a) a local `mix` / `initialMix` = `Math.max(0, Math.min(1,
+    #     initialColorMix))` used in both opacity emissions, OR
+    # (b) the Math.max/min inline at both emission sites.
+    has_local_clamp = re.search(
+        r"const\s+(?:mix|initialMix)\s*=\s*Math\.max\s*\(\s*0\s*,\s*"
+        r"Math\.min\s*\(\s*1\s*,\s*initialColorMix",
+        executable,
+    )
+    has_inline_clamp_idle = re.search(
+        r"const\s+initialIdleOpacity\s*=\s*"
+        r"\(\s*1\s*-\s*Math\.max\s*\(\s*0\s*,\s*Math\.min\s*\(\s*1\s*,\s*initialColorMix",
+        executable,
+    )
+    has_inline_clamp_charge = re.search(
+        r"const\s+initialChargeOpacity\s*=\s*"
+        r"Math\.max\s*\(\s*0\s*,\s*Math\.min\s*\(\s*1\s*,\s*initialColorMix",
+        executable,
+    )
+    assert has_local_clamp or (has_inline_clamp_idle and has_inline_clamp_charge), (
+        "qs-car-card.js (review-fix #02 #6): the initial-paint "
+        "opacity emission must clamp `initialColorMix` to `[0, 1]` "
+        "before `.toFixed(3)` — either via a `const mix = "
+        "Math.max(0, Math.min(1, initialColorMix));` (or `initialMix`) "
+        "local OR via the Math.max/min inline at both "
+        "`initialIdleOpacity` and `initialChargeOpacity` sites."
+    )
+
+
+def test_car_card_rabbit_btn_render_and_cover_gates_match():
+    """QS-232 review-fix #02 #7: `rabbit_btn` and `rabbit_btn_cover`
+    must share the same render gate. Symmetric to the fix-#01-#6
+    treatment for `time_btn`. Currently `<div id="rabbit_btn">`
+    renders unconditionally while the cover is gated on `e.force_now`
+    — when `force_now` is undefined, the button draws over un-carved
+    soup and sparkles bleed behind it.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+
+    # Extract each ternary's predicate by:
+    # 1. Locating the target element (`<div id="rabbit_btn"` /
+    #    `<circle id="rabbit_btn_cover"`).
+    # 2. Walking BACKWARD via `rfind` to the immediately preceding
+    #    `${` template substitution opener.
+    # 3. Reading the predicate text between `${` and the next `?`.
+    # This avoids the cross-template greedy-match pathology of
+    # using `\$\{[^?]+?\?` directly (which can match across
+    # unrelated `${...}` substitutions appearing earlier in the
+    # same source).
+    def _extract_template_predicate(target_marker: str) -> str | None:
+        target_idx = source.find(target_marker)
+        if target_idx == -1:
+            return None
+        dollar_idx = source.rfind("${", 0, target_idx)
+        if dollar_idx == -1:
+            return None
+        question_idx = source.find("?", dollar_idx, target_idx)
+        if question_idx == -1:
+            return None
+        return source[dollar_idx + 2 : question_idx].strip()
+
+    btn_predicate = _extract_template_predicate('<div id="rabbit_btn"')
+    assert btn_predicate is not None, (
+        "qs-car-card.js (review-fix #02 #7): the `rabbit_btn` <div> "
+        "must be wrapped in a `${predicate ? `<div id=\"rabbit_btn\""
+        " …>` : ''}` ternary so its render gate aligns with the "
+        "`rabbit_btn_cover` gate."
+    )
+    cover_predicate = _extract_template_predicate(
+        '<circle id="rabbit_btn_cover"'
+    )
+    assert cover_predicate is not None, (
+        "qs-car-card.js (review-fix #02 #7): missing the "
+        "`rabbit_btn_cover` <circle> with a gating ternary."
+    )
+
+    def _normalise(s: str) -> str:
+        return re.sub(r"\s+", "", s)
+
+    assert _normalise(btn_predicate) == _normalise(cover_predicate), (
+        f"qs-car-card.js (review-fix #02 #7): `rabbit_btn` render "
+        f"gate `{btn_predicate}` and `rabbit_btn_cover` gate "
+        f"`{cover_predicate}` must be equal (whitespace-normalised)."
+    )
+
+
+def test_car_card_mix_clamp_traps_nan():
+    """QS-232 review-fix #02 #9: the RAF-step `const mix = Math.max(0,
+    Math.min(1, this._currentColorMix));` clamp doesn't trap NaN
+    (since `Math.max(0, Math.min(1, NaN)) === NaN`). Wrap with a
+    `Number.isFinite` ternary so NaN falls back to 0.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    mix_finite_re = re.compile(
+        r"const\s+mix\s*=\s*"
+        r"Number\.isFinite\s*\(\s*this\._currentColorMix\s*\)\s*\?\s*"
+        r"Math\.max\s*\(\s*0\s*,\s*Math\.min\s*\(\s*1\s*,\s*this\._currentColorMix\s*\)\s*\)\s*:\s*0",
+    )
+    assert mix_finite_re.search(executable), (
+        "qs-car-card.js (review-fix #02 #9): the RAF-step "
+        "`const mix = ...` clamp must be wrapped in a "
+        "`Number.isFinite(this._currentColorMix)` ternary so NaN "
+        "falls back to 0 (Math.max/min don't trap NaN)."
+    )
+
+
+def test_car_card_wave_els_retry_on_null():
+    """QS-232 review-fix #02 #10: the `_waveEls` lazy-resolve must
+    retry if EITHER slot is null. The previous form
+    `if (!this._waveEls) { this._waveEls = [idle, charge]; }` caches
+    `[null, null]` (which is truthy) permanently if both lookups
+    miss during a transient detach.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    retry_re = re.compile(
+        r"if\s*\(\s*"
+        r"!\s*this\._waveEls"
+        r"\s*\|\|\s*!\s*this\._waveEls\s*\[\s*0\s*\]"
+        r"\s*\|\|\s*!\s*this\._waveEls\s*\[\s*1\s*\]"
+        r"\s*\)",
+    )
+    assert retry_re.search(executable), (
+        "qs-car-card.js (review-fix #02 #10): the `_waveEls` "
+        "lazy-resolve guard must be "
+        "`if (!this._waveEls || !this._waveEls[0] || "
+        "!this._waveEls[1])` so a transient `[null, null]` cache is "
+        "retried on subsequent ticks."
+    )
+
+
+def test_car_card_has_valid_base_uses_number_is_finite():
+    """QS-232 review-fix #02 #11: `hasValidBase` must use
+    `Number.isFinite(waterBaseY)` (not `!Number.isNaN(...)`), so a
+    spurious `Infinity` doesn't slip through the guard. Asymmetric
+    with fix-#01-#3 / fix-#01-#5 which already use `Number.isFinite`.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    finite_re = re.compile(
+        r"const\s+hasValidBase\s*=\s*"
+        r"waterBaseY\s*!=\s*null\s*&&\s*"
+        r"Number\.isFinite\s*\(\s*waterBaseY\s*\)",
+    )
+    assert finite_re.search(executable), (
+        "qs-car-card.js (review-fix #02 #11): `const hasValidBase = "
+        "waterBaseY != null && Number.isFinite(waterBaseY);` — "
+        "`!Number.isNaN(...)` is asymmetric with the other guards "
+        "in the file and lets `Infinity` through."
+    )
+
+
+def test_car_card_render_snapshot_defensively_coerces_undefined_sparkles():
+    """QS-232 review-fix #02 #18: the `_render` snapshot block at the
+    start of `_render` reads `this._sparkles` / `this._lightningBolts`
+    BEFORE the first call to `_startAnimation` (which lazy-inits
+    them). On the very first `_render` (from `setConfig`), both are
+    `undefined`. Currently safe because the snapshot just captures
+    `undefined` and the restore branches skip. But if a downstream
+    consumer ever dereferences `.length`, this becomes a runtime
+    crash. Defensive `?? []` coercion eliminates the coupling.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    sparkle_snap_re = re.compile(
+        r"const\s+preservedSparkles\s*=\s*"
+        r"this\._sparkles\s*\?\?\s*\[\s*\]",
+    )
+    lightning_snap_re = re.compile(
+        r"const\s+preservedLightningBolts\s*=\s*"
+        r"this\._lightningBolts\s*\?\?\s*\[\s*\]",
+    )
+    assert sparkle_snap_re.search(executable), (
+        "qs-car-card.js (review-fix #02 #18): the `preservedSparkles` "
+        "snapshot must defensively coerce undefined to `[]` via "
+        "`this._sparkles ?? []`."
+    )
+    assert lightning_snap_re.search(executable), (
+        "qs-car-card.js (review-fix #02 #18): the "
+        "`preservedLightningBolts` snapshot must defensively coerce "
+        "undefined to `[]` via `this._lightningBolts ?? []`."
+    )
+
+
+def test_car_card_restore_drops_sparkles_above_new_water_base_y():
+    """QS-232 review-fix #02 #16: a sparkle spawned at
+    `cy ≈ _waterBaseY + 2` is preserved across `_render`; if the SOC
+    changed enough that the new `_waterBaseY` is now BELOW the
+    sparkle's frozen `cy` (i.e., new water surface is HIGHER on the
+    SVG, meaning lower y value), the sparkle would visually appear
+    in the air ABOVE the soup. Drop those sparkles at restore time.
+    """
+    import re
+
+    source = (
+        COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+    ).read_text()
+    executable = _strip_js_comments(source)
+
+    # The restore loop must filter sparkles whose `cy` is above
+    # (less than) the new `_waterBaseY`. Accept either an inline
+    # filter on the preserved array OR an explicit `if (s.cy < ...)`
+    # branch inside the restore loop.
+    inline_filter_re = re.compile(
+        r"preservedSparkles\s*\.\s*filter\s*\([^)]*"
+        r"\.cy\s*>=\s*this\._waterBaseY",
+        re.DOTALL,
+    )
+    body_filter_re = re.compile(
+        r"if\s*\(\s*[a-zA-Z_]+\.cy\s*<\s*this\._waterBaseY\s*\)",
+    )
+    assert inline_filter_re.search(executable) or body_filter_re.search(executable), (
+        "qs-car-card.js (review-fix #02 #16): the sparkle restore "
+        "block must drop preserved sparkles whose `cy` is above the "
+        "NEW `_waterBaseY` (i.e., `cy < this._waterBaseY`) — "
+        "otherwise they appear floating above the soup after a "
+        "large SOC change."
     )
 
 


### PR DESCRIPTION
## Summary
Single sine wave inside a circular clipPath with binary idle↔charge cross-fade. Sparkle and lightning-bolt particles inside the soup, sparkles power-scaling on [1500W, 22000W]. feTurbulence grain on wave fill; degraded CSS filter on clip group. Three QS-217-style carve covers (sun/rabbit/time buttons). Continuous-RAF model.

Fixes #232

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Continuous "electron-soup" SOC wave with always-visible sparkles, charging-only lightning, and three in-disc cover buttons (sun/rabbit/time).

* **Improvements**
  * RAF animation runs while connected with hidden-tab dt clamping, per-instance SVG isolation, primed initial render, improved teardown/restoration on disconnect/reconnect, sparkle/lightning spawn throttling and opacity clamping, degraded-state desaturate/brighten and lightning suppression, repositioned sun button with spacer, NaN/finite guarding for visual stability.

* **Documentation**
  * Full QS-232 spec, story, and two review-fix plans.

* **Tests**
  * Expanded visual, lifecycle, dt-clamp, degraded-state, particle, and multi-card rendering tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->