### PR TITLE
QS-245: Water boiler card ring empty when active constraint finishes after local midnight

### DIFF
--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -16,7 +16,7 @@ from ..const import (
 )
 from ..ha_model.device import HADeviceMixin
 from ..home_model.commands import CMD_IDLE, LoadCommand
-from ..home_model.constraints import DATETIME_MAX_UTC, TimeBasedSimplePowerLoadConstraint
+from ..home_model.constraints import DATETIME_MAX_UTC, LoadConstraint, TimeBasedSimplePowerLoadConstraint
 from ..home_model.load import AbstractLoad
 
 if TYPE_CHECKING:
@@ -173,6 +173,31 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         """Return True if the current mode uses calendar events for daily metrics."""
         return bistate_mode in ("bistate_mode_auto", "bistate_mode_exact_calendar") and self.calendar is not None
 
+    def _overnight_active_constraint_extra(self, time: datetime, tomorrow_utc: datetime) -> LoadConstraint | None:
+        """Return the currently-running active constraint whose finish time falls
+        after the today window (overnight finish time), else ``None``.
+
+        The today-window loops only count constraints finishing
+        ``<= tomorrow_utc``, so an active constraint that started today but ends
+        after local midnight (e.g. 06:30 tomorrow) is otherwise dropped from both
+        the ring fill and the target — leaving the card empty while the
+        constraint_completion sensor rises. This returns it so the caller can add
+        its target/runtime back in.
+
+        Returns ``None`` when there is no active constraint, when the active
+        constraint has not started yet (future start, e.g. a tomorrow-only
+        constraint), or when it already finishes inside the today window (it is
+        then counted exactly once by the window loop — no double count).
+        """
+        active = self.get_current_active_constraint(time)
+        if (
+            active is not None
+            and active.end_of_constraint > tomorrow_utc
+            and active.current_start_of_constraint <= time
+        ):
+            return active
+        return None
+
     async def update_current_metrics(self, time: datetime, end_range: dt_time | None = None):
         """Update bistate UI metrics with today-only values.
 
@@ -198,6 +223,9 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
             # Calendar path: fetch events and compute today target + past actuals
             today_utc, tomorrow_utc = self._get_today_boundaries(time)
             events = await self.get_next_scheduled_events(time=today_utc, give_currently_running_event=True)
+
+            overnight_ct = self._overnight_active_constraint_extra(time, tomorrow_utc)
+
             target_s = 0.0
             past_actual_s = 0.0
             for ev_start, ev_end in events:
@@ -213,8 +241,16 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
 
             # Add active constraint current_value for today
             for ct in self._constraints:
+                if ct is overnight_ct:
+                    continue
                 if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc:
                     run_s += ct.current_value
+
+            # Include the currently-active constraint when it finishes overnight
+            # (after local midnight) — excluded by the in-window loops above.
+            if overnight_ct is not None:
+                duration_s += overnight_ct.target_value
+                run_s += overnight_ct.current_value
 
             # AC5: Sanity-check _last_completed_constraint against calendar
             if self._last_completed_constraint is not None:
@@ -238,10 +274,20 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
             # Default/pool path: day-filter constraints + last-completed
             today_utc, tomorrow_utc = self._get_today_boundaries(time)
 
+            overnight_ct = self._overnight_active_constraint_extra(time, tomorrow_utc)
+
             for ct in self._constraints:
+                if ct is overnight_ct:
+                    continue
                 if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc:
                     duration_s += ct.target_value
                     run_s += ct.current_value
+
+            # Include the currently-active constraint when it finishes overnight
+            # (after local midnight) — excluded by the in-window loop above.
+            if overnight_ct is not None:
+                duration_s += overnight_ct.target_value
+                run_s += overnight_ct.current_value
 
             if self._last_completed_constraint is not None:
                 lcc = self._last_completed_constraint

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -173,30 +173,37 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         """Return True if the current mode uses calendar events for daily metrics."""
         return bistate_mode in ("bistate_mode_auto", "bistate_mode_exact_calendar") and self.calendar is not None
 
-    def _overnight_active_constraint_extra(self, time: datetime, tomorrow_utc: datetime) -> LoadConstraint | None:
-        """Return the currently-running active constraint whose finish time falls
-        after the today window (overnight finish time), else ``None``.
+    def _overnight_active_constraints(self, time: datetime, tomorrow_utc: datetime) -> list[LoadConstraint]:
+        """Return every currently-running active constraint whose finish time falls
+        after the today window (overnight finish time), in ``_constraints`` order.
 
         The today-window loops only count constraints finishing
         ``<= tomorrow_utc``, so an active constraint that started today but ends
         after local midnight (e.g. 06:30 tomorrow) is otherwise dropped from both
         the ring fill and the target — leaving the card empty while the
-        constraint_completion sensor rises. This returns it so the caller can add
-        its target/runtime back in.
+        constraint_completion sensor rises. The caller adds the returned
+        constraints' target/runtime back in.
 
-        Returns ``None`` when there is no active constraint, when the active
-        constraint has not started yet (future start, e.g. a tomorrow-only
-        constraint), or when it already finishes inside the today window (it is
-        then counted exactly once by the window loop — no double count).
+        A bistate load can hold several live constraints at once
+        (``push_live_constraint`` appends; bug #68 / #95), so *all* matching
+        constraints are returned, not just the first. A constraint qualifies when
+        it (a) finishes after the today window
+        (``end_of_constraint > tomorrow_utc``), (b) has already started
+        (``current_start_of_constraint <= time``), (c) is active/unmet at ``time``
+        (``is_constraint_active_for_time_period``), and (d) carries a real target
+        (``target_value is not None`` — a target-less constraint cannot drive a
+        ring/target and is reported unmet, so it is skipped defensively). The
+        result is empty when no constraint qualifies, so the caller's behaviour is
+        unchanged for the common same-day case.
         """
-        active = self.get_current_active_constraint(time)
-        if (
-            active is not None
-            and active.end_of_constraint > tomorrow_utc
-            and active.current_start_of_constraint <= time
-        ):
-            return active
-        return None
+        return [
+            ct
+            for ct in self._constraints
+            if ct.end_of_constraint > tomorrow_utc
+            and ct.current_start_of_constraint <= time
+            and ct.target_value is not None
+            and ct.is_constraint_active_for_time_period(time)
+        ]
 
     async def update_current_metrics(self, time: datetime, end_range: dt_time | None = None):
         """Update bistate UI metrics with today-only values.
@@ -224,7 +231,7 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
             today_utc, tomorrow_utc = self._get_today_boundaries(time)
             events = await self.get_next_scheduled_events(time=today_utc, give_currently_running_event=True)
 
-            overnight_ct = self._overnight_active_constraint_extra(time, tomorrow_utc)
+            overnight_cts = self._overnight_active_constraints(time, tomorrow_utc)
 
             target_s = 0.0
             past_actual_s = 0.0
@@ -241,16 +248,16 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
 
             # Add active constraint current_value for today
             for ct in self._constraints:
-                if ct is overnight_ct:
+                if any(ct is oct for oct in overnight_cts):
                     continue
                 if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc:
                     run_s += ct.current_value
 
-            # Include the currently-active constraint when it finishes overnight
+            # Include the currently-active constraint(s) finishing overnight
             # (after local midnight) — excluded by the in-window loops above.
-            if overnight_ct is not None:
-                duration_s += overnight_ct.target_value
-                run_s += overnight_ct.current_value
+            for oct in overnight_cts:
+                duration_s += oct.target_value
+                run_s += oct.current_value
 
             # AC5: Sanity-check _last_completed_constraint against calendar
             if self._last_completed_constraint is not None:
@@ -274,20 +281,20 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
             # Default/pool path: day-filter constraints + last-completed
             today_utc, tomorrow_utc = self._get_today_boundaries(time)
 
-            overnight_ct = self._overnight_active_constraint_extra(time, tomorrow_utc)
+            overnight_cts = self._overnight_active_constraints(time, tomorrow_utc)
 
             for ct in self._constraints:
-                if ct is overnight_ct:
+                if any(ct is oct for oct in overnight_cts):
                     continue
                 if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc:
                     duration_s += ct.target_value
                     run_s += ct.current_value
 
-            # Include the currently-active constraint when it finishes overnight
+            # Include the currently-active constraint(s) finishing overnight
             # (after local midnight) — excluded by the in-window loop above.
-            if overnight_ct is not None:
-                duration_s += overnight_ct.target_value
-                run_s += overnight_ct.current_value
+            for oct in overnight_cts:
+                duration_s += oct.target_value
+                run_s += oct.current_value
 
             if self._last_completed_constraint is not None:
                 lcc = self._last_completed_constraint
@@ -303,11 +310,18 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                 )
                 # Bug #101: skip lcc when it ended exactly at local midnight
                 # (previous day's rollover) and a same-type active constraint
-                # represents today's cycle — avoids double-counting yesterday
-                rollover_from_previous_day = lcc.end_of_constraint == today_utc and any(
-                    type(ct) == type(lcc)
-                    for ct in self._constraints
-                    if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc
+                # represents today's cycle — avoids double-counting yesterday.
+                # QS-245 fix #01: today's cycle may itself finish overnight
+                # (out-of-window), so treat a same-type overnight constraint as
+                # today's active cycle too — otherwise the lcc would be added on
+                # top of the overnight constraint and yesterday double-counted.
+                rollover_from_previous_day = lcc.end_of_constraint == today_utc and (
+                    any(
+                        type(ct) == type(lcc)
+                        for ct in self._constraints
+                        if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc
+                    )
+                    or any(type(oct) == type(lcc) for oct in overnight_cts)
                 )
                 if (
                     not already_absorbed

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -173,37 +173,45 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         """Return True if the current mode uses calendar events for daily metrics."""
         return bistate_mode in ("bistate_mode_auto", "bistate_mode_exact_calendar") and self.calendar is not None
 
-    def _overnight_active_constraints(self, time: datetime, tomorrow_utc: datetime) -> list[LoadConstraint]:
-        """Return every currently-running active constraint whose finish time falls
-        after the today window (overnight finish time), in ``_constraints`` order.
+    def _overnight_active_constraint(self, time: datetime, tomorrow_utc: datetime) -> LoadConstraint | None:
+        """Return the currently-running active constraint whose finish time falls
+        after the today window (overnight finish time), else ``None``.
 
         The today-window loops only count constraints finishing
         ``<= tomorrow_utc``, so an active constraint that started today but ends
         after local midnight (e.g. 06:30 tomorrow) is otherwise dropped from both
         the ring fill and the target — leaving the card empty while the
         constraint_completion sensor rises. The caller adds the returned
-        constraints' target/runtime back in.
+        constraint's target/runtime back in.
 
-        A bistate load can hold several live constraints at once
-        (``push_live_constraint`` appends; bug #68 / #95), so *all* matching
-        constraints are returned, not just the first. A constraint qualifies when
-        it (a) finishes after the today window
-        (``end_of_constraint > tomorrow_utc``), (b) has already started
-        (``current_start_of_constraint <= time``), (c) is active/unmet at ``time``
-        (``is_constraint_active_for_time_period``), and (d) carries a real target
-        (``target_value is not None`` — a target-less constraint cannot drive a
-        ring/target and is reported unmet, so it is skipped defensively). The
-        result is empty when no constraint qualifies, so the caller's behaviour is
-        unchanged for the common same-day case.
+        INVARIANT — at most one active constraint at a time. A load's constraints
+        follow each other in time **by construction**: their active windows are
+        sequential and non-overlapping (``push_live_constraint`` chains them, each
+        new one starting at/after the previous one's end). So a single constraint
+        is "current" at any ``time`` — we reuse ``get_current_active_constraint``
+        (which returns that one, already filtered for unmet/active) and simply ask
+        whether it finishes overnight. There is no need to scan for several
+        overnight constraints; overlapping windows cannot occur here.
+
+        The current active constraint qualifies as the overnight one when it
+        (a) finishes after the today window (``end_of_constraint > tomorrow_utc``),
+        (b) has already started (``current_start_of_constraint <= time`` — excludes
+        a not-yet-started tomorrow-only constraint that ``get_current_active_
+        constraint`` still reports active because it is unmet and ends in the
+        future), and (c) carries a real target (``target_value is not None`` — a
+        target-less constraint cannot drive a ring/target and is reported unmet, so
+        it is skipped defensively). Returns ``None`` for the common same-day case,
+        leaving caller behaviour unchanged.
         """
