### PR TITLE
QS-247: Bistate boiler counts yesterday's load over end-of-duration boundary in update_current_metrics

### DIFF
--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -331,6 +331,17 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                     # push_live_constraint). Anything ending before today_utc,
                     # the DATETIME_MAX_UTC sentinel, or after tomorrow_utc is
                     # excluded (a constraint ending yesterday is not "today").
+                    #
+                    # QS-247: also drop the lcc when an overnight active
+                    # constraint is running (overnight_ct is not None). In
+                    # default/pool mode there is exactly one daily cycle, and
+                    # constraints chain sequentially (the QS-245 invariant), so
+                    # an lcc that ended earlier today is the previous day's cycle
+                    # of this same recurring load — counting it on top of today's
+                    # running overnight cycle is the reported growing / overfull
+                    # ring. This is symmetric with the lcc.end == today_utc branch
+                    # above, which already drops the lcc whenever has_today_content
+                    # (overnight_ct included).
                     already_absorbed = any(
                         type(ct) == type(lcc)
                         and (ct.end_of_constraint == lcc.end_of_constraint or ct.end_of_constraint == lcc_end)
@@ -339,6 +350,7 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                     )
                     use_lcc = (
                         not already_absorbed
+                        and overnight_ct is None
                         and lcc.end_of_constraint != DATETIME_MAX_UTC
                         and today_utc < lcc.end_of_constraint <= tomorrow_utc
                     )

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -10,7 +10,7 @@ covers:
   - custom_components/quiet_solar/ha_model/radiator.py
   - custom_components/quiet_solar/ha_model/bistate_transport.py
   - custom_components/quiet_solar/ha_model/water_boiler.py
-last_verified: 2026-05-31
+last_verified: 2026-06-01
 ---
 
 # Bistate-duration devices (pool, on/off duration, water boiler, climate, radiator)
