### PR TITLE
QS-240: Do not set max effort for Claude in dev harness

### DIFF
--- a/docs/stories/QS-240.story.md
+++ b/docs/stories/QS-240.story.md
@@ -1,0 +1,247 @@
+---
+issue: 240
+title: Do not set max effort for Claude in dev harness
+branch: QS_240
+status: ready-for-dev
+next_phase: implement-setup-task
+labels: [area:car]
+---
+
+# QS-240 — Do not set max effort for Claude in dev harness
+
+## Why
+
+Issue [#240](https://github.com/tmenguy/quiet-solar/issues/240): "I want
+now to not set the max effort for claude in my dev harness."
+
+The Claude launcher (`scripts/qs/launchers/claude.py`) builds the
+interactive phase-session one-liner
+
+```text
+claude {CLAUDE_LAUNCH_OPTS} --agent qs-<phase> --name 'QS_<N>: <title>'
+```
+
+from a single hardcoded module-level constant, `CLAUDE_LAUNCH_OPTS`,
+which currently pins `--effort max`:
+
+```python
+CLAUDE_LAUNCH_OPTS = "--dangerously-skip-permissions --model opus --effort max"
+```
+
+We drop `--effort max` so Claude uses its own CLI default effort.
+
+**User clarifications obtained during planning:**
+
+1. Remove `--effort max` **entirely** (let Claude use its default
+   effort) — not downgrade to a fixed lower value.
+2. Keep `--dangerously-skip-permissions` and `--model opus` untouched.
+3. **No** regression / negative-assertion guard — do not add an
+   `assert "--effort" not in script` line.
+
+## Inputs
+
+- `scripts/qs/launchers/claude.py` — the only behavioural change. Edit
+  the `CLAUDE_LAUNCH_OPTS` constant (today at ~line 49; **locate by
+  symbol name**, line numbers here are approximate). The module
+  docstring renders the constant via the `{CLAUDE_LAUNCH_OPTS}`
+  placeholder, not a literal `--effort` token, so it updates
+  automatically — no docstring edit.
+- `tests/qs/launchers/test_claude_launcher.py` — the one launcher test
+  that pins the flag. Edit `test_build_payload_preserves_launch_opts_and_workdir`
+  (today at ~lines 107-128; locate by symbol name).
+
+### Verified preconditions (from adversarial review)
+
+- **`CLAUDE_LAUNCH_OPTS` is the sole origin of `--effort`** in the
+  rendered command. There is no env-var or argument injection of an
+  effort flag anywhere in `claude.py` / `launchers/phases.py`; editing
+  the constant fully removes the flag from `new_context`.
+- **Repo-wide, the only references to the `--effort` CLI flag /
+  `CLAUDE_LAUNCH_OPTS` are this constant (+ its two uses) and the one
+  test assertion below.** Every other "effort" hit is unrelated prose
+  ("best-effort") or the `qs_best_effort_green_only` domain attribute.
+  The implement step re-greps `--effort` as a cheap safety check before
+  editing.
+- **The Cursor, Codex, and OpenCode launchers carry no effort flag** —
+  this is Claude-only; no sibling launcher changes.
+- **No `docs/agents/**` file covers `scripts/qs/launchers/claude.py`,
+  and neither `harness.md` nor `overview.md` mentions the effort flag.**
+
+## Out of scope
+
+- Making the launch flags env-configurable (the line-47 comment invites
+  it; YAGNI — not requested).
+- Touching `--model opus` or `--dangerously-skip-permissions`.
+- Adding a negative-assertion regression guard (user declined, #3).
+- Changing the Cursor / Codex / OpenCode launchers (no effort flag).
+
+## Acceptance criteria
+
+### AC-1 — Effort flag removed from the launch constant
+
+- **Given** the module `scripts/qs/launchers/claude.py`
+- **When** `CLAUDE_LAUNCH_OPTS` is inspected
+- **Then** its string value is exactly
+  `"--dangerously-skip-permissions --model opus"` — i.e. the
+  `--dangerously-skip-permissions` and `--model opus` tokens with a
+  single space between them and **no `--effort` token** and no trailing
+  or doubled space.
+
+### AC-2 — Rendered launcher command no longer carries `--effort`
+
+- **Given** a call to `claude.build_payload(...)`
+- **When** the `new_context` launcher script is rendered
+- **Then**, as an observation of the rendered output, it contains
+  `--dangerously-skip-permissions` and `--model opus` and carries **no**
+  `--effort` token.
+- This is satisfied transitively by AC-1 + T1 (the constant is the sole
+  source of the flag — see Verified preconditions). It is **not** a
+  mandate to add a new negative test assertion (see #3 / Out of scope).
+
+### AC-3 — Other launch flags and layout invariant preserved
+
+- **Given** the rendered launcher command
+- **When** inspected
+- **Then** `--dangerously-skip-permissions` and `--model opus` are still
+  present, and the existing layout invariant holds: the launch opts
+  appear before `--agent` in the rendered line
+  (`script.index("--dangerously-skip-permissions") < script.index("--agent")`).
+
+### AC-4 — Launcher test reflects the change and the suite passes
+
+- **Given** `tests/qs/launchers/test_claude_launcher.py`
+- **When** `test_build_payload_preserves_launch_opts_and_workdir` runs
+- **Then** it no longer asserts the presence of `--effort max`, it still
+  renders the launcher payload and asserts the two surviving flags plus
+  the `--agent` ordering invariant, and the full launcher test passes.
+
+## Tasks / file-level diff
+
+### T1 — Drop `--effort max` from the constant
+
+`scripts/qs/launchers/claude.py`, `CLAUDE_LAUNCH_OPTS`:
+
+```python
+# before
+CLAUDE_LAUNCH_OPTS = "--dangerously-skip-permissions --model opus --effort max"
+# after
+CLAUDE_LAUNCH_OPTS = "--dangerously-skip-permissions --model opus"
+```
+
+Delete the **whole** ` --effort max` segment **including its leading
+space**, so the resulting literal is byte-for-byte
+`"--dangerously-skip-permissions --model opus"` with no trailing or
+doubled space. No docstring change (placeholder-only, see Inputs).
+
+### T2 — Remove the `--effort max` assertion
+
+`tests/qs/launchers/test_claude_launcher.py`, in
+`test_build_payload_preserves_launch_opts_and_workdir`: delete the line
+
+```python
+assert "--effort max" in script
+```
+
+Keep everything else in the test, in particular:
+- the `build_payload(...)` call and `_read_script(...)` render step (the
+  call that actually exercises `claude.py` — keeping it means removing
+  the assertion drops **no** covered line);
+- `assert "--dangerously-skip-permissions" in script`;
+- `assert "--model opus" in script`;
+- the ordering assertion
+  `script.index("--dangerously-skip-permissions") < script.index("--agent")`.
+
+Do **not** add a negative assertion (#3). Leave the adjacent comment
+("CLAUDE_LAUNCH_OPTS keeps these defaults — change here is intentional
+and caught by this assertion") **as-is** — it remains accurate for the
+two surviving assertions; do not over-edit it.
+
+### T3 — Quality gate
+
+Run `python scripts/qs/quality_gate.py`. Only dev-environment paths
+change (`scripts/qs/**`, `tests/qs/**`), so the gate's scope detection
+should auto-select its dev-only fast path; **whichever scope it selects
+(fast path or full) must pass** — the plan does not depend on the fast
+path triggering. 100% coverage, ruff, mypy, translations all green.
+
+## Doc maintenance
+
+**Doc-OK.** `check_doc_drift.py --paths scripts/qs/launchers/claude.py
+tests/qs/launchers/test_claude_launcher.py` surfaced no docs (only
+pre-existing, unrelated `testing-layers.md` warnings). No
+`docs/agents/**` file covers the launcher; `harness.md` and
+`overview.md` do not mention the effort flag. No doc updates required.
+
+## Test plan
+
+- `python scripts/qs/quality_gate.py --quick tests/qs/launchers/test_claude_launcher.py`
+  during the red/green loop.
+- Full gate before commit (per T3).
+
+## Adversarial Review Notes
+
+Four reviewers (critic, concrete-planner, dev-proxy, scope-guardian) ran
+in parallel. Consensus: a near-minimal, sound plan. **No `critical` or
+`redesign` finding survived verification.** Findings and decisions:
+
+- **AC-2's "but NOT `--effort`" could be misread as a mandate to add a
+  negative assertion** (critic `critical` → reframed; dev-proxy
+  `improve`; scope-guardian `clarify`). **Decision: FIXED.** AC-2
+  reworded as an *observation* of the rendered output, explicitly
+  satisfied transitively via AC-1 + T1, not via a new test assertion —
+  keeping it consistent with user decision #3.
+- **"Sole source of `--effort`" assumption** (critic `critical`).
+  **Resolved by verification:** the concrete-planner read the code and
+  confirmed `--effort` derives only from `CLAUDE_LAUNCH_OPTS` (no
+  env/arg injection) and that no other file references the flag.
+  Recorded as a Verified precondition.
+- **Delete the leading space, not just `--effort max`** (concrete-planner
+  `improve`). **Decision: FIXED** — T1 now pins the byte-exact resulting
+  literal with no trailing/doubled space.
+- **"dev-only fast path" not named in the rule docs** (dev-proxy
+  `clarify`; the mechanism does exist in `quality_gate.py`
+  `_DEV_ONLY_PATTERNS`). **Decision: FIXED** — T3 reworded to "whichever
+  scope the gate auto-selects must pass," removing dependence on the
+  fast path.
+- **Coverage impact of removing the assertion** (dev-proxy, critic
+  `clarify`). **Decision: FIXED** — T2 explicitly keeps the
+  `build_payload` / `_read_script` render call, so no covered line is
+  dropped; the 100%-cov gate enforces this regardless.
+- **`tests/qs/**` edit-permission for implement-setup-task** (dev-proxy
+  `clarify` — it cannot read agent files). **Resolved:** the orchestrator
+  verified `.claude/agents/qs-implement-setup-task.md` lines 70-72
+  explicitly permit `tests/` edits that are *dev-tooling tests*;
+  `test_claude_launcher.py` tests the QS launcher script and qualifies.
+  Routing to `implement-setup-task` stands.
+- **Brittle hardcoded line numbers** (critic `improve`). **Decision:
+  FIXED** — Inputs/Tasks instruct locating by symbol name; line numbers
+  marked approximate.
+- **AC-1 exact-equality vs token-presence ambiguity** (critic
+  `clarify`). **Decision: FIXED** — AC-1 states the exact string value;
+  the "no `--effort` token" note is explanatory, not a second
+  conflicting check.
+- **Stale/anaphoric comment "keeps these defaults"** (concrete-planner,
+  critic `clarify`). **Decision:** leave the comment as-is (still
+  accurate for the two surviving assertions); T2 says so explicitly to
+  prevent over-editing.
+- **No regression guard → `--effort max` could silently creep back**
+  (critic `redesign`). **Decision: SKIP** — conscious, user-directed
+  trade-off (#3). Recorded here as the trade-off rather than acted on.
+- **Default effort level not documented** (critic `improve`).
+  **Decision: SKIP** — letting Claude's CLI use its own default *is* the
+  goal; the external CLI default is not this repo's to document.
+- **Repo-wide grep to confirm only two occurrences** (scope-guardian
+  `clarify`). **Resolved** — already verified; retained as a cheap
+  re-grep safety step in the implement phase.
+
+Process note: the scope-guardian made one `Read` call against
+`claude.py` despite its no-repo-files rule and self-reported that it did
+not use the content for its judgment; no impact on findings.
+
+## Commit
+
+```bash
+git add docs/stories/QS-240.story.md
+git commit -m "QS-240: create plan"
+git push -u origin QS_240
+```

--- a/scripts/qs/launchers/claude.py
+++ b/scripts/qs/launchers/claude.py
@@ -46,7 +46,7 @@ Caller = Literal["setup_task", "next_step"]
 
 # Extra flags appended to ``claude`` invocations. Kept narrow on purpose
 # — users can override via env or by editing this constant.
-CLAUDE_LAUNCH_OPTS = "--dangerously-skip-permissions --model opus --effort max"
+CLAUDE_LAUNCH_OPTS = "--dangerously-skip-permissions --model opus"
 
 
 def _pycharm_bin() -> str | None:

--- a/tests/qs/launchers/test_claude_launcher.py
+++ b/tests/qs/launchers/test_claude_launcher.py
@@ -120,7 +120,6 @@ def test_build_payload_preserves_launch_opts_and_workdir() -> None:
     # caught by this assertion.
     assert "--dangerously-skip-permissions" in script
     assert "--model opus" in script
-    assert "--effort max" in script
     # Stable layout invariant: ``--agent`` appears after CLAUDE_LAUNCH_OPTS
     # in the rendered command line. (CLI flag ORDER is independent in
     # argparse-style parsers — this is a layout/cosmetic check, not a


### PR DESCRIPTION
## Summary
Remove the matching --effort max assertion from test_build_payload_preserves_launch_opts_and_workdir (other flag + ordering assertions retained).

Fixes #240

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Feature Changes**
  * Claude launcher configuration updated to no longer pin effort to maximum, enabling more flexible effort-level control.

* **Tests**
  * Updated launcher test assertions to validate the new configuration while preserving critical flag ordering verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->