-        return [
-            ct
-            for ct in self._constraints
-            if ct.end_of_constraint > tomorrow_utc
-            and ct.current_start_of_constraint <= time
-            and ct.target_value is not None
-            and ct.is_constraint_active_for_time_period(time)
-        ]
+        active = self.get_current_active_constraint(time)
+        if (
+            active is not None
+            and active.end_of_constraint > tomorrow_utc
+            and active.current_start_of_constraint <= time
+            and active.target_value is not None
+        ):
+            return active
+        return None
 
     async def update_current_metrics(self, time: datetime, end_range: dt_time | None = None):
         """Update bistate UI metrics with today-only values.
@@ -231,7 +239,7 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
             today_utc, tomorrow_utc = self._get_today_boundaries(time)
             events = await self.get_next_scheduled_events(time=today_utc, give_currently_running_event=True)
 
-            overnight_cts = self._overnight_active_constraints(time, tomorrow_utc)
+            overnight_ct = self._overnight_active_constraint(time, tomorrow_utc)
 
             target_s = 0.0
             past_actual_s = 0.0
@@ -248,16 +256,16 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
 
             # Add active constraint current_value for today
             for ct in self._constraints:
-                if any(ct is oct for oct in overnight_cts):
+                if ct is overnight_ct:
                     continue
                 if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc:
                     run_s += ct.current_value
 
-            # Include the currently-active constraint(s) finishing overnight
+            # Include the currently-active constraint finishing overnight
             # (after local midnight) — excluded by the in-window loops above.
-            for oct in overnight_cts:
-                duration_s += oct.target_value
-                run_s += oct.current_value
+            if overnight_ct is not None:
+                duration_s += overnight_ct.target_value
+                run_s += overnight_ct.current_value
 
             # AC5: Sanity-check _last_completed_constraint against calendar
             if self._last_completed_constraint is not None:
@@ -281,55 +289,61 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
             # Default/pool path: day-filter constraints + last-completed
             today_utc, tomorrow_utc = self._get_today_boundaries(time)
 
-            overnight_cts = self._overnight_active_constraints(time, tomorrow_utc)
+            overnight_ct = self._overnight_active_constraint(time, tomorrow_utc)
 
             for ct in self._constraints:
-                if any(ct is oct for oct in overnight_cts):
+                if ct is overnight_ct:
                     continue
                 if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc:
                     duration_s += ct.target_value
                     run_s += ct.current_value
 
-            # Include the currently-active constraint(s) finishing overnight
+            # Include the currently-active constraint finishing overnight
             # (after local midnight) — excluded by the in-window loop above.
-            for oct in overnight_cts:
-                duration_s += oct.target_value
-                run_s += oct.current_value
+            if overnight_ct is not None:
+                duration_s += overnight_ct.target_value
+                run_s += overnight_ct.current_value
 
             if self._last_completed_constraint is not None:
                 lcc = self._last_completed_constraint
                 lcc_end = getattr(lcc, "initial_end_of_constraint", lcc.end_of_constraint)
-                # Skip lcc when an active today-constraint of the same type shares
-                # its end date (same-day-cycle: push_live_constraint already
-                # carried over runtime — mirror its type + end-date checks)
-                already_absorbed = any(
-                    type(ct) == type(lcc)
-                    and (ct.end_of_constraint == lcc.end_of_constraint or ct.end_of_constraint == lcc_end)
-                    for ct in self._constraints
-                    if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc
+
+                # "Today content" already on the card: any constraint finishing
+                # inside the today window, plus the overnight active constraint.
+                # (overnight_ct ends > tomorrow_utc, so it is never in the window
+                # set — count it explicitly.)
+                has_today_content = overnight_ct is not None or any(
+                    today_utc < ct.end_of_constraint <= tomorrow_utc for ct in self._constraints
                 )
-                # Bug #101: skip lcc when it ended exactly at local midnight
-                # (previous day's rollover) and a same-type active constraint
-                # represents today's cycle — avoids double-counting yesterday.
-                # QS-245 fix #01: today's cycle may itself finish overnight
-                # (out-of-window), so treat a same-type overnight constraint as
-                # today's active cycle too — otherwise the lcc would be added on
-                # top of the overnight constraint and yesterday double-counted.
-                rollover_from_previous_day = lcc.end_of_constraint == today_utc and (
-                    any(
+
+                if lcc.end_of_constraint == today_utc:
+                    # Bug #101 / #95: lcc ended exactly at local midnight (the
+                    # previous day's cycle rolling over). Surface it ONLY when
+                    # nothing else represents today — otherwise it is stale and
+                    # would double-count yesterday on top of today's cycle
+                    # (in-window OR finishing overnight).
+                    use_lcc = not has_today_content
+                else:
+                    # lcc completed strictly within today (today_utc < end <=
+                    # tomorrow_utc): show it unless an active same-type
+                    # constraint sharing its (initial) end date already absorbed
+                    # its runtime (same-day cycle carry-over by
+                    # push_live_constraint). Anything ending before today_utc,
+                    # the DATETIME_MAX_UTC sentinel, or after tomorrow_utc is
+                    # excluded (a constraint ending yesterday is not "today").
+                    already_absorbed = any(
                         type(ct) == type(lcc)
+                        and (ct.end_of_constraint == lcc.end_of_constraint or ct.end_of_constraint == lcc_end)
                         for ct in self._constraints
-                        if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc
+                        if today_utc < ct.end_of_constraint <= tomorrow_utc
                     )
-                    or any(type(oct) == type(lcc) for oct in overnight_cts)
-                )
-                if (
-                    not already_absorbed
-                    and not rollover_from_previous_day
-                    and lcc.end_of_constraint != DATETIME_MAX_UTC
-                    and lcc.end_of_constraint >= today_utc  # >= includes exact-midnight boundary (DST)
-                    and lcc.end_of_constraint <= tomorrow_utc
-                ):
+                    use_lcc = (
+                        not already_absorbed
+                        and lcc.end_of_constraint != DATETIME_MAX_UTC
+                        and today_utc < lcc.end_of_constraint <= tomorrow_utc
+                    )
+
+                if use_lcc:
                     duration_s += lcc.target_value
                     run_s += lcc.current_value
 

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -10,7 +10,7 @@ covers:
   - custom_components/quiet_solar/ha_model/radiator.py
   - custom_components/quiet_solar/ha_model/bistate_transport.py
   - custom_components/quiet_solar/ha_model/water_boiler.py
-last_verified: 2026-05-30
+last_verified: 2026-05-31
 ---
 
 # Bistate-duration devices (pool, on/off duration, water boiler, climate, radiator)
@@ -184,12 +184,24 @@ transport based on which `CONF_*` the user filled.
   overnight (e.g. 06:30 tomorrow) falls outside that window, so the card
   ring (`qs_bistate_current_on_h`) and target
   (`qs_bistate_current_duration_h`) would show 0 while the
-  `constraint_completion` sensor rises. `_overnight_active_constraint_extra`
-  re-adds the running active constraint (guarded by
-  `current_start_of_constraint <= time` so a not-yet-started tomorrow-only
-  constraint stays excluded, and by `end_of_constraint > tomorrow_utc` so
-  in-window constraints are not double-counted). Both metric paths must
-  call it (QS-245).
+  `constraint_completion` sensor rises. `_overnight_active_constraints`
+  returns **every** qualifying constraint — a load can hold several live
+  constraints (`push_live_constraint` appends), so all overnight-finishing
+  active ones must be re-added, not just the first. A constraint qualifies
+  when `end_of_constraint > tomorrow_utc` (overnight finish),
+  `current_start_of_constraint <= time` (already started — excludes a
+  not-yet-started tomorrow-only constraint), `target_value is not None`, and
+  `is_constraint_active_for_time_period(time)` (unmet/active). Both metric
+  paths call it, skip the returned constraints in their in-window loops, and
+  add each one's target/runtime back (QS-245).
+- Forgetting that "today's active cycle" can finish overnight when
+  deduping `_last_completed_constraint`. The bug #101 rollover guard skips
+  an lcc that ended exactly at local midnight when a same-type active
+  constraint represents today's cycle. That cycle may itself finish overnight
+  (out-of-window), so the guard must also treat a same-type
+  `_overnight_active_constraints` entry as today's cycle — otherwise the lcc
+  is added on top of the overnight constraint and yesterday's runtime is
+  double-counted (QS-245 review fix #01).
 
 ## See also
 

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -10,7 +10,7 @@ covers:
   - custom_components/quiet_solar/ha_model/radiator.py
   - custom_components/quiet_solar/ha_model/bistate_transport.py
   - custom_components/quiet_solar/ha_model/water_boiler.py
-last_verified: 2026-05-24
+last_verified: 2026-05-30
 ---
 
 # Bistate-duration devices (pool, on/off duration, water boiler, climate, radiator)
@@ -176,6 +176,20 @@ transport based on which `CONF_*` the user filled.
   (`QSBiStateDuration`) owns the bistate-mode signals; the transport
   owns the service-call. Crossing that boundary breaks
   `QSRadiator`'s ability to pick a transport at construction time.
+- Dropping the currently-active constraint from the daily metrics
+  when its finish time crosses local midnight. `update_current_metrics`
+  filters constraints to a today-only window
+  (`end_of_constraint <= tomorrow_utc`) in **both** the calendar and
+  default/pool paths. An active constraint that started today but ends
+  overnight (e.g. 06:30 tomorrow) falls outside that window, so the card
+  ring (`qs_bistate_current_on_h`) and target
+  (`qs_bistate_current_duration_h`) would show 0 while the
+  `constraint_completion` sensor rises. `_overnight_active_constraint_extra`
+  re-adds the running active constraint (guarded by
+  `current_start_of_constraint <= time` so a not-yet-started tomorrow-only
+  constraint stays excluded, and by `end_of_constraint > tomorrow_utc` so
+  in-window constraints are not double-counted). Both metric paths must
+  call it (QS-245).
 
 ## See also
 

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -184,24 +184,37 @@ transport based on which `CONF_*` the user filled.
   overnight (e.g. 06:30 tomorrow) falls outside that window, so the card
   ring (`qs_bistate_current_on_h`) and target
   (`qs_bistate_current_duration_h`) would show 0 while the
-  `constraint_completion` sensor rises. `_overnight_active_constraints`
-  returns **every** qualifying constraint — a load can hold several live
-  constraints (`push_live_constraint` appends), so all overnight-finishing
-  active ones must be re-added, not just the first. A constraint qualifies
+  `constraint_completion` sensor rises. `_overnight_active_constraint`
+  returns the single qualifying constraint (or `None`). A constraint qualifies
   when `end_of_constraint > tomorrow_utc` (overnight finish),
   `current_start_of_constraint <= time` (already started — excludes a
   not-yet-started tomorrow-only constraint), `target_value is not None`, and
   `is_constraint_active_for_time_period(time)` (unmet/active). Both metric
-  paths call it, skip the returned constraints in their in-window loops, and
-  add each one's target/runtime back (QS-245).
-- Forgetting that "today's active cycle" can finish overnight when
-  deduping `_last_completed_constraint`. The bug #101 rollover guard skips
-  an lcc that ended exactly at local midnight when a same-type active
-  constraint represents today's cycle. That cycle may itself finish overnight
-  (out-of-window), so the guard must also treat a same-type
-  `_overnight_active_constraints` entry as today's cycle — otherwise the lcc
-  is added on top of the overnight constraint and yesterday's runtime is
-  double-counted (QS-245 review fix #01).
+  paths call it, skip the returned constraint in their in-window loop, and add
+  its target/runtime back (QS-245).
+  **Invariant — at most one active constraint at a time.** A load's constraints
+  follow each other in time *by construction*: their active windows are sequential
+  and non-overlapping (`push_live_constraint` chains them, each new one starting
+  at/after the previous one's end). So a single constraint is "current" at any
+  `time` — the helper reuses `get_current_active_constraint` (already filtered for
+  unmet/active) and just asks whether that one finishes overnight. It **must not**
+  be generalised to scan for several overnight constraints (that would only matter
+  for overlapping windows, which cannot occur here).
+- Mishandling `_last_completed_constraint` (lcc) at the local-midnight
+  boundary. The default/pool path adds the lcc to the daily metrics following a
+  single rule keyed on "is there already today content?" — where *today content*
+  = any in-window constraint (`today_utc < end <= tomorrow_utc`) **or** the
+  overnight active constraint:
+  - `lcc.end == today_utc` (a cycle that ended exactly at local midnight, bug
+    #101 / #95): surface it **only when there is no today content** — otherwise
+    it is stale and would double-count yesterday on top of today's cycle
+    (whether that cycle is in-window or finishes overnight, QS-245 fix #01).
+  - `today_utc < lcc.end <= tomorrow_utc`: show it unless an active same-type
+    constraint sharing its (initial) end date already absorbed its runtime
+    (same-day cycle carry-over).
+  - anything ending before `today_utc`, the `DATETIME_MAX_UTC` sentinel, or
+    after `tomorrow_utc`: excluded. Use `== today_utc` (not `<=`) for the
+    boundary case so genuinely-old cycles are never resurrected.
 
 ## See also
 

--- a/docs/stories/QS-245.story.md
+++ b/docs/stories/QS-245.story.md
@@ -90,36 +90,56 @@ In **default** mode the card displays the configured `default_on_duration`
   so the new post-loop code is naturally skipped during an override.
 - `get_current_active_constraint` iterates `self._constraints` and can never
   return `_last_completed_constraint`, so there is no interaction with the lcc
-  absorption logic.
+  absorption logic. **(Review fix #01 reconciliation:** the shipped helper
+  iterates `self._constraints` directly instead of calling
+  `get_current_active_constraint`, so it can collect *all* active overnight
+  constraints, not just the first. It still never touches
+  `_last_completed_constraint`. The default/pool lcc-rollover guard is now made
+  aware of the overnight constraints — see the must-fix below.**)**
 - The drift checker confirms `docs/agents/concepts/bistate-duration-devices.md`
   has `covers: custom_components/quiet_solar/ha_model/bistate_duration.py`, so a
   co-modification is required.
 
 ## Fix
 
+> **Post-implementation reconciliation (review fix #01).** The shipped helper
+> differs from the original sketch below: it returns the **list of all** active
+> overnight constraints (`list[LoadConstraint]`, not a `tuple[float, float]`),
+> each caller adds the `target_value` / `current_value` itself, and there are
+> extra guards (`current_start_of_constraint <= time`, `target_value is not
+> None`, `is_constraint_active_for_time_period`) plus an `if ct in overnight_cts`
+> window-loop skip. The list form handles a load holding several live
+> constraints (`push_live_constraint` appends). The default/pool path also makes
+> the bug #101 lcc-rollover guard overnight-aware. See AC1/AC5/AC7-AC9.
+
 Add a single private helper on `QSBiStateDuration`:
 
 ```python
-def _overnight_active_constraint_extra(
+def _overnight_active_constraints(
     self, time: datetime, tomorrow_utc: datetime
-) -> tuple[float, float]:
-    """Return (extra_duration_s, extra_run_s) for an active constraint that
-    finishes after the today window (overnight finish time). Zero when there is
-    no active constraint or it already falls inside the today window."""
-    active = self.get_current_active_constraint(time)
-    if active is not None and active.end_of_constraint > tomorrow_utc:
-        return active.target_value, active.current_value
-    return 0.0, 0.0
+) -> list[LoadConstraint]:
+    """Return every currently-running active constraint finishing after the
+    today window (overnight finish time), in _constraints order."""
+    return [
+        ct
+        for ct in self._constraints
+        if ct.end_of_constraint > tomorrow_utc
+        and ct.current_start_of_constraint <= time
+        and ct.target_value is not None
+        and ct.is_constraint_active_for_time_period(time)
+    ]
 ```
 
-Call it in **both** paths of `update_current_metrics`, after the respective
-window loop and before the final `qs_bistate_current_on_h` / `_duration_h`
-assignment:
+Call it in **both** paths of `update_current_metrics`, skipping the returned
+constraints in the today-window loop and adding each one's target/runtime before
+the final `qs_bistate_current_on_h` / `_duration_h` assignment:
 
 ```python
-extra_duration_s, extra_run_s = self._overnight_active_constraint_extra(time, tomorrow_utc)
-duration_s += extra_duration_s
-run_s      += extra_run_s
+overnight_cts = self._overnight_active_constraints(time, tomorrow_utc)
+# ... in the window loop:  if any(ct is oct for oct in overnight_cts): continue
+for oct in overnight_cts:
+    duration_s += oct.target_value
+    run_s      += oct.current_value
 ```
 
 This makes the card show the **full active-constraint runtime/target**,

--- a/docs/stories/QS-245.story.md
+++ b/docs/stories/QS-245.story.md
@@ -103,43 +103,51 @@ In **default** mode the card displays the configured `default_on_duration`
 ## Fix
 
 > **Post-implementation reconciliation (review fix #01).** The shipped helper
-> differs from the original sketch below: it returns the **list of all** active
-> overnight constraints (`list[LoadConstraint]`, not a `tuple[float, float]`),
-> each caller adds the `target_value` / `current_value` itself, and there are
-> extra guards (`current_start_of_constraint <= time`, `target_value is not
-> None`, `is_constraint_active_for_time_period`) plus an `if ct in overnight_cts`
-> window-loop skip. The list form handles a load holding several live
-> constraints (`push_live_constraint` appends). The default/pool path also makes
-> the bug #101 lcc-rollover guard overnight-aware. See AC1/AC5/AC7-AC9.
+> differs from the original sketch below: it returns a single
+> `LoadConstraint | None` (not a `tuple[float, float]`) and the caller adds the
+> `target_value` / `current_value` itself, with extra guards
+> (`current_start_of_constraint <= time`, `target_value is not None`) plus an
+> `if ct is overnight_ct` window-loop skip. It reuses `get_current_active_
+> constraint` (already filtered for unmet/active): **at most one** active
+> constraint exists at a time because a load's constraints follow each other
+> sequentially by construction (non-overlapping active windows), so there is no
+> need to scan for several. The default/pool path also unifies the
+> `_last_completed_constraint` handling around a single "is there today content?"
+> rule (in-window constraint OR overnight active): an lcc ending exactly at
+> `today_utc` is shown only when nothing else represents today, so it is dropped
+> when today's cycle finishes overnight (no yesterday double-count). See
+> AC1/AC5/AC7-AC9.
 
 Add a single private helper on `QSBiStateDuration`:
 
 ```python
-def _overnight_active_constraints(
+def _overnight_active_constraint(
     self, time: datetime, tomorrow_utc: datetime
-) -> list[LoadConstraint]:
-    """Return every currently-running active constraint finishing after the
-    today window (overnight finish time), in _constraints order."""
-    return [
-        ct
-        for ct in self._constraints
-        if ct.end_of_constraint > tomorrow_utc
-        and ct.current_start_of_constraint <= time
-        and ct.target_value is not None
-        and ct.is_constraint_active_for_time_period(time)
-    ]
+) -> LoadConstraint | None:
+    """Return the currently-running active constraint finishing after the today
+    window (overnight finish time), else None. At most one active constraint
+    exists by construction (constraints follow each other sequentially)."""
+    active = self.get_current_active_constraint(time)
+    if (
+        active is not None
+        and active.end_of_constraint > tomorrow_utc
+        and active.current_start_of_constraint <= time
+        and active.target_value is not None
+    ):
+        return active
+    return None
 ```
 
 Call it in **both** paths of `update_current_metrics`, skipping the returned
-constraints in the today-window loop and adding each one's target/runtime before
-the final `qs_bistate_current_on_h` / `_duration_h` assignment:
+constraint in the today-window loop and adding its target/runtime before the
+final `qs_bistate_current_on_h` / `_duration_h` assignment:
 
 ```python
-overnight_cts = self._overnight_active_constraints(time, tomorrow_utc)
-# ... in the window loop:  if any(ct is oct for oct in overnight_cts): continue
-for oct in overnight_cts:
-    duration_s += oct.target_value
-    run_s      += oct.current_value
+overnight_ct = self._overnight_active_constraint(time, tomorrow_utc)
+# ... in the window loop:  if ct is overnight_ct: continue
+if overnight_ct is not None:
+    duration_s += overnight_ct.target_value
+    run_s      += overnight_ct.current_value
 ```
 
 This makes the card show the **full active-constraint runtime/target**,

--- a/docs/stories/QS-245.story.md
+++ b/docs/stories/QS-245.story.md
@@ -1,0 +1,286 @@
+# QS-245 — Water-boiler card: progress ring empty when the constraint finishes after local midnight
+
+- **Issue:** #245
+- **Branch:** QS_245
+- **Type:** Bug fix (UI metric data source)
+- **Area:** `ha_model` bistate-duration daily metrics
+
+## Summary
+
+A water-boiler card ("Cumulus Pool House", default **End+Duration** mode,
+green-only, switch ON, 0 W because the tank is already hot) shows
+**`Actual / Target Hours = 0.0h / 3h`** with an **empty progress ring**, while
+the companion sensor
+`sensor.water_boiler_cumulus_pool_house_constraint_completion` correctly shows
+a **rising** percentage (observed live: 10 % → 15 %).
+
+## Root cause
+
+The card's "Actual Hours" (the ring fill) comes from the sensor
+`qs_bistate_current_on_h`, produced by `update_current_metrics()` in
+`custom_components/quiet_solar/ha_model/bistate_duration.py`. That method sums
+constraint runtime/target **only for constraints inside a today-only window**:
+
+```python
+if ct.end_of_constraint > today_utc and ct.end_of_constraint <= tomorrow_utc:
+    duration_s += ct.target_value      # → qs_bistate_current_duration_h
+    run_s      += ct.current_value     # → qs_bistate_current_on_h
+```
+
+`today_utc` / `tomorrow_utc` are **local midnight today / local midnight
+tomorrow** (`ha_model/device.py::get_proper_local_adapted_today/tomorrow`). The
+active constraint has an **overnight finish time (06:30 tomorrow)**, so
+`end_of_constraint > tomorrow_utc` and it is excluded from **both** `run_s` and
+`duration_s` → `qs_bistate_current_on_h` stays `0.0h` → empty ring.
+
+Meanwhile the completion sensor reads the **live active constraint directly**
+via `LoadConstraint.get_percent_completion()` (no window filter, set in
+`home_model/load.py::update_live_constraints`), so it rises normally. The two
+readings are computed from different code paths and disagree.
+
+The same `<= tomorrow_utc` filter exists in the method's **calendar path**
+(lines ~215-217) and **default/pool path** (lines ~241-244) — so both paths
+exhibit the bug.
+
+### What is *not* the cause (red herring)
+
+The "green-only / 0 W" framing is incidental. Runtime accumulates on **command
+state, not measured power**: `TimeBasedSimplePowerLoadConstraint.compute_value`
+(`home_model/constraints.py` ~2662) adds elapsed seconds whenever the command
+is **not** off/idle, and `CMD_AUTO_GREEN_ONLY` (`command="auto_green"`) is not
+off/idle. That is why the completion sensor keeps rising at 0 W. The trigger is
+purely the finish time crossing local midnight; any mode whose active
+constraint ends after tonight's local midnight reproduces it.
+
+### The "3h" target
+
+In **default** mode the card displays the configured `default_on_duration`
+(3 h) as the target and uses `qs_bistate_current_on_h` for the ring fill
+(`ui/resources/qs-water-boiler-card.js`: `displayTargetHours = defaultDuration`,
+`hoursRun = current_duration`). So in this user's case fixing `run_s` (→
+`qs_bistate_current_on_h`) is what re-fills the ring; `duration_s` (→
+`qs_bistate_current_duration_h`) drives the displayed target only in
+**non-default** modes.
+
+## Verified facts (from review)
+
+- `current_value` / `target_value` on `TimeBasedSimplePowerLoadConstraint` are
+  in **seconds** (`compute_value` returns seconds; hence the `/3600`).
+- `get_current_active_constraint(time)` is inherited from
+  `home_model/load.py::AbstractLoad` (defined ~515); calling
+  `self.get_current_active_constraint(time)` from the `ha_model` device is a
+  normal call, **no layer-boundary violation** (we are not importing
+  `homeassistant.*` into `home_model`).
+- With the default `end_time=DATETIME_MAX_UTC`,
+  `is_constraint_active_for_time_period(now)` returns **True** for an unmet
+  constraint that ends in the future — so the overnight constraint (end 06:30
+  tomorrow) **is** returned active at ~22:00.
+- The new branch is **mutually exclusive** with the existing window loop: the
+  loop counts only `end <= tomorrow_utc`; the new branch adds only
+  `end > tomorrow_utc`. An active constraint ending *today* (`<= tomorrow_utc`)
+  is counted once by the loop and skipped by the new branch → **no double
+  count**. We add full `current_value` / `target_value` (not time-sliced), so
+  there is no partial-counting concern.
+- Calendar path: an event with `ev_end > tomorrow_utc` is dropped entirely from
+  `target_s` (line ~204), so adding the overnight active constraint's
+  `target_value` is the intended replacement, not a duplicate. An event/
+  constraint ending **exactly at** `tomorrow_utc` stays in-window
+  (`end == tomorrow_utc` is not `> tomorrow_utc`) → counted once.
+- The user-override short-circuit `return`s at line ~195 (before either path),
+  so the new post-loop code is naturally skipped during an override.
+- `get_current_active_constraint` iterates `self._constraints` and can never
+  return `_last_completed_constraint`, so there is no interaction with the lcc
+  absorption logic.
+- The drift checker confirms `docs/agents/concepts/bistate-duration-devices.md`
+  has `covers: custom_components/quiet_solar/ha_model/bistate_duration.py`, so a
+  co-modification is required.
+
+## Fix
+
+Add a single private helper on `QSBiStateDuration`:
+
+```python
+def _overnight_active_constraint_extra(
+    self, time: datetime, tomorrow_utc: datetime
+) -> tuple[float, float]:
+    """Return (extra_duration_s, extra_run_s) for an active constraint that
+    finishes after the today window (overnight finish time). Zero when there is
+    no active constraint or it already falls inside the today window."""
+    active = self.get_current_active_constraint(time)
+    if active is not None and active.end_of_constraint > tomorrow_utc:
+        return active.target_value, active.current_value
+    return 0.0, 0.0
+```
+
+Call it in **both** paths of `update_current_metrics`, after the respective
+window loop and before the final `qs_bistate_current_on_h` / `_duration_h`
+assignment:
+
+```python
+extra_duration_s, extra_run_s = self._overnight_active_constraint_extra(time, tomorrow_utc)
+duration_s += extra_duration_s
+run_s      += extra_run_s
+```
+
+This makes the card show the **full active-constraint runtime/target**,
+consistent with the `constraint_completion` sensor.
+
+## Acceptance criteria
+
+### AC1 — Default mode includes the overnight active constraint
+**Given** a bistate device in default mode with (a) an in-window constraint
+ending today and (b) an **active** constraint whose `end_of_constraint` is
+`> tomorrow_utc` (e.g. 06:30 tomorrow) with `current_value = C_s`,
+`target_value = T_s`,
+**When** `update_current_metrics(now)` runs with `now` before local midnight,
+**Then** `qs_bistate_current_on_h == (in_window_run_s + C_s) / 3600` and
+`qs_bistate_current_duration_h == (in_window_duration_s + T_s) / 3600`
+(the overnight constraint is now counted).
+
+### AC2 — Calendar mode includes the overnight active constraint
+**Given** calendar mode with today event totals (`target_s` / `past_actual_s`)
+**and** an active constraint ending `> tomorrow_utc` (`current_value = C_s`,
+`target_value = T_s`),
+**When** metrics update,
+**Then** `qs_bistate_current_on_h == (past_actual_s + C_s)/3600` and
+`qs_bistate_current_duration_h == (target_s + T_s)/3600`.
+
+### AC3 — In-window active constraint is not double-counted
+**Given** an **active** constraint whose `end_of_constraint <= tomorrow_utc`,
+**When** metrics update,
+**Then** it is counted exactly once (values identical to pre-fix behavior in
+both paths).
+
+### AC4 — Not-yet-active future constraint stays excluded
+**Given** a constraint that **starts** tomorrow (not active now) and ends
+tomorrow,
+**When** metrics update,
+**Then** it contributes nothing (target/actual unchanged), preserving the
+bug #78 / bug #95 today-only semantics for not-yet-active constraints.
+
+### AC5 — No active constraint → branch inert (regression)
+**Given** only same-day constraints (no active constraint ends after the
+window),
+**When** metrics update,
+**Then** `qs_bistate_current_on_h` / `_duration_h` are **identical** to the
+pre-fix values (the new helper returns `(0.0, 0.0)`).
+
+### AC6 — Local-midnight boundary correctness (DST-aware)
+**Given** a timezone where local midnight ≠ UTC midnight (and a DST-transition
+date) with an active constraint ending after local midnight,
+**When** metrics update,
+**Then** the constraint is included via the `> tomorrow_utc` comparison.
+
+## Task breakdown
+
+1. **TDD — red.** Add/adjust tests in
+   `tests/test_bug_78_daily_metrics.py` (reuse helpers `_create_bistate_device`,
+   `_make_constraint`, `_set_day_boundaries`, `_mock_calendar_events`; real
+   `TimeBasedSimplePowerLoadConstraint` objects, per the no-MagicMock-for-domain
+   rule):
+   - `test_default_mode_includes_overnight_active_constraint` (AC1): `now=22:00`,
+     in-window ct (end today 23:00, target 3600, current 1800) + overnight active
+     ct (start 22:00, end tomorrow 06:30, target 12600, current 900) →
+     `duration_h == approx((3600+12600)/3600)`, `on_h == approx((1800+900)/3600)`.
+   - **Rename + retarget** existing
+     `test_calendar_mode_excludes_tomorrow_active_constraint`
+     → `test_calendar_mode_includes_overnight_active_constraint` (AC2): same
+     fixture (past 1h event + overnight ct target 7200/current 900, end tomorrow
+     01:00) now asserts `duration_h == approx(3.0)`, `on_h == approx(1.25)`;
+     update the docstring.
+   - `test_default_mode_active_in_window_not_double_counted` (AC3): single active
+     ct ending today → metrics equal the plain window-loop result.
+   - Keep `test_default_mode_filters_constraints_to_today` and
+     `test_tomorrow_only_constraints_show_zero_target` green (AC4 — those
+     constraints start tomorrow, so `get_current_active_constraint(now)` returns
+     `None`).
+   - `test_overnight_helper_no_active_constraint_inert` (AC5): assert metrics
+     unchanged when there is no overnight active constraint (covers the
+     `active is None` / `end <= tomorrow_utc` branches in the helper).
+   - `test_calendar_event_ending_exactly_at_tomorrow_utc_no_double_count`: event
+     `ev_end == tomorrow_utc` plus a separate truly-overnight active ct →
+     verifies the exact-boundary edge is counted once.
+   - `test_overnight_active_constraint_local_midnight_boundary` (AC6): freezegun
+     in a non-UTC TZ (e.g. `Europe/Paris`) on a DST date, using the real
+     `_get_today_boundaries` (not mocked), with an active ct ending after local
+     midnight → included.
+   - Add a dedicated **exclusion** test for a constraint that ends after
+     tomorrow but is **already met / inactive** (so `get_current_active_constraint`
+     returns `None`) → still excluded, preserving "exclusion" coverage lost by the
+     rename above.
+
+2. **Implement — green.** In
+   `custom_components/quiet_solar/ha_model/bistate_duration.py`:
+   - Add the `_overnight_active_constraint_extra(self, time, tomorrow_utc)`
+     helper (returns `(extra_duration_s, extra_run_s)`; full type hints; short
+     docstring; no logging, no blocking calls, no `homeassistant.*` import).
+   - Call it in the **calendar path** (after the active-constraint loop ~217 /
+     before the lcc sanity-check is fine; `tomorrow_utc` already in scope at
+     ~199) and in the **default/pool path** (after the loop ~244 / the lcc block;
+     `tomorrow_utc` in scope at ~239), accumulating into `duration_s` / `run_s`
+     before the final assignments at ~276-277.
+   - Do not touch the user-override short-circuit (~187-195) or the lcc logic.
+
+3. **Docs.** Update
+   `docs/agents/concepts/bistate-duration-devices.md`: add a short
+   "Common mistakes" note that daily metrics must include the currently-active
+   constraint even when its finish time is after local midnight (both calendar
+   and default paths), and **bump `last_verified` to 2026-05-30**. (Required:
+   the drift checker covers this file.)
+
+4. **Quality gate.** `source venv/bin/activate` first. TDD loop:
+   `python scripts/qs/quality_gate.py --quick tests/test_bug_78_daily_metrics.py`
+   (red → green). Before commit, full gate:
+   `python scripts/qs/quality_gate.py` (pytest 100 % cov + ruff + mypy +
+   translations). Do **not** use raw `pytest tests/`.
+
+## Scope / risk
+
+- Edit confined to one method + one new private helper in
+  `bistate_duration.py`, tests in `test_bug_78_daily_metrics.py`, and one doc.
+- `update_current_metrics` feeds **every** bistate-duration device's ring
+  (pool, on/off, water boiler, climate, radiator) — AC5 guards against
+  regressing the common same-day case (new branch inert).
+- One existing test is intentionally retargeted (it encoded the old, buggy
+  today-only exclusion of an active overnight constraint); this is a repair, not
+  a regression.
+- No new config keys, no `const.py` change, no card-side change (the card
+  already renders from these sensors).
+
+`Doc-OK:` not applicable — `bistate-duration-devices.md` is updated in Task 3.
+
+## Adversarial review notes
+
+Four reviewers ran in parallel (critic, concrete-planner, dev-proxy,
+scope-guardian). All findings were accepted and folded into this story:
+
+- **[critical] Calendar exact-boundary double-count** (concrete-planner): the
+  `> tomorrow_utc` guard is mutually exclusive with the window loop and with the
+  events loop (which drops events `ev_end > tomorrow_utc`). Reasoning documented
+  in "Verified facts"; covered by
+  `test_calendar_event_ending_exactly_at_tomorrow_utc_no_double_count`.
+- **[critical] AC1/AC2 must be deltas, not absolute equalities** (critic): ACs
+  rewritten as `(in_window_total + active value)/3600`.
+- **[redesign] Rename + retarget the existing "excludes" test, compute numbers,
+  keep a real exclusion test** (concrete-planner, critic, scope-guardian):
+  done — `…includes_overnight…` asserts `3.0` / `1.25`; a separate
+  met/inactive-constraint exclusion test preserves coverage.
+- **[redesign] Commit to a helper instead of "possibly"** (critic,
+  concrete-planner): committed to `_overnight_active_constraint_extra`.
+- **[improve] Enumerate all new branches for 100 % coverage incl. `active is
+  None`** (critic, dev-proxy): explicit tests AC3 / AC5 + inert-branch test.
+- **[improve] DST / local-vs-UTC midnight test with freezegun** (critic,
+  dev-proxy): AC6 + `test_overnight_active_constraint_local_midnight_boundary`.
+- **[improve] Name the quality-gate commands; avoid forbidden raw `pytest`**
+  (dev-proxy): Task 4 specifies `--quick` loop + full gate + venv.
+- **[clarify] units, displayed-target semantics, method ownership/layer, `time`
+  consistency, override ordering** (critic, dev-proxy): all resolved in
+  "Verified facts" / "The 3h target".
+- **[clarify] both paths exhibit the bug; doc `covers:` linkage** (scope-guardian,
+  dev-proxy): confirmed — both paths share the filter; drift checker flags the
+  doc.
+
+Scope-guardian found **no** YAGNI / gold-plating violations: both-path fix and
+the doc update are user-confirmed / drift-checker-mandated; the retarget is a
+repair; the fix reuses the existing `get_current_active_constraint` primitive
+with no new abstraction beyond the one small helper.

--- a/docs/stories/QS-245.story.md
+++ b/docs/stories/QS-245.story.md
@@ -91,11 +91,14 @@ In **default** mode the card displays the configured `default_on_duration`
 - `get_current_active_constraint` iterates `self._constraints` and can never
   return `_last_completed_constraint`, so there is no interaction with the lcc
   absorption logic. **(Review fix #01 reconciliation:** the shipped helper
-  iterates `self._constraints` directly instead of calling
-  `get_current_active_constraint`, so it can collect *all* active overnight
-  constraints, not just the first. It still never touches
+  *reuses* `get_current_active_constraint`, which returns the single currently
+  active constraint (already filtered for unmet/active). At most one active
+  constraint exists at a time because a load's constraints follow each other
+  sequentially by construction (non-overlapping active windows), so there is no
+  need to scan for several overnight constraints — the helper just asks whether
+  that one finishes overnight. It still never touches
   `_last_completed_constraint`. The default/pool lcc-rollover guard is now made
-  aware of the overnight constraints — see the must-fix below.**)**
+  aware of the overnight constraint — see the must-fix below.**)**
 - The drift checker confirms `docs/agents/concepts/bistate-duration-devices.md`
   has `covers: custom_components/quiet_solar/ha_model/bistate_duration.py`, so a
   co-modification is required.

--- a/docs/stories/QS-245.story_review_fix_#01.md
+++ b/docs/stories/QS-245.story_review_fix_#01.md
@@ -1,0 +1,170 @@
+# QS-245 — Review fix plan #01
+
+## Summary
+- Source PR: #246
+- Source story: docs/stories/QS-245.story.md
+- Findings to fix: 9 (1 must-fix, 4 should-fix, 4 nice-to-have)
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [must-fix] LCC dedupe ignores the overnight active constraint (default/pool path)
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:292-320`
+- Severity: must-fix
+- Source: qs-review-coderabbit
+- Description: The `_last_completed_constraint` skip guards `already_absorbed`
+  (lines 298-303) and `rollover_from_previous_day` (lines 307-311) only scan
+  **in-window** constraints (`ct.end_of_constraint > today_utc and
+  ct.end_of_constraint <= tomorrow_utc`). The QS-245 branch now adds an
+  **out-of-window** overnight active constraint (`end_of_constraint >
+  tomorrow_utc`) into `duration_s`/`run_s`, but that constraint is invisible to
+  both guards. So when today's cycle finishes overnight **and** an lcc rolled
+  over at the previous local midnight (bug #101 scenario), neither guard fires,
+  the lcc is added on top of `overnight_ct`, and yesterday's runtime is
+  double-counted in the ring/target.
+- Proposed fix: Make the lcc skip guards aware of `overnight_ct`. When
+  `overnight_ct is not None`, treat it as "today's active cycle" for the
+  same-type / rollover checks — e.g. extend both `any(...)` comprehensions so a
+  same-type `overnight_ct` also satisfies `already_absorbed` /
+  `rollover_from_previous_day` (or add an explicit
+  `type(overnight_ct) == type(lcc)` short-circuit before the lcc add). Keep the
+  existing in-window behavior unchanged.
+- Tests: add a default/pool-path test — lcc ending exactly at `today_utc`
+  (previous-day rollover) of the same type as an **active overnight** constraint
+  (`end > tomorrow_utc`); assert the lcc is **not** added on top of the overnight
+  constraint (no double count). Also add the symmetric `already_absorbed`-style
+  case if applicable.
+
+### [should-fix] AC3/AC5 tests don't exercise an active constraint
+- File: `tests/test_bug_78_daily_metrics.py`
+  (`test_default_mode_active_in_window_not_double_counted`,
+  `test_overnight_helper_no_active_constraint_inert`)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: Both tests use `now = 11:30` while the constraint's `start =
+  16:00`, so `get_current_active_constraint(now)` returns `None`. The branch the
+  docstrings claim to cover ("active in-window constraint") is never hit; the
+  assertions pass purely via the window loop. AC3's double-count guard and the
+  helper's `end <= tomorrow_utc` False branch are therefore not genuinely
+  validated as "active".
+- Proposed fix: Move `now` to a time **after** each constraint's
+  `current_start_of_constraint` (e.g. `now = 16:30` for a `16:00`-start, end
+  `17:00` constraint) so `get_current_active_constraint(now)` returns the
+  constraint and the intended branch is exercised. Adjust `current_value`
+  expectations only if the change in `now` alters them; keep the assertions
+  meaningful. Update docstrings to match what is actually exercised.
+
+### [should-fix] Pool fake treats unstubbed MagicMocks as active
+- File: `tests/test_ha_pool.py:65` (`FakeQSPool.get_current_active_constraint`)
+- Severity: should-fix
+- Source: qs-review-coderabbit, qs-review-edge-case-hunter
+- Description: `FakeQSPool.get_current_active_constraint` returns the first
+  constraint whose `is_constraint_active_for_time_period(time)` is truthy. For a
+  bare `MagicMock` constraint that method is truthy by default, so unstubbed
+  mocks are always "active" — the pool overnight-path tests are easier to pass
+  than the real `AbstractLoad` behavior, and the helper's
+  `current_start_of_constraint <= time` guard is the only thing preventing false
+  positives.
+- Proposed fix: In the affected pool tests, explicitly stub
+  `ct.is_constraint_active_for_time_period` (return `True`/`False` per the
+  scenario) so the fake reflects real activeness rather than MagicMock
+  truthiness. Verify `test_pool_update_current_metrics_tomorrow_constraint_excluded`
+  still asserts exclusion with an explicit non-active stub.
+
+### [should-fix] Only the first overnight active constraint is re-added
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:18-41`
+  (`_overnight_active_constraint_extra`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `get_current_active_constraint(time)` returns only the **first**
+  active constraint, but the window loops drop **every** constraint with
+  `end_of_constraint > tomorrow_utc`. If `self._constraints` holds two or more
+  simultaneously-active constraints that both finish overnight, only the first is
+  re-added; the rest stay dropped — re-creating the empty-ring symptom for the
+  second cycle.
+- Proposed fix: First confirm whether a bistate-duration load can hold more than
+  one simultaneously-active constraint (check `push_live_constraint` /
+  `update_live_constraints` semantics). If yes, change the helper to return the
+  set/list of all active constraints with `end_of_constraint > tomorrow_utc` and
+  `current_start_of_constraint <= time`, and accumulate every one of them in both
+  paths (updating the `if ct is overnight_ct` skip to a membership test). If a
+  bistate load can only ever have one active constraint, instead document that
+  invariant in the helper docstring and add a guarding test asserting the
+  single-active assumption, so the limitation is explicit. Add a test with two
+  active overnight constraints covering the chosen behavior.
+
+### [should-fix] Story spec out of sync with implementation
+- File: `docs/stories/QS-245.story.md:123, 214-220, 234-261`
+- Severity: should-fix
+- Source: qs-review-blind-hunter, qs-review-coderabbit
+- Description: The story's "Fix" code block and "Verified facts" document
+  `_overnight_active_constraint_extra` as returning `tuple[float, float]`
+  (`return active.target_value, active.current_value` / `return 0.0, 0.0`), but
+  the shipped helper returns `LoadConstraint | None` and each caller adds
+  `target_value` / `current_value` itself (plus the extra
+  `current_start_of_constraint <= time` guard). The stale spec will misdirect
+  future readers and follow-up work.
+- Proposed fix: Update the story's "Fix" snippet, "Verified facts", and AC1/AC5
+  prose to describe the final `LoadConstraint | None` contract, the
+  `current_start_of_constraint <= time` guard, and the `if ct is overnight_ct:
+  continue` window-loop skip. Note it as a post-implementation reconciliation.
+
+### [nice-to-have] overnight_ct.target_value None would raise TypeError
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:252, 289`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The helper is typed `-> LoadConstraint | None` (general type). A
+  constraint with `target_value is None` is reported not-met (constraints.py
+  ~542-543) and can thus be returned active; the callers then do `duration_s +=
+  overnight_ct.target_value`, raising `TypeError`. Not reachable for the
+  `TimeBasedSimplePowerLoadConstraint` instances bistate devices actually hold,
+  so defensive only.
+- Proposed fix: Either narrow the helper's intent (guard
+  `target_value is not None` before adding, defaulting to `0.0`) or tighten the
+  return type / add an assertion documenting the time-based-constraint
+  invariant. Pick the lighter option consistent with the layer's conventions.
+
+### [nice-to-have] DST boundary test docstring says "freezegun" but uses TZ env
+- File: `tests/test_bug_78_daily_metrics.py`
+  (`test_overnight_active_constraint_local_midnight_boundary`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The docstring states the test "Uses freezegun", but it actually
+  manipulates `os.environ["TZ"]` + `time.tzset()` with no `freeze_time`.
+  Misleading comment.
+- Proposed fix: Correct the docstring to describe the actual mechanism (TZ env +
+  `tzset`), or convert to `freeze_time` if that better matches intent. Comment
+  fix only.
+
+### [nice-to-have] Duplicated "include overnight" blocks
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:249-253,
+  286-290`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Both metric paths contain near-identical
+  `duration_s += overnight_ct.target_value; run_s += overnight_ct.current_value`
+  blocks. Mild duplication.
+- Proposed fix: Optionally fold the delta into the helper (e.g. return
+  `(extra_duration_s, extra_run_s)` as the story originally intended, or a small
+  apply helper) so both call sites share one expression. Keep it only if it
+  genuinely reduces duplication without obscuring the skip logic. Skip if it
+  conflicts with the must-fix M1 lcc-awareness change (which needs the constraint
+  object, not just the deltas).
+
+### [nice-to-have] DATETIME_MAX_UTC end-time path untested
+- File: `tests/test_bug_78_daily_metrics.py`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: A constraint with `end_of_constraint == DATETIME_MAX_UTC`
+  (`as_fast_as_possible` / unbounded) is active and satisfies `MAX >
+  tomorrow_utc`, so its full `target_value` is re-added each refresh. This is the
+  intended behavior but is not exercised by any new test (all use bounded
+  overnight ends).
+- Proposed fix: Add a test with an active unbounded constraint
+  (`end_of_constraint = DATETIME_MAX_UTC`) asserting it is included by the
+  overnight branch, locking in the intended behavior.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/tests/test_bug_78_daily_metrics.py
+++ b/tests/test_bug_78_daily_metrics.py
@@ -815,9 +815,15 @@ async def test_default_mode_includes_overnight_active_constraint():
 
 
 async def test_default_mode_active_in_window_not_double_counted():
-    """An active constraint ending within today is counted exactly once (AC3)."""
+    """An active constraint ending within today is counted exactly once (AC3).
+
+    ``now`` sits inside the constraint window (16:00-17:00) so the constraint is
+    genuinely active at ``time`` — the overnight helper sees an active constraint
+    but excludes it via its ``end_of_constraint > tomorrow_utc`` False branch, and
+    the window loop counts it exactly once.
+    """
     device = _create_bistate_device()
-    now = datetime(2026, 3, 30, 11, 30, 0, tzinfo=pytz.UTC)
+    now = datetime(2026, 3, 30, 16, 30, 0, tzinfo=pytz.UTC)
     today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
     tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
     _set_day_boundaries(device, today_utc, tomorrow_utc)
@@ -831,6 +837,7 @@ async def test_default_mode_active_in_window_not_double_counted():
         start=datetime(2026, 3, 30, 16, 0, 0, tzinfo=pytz.UTC),
         end=datetime(2026, 3, 30, 17, 0, 0, tzinfo=pytz.UTC),
     )
+    assert ct.is_constraint_active_for_time_period(now) is True  # genuinely active
     device._constraints = [ct]
     device._last_completed_constraint = None
 
@@ -842,13 +849,15 @@ async def test_default_mode_active_in_window_not_double_counted():
 
 
 async def test_overnight_helper_no_active_constraint_inert():
-    """With only an in-window same-day constraint, the helper adds nothing (AC5).
+    """With only an in-window active constraint, the helper adds nothing (AC5).
 
-    Covers the ``end_of_constraint > tomorrow_utc`` False branch of the helper:
-    an active constraint exists but finishes inside the today window.
+    ``now`` sits inside the constraint window (16:00-17:00) so the constraint is
+    genuinely active; the helper still returns an empty list because the
+    constraint finishes inside the today window (``end_of_constraint <=
+    tomorrow_utc``), so metrics equal the plain window-loop result.
     """
     device = _create_bistate_device()