@@ -211,7 +211,12 @@ transport based on which `CONF_*` the user filled.
     (whether that cycle is in-window or finishes overnight, QS-245 fix #01).
   - `today_utc < lcc.end <= tomorrow_utc`: show it unless an active same-type
     constraint sharing its (initial) end date already absorbed its runtime
-    (same-day cycle carry-over).
+    (same-day cycle carry-over). Also drop it when an **overnight active
+    constraint is running** (`overnight_ct is not None`, QS-247): for a
+    non-midnight finish time the just-completed cycle is then the previous day's
+    cycle of this single-daily-cycle load and would otherwise be counted on top
+    of today's running cycle (the growing / overfull ring) — symmetric with the
+    `lcc.end == today_utc` rule above.
   - anything ending before `today_utc`, the `DATETIME_MAX_UTC` sentinel, or
     after `tomorrow_utc`: excluded. Use `== today_utc` (not `<=`) for the
     boundary case so genuinely-old cycles are never resurrected.

--- a/docs/stories/QS-247.story.md
+++ b/docs/stories/QS-247.story.md
@@ -1,0 +1,357 @@
+# QS-247 — Bistate boiler counts yesterday's overnight cycle over the end-of-duration boundary
+
+- **Issue:** #247
+- **Branch:** QS_247
+- **Type:** Bug fix (UI metric data source)
+- **Area:** `ha_model` bistate-duration daily metrics
+- **Next phase:** implement-task (edits `custom_components/quiet_solar/ha_model/bistate_duration.py`)
+
+## Summary
+
+Same device as QS-245 — "Cumulus Pool House", **Default: End+Duration** mode,
+**finish time 06:30**, configured **3h** duration. After QS-245 made the card
+count overnight usage, a new defect appeared:
+
+- At **09:00** the card (`Actual / Target Hours`) shows **`3.4h / 3h`**.
+- At **10:00** it shows **`4.4h / 3h`** — the actual-hours value is **growing**
+  by ~1h/h and has overshot the 3h target ring.
+
+User-confirmed interpretation: it is **3h of yesterday's completed overnight
+cycle (fixed) + today's growing run**. The just-completed overnight cycle is
+being counted on top of the currently-running new cycle.
+
+## Root cause
+
+`update_current_metrics()` in
+`custom_components/quiet_solar/ha_model/bistate_duration.py` (default/pool
+`else` path, lines 288-348) frames "today" as **local midnight → local
+midnight** (`today_utc` / `tomorrow_utc` from `_get_today_boundaries`, which
+calls `get_proper_local_adapted_today/tomorrow`).
+
+For a device whose daily cycle finishes at a **non-midnight** finish time
+(06:30):
+
+1. The overnight cycle that completed **this morning at 06:30** is now
+   `_last_completed_constraint` (lcc) with `end_of_constraint = today 06:30`,
+   which sits **strictly inside** the today window
+   (`today_utc < 06:30 < tomorrow_utc`), so it is *not* "yesterday" by the
+   midnight frame.
+2. The **new** cycle heads to **tomorrow 06:30** and, once running, is returned
+   by the existing helper `_overnight_active_constraint(time, tomorrow_utc)`
+   (line 292) as `overnight_ct` — it ends `> tomorrow_utc`. Its target/runtime
+   are added explicitly at lines 303-305 (correct, this is QS-245's fix).
+
+The method then **also** surfaces the stale lcc. In the `else` branch the only
+suppression is `already_absorbed` (lines 334-339), which scans for an
+**in-window** same-end constraint (`today_utc < ct.end_of_constraint <=
+tomorrow_utc`). `overnight_ct` ends **out of window** (tomorrow 06:30 `>
+tomorrow_utc`), so it never matches → `already_absorbed = False` → `use_lcc =
+True` (lines 340-344) → lcc added.
+
+Net result:
+
+| source | → `run_s` | → `duration_s` |
+| --- | --- | --- |
+| `overnight_ct` (today's running cycle, lines 303-305) | growing: 0.4h @09:00 → 1.4h @10:00 | 3h |
+| stale `lcc` (yesterday's overnight cycle, lines 346-348) | 3.0h (fixed) | 3h |
+| **total** | **3.4h → 4.4h** | **6h** |
+
+`qs_bistate_current_on_h = run_s/3600` (the ring fill) and
+`qs_bistate_current_duration_h = duration_s/3600`. **In default mode the card's
+target ring is the card-side constant `default_on_duration` (3h), not
+`duration_s`** (established in QS-245: `displayTargetHours = defaultDuration`).
+So `duration_s = 6h` is computed but discarded for display — the card shows
+`run_s` over a fixed 3h ring → the misleading overfull `3.4h/3h`, `4.4h/3h`.
+(This is why the user's "shouldn't I see 6h in duration?" does not manifest: in
+default mode `duration_s` never reaches the card.)
+
+### Why the existing guards miss it
+
+The QS-101/#95 rollover guard only suppresses the lcc when it ends **exactly at
+local midnight** (`lcc.end_of_constraint == today_utc`, line 319), in a separate
+branch that already drops the lcc when `has_today_content` (line 315 — which
+**includes** `overnight_ct is not None`). A **06:30** finish time lands in the
+`else` branch (line 326), which has **no overnight awareness** — that is the
+gap. QS-247 is the **non-midnight finish-time sibling** of the QS-101
+midnight-finish rollover.
+
+### Inlined prior-fix contracts (so the regression ACs are checkable here)
+
+- **#95 / #101 (midnight rollover):** when the lcc ended at the previous local
+  midnight (`lcc.end == today_utc`) and today's cycle is represented (in-window
+  or overnight), the lcc must **not** be added (no yesterday double-count).
+  Encoded by line 319's `use_lcc = not has_today_content`.
+- **#101 AC3 (intra-day multi-segment):** when a cycle completed **earlier
+  today** (lcc) and a separate active constraint runs to a later time **within
+  the same calendar day** (in-window, `end <= tomorrow_utc`), **both** count
+  (e.g. lcc 07:00 done + active until 17:00 → duration 2.0h, run 1.0h). Here
+  the active constraint ends in-window, so `_overnight_active_constraint`
+  returns `None` and the lcc is correctly retained.
+
+## Fix
+
+In the `else` branch of the default/pool path, add **`overnight_ct is None`** to
+the `use_lcc` condition.
+
+Current code (lines 340-344):
+
+```python
+use_lcc = (
+    not already_absorbed
+    and lcc.end_of_constraint != DATETIME_MAX_UTC
+    and today_utc < lcc.end_of_constraint <= tomorrow_utc
+)
+```
+
+After:
+
+```python
+use_lcc = (
+    not already_absorbed
+    and overnight_ct is None
+    and lcc.end_of_constraint != DATETIME_MAX_UTC
+    and today_utc < lcc.end_of_constraint <= tomorrow_utc
+)
+```
+
+`overnight_ct` is already in scope (assigned at line 292). The clause is placed
+**second** so that both new tests reach it (the preceding `not already_absorbed`
+is `True` in both — see Coverage map).
+
+**Rationale.** When today's *current* cycle finishes overnight (`overnight_ct is
+not None`), an lcc that ended **earlier today** is the **previous** overnight
+cycle and must not be re-counted. This mirrors — and completes the symmetry
+with — the `lcc.end == today_utc` branch (line 319), which already drops the lcc
+whenever `has_today_content` (which includes `overnight_ct`). It is **not** a
+new ad-hoc special case: it is the same overnight-awareness rule applied to the
+in-window-lcc branch that QS-245 left untouched. A full reframe of the
+local-midnight window is deliberately **out of scope**.
+
+**Why dropping the lcc cannot under-count (identity argument).** In
+default/pool mode there is **exactly one daily cycle** (one finish time). A
+load's constraints follow each other in time **by construction** —
+`push_live_constraint` chains sequential, non-overlapping active windows (the
+QS-245 invariant). So the lcc (previous cycle) and `overnight_ct` (current
+cycle) are **consecutive daily cycles**, never two co-existing same-day cycles.
+Therefore, when `overnight_ct is not None`, the only thing the in-window lcc can
+represent is the prior day's cycle → safe to drop.
+
+**Why this fully kills the reported (growing/overfull) symptom — and what
+residual remains (the "idle gap").** The gate is **self-correcting**:
+
+- The misleading symptom is *runtime growing past the target*. New runtime can
+  only accrue via `overnight_ct` (the running cycle). The instant runtime
+  accrues, the constraint is active with `current_start_of_constraint <= time`,
+  so `_overnight_active_constraint` returns it → `overnight_ct is not None` →
+  the lcc is dropped. Hence **the ring can never again show a growing/overfull
+  value.**
+- The only residual: in the brief window *after* 06:30 completion and *before*
+  the new cycle starts running (`overnight_ct is None`), the just-finished
+  cycle's **full** `3.0h / 3h` ring is shown. This is **benign** (full, never
+  overfull/growing) and arguably correct ("you completed today's duration").
+  The user confirmed that for this always-eligible green-only boiler the
+  new cycle starts within seconds, so the window is negligible in practice. We
+  deliberately keep this behaviour rather than reframe the window.
+
+## Acceptance criteria
+
+### AC1 — Non-midnight finish-time rollover with a running overnight cycle (the bug)
+**Given** a default-mode device (no calendar attached) at `now = 09:00`, with
+`_constraints = [overnight_ct]` where `overnight_ct` started earlier today and
+ends **tomorrow 06:30** (`target_value = 10800` s, `current_value = 1440` s =
+0.4h), and `_last_completed_constraint` ended **today 06:30**
+(`target_value = 10800` s, `current_value = 10800` s = 3.0h),
+**When** `update_current_metrics(now)` runs,
+**Then** the lcc is dropped and only `overnight_ct` contributes:
+`qs_bistate_current_on_h == approx(0.4)` (= `overnight_ct.current_value/3600`,
+lcc contributes 0) and `qs_bistate_current_duration_h == approx(3.0)`
+(= `overnight_ct.target_value/3600`, lcc contributes 0).
+*(Pre-fix this asserts 3.4 / 6.0 → true red→green.)*
+
+### AC2 — Intra-day multi-segment preserved (#101 AC3 regression)
+**Given** lcc ended **today 07:00** (`target 3600`, `current 3600`) and a single
+active constraint ends **today 17:00** in-window (`target 3600`, `current 0`),
+no overnight constraint,
+**When** metrics update,
+**Then** `_overnight_active_constraint` returns `None`, the lcc is retained, and
+both count: `qs_bistate_current_duration_h == approx(2.0)`,
+`qs_bistate_current_on_h == approx(1.0)`. *(Existing
+`test_default_mode_includes_last_completed_from_today`, line 310, must stay
+green and is the pre-existing `overnight_ct is None` True-branch witness.)*
+
+### AC3 — Midnight-finish rollover still handled (#101/#95 regression)
+**Given** the existing
+`test_default_mode_lcc_rollover_not_double_counted_with_overnight_active` (line
+1050: lcc ends at `today_utc`, active overnight ct),
+**When** metrics update,
+**Then** it stays green (lcc dropped via the `lcc.end == today_utc` /
+`has_today_content` branch — untouched by this fix).
+
+### AC4 — Idle gap: lcc retained (benign full ring), documented decision
+**Given** lcc ended **today 06:30** (`target 10800`, `current 10800` = 3.0h) and
+`_constraints = []` (the new cycle is scheduled but not yet running, so
+`overnight_ct is None`),
+**When** metrics update,
+**Then** the lcc is retained: `qs_bistate_current_on_h == approx(3.0)`,
+`qs_bistate_current_duration_h == approx(3.0)` — a **full** (never overfull)
+ring. This pins the `overnight_ct is None == True` branch of the new clause and
+documents the accepted residual behaviour.
+
+### AC5 — `already_absorbed` carry-over still works (regression)
+Existing same-end / `initial_end_of_constraint` absorb tests
+(`test_default_mode_same_end_date_lcc_not_double_counted` line 610,
+`test_default_mode_extended_lcc_absorbed_via_initial_end` line 725) stay green.
+
+### AC6 — `DATETIME_MAX_UTC` and yesterday-lcc exclusions still work
+Existing `test_default_mode_excludes_last_completed_with_max_sentinel` (line
+371) and `test_default_mode_excludes_last_completed_from_yesterday` (line 346)
+stay green.
+
+### AC7 — 100% coverage maintained.
+
+## Coverage map (branch coverage of the new compound `use_lcc`)
+
+The new clause is `... and overnight_ct is None and ...`. Both outcomes are
+reached because the preceding `not already_absorbed` is `True` in both new
+tests:
+
+| clause | True witness | False witness |
+| --- | --- | --- |
+| `not already_absorbed` | AC1, AC4 | line 610 (same-end absorbed) |
+| `overnight_ct is None` | **AC4 (new)**, line 310 | **AC1 (new)** |
+| `lcc.end != DATETIME_MAX_UTC` | AC1/AC4 | line 371 (MAX sentinel) |
+| `today < lcc.end <= tomorrow` | AC1/AC4 | line 346 (yesterday) |
+
+## Task breakdown
+
+1. **TDD — red.** In `tests/test_bug_78_daily_metrics.py`, reuse the local
+   helpers `_create_bistate_device(calendar=None)` (no calendar → `else`/default
+   path runs because `_is_calendar_based_mode` is `False` on the
+   `self.calendar is not None` clause, even though `bistate_mode` defaults to
+   `"bistate_mode_auto"`), `_make_constraint(device, time, target_s, current_s,
+   start, end)` (builds a real `TimeBasedSimplePowerLoadConstraint`;
+   `initial_end_of_constraint` is set to `end` by the ctor), and
+   `_set_day_boundaries(device, today_utc, tomorrow_utc)`. Mirror the field
+   shapes of `test_default_mode_includes_overnight_active_constraint` (line 775)
+   and `test_default_mode_lcc_rollover_not_double_counted_with_overnight_active`
+   (line 1050). Use real `TimeBasedSimplePowerLoadConstraint` objects (no
+   MagicMock for domain objects).
+   - `test_default_mode_nonmidnight_finish_lcc_not_double_counted_with_running_overnight`
+     (AC1): `now = datetime(2026, 3, 30, 9, 0, tzinfo=pytz.UTC)`;
+     `today_utc = 2026-03-30 00:00 UTC`, `tomorrow_utc = 2026-03-31 00:00 UTC`;
+     `overnight_ct = _make_constraint(..., target_s=10800, current_s=1440,
+     start=datetime(2026,3,30,2,0,tzinfo=UTC),
+     end=datetime(2026,3,31,6,30,tzinfo=UTC))` (start before `now` so
+     `current_start_of_constraint <= time` and the helper returns it — assert
+     `device._overnight_active_constraint(now, tomorrow_utc) is overnight_ct` to
+     lock this in); `lcc = _make_constraint(..., target_s=10800, current_s=10800,
+     start=datetime(2026,3,30,3,30,tzinfo=UTC),
+     end=datetime(2026,3,30,6,30,tzinfo=UTC))`; `device._constraints =
+     [overnight_ct]`, `device._last_completed_constraint = lcc`. Assert
+     `on_h == approx(0.4)`, `duration_h == approx(3.0)`.
+   - `test_default_mode_nonmidnight_finish_lcc_kept_when_no_overnight` (AC4):
+     same `now`/boundaries; `device._constraints = []`; `lcc` ends
+     `datetime(2026,3,30,6,30,tzinfo=UTC)` with `target_s=10800,
+     current_s=10800`. Assert `device._overnight_active_constraint(now,
+     tomorrow_utc) is None`, `on_h == approx(3.0)`, `duration_h == approx(3.0)`.
+   - Confirm AC2 (line 310), AC3 (line 1050), AC5 (lines 610/725), AC6 (lines
+     371/346) stay green.
+
+2. **Implement — green.** In `bistate_duration.py::update_current_metrics`
+   default/pool `else` branch, add `and overnight_ct is None` as the **second**
+   clause of `use_lcc` (lines 340-344). Update the adjacent comment (lines
+   326-333) to state the invariant in sentence case, American English,
+   explaining *why*: an lcc that ended earlier today while an overnight active
+   cycle is running is the **previous day's cycle** of this single-daily-cycle
+   load and must not be re-summed (QS-247) — symmetric with the
+   `lcc.end == today_utc` / `has_today_content` branch. Do **not** touch the
+   `lcc.end == today_utc` branch, the overnight `if overnight_ct is not None`
+   block, the calendar path, the user-override short-circuit, `const.py`, or the
+   card JS.
+
+3. **Docs.** Update `docs/agents/concepts/bistate-duration-devices.md`
+   "Common mistakes" lcc bullet (the `today_utc < lcc.end <= tomorrow_utc`
+   sub-bullet, lines 212-214): append that this case must also drop the lcc when
+   an **overnight active constraint is running** — the just-completed
+   non-midnight cycle is then the previous day's cycle and would otherwise be
+   counted on top of today's running cycle (QS-247). Keep the delta to that one
+   sub-bullet. **Bump `last_verified` to 2026-06-01** (required — `check_doc_drift.py`
+   reports this file stale because its `covers:` includes
+   `custom_components/quiet_solar/ha_model/bistate_duration.py`).
+
+4. **Quality gate.** `source venv/bin/activate` first. TDD loop:
+   `python scripts/qs/quality_gate.py --quick tests/test_bug_78_daily_metrics.py`
+   (red → green). Before commit, full gate:
+   `python scripts/qs/quality_gate.py` (pytest 100% cov + ruff + mypy +
+   translations). Do **not** use raw `pytest tests/`.
+
+## Scope / risk
+
+- Edit confined to **one boolean clause + one comment** in the default/pool
+  `else` branch of `update_current_metrics`, two new tests in
+  `tests/test_bug_78_daily_metrics.py`, and one doc sub-bullet + `last_verified`
+  bump.
+- `update_current_metrics` feeds **every** bistate-duration device's ring (pool,
+  on/off, water boiler, climate, radiator). Risk is regressing the retained-lcc
+  cases — guarded by AC2 (intra-day multi-segment) and AC5/AC6 (absorb / MAX /
+  yesterday exclusions), all already-green existing tests.
+- The midnight branch, calendar path, `_overnight_active_constraint` helper,
+  `const.py`, and the card JS are untouched.
+- No new config keys, no harness-sync requirement (the doc is under
+  `docs/agents/`, not a `.claude`/`.cursor`/`.opencode` agent file).
+
+`Doc-OK:` not applicable — `bistate-duration-devices.md` is updated in Task 3
+(drift-mandated).
+
+## Adversarial review notes
+
+Four reviewers ran in parallel (critic, scope-guardian, concrete-planner,
+dev-proxy). Dispositions:
+
+- **[critical] AC4 "idle gap" defect waved away by a timing assumption**
+  (critic): **partially accepted.** Reframed — the `overnight_ct` gate is
+  *self-correcting*, so the misleading **growing/overfull** ring is fully
+  eliminated; only a benign **full** `3.0h/3h` ring can remain during the
+  few-second idle window. Documented in "Fix" and pinned by AC4. A full
+  window-reframe is deliberately out of scope (user wants minimal, accepts this
+  residual).
+- **[redesign] Patches a symptom, not the window-framing root cause; risks a
+  4th special case** (critic): **redesign rejected, documentation accepted.**
+  The fix *completes* the overnight-awareness symmetry the midnight branch
+  already established (same `overnight_ct`/`has_today_content` rule applied to
+  the in-window-lcc branch), not a new ad-hoc case. Rationale documented.
+- **[redesign] No identity check that lcc and `overnight_ct` are the same
+  recurring cycle → could under-count** (critic): **accepted as justification.**
+  Default/pool is single-daily-cycle by construction (sequential, non-overlapping
+  constraints — QS-245 invariant), so lcc and `overnight_ct` are consecutive
+  cycles and can never co-exist as two same-day cycles. Documented in "Fix".
+- **[improve] AC numbers must assert the run/duration decomposition** (critic):
+  **accepted** — AC1/AC4 now state which constraint contributes to each scalar.
+- **[improve] Prove both branches of the new clause are covered; short-circuit
+  order** (critic, dev-proxy): **accepted** — added the Coverage map and fixed
+  the clause position (second, after `not already_absorbed`, which is True in
+  both new tests).
+- **[improve] Test 2 may be redundant** (scope-guardian): **kept, justified** —
+  concrete-planner confirmed `_constraints=[]` exercises a distinct path (empty
+  `already_absorbed` iteration + `overnight_ct is None` True) and it encodes the
+  user-requested AC4 decision.
+- **[improve] `bistate_mode` default is `auto`; the `else` path runs because no
+  calendar is attached** (concrete-planner): **accepted** — Task 1 states the
+  correct reason (`self.calendar is None`), not "non-calendar mode".
+- **[clarify] Inline #101 AC3 / #95 contracts; quote the current `use_lcc`
+  verbatim; specify exact comment + doc text; pin exact `start_of_constraint`
+  datetimes for non-flaky tests; define what makes `overnight_ct` non-None**
+  (critic, dev-proxy, concrete-planner): **all accepted** — folded into "Why the
+  existing guards miss it", "Fix" (verbatim before/after), Task 1 (concrete
+  datetimes + `is overnight_ct` assertion), Task 2 (comment spec), Task 3 (doc
+  spec).
+- **[clarify] Confirm the doc update is drift-mandated and minimal**
+  (scope-guardian, dev-proxy): **accepted** — `check_doc_drift.py` reports the
+  file stale (its `covers:` lists `bistate_duration.py`); delta kept to one
+  sub-bullet + `last_verified` bump.
+
+Scope-guardian found **no** YAGNI/gold-plating violations beyond the
+(retained, justified) second test; no scope creep into `const.py`, the card, or
+the calendar path. Concrete-planner verified every referenced path, function,
+and line against the worktree and confirmed the bug-scenario test is a true
+red→green.

--- a/tests/test_bug_78_daily_metrics.py
+++ b/tests/test_bug_78_daily_metrics.py
@@ -1148,3 +1148,87 @@ async def test_overnight_targetless_constraint_excluded():
 
     assert device.qs_bistate_current_duration_h == pytest.approx(0.0)
     assert device.qs_bistate_current_on_h == pytest.approx(0.0)
+
+
+async def test_default_mode_nonmidnight_finish_lcc_not_double_counted_with_running_overnight():
+    """QS-247 (AC1): non-midnight finish-time rollover with a running overnight cycle.
+
+    The lcc completed this morning at a non-midnight finish time (today 06:30),
+    so it sits strictly inside the today window (not "yesterday" by the midnight
+    frame). Today's new cycle is already running and finishes overnight
+    (tomorrow 06:30), so ``_overnight_active_constraint`` returns it. The
+    just-completed prior overnight cycle (lcc) must be dropped — otherwise it is
+    counted on top of today's growing run, producing the reported growing /
+    overfull ring (3.4h/3h -> 4.4h/3h). Only ``overnight_ct`` contributes.
+    """
+    device = _create_bistate_device()
+    now = datetime(2026, 3, 30, 9, 0, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    # Today's new cycle: started 02:00 today (before now -> active), ends
+    # tomorrow 06:30 (overnight, out of window). 3h target, 0.4h run so far.
+    overnight_ct = _make_constraint(
+        device,
+        now,
+        target_s=10800.0,
+        current_s=1440.0,
+        start=datetime(2026, 3, 30, 2, 0, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 31, 6, 30, 0, tzinfo=pytz.UTC),
+    )
+    # Yesterday's overnight cycle, completed this morning at 06:30 (in-window).
+    lcc = _make_constraint(
+        device,
+        now,
+        target_s=10800.0,
+        current_s=10800.0,
+        start=datetime(2026, 3, 30, 3, 30, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 30, 6, 30, 0, tzinfo=pytz.UTC),
+    )
+    device._constraints = [overnight_ct]
+    device._last_completed_constraint = lcc
+
+    # Lock in that the helper surfaces the running overnight cycle.
+    assert device._overnight_active_constraint(now, tomorrow_utc) is overnight_ct
+
+    await device.update_current_metrics(now)
+
+    # Only overnight_ct contributes; lcc (yesterday's cycle) is dropped.
+    assert device.qs_bistate_current_on_h == pytest.approx(0.4)
+    assert device.qs_bistate_current_duration_h == pytest.approx(3.0)
+
+
+async def test_default_mode_nonmidnight_finish_lcc_kept_when_no_overnight():
+    """QS-247 (AC4): idle gap — lcc retained as a benign full ring.
+
+    In the brief window after the 06:30 completion and before the new cycle
+    starts running, ``_constraints`` is empty so ``overnight_ct is None``. The
+    just-finished cycle's lcc (today 06:30, 3.0h/3h) is retained: a full, never
+    overfull ring. This pins the ``overnight_ct is None`` True branch and
+    documents the accepted residual behaviour.
+    """
+    device = _create_bistate_device()
+    now = datetime(2026, 3, 30, 9, 0, 0, tzinfo=pytz.UTC)
+    today_utc = datetime(2026, 3, 30, 0, 0, 0, tzinfo=pytz.UTC)
+    tomorrow_utc = datetime(2026, 3, 31, 0, 0, 0, tzinfo=pytz.UTC)
+    _set_day_boundaries(device, today_utc, tomorrow_utc)
+
+    lcc = _make_constraint(
+        device,
+        now,
+        target_s=10800.0,
+        current_s=10800.0,
+        start=datetime(2026, 3, 30, 3, 30, 0, tzinfo=pytz.UTC),
+        end=datetime(2026, 3, 30, 6, 30, 0, tzinfo=pytz.UTC),
+    )
+    device._constraints = []
+    device._last_completed_constraint = lcc
+
+    assert device._overnight_active_constraint(now, tomorrow_utc) is None
+
+    await device.update_current_metrics(now)
+
+    # No running overnight cycle -> the completed cycle's full ring is shown.
+    assert device.qs_bistate_current_on_h == pytest.approx(3.0)
+    assert device.qs_bistate_current_duration_h == pytest.approx(3.0)


### PR DESCRIPTION
## Summary
Two new tests (AC1 red->green, AC4 idle-gap full ring) + doc note in bistate-duration-devices.md. Full quality gate green (100% cov, ruff, mypy, translations).

Fixes #247

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a daily metrics calculation issue that resulted in inflated readings when overnight cycles were active. The fix prevents incorrect duplicate counting of completed cycles, ensuring accurate and reliable duration tracking and target metrics throughout the day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->