### PR TITLE
QS-248: Enable native pyright LSP in the Claude harness

### DIFF
--- a/.claude/agents/qs-create-plan.md
+++ b/.claude/agents/qs-create-plan.md
@@ -6,7 +6,7 @@ description: >-
   sub-agents, then commits the story. Runs inside the worktree after
   /setup-task. Use when the user says "create plan" or "plan this
   issue".
-tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch
+tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch, LSP
 ---
 
 # qs-create-plan — story drafting + adversarial review

--- a/.claude/agents/qs-implement-setup-task.md
+++ b/.claude/agents/qs-implement-setup-task.md
@@ -6,7 +6,7 @@ description: >-
   config). Same TDD flow as qs-implement-task but narrower edit scope
   and the fast-path quality gate. Use when /create-plan selected
   implement-setup-task as the next phase.
-tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch
+tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch, LSP
 ---
 
 # qs-implement-setup-task — TDD implementation (dev-env scope)

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -5,7 +5,7 @@ description: >-
   custom_components/quiet_solar/, must pass the full quality gate,
   opens a PR. Use when the user says "implement task" or "implement
   story" inside a worktree.
-tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch
+tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch, LSP
 ---
 
 # qs-implement-task — TDD implementation (production code scope)

--- a/.claude/agents/qs-plan-concrete-planner.md
+++ b/.claude/agents/qs-plan-concrete-planner.md
@@ -5,7 +5,7 @@ description: >-
   verifies the plan translates to concrete diffs (exact paths,
   functions, test specs). Spawned in parallel by qs-create-plan. Use
   only when explicitly invoked by qs-create-plan.
-tools: Read, Glob, Grep
+tools: Read, Glob, Grep, LSP
 ---
 
 # qs-plan-concrete-planner — file-level concreteness review

--- a/.claude/agents/qs-review-acceptance-auditor.md
+++ b/.claude/agents/qs-review-acceptance-auditor.md
@@ -5,7 +5,7 @@ description: >-
   in the story is implemented AND tested by the PR. Builds a
   traceability matrix. Spawned in parallel by qs-review-task. Use only
   when explicitly invoked by qs-review-task.
-tools: Bash, Read, Grep, Glob
+tools: Bash, Read, Grep, Glob, LSP
 ---
 
 # qs-review-acceptance-auditor — AC traceability

--- a/.claude/agents/qs-review-edge-case-hunter.md
+++ b/.claude/agents/qs-review-edge-case-hunter.md
@@ -5,7 +5,7 @@ description: >-
   boundary in the PR. Flags ONLY unhandled edge cases. Spawned in
   parallel by qs-review-task. Use only when explicitly invoked by
   qs-review-task.
-tools: Bash, Read, Grep, Glob
+tools: Bash, Read, Grep, Glob, LSP
 ---
 
 # qs-review-edge-case-hunter — exhaustive boundary review

--- a/.claude/agents/qs-review-task.md
+++ b/.claude/agents/qs-review-task.md
@@ -6,7 +6,7 @@ description: >-
   consolidates findings, drives interactive triage, and emits a fix
   plan or routes the user to /finish-task. Use when the user says
   "review task" or "review PR".
-tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite
+tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, LSP
 ---
 
 # qs-review-task — orchestrator (does not review code itself)

--- a/.claude/agents/qs-setup-task.md
+++ b/.claude/agents/qs-setup-task.md
@@ -6,7 +6,7 @@ description: >-
   session on the worktree. Runs on the main checkout. Use when the user
   says "setup task", "new task", "work on issue #N", or describes a new
   feature to start.
-tools: Bash, Read, Glob, Grep
+tools: Bash, Read, Glob, Grep, LSP
 ---
 
 # qs-setup-task — entry point (runs on main)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,9 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "_comment": "Shared Claude Code permissions for the Quiet Solar pipeline. Per-user overrides live in settings.local.json.",
   "autoMemoryEnabled": false,
+  "enabledPlugins": {
+    "pyright-lsp@claude-plugins-official": true
+  },
   "permissions": {
     "allow": [
       "Bash(python scripts/qs/setup_task.py:*)",

--- a/.cursor/agents/qs-create-plan.md
+++ b/.cursor/agents/qs-create-plan.md
@@ -136,6 +136,17 @@ Select qs-{{NEXT_PHASE}} from the Cursor agent picker, then paste:
   {{new_context}}
 ```
 
+## Code intelligence (LSP)
+
+Cursor provides editor-native LSP (2.4+): pyright diagnostics,
+go-to-definition, find-references, and hover types are surfaced
+in-session by the editor itself, not as a separate agent tool. There is
+nothing to enable in this agent file — type errors and navigation are
+ambient as you read and edit. The Claude twin wires an explicit `LSP`
+tool over the same pyright backend; Cursor's equivalent is implicit, so
+no `tools:` change is needed here. See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - Do not write code in this phase. Edit scope = the story file only.

--- a/.cursor/agents/qs-implement-setup-task.md
+++ b/.cursor/agents/qs-implement-setup-task.md
@@ -142,6 +142,17 @@ Select qs-review-task from the Cursor agent picker, then paste:
   {{new_context}}
 ```
 
+## Code intelligence (LSP)
+
+Cursor provides editor-native LSP (2.4+): pyright diagnostics,
+go-to-definition, find-references, and hover types are surfaced
+in-session by the editor itself, not as a separate agent tool. There is
+nothing to enable in this agent file — type errors and navigation are
+ambient as you read and edit. The Claude twin wires an explicit `LSP`
+tool over the same pyright backend; Cursor's equivalent is implicit, so
+no `tools:` change is needed here. See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - Edit scope is **strictly** dev-environment paths. If you find yourself

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -152,6 +152,17 @@ Select qs-review-task from the Cursor agent picker, then paste:
   {{new_context}}
 ```
 
+## Code intelligence (LSP)
+
+Cursor provides editor-native LSP (2.4+): pyright diagnostics,
+go-to-definition, find-references, and hover types are surfaced
+in-session by the editor itself, not as a separate agent tool. There is
+nothing to enable in this agent file — type errors and navigation are
+ambient as you read and edit. The Claude twin wires an explicit `LSP`
+tool over the same pyright backend; Cursor's equivalent is implicit, so
+no `tools:` change is needed here. See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - No code without a failing test first.

--- a/.cursor/agents/qs-plan-concrete-planner.md
+++ b/.cursor/agents/qs-plan-concrete-planner.md
@@ -58,6 +58,17 @@ For each task in the plan, evaluate:
 - ...
 ```
 
+## Code intelligence (LSP)
+
+Cursor provides editor-native LSP (2.4+): pyright diagnostics,
+go-to-definition, find-references, and hover types are surfaced
+in-session by the editor itself, not as a separate agent tool. There is
+nothing to enable in this agent file — type errors and navigation are
+ambient as you read and edit. The Claude twin wires an explicit `LSP`
+tool over the same pyright backend; Cursor's equivalent is implicit, so
+no `tools:` change is needed here. See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - NEVER run `Bash`. You're read-only.

--- a/.cursor/agents/qs-review-acceptance-auditor.md
+++ b/.cursor/agents/qs-review-acceptance-auditor.md
@@ -60,6 +60,17 @@ prompt.
   for the failure case described in the AC.
 ```
 
+## Code intelligence (LSP)
+
+Cursor provides editor-native LSP (2.4+): pyright diagnostics,
+go-to-definition, find-references, and hover types are surfaced
+in-session by the editor itself, not as a separate agent tool. There is
+nothing to enable in this agent file — type errors and navigation are
+ambient as you read and edit. The Claude twin wires an explicit `LSP`
+tool over the same pyright backend; Cursor's equivalent is implicit, so
+no `tools:` change is needed here. See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - Your sole authority is the story file + the PR diff. Don't read

--- a/.cursor/agents/qs-review-edge-case-hunter.md
+++ b/.cursor/agents/qs-review-edge-case-hunter.md
@@ -58,6 +58,17 @@ for related call sites.
 - ...
 ```
 
+## Code intelligence (LSP)
+
+Cursor provides editor-native LSP (2.4+): pyright diagnostics,
+go-to-definition, find-references, and hover types are surfaced
+in-session by the editor itself, not as a separate agent tool. There is
+nothing to enable in this agent file — type errors and navigation are
+ambient as you read and edit. The Claude twin wires an explicit `LSP`
+tool over the same pyright backend; Cursor's equivalent is implicit, so
+no `tools:` change is needed here. See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - NEVER duplicate findings that belong to `qs-review-blind-hunter`

--- a/.cursor/agents/qs-review-task.md
+++ b/.cursor/agents/qs-review-task.md
@@ -225,6 +225,17 @@ Then re-run qs-review-task to verify.
 When the user returns after applying fixes (a new push has landed),
 loop back to step 1. Repeat until no must-fix/should-fix remains.
 
+## Code intelligence (LSP)
+
+Cursor provides editor-native LSP (2.4+): pyright diagnostics,
+go-to-definition, find-references, and hover types are surfaced
+in-session by the editor itself, not as a separate agent tool. There is
+nothing to enable in this agent file — type errors and navigation are
+ambient as you read and edit. The Claude twin wires an explicit `LSP`
+tool over the same pyright backend; Cursor's equivalent is implicit, so
+no `tools:` change is needed here. See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - You are an orchestrator. NEVER review code yourself. Always delegate

--- a/.cursor/agents/qs-setup-task.md
+++ b/.cursor/agents/qs-setup-task.md
@@ -88,6 +88,17 @@ from the agent picker, then paste:
 Do NOT attempt to spawn the next agent in this session — the ergonomic
 flow is one session per phase.
 
+## Code intelligence (LSP)
+
+Cursor provides editor-native LSP (2.4+): pyright diagnostics,
+go-to-definition, find-references, and hover types are surfaced
+in-session by the editor itself, not as a separate agent tool. There is
+nothing to enable in this agent file — type errors and navigation are
+ambient as you read and edit. The Claude twin wires an explicit `LSP`
+tool over the same pyright backend; Cursor's equivalent is implicit, so
+no `tools:` change is needed here. See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - Do NOT analyze the input. The launcher must come within a few seconds.

--- a/.opencode/agents/qs-create-plan.md
+++ b/.opencode/agents/qs-create-plan.md
@@ -210,6 +210,17 @@ Parse the stdout of that command as JSON. The success contract is
   ``fallback_unavailable``, ``session_orphaned`` — each documented in
   ``scripts/qs/spawn_session.py``).
 
+## Code intelligence (LSP)
+
+OpenCode defaults to pyright (`"lsp": true` in `opencode.json`) but, per
+opencode.ai/docs/lsp, exposes LSP to the agent **only as diagnostics** —
+no go-to-definition / find-references navigation. Because navigation is
+the larger ergonomics win and the diagnostics-only mode is not worth
+dedicated wiring, LSP is intentionally **not** enabled for this agent;
+use grep/glob for code navigation here. The Claude twin carries an
+explicit `LSP` tool (diagnostics + navigation). See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - Do not write code in this phase. Edit scope = the story file only.

--- a/.opencode/agents/qs-implement-setup-task.md
+++ b/.opencode/agents/qs-implement-setup-task.md
@@ -236,6 +236,17 @@ Parse the stdout of that command as JSON. The success contract is
   ``fallback_unavailable``, ``session_orphaned`` — each documented in
   ``scripts/qs/spawn_session.py``).
 
