### PR TITLE
QS-243: Manual SOC override + charge-energy SOC estimation for cars

### DIFF
--- a/custom_components/quiet_solar/binary_sensor.py
+++ b/custom_components/quiet_solar/binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     BINARY_SENSOR_CAR_API_OK,
+    BINARY_SENSOR_CAR_IS_SOC_ESTIMATED,
     BINARY_SENSOR_CAR_IS_STALE,
     BINARY_SENSOR_CAR_USE_CHARGE_PERCENT_CONSTRAINTS,
     BINARY_SENSOR_HOME_IS_OFF_GRID,
@@ -98,6 +99,18 @@ def create_ha_binary_sensor_for_QSCar(device: QSCar):
         value_fn=lambda d, key: d.is_car_effectively_stale(d._get_time_for_sensor()),
     )
     entities.append(QSBaseBinarySensor(data_handler=device.data_handler, device=device, description=is_stale))
+
+    # SOC is estimated (manual override / charge-energy interpolation) — drives
+    # the asterisk on the card. Independent of API staleness.
+    if device.can_use_charge_percent_constraints():
+        is_soc_estimated = QSBinarySensorEntityDescription(
+            key=BINARY_SENSOR_CAR_IS_SOC_ESTIMATED,
+            translation_key=BINARY_SENSOR_CAR_IS_SOC_ESTIMATED,
+            value_fn=lambda d, key: d.has_soc_estimate(),
+        )
+        entities.append(
+            QSBaseBinarySensor(data_handler=device.data_handler, device=device, description=is_soc_estimated)
+        )
 
     return entities
 

--- a/custom_components/quiet_solar/button.py
+++ b/custom_components/quiet_solar/button.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import (
     BUTTON_CAR_NEXT_CHARGE_ADD_DEFAULT,
     BUTTON_CAR_NEXT_CHARGE_FORCE_NOW,
+    BUTTON_CAR_RESET_SOC_ESTIMATE,
     BUTTON_DEVICE_CLEAN_AND_RESET,
     BUTTON_DEVICE_CLEAN_COMMAND_AND_CONSTRAINTS,
     BUTTON_HOME_GENERATE_YAML_DASHBOARD,
@@ -166,6 +167,16 @@ def create_ha_button_for_QSCar(device: QSCar):
     entities.append(
         QSButtonEntity(data_handler=device.data_handler, device=device, description=qs_add_default_next_charge)
     )
+
+    if device.can_use_charge_percent_constraints():
+        qs_reset_soc_estimate = QSButtonEntityDescription(
+            key=BUTTON_CAR_RESET_SOC_ESTIMATE,
+            translation_key=BUTTON_CAR_RESET_SOC_ESTIMATE,
+            async_press=lambda x: x.device.user_button_reset_soc_estimate(),
+        )
+        entities.append(
+            QSButtonEntity(data_handler=device.data_handler, device=device, description=qs_reset_soc_estimate)
+        )
 
     return entities
 

--- a/custom_components/quiet_solar/const.py
+++ b/custom_components/quiet_solar/const.py
@@ -252,6 +252,7 @@ BINARY_SENSOR_HOME_PERSISTENCE_HEALTH = "qs_home_persistence_health"
 BINARY_SENSOR_SOLAR_FORECAST_OK = "qs_solar_forecast_ok"
 BINARY_SENSOR_CAR_API_OK = "qs_car_api_ok"
 BINARY_SENSOR_CAR_IS_STALE = "qs_car_is_stale"
+BINARY_SENSOR_CAR_IS_SOC_ESTIMATED = "qs_car_is_soc_estimated"
 
 SENSOR_SOLAR_FORECAST_AGE = "qs_solar_forecast_age"
 SENSOR_SOLAR_FORECAST_SCORE_PREFIX = "qs_solar_forecast_score_"
@@ -310,6 +311,9 @@ SWITCH_CAR_NEXT_CHARGE_FULL = "qs_next_car_charge_full"
 SWITCH_CAR_BUMP_SOLAR_CHARGE_PRIORITY = "qs_bump_solar_charge_priority"
 BUTTON_CAR_NEXT_CHARGE_FORCE_NOW = "qs_next_car_charge_force_now"
 BUTTON_CAR_NEXT_CHARGE_ADD_DEFAULT = "qs_next_car_charge_add_default"
+BUTTON_CAR_RESET_SOC_ESTIMATE = "qs_car_reset_soc_estimate"
+
+NUMBER_CAR_MANUAL_SOC_PERCENT = "qs_car_manual_soc_percent"
 
 
 BUTTON_LOAD_MARK_CURRENT_CONSTRAINT_DONE = "qs_load_mark_current_constraint_done"

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -235,6 +235,16 @@ class QSCar(HADeviceMixin, AbstractDevice):
         self._car_not_home_since: datetime | None = None
         self._departure_auto_reset_done: bool = False
 
+        # ── Estimated-SOC model (Story QS-243) ───────────────────────────
+        # Persisted baselines + accumulator that back the effective-SOC
+        # accessor when the SOC API is failed, inaccurate, or absent.
+        self._user_base_soc_value: float | None = None
+        self._last_valid_base_soc_value: float | None = None
+        self._computed_added_delta_soc_percent: float | None = None
+        self._user_base_soc_entry_sensor_value: float | None = None
+        # Not persisted — re-anchored on reboot to avoid counting downtime energy.
+        self._delta_soc_last_integration_time: datetime | None = None
+
         self.attach_ha_state_to_probe(self.car_charge_percent_sensor, is_numerical=True, reload_from_history=True)
 
         self.attach_ha_state_to_probe(self.car_plugged, is_numerical=False, reload_from_history=True)
@@ -285,11 +295,28 @@ class QSCar(HADeviceMixin, AbstractDevice):
             forecasted_name = self.current_forecasted_person.name
         data_to_update["current_forecasted_person_name_from_boot"] = forecasted_name
 
+        # Estimated-SOC model (Story QS-243). The integration cursor is
+        # deliberately NOT persisted (re-anchored on reboot).
+        data_to_update["user_base_soc_value"] = self._user_base_soc_value
+        data_to_update["last_valid_base_soc_value"] = self._last_valid_base_soc_value
+        data_to_update["computed_added_delta_soc_percent"] = self._computed_added_delta_soc_percent
+        data_to_update["user_base_soc_entry_sensor_value"] = self._user_base_soc_entry_sensor_value
+
     def use_saved_extra_device_info(self, stored_load_info: dict):
         super().use_saved_extra_device_info(stored_load_info)
         self._current_forecasted_person_name_from_boot = stored_load_info.get(
             "current_forecasted_person_name_from_boot", None
         )
+
+        # Estimated-SOC model (Story QS-243). Pre-QS-243 saved blobs lack
+        # these keys and default to None (all-None defaults, no exception).
+        self._user_base_soc_value = stored_load_info.get("user_base_soc_value", None)
+        self._last_valid_base_soc_value = stored_load_info.get("last_valid_base_soc_value", None)
+        self._computed_added_delta_soc_percent = stored_load_info.get("computed_added_delta_soc_percent", None)
+        self._user_base_soc_entry_sensor_value = stored_load_info.get("user_base_soc_entry_sensor_value", None)
+        # Re-anchor the integration cursor so the next charge cycle does not
+        # integrate energy "delivered" during downtime.
+        self._delta_soc_last_integration_time = None
 
     def device_post_home_init(self, time: datetime):
         """Initialize person assignment from persisted state at startup."""
@@ -582,6 +609,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         """Update states and check car API staleness each cycle."""
         await super().update_states(time)
         self._update_car_api_staleness(time)
+        self._update_soc_estimation(time)
         await self._check_departure_auto_reset(time)
 
     async def _check_departure_auto_reset(self, time: datetime) -> None:
@@ -681,7 +709,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
             and self.can_use_charge_percent_constraints()
             and self._is_soc_sensor_stale(time)
         ):
-            self.car_api_stale_percent_mode = True
+            self._enter_stale_percent_mode(time)
 
         # Periodic contradiction check for attached cars
         if (
@@ -722,7 +750,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
                 )
             # Activate stale-percent mode if car can use percent constraints
             if self.can_use_charge_percent_constraints():
-                self.car_api_stale_percent_mode = True
+                self._enter_stale_percent_mode(time)
 
         # Transition: stale -> not stale (from select change or non-percent recovery)
         elif not effectively_stale and self._was_car_api_stale:
@@ -762,12 +790,20 @@ class QSCar(HADeviceMixin, AbstractDevice):
         return ", ".join(parts)
 
     def _exit_stale_mode(self) -> None:
-        """Clear all stale flags and exit stale-percent mode."""
+        """Clear all stale flags and exit stale-percent mode.
+
+        Also clears the system-captured SOC base and accumulator so the live
+        sensor takes over on API recovery. The user-entered base is left
+        untouched — only `_update_soc_estimation` / the user can clear it.
+        """
         self._car_api_stale = False
         self.car_api_stale_percent_mode = False
         self._car_api_inferred_home = False
         self._car_api_inferred_plugged = False
         self._car_api_stale_since = None
+        self._last_valid_base_soc_value = None
+        self._computed_added_delta_soc_percent = None
+        self._delta_soc_last_integration_time = None
 
     def check_manual_assignment_contradiction(self, charger_name: str, time: datetime) -> None:
         """Check if manual charger assignment contradicts API data (Feature B).
@@ -805,7 +841,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
                 self._car_api_stale_since = time
             # Activate stale-percent mode if possible
             if self.can_use_charge_percent_constraints():
-                self.car_api_stale_percent_mode = True
+                self._enter_stale_percent_mode(time)
             self._was_car_api_stale = True
             # Notify on contradiction (Feature B)
             self._schedule_person_notification(
@@ -824,9 +860,9 @@ class QSCar(HADeviceMixin, AbstractDevice):
         self.car_stale_mode_override = option
         if for_init and option == CAR_STALE_MODE_FORCE_STALE:
             # Restore stale-percent mode immediately so get_car_charge_percent()
-            # returns None before the first update_states cycle runs
+            # reflects the estimate before the first update_states cycle runs
             if self.can_use_charge_percent_constraints():
-                self.car_api_stale_percent_mode = True
+                self._enter_stale_percent_mode(None, for_init=True)
         if not for_init:
             time = datetime.now(tz=pytz.UTC)
             self._update_car_api_staleness(time)
@@ -885,7 +921,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         if self.car_odometer_sensor is None or self.car_charge_percent_sensor is None:
             return None
 
-        soc = self.get_car_charge_percent(time)
+        soc = self.get_car_charge_percent_raw_sensor(time)
         odo = self.get_car_odometer_km(time)
         if soc is None or odo is None:
             return None
@@ -904,7 +940,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         sample_eff = None
         if self.car_estimated_range_sensor is not None:
-            current_soc = self.get_car_charge_percent(time)
+            current_soc = self.get_car_charge_percent_raw_sensor(time)
             car_estimate = self.get_car_estimated_range_km_from_sensor(time)
             if current_soc is not None and car_estimate is not None and current_soc > 0.0:
                 sample_eff = float(car_estimate) / (
@@ -975,7 +1011,9 @@ class QSCar(HADeviceMixin, AbstractDevice):
     def get_platforms(self):
         parent = super().get_platforms()
         parent = set(parent)
-        parent.update([Platform.SENSOR, Platform.SELECT, Platform.SWITCH, Platform.BUTTON, Platform.TIME])
+        parent.update(
+            [Platform.SENSOR, Platform.SELECT, Platform.SWITCH, Platform.BUTTON, Platform.TIME, Platform.NUMBER]
+        )
         return list(parent)
 
     def _add_soc_odo_value_to_segments(self, soc: float, odo: float, time: datetime):
@@ -1276,16 +1314,149 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
             return latest_state == "home"
 
+    def get_car_charge_percent_raw_sensor(
+        self, time: datetime | None = None, tolerance_seconds: float | None = None
+    ) -> float | None:
+        """Return the raw SOC sensor value, ignoring any estimate/override.
+
+        This is the trusted-sensor source used by efficiency learning and the
+        charge callback — it must never see the estimated value.
+        """
+        if self.car_charge_percent_sensor is None:
+            return None
+        return self.get_sensor_latest_possible_valid_value(
+            entity_id=self.car_charge_percent_sensor, time=time, tolerance_seconds=tolerance_seconds
+        )
+
+    @property
+    def _estimated_soc_percent(self) -> float | None:
+        """Absolute estimated SOC (`base + accumulated delta`), clamped, or None.
+
+        Returns None when there is no base (the pure-delta `+XX%` case).
+        """
+        delta = self._computed_added_delta_soc_percent or 0.0
+        if self._user_base_soc_value is not None:
+            base = self._user_base_soc_value
+        elif self._last_valid_base_soc_value is not None:
+            base = self._last_valid_base_soc_value
+        else:
+            return None
+        return max(0.0, min(100.0, base + delta))
+
+    def is_in_soc_estimation_mode(self, time: datetime | None = None) -> bool:
+        """Return True when the effective SOC is estimated, not read from the sensor."""
+        if self.car_is_invited:
+            return False
+        if self.car_battery_capacity is None or self.car_battery_capacity <= 0:
+            return False
+        if self.car_charge_percent_sensor is None:
+            return True  # no-sensor car: always estimating
+        if self.car_api_stale_percent_mode:
+            return True  # API failure / SOC stale / force_stale
+        return self._user_base_soc_value is not None  # manual override on a healthy API
+
+    def has_soc_estimate(self) -> bool:
+        """Return True when an absolute SOC estimate exists (drives the asterisk)."""
+        return self._estimated_soc_percent is not None
+
     def get_car_charge_percent(
         self, time: datetime | None = None, tolerance_seconds: float | None = None
     ) -> float | None:
-        """Get car SOC percent. Returns None when in stale-percent mode (SOC sensor is poisoned)."""
-        if self.car_api_stale_percent_mode:
-            return None
-        ret = self.get_sensor_latest_possible_valid_value(
-            entity_id=self.car_charge_percent_sensor, time=time, tolerance_seconds=tolerance_seconds
-        )
-        return ret
+        """Get the effective car SOC percent.
+
+        Returns the estimate while estimating (may be None for the pure-delta
+        case), otherwise the live raw sensor value.
+        """
+        if self.is_in_soc_estimation_mode(time):
+            return self._estimated_soc_percent
+        return self.get_car_charge_percent_raw_sensor(time, tolerance_seconds)
+
+    def _update_soc_estimation(self, time: datetime) -> None:
+        """Per-cycle recovery for a user-base override on a healthy sensor.
+
+        When the real sensor reports a fresh value that differs from the value
+        captured at manual-entry time, the genuine reading wins and the whole
+        SOC estimate is cleared. System-base recovery is handled separately by
+        `_exit_stale_mode` on API recovery.
+        """
+        if self._user_base_soc_value is None:
+            return
+        if self.car_charge_percent_sensor is None:
+            return
+        if self._is_soc_sensor_stale(time):
+            return
+        raw = self.get_car_charge_percent_raw_sensor(time)
+        if raw is None:
+            return
+        if self._user_base_soc_entry_sensor_value is None or raw != self._user_base_soc_entry_sensor_value:
+            self.reset_soc_estimate()
+
+    def _capture_last_valid_base_soc(self, time: datetime) -> None:
+        """Capture the last valid sensor value as the system base at a fresh→stale edge."""
+        if self._user_base_soc_value is not None or self._last_valid_base_soc_value is not None:
+            return
+        raw = self.get_car_charge_percent_raw_sensor(time)
+        if raw is not None:
+            self._last_valid_base_soc_value = raw
+            self._computed_added_delta_soc_percent = 0.0
+            self._delta_soc_last_integration_time = None
+
+    def _enter_stale_percent_mode(self, time: datetime | None, for_init: bool = False) -> None:
+        """Set stale-percent mode and capture the last valid base on a genuine edge.
+
+        The `for_init` restore path must not capture — the persisted value is
+        the source of truth.
+        """
+        self.car_api_stale_percent_mode = True
+        if for_init or time is None:
+            return
+        self._capture_last_valid_base_soc(time)
+
+    async def user_set_manual_soc_percent(self, value: float, for_init: bool = False) -> None:
+        """Set a manual SOC baseline. `for_init` (entity restore) is a no-op."""
+        if for_init:
+            return
+        self._user_base_soc_value = float(max(0, min(100, int(value))))
+        now = datetime.now(tz=pytz.UTC)
+        self._user_base_soc_entry_sensor_value = self.get_car_charge_percent_raw_sensor(now)
+        self._computed_added_delta_soc_percent = 0.0
+        self._delta_soc_last_integration_time = None
+        if self.charger:
+            await self.charger.update_charger_for_user_change()
+
+    def reset_soc_estimate(self) -> None:
+        """Clear every SOC-estimate field and the integration cursor.
+
+        Called on `user_clean_and_reset`, the unplug edge, and a **genuine
+        plug-in** (charger.py, the `do_full_reset` branch). It is deliberately
+        NOT part of the low-level `reset()`: `attach_car` runs `reset()` on both
+        a genuine plug-in AND the boot re-attach, and only the charger can tell
+        them apart. Clearing on the genuine-plug branch gives "reset on plug-in"
+        while the boot re-attach (`do_full_reset=False`) leaves the persisted
+        estimate intact, so it survives an HA reboot.
+        """
+        self._user_base_soc_value = None
+        self._last_valid_base_soc_value = None
+        self._computed_added_delta_soc_percent = None
+        self._user_base_soc_entry_sensor_value = None
+        self._delta_soc_last_integration_time = None
+
+    async def user_button_reset_soc_estimate(self) -> None:
+        """Reset button action: clear the estimate and re-solve the charger."""
+        self.reset_soc_estimate()
+        if self.charger:
+            await self.charger.update_charger_for_user_change()
+
+    @property
+    def qs_car_manual_soc_percent(self) -> float:
+        """Current value for the manual-SOC number entity (0 when unset).
+
+        Named to match the number entity's description `key` so the entity's
+        restore path (`getattr(device, key)`) reads a numeric default.
+        """
+        if self._user_base_soc_value is None:
+            return 0.0
+        return float(self._user_base_soc_value)
 
     def get_car_charge_energy(self, time: datetime, tolerance_seconds: float | None = None) -> float | None:
         res = self.get_car_charge_percent(time, tolerance_seconds)
@@ -1322,7 +1493,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         )
 
     def is_car_charge_growing(self, num_seconds: float, time: datetime) -> bool | None:
-        if self.car_api_stale_percent_mode:
+        if self.is_in_soc_estimation_mode(time):
             return None
         return self.is_sensor_growing(entity_id=self.car_charge_percent_sensor, num_seconds=num_seconds, time=time)
 
@@ -2001,10 +2172,10 @@ class QSCar(HADeviceMixin, AbstractDevice):
     def can_use_charge_percent_constraints(self):
         if self.car_is_invited:
             return False
-        if self.car_battery_capacity is None:
+        if self.car_battery_capacity is None or self.car_battery_capacity <= 0:
             return False
-        if self.car_charge_percent_sensor is None:
-            return False
+        # A SOC sensor is no longer required (Story QS-243): a non-invited car
+        # with a true battery capacity estimates SOC from charged energy.
         return True
 
     def _reset_charge_targets(self):
@@ -2274,6 +2445,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         await super().user_clean_and_reset()
 
         self.current_forecasted_person = None
+        self.reset_soc_estimate()
 
         self.reset(keep_commands=True)  # will detach the car
 

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -68,6 +68,11 @@ CAR_DEFAULT_CAPACITY = 100000  # 100 kWh
 CAR_MINIMUM_LEFT_RANGE_KM = 40.0
 
 
+def _round_half_up(value: float) -> int:
+    """Round half away-from-zero (avoids Python's banker's rounding at `.5`)."""
+    return int(math.floor(value + 0.5))
+
+
 class QSCar(HADeviceMixin, AbstractDevice):
     conf_type_name = CONF_TYPE_NAME_QSCar
 
@@ -1437,8 +1442,11 @@ class QSCar(HADeviceMixin, AbstractDevice):
             return
         if self.car_charge_percent_sensor is None:
             return
-        # Every case is triggered by a fresh, valid raw reading.
-        if self._is_soc_sensor_stale(time):
+        # Every case is triggered by a valid raw reading. Normally we wait for a
+        # *fresh* one, but Force-Not-Stale means the user asserts the sensor is
+        # trusted even if it is time-stale (S2) — so recovery may proceed then.
+        forced_not_stale = self.car_stale_mode_override == CAR_STALE_MODE_FORCE_NOT_STALE
+        if self._is_soc_sensor_stale(time) and not forced_not_stale:
             return
         raw = self.get_car_charge_percent_raw_sensor(time)
         if raw is None:
@@ -1455,8 +1463,9 @@ class QSCar(HADeviceMixin, AbstractDevice):
             self.reset_soc_estimate()
             return
 
-        # Case 2 — clear only on a value that differs from the entry reference.
-        if round(raw) != round(self._user_base_soc_entry_sensor_value):
+        # Case 2 — clear only on a value that differs from the entry reference
+        # (half-up rounding so an exact `.5` reading is not mis-binned — N3).
+        if _round_half_up(raw) != _round_half_up(self._user_base_soc_entry_sensor_value):
             self.reset_soc_estimate()
 
     def _capture_last_valid_base_soc(self, time: datetime) -> None:
@@ -1491,7 +1500,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         if not math.isfinite(value):
             # Reject NaN / ±inf (e.g. a raw `number.set_value` bypassing the card).
             return
-        self._user_base_soc_value = float(max(0, min(100, round(value))))
+        self._user_base_soc_value = float(max(0, min(100, _round_half_up(value))))
         now = datetime.now(tz=pytz.UTC)
         self._user_base_soc_entry_sensor_value = self.get_car_charge_percent_raw_sensor(now)
         # Record the API state at entry so recovery can branch on it (M1).

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -1,5 +1,6 @@
 import bisect
 import logging
+import math
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from operator import itemgetter
@@ -242,6 +243,9 @@ class QSCar(HADeviceMixin, AbstractDevice):
         self._last_valid_base_soc_value: float | None = None
         self._computed_added_delta_soc_percent: float | None = None
         self._user_base_soc_entry_sensor_value: float | None = None
+        # API stale-percent state captured at the instant the user entered the
+        # manual override — drives the 4-case recovery (None for pre-QS-243).
+        self._user_base_soc_entry_api_stale: bool | None = None
         # Not persisted — re-anchored on reboot to avoid counting downtime energy.
         self._delta_soc_last_integration_time: datetime | None = None
 
@@ -301,6 +305,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         data_to_update["last_valid_base_soc_value"] = self._last_valid_base_soc_value
         data_to_update["computed_added_delta_soc_percent"] = self._computed_added_delta_soc_percent
         data_to_update["user_base_soc_entry_sensor_value"] = self._user_base_soc_entry_sensor_value
+        data_to_update["user_base_soc_entry_api_stale"] = self._user_base_soc_entry_api_stale
 
     def use_saved_extra_device_info(self, stored_load_info: dict):
         super().use_saved_extra_device_info(stored_load_info)
@@ -314,6 +319,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         self._last_valid_base_soc_value = stored_load_info.get("last_valid_base_soc_value", None)
         self._computed_added_delta_soc_percent = stored_load_info.get("computed_added_delta_soc_percent", None)
         self._user_base_soc_entry_sensor_value = stored_load_info.get("user_base_soc_entry_sensor_value", None)
+        self._user_base_soc_entry_api_stale = stored_load_info.get("user_base_soc_entry_api_stale", None)
         # Re-anchor the integration cursor so the next charge cycle does not
         # integrate energy "delivered" during downtime.
         self._delta_soc_last_integration_time = None
@@ -792,9 +798,11 @@ class QSCar(HADeviceMixin, AbstractDevice):
     def _exit_stale_mode(self) -> None:
         """Clear all stale flags and exit stale-percent mode.
 
