### PR TITLE
QS-239: Do not enforce car native SOC max limit when detached from charger

### DIFF
--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -1480,8 +1480,22 @@ class QSCar(HADeviceMixin, AbstractDevice):
         return self.get_car_estimated_range_km(from_soc=soc, to_soc=0.0, time=time)
 
     async def adapt_max_charge_limit(self, asked_percent):
+        # Precondition: this writes the car's native "max charge limit" entity and
+        # is only valid while the car is plugged into a QS-managed charger.
 
         if self.car_charge_percent_max_number is None:
+            return
+
+        # Only Quiet Solar should manage the car's native charge limit while the car
+        # is plugged into a QS-managed charger. When detached (charging away from
+        # home), leave the native limit untouched — the target is preserved and is
+        # reapplied automatically on reconnect (see setup_car_charge_target_if_needed
+        # callers in charger.py).
+        if self.charger is None:
+            _LOGGER.debug(
+                "Car %s not connected to a managed charger — skipping max charge limit write (target preserved, reapplied on reconnect)",
+                self.name,
+            )
             return
 
         percent = asked_percent

--- a/docs/stories/QS-239.story.md
+++ b/docs/stories/QS-239.story.md
@@ -1,0 +1,242 @@
+# QS-239 — Do not enforce the car's native SOC max charge limit when it is not connected to a QS-managed charger
+
+- **Issue:** #239
+- **Branch:** `QS_239`
+- **Next phase:** `implement-task` (touches product code under `custom_components/quiet_solar/ha_model/car.py`)
+- **Labels:** `area:car`, `area:charger`, `area:ui` — the `area:ui` label is triage
+  routing, **not** a deliverable. This is a backend-only fix: it removes an
+  unwanted write, it does not add any user-facing control. No UI/dashboard change.
+
+## Context & goal
+
+When a car (e.g. a Tesla, but the issue applies to any car) is **not** plugged
+into a Quiet-Solar-managed charger — it is away from home charging at a public
+charger or a friend's house — Quiet Solar still writes the car's **native**
+"max charge limit" number entity (`car_charge_percent_max_number`, the
+manufacturer's charge-limit slider). This forces the SOC target even when the
+car is charging elsewhere, which is abnormal (issue #239).
+
+**Goal:** Quiet Solar must only manage the car's native charge-limit entity
+while the car is plugged into a QS-managed charger. When the car is detached,
+QS must leave the native limit untouched.
+
+## Root cause
+
+`QSCar.adapt_max_charge_limit()` (`custom_components/quiet_solar/ha_model/car.py:1482`)
+is the **single** production writer of `car_charge_percent_max_number` (verified:
+the only `number.SERVICE_SET_VALUE` call targeting this entity is at
+car.py:1502-1508). It guards only on the entity being configured
+(`if self.car_charge_percent_max_number is None: return`, line 1484), **not** on
+whether the car is attached to a QS charger.
+
+`self.charger` is the attachment sentinel: initialised to `None` (car.py:185),
+cleared in `reset()` (car.py:1165), and set to the charger in
+`Charger.attach_car()` (`charger.py:3862`).
+
+### Call-graph inventory of the write funnel
+
+`setup_car_charge_target_if_needed()` (car.py:2000) → `adapt_max_charge_limit()`
+(car.py:2008) is the funnel. Its callers:
+
+| Caller | File:line | Attachment at call time |
+| ------ | --------- | ----------------------- |
+| Departure auto-reset → `user_clean_and_reset()` → `reset()` (sets `charger=None`) → `setup_car_charge_target_if_needed()` | car.py:614 → 2264 → 2267 | **Detached** (self-detaches via `reset()`). Fires once per departure, ~15 min after leaving home (`CAR_NOT_HOME_AUTO_RESET_S`). |
+| "Clean & reset" button → `user_clean_and_reset()` → `reset()` → `setup_car_charge_target_if_needed()` | car.py:2267 | **Detached** (self-detaches via `reset()`). |
+| "Clean constraints" button → `user_clean_constraints()` → `setup_car_charge_target_if_needed()` | car.py:2280 | **Current attachment** — `user_clean_constraints` does **not** call `reset()`, so it only writes-while-detached when the car was already detached on entry. |
+| "Set next charge target" → `set_next_charge_target_percent()` → `setup_car_charge_target_if_needed()` | car.py:2110 → 2112 | **Current attachment** — records `_next_charge_target` at line 2110 **before** the funnel call at 2112. |
+| Charger plug-in / refresh | charger.py:3281, 3307 | **Attached** — `attach_car()` (charger.py:3275) runs first. |
+| Charger active-charge callback | charger.py:4771 | **Attached** — dereferences `self.car.name` at 4777. Non-regressing. |
+
+So the bug manifests via the detached paths; the charger.py paths are
+legitimate and always have an attached car.
+
+## Fix — single attachment guard at the write chokepoint
+
+In `adapt_max_charge_limit`, **after** the existing entity-None guard
+(car.py:1484-1485) and **before** the steps/clamp/write logic, add:
+
+```python
+# Only Quiet Solar should manage the car's native charge limit while the car
+# is plugged into a QS-managed charger. When detached (charging away from
+# home), leave the native limit untouched — the target is preserved and is
+# reapplied automatically on reconnect (see setup_car_charge_target_if_needed
+# callers in charger.py).
+if self.charger is None:
+    _LOGGER.debug(
+        "Car %s not connected to a managed charger — skipping max charge limit write (target preserved, reapplied on reconnect)",
+        self.name,
+    )
+    return
+```
+
+Ordering is deliberate: the entity-None check stays first so its existing test
+branch keeps coverage; the new charger guard is reached only when the entity is
+configured.
+
+### Why this is necessary and sufficient (product decision)
+
+The repo owner confirmed: gating on `self.charger is not None` is the correct,
+necessary, **and** sufficient condition — the native limit should be assessed
+only when the charge is tied to a QS-solar-controlled charger. We do **not**
+add a separate "is home" check.
+
+### No restore, no new storage (product decisions)
+
+- **No restore.** When the car detaches, QS leaves the native limit exactly as
+  it is. We do not write a "default" or "restore original" value.
+- **No new storage.** The user's target already persists in `_next_charge_target`
+  (mirrored to the persisted user-originated state at car.py:265). It is
+  reapplied automatically on reconnect: `attach_car()` sets `self.charger`
+  (charger.py:3862, guaranteed before the funnel call at 3281), then
+  `setup_car_charge_target_if_needed()` writes it, and `adapt_max_charge_limit`
+  is idempotent — it issues the service call only when the current native value
+  differs (car.py:1499). Recording is independent of the guarded write (set at
+  car.py:2110 before the funnel call at 2112), so the guard's early return can
+  never drop the user's target.
+
+## Acceptance criteria
+
+### AC1 — Detached car: native limit is never written
+- **Given** a car with a configured `car_charge_percent_max_number` and `car.charger is None`
+- **When** `adapt_max_charge_limit(asked_percent)` is called
+- **Then** no `number.set_value` service call is made (method returns at the new guard).
+
+### AC2 — Attached car: native limit still written (behavior preserved)
+- **Given** a car with a configured `car_charge_percent_max_number` and `car.charger` set
+- **When** `adapt_max_charge_limit(asked_percent)` is called
+- **Then** the native limit is written exactly as before (steps/clamp logic unchanged).
+
+### AC3 — Detached funnel paths do not write
+- **Given** a detached car (`car.charger is None`) with the native entity configured
+- **When** any funnel caller runs (`setup_car_charge_target_if_needed`, exercised by
+  departure auto-reset and the "clean & reset" / "clean constraints" buttons)
+- **Then** no `number.set_value` write occurs. (Pinned transitively by AC1 at the
+  single write chokepoint; the funnel itself has no independent branch.)
+
+### AC4 — Target recorded while detached is reapplied on reconnect
+- **Given** the user set a charge target while the car was detached (recorded only, not written)
+- **When** the car is plugged back into a QS charger (`car.charger` set) and the
+  plug-in funnel `setup_car_charge_target_if_needed()` runs
+- **Then** the native limit is written to the recorded target.
+
+## Task breakdown
+
+### T1 — Product guard (`custom_components/quiet_solar/ha_model/car.py`)
+Add the charger guard + precondition comment in `adapt_max_charge_limit`, after
+the entity-None check (car.py:1484-1485), as specified above.
+
+### T2 — Tests in `tests/ha_tests/test_car_extended_coverage.py`
+- **Update** `test_adapt_max_charge_limit_with_steps` (~line 1890): set
+  `car.charger = SimpleNamespace()` before the `adapt_max_charge_limit` call so
+  the asserted write still fires (covers AC2 / the guard's not-None branch). A
+  bare `SimpleNamespace()` is sufficient — `adapt_max_charge_limit` never calls
+  a charger method (verified); follow the local `car.charger = SimpleNamespace(...)`
+  pattern already used in this file (e.g. line 91).
+- **Add** `test_adapt_max_charge_limit_skips_when_detached` (AC1): configure the
+  entity via `CONF_CAR_CHARGE_PERCENT_MAX_NUMBER` (**must be non-None** so
+  execution passes the entity guard and reaches the charger guard), leave
+  `car.charger` at its `None` default, register an `AsyncMock` number service via
+  `hass.services.async_register(number.DOMAIN, number.SERVICE_SET_VALUE, handler)`,
+  call `await car.adapt_max_charge_limit(asked_percent=90)`, and assert
+  `handler.assert_not_awaited()`.
+- **Add** `test_charge_target_recorded_while_detached_reapplied_on_reconnect` (AC4):
+  with the entity configured and `car.charger is None`, record a target (e.g. set
+  `car._next_charge_target` / call `set_next_charge_target_percent`) and assert no
+  write; then set `car.charger = SimpleNamespace()`, call
+  `await car.setup_car_charge_target_if_needed()`, and assert the number service
+  was awaited with the recorded target value.
+
+### T3 — Tests in `tests/ha_tests/test_car_missing_lines.py`
+- **Update** `test_adapt_max_charge_limit_steps_overflow` (~line 735): set
+  **`car2.charger = SimpleNamespace()`** before the asserted write at line 779
+  (the assertion is on `car2`, not `car` — the first `car` is vestigial).
+- **Update** `test_adapt_max_charge_limit_service_exception` (~line 785): set
+  `car.charger = SimpleNamespace()` before the patched `async_call`, so execution
+  reaches the service call and keeps the `try/except` branch (car.py:1502-1514) covered.
+- Optional: refresh the stale line-number references in these two test docstrings
+  ("line 1091", "lines 1109-1110") to the current car.py:1502-1514 while editing.
+- `test_adapt_max_charge_limit_no_entity` is **unchanged** — the entity-None guard
+  fires first.
+
+### T4 — Documentation
+**Doc-OK:** `docs/agents/concepts/person-trip-prediction.md` is the only doc whose
+`covers:` frontmatter includes `ha_model/car.py` (per `check_doc_drift.py`, the
+authority). It documents trip prediction, SOC tracking, person allocation, and the
+power→amperage table — **none of which change**. Native-limit enforcement is not
+described in it (nor in any other doc; a `docs/` grep for `adapt_max_charge_limit` /
+"charge limit" surfaces no concept doc covering it). No doc edit required.
+
+## Coverage & caller/test matrix
+
+- New guard adds one branch. **None branch** (detached) covered by the new AC1
+  test; **not-None branch** (attached) covered by the updated existing tests (T2/T3)
+  and the AC4 test.
+- Caller/test matrix: the only car-side tests that drive the real
+  `adapt_max_charge_limit` write are the three updated in T2/T3. All charger-side
+  tests mock `setup_car_charge_target_if_needed` (`AsyncMock`), so they are
+  unaffected. The new AC1 test is the only test that reaches the guard with
+  `charger is None`. 100% coverage maintained.
+
+## Out of scope
+
+- Restoring / resetting the native limit on detach (explicitly declined).
+- Any "is home" check beyond charger attachment (declined; attachment is
+  necessary + sufficient).
+- Any UI/dashboard work (the `area:ui` label is triage routing only).
+- A full 15-minute departure-cycle integration test (covered transitively by the
+  chokepoint guard test).
+
+## Adversarial Review Notes
+
+Four reviewers ran in parallel on the draft. The concrete-planner (with source
+access) verified every path/line and found no critical/redesign issues. Round 1
+of 1 — all dispositions below were accepted by the repo owner.
+
+**Accepted into the plan:**
+- *Reframe root cause (critic F1 / concrete F14):* clarified that only
+  departure-reset and "clean & reset" self-detach via `reset()`; "clean
+  constraints" and "set next charge target" write at the current attachment and
+  are problematic only when already detached. The single guard is correct for all
+  paths (it blocks only when `charger is None`; attached paths still write).
+- *Add reconnect re-apply test (critic F2 → AC4):* validates decision #3
+  end-to-end (record while detached → reapply on reconnect).
+- *Precondition comment (critic/dev-proxy F3):* documented the
+  attached-only precondition at `adapt_max_charge_limit` since the guard lives in
+  the write primitive (kept there as the sole chokepoint — most robust).
+- *Reach-the-guard coverage note (critic/dev-proxy F5):* AC1 test sets the entity
+  non-None so the charger guard is actually exercised.
+- *Debug message wording (critic/dev-proxy F10):* states the target is preserved
+  and reapplied on reconnect, to avoid future "lost target" confusion.
+- *Concrete test fixes (concrete F11/F12/F13):* `steps_overflow` must set
+  `car2.charger` (not `car`) before line 779; `service_exception` must set
+  `car.charger` so the `try/except` lines stay covered; a bare `SimpleNamespace()`
+  charger is sufficient.
+- *Call-graph completeness (concrete F15):* added the charger.py:4771 active-charge
+  call site (non-regressing, car attached).
+- *Optional docstring refresh (concrete F16):* refresh stale line refs in the two
+  edited tests.
+- *Scope (scope-guardian F21/F22):* `area:ui` is triage noise — no UI work; dropped
+  the redundant pure-funnel test in favor of the higher-value reconnect test.
+- *Positive-path contract (dev-proxy F20):* AC2 makes "write still happens when
+  attached" explicit.
+
+**Resolved by verified fact (no plan change needed):**
+- *Sole writer (scope-guardian / dev-proxy):* `adapt_max_charge_limit` is the only
+  production writer of `car_charge_percent_max_number` (concrete-planner confirmed).
+- *Detach sentinel (dev-proxy F19):* `self.charger` defaults to `None` (car.py:185),
+  cleared in `reset()` (1165), set in `attach_car()` (charger.py:3862).
+- *Reconnect re-apply (critic F4):* `adapt_max_charge_limit` is idempotent
+  (writes only when the value differs, car.py:1499); plug-in funnel calls it
+  with the charger attached.
+- *Recording independent of write (critic F8):* `_next_charge_target` is set at
+  car.py:2110, before the funnel call at 2112.
+- *Negative-assertion mechanism (dev-proxy F17):* `AsyncMock` service handler +
+  `assert_not_awaited()` — the established pattern in these test files.
+- *Doc completeness (critic/dev-proxy F9):* drift checker flags only
+  `person-trip-prediction.md`; no doc documents `adapt_max_charge_limit`.
+
+**Declined / noted:**
+- *Heavy departure-cycle integration test (critic F7):* declined — covered
+  transitively by the chokepoint guard test; keeps scope minimal.
+- *"charger implies home" proof (critic F6):* not required — the repo owner
+  decided `car.charger` is necessary + sufficient.

--- a/tests/ha_tests/test_car.py
+++ b/tests/ha_tests/test_car.py
@@ -1675,6 +1675,11 @@ async def test_car_charge_energy_and_charge_limit(
 
     assert car_device.get_max_charge_limit() == 90
 
+    # Attached to a QS-managed charger so the native-limit write is permitted
+    # (a bare SimpleNamespace suffices — adapt_max_charge_limit never calls a
+    # charger method).
+    car_device.charger = SimpleNamespace()
+
     set_value_handler.reset_mock()
     await car_device.adapt_max_charge_limit(asked_percent=50)
     set_value_handler.assert_awaited_once()

--- a/tests/ha_tests/test_car_extended_coverage.py
+++ b/tests/ha_tests/test_car_extended_coverage.py
@@ -35,6 +35,7 @@ from custom_components.quiet_solar.const import (
     CONF_CAR_CHARGE_PERCENT_MAX_NUMBER,
     CONF_CAR_CHARGE_PERCENT_MAX_NUMBER_STEPS,
     CONF_CAR_IS_INVITED,
+    CONF_DEFAULT_CAR_CHARGE,
     DATA_HANDLER,
     DOMAIN,
     FORCE_CAR_NO_PERSON_ATTACHED,
@@ -1911,6 +1912,11 @@ async def test_adapt_max_charge_limit_with_steps(
         entry_id_suffix="lim_steps",
     )
 
+    # Attached to a QS-managed charger so the native-limit write is permitted
+    # (a bare SimpleNamespace suffices — adapt_max_charge_limit never calls a
+    # charger method).
+    car.charger = SimpleNamespace()
+
     # Reset mock after setup (setup may have already called the service)
     set_value_handler.reset_mock()
 
@@ -1932,6 +1938,94 @@ async def test_adapt_max_charge_limit_no_entity(
     car.car_charge_percent_max_number = None
     # Should not raise
     await car.adapt_max_charge_limit(asked_percent=80)
+
+
+async def test_adapt_max_charge_limit_skips_when_detached(
+    hass: HomeAssistant,
+    home_config_entry: ConfigEntry,
+) -> None:
+    """AC1: a car not plugged into a QS charger must not have its native limit written.
+
+    The entity is configured (so execution passes the entity-None guard and
+    reaches the new charger guard), but ``car.charger`` is left at its ``None``
+    default, so ``adapt_max_charge_limit`` must early-return before any
+    ``number.set_value`` service call.
+    """
+    from homeassistant.components import number as number_mod
+
+    set_value_handler = AsyncMock()
+    hass.services.async_register(number_mod.DOMAIN, number_mod.SERVICE_SET_VALUE, set_value_handler)
+
+    entity = "number.car_max_charge_detached"
+    hass.states.async_set(entity, "50")
+
+    car, _ = await _create_car(
+        hass,
+        home_config_entry,
+        extra_config={CONF_CAR_CHARGE_PERCENT_MAX_NUMBER: entity},
+        entry_id_suffix="lim_detached",
+    )
+
+    # Detached: no charger attached to the car.
+    assert car.charger is None
+    # Entity is configured, so the entity-None guard does not short-circuit us.
+    assert car.car_charge_percent_max_number is not None
+
+    set_value_handler.reset_mock()
+
+    await car.adapt_max_charge_limit(asked_percent=90)
+
+    set_value_handler.assert_not_awaited()
+
+
+async def test_charge_target_recorded_while_detached_reapplied_on_reconnect(
+    hass: HomeAssistant,
+    home_config_entry: ConfigEntry,
+) -> None:
+    """AC4: a target set while detached is recorded (not written) then reapplied on reconnect.
+
+    While ``car.charger is None`` the user records a charge target — the native
+    limit must NOT be written. Once the car is plugged back into a QS charger
+    (``car.charger`` set), the plug-in funnel ``setup_car_charge_target_if_needed``
+    writes the recorded target to the native limit.
+    """
+    from homeassistant.components import number as number_mod
+
+    set_value_handler = AsyncMock()
+    hass.services.async_register(number_mod.DOMAIN, number_mod.SERVICE_SET_VALUE, set_value_handler)
+
+    entity = "number.car_max_charge_reconnect"
+    # Native limit currently at 50; the recorded target (90) differs, so a
+    # write is expected once reattached.
+    hass.states.async_set(entity, "50")
+
+    car, _ = await _create_car(
+        hass,
+        home_config_entry,
+        extra_config={
+            CONF_CAR_CHARGE_PERCENT_MAX_NUMBER: entity,
+            # Low default so the asked 90% is not clamped up to the default.
+            CONF_DEFAULT_CAR_CHARGE: 50.0,
+        },
+        entry_id_suffix="lim_reconnect",
+    )
+
+    # Detached on entry.
+    assert car.charger is None
+    set_value_handler.reset_mock()
+
+    # Record a target while detached: it is stored but must not be written.
+    await car.set_next_charge_target_percent(90)
+    assert car._next_charge_target == 90
+    set_value_handler.assert_not_awaited()
+
+    # Plug back into a QS-managed charger and run the plug-in funnel.
+    car.charger = SimpleNamespace()
+    await car.setup_car_charge_target_if_needed()
+
+    set_value_handler.assert_awaited_once()
+    call = set_value_handler.call_args.args[0]
+    assert call.data[number_mod.ATTR_VALUE] == 90
 
 
 # ===========================================================================

--- a/tests/ha_tests/test_car_missing_lines.py
+++ b/tests/ha_tests/test_car_missing_lines.py
@@ -736,7 +736,7 @@ async def test_adapt_max_charge_limit_steps_overflow(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
-    """When bisect_left returns index >= len(steps), uses last step (line 1091)."""
+    """When bisect_left returns index >= len(steps), uses last step (car.py:1508)."""
     from homeassistant.components import number as number_mod
 
     set_value_handler = AsyncMock()
@@ -774,6 +774,9 @@ async def test_adapt_max_charge_limit_steps_overflow(
     )
     set_value_handler.reset_mock()
 
+    # Attached to a QS-managed charger so the native-limit write is permitted.
+    car2.charger = SimpleNamespace()
+
     # Ask for 90 → percent becomes max(90, default_charge=80)=90
     # steps = [50,70,100], bisect_left(90) = 2, step=100
     await car2.adapt_max_charge_limit(asked_percent=90)
@@ -786,7 +789,7 @@ async def test_adapt_max_charge_limit_service_exception(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,
 ) -> None:
-    """Exception calling service is caught and logged (lines 1109-1110)."""
+    """Exception calling service is caught and logged (car.py:1522-1528)."""
     entity = "number.car_max_charge_exc"
     hass.states.async_set(entity, "50")
 
@@ -796,6 +799,9 @@ async def test_adapt_max_charge_limit_service_exception(
         extra_config={CONF_CAR_CHARGE_PERCENT_MAX_NUMBER: entity},
         entry_id_suffix="lim_exc",
     )
+    # Attached to a QS-managed charger so execution reaches the service call and
+    # keeps the try/except branch covered.
+    car.charger = SimpleNamespace()
     with patch(
         "homeassistant.core.ServiceRegistry.async_call",
         side_effect=RuntimeError("service fail"),


### PR DESCRIPTION
## Summary
Add an attachment guard in `adapt_max_charge_limit` (the single production writer of the car's native charge-limit entity): when `car.charger is None` (car charging away from a QS-managed charger), the native limit is left untouched instead of being forced.
- The user's target persists in `_next_charge_target` and is reapplied idempotently on reconnect via the plug-in funnel — no restore, no new storage.
- Tests: new AC1 (detached → no write) and AC4 (recorded-while-detached → reapplied on reconnect); updated the four existing tests that drive the real write to attach a charger so the write still fires (AC2).

## Doc maintenance
`docs/agents/concepts/person-trip-prediction.md` is the only doc whose `covers:` frontmatter includes `ha_model/car.py`, so the drift checker flags it. It documents trip prediction, SOC tracking, person allocation, and the power→amperage table — none of which change. It contains no reference to native charge-limit enforcement (`adapt_max_charge_limit` / charge limit), verified by grep. This is a backend-only fix that removes an unwanted write; no doc edit is required.

Fixes #239

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)