+## Code intelligence (LSP)
+
+OpenCode defaults to pyright (`"lsp": true` in `opencode.json`) but, per
+opencode.ai/docs/lsp, exposes LSP to the agent **only as diagnostics** —
+no go-to-definition / find-references navigation. Because navigation is
+the larger ergonomics win and the diagnostics-only mode is not worth
+dedicated wiring, LSP is intentionally **not** enabled for this agent;
+use grep/glob for code navigation here. The Claude twin carries an
+explicit `LSP` tool (diagnostics + navigation). See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - Edit scope is **strictly** dev-environment paths. If you find yourself

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -229,6 +229,17 @@ Parse the stdout of that command as JSON. The success contract is
   ``fallback_unavailable``, ``session_orphaned`` — each documented in
   ``scripts/qs/spawn_session.py``).
 
+## Code intelligence (LSP)
+
+OpenCode defaults to pyright (`"lsp": true` in `opencode.json`) but, per
+opencode.ai/docs/lsp, exposes LSP to the agent **only as diagnostics** —
+no go-to-definition / find-references navigation. Because navigation is
+the larger ergonomics win and the diagnostics-only mode is not worth
+dedicated wiring, LSP is intentionally **not** enabled for this agent;
+use grep/glob for code navigation here. The Claude twin carries an
+explicit `LSP` tool (diagnostics + navigation). See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - No code without a failing test first.

--- a/.opencode/agents/qs-plan-concrete-planner.md
+++ b/.opencode/agents/qs-plan-concrete-planner.md
@@ -69,6 +69,17 @@ For each task in the plan, evaluate:
 - ...
 ```
 
+## Code intelligence (LSP)
+
+OpenCode defaults to pyright (`"lsp": true` in `opencode.json`) but, per
+opencode.ai/docs/lsp, exposes LSP to the agent **only as diagnostics** —
+no go-to-definition / find-references navigation. Because navigation is
+the larger ergonomics win and the diagnostics-only mode is not worth
+dedicated wiring, LSP is intentionally **not** enabled for this agent;
+use grep/glob for code navigation here. The Claude twin carries an
+explicit `LSP` tool (diagnostics + navigation). See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - NEVER run `Bash` beyond the read-only `grep`/`rg`/`ls`/`wc` allowlist.

--- a/.opencode/agents/qs-review-acceptance-auditor.md
+++ b/.opencode/agents/qs-review-acceptance-auditor.md
@@ -101,6 +101,17 @@ prompt.
   for the failure case described in the AC.
 ```
 
+## Code intelligence (LSP)
+
+OpenCode defaults to pyright (`"lsp": true` in `opencode.json`) but, per
+opencode.ai/docs/lsp, exposes LSP to the agent **only as diagnostics** —
+no go-to-definition / find-references navigation. Because navigation is
+the larger ergonomics win and the diagnostics-only mode is not worth
+dedicated wiring, LSP is intentionally **not** enabled for this agent;
+use grep/glob for code navigation here. The Claude twin carries an
+explicit `LSP` tool (diagnostics + navigation). See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - Your sole authority is the story file + the PR diff. Don't read