-        Also clears the system-captured SOC base and accumulator so the live
-        sensor takes over on API recovery. The user-entered base is left
-        untouched — only `_update_soc_estimation` / the user can clear it.
+        Also clears the system-captured SOC base. When there is NO user
+        override, it clears the accumulator + cursor too so the live sensor
+        takes over. When a user override IS active, the override owns its own
+        accumulator lifecycle (the case-1/2 recovery in `_update_soc_estimation`),
+        so a transient stale blip must not wipe its accumulated delta.
         """
         self._car_api_stale = False
         self.car_api_stale_percent_mode = False
@@ -802,8 +810,9 @@ class QSCar(HADeviceMixin, AbstractDevice):
         self._car_api_inferred_plugged = False
         self._car_api_stale_since = None
         self._last_valid_base_soc_value = None
-        self._computed_added_delta_soc_percent = None
-        self._delta_soc_last_integration_time = None
+        if self._user_base_soc_value is None:
+            self._computed_added_delta_soc_percent = None
+            self._delta_soc_last_integration_time = None
 
     def check_manual_assignment_contradiction(self, charger_name: str, time: datetime) -> None:
         """Check if manual charger assignment contradicts API data (Feature B).
@@ -1359,6 +1368,42 @@ class QSCar(HADeviceMixin, AbstractDevice):
         """Return True when an absolute SOC estimate exists (drives the asterisk)."""
         return self._estimated_soc_percent is not None
 
+    def is_soc_sensor_distrusted(self) -> bool:
+        """Return True when the raw SOC sensor cannot be trusted.
+
+        True only when the SOC API is in stale-percent mode or there is no SOC
+        sensor at all. A *manual override on a healthy sensor* is NOT distrust:
+        the hardware zero-power fault check must still run in that case.
+        """
+        return self.car_api_stale_percent_mode or self.car_charge_percent_sensor is None
+
+    @property
+    def soc_integration_cursor(self) -> datetime | None:
+        """Read-only accessor for the SOC accumulator integration cursor."""
+        return self._delta_soc_last_integration_time
+
+    def accumulate_soc_delta(self, inc: float | None, time: datetime) -> float:
+        """Advance the SOC accumulator and return the value the constraint should use.
+
+        The car owns the running accumulator; the charge callback is its sole
+        writer and calls this once per cycle. `inc` is the efficiency-aware
+        percent charged since `soc_integration_cursor` (None → first cycle /
+        post-reboot / post-base-set: anchor only, do not integrate the gap).
+        Returns the absolute estimate when a base exists, otherwise the
+        pure-delta accumulator clamped to `[0, 100]`.
+        """
+        if self._computed_added_delta_soc_percent is None:
+            self._computed_added_delta_soc_percent = 0.0
+        if self._delta_soc_last_integration_time is None:
+            self._delta_soc_last_integration_time = time
+        elif inc is not None:
+            self._computed_added_delta_soc_percent += inc
+            self._delta_soc_last_integration_time = time
+        est = self._estimated_soc_percent
+        if est is not None:
+            return est
+        return max(0.0, min(100.0, self._computed_added_delta_soc_percent or 0.0))
+
     def get_car_charge_percent(
         self, time: datetime | None = None, tolerance_seconds: float | None = None
     ) -> float | None:
@@ -1372,23 +1417,46 @@ class QSCar(HADeviceMixin, AbstractDevice):
         return self.get_car_charge_percent_raw_sensor(time, tolerance_seconds)
 
     def _update_soc_estimation(self, time: datetime) -> None:
-        """Per-cycle recovery for a user-base override on a healthy sensor.
+        """Per-cycle recovery for a user manual override (4-case, keyed on entry state).
 
