### PR TITLE
QS-235: Commonalize qs-car-card.js: adopt shared base structural helpers

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -7,9 +7,9 @@
   mirroring the QS-200 / QS-211 / QS-214 boiler architecture. The
   high-level design — single-layer sine wave inside a clipPath,
   idle↔charge cross-fade, lightning-blue sparkle particles, lightning
-  bolts during charging, feTurbulence grain on the wave fill,
-  degraded-state CSS desaturate, continuous RAF, and QS-217 carve
-  covers extended to three inside-disc buttons — is documented in
+  bolts during charging, degraded-state CSS desaturate, continuous
+  RAF, and QS-217 carve covers extended to three inside-disc buttons
+  — is documented in
   `docs/agents/concepts/dashboard-and-cards.md` (search for
   "QS-232 — Car-card electron-soup animation"). Tuning constants
   (sparkle power-scaling range, lightning spawn interval, life
@@ -203,7 +203,7 @@ const TIME_BTN_CARVE_R  = 32;
 // bottom). Inherits lifecycle, service callers, defensive utilities,
 // modal dialog, keyboard activation, and the 5 wire-helpers. Car
 // retains its own ring HTML (full-circle, sun/rabbit/time-btn carve
-// covers), sparkle system, lightning system, feTurbulence grain.
+// covers), sparkle system, lightning system.
 import { baseCardCSS } from './shared/qs-card-styles.js';
 import { QsCardBase, rad2deg, polar, arcPath, pctToDeg } from './shared/qs-card-base.js';
 
@@ -245,10 +245,6 @@ class QsCarCard extends QsCardBase {
   // `test_water_boiler_card_factors_reset_dom_refs_helper`).
   _resetDomRefs() {
     this._waveEls = null;             // [idleWave, chargeWave]
-    // Review-fix #01 #14: removed `_grainFilterEl` — no code path
-    // ever read or lazily-resolved it. The grain filter is declared
-    // once in `<defs>` and referenced by the wave paths via
-    // `filter="url(#${grainFilterId})"`; no JS-side ref needed.
     this._sparkleLayerEl = null;
     this._lightningLayerEl = null;
     this._sparkles = [];
@@ -855,7 +851,6 @@ class QsCarCard extends QsCardBase {
         this._electronClipId   = `car_eClip_${uid}`;
         this._sparkleLayerId   = `car_sparkLayer_${uid}`;
         this._lightningLayerId = `car_lightningLayer_${uid}`;
-        this._grainFilterId    = `car_grainFilter_${uid}`;
         // Review-fix #02 user follow-up #2: `_lightningFilterId`
         // removed alongside the lightning glow filter — the new
         // sharp purple bolt doesn't use a `<filter>`.
@@ -863,7 +858,6 @@ class QsCarCard extends QsCardBase {
       const electronClipId   = this._electronClipId;
       const sparkleLayerId   = this._sparkleLayerId;
       const lightningLayerId = this._lightningLayerId;
-      const grainFilterId    = this._grainFilterId;
       const carChargeTypeIcons = {
           "Unknown": "mdi:help-circle-outline",
           "Not Plugged": "mdi:power-plug-off",
@@ -1316,21 +1310,13 @@ class QsCarCard extends QsCardBase {
                     <feMergeNode in="SourceGraphic" />
                   </feMerge>
                 </filter>
-                <filter id="${grainFilterId}" x="-20%" y="-20%" width="140%" height="140%">
-                  <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" seed="3" result="noise" />
-                  <feComposite in="noise" in2="SourceGraphic" operator="in" result="grain" />
-                  <feMerge>
-                    <feMergeNode in="SourceGraphic" />
-                    <feMergeNode in="grain" />
-                  </feMerge>
-                </filter>
                 <clipPath id="${electronClipId}">
                   <circle cx="${CENTER_CX}" cy="${CENTER_CY}" r="${CLIP_R}" />
                 </clipPath>
               </defs>
               <g clip-path="url(#${electronClipId})" style="${degraded ? 'filter: saturate(0.3) brightness(0.7);' : ''}">
-                <path id="electron_wave_idle" d="${initialWavePath}" fill="${IDLE_SOUP_COLOR}" opacity="${initialIdleOpacity}" filter="url(#${grainFilterId})" pointer-events="none" style="will-change: transform;" />
-                <path id="electron_wave_charge" d="${initialWavePath}" fill="${CHARGE_SOUP_COLOR}" opacity="${initialChargeOpacity}" filter="url(#${grainFilterId})" pointer-events="none" style="will-change: transform;" />
+                <path id="electron_wave_idle" d="${initialWavePath}" fill="${IDLE_SOUP_COLOR}" opacity="${initialIdleOpacity}" pointer-events="none" style="will-change: transform;" />
+                <path id="electron_wave_charge" d="${initialWavePath}" fill="${CHARGE_SOUP_COLOR}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
                 <g id="${sparkleLayerId}" pointer-events="none"></g>
                 <g id="${lightningLayerId}" pointer-events="none" style="mix-blend-mode: screen; will-change: opacity;"></g>
               </g>

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -187,9 +187,11 @@ const LIGHTNING_BRANCH_MAX_LEN = 22;
 // - The sun-btn DOM was restructured to a direct child of the
 //   .ring container (out of `.center > .stack > .center-controls`)
 //   so its CSS layout matches override-btn exactly.
-const SUN_BTN_CARVE_CX = 160;       // bottom-center of ring
-const SUN_BTN_CARVE_CY = 277;       // matches OVERRIDE_BTN_CARVE_CY in other cards
-const SUN_BTN_CARVE_R  = 35;        // matches OVERRIDE_BTN_CARVE_R in other cards
+// QS-235 — the bottom-center sun-btn cover now uses the shared
+// `RING_BOTTOM_CARVE_CX/CY/R` constants (`shared/qs-card-base.js`,
+// imported above) — the same set the duration cards use for their
+// `override_btn_cover`. The per-card `SUN_BTN_CARVE_*` duplicate is
+// removed. The rabbit/time covers keep their own car-local geometry.
 const RABBIT_BTN_CARVE_CX = 96;     // left column of mini-grid
 const RABBIT_BTN_CARVE_CY = 206;
 const RABBIT_BTN_CARVE_R  = 32;
@@ -205,7 +207,7 @@ const TIME_BTN_CARVE_R  = 32;
 // retains its own ring HTML (full-circle, sun/rabbit/time-btn carve
 // covers), sparkle system, lightning system.
 import { baseCardCSS } from './shared/qs-card-styles.js';
-import { QsCardBase, rad2deg, polar, arcPath, pctToDeg } from './shared/qs-card-base.js';
+import { QsCardBase, polar, arcPath, pctToDeg, RING_BOTTOM_CARVE_CX, RING_BOTTOM_CARVE_CY, RING_BOTTOM_CARVE_R } from './shared/qs-card-base.js';
 
 class QsCarCard extends QsCardBase {
   constructor() {
@@ -836,10 +838,13 @@ class QsCarCard extends QsCardBase {
       // Check if car API data is stale
       const isStale = sCarIsStale?.state === 'on';
       let soc = this._percent(sSoc?.state);
-      const power = sPower?.state || "0";
-      this._chargePower = Number(power) || 0;
+      // QS-235 AC6 — guard-shaped sensor read via the shared `_safeNumber`
+      // (trims, rejects unknown/unavailable/±Infinity) instead of the raw
+      // `Number(sPower?.state || "0")` pattern.
+      const powerW = this._safeNumber(sPower, 0);
+      this._chargePower = powerW;
       const target = selLimit?.state || "";
-      const charging = (Number(power) > 50);
+      const charging = (powerW > 50);
       this._charging = charging;
       // QS-232: per-instance unique SVG IDs so two car cards on the
       // same dashboard don't collide (cheap insurance — households
@@ -944,7 +949,8 @@ class QsCarCard extends QsCardBase {
           }
 
           // Use current_inputed_energy for energy mode (value is in Wh, convert to kWh)
-          const energyValue = Number(sCurrentInputedEnergy?.state || 0);
+          // QS-235 AC6 — guard-shaped sensor read via `_safeNumber`.
+          const energyValue = this._safeNumber(sCurrentInputedEnergy, 0);
           const socKwhNum = Math.round(energyValue / 1000);
           const socKwh = this._fmt(socKwhNum);
 
@@ -1273,24 +1279,16 @@ class QsCarCard extends QsCardBase {
       const preservedLightningBolts  = this._lightningBolts ?? [];
       const preservedNextLightningAt = this._nextLightningAt;
 
-      this._root.innerHTML = `
-      <ha-card class="card ${isDisconnected ? 'disabled' : ''} ${isFaulted ? 'fault' : ''} ${isOffGrid ? 'off-grid' : ''} ${isStale ? 'stale' : ''}">
-        <style>${css}</style>
-        <div class="card-title">${this._escapeHtml(displayTitle)}</div>
-        <div class="top"></div>
-
-        <div class="hero">
-          <div class="ring" title="${soc}%">
-            <svg viewBox="0 0 320 320" width="300" height="300" style="touch-action: none;" aria-hidden="true">
-              <defs>
-                <linearGradient id="${gradGreenId}" x1="0%" y1="0%" x2="100%" y2="0%">
-                  <stop offset="0%" stop-color="#00bcd4"/>
-                  <stop offset="100%" stop-color="#8bc34a"/>
-                </linearGradient>
-                <linearGradient id="${gradChargeId}" x1="0%" y1="0%" x2="100%" y2="0%">
-                  <stop offset="0%" stop-color="#00e1ff"/>
-                  <stop offset="100%" stop-color="#0066ff"/>
-                </linearGradient>
+      // QS-235 AC2 — the bg-arc / progress-arc / dash-anim / handle are
+      // built by the shared `_buildRingHTML`. The builder emits its own
+      // <defs> for the green + charge gradients (via the standard
+      // gradGreenId / gradRunningId params) plus a per-instance glow; the
+      // car's disabled / fault / stale gradients + the soup clipPath are
+      // injected via `extraDefs` (forward-referenced by the clip <g>
+      // rendered just above ${ringMarkup} — valid SVG). The car follows
+      // the radiator composition pattern: clip backdrop <g> + carves
+      // first, then ${ringMarkup}.
+      const extraDefs = `
                 <linearGradient id="${gradDisabledId}" x1="0%" y1="0%" x2="100%" y2="0%">
                   <stop offset="0%" stop-color="#6b6b6b" stop-opacity="0.65"/>
                   <stop offset="100%" stop-color="#a0a0a0" stop-opacity="0.75"/>
@@ -1303,43 +1301,50 @@ class QsCarCard extends QsCardBase {
                   <stop offset="0%" stop-color="#ffa726"/>
                   <stop offset="100%" stop-color="#ff8f00"/>
                 </linearGradient>
-                <filter id="chargeGlow" x="-50%" y="-50%" width="200%" height="200%">
-                  <feGaussianBlur stdDeviation="2" result="blur" />
-                  <feMerge>
-                    <feMergeNode in="blur" />
-                    <feMergeNode in="SourceGraphic" />
-                  </feMerge>
-                </filter>
                 <clipPath id="${electronClipId}">
                   <circle cx="${CENTER_CX}" cy="${CENTER_CY}" r="${CLIP_R}" />
-                </clipPath>
-              </defs>
+                </clipPath>`;
+      const ringMarkup = this._buildRingHTML({
+          palette: colors, ringCirc, center,
+          progressPath: socPath, bgPath,
+          handlePos, handlePct,
+          showAnimation, canDragHandle: true,
+          gradGreenId, gradRunningId: gradChargeId, activeGradId,
+          dashLen, gapLen,
+          // QS-235 — car-specific overrides over the duration defaults.
+          bgStroke: isFaulted ? 'rgba(244,67,54,0.35)' : 'var(--divider-color)',
+          handleFontSize: useEnergyMode ? '11' : '13',
+          handleStroke: isDisconnected ? 'var(--divider-color)' : 'var(--primary-color)',
+          handleFill: isDisconnected ? 'var(--secondary-text-color)' : 'var(--primary-color)',
+          // Handle TEXT shows the TRUE (unclamped) target — energy or
+          // percent — mirroring the duration-card round-trip invariant
+          // (position is clamped via pctToDeg, label is not).
+          handleLabel: useEnergyMode
+              ? this._fmt(parseTargetEnergy(target) ?? (this._safeNumber(sCurrentInputedEnergy, 0) / 1000))
+              : this._fmt(targetPct ?? soc),
+          animPathId: 'charge_anim',
+          extraDefs,
+      });
+
+      this._root.innerHTML = `
+      <ha-card class="card ${isDisconnected ? 'disabled' : ''} ${isFaulted ? 'fault' : ''} ${isOffGrid ? 'off-grid' : ''} ${isStale ? 'stale' : ''}">
+        <style>${css}</style>
+        <div class="card-title">${this._escapeHtml(displayTitle)}</div>
+        <div class="top"></div>
+
+        <div class="hero">
+          <div class="ring" title="${soc}%">
+            <svg viewBox="0 0 320 320" width="300" height="300" style="touch-action: none;" aria-hidden="true">
               <g clip-path="url(#${electronClipId})" style="${degraded ? 'filter: saturate(0.3) brightness(0.7);' : ''}">
                 <path id="electron_wave_idle" d="${initialWavePath}" fill="${IDLE_SOUP_COLOR}" opacity="${initialIdleOpacity}" pointer-events="none" style="will-change: transform;" />
                 <path id="electron_wave_charge" d="${initialWavePath}" fill="${CHARGE_SOUP_COLOR}" opacity="${initialChargeOpacity}" pointer-events="none" style="will-change: transform;" />
                 <g id="${sparkleLayerId}" pointer-events="none"></g>
                 <g id="${lightningLayerId}" pointer-events="none" style="mix-blend-mode: screen; will-change: opacity;"></g>
               </g>
-              ${swPriority ? `<circle id="sun_btn_cover" cx="${SUN_BTN_CARVE_CX}" cy="${SUN_BTN_CARVE_CY}" r="${SUN_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
-              ${e.force_now ? `<circle id="rabbit_btn_cover" cx="${RABBIT_BTN_CARVE_CX}" cy="${RABBIT_BTN_CARVE_CY}" r="${RABBIT_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
-              ${(tNext && e.schedule) ? `<circle id="time_btn_cover" cx="${TIME_BTN_CARVE_CX}" cy="${TIME_BTN_CARVE_CY}" r="${TIME_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
-              <path d="${bgPath}" stroke="${isFaulted ? 'rgba(244,67,54,0.35)' : 'var(--divider-color)'}" stroke-width="14" fill="none" stroke-linecap="round" />
-              <path d="${socPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
-              ${showAnimation ? `
-              <path id="charge_anim"
-                    d="${socPath}"
-                    stroke="url(#${isFaulted ? gradFaultId : gradChargeId})"
-                    stroke-width="16"
-                    fill="none"
-                    stroke-linecap="round"
-                    stroke-dasharray="${dashLen} ${gapLen}"
-                    stroke-opacity="1"
-                    filter="url(#chargeGlow)"
-                    style="mix-blend-mode:screen; will-change: stroke-dashoffset"
-              />
-              ` : ''}
-              <circle id="target_handle" cx="${handlePos.x.toFixed(2)}" cy="${handlePos.y.toFixed(2)}" r="13" fill="var(--card-background-color)" stroke="${isDisconnected ? 'var(--divider-color)' : 'var(--primary-color)'}" stroke-width="3" style="cursor: grab; pointer-events: all;" />
-              <text id="target_handle_text" x="${handlePos.x.toFixed(2)}" y="${handlePos.y.toFixed(2)}" text-anchor="middle" dominant-baseline="middle" fill="${isDisconnected ? 'var(--secondary-text-color)' : 'var(--primary-color)'}" font-size="${useEnergyMode ? '11' : '13'}" font-weight="800" style="cursor: grab; pointer-events: none; user-select: none;">${useEnergyMode ? this._fmt(parseTargetEnergy(target) ?? (Number(sCurrentInputedEnergy?.state || 0) / 1000)) : this._fmt(targetPct ?? soc)}</text>
+              ${this._ringCarveCover({ cx: RING_BOTTOM_CARVE_CX, cy: RING_BOTTOM_CARVE_CY, r: RING_BOTTOM_CARVE_R, id: 'sun_btn_cover', show: swPriority })}
+              ${this._ringCarveCover({ cx: RABBIT_BTN_CARVE_CX, cy: RABBIT_BTN_CARVE_CY, r: RABBIT_BTN_CARVE_R, id: 'rabbit_btn_cover', show: e.force_now })}
+              ${this._ringCarveCover({ cx: TIME_BTN_CARVE_CX, cy: TIME_BTN_CARVE_CY, r: TIME_BTN_CARVE_R, id: 'time_btn_cover', show: (tNext && e.schedule) })}
+              ${ringMarkup}
             </svg>
             <div class="center">
               <div class="stack">
@@ -1610,30 +1615,12 @@ class QsCarCard extends QsCardBase {
       // DOM node is destroyed before the synthetic click fires, so the tap is lost. The
       // touchend handler fires immediately, calls preventDefault() to suppress the delayed
       // synthetic click (avoiding double-fire on desktop), and invokes the action directly.
+      // QS-235 AC4 — the solar-priority (sun) button adopts the shared
+      // `_wireGreenButton` (toggle the `bump_priority` switch with the
+      // click + touchend + keyboard-activation plumbing). The dead
+      // `ids('priority')` listener (no matching DOM element) is dropped.
       if (swPriority) {
-          const togglePriority = async () => {
-              const btn = ids('sun_btn');
-              try {
-                  if (swPriority.state === 'on') {
-                      await this._turnOff(e.bump_priority);
-                      btn?.classList.remove('on');
-                  } else {
-                      await this._turnOn(e.bump_priority);
-                      btn?.classList.add('on');
-                  }
-              } catch (_) {
-                  // ignore errors; HA state will resync UI on next render
-              }
-          };
-          ids('priority')?.addEventListener('click', togglePriority);
-          const sbtn = ids('sun_btn');
-          if (sbtn) {
-              sbtn.style.pointerEvents = 'auto';
-              sbtn.addEventListener('click', togglePriority);
-              sbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); togglePriority(); });
-              // S5: keyboard activation (Enter/Space) for the focusable div.
-              this._registerKeyActivation(sbtn, togglePriority);
-          }
+          this._wireGreenButton({ buttonEl: ids('sun_btn'), swEntity: swPriority, entityId: e.bump_priority });
       }
 
       // Rabbit button for force now
@@ -1682,94 +1669,42 @@ class QsCarCard extends QsCardBase {
           }
       }
 
-      // Time button for finish time
-      if (tNext && e.schedule) {
-          const tbtn = ids('time_btn');
-          if (tbtn) {
-              tbtn.style.pointerEvents = 'auto';
-              const tbtnAction = async () => {
-                  if (this._root?.querySelector('.disabled')) return;
-
-                  let defaultHour, defaultMin;
-                  if (chargeTime && chargeTime !== '--:--' && chargeTime.includes(':')) {
-                      const chargeMins = this._parseTimeToMinutes(chargeTime);
-                      defaultHour = Math.floor(chargeMins / 60);
-                      defaultMin = chargeMins % 60;
-                      defaultMin = Math.ceil(defaultMin / 5) * 5;
-                      if (defaultMin === 60) {
-                          defaultMin = 0;
-                          defaultHour = (defaultHour + 1) % 24;
-                      }
-                  } else {
-                      defaultHour = Math.floor(nextTimeMins / 60);
-                      defaultMin = nextTimeMins % 60;
-                      defaultMin = Math.ceil(defaultMin / 5) * 5;
-                      if (defaultMin === 60) {
-                          defaultMin = 0;
-                          defaultHour = (defaultHour + 1) % 24;
-                      }
-                  }
-
-                  const customContent = `
-            <p>Select the next time the charge of the car should end:</p>
-            <div class="time-picker">
-              <select id="dialog_hour_select">
-                ${Array.from({length: 24}, (_, h) => `<option value="${h}" ${defaultHour === h ? 'selected' : ''}>${String(h).padStart(2, '0')}</option>`).join('')}
-              </select>
-              <span>:</span>
-              <select id="dialog_minute_select">
-                ${[0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55].map(m => `<option value="${m}" ${defaultMin === m ? 'selected' : ''}>${String(m).padStart(2, '0')}</option>`).join('')}
-              </select>
-            </div>
-          `;
-
-                  const dialog = this._showDialog({
-                      title: 'Charge Finish Time',
-                      customContent: customContent,
-                      buttons: [
-                          {text: 'Cancel', variant: 'secondary'},
-                          {
-                              text: 'Reset',
-                              variant: 'danger',
-                              onClick: async () => {
-                                  if (e.clean_constraints) await this._press(e.clean_constraints);
-                              }
-                          },
-                          {
-                              text: 'Apply',
-                              variant: 'primary',
-                              onClick: async () => {
-                                  const dialogRoot = dialog.querySelector('.dialog');
-                                  const hourSel = dialogRoot?.querySelector('#dialog_hour_select');
-                                  const minSel = dialogRoot?.querySelector('#dialog_minute_select');
-                                  const h = Number(hourSel?.value ?? 0);
-                                  const m = Number(minSel?.value ?? 0);
-                                  const mins = h * 60 + m;
-                                  const hm = this._formatHm(mins);
-                                  const val = hm + ':00';
-                                  this._localNextTimeMins = mins;
-                                  // S9: clear the local override after a
-                                  // grace period so out-of-band backend
-                                  // updates aren't masked indefinitely.
-                                  if (this._localNextTimeClearTimer) {
-                                      clearTimeout(this._localNextTimeClearTimer);
-                                  }
-                                  this._localNextTimeClearTimer = setTimeout(() => {
-                                      this._localNextTimeMins = null;
-                                      this._render();
-                                  }, 5000);
-                                  await this._setTime(e.next_time, val);
-                                  await this._press(e.schedule);
-                              }
-                          },
-                      ]
-                  });
-              };
-              tbtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); tbtnAction(); });
-              tbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); tbtnAction(); });
-              // S5: keyboard activation for the focusable div.
-              this._registerKeyActivation(tbtn, tbtnAction);
+      // QS-235 AC5 — the finish-time button adopts the generalized shared
+      // `_wireTimePicker`. The car-specific bits map onto its new optional
+      // params: `onAfterCommit` (await `_press(schedule)` after the
+      // `_setTime` write), `resetButton` (a 3rd dialog button → reset via
+      // `clean_constraints`), and the `title` / `bodyText` overrides. The
+      // dialog pre-selects the next charge-end time (preferring the live
+      // `chargeTime`, falling back to `nextTimeMins`), rounded UP to the
+      // nearest 5-minute select option — so the car PRE-rounds `currentMins`
+      // (the base picker computes `currentMins % 60` against the 5-minute
+      // option grid). Wiring is gated on `!isDisconnected`, preserving the
+      // old `.disabled` bail (an unplugged car can't schedule a charge).
+      if (tNext && e.schedule && !isDisconnected) {
+          const rawFinishMins = (chargeTime && chargeTime !== '--:--' && chargeTime.includes(':'))
+              ? this._parseTimeToMinutes(chargeTime)
+              : nextTimeMins;
+          let finishHour = Math.floor(rawFinishMins / 60);
+          let finishMin = Math.ceil((rawFinishMins % 60) / 5) * 5;
+          if (finishMin === 60) {
+              finishMin = 0;
+              finishHour = (finishHour + 1) % 24;
           }
+          this._wireTimePicker({
+              buttonEl: ids('time_btn'),
+              entityId: e.next_time,
+              currentMins: finishHour * 60 + finishMin,
+              localStateKey: '_localNextTimeMins',
+              clearTimerKey: '_localNextTimeClearTimer',
+              onAfterCommit: () => this._press(e.schedule),
+              resetButton: {
+                  text: 'Reset',
+                  variant: 'danger',
+                  onClick: async () => { if (e.clean_constraints) await this._press(e.clean_constraints); },
+              },
+              title: 'Charge Finish Time',
+              bodyText: 'Select the next time the charge of the car should end:',
+          });
       }
       // QS-199 review-fix M3/M5 — the inline `showDialog` closure (which
       // lacked the N12 close-fallback, N13 try/finally, and S16 keyboard
@@ -1820,24 +1755,12 @@ class QsCarCard extends QsCardBase {
           schedBtn?.addEventListener('touchend', (ev) => { ev.preventDefault(); schedAction(); });
       }
 
+      // QS-235 AC4 — the reset button adopts the shared `_wireResetButton`
+      // (confirmation dialog → `_press(reset)`). The native `<button
+      // id="reset">` is keyboard-native, so the helper intentionally
+      // does not register an extra Enter/Space hook.
       if (e.reset) {
-          const resetBtn = ids('reset');
-          const resetAction = async () => {
-              this._showDialog({
-                  title: 'Reset car state',
-                  message: 'This will reset internal state for this car and cannot be undone.\nProceed?',
-                  buttons: [
-                      {text: 'Cancel', variant: 'secondary'},
-                      {
-                          text: 'Reset', variant: 'danger', onClick: async () => {
-                              await this._press(e.reset);
-                          }
-                      },
-                  ]
-              });
-          };
-          resetBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); resetAction(); });
-          resetBtn?.addEventListener('touchend', (ev) => { ev.preventDefault(); resetAction(); });
+          this._wireResetButton({ buttonEl: ids('reset'), entityId: e.reset });
       }
 
       // Quick percent chips
@@ -1897,125 +1820,39 @@ class QsCarCard extends QsCardBase {
           });
       });
 
-      // Drag target handle on ring
+      // QS-235 AC1 — the ~120-LOC inline pointer-drag block is replaced by
+      // the shared `_wireTargetHandle` (byte-identical pointer/mouse/touch
+      // plumbing + the S17 try/finally the car previously lacked). The car
+      // layers four callbacks over that plumbing:
+      //   - pctToValue / valueToPct — the %↔kWh mapping (branch on
+      //     `useEnergyMode` against `maxCircleValue`),
+      //   - onDragMove — the live `#target_value` label update,
+      //   - onCommit — map the snapped value → a select option
+      //     (`findOptionByEnergy` / `findOptionByPercent`) then
+      //     `_select(next_limit, opt)`,
+      //   - fmtHandleText — keep the handle text rounded (the car shows
+      //     integers; the duration default shows one decimal).
       const svg = this._root.querySelector('.ring svg');
       const handle = this._root.getElementById('target_handle');
-      if (svg && handle) {
-          const pt = svg.createSVGPoint();
-          const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
-          const onMove = (ev) => {
-              ev.stopPropagation();
-              ev.preventDefault();
-              const e2 = ev.touches ? ev.touches[0] : ev;
-              pt.x = e2.clientX;
-              pt.y = e2.clientY;
-              const cursor = pt.matrixTransform(svg.getScreenCTM().inverse());
-              const dx = cursor.x - center.cx;
-              const dy = cursor.y - center.cy;
-              // Convert to [0,360]
-              // -dy because svg y are downward
-              let ang = rad2deg(Math.atan2(-dy, dx));
-              // Map to arc domain [startDeg, endDeg] allowing values > 360
-              let a = ang;
-              if (a < startDeg) a = startDeg;
-              if (a > endDeg) a = endDeg;
-              // Snap to available select options
-              const rawPct = ((a - startDeg) / rangeDeg) * 100;
-              const list = allowedOrDefault;
-              const snapValue = list.reduce((best, v) => Math.abs(v - (useEnergyMode ? (rawPct / 100 * maxCircleValue) : rawPct)) < Math.abs(best - (useEnergyMode ? (rawPct / 100 * maxCircleValue) : rawPct)) ? v : best, list[0]);
-
-              // Store the percentage for the circle (0-100)
-              const displayPct = useEnergyMode ? (snapValue / maxCircleValue * 100) : snapValue;
-              this._targetDragPct = displayPct;
-              this._targetDragValue = snapValue; // Store actual value (percent or kWh)
-              this._isInteractingTarget = true;
-
-              // Update handle and target label without full render to keep it smooth
-              const angSnap = startDeg + (displayPct / 100) * rangeDeg;
-              const pos = polar(center.cx, center.cy, ringCirc, angSnap);
-              handle.setAttribute('cx', pos.x.toFixed(2));
-              handle.setAttribute('cy', pos.y.toFixed(2));
-              const handleText = this._root.getElementById('target_handle_text');
-              if (handleText) {
-                  handleText.setAttribute('x', pos.x.toFixed(2));
-                  handleText.setAttribute('y', pos.y.toFixed(2));
-                  handleText.textContent = this._fmt(snapValue);
-              }
+      this._wireTargetHandle({
+          ringSvg: svg,
+          handle,
+          center,
+          ringCirc,
+          startDeg, endDeg, rangeDeg,
+          allowedValues: allowedOrDefault,
+          pctToValue: (rawPct) => (useEnergyMode ? (rawPct / 100 * maxCircleValue) : rawPct),
+          valueToPct: (v) => (useEnergyMode ? (v / maxCircleValue * 100) : v),
+          fmtHandleText: (v) => this._fmt(v),
+          onDragMove: (v) => {
               const tv = this._root.getElementById('target_value');
-              if (tv) tv.innerHTML = useEnergyMode ? `${this._fmt(snapValue)}<span style="font-size: ${energyUnitFontSize}em;"> kWh</span>` : `${this._fmt(snapValue)}%`;
-          };
-          const onUp = async (ev) => {
-              if (this._upInProgress) return;
-              this._upInProgress = true;
-
-              if (ev) {
-                  ev.stopPropagation();
-                  ev.preventDefault();
-              }
-
-              const dragPct = this._targetDragPct;
-              const dragValue = this._targetDragValue;
-
-              if (dragValue != null) {
-                  const opt = useEnergyMode ? findOptionByEnergy(dragValue) : findOptionByPercent(dragValue);
-                  if (opt) await this._select(e.next_limit, opt);
-                  this._localTargetPct = dragPct;
-                  this._pendingClearLocalTarget && clearTimeout(this._pendingClearLocalTarget);
-                  this._pendingClearLocalTarget = setTimeout(() => {
-                      this._localTargetPct = null;
-                      this._pendingClearLocalTarget = null;
-                      this._render();
-                  }, 5000);
-              }
-              this._targetDragPct = null;
-              this._targetDragValue = null;
-              this._isInteractingTarget = false;
-              this._upInProgress = false;
-              handle.style.cursor = 'grab';
-          };
-
-          if (window.PointerEvent) {
-              const onPointerMove = (ev) => onMove(ev);
-              const onPointerUp = async (ev) => {
-                  try { handle.releasePointerCapture(ev.pointerId); } catch (_) {}
-                  handle.removeEventListener('pointermove', onPointerMove);
-                  handle.removeEventListener('pointerup', onPointerUp);
-                  handle.removeEventListener('pointercancel', onPointerUp);
-                  await onUp(ev);
-              };
-              const onPointerDown = (ev) => {
-                  ev.stopPropagation();
-                  ev.preventDefault();
-                  this._isInteractingTarget = true;
-                  try { handle.setPointerCapture(ev.pointerId); } catch (_) {}
-                  handle.addEventListener('pointermove', onPointerMove);
-                  handle.addEventListener('pointerup', onPointerUp);
-                  handle.addEventListener('pointercancel', onPointerUp);
-                  handle.style.cursor = 'grabbing';
-              };
-              handle.addEventListener('pointerdown', onPointerDown);
-          } else {
-              const onDown = (ev) => {
-                  ev.stopPropagation();
-                  ev.preventDefault();
-                  this._isInteractingTarget = true;
-                  document.addEventListener('mousemove', onMove);
-                  document.addEventListener('touchmove', onMove, {passive: false});
-                  document.addEventListener('mouseup', onUpLegacy);
-                  document.addEventListener('touchend', onUpLegacy);
-                  handle.style.cursor = 'grabbing';
-              };
-              const onUpLegacy = async (ev) => {
-                  document.removeEventListener('mousemove', onMove);
-                  document.removeEventListener('touchmove', onMove);
-                  document.removeEventListener('mouseup', onUpLegacy);
-                  document.removeEventListener('touchend', onUpLegacy);
-                  await onUp(ev);
-              };
-              handle.addEventListener('mousedown', onDown);
-              handle.addEventListener('touchstart', onDown, {passive: false});
-          }
-      }
+              if (tv) tv.innerHTML = useEnergyMode ? `${this._fmt(v)}<span style="font-size: ${energyUnitFontSize}em;"> kWh</span>` : `${this._fmt(v)}%`;
+          },
+          onCommit: async (v) => {
+              const opt = useEnergyMode ? findOptionByEnergy(v) : findOptionByPercent(v);
+              if (opt) await this._select(e.next_limit, opt);
+          },
+      });
   }
 }
 

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -1312,6 +1312,13 @@ class QsCarCard extends QsCardBase {
           gradGreenId, gradRunningId: gradChargeId, activeGradId,
           dashLen, gapLen,
           // QS-235 — car-specific overrides over the duration defaults.
+          // SF1 — the moving dash matches the static arc when faulted:
+          // faulted-while-charging draws the dash with `gradFaultId`
+          // (red, defined in extraDefs), else `gradChargeId` (cyan/blue,
+          // defined by the builder via the `gradRunningId` param). This
+          // restores the pre-refactor `stroke="url(#${isFaulted ?
+          // gradFaultId : gradChargeId})"` exactly.
+          animGradId: isFaulted ? gradFaultId : gradChargeId,
           bgStroke: isFaulted ? 'rgba(244,67,54,0.35)' : 'var(--divider-color)',
           handleFontSize: useEnergyMode ? '11' : '13',
           handleStroke: isDisconnected ? 'var(--divider-color)' : 'var(--primary-color)',

--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -54,8 +54,9 @@ const CLIP_R = 120;                 // backdrop clip circle radius
 // 25 CSS-px-radius button outline. User-tunable.
 // The cover applies uniformly across all backdrops (flame / snow /
 // wind / none) — same DN-3 rationale as the original carve.
-const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 35;
+// QS-235 — these values now live in the shared `RING_BOTTOM_CARVE_*`
+// constants (`shared/qs-card-base.js`, imported below) and the cover is
+// rendered via the shared `_ringCarveCover` helper.
 
 // --- Flame engine constants (QS-204 verbatim from qs-radiator-card.js) ---
 const FLAME_WIDTH = 480;            // single layer width in SVG px (2× clip diameter)
@@ -101,7 +102,7 @@ console.assert(
 // generic engines).
 import { baseCardCSS } from './shared/qs-card-styles.js';
 import { QsRingDurationCardBase } from './shared/qs-ring-duration-base.js';
-import { arcPath, polar, pctToDeg } from './shared/qs-card-base.js';
+import { arcPath, polar, pctToDeg, RING_BOTTOM_CARVE_CX, RING_BOTTOM_CARVE_CY, RING_BOTTOM_CARVE_R } from './shared/qs-card-base.js';
 
 // QS-199 review-fix S1 — climate keeps its OWN inline flame/snow/wind
 // engines (the 4-backdrop dispatch + snow-pile particle system don't fit
@@ -1219,7 +1220,7 @@ class QsClimateCard extends QsRingDurationCardBase {
                 </g>
                 ` : ''}
               </g>
-              ${e.override_reset ? `<circle id="override_btn_cover" cx="${CENTER_X}" cy="${OVERRIDE_BTN_CARVE_CY}" r="${OVERRIDE_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
+              ${this._ringCarveCover({ cx: RING_BOTTOM_CARVE_CX, cy: RING_BOTTOM_CARVE_CY, r: RING_BOTTOM_CARVE_R, id: 'override_btn_cover', show: e.override_reset })}
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${ringDashActive ? 'stroke-opacity="0.35"' : ''} />
               ${ringDashActive ? `

--- a/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-radiator-card.js
@@ -26,7 +26,7 @@
 
 import { baseCardCSS } from './shared/qs-card-styles.js';
 import { QsRingDurationCardBase } from './shared/qs-ring-duration-base.js';
-import { arcPath, polar, pctToDeg } from './shared/qs-card-base.js';
+import { arcPath, polar, pctToDeg, RING_BOTTOM_CARVE_CX, RING_BOTTOM_CARVE_CY, RING_BOTTOM_CARVE_R } from './shared/qs-card-base.js';
 import { FLAME_CONSTANTS, QsFlameEngine } from './shared/qs-anim-flame.js';
 
 // Local aliases for the engine constants — keeps the radiator-card
@@ -38,9 +38,9 @@ const { FLAME_BASE_MIN_PCT, FLAME_BASE_MAX_PCT } = FLAME_CONSTANTS;
 const CENTER_CY = 160;              // SVG y-centre of the ring / clip circle
 const CLIP_R = 120;                 // flame clip circle radius
 
-// QS-217 — Override-button cover overlay geometry.
-const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 35;
+// QS-235 — the override-button cover geometry moved to the shared
+// `RING_BOTTOM_CARVE_*` constants in `shared/qs-card-base.js` (imported
+// above) and is rendered via the shared `_ringCarveCover` helper.
 
 // --- Per-layer tuning ---
 // LAYER_BASE_HEIGHTS — back layer reaches ≈ half clip radius (~100 px)
@@ -395,7 +395,7 @@ class QsRadiatorCard extends QsRingDurationCardBase {
                     `<path id="flame${i}" d="${d}" fill="${initialFlameColors[i]}" opacity="1" pointer-events="none" style="will-change: transform;" />`,
                 ).join("\n                ")}
               </g>
-              ${e.override_reset ? `<circle id="override_btn_cover" cx="${CENTER_CY}" cy="${OVERRIDE_BTN_CARVE_CY}" r="${OVERRIDE_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
+              ${this._ringCarveCover({ cx: RING_BOTTOM_CARVE_CX, cy: RING_BOTTOM_CARVE_CY, r: RING_BOTTOM_CARVE_R, id: 'override_btn_cover', show: e.override_reset })}
               ${ringMarkup}
             </svg>
             <div class="center">

--- a/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-water-boiler-card.js
@@ -59,8 +59,9 @@ const WAVE_BOTTOM_Y = 400;          // closing rectangle y; clipped by circle
 // SVG units: (160, 277.33) → rounded to (CENTER_CX, 277).
 // Cover radius R = 35 SVG ≈ 33 CSS px ⇒ ~8 CSS px padding around
 // the 25 CSS-px-radius button outline. User-tunable.
-const OVERRIDE_BTN_CARVE_CY = 277;
-const OVERRIDE_BTN_CARVE_R  = 35;
+// QS-235 — these values now live in the shared `RING_BOTTOM_CARVE_*`
+// constants (`shared/qs-card-base.js`, imported below) and the cover is
+// rendered via the shared `_ringCarveCover` helper.
 
 // --- Per-layer wave offsets ---
 const LAYER_SCROLL_OFFSET = 1.2;
@@ -156,7 +157,7 @@ const SURFACE_GLOW_BLUR_STDDEV = 6;
 // for the wrap-around scroll.
 import { baseCardCSS } from './shared/qs-card-styles.js';
 import { QsRingDurationCardBase } from './shared/qs-ring-duration-base.js';
-import { arcPath, polar, pctToDeg } from './shared/qs-card-base.js';
+import { arcPath, polar, pctToDeg, RING_BOTTOM_CARVE_CX, RING_BOTTOM_CARVE_CY, RING_BOTTOM_CARVE_R } from './shared/qs-card-base.js';
 // QS-199 review-fix S1 — water-boiler keeps its own `_generateWavePath`
 // (2× width for the GPU scroll, same as pool), so it does NOT import the
 // shared single-period `generateWavePath`.
@@ -1105,7 +1106,7 @@ class QsWaterBoilerCard extends QsRingDurationCardBase {
                 <path id="surface_glow" d="${initialWavePaths[0]}" stroke="${SURFACE_GLOW_COLOR}" stroke-width="${SURFACE_GLOW_STROKE_WIDTH}" fill="none" filter="url(#${surfaceGlowFilterId})" opacity="${initialBoilOpacity}" pointer-events="none" style="mix-blend-mode: screen; will-change: transform, opacity, d;" />
                 <g id="${steamLayerId}" filter="url(#${steamFilterId})" pointer-events="none"></g>
               </g>
-              ${e.override_reset ? `<circle id="override_btn_cover" cx="${CENTER_CX}" cy="${OVERRIDE_BTN_CARVE_CY}" r="${OVERRIDE_BTN_CARVE_R}" fill="var(--card-background-color)" pointer-events="none" />` : ''}
+              ${this._ringCarveCover({ cx: RING_BOTTOM_CARVE_CX, cy: RING_BOTTOM_CARVE_CY, r: RING_BOTTOM_CARVE_R, id: 'override_btn_cover', show: e.override_reset })}
               <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
               <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
               ${showAnimation ? `

--- a/custom_components/quiet_solar/ui/resources/shared/qs-card-base.js
+++ b/custom_components/quiet_solar/ui/resources/shared/qs-card-base.js
@@ -573,9 +573,11 @@ export class QsCardBase extends HTMLElement {
       byte-equivalent:
           onAfterCommit  — async () => …; AWAITED after `_setTime`
                            (car: `_press(schedule)`).
-          resetButton    — {text, variant, onClick}; inserted as a 3rd
+          resetButton    — {text, variant?, onClick}; inserted as a 3rd
                            dialog button between Cancel and Apply
                            (car: Reset → `_press(clean_constraints)`).
+                           Only spread when both `text` and `onClick` are
+                           present (NTH2 shape guard).
           title          — dialog title (default `'Finish Time'`).
           bodyText       — body prompt (default `'Select the time the
                            device should finish by:'`).
@@ -614,7 +616,10 @@ export class QsCardBase extends HTMLElement {
                 buttons: [
                     { text: 'Cancel', variant: 'secondary' },
                     // QS-235 — optional reset button (car: clean_constraints).
-                    ...(resetButton ? [resetButton] : []),
+                    // review-fix #01 NTH2 — only spread a well-shaped
+                    // `{text, onClick}` so a malformed object can't render a
+                    // silent broken button.
+                    ...(resetButton && resetButton.text && resetButton.onClick ? [resetButton] : []),
                     {
                         text: 'Apply',
                         variant: 'primary',
@@ -779,6 +784,9 @@ export class QsCardBase extends HTMLElement {
         handleStroke                 — handle circle stroke (default `palette.primary`)
         handleFill                   — handle text fill (default `palette.primary`)
         animPathId                   — dash anim path id (default `'running_anim'`)
+        animGradId                   — dash anim stroke gradient id
+                                       (default `gradRunningId`; SF1 — the car
+                                       passes a fault-aware gradient)
         extraDefs                    — extra `<defs>` children (default `''`)
       Returns string.
     */
@@ -794,6 +802,11 @@ export class QsCardBase extends HTMLElement {
             bgStroke = 'var(--divider-color)',
             handleFontSize = 13,
             animPathId = 'running_anim',
+            // QS-235 review-fix #01 SF1 — the dash anim stroke gradient,
+            // defaulting to `gradRunningId` (so the duration callers are
+            // byte-identical). The car passes a fault-aware gradient so
+            // the moving dash matches its static fault arc.
+            animGradId = gradRunningId,
             extraDefs = '',
         } = params;
 
@@ -814,7 +827,11 @@ export class QsCardBase extends HTMLElement {
         // QS-235 — `handleLabel` lets the car supply its own
         // energy/percent TRUE-target string (still unclamped); the
         // duration default reproduces the round-trip above byte-for-byte.
-        const escapedHandleLabel = params.handleLabel != null
+        // review-fix #01 NTH3 — named `handleLabelText` (NOT
+        // `escaped…`): a supplied `handleLabel` is used verbatim, with no
+        // escaping (SVG <text> content renders metacharacters as text, so
+        // this is safe; the old name wrongly implied sanitization).
+        const handleLabelText = params.handleLabel != null
             ? params.handleLabel
             : this._fmt(pctToHours(handlePct));
         // QS-235 — handle stroke/fill default to `palette.primary` (the
@@ -851,7 +868,7 @@ export class QsCardBase extends HTMLElement {
               ${showAnimation ? `
               <path id="${animPathId}"
                     d="${progressPath}"
-                    stroke="url(#${gradRunningId})"
+                    stroke="url(#${animGradId})"
                     stroke-width="16"
                     fill="none"
                     stroke-linecap="round"
@@ -863,7 +880,7 @@ export class QsCardBase extends HTMLElement {
               ` : ''}
               ${canDragHandle ? `
               <circle id="target_handle" cx="${handlePos.x.toFixed(2)}" cy="${handlePos.y.toFixed(2)}" r="13" fill="var(--card-background-color)" stroke="${handleStroke}" stroke-width="3" style="cursor: grab; pointer-events: all;" />
-              <text id="target_handle_text" x="${handlePos.x.toFixed(2)}" y="${handlePos.y.toFixed(2)}" text-anchor="middle" dominant-baseline="middle" fill="${handleFill}" font-size="${handleFontSize}" font-weight="800" style="cursor: grab; pointer-events: none; user-select: none;">${escapedHandleLabel}</text>
+              <text id="target_handle_text" x="${handlePos.x.toFixed(2)}" y="${handlePos.y.toFixed(2)}" text-anchor="middle" dominant-baseline="middle" fill="${handleFill}" font-size="${handleFontSize}" font-weight="800" style="cursor: grab; pointer-events: none; user-select: none;">${handleLabelText}</text>
               ` : ''}
         `;
     }

--- a/custom_components/quiet_solar/ui/resources/shared/qs-card-base.js
+++ b/custom_components/quiet_solar/ui/resources/shared/qs-card-base.js
@@ -18,6 +18,17 @@
       _wirePowerButton, _wireGreenButton) hoisted from the duration sub-base
       so the car card (which does NOT extend `QsRingDurationCardBase`) can
       consume them too.
+    - Ring builder (_buildRingHTML) — QS-235 moved it UP from
+      `QsRingDurationCardBase` so the car card (which extends `QsCardBase`
+      directly) consumes it too. The 5 duration cards inherit it unchanged.
+      Backward-compatible optional params (handleLabel / bgStroke /
+      handleFontSize / handleStroke / handleFill / animPathId / extraDefs)
+      default to the duration-card output; the car overrides them.
+    - Ring bottom-center carve cover (_ringCarveCover + shared
+      RING_BOTTOM_CARVE_* constants) — QS-235 unified the duplicated
+      bottom-center `<circle>` cover across the car (sun-btn) and the
+      duration cards (override-btn). The car reuses the helper for its
+      rabbit/time covers with car-local geometry.
     - Named exports of the geometry pure functions (deg2rad, rad2deg,
       polar, arcPath, pctToDeg) — concrete-planner finding R5.
 
@@ -69,6 +80,17 @@ export function arcPath(cx, cy, r, a0, a1) {
 export function pctToDeg(p, startDeg, rangeDeg) {
     return startDeg + (Math.max(0, Math.min(100, p)) / 100) * rangeDeg;
 }
+
+// QS-235 — shared bottom-center carve-cover geometry. The duration
+// cards (radiator / water-boiler / climate) draw an `override_btn_cover`
+// circle here; the car draws its `sun_btn_cover` at the same point. Both
+// erase a clean circular patch of the inside-disc animation so the
+// bottom-center button reads clearly (QS-217 motivation). Single source
+// of truth so the three duration `OVERRIDE_BTN_CARVE_*` duplicates and
+// the car's `SUN_BTN_CARVE_*` duplicate collapse to one constant set.
+export const RING_BOTTOM_CARVE_CX = 160;   // SVG x-centre of the ring
+export const RING_BOTTOM_CARVE_CY = 277;   // button-centre y (derived from CSS .*-btn position)
+export const RING_BOTTOM_CARVE_R = 35;     // cover radius (user-tunable)
 
 
 export class QsCardBase extends HTMLElement {
@@ -332,40 +354,70 @@ export class QsCardBase extends HTMLElement {
     // ----- Wire helpers -----
     /*
       _wireTargetHandle — wires pointer + mouse + touch drag on the ring
-      target handle (SVG <circle id="target_handle">). Snaps to allowedHours.
-      S17: try/finally around _setNumber so the drag-release guards always
-      clear, even on service failure.
+      target handle (SVG <circle id="target_handle">). Snaps the cursor
+      angle to the nearest allowed value. S17: try/finally around the
+      commit so the drag-release guards always clear, even on service
+      failure.
 
       params: {
           ringSvg, handle,        // DOM refs
           center, ringCirc,        // {cx, cy} and ring radius
           startDeg, endDeg, rangeDeg,
-          hoursToPct, pctToHours, allowedHours,
-          entityId,                // service target for _setNumber
-          onBeforeCommit,          // optional async hook AWAITED before _setNumber
+          hoursToPct, pctToHours,  // duration value↔pct mapping (defaults below)
+          allowedHours,            // duration snap list (alias of allowedValues)
+          entityId,                // service target for the default _setNumber commit
+          onBeforeCommit,          // optional async hook AWAITED before the commit
                                    //   (e.g. pool selects default mode first)
-          getHoursRun,             // optional () => current hours for inline label update
-          colors,                  // optional palette {primary} for inline label update
+          getHoursRun,             // optional () => current hours for the default label update
+          colors,                  // optional palette {primary} for the default label update
       }
-      QS-199 review-fix #04 NH1 — the post-write `onCommit` param was
-      removed (no card used it; scheduling the local-target clear timer
-      before a dead awaited `onCommit` was a latent footgun). Cards that
-      need a pre-duration side effect use `onBeforeCommit`.
+
+      QS-235 — generalized so the car card (which commits via
+      `_select`, maps %↔kWh, and updates a different live label) can
+      consume it. All NEW params default to the duration behaviour so a
+      caller that passes none of them is byte-equivalent:
+          allowedValues  — snap list (default `allowedHours`)
+          pctToValue     — pct → snap-domain value (default `pctToHours`)
+          valueToPct     — snap-domain value → pct (default `hoursToPct`)
+          onCommit       — async (value) => …; REPLACES the default
+                           `_setNumber(entityId, value)` write when provided
+                           (still AFTER `onBeforeCommit`). The car maps
+                           value → select option then `_select(...)`.
+          onDragMove     — (value) => …; REPLACES the default `.target-value`
+                           live-label update (car updates `#target_value`).
+          fmtHandleText  — (value) => string for the handle TEXT
+                           (default `this._fmt(value, false)`).
     */
     _wireTargetHandle(params) {
         const {
             ringSvg, handle, center, ringCirc,
             startDeg, endDeg, rangeDeg,
             hoursToPct, pctToHours, allowedHours,
+            allowedValues = allowedHours,
+            pctToValue = pctToHours,
+            valueToPct = hoursToPct,
             entityId, onBeforeCommit, getHoursRun, colors,
+            onCommit, onDragMove,
+            fmtHandleText = (v) => this._fmt(v, false),
         } = params;
         if (!ringSvg || !handle) return;
-        // QS-199 review-fix S15 — guard against an empty `allowedHours`
-        // list: the `reduce` below would otherwise seed `best = undefined`
-        // and `hoursToPct(undefined)` → NaN would break the handle.
-        if (!Array.isArray(allowedHours) || allowedHours.length === 0) return;
+        // QS-199 review-fix S15 — guard against an empty snap list: the
+        // `reduce` below would otherwise seed `best = undefined` and
+        // `valueToPct(undefined)` → NaN would break the handle.
+        if (!Array.isArray(allowedValues) || allowedValues.length === 0) return;
 
         const pt = ringSvg.createSVGPoint();
+
+        // QS-235 — default live `.target-value` updater reproduces the
+        // duration-card label byte-for-byte; the car overrides it via
+        // `onDragMove` to update its `#target_value` (energy/percent).
+        const dragMove = onDragMove || ((snapValue) => {
+            const tv = this._root.querySelector('.target-value');
+            if (tv && getHoursRun && colors) {
+                const hoursRun = getHoursRun();
+                tv.innerHTML = `<span style="color: var(--primary-text-color);">${this._fmt(hoursRun, false)}h</span><span style="color: var(--primary-text-color);"> / </span><span style="color: ${colors.primary};">${this._fmt(snapValue, false)}h</span>`;
+            }
+        });
 
         const onMove = (ev) => {
             ev.stopPropagation();
@@ -381,16 +433,16 @@ export class QsCardBase extends HTMLElement {
             if (a < startDeg) a = startDeg;
             if (a > endDeg) a = endDeg;
             const rawPct = ((a - startDeg) / rangeDeg) * 100;
-            const rawHours = pctToHours(rawPct);
+            const rawValue = pctToValue(rawPct);
 
-            const snapHours = allowedHours.reduce(
-                (best, v) => (Math.abs(v - rawHours) < Math.abs(best - rawHours) ? v : best),
-                allowedHours[0],
+            const snapValue = allowedValues.reduce(
+                (best, v) => (Math.abs(v - rawValue) < Math.abs(best - rawValue) ? v : best),
+                allowedValues[0],
             );
 
-            const displayPct = hoursToPct(snapHours);
+            const displayPct = valueToPct(snapValue);
             this._targetDragPct = displayPct;
-            this._targetDragValue = snapHours;
+            this._targetDragValue = snapValue;
             this._isInteractingTarget = true;
 
             const angSnap = startDeg + (displayPct / 100) * rangeDeg;
@@ -401,13 +453,9 @@ export class QsCardBase extends HTMLElement {
             if (handleText) {
                 handleText.setAttribute('x', pos.x.toFixed(2));
                 handleText.setAttribute('y', pos.y.toFixed(2));
-                handleText.textContent = this._fmt(snapHours, false);
+                handleText.textContent = fmtHandleText(snapValue);
             }
-            const tv = this._root.querySelector('.target-value');
-            if (tv && getHoursRun && colors) {
-                const hoursRun = getHoursRun();
-                tv.innerHTML = `<span style="color: var(--primary-text-color);">${this._fmt(hoursRun, false)}h</span><span style="color: var(--primary-text-color);"> / </span><span style="color: ${colors.primary};">${this._fmt(snapHours, false)}h</span>`;
-            }
+            dragMove(snapValue);
         };
 
         const onUp = async (ev) => {
@@ -424,15 +472,21 @@ export class QsCardBase extends HTMLElement {
 
             // S17 — try/finally: drag-release guards always clear.
             try {
-                if (dragValue != null && entityId) {
+                if (dragValue != null && (entityId || onCommit)) {
                     // QS-199 review-fix #03 S1/S2 — await an optional
-                    // pre-commit hook BEFORE the duration write (the pool
-                    // selects default mode first; writing the duration
-                    // while not yet in default mode can be rejected
-                    // backend-side). Both hooks are awaited so neither
-                    // races the local-target timeout / next render.
+                    // pre-commit hook BEFORE the commit (the pool selects
+                    // default mode first; writing while not yet in default
+                    // mode can be rejected backend-side). Both hooks are
+                    // awaited so neither races the local-target timeout /
+                    // next render.
                     if (onBeforeCommit) await onBeforeCommit(dragValue);
-                    await this._setNumber(entityId, dragValue);
+                    // QS-235 — `onCommit` (car: map value → option then
+                    // `_select`) replaces the default `_setNumber` write.
+                    if (onCommit) {
+                        await onCommit(dragValue);
+                    } else {
+                        await this._setNumber(entityId, dragValue);
+                    }
                     this._localTargetPct = dragPct;
                     if (this._pendingClearLocalTarget) clearTimeout(this._pendingClearLocalTarget);
                     this._pendingClearLocalTarget = setTimeout(() => {
@@ -512,12 +566,28 @@ export class QsCardBase extends HTMLElement {
           localStateKey,           — e.g. '_localFinishTimeMins'
           clearTimerKey,           — e.g. '_localFinishTimeClearTimer'
       }
+
+      QS-235 — generalized so the car card can adopt its bespoke
+      finish-time flow. NEW optional params default to the duration
+      2-button dialog so a caller that passes none of them is
+      byte-equivalent:
+          onAfterCommit  — async () => …; AWAITED after `_setTime`
+                           (car: `_press(schedule)`).
+          resetButton    — {text, variant, onClick}; inserted as a 3rd
+                           dialog button between Cancel and Apply
+                           (car: Reset → `_press(clean_constraints)`).
+          title          — dialog title (default `'Finish Time'`).
+          bodyText       — body prompt (default `'Select the time the
+                           device should finish by:'`).
     */
     _wireTimePicker(params) {
         const {
             buttonEl, entityId, currentMins,
             localStateKey = '_localFinishTimeMins',
             clearTimerKey = '_localFinishTimeClearTimer',
+            onAfterCommit, resetButton,
+            title = 'Finish Time',
+            bodyText = 'Select the time the device should finish by:',
         } = params;
         if (!buttonEl || !entityId) return;
 
@@ -526,7 +596,7 @@ export class QsCardBase extends HTMLElement {
             const defaultMin = currentMins % 60;
 
             const customContent = `
-            <p>Select the time the device should finish by:</p>
+            <p>${this._escapeHtml(bodyText)}</p>
             <div class="time-picker">
               <select id="dialog_hour_select">
                 ${Array.from({ length: 24 }, (_, h) => `<option value="${h}" ${defaultHour === h ? 'selected' : ''}>${String(h).padStart(2, '0')}</option>`).join('')}
@@ -539,10 +609,12 @@ export class QsCardBase extends HTMLElement {
           `;
 
             const dialog = this._showDialog({
-                title: 'Finish Time',
+                title,
                 customContent,
                 buttons: [
                     { text: 'Cancel', variant: 'secondary' },
+                    // QS-235 — optional reset button (car: clean_constraints).
+                    ...(resetButton ? [resetButton] : []),
                     {
                         text: 'Apply',
                         variant: 'primary',
@@ -567,6 +639,8 @@ export class QsCardBase extends HTMLElement {
                                 if (this.isConnected && this._root) this._render();
                             }, 5000);
                             await this._setTime(entityId, val);
+                            // QS-235 — car presses `schedule` after the write.
+                            if (onAfterCommit) await onAfterCommit();
                         },
                     },
                 ],
@@ -664,5 +738,151 @@ export class QsCardBase extends HTMLElement {
         buttonEl.addEventListener('click', toggleGreen);
         buttonEl.addEventListener('touchend', (ev) => { ev.preventDefault(); toggleGreen(); });
         this._registerKeyActivation(buttonEl, toggleGreen);
+    }
+
+    // ----- Ring builder -----
+    /*
+      _buildRingHTML — returns an HTML string for the outer .ring SVG
+      markup. Caller injects this string into innerHTML between any
+      card-specific backdrop SVG and the .center / override-btn /
+      green-btn DOM nodes.
+
+      QS-235 — moved UP here from `QsRingDurationCardBase` so the car
+      card (which extends `QsCardBase` directly) can consume it. The 5
+      duration cards inherit it unchanged: every NEW param defaults to
+      the duration-card behaviour, so a caller that passes none of them
+      gets byte-equivalent output (the empty `extraDefs` adds only
+      insignificant SVG whitespace).
+
+      params (long but mechanical — every duration card needs them):
+        palette                      — {primary, gradStart, gradEnd, animStart, animEnd}
+        ringCirc                     — ring radius in SVG units (typically 130)
+        center                       — {cx, cy} centre of the ring
+        startDeg, endDeg, rangeDeg, gapDeg
+        progressPath, bgPath         — pre-computed SVG `d` attribute strings
+        handlePos                    — {x, y} handle centre
+        handlePct                    — handle percentage (for label)
+        displayTargetHours           — value to display at the handle text
+        hoursRun                     — current run hours
+        showAnimation                — boolean — whether to render the dash anim path
+        canDragHandle                — boolean — whether to render handle circle
+        gradGreenId, gradRunningId, activeGradId
+        dashLen, gapLen              — stroke-dasharray
+        pctToHours                   — function used in the DEFAULT label render
+
+      QS-235 backward-compatible optional params (car overrides):
+        handleLabel                  — handle TEXT label (default
+                                       `this._fmt(pctToHours(handlePct))`)
+        bgStroke                     — background-arc stroke (default
+                                       `'var(--divider-color)'`)
+        handleFontSize               — handle text font-size (default `13`)
+        handleStroke                 — handle circle stroke (default `palette.primary`)
+        handleFill                   — handle text fill (default `palette.primary`)
+        animPathId                   — dash anim path id (default `'running_anim'`)
+        extraDefs                    — extra `<defs>` children (default `''`)
+      Returns string.
+    */
+    _buildRingHTML(params) {
+        const {
+            palette, ringCirc, center,
+            progressPath, bgPath,
+            handlePos, handlePct, displayTargetHours, hoursRun,
+            showAnimation, canDragHandle,
+            gradGreenId, gradRunningId, activeGradId,
+            dashLen, gapLen,
+            pctToHours,
+            bgStroke = 'var(--divider-color)',
+            handleFontSize = 13,
+            animPathId = 'running_anim',
+            extraDefs = '',
+        } = params;
+
+        // QS-199 review-fix #07 N1 — the handle's TEXT LABEL round-trips
+        // the target back from `handlePct`: `pctToHours(handlePct)`. On the
+        // non-default branch each card sets
+        // `handlePct = hoursToPct(displayTargetHours)` with
+        // `displayTargetHours = targetHours` left UNCLAMPED on purpose, so
+        // this label shows the TRUE target even when it exceeds `maxHours`.
+        // Only the handle POSITION is clamped (the card's `pctToDeg`
+        // clamps to [0,100] → the handle pins at the ring top for an
+        // out-of-range target while the number stays correct).
+        // DO NOT "fix" the >100% `handlePct` by clamping `handlePct` or
+        // `displayTargetHours` — that would make this label render
+        // `maxHours` instead of the real value (a regression across all
+        // duration cards). The pin-at-top-but-number-correct behaviour is
+        // intentional and graceful.
+        // QS-235 — `handleLabel` lets the car supply its own
+        // energy/percent TRUE-target string (still unclamped); the
+        // duration default reproduces the round-trip above byte-for-byte.
+        const escapedHandleLabel = params.handleLabel != null
+            ? params.handleLabel
+            : this._fmt(pctToHours(handlePct));
+        // QS-235 — handle stroke/fill default to `palette.primary` (the
+        // duration behaviour); the car passes connection-state colours.
+        const handleStroke = params.handleStroke != null ? params.handleStroke : palette.primary;
+        const handleFill = params.handleFill != null ? params.handleFill : palette.primary;
+
+        // QS-199 review-fix N6 — per-instance glow filter id (parity with
+        // gradGreenId / gradRunningId) so two cards on one page can't
+        // collide if shadow-DOM id scoping ever changes.
+        const glowId = this._instanceId('runningGlow');
+
+        return `
+              <defs>
+                <linearGradient id="${gradGreenId}" x1="0%" y1="0%" x2="100%" y2="0%">
+                  <stop offset="0%" stop-color="${palette.gradStart}"/>
+                  <stop offset="100%" stop-color="${palette.gradEnd}"/>
+                </linearGradient>
+                <linearGradient id="${gradRunningId}" x1="0%" y1="0%" x2="100%" y2="0%">
+                  <stop offset="0%" stop-color="${palette.animStart}"/>
+                  <stop offset="100%" stop-color="${palette.animEnd}"/>
+                </linearGradient>
+                <filter id="${glowId}" x="-50%" y="-50%" width="200%" height="200%">
+                  <feGaussianBlur stdDeviation="2" result="blur" />
+                  <feMerge>
+                    <feMergeNode in="blur" />
+                    <feMergeNode in="SourceGraphic" />
+                  </feMerge>
+                </filter>
+                ${extraDefs}
+              </defs>
+              <path d="${bgPath}" stroke="${bgStroke}" stroke-width="14" fill="none" stroke-linecap="round" />
+              <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
+              ${showAnimation ? `
+              <path id="${animPathId}"
+                    d="${progressPath}"
+                    stroke="url(#${gradRunningId})"
+                    stroke-width="16"
+                    fill="none"
+                    stroke-linecap="round"
+                    stroke-dasharray="${dashLen} ${gapLen}"
+                    stroke-opacity="1"
+                    filter="url(#${glowId})"
+                    style="mix-blend-mode:screen; will-change: stroke-dashoffset"
+              />
+              ` : ''}
+              ${canDragHandle ? `
+              <circle id="target_handle" cx="${handlePos.x.toFixed(2)}" cy="${handlePos.y.toFixed(2)}" r="13" fill="var(--card-background-color)" stroke="${handleStroke}" stroke-width="3" style="cursor: grab; pointer-events: all;" />
+              <text id="target_handle_text" x="${handlePos.x.toFixed(2)}" y="${handlePos.y.toFixed(2)}" text-anchor="middle" dominant-baseline="middle" fill="${handleFill}" font-size="${handleFontSize}" font-weight="800" style="cursor: grab; pointer-events: none; user-select: none;">${escapedHandleLabel}</text>
+              ` : ''}
+        `;
+    }
+
+    // ----- Ring bottom-center carve cover -----
+    /*
+      _ringCarveCover({cx, cy, r, id, show}) — QS-235. Returns a single
+      `<circle>` cover overlay string (or '' when `show` is falsy) that
+      erases a clean circular patch of the inside-disc animation so a
+      button drawn there reads clearly. Replaces the per-card inline
+      `<circle id="…_cover" fill="var(--card-background-color)"
+      pointer-events="none" />` literals (QS-217 + QS-232). The shared
+      `RING_BOTTOM_CARVE_*` constants supply the bottom-center geometry;
+      the car passes its own car-local geometry for the rabbit/time
+      covers.
+    */
+    _ringCarveCover(params) {
+        const { cx, cy, r, id, show } = params;
+        if (!show) return '';
+        return `<circle id="${id}" cx="${cx}" cy="${cy}" r="${r}" fill="var(--card-background-color)" pointer-events="none" />`;
     }
 }

--- a/custom_components/quiet_solar/ui/resources/shared/qs-ring-duration-base.js
+++ b/custom_components/quiet_solar/ui/resources/shared/qs-ring-duration-base.js
@@ -6,16 +6,18 @@
   3 inside-disc buttons instead of one override-btn).
 
   Adds:
-    - _buildRingHTML({...}) — produces the outer .ring SVG markup
-      (linear-gradient defs, background-arc + progress-arc, override-btn
-      cover circle, target-handle circle + text, power-btn + green-btn +
-      override-btn DOM elements). Cards layer their backdrop-specific
-      SVG inside the returned template.
     - _wireOverrideButton({buttonEl, entityId, overrideBtnClickable}) —
       confirmation dialog + state-aware class assignment.
     - _wireBistateMode({selectEl, entityId, translationNamespace}) —
       focus/blur/change handlers; M2 try/finally + 300ms setTimeout
       cleanup.
+
+  QS-235 — `_buildRingHTML` was moved UP to `QsCardBase` (single source
+  of truth) so the car card, which extends `QsCardBase` directly, can
+  consume it too. The duration cards inherit it unchanged through this
+  sub-base. The hours-/override-specific helpers (`_clampMaxHours`,
+  `_allowedHalfHours`, `_wireOverrideButton`, `_wireBistateMode`) stay
+  here — the car needs none of them.
 */
 
 import { QsCardBase, arcPath, polar } from './qs-card-base.js';
@@ -29,103 +31,6 @@ const SNAP_STEP_HOURS = 0.5;    // draggable snap granularity (gauge max grid-al
 const MAX_HOURS_CEILING = 168;  // one week — bounds the gauge scale AND the snap-list loop
 
 export class QsRingDurationCardBase extends QsCardBase {
-    /*
-      _buildRingHTML — returns an HTML string for the outer .ring SVG
-      markup. Caller injects this string into innerHTML between any
-      card-specific backdrop SVG and the .center / override-btn /
-      green-btn DOM nodes.
-
-      params (long but mechanical — every duration card needs them):
-        palette                      — {primary, gradStart, gradEnd, animStart, animEnd}
-        ringCirc                     — ring radius in SVG units (typically 130)
-        center                       — {cx, cy} centre of the ring
-        startDeg, endDeg, rangeDeg, gapDeg
-        progressPath, bgPath         — pre-computed SVG `d` attribute strings
-        handlePos                    — {x, y} handle centre
-        handlePct                    — handle percentage (for label)
-        displayTargetHours           — value to display at the handle text
-        hoursRun                     — current run hours
-        showAnimation                — boolean — whether to render running_anim path
-        canDragHandle                — boolean — whether to render handle circle
-        gradGreenId, gradRunningId, activeGradId
-        dashLen, gapLen              — stroke-dasharray
-        title                        — escaped card title
-        running                      — boolean — for active-state colouring
-        pctToHours                   — function used in label render
-      Returns string.
-    */
-    _buildRingHTML(params) {
-        const {
-            palette, ringCirc, center,
-            progressPath, bgPath,
-            handlePos, handlePct, displayTargetHours, hoursRun,
-            showAnimation, canDragHandle,
-            gradGreenId, gradRunningId, activeGradId,
-            dashLen, gapLen,
-            pctToHours,
-        } = params;
-
-        // QS-199 review-fix #07 N1 — the handle's TEXT LABEL round-trips
-        // the target back from `handlePct`: `pctToHours(handlePct)`. On the
-        // non-default branch each card sets
-        // `handlePct = hoursToPct(displayTargetHours)` with
-        // `displayTargetHours = targetHours` left UNCLAMPED on purpose, so
-        // this label shows the TRUE target even when it exceeds `maxHours`.
-        // Only the handle POSITION is clamped (the card's `pctToDeg`
-        // clamps to [0,100] → the handle pins at the ring top for an
-        // out-of-range target while the number stays correct).
-        // DO NOT "fix" the >100% `handlePct` by clamping `handlePct` or
-        // `displayTargetHours` — that would make this label render
-        // `maxHours` instead of the real value (a regression across all
-        // duration cards). The pin-at-top-but-number-correct behaviour is
-        // intentional and graceful.
-        const escapedHandleLabel = this._fmt(pctToHours(handlePct));
-
-        // QS-199 review-fix N6 — per-instance glow filter id (parity with
-        // gradGreenId / gradRunningId) so two cards on one page can't
-        // collide if shadow-DOM id scoping ever changes.
-        const glowId = this._instanceId('runningGlow');
-
-        return `
-              <defs>
-                <linearGradient id="${gradGreenId}" x1="0%" y1="0%" x2="100%" y2="0%">
-                  <stop offset="0%" stop-color="${palette.gradStart}"/>
-                  <stop offset="100%" stop-color="${palette.gradEnd}"/>
-                </linearGradient>
-                <linearGradient id="${gradRunningId}" x1="0%" y1="0%" x2="100%" y2="0%">
-                  <stop offset="0%" stop-color="${palette.animStart}"/>
-                  <stop offset="100%" stop-color="${palette.animEnd}"/>
-                </linearGradient>
-                <filter id="${glowId}" x="-50%" y="-50%" width="200%" height="200%">
-                  <feGaussianBlur stdDeviation="2" result="blur" />
-                  <feMerge>
-                    <feMergeNode in="blur" />
-                    <feMergeNode in="SourceGraphic" />
-                  </feMerge>
-                </filter>
-              </defs>
-              <path d="${bgPath}" stroke="var(--divider-color)" stroke-width="14" fill="none" stroke-linecap="round" />
-              <path d="${progressPath}" stroke="url(#${activeGradId})" stroke-width="14" fill="none" stroke-linecap="round" ${showAnimation ? 'stroke-opacity="0.35"' : ''} />
-              ${showAnimation ? `
-              <path id="running_anim"
-                    d="${progressPath}"
-                    stroke="url(#${gradRunningId})"
-                    stroke-width="16"
-                    fill="none"
-                    stroke-linecap="round"
-                    stroke-dasharray="${dashLen} ${gapLen}"
-                    stroke-opacity="1"
-                    filter="url(#${glowId})"
-                    style="mix-blend-mode:screen; will-change: stroke-dashoffset"
-              />
-              ` : ''}
-              ${canDragHandle ? `
-              <circle id="target_handle" cx="${handlePos.x.toFixed(2)}" cy="${handlePos.y.toFixed(2)}" r="13" fill="var(--card-background-color)" stroke="${palette.primary}" stroke-width="3" style="cursor: grab; pointer-events: all;" />
-              <text id="target_handle_text" x="${handlePos.x.toFixed(2)}" y="${handlePos.y.toFixed(2)}" text-anchor="middle" dominant-baseline="middle" fill="${palette.primary}" font-size="13" font-weight="800" style="cursor: grab; pointer-events: none; user-select: none;">${escapedHandleLabel}</text>
-              ` : ''}
-        `;
-    }
-
     /*
       _clampMaxHours(raw) — the SINGLE source-of-truth normalizer for a
       card's draggable-range maximum. QS-199 review-fix #04 ES1 + #05 S1

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -793,6 +793,18 @@ owner-authorized visual simplification isolated in its own commit
 for a clean Phase-F smoke read. There is no per-instance grain id
 or wave-fill `filter="url(#…)"` reference anymore.
 
+**Energy-mode SOC on sensor dropout (QS-235 AC6 / review-fix #01
+NTH1).** The `current_inputed_energy` read now goes through the
+shared `_safeNumber(sensor, 0)`, which returns `0` (not `NaN`) for an
+`unavailable` / `unknown` / missing sensor. In energy mode with no
+valid target limit, the SOC readout and ring handle therefore show
+`0` / `0 kWh` rather than the pre-QS-235 `--` / `-- kWh`. This is
+intentional: besides being arguably more correct, it **hardens the
+ring geometry** — the old `NaN` propagated through
+`socPct → handlePct → pctToDeg → polar`, emitting a `cx="NaN"` handle
+position; the `0` keeps the handle pinned at the bottom of the gauge.
+Confirm the `0`-on-dropout readout in the Phase-F smoke.
+
 **Degraded state CSS filter.** When `degraded === true` (computed
 as `isDisconnected || isFaulted || isStale` — `isOffGrid` is
 explicitly excluded; the card-level pinkish `.off-grid` CSS class

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -159,15 +159,27 @@ Five shared modules:
   (`_wireTargetHandle`, `_wireTimePicker`, `_wireResetButton`,
   `_wirePowerButton`, `_wireGreenButton`). Wire-helpers live on the
   base (not the sub-base) because the car card uses several of them
-  too — it inherits `QsCardBase` directly.
+  too — it inherits `QsCardBase` directly. **QS-235** moved
+  `_buildRingHTML` (the ring SVG builder) UP here from the duration
+  sub-base — it is the single source of truth, with backward-compatible
+  optional params (`handleLabel` / `bgStroke` / `handleFontSize` /
+  `handleStroke` / `handleFill` / `animPathId` / `extraDefs`) that
+  default to the duration-card output so the car can override them.
+  QS-235 also added `_ringCarveCover({cx, cy, r, id, show})` + the
+  shared `RING_BOTTOM_CARVE_CX/CY/R` constants (the unified
+  bottom-center carve cover — see the QS-217 section), and generalized
+  `_wireTargetHandle` (added `onCommit` / `pctToValue` / `valueToPct` /
+  `onDragMove` / `fmtHandleText`) and `_wireTimePicker` (added
+  `onAfterCommit` / `resetButton` / `title` / `bodyText`) in place so
+  the car adopts them with no duration-card source change.
 - **`shared/qs-ring-duration-base.js`** — exports `class
-  QsRingDurationCardBase extends QsCardBase`. Adds `_buildRingHTML`
-  (the ring SVG markup with linear-gradient defs, background +
-  progress arcs, override-btn cover circle, target-handle circle +
-  text, power-btn / green-btn / override-btn DOM nodes),
+  QsRingDurationCardBase extends QsCardBase`. Adds `_clampMaxHours` /
+  `_allowedHalfHours` (the hours-specific drag-range helpers),
   `_wireOverrideButton`, and `_wireBistateMode` (the latter wraps
   `_select` in try/catch/finally + 300ms cleanup setTimeout — M2
-  hardening).
+  hardening). QS-235 moved `_buildRingHTML` UP to `QsCardBase` (the
+  five duration cards inherit it unchanged); the hours-/override-only
+  helpers stay here because the car needs none of them.
 - **`shared/qs-anim-flame.js`** — exports `FLAME_CONSTANTS` plus
   `class QsFlameEngine`. The engine is a pure state machine + path
   generator (`step(dt, fireOn, baseY, ts)` →
@@ -669,24 +681,30 @@ affected cards — `qs-radiator-card.js`, `qs-water-boiler-card.js`,
 and `qs-climate-card.js` — each render the cover element
 immediately after their `<g clip-path="url(#…ClipId)">` group and
 before the outer-ring stroke, gated on `e.override_reset` (the same
-truthy check that already controls the button DOM render):
+truthy check that already controls the button DOM render).
+
+**QS-235 unification.** The cover markup + geometry are now shared.
+The geometry lives in the `RING_BOTTOM_CARVE_CX / RING_BOTTOM_CARVE_CY
+/ RING_BOTTOM_CARVE_R` constants (`shared/qs-card-base.js`), and the
+markup is emitted by the shared `_ringCarveCover({cx, cy, r, id,
+show})` helper on `QsCardBase`. The car card reuses the SAME helper +
+constants for its bottom-center `sun_btn_cover` (and the helper again,
+with car-local geometry, for its `rabbit_btn_cover` / `time_btn_cover`).
+There is no per-card `OVERRIDE_BTN_CARVE_*` / `SUN_BTN_CARVE_*`
+duplication left:
 
 ```html
 <g clip-path="url(#…ClipId)"> … animation paths … </g>
-${e.override_reset ? `<circle id="override_btn_cover"
-  cx="${CENTER_*}"
-  cy="${OVERRIDE_BTN_CARVE_CY}"
-  r="${OVERRIDE_BTN_CARVE_R}"
-  fill="var(--card-background-color)"
-  pointer-events="none" />` : ''}
+${this._ringCarveCover({ cx: RING_BOTTOM_CARVE_CX,
+  cy: RING_BOTTOM_CARVE_CY, r: RING_BOTTOM_CARVE_R,
+  id: 'override_btn_cover', show: e.override_reset })}
 <path d="${bgPath}" … />  <!-- outer ring stroke -->
 ```
 
-Two module-level constants control the cover geometry:
-`OVERRIDE_BTN_CARVE_CY = 277` is the button centre y in SVG units
+`RING_BOTTOM_CARVE_CY = 277` is the button centre y in SVG units
 (derived from the CSS `.override-btn` position: button centre
 `(150, 260)` CSS px, scaled by the SVG viewBox factor `320/300` →
-`(160, 277.33)`, rounded to integer). `OVERRIDE_BTN_CARVE_R` is
+`(160, 277.33)`, rounded to integer). `RING_BOTTOM_CARVE_R` is
 the cover radius in SVG units; the integer is intentionally user-
 tunable for visual iteration (tests pin the constant NAME only,
 not the value). The cover applies uniformly across all backdrops

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -766,15 +766,14 @@ by a single `<filter id="${lightningFilterId}">` with
 `<feGaussianBlur stdDeviation="${LIGHTNING_GLOW_STDDEV}">` plus
 `mix-blend-mode: screen` on the layer `<g>`.
 
-**feTurbulence grain on wave fill.** The fuzzy granularity comes
-from a single `<filter id="${grainFilterId}">` declaring
-`<feTurbulence type="fractalNoise" baseFrequency="0.9"
-numOctaves="2" …>`, composited against `SourceGraphic` via
-`<feComposite operator="in">` so the grain is masked to the
-wave's filled shape (water region only). Both wave `<path>`
-elements carry `filter="url(#${grainFilterId})"`. There is NO
-separate overlay `<rect>` — the grain naturally ends at the wave
-surface and is automatically clipped to the soup boundary.
+**Wave fill — grain removed (QS-235 AC7).** The two wave `<path>`
+elements now carry only `fill` (`IDLE_SOUP_COLOR` /
+`CHARGE_SOUP_COLOR`) and `opacity`. The earlier `feTurbulence`
+grain filter (a `<filter>` declaring `fractalNoise` composited
+against `SourceGraphic`) was removed in QS-235 — a deliberate,
+owner-authorized visual simplification isolated in its own commit
+for a clean Phase-F smoke read. There is no per-instance grain id
+or wave-fill `filter="url(#…)"` reference anymore.
 
 **Degraded state CSS filter.** When `degraded === true` (computed
 as `isDisconnected || isFaulted || isStale` — `isOffGrid` is

--- a/docs/stories/QS-235.story.md
+++ b/docs/stories/QS-235.story.md
@@ -1,0 +1,337 @@
+# QS-235 — Commonalize `qs-car-card.js`: adopt shared base structural helpers
+
+- **Issue:** #235 (follow-up to #199 / PR #234)
+- **Branch:** `QS_235`
+- **Next phase:** `implement-task` (touches product code under `custom_components/quiet_solar/ui/resources/`)
+
+## Authorization
+
+The project rule "do not modify JS card code without explicit instruction"
+is **explicitly waived** for this work by issue #235, which directs the
+commonalization of `qs-car-card.js`. One deliberate visual change is also
+authorized by the repo owner during planning: **removing the car's
+`feTurbulence` grain filter** (AC7).
+
+## Context & goal
+
+`qs-car-card.js` (2047 LOC) is the least-migrated of the six JS Lovelace
+cards. It already extends `QsCardBase` and uses the *leaf* helpers
+(`_showDialog`, `_escapeHtml`, `_registerKeyActivation`, geometry,
+`baseCardCSS`), but still **reimplements** structural pieces the shared
+base provides or can provide with light generalization:
+
+- ~120 LOC of inline pointer-drag machinery (near-identical to the shared
+  `_wireTargetHandle` pointer plumbing).
+- An inline ring `<defs>`/arcs/handle block (vs `_buildRingHTML`).
+- Inline `bump_priority` toggle + reset dialog + a bespoke 3-button finish-time
+  dialog (vs `_wireGreenButton` / `_wireResetButton` / `_wireTimePicker`).
+- A handful of inline `Number(sensor?.state || N)` guards (vs `_safeNumber`).
+
+The goal is a **behavior-preserving refactor** (one intentional exception:
+the grain kill) that removes the duplication, with a **net LOC reduction**
+in the car and extended structural tests pinning the commonalization.
+
+## Architecture decision — partial hoist, move-not-copy
+
+The wire helpers (`_wireTargetHandle`, `_wireTimePicker`, `_wireResetButton`,
+`_wirePowerButton`, `_wireGreenButton`) and `_safeNumber` were already
+hoisted to `QsCardBase` by QS-199 — the car consumes them directly. This
+story adds:
+
+- **Move `_buildRingHTML` UP** from `QsRingDurationCardBase` → `QsCardBase`.
+  It is *deleted* from the duration sub-base and *defined once* on the base.
+  `QsRingDurationCardBase extends QsCardBase`, so the 5 duration cards inherit
+  it unchanged. **No duplication** — single source of truth.
+- **Add `_ringCarveCover()` + shared `RING_BOTTOM_CARVE_*` constants** to
+  `QsCardBase`. The per-card `OVERRIDE_BTN_CARVE_*` (radiator/water-boiler/
+  climate) and `SUN_BTN_CARVE_*` (car) bottom-center duplicates are removed
+  and repointed to the shared constants/helper. **No duplication.**
+- **Generalize `_wireTargetHandle` and `_wireTimePicker` in place** on
+  `QsCardBase` with backward-compatible optional callbacks (defaults
+  reproduce current duration-card behavior byte-for-byte).
+
+**Stays on `QsRingDurationCardBase`** (hours/override-specific; the car needs
+none): `_clampMaxHours`, `_allowedHalfHours`, `_wireOverrideButton`,
+`_wireBistateMode`. Not duplicated — just not hoisted.
+
+## Verification reality (read before implementing)
+
+The JS cards are **outside the automated pipeline** — Python cannot execute
+them; the "structural tests" in `tests/test_dashboard_rendering.py`
+**grep source text**. Consequences:
+
+- **Duration cards "unchanged"** means their *source files are byte-untouched*
+  (the `_buildRingHTML` move is body-preserving; new params activate only on
+  the car's call) **and** the existing duration tests stay green. There is no
+  rendered-HTML diff harness — do not promise "byte-identical rendered output",
+  promise "source untouched + existing tests green".
+- **The car's runtime correctness is verified by the Phase-F live-HA visual
+  smoke only.** No automated net exists under it. See the smoke checklist.
+- TDD asymmetry: the *removal/adoption* ACs (3–7) are genuine red→green
+  presence/absence greps. The *behavior-preservation* ACs (1, 2) are
+  **characterization** checks (duration source untouched; new car structural
+  greps go red→green), **not** red-first behavior tests — do not waste a cycle
+  trying to make a "don't break this" test fail first.
+- Run the **full** quality gate (`python scripts/qs/quality_gate.py`). The
+  `docs/` + `tests/utils/card_sources.py` edits de-classify the UI-only fast
+  path. `card_sources.py` changes are **data/docstring-only** (no new
+  executable Python → no new coverage burden); if that stops being true, the
+  new line must be exercised by a test.
+
+## Current signatures (the implementer has no prior source context)
+
+**`_buildRingHTML(params)`** — currently in `shared/qs-ring-duration-base.js`,
+called by on-off-duration, pool, radiator. Today's params: `palette,
+ringCirc, center, startDeg, endDeg, rangeDeg, gapDeg, progressPath, bgPath,
+handlePos, handlePct, displayTargetHours, hoursRun, showAnimation,
+canDragHandle, gradGreenId, gradRunningId, activeGradId, dashLen, gapLen,
+pctToHours`. Internally computes the handle label as
+`this._fmt(pctToHours(handlePct))`, emits a `<defs>` (2 gradients + per-instance
+glow filter), bg arc (`stroke="var(--divider-color)"`), progress arc
+(`url(#${activeGradId})`), an optional `running_anim` dashed path, and an
+optional `target_handle` circle (r=13) + `target_handle_text` (font-size 13).
+
+Radiator's call site (the byte-identical baseline to preserve):
+`this._buildRingHTML({ palette: colors, ringCirc, center, startDeg, endDeg,
+rangeDeg, gapDeg, progressPath, bgPath, handlePos, handlePct,
+displayTargetHours, hoursRun, showAnimation: ringDashActive, canDragHandle,
+gradGreenId, gradRunningId, activeGradId, dashLen, gapLen, pctToHours })`.
+
+**`_wireTargetHandle(params)`** — `shared/qs-card-base.js`. Today's params:
+`ringSvg, handle, center, ringCirc, startDeg, endDeg, rangeDeg, hoursToPct,
+pctToHours, allowedHours, entityId, onBeforeCommit, getHoursRun, colors`.
+Snaps in *hours* (`pctToHours(rawPct)` → reduce over `allowedHours`),
+commits via `_setNumber(entityId, dragValue)` inside a `try/finally` (S17),
+updates the handle text + the `.target-value` (class) element.
+
+**`_wireTimePicker(params)`** — `shared/qs-card-base.js`. Today: a fixed
+2-button (`Cancel`/`Apply`) dialog; `Apply` does only `_setTime(entityId, val)`
++ a 5s local-state clear. Title `'Finish Time'`.
+
+**Car bottom-center carve (today, duplicated 4×):** `cx=160, cy=277, r=35`,
+`fill="var(--card-background-color)" pointer-events="none"`. Car ids:
+`sun_btn_cover` (bottom-center), `rabbit_btn_cover` (96/206/32),
+`time_btn_cover` (224/206/32). Duration id: `override_btn_cover`.
+
+## Acceptance criteria
+
+### AC1 — Drag handle adopts a generalized `_wireTargetHandle`
+- **Given** the car's ~120 LOC inline pointer-drag block (the `const svg =
+  this._root.querySelector('.ring svg')` … `handle.addEventListener('touchstart'…)`
+  region near the end of `_render`),
+- **When** it is replaced by a call to `_wireTargetHandle`, generalized with
+  optional callbacks `pctToValue` / `valueToPct` (default: `pctToHours` /
+  `hoursToPct`), `onCommit(value)` (default: `(v) => this._setNumber(entityId, v)`),
+  and `onDragMove(value)` (default: the existing `.target-value` update),
+  and `allowedHours` is generalized to `allowedValues`,
+- **Then** the car passes its select-commit (`onCommit` → map value to option
+  via `findOptionByEnergy`/`findOptionByPercent` then `_select(e.next_limit, opt)`),
+  its %↔kWh mapping (`pctToValue`/`valueToPct` branching on `useEnergyMode`),
+  and its `#target_value` live-label updater; **and** the car gains the S17
+  `try/finally` it currently lacks; **and** every duration caller passes none
+  of the new params so their source is untouched and their tests stay green.
+
+### AC2 — Ring builder hoisted to `QsCardBase`, car adopts it (option A2)
+- **Given** `_buildRingHTML` lives on `QsRingDurationCardBase` and the car
+  inlines its ring,
+- **When** `_buildRingHTML` is **moved** to `QsCardBase` (deleted from the
+  duration sub-base) and gains backward-compatible params — `handleLabel?`
+  (default `this._fmt(pctToHours(handlePct))`), `bgStroke?` (default
+  `'var(--divider-color)'`), `handleFontSize?` (default `13`), `handleStroke?`/
+  `handleFill?` (default `palette.primary`), `animPathId?` (default
+  `'running_anim'`), `extraDefs?` (default `''`) —
+- **Then** the 3 duration callers are unchanged (defaults reproduce current
+  output) and the car builds its bg-arc/progress-arc/dash/handle via
+  `_buildRingHTML` (following the radiator composition pattern: the car
+  renders its own clip backdrop `<g>` + carves before injecting
+  `${ringMarkup}`), passing `animPathId: 'charge_anim'`, `bgStroke` (fault
+  conditional), `handleLabel` (the energy/percent **true target, unclamped**),
+  `handleFontSize` (mode-switched), and its disabled/fault/stale gradients +
+  clipPath via `extraDefs`.
+
+### AC3 — Bottom-center carve unified across all 4 cards (option B1)
+- **Given** the carve cover is duplicated 4× with identical geometry,
+- **When** `QsCardBase` gains `_ringCarveCover({cx, cy, r, id, show})` and
+  shared constants `RING_BOTTOM_CARVE_CX/CY/R`,
+- **Then** the car (`sun_btn_cover`) and radiator/water-boiler/climate
+  (`override_btn_cover`) all render their bottom-center carve via the shared
+  helper + shared constants; the per-card `OVERRIDE_BTN_CARVE_*`/`SUN_BTN_CARVE_*`
+  duplicates are removed; the car's `rabbit_btn_cover`/`time_btn_cover` reuse
+  the helper with their own (car-local) geometry; rendered `id` attributes are
+  preserved.
+
+### AC4 — Green + reset buttons adopt the shared helpers
+- **Given** the car's inline `bump_priority` toggle and inline reset dialog,
+- **When** refactored, **then** the car uses `_wireGreenButton`
+  (`bump_priority`) and `_wireResetButton` (`reset`); the dead `#priority`
+  listener (no matching DOM element) is removed; the buttons gain the helpers'
+  built-in keyboard activation (the one intended behavior addition from issue
+  item 3).
+
+### AC5 — `_wireTimePicker` generalized and adopted
+- **Given** the car's bespoke 3-button finish-time dialog (`Cancel` / `Reset`
+  → `_press(clean_constraints)` / `Apply` → `_setTime` + `_press(schedule)`),
+- **When** `_wireTimePicker` gains optional `onAfterCommit` (awaited press after
+  `_setTime`), an optional `resetButton: {text, variant, onClick}` (inserted as
+  a 3rd dialog button), and optional `title`/`bodyText` overrides,
+- **Then** the car adopts it; the 4 duration callers pass none of the new
+  params and keep their 2-button dialog byte-for-byte.
+
+### AC6 — `_safeNumber` adoption for genuine sensor reads
+- **Given** the car's inline numeric guards,
+- **When** **only** the guard-shaped sensor reads of the form
+  `Number(<sensor>?.state || N)` (e.g. the `power` and `current_inputed_energy`
+  reads) are swapped to `this._safeNumber(<sensor>, N)`,
+- **Then** config reads (`Number(e.car_battery_capacity_kwh)`), regex captures
+  (`Number(m[1])`), and DOM value/attr reads (`Number(hourSel?.value)`,
+  `Number(el.getAttribute('data-pct'))`) are **left untouched**.
+
+### AC7 — `feTurbulence` grain filter removed (isolated commit)
+- **Given** the car's grain filter on the two wave-fill paths,
+- **When** the `<filter id="${grainFilterId}">` def, both
+  `filter="url(#${grainFilterId})"` references, the `this._grainFilterId`
+  allocation, and the stale comments are removed **in a dedicated commit**,
+- **Then** the sparkle layer, lightning layer, and wave motion are untouched;
+  a negative guard test pins grain's absence **scoped to the car source only**.
+
+### AC8 — Net LOC reduction
+- **Given** the car is 2047 LOC, **when** the refactor lands, **then**
+  `qs-car-card.js` is net smaller (sign-negative). No magnitude gate. If the
+  shared-base additions exceed the car removals, that is an over-engineering
+  smell to flag, not a target to chase.
+
+### AC9 — Structural tests extended + invariant pinned
+- **Given** the car under-tests its shared-helper usage,
+- **When** tests are added/updated, **then** the car's use of `_buildRingHTML`,
+  `_wireTargetHandle`, `_ringCarveCover`, `_wireGreenButton`,
+  `_wireResetButton`, `_wireTimePicker`, and `_safeNumber` is pinned; the
+  **handle-label round-trip invariant** is pinned for the car (label shows the
+  true target via `handleLabel`; position is clamped via `pctToDeg`); the carve
+  + grain tests are updated/removed per the disposition table.
+
+### AC10 — Doc, gate, smoke
+- **Given** the refactor, **when** complete, **then**
+  `docs/agents/concepts/dashboard-and-cards.md` is updated (inheritance moves,
+  unified carve, generalized helpers, grain removed, `last_verified` bumped);
+  100% Python coverage; ruff/mypy/translations green; and the Phase-F car-card
+  visual smoke passes.
+
+## Task breakdown
+
+1. **`shared/qs-card-base.js`**
+   - Move `_buildRingHTML` here (delete from the duration sub-base); add the
+     AC2 optional params with duration-preserving defaults.
+   - Add `RING_BOTTOM_CARVE_CX/CY/R` constants + `_ringCarveCover({cx, cy, r,
+     id, show})` (returns the `<circle>` string or `''`).
+   - Generalize `_wireTargetHandle`: `allowedHours` → `allowedValues`; add
+     `pctToValue`/`valueToPct`/`onCommit`/`onDragMove` with the documented
+     defaults; keep the S17 try/finally, the snap reduce, the
+     `_targetDragPct`/`_targetDragValue`/`_localTargetPct`/`_pendingClearLocalTarget`/
+     `_upInProgress` flags, and the 5s clear timer.
+   - Generalize `_wireTimePicker`: add `onAfterCommit`, `resetButton`,
+     `title`/`bodyText` overrides.
+2. **`shared/qs-ring-duration-base.js`** — remove `_buildRingHTML`; update the
+   header comment; keep `_clampMaxHours`/`_allowedHalfHours`/
+   `_wireOverrideButton`/`_wireBistateMode`.
+3. **`qs-radiator-card.js` / `qs-water-boiler-card.js` / `qs-climate-card.js`**
+   — repoint the `override_btn_cover` to `_ringCarveCover` + shared constants;
+   remove the local `OVERRIDE_BTN_CARVE_*` constants. (Duration `_buildRingHTML`
+   call sites unchanged.)
+4. **`qs-pool-card.js` / `qs-on-off-duration-card.js`** — no carve; verify
+   `_buildRingHTML` still resolves via inheritance (no source change needed).
+5. **`qs-car-card.js`** (the bulk)
+   - **Commit A (isolated): grain kill** — remove the filter def, both path
+     refs, `_grainFilterId` alloc, stale comments.
+   - Adopt `_buildRingHTML` for bg/progress/dash/handle (A2 params); render
+     the clip backdrop `<g>` + sun/rabbit/time carves (via `_ringCarveCover`)
+     before `${ringMarkup}`.
+   - Replace the inline drag block with `_wireTargetHandle` (select-commit +
+     %/kWh mapping + `#target_value` `onDragMove`).
+   - `bump_priority` → `_wireGreenButton`; `reset` → `_wireResetButton`;
+     remove the dead `#priority` listener.
+   - Finish-time flow → `_wireTimePicker({ onAfterCommit: () =>
+     this._press(e.schedule), resetButton: { text: 'Reset', variant: 'danger',
+     onClick: () => e.clean_constraints && this._press(e.clean_constraints) },
+     title: 'Charge Finish Time', bodyText: … })`.
+   - Swap the guard-shaped sensor `Number(...)` reads to `_safeNumber`.
+6. **`tests/test_dashboard_rendering.py`** — apply the disposition table below.
+7. **`tests/utils/card_sources.py`** — no `CARD_TO_SHARED_FILES` change needed
+   (the car already unions `qs-card-base.js`, which now hosts `_buildRingHTML`);
+   update the module docstring to note the car now consumes `_buildRingHTML`.
+8. **`docs/agents/concepts/dashboard-and-cards.md`** — update per AC10.
+
+### Test disposition
+
+| Test(s) | Action |
+|---|---|
+| `test_car_card_grain_filter_uses_feturbulence_on_wave_fill` | **delete** |
+| `test_car_card_electron_soup_clip_group_and_two_waves` (grain asserts) | **edit** — drop grain asserts, keep the two-wave asserts |
+| `test_car_card_per_instance_unique_svg_ids` (`_grainFilterId`) | **edit** — remove the `_grainFilterId` key |
+| `_resetDomRefs`/disconnect test referencing `_grainFilterEl` | **edit** if present |
+| new negative grain guard (`feTurbulence`/`grainFilterId` absent from car) | **add** |
+| 3 car carve tests pinning inline `<circle id="sun_btn_cover" …>` literals + order | **rewrite** to assert `_ringCarveCover` usage + shared constants |
+| 3 duration carve tests (`_qs217_assert_card_carve_out`) pinning `OVERRIDE_BTN_CARVE_*` names | **rewrite** to the shared `RING_BOTTOM_CARVE_*` name + helper usage |
+| car structural tests: `_buildRingHTML`, `_wireTargetHandle`, `_ringCarveCover`, `_wireGreenButton`, `_wireResetButton`, `_wireTimePicker`, `_safeNumber`, handle-label invariant | **add** |
+| `test_card_raf_idle_gated` parametrize list | no change (car already excluded) |
+| `CARDS_TO_RING_TEXT_CLASSES` / ring-text-shadow test | verify the car's handle text classes are unchanged; no edit expected |
+
+## Phase-F visual smoke checklist (manual, post-merge)
+
+1. Car renders; the soup fill is smooth (no grain), **sparkles + lightning
+   still animate**.
+2. Drag the ring handle in **percent mode** and in **kWh mode**: the
+   `#target_value` label tracks during drag; on release the `select_option`
+   service fires.
+3. An out-of-range target pins the handle at the ring top **but the label shows
+   the true number** (unclamped-label invariant).
+4. Solar-priority (green), reset, force-now, and finish-time (Apply +
+   schedule, Reset + clean) all behave as before; keyboard Enter/Space activate
+   green/reset.
+5. Connection/fault/stale states still recolor the ring + handle.
+
+## Adversarial Review Notes
+
+Four reviewers (critic, concrete-planner, dev-proxy, scope-guardian) ran in
+parallel. Key findings and decisions:
+
+- **Carve unification breaks ~9 green tests** (concrete-planner) — they pin
+  inline `<circle>` literals + per-card constant *names*. **Decision:** accept
+  the test rewrites (the user chose full unification, B1); move the geometry to
+  shared `RING_BOTTOM_CARVE_*` constants so there is genuinely no duplication.
+- **The three "generalizations" are real, not "minimal optional params"**
+  (concrete-planner, critic) — `_wireTargetHandle` has no commit/mapping/label
+  callbacks today (and `onCommit` was deliberately removed in QS-199);
+  `_wireTimePicker` is a fixed 2-button dialog; `_buildRingHTML` cannot express
+  the car's variants. **Decision:** scope them honestly as callback additions
+  with duration-preserving defaults; embed current signatures in this story.
+  The drag diff was examined line-by-line with the owner — the divergence is 4
+  clean callbacks (value-map pair, commit, live-label) over byte-identical
+  pointer plumbing; adopting also fixes the car's missing S17 try/finally.
+- **Ring divergence is cosmetic** (owner-reviewed) — colors/fonts/ids/label
+  string + the established radiator composition pattern; only `animPathId` is a
+  (one-line) wiring param. **Decision:** A2 confirmed.
+- **`_safeNumber` count was ~5× off** (concrete-planner) — only ~3–5 genuine
+  sensor reads qualify. **Decision:** AC6 rewritten with an explicit
+  discriminator; config/regex/DOM reads excluded.
+- **Drop the chargeGlow→shared-glow fold** (concrete-planner) — no clean
+  per-instance-id wiring path; gold-plating. **Decision:** dropped; the car
+  keeps its own glow; only grain is removed.
+- **"Byte-identical" is not machine-verifiable** (dev-proxy, critic) — Python
+  can't run the JS. **Decision:** reframed as "duration source untouched +
+  existing tests green"; car correctness is Phase-F only; documented in
+  *Verification reality*.
+- **Grain kill muddies the Phase-F baseline** (scope-guardian, critic) —
+  bundling a visual change into a pure refactor. **Decision:** keep one PR (per
+  owner) but isolate grain in its own commit (AC7) for a clean smoke read.
+- **AC8 LOC ≥150 is a perverse incentive** (critic, scope-guardian).
+  **Decision:** dropped the magnitude gate; sign-only + over-engineering
+  inversion guard.
+- **Scope-guardian flagged AC3/AC5/AC7 as beyond the issue** — all three were
+  **explicitly requested by the repo owner** during planning; accepted as
+  owner-directed scope, kept in one PR with grain isolated.
+- **TDD red asymmetry** (dev-proxy) — documented in *Verification reality*:
+  removal/adoption ACs are red→green greps; behavior-preservation is
+  characterization, not red-first.
+- **Doc-drift + full gate** (dev-proxy) — `check_doc_drift.py` flags only
+  `dashboard-and-cards.md`; the full gate runs (fast path de-classified);
+  `card_sources.py` edit is data/docstring-only. Documented.

--- a/docs/stories/QS-235.story_review_fix_#01.md
+++ b/docs/stories/QS-235.story_review_fix_#01.md
@@ -35,8 +35,8 @@
   body itself flags this as a Phase-F nuance, and AC2 mandates the dash be
   behavior-equivalent — so this is a regression against the story's own
   contract, not an intended change.
-- Proposed fix (preferred — behavior-preserving, satisfies AC2): restore the
-  fault-conditional dash stroke. Have the car drive the shared
+- Proposed fix (DECIDED — owner-confirmed; behavior-preserving, satisfies
+  AC2): **restore the fault-conditional dash stroke.** Drive the shared
   `_buildRingHTML` anim stroke off the fault state — e.g. pass the already
   fault-aware `activeGradId` (or a dedicated `gradRunningId: isFaulted ?
   gradFaultId : gradChargeId`) so the moving dash matches the static arc.
@@ -44,13 +44,14 @@
   same change. If `_buildRingHTML` cannot today thread a fault-conditional
   stroke, add a minimal back-compat param (e.g. `animGradId`, defaulting to
   `gradRunningId`) so the four duration callers stay byte-identical while the
-  car can pass the fault-aware gradient.
-- Alternative (only if product owner confirms the blue tint is intended):
-  delete the now-dead `gradFaultId` `<linearGradient>` from the car's
-  `extraDefs`, update the static progress arc to stop using it, document the
-  deliberate visual change in `dashboard-and-cards.md`, and adjust AC2's
-  byte-equivalence claim. Do **not** pick this path without explicit owner
-  sign-off — restoring the tint is the default.
+  car can pass the fault-aware gradient. Add/extend a structural test that
+  pins the fault-aware anim stroke (e.g. the car wires the anim gradient off
+  `isFaulted`, and `gradFaultId` is referenced — not orphaned).
+- Rejected alternative — **do NOT take this path.** The owner has explicitly
+  ruled out accepting the blue charge tint for faulted-while-charging. Do not
+  delete `gradFaultId`, do not change the static progress arc to drop it, and
+  do not relax AC2's byte-equivalence claim. The only acceptable resolution is
+  restoring the fault tint as described above.
 
 ### [should-fix] SF2 — `test_car_card_grain_filter_removed` negative assertion is too broad
 - File: `tests/test_dashboard_rendering.py:~3916-3921`
@@ -154,7 +155,8 @@
 ## How to apply
 
 Run `/implement-task` against this fix plan. Start with SF1 (the only
-runtime-behavior finding — confirm the SF1 direction: default is restore the
-fault tint). SF2/SF3/SF4 are test-robustness changes; NTH1–NTH3 are polish.
+runtime-behavior finding — the resolution is DECIDED: **restore the
+fault-conditional dash stroke**; the blue-tint alternative is rejected, do not
+take it). SF2/SF3/SF4 are test-robustness changes; NTH1–NTH3 are polish.
 The full quality gate (pytest 100% cov + ruff + mypy + translations) must stay
 green. When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-235.story_review_fix_#01.md
+++ b/docs/stories/QS-235.story_review_fix_#01.md
@@ -1,0 +1,160 @@
+# QS-235 — Review fix plan #01
+
+## Summary
+- Source PR: #236
+- Source story: `docs/stories/QS-235.story.md`
+- Findings to fix: 7 (4 should-fix, 3 nice-to-have)
+- Next implement phase: `/implement-task`
+
+> Triage decision: **fix all**. AC10 `last_verified` was flagged by the
+> acceptance-auditor but resolved during consolidation — the field is
+> already `2026-05-27` (today), set by the prior same-day commit
+> `69d87987`; bumping is a no-op. No action. Doc-maintenance audit also
+> passed (drift check exit 0; `docs/agents/concepts/dashboard-and-cards.md`
+> covers the changed source).
+
+## Findings to fix
+
+### [should-fix] SF1 — Faulted-while-charging dash loses its fault tint; `gradFaultId` is now dead SVG
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:~1312` → `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js:854`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (independent agreement)
+- Description: The pre-refactor car drew the moving dashed arc with
+  `stroke="url(#${isFaulted ? gradFaultId : gradChargeId})"`, so a car that
+  was **faulted while still drawing current** rendered the dash with the
+  amber/red fault gradient. The shared `_buildRingHTML` hardcodes the dash
+  anim stroke to `url(#${gradRunningId})` (`qs-card-base.js:854`), and the
+  car passes `gradRunningId: gradChargeId` (blue). Result: a
+  faulted-while-charging car now renders a **blue dash over an amber static
+  progress arc** (the static arc still uses `activeGradId = gradFaultId`,
+  car:~1181) — the two layers disagree. As a corroborating symptom, the
+  `gradFaultId` `<linearGradient>` is still emitted in the car's `extraDefs`
+  but is no longer referenced by any stroke → dead SVG. Reachable when
+  `isFaulted` (`sChargeType` ∈ {`faulted`, `no power to car`, `unknown`})
+  AND `charging` (power > 50W) AND a drawable segment (`segLen > 6`). The PR
+  body itself flags this as a Phase-F nuance, and AC2 mandates the dash be
+  behavior-equivalent — so this is a regression against the story's own
+  contract, not an intended change.
+- Proposed fix (preferred — behavior-preserving, satisfies AC2): restore the
+  fault-conditional dash stroke. Have the car drive the shared
+  `_buildRingHTML` anim stroke off the fault state — e.g. pass the already
+  fault-aware `activeGradId` (or a dedicated `gradRunningId: isFaulted ?
+  gradFaultId : gradChargeId`) so the moving dash matches the static arc.
+  This re-references `gradFaultId`, eliminating the dead-SVG symptom in the
+  same change. If `_buildRingHTML` cannot today thread a fault-conditional
+  stroke, add a minimal back-compat param (e.g. `animGradId`, defaulting to
+  `gradRunningId`) so the four duration callers stay byte-identical while the
+  car can pass the fault-aware gradient.
+- Alternative (only if product owner confirms the blue tint is intended):
+  delete the now-dead `gradFaultId` `<linearGradient>` from the car's
+  `extraDefs`, update the static progress arc to stop using it, document the
+  deliberate visual change in `dashboard-and-cards.md`, and adjust AC2's
+  byte-equivalence claim. Do **not** pick this path without explicit owner
+  sign-off — restoring the tint is the default.
+
+### [should-fix] SF2 — `test_car_card_grain_filter_removed` negative assertion is too broad
+- File: `tests/test_dashboard_rendering.py:~3916-3921`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-coderabbit (should-fix); qs-review-acceptance-auditor (nice-to-have) — majority should-fix
+- Description: `assert "grain" not in source.lower()` bans the bare substring
+  "grain" anywhere in the car source. Any future unrelated identifier or
+  comment containing those letters (e.g. "granular", "fine-grained",
+  "migrant") would fail CI even though grain-filter artifacts are correctly
+  gone. Brittle pin.
+- Proposed fix: replace the blanket substring ban with scoped assertions for
+  the specific grain-filter artifacts already named just above in the test —
+  `feTurbulence`, `grainFilterId`, `_grainFilterId`, `grainFilter` — so the
+  test fails only when an actual grain-filter token reappears.
+
+### [should-fix] SF3 — Commit-order assertions use whole-file `index(...)`
+- File: `tests/test_dashboard_rendering.py:~7814-7833`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The `await onBeforeCommit(` / `await onCommit(` /
+  `await this._setNumber(` membership and `before_idx`/`commit_idx`/
+  `setnum_idx` ordering assertions run `index(...)` against the whole
+  `qs-card-base.js` source text. If a matching token appears elsewhere in the
+  file, the test can become a false pass/fail and stops actually pinning the
+  `_wireTargetHandle` commit ordering.
+- Proposed fix: extract the `_wireTargetHandle` function body into a substring
+  first (slice from the `_wireTargetHandle(` definition to the next top-level
+  method), then run the membership and ordering assertions against that body
+  substring rather than the whole file.
+
+### [should-fix] SF4 — AC6 negative half is untested
+- File: `tests/test_dashboard_rendering.py` (coverage gap)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC6 has two halves — (a) swap the guard-shaped
+  `Number(sensor?.state || N)` reads to `_safeNumber`, and (b) leave config
+  (`Number(e.car_battery_capacity_kwh)`), regex (`Number(m[1])`), and DOM
+  (`Number(hourSel?.value)`) reads untouched. The only coverage
+  (`test_car_card_adopts_shared_structural_helpers`) asserts `this._safeNumber(`
+  merely appears — nothing pins the negative half. A future edit that wrongly
+  converts a config/DOM scalar read to `_safeNumber` (which expects a sensor
+  object, not a scalar) would be a real bug and go uncaught. Implementation is
+  currently correct (only `sPower` car:~843 and `sCurrentInputedEnergy`
+  car:~952 were swapped); this is a coverage gap, not a defect.
+- Proposed fix: add a negative-grep assertion to the car structural test that
+  the scalar/DOM/regex reads survive untouched — e.g. assert
+  `Number(e.car_battery_capacity_kwh)` (or its current form),
+  `Number(m[1])`, and `Number(hourSel?.value)` (now inside `_wireTimePicker`)
+  are still present and are **not** wrapped in `_safeNumber`.
+
+### [nice-to-have] NTH1 — Energy-mode SOC/handle-label shows `0` instead of `--` on unavailable sensor
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:~953, ~1323`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The AC6 swap to `_safeNumber(sCurrentInputedEnergy, 0)` returns
+  `0` where the old `Number("unavailable") || 0` produced `NaN` →
+  `Math.round(NaN/1000)=NaN` → `_fmt(NaN)='--'`. In energy mode, when the
+  energy sensor is `unavailable`/`unknown` and there is no valid target limit,
+  the SOC readout and ring handle now show `0`/`0 kWh` instead of the prior
+  `--`/`-- kWh`. Arguably more correct, but a real boundary delta at sensor
+  dropout that the "behavior-preserving" framing did not call out.
+- Proposed fix: if preserving the old `--` display on unavailable is desired,
+  read the energy via a path that yields `NaN` (not `0`) for non-numeric
+  states before `_fmt`, or special-case the unavailable/unknown state to keep
+  the `--` placeholder. Otherwise document the intentional `0`-on-unavailable
+  behavior in `dashboard-and-cards.md` and note it for Phase-F smoke. Low
+  impact; confirm desired direction during implementation.
+
+### [nice-to-have] NTH2 — `resetButton` spread without shape validation in `_wireTimePicker`
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js` (`_wireTimePicker`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The caller-supplied `resetButton` is spread directly into the
+  dialog `buttons` array via `...(resetButton ? [resetButton] : [])` and is
+  trusted to have a valid `{text, variant, onClick}` shape; a malformed object
+  would render a broken button silently. Only the car passes it today, so
+  impact is minimal.
+- Proposed fix: add a light shape guard (only spread when `resetButton.text`
+  and `resetButton.onClick` are present) or a brief JSDoc contract on the
+  param so future callers get the shape right.
+
+### [nice-to-have] NTH3 — `escapedHandleLabel` is a misleading name
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js:817-819`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: When `params.handleLabel` is supplied it is used directly,
+  without escaping, despite the variable being named `escapedHandleLabel`.
+  SVG `<text>` content is relatively safe (metacharacters render as text), so
+  this is a naming/clarity issue, not a security defect.
+- Proposed fix: rename the variable to `handleLabelText` (or similar) so it
+  does not imply sanitization that does not occur; keep behavior unchanged.
+
+## Informational (no fix — Phase-F smoke / story-acknowledged)
+- AC4/AC5 behavior-equivalence cannot be pinned by the Python gate (JS is not
+  executed). Two deliberate, owner-accepted deltas to confirm during Phase-F
+  smoke, not code changes: (1) the finish-time button gate tightened from a
+  `.disabled`-class bail to `!isDisconnected` wiring (car:~1662), and (2) reset
+  keyboard activation relies on the native `<button>` (no Enter/Space hook by
+  design, unlike the sun-btn `<div>` which gains one via `_wireGreenButton`).
+
+## How to apply
+
+Run `/implement-task` against this fix plan. Start with SF1 (the only
+runtime-behavior finding — confirm the SF1 direction: default is restore the
+fault tint). SF2/SF3/SF4 are test-robustness changes; NTH1–NTH3 are polish.
+The full quality gate (pytest 100% cov + ruff + mypy + translations) must stay
+green. When done, return and run `/review-task` again to re-verify.

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -3899,7 +3899,15 @@ def test_car_card_grain_filter_removed():
     """
     source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
 
-    # AC7: every grain artifact — code AND stale comments — is gone.
+    # AC7: every concrete grain-filter artifact — the filter def, its
+    # `<feTurbulence>` / `<feComposite>` steps, both wave-fill
+    # references, and the per-instance id allocation — is gone.
+    #
+    # QS-235 review-fix #01 SF2 — scoped to these specific tokens rather
+    # than a blanket `"grain" not in source` ban: the blanket form would
+    # fail CI for any future unrelated identifier or comment that merely
+    # contains the letters "grain" (e.g. "granular", "fine-grained"),
+    # even with the grain filter correctly removed.
     for forbidden in (
         "feTurbulence",
         "fractalNoise",
@@ -3913,12 +3921,6 @@ def test_car_card_grain_filter_removed():
             f"along with the feTurbulence grain filter (def + both wave "
             f"refs + per-instance id allocation + stale comments)."
         )
-    # AC7 also mandates removing the stale grain comments, so the bare
-    # word `grain` no longer appears anywhere in the source.
-    assert "grain" not in source.lower(), (
-        "qs-car-card.js (QS-235 AC7): no mention of `grain` should "
-        "remain — the filter is gone and the stale comments are removed."
-    )
 
     # The two wave paths survive — just without the grain filter.
     assert 'id="electron_wave_idle"' in source, (
@@ -4509,6 +4511,64 @@ def test_car_card_adopts_shared_structural_helpers():
     )
 
 
+def test_car_card_ac6_leaves_non_sensor_reads_untouched():
+    """QS-235 review-fix #01 SF4 — AC6's NEGATIVE half. AC6 swaps ONLY
+    the guard-shaped sensor reads (`sPower`, `sCurrentInputedEnergy`) to
+    `_safeNumber`. The config read (`Number(e.car_battery_capacity_kwh)`),
+    the regex captures (`Number(m[1])`), and the DOM reads
+    (`Number(hourSel?.value …)`, `Number(el.getAttribute('data-pct'))`)
+    must survive as raw `Number(...)` coercions — `_safeNumber` expects a
+    sensor object `{state}`, so wrapping a scalar/regex/DOM read would be
+    a real bug (and silently coerce wrong). The positive half is pinned
+    by `test_car_card_adopts_shared_structural_helpers`.
+    """
+    import re
+
+    car = _strip_js_comments(
+        (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text(encoding="utf-8")
+    )
+
+    # The non-sensor reads survive as raw `Number(...)` coercions.
+    for survivor in (
+        "Number(e.car_battery_capacity_kwh)",  # config scalar
+        "Number(m[1])",                        # regex capture
+        "Number(hourSel?.value",               # DOM value read
+        "Number(el.getAttribute('data-pct'))",  # DOM attribute read
+    ):
+        assert survivor in car, (
+            f"qs-car-card.js (QS-235 AC6 negative half): the non-sensor "
+            f"read `{survivor}` must survive untouched — AC6 only swaps "
+            f"guard-shaped SENSOR reads to `_safeNumber`."
+        )
+
+    # And none of them is wrapped in `_safeNumber` (which takes a sensor
+    # object, not a scalar / regex match / DOM value).
+    for forbidden in (
+        "_safeNumber(e.car_battery_capacity_kwh",
+        "_safeNumber(configBatteryCapacity",
+        "_safeNumber(m[1]",
+        "_safeNumber(hourSel",
+        "_safeNumber(minSel",
+        "_safeNumber(el.getAttribute",
+    ):
+        assert forbidden not in car, (
+            f"qs-car-card.js (QS-235 AC6 negative half): `{forbidden}…)` "
+            f"must NOT exist — `_safeNumber` expects a sensor `{{state}}` "
+            f"object, not a scalar/regex/DOM read."
+        )
+
+    # Positive corroboration: every `_safeNumber` call in the car targets
+    # a sensor object (`sPower` / `sCurrentInputedEnergy`), nothing else.
+    safe_args = re.findall(r"_safeNumber\(\s*([A-Za-z_][\w.]*)", car)
+    assert safe_args, "qs-car-card.js (QS-235 AC6): expected `_safeNumber` calls in the car."
+    for arg in safe_args:
+        assert arg in ("sPower", "sCurrentInputedEnergy"), (
+            f"qs-car-card.js (QS-235 AC6): `_safeNumber` should only wrap "
+            f"sensor objects (`sPower` / `sCurrentInputedEnergy`); got "
+            f"`{arg}`."
+        )
+
+
 def test_car_card_handle_label_round_trip_invariant():
     """QS-235 AC9 — the car's ring handle shows the TRUE (unclamped)
     target via `_buildRingHTML`'s `handleLabel`, while the handle
@@ -4548,6 +4608,59 @@ def test_car_card_handle_label_round_trip_invariant():
     assert re.search(r"handlePos\s*=\s*polar\([^)]*handleDeg", car), (
         "qs-car-card.js (QS-235 AC9): `handlePos` must derive from the "
         "clamped `handleDeg` via `polar(…, handleDeg)`."
+    )
+
+
+def test_car_card_faulted_dash_uses_fault_gradient():
+    """QS-235 review-fix #01 SF1 — a car that is faulted WHILE still
+    drawing current must render the moving dashed arc with the SAME
+    fault gradient as the static progress arc (pre-refactor behavior:
+    `stroke="url(#${isFaulted ? gradFaultId : gradChargeId})"`).
+
+    The shared `_buildRingHTML` dash stroke is driven by an `animGradId`
+    param that defaults to `gradRunningId` (so the four duration callers
+    stay byte-identical). The car passes the fault-aware
+    `animGradId: isFaulted ? gradFaultId : gradChargeId`, which restores
+    the dash↔static-arc agreement AND keeps `gradFaultId` referenced by
+    a stroke (not just emitted as a dead `<linearGradient>` in
+    `extraDefs`).
+    """
+    import re
+
+    base = _strip_js_comments(
+        (COMPONENT_ROOT / "ui" / "resources" / "shared" / "qs-card-base.js").read_text(encoding="utf-8")
+    )
+    car = _strip_js_comments(
+        (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text(encoding="utf-8")
+    )
+
+    # The shared dash anim stroke is parameterised by `animGradId`,
+    # defaulting to `gradRunningId` (duration cards unchanged).
+    assert 'stroke="url(#${animGradId})"' in base, (
+        "qs-card-base.js (SF1): `_buildRingHTML`'s dash anim `<path>` "
+        'must use `stroke="url(#${animGradId})"` so the dash gradient '
+        "is caller-selectable."
+    )
+    assert re.search(r"animGradId\s*=\s*gradRunningId", base), (
+        "qs-card-base.js (SF1): `animGradId` must default to "
+        "`gradRunningId` so the duration callers stay byte-identical."
+    )
+
+    # The car drives `animGradId` off the fault state, matching the
+    # static arc's `activeGradId` selection (which also uses gradFaultId
+    # when faulted).
+    assert re.search(
+        r"animGradId:\s*isFaulted\s*\?\s*gradFaultId\s*:\s*gradChargeId",
+        car,
+    ), (
+        "qs-car-card.js (SF1): the `_buildRingHTML` call must pass "
+        "`animGradId: isFaulted ? gradFaultId : gradChargeId` so the "
+        "faulted-while-charging dash matches the static fault arc."
+    )
+    # `gradFaultId` is referenced by a stroke selector, not orphaned.
+    assert "gradFaultId" in car, (
+        "qs-car-card.js (SF1): `gradFaultId` must remain referenced "
+        "(static arc + fault-aware dash), not a dead gradient."
     )
 
 
@@ -7811,25 +7924,34 @@ def test_wire_target_handle_awaits_commit_hook_before_setnumber():
     src = _strip_js_comments(
         (COMPONENT_ROOT / "ui" / "resources" / "shared" / "qs-card-base.js").read_text(encoding="utf-8")
     )
-    assert "await onBeforeCommit(" in src, (
+    # QS-235 review-fix #01 SF3 — scope the membership + ordering checks
+    # to the `_wireTargetHandle` BODY (not the whole file), so a matching
+    # token elsewhere in `qs-card-base.js` can't turn this into a false
+    # pass/fail and the ordering pin actually tracks this method.
+    body = _extract_js_function_body(src, r"_wireTargetHandle\s*\([^)]*\)\s*\{")
+    assert body is not None, (
+        "qs-card-base.js: `_wireTargetHandle` method body must be extractable for SF3 inspection."
+    )
+
+    assert "await onBeforeCommit(" in body, (
         "S1: `_wireTargetHandle` must `await onBeforeCommit(...)` (pool mode-select)."
     )
     # QS-235 AC1 — the commit-override hook is awaited.
-    assert "await onCommit(" in src, (
+    assert "await onCommit(" in body, (
         "QS-235 AC1: `_wireTargetHandle` must support an `await "
         "onCommit(...)` commit override (the car commits via `_select`)."
     )
     # The default `_setNumber` write survives for the duration cards.
-    assert "await this._setNumber(" in src, (
+    assert "await this._setNumber(" in body, (
         "QS-235 AC1: the default (no-`onCommit`) branch must still "
         "`await this._setNumber(entityId, ...)` so the duration cards "
         "are unchanged."
     )
     # Ordering: onBeforeCommit fires before BOTH the override commit and
     # the default `_setNumber` write.
-    before_idx = src.index("await onBeforeCommit(")
-    commit_idx = src.index("await onCommit(")
-    setnum_idx = src.index("await this._setNumber(")
+    before_idx = body.index("await onBeforeCommit(")
+    commit_idx = body.index("await onCommit(")
+    setnum_idx = body.index("await this._setNumber(")
     assert before_idx < commit_idx and before_idx < setnum_idx, (
         "S1: `onBeforeCommit` (mode-select) must run BEFORE the commit "
         "(override or the default `_setNumber` write) to preserve the "

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -3475,24 +3475,19 @@ def test_car_card_electron_soup_clip_group_and_two_waves():
     group contains exactly two wave `<path>` elements sharing one `d`
     placeholder, differing only in fill (IDLE_SOUP_COLOR vs
     CHARGE_SOUP_COLOR) and opacity. Sparkle and lightning layers
-    follow the waves in source order. The grain filter is declared in
-    `<defs>` with `<feTurbulence type="fractalNoise" …>` and BOTH
-    waves carry `filter="url(#${grainFilterId})"`. The issue's
+    follow the waves in source order. The issue's
     "do not superpose 3 layer of sin" is pinned negatively: NO
     `wave1_*` / `wave2_*` ids.
+
+    QS-235 AC7: the `feTurbulence` grain filter that previously
+    decorated both wave fills has been removed; its dedicated negative
+    guard is `test_car_card_grain_filter_removed`. This test no longer
+    asserts the grain filter — only the surviving two-wave structure.
     """
     import re
 
     source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
     executable = _strip_js_comments(source)
-
-    # Grain filter in <defs> declares feTurbulence type="fractalNoise".
-    assert re.search(r'<filter\s+id="\$\{grainFilterId\}"', source), (
-        'qs-car-card.js: missing `<filter id="${grainFilterId}">` declaration in <defs>.'
-    )
-    assert '<feTurbulence type="fractalNoise"' in source, (
-        'qs-car-card.js: grain filter must use `<feTurbulence type="fractalNoise" …>` (AC-1 #1).'
-    )
 
     # The two wave paths share the clip group anchor.
     clip_g_anchor = '<g clip-path="url(#${electronClipId})"'
@@ -3505,33 +3500,34 @@ def test_car_card_electron_soup_clip_group_and_two_waves():
         'qs-car-card.js: missing `<path id="electron_wave_charge">` (AC-1 #2).'
     )
 
-    # Both waves share the same `d` placeholder (initialWavePath) and
-    # carry filter="url(#${grainFilterId})".
+    # Both waves share the same `d` placeholder (initialWavePath),
+    # differing only in fill + opacity. QS-235 AC7 dropped the trailing
+    # `filter="url(#${grainFilterId})"` token from each.
     idle_wave_re = re.compile(
         r'<path\s+id="electron_wave_idle"\s+'
         r'd="\$\{initialWavePath\}"\s+'
         r'fill="\$\{IDLE_SOUP_COLOR\}"\s+'
         r'opacity="\$\{initialIdleOpacity\}"\s+'
-        r'filter="url\(#\$\{grainFilterId\}\)"',
+        r'pointer-events="none"',
     )
     assert idle_wave_re.search(source), (
         "qs-car-card.js: `electron_wave_idle` <path> must carry "
         '`d="${initialWavePath}" fill="${IDLE_SOUP_COLOR}" '
-        'opacity="${initialIdleOpacity}" '
-        'filter="url(#${grainFilterId})"` (AC-1 #2/#3).'
+        'opacity="${initialIdleOpacity}" pointer-events="none"` '
+        "(AC-1 #2; grain filter removed per QS-235 AC7)."
     )
     charge_wave_re = re.compile(
         r'<path\s+id="electron_wave_charge"\s+'
         r'd="\$\{initialWavePath\}"\s+'
         r'fill="\$\{CHARGE_SOUP_COLOR\}"\s+'
         r'opacity="\$\{initialChargeOpacity\}"\s+'
-        r'filter="url\(#\$\{grainFilterId\}\)"',
+        r'pointer-events="none"',
     )
     assert charge_wave_re.search(source), (
         "qs-car-card.js: `electron_wave_charge` <path> must carry "
         '`d="${initialWavePath}" fill="${CHARGE_SOUP_COLOR}" '
-        'opacity="${initialChargeOpacity}" '
-        'filter="url(#${grainFilterId})"` (AC-1 #2/#3).'
+        'opacity="${initialChargeOpacity}" pointer-events="none"` '
+        "(AC-1 #2; grain filter removed per QS-235 AC7)."
     )
 
     # Sparkle layer follows waves; lightning layer follows sparkles.
@@ -3890,61 +3886,46 @@ def test_car_card_lightning_life_and_glow_filter():
     )
 
 
-def test_car_card_grain_filter_uses_feturbulence_on_wave_fill():
-    """QS-232 AC-7: the grain filter declares `<feTurbulence
-    type="fractalNoise" baseFrequency="0.9" numOctaves="2" …>` in
-    `<defs>` and BOTH wave `<path>` elements carry
-    `filter="url(#${grainFilterId})"`. No separate overlay `<rect>`
-    carries the grain filter — the grain composites within the wave
-    shape via `feComposite operator="in"`.
+def test_car_card_grain_filter_removed():
+    """QS-235 AC7 — the `feTurbulence` grain filter is removed from the
+    car card. The `<filter id="${grainFilterId}">` def, both
+    `filter="url(#${grainFilterId})"` wave references, the
+    `this._grainFilterId` allocation, AND the stale grain comments are
+    all gone. The negative guard is scoped to the car source ONLY
+    (no other card ever carried grain). The sparkle / lightning / wave
+    motion layers are untouched — those positive pins live in their own
+    tests (`test_car_card_electron_soup_clip_group_and_two_waves`,
+    `test_car_card_sparkle_*`, `test_car_card_lightning_*`).
     """
-    import re
-
     source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
-    executable = _strip_js_comments(source)
 
-    # Grain filter declaration substring.
-    assert ('<feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2"') in source, (
-        "qs-car-card.js (AC-7): grain filter must declare "
-        '`<feTurbulence type="fractalNoise" baseFrequency="0.9" '
-        'numOctaves="2" …>` (substring assert; `seed`/`result` not '
-        "pinned)."
-    )
-
-    # The composite step that masks turbulence to the wave fill.
-    assert "<feComposite" in source and 'operator="in"' in source, (
-        "qs-car-card.js (AC-7): grain filter must contain a "
-        '`<feComposite … operator="in" …>` step so the grain is '
-        "masked to the wave's filled shape (water region only)."
-    )
-
-    # Both waves reference filter="url(#${grainFilterId})".
-    idle_filter = re.compile(
-        r'id="electron_wave_idle"[^>]*filter="url\(#\$\{grainFilterId\}\)"',
-        re.DOTALL,
-    )
-    charge_filter = re.compile(
-        r'id="electron_wave_charge"[^>]*filter="url\(#\$\{grainFilterId\}\)"',
-        re.DOTALL,
-    )
-    assert idle_filter.search(source), (
-        'qs-car-card.js (AC-7): `electron_wave_idle` must carry `filter="url(#${grainFilterId})"`.'
-    )
-    assert charge_filter.search(source), (
-        'qs-car-card.js (AC-7): `electron_wave_charge` must carry `filter="url(#${grainFilterId})"`.'
+    # AC7: every grain artifact — code AND stale comments — is gone.
+    for forbidden in (
+        "feTurbulence",
+        "fractalNoise",
+        "feComposite",
+        "grainFilterId",
+        "_grainFilterId",
+        "grainFilter",
+    ):
+        assert forbidden not in source, (
+            f"qs-car-card.js (QS-235 AC7): `{forbidden}` must be removed "
+            f"along with the feTurbulence grain filter (def + both wave "
+            f"refs + per-instance id allocation + stale comments)."
+        )
+    # AC7 also mandates removing the stale grain comments, so the bare
+    # word `grain` no longer appears anywhere in the source.
+    assert "grain" not in source.lower(), (
+        "qs-car-card.js (QS-235 AC7): no mention of `grain` should "
+        "remain — the filter is gone and the stale comments are removed."
     )
 
-    # Negative: no <rect> immediately preceding the sparkle layer
-    # carries the grain filter.
-    forbidden = re.compile(
-        r'<rect[^>]*filter="url\(#\$\{grainFilterId\}\)"[^>]*/?>\s*'
-        r'<g\s+id="\$\{sparkleLayerId\}"',
-        re.DOTALL,
+    # The two wave paths survive — just without the grain filter.
+    assert 'id="electron_wave_idle"' in source, (
+        "qs-car-card.js (QS-235 AC7): the idle wave must survive the grain removal."
     )
-    assert not forbidden.search(source), (
-        "qs-car-card.js (AC-7): no separate `<rect>` overlay should "
-        "carry the grain filter — grain composites within the wave "
-        'shape via `feComposite operator="in"` (D7).'
+    assert 'id="electron_wave_charge"' in source, (
+        "qs-car-card.js (QS-235 AC7): the charge wave must survive the grain removal."
     )
 
 
@@ -4100,12 +4081,11 @@ def test_car_card_continuous_raf_from_connected_callback():
 
 def test_car_card_reset_dom_refs_helper_and_disconnect_teardown():
     """QS-232 AC-10: `_resetDomRefs()` instance method exists. It
-    nulls `_waveEls`, `_grainFilterEl`, `_sparkleLayerEl`,
-    `_lightningLayerEl` AND clears `_sparkles = []` and
-    `_lightningBolts = []`. It is called from `_invalidateAnimCache()`
-    AND from the post-`innerHTML` cleanup in `_render()` (≥ 2 call
-    sites). `disconnectedCallback()` tears down sparkle AND lightning
-    DOM with optional-chaining shape.
+    nulls `_waveEls`, `_sparkleLayerEl`, `_lightningLayerEl` AND clears
+    `_sparkles = []` and `_lightningBolts = []`. It is called from
+    `_invalidateAnimCache()` AND from the post-`innerHTML` cleanup in
+    `_render()` (≥ 2 call sites). `disconnectedCallback()` tears down
+    sparkle AND lightning DOM with optional-chaining shape.
     """
     import re
 
@@ -4115,9 +4095,10 @@ def test_car_card_reset_dom_refs_helper_and_disconnect_teardown():
     body = _extract_js_function_body(executable, r"_resetDomRefs\s*\(\s*\)\s*")
     assert body is not None, "qs-car-card.js (AC-10): `_resetDomRefs()` method not found."
 
-    # Review-fix #01 #14: `_grainFilterEl` was a dead field — no
-    # code path ever read or lazily-resolved it. Removed from
-    # `_resetDomRefs()` to match the actual DOM-ref surface area.
+    # Review-fix #01 #14: `_grainFilterEl` was a dead field — no code
+    # path ever read or lazily-resolved it (and QS-235 AC7 removed the
+    # grain filter entirely). `_resetDomRefs()` tracks only the live
+    # DOM-ref surface area.
     for assignment_re in (
         r"this\._waveEls\s*=\s*null",
         r"this\._sparkleLayerEl\s*=\s*null",
@@ -4175,15 +4156,18 @@ def test_car_card_reset_dom_refs_helper_and_disconnect_teardown():
 
 def test_car_card_per_instance_unique_svg_ids():
     """QS-232 AC-11: `QsCarCard._nextClipId` static counter is bumped
-    inside `if (!this._electronClipId)`. Four per-instance ID fields
+    inside `if (!this._electronClipId)`. Three per-instance ID fields
     are derived from the same `uid`: `_electronClipId`,
-    `_sparkleLayerId`, `_lightningLayerId`, `_grainFilterId`. All
-    follow the `car_<role>_${uid}` naming convention.
+    `_sparkleLayerId`, `_lightningLayerId`. All follow the
+    `car_<role>_${uid}` naming convention.
 
     Review-fix #02 user follow-up #2: `_lightningFilterId` was
     removed alongside the lightning glow filter — the new sharp
     purple bolt has no `<filter>` element, so the per-instance
     filter ID is unused.
+
+    QS-235 AC7: `_grainFilterId` was removed alongside the
+    `feTurbulence` grain filter, dropping the field count from 4 → 3.
     """
     import re
 
@@ -4205,14 +4189,14 @@ def test_car_card_per_instance_unique_svg_ids():
         "once."
     )
 
-    # Four ID fields, all `car_<role>_${uid}`-shaped. The
+    # Three ID fields, all `car_<role>_${uid}`-shaped. The
     # `_lightningFilterId` was removed in review-fix #02 follow-up
-    # alongside the lightning glow filter.
+    # alongside the lightning glow filter; `_grainFilterId` was
+    # removed in QS-235 AC7 alongside the feTurbulence grain filter.
     id_assignments = {
         "_electronClipId": "car_eClip_",
         "_sparkleLayerId": "car_sparkLayer_",
         "_lightningLayerId": "car_lightningLayer_",
-        "_grainFilterId": "car_grainFilter_",
     }
     for field, prefix in id_assignments.items():
         pat = re.compile(
@@ -4250,9 +4234,13 @@ def test_dashboard_and_cards_doc_pins_qs_232_paragraph():
     H2 header. The section body mentions the key concepts:
     single-layer wave, dual-opacity cross-fade, sparkle palette switch
     + [1500W, 22000W] power-scaling, lightning bolt 3-segment path +
-    glow + spawn interval, feTurbulence grain on wave fill, degraded
-    CSS filter, continuous RAF, three carve covers (D17). The
-    `last_verified` field is present and well-formed.
+    glow + spawn interval, degraded CSS filter, continuous RAF, three
+    carve covers (D17). The `last_verified` field is present and
+    well-formed.
+
+    QS-235 AC7: the `feTurbulence` grain filter was removed, so the
+    `feturbulence` / `grain` key-concept pins are dropped here (the
+    grain's absence is pinned by `test_car_card_grain_filter_removed`).
     """
     doc_path = Path(__file__).parent.parent / "docs" / "agents" / "concepts" / "dashboard-and-cards.md"
     doc = doc_path.read_text(encoding="utf-8")
@@ -4294,8 +4282,6 @@ def test_dashboard_and_cards_doc_pins_qs_232_paragraph():
         ("electron", "soup electron-soup concept"),
         ("sparkle", "sparkle palette switch"),
         ("lightning", "lightning bolt subsystem"),
-        ("feturbulence", "feTurbulence grain filter"),
-        ("grain", "grain on wave fill"),
         ("degraded", "degraded CSS filter"),
         ("continuous", "continuous-RAF model"),
         ("1500", "[1500W, 22000W] power-scaling range (lower)"),

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -4312,27 +4312,53 @@ def test_dashboard_and_cards_doc_pins_qs_232_paragraph():
 
 
 def test_car_card_inside_disc_button_carve_covers():
-    """QS-232 AC-14: three inside-disc button carve-out covers
-    (sun-btn, rabbit-btn, time-btn) extend QS-217's `<circle>` cover
-    pattern from one button to three on the car card. Nine module-
-    level constants (3 × {CX, CY, R}) are present (NAMES pinned, not
-    values — user-tunable per QS-217 precedent). Three `<circle
-    id="…_cover" fill="var(--card-background-color)"
-    pointer-events="none" />` elements appear in source AFTER the
-    clipped `</g>` AND BEFORE the `<path d="${bgPath}"` line. Each is
-    gated on its corresponding render predicate (`swPriority`,
-    `e.force_now`, `(tNext && e.schedule)`).
+    """QS-235 AC3 — the car's three inside-disc carve covers (sun /
+    rabbit / time) are emitted via the shared `_ringCarveCover` helper
+    (replacing the QS-232 inline `<circle id="…_cover">` literals):
+
+    - the bottom-center `sun_btn_cover` uses the SHARED
+      `RING_BOTTOM_CARVE_CX/CY/R` constants (the same set the duration
+      cards use for `override_btn_cover`); the per-card `SUN_BTN_CARVE_*`
+      duplicate is REMOVED (negative pin);
+    - `rabbit_btn_cover` / `time_btn_cover` reuse the helper with the
+      car-local `RABBIT_BTN_CARVE_*` / `TIME_BTN_CARVE_*` geometry
+      (those constants survive — NAMES pinned, values user-tunable);
+    - each call carries its render predicate via `show:` (`swPriority`,
+      `e.force_now`, `(tNext && e.schedule)`), and the rendered cover
+      ids are preserved;
+    - the three calls appear AFTER the clipped `</g>` and BEFORE
+      `${ringMarkup}` (so the covers paint on top of the soup, under
+      the ring built by `_buildRingHTML`).
     """
     import re
 
     source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
     executable = _strip_js_comments(source)
 
-    # Nine constants — NAMES only (values are user-tunable).
+    # The car imports the shared bottom-center carve constants.
+    assert (
+        re.search(
+            r"import\s*\{[^}]*RING_BOTTOM_CARVE_CX[^}]*RING_BOTTOM_CARVE_CY[^}]*RING_BOTTOM_CARVE_R[^}]*\}\s*from\s*['\"]\./shared/qs-card-base\.js['\"]",
+            source,
+            re.DOTALL,
+        )
+        is not None
+    ), (
+        "qs-car-card.js (QS-235 AC3): must import `RING_BOTTOM_CARVE_CX, "
+        "RING_BOTTOM_CARVE_CY, RING_BOTTOM_CARVE_R` from "
+        "`./shared/qs-card-base.js` (shared bottom-center carve geometry)."
+    )
+
+    # The per-card SUN_BTN_CARVE_* duplicate is removed.
+    for legacy_const in ("SUN_BTN_CARVE_CX", "SUN_BTN_CARVE_CY", "SUN_BTN_CARVE_R"):
+        assert re.search(rf"const\s+{legacy_const}\s*=", executable) is None, (
+            f"qs-car-card.js (QS-235 AC3): the per-card `const "
+            f"{legacy_const} = …` must be removed — the bottom-center "
+            f"sun cover now uses the shared `RING_BOTTOM_CARVE_*` set."
+        )
+
+    # The car-local rabbit/time carve constants survive (NAMES only).
     for const_name in (
-        "SUN_BTN_CARVE_CX",
-        "SUN_BTN_CARVE_CY",
-        "SUN_BTN_CARVE_R",
         "RABBIT_BTN_CARVE_CX",
         "RABBIT_BTN_CARVE_CY",
         "RABBIT_BTN_CARVE_R",
@@ -4341,70 +4367,54 @@ def test_car_card_inside_disc_button_carve_covers():
         "TIME_BTN_CARVE_R",
     ):
         assert re.search(rf"const\s+{const_name}\s*=\s*\d+\b", executable), (
-            f"qs-car-card.js (AC-14): missing module-level "
-            f"`const {const_name} = <integer>;` declaration. Values "
-            f"are user-tunable per QS-217 precedent — only the NAME "
-            f"is pinned."
+            f"qs-car-card.js (QS-235 AC3): missing module-level "
+            f"`const {const_name} = <integer>;` (car-local rabbit/time "
+            f"carve geometry; only the NAME is pinned)."
         )
 
-    # The three cover circles, each gated on its render predicate.
-    sun_cover_re = re.compile(
-        r"swPriority\s*\?\s*`?\s*"
-        r'<circle\s+id="sun_btn_cover"\s+'
-        r'cx="\$\{SUN_BTN_CARVE_CX\}"\s+'
-        r'cy="\$\{SUN_BTN_CARVE_CY\}"\s+'
-        r'r="\$\{SUN_BTN_CARVE_R\}"\s+'
-        r'fill="var\(--card-background-color\)"\s+'
-        r'pointer-events="none"\s*/>',
-    )
-    assert sun_cover_re.search(source), (
-        "qs-car-card.js (AC-14): missing the `sun_btn_cover` <circle> element gated on `swPriority`."
-    )
-    rabbit_cover_re = re.compile(
-        r"e\.force_now\s*\?\s*`?\s*"
-        r'<circle\s+id="rabbit_btn_cover"\s+'
-        r'cx="\$\{RABBIT_BTN_CARVE_CX\}"\s+'
-        r'cy="\$\{RABBIT_BTN_CARVE_CY\}"\s+'
-        r'r="\$\{RABBIT_BTN_CARVE_R\}"\s+'
-        r'fill="var\(--card-background-color\)"\s+'
-        r'pointer-events="none"\s*/>',
-    )
-    assert rabbit_cover_re.search(source), (
-        "qs-car-card.js (AC-14): missing the `rabbit_btn_cover` <circle> element gated on `e.force_now`."
-    )
-    time_cover_re = re.compile(
-        r"\(\s*tNext\s*&&\s*e\.schedule\s*\)\s*\?\s*`?\s*"
-        r'<circle\s+id="time_btn_cover"\s+'
-        r'cx="\$\{TIME_BTN_CARVE_CX\}"\s+'
-        r'cy="\$\{TIME_BTN_CARVE_CY\}"\s+'
-        r'r="\$\{TIME_BTN_CARVE_R\}"\s+'
-        r'fill="var\(--card-background-color\)"\s+'
-        r'pointer-events="none"\s*/>',
-    )
-    assert time_cover_re.search(source), (
-        "qs-car-card.js (AC-14): missing the `time_btn_cover` <circle> element gated on `(tNext && e.schedule)`."
-    )
+    # Three `_ringCarveCover` calls, each with the right geometry + id +
+    # render predicate.
+    covers = {
+        "sun_btn_cover": ("RING_BOTTOM_CARVE_CX", "RING_BOTTOM_CARVE_CY", "RING_BOTTOM_CARVE_R", "swPriority"),
+        "rabbit_btn_cover": ("RABBIT_BTN_CARVE_CX", "RABBIT_BTN_CARVE_CY", "RABBIT_BTN_CARVE_R", "e.force_now"),
+        "time_btn_cover": ("TIME_BTN_CARVE_CX", "TIME_BTN_CARVE_CY", "TIME_BTN_CARVE_R", "(tNext && e.schedule)"),
+    }
+    for cover_id, (cx, cy, r, show) in covers.items():
+        call_m = re.search(
+            rf"this\._ringCarveCover\(\s*\{{([^}}]*id:\s*'{re.escape(cover_id)}'[^}}]*)\}}\s*\)",
+            source,
+        )
+        assert call_m is not None, (
+            f"qs-car-card.js (QS-235 AC3): missing a "
+            f"`this._ringCarveCover({{ … id: '{cover_id}' … }})` call."
+        )
+        norm = re.sub(r"\s+", " ", call_m.group(1))
+        for token in (f"cx: {cx}", f"cy: {cy}", f"r: {r}", f"show: {show}"):
+            assert token in norm, (
+                f"qs-car-card.js (QS-235 AC3): the `_ringCarveCover` "
+                f"call for `{cover_id}` must pass `{token}`. Got: {norm.strip()}"
+            )
 
-    # Source order: covers must appear AFTER the clipped </g> AND
-    # BEFORE `<path d="${bgPath}"` so they paint on top of the soup
-    # and under the outer ring.
-    sun_idx = source.find('id="sun_btn_cover"')
-    rabbit_idx = source.find('id="rabbit_btn_cover"')
-    time_idx = source.find('id="time_btn_cover"')
-    bg_idx = source.find('<path d="${bgPath}"')
-    # Find the OUTER closing </g> of the clipped group. Review-fix
-    # #01 #11: the original `find("</g>", clip_g_idx)` returned the
-    # FIRST nested `</g>` (sparkle layer or lightning layer), so a
-    # misplaced cover inserted between inner layers would falsely
-    # satisfy the ordering check. Use `rfind` scoped to the
-    # [clip_g_idx, bg_idx] window to locate the OUTER close.
+    # Source order: cover calls must appear AFTER the clipped </g> AND
+    # BEFORE `${ringMarkup}` (so they paint on top of the soup and under
+    # the ring emitted by `_buildRingHTML`).
+    sun_idx = source.find("id: 'sun_btn_cover'")
+    rabbit_idx = source.find("id: 'rabbit_btn_cover'")
+    time_idx = source.find("id: 'time_btn_cover'")
+    # `${ringMarkup}` also appears in a code comment above the template;
+    # `rfind` selects the actual SVG injection point (the last one).
+    ringmarkup_idx = source.rfind("${ringMarkup}")
+    assert ringmarkup_idx != -1, "qs-car-card.js (QS-235 AC2): missing the `${ringMarkup}` injection point."
+    # Locate the OUTER closing </g> of the clipped group via `rfind`
+    # scoped to the [clip_g_idx, ringmarkup_idx] window (so a nested
+    # sparkle/lightning `</g>` can't falsely satisfy the order check).
     clip_g_idx = source.find('<g clip-path="url(#${electronClipId})"')
-    assert clip_g_idx != -1, "qs-car-card.js (AC-14): missing the electron-soup clipped group anchor."
-    clip_g_close_idx = source.rfind("</g>", clip_g_idx, bg_idx)
+    assert clip_g_idx != -1, "qs-car-card.js (QS-235 AC2): missing the electron-soup clipped group anchor."
+    clip_g_close_idx = source.rfind("</g>", clip_g_idx, ringmarkup_idx)
     assert clip_g_close_idx != -1, (
-        "qs-car-card.js (AC-14): cannot find the outer closing "
-        "`</g>` of the electron-soup clipped group within the "
-        "expected [clip_g_idx, bg_idx] window."
+        "qs-car-card.js (QS-235): cannot find the outer closing `</g>` "
+        "of the electron-soup clipped group within the expected "
+        "[clip_g_idx, ringmarkup_idx] window."
     )
 
     for cover_name, cover_idx in (
@@ -4412,13 +4422,133 @@ def test_car_card_inside_disc_button_carve_covers():
         ("rabbit_btn_cover", rabbit_idx),
         ("time_btn_cover", time_idx),
     ):
-        assert cover_idx != -1, f"qs-car-card.js (AC-14): missing the `{cover_name}` element in source."
-        assert clip_g_close_idx < cover_idx < bg_idx, (
-            f"qs-car-card.js (AC-14): `{cover_name}` must appear "
-            f"AFTER the clipped `</g>` (idx {clip_g_close_idx}) AND "
-            f'BEFORE the `<path d="${{bgPath}}"` line '
-            f"(idx {bg_idx}). Got cover idx {cover_idx}."
+        assert cover_idx != -1, f"qs-car-card.js (QS-235 AC3): missing the `{cover_name}` cover call in source."
+        assert clip_g_close_idx < cover_idx < ringmarkup_idx, (
+            f"qs-car-card.js (QS-235 AC3): the `{cover_name}` cover call "
+            f"must appear AFTER the clipped `</g>` (idx {clip_g_close_idx}) "
+            f"AND BEFORE `${{ringMarkup}}` (idx {ringmarkup_idx}). Got "
+            f"cover idx {cover_idx}."
         )
+
+
+def test_car_card_adopts_shared_structural_helpers():
+    """QS-235 AC9 — the car card consumes the shared structural helpers
+    (the commonalization) instead of reimplementing them inline:
+
+    - `_buildRingHTML` (AC2 ring builder; car passes `animPathId:
+      'charge_anim'` + `extraDefs`),
+    - `_wireTargetHandle` (AC1 drag; car passes `onCommit` /
+      `pctToValue` / `valueToPct` / `onDragMove`),
+    - `_ringCarveCover` (AC3 covers; geometry pinned in
+      `test_car_card_inside_disc_button_carve_covers`),
+    - `_wireGreenButton` (AC4 solar-priority),
+    - `_wireResetButton` (AC4 reset),
+    - `_wireTimePicker` (AC5 finish-time; car passes `onAfterCommit` +
+      `resetButton`),
+    - `_safeNumber` (AC6 guard-shaped sensor reads).
+
+    The ~120-LOC inline pointer-drag block is gone — pinned negatively
+    by the absence of its `createSVGPoint()` / `_targetDragValue` (the
+    drag state now lives in the shared `_wireTargetHandle`). The
+    single-definition rule (`test_no_duplicate_card_method_definitions`)
+    proves none of the helpers are re-defined here.
+    """
+    car = _strip_js_comments(
+        (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text(encoding="utf-8")
+    )
+
+    for call in (
+        "this._buildRingHTML(",
+        "this._wireTargetHandle(",
+        "this._ringCarveCover(",
+        "this._wireGreenButton(",
+        "this._wireResetButton(",
+        "this._wireTimePicker(",
+        "this._safeNumber(",
+    ):
+        assert call in car, (
+            f"qs-car-card.js (QS-235 AC9): must call `{call}…)` — the car "
+            f"adopts the shared helper rather than reimplementing it inline."
+        )
+
+    # AC2 — car-specific wiring params on the `_buildRingHTML` call.
+    assert "animPathId: 'charge_anim'" in car, (
+        "qs-car-card.js (QS-235 AC2): `_buildRingHTML` call must pass "
+        "`animPathId: 'charge_anim'` (the car's dashed-arc id)."
+    )
+    assert "extraDefs" in car, (
+        "qs-car-card.js (QS-235 AC2): `_buildRingHTML` call must pass "
+        "`extraDefs` (the car's disabled/fault/stale gradients + clipPath)."
+    )
+
+    # AC1 — the four drag callbacks on the `_wireTargetHandle` call.
+    for param in ("onCommit:", "pctToValue:", "valueToPct:", "onDragMove:"):
+        assert param in car, (
+            f"qs-car-card.js (QS-235 AC1): `_wireTargetHandle` call must "
+            f"pass `{param}` (the car's select-commit / %↔kWh mapping / "
+            f"live-label callbacks)."
+        )
+
+    # AC5 — the finish-time generalization params.
+    for param in ("onAfterCommit:", "resetButton:"):
+        assert param in car, (
+            f"qs-car-card.js (QS-235 AC5): `_wireTimePicker` call must "
+            f"pass `{param}` (the car's schedule-press / reset-button)."
+        )
+
+    # AC1 — the inline pointer-drag block is gone (the helper owns it).
+    assert "createSVGPoint()" not in car, (
+        "qs-car-card.js (QS-235 AC1): the inline pointer-drag block must "
+        "be removed — `createSVGPoint()` belongs to the shared "
+        "`_wireTargetHandle` now."
+    )
+    assert "_targetDragValue" not in car, (
+        "qs-car-card.js (QS-235 AC1): the inline drag state "
+        "`_targetDragValue` must be gone — it lives in the shared "
+        "`_wireTargetHandle`."
+    )
+
+
+def test_car_card_handle_label_round_trip_invariant():
+    """QS-235 AC9 — the car's ring handle shows the TRUE (unclamped)
+    target via `_buildRingHTML`'s `handleLabel`, while the handle
+    POSITION is clamped via `pctToDeg`. So an out-of-range target pins
+    the handle at the ring top but the label still reads the real
+    number (the same pin-at-top-but-number-correct invariant the
+    duration cards get from `pctToHours(handlePct)`). The car supplies
+    energy-/percent-mode label text instead of hours.
+    """
+    import re
+
+    car = _strip_js_comments(
+        (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text(encoding="utf-8")
+    )
+
+    # The handle TEXT label is the true target (mode-switched), passed
+    # via `_buildRingHTML`'s `handleLabel` param — NOT a clamped %.
+    assert re.search(r"handleLabel:\s*useEnergyMode\s*\?", car), (
+        "qs-car-card.js (QS-235 AC9): `_buildRingHTML` must receive a "
+        "mode-switched `handleLabel: useEnergyMode ? … : …`."
+    )
+    assert "parseTargetEnergy(target)" in car, (
+        "qs-car-card.js (QS-235 AC9): the energy-mode handle label must "
+        "show the parsed true target energy (`parseTargetEnergy(target)`)."
+    )
+    assert "this._fmt(targetPct ?? soc)" in car, (
+        "qs-car-card.js (QS-235 AC9): the percent-mode handle label must "
+        "show the true target percent (`this._fmt(targetPct ?? soc)`)."
+    )
+
+    # The handle POSITION is clamped via `pctToDeg` (which clamps the
+    # percentage to [0,100]); the position derives from that angle.
+    assert re.search(r"handleDeg\s*=\s*pctToDeg\(\s*handlePct", car), (
+        "qs-car-card.js (QS-235 AC9): the handle angle must be "
+        "`handleDeg = pctToDeg(handlePct, …)` (position clamped to [0,100])."
+    )
+    assert re.search(r"handlePos\s*=\s*polar\([^)]*handleDeg", car), (
+        "qs-car-card.js (QS-235 AC9): `handlePos` must derive from the "
+        "clamped `handleDeg` via `polar(…, handleDeg)`."
+    )
 
 
 # ============================================================================
@@ -4526,43 +4656,37 @@ def test_car_card_setConfig_primes_animation_state():
 
 
 def test_car_card_time_btn_render_and_cover_gates_match():
-    """QS-232 review-fix #01 #6: `time_btn` and `time_btn_cover`
-    must share the same render gate. The original implementation
-    had the button render unconditionally inside the mini-grid while
-    the cover was gated on `(tNext && e.schedule)` — when
-    `chargeTime` was set but `e.schedule` wasn't, the button face
-    drew over un-carved soup. This pin extracts both predicates
-    and asserts string equality.
+    """QS-232 review-fix #01 #6 (QS-235 form): `time_btn` and
+    `time_btn_cover` must share the same render gate. If the button
+    rendered under a different predicate than its cover, the button
+    face could draw over un-carved soup. QS-235 moved the cover to a
+    `_ringCarveCover({ … show: <gate> })` call, so the cover gate is
+    now the `show:` value; this pin extracts the button ternary
+    predicate and the cover `show:` predicate and asserts equality.
     """
     import re
 
     source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
 
-    # Extract the time_btn render gate. The fix gates the button on
-    # the same `(tNext && e.schedule)` predicate as the cover.
-    # Accept either form:
-    # - `(tNext && e.schedule) ? \`<div id="time_btn"…>\` : ''`
-    # - or any equivalent predicate that matches the cover's gate.
-    btn_gate_re = re.compile(
-        r"(\([^)]*\))\s*\?\s*`?\s*<div\s+id=\"time_btn\"",
-    )
-    btn_m = btn_gate_re.search(source)
+    # The `time_btn` <div> render gate (the ternary predicate).
+    btn_m = re.search(r"(\([^)]*\))\s*\?\s*`?\s*<div\s+id=\"time_btn\"", source)
     assert btn_m is not None, (
         "qs-car-card.js (review-fix #01 #6): the `time_btn` <div> "
-        'must now be wrapped in a `(predicate) ? `<div id="time_btn"'
-        " …>` : ''` ternary so its render gate aligns with the "
-        "`time_btn_cover` gate."
+        'must be wrapped in a `(predicate) ? `<div id="time_btn" …>` '
+        ": ''` ternary so its render gate aligns with the "
+        "`time_btn_cover` carve gate."
     )
 
-    cover_gate_re = re.compile(
-        r"(\([^)]*\))\s*\?\s*`?\s*<circle\s+id=\"time_btn_cover\"",
+    # The `time_btn_cover` carve gate (the `_ringCarveCover` `show:`).
+    cover_m = re.search(
+        r"this\._ringCarveCover\(\s*\{[^}]*id:\s*'time_btn_cover'[^}]*show:\s*([^}]+?)\s*\}\s*\)",
+        source,
     )
-    cover_m = cover_gate_re.search(source)
     assert cover_m is not None, (
-        "qs-car-card.js (review-fix #01 #6): missing the `time_btn_cover` <circle> element with a gating ternary."
+        "qs-car-card.js (QS-235 AC3): missing the `time_btn_cover` "
+        "`_ringCarveCover({ … show: <gate> })` call."
     )
 
-    # Whitespace-normalise both predicates and compare.
     def _normalise(s: str) -> str:
         return re.sub(r"\s+", "", s)
 
@@ -4570,10 +4694,10 @@ def test_car_card_time_btn_render_and_cover_gates_match():
     cover_predicate = _normalise(cover_m.group(1))
     assert btn_predicate == cover_predicate, (
         f"qs-car-card.js (review-fix #01 #6): the `time_btn` render "
-        f"gate `{btn_m.group(1)}` and the `time_btn_cover` gate "
-        f"`{cover_m.group(1)}` must be equal (whitespace-normalised). "
-        f"Asymmetric gates allow the button face to draw over "
-        f"un-covered soup."
+        f"gate `{btn_m.group(1)}` and the `time_btn_cover` carve "
+        f"`show:` gate `{cover_m.group(1)}` must be equal "
+        f"(whitespace-normalised). Asymmetric gates allow the button "
+        f"face to draw over un-covered soup."
     )
 
 
@@ -4973,27 +5097,20 @@ def test_car_card_initial_paint_opacity_is_clamped():
 
 
 def test_car_card_rabbit_btn_render_and_cover_gates_match():
-    """QS-232 review-fix #02 #7: `rabbit_btn` and `rabbit_btn_cover`
-    must share the same render gate. Symmetric to the fix-#01-#6
-    treatment for `time_btn`. Currently `<div id="rabbit_btn">`
-    renders unconditionally while the cover is gated on `e.force_now`
-    — when `force_now` is undefined, the button draws over un-carved
-    soup and sparkles bleed behind it.
+    """QS-232 review-fix #02 #7 (QS-235 form): `rabbit_btn` and
+    `rabbit_btn_cover` must share the same render gate (symmetric to
+    the `time_btn` pin) — otherwise the button draws over un-carved
+    soup. QS-235 moved the cover to a `_ringCarveCover({ … show:
+    <gate> })` call, so the cover gate is the `show:` value.
     """
     import re
 
     source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
 
-    # Extract each ternary's predicate by:
-    # 1. Locating the target element (`<div id="rabbit_btn"` /
-    #    `<circle id="rabbit_btn_cover"`).
-    # 2. Walking BACKWARD via `rfind` to the immediately preceding
-    #    `${` template substitution opener.
-    # 3. Reading the predicate text between `${` and the next `?`.
-    # This avoids the cross-template greedy-match pathology of
-    # using `\$\{[^?]+?\?` directly (which can match across
-    # unrelated `${...}` substitutions appearing earlier in the
-    # same source).
+    # The `rabbit_btn` <div> render gate. Walk BACKWARD from the marker
+    # to the enclosing `${` template opener and read up to the `?` (the
+    # rabbit gate `e.force_now` has no parens, so a parens-only regex
+    # wouldn't match it).
     def _extract_template_predicate(target_marker: str) -> str | None:
         target_idx = source.find(target_marker)
         if target_idx == -1:
@@ -5009,22 +5126,28 @@ def test_car_card_rabbit_btn_render_and_cover_gates_match():
     btn_predicate = _extract_template_predicate('<div id="rabbit_btn"')
     assert btn_predicate is not None, (
         "qs-car-card.js (review-fix #02 #7): the `rabbit_btn` <div> "
-        'must be wrapped in a `${predicate ? `<div id="rabbit_btn"'
-        " …>` : ''}` ternary so its render gate aligns with the "
-        "`rabbit_btn_cover` gate."
+        'must be wrapped in a `${predicate ? `<div id="rabbit_btn" …>` '
+        ": ''}` ternary so its render gate aligns with the "
+        "`rabbit_btn_cover` carve gate."
     )
-    cover_predicate = _extract_template_predicate('<circle id="rabbit_btn_cover"')
-    assert cover_predicate is not None, (
-        "qs-car-card.js (review-fix #02 #7): missing the `rabbit_btn_cover` <circle> with a gating ternary."
+
+    # The `rabbit_btn_cover` carve gate (the `_ringCarveCover` `show:`).
+    cover_m = re.search(
+        r"this\._ringCarveCover\(\s*\{[^}]*id:\s*'rabbit_btn_cover'[^}]*show:\s*([^}]+?)\s*\}\s*\)",
+        source,
+    )
+    assert cover_m is not None, (
+        "qs-car-card.js (QS-235 AC3): missing the `rabbit_btn_cover` "
+        "`_ringCarveCover({ … show: <gate> })` call."
     )
 
     def _normalise(s: str) -> str:
         return re.sub(r"\s+", "", s)
 
-    assert _normalise(btn_predicate) == _normalise(cover_predicate), (
+    assert _normalise(btn_predicate) == _normalise(cover_m.group(1)), (
         f"qs-car-card.js (review-fix #02 #7): `rabbit_btn` render "
-        f"gate `{btn_predicate}` and `rabbit_btn_cover` gate "
-        f"`{cover_predicate}` must be equal (whitespace-normalised)."
+        f"gate `{btn_predicate}` and `rabbit_btn_cover` carve `show:` "
+        f"gate `{cover_m.group(1)}` must be equal (whitespace-normalised)."
     )
 
 
@@ -5184,49 +5307,41 @@ def test_car_card_restore_drops_sparkles_above_new_water_base_y():
 # ============================================================================
 
 
-def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None:
-    """Shared QS-217 invariant check used by the three carve-out tests.
+def _qs217_assert_card_carve_out(card_filename: str) -> None:
+    """Shared override-button carve-cover invariant check.
 
-    Review-fix #03 abandoned the original clipPath carve-out approach
-    (outer disc + carve disc + cancel subpath under evenodd, which
-    produced a geometric lens-shape hole that the user repeatedly
-    flagged) in favour of a much simpler COVER OVERLAY: a single
-    ``<circle>`` element with ``fill="var(--card-background-color)"``
-    drawn ON TOP of the clipped animation group. The cover IS a
-    circle by construction — no lens shape possible.
+    QS-217 introduced a per-card COVER OVERLAY (a single ``<circle>``
+    with ``fill="var(--card-background-color)"`` drawn ON TOP of the
+    clipped animation group) to keep the bottom-center override button
+    legible. QS-235 UNIFIED that cover across the car + the three
+    duration cards: the geometry now lives in the shared
+    ``RING_BOTTOM_CARVE_*`` constants (`shared/qs-card-base.js`) and
+    the markup is emitted by the shared ``_ringCarveCover({…})`` helper
+    — there is genuinely no per-card duplication left.
 
-    Pinned invariants (review-fix #03):
+    Pinned invariants (QS-235):
 
     - (a) the ``<clipPath>`` is just the outer disc (no carve, no
-      cancel subpath in ``clipPathD``).
-    - (b) the two module-level constants ``OVERRIDE_BTN_CARVE_CY = 277``
-      and ``OVERRIDE_BTN_CARVE_R`` (integer) are declared at file
-      scope. The radius value is intentionally NOT pinned by tests so
-      visual-iteration tweaks (e.g. 35 → 40 → 30) leave the suite
-      green — only the constant NAME is required.
-    - (c) the ``<circle id="override_btn_cover" …>`` cover element
-      is present in the SVG markup, gated on ``e.override_reset``
-      (same truthy check as the existing button render), and uses the
-      file-local x-centre constant for ``cx``, ``OVERRIDE_BTN_CARVE_CY``
-      for ``cy``, ``OVERRIDE_BTN_CARVE_R`` for ``r``, and
-      ``fill="var(--card-background-color)"`` so it visually erases
-      the animation in a clean circular patch.
-    - (d) ``<g clip-path="url(#${…ClipId})">`` wrapper unchanged.
-    - (e) the obsolete carve-out artifacts (carveSubpath, cancelSubpath,
+      cancel subpath in ``clipPathD``) — unchanged.
+    - (b) the per-card ``OVERRIDE_BTN_CARVE_*`` constants are GONE
+      (negative pin) — the geometry moved to the shared
+      ``RING_BOTTOM_CARVE_*`` constants.
+    - (c) the card imports the shared ``RING_BOTTOM_CARVE_CX/CY/R``
+      constants from ``./shared/qs-card-base.js``.
+    - (d) the card emits its bottom-center cover via
+      ``this._ringCarveCover({ cx: RING_BOTTOM_CARVE_CX, cy:
+      RING_BOTTOM_CARVE_CY, r: RING_BOTTOM_CARVE_R, id:
+      'override_btn_cover', show: e.override_reset })`` — same
+      ``override_btn_cover`` id + ``e.override_reset`` gate as before.
+    - (e) ``<g clip-path="url(#${…ClipId})">`` wrapper unchanged.
+    - (f) the obsolete carve-out artifacts (carveSubpath, cancelSubpath,
       OVERRIDE_BTN_CARVE_INT_X, OVERRIDE_BTN_CARVE_INT_Y) MUST be
       absent — pinned as negative assertions so a regression can't
       silently reintroduce the lens-shape approach.
-
-    ``x_center_name`` is the file-local x-centre constant name (radiator
-    uses ``CENTER_CY`` for both axes; water-boiler uses ``CENTER_CX``;
-    climate uses ``CENTER_X``).
     """
     content = (COMPONENT_ROOT / "ui" / "resources" / card_filename).read_text()
 
-    # (a) clipPath has the simple outer disc (no carve, no cancel). The
-    # SVG markup uses the `<path clip-rule="evenodd" d="${clipPathD}">`
-    # form for backward-compatibility with other tests, but `clipPathD`
-    # is just an outer-disc circle path now.
+    # (a) clipPath has the simple outer disc (no carve, no cancel).
     assert (
         re.search(
             r"<clipPath\s+id=\"\$\{[^}]+\}\">\s*<path\s+clip-rule=\"evenodd\"\s+d=\"\$\{clipPathD\}\"\s*/>\s*</clipPath>",
@@ -5237,59 +5352,63 @@ def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None
     ), (
         f"{card_filename}: missing `<clipPath …><path "
         f'clip-rule="evenodd" d="${{clipPathD}}" /></clipPath>` '
-        f"form. The clipPath wraps the simple outer-disc circle now "
-        f"(review-fix #03 dropped the carve+cancel subpaths)."
+        f"form. The clipPath wraps the simple outer-disc circle."
     )
 
-    # (b) The two module-level constants are declared. CY pinned by
-    # value (geometry-fixed, derives from CSS button position). R
-    # pinned by NAME only — visual-iteration friendly.
+    # (b) QS-235 — the per-card OVERRIDE_BTN_CARVE_* constants are gone.
+    for legacy_const in (
+        "OVERRIDE_BTN_CARVE_CX",
+        "OVERRIDE_BTN_CARVE_CY",
+        "OVERRIDE_BTN_CARVE_R",
+    ):
+        assert re.search(rf"const\s+{legacy_const}\s*=", content) is None, (
+            f"{card_filename} (QS-235 AC3): the per-card `const "
+            f"{legacy_const} = …` declaration must be removed — the "
+            f"geometry moved to the shared `RING_BOTTOM_CARVE_*` "
+            f"constants in `shared/qs-card-base.js`."
+        )
+
+    # (c) QS-235 — the card imports the shared carve constants.
     assert (
         re.search(
-            r"const\s+OVERRIDE_BTN_CARVE_CY\s*=\s*277\b",
+            r"import\s*\{[^}]*RING_BOTTOM_CARVE_CX[^}]*RING_BOTTOM_CARVE_CY[^}]*RING_BOTTOM_CARVE_R[^}]*\}\s*from\s*['\"]\./shared/qs-card-base\.js['\"]",
             content,
+            re.DOTALL,
         )
         is not None
     ), (
-        f"{card_filename}: missing module-level `const "
-        f"OVERRIDE_BTN_CARVE_CY = 277;` declaration (button-centre y "
-        f"in SVG units, derived from CSS .override-btn position)."
+        f"{card_filename} (QS-235 AC3): must import "
+        f"`RING_BOTTOM_CARVE_CX, RING_BOTTOM_CARVE_CY, "
+        f"RING_BOTTOM_CARVE_R` from `./shared/qs-card-base.js`."
     )
-    assert (
-        re.search(
-            r"const\s+OVERRIDE_BTN_CARVE_R\s*=\s*\d+\b",
-            content,
+
+    # (d) QS-235 — the cover is emitted via the shared `_ringCarveCover`
+    # helper with the shared constants + the `override_btn_cover` id +
+    # the `e.override_reset` gate.
+    call_re = re.compile(
+        r"this\._ringCarveCover\(\s*\{([^}]*id:\s*'override_btn_cover'[^}]*)\}\s*\)",
+        re.DOTALL,
+    )
+    call_m = call_re.search(content)
+    assert call_m is not None, (
+        f"{card_filename} (QS-235 AC3): missing a "
+        f"`this._ringCarveCover({{ … id: 'override_btn_cover' … }})` "
+        f"call. Review-fix #03's inline `<circle id=\"override_btn_cover\">` "
+        f"literal is replaced by the shared helper."
+    )
+    call_body = call_m.group(1)
+    for token_re, label in (
+        (r"cx:\s*RING_BOTTOM_CARVE_CX", "cx: RING_BOTTOM_CARVE_CX"),
+        (r"cy:\s*RING_BOTTOM_CARVE_CY", "cy: RING_BOTTOM_CARVE_CY"),
+        (r"r:\s*RING_BOTTOM_CARVE_R", "r: RING_BOTTOM_CARVE_R"),
+        (r"show:\s*e\.override_reset", "show: e.override_reset"),
+    ):
+        assert re.search(token_re, call_body) is not None, (
+            f"{card_filename} (QS-235 AC3): the `_ringCarveCover` call "
+            f"for `override_btn_cover` must pass `{label}`."
         )
-        is not None
-    ), (
-        f"{card_filename}: missing module-level `const "
-        f"OVERRIDE_BTN_CARVE_R = <integer>;` declaration. The integer "
-        f"value is user-tunable; tests pin the NAME only so visual-"
-        f"iteration tweaks leave the suite green."
-    )
 
-    # (c) The `<circle id="override_btn_cover" …>` cover element is
-    # present, gated on `e.override_reset`, and uses the correct
-    # constants for its geometry + the card-background-color fill.
-    cover_re = re.compile(
-        r"e\.override_reset\s*\?\s*`?\s*<circle\s+id=\"override_btn_cover\""
-        r"\s+cx=\"\$\{" + x_center_name + r"\}\""
-        r"\s+cy=\"\$\{OVERRIDE_BTN_CARVE_CY\}\""
-        r"\s+r=\"\$\{OVERRIDE_BTN_CARVE_R\}\""
-        r"\s+fill=\"var\(--card-background-color\)\""
-        r"\s+pointer-events=\"none\"\s*/>",
-    )
-    assert cover_re.search(content) is not None, (
-        f"{card_filename}: missing the override-button cover element "
-        f'`<circle id="override_btn_cover" cx="${{{x_center_name}}}" '
-        f'cy="${{OVERRIDE_BTN_CARVE_CY}}" r="${{OVERRIDE_BTN_CARVE_R}}" '
-        f'fill="var(--card-background-color)" pointer-events="none" />` '
-        f"gated on `e.override_reset`. Review-fix #03 replaces the "
-        f"clipPath carve approach with a simple cover overlay drawn on "
-        f"top of the animation."
-    )
-
-    # (d) `<g clip-path="url(#${…ClipId})">` wrapper unchanged.
+    # (e) `<g clip-path="url(#${…ClipId})">` wrapper unchanged.
     assert (
         re.search(
             r'<g\s+clip-path="url\(#\$\{[a-zA-Z]+ClipId\}\)">',
@@ -5298,7 +5417,7 @@ def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None
         is not None
     ), f'{card_filename}: expected unchanged `<g clip-path="url(#${{…ClipId}})">` wrapper.'
 
-    # (e) Negative pins — the obsolete carve+cancel artifacts MUST be
+    # (f) Negative pins — the obsolete carve+cancel artifacts MUST be
     # absent so a regression cannot silently reintroduce the lens-
     # shape approach.
     for artifact in (
@@ -5308,55 +5427,34 @@ def _qs217_assert_card_carve_out(card_filename: str, x_center_name: str) -> None
         "OVERRIDE_BTN_CARVE_INT_Y",
     ):
         assert artifact not in content, (
-            f"{card_filename}: review-fix #03 dropped the carve+cancel "
-            f"clipPath approach, but `{artifact}` is still present in "
-            f"the source. Removing the cover-overlay approach requires "
-            f"an explicit design discussion — don't silently reintroduce "
+            f"{card_filename}: the obsolete carve+cancel clipPath "
+            f"approach, but `{artifact}` is still present in the "
+            f"source. Removing the cover-overlay approach requires an "
+            f"explicit design discussion — don't silently reintroduce "
             f"the lens-shape geometry."
         )
 
 
 def test_radiator_card_override_btn_carve_out():
-    """QS-217 AC-7 — radiator card: clipPath swaps `<circle>` for
-    `<path clip-rule="evenodd" d="${clipPathD}" />`, adds the two
-    `OVERRIDE_BTN_CARVE_*` constants at module scope, and gates the
-    carve subpath on `e.override_reset`.
+    """QS-235 AC3 — radiator card: bottom-center override cover emitted
+    via the shared `_ringCarveCover` helper + the shared
+    `RING_BOTTOM_CARVE_*` constants (no per-card `OVERRIDE_BTN_CARVE_*`).
 
-    See the helper docstring for invariant (a)/(b)/(c) details.
+    See the helper docstring for invariant (a)–(f) details.
     """
-    _qs217_assert_card_carve_out(
-        "qs-radiator-card.js",
-        x_center_name="CENTER_CY",
-    )
+    _qs217_assert_card_carve_out("qs-radiator-card.js")
 
 
 def test_water_boiler_card_override_btn_carve_out():
-    """QS-217 AC-7 — water-boiler card carve-out invariants.
-
-    Same three pins as the radiator card (AC-7 helper), anchored to
-    `qs-water-boiler-card.js`. The water-boiler card uses `CENTER_CX`
-    (not `CENTER_CY`) for the x-centre — review-fix #01 N4 introduced
-    that explicit constant, and QS-217's `clipPathD` builder must
-    reference it.
-    """
-    _qs217_assert_card_carve_out(
-        "qs-water-boiler-card.js",
-        x_center_name="CENTER_CX",
-    )
+    """QS-235 AC3 — water-boiler card: shared `_ringCarveCover` +
+    `RING_BOTTOM_CARVE_*` carve cover (helper invariants (a)–(f))."""
+    _qs217_assert_card_carve_out("qs-water-boiler-card.js")
 
 
 def test_climate_card_override_btn_carve_out():
-    """QS-217 AC-7 — climate card carve-out invariants.
-
-    Same three pins as the radiator card (AC-7 helper), anchored to
-    `qs-climate-card.js`. The climate card uses `CENTER_X` (QS-210
-    review-fix S5 introduced that explicit x-centre constant), and
-    QS-217's `clipPathD` builder must reference it.
-    """
-    _qs217_assert_card_carve_out(
-        "qs-climate-card.js",
-        x_center_name="CENTER_X",
-    )
+    """QS-235 AC3 — climate card: shared `_ringCarveCover` +
+    `RING_BOTTOM_CARVE_*` carve cover (helper invariants (a)–(f))."""
+    _qs217_assert_card_carve_out("qs-climate-card.js")
 
 
 def test_dashboard_and_cards_doc_pins_qs_217_carve_paragraph():
@@ -5503,14 +5601,22 @@ def test_dashboard_and_cards_doc_pins_qs_217_carve_paragraph():
         "reproducible from the doc alone."
     )
 
-    # (d) Both constant names + a CSS-to-SVG scale reference.
-    for const_name in ("OVERRIDE_BTN_CARVE_CY", "OVERRIDE_BTN_CARVE_R"):
+    # (d) Both shared constant names + a CSS-to-SVG scale reference.
+    # QS-235 unified the per-card `OVERRIDE_BTN_CARVE_*` duplicates into
+    # the shared `RING_BOTTOM_CARVE_*` constants, so the doc now names
+    # those (and the `_ringCarveCover` helper).
+    for const_name in ("RING_BOTTOM_CARVE_CY", "RING_BOTTOM_CARVE_R"):
         assert const_name in section, (
             f"dashboard-and-cards.md (QS-217 section): missing "
-            f"`{const_name}` — AC-8 (d) requires both carve constants "
-            f"be named (so the doc reader can grep them back to the "
-            f"source)."
+            f"`{const_name}` — AC-8 (d) / QS-235 AC3 require both shared "
+            f"carve constants be named (so the doc reader can grep them "
+            f"back to the source)."
         )
+    assert "_ringCarveCover" in section, (
+        "dashboard-and-cards.md (QS-217 section): missing the shared "
+        "`_ringCarveCover` helper name — QS-235 AC3 unified the carve "
+        "cover into this helper, which the doc must name."
+    )
     scale_patterns = ("320/300", "320×320", "300×300", "1.0667")
     assert any(pat in section for pat in scale_patterns), (
         f"dashboard-and-cards.md (QS-217 section): missing a CSS-to-"
@@ -7042,6 +7148,9 @@ _QS_199_CANONICAL_SHARED_METHODS = (
     "_wireOverrideButton",
     "_wireBistateMode",
     "_buildRingHTML",
+    # QS-235 — the bottom-center carve cover helper, defined once on
+    # `QsCardBase` and consumed by the car + the three duration cards.
+    "_ringCarveCover",
 )
 
 
@@ -7684,16 +7793,20 @@ def test_card_derives_max_hours_via_clamp_helper(card_filename):
 
 
 def test_wire_target_handle_awaits_commit_hook_before_setnumber():
-    """QS-199 review-fix #03 S1 + S2 / #04 NH1 — the shared
-    `_wireTargetHandle` must run an optional `onBeforeCommit` hook
-    (awaited) BEFORE the `_setNumber` duration write, so the pool's
-    `_select(pool_mode, 'bistate_mode_default')` lands first (the old
-    pre-migration ordering — writing the duration before default mode is
-    active can be rejected/clamped backend-side).
+    """QS-199 review-fix #03 S1 + S2 — the shared `_wireTargetHandle`
+    must run an optional `onBeforeCommit` hook (awaited) BEFORE the
+    commit, so the pool's `_select(pool_mode, 'bistate_mode_default')`
+    lands first (the old pre-migration ordering — writing the duration
+    before default mode is active can be rejected/clamped backend-side).
 
-    #04 NH1 — the unused post-write `onCommit` param was dropped (no card
-    passed it; scheduling the local-target clear timer before a dead
-    awaited `onCommit` was a latent footgun).
+    QS-235 AC1 — re-introduces `onCommit` as a commit OVERRIDE (the car
+    maps the dragged value → a select option then `_select(...)` instead
+    of `_setNumber`). Unlike the QS-199-NH1 footgun (a dead post-write
+    `onCommit`), this `onCommit` REPLACES the `_setNumber` write and is
+    awaited in the same position, AFTER `onBeforeCommit`, BEFORE the
+    local-target clear timer is scheduled. The default branch (no
+    `onCommit`) still calls `_setNumber`, so the duration cards are
+    byte-equivalent.
     """
     src = _strip_js_comments(
         (COMPONENT_ROOT / "ui" / "resources" / "shared" / "qs-card-base.js").read_text(encoding="utf-8")
@@ -7701,17 +7814,26 @@ def test_wire_target_handle_awaits_commit_hook_before_setnumber():
     assert "await onBeforeCommit(" in src, (
         "S1: `_wireTargetHandle` must `await onBeforeCommit(...)` (pool mode-select)."
     )
-    # NH1 — the dead `onCommit` param is gone.
-    assert "onCommit" not in src, (
-        "NH1: the unused `onCommit` param/branch must be removed from "
-        "`_wireTargetHandle` (only `onBeforeCommit` is used by any card)."
+    # QS-235 AC1 — the commit-override hook is awaited.
+    assert "await onCommit(" in src, (
+        "QS-235 AC1: `_wireTargetHandle` must support an `await "
+        "onCommit(...)` commit override (the car commits via `_select`)."
     )
-    # Ordering: onBeforeCommit fires before the _setNumber write.
+    # The default `_setNumber` write survives for the duration cards.
+    assert "await this._setNumber(" in src, (
+        "QS-235 AC1: the default (no-`onCommit`) branch must still "
+        "`await this._setNumber(entityId, ...)` so the duration cards "
+        "are unchanged."
+    )
+    # Ordering: onBeforeCommit fires before BOTH the override commit and
+    # the default `_setNumber` write.
     before_idx = src.index("await onBeforeCommit(")
+    commit_idx = src.index("await onCommit(")
     setnum_idx = src.index("await this._setNumber(")
-    assert before_idx < setnum_idx, (
-        "S1: `onBeforeCommit` (mode-select) must run BEFORE the `_setNumber` "
-        "duration write to preserve the pool's service-call ordering."
+    assert before_idx < commit_idx and before_idx < setnum_idx, (
+        "S1: `onBeforeCommit` (mode-select) must run BEFORE the commit "
+        "(override or the default `_setNumber` write) to preserve the "
+        "pool's service-call ordering."
     )
 
 

--- a/tests/utils/card_sources.py
+++ b/tests/utils/card_sources.py
@@ -8,6 +8,13 @@ patterns; `card_source_union(card_filename)` returns the concatenated
 text of the card file and every shared module it transitively imports,
 so the existing grep-based tests keep working without per-test rewrite.
 
+QS-235 — `_buildRingHTML` moved UP from `qs-ring-duration-base.js` to
+`qs-card-base.js` (so the car card, which extends `QsCardBase`
+directly, can consume it). The `qs-car-card.js` union already includes
+`qs-card-base.js`, so the car now picks up `_buildRingHTML` (plus the
+shared `_ringCarveCover` carve helper) through its existing mapping —
+no `CARD_TO_SHARED_FILES` change is needed.
+
 The mapping is a **static dict** (`CARD_TO_SHARED_FILES`) rather than
 being parsed from `import` statements in the card source. This lets the
 Phase C migration land per-card incrementally — a card that has not yet


### PR DESCRIPTION
## Summary
Verification: full quality gate green (5744 tests, 100% coverage, ruff/mypy/translations); plus a node syntax check (8/8 JS modules) and a logic harness (23/23) since the gate can't execute the JS cards. Behavior nuances to confirm in Phase-F smoke: reset dialog copy is now the generic shared wording, and a faulted-while-charging dash tint uses the charge gradient.

Fixes #235

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust sensor/energy readings to avoid NaN/-- displays; charging thresholds behave correctly.
  * Improved override/reset button gating and reset behavior.

* **Style & Visual Updates**
  * Simplified car-card wave visuals (grain/filter removed).
  * Unified bottom-center button carve-out and ring rendering for consistent visuals across cards.

* **Documentation**
  * Updated architecture and story docs to reflect shared ring/handle and cover refactor.

* **Tests**
  * Updated/added UI tests to validate the new shared rendering and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->