--- a/.opencode/agents/qs-review-edge-case-hunter.md
+++ b/.opencode/agents/qs-review-edge-case-hunter.md
@@ -91,6 +91,17 @@ for related call sites.
 - ...
 ```
 
+## Code intelligence (LSP)
+
+OpenCode defaults to pyright (`"lsp": true` in `opencode.json`) but, per
+opencode.ai/docs/lsp, exposes LSP to the agent **only as diagnostics** —
+no go-to-definition / find-references navigation. Because navigation is
+the larger ergonomics win and the diagnostics-only mode is not worth
+dedicated wiring, LSP is intentionally **not** enabled for this agent;
+use grep/glob for code navigation here. The Claude twin carries an
+explicit `LSP` tool (diagnostics + navigation). See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - NEVER duplicate findings that belong to `qs-review-blind-hunter`

--- a/.opencode/agents/qs-review-task.md
+++ b/.opencode/agents/qs-review-task.md
@@ -345,6 +345,17 @@ Parse the stdout of that command as JSON. The success contract is
 When the user returns after applying fixes (a new push has landed),
 loop back to step 1. Repeat until no must-fix/should-fix remains.
 
+## Code intelligence (LSP)
+
+OpenCode defaults to pyright (`"lsp": true` in `opencode.json`) but, per
+opencode.ai/docs/lsp, exposes LSP to the agent **only as diagnostics** —
+no go-to-definition / find-references navigation. Because navigation is
+the larger ergonomics win and the diagnostics-only mode is not worth
+dedicated wiring, LSP is intentionally **not** enabled for this agent;
+use grep/glob for code navigation here. The Claude twin carries an
+explicit `LSP` tool (diagnostics + navigation). See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - You are an orchestrator. NEVER review code yourself. Always delegate

--- a/.opencode/agents/qs-setup-task.md
+++ b/.opencode/agents/qs-setup-task.md
@@ -143,6 +143,17 @@ flow is one session per phase. OpenCode's HTTP-API
 `spawn_session.py` one-liner is the in-band activation path; the agent
 picker is the manual one.
 
+## Code intelligence (LSP)
+
+OpenCode defaults to pyright (`"lsp": true` in `opencode.json`) but, per
+opencode.ai/docs/lsp, exposes LSP to the agent **only as diagnostics** —
+no go-to-definition / find-references navigation. Because navigation is
+the larger ergonomics win and the diagnostics-only mode is not worth
+dedicated wiring, LSP is intentionally **not** enabled for this agent;
+use grep/glob for code navigation here. The Claude twin carries an
+explicit `LSP` tool (diagnostics + navigation). See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
 ## Hard rules
 
 - Do NOT analyze the input. The launcher must come within a few seconds.

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -95,7 +95,8 @@ docs covering it before you write the change.
 
 - [glossary.md](glossary.md) — ~40 domain terms.
 - [lsp-evaluation.md](lsp-evaluation.md) — should agents pair with a
-  Python LSP server? (Decision: defer.)
+  Python LSP server? (Decision: adopt native pyright in the Claude
+  harness; OpenCode diagnostics-only, Cursor TBD.)
 - [../workflow/project-rules.md](../workflow/project-rules.md) —
   the quality-gate rules and the "Doc maintenance" subsection.
 - [../workflow/project-context.md](../workflow/project-context.md)

--- a/docs/agents/lsp-evaluation.md
+++ b/docs/agents/lsp-evaluation.md
@@ -85,7 +85,7 @@ forbids reading the codebase / the repo) and the merge/release agents
 | `qs-plan-concrete-planner` | ✅ | Reads file tree + source snippets to verify diffs |
 | `qs-review-edge-case-hunter` | ✅ | Walks branching paths in the PR source |
 | `qs-review-acceptance-auditor` | ✅ | Builds a traceability matrix over source |
-| `qs-setup-task` | ✅ | Globs/reads code to scope a new issue |
+| `qs-setup-task` | ✅ | Carries `LSP` for capability parity with the other code-reading agents — but see the note below |
 | `qs-plan-critic` | ❌ | **Blind** — reviews plan text only |
 | `qs-plan-dev-proxy` | ❌ | **Blind** — never reads source |
 | `qs-plan-scope-guardian` | ❌ | **Blind** — plan + issue only |
@@ -94,9 +94,18 @@ forbids reading the codebase / the repo) and the merge/release agents
 | `qs-finish-task` | ❌ | Merge / cleanup only |
 | `qs-release` | ❌ | Version bump / tag only |
 
+> **`qs-setup-task` caveat.** This agent's hard rule is "do NOT analyze
+> the input; the launcher must come within a few seconds." It carries
+> `LSP` only for **capability parity** with the other code-reading
+> agents (and for the rare case where a session lingers past the
+> launcher) — it is **not** expected to exercise LSP on the
+> fast-launcher path. No tension with the hard rule: the tool is
+> available but unused during the few-second launch.
+
 A pin test (`tests/qs/agents/test_lsp_tool_enabled.py`) asserts **both**
-the include set and the exclude set, so granting `LSP` to a blind
-reviewer can't slip in silently.
+the include set and the exclude set (and that they partition every agent
+on disk), so granting `LSP` to a blind reviewer — or adding a new agent
+that escapes the split — can't slip in silently.
 
 ## Prerequisite: install pyright (manual, per-machine)
 

--- a/docs/agents/lsp-evaluation.md
+++ b/docs/agents/lsp-evaluation.md
@@ -2,126 +2,204 @@
 title: LSP evaluation
 slug: lsp-evaluation
 kind: principle
-last_verified: 2026-05-19
+last_verified: 2026-06-01
 ---
 
 # LSP evaluation — should agents pair with a Python language server?
+
+## Decision (2026-06-01): adopt native pyright in the Claude harness
+
+**Enabled for Claude.** The Claude Code agents now use the built-in
+`LSP` tool backed by the official `pyright-lsp` plugin. This supersedes
+the previous "defer + build a jedi-via-MCP server" recommendation
+(see [the rebuttal](#why-native-pyright-now-beats-the-old-jedi--mcp-plan)).
+
+- **Claude Code** — adopted. The `pyright-lsp` plugin is enabled at
+  project scope in `.claude/settings.json`
+  (`enabledPlugins["pyright-lsp@claude-plugins-official"] = true`), and
+  the `LSP` tool is added to the closed `tools:` allowlist of the 8
+  code-navigating agents.
+- **OpenCode** — **not enabled.** OpenCode defaults to pyright
+  (`"lsp": true` in `opencode.json`) but exposes LSP to the agent only
+  as diagnostics — no navigation. Not worth wiring now.
+- **Cursor** — **TBD / deferred.** Cursor (2.4+) has editor-native LSP
+  that surfaces ambiently in-session; there is no separate agent tool to
+  enable, and no decision is forced.
 
 ## Problem statement
 
 When a plan, implement, or review agent needs symbol-level information
 about the codebase — "find all callers of `Battery.charge`", "what's
 the return type of `LoadConstraint.score`", "where is `SOLVER_STEP_S`
-referenced?" — its only tools today are `grep`, `glob`, and reading
-whole files. The token cost is significant: a `grep` for `SOLVER_STEP_S`
-returns ~20 lines of context per match; reading even a moderate file
-like `home_model/solver.py` (1,683 LOC) burns roughly 35k tokens; a
-broad grep across `custom_components/quiet_solar/` consumes O(50k)
-tokens for a single lookup. A Python LSP server, by contrast, returns
-**structured** answers (definition location, call sites, type) in
-hundreds of bytes — two orders of magnitude cheaper.
+referenced?" — its baseline tools are `grep`, `glob`, and reading whole
+files. The token cost is significant: a broad `grep` returns many lines
+of context per match; reading even a moderate file like
+`home_model/solver.py` (~1,700 LOC) burns tens of thousands of tokens.
+A language server returns **structured** answers (definition location,
+call sites, type) in hundreds of bytes — often two orders of magnitude
+cheaper for the dynamic queries grep is worst at.
 
-This document evaluates whether the cost of installing, running, and
-wiring an LSP into the agent harness is worth that token savings —
-and, if so, which LSP and which integration mechanism.
+This document records what native LSP brings to the harness, why it now
+beats the prior build-it-ourselves plan, and how the wiring works.
 
-## Three Python LSP options
+## Per-harness capability matrix
 
-| LSP | Install footprint | Query latency | Output verbosity | Strengths | Weaknesses |
-|---|---|---|---|---|---|
-| **pyright** (Microsoft) | npm package, ~50MB | <100ms typical | Verbose, structured JSON | Best type inference of the three; well-maintained; understands modern Python (3.13+) including `from __future__ import annotations`. | Node.js runtime dependency; not Python-native. |
-| **jedi-language-server** | Single `pip install` (~30MB with deps) | <50ms for symbol lookup | Compact LSP-spec responses | Pure-Python; understands quiet-solar's `numpy`/`scipy` stack via Jedi's type-stub bundling; no Node dependency. | Weaker type inference than pyright; struggles with complex generics. |
-| **pylsp** (Palantir/python-lsp) | `pip install python-lsp-server` + plugins | ~75ms typical | Variable per plugin | Plugin ecosystem (rope, pylint integration, etc.); the most extensible option. | Configuration burden; plugins have overlapping/conflicting behaviour. |
-
-## Three consumption mechanisms for an agent
-
-| Mechanism | Setup cost | Per-call cost | Privacy | Notes |
+| Harness | LSP backend | Diagnostics (type errors, missing imports) | Navigation (defs, refs, hover, symbols, impls, call hierarchy) | Status here |
 |---|---|---|---|---|
-| **MCP server wrapper** (Model Context Protocol) | One-time MCP server scaffold (~1 day eng); restart the harness to pick it up. | Single JSON-RPC round trip. | LSP stays local — no data leaves the machine. | Best long-term: works across Claude / Cursor / OpenCode / Codex harnesses, matching the multi-harness story (QS-184). |
-| **Direct subprocess via Bash tool** | Zero — `pyright --outputjson <symbol>` is callable from the existing Bash tool. | Per-call subprocess spawn (~200ms overhead). | Local. | Cheapest to prototype; awkward for repeated queries in one session. |
-| **Custom Claude Code / Cursor tool** | Per-harness tool implementation. | Native tool call. | Local. | Most ergonomic for the user (autocomplete, dedicated tool surface), but multiplies maintenance — one tool per harness. |
+| **Claude Code** | pyright (`pyright-lsp` plugin) | ✅ surfaced in-turn, before the quality gate | ✅ via the `LSP` tool | **Adopted** |
+| **OpenCode** | pyright (`opencode.json` `"lsp": true`) | ✅ diagnostics-only | ❌ not surfaced to the agent | Not enabled |
+| **Cursor** | editor-native (2.4+) | ✅ ambient in editor | ✅ ambient in editor | TBD / deferred |
 
-## Quantitative comparison on three sample agent queries
+The two Claude wins are distinct: **post-edit diagnostics** (type errors
+and missing imports surfaced in the same turn as the edit, catching
+mistakes before the quality gate runs) and **code navigation**
+(definitions, find-references, hover types, document/workspace symbols,
+implementations, call hierarchies).
 
-The numbers below are order-of-magnitude estimates from running the
-relevant `grep`/`glob` commands against the current repo (May 2026)
-and from the LSP-spec responses for the same queries. They are meant
-to anchor the recommendation, not to be precise benchmarks.
+## The `tools:` allowlist gate
 
-### Query 1 — "find all callers of `Battery.charge`"
+Every qs Claude agent declares a **closed** `tools:` allowlist (e.g.
+`tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch`).
+Per `code.claude.com/docs/en/sub-agents`, a `tools:` list is a strict
+**allowlist**: an agent gets *only* the listed tools (it inherits all
+tools *only* when the field is omitted). `LSP` is a gated tool, so
+**enabling the plugin is necessary but not sufficient** — `LSP` must
+appear on an agent's `tools:` line for that agent to use it. Because the
+auto post-edit diagnostics are a behavior *of the same `LSP` tool*, they
+also stay dormant until `LSP` is on the list.
 
-| Approach | Tokens | Wall-clock |
+### Which agents get `LSP`
+
+Principle: grant `LSP` to agents whose toolset already includes
+code-reading tools **and** whose role navigates the real codebase.
+Deliberately **exclude** the context-starved reviewers (whose design
+forbids reading the codebase / the repo) and the merge/release agents
+(no code navigation).
+
+| Agent | `LSP`? | Why |
 |---|---|---|
-| `grep -rn "\.charge(" custom_components/` then filter, then re-read context | ~3,500 (multiple file excerpts) | ~10s |
-| LSP `textDocument/references` | ~250 (file:line list) | <1s |
+| `qs-create-plan` | ✅ | Globs/reads code while planning |
+| `qs-implement-task` | ✅ | Edits code — post-edit diagnostics are the headline win |
+| `qs-implement-setup-task` | ✅ | Edits scripts/config — same diagnostics win |
+| `qs-review-task` | ✅ | Navigates code during consolidation |
+| `qs-plan-concrete-planner` | ✅ | Reads file tree + source snippets to verify diffs |
+| `qs-review-edge-case-hunter` | ✅ | Walks branching paths in the PR source |
+| `qs-review-acceptance-auditor` | ✅ | Builds a traceability matrix over source |
+| `qs-setup-task` | ✅ | Globs/reads code to scope a new issue |
+| `qs-plan-critic` | ❌ | **Blind** — reviews plan text only |
+| `qs-plan-dev-proxy` | ❌ | **Blind** — never reads source |
+| `qs-plan-scope-guardian` | ❌ | **Blind** — plan + issue only |
+| `qs-review-blind-hunter` | ❌ | **Blind** — diff only |
+| `qs-review-coderabbit` | ❌ | Pass-through wrapper; no code navigation |
+| `qs-finish-task` | ❌ | Merge / cleanup only |
+| `qs-release` | ❌ | Version bump / tag only |
 
-**Savings: ~14× tokens, ~10× wall-clock.**
+A pin test (`tests/qs/agents/test_lsp_tool_enabled.py`) asserts **both**
+the include set and the exclude set, so granting `LSP` to a blind
+reviewer can't slip in silently.
 
-### Query 2 — "list the type of `LoadConstraint.score`"
+## Prerequisite: install pyright (manual, per-machine)
 
-| Approach | Tokens | Wall-clock |
-|---|---|---|
-| Read `home_model/constraints.py` (2,683 LOC, ~55k tokens) and trace the attribute | ~55,000 | ~30s |
-| LSP `textDocument/hover` on `LoadConstraint.score` | ~150 (one signature + docstring) | <1s |
+The `pyright-lsp` plugin shells out to the `pyright-langserver` binary.
+Install it machine-level with npm:
 
-**Savings: ~360× tokens.**
+```bash
+npm install -g pyright
+```
 
-### Query 3 — "find references to `SOLVER_STEP_S`"
+This ships both `pyright` and `pyright-langserver` (confirmed in
+`code.claude.com/docs/en/plugins-reference`). **Not** via pip and
+**not** in the venv — the project's type-checker is **mypy**; pyright
+here is purely agent ergonomics and must not leak into
+`requirements*.txt`. The Claude Code process spawns the language server
+from its own login-shell PATH, so an npm-global binary is reliably
+visible; a venv `bin/` (only on PATH when activated) is not.
 
-| Approach | Tokens | Wall-clock |
-|---|---|---|
-| `grep -rn SOLVER_STEP_S custom_components/ tests/` | ~1,800 (~30 matches with context) | ~5s |
-| LSP `workspace/symbol` + `textDocument/references` | ~400 | <1s |
+### Graceful degradation
 
-**Savings: ~4× tokens.**
+The committed wiring degrades gracefully when `pyright-langserver` is
+absent: the `LSP` tool simply stays inactive and agents fall back to
+grep/glob. This is a documented Claude-side runtime expectation, not
+something this repo's tests assert.
 
-### Cumulative across a typical implement session
+### How to disable
 
-A typical implement-task session for a charger change runs 8–12 such
-queries. Estimated savings:
+- **One agent:** remove `LSP` from that agent's `tools:` line.
+- **Whole harness:** remove the
+  `"pyright-lsp@claude-plugins-official"` entry from `enabledPlugins`
+  in `.claude/settings.json` (or set it to `false`).
+- **Per machine:** uninstall the binary (`npm uninstall -g pyright`) —
+  the tool then degrades silently as above.
 
-- **Token cost reduction**: 20–40% of the implement-task session
-  (queries are not the dominant cost — code reading and writing
-  dominate — but they are still meaningful).
-- **Latency reduction**: cumulative ~30–60s per session.
+## Why native pyright now beats the old jedi + MCP plan
 
-## Recommendation
+The previous version of this doc recommended **defer**, and — if ever
+adopted — building a **jedi-language-server** wrapped in a custom **MCP
+server** for multi-harness reach. Two objections drove that plan:
+pyright's **Node-dependency** and the desire for a **single
+multi-harness** integration. Both are now outweighed:
 
-**Defer** — until at least one of the following unlocks:
+- **Zero-build native integration.** Claude Code ships the `LSP` tool
+  and an official `pyright-lsp` plugin. Adopting it is a two-line config
+  change (enable the plugin, add `LSP` to allowlists) versus ~1 day of
+  MCP-server scaffolding plus ongoing maintenance. The build cost the
+  old plan tried to justify no longer exists.
+- **The Node dependency is a one-line npm install**, isolated to the
+  developer's machine and explicitly kept out of the venv and
+  `requirements*.txt`. It does not touch the product runtime or CI.
+- **The "multi-harness MCP" argument is moot for the win we want.**
+  Cursor already has editor-native LSP; OpenCode already bundles
+  pyright. We are not blocked on a portable MCP layer to get value —
+  each harness provides its own. A custom MCP server would *duplicate*
+  capabilities the harnesses already ship.
+- **pyright's type inference is stronger than jedi's**, which matters
+  most for the diagnostics win (catching real type errors before the
+  gate) — the capability jedi was weakest at.
 
-1. **Token cost becomes the dominant constraint on agent throughput.**
-   Today, code generation and quality-gate iteration dominate cost.
-   Until lookups are >30% of session tokens, the LSP wiring is
-   premature optimisation.
-2. **A multi-harness MCP standard ships** that doesn't require us
-   to maintain a per-harness tool. The MCP path is the only one
-   that scales across Claude / Cursor / OpenCode / Codex without
-   parallel maintenance.
-3. **A reviewer agent shows it would catch defects** that the
-   current adversarial-review fan-out misses because the reviewers
-   can't trace symbol references at scale. Hypothetical today; no
-   evidence yet.
+The structural insight from the old doc still holds: the `docs/agents/`
+hierarchy answers *static* "what is a LoadCommand?" questions more
+cheaply than any LSP because the answer is pre-curated. The LSP pulls
+ahead for **dynamic** queries (call sites, type inference on arbitrary
+expressions) and for **post-edit diagnostics**, which docs can't
+provide.
 
-In the meantime, the `docs/agents/` hierarchy (created by QS-185)
-addresses the **same problem from a different angle**: agents pull
-small, scoped, addressable documentation files instead of grep-ing
-the whole codebase. This is structurally cheaper than even an LSP
-for the common queries ("what's a LoadCommand?") because the answer
-is pre-curated. The LSP only pulls ahead for **dynamic** queries
-(call sites, type inference on arbitrary expressions).
+## The issue's three questions, answered
 
-If the LSP becomes worth adopting, the path is:
+The originating issue (#248) asked three things:
 
-1. Install **jedi-language-server** locally (pure-Python, no Node).
-2. Wrap it in an **MCP server** that exposes `findReferences`,
-   `hover`, and `workspaceSymbols` to all harnesses uniformly.
-3. Add an opt-in note to `docs/workflow/overview.md` so agents
-   know the tool exists.
+1. **What does it bring?** Two things grep cannot: (a) **post-edit
+   diagnostics** — type errors and missing imports surfaced in the same
+   turn as an edit, before the quality gate; and (b) **structured
+   navigation** — exact definition/reference/hover/symbol answers
+   instead of regex matches the agent must still open files to confirm.
+2. **Is it better than grepping?** For *dynamic symbol* queries, yes —
+   it returns precise, semantically-resolved locations and types where
+   grep returns textual matches (including false positives in comments,
+   strings, and unrelated names). For *conceptual* queries, the curated
+   `docs/agents/` hierarchy is still cheaper. The two are complementary;
+   the LSP does not replace grep for plain text search.
+3. **Does it reduce or multiply tokens?** Qualitatively, it **reduces**
+   tokens for the dynamic queries it targets — a `references` result is
+   a short file:line list rather than many grepped context windows, and
+   a `hover` is one signature rather than a whole-file read. There is a
+   small fixed per-session cost (the language server handshake), but it
+   is dominated by the savings on even a handful of navigation queries.
+
+### Token benchmark — consciously deferred (not dropped)
+
+A *precise* token benchmark (controlled before/after on real sessions)
+is **deliberately deferred**, not abandoned. Rationale: the adoption
+cost is now near-zero and reversible (see [How to disable](#how-to-disable)),
+so a measurement gate would cost more than the change it guards. The
+prior doc's order-of-magnitude estimates (≈4–360× per-query savings,
+20–40% of an implement session) remain the working hypothesis. Revisit
+with a real benchmark if/when token cost becomes the dominant constraint
+on agent throughput, or if the diagnostics win proves marginal in
+practice.
 
 ## See also
 
-- [index.md](index.md) — the doc hierarchy LSP would augment, not
-  replace.
+- [index.md](index.md) — the doc hierarchy LSP augments, not replaces.
 - [../workflow/harness.md](../workflow/harness.md) — multi-harness
-  abstraction (Claude / Cursor / OpenCode / Codex) any LSP wiring
-  must respect.
+  abstraction (Claude / Cursor / OpenCode / Codex) and the "Code
+  intelligence (LSP)" subsection.

--- a/docs/stories/QS-248.story.md
+++ b/docs/stories/QS-248.story.md
@@ -1,0 +1,247 @@
+# QS-248 — Enable native pyright LSP in the Claude harness (and re-decide the LSP question)
+
+- **Issue:** #248
+- **Branch:** QS_248
+- **Type:** Dev-infrastructure (agent harness wiring + doc decision)
+- **Area:** `.claude/` agents & settings, `.cursor/` & `.opencode/` agents, `docs/agents/`, `docs/workflow/`, `tests/qs/agents/`
+
+## Summary
+
+Issue #248 asks whether an LSP server is worthwhile in the agent harness:
+*what does it bring, is it better than grepping, does it reduce or multiply
+tokens?* A prior evaluation (`docs/agents/lsp-evaluation.md`, estimate-based)
+recommended **defer** and proposed building a **jedi-language-server** wrapped
+in a custom **MCP server**.
+
+That recommendation is now obsolete. Both harnesses we care about ship a
+**native pyright** LSP integration — no MCP build required:
+
+- **Claude Code** exposes a built-in `LSP` tool via the official
+  `pyright-lsp` plugin (needs the `pyright-langserver` binary on PATH). It
+  provides **both** post-edit diagnostics (type errors / missing imports
+  surfaced in-turn, before the quality gate) **and** code navigation
+  (definitions, find-references, hover types, symbols, implementations, call
+  hierarchies). Tool name is literally `LSP`; permission required: *No*
+  (verified against `code.claude.com/docs/en/tools-reference`).
+- **OpenCode** also defaults to **pyright** (`"lsp": true` in `opencode.json`)
+  but surfaces LSP to the agent **only as diagnostics** — no navigation
+  (per `opencode.ai/docs/lsp/`). Decision: **not worth enabling now.**
+- **Cursor** has editor-native LSP (2.4+); **deferred / TBD.**
+
+This story (a) **enables the native Claude integration** and (b) **rewrites the
+evaluation doc** to reflect reality and flip the decision.
+
+## Key mechanic — the `tools:` allowlist gate
+
+Every qs Claude agent declares a **closed** `tools:` allowlist (e.g.
+`tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch`). Per
+`code.claude.com/docs/en/sub-agents`, a `tools:` list is a strict **allowlist**:
+the agent gets *only* the listed tools (inherits all *only* if the field is
+omitted). `LSP` is a gated tool, so **installing the plugin is necessary but
+not sufficient** — `LSP` must be added to an agent's `tools:` line for that
+agent to use it. Because the auto post-edit diagnostics are a behavior *of the
+same `LSP` tool*, they will not surface in our agents either until `LSP` is on
+the list.
+
+## pyright install (manual, per-machine prerequisite)
+
+Install machine-level: `npm install -g pyright` (ships both `pyright` and
+`pyright-langserver` binaries — confirmed in
+`code.claude.com/docs/en/plugins-reference`). **Not** via pip, **not** in the
+venv — the project's type-checker is **mypy**; pyright here is purely agent
+ergonomics and must not leak into `requirements*.txt`. The Claude Code process
+spawns the language server from its own login-shell PATH, so an npm-global
+binary is reliably visible; a venv `bin/` (only on PATH when activated) is not.
+
+The committed wiring (plugin enablement + `LSP` in agent allowlists) must
+**degrade gracefully** when `pyright-langserver` is absent: the `LSP` tool
+simply stays inactive and agents fall back to grep. This is a documented
+runtime expectation (Claude-side behavior), **not** an acceptance criterion this
+repo's tests can prove.
+
+## Which agents get `LSP`
+
+Principle: grant `LSP` to agents whose toolset already includes code-reading
+tools **and** whose role navigates the real codebase. Deliberately **exclude**
+the context-starved reviewers (their design forbids reading the codebase / the
+repo) and the merge/release agents (no code navigation).
+
+| Agent | `LSP`? | Why |
+|---|---|---|
+| `qs-create-plan` | ✅ | Globs/reads code while planning |
+| `qs-implement-task` | ✅ | Edits code — post-edit diagnostics are the headline win |
+| `qs-implement-setup-task` | ✅ | Edits scripts/config — same diagnostics win |
+| `qs-review-task` | ✅ | Navigates code during consolidation |
+| `qs-plan-concrete-planner` | ✅ | Reads file tree + source snippets to verify diffs |
+| `qs-review-edge-case-hunter` | ✅ | Walks branching paths in the PR source |
+| `qs-review-acceptance-auditor` | ✅ | Builds a traceability matrix over source |
+| `qs-setup-task` | ✅ | Globs/reads code to scope a new issue |
+| `qs-plan-critic` | ❌ | **Blind** — reviews plan text only |
+| `qs-plan-dev-proxy` | ❌ | **Blind** — never reads source |
+| `qs-plan-scope-guardian` | ❌ | **Blind** — plan + issue only |
+| `qs-review-blind-hunter` | ❌ | **Blind** — diff only |
+| `qs-review-coderabbit` | ❌ | Pass-through wrapper; no code navigation |
+| `qs-finish-task` | ❌ | Merge / cleanup only |
+| `qs-release` | ❌ | Version bump / tag only |
+
+## Cross-harness co-modification
+
+`scripts/qs/check_doc_drift.py::_check_harness_sync` requires that when a
+`.claude/agents/<name>.md` is modified, the matching `.cursor/` and
+`.opencode/` files appear in the same diff (a **content-blind co-modification**
+check — verified: `tests/qs/test_check_doc_drift.py::test_harness_sync_allows_body_divergence`).
+Per the user's decision, we satisfy it by co-modifying all three copies — but
+with **substantive** per-harness content, not filler (a content-free note would
+be gate-gaming). For each of the 8 modified Claude agents, the `.cursor/` and
+`.opencode/` twins get a short, harness-honest "Code intelligence (LSP)"
+note: Cursor → editor-native in-session LSP; OpenCode → `opencode.json`
+`"lsp": true` is diagnostics-only and intentionally not enabled. Notes must
+**not** be placed inside a ```` ```bash ```` fence (avoids
+`tests/qs/agents/test_harness_flag_explicit.py` false positives).
+
+## Acceptance criteria
+
+### AC1 — `LSP` enabled on the 8 code-navigating Claude agents, excluded on the other 7
+- **Given** the qs Claude agents declare closed `tools:` allowlists,
+- **When** this story is implemented,
+- **Then** each of the 8 agents in the ✅ table has `, LSP` appended to its
+  `tools:` line, the 7 ❌ agents do **not**, and a pin test
+  (`tests/qs/agents/test_lsp_tool_enabled.py`) asserts both the include set and
+  the exclude set so the deliberate exclusion can't silently regress.
+
+### AC2 — Plugin enabled at project scope with the exact verified schema
+- **Given** `pyright-lsp` lives in the always-available `claude-plugins-official`
+  marketplace,
+- **When** the wiring is committed,
+- **Then** `.claude/settings.json` gains a top-level
+  `"enabledPlugins": { "pyright-lsp@claude-plugins-official": true }` key
+  (object form `plugin-id@marketplace-id → true`, verified against
+  `json.schemastore.org/claude-code-settings.json`), **no**
+  `extraKnownMarketplaces` entry is added (official marketplace is auto-known),
+  and the file remains valid JSON. The pin test asserts the plugin id is
+  enabled.
+
+### AC3 — Cross-harness co-modification, honestly
+- **Given** the content-blind harness-sync check,
+- **When** the 8 Claude agents change,
+- **Then** their `.cursor/` and `.opencode/` twins are co-modified with a
+  substantive per-harness "Code intelligence (LSP)" note (no `bash`-fenced
+  prose), and
+  `python scripts/qs/check_doc_drift.py --paths <all changed agent files>`
+  exits 0 (no `harness_drift`).
+
+### AC4 — `lsp-evaluation.md` rewritten and the decision flipped
+- **Given** the doc recommends jedi + MCP and "defer",
+- **When** rewritten,
+- **Then** it: documents the **native pyright** reality per harness; includes a
+  per-harness capability matrix (Claude = diagnostics + navigation; OpenCode =
+  diagnostics-only; Cursor = TBD); explains the `tools:`-allowlist gate; records
+  the npm prerequisite and the graceful-degradation expectation; **explicitly
+  rebuts** the old jedi-via-MCP rationale (i.e. why native pyright-via-plugin
+  now beats it — the Node-dependency and multi-harness-MCP objections are
+  outweighed by zero-build native integration); **answers the issue's three
+  questions** (what it brings / better than grep / token impact) **qualitatively**
+  and explicitly marks a precise token benchmark as **consciously deferred**
+  (not dropped) with rationale; notes how to disable (remove from
+  `enabledPlugins` / strip `LSP`); and bumps `last_verified` to `2026-06-01`.
+  `docs/agents/index.md:98` one-liner changes from `(Decision: defer.)` to a
+  string reflecting the adopt-for-Claude decision.
+
+### AC5 — Workflow docs updated (concentrated, not redundant)
+- **Given** `lsp-evaluation.md` holds the substance,
+- **When** workflow docs are touched,
+- **Then** `docs/workflow/harness.md` gains a short "Code intelligence (LSP)"
+  subsection (the `LSP` tool, per-harness support, npm prerequisite, Claude-only
+  nature given the multi-harness contract) and `docs/workflow/overview.md` gains
+  a single opt-in pointer line — no duplication of the matrix.
+
+### AC6 — Quality gate green via the dev-only fast path
+- **Given** every changed path is dev-infrastructure,
+- **When** `python scripts/qs/quality_gate.py` runs,
+- **Then** scope is detected as dev-only, ruff/mypy/translations pass, the new
+  pin test passes and is itself 100 % covered, and `check_doc_drift.py` exits 0.
+
+## Task breakdown
+
+1. **T1 — `tests/qs/agents/test_lsp_tool_enabled.py` (TDD first).** Following
+   the `test_opencode_agents.py` pattern (`REPO_ROOT = Path(__file__).resolve().parents[3]`,
+   a local `_parse_frontmatter`): parametrize the 8 include-agents and assert
+   `"LSP" in [t.strip() for t in fm["tools"].split(",")]`; parametrize the 7
+   exclude-agents and assert `LSP` absent; read `.claude/settings.json` and
+   assert `enabledPlugins["pyright-lsp@claude-plugins-official"] is True`.
+2. **T2 — Add `, LSP`** to the `tools:` line of the 8 ✅ `.claude/agents/*.md`
+   (append at end of list).
+3. **T3 — `.claude/settings.json`**: add the verified `enabledPlugins` object
+   key alongside `permissions`.
+4. **T4 — Co-modify** the 8 matching `.cursor/agents/*.md` and 8
+   `.opencode/agents/*.md` with the substantive per-harness LSP note (not in a
+   `bash` fence).
+5. **T5 — Rewrite `docs/agents/lsp-evaluation.md`** per AC4; update
+   `docs/agents/index.md:98`.
+6. **T6 — `docs/workflow/harness.md`** LSP subsection + **`docs/workflow/overview.md`**
+   one-line pointer per AC5.
+7. **T7 — Gate**: `python scripts/qs/check_doc_drift.py --paths <changed agent
+   files>` → exit 0; `python scripts/qs/quality_gate.py` → green.
+
+## Doc maintenance
+
+`python scripts/qs/check_doc_drift.py --paths <planned files>` was run during
+planning. No `docs/agents/concepts/*` doc `covers:` any source file touched by
+this story (the change set is dev-infra/docs/config only — no
+`custom_components/quiet_solar/**`). **Doc-OK:** no concept/principle doc is
+affected. The harness-sync dimension is handled explicitly by T4 (AC3).
+
+## NEXT_PHASE
+
+`implement-setup-task`. Every changed path is dev-infrastructure:
+`docs/`, `.claude/`, `.cursor/`, `.opencode/`, top-level config
+(`.claude/settings.json`), and `tests/qs/agents/`.
+
+**Scope note (resolves the reviewer-flagged ambiguity):** the create-plan
+routing blurb enumerates `scripts/.claude/.cursor/.opencode/legacy/docs/.github/`
++ top-level config and does **not** list `tests/`. The authoritative tiebreaker
+is `scripts/qs/quality_gate.py::_DEV_ONLY_PATTERNS`, which **does** include
+`tests/`. `tests/qs/agents/test_lsp_tool_enabled.py` is **pure dev-infra**: it
+asserts on agent frontmatter and settings JSON and imports **no**
+`custom_components` product code. It is therefore in implement-setup-task scope
+and on the dev-only fast path.
+
+## Adversarial review notes
+
+Four reviewers ran in parallel. Consolidated findings and decisions:
+
+- **Blind reviewers must not get `LSP` (critical — all 4 reviewers).** The
+  original "all agents" intent conflicted with the context-starved reviewer
+  design (dev-proxy: a direct hard-rule violation). **Decision (user-approved):**
+  exclude the 5 blind/no-nav reviewers + the 2 merge/release agents; grant `LSP`
+  to the 8 code-navigating agents only. The pin test encodes both sets so the
+  exclusion can't regress.
+- **Issue's token question was dropped (critical — scope-guardian, critic).**
+  **Decision (user-approved):** the doc rewrite answers the three questions
+  qualitatively and **consciously defers** a precise token benchmark with stated
+  rationale — explicitly a decision, not an omission.
+- **"Per-harness note to satisfy the drift checker" rested on a false premise
+  (critical — concrete-planner).** The harness-sync check is content-blind;
+  filler would be gate-gaming (dev-proxy). **Decision:** keep the user's chosen
+  approach (a) — co-modify all three — but with **substantive** per-harness LSP
+  content. *Recorded dissent:* scope-guardian prefers relaxing the checker over
+  touching 16 twin files; the user explicitly chose (a), so we honor it and keep
+  the content meaningful.
+- **`enabledPlugins` schema unverified (critical — concrete-planner, critic,
+  dev-proxy).** **Resolved during planning:** object form
+  `{ "pyright-lsp@claude-plugins-official": true }`, no `extraKnownMarketplaces`,
+  verified against the live SchemaStore schema.
+- **Rewrite must rebut the old jedi+MCP rationale (redesign — concrete-planner).**
+  Folded into AC4.
+- **Graceful degradation framed as an untestable AC (critic, dev-proxy).**
+  **Decision:** downgraded to a documented runtime expectation, not an AC.
+- **tests/qs routing-scope ambiguity (critical — dev-proxy).** **Resolved** via
+  the explicit NEXT_PHASE scope note above (`_DEV_ONLY_PATTERNS` is
+  authoritative; the test is pure dev-infra).
+- **Doc-surface redundancy (improve — scope-guardian).** **Decision:** substance
+  in `lsp-evaluation.md`; one-liners only in `index.md` / `overview.md`; a short
+  genuine subsection in `harness.md`.
+- **Concreteness (clarify — concrete-planner):** tool name is literally `LSP`
+  (confirmed); `npm i -g pyright` ships `pyright-langserver` (confirmed); exact
+  agent filenames enumerated; keep agent-body notes out of `bash` fences; exact
+  `index.md:98` edit specified. All folded into the tasks/ACs.