-        When the real sensor reports a fresh value that differs from the value
-        captured at manual-entry time, the genuine reading wins and the whole
-        SOC estimate is cleared. System-base recovery is handled separately by
-        `_exit_stale_mode` on API recovery.
+        The recovery branches on what the API state was at the moment the user
+        entered the override (`_user_base_soc_entry_api_stale`):
+
+        - **Case 1** — entered while in stale API mode: clear once the car has
+          exited stale mode and a fresh valid sensor value is available (live
+          sensor wins).
+        - **Case 2** — entered with API not stale and a valid value: clear only
+          when a fresh valid value appears that is *different* from the entry
+          value (tolerant compare); if equal, keep both base and delta.
+        - **Case 3** — entered with API not stale but no valid value: clear when
+          *any* valid value appears.
+
+        System-base recovery (no user override) is handled by `_exit_stale_mode`.
         """
         if self._user_base_soc_value is None:
             return
         if self.car_charge_percent_sensor is None:
             return
+        # Every case is triggered by a fresh, valid raw reading.
         if self._is_soc_sensor_stale(time):
             return
         raw = self.get_car_charge_percent_raw_sensor(time)
         if raw is None:
             return
-        if self._user_base_soc_entry_sensor_value is None or raw != self._user_base_soc_entry_sensor_value:
+
+        if self._user_base_soc_entry_api_stale:
+            # Case 1 — wait until the car has genuinely left stale-percent mode.
+            if not self.car_api_stale_percent_mode:
+                self.reset_soc_estimate()
+            return
+
+        if self._user_base_soc_entry_sensor_value is None:
+            # Case 3 — any valid reading clears.
+            self.reset_soc_estimate()
+            return
+
+        # Case 2 — clear only on a value that differs from the entry reference.
+        if round(raw) != round(self._user_base_soc_entry_sensor_value):
             self.reset_soc_estimate()
 
     def _capture_last_valid_base_soc(self, time: datetime) -> None:
@@ -1416,9 +1484,18 @@ class QSCar(HADeviceMixin, AbstractDevice):
         """Set a manual SOC baseline. `for_init` (entity restore) is a no-op."""
         if for_init:
             return
-        self._user_base_soc_value = float(max(0, min(100, int(value))))
+        try:
+            value = float(value)
+        except TypeError, ValueError:
+            return
+        if not math.isfinite(value):
+            # Reject NaN / ±inf (e.g. a raw `number.set_value` bypassing the card).
+            return
+        self._user_base_soc_value = float(max(0, min(100, round(value))))
         now = datetime.now(tz=pytz.UTC)
         self._user_base_soc_entry_sensor_value = self.get_car_charge_percent_raw_sensor(now)
+        # Record the API state at entry so recovery can branch on it (M1).
+        self._user_base_soc_entry_api_stale = self.car_api_stale_percent_mode
         self._computed_added_delta_soc_percent = 0.0
         self._delta_soc_last_integration_time = None
         if self.charger:
@@ -1439,6 +1516,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         self._last_valid_base_soc_value = None
         self._computed_added_delta_soc_percent = None
         self._user_base_soc_entry_sensor_value = None
+        self._user_base_soc_entry_api_stale = None
         self._delta_soc_last_integration_time = None
 
     async def user_button_reset_soc_estimate(self) -> None:

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -3192,6 +3192,10 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                     self.car.get_user_originated("person_name"),
                 )
                 self.car.clear_all_user_originated()
+                # Edge-triggered (plugged→unplugged): clear the estimated-SOC
+                # state. A manual value set while already unplugged survives a
+                # later plug-in because there is no intervening unplug edge here.
+                self.car.reset_soc_estimate()
                 self.reset(keep_commands=True)  # will detach the car
                 self.clear_user_originated("car_name")  # physical unplug, reset the user selected car for charger
                 do_force_solve = True
@@ -3268,6 +3272,12 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                     do_full_reset = False
                 else:
                     do_full_reset = True
+                if do_full_reset:
+                    # QS-243 — a genuine new plug-in resets the estimated-SOC
+                    # state (fresh charge session). A boot re-attach has
+                    # do_full_reset=False, so the persisted estimate survives an
+                    # HA reboot.
+                    best_car.reset_soc_estimate()
                 if self.clean_constraints_for_load_param_and_if_same_key_same_value_info(
                     time, load_param=best_car.name, for_full_reset=do_full_reset
                 ):
@@ -4631,6 +4641,9 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
 
         result_calculus = None
         sensor_result = None
+        delta_added = None
+
+        estimating = is_target_percent and self.car.is_in_soc_estimation_mode(time)
 
         if self.current_command is None or self.current_command.is_off_or_idle():
             _LOGGER.info("update_value_callback (is %%:%s): %s no command or idle/off", is_target_percent, self.name)
@@ -4638,26 +4651,50 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
         else:
             probe_charge_window = 30 * 60
             if is_target_percent:
-                if self.car.car_api_stale_percent_mode:
-                    sensor_result = None  # explicit bypass — SOC sensor is poisoned
+                if estimating:
+                    sensor_result = None  # explicit bypass — SOC sensor not trusted while estimating
                 else:
-                    sensor_result = self.car.get_car_charge_percent(time, tolerance_seconds=probe_charge_window)
+                    sensor_result = self.car.get_car_charge_percent_raw_sensor(
+                        time, tolerance_seconds=probe_charge_window
+                    )
             else:
                 sensor_result = self.car.get_car_charge_energy(time, tolerance_seconds=probe_charge_window)
 
             total_charge_duration = (ct.last_value_update - ct.first_value_update).total_seconds()
 
-            delta_added = self._compute_added_charge_update(
-                start_time=ct.last_value_change_update, end_time=time, is_target_percent=is_target_percent
-            )
-
-            if delta_added is not None:
-                if is_target_percent:
-                    result_calculus = ct.current_value + int(
-                        delta_added
-                    )  # round it to int ... so stay the same for small updates
+            if estimating:
+                # Car-level float accumulator with a dedicated integration cursor:
+                # advances every cycle so sub-1%/cycle slices are never lost and
+                # never double-counted across solver / constraint churn. The car
+                # owns the running value; this callback is its sole writer.
+                if self.car._computed_added_delta_soc_percent is None:
+                    self.car._computed_added_delta_soc_percent = 0.0
+                if self.car._delta_soc_last_integration_time is None:
+                    # post-reboot / post-base-set: anchor only, do not integrate the gap
+                    self.car._delta_soc_last_integration_time = time
                 else:
-                    result_calculus = ct.current_value + delta_added
+                    inc = self._compute_added_charge_update(
+                        start_time=self.car._delta_soc_last_integration_time,
+                        end_time=time,
+                        is_target_percent=True,
+                    )
+                    if inc is not None:
+                        self.car._computed_added_delta_soc_percent += inc
+                        self.car._delta_soc_last_integration_time = time
+                est = self.car._estimated_soc_percent  # base+delta clamped, or None
+                result_calculus = est if est is not None else (self.car._computed_added_delta_soc_percent or 0.0)
+            else:
+                delta_added = self._compute_added_charge_update(
+                    start_time=ct.last_value_change_update, end_time=time, is_target_percent=is_target_percent
+                )
+
+                if delta_added is not None:
+                    if is_target_percent:
+                        result_calculus = ct.current_value + int(
+                            delta_added
+                        )  # round it to int ... so stay the same for small updates
+                    else:
+                        result_calculus = ct.current_value + delta_added
 
             result = sensor_result
 
@@ -4717,7 +4754,7 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
             is_target_percent
             and result is not None
             and ct.target_value - result >= CHARGER_CHECK_REAL_POWER_MIN_SOC_DIFF_PERCENT
-            and not self.car.car_api_stale_percent_mode
+            and not estimating
         ):
             if (
                 self._expected_charge_state.value is True

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -4666,23 +4666,15 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                 # Car-level float accumulator with a dedicated integration cursor:
                 # advances every cycle so sub-1%/cycle slices are never lost and
                 # never double-counted across solver / constraint churn. The car
-                # owns the running value; this callback is its sole writer.
-                if self.car._computed_added_delta_soc_percent is None:
-                    self.car._computed_added_delta_soc_percent = 0.0
-                if self.car._delta_soc_last_integration_time is None:
-                    # post-reboot / post-base-set: anchor only, do not integrate the gap
-                    self.car._delta_soc_last_integration_time = time
+                # owns the running value; this callback is its sole writer and
+                # drives it through the car's public accessors.
+                cursor = self.car.soc_integration_cursor
+                if cursor is None:
+                    # first cycle / post-reboot / post-base-set: anchor only.
+                    inc = None
                 else:
-                    inc = self._compute_added_charge_update(
-                        start_time=self.car._delta_soc_last_integration_time,
-                        end_time=time,
-                        is_target_percent=True,
-                    )
-                    if inc is not None:
-                        self.car._computed_added_delta_soc_percent += inc
-                        self.car._delta_soc_last_integration_time = time
-                est = self.car._estimated_soc_percent  # base+delta clamped, or None
-                result_calculus = est if est is not None else (self.car._computed_added_delta_soc_percent or 0.0)
+                    inc = self._compute_added_charge_update(start_time=cursor, end_time=time, is_target_percent=True)
+                result_calculus = self.car.accumulate_soc_delta(inc, time)
             else:
                 delta_added = self._compute_added_charge_update(
                     start_time=ct.last_value_change_update, end_time=time, is_target_percent=is_target_percent
@@ -4750,11 +4742,16 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
         # in case we do have a proper soc % and we expect a charge ongoing (ie "far" from the target)
         # we can check that the charger is really delivering power to the car
 
+        # The zero-power hardware-fault check needs a *trusted* SOC reference to
+        # decide growth, but it can also fall back to raw power measurement. It
+        # is therefore only skipped when the SOC sensor is genuinely distrusted
+        # (stale-percent mode / no sensor) — NOT for a plain manual override on a
+        # healthy, sensor-equipped car (S1).
         if (
             is_target_percent
             and result is not None
             and ct.target_value - result >= CHARGER_CHECK_REAL_POWER_MIN_SOC_DIFF_PERCENT
-            and not estimating
+            and not self.car.is_soc_sensor_distrusted()
         ):
             if (
                 self._expected_charge_state.value is True

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -3193,8 +3193,10 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                 )
                 self.car.clear_all_user_originated()
                 # Edge-triggered (plugged→unplugged): clear the estimated-SOC
-                # state. A manual value set while already unplugged survives a
-                # later plug-in because there is no intervening unplug edge here.
+                # state. The genuine plug-in path also clears it (the
+                # do_full_reset branch below), so the estimate is reset on every
+                # plug cycle; only an HA reboot (boot re-attach, with
+                # do_full_reset=False) preserves the persisted estimate.
                 self.car.reset_soc_estimate()
                 self.reset(keep_commands=True)  # will detach the car
                 self.clear_user_originated("car_name")  # physical unplug, reset the user selected car for charger

--- a/custom_components/quiet_solar/number.py
+++ b/custom_components/quiet_solar/number.py
@@ -1,12 +1,13 @@
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -27,6 +28,10 @@ from .entity import QSDeviceEntity
 class QSNumberEntityDescription(NumberEntityDescription):
     qs_default_option: str | None = None
     async_set_fn: Callable[[AbstractDevice, float, bool], Any] | None = None
+    # When True, the entity's displayed value tracks `getattr(device, key)` every
+    # update cycle, so a runtime reset of the backing attribute is reflected in
+    # the card (QS-243 S1).
+    qs_track_device_value: bool = False
 
 
 def create_ha_number_for_QSBiStateDuration(device: QSBiStateDuration):
@@ -71,6 +76,7 @@ def create_ha_number_for_QSCar(device: QSCar):
             native_unit_of_measurement=PERCENTAGE,
             mode=NumberMode.BOX,
             async_set_fn=lambda device, value, for_init: device.user_set_manual_soc_percent(value, for_init),
+            qs_track_device_value=True,
         )
         entities.append(
             QSBaseNumber(data_handler=device.data_handler, device=device, description=manual_soc_description)
@@ -169,4 +175,14 @@ class QSBaseNumber(QSDeviceEntity, NumberEntity, RestoreEntity):
                     "can't set number %s on %s for %s: %s", value, self.device.name, self.entity_description.key, e
                 )
         self._set_availabiltiy()
+        self.async_write_ha_state()
+
+    @callback
+    def async_update_callback(self, time: datetime) -> None:
+        """Re-sync the displayed value from the device when tracking it (S1)."""
+        self._set_availabiltiy()
+        if self.entity_description.qs_track_device_value:
+            new_val = getattr(self.device, self.entity_description.key, None)
+            if new_val is not None and new_val != self._attr_native_value:
+                self._attr_native_value = new_val
         self.async_write_ha_state()

--- a/custom_components/quiet_solar/number.py
+++ b/custom_components/quiet_solar/number.py
@@ -5,15 +5,17 @@ from typing import Any
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTime
+from homeassistant.const import PERCENTAGE, STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     DOMAIN,
+    NUMBER_CAR_MANUAL_SOC_PERCENT,
 )
 from .ha_model.bistate_duration import QSBiStateDuration
+from .ha_model.car import QSCar
 from .home_model.load import AbstractDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,11 +58,35 @@ def create_ha_number_for_QSBiStateDuration(device: QSBiStateDuration):
     return entities
 
 
+def create_ha_number_for_QSCar(device: QSCar):
+    entities = []
+
+    if device.can_use_charge_percent_constraints():
+        manual_soc_description = QSNumberEntityDescription(
+            key=NUMBER_CAR_MANUAL_SOC_PERCENT,
+            translation_key=NUMBER_CAR_MANUAL_SOC_PERCENT,
+            native_max_value=100,
+            native_min_value=0,
+            native_step=1,
+            native_unit_of_measurement=PERCENTAGE,
+            mode=NumberMode.BOX,
+            async_set_fn=lambda device, value, for_init: device.user_set_manual_soc_percent(value, for_init),
+        )
+        entities.append(
+            QSBaseNumber(data_handler=device.data_handler, device=device, description=manual_soc_description)
+        )
+
+    return entities
+
+
 def create_ha_number(device: AbstractDevice):
     ret = []
 
     if isinstance(device, QSBiStateDuration):
         ret.extend(create_ha_number_for_QSBiStateDuration(device))
+
+    if isinstance(device, QSCar):
+        ret.extend(create_ha_number_for_QSCar(device))
 
     return ret
 

--- a/custom_components/quiet_solar/strings.json
+++ b/custom_components/quiet_solar/strings.json
@@ -851,6 +851,9 @@
       },
       "qs_car_is_stale": {
         "name": "Car API Stale"
+      },
+      "qs_car_is_soc_estimated": {
+        "name": "Car charge is estimated"
       }
     },
 
@@ -973,6 +976,9 @@
       },
       "qs_next_car_charge_add_default": {
         "name": "Add Charge"
+      },
+      "qs_car_reset_soc_estimate": {
+        "name": "Reset charge estimate"
       },
       "qs_home_recompute_people_historical_data": {
         "name": "Recompute People Historical Data"
@@ -1135,6 +1141,9 @@
       },
       "override_duration": {
         "name": "Reset user override duration (hours)"
+      },
+      "qs_car_manual_soc_percent": {
+        "name": "Manual charge percent"
       }
     },
     "time": {

--- a/custom_components/quiet_solar/translations/en.json
+++ b/custom_components/quiet_solar/translations/en.json
@@ -432,6 +432,9 @@
             "qs_car_api_ok": {
                 "name": "Car API OK"
             },
+            "qs_car_is_soc_estimated": {
+                "name": "Car charge is estimated"
+            },
             "qs_car_is_stale": {
                 "name": "Car API Stale"
             },
@@ -455,6 +458,9 @@
             }
         },
         "button": {
+            "qs_car_reset_soc_estimate": {
+                "name": "Reset charge estimate"
+            },
             "qs_device_clean_and_reset": {
                 "name": "BEWARE: Force Reset"
             },
@@ -507,6 +513,9 @@
             },
             "override_duration": {
                 "name": "Reset user override duration (hours)"
+            },
+            "qs_car_manual_soc_percent": {
+                "name": "Manual charge percent"
             }
         },
         "select": {

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
@@ -77,6 +77,12 @@ views:
               {% if e %}force_now: {{ e.entity_id }}{% endif %}
               {%- set e = ha.get("qs_next_car_charge_add_default") %}
               {% if e %}schedule: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("qs_car_is_soc_estimated") %}
+              {% if e %}is_soc_estimated: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("qs_car_manual_soc_percent") %}
+              {% if e %}manual_soc: {{ e.entity_id }}{% endif %}
+              {%- set e = ha.get("qs_car_reset_soc_estimate") %}
+              {% if e %}reset_soc: {{ e.entity_id }}{% endif %}
               {%- set e = ha.get("car_soc_percentage") %}
               {%- if e %}
               {%-    set badges_list.badges = badges_list.badges + [(e.entity_id, device.name)] %}

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2
@@ -105,6 +105,21 @@ views:
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
               {%- endif %}
               {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("qs_car_is_soc_estimated") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("qs_car_manual_soc_percent") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("qs_car_reset_soc_estimate") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
               {%- set ha_entity = device.ha_entities.get("best_power_value") %}
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -830,6 +830,10 @@ class QsCarCard extends QsCardBase {
       const sUsePercentMode = this._entity(e.use_percent_mode);
       const sIsOffGrid = this._entity(e.is_off_grid);
       const sCarIsStale = this._entity(e.car_is_stale);
+      // QS-243 — estimated-SOC wiring: the asterisk flag, the manual-SOC
+      // number entity (popup prefill + write target), and the reset button.
+      const sIsSocEstimated = this._entity(e.is_soc_estimated);
+      const sManualSoc = this._entity(e.manual_soc);
 
       const title = (cfg.title || cfg.name) || (sSoc ? (sSoc.attributes.friendly_name || sSoc.entity_id) : "Car");
 
@@ -908,8 +912,15 @@ class QsCarCard extends QsCardBase {
       // Font size for energy unit (kWh) relative to the number
       const energyUnitFontSize = 0.4; // 40% of the number size
 
-      // Get target value based on mode
-      const isStalePercentMode = isStale && !useEnergyMode;
+      // Get target value based on mode.
+      // QS-243 — display is keyed on the estimate state, not raw staleness:
+      //   - `hasSocEstimate` (absolute estimate) → `NN%*` via the percent
+      //     branch (the SOC sensor already returns the estimate);
+      //   - pure-delta (estimating, no base → SOC sensor unknown) → `+XX%`;
+      //   - a real fresh sensor → plain `NN%`.
+      const hasSocEstimate = sIsSocEstimated?.state === 'on';
+      const socNumeric = isNumberLike(sSoc?.state);
+      const isStalePercentMode = !useEnergyMode && !hasSocEstimate && !socNumeric;
       let targetPct, displayTargetValue, maxCircleValue, displaySocValue;
       if (isStalePercentMode) {
           // Stale-percent mode: show +XX% based on energy delivered
@@ -969,7 +980,9 @@ class QsCarCard extends QsCardBase {
           targetPct = parseTargetPercent(target);
           maxCircleValue = 100;
           displayTargetValue = `${this._fmt(targetPct ?? soc)}%`;
-          displaySocValue = `${this._fmt(soc)}%`;
+          // QS-243 — append an asterisk when the SOC is estimated rather
+          // than read live from the car's sensor.
+          displaySocValue = `${this._fmt(soc)}%${hasSocEstimate ? '*' : ''}`;
       }
 
       // QS-199 review-fix #02 S2 — use the inherited hardened
@@ -1357,7 +1370,7 @@ class QsCarCard extends QsCardBase {
               <div class="stack">
                 <div class="soc-block">
                   ${chargeIcon ? `<ha-icon class="charge-type-icon" icon="${chargeIcon}"></ha-icon>` : ''}
-                  <div class="pct" style="margin-bottom:0;">${displaySocValue}</div>
+                  <div class="pct${(!useEnergyMode && e.manual_soc) ? ' soc-editable' : ''}" id="soc_pct"${(!useEnergyMode && e.manual_soc) ? ` role="button" ${ctrlTabAttrs} aria-label="Edit charge percent"` : ''} style="margin-bottom:0;${(!useEnergyMode && e.manual_soc) ? ' cursor: pointer;' : ''}">${displaySocValue}</div>
                   ${useEnergyMode ? '' : `<div class="mini-range-now" aria-label="current range">${rangeNowStr}</div>`}
                 </div>
                 <div class="target-block">
@@ -1760,6 +1773,46 @@ class QsCarCard extends QsCardBase {
           };
           schedBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); schedAction(); });
           schedBtn?.addEventListener('touchend', (ev) => { ev.preventDefault(); schedAction(); });
+      }
+
+      // QS-243 — the big SOC number opens a manual-charge popup with an
+      // integer 0–100 input and Save / Cancel / Reset actions. Save writes
+      // the manual-SOC number entity; Reset presses the reset button.
+      if (!useEnergyMode && e.manual_soc) {
+          const socEl = ids('soc_pct');
+          const openSocDialog = () => {
+              if (this._root?.querySelector('.disabled')) return;
+              const manualRaw = sManualSoc?.state;
+              const cur = isNumberLike(manualRaw)
+                  ? Math.round(Number(manualRaw))
+                  : (isNumberLike(sSoc?.state) ? Math.round(Number(sSoc.state)) : 0);
+              const content = `<div class="qs-soc-edit" style="text-align:center; padding: 8px 0;">`
+                  + `<input id="qs_soc_input" type="number" min="0" max="100" step="1" inputmode="numeric" value="${cur}" `
+                  + `style="font-size:1.4rem; width:96px; text-align:center; padding:6px;" /> %</div>`;
+              const buttons = [
+                  {
+                      text: 'Save', variant: 'primary', onClick: async () => {
+                          const inp = this._root?.querySelector('#qs_soc_input');
+                          let v = inp ? Number(inp.value) : NaN;
+                          if (!Number.isFinite(v)) return;
+                          v = Math.max(0, Math.min(100, Math.round(v)));
+                          await this._setNumber(e.manual_soc, v);
+                      }
+                  },
+                  { text: 'Cancel', variant: 'secondary' },
+              ];
+              if (e.reset_soc) {
+                  buttons.push({
+                      text: 'Reset', variant: 'secondary', onClick: async () => {
+                          await this._press(e.reset_soc);
+                      }
+                  });
+              }
+              this._showDialog({ title: 'Set charge percent', customContent: content, buttons });
+          };
+          socEl?.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); openSocDialog(); });
+          socEl?.addEventListener('touchend', (ev) => { ev.preventDefault(); openSocDialog(); });
+          this._registerKeyActivation(socEl, openSocDialog);
       }
 
       // QS-235 AC4 — the reset button adopts the shared `_wireResetButton`

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -1808,6 +1808,9 @@ class QsCarCard extends QsCardBase {
                       }
                   });
               }
+              // `_showDialog`'s per-button `activate()` removes the modal in a
+              // finally block after `onClick` resolves, so Save / Cancel / Reset
+              // all dismiss the popup — no explicit close needed here (N6).
               this._showDialog({ title: 'Set charge percent', customContent: content, buttons });
           };
           socEl?.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); openSocDialog(); });

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -1026,6 +1026,12 @@ class QsCarCard extends QsCardBase {
       .hero .side { text-align:center; color: var(--secondary-text-color); font-weight:600; }
       .hero .side .value { display:block; font-size:1.2rem; color: var(--primary-text-color); }
       .ring .pct { font-size: 4rem; font-weight:800; letter-spacing:-1px; line-height:1; text-shadow: var(--ring-text-shadow); }
+      /* QS-243 M1 -- .ring .center is pointer-events:none (so the SVG gauge
+         stays interactive); the editable SOC variant must re-enable pointer
+         events or its click/tap handlers never fire. The non-editable SOC text
+         stays click-through. The .disabled guard still no-ops it when the car
+         is not plugged into a charger. */
+      .ring .pct.soc-editable { pointer-events: auto; cursor: pointer; }
       .ring ha-icon { --mdc-icon-size: 32px; color: var(--secondary-text-color); margin-bottom: 6px; }
       .ring .soc-block { display:flex; flex-direction:column; align-items:center; gap:2px; margin-top:4px; margin-bottom:8px; }
       .ring .soc-block .charge-type-icon { --mdc-icon-size: 20px; color: var(--secondary-text-color); margin-bottom: 2px; }
@@ -1794,7 +1800,11 @@ class QsCarCard extends QsCardBase {
                       text: 'Save', variant: 'primary', onClick: async () => {
                           const inp = this._root?.querySelector('#qs_soc_input');
                           let v = inp ? Number(inp.value) : NaN;
-                          if (!Number.isFinite(v)) return;
+                          // QS-243 N1 — never silently discard: invalid / non-finite
+                          // input falls back to the prefilled current value and is
+                          // still clamped + saved (the dialog always commits a sane
+                          // value rather than closing with no save).
+                          if (!Number.isFinite(v)) v = cur;
                           v = Math.max(0, Math.min(100, Math.round(v)));
                           await this._setNumber(e.manual_soc, v);
                       }

--- a/docs/agents/concepts/car-soc-estimation.md
+++ b/docs/agents/concepts/car-soc-estimation.md
@@ -1,0 +1,89 @@
+---
+title: Car SOC estimation
+slug: car-soc-estimation
+kind: concept
+covers:
+  - custom_components/quiet_solar/ha_model/car.py
+last_verified: 2026-05-29
+---
+
+# Car SOC estimation — the effective-SOC model
+
+## TL;DR
+
+A car's *effective* SOC is unified behind one accessor,
+`QSCar.get_car_charge_percent`. When the SOC API is **failed**,
+**inaccurate**, or **absent**, the car estimates SOC as `base + charged
+energy since`, where the base is either a **manual entry** or the **last
+valid sensor reading** captured at the fresh→stale edge. A genuine new
+sensor reading always wins and clears the estimate.
+
+## When you need this concept
+
+- Touching `get_car_charge_percent` or any SOC read in the charge loop.
+- Changing stale-percent-mode entry/exit or the manual-SOC entities.
+- Reasoning about why the constraint seed (`car_initial_value`) is no
+  longer forced to `0.0`.
+
+## State model (persisted on `QSCar`)
+
+- `_user_base_soc_value` — manually-entered baseline.
+- `_last_valid_base_soc_value` — last valid real sensor value, captured at
+  the fresh→stale transition (only when no user base exists).
+- `_computed_added_delta_soc_percent` — accumulated, efficiency-aware
+  percent added during the current plugged session (a **float**).
+- `_user_base_soc_entry_sensor_value` — raw sensor value at the instant the
+  user entered the manual value (recovery reference; may be `None`).
+- `_delta_soc_last_integration_time` — **not persisted**; the dedicated
+  integration cursor, re-anchored on reboot so downtime energy is not
+  counted.
+
+## Accessors
+
+- `get_car_charge_percent_raw_sensor` — the trusted-sensor read; efficiency
+  learning and the charge callback use this so they never see the estimate.
+- `_estimated_soc_percent` — `clamp(base + delta, 0, 100)`, or `None` with no
+  base (pure-delta `+XX%`).
+- `is_in_soc_estimation_mode` — True for a no-sensor car, in stale-percent
+  mode, or with a manual base on a healthy API.
+- `has_soc_estimate` — an absolute estimate exists (drives the `*` /
+  `is_soc_estimated` sensor). Distinct from `is_in_soc_estimation_mode`:
+  they diverge for the pure-delta case.
+
+## Accumulator (charger callback is the sole writer)
+
+`constraint_update_value_callback_soc` advances the car-level float
+accumulator with its own cursor **every cycle** so sub-1%/cycle slices are
+never lost and never double-counted across solver / constraint churn. The
+first cycle (or post-reboot / post-base-set) only **anchors** the cursor.
+
+## Recovery and orthogonality
+
+- **User-base recovery** (`_update_soc_estimation`, per cycle): a fresh
+  sensor value that differs from `_user_base_soc_entry_sensor_value` (exact
+  compare; a `None` reference also counts) clears everything.
+- **System-base recovery**: `_exit_stale_mode` clears the system base,
+  accumulator, and cursor on API recovery. The user base is never cleared
+  by stale-mode exit.
+- Estimation is **orthogonal** to `is_car_effectively_stale`: a manual
+  override on a healthy API marks the car *estimated* (asterisk) but **not**
+  API-stale.
+
+## Capture at the fresh→stale edge
+
+`_enter_stale_percent_mode(time)` wraps every stale-percent write site and
+captures the last valid raw SOC into `_last_valid_base_soc_value` (zeroing
+the accumulator) only on a genuine edge and only when no base exists. The
+`for_init` restore path never captures — the persisted value is the truth.
+
+## Gotchas
+
+- `can_use_charge_percent_constraints` no longer requires a SOC sensor — a
+  non-invited car with a true battery capacity estimates from energy.
+- Clearing the estimate happens on `user_clean_and_reset` / the reset button,
+  on the unplug edge, and on a **genuine plug-in** (charger.py
+  `do_full_reset=True` branch). It is **never** in the low-level `car.reset()`:
+  `attach_car` runs `reset()` on both a genuine plug-in and the boot re-attach,
+  so only the charger can tell them apart. A plug-in resets the estimate (fresh
+  charge session); a boot re-attach (`do_full_reset=False`) preserves the
+  persisted estimate, so it survives an HA reboot.

--- a/docs/agents/concepts/car-soc-estimation.md
+++ b/docs/agents/concepts/car-soc-estimation.md
@@ -41,8 +41,10 @@ sensor reading always wins and clears the estimate.
   counted.
 
 `user_set_manual_soc_percent` guards non-finite input (`math.isfinite`) and
-`round()`s before clamping — a raw `number.set_value` can bypass the card's
-finite/round guard.
+half-up-rounds before clamping — a raw `number.set_value` can bypass the card's
+finite/round guard. The manual-SOC **number entity** tracks
+`qs_car_manual_soc_percent` every update cycle (`qs_track_device_value`), so a
+runtime reset (plug-in / reset button / recovery) is reflected in the card.
 
 ## Accessors
 
@@ -83,6 +85,10 @@ charger computes `inc` from `soc_integration_cursor` then calls
     value *differs* from the entry reference (tolerant `round` compare); equal
     → keep base **and** delta.
   - *Case 3* — entered not-stale without a valid value: any valid value clears.
+  - Force-Not-Stale is treated as "sensor trusted": recovery may proceed even
+    when the SOC sensor is time-stale (the user has asserted it is reliable).
+  The tolerant compare uses half-away-from-zero rounding (`_round_half_up`), not
+  Python's banker's rounding, so an exact `.5` reading is not mis-binned.
 - **System-base recovery**: `_exit_stale_mode` clears the system base. It also
   clears the accumulator + cursor **only when no user override is active** — an
   override owns its own accumulator lifecycle, so a transient stale blip must

--- a/docs/agents/concepts/car-soc-estimation.md
+++ b/docs/agents/concepts/car-soc-estimation.md
@@ -4,7 +4,7 @@ slug: car-soc-estimation
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/car.py
-last_verified: 2026-05-29
+last_verified: 2026-05-30
 ---
 
 # Car SOC estimation — the effective-SOC model
@@ -34,9 +34,15 @@ sensor reading always wins and clears the estimate.
   percent added during the current plugged session (a **float**).
 - `_user_base_soc_entry_sensor_value` — raw sensor value at the instant the
   user entered the manual value (recovery reference; may be `None`).
+- `_user_base_soc_entry_api_stale` — the stale-percent state at manual entry;
+  drives the 4-case recovery branch (`None` for pre-QS-243 blobs).
 - `_delta_soc_last_integration_time` — **not persisted**; the dedicated
   integration cursor, re-anchored on reboot so downtime energy is not
   counted.
+
+`user_set_manual_soc_percent` guards non-finite input (`math.isfinite`) and
+`round()`s before clamping — a raw `number.set_value` can bypass the card's
+finite/round guard.
 
 ## Accessors
 
@@ -46,25 +52,42 @@ sensor reading always wins and clears the estimate.
   base (pure-delta `+XX%`).
 - `is_in_soc_estimation_mode` — True for a no-sensor car, in stale-percent
   mode, or with a manual base on a healthy API.
+- `is_soc_sensor_distrusted` — True only in stale-percent mode or with no SOC
+  sensor. A manual override on a healthy sensor is **not** distrust — the
+  charger's zero-power hardware-fault check still runs (it is gated on distrust,
+  not on `is_in_soc_estimation_mode`).
 - `has_soc_estimate` — an absolute estimate exists (drives the `*` /
   `is_soc_estimated` sensor). Distinct from `is_in_soc_estimation_mode`:
   they diverge for the pure-delta case.
+- `soc_integration_cursor` (property) + `accumulate_soc_delta(inc, time)` — the
+  car's public accumulator API; the charger drives it through these instead of
+  reaching into the underscore-private fields. `accumulate_soc_delta` clamps the
+  pure-delta return to `[0, 100]`.
 
 ## Accumulator (charger callback is the sole writer)
 
 `constraint_update_value_callback_soc` advances the car-level float
 accumulator with its own cursor **every cycle** so sub-1%/cycle slices are
 never lost and never double-counted across solver / constraint churn. The
-first cycle (or post-reboot / post-base-set) only **anchors** the cursor.
+first cycle (or post-reboot / post-base-set) only **anchors** the cursor. The
+charger computes `inc` from `soc_integration_cursor` then calls
+`accumulate_soc_delta(inc, time)`.
 
 ## Recovery and orthogonality
 
-- **User-base recovery** (`_update_soc_estimation`, per cycle): a fresh
-  sensor value that differs from `_user_base_soc_entry_sensor_value` (exact
-  compare; a `None` reference also counts) clears everything.
-- **System-base recovery**: `_exit_stale_mode` clears the system base,
-  accumulator, and cursor on API recovery. The user base is never cleared
-  by stale-mode exit.
+- **User-base recovery** (`_update_soc_estimation`, per cycle) is a 4-case
+  state machine keyed on `_user_base_soc_entry_api_stale`:
+  - *Case 1* — entered while stale: clear once the car has exited stale mode
+    and a fresh valid value is available (live sensor wins).
+  - *Case 2* — entered not-stale with a valid value: clear only when a fresh
+    value *differs* from the entry reference (tolerant `round` compare); equal
+    → keep base **and** delta.
+  - *Case 3* — entered not-stale without a valid value: any valid value clears.
+- **System-base recovery**: `_exit_stale_mode` clears the system base. It also
+  clears the accumulator + cursor **only when no user override is active** — an
+  override owns its own accumulator lifecycle, so a transient stale blip must
+  not wipe its accumulated delta. The user base is never cleared by stale-mode
+  exit.
 - Estimation is **orthogonal** to `is_car_effectively_stale`: a manual
   override on a healthy API marks the car *estimated* (asterisk) but **not**
   API-stale.

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -4,7 +4,7 @@ slug: charger-budgeting
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/charger.py
-last_verified: 2026-05-19
+last_verified: 2026-05-29
 ---
 
 # Charger Dynamic Budgeting — the tactical layer
@@ -110,3 +110,7 @@ apply_budget_strategy()
   — why the split exists.
 - [../use-cases/magali-plugs-in-car.md](../use-cases/magali-plugs-in-car.md)
   — the magic-moment use case this layer enables.
+- [car-soc-estimation.md](car-soc-estimation.md) — `constraint_update_value_callback_soc`
+  is the **sole writer** of the car's float SOC accumulator (QS-243); while
+  the car is estimating it bypasses the raw sensor and seeds the constraint
+  from the effective estimate instead of a forced `0.0`.

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -4,7 +4,7 @@ slug: charger-budgeting
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/charger.py
-last_verified: 2026-05-29
+last_verified: 2026-05-30
 ---
 
 # Charger Dynamic Budgeting — the tactical layer
@@ -113,4 +113,9 @@ apply_budget_strategy()
 - [car-soc-estimation.md](car-soc-estimation.md) — `constraint_update_value_callback_soc`
   is the **sole writer** of the car's float SOC accumulator (QS-243); while
   the car is estimating it bypasses the raw sensor and seeds the constraint
-  from the effective estimate instead of a forced `0.0`.
+  from the effective estimate instead of a forced `0.0`. It drives the
+  accumulator through the car's public `soc_integration_cursor` /
+  `accumulate_soc_delta` accessors (no underscore reach-in), and gates the
+  zero-power hardware-fault check on `car.is_soc_sensor_distrusted()` (stale /
+  no-sensor) — **not** on the broad estimation flag, so a manual override on a
+  healthy car still gets fault detection.

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -118,4 +118,6 @@ apply_budget_strategy()
   `accumulate_soc_delta` accessors (no underscore reach-in), and gates the
   zero-power hardware-fault check on `car.is_soc_sensor_distrusted()` (stale /
   no-sensor) — **not** on the broad estimation flag, so a manual override on a
-  healthy car still gets fault detection.
+  healthy car still gets fault detection. The estimate is reset on the
+  genuine-plug-in branch (`do_full_reset`) and the unplug edge; a boot re-attach
+  preserves it (reboot survival).

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/__init__.py
   - custom_components/quiet_solar/data_handler.py
   - custom_components/quiet_solar/const.py
-last_verified: 2026-05-22
+last_verified: 2026-05-29
 ---
 
 # Config flow and setup

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -17,7 +17,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/shared/qs-ring-duration-base.js
   - custom_components/quiet_solar/ui/resources/shared/qs-anim-flame.js
   - custom_components/quiet_solar/ui/resources/shared/qs-anim-wave.js
-last_verified: 2026-05-29
+last_verified: 2026-05-30
 ---
 
 # Dashboard generation and JS Lovelace cards
@@ -804,6 +804,11 @@ ring geometry** — the old `NaN` propagated through
 `socPct → handlePct → pctToDeg → polar`, emitting a `cx="NaN"` handle
 position; the `0` keeps the handle pinned at the bottom of the gauge.
 Confirm the `0`-on-dropout readout in the Phase-F smoke.
+
+**SOC popup dismissal (QS-243).** Save / Cancel / Reset all dismiss the popup
+via `_showDialog`'s per-button `activate()` `finally` block (it removes the
+modal after `onClick` resolves) — no explicit close call is needed in
+`openSocDialog`.
 
 **Estimated-SOC display + manual popup (QS-243).** The percent display is
 keyed on the `is_soc_estimated` binary sensor, not raw staleness: an

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -805,6 +805,15 @@ ring geometry** — the old `NaN` propagated through
 position; the `0` keeps the handle pinned at the bottom of the gauge.
 Confirm the `0`-on-dropout readout in the Phase-F smoke.
 
+**CSS template-literal hazard (QS-243).** The car card's CSS block is a JS
+template literal (`baseCardCSS(colors) + ` + backtick … backtick). A stray
+backtick **anywhere inside it — including a comment** — closes the literal early
+and turns the trailing CSS into JS, which throws at render time and surfaces as
+a Lovelace "Configuration error" placeholder (`setConfig` calls `_render`).
+Never put backticks in that block; a regression test asserts there are none. The
+editable SOC `.pct.soc-editable` re-enables `pointer-events: auto` (its parent
+`.ring .center` is `pointer-events: none`), else the popup click never fires.
+
 **SOC popup dismissal (QS-243).** Save / Cancel / Reset all dismiss the popup
 via `_showDialog`'s per-button `activate()` `finally` block (it removes the
 modal after `onClick` resolves) — no explicit close call is needed in

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -805,6 +805,17 @@ ring geometry** — the old `NaN` propagated through
 position; the `0` keeps the handle pinned at the bottom of the gauge.
 Confirm the `0`-on-dropout readout in the Phase-F smoke.
 
+**Estimated-SOC display + manual popup (QS-243).** The percent display is
+keyed on the `is_soc_estimated` binary sensor, not raw staleness: an
+absolute estimate renders as `NN%*` (the `*` flags an estimated value),
+the pure-delta case (estimating with no base → SOC sensor unknown) renders
+`+XX%`, and a live fresh sensor renders plain `NN%`. In percent mode the big
+SOC number is clickable → a popup with an integer 0–100 input and **Save**
+(`number.set_value` on `manual_soc`) / **Cancel** / **Reset**
+(`button.press` on `reset_soc`). The template wires `is_soc_estimated`,
+`manual_soc`, and `reset_soc` into the card. See
+[car-soc-estimation.md](car-soc-estimation.md) for the backing model.
+
 **Degraded state CSS filter.** When `degraded === true` (computed
 as `isDisconnected || isFaulted || isStale` — `isOffGrid` is
 explicitly excluded; the card-level pinkish `.off-grid` CSS class

--- a/docs/agents/concepts/person-trip-prediction.md
+++ b/docs/agents/concepts/person-trip-prediction.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/person.py
   - custom_components/quiet_solar/ha_model/car.py
-last_verified: 2026-05-19
+last_verified: 2026-05-29
 ---
 
 # Person, Car, and trip prediction
@@ -41,7 +41,11 @@ tomorrow's predicted trips with margin.
 
 **Car side**:
 
-- SOC tracking via HA entity (manufacturer-specific).
+- SOC tracking via HA entity (manufacturer-specific). The trip-prediction
+  read goes through the unified effective-SOC accessor
+  `get_car_charge_percent`, which returns an **estimate** when the SOC API
+  is failed / inaccurate / absent — see
+  [car-soc-estimation.md](car-soc-estimation.md).
 - Charger assignment: which charger this car is plugged into.
 - Person allocation: which person owns this car (drives prediction
   targeting).

--- a/docs/agents/concepts/person-trip-prediction.md
+++ b/docs/agents/concepts/person-trip-prediction.md
@@ -43,9 +43,9 @@ tomorrow's predicted trips with margin.
 
 - SOC tracking via HA entity (manufacturer-specific). The trip-prediction
   read goes through the unified effective-SOC accessor
-  `get_car_charge_percent`, which returns an **estimate** when the SOC API
-  is failed / inaccurate / absent — see
-  [car-soc-estimation.md](car-soc-estimation.md).
+  `get_car_charge_percent`, which returns an **estimate** (manual override or
+  charged-energy interpolation) when the SOC API is failed / inaccurate /
+  absent — see [car-soc-estimation.md](car-soc-estimation.md).
 - Charger assignment: which charger this car is plugged into.
 - Person allocation: which person owns this car (drives prediction
   targeting).

--- a/docs/agents/concepts/person-trip-prediction.md
+++ b/docs/agents/concepts/person-trip-prediction.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/person.py
   - custom_components/quiet_solar/ha_model/car.py
-last_verified: 2026-05-29
+last_verified: 2026-05-30
 ---
 
 # Person, Car, and trip prediction

--- a/docs/stories/QS-243.story.md
+++ b/docs/stories/QS-243.story.md
@@ -1,0 +1,501 @@
+# QS-243 — Manual SOC override + charge-energy SOC estimation for cars
+
+- **Issue:** #243
+- **Branch:** QS_243
+- **Next phase:** implement-task (touches `custom_components/quiet_solar/` product code)
+
+## Summary
+
+Let a user manually override a car's State of Charge (SOC), and otherwise
+estimate SOC from charged energy when the SOC API is **failed**,
+**inaccurate**, or **absent**. We unify the existing "stale-percent /
+delta-only" mode and the no-SOC-sensor case behind a single **effective-SOC**
+accessor (`get_car_charge_percent`) backed by a small, persisted state model on
+the car. The displayed/used SOC is `base + charged-energy-since`, where the base
+is either a manual entry or the last valid sensor reading captured when the API
+went stale. A genuine new sensor reading overrides the manual/estimated value.
+
+This piggybacks on the already-existing delta interpolation in
+`constraint_update_value_callback_soc` / `_compute_added_charge_update` — we add
+the missing baseline (today it is forced to `0.0` when no SOC data exists) and a
+single source of truth for "what SOC do we believe."
+
+## Background — what already exists
+
+- `car_api_stale_percent_mode` (car.py): when set, `get_car_charge_percent()`
+  returns `None` ("SOC sensor poisoned"). Entered on API-failure / SOC-stale /
+  contradiction / `force_stale`.
+- Stale-mode select `auto`/`force_stale`/`force_not_stale`
+  (`car.car_stale_mode_override`).
+- Delta interpolation: `charger.py::constraint_update_value_callback_soc`
+  (~4612) + `_compute_added_charge_update` (~4556) accumulate
+  `ct.current_value += efficiency-aware energy` when the sensor returns `None`.
+- Constraint seeding `charger.py:3283-3285`:
+  `car_initial_value = get_car_charge_percent(time)`, **forced to `0.0` when
+  `None`** — the core gap this story fixes.
+- `can_use_charge_percent_constraints()` (car.py:2001) requires **both** a SOC
+  sensor and a battery capacity; no-sensor cars use kWh constraints.
+- Persistence: `QSCar.update_to_be_saved_extra_device_info` (car.py:280) /
+  `use_saved_extra_device_info` (car.py:288) (call `super()`).
+- The charger's `_default_generic_car` (charger.py:2064) is created with
+  `CONF_CAR_IS_INVITED: True` — that is the "default car"; it must remain
+  excluded.
+
+## Design
+
+### State model (on `QSCar`, standalone attributes, persisted)
+
+Persisted via `update_to_be_saved_extra_device_info` / restored in
+`use_saved_extra_device_info` (plain dict keys, default `None`):
+
+- `_user_base_soc_value: float | None` — manually-entered SOC baseline.
+- `_last_valid_base_soc_value: float | None` — last valid real sensor value,
+  captured at the fresh→stale transition (only if no user base exists yet).
+- `_computed_added_delta_soc_percent: float | None` — accumulated,
+  efficiency-aware percent charge added during the current plugged session.
+- `_user_base_soc_entry_sensor_value: float | None` — raw sensor value captured
+  at the instant the user entered the manual value (recovery reference; `None`
+  if the sensor was stale/invalid then).
+
+Not persisted (re-anchored on reboot to avoid counting downtime energy):
+
+- `_delta_soc_last_integration_time: datetime | None` — dedicated integration
+  cursor for the accumulator (decoupled from `ct.last_value_change_update`).
+
+> **Boundary note (decision):** this estimate arithmetic stays in
+> `ha_model/car.py` to unify with the existing stale-delta path. It imports
+> nothing from `homeassistant.*` (no domain/HA boundary violation) and could be
+> lifted to `home_model/` later as a pure helper. Persisted state on the
+> `ha_model` `QSCar` is an HA-layer concern by design.
+
+### `_computed_added_delta_soc_percent` lifecycle (resolves double-count)
+
+- Set to **`0.0`** when: the user sets `_user_base_soc_value`; **or** the system
+  sets `_last_valid_base_soc_value` (only when no user base exists yet); **or** a
+  charge session starts estimating with no base (pure-delta `+XX%` case).
+- Accumulates as a **float** (no int rounding) in the charge callback while
+  charging in estimation mode.
+- Set to **`None`** on the unplug transition and on user reset.
+
+### Accumulator mechanics (charge callback)
+
+In `constraint_update_value_callback_soc` (charger.py ~4612-4780), percent path:
+
+```
+estimating = self.car.is_in_soc_estimation_mode(time)
+if is_target_percent:
+    sensor_result = None if estimating else self.car.get_car_charge_percent_raw_sensor(time, tolerance_seconds=probe_charge_window)
+else:
+    sensor_result = self.car.get_car_charge_energy(time, tolerance_seconds=probe_charge_window)
+
+if estimating and is_target_percent:
+    if self.car._computed_added_delta_soc_percent is None:
+        self.car._computed_added_delta_soc_percent = 0.0
+    if self.car._delta_soc_last_integration_time is None:
+        # post-reboot / post-base-set: anchor only, do NOT integrate the gap
+        self.car._delta_soc_last_integration_time = time
+    else:
+        inc = self._compute_added_charge_update(            # FLOAT, not int()
+            start_time=self.car._delta_soc_last_integration_time, end_time=time, is_target_percent=True)
+        if inc is not None:
+            self.car._computed_added_delta_soc_percent += inc
+            self.car._delta_soc_last_integration_time = time
+    # single accumulator owns the running value; constraint reads it
+    est = self.car._estimated_soc_percent                  # base+delta clamped, or None
+    result_calculus = est if est is not None else (self.car._computed_added_delta_soc_percent or 0.0)
+```
+
+Rationale (concrete-planner C1): the existing `ct.current_value + int(delta)`
+relies on `ct.last_value_change_update` only advancing when the **rounded int**
+changes, so sub-1% slices re-integrate until they cross 1%. The car-level float
+accumulator with its own cursor advancing **every** cycle reproduces that
+without loss and survives constraint churn within a session. The constraint
+reports `int(round(...))`; `result_calculus` stays the source for
+`is_car_charged` and the `sensor_result > 99` clamp.
+
+### Effective-SOC accessors (car.py)
+
+```
+def get_car_charge_percent_raw_sensor(self, time=None, tolerance_seconds=None) -> float | None:
+    if self.car_charge_percent_sensor is None:
+        return None
+    return self.get_sensor_latest_possible_valid_value(
+        entity_id=self.car_charge_percent_sensor, time=time, tolerance_seconds=tolerance_seconds)
+
+@property
+def _estimated_soc_percent(self) -> float | None:
+    delta = self._computed_added_delta_soc_percent or 0.0
+    if self._user_base_soc_value is not None:
+        base = self._user_base_soc_value
+    elif self._last_valid_base_soc_value is not None:
+        base = self._last_valid_base_soc_value
+    else:
+        return None
+    return max(0.0, min(100.0, base + delta))            # clamp [0,100]
+
+def is_in_soc_estimation_mode(self, time=None) -> bool:
+    if self.car_is_invited:
+        return False
+    if self.car_battery_capacity is None or self.car_battery_capacity <= 0:
+        return False
+    if self.car_charge_percent_sensor is None:
+        return True                                       # no-sensor car: always estimating
+    if self.car_api_stale_percent_mode:
+        return True                                       # API failure / SOC stale / force_stale
+    return self._user_base_soc_value is not None          # manual override on a healthy API
+
+def has_soc_estimate(self) -> bool:                       # drives is_soc_estimated sensor + asterisk
+    return self._estimated_soc_percent is not None
+
+def get_car_charge_percent(self, time=None, tolerance_seconds=None) -> float | None:
+    if self.is_in_soc_estimation_mode(time):
+        return self._estimated_soc_percent                # may be None (pure-delta case)
+    return self.get_car_charge_percent_raw_sensor(time, tolerance_seconds)
+```
+
+> **Naming (critic):** `is_in_soc_estimation_mode` (estimation active) vs
+> `has_soc_estimate` (an absolute estimate exists) are deliberately distinct —
+> they diverge when estimating without a base (`+XX%`). Do not collapse them.
+
+> **Orthogonality (decision):** estimation is **independent** of
+> `is_car_effectively_stale`. A manual override on a healthy API marks the car
+> as *estimated* (asterisk) but **not** API-stale (no red border).
+
+### Recovery state machine (per cycle, ordered)
+
+New `_update_soc_estimation(time)` (called each state cycle, e.g. from
+`update_states` after `_update_car_api_staleness`):
+
+1. **User-base recovery (D1 — any change):** if `_user_base_soc_value is not
+   None` and the raw sensor yields a **valid, fresh** value `raw`
+   (`not _is_soc_sensor_stale`): clear everything (`user_reset_soc_estimate()`)
+   when `_user_base_soc_entry_sensor_value is None` **or** `raw !=
+   _user_base_soc_entry_sensor_value`. (Same-sensor discrete %, exact compare;
+   any difference is a genuine new reading → real sensor wins.)
+2. **System-base recovery:** handled by `_exit_stale_mode()` on API recovery —
+   extend it to also clear `_last_valid_base_soc_value`,
+   `_computed_added_delta_soc_percent`, `_delta_soc_last_integration_time`.
+
+On full API recovery both bases clear and the live sensor takes over.
+
+### Capture of `_last_valid_base_soc_value` (fresh→stale edge)
+
+Centralize the six `car_api_stale_percent_mode = True` write sites
+(car.py:684,725,808,829 + the transition block ~698) so the capture happens
+**only on a genuine fresh→stale edge** (guarded by `_was_car_api_stale`), and
+**only when** `_user_base_soc_value is None and _last_valid_base_soc_value is
+None`. Capture the last valid buffered value via
+`get_car_charge_percent_raw_sensor(time)` and zero the accumulator. The
+`for_init` restore path (829) must **not** capture (persisted value is the
+truth).
+
+### Manual entry & reset (car.py)
+
+```
+async def user_set_manual_soc_percent(self, value, for_init=False):
+    self._user_base_soc_value = float(max(0, min(100, int(value))))
+    if not for_init:                                      # for_init = entity restore; fields already restored
+        self._user_base_soc_entry_sensor_value = self.get_car_charge_percent_raw_sensor(now)   # may be None
+        self._computed_added_delta_soc_percent = 0.0
+        self._delta_soc_last_integration_time = None      # re-anchor next charge cycle
+        if self.charger:
+            await self.charger.update_charger_for_user_change()
+
+def user_reset_soc_estimate(self):
+    self._user_base_soc_value = None
+    self._last_valid_base_soc_value = None
+    self._computed_added_delta_soc_percent = None
+    self._user_base_soc_entry_sensor_value = None
+    self._delta_soc_last_integration_time = None
+```
+
+`user_reset_soc_estimate()` is also called from:
+
+- `car.user_clean_and_reset()` (car.py ~2272).
+- The **unplug transition** branch (charger.py ~3185-3197) — must be
+  edge-triggered (plugged→unplugged), **not** `car.reset()` (runs on every
+  attach, charger.py ~3854). A manual value set while already unplugged survives
+  a later plug-in (no intervening unplug edge); a reboot-while-unplugged must not
+  be treated as a fresh unplug edge.
+
+### `can_use_charge_percent_constraints` flip (car.py:2001)
+
+```
+def can_use_charge_percent_constraints(self):
+    if self.car_is_invited:                 # excludes the default generic car (unchanged)
+        return False
+    if self.car_battery_capacity is None or self.car_battery_capacity <= 0:
+        return False
+    return True                             # SOC sensor NO LONGER required
+```
+
+Existing real no-sensor cars with a true capacity flip kWh→% (D3 approved); rely
+on the existing `copy_to_other_type` machinery (`convert_target_value_to_energy`
+uses only `total_capacity_wh`, constraints.py ~2558 — no SOC sensor needed).
+**Call-site audit (must verify each):**
+
+| Site | Expected after flip |
+|---|---|
+| car.py:681,724,807,828 (stale-percent entry) | No-sensor car can't take the SOC-stale path (`_is_soc_sensor_stale` returns False when sensor None) — it estimates via the no-sensor arm instead. Confirm. |
+| car.py:2028,2037,2042,2051 (option/target routing) | No-sensor car routes to percent options. |
+| charger.py:3279,3306,3311,3317 (constraint class + copy_to_other_type) | kWh→% migration safe; assert by test. |
+| sensor.py:149 (SOC sensor exposure) | SOC sensor now created for no-sensor car; `value_fn=get_car_charge_percent` must return the estimate. |
+| binary_sensor.py:81 (`BINARY_SENSOR_CAR_USE_CHARGE_PERCENT_CONSTRAINTS`) | Flips True for capacity-only car. |
+| dashboard template `*.yaml.j2` line ~93 | Percent-mode card path engages for no-sensor car. |
+| **Invariant AC:** real-sensor + capacity car → predicate unchanged (still True). | |
+
+### Raw-sensor isolation (must NOT see the estimate)
+
+- Charge callback `sensor_result` (charger.py:4644) → raw + estimation bypass.
+- Efficiency learning (car.py ~888, ~907) → `get_car_charge_percent_raw_sensor`.
+- `is_car_charge_growing` (car.py:1324) → gate on `is_in_soc_estimation_mode`.
+- Real-power "no power detected" check (charger.py:4720): gate becomes `and not
+  self.car.is_in_soc_estimation_mode(time)` (the check is **skipped** in
+  estimation mode — no trusted sensor to compare growth against).
+
+### UI
+
+- **New binary sensor** `BINARY_SENSOR_CAR_IS_SOC_ESTIMATED` (`qs_car_is_soc_estimated`),
+  `value_fn = has_soc_estimate()` — created when
+  `can_use_charge_percent_constraints()`.
+- **New number entity** `NUMBER_CAR_MANUAL_SOC_PERCENT` (0–100, step 1,
+  `NumberMode.BOX`) → `user_set_manual_soc_percent`. Add
+  `create_ha_number_for_QSCar(device)` and wire `if isinstance(device, QSCar)`
+  into `create_ha_number` (mirror `time.py:71`; setup loops already iterate cars
+  + virtual devices). Current value reads `_user_base_soc_value`; `for_init`
+  restore is a no-op on side effects (extra_device_info is the source of truth).
+- **New reset button** `BUTTON_CAR_RESET_SOC_ESTIMATE` → `user_reset_soc_estimate`
+  (extend `create_ha_button_for_QSCar`, button.py ~147).
+- **SOC sensor** `SENSOR_CAR_SOC_PERCENT`: no new attribute (card reads the
+  binary sensor — D4).
+- **`qs-car-card.js`** (authorized by user request): wire the
+  `is_soc_estimated` binary sensor, the manual-SOC number, and the reset button
+  into the card config (via `dashboard.py` + `quiet_solar_dashboard_template*.yaml.j2`).
+  Re-gate the display (current `+XX%` branch is keyed on
+  `isStalePercentMode = isStale && !useEnergyMode`, ~line 912): show absolute
+  `NN%` + `*` when `is_soc_estimated` on; `+XX%` when estimating without a base
+  (SOC null but charging); plain `NN%` for a real fresh sensor. In percent mode,
+  make the big SOC number clickable → popup: integer 0–100 input with
+  **Save** / **Cancel** / **Reset** (sentence case, no abbreviations). Save →
+  `number.set_value` on the manual-SOC entity; Reset → `button.press` on the
+  reset entity.
+
+## Acceptance criteria
+
+**AC1 — Healthy sensor passthrough.** Given a car with a fresh, valid SOC sensor
+and no manual base, When `get_car_charge_percent()` is called, Then it returns
+the live raw sensor value, `is_in_soc_estimation_mode` is False, and
+`has_soc_estimate()` is False.
+
+**AC2 — Manual override on an inaccurate (fresh) sensor + any-change recovery.**
+Given a car whose fresh sensor reads `X0`, When the user sets manual `M`
+(`M != X0`), Then `get_car_charge_percent()` returns `M (+ charged delta)`, the
+raw sensor is ignored by the constraint, and `has_soc_estimate()` is True; And
+the entry reference is `X0`. When the sensor later reports a valid fresh value
+`X1 != X0`, Then all SOC-estimate fields clear and `get_car_charge_percent()`
+returns the live sensor again. When the sensor keeps reporting `X0`, Then the
+manual override persists.
+
+**AC3 — API failure captures last-valid + recovery on API return.** Given a car
+charging with a working sensor last reading `L`, When the SOC sensor goes stale
+(fresh→stale edge) and no user base exists, Then `_last_valid_base_soc_value = L`
+and the accumulator zeroes; And `get_car_charge_percent()` returns `L (+ delta)`.
+When the API later returns a valid fresh reading, Then both bases clear and the
+live sensor takes over.
+
+**AC4 — No-sensor car with true capacity.** Given a non-invited car with a true
+battery capacity and no SOC sensor, Then `can_use_charge_percent_constraints()`
+is True, the percent path / SOC sensor / `is_soc_estimated` sensor are exposed,
+and `get_car_charge_percent()` returns the manual base `+ delta` or `None`.
+
+**AC5 — Efficiency-aware interpolation matches an independent integral.** Given a
+car estimating SOC from base `B` charging at a fixed power `P` for duration `T`
+with charger efficiency `e` and capacity `C` (all hand-fixed in the test), When
+charging completes, Then `get_car_charge_percent()` equals
+`clamp(B + 100·(P·T·e)/C, 0, 100)` within **±1% SOC**, with no double-count
+across multiple solver cycles / constraint churn, and no loss of sub-1%-per-cycle
+slices on a slow (solar) charge over N cycles.
+
+**AC6 — Constraint seeding uses effective SOC.** Given an estimating car with a
+base, When a charge constraint is created (charger.py:3283), Then
+`car_initial_value` is the effective estimate (not forced `0.0`); with no base it
+remains `0.0` (pure-delta).
+
+**AC7 — Pure-delta `+XX%`.** Given an estimating car with **no** base that begins
+charging, Then `has_soc_estimate()` is False, the accumulator grows from 0, and
+the card shows `+XX%`.
+
+**AC8 — Reset / unplug clears all.** Given an estimating car with populated
+fields, When the user presses reset OR the car crosses the unplug transition,
+Then all four SOC-estimate fields and the integration cursor become `None`. A
+manual value set while already unplugged survives a subsequent plug-in.
+
+**AC9 — Persistence & reboot.** Given populated SOC-estimate fields, When HA
+restarts, Then the four persisted fields are restored before the first staleness
+evaluation, the integration cursor re-anchors to "now" (no downtime energy
+counted), and restoring a pre-QS-243 saved blob yields all-`None` defaults with
+no exception.
+
+**AC10 — Raw-sensor isolation.** Given an estimating car, Then efficiency
+learning, `is_car_charge_growing`, and the callback's `sensor_result` read only
+the raw sensor (never the estimate); a real-sensor car's efficiency-learning and
+growth outputs are unchanged by this story.
+
+**AC11 — UI.** Given an estimating car with a base in percent mode, Then the card
+shows `NN%*`; with no base while charging it shows `+XX%`; with a real fresh
+sensor it shows `NN%`. Clicking the SOC number opens a 0–100 popup; Save writes
+the manual-SOC number; Reset presses the reset button; the `is_soc_estimated`
+binary sensor reflects `has_soc_estimate()`.
+
+**AC12 — Orthogonality.** Given a manual override on a car with a healthy API,
+Then `is_car_effectively_stale` is unchanged (not stale) while
+`has_soc_estimate()` is True.
+
+## Task breakdown
+
+1. **const.py** — add `NUMBER_CAR_MANUAL_SOC_PERCENT`,
+   `BUTTON_CAR_RESET_SOC_ESTIMATE`, `BINARY_SENSOR_CAR_IS_SOC_ESTIMATED`
+   (no recovery-threshold constant — D1 uses exact compare).
+2. **car.py — state & persistence** — add the four fields + integration cursor;
+   init; persist/restore (default `None`) in
+   `update_to_be_saved_extra_device_info` / `use_saved_extra_device_info`.
+3. **car.py — accessors** — `get_car_charge_percent_raw_sensor`,
+   `_estimated_soc_percent` property, `is_in_soc_estimation_mode`,
+   `has_soc_estimate`, rewrite `get_car_charge_percent`.
+4. **car.py — lifecycle** — `user_set_manual_soc_percent`,
+   `user_reset_soc_estimate`; hook reset into `user_clean_and_reset`; centralize
+   fresh→stale capture of `_last_valid_base_soc_value`; extend `_exit_stale_mode`
+   to clear system base; add per-cycle `_update_soc_estimation` recovery.
+5. **car.py — gating** — flip `can_use_charge_percent_constraints`; route
+   efficiency learning (~888, ~907) and `is_car_charge_growing` (1324) through
+   raw / estimation-mode gating.
+6. **charger.py** — callback raw-sensor + estimation bypass + float accumulator;
+   `result_calculus` from the accumulator; seeding unchanged (benefits
+   automatically); gate real-power check on `is_in_soc_estimation_mode`; add the
+   unplug-transition reset hook (~3185-3197, edge-triggered).
+7. **number.py** — `create_ha_number_for_QSCar` (manual SOC, gated on
+   `can_use_charge_percent_constraints`) + wire into `create_ha_number`.
+8. **button.py** — reset-SOC button in `create_ha_button_for_QSCar`.
+9. **binary_sensor.py** — `is_soc_estimated` sensor in
+   `create_ha_binary_sensor_for_QSCar`.
+10. **ui/dashboard.py + `quiet_solar_dashboard_template*.yaml.j2`** — feed the
+    new entities into the car-card config.
+11. **ui/resources/qs-car-card.js** — clickable SOC popup (Save/Cancel/Reset) +
+    asterisk/`+XX%` re-gating wired to the new entities.
+12. **strings.json** — entries for the new number/button/binary_sensor (sentence
+    case, second person, backticks); run `bash scripts/generate-translations.sh`
+    (NEVER edit `translations/en.json`).
+13. **Tests** — see below. Full quality gate (mixed changeset; UI-only fast path
+    does **not** apply).
+14. **Docs** — see Doc maintenance.
+
+### Test surface (100% coverage; concrete targets)
+
+- Fixtures: add `real_car_no_soc_sensor` (battery set, `car_charge_percent_sensor=None`)
+  and manual-SOC scenarios (extend `tests/ha_tests/const.py` / `tests/conftest.py`,
+  `tests/test_car_api_staleness.py` fixtures).
+- `tests/test_cars.py` — property 3 arms + clamp; `is_in_soc_estimation_mode` /
+  `has_soc_estimate`; `can_use_charge_percent_constraints` flip (incl. invariant:
+  real sensor + capacity unchanged; invited unchanged); manual entry / reset;
+  persistence round-trip incl. pre-QS-243 blob.
+- `tests/test_car_api_staleness.py` — orthogonality (AC12); fresh→stale capture;
+  any-change recovery (AC2) incl. ref-`None` path; API-return recovery (AC3).
+- `tests/test_chargers.py` — accumulator across N slow cycles (no loss / no
+  double-count); seeding from estimate (AC6); pure-delta (AC7); real-power check
+  skipped in estimation mode; kWh→% `copy_to_other_type` migration safety.
+- `tests/ha_tests/` — number/button/binary_sensor creation for cars (mirror
+  existing select/time platform tests).
+- `tests/test_dashboard_rendering.py` — card render-time wiring of the new
+  entities + asterisk/`+XX%` gating.
+
+## Doc maintenance
+
+Surfaced by `scripts/qs/check_doc_drift.py` for the touched sources:
+
+- **New** `docs/agents/concepts/car-soc-estimation.md` (kind: concept;
+  `covers: custom_components/quiet_solar/ha_model/car.py`) — the estimated-SOC
+  model, the three bases + accumulator, estimation-vs-stale orthogonality,
+  recovery rule.
+- Update `docs/agents/concepts/charger-budgeting.md` (charger.py — callback
+  accumulator / seeding).
+- Update `docs/agents/concepts/config-and-setup-flow.md` (const.py — new keys).
+- Update `docs/agents/concepts/person-trip-prediction.md` (car.py — SOC source).
+- Update `docs/agents/concepts/dashboard-and-cards.md` (qs-car-card.js — SOC
+  popup + asterisk).
+
+(Refresh `last_verified` on each. No `.claude/.cursor/.opencode` agent files are
+touched, so the harness-sync co-modification rule does not fire.)
+
+## Edge cases
+
+- Manual entry mid-charge → accumulator zeroed (no double-count).
+- `base + delta` clamped to `[0, 100]`; the AC5 integral test compares against the
+  clamp-aware expectation.
+- Capacity `0`/`None` → `is_in_soc_estimation_mode` False; no divide-by-zero.
+- Reboot: fields restored before first staleness eval; integration cursor
+  re-anchored (no downtime energy); pre-QS-243 blob → all `None`.
+- Unplug edge-triggered; manual-while-unplugged survives plug-in.
+- No-sensor car: always estimating; SOC sensor shows estimate or unknown.
+- Inaccuracy: entry ref = the (wrong) sensor value; any later differing valid
+  reading clears (D1 — accepted that a 1% sensor jitter counts as a real change).
+- Invited / default generic car: never estimating; no manual entry; unchanged.
+- Energy (kWh) constraint cars (invited): unchanged.
+
+## Decisions log
+
+- **D1:** Recovery on **any change** from `_user_base_soc_entry_sensor_value`
+  (no threshold) — a new value is by construction a true SOC change. The 4th
+  field is the mechanical realization of the user's reset rules, not scope creep.
+- **D2:** Single story (the card is essential to the feature).
+- **D3:** Flip `can_use_charge_percent_constraints` for real cars with true
+  capacity; existing kWh no-sensor cars migrate via existing machinery (no
+  bespoke migration code; covered by a test).
+- **D4:** Keep the manual-SOC **number** + **reset button** as real HA entities
+  (popup drives them); drop the redundant SOC-sensor `is_estimated` attribute.
+- Estimation is **orthogonal** to API-staleness (separate `is_soc_estimated`).
+- Accumulator is a **float** with a dedicated integration cursor; the **car** is
+  its sole owner; the charger callback is the sole writer.
+
+## Adversarial Review Notes
+
+Four reviewers ran in parallel (critic, concrete-planner, dev-proxy,
+scope-guardian). No hard rule violations. Dispositions:
+
+- **Accumulator baseline / double-count (critic C1, dev-proxy C3):** resolved by
+  the user's clarification (zero on base-set) + a **float accumulator with a
+  dedicated integration cursor** advancing every cycle (concrete-planner C1).
+  Folded into the accumulator-mechanics section.
+- **Unclamped `base+delta` (critic C2):** property clamps `[0,100]`. Folded.
+- **AC5 untestable (critic C3):** rewritten with a fixed power×efficiency profile
+  and ±1% tolerance (non-circular).
+- **Recovery defeats AC2 (critic C4) + 4th field "scope creep" (scope):**
+  resolved by D1 — exact "any change" compare against the entry reference (no
+  threshold); the 4th field realizes the user's own rule #2.
+- **Two recovery mechanisms / ordering (critic R1):** single ordered state
+  machine (`_update_soc_estimation`); on API recovery both bases clear.
+- **Centralize 6 stale-write sites (critic R2, concrete):** capture only on a
+  true fresh→stale edge, guarded, last-valid only, never on `for_init`.
+- **kWh→% migration (critic R3, scope, concrete):** D3 — rely on verified
+  `copy_to_other_type`; add a migration test.
+- **Card display keyed on stale, not estimated (concrete R1):** re-gate on
+  `is_soc_estimated`; wire the binary sensor into the card config + templates.
+- **`can_use_charge_percent_constraints` 13 call sites (concrete, dev-proxy C2):**
+  added the call-site checklist + the real-sensor-unchanged invariant AC.
+- **Persistence home / clear hooks (concrete, dev-proxy):** standalone attrs in
+  extra_device_info; clear in `user_clean_and_reset` + unplug branch, never
+  `car.reset()`.
+- **Reboot ordering / unplug edge across reboot (critic, dev-proxy):** restore→
+  evaluate; re-anchor cursor; edge-triggered unplug; pre-QS-243 default AC.
+- **Naming `is_soc_estimated(_mode)` (critic):** renamed to
+  `is_in_soc_estimation_mode` vs `has_soc_estimate`.
+- **Boundary smell (dev-proxy R1):** decision note — arithmetic stays in
+  `ha_model/car.py`, imports no `homeassistant.*`.
+- **Constants / translations / full gate / JS strings (dev-proxy):** folded
+  (constants enumerated; strings.json + regenerate; full gate; card strings
+  sentence-case, "Save" not "OK").
+- **Test fixtures for no-sensor + manual SOC (concrete):** added concrete fixture
+  + per-file test list.
+- **UI control redundancy (scope) / story split (scope):** D4 (keep entities as
+  popup backing; drop the sensor attribute) and D2 (single story).
+- **Raw accessor YAGNI (scope):** justified — efficiency learning + callback are
+  real raw-only callers (regression AC added).

--- a/docs/stories/QS-243.story.md
+++ b/docs/stories/QS-243.story.md
@@ -212,11 +212,14 @@ def user_reset_soc_estimate(self):
 `user_reset_soc_estimate()` is also called from:
 
 - `car.user_clean_and_reset()` (car.py ~2272).
-- The **unplug transition** branch (charger.py ~3185-3197) — must be
-  edge-triggered (plugged→unplugged), **not** `car.reset()` (runs on every
-  attach, charger.py ~3854). A manual value set while already unplugged survives
-  a later plug-in (no intervening unplug edge); a reboot-while-unplugged must not
-  be treated as a fresh unplug edge.
+- The **unplug transition** branch (charger.py ~3185-3197) — edge-triggered
+  (plugged→unplugged).
+- The **genuine plug-in** branch (charger.py, the `do_full_reset=True` arm of
+  `check_load_activity_and_constraints`) — a new plug resets the estimate; a
+  boot re-attach (`do_full_reset=False`) does NOT, so the persisted estimate
+  survives an HA reboot (AC9). It is **not** placed in the low-level
+  `car.reset()`: `attach_car` runs `reset()` on both a genuine plug-in and the
+  boot re-attach, so only the charger can distinguish them.
 
 ### `can_use_charge_percent_constraints` flip (car.py:2001)
 
@@ -325,10 +328,21 @@ remains `0.0` (pure-delta).
 charging, Then `has_soc_estimate()` is False, the accumulator grows from 0, and
 the card shows `+XX%`.
 
-**AC8 — Reset / unplug clears all.** Given an estimating car with populated
-fields, When the user presses reset OR the car crosses the unplug transition,
-Then all four SOC-estimate fields and the integration cursor become `None`. A
-manual value set while already unplugged survives a subsequent plug-in.
+**AC8 — Reset / unplug / plug-in clears all (revised post-review).** Given an
+estimating car with populated fields, When the user presses reset, OR the car
+crosses the unplug transition, OR the car is **genuinely plugged in** (a new
+plug, not a boot re-attach), Then all four SOC-estimate fields and the
+integration cursor become `None`. A manual value set while unplugged is
+therefore reset on the next plug-in. **Reboot is the exception** (see AC9): a
+boot re-attach (`do_full_reset=False`) preserves the persisted estimate.
+
+> **Decision (user, post-implementation review):** the earlier "manual value
+> survives a plug-in" rule was wrong — that exemption was only ever meant for
+> an **HA reboot**, not a plug-in. A plug-in is a fresh charge session and must
+> reset. Because `attach_car` calls `car.reset()` on both a genuine plug-in and
+> the boot re-attach, the clear lives on the charger's genuine-plug branch
+> (`do_full_reset=True`), not in the low-level `car.reset()` — only the charger
+> can tell a new plug from a boot re-attach.
 
 **AC9 — Persistence & reboot.** Given populated SOC-estimate fields, When HA
 restarts, Then the four persisted fields are restored before the first staleness

--- a/docs/stories/QS-243.story_review_fix_#01.md
+++ b/docs/stories/QS-243.story_review_fix_#01.md
@@ -1,0 +1,191 @@
+# QS-243 — Review fix plan #01
+
+## Summary
+- Source PR: #244
+- Source story: docs/stories/QS-243.story.md
+- Findings to fix: 12 (1 must-fix, 6 should-fix, 5 nice-to-have)
+- Next implement phase: `implement-task`
+
+## Findings to fix
+
+### [must-fix] M1 — Override recovery must be keyed on the API state at entry (4-case spec)
+- File: `custom_components/quiet_solar/ha_model/car.py:792-806, 1374-1392, 1415-1423, 1427-1442`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter (reframed with author's design spec)
+- Description: The override-recovery logic must branch on **what the API state
+  was at the moment the user entered the manual override**, which the code does
+  not currently record. Required behavior:
+  - **Case 1** — override entered **while in stale API mode**: clear
+    `_user_base_soc_value` once the car exits stale mode AND a valid sensor value
+    is available (the live sensor wins).
+  - **Case 2** — override entered, API **not stale and value valid**: clear only
+    when a fresh valid value appears that is **different** from the entry value;
+    if **equal, reset nothing** — keep both the manual base AND the accumulated
+    delta.
+  - **Case 3** — override entered, API **not stale but value not valid** (entry
+    sensor value None): clear when **any** valid value appears.
+  - **Case 4** — API goes stale: set `_last_valid_base_soc_value` from the last
+    valid sensor buffer value (already implemented in
+    `_capture_last_valid_base_soc`).
+
+  Two concrete defects this fixes:
+  1. Case 1 is unimplemented — `_exit_stale_mode` never clears
+     `_user_base_soc_value`, so an override entered during a stale window lingers
+     forever (until the sensor happens to read a different value). The code can't
+     distinguish case 1 from case 2 because it stores no entry-time stale flag.
+  2. Case 2's delta is wrongly destroyed by a transient stale blip:
+     `_exit_stale_mode` (car.py:804-806) zeroes the **shared**
+     `_computed_added_delta_soc_percent` / `_delta_soc_last_integration_time`, so
+     a case-2 override that lived through a stale window loses its accumulated
+     charge on recovery (SOC jumps backward to the bare base), violating
+     "if equal, reset nothing".
+- Proposed fix:
+  - Add `_user_base_soc_entry_api_stale: bool | None`, set in
+    `user_set_manual_soc_percent` (= `self.car_api_stale_percent_mode` at entry),
+    persisted in `update_to_be_saved_extra_device_info` /
+    `use_saved_extra_device_info`, and cleared in `reset_soc_estimate`.
+  - Rework `_update_soc_estimation` to implement the case 1/2/3 branches above.
+  - Guard `_exit_stale_mode`: when `_user_base_soc_value is not None`, do NOT
+    touch `_computed_added_delta_soc_percent` / `_delta_soc_last_integration_time`
+    (the case-1/2 recovery logic owns the override lifecycle).
+  - Confirms CodeRabbit's "always clear override on a fresh reading" suggestion is
+    intentionally rejected (case 2: equal → keep).
+- Tests: cover all four entry/recovery cases, including the regression where a
+  case-2 override survives a transient stale blip without losing its delta, and
+  pre-QS-243 persistence blobs default the new flag to None without exception.
+
+### [should-fix] S1 — Zero-power charging fault detection disabled by a manual override on a healthy car
+- File: `custom_components/quiet_solar/ha_model/charger.py:4452, 4753-4758`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `estimating = is_target_percent and self.car.is_in_soc_estimation_mode(time)`
+  is True whenever a manual base is set — even on a fully healthy, non-stale,
+  sensor-equipped car. The "expected to be charging but no power delivered" safety
+  check is gated on `not estimating`, so a plain manual override silently
+  suppresses genuine hardware-fault detection.
+- Proposed fix: gate the zero-power fault check on real sensor distrust
+  (`car_api_stale_percent_mode` / no-sensor) rather than the broad
+  `is_in_soc_estimation_mode`. A manual override on a healthy car must not suppress
+  fault detection.
+
+### [should-fix] S2 — AC5: real efficiency-integral test (non-mocked, ±1%)
+- File: `tests/test_charger_soc_estimation.py`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: Existing tests mock `_compute_added_charge_update` to fixed
+  constants, verifying accumulator bookkeeping but never that the real
+  efficiency-aware integral equals `clamp(B + 100·P·T·e/C, 0, 100)` within ±1% —
+  exactly what AC5 was reworded to demand.
+- Proposed fix: add a test driving a real power × efficiency × capacity profile
+  through the actual `_compute_added_charge_update` and assert the estimate matches
+  an independently computed integral within ±1% over N cycles (no double-count).
+
+### [should-fix] S3 — AC6: constraint-seeding-from-estimate test
+- File: `tests/test_chargers.py` (or the appropriate charger test module)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: Seeding at `charger.py:~3283` reads `get_car_charge_percent` (now
+  the estimate, not forced 0.0) but nothing asserts it.
+- Proposed fix: add a test that a charge constraint created for an estimating car
+  receives `car_initial_value == effective estimate`, and `0.0` in the pure-delta
+  no-base case.
+
+### [should-fix] S4 — AC3: end-to-end staleness flow test
+- File: `tests/test_car_soc_estimation.py` (or `tests/test_car_api_staleness.py`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The capture/clear helpers are unit-tested individually but nothing
+  drives `_update_car_api_staleness` through a full fresh→stale→recover cycle to
+  prove capture fires exactly once on the genuine edge (`_was_car_api_stale` guard)
+  and that recovery hands SOC back to the live sensor.
+- Proposed fix: add an end-to-end test across the transition; fold in the M1
+  case-1 / case-2-stale-blip regressions which live in the same flow.
+
+### [should-fix] S5 — Make `reset_soc_estimate()` observable in the test double
+- File: `tests/factories.py:743`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The fake car's `reset_soc_estimate()` only satisfies the interface,
+  so charger plug-in / full-reset tests can pass without proving the reset ran.
+- Proposed fix: record the call (e.g. `self.reset_soc_estimate_called = True` or a
+  counter) and assert it fires on the genuine-plug-in and `do_full_reset` paths.
+
+### [should-fix] S6 — Assert SOC keys on the car-card payload, not anywhere in YAML
+- File: `tests/test_dashboard_rendering.py:331`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: Current checks pass if the SOC key strings appear anywhere in the
+  rendered YAML, not specifically inside the car card.
+- Proposed fix: traverse parsed YAML to the `custom:qs-car-card` entry and assert
+  the keys live in its `entities` mapping. (Combine with N5.)
+
+### [nice-to-have] N1 — Clamp pure-delta `result_calculus` to ≤100
+- File: `custom_components/quiet_solar/ha_model/charger.py:4683-4684`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The pure-delta branch feeds
+  `self.car._computed_added_delta_soc_percent or 0.0` without clamping (unlike
+  `_estimated_soc_percent`), so a long session can show `+XX%` above 100.
+- Proposed fix: clamp the pure-delta value to `[0, 100]` before use/display.
+
+### [nice-to-have] N2 — `user_set_manual_soc_percent` finite-guard + round
+- File: `custom_components/quiet_solar/ha_model/car.py:1419`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter
+- Description: `float(max(0, min(100, int(value))))` truncates (50.9→50) instead of
+  rounding, and `int(NaN)`/`int(inf)` raises when `number.set_value` is called
+  directly (bypassing the card's `Number.isFinite` guard).
+- Proposed fix: guard for finite input (`math.isfinite`) and `round()` before
+  clamping.
+
+### [nice-to-have] N3 — Accessor on `QSCar` instead of private-attr reach-in
+- File: `custom_components/quiet_solar/ha_model/charger.py`, `custom_components/quiet_solar/ha_model/car.py`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `constraint_update_value_callback_soc` reads
+  `self.car._computed_added_delta_soc_percent`,
+  `self.car._delta_soc_last_integration_time`, and `self.car._estimated_soc_percent`
+  directly — cross-object underscore-private access.
+- Proposed fix: expose small accessors/properties on `QSCar` and have the charger
+  use them. Cleanup only; no behavior change. Coordinate with S1/M1 edits.
+
+### [nice-to-have] N5 — Use `const.py` constants in the dashboard test
+- File: `tests/test_dashboard_rendering.py:331-338`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: Test hardcodes `is_soc_estimated`, `manual_soc`, `reset_soc` instead
+  of importing the `const.py` constants ("never hardcode config keys").
+- Proposed fix: import and use the `const.py` constants. Fold into S6.
+
+### [nice-to-have] N6 — Explicit JS dialog close on Save/Reset
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js` (`openSocDialog`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: After `await this._setNumber(...)` (Save) and in the Reset handler
+  there is no explicit dialog dismiss; it relies on framework defaults.
+- Proposed fix: verify the dialog closes on Save/Reset; add an explicit close if it
+  does not.
+
+### [nice-to-have] N7 — Tolerance-based float compare in override recovery
+- File: `custom_components/quiet_solar/ha_model/car.py:1391`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter
+- Description: `raw != self._user_base_soc_entry_sensor_value` is an exact float
+  compare. The M1 rework already rewrites this branch.
+- Proposed fix: compare with a small tolerance (or round both sides) when deciding
+  case-2 "different value" recovery.
+
+## Decisions log
+- Fix: M1, S1, S2, S3, S4, S5, S6, N1, N2, N3, N5, N6, N7 (12 total)
+- Skip: N4 (unused `time` param on `is_in_soc_estimation_mode` — kept for call-site
+  signature symmetry)
+- Invalid / not actioned:
+  - blind-hunter "efficiency getters switched to raw sensor" — intentional per AC10
+    (raw-sensor isolation for efficiency learning).
+  - CodeRabbit "always clear override on a fresh reading" — contradicts AC2 / M1
+    case 2 (equal → keep) by design.
+
+## How to apply
+
+Run `implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/stories/QS-243.story_review_fix_#02.md
+++ b/docs/stories/QS-243.story_review_fix_#02.md
@@ -1,0 +1,137 @@
+# QS-243 — Review fix plan #02
+
+## Summary
+- Source PR: #244
+- Source story: docs/stories/QS-243.story.md
+- Prior fix plan: docs/stories/QS-243.story_review_fix_#01.md (all items verified closed)
+- Findings to fix: 6 (1 must-fix, 2 should-fix, 3 nice-to-have)
+- Next implement phase: `implement-task`
+
+## Context
+
+Re-review after fix plan #01 confirmed every #01 item closed (M1 4-case
+recovery, S1 fault-gate, S2 real efficiency integral, S3 seeding test, S4
+end-to-end staleness test, S5/S6, N1/N2/N5/N7). Two disputed items were
+resolved as non-defects:
+- `except TypeError, ValueError:` — valid PEP 758 syntax (project runs Python
+  3.14.3, `pyproject.toml` pins `python_version = "3.14"`, file parses, 3
+  pre-existing identical clauses). NOT a bug.
+- CodeRabbit was unavailable this round (org out of usage credits / rate
+  limited); no signal — covered by the other three reviewers + manual review.
+
+The user-reported "SOC% not clickable" symptom was root-caused to a real CSS
+pointer-events defect (M1 below), NOT a config/dashboard issue (entity exists,
+dashboard regenerated, car plugged in, still unclickable). The user confirmed
+the desired behavior is: the SOC% should be editable **only when the car is
+connected to a charger** — which the existing `.disabled` guard
+(`openSocDialog`, qs-car-card.js:1784) + `.card.disabled { pointer-events:none }`
+(shared/qs-card-styles.js:80) already enforce. Keep that guard.
+
+## Findings to fix
+
+### [must-fix] M1 — Editable SOC% is unclickable (`.pct.soc-editable` lacks `pointer-events: auto`)
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js` (CSS block ~line 1028; element at line 1373; listeners at 1816-1818)
+- Severity: must-fix
+- Source: user report + orchestrator root-cause
+- Description: The SOC number `#soc_pct` lives inside `.ring .center`, which the
+  shared base CSS sets to `pointer-events: none`
+  (`custom_components/quiet_solar/ui/resources/shared/qs-card-styles.js:82`) so the
+  SVG gauge underneath stays interactive. Every other interactive child
+  (`.sun-btn`, `.rabbit-btn`, `.time-btn`, `.green-btn`, `.power-btn`,
+  `.override-btn`) re-enables `pointer-events: auto`, but the editable SOC variant
+  `.pct.soc-editable` does not. So clicks/taps on the SOC% pass through to the
+  gauge and the `click`/`touchend` handlers wired at qs-car-card.js:1816-1817 never
+  fire. Reproduces whenever the car is plugged in, the manual_soc entity exists,
+  and the dashboard is current — i.e. always, for the intended use case.
+- Proposed fix: add a car-card CSS rule re-enabling pointer events only for the
+  editable variant, e.g.:
+  ```css
+  .ring .pct.soc-editable { pointer-events: auto; }
+  ```
+  Scope it to `.soc-editable` so the non-editable SOC text stays click-through and
+  does not block gauge interaction. Keep the existing `.disabled` guard so the
+  control remains a no-op when the car is not plugged in (user requirement:
+  "editable only if connected to a charger").
+- Tests: extend `tests/test_dashboard_rendering.py` to assert the generated card
+  CSS contains a `.soc-editable` rule with `pointer-events: auto` (source-substring
+  assertion, consistent with the repo's JS-testing approach).
+
+### [should-fix] S1 — Manual-SOC number entity value not re-synced on runtime reset
+- File: `custom_components/quiet_solar/number.py:139-172` (and `custom_components/quiet_solar/ha_model/car.py` reset paths)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The manual-SOC number entity writes `_attr_native_value` only on
+  user-set and on restore; it has no `native_value` reading
+  `qs_car_manual_soc_percent`, and `async_update_callback` refreshes only
+  availability. When `_user_base_soc_value` is cleared at runtime — reset button
+  (`user_button_reset_soc_estimate`), genuine plug-in (charger.py `do_full_reset`),
+  unplug edge, or override recovery in `_update_soc_estimation` — the entity keeps
+  showing the old value (e.g. 80) while the internal override is gone. Control and
+  state diverge until restart.
+- Proposed fix: drive the entity's displayed value from
+  `qs_car_manual_soc_percent` (e.g. a `native_value` property or push a refresh in
+  the update callback) so a runtime reset is reflected in the card.
+- Tests: assert the number entity reports the cleared value (0.0 / unset) after a
+  reset path runs.
+
+### [should-fix] S2 — Case-1 recovery blocked under FORCE_NOT_STALE while SOC sensor still time-stale
+- File: `custom_components/quiet_solar/ha_model/car.py:1441`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: When an override was entered during a stale window
+  (`_user_base_soc_entry_api_stale=True`) and the user then sets the stale-mode
+  select to Force-Not-Stale while the SOC sensor is still genuinely time-stale,
+  `can_exit_stale_percent_mode` returns True and `_exit_stale_mode` clears
+  `car_api_stale_percent_mode`, but `_update_soc_estimation` early-returns at the
+  `_is_soc_sensor_stale(time)` guard, so the Case-1 `reset_soc_estimate()` never
+  fires. The card keeps showing the manual estimate and cannot hand back to the
+  (now force-trusted) live sensor until the sensor naturally reports fresh.
+- Proposed fix: in Case-1 recovery, treat FORCE_NOT_STALE as "sensor trusted" —
+  do not early-return on `_is_soc_sensor_stale` when the stale-mode override forces
+  not-stale; allow the Case-1 reset to fire once a (force-trusted) value is
+  available.
+- Tests: cover override-entered-during-stale + Force-Not-Stale → estimate cleared.
+
+### [nice-to-have] N1 — Invalid SOC input silently closes the dialog
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1794-1800`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: On non-finite input the Save handler `return`s with no feedback, yet
+  the button framework still dismisses the dialog — an invalid entry silently
+  closes the popup with no save and no error shown.
+- Proposed fix: surface a validation error / keep the dialog open on invalid input
+  (or clamp+save instead of silently discarding).
+
+### [nice-to-have] N2 — Misleading unplug-vs-plug-in comment
+- File: `custom_components/quiet_solar/ha_model/charger.py:3194-3196`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The unplug-edge comment claims "a manual value set while already
+  unplugged survives a later plug-in," but the genuine-plug-in path
+  (`if do_full_reset: best_car.reset_soc_estimate()`) wipes it on the next real
+  plug-in. Behavior is the intended "reset on plug-in"; the comment is misleading.
+- Proposed fix: correct the comment to match the actual behavior.
+
+### [nice-to-have] N3 — `round()` banker's-rounding at exact .5 boundary
+- File: `custom_components/quiet_solar/ha_model/car.py:1459, 1494`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter + qs-review-blind-hunter
+- Description: Exact `.5` SOC values use Python half-to-even rounding
+  (`round(2.5)==2`, `round(3.5)==4`), which can cause a 1% off-by-one in the
+  Case-2 tolerant compare at half-percent readings. Negligible in practice (the
+  card feeds integers).
+- Proposed fix: use an explicit rounding/tolerance scheme (e.g. `math.floor(x+0.5)`
+  or a small epsilon) for the Case-2 comparison if deemed worthwhile.
+
+## Decisions log
+- Fix: M1, S1, S2, N1, N2, N3 (all 6 — user chose "fix all").
+- Dropped (non-defects):
+  - `except TypeError, ValueError:` — valid PEP 758 syntax on Python 3.14.
+  - "remove the `.disabled` guard" — REJECTED; the guard implements the desired
+    "editable only when connected to a charger" behavior. Keep it.
+- CodeRabbit unavailable this round (no signal).
+
+## How to apply
+
+Run `implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -717,6 +717,9 @@ class TestCarDouble:
         self.charger = None
         self._current_charge_percent = kwargs.get("current_soc", 50.0)
         self._user_originated: dict[str, Any] = {}
+        # QS-243 — observable so plug-in / full-reset tests can prove the
+        # SOC-estimate reset actually fired.
+        self.reset_soc_estimate_call_count = 0
 
         # Apply any additional kwargs as attributes
         for key, value in kwargs.items():
@@ -739,8 +742,8 @@ class TestCarDouble:
         self._user_originated.clear()
 
     def reset_soc_estimate(self) -> None:
-        """Mirror QSCar.reset_soc_estimate (QS-243) — no-op for the double."""
-        return None
+        """Mirror QSCar.reset_soc_estimate (QS-243); records that it fired."""
+        self.reset_soc_estimate_call_count += 1
 
     def get_charge_power_per_phase_A(
         self,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -738,6 +738,10 @@ class TestCarDouble:
     def clear_all_user_originated(self) -> None:
         self._user_originated.clear()
 
+    def reset_soc_estimate(self) -> None:
+        """Mirror QSCar.reset_soc_estimate (QS-243) — no-op for the double."""
+        return None
+
     def get_charge_power_per_phase_A(
         self,
         target_amps: int,

--- a/tests/ha_tests/test_car.py
+++ b/tests/ha_tests/test_car.py
@@ -1107,13 +1107,13 @@ async def test_car_efficiency_from_soc_and_odometer(
     car_device.car_estimated_range_sensor = None
 
     time1 = datetime(2026, 1, 15, 8, 0, tzinfo=pytz.UTC)
-    car_device.get_car_charge_percent = MagicMock(return_value=80.0)
+    car_device.get_car_charge_percent_raw_sensor = MagicMock(return_value=80.0)
     car_device.get_car_odometer_km = MagicMock(return_value=1000.0)
 
     car_device.car_efficiency_km_per_kwh_sensor_state_getter("sensor.car_efficiency", time1)
 
     time2 = datetime(2026, 1, 15, 18, 0, tzinfo=pytz.UTC)
-    car_device.get_car_charge_percent = MagicMock(return_value=70.0)
+    car_device.get_car_charge_percent_raw_sensor = MagicMock(return_value=70.0)
     car_device.get_car_odometer_km = MagicMock(return_value=1010.0)
 
     result = car_device.car_efficiency_km_per_kwh_sensor_state_getter("sensor.car_efficiency", time2)
@@ -1428,9 +1428,11 @@ async def test_car_charge_percent_constraints_flags(
     car_device.car_battery_capacity = None
     assert car_device.can_use_charge_percent_constraints() is False
 
+    # QS-243 — a no-sensor car with a true capacity now uses percent
+    # constraints (estimates SOC from charged energy).
     car_device.car_battery_capacity = 50000
     car_device.car_charge_percent_sensor = None
-    assert car_device.can_use_charge_percent_constraints() is False
+    assert car_device.can_use_charge_percent_constraints() is True
 
     car_device.car_charge_percent_sensor = "sensor.car_soc"
     assert car_device.can_use_charge_percent_constraints() is True
@@ -1663,6 +1665,11 @@ async def test_car_charge_energy_and_charge_limit(
 
     car_device = hass.data[DOMAIN].get(car_entry.entry_id)
     assert car_device is not None
+
+    # QS-243 — the car now registers the NUMBER platform (manual-SOC entity),
+    # which re-registers HA's real `number.set_value` during setup. Re-register
+    # the mock afterwards so it is the active handler.
+    hass.services.async_register(number.DOMAIN, number.SERVICE_SET_VALUE, set_value_handler)
 
     time_now = datetime(2026, 1, 20, 14, 0, tzinfo=pytz.UTC)
     soc_entity = car_device.car_charge_percent_sensor

--- a/tests/ha_tests/test_car_extended_coverage.py
+++ b/tests/ha_tests/test_car_extended_coverage.py
@@ -334,7 +334,7 @@ async def test_efficiency_getter_no_soc_value(
     """Returns None when soc is None."""
     car, _ = await _create_car(hass, home_config_entry, entry_id_suffix="eff_no_val")
     car.car_odometer_sensor = "sensor.odo"
-    car.get_car_charge_percent = MagicMock(return_value=None)
+    car.get_car_charge_percent_raw_sensor = MagicMock(return_value=None)
     car.get_car_odometer_km = MagicMock(return_value=1000.0)
 
     result = car.car_efficiency_km_per_kwh_sensor_state_getter("sensor.eff", datetime.now(pytz.UTC))
@@ -354,14 +354,14 @@ async def test_efficiency_getter_with_estimated_range_sensor(
     time = datetime(2026, 2, 10, 10, 0, tzinfo=pytz.UTC)
 
     # First call to establish first segment
-    car.get_car_charge_percent = MagicMock(return_value=80.0)
+    car.get_car_charge_percent_raw_sensor = MagicMock(return_value=80.0)
     car.get_car_odometer_km = MagicMock(return_value=5000.0)
     car.get_car_estimated_range_km_from_sensor = MagicMock(return_value=320.0)  # 320 km range at 80%
     car.car_efficiency_km_per_kwh_sensor_state_getter("sensor.eff", time)
 
     # Second call with decreased SOC
     time2 = time + timedelta(hours=2)
-    car.get_car_charge_percent = MagicMock(return_value=70.0)
+    car.get_car_charge_percent_raw_sensor = MagicMock(return_value=70.0)
     car.get_car_odometer_km = MagicMock(return_value=5050.0)
     car.get_car_estimated_range_km_from_sensor = MagicMock(return_value=280.0)  # 280 km range at 70%
     result = car.car_efficiency_km_per_kwh_sensor_state_getter("sensor.eff", time2)
@@ -384,7 +384,7 @@ async def test_efficiency_getter_ema_update(
     time = datetime(2026, 2, 10, 10, 0, tzinfo=pytz.UTC)
     car._km_per_kwh = 5.0  # Previous EMA value
 
-    car.get_car_charge_percent = MagicMock(return_value=80.0)
+    car.get_car_charge_percent_raw_sensor = MagicMock(return_value=80.0)
     car.get_car_odometer_km = MagicMock(return_value=5000.0)
     car.get_car_estimated_range_km_from_sensor = MagicMock(return_value=320.0)
 
@@ -411,12 +411,12 @@ async def test_efficiency_getter_from_segments_no_range_sensor(
     time = datetime(2026, 2, 10, 8, 0, tzinfo=pytz.UTC)
 
     # Build a decreasing segment: 80% -> 70%, odometer 1000 -> 1050
-    car.get_car_charge_percent = MagicMock(return_value=80.0)
+    car.get_car_charge_percent_raw_sensor = MagicMock(return_value=80.0)
     car.get_car_odometer_km = MagicMock(return_value=1000.0)
     car.car_efficiency_km_per_kwh_sensor_state_getter("sensor.eff", time)
 
     time2 = time + timedelta(hours=1)
-    car.get_car_charge_percent = MagicMock(return_value=70.0)
+    car.get_car_charge_percent_raw_sensor = MagicMock(return_value=70.0)
     car.get_car_odometer_km = MagicMock(return_value=1050.0)
     result = car.car_efficiency_km_per_kwh_sensor_state_getter("sensor.eff", time2)
 
@@ -1912,6 +1912,11 @@ async def test_adapt_max_charge_limit_with_steps(
         entry_id_suffix="lim_steps",
     )
 
+    # QS-243 — the car now registers the NUMBER platform (for the manual-SOC
+    # entity), which re-registers HA's real `number.set_value` during setup.
+    # Re-register the mock afterwards so it is the active handler.
+    hass.services.async_register(number_mod.DOMAIN, number_mod.SERVICE_SET_VALUE, set_value_handler)
+
     # Attached to a QS-managed charger so the native-limit write is permitted
     # (a bare SimpleNamespace suffices — adapt_max_charge_limit never calls a
     # charger method).
@@ -2009,6 +2014,10 @@ async def test_charge_target_recorded_while_detached_reapplied_on_reconnect(
         },
         entry_id_suffix="lim_reconnect",
     )
+
+    # QS-243 — re-register after setup (the NUMBER platform re-registers the
+    # real `number.set_value`).
+    hass.services.async_register(number_mod.DOMAIN, number_mod.SERVICE_SET_VALUE, set_value_handler)
 
     # Detached on entry.
     assert car.charger is None

--- a/tests/ha_tests/test_car_missing_lines.py
+++ b/tests/ha_tests/test_car_missing_lines.py
@@ -772,6 +772,9 @@ async def test_adapt_max_charge_limit_steps_overflow(
         },
         entry_id_suffix="lim_overflow2",
     )
+    # QS-243 — re-register after setup (the NUMBER platform re-registers the
+    # real `number.set_value`).
+    hass.services.async_register(number_mod.DOMAIN, number_mod.SERVICE_SET_VALUE, set_value_handler)
     set_value_handler.reset_mock()
 
     # Attached to a QS-managed charger so the native-limit write is permitted.

--- a/tests/ha_tests/test_charger.py
+++ b/tests/ha_tests/test_charger.py
@@ -3342,6 +3342,8 @@ async def test_charger_check_load_activity_unplugged(
     assert await charger_device.check_load_activity_and_constraints(now) is True
     charger_device.reset.assert_called_once()
     charger_device.set_max_charging_current.assert_awaited()
+    # QS-243 S5 — the unplug edge cleared the car's SOC estimate.
+    assert car.reset_soc_estimate_call_count == 1
 
 
 async def test_charger_check_load_activity_plugged_best_car_none(

--- a/tests/ha_tests/test_charger.py
+++ b/tests/ha_tests/test_charger.py
@@ -3108,6 +3108,9 @@ async def test_charger_constraint_update_value_callback(
 
     car_device.car_charge_percent_sensor = "sensor.car_soc"
     car_device.get_car_charge_percent = MagicMock(return_value=50)
+    # QS-243 — the callback reads the raw sensor and gates on estimation mode.
+    car_device.get_car_charge_percent_raw_sensor = MagicMock(return_value=50)
+    car_device.car_api_stale_percent_mode = False
     car_device.is_car_charge_growing = MagicMock(return_value=False)
     car_device.setup_car_charge_target_if_needed = AsyncMock()
 
@@ -3235,6 +3238,8 @@ async def test_charger_constraint_update_value_callback_sensor_path(
     charger_device._compute_added_charge_update = MagicMock(return_value=5.0)
 
     car_device.get_car_charge_percent = MagicMock(return_value=90.0)
+    car_device.get_car_charge_percent_raw_sensor = MagicMock(return_value=90.0)
+    car_device.car_api_stale_percent_mode = False
     car_device.is_car_charge_growing = MagicMock(return_value=None)
     car_device.setup_car_charge_target_if_needed = AsyncMock()
     car_device.car_charge_percent_sensor = "sensor.car"
@@ -3685,6 +3690,8 @@ async def test_charger_constraint_update_value_callback_growth_path(
     charger_device._expected_charge_state.last_ping_time_success = None
 
     car_device.get_car_charge_percent = MagicMock(return_value=100.0)
+    car_device.get_car_charge_percent_raw_sensor = MagicMock(return_value=100.0)
+    car_device.car_api_stale_percent_mode = False
     car_device.is_car_charge_growing = MagicMock(return_value=False)
     car_device.setup_car_charge_target_if_needed = AsyncMock()
     car_device.car_charge_percent_sensor = "sensor.car"

--- a/tests/test_car_range_estimation.py
+++ b/tests/test_car_range_estimation.py
@@ -340,11 +340,11 @@ class TestCarRangeEstimation(unittest.TestCase):
                 return 70.0
             return None
 
-        # Replace methods
+        # Replace methods (efficiency learning reads the raw sensor — QS-243)
         original_get_odo = self.car.get_car_odometer_km
-        original_get_soc = self.car.get_car_charge_percent
+        original_get_soc = self.car.get_car_charge_percent_raw_sensor
         self.car.get_car_odometer_km = mock_get_odometer
-        self.car.get_car_charge_percent = mock_get_soc
+        self.car.get_car_charge_percent_raw_sensor = mock_get_soc
 
         # Add first value
         result = self.car.car_efficiency_km_per_kwh_sensor_state_getter(self.car.car_efficiency_km_per_kwh_sensor, time)
@@ -356,7 +356,7 @@ class TestCarRangeEstimation(unittest.TestCase):
 
         # Restore methods
         self.car.get_car_odometer_km = original_get_odo
-        self.car.get_car_charge_percent = original_get_soc
+        self.car.get_car_charge_percent_raw_sensor = original_get_soc
 
         # Check that _km_per_kwh was computed
         # 60km traveled, 10% SOC (6 kWh), so 60/6 = 10 km/kWh

--- a/tests/test_car_soc_estimation.py
+++ b/tests/test_car_soc_estimation.py
@@ -1,0 +1,517 @@
+"""Tests for the estimated-SOC model (Story QS-243).
+
+Covers the effective-SOC accessors, estimation-mode gating, the
+`can_use_charge_percent_constraints` flip, manual entry / reset, persistence,
+the per-cycle recovery state machine, the fresh→stale capture, and the
+estimation-vs-staleness orthogonality.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.quiet_solar.const import (
+    BINARY_SENSOR_CAR_IS_SOC_ESTIMATED,
+    BUTTON_CAR_RESET_SOC_ESTIMATE,
+    CAR_SOC_STALE_THRESHOLD_S,
+    CAR_STALE_MODE_FORCE_NOT_STALE,
+    CAR_STALE_MODE_FORCE_STALE,
+    NUMBER_CAR_MANUAL_SOC_PERCENT,
+)
+from custom_components.quiet_solar.ha_model.car import QSCar
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+def _make_car(fake_hass, mock_data_handler, **overrides) -> QSCar:
+    from tests.ha_tests.const import MOCK_CAR_CONFIG
+
+    config = {
+        **MOCK_CAR_CONFIG,
+        "hass": fake_hass,
+        "config_entry": MagicMock(),
+        "data_handler": mock_data_handler,
+        "home": mock_data_handler.home,
+    }
+    config.update(overrides)
+    return QSCar(**config)
+
+
+@pytest.fixture
+def est_car(fake_hass, mock_data_handler, current_time):
+    """A normal car: SOC sensor + battery capacity, not invited."""
+    return _make_car(fake_hass, mock_data_handler)
+
+
+@pytest.fixture
+def est_car_no_sensor(fake_hass, mock_data_handler, current_time):
+    """A real car with a true capacity but no SOC sensor."""
+    from custom_components.quiet_solar.const import CONF_CAR_CHARGE_PERCENT_SENSOR
+
+    return _make_car(fake_hass, mock_data_handler, **{CONF_CAR_CHARGE_PERCENT_SENSOR: None})
+
+
+def _set_soc(car: QSCar, value, time):
+    car._entity_probed_last_valid_state[car.car_charge_percent_sensor] = (time, value, {})
+
+
+# ── Constants ────────────────────────────────────────────────────────────
+
+
+def test_constants():
+    assert BINARY_SENSOR_CAR_IS_SOC_ESTIMATED == "qs_car_is_soc_estimated"
+    assert BUTTON_CAR_RESET_SOC_ESTIMATE == "qs_car_reset_soc_estimate"
+    assert NUMBER_CAR_MANUAL_SOC_PERCENT == "qs_car_manual_soc_percent"
+
+
+# ── AC1: healthy sensor passthrough ──────────────────────────────────────
+
+
+def test_healthy_sensor_passthrough(est_car, current_time):
+    _set_soc(est_car, 42.0, current_time)
+    assert est_car.is_in_soc_estimation_mode(current_time) is False
+    assert est_car.has_soc_estimate() is False
+    assert est_car.get_car_charge_percent(current_time) == 42.0
+
+
+# ── Estimation-mode gating arms ──────────────────────────────────────────
+
+
+def test_estimation_mode_invited(est_car):
+    est_car.car_is_invited = True
+    assert est_car.is_in_soc_estimation_mode() is False
+
+
+def test_estimation_mode_no_capacity(est_car):
+    est_car.car_battery_capacity = None
+    assert est_car.is_in_soc_estimation_mode() is False
+    est_car.car_battery_capacity = 0
+    assert est_car.is_in_soc_estimation_mode() is False
+
+
+def test_estimation_mode_no_sensor(est_car_no_sensor):
+    assert est_car_no_sensor.is_in_soc_estimation_mode() is True
+
+
+def test_estimation_mode_stale_percent(est_car):
+    est_car.car_api_stale_percent_mode = True
+    assert est_car.is_in_soc_estimation_mode() is True
+
+
+def test_estimation_mode_manual_base_on_healthy(est_car):
+    est_car._user_base_soc_value = 55.0
+    assert est_car.is_in_soc_estimation_mode() is True
+
+
+# ── _estimated_soc_percent: three arms + clamp ───────────────────────────
+
+
+def test_estimated_soc_user_base(est_car):
+    est_car._user_base_soc_value = 40.0
+    est_car._computed_added_delta_soc_percent = 5.0
+    assert est_car._estimated_soc_percent == 45.0
+
+
+def test_estimated_soc_system_base(est_car):
+    est_car._last_valid_base_soc_value = 30.0
+    est_car._computed_added_delta_soc_percent = 2.0
+    assert est_car._estimated_soc_percent == 32.0
+
+
+def test_estimated_soc_no_base_is_none(est_car):
+    est_car._computed_added_delta_soc_percent = 7.0
+    assert est_car._estimated_soc_percent is None
+
+
+def test_estimated_soc_clamped(est_car):
+    est_car._user_base_soc_value = 98.0
+    est_car._computed_added_delta_soc_percent = 10.0
+    assert est_car._estimated_soc_percent == 100.0
+    est_car._user_base_soc_value = 2.0
+    est_car._computed_added_delta_soc_percent = -10.0
+    assert est_car._estimated_soc_percent == 0.0
+
+
+def test_estimated_soc_delta_none(est_car):
+    est_car._user_base_soc_value = 50.0
+    est_car._computed_added_delta_soc_percent = None
+    assert est_car._estimated_soc_percent == 50.0
+
+
+def test_has_soc_estimate(est_car):
+    assert est_car.has_soc_estimate() is False
+    est_car._user_base_soc_value = 50.0
+    assert est_car.has_soc_estimate() is True
+
+
+def test_get_car_charge_percent_returns_estimate(est_car, current_time):
+    _set_soc(est_car, 10.0, current_time)
+    est_car._user_base_soc_value = 60.0
+    est_car._computed_added_delta_soc_percent = 5.0
+    # estimate wins over raw sensor
+    assert est_car.get_car_charge_percent(current_time) == 65.0
+    assert est_car.get_car_charge_percent_raw_sensor(current_time) == 10.0
+
+
+def test_raw_sensor_none_when_no_sensor(est_car_no_sensor, current_time):
+    assert est_car_no_sensor.get_car_charge_percent_raw_sensor(current_time) is None
+
+
+def test_pure_delta_get_charge_percent_none(est_car_no_sensor):
+    # estimating, no base -> get_car_charge_percent returns None
+    assert est_car_no_sensor.get_car_charge_percent() is None
+    assert est_car_no_sensor.has_soc_estimate() is False
+
+
+# ── AC4 + invariants: can_use_charge_percent_constraints ─────────────────
+
+
+def test_can_use_percent_real_sensor_and_capacity(est_car):
+    assert est_car.can_use_charge_percent_constraints() is True
+
+
+def test_can_use_percent_no_sensor_with_capacity(est_car_no_sensor):
+    assert est_car_no_sensor.can_use_charge_percent_constraints() is True
+
+
+def test_can_use_percent_invited_false(est_car):
+    est_car.car_is_invited = True
+    assert est_car.can_use_charge_percent_constraints() is False
+
+
+def test_can_use_percent_no_capacity_false(est_car):
+    est_car.car_battery_capacity = None
+    assert est_car.can_use_charge_percent_constraints() is False
+    est_car.car_battery_capacity = 0
+    assert est_car.can_use_charge_percent_constraints() is False
+
+
+# ── Manual entry / reset ─────────────────────────────────────────────────
+
+
+async def test_user_set_manual_soc(est_car, current_time):
+    _set_soc(est_car, 30.0, current_time - timedelta(seconds=10))
+    est_car.charger = None
+    await est_car.user_set_manual_soc_percent(72.4)
+    assert est_car._user_base_soc_value == 72.0  # int() then float
+    assert est_car._user_base_soc_entry_sensor_value == 30.0
+    assert est_car._computed_added_delta_soc_percent == 0.0
+    assert est_car._delta_soc_last_integration_time is None
+
+
+async def test_user_set_manual_soc_clamped(est_car):
+    est_car.charger = None
+    await est_car.user_set_manual_soc_percent(150)
+    assert est_car._user_base_soc_value == 100.0
+    await est_car.user_set_manual_soc_percent(-5)
+    assert est_car._user_base_soc_value == 0.0
+
+
+async def test_user_set_manual_soc_for_init_noop(est_car):
+    await est_car.user_set_manual_soc_percent(50, for_init=True)
+    assert est_car._user_base_soc_value is None
+
+
+async def test_user_set_manual_soc_updates_charger(est_car):
+    charger = MagicMock()
+    charger.update_charger_for_user_change = AsyncMock()
+    est_car.charger = charger
+    await est_car.user_set_manual_soc_percent(40)
+    charger.update_charger_for_user_change.assert_awaited_once()
+
+
+def test_user_reset_soc_estimate(est_car):
+    est_car._user_base_soc_value = 10.0
+    est_car._last_valid_base_soc_value = 20.0
+    est_car._computed_added_delta_soc_percent = 3.0
+    est_car._user_base_soc_entry_sensor_value = 5.0
+    est_car._delta_soc_last_integration_time = "x"
+    est_car.reset_soc_estimate()
+    assert est_car._user_base_soc_value is None
+    assert est_car._last_valid_base_soc_value is None
+    assert est_car._computed_added_delta_soc_percent is None
+    assert est_car._user_base_soc_entry_sensor_value is None
+    assert est_car._delta_soc_last_integration_time is None
+
+
+async def test_user_button_reset_no_charger(est_car):
+    est_car._user_base_soc_value = 10.0
+    est_car.charger = None
+    await est_car.user_button_reset_soc_estimate()
+    assert est_car._user_base_soc_value is None
+
+
+async def test_user_button_reset_with_charger(est_car):
+    charger = MagicMock()
+    charger.update_charger_for_user_change = AsyncMock()
+    est_car.charger = charger
+    est_car._user_base_soc_value = 10.0
+    await est_car.user_button_reset_soc_estimate()
+    assert est_car._user_base_soc_value is None
+    charger.update_charger_for_user_change.assert_awaited_once()
+
+
+def test_manual_soc_number_value_property(est_car):
+    assert est_car.qs_car_manual_soc_percent == 0.0
+    est_car._user_base_soc_value = 63.0
+    assert est_car.qs_car_manual_soc_percent == 63.0
+
+
+async def test_user_clean_and_reset_clears_estimate(est_car):
+    est_car._user_base_soc_value = 44.0
+    est_car.charger = None
+    est_car.home = None
+    await est_car.user_clean_and_reset()
+    assert est_car._user_base_soc_value is None
+
+
+# ── Persistence ──────────────────────────────────────────────────────────
+
+
+def test_persistence_round_trip(est_car, fake_hass, mock_data_handler, current_time):
+    est_car._user_base_soc_value = 40.0
+    est_car._last_valid_base_soc_value = 35.0
+    est_car._computed_added_delta_soc_percent = 4.5
+    est_car._user_base_soc_entry_sensor_value = 33.0
+
+    data: dict = {}
+    est_car.update_to_be_saved_extra_device_info(data)
+    assert data["user_base_soc_value"] == 40.0
+    assert data["last_valid_base_soc_value"] == 35.0
+    assert data["computed_added_delta_soc_percent"] == 4.5
+    assert data["user_base_soc_entry_sensor_value"] == 33.0
+
+    other = _make_car(fake_hass, mock_data_handler)
+    other.use_saved_extra_device_info(data)
+    assert other._user_base_soc_value == 40.0
+    assert other._last_valid_base_soc_value == 35.0
+    assert other._computed_added_delta_soc_percent == 4.5
+    assert other._user_base_soc_entry_sensor_value == 33.0
+    assert other._delta_soc_last_integration_time is None
+
+
+def test_persistence_pre_qs243_blob(est_car):
+    # A saved blob from before this story lacks the SOC keys.
+    est_car._user_base_soc_value = 12.0
+    est_car.use_saved_extra_device_info({"current_forecasted_person_name_from_boot": None})
+    assert est_car._user_base_soc_value is None
+    assert est_car._last_valid_base_soc_value is None
+    assert est_car._computed_added_delta_soc_percent is None
+    assert est_car._user_base_soc_entry_sensor_value is None
+
+
+# ── Recovery state machine: _update_soc_estimation ───────────────────────
+
+
+def test_recovery_any_change_clears(est_car, current_time):
+    est_car._user_base_soc_value = 70.0
+    est_car._user_base_soc_entry_sensor_value = 50.0
+    _set_soc(est_car, 51.0, current_time)  # different from entry ref
+    est_car._update_soc_estimation(current_time)
+    assert est_car._user_base_soc_value is None
+
+
+def test_recovery_same_value_persists(est_car, current_time):
+    est_car._user_base_soc_value = 70.0
+    est_car._user_base_soc_entry_sensor_value = 50.0
+    _set_soc(est_car, 50.0, current_time)  # same as entry ref
+    est_car._update_soc_estimation(current_time)
+    assert est_car._user_base_soc_value == 70.0
+
+
+def test_recovery_ref_none_clears_on_fresh(est_car, current_time):
+    est_car._user_base_soc_value = 70.0
+    est_car._user_base_soc_entry_sensor_value = None
+    _set_soc(est_car, 50.0, current_time)
+    est_car._update_soc_estimation(current_time)
+    assert est_car._user_base_soc_value is None
+
+
+def test_recovery_no_user_base_noop(est_car, current_time):
+    _set_soc(est_car, 50.0, current_time)
+    est_car._update_soc_estimation(current_time)  # nothing to do
+    assert est_car._user_base_soc_value is None
+
+
+def test_recovery_no_sensor_noop(est_car_no_sensor, current_time):
+    est_car_no_sensor._user_base_soc_value = 70.0
+    est_car_no_sensor._update_soc_estimation(current_time)
+    assert est_car_no_sensor._user_base_soc_value == 70.0
+
+
+def test_recovery_stale_sensor_skips(est_car, current_time):
+    est_car._user_base_soc_value = 70.0
+    est_car._user_base_soc_entry_sensor_value = 50.0
+    stale_time = current_time - timedelta(seconds=CAR_SOC_STALE_THRESHOLD_S + 1)
+    _set_soc(est_car, 51.0, stale_time)
+    est_car._update_soc_estimation(current_time)
+    assert est_car._user_base_soc_value == 70.0
+
+
+def test_recovery_raw_none_skips(est_car, current_time):
+    # Defensive guard: sensor not stale but the raw read still yields None.
+    est_car._user_base_soc_value = 70.0
+    est_car._user_base_soc_entry_sensor_value = 50.0
+    est_car._is_soc_sensor_stale = lambda time: False
+    est_car.get_car_charge_percent_raw_sensor = lambda time=None, tolerance_seconds=None: None
+    est_car._update_soc_estimation(current_time)
+    assert est_car._user_base_soc_value == 70.0
+
+
+# ── Fresh→stale capture ──────────────────────────────────────────────────
+
+
+def test_capture_last_valid_base(est_car, current_time):
+    _set_soc(est_car, 64.0, current_time)
+    est_car._enter_stale_percent_mode(current_time)
+    assert est_car.car_api_stale_percent_mode is True
+    assert est_car._last_valid_base_soc_value == 64.0
+    assert est_car._computed_added_delta_soc_percent == 0.0
+    assert est_car._delta_soc_last_integration_time is None
+
+
+def test_capture_skipped_when_user_base(est_car, current_time):
+    _set_soc(est_car, 64.0, current_time)
+    est_car._user_base_soc_value = 80.0
+    est_car._enter_stale_percent_mode(current_time)
+    assert est_car._last_valid_base_soc_value is None
+
+
+def test_capture_skipped_when_system_base_exists(est_car, current_time):
+    _set_soc(est_car, 64.0, current_time)
+    est_car._last_valid_base_soc_value = 30.0
+    est_car._enter_stale_percent_mode(current_time)
+    assert est_car._last_valid_base_soc_value == 30.0
+
+
+def test_capture_skipped_when_raw_none(est_car, current_time):
+    est_car._entity_probed_last_valid_state[est_car.car_charge_percent_sensor] = None
+    est_car._enter_stale_percent_mode(current_time)
+    assert est_car._last_valid_base_soc_value is None
+
+
+def test_enter_stale_for_init_no_capture(est_car, current_time):
+    _set_soc(est_car, 64.0, current_time)
+    est_car._enter_stale_percent_mode(None, for_init=True)
+    assert est_car.car_api_stale_percent_mode is True
+    assert est_car._last_valid_base_soc_value is None
+
+
+# ── _exit_stale_mode clears system base ──────────────────────────────────
+
+
+def test_exit_stale_clears_system_base(est_car):
+    est_car.car_api_stale_percent_mode = True
+    est_car._last_valid_base_soc_value = 40.0
+    est_car._computed_added_delta_soc_percent = 6.0
+    est_car._delta_soc_last_integration_time = "x"
+    est_car._user_base_soc_value = 88.0
+    est_car._exit_stale_mode()
+    assert est_car._last_valid_base_soc_value is None
+    assert est_car._computed_added_delta_soc_percent is None
+    assert est_car._delta_soc_last_integration_time is None
+    # user base is NOT cleared by stale-mode exit
+    assert est_car._user_base_soc_value == 88.0
+
+
+# ── AC12: orthogonality ──────────────────────────────────────────────────
+
+
+def test_orthogonality_manual_override_not_stale(est_car, current_time):
+    fresh = current_time - timedelta(seconds=30)
+    for sensor_id in est_car._car_api_all_sensors:
+        est_car._entity_probed_last_valid_state[sensor_id] = (fresh, "value", {})
+    est_car._user_base_soc_value = 55.0
+    est_car._car_api_stale = False
+    assert est_car.has_soc_estimate() is True
+    assert est_car.is_car_effectively_stale(current_time) is False
+
+
+# ── is_car_charge_growing gating ─────────────────────────────────────────
+
+
+def test_is_car_charge_growing_none_when_estimating(est_car_no_sensor, current_time):
+    assert est_car_no_sensor.is_car_charge_growing(60, current_time) is None
+
+
+def test_is_car_charge_growing_reads_sensor_when_not_estimating(est_car, current_time):
+    _set_soc(est_car, 50.0, current_time)
+    # not estimating -> delegates to is_sensor_growing (returns None/bool, no exception)
+    result = est_car.is_car_charge_growing(60, current_time)
+    assert result is None or isinstance(result, bool)
+
+
+# ── Platform entity creation ─────────────────────────────────────────────
+
+
+def test_create_number_for_car(est_car):
+    from custom_components.quiet_solar.number import create_ha_number_for_QSCar
+
+    entities = create_ha_number_for_QSCar(est_car)
+    keys = [e.entity_description.translation_key for e in entities]
+    assert NUMBER_CAR_MANUAL_SOC_PERCENT in keys
+
+
+def test_create_number_for_invited_car_empty(est_car):
+    from custom_components.quiet_solar.number import create_ha_number_for_QSCar
+
+    est_car.car_is_invited = True
+    assert create_ha_number_for_QSCar(est_car) == []
+
+
+async def test_number_async_set_fn_writes_manual_soc(est_car):
+    from custom_components.quiet_solar.number import create_ha_number_for_QSCar
+
+    est_car.charger = None
+    entities = create_ha_number_for_QSCar(est_car)
+    desc = entities[0].entity_description
+    await desc.async_set_fn(est_car, 66, False)
+    assert est_car._user_base_soc_value == 66.0
+
+
+def test_create_button_for_car_includes_reset(est_car):
+    from custom_components.quiet_solar.button import create_ha_button_for_QSCar
+
+    entities = create_ha_button_for_QSCar(est_car)
+    keys = [e.entity_description.key for e in entities]
+    assert BUTTON_CAR_RESET_SOC_ESTIMATE in keys
+
+
+def test_create_button_for_invited_car_no_reset(est_car):
+    from custom_components.quiet_solar.button import create_ha_button_for_QSCar
+
+    est_car.car_is_invited = True
+    entities = create_ha_button_for_QSCar(est_car)
+    keys = [e.entity_description.key for e in entities]
+    assert BUTTON_CAR_RESET_SOC_ESTIMATE not in keys
+
+
+def test_create_binary_sensor_for_car_includes_estimated(est_car):
+    from custom_components.quiet_solar.binary_sensor import create_ha_binary_sensor_for_QSCar
+
+    entities = create_ha_binary_sensor_for_QSCar(est_car)
+    keys = [e.entity_description.key for e in entities]
+    assert BINARY_SENSOR_CAR_IS_SOC_ESTIMATED in keys
+
+
+def test_binary_sensor_estimated_value_fn(est_car):
+    from custom_components.quiet_solar.binary_sensor import create_ha_binary_sensor_for_QSCar
+
+    entities = create_ha_binary_sensor_for_QSCar(est_car)
+    est = next(e for e in entities if e.entity_description.key == BINARY_SENSOR_CAR_IS_SOC_ESTIMATED)
+    assert est.entity_description.value_fn(est_car, "k") is False
+    est_car._user_base_soc_value = 50.0
+    assert est.entity_description.value_fn(est_car, "k") is True
+
+
+def test_create_binary_sensor_invited_no_estimated(est_car):
+    from custom_components.quiet_solar.binary_sensor import create_ha_binary_sensor_for_QSCar
+
+    est_car.car_is_invited = True
+    entities = create_ha_binary_sensor_for_QSCar(est_car)
+    keys = [e.entity_description.key for e in entities]
+    assert BINARY_SENSOR_CAR_IS_SOC_ESTIMATED not in keys