-    now = datetime(2026, 3, 30, 11, 30, 0, tzinfo=pytz.UTC)
+    now = datetime(2026, 3, 30, 16, 30, 0, tzinfo=pytz.UTC)
     today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
     tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
     _set_day_boundaries(device, today_utc, tomorrow_utc)
@@ -861,12 +870,13 @@ async def test_overnight_helper_no_active_constraint_inert():
         start=datetime(2026, 3, 30, 16, 0, 0, tzinfo=pytz.UTC),
         end=datetime(2026, 3, 30, 17, 0, 0, tzinfo=pytz.UTC),
     )
+    assert ct.is_constraint_active_for_time_period(now) is True  # genuinely active
     device._constraints = [ct]
     device._last_completed_constraint = None
 
     await device.update_current_metrics(now)
 
-    # Same as pre-fix: helper returned (0.0, 0.0) because end <= tomorrow_utc.
+    # Same as pre-fix: helper returned [] because end <= tomorrow_utc.
     assert device.qs_bistate_current_duration_h == pytest.approx(1.0)
     assert device.qs_bistate_current_on_h == pytest.approx(0.5)
 
@@ -874,10 +884,10 @@ async def test_overnight_helper_no_active_constraint_inert():
 async def test_overnight_met_constraint_excluded():
     """A constraint ending after tomorrow but already met stays excluded.
 
-    Covers the ``active is None`` branch of the helper: a met constraint is not
-    returned by get_current_active_constraint, so its overnight finish time does
-    not leak into the metrics. Preserves the exclusion semantics lost by the
-    rename of the old 'excludes tomorrow' calendar test.
+    Covers the ``is_constraint_active_for_time_period`` False branch of the
+    helper: a met (current >= target) overnight constraint is not active, so its
+    overnight finish time does not leak into the metrics. Preserves the exclusion
+    semantics lost by the rename of the old 'excludes tomorrow' calendar test.
     """
     device = _create_bistate_device()
     now = datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC)
@@ -946,9 +956,11 @@ async def test_overnight_active_constraint_local_midnight_boundary():
     """Overnight active constraint included via the > tomorrow_utc comparison
     when local midnight differs from UTC midnight on a DST date (AC6).
 
-    Uses the real _get_today_boundaries (not mocked) under Europe/Paris on the
-    spring-forward day (2026-03-29). tomorrow_utc is local midnight expressed in
-    UTC (2026-03-29 22:00 UTC), so a constraint ending 2026-03-30 04:00 UTC is
+    Mechanism: sets the process timezone via ``os.environ["TZ"]`` + ``time.tzset()``
+    (no freezegun — ``now`` is passed explicitly) and uses the real
+    _get_today_boundaries (not mocked) under Europe/Paris on the spring-forward day
+    (2026-03-29). tomorrow_utc is local midnight expressed in UTC
+    (2026-03-29 22:00 UTC), so a constraint ending 2026-03-30 04:00 UTC is
     correctly treated as overnight.
     """
     import os
@@ -982,3 +994,153 @@ async def test_overnight_active_constraint_local_midnight_boundary():
         else:
             os.environ["TZ"] = prev_tz
         _time.tzset()
+
+
+# =============================================================================
+# QS-245 review fix #01: multiple overnight constraints, lcc-rollover awareness,
+# unbounded (DATETIME_MAX_UTC) and target-less constraints.
+# =============================================================================
+
+
+async def test_default_mode_includes_multiple_overnight_active_constraints():
+    """All simultaneously-active overnight constraints are re-added, not just one.
+
+    A bistate load can hold several live constraints (push_live_constraint
+    appends). If two are active and both finish overnight, both must contribute
+    to the ring/target — otherwise the second cycle re-creates the empty-ring
+    symptom.
+    """
+    device = _create_bistate_device()
+    now = datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    ct1 = _make_constraint(
+        device,
+        now,
+        target_s=7200.0,
+        current_s=1800.0,
+        start=datetime(2026, 3, 30, 20, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 31, 5, 0, 0, tzinfo=pytz.UTC),
+    )
+    ct2 = _make_constraint(
+        device,
+        now,
+        target_s=3600.0,
+        current_s=900.0,
+        start=datetime(2026, 3, 30, 21, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 31, 6, 0, 0, tzinfo=pytz.UTC),
+    )
+    assert ct1.is_constraint_active_for_time_period(now) is True
+    assert ct2.is_constraint_active_for_time_period(now) is True
+    device._constraints = [ct1, ct2]
+    device._last_completed_constraint = None
+
+    await device.update_current_metrics(now)
+
+    assert device.qs_bistate_current_duration_h == pytest.approx((7200.0 + 3600.0) / 3600.0)
+    assert device.qs_bistate_current_on_h == pytest.approx((1800.0 + 900.0) / 3600.0)
+
+
+async def test_default_mode_lcc_rollover_not_double_counted_with_overnight_active():
+    """must-fix M1: lcc rolled over at local midnight is not double-counted on top
+    of an active *overnight* constraint of the same type.
+
+    The lcc ends exactly at today_utc (previous-day rollover, bug #101) and the
+    active constraint representing today's cycle finishes overnight
+    (end > tomorrow_utc), so it is out-of-window. The rollover guard must treat
+    the overnight constraint as today's cycle and skip the lcc.
+    """
+    device = _create_bistate_device()
+    now = datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    # Today's active cycle finishes overnight (06:30 tomorrow).
+    active_overnight = _make_constraint(
+        device,
+        now,
+        target_s=36000.0,
+        current_s=10800.0,
+        start=datetime(2026, 3, 30, 20, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 31, 6, 30, 0, tzinfo=pytz.UTC),
+    )
+    # Yesterday's completed constraint, ended exactly at local midnight today.
+    lcc = _make_constraint(
+        device,
+        now,
+        target_s=28800.0,
+        current_s=28800.0,
+        start=datetime(2026, 3, 29, 16, 0, 0, tzinfo=pytz.UTC),
+        end=today_utc,
+    )
+    device._constraints = [active_overnight]
+    device._last_completed_constraint = lcc
+
+    await device.update_current_metrics(now)
+
+    # Only the overnight active cycle counts; lcc (yesterday) is NOT added.
+    assert device.qs_bistate_current_duration_h == pytest.approx(36000.0 / 3600.0)
+    assert device.qs_bistate_current_on_h == pytest.approx(10800.0 / 3600.0)
+
+
+async def test_overnight_unbounded_constraint_included():
+    """An active constraint with end_of_constraint == DATETIME_MAX_UTC
+    (as-fast-as-possible / unbounded) satisfies MAX > tomorrow_utc and is
+    included by the overnight branch (intended behaviour)."""
+    device = _create_bistate_device()
+    now = datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    ct = _make_constraint(
+        device,
+        now,
+        target_s=7200.0,
+        current_s=1800.0,
+        start=datetime(2026, 3, 30, 20, 0, 0, tzinfo=pytz.UTC),
+        end=DATETIME_MAX_UTC,
+    )
+    assert ct.is_constraint_active_for_time_period(now) is True
+    device._constraints = [ct]
+    device._last_completed_constraint = None
+
+    await device.update_current_metrics(now)
+
+    assert device.qs_bistate_current_duration_h == pytest.approx(2.0)
+    assert device.qs_bistate_current_on_h == pytest.approx(0.5)
+
+
+async def test_overnight_targetless_constraint_excluded():
+    """An overnight active constraint with target_value None is skipped (defensive).
+
+    Covers the helper's ``target_value is not None`` guard False branch: such a
+    constraint is reported unmet (target None) and would otherwise be 'active',
+    but adding its None target would raise — so it is excluded.
+    """
+    device = _create_bistate_device()
+    now = datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    ct = _make_constraint(
+        device,
+        now,
+        target_s=7200.0,
+        current_s=1800.0,
+        start=datetime(2026, 3, 30, 20, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 31, 6, 0, 0, tzinfo=pytz.UTC),
+    )
+    ct.target_value = None  # target-less: cannot drive a ring/target
+    assert ct.is_constraint_active_for_time_period(now) is True
+    device._constraints = [ct]
+    device._last_completed_constraint = None
+
+    await device.update_current_metrics(now)
+
+    assert device.qs_bistate_current_duration_h == pytest.approx(0.0)
+    assert device.qs_bistate_current_on_h == pytest.approx(0.0)