--- a/docs/stories/QS-248.story_review_fix_#01.md
+++ b/docs/stories/QS-248.story_review_fix_#01.md
@@ -1,0 +1,81 @@
+# QS-248 — Review fix plan #01
+
+## Summary
+- Source PR: #250
+- Source story: docs/stories/QS-248.story.md
+- Findings to fix: 5 (1 should-fix, 4 nice-to-have)
+- Next implement phase: `/implement-task`
+
+> Scope note: the fix set touches `tests/qs/agents/test_lsp_tool_enabled.py`,
+> which is outside the dev-env allowlist (`scripts/`, `.claude/`, `.cursor/`,
+> `.opencode/`, `legacy/`, `docs/`, `.github/`, top-level config). Per the
+> `/create-plan` variant rule, the next phase is `/implement-task`, not
+> `/implement-setup-task`.
+
+## Findings to fix
+
+### [should-fix] Pin test has no completeness/disjointness assertion
+- File: `tests/qs/agents/test_lsp_tool_enabled.py` (`LSP_INCLUDE_AGENTS` / `LSP_EXCLUDE_AGENTS`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (independent convergence)
+- Description: The include/exclude agent-name lists are hardcoded. Nothing
+  asserts that `set(LSP_INCLUDE_AGENTS) | set(LSP_EXCLUDE_AGENTS)` equals the
+  set of `.claude/agents/*.md` files actually on disk, and nothing asserts the
+  two sets are disjoint. A newly-added agent file falls into neither list, so
+  neither parametrized test runs against it and the "the deliberate
+  include/exclude split cannot silently regress" guarantee (AC1) has a hole.
+  Sibling test `tests/qs/agents/test_harness_flag_explicit.py` already globs
+  the agents directory dynamically.
+- Proposed fix: Add a test (e.g. `test_include_exclude_partition_is_complete`)
+  that globs `.claude/agents/*.md`, derives the on-disk agent-name set, and
+  asserts (a) `INCLUDE ∪ EXCLUDE == on-disk set` and (b) `INCLUDE ∩ EXCLUDE ==
+  ∅`. Reuse the directory-globbing pattern from `test_harness_flag_explicit.py`.
+
+### [nice-to-have] `_tools()` errors out instead of catching an omitted `tools:` field
+- File: `tests/qs/agents/test_lsp_tool_enabled.py` (`_tools` helper, str assertion)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `_tools()` hard-asserts the `tools` frontmatter is a `str`. If an
+  EXCLUDE agent later omits its `tools:` line (meaning "inherit all tools",
+  which would silently grant LSP), the test raises `AssertionError` rather than
+  failing on the intended "LSP must be absent" check — masking the regression.
+- Proposed fix: When `tools` is absent/non-string, treat it as "inherits all
+  tools" so the exclude assertion fails meaningfully (LSP considered present),
+  rather than raising on the type assertion.
+
+### [nice-to-have] `_tools` split tolerates empty/trailing tokens silently
+- File: `tests/qs/agents/test_lsp_tool_enabled.py` (`_tools` helper)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter / qs-review-edge-case-hunter
+- Description: Splitting on `,` without filtering yields an empty token for a
+  trailing comma (e.g. `"Bash, LSP,"`). Membership checks still work today.
+- Proposed fix: Filter out empty tokens after strip, and add a one-line comment
+  that LSP membership is intentionally exact-token (not substring) so a future
+  refactor to a raw-string `in` check (which would match `LSPFoo`) is avoided.
+
+### [nice-to-have] Non-ASCII glyphs in lsp-evaluation.md
+- File: `docs/agents/lsp-evaluation.md`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Heavy use of non-ASCII glyphs (✅ ❌ ≈ ×). Harmless in Markdown
+  but inconsistent if the repo prefers ASCII in docs.
+- Proposed fix: Confirm against repo doc conventions; if ASCII is preferred,
+  replace glyphs with ASCII equivalents (yes/no, ~, x). Otherwise leave and
+  drop this item — purely cosmetic.
+
+### [nice-to-have] Doc tension: qs-setup-task LSP vs "fast launcher" hard rule
+- File: `docs/agents/lsp-evaluation.md` (and cross-reference `.cursor/agents/qs-setup-task.md`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `lsp-evaluation.md` grants `qs-setup-task` LSP for "code
+  navigation," while the `qs-setup-task` hard rule says "do NOT analyze the
+  input; the launcher must come within a few seconds." The two framings sit in
+  tension.
+- Proposed fix: Add a one-line clarification in `lsp-evaluation.md` that
+  `qs-setup-task` carries LSP for capability parity but is not expected to
+  exercise it during the fast-launcher path, reconciling the two statements.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/workflow/harness.md
+++ b/docs/workflow/harness.md
@@ -13,6 +13,30 @@ The agent **bodies** are identical across harnesses (same protocol, same
 hard rules). Only the **frontmatter** differs and the **handoff
 mechanics** are isolated in Python.
 
+## Code intelligence (LSP)
+
+The Claude harness wires a native Python language server. The built-in
+`LSP` tool (backed by the official `pyright-lsp` plugin, enabled in
+`.claude/settings.json`) gives agents pyright **diagnostics** — type
+errors and missing imports surfaced in-turn, before the quality gate —
+**and** code **navigation** (definitions, references, hover types,
+symbols). Because the qs `tools:` allowlists are closed, `LSP` is granted
+only to the 8 code-navigating agents; the blind reviewers and
+merge/release agents deliberately omit it. The plugin shells out to the
+`pyright-langserver` binary, a per-machine prerequisite installed with
+`npm install -g pyright` (machine-level, **not** in the venv or
+`requirements*.txt` — the product type-checker stays mypy); it degrades
+gracefully to grep when the binary is absent.
+
+This is **Claude-only** for now. Per the multi-harness contract, the
+other harnesses provide their own code intelligence rather than a shared
+layer: Cursor (2.4+) has ambient editor-native LSP (no agent tool to
+enable), and OpenCode bundles pyright but surfaces it as diagnostics-only
+(no navigation), so it is intentionally not enabled there. Full rationale,
+the per-harness capability matrix, and the rebuttal of the old
+jedi-via-MCP plan live in
+[../agents/lsp-evaluation.md](../agents/lsp-evaluation.md).
+
 ## Detection — `scripts/qs/harness.py`
 
 `harness.detect()` returns one of `claude-code` / `cursor` / `opencode` /

--- a/docs/workflow/overview.md
+++ b/docs/workflow/overview.md
@@ -123,6 +123,7 @@ nearly identical across harnesses; only the frontmatter differs
 
 See [harness.md](harness.md) for how to add a new harness.
 See [project-rules.md](project-rules.md) § "Harness sync" for the cross-harness body-parity rule.
+Code intelligence is opt-in per harness: Claude agents carry a native pyright `LSP` tool — see [harness.md](harness.md) § "Code intelligence (LSP)" and [../agents/lsp-evaluation.md](../agents/lsp-evaluation.md).
 
 ## Required reading
 

--- a/tests/qs/agents/test_lsp_tool_enabled.py
+++ b/tests/qs/agents/test_lsp_tool_enabled.py
@@ -1,0 +1,112 @@
+"""Pin the native-pyright ``LSP`` wiring for the Claude harness (QS-248).
+
+Three assertions, encoded as pin tests so the deliberate include/exclude
+split and the plugin-enablement schema cannot silently regress:
+
+- ``test_lsp_enabled_on_code_navigating_agents`` — each of the 8
+  code-navigating Claude agents has ``LSP`` on its closed ``tools:``
+  allowlist. Because a ``tools:`` list is a strict allowlist (per
+  ``code.claude.com/docs/en/sub-agents``), the ``LSP`` tool — and its
+  auto post-edit diagnostics, which are a behavior of the same tool —
+  stays inactive for any agent that omits it.
+- ``test_lsp_excluded_on_blind_and_merge_agents`` — the 7
+  context-starved reviewers / merge / release agents do **not** list
+  ``LSP``. The blind reviewers' design forbids reading the codebase, so
+  granting them code navigation would be a direct hard-rule violation.
+- ``test_pyright_plugin_enabled_in_settings`` — ``.claude/settings.json``
+  enables the official plugin via the object form
+  ``enabledPlugins["pyright-lsp@claude-plugins-official"] is True``
+  (schema verified against ``json.schemastore.org/claude-code-settings.json``).
+
+Follows the ``test_opencode_agents.py`` pattern: ``REPO_ROOT`` via
+``parents[3]`` and a local ``_parse_frontmatter``. ``yaml`` (PyYAML) is
+transitively available via ``homeassistant``; no extra test requirement.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLAUDE_AGENTS_DIR = REPO_ROOT / ".claude" / "agents"
+CLAUDE_SETTINGS = REPO_ROOT / ".claude" / "settings.json"
+
+# Agents whose toolset already reads code AND whose role navigates the
+# real codebase. They get ``LSP``.
+LSP_INCLUDE_AGENTS: tuple[str, ...] = (
+    "qs-create-plan",
+    "qs-implement-task",
+    "qs-implement-setup-task",
+    "qs-review-task",
+    "qs-plan-concrete-planner",
+    "qs-review-edge-case-hunter",
+    "qs-review-acceptance-auditor",
+    "qs-setup-task",
+)
+
+# Context-starved (blind) reviewers + merge/release agents. They must
+# NOT get ``LSP`` — code navigation contradicts their design.
+LSP_EXCLUDE_AGENTS: tuple[str, ...] = (
+    "qs-plan-critic",
+    "qs-plan-dev-proxy",
+    "qs-plan-scope-guardian",
+    "qs-review-blind-hunter",
+    "qs-review-coderabbit",
+    "qs-finish-task",
+    "qs-release",
+)
+
+PYRIGHT_PLUGIN_ID = "pyright-lsp@claude-plugins-official"
+
+
+def _parse_frontmatter(path: Path) -> tuple[dict, str]:
+    """Split an agent file into ``(frontmatter_dict, body_text)``.
+
+    Normalizes CRLF before scanning so a Windows-saved file parses
+    identically; raises ``AssertionError`` with a path-anchored message
+    on a malformed file (mirrors ``test_opencode_agents._parse_frontmatter``).
+    """
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n")
+    assert text.startswith("---\n"), f"{path}: missing opening ``---`` delimiter"
+    rest = text[len("---\n") :]
+    end = rest.find("\n---\n")
+    assert end != -1, f"{path}: missing closing ``---`` delimiter"
+    return yaml.safe_load(rest[:end]), rest[end + len("\n---\n") :]
+
+
+def _tools(name: str) -> list[str]:
+    fm, _ = _parse_frontmatter(CLAUDE_AGENTS_DIR / f"{name}.md")
+    tools = fm.get("tools")
+    assert isinstance(tools, str), f"{name}: 'tools' frontmatter must be a string"
+    return [t.strip() for t in tools.split(",")]
+
+
+@pytest.mark.parametrize("name", LSP_INCLUDE_AGENTS)
+def test_lsp_enabled_on_code_navigating_agents(name: str) -> None:
+    assert "LSP" in _tools(name), (
+        f"{name}: expected 'LSP' on the tools allowlist — code-navigating "
+        "agents must carry the LSP tool for diagnostics + navigation."
+    )
+
+
+@pytest.mark.parametrize("name", LSP_EXCLUDE_AGENTS)
+def test_lsp_excluded_on_blind_and_merge_agents(name: str) -> None:
+    assert "LSP" not in _tools(name), (
+        f"{name}: 'LSP' must NOT be on the tools allowlist — this agent is "
+        "context-starved or merge/release-only and must not navigate code."
+    )
+
+
+def test_pyright_plugin_enabled_in_settings() -> None:
+    settings = json.loads(CLAUDE_SETTINGS.read_text(encoding="utf-8"))
+    enabled = settings.get("enabledPlugins")
+    assert isinstance(enabled, dict), (
+        ".claude/settings.json must declare an 'enabledPlugins' object"
+    )
+    assert enabled.get(PYRIGHT_PLUGIN_ID) is True, (
+        f"enabledPlugins['{PYRIGHT_PLUGIN_ID}'] must be the JSON boolean true"
+    )

--- a/tests/qs/agents/test_lsp_tool_enabled.py
+++ b/tests/qs/agents/test_lsp_tool_enabled.py
@@ -1,6 +1,6 @@
 """Pin the native-pyright ``LSP`` wiring for the Claude harness (QS-248).
 
-Three assertions, encoded as pin tests so the deliberate include/exclude
+Four assertions, encoded as pin tests so the deliberate include/exclude
 split and the plugin-enablement schema cannot silently regress:
 
 - ``test_lsp_enabled_on_code_navigating_agents`` — each of the 8
@@ -17,6 +17,14 @@ split and the plugin-enablement schema cannot silently regress:
   enables the official plugin via the object form
   ``enabledPlugins["pyright-lsp@claude-plugins-official"] is True``
   (schema verified against ``json.schemastore.org/claude-code-settings.json``).
+- ``test_include_exclude_partition_is_complete`` — the include and
+  exclude lists are disjoint and jointly cover every ``.claude/agents/*.md``
+  file on disk, so a newly-added agent can't escape both parametrized
+  tests (review-fix #01).
+
+Plus one helper-robustness check, ``test_tools_helper_edge_cases``,
+covering the omitted-``tools:`` (inherits-all), trailing-comma, and
+exact-token-membership branches (review-fix #01).
 
 Follows the ``test_opencode_agents.py`` pattern: ``REPO_ROOT`` via
 ``parents[3]`` and a local ``_parse_frontmatter``. ``yaml`` (PyYAML) is
@@ -78,16 +86,50 @@ def _parse_frontmatter(path: Path) -> tuple[dict, str]:
     return yaml.safe_load(rest[:end]), rest[end + len("\n---\n") :]
 
 
-def _tools(name: str) -> list[str]:
+# Sentinel for an agent that OMITS the ``tools:`` field. Per
+# ``code.claude.com/docs/en/sub-agents`` an omitted ``tools`` means the
+# agent inherits ALL tools — which includes ``LSP``. We model that as
+# "LSP present" so the exclude assertion fails meaningfully (catching a
+# regression where an exclude agent drops its allowlist and silently
+# regains LSP) instead of erroring on a type check (review-fix #01).
+_INHERITS_ALL_TOOLS = object()
+
+
+def _tools(name: str) -> object:
+    """Return the agent's tool tokens, or ``_INHERITS_ALL_TOOLS``.
+
+    A string ``tools`` field is split on commas with empty/whitespace
+    tokens filtered out (so a trailing comma like ``"Bash, LSP,"`` does
+    not yield a phantom ``""`` token — review-fix #01). When ``tools`` is
+    absent or not a string, the agent inherits all tools; we return the
+    sentinel rather than asserting, so callers can treat it as
+    "LSP present".
+    """
     fm, _ = _parse_frontmatter(CLAUDE_AGENTS_DIR / f"{name}.md")
     tools = fm.get("tools")
-    assert isinstance(tools, str), f"{name}: 'tools' frontmatter must be a string"
-    return [t.strip() for t in tools.split(",")]
+    if not isinstance(tools, str):
+        return _INHERITS_ALL_TOOLS
+    return [t.strip() for t in tools.split(",") if t.strip()]
+
+
+def _has_lsp(name: str) -> bool:
+    """Whether ``name`` can use the ``LSP`` tool.
+
+    ``LSP`` membership is intentionally an **exact-token** check (not a
+    substring ``in`` on the raw frontmatter string) so a hypothetical
+    future tool named ``LSPFoo`` can never be mistaken for ``LSP``. An
+    agent that inherits all tools counts as having ``LSP``.
+    """
+    tools = _tools(name)
+    if tools is _INHERITS_ALL_TOOLS:
+        return True
+    assert isinstance(tools, list)  # narrow for the type checker
+    return "LSP" in tools
 
 
 @pytest.mark.parametrize("name", LSP_INCLUDE_AGENTS)
 def test_lsp_enabled_on_code_navigating_agents(name: str) -> None:
-    assert "LSP" in _tools(name), (
+    assert _has_lsp(name), (
         f"{name}: expected 'LSP' on the tools allowlist — code-navigating "
         "agents must carry the LSP tool for diagnostics + navigation."
     )
@@ -95,10 +137,69 @@ def test_lsp_enabled_on_code_navigating_agents(name: str) -> None:
 
 @pytest.mark.parametrize("name", LSP_EXCLUDE_AGENTS)
 def test_lsp_excluded_on_blind_and_merge_agents(name: str) -> None:
-    assert "LSP" not in _tools(name), (
+    assert not _has_lsp(name), (
         f"{name}: 'LSP' must NOT be on the tools allowlist — this agent is "
-        "context-starved or merge/release-only and must not navigate code."
+        "context-starved or merge/release-only and must not navigate code "
+        "(an omitted 'tools:' line inherits all tools, including LSP — also a "
+        "regression)."
     )
+
+
+def test_include_exclude_partition_is_complete() -> None:
+    """The include/exclude lists must partition every on-disk agent.
+
+    Globs ``.claude/agents/*.md`` (the dynamic pattern used by sibling
+    ``test_harness_flag_explicit.py``) and asserts the two hardcoded
+    lists are (a) disjoint and (b) jointly exhaustive. Without this, a
+    newly-added agent file would fall into neither parametrized test and
+    the deliberate include/exclude split (AC1) could silently regress.
+    """
+    on_disk = {p.stem for p in CLAUDE_AGENTS_DIR.glob("*.md")}
+    include = set(LSP_INCLUDE_AGENTS)
+    exclude = set(LSP_EXCLUDE_AGENTS)
+
+    overlap = include & exclude
+    assert not overlap, f"agents appear in BOTH include and exclude lists: {overlap}"
+
+    partition = include | exclude
+    missing = on_disk - partition
+    extra = partition - on_disk
+    assert not missing, (
+        f"on-disk agents missing from the include/exclude partition: {missing} "
+        "— add each to exactly one list so the LSP split is asserted for it."
+    )
+    assert not extra, (
+        f"include/exclude lists reference non-existent agent files: {extra}"
+    )
+
+
+def test_tools_helper_edge_cases(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cover the ``_tools`` / ``_has_lsp`` edge cases (review-fix #01).
+
+    Exercises the three branches the real agent files don't trigger:
+    an omitted ``tools:`` field (inherits all tools → LSP present), a
+    trailing comma (no phantom empty token), and the exact-token
+    membership guard (``LSPFoo`` is not ``LSP``).
+    """
+    monkeypatch.setattr(f"{__name__}.CLAUDE_AGENTS_DIR", tmp_path)
+
+    # Omitted ``tools:`` field → inherits all tools → counts as LSP-present.
+    (tmp_path / "no-tools.md").write_text("---\nname: a\n---\nbody\n", encoding="utf-8")
+    assert _tools("no-tools") is _INHERITS_ALL_TOOLS
+    assert _has_lsp("no-tools") is True
+
+    # Trailing comma must not yield a phantom empty token.
+    (tmp_path / "trailing.md").write_text(
+        "---\nname: b\ntools: Bash, LSP,\n---\nbody\n", encoding="utf-8"
+    )
+    assert _tools("trailing") == ["Bash", "LSP"]
+    assert _has_lsp("trailing") is True
+
+    # Exact-token membership: a ``LSPFoo`` tool is NOT ``LSP``.
+    (tmp_path / "substr.md").write_text(
+        "---\nname: c\ntools: Bash, LSPFoo\n---\nbody\n", encoding="utf-8"
+    )
+    assert _has_lsp("substr") is False
 
 
 def test_pyright_plugin_enabled_in_settings() -> None:


### PR DESCRIPTION
## Summary
- Rewrite docs/agents/lsp-evaluation.md (decision flipped to adopt-for-Claude) and update index.md / harness.md / overview.md.

Fixes #248

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled native LSP support for selected agents, providing diagnostics and code navigation where opted in.

* **Documentation**
  * Added and expanded guidance on LSP behavior, per-harness differences, and how/when it’s enabled or intentionally disabled.

* **Tests**
  * Added coverage to validate which agents opt into LSP, which do not, and that the pyright plugin is enabled.

* **Chores**
  * Updated agent metadata and harness settings to reflect the new LSP strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->