--- a/tests/test_car_soc_estimation.py
+++ b/tests/test_car_soc_estimation.py
@@ -8,10 +8,11 @@ estimation-vs-staleness orthogonality.
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import pytz
 
 from custom_components.quiet_solar.const import (
     BINARY_SENSOR_CAR_IS_SOC_ESTIMATED,
@@ -391,6 +392,13 @@ async def test_manual_soc_rounds_not_truncates(est_car):
     assert est_car._user_base_soc_value == 51.0
 
 
+async def test_manual_soc_half_up_rounding(est_car):
+    # N3 — half-up, not Python banker's rounding (round(2.5) == 2).
+    est_car.charger = None
+    await est_car.user_set_manual_soc_percent(2.5)
+    assert est_car._user_base_soc_value == 3.0
+
+
 def test_is_soc_sensor_distrusted(est_car, est_car_no_sensor):
     assert est_car.is_soc_sensor_distrusted() is False
     est_car.car_api_stale_percent_mode = True
@@ -418,6 +426,50 @@ def test_recovery_case1_entered_during_stale_clears_on_exit(est_car, current_tim
     est_car.car_api_stale_percent_mode = False
     est_car._update_soc_estimation(current_time)
     assert est_car._user_base_soc_value is None
+
+
+def test_recovery_case1_force_not_stale_clears_while_time_stale(est_car, current_time):
+    # S2 — override entered during stale; user sets Force-Not-Stale while the SOC
+    # sensor is still time-stale → the (force-trusted) live sensor takes over.
+    est_car._user_base_soc_value = 70.0
+    est_car._user_base_soc_entry_api_stale = True
+    est_car._user_base_soc_entry_sensor_value = None
+    stale_time = current_time - timedelta(seconds=CAR_SOC_STALE_THRESHOLD_S + 1)
+    _set_soc(est_car, 55.0, stale_time)  # genuinely time-stale value
+    est_car.car_stale_mode_override = CAR_STALE_MODE_FORCE_NOT_STALE
+    est_car.car_api_stale_percent_mode = False  # forced not-stale → exited stale mode
+    est_car._update_soc_estimation(current_time)
+    assert est_car._user_base_soc_value is None
+
+
+def test_recovery_case1_time_stale_without_force_keeps(est_car, current_time):
+    # Without Force-Not-Stale, a time-stale sensor does not trigger recovery.
+    est_car._user_base_soc_value = 70.0
+    est_car._user_base_soc_entry_api_stale = True
+    est_car._user_base_soc_entry_sensor_value = None
+    stale_time = current_time - timedelta(seconds=CAR_SOC_STALE_THRESHOLD_S + 1)
+    _set_soc(est_car, 55.0, stale_time)
+    est_car.car_api_stale_percent_mode = False
+    est_car._update_soc_estimation(current_time)
+    assert est_car._user_base_soc_value == 70.0
+
+
+def test_number_entity_resyncs_on_runtime_reset(est_car):
+    # S1 — the manual-SOC number entity tracks the device value, so a runtime
+    # reset (e.g. plug-in / reset button / recovery) is reflected in the card.
+    from custom_components.quiet_solar.number import create_ha_number_for_QSCar
+
+    entity = create_ha_number_for_QSCar(est_car)[0]
+    entity.hass = est_car.hass
+    entity.async_write_ha_state = MagicMock()
+
+    est_car._user_base_soc_value = 80.0
+    entity.async_update_callback(datetime.now(tz=pytz.UTC))
+    assert entity._attr_native_value == 80.0
+
+    est_car.reset_soc_estimate()
+    entity.async_update_callback(datetime.now(tz=pytz.UTC))
+    assert entity._attr_native_value == 0.0
 
 
 def test_recovery_case2_stale_blip_preserves_delta(est_car, current_time):

--- a/tests/test_car_soc_estimation.py
+++ b/tests/test_car_soc_estimation.py
@@ -229,12 +229,14 @@ def test_user_reset_soc_estimate(est_car):
     est_car._last_valid_base_soc_value = 20.0
     est_car._computed_added_delta_soc_percent = 3.0
     est_car._user_base_soc_entry_sensor_value = 5.0
+    est_car._user_base_soc_entry_api_stale = True
     est_car._delta_soc_last_integration_time = "x"
     est_car.reset_soc_estimate()
     assert est_car._user_base_soc_value is None
     assert est_car._last_valid_base_soc_value is None
     assert est_car._computed_added_delta_soc_percent is None
     assert est_car._user_base_soc_entry_sensor_value is None
+    assert est_car._user_base_soc_entry_api_stale is None
     assert est_car._delta_soc_last_integration_time is None
 
 
@@ -294,14 +296,27 @@ def test_persistence_round_trip(est_car, fake_hass, mock_data_handler, current_t
     assert other._delta_soc_last_integration_time is None
 
 
+def test_persistence_entry_api_stale_round_trip(est_car, fake_hass, mock_data_handler):
+    est_car._user_base_soc_value = 40.0
+    est_car._user_base_soc_entry_api_stale = True
+    data: dict = {}
+    est_car.update_to_be_saved_extra_device_info(data)
+    assert data["user_base_soc_entry_api_stale"] is True
+    other = _make_car(fake_hass, mock_data_handler)
+    other.use_saved_extra_device_info(data)
+    assert other._user_base_soc_entry_api_stale is True
+
+
 def test_persistence_pre_qs243_blob(est_car):
     # A saved blob from before this story lacks the SOC keys.
     est_car._user_base_soc_value = 12.0
+    est_car._user_base_soc_entry_api_stale = True
     est_car.use_saved_extra_device_info({"current_forecasted_person_name_from_boot": None})
     assert est_car._user_base_soc_value is None
     assert est_car._last_valid_base_soc_value is None
     assert est_car._computed_added_delta_soc_percent is None
     assert est_car._user_base_soc_entry_sensor_value is None
+    assert est_car._user_base_soc_entry_api_stale is None
 
 
 # ── Recovery state machine: _update_soc_estimation ───────────────────────
@@ -350,6 +365,80 @@ def test_recovery_stale_sensor_skips(est_car, current_time):
     _set_soc(est_car, 51.0, stale_time)
     est_car._update_soc_estimation(current_time)
     assert est_car._user_base_soc_value == 70.0
+
+
+async def test_user_set_manual_records_entry_api_stale_true(est_car, current_time):
+    _set_soc(est_car, 30.0, current_time)
+    est_car.car_api_stale_percent_mode = True
+    est_car.charger = None
+    await est_car.user_set_manual_soc_percent(60)
+    assert est_car._user_base_soc_entry_api_stale is True
+
+
+async def test_manual_soc_finite_guard(est_car):
+    est_car.charger = None
+    await est_car.user_set_manual_soc_percent(float("nan"))
+    assert est_car._user_base_soc_value is None
+    await est_car.user_set_manual_soc_percent(float("inf"))
+    assert est_car._user_base_soc_value is None
+    await est_car.user_set_manual_soc_percent("not-a-number")
+    assert est_car._user_base_soc_value is None
+
+
+async def test_manual_soc_rounds_not_truncates(est_car):
+    est_car.charger = None
+    await est_car.user_set_manual_soc_percent(50.9)
+    assert est_car._user_base_soc_value == 51.0
+
+
+def test_is_soc_sensor_distrusted(est_car, est_car_no_sensor):
+    assert est_car.is_soc_sensor_distrusted() is False
+    est_car.car_api_stale_percent_mode = True
+    assert est_car.is_soc_sensor_distrusted() is True
+    # no-sensor car is always distrusted
+    assert est_car_no_sensor.is_soc_sensor_distrusted() is True
+
+
+# ── M1: 4-case override recovery keyed on entry API state ────────────────
+
+
+def test_recovery_case1_entered_during_stale_clears_on_exit(est_car, current_time):
+    # Case 1: override entered during stale mode → clear once stale exits.
+    est_car._user_base_soc_value = 70.0
+    est_car._user_base_soc_entry_api_stale = True
+    est_car._user_base_soc_entry_sensor_value = None
+    _set_soc(est_car, 55.0, current_time)
+
+    # Still stale → keep the override.
+    est_car.car_api_stale_percent_mode = True
+    est_car._update_soc_estimation(current_time)
+    assert est_car._user_base_soc_value == 70.0
+
+    # Exited stale + fresh valid sensor → live sensor wins.
+    est_car.car_api_stale_percent_mode = False
+    est_car._update_soc_estimation(current_time)
+    assert est_car._user_base_soc_value is None
+
+
+def test_recovery_case2_stale_blip_preserves_delta(est_car, current_time):
+    # Case 2 regression: a transient stale blip must not lose the delta.
+    est_car._user_base_soc_value = 60.0
+    est_car._user_base_soc_entry_api_stale = False
+    est_car._user_base_soc_entry_sensor_value = 50.0
+    est_car._computed_added_delta_soc_percent = 5.0
+    est_car._delta_soc_last_integration_time = current_time
+
+    # Stale blip recovers: accumulator preserved (user override owns it).
+    est_car.car_api_stale_percent_mode = True
+    est_car._exit_stale_mode()
+    assert est_car._computed_added_delta_soc_percent == 5.0
+
+    # Sensor still reads the entry value → keep base + delta.
+    _set_soc(est_car, 50.0, current_time)
+    est_car._update_soc_estimation(current_time)
+    assert est_car._user_base_soc_value == 60.0
+    assert est_car._computed_added_delta_soc_percent == 5.0
+    assert est_car._estimated_soc_percent == 65.0
 
 
 def test_recovery_raw_none_skips(est_car, current_time):
@@ -401,21 +490,83 @@ def test_enter_stale_for_init_no_capture(est_car, current_time):
     assert est_car._last_valid_base_soc_value is None
 
 
+# ── S4 / AC3: end-to-end fresh→stale→recover flow ────────────────────────
+
+
+def test_end_to_end_stale_capture_and_recovery(est_car, current_time):
+    """Drive `_update_car_api_staleness` across a full fresh→stale→recover cycle:
+    capture fires exactly once on the genuine edge, then recovery hands SOC back
+    to the live sensor."""
+    tracker = est_car.car_tracker
+    plugged = est_car.car_plugged
+    soc = est_car.car_charge_percent_sensor
+
+    def _fresh_non_soc(t):
+        est_car._entity_probed_last_valid_state[tracker] = (t, "home", {})
+        est_car._entity_probed_last_valid_state[plugged] = (t, "on", {})
+
+    # 1) Everything fresh, SOC = 60 → not stale.
+    _fresh_non_soc(current_time)
+    est_car._entity_probed_last_valid_state[soc] = (current_time, 60.0, {})
+    est_car._update_car_api_staleness(current_time)
+    assert est_car.car_api_stale_percent_mode is False
+    assert est_car.get_car_charge_percent(current_time) == 60.0
+
+    # 2) SOC sensor goes stale (others fresh) → SOC-only stale edge captures L=60.
+    stale_time = current_time - timedelta(seconds=CAR_SOC_STALE_THRESHOLD_S + 1)
+    est_car._entity_probed_last_valid_state[soc] = (stale_time, 60.0, {})
+    _fresh_non_soc(current_time)
+    est_car._update_car_api_staleness(current_time)
+    assert est_car.car_api_stale_percent_mode is True
+    assert est_car._last_valid_base_soc_value == 60.0
+    assert est_car._computed_added_delta_soc_percent == 0.0
+    assert est_car.get_car_charge_percent(current_time) == 60.0  # base + 0 delta
+
+    # 3) A second stale cycle must NOT re-capture (genuine-edge guard).
+    est_car._last_valid_base_soc_value = 999.0  # sentinel — must be left untouched
+    est_car._update_car_api_staleness(current_time)
+    assert est_car._last_valid_base_soc_value == 999.0
+    est_car._last_valid_base_soc_value = 60.0
+
+    # 4) API recovers: SOC fresh again with a new value → live sensor takes over.
+    recover_time = current_time + timedelta(seconds=10)
+    _fresh_non_soc(recover_time)
+    est_car._entity_probed_last_valid_state[soc] = (recover_time, 65.0, {})
+    est_car._update_car_api_staleness(recover_time)
+    assert est_car.car_api_stale_percent_mode is False
+    assert est_car._last_valid_base_soc_value is None
+    assert est_car.get_car_charge_percent(recover_time) == 65.0
+
+
 # ── _exit_stale_mode clears system base ──────────────────────────────────
 
 
-def test_exit_stale_clears_system_base(est_car):
+def test_exit_stale_clears_system_base_no_user_override(est_car):
+    # No user override: the system-base recovery clears base + accumulator.
+    est_car.car_api_stale_percent_mode = True
+    est_car._last_valid_base_soc_value = 40.0
+    est_car._computed_added_delta_soc_percent = 6.0
+    est_car._delta_soc_last_integration_time = "x"
+    est_car._exit_stale_mode()
+    assert est_car._last_valid_base_soc_value is None
+    assert est_car._computed_added_delta_soc_percent is None
+    assert est_car._delta_soc_last_integration_time is None
+
+
+def test_exit_stale_preserves_accumulator_with_user_override(est_car):
+    # M1 defect 2: a transient stale blip must NOT wipe an override's delta.
     est_car.car_api_stale_percent_mode = True
     est_car._last_valid_base_soc_value = 40.0
     est_car._computed_added_delta_soc_percent = 6.0
     est_car._delta_soc_last_integration_time = "x"
     est_car._user_base_soc_value = 88.0
     est_car._exit_stale_mode()
-    assert est_car._last_valid_base_soc_value is None
-    assert est_car._computed_added_delta_soc_percent is None
-    assert est_car._delta_soc_last_integration_time is None
-    # user base is NOT cleared by stale-mode exit
+    # the override owns its accumulator lifecycle → delta + cursor preserved
+    assert est_car._computed_added_delta_soc_percent == 6.0
+    assert est_car._delta_soc_last_integration_time == "x"
+    # user base untouched; system base cleared
     assert est_car._user_base_soc_value == 88.0
+    assert est_car._last_valid_base_soc_value is None
 
 
 # ── AC12: orthogonality ──────────────────────────────────────────────────

--- a/tests/test_charger_additional_coverage.py
+++ b/tests/test_charger_additional_coverage.py
@@ -319,6 +319,9 @@ async def test_constraint_update_value_callback_soc_paths() -> None:
     charger.car = MagicMock()
     charger.car.name = "TestCar"
     charger.car.get_car_charge_percent.return_value = 50.0
+    # QS-243 — the callback reads the raw sensor and gates on estimation mode.
+    charger.car.get_car_charge_percent_raw_sensor.return_value = 50.0
+    charger.car.is_in_soc_estimation_mode.return_value = False
     charger.car.get_car_charge_energy.return_value = 20000.0
     charger.car.car_battery_capacity = 60000
     charger.car.efficiency_factor = 1.0

--- a/tests/test_charger_coverage_deep.py
+++ b/tests/test_charger_coverage_deep.py
@@ -526,6 +526,30 @@ class TestCheckLoadActivityAndConstraints:
         assert charger._boot_time is None
 
     @pytest.mark.asyncio
+    async def test_genuine_plug_in_resets_soc_estimate(self):
+        """QS-243 — a genuine new plug-in clears the estimated-SOC state."""
+        *_, charger, car, now = self._setup()
+        charger.car = None
+        charger._boot_car = None  # genuine new plug, not a boot re-attach
+        charger.get_best_car = MagicMock(return_value=car)
+        car._user_base_soc_value = 55.0
+        car._computed_added_delta_soc_percent = 3.0
+        await charger.check_load_activity_and_constraints(now)
+        assert car._user_base_soc_value is None
+        assert car._computed_added_delta_soc_percent is None
+
+    @pytest.mark.asyncio
+    async def test_boot_reattach_preserves_soc_estimate(self):
+        """QS-243 — a boot re-attach preserves the persisted estimate (reboot survives)."""
+        *_, charger, car, now = self._setup()
+        charger.car = None
+        charger._boot_car = car  # boot re-attach for the same car
+        charger.get_best_car = MagicMock(return_value=car)
+        car._user_base_soc_value = 55.0
+        await charger.check_load_activity_and_constraints(now)
+        assert car._user_base_soc_value == 55.0
+
+    @pytest.mark.asyncio
     async def test_unplug_with_car_resets(self):
         *_, charger, car, now = self._setup()
         charger.is_not_plugged = MagicMock(return_value=True)
@@ -770,9 +794,15 @@ class TestCheckLoadActivityAndConstraints:
 
     @pytest.mark.asyncio
     async def test_non_percent_car(self):
-        """Car without SOC sensor uses energy-based constraints."""
+        """Car without SOC sensor AND without a battery capacity uses energy constraints.
+
+        QS-243 — a no-sensor car with a *true* capacity now uses percent
+        constraints, so the energy path requires no capacity here.
+        """
         hass, home, charger, _, now = self._setup()
         car_no_soc = _make_real_car(hass, home, name="NoSocCar", has_soc_sensor=False)
+        car_no_soc.car_battery_capacity = None
+        assert car_no_soc.can_use_charge_percent_constraints() is False
         _plug_car(charger, car_no_soc, now)
         charger.get_best_car = MagicMock(return_value=car_no_soc)
         car_no_soc.do_force_next_charge = True
@@ -6637,9 +6667,10 @@ class TestUpdateValueCallbackLines3967_3971:
         ct.target_value = 80.0
         ct.is_constraint_met = MagicMock(return_value=False)
 
-        # sensor_result is non-None (e.g. 52%)
-        car.get_car_charge_percent = MagicMock(return_value=52.0)
+        # sensor_result is non-None (e.g. 52%) — the callback reads the raw sensor (QS-243)
         car.car_charge_percent_sensor = "sensor.car_soc"
+        car.get_car_charge_percent_raw_sensor = MagicMock(return_value=52.0)
+        assert car.is_in_soc_estimation_mode(now) is False
 
         # _compute_added_charge_update: first call for delta_added, second for delta_begin, third for computed_change
         # delta_added => 6 (so result_calculus = 50 + 6 = 56)

--- a/tests/test_charger_coverage_deep.py
+++ b/tests/test_charger_coverage_deep.py
@@ -550,6 +550,38 @@ class TestCheckLoadActivityAndConstraints:
         assert car._user_base_soc_value == 55.0
 
     @pytest.mark.asyncio
+    async def test_seeding_uses_effective_estimate(self):
+        """QS-243 S3 / AC6 — a constraint on an estimating car seeds from the estimate."""
+        *_, charger, car, now = self._setup()
+        _plug_car(charger, car, now)  # already attached → no genuine-plug reset
+        charger.get_best_car = MagicMock(return_value=car)
+        car.car_api_stale_percent_mode = True  # estimating
+        car._last_valid_base_soc_value = 42.0
+        car._computed_added_delta_soc_percent = 0.0
+        car.car_default_charge = 100.0
+        car.do_force_next_charge = True
+        assert car.get_car_charge_percent(now) == 42.0
+        await charger.check_load_activity_and_constraints(now)
+        cts = [c for c in charger._constraints if c is not None]
+        assert cts, "expected a constraint to be created"
+        assert cts[0].initial_value == 42.0
+
+    @pytest.mark.asyncio
+    async def test_seeding_pure_delta_no_base_is_zero(self):
+        """QS-243 S3 / AC6 — with no base (pure-delta) the seed remains 0.0."""
+        *_, charger, car, now = self._setup()
+        _plug_car(charger, car, now)
+        charger.get_best_car = MagicMock(return_value=car)
+        car.car_api_stale_percent_mode = True  # estimating, but no base
+        car.car_default_charge = 100.0
+        car.do_force_next_charge = True
+        assert car.get_car_charge_percent(now) is None
+        await charger.check_load_activity_and_constraints(now)
+        cts = [c for c in charger._constraints if c is not None]
+        assert cts, "expected a constraint to be created"
+        assert cts[0].initial_value == 0.0
+
+    @pytest.mark.asyncio
     async def test_unplug_with_car_resets(self):
         *_, charger, car, now = self._setup()
         charger.is_not_plugged = MagicMock(return_value=True)

--- a/tests/test_charger_soc_estimation.py
+++ b/tests/test_charger_soc_estimation.py
@@ -1,0 +1,207 @@
+"""Charger-side tests for the estimated-SOC accumulator (Story QS-243).
+
+Covers the float accumulator with its dedicated integration cursor in
+`constraint_update_value_callback_soc`: no loss / no double-count across
+cycles, the pure-delta case, the absolute-estimate case, and the real-power
+check being skipped while estimating.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytz
+from homeassistant.const import CONF_NAME
+
+from custom_components.quiet_solar.const import (
+    CONF_CAR_BATTERY_CAPACITY,
+    CONF_CAR_CHARGE_PERCENT_SENSOR,
+    CONF_CHARGER_DEVICE_WALLBOX,
+    CONF_CHARGER_MAX_CHARGE,
+    CONF_CHARGER_MIN_CHARGE,
+    CONF_DYN_GROUP_MAX_PHASE_AMPS,
+    CONF_IS_3P,
+    CONF_MONO_PHASE,
+    DATA_HANDLER,
+    DOMAIN,
+)
+from custom_components.quiet_solar.ha_model.car import QSCar
+from custom_components.quiet_solar.ha_model.charger import QSChargerWallbox
+from custom_components.quiet_solar.ha_model.dynamic_group import QSDynamicGroup
+from custom_components.quiet_solar.ha_model.home import QSHome
+from custom_components.quiet_solar.home_model.commands import CMD_ON, copy_command
+
+
+class _Ct:
+    def __init__(self, now: datetime, current_value: float = 0.0, target_value: float = 80.0) -> None:
+        self.current_value = current_value
+        self.target_value = target_value
+        self.first_value_update = now - timedelta(hours=1)
+        self.last_value_update = now
+        self.last_value_change_update = now - timedelta(minutes=10)
+
+    def is_constraint_met(self, time: datetime, current_value: float) -> bool:
+        return False
+
+
+def _build_charger_and_car(no_sensor: bool):
+    hass = MagicMock()
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=None)
+    data_handler = MagicMock()
+    hass.data = {DOMAIN: {DATA_HANDLER: data_handler}}
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry_id"
+    config_entry.data = {}
+
+    home = QSHome(
+        **{
+            CONF_NAME: "TestHome",
+            CONF_DYN_GROUP_MAX_PHASE_AMPS: 33,
+            CONF_IS_3P: True,
+            "hass": hass,
+            "config_entry": config_entry,
+        }
+    )
+    data_handler.home = home
+
+    group = QSDynamicGroup(
+        **{
+            CONF_NAME: "Wallboxes",
+            CONF_DYN_GROUP_MAX_PHASE_AMPS: 32,
+            CONF_IS_3P: True,
+            "home": home,
+            "hass": hass,
+            "config_entry": config_entry,
+        }
+    )
+    home.add_device(group)
+
+    now = datetime.now(pytz.UTC)
+    with patch("custom_components.quiet_solar.ha_model.charger.entity_registry") as mock_reg:
+        mock_reg.async_get = MagicMock()
+        mock_reg.async_entries_for_device = MagicMock(return_value=[])
+        charger = QSChargerWallbox(
+            **{
+                CONF_NAME: "Wallbox_1",
+                CONF_MONO_PHASE: 1,
+                CONF_CHARGER_DEVICE_WALLBOX: "device_wallbox_1",
+                CONF_CHARGER_MIN_CHARGE: 6,
+                CONF_CHARGER_MAX_CHARGE: 16,
+                CONF_IS_3P: False,
+                "dynamic_group_name": "Wallboxes",
+                "home": home,
+                "hass": hass,
+                "config_entry": config_entry,
+            }
+        )
+    home.add_device(charger)
+
+    car_conf = {
+        CONF_NAME: "EstCar",
+        CONF_CAR_BATTERY_CAPACITY: 60000,
+        "home": home,
+        "hass": hass,
+        "config_entry": config_entry,
+    }
+    if no_sensor:
+        car_conf[CONF_CAR_CHARGE_PERCENT_SENSOR] = None
+    else:
+        car_conf[CONF_CAR_CHARGE_PERCENT_SENSOR] = "sensor.est_car_soc"
+    car = QSCar(**car_conf)
+
+    charger.car = car
+    car.charger = charger
+
+    # Neutralize the heavy charger plumbing for a focused callback test.
+    charger._do_update_charger_state = AsyncMock()
+    charger.is_not_plugged = MagicMock(return_value=False)
+    charger.current_command = copy_command(CMD_ON)
+    charger.is_car_stopped_asking_current = MagicMock(return_value=False)
+    charger.is_charging_power_zero = MagicMock(return_value=True)
+    charger.on_device_state_change = AsyncMock()
+    charger.possible_charge_error_start_time = None
+    charger.charger_group.dyn_handle = AsyncMock()
+    car.setup_car_charge_target_if_needed = AsyncMock()
+
+    return charger, car, now
+
+
+async def test_accumulator_no_loss_no_double_count():
+    """N slow cycles each add exactly one increment (pure-delta, no base)."""
+    charger, car, now = _build_charger_and_car(no_sensor=True)
+    charger._compute_added_charge_update = MagicMock(return_value=0.4)
+
+    times = [now + timedelta(minutes=15 * i) for i in range(5)]
+    for t in times:
+        ct = _Ct(t)
+        await charger.constraint_update_value_callback_soc(ct, t, is_target_percent=True)
+
+    # First cycle only anchors the cursor (no integration); the next four
+    # each add 0.4 → 4 * 0.4 = 1.6, with no loss and no double-count.
+    assert car._computed_added_delta_soc_percent == pytest.approx(1.6)
+    assert car.has_soc_estimate() is False  # pure-delta: no base
+
+
+async def test_accumulator_absolute_estimate_with_base():
+    """With a system base, result tracks clamp(base + accumulated delta)."""
+    charger, car, now = _build_charger_and_car(no_sensor=True)
+    car._last_valid_base_soc_value = 50.0
+    car._computed_added_delta_soc_percent = 0.0
+    charger._compute_added_charge_update = MagicMock(return_value=2.0)
+
+    t0 = now
+    await charger.constraint_update_value_callback_soc(_Ct(t0), t0, is_target_percent=True)
+    # anchor only
+    assert car._computed_added_delta_soc_percent == 0.0
+
+    t1 = now + timedelta(minutes=15)
+    result, _cont = await charger.constraint_update_value_callback_soc(_Ct(t1), t1, is_target_percent=True)
+    assert car._computed_added_delta_soc_percent == pytest.approx(2.0)
+    # result derives from the estimate (base + delta) = 52
+    assert car.get_car_charge_percent(t1) == pytest.approx(52.0)
+
+
+async def test_real_power_check_skipped_when_estimating():
+    """While estimating, the 'no power detected' check is skipped."""
+    charger, car, now = _build_charger_and_car(no_sensor=True)
+    car._last_valid_base_soc_value = 10.0  # far below target → would trigger check
+    car._computed_added_delta_soc_percent = 0.0
+    charger._compute_added_charge_update = MagicMock(return_value=1.0)
+    charger._expected_charge_state.value = True
+    charger._expected_charge_state.last_ping_time_success = now - timedelta(seconds=3600)
+
+    t1 = now + timedelta(minutes=15)
+    await charger.constraint_update_value_callback_soc(_Ct(t1, target_value=80.0), t1, is_target_percent=True)
+    charger.on_device_state_change.assert_not_awaited()
+
+
+async def test_accumulator_inc_none_does_not_advance():
+    """When the energy probe returns None, the accumulator and cursor hold."""
+    charger, car, now = _build_charger_and_car(no_sensor=True)
+    car._last_valid_base_soc_value = 40.0
+    car._computed_added_delta_soc_percent = 1.0
+    charger._compute_added_charge_update = MagicMock(return_value=None)
+
+    t0 = now
+    await charger.constraint_update_value_callback_soc(_Ct(t0), t0, is_target_percent=True)
+    cursor_after_anchor = car._delta_soc_last_integration_time
+
+    t1 = now + timedelta(minutes=15)
+    await charger.constraint_update_value_callback_soc(_Ct(t1), t1, is_target_percent=True)
+    # inc is None → accumulator unchanged, cursor not advanced past the anchor
+    assert car._computed_added_delta_soc_percent == 1.0
+    assert car._delta_soc_last_integration_time == cursor_after_anchor
+
+
+async def test_real_sensor_path_not_estimating():
+    """A healthy real sensor is read raw and drives the result (not estimated)."""
+    charger, car, now = _build_charger_and_car(no_sensor=False)
+    car._entity_probed_last_valid_state[car.car_charge_percent_sensor] = (now, 47.0, {})
+    charger._compute_added_charge_update = MagicMock(return_value=1.0)
+
+    assert car.is_in_soc_estimation_mode(now) is False
+    result, _cont = await charger.constraint_update_value_callback_soc(_Ct(now), now, is_target_percent=True)
+    assert result == 47.0

--- a/tests/test_charger_soc_estimation.py
+++ b/tests/test_charger_soc_estimation.py
@@ -124,7 +124,6 @@ def _build_charger_and_car(no_sensor: bool):
     charger.on_device_state_change = AsyncMock()
     charger.possible_charge_error_start_time = None
     charger.charger_group.dyn_handle = AsyncMock()
-    car.setup_car_charge_target_if_needed = AsyncMock()
 
     return charger, car, now
 
@@ -205,3 +204,70 @@ async def test_real_sensor_path_not_estimating():
     assert car.is_in_soc_estimation_mode(now) is False
     result, _cont = await charger.constraint_update_value_callback_soc(_Ct(now), now, is_target_percent=True)
     assert result == 47.0
+
+
+async def test_pure_delta_result_calculus_clamped_to_100():
+    """N1 — the pure-delta accumulator value is clamped to <=100 before use."""
+    charger, car, now = _build_charger_and_car(no_sensor=True)
+    car._computed_added_delta_soc_percent = 130.0  # already over 100 (long session)
+    car._delta_soc_last_integration_time = now - timedelta(minutes=15)
+    charger._compute_added_charge_update = MagicMock(return_value=10.0)
+    result, _cont = await charger.constraint_update_value_callback_soc(
+        _Ct(now, target_value=100.0), now, is_target_percent=True
+    )
+    assert result == 100.0
+
+
+async def test_manual_override_on_healthy_car_does_not_suppress_fault_check():
+    """S1 — a manual override on a healthy, sensor-equipped car must NOT disable
+    the zero-power hardware-fault detection."""
+    charger, car, now = _build_charger_and_car(no_sensor=False)
+    # Healthy fresh sensor, but a manual override is active → estimating, yet the
+    # SOC sensor is NOT distrusted.
+    car._entity_probed_last_valid_state[car.car_charge_percent_sensor] = (now, 50.0, {})
+    car._user_base_soc_value = 10.0  # far below target → fault window applies
+    car._computed_added_delta_soc_percent = 0.0
+    assert car.is_in_soc_estimation_mode(now) is True
+    assert car.is_soc_sensor_distrusted() is False
+    charger._compute_added_charge_update = MagicMock(return_value=0.0)
+    charger._expected_charge_state.value = True
+    charger._expected_charge_state.last_ping_time_success = now - timedelta(seconds=3600)
+
+    t1 = now + timedelta(minutes=15)
+    await charger.constraint_update_value_callback_soc(_Ct(t1, target_value=80.0), t1, is_target_percent=True)
+    # power is zero (is_charging_power_zero mocked True) → fault reported
+    charger.on_device_state_change.assert_awaited()
+
+
+async def test_real_efficiency_integral_within_1pct():
+    """S2 / AC5 — the real efficiency-aware integral matches an independent
+    computation within ±1% SOC, with no double-count across N cycles."""
+    charger, car, now = _build_charger_and_car(no_sensor=True)
+    car.car_battery_capacity = 60000  # Wh
+    car._last_valid_base_soc_value = 50.0  # base B
+    car._computed_added_delta_soc_percent = 0.0
+    eff = charger.efficiency_factor  # the charger's real efficiency factor
+
+    # Drive the REAL _compute_added_charge_update via the energy source: a fixed
+    # 11 kW over each 15-minute slice → 2750 Wh/slice.
+    power_w = 11000.0
+    dt_s = 15 * 60
+    energy_per_slice_wh = power_w * dt_s / 3600.0
+    charger._can_use_group_power_sensor = MagicMock(return_value=False)
+    charger.get_device_real_energy = MagicMock(return_value=energy_per_slice_wh)
+
+    n_integrating_cycles = 4
+    t = now
+    await charger.constraint_update_value_callback_soc(_Ct(t), t, is_target_percent=True)  # anchor
+    for _ in range(n_integrating_cycles):
+        t = t + timedelta(seconds=dt_s)
+        result, _cont = await charger.constraint_update_value_callback_soc(_Ct(t), t, is_target_percent=True)
+
+    # Independent integral: B + sum(100 * (P*dt/e) / C)
+    expected_delta = n_integrating_cycles * 100.0 * (energy_per_slice_wh / eff) / 60000.0
+    expected = max(0.0, min(100.0, 50.0 + expected_delta))
+    assert abs(result - expected) <= 1.0
+    # no double-count: accumulator equals exactly the integrated delta
+    assert abs(car._computed_added_delta_soc_percent - expected_delta) <= 0.01
+
+

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -23,8 +23,11 @@ from homeassistant.helpers.template import Template
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.quiet_solar.const import (
+    BINARY_SENSOR_CAR_IS_SOC_ESTIMATED,
+    BUTTON_CAR_RESET_SOC_ESTIMATE,
     CONF_POOL_TEMPERATURE_SENSOR,
     CONF_POWER,
+    NUMBER_CAR_MANUAL_SOC_PERCENT,
     CONF_SOLAR_FORECAST_PROVIDERS,
     CONF_SOLAR_PROVIDER_DOMAIN,
     CONF_SOLAR_PROVIDER_NAME,
@@ -326,9 +329,35 @@ class TestDashboardTemplateRendering:
 
         parsed = yaml.safe_load(rendered)
         assert parsed is not None
-        assert "is_soc_estimated:" in rendered
-        assert "manual_soc:" in rendered
-        assert "reset_soc:" in rendered
+
+        # Traverse to the real car's qs-car-card and inspect ITS entities mapping
+        # (not just "the key appears somewhere in the YAML"). The charger's
+        # invited default-generic car also renders a qs-car-card but without the
+        # SOC-estimate entities, so select the card that actually has them.
+        soc_car_cards = []
+        for view in parsed.get("views", []):
+            for section in view.get("sections", []):
+                for card in section.get("cards", []):
+                    if (
+                        isinstance(card, dict)
+                        and card.get("type") == "custom:qs-car-card"
+                        and isinstance(card.get("entities"), dict)
+                        and "is_soc_estimated" in card["entities"]
+                    ):
+                        soc_car_cards.append(card)
+        assert len(soc_car_cards) == 1, "expected exactly one estimating car card"
+        entities = soc_car_cards[0]["entities"]
+        # The card-config keys are wired to entities of the expected domains.
+        assert entities["is_soc_estimated"].startswith("binary_sensor.")
+        assert entities["manual_soc"].startswith("number.")
+        assert entities["reset_soc"].startswith("button.")
+
+        # N5 — the template resolves those entities via the const.py keys
+        # (never hardcoded ha.get("qs_car_...") string literals in the source).
+        template_src = template_content
+        assert f'ha.get("{BINARY_SENSOR_CAR_IS_SOC_ESTIMATED}")' in template_src
+        assert f'ha.get("{NUMBER_CAR_MANUAL_SOC_PERCENT}")' in template_src
+        assert f'ha.get("{BUTTON_CAR_RESET_SOC_ESTIMATE}")' in template_src
 
     def test_car_card_consumes_soc_estimate_keys(self):
         """QS-243 — the JS card reads the three estimated-SOC entity keys."""

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -368,6 +368,41 @@ class TestDashboardTemplateRendering:
         # The asterisk gating must be present.
         assert "hasSocEstimate" in source
 
+    def test_car_card_soc_editable_pointer_events(self):
+        """QS-243 #02 M1 — the editable SOC re-enables pointer events (it sits
+        inside `.ring .center` which is pointer-events:none), else clicks pass
+        through to the gauge and the popup never opens."""
+        import re
+
+        source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
+        # A `.soc-editable` CSS rule that sets pointer-events: auto.
+        assert re.search(r"\.soc-editable\s*\{[^}]*pointer-events:\s*auto", source), (
+            "qs-car-card.js: missing `.soc-editable { ... pointer-events: auto }` rule (M1)"
+        )
+
+    def test_car_card_soc_save_never_silently_discards(self):
+        """QS-243 #02 N1 — invalid SOC input falls back to the current value and
+        is still clamped + saved (no silent discard)."""
+        source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
+        assert "if (!Number.isFinite(v)) v = cur;" in source
+
+    def test_car_card_css_template_literal_has_no_stray_backtick(self):
+        """QS-243 #02 — the CSS block is a template literal
+        (`baseCardCSS(colors) + ` + backtick ... backtick); a stray backtick
+        inside (e.g. in a comment) would prematurely close the literal and turn
+        CSS text into JS, throwing at render time → 'Configuration error'.
+        CSS legitimately contains no backticks, so assert there are none.
+        """
+        source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
+        marker = "const css = baseCardCSS(colors) + `"
+        start = source.index(marker) + len(marker)
+        end = source.index("`;", start)  # the closing delimiter of the literal
+        css_body = source[start:end]
+        assert "`" not in css_body, (
+            "qs-car-card.js: stray backtick inside the CSS template literal — "
+            "it closes the literal early and breaks render (Configuration error)."
+        )
+
     def test_radiator_card_s14_safe_number_guards_against_nan(self):  # CR2 — sync (no hass)
         """A2 — pin S14 via regex, not a bare substring.
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -308,6 +308,37 @@ class TestDashboardTemplateRendering:
         # Stub config also reads the renamed display name.
         assert "QS Radiator" in content
 
+    @pytest.mark.asyncio
+    async def test_car_card_wires_soc_estimate_entities(self, hass, full_dashboard_home):
+        """QS-243 AC11 — the car card wires the estimated-SOC entities.
+
+        With a SOC sensor + battery capacity the car exposes the
+        `is_soc_estimated` binary sensor, the `manual_soc` number, and the
+        `reset_soc` button; the custom template must feed all three into the
+        car card config.
+        """
+        home = full_dashboard_home
+        template_path = COMPONENT_ROOT / "ui" / "quiet_solar_dashboard_template.yaml.j2"
+        template_content = await hass.async_add_executor_job(template_path.read_text)
+
+        tpl = Template(template_content, hass)
+        rendered = tpl.async_render(variables={"home": home})
+
+        parsed = yaml.safe_load(rendered)
+        assert parsed is not None
+        assert "is_soc_estimated:" in rendered
+        assert "manual_soc:" in rendered
+        assert "reset_soc:" in rendered
+
+    def test_car_card_consumes_soc_estimate_keys(self):
+        """QS-243 — the JS card reads the three estimated-SOC entity keys."""
+        source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
+        assert "e.is_soc_estimated" in source
+        assert "e.manual_soc" in source
+        assert "e.reset_soc" in source
+        # The asterisk gating must be present.
+        assert "hasSocEstimate" in source
+
     def test_radiator_card_s14_safe_number_guards_against_nan(self):  # CR2 — sync (no hass)
         """A2 — pin S14 via regex, not a bare substring.
 

--- a/tests/test_platform_button.py
+++ b/tests/test_platform_button.py
@@ -69,10 +69,17 @@ def test_create_ha_button_for_car():
     mock_car.user_clean_and_reset = AsyncMock()
     mock_car.can_force_a_charge_now = MagicMock(return_value=True)
     mock_car.can_add_default_charge = MagicMock(return_value=True)
+    mock_car.can_use_charge_percent_constraints = MagicMock(return_value=True)
 
     entities = create_ha_button_for_QSCar(mock_car)
 
-    assert len(entities) == 2  # Force charge, add default
+    # Force charge, add default, reset SOC estimate (QS-243)
+    assert len(entities) == 3
+
+    # Without percent constraints the reset-SOC button is not created.
+    mock_car.can_use_charge_percent_constraints = MagicMock(return_value=False)
+    entities_no_percent = create_ha_button_for_QSCar(mock_car)
+    assert len(entities_no_percent) == 2
 
 
 def test_create_ha_button_for_load():


### PR DESCRIPTION
## Summary
The estimate resets on a genuine plug-in but survives an HA reboot (clear lives on the charger do_full_reset branch, not car.reset()).

Fixes #243

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [x] CRITICAL (solver, constraints, charger budgeting)
- [x] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual SOC override: editable 0–100 popup with Save/Cancel/Reset and a reset button.
  * Automatic SOC estimation when SOC data is missing/stale; estimated SOC shown with “*”.
  * New entities: estimated-status binary sensor, manual-SOC number, and reset button.
  * Percent-based charging constraints may be used when battery capacity is set even without a SOC sensor.

* **Documentation**
  * Full spec, dashboard and docs updated to describe the estimation model and UI.

* **Tests**
  * Extensive new and updated tests for estimation, UI, charger logic, and persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tmenguy/quiet-solar/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->