--- a/tests/test_bug_78_daily_metrics.py
+++ b/tests/test_bug_78_daily_metrics.py
@@ -884,10 +884,10 @@ async def test_overnight_helper_no_active_constraint_inert():
 async def test_overnight_met_constraint_excluded():
     """A constraint ending after tomorrow but already met stays excluded.
 
-    Covers the ``is_constraint_active_for_time_period`` False branch of the
-    helper: a met (current >= target) overnight constraint is not active, so its
-    overnight finish time does not leak into the metrics. Preserves the exclusion
-    semantics lost by the rename of the old 'excludes tomorrow' calendar test.
+    A met (current >= target) overnight constraint is not active, so
+    get_current_active_constraint returns None and its overnight finish time does
+    not leak into the metrics. Preserves the exclusion semantics lost by the
+    rename of the old 'excludes tomorrow' calendar test.
     """
     device = _create_bistate_device()
     now = datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC)
@@ -1002,13 +1002,17 @@ async def test_overnight_active_constraint_local_midnight_boundary():
 # =============================================================================
 
 
-async def test_default_mode_includes_multiple_overnight_active_constraints():
-    """All simultaneously-active overnight constraints are re-added, not just one.
+async def test_default_mode_single_overnight_constraint_by_construction():
+    """The helper returns exactly ONE overnight constraint (the first match).
 
-    A bistate load can hold several live constraints (push_live_constraint
-    appends). If two are active and both finish overnight, both must contribute
-    to the ring/target — otherwise the second cycle re-creates the empty-ring
-    symptom.
+    Invariant: a load's constraints follow each other in time by construction
+    (sequential, non-overlapping active windows), so at most one constraint can be
+    simultaneously started, unmet and finishing overnight — `_overnight_active_
+    constraint` returns the first match and does not accumulate several. This test
+    documents/locks that single-return contract by feeding a (by-construction
+    impossible) pair of overlapping overnight constraints and asserting only the
+    first contributes; if the invariant ever broke, this guards the deliberate
+    behaviour.
     """
     device = _create_bistate_device()
     now = datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC)
@@ -1032,15 +1036,15 @@ async def test_default_mode_includes_multiple_overnight_active_constraints():
         start=datetime(2026, 3, 30, 21, 0, 0, tzinfo=pytz.UTC),
         end=datetime(2026, 3, 31, 6, 0, 0, tzinfo=pytz.UTC),
     )
-    assert ct1.is_constraint_active_for_time_period(now) is True
-    assert ct2.is_constraint_active_for_time_period(now) is True
     device._constraints = [ct1, ct2]
     device._last_completed_constraint = None
 
     await device.update_current_metrics(now)
 
-    assert device.qs_bistate_current_duration_h == pytest.approx((7200.0 + 3600.0) / 3600.0)
-    assert device.qs_bistate_current_on_h == pytest.approx((1800.0 + 900.0) / 3600.0)
+    # Only the first overnight constraint (ct1) is counted — ct2 is not added by
+    # the overnight branch (single-return) nor by the in-window loop (out-of-window).
+    assert device.qs_bistate_current_duration_h == pytest.approx(7200.0 / 3600.0)
+    assert device.qs_bistate_current_on_h == pytest.approx(1800.0 / 3600.0)
 
 
 async def test_default_mode_lcc_rollover_not_double_counted_with_overnight_active():

--- a/tests/test_bug_78_daily_metrics.py
+++ b/tests/test_bug_78_daily_metrics.py
@@ -230,8 +230,14 @@ async def test_calendar_mode_actual_includes_active_constraint_current_value():
     assert device.qs_bistate_current_on_h == pytest.approx(1.5)
 
 
-async def test_calendar_mode_excludes_tomorrow_active_constraint():
-    """Calendar mode excludes active constraints ending tomorrow."""
+async def test_calendar_mode_includes_overnight_active_constraint():
+    """Calendar mode includes a currently-active constraint finishing overnight.
+
+    QS-245 (AC2): the active constraint started today (running now) but its
+    finish time is after local midnight (``end_of_constraint > tomorrow_utc``).
+    Its full target/current values are added on top of today's calendar event
+    totals, matching the constraint_completion sensor.
+    """
     device = _create_bistate_device(calendar="calendar.test")
     device.bistate_mode = "bistate_mode_auto"
     now = datetime(2026, 3, 30, 23, 0, 0, tzinfo=pytz.UTC)
@@ -239,12 +245,12 @@ async def test_calendar_mode_excludes_tomorrow_active_constraint():
     tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
     _set_day_boundaries(device, today_utc, tomorrow_utc)
 
-    # One past 1h event today
+    # One past 1h event today -> target_s = 3600, past_actual_s = 3600
     _mock_calendar_events(device, [
         (datetime(2026, 3, 30, 6, 0, 0, tzinfo=pytz.UTC), datetime(2026, 3, 30, 7, 0, 0, tzinfo=pytz.UTC)),
     ])
 
-    # Constraint ending tomorrow — should NOT add current_value
+    # Active constraint started today (23:00), finishing overnight (tomorrow 01:00).
     ct = _make_constraint(
         device,
         now,
@@ -258,8 +264,9 @@ async def test_calendar_mode_excludes_tomorrow_active_constraint():
 
     await device.update_current_metrics(now)
 
-    assert device.qs_bistate_current_duration_h == pytest.approx(1.0)
-    assert device.qs_bistate_current_on_h == pytest.approx(1.0)
+    # duration = (3600 + 7200) / 3600 = 3.0 ; on = (3600 + 900) / 3600 = 1.25
+    assert device.qs_bistate_current_duration_h == pytest.approx(3.0)
+    assert device.qs_bistate_current_on_h == pytest.approx(1.25)
 
 
 # =============================================================================
@@ -757,3 +764,221 @@ async def test_default_mode_extended_lcc_absorbed_via_initial_end():
     # lcc absorbed via initial_end match — only active counted
     assert device.qs_bistate_current_duration_h == pytest.approx(21600.0 / 3600.0)
     assert device.qs_bistate_current_on_h == pytest.approx(14400.0 / 3600.0)
+
+
+# =============================================================================
+# QS-245: include the currently-active constraint when it finishes overnight
+# (after local midnight). Both calendar and default paths.
+# =============================================================================
+
+
+async def test_default_mode_includes_overnight_active_constraint():
+    """Default mode adds an active constraint that finishes after local midnight.
+
+    QS-245 (AC1): the card's ring (qs_bistate_current_on_h) and target
+    (qs_bistate_current_duration_h) must include the currently-running active
+    constraint even when its finish time is overnight, on top of the in-window
+    constraint totals.
+    """
+    device = _create_bistate_device()
+    now = datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    # In-window constraint ending today 23:00 (already met -> inactive).
+    ct_in_window = _make_constraint(
+        device,
+        now,
+        target_s=3600.0,
+        current_s=3600.0,
+        start=datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 30, 23, 0, 0, tzinfo=pytz.UTC),
+    )
+    # Active overnight constraint: started 22:00 today, ends 06:30 tomorrow.
+    ct_overnight = _make_constraint(
+        device,
+        now,
+        target_s=12600.0,
+        current_s=900.0,
+        start=datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 31, 6, 30, 0, tzinfo=pytz.UTC),
+    )
+    device._constraints = [ct_in_window, ct_overnight]
+    device._last_completed_constraint = None
+
+    await device.update_current_metrics(now)
+
+    # duration = (3600 + 12600) / 3600 ; on = (3600 + 900) / 3600
+    assert device.qs_bistate_current_duration_h == pytest.approx((3600.0 + 12600.0) / 3600.0)
+    assert device.qs_bistate_current_on_h == pytest.approx((3600.0 + 900.0) / 3600.0)
+
+
+async def test_default_mode_active_in_window_not_double_counted():
+    """An active constraint ending within today is counted exactly once (AC3)."""
+    device = _create_bistate_device()
+    now = datetime(2026, 3, 30, 11, 30, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    # Active constraint ending today 17:00 (in-window, end <= tomorrow_utc).
+    ct = _make_constraint(
+        device,
+        now,
+        target_s=3600.0,
+        current_s=1800.0,
+        start=datetime(2026, 3, 30, 16, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 30, 17, 0, 0, tzinfo=pytz.UTC),
+    )
+    device._constraints = [ct]
+    device._last_completed_constraint = None
+
+    await device.update_current_metrics(now)
+
+    # Identical to the plain window-loop result: 3600/3600 and 1800/3600.
+    assert device.qs_bistate_current_duration_h == pytest.approx(1.0)
+    assert device.qs_bistate_current_on_h == pytest.approx(0.5)
+
+
+async def test_overnight_helper_no_active_constraint_inert():
+    """With only an in-window same-day constraint, the helper adds nothing (AC5).
+
+    Covers the ``end_of_constraint > tomorrow_utc`` False branch of the helper:
+    an active constraint exists but finishes inside the today window.
+    """
+    device = _create_bistate_device()
+    now = datetime(2026, 3, 30, 11, 30, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    ct = _make_constraint(
+        device,
+        now,
+        target_s=3600.0,
+        current_s=1800.0,
+        start=datetime(2026, 3, 30, 16, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 30, 17, 0, 0, tzinfo=pytz.UTC),
+    )
+    device._constraints = [ct]
+    device._last_completed_constraint = None
+
+    await device.update_current_metrics(now)
+
+    # Same as pre-fix: helper returned (0.0, 0.0) because end <= tomorrow_utc.
+    assert device.qs_bistate_current_duration_h == pytest.approx(1.0)
+    assert device.qs_bistate_current_on_h == pytest.approx(0.5)
+
+
+async def test_overnight_met_constraint_excluded():
+    """A constraint ending after tomorrow but already met stays excluded.
+
+    Covers the ``active is None`` branch of the helper: a met constraint is not
+    returned by get_current_active_constraint, so its overnight finish time does
+    not leak into the metrics. Preserves the exclusion semantics lost by the
+    rename of the old 'excludes tomorrow' calendar test.
+    """
+    device = _create_bistate_device()
+    now = datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    # Met (current >= target) overnight constraint -> inactive -> not returned.
+    ct = _make_constraint(
+        device,
+        now,
+        target_s=12600.0,
+        current_s=12600.0,
+        start=datetime(2026, 3, 30, 22, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 31, 6, 30, 0, tzinfo=pytz.UTC),
+    )
+    device._constraints = [ct]
+    device._last_completed_constraint = None
+
+    await device.update_current_metrics(now)
+
+    assert device.qs_bistate_current_duration_h == pytest.approx(0.0)
+    assert device.qs_bistate_current_on_h == pytest.approx(0.0)
+
+
+async def test_calendar_event_ending_exactly_at_tomorrow_utc_no_double_count():
+    """Calendar event ending exactly at tomorrow_utc is counted once (edge).
+
+    QS-245: an event whose ev_end == tomorrow_utc stays in-window (it is not
+    ``> tomorrow_utc``), while a separate truly-overnight active constraint is
+    added by the helper. No double-counting at the exact boundary.
+    """
+    device = _create_bistate_device(calendar="calendar.test")
+    device.bistate_mode = "bistate_mode_auto"
+    now = datetime(2026, 3, 30, 23, 0, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    # Event ending exactly at tomorrow_utc (23:00 -> 00:00) -> in-window, 1h.
+    _mock_calendar_events(device, [
+        (datetime(2026, 3, 30, 23, 0, 0, tzinfo=pytz.UTC), datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)),
+    ])
+
+    # Separate overnight active constraint ending 01:00 tomorrow.
+    ct = _make_constraint(
+        device,
+        now,
+        target_s=7200.0,
+        current_s=900.0,
+        start=datetime(2026, 3, 30, 23, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 31, 1, 0, 0, tzinfo=pytz.UTC),
+    )
+    device._constraints = [ct]
+    device._last_completed_constraint = None
+
+    await device.update_current_metrics(now)
+
+    # event target 3600 (in-window, future so not past actual) + overnight 7200.
+    # on = overnight current 900 only (event not yet past at 23:00).
+    assert device.qs_bistate_current_duration_h == pytest.approx((3600.0 + 7200.0) / 3600.0)
+    assert device.qs_bistate_current_on_h == pytest.approx(900.0 / 3600.0)
+
+
+async def test_overnight_active_constraint_local_midnight_boundary():
+    """Overnight active constraint included via the > tomorrow_utc comparison
+    when local midnight differs from UTC midnight on a DST date (AC6).
+
+    Uses the real _get_today_boundaries (not mocked) under Europe/Paris on the
+    spring-forward day (2026-03-29). tomorrow_utc is local midnight expressed in
+    UTC (2026-03-29 22:00 UTC), so a constraint ending 2026-03-30 04:00 UTC is
+    correctly treated as overnight.
+    """
+    import os
+    import time as _time
+
+    prev_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "Europe/Paris"
+    _time.tzset()
+    try:
+        device = _create_bistate_device()
+        now = datetime(2026, 3, 29, 20, 0, 0, tzinfo=pytz.UTC)
+
+        ct = _make_constraint(
+            device,
+            now,
+            target_s=7200.0,
+            current_s=1800.0,
+            start=datetime(2026, 3, 29, 19, 0, 0, tzinfo=pytz.UTC),
+            end=datetime(2026, 3, 30, 4, 0, 0, tzinfo=pytz.UTC),
+        )
+        device._constraints = [ct]
+        device._last_completed_constraint = None
+
+        await device.update_current_metrics(now)
+
+        assert device.qs_bistate_current_duration_h == pytest.approx(2.0)
+        assert device.qs_bistate_current_on_h == pytest.approx(0.5)
+    finally:
+        if prev_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = prev_tz
+        _time.tzset()

--- a/tests/test_ha_pool.py
+++ b/tests/test_ha_pool.py
@@ -14,6 +14,7 @@ from custom_components.quiet_solar.const import (
     CONF_POOL_WINTER_IDX,
     POOL_TEMP_STEPS,
 )
+from custom_components.quiet_solar.ha_model.bistate_duration import QSBiStateDuration
 
 
 class FakeQSPool:
@@ -52,6 +53,21 @@ class FakeQSPool:
     def _is_calendar_based_mode(self, bistate_mode):
         """Pool never uses calendar-based mode for auto/winter."""
         return False
+
+    def get_current_active_constraint(self, time=None):
+        """Mirror AbstractLoad.get_current_active_constraint for the fake double.
+
+        Returns the first constraint active for the given time, else None — the
+        primitive QSBiStateDuration._overnight_active_constraint_extra relies on.
+        """
+        for c in getattr(self, "_constraints", None) or []:
+            if c.is_constraint_active_for_time_period(time):
+                return c
+        return None
+
+    # Reuse the real overnight-active-constraint helper so update_current_metrics
+    # exercises production logic (QS-245).
+    _overnight_active_constraint_extra = QSBiStateDuration._overnight_active_constraint_extra
 
     def is_best_effort_only_load(self):
         return False
@@ -357,6 +373,9 @@ async def test_pool_update_current_metrics_tomorrow_constraint_excluded():
     ct = MagicMock()
     ct.end_of_constraint = datetime(2026, 3, 31, 7, 0, 0, tzinfo=pytz.UTC)  # tomorrow
     ct.start_of_constraint = datetime(2026, 3, 31, 6, 0, 0, tzinfo=pytz.UTC)
+    # current_start mirrors start at init (real constraints do this); future start
+    # so the overnight-active helper must NOT treat it as currently running.
+    ct.current_start_of_constraint = datetime(2026, 3, 31, 6, 0, 0, tzinfo=pytz.UTC)
     ct.target_value = 3600.0
     ct.current_value = 0.0
 

--- a/tests/test_ha_pool.py
+++ b/tests/test_ha_pool.py
@@ -54,20 +54,11 @@ class FakeQSPool:
         """Pool never uses calendar-based mode for auto/winter."""
         return False
 
-    def get_current_active_constraint(self, time=None):
-        """Mirror AbstractLoad.get_current_active_constraint for the fake double.
-
-        Returns the first constraint active for the given time, else None — the
-        primitive QSBiStateDuration._overnight_active_constraint_extra relies on.
-        """
-        for c in getattr(self, "_constraints", None) or []:
-            if c.is_constraint_active_for_time_period(time):
-                return c
-        return None
-
-    # Reuse the real overnight-active-constraint helper so update_current_metrics
-    # exercises production logic (QS-245).
-    _overnight_active_constraint_extra = QSBiStateDuration._overnight_active_constraint_extra
+    # Reuse the real overnight-active-constraints helper so update_current_metrics
+    # exercises production logic (QS-245). It iterates self._constraints directly
+    # and consults each constraint's is_constraint_active_for_time_period, so the
+    # tests stub that method explicitly rather than relying on MagicMock truthiness.
+    _overnight_active_constraints = QSBiStateDuration._overnight_active_constraints
 
     def is_best_effort_only_load(self):
         return False
@@ -376,6 +367,10 @@ async def test_pool_update_current_metrics_tomorrow_constraint_excluded():
     # current_start mirrors start at init (real constraints do this); future start
     # so the overnight-active helper must NOT treat it as currently running.
     ct.current_start_of_constraint = datetime(2026, 3, 31, 6, 0, 0, tzinfo=pytz.UTC)
+    # Explicit activeness (not MagicMock truthiness): the real
+    # is_constraint_active_for_time_period returns True for an unmet future-ending
+    # constraint, so the current_start_of_constraint guard is what excludes it.
+    ct.is_constraint_active_for_time_period = MagicMock(return_value=True)
     ct.target_value = 3600.0
     ct.current_value = 0.0
 

--- a/tests/test_ha_pool.py
+++ b/tests/test_ha_pool.py
@@ -54,11 +54,23 @@ class FakeQSPool:
         """Pool never uses calendar-based mode for auto/winter."""
         return False
 
-    # Reuse the real overnight-active-constraints helper so update_current_metrics
-    # exercises production logic (QS-245). It iterates self._constraints directly
-    # and consults each constraint's is_constraint_active_for_time_period, so the
-    # tests stub that method explicitly rather than relying on MagicMock truthiness.
-    _overnight_active_constraints = QSBiStateDuration._overnight_active_constraints
+    def get_current_active_constraint(self, time=None):
+        """Mirror AbstractLoad.get_current_active_constraint for the fake double:
+        return the first constraint active for the given time, else None.
+
+        The overnight path is only reached when this returns a constraint whose
+        end is overnight; the single test that exercises that exclusion stubs
+        is_constraint_active_for_time_period explicitly rather than relying on
+        MagicMock truthiness (QS-245 review fix #01).
+        """
+        for c in getattr(self, "_constraints", None) or []:
+            if c.is_constraint_active_for_time_period(time):
+                return c
+        return None
+
+    # Reuse the real overnight-active-constraint helper so update_current_metrics
+    # exercises production logic (QS-245).
+    _overnight_active_constraint = QSBiStateDuration._overnight_active_constraint
 
     def is_best_effort_only_load(self):
         return False


### PR DESCRIPTION
## Summary
- update_current_metrics excluded the currently-active constraint when its finish time crossed local midnight (overnight finish), leaving the card ring/target at 0 while constraint_completion rose
- Added _overnight_active_constraint_extra to re-include the running active constraint in both calendar and default/pool metric paths, guarded against not-yet-started constraints and double-counting
- New tests (AC1-AC6 + edge/boundary/DST cases) and updated bistate-duration-devices doc

Fixes #245

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected daily duration/progress metrics so an active constraint that finishes after local midnight is included in "today" totals while avoiding double-counting and incorrect resurrection of old cycles.

* **Tests**
  * Added and expanded tests covering overnight-active constraints, calendar vs default behavior, DST/local‑midnight edge cases, single‑constraint guarantees, and other double‑counting scenarios.

* **Documentation**
  * Updated device docs, an engineering story, and verification date to describe the overnight metrics edge case and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->