### PR TITLE
QS-251: Option flow reset: cleared fields revert to previous value on save

### DIFF
--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -306,15 +306,14 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
     """Common methods for Quiet Solar config flows."""
 
     # The optional marker keys rendered in the most recent form. Captured by
-    # `async_show_form` so the terminal options-flow save sites can tell a
-    # field the user CLEARED (rendered but omitted from the submission) apart
-    # from a field that was never on the form. A form is always rendered
-    # before any submit/merge in real usage; the empty-set default keeps the
-    # additive-merge behavior intact for any code path that saves without a
-    # prior render (and avoids a `getattr` fallback branch — coverage stays
-    # at 100%). Always reassigned, never mutated in place, so sharing the
-    # default across instances is safe.
-    _last_optional_keys: set[str] = set()
+    # `async_show_form` so the save sites can tell a field the user CLEARED
+    # (rendered but omitted from the submission) apart from a field that was
+    # never on the form. Initialized per-instance in each concrete handler's
+    # `__init__` (annotation-only here — no shared mutable class state); a form
+    # is always rendered before any submit/merge in real usage, and the
+    # empty-set initial value keeps the additive-merge behavior intact for any
+    # code path that saves without a prior render.
+    _last_optional_keys: set[str]
 
     @abstractmethod
     def is_creation_flow(self) -> bool:
@@ -332,21 +331,18 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
     ) -> ConfigFlowResult:
         """Record the rendered optional keys, then defer to Home Assistant.
 
-        Capturing the optional markers on every render lets the terminal
-        options-flow save sites distinguish a deliberately-cleared optional
-        field (rendered but omitted from the submission) from a field that was
-        never part of the form. Without it the additive merge would silently
-        re-persist a stale value, so clearing the ✕ on an optional selector
-        never stuck.
+        Capturing the optional markers on every render lets the save sites
+        distinguish a deliberately-cleared optional field (rendered but omitted
+        from the submission) from a field that was never part of the form.
+        Without it the additive merge would silently re-persist a stale value,
+        so clearing the ✕ on an optional selector never stuck. Flow-agnostic:
+        the creation flow simply never consults the captured set.
         """
         keys: set[str] = set()
         if data_schema is not None:
-            for marker in data_schema.schema:
-                if isinstance(marker, vol.Optional):
-                    # `marker.schema` holds the wrapped key, a bare `CONF_*`
-                    # string for every QS field; normalise defensively.
-                    key = marker.schema if isinstance(marker.schema, str) else str(marker.schema)
-                    keys.add(key)
+            # Every QS optional marker wraps a bare `CONF_*` string in
+            # `marker.schema`, so the wrapped key is captured directly.
+            keys = {marker.schema for marker in data_schema.schema if isinstance(marker, vol.Optional)}
         self._last_optional_keys = keys
         return super().async_show_form(
             step_id=step_id,
@@ -362,16 +358,18 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         the submission — i.e. the fields the user actively cleared."""
         return {key for key in self._last_optional_keys if key not in submitted}
 
-    def _merge_with_cleared(self, submitted: dict) -> dict:
-        """Additive merge of `submitted` onto the persisted entry data that
-        also DROPS optional fields the user cleared.
+    def _merge_with_cleared(self, base: dict, submitted: dict) -> dict:
+        """Additive merge of `submitted` onto `base`, dropping cleared fields.
 
-        Preserves runtime-only keys (e.g. `measured_power`,
-        `measured_charge_*`) that never appear in the form schema, while
-        letting a cleared optional field actually disappear instead of being
-        re-persisted from the stale `config_entry.data`.
+        Flow-agnostic: the merge `base` (the persisted data being extended) is
+        passed in explicitly rather than read from `config_entry`, so both the
+        terminal save and the multi-pass intermediate persists can reuse it.
+        Runtime-only keys (e.g. `measured_power`, `measured_charge_*`) that
+        never appear in the form schema are preserved, while an optional field
+        the user cleared (rendered but omitted) actually disappears instead of
+        being re-persisted from the stale `base`.
         """
-        merged = dict(self.config_entry.data)
+        merged = dict(base)
         merged.update(submitted)
         for key in self._cleared_optional_keys(submitted):
             merged.pop(key, None)
@@ -1234,9 +1232,11 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                 )
 
                 if need_dampening_redisplay:
-                    # Merge with existing data to preserve runtime-saved measured values
-                    merged = dict(self.config_entry.data)
-                    merged.update(user_input)
+                    # Preserve runtime-saved measured values while dropping any
+                    # optional field the user cleared in this (Pass 1) form —
+                    # `_last_optional_keys` still reflects the just-submitted
+                    # schema, so the clear can't be revived by Pass 2 (QS-251).
+                    merged = self._merge_with_cleared(self.config_entry.data, user_input)
                     self.hass.config_entries.async_update_entry(self.config_entry, data=merged)
                     return await self.async_step_car({"force_dampening": True})
 
@@ -1610,11 +1610,11 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
 
         self.add_entity_selector(sc_dict, CONF_SWITCH, True, domain=[SWITCH_DOMAIN])
 
-        # WF-4: surface the field even when no live temperature entities
-        # remain — otherwise a previously-configured sensor that's since
-        # been removed from HA stays silently stranded in config_entry.data,
-        # because the OptionsFlow merges user_input onto the prior data
-        # and an absent key never clears the old value.
+        # Surface the field even when no live temperature entities remain, so
+        # a previously-configured sensor that HA has since dropped is still
+        # shown (with the stored id in the selector) and the user can replace
+        # or clear it — clearing then persists via the generic clear-on-absence
+        # path (QS-251).
         temperature_entities = selectable_temperature_entities(self.hass)
         entity_list = list(temperature_entities)
         if stored_temp_sensor and stored_temp_sensor not in entity_list:
@@ -1670,10 +1670,11 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                     or user_input.get(CONF_CLIMATE_HVAC_MODE_OFF) is None
                     or user_input.get(CONF_CLIMATE_HVAC_MODE_ON) is None
                 ):
-                    # we need to force to come back to reselect the hvac modes
-                    # Merge with existing data to preserve runtime-saved measured values
-                    merged = dict(self.config_entry.data)
-                    merged.update(user_input)
+                    # we need to force to come back to reselect the hvac modes.
+                    # Preserve runtime-saved measured values while dropping any
+                    # optional field the user cleared in this (Pass 1) form so
+                    # the clear survives the Pass 2 re-render (QS-251).
+                    merged = self._merge_with_cleared(self.config_entry.data, user_input)
                     self.config_entry.data = merged
                     return await self.async_step_climate({"force_climate": True})
 
@@ -1771,10 +1772,11 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         entries, or directly into the FakeConfigEntry's `data` for the
         creation flow. Pass 2's form-render then reads `config_entry.data`
         as usual and every field (name, dashboard, power, …) gets the
-        right default — no per-field plumbing.
+        right default — no per-field plumbing. The merge drops any optional
+        field the user cleared in this (Pass 1) form so the clear survives
+        the Pass 2 re-render (QS-251).
         """
-        merged = dict(self.config_entry.data)
-        merged.update(cleaned)
+        merged = self._merge_with_cleared(self.config_entry.data, cleaned)
         if isinstance(self.config_entry, FakeConfigEntry):
             # Creation flow — direct assignment is safe; the entry
             # is not persisted until `async_create_entry` runs.
@@ -2152,10 +2154,9 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             # S8 + B4 — if the persisted heat-pump name no longer
             # exists, drop the suggested value and surface a
             # field-specific error to the user. Using
-            # `errors["device_to_pilot_name"]` instead of
+            # `errors[CONF_DEVICE_TO_PILOT_NAME]` instead of
             # `errors["base"]` so a co-occurring XOR error (under
-            # `"base"`) doesn't mask the heat-pump warning via the
-            # previous `setdefault` no-op.
+            # `"base"`) doesn't mask the heat-pump warning.
             if default_heat_pump and default_heat_pump not in heat_pump_options:
                 merged_errors[CONF_DEVICE_TO_PILOT_NAME] = "piloted_heat_pump_unknown"
                 default_heat_pump = None
@@ -2222,6 +2223,8 @@ class QSFlowHandler(QSFlowHandlerMixin, config_entries.ConfigFlow, domain=DOMAIN
         """Initialize Quiet Solar config flow."""
         super().__init__()
         self.config_entry: FakeConfigEntry | None | ConfigEntry = FakeConfigEntry()
+        # Per-instance init — no shared mutable class state (see mixin).
+        self._last_optional_keys = set()
 
     @staticmethod
     @callback
@@ -2301,6 +2304,8 @@ class QSOptionsFlowHandler(QSFlowHandlerMixin, OptionsFlow):
             self.config_entry = config_entry
 
         self._errors = {}
+        # Per-instance init — no shared mutable class state (see mixin).
+        self._last_optional_keys = set()
 
     def is_creation_flow(self) -> bool:
         return False
@@ -2312,7 +2317,7 @@ class QSOptionsFlowHandler(QSFlowHandlerMixin, OptionsFlow):
         # while dropping optional fields the user cleared in the form — a
         # cleared key is absent from `data`, so a plain additive merge would
         # re-persist the stale value (QS-251).
-        merged = self._merge_with_cleared(data)
+        merged = self._merge_with_cleared(self.config_entry.data, data)
         self.hass.config_entries.async_update_entry(
             self.config_entry, data=merged, options=self.config_entry.options, title=self.get_entry_title(merged)
         )

--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -1,5 +1,6 @@
 import logging
 from abc import abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -304,9 +305,77 @@ def _get_entity_key_from_selector_key(key: str):
 class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING else object):
     """Common methods for Quiet Solar config flows."""
 
+    # The optional marker keys rendered in the most recent form. Captured by
+    # `async_show_form` so the terminal options-flow save sites can tell a
+    # field the user CLEARED (rendered but omitted from the submission) apart
+    # from a field that was never on the form. A form is always rendered
+    # before any submit/merge in real usage; the empty-set default keeps the
+    # additive-merge behavior intact for any code path that saves without a
+    # prior render (and avoids a `getattr` fallback branch — coverage stays
+    # at 100%). Always reassigned, never mutated in place, so sharing the
+    # default across instances is safe.
+    _last_optional_keys: set[str] = set()
+
     @abstractmethod
     def is_creation_flow(self) -> bool:
         """Return True if this is a creation flow, False if it is an options flow."""
+
+    def async_show_form(
+        self,
+        *,
+        step_id: str | None = None,
+        data_schema: vol.Schema | None = None,
+        errors: dict[str, str] | None = None,
+        description_placeholders: Mapping[str, str] | None = None,
+        last_step: bool | None = None,
+        preview: str | None = None,
+    ) -> ConfigFlowResult:
+        """Record the rendered optional keys, then defer to Home Assistant.
+
+        Capturing the optional markers on every render lets the terminal
+        options-flow save sites distinguish a deliberately-cleared optional
+        field (rendered but omitted from the submission) from a field that was
+        never part of the form. Without it the additive merge would silently
+        re-persist a stale value, so clearing the ✕ on an optional selector
+        never stuck.
+        """
+        keys: set[str] = set()
+        if data_schema is not None:
+            for marker in data_schema.schema:
+                if isinstance(marker, vol.Optional):
+                    # `marker.schema` holds the wrapped key, a bare `CONF_*`
+                    # string for every QS field; normalise defensively.
+                    key = marker.schema if isinstance(marker.schema, str) else str(marker.schema)
+                    keys.add(key)
+        self._last_optional_keys = keys
+        return super().async_show_form(
+            step_id=step_id,
+            data_schema=data_schema,
+            errors=errors,
+            description_placeholders=description_placeholders,
+            last_step=last_step,
+            preview=preview,
+        )
+
+    def _cleared_optional_keys(self, submitted: dict) -> set[str]:
+        """Return optional keys rendered in the last form but omitted from
+        the submission — i.e. the fields the user actively cleared."""
+        return {key for key in self._last_optional_keys if key not in submitted}
+
+    def _merge_with_cleared(self, submitted: dict) -> dict:
+        """Additive merge of `submitted` onto the persisted entry data that
+        also DROPS optional fields the user cleared.
+
+        Preserves runtime-only keys (e.g. `measured_power`,
+        `measured_charge_*`) that never appear in the form schema, while
+        letting a cleared optional field actually disappear instead of being
+        re-persisted from the stale `config_entry.data`.
+        """
+        merged = dict(self.config_entry.data)
+        merged.update(submitted)
+        for key in self._cleared_optional_keys(submitted):
+            merged.pop(key, None)
+        return merged
 
     def add_entity_selector(self, sc_dict, key, is_required, entity_list=None, domain=None):
 
@@ -1521,18 +1590,12 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         )
 
         if user_input is not None:
-            # M3: even with the WF-4 fix that re-surfaces a stranded id in
-            # the form, `vol.Optional` lets the user omit the key — the
-            # OptionsFlow's `merged.update(user_input)` then silently
-            # re-persists the stranded value. Force the key to be present
-            # ONLY when the field was actually rendered in the form, so
-            # the merge can overwrite. Use empty-string as the sentinel
-            # rather than None because `clean_data` strips None values
-            # before the merge; `QSWaterBoiler.__init__`'s WF-3 normalises
-            # the empty string back to `None` at device-construction time.
-            field_was_rendered = bool(selectable_temperature_entities(self.hass)) or stored_temp_sensor is not None
-            if field_was_rendered:
-                user_input.setdefault(CONF_WATER_BOILER_TEMPERATURE_SENSOR, "")
+            # QS-251 — the generic clear-on-absence path in the options-flow
+            # terminal save now drops a cleared `CONF_WATER_BOILER_TEMPERATURE_SENSOR`
+            # (the field was rendered but omitted from the submission), so the
+            # former per-field `setdefault("")` band-aid is no longer needed.
+            # `QSWaterBoiler.__init__`'s WF-3 still normalises a stored `""` to
+            # `None` for any pre-existing entry.
             return await self.async_entry_next(user_input, TYPE)
 
         sc_dict, placeholders = self.get_common_schema(
@@ -1777,7 +1840,14 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         # Options flow — compute the desired final data ourselves so we
         # can EXCLUDE the stale-backing keys from the merge (which
         # `_async_entry_next` would otherwise carry over additively).
-        stale_keys = self._stale_radiator_backing_keys(keep_climate) + tuple(extra_stale_keys)
+        # QS-251 — fold the generic "rendered-but-cleared" optional keys into
+        # the stale set so a cleared optional radiator field (e.g. the pilot
+        # dropdown) is dropped instead of re-merged from `config_entry.data`.
+        stale_keys = (
+            self._stale_radiator_backing_keys(keep_climate)
+            + tuple(extra_stale_keys)
+            + tuple(self._cleared_optional_keys(cleaned))
+        )
         merged = {k: v for k, v in self.config_entry.data.items() if k not in stale_keys}
         merged.update(cleaned)
 
@@ -1814,35 +1884,15 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
                     pending=user_input,
                 )
 
-            # EH5 + BH-D — detect "user explicitly cleared the pilot
-            # dropdown" BEFORE we strip empty values from `cleaned`. The
-            # form renders `CONF_DEVICE_TO_PILOT_NAME` only when at
-            # least one heat pump exists, so finding the key in
-            # `user_input` with a falsy value means the user actively
-            # cleared it. Without this, `_async_save_radiator_entry`'s
-            # merge would re-inject the old persisted value from
-            # `config_entry.data`.
-            #
-            # BH-D: HA's `vol.Optional` could deliver "user cleared"
-            # as either `{"key": None}` or `{}` (key absent). The
-            # current pattern only handles the former. Use a sentinel
-            # so both shapes funnel into the same branch — if the
-            # form rendered the field AND the user submitted nothing
-            # for it, treat it as an explicit clear regardless of
-            # which selector variant HA picked.
-            _UNSET = object()
-            pilot_value = user_input.get(CONF_DEVICE_TO_PILOT_NAME, _UNSET)
-            # The pilot dropdown is only rendered when heat pumps
-            # exist, so the previous form-render decision is the
-            # `explicit_pilot_clear` precondition.
-            data_handler = self.hass.data.get(DOMAIN, {}).get(DATA_HANDLER)
-            had_pilot_dropdown = bool(
-                data_handler and data_handler.home is not None and data_handler.home.get_heat_pumps()
-            )
-            had_persisted_pilot = bool(self.config_entry.data.get(CONF_DEVICE_TO_PILOT_NAME))
-            explicit_pilot_clear = (
-                had_pilot_dropdown and had_persisted_pilot and (pilot_value is _UNSET or not pilot_value)
-            )
+            # QS-251 — the pilot dropdown is a plain `vol.Optional` selector,
+            # so the generic "rendered-but-omitted → cleared" path in
+            # `_async_save_radiator_entry` now removes a deliberately-cleared
+            # `CONF_DEVICE_TO_PILOT_NAME` (matching how `async_step_climate`
+            # treats its fields). The former bespoke `explicit_pilot_clear`
+            # sentinel machinery is gone. The orphan-pilot cleanup
+            # (`_radiator_orphan_pilot_keys`, all heat pumps deleted — a case
+            # the generic mechanism cannot see) and the submitted-name
+            # revalidation below are kept.
 
             # N8 + EH-D — drop empty/None values from the merged dict
             # so downstream `key in dict` checks see the canonical
@@ -1872,11 +1922,6 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
             # pump but the persisted name is stale, drop the orphan
             # reference so it doesn't reappear on the next edit.
             extra_stale_keys = self._radiator_orphan_pilot_keys(cleaned)
-            # EH5 — when the user EXPLICITLY cleared a still-valid pilot,
-            # add the key to the stale list so the merge doesn't re-inject
-            # the old persisted value.
-            if explicit_pilot_clear and CONF_DEVICE_TO_PILOT_NAME not in extra_stale_keys:
-                extra_stale_keys = extra_stale_keys + (CONF_DEVICE_TO_PILOT_NAME,)
 
             # EH-B — re-validate the SUBMITTED heat-pump name against the
             # LIVE heat-pumps list. `_radiator_orphan_pilot_keys` only
@@ -2264,8 +2309,10 @@ class QSOptionsFlowHandler(QSFlowHandlerMixin, OptionsFlow):
         """Handle the next step based on user input."""
         # Merge with existing data to preserve runtime-saved measured values
         # (e.g. measured_power, measured_charge_X, measured_car_custom_power_charge_values)
-        merged = dict(self.config_entry.data)
-        merged.update(data)
+        # while dropping optional fields the user cleared in the form — a
+        # cleared key is absent from `data`, so a plain additive merge would
+        # re-persist the stale value (QS-251).
+        merged = self._merge_with_cleared(data)
         self.hass.config_entries.async_update_entry(
             self.config_entry, data=merged, options=self.config_entry.options, title=self.get_entry_title(merged)
         )

--- a/custom_components/quiet_solar/config_flow.py
+++ b/custom_components/quiet_solar/config_flow.py
@@ -2070,7 +2070,24 @@ class QSFlowHandlerMixin(config_entries.ConfigEntryBaseFlow if TYPE_CHECKING els
         # single re-render so the user sees their own selections.
         explicit_pending: dict = pending or {}
 
+        # QS-251 review-fix #02 — on a validation-error re-render the rejected
+        # `pending` IS the user's submission, so an optional field they cleared
+        # is absent (or None/"") in it. Without this, `_suggest` would fall
+        # back to the still-persisted stale value and re-prefill the selector;
+        # the user fixing the unrelated backing error then resubmits the
+        # revived value and the clear is silently lost. Treat such keys as
+        # cleared and suppress the `config_entry.data` fallback so the field
+        # renders empty. Only the error re-render passes `pending`; the initial
+        # render and the Pass 2 re-render (`pending is None`) keep the
+        # persisted-value prefill — Pass 2 already dropped cleared keys from
+        # `config_entry.data` via `_persist_radiator_pass1`.
+        cleared_on_rerender: set[str] = set()
+        if pending is not None:
+            cleared_on_rerender = {key for key in self._last_optional_keys if explicit_pending.get(key) in (None, "")}
+
         def _suggest(key: str):
+            if key in cleared_on_rerender:
+                return None
             return explicit_pending.get(key) or self.config_entry.data.get(key)
 
         # B1 — Pass 2 form pre-fills the entity selectors with the

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -128,12 +128,16 @@ captured set is simply unused there. This replaced two per-field
 band-aids: the water-boiler `setdefault(CONF_WATER_BOILER_TEMPERATURE_SENSOR, "")`
 and the radiator `explicit_pilot_clear` sentinel block.
 
-**Known limitation:** the mechanism only corrects the two *terminal*
-save sites. The *intermediate* multi-pass persists (car dampening,
-climate/radiator HVAC reprompt, `_persist_radiator_pass1`) are
-transient writes overwritten by the final submit, so a field cleared
-mid-multi-pass may still re-suggest until the terminal save — a
-documented follow-up, not fixed here.
+**Multi-pass coverage:** the mechanism is applied at the two *terminal*
+save sites **and** at the three *intermediate* multi-pass persists (car
+dampening, climate/radiator HVAC reprompt, `_persist_radiator_pass1`).
+At an intermediate write, `_last_optional_keys` still reflects the
+just-submitted Pass-1 form (Pass 2 has not rendered yet), so routing the
+write through `_merge_with_cleared` drops a Pass-1-cleared field before
+Pass 2 can re-suggest it — no need to accumulate keys across passes. The
+helper takes the merge `base` explicitly (it never reads `config_entry`),
+so the same call serves both the terminal saves and the intermediate
+persists in both the creation and options flows.
 
 **Home options-flow section editor** (`async_step_home`): the 8
 dashboard-section slot suggestions (`CONF_DASHBOARD_SECTION_NAME_<i>`

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/__init__.py
   - custom_components/quiet_solar/data_handler.py
   - custom_components/quiet_solar/const.py
-last_verified: 2026-06-01
+last_verified: 2026-06-02
 ---
 
 # Config flow and setup
@@ -138,6 +138,16 @@ Pass 2 can re-suggest it — no need to accumulate keys across passes. The
 helper takes the merge `base` explicitly (it never reads `config_entry`),
 so the same call serves both the terminal saves and the intermediate
 persists in both the creation and options flows.
+
+**Radiator validation-error re-render:** when a radiator submit trips a
+validation error (XOR backing, HVAC modes), `_async_show_radiator_form`
+re-renders with the rejected `pending` submission so the user keeps
+their selections. `_suggest` normally falls back to `config_entry.data`,
+but for an optional field the user *cleared* (present in
+`_last_optional_keys` yet absent/empty in `pending`) that fallback is
+suppressed so the selector renders empty — otherwise the error round-trip
+would revive the stale value and re-persist it once the user fixes the
+unrelated error. Other rejected fields are still re-prefilled.
 
 **Home options-flow section editor** (`async_step_home`): the 8
 dashboard-section slot suggestions (`CONF_DASHBOARD_SECTION_NAME_<i>`

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/__init__.py
   - custom_components/quiet_solar/data_handler.py
   - custom_components/quiet_solar/const.py
-last_verified: 2026-05-29
+last_verified: 2026-06-01
 ---
 
 # Config flow and setup
@@ -93,13 +93,47 @@ the LIVE `home.get_heat_pumps()` so a parallel admin action that
 removed a heat-pump between Pass 1 and the final submit can't
 silently persist a stale name.
 
-User-explicit pilot clear: the form's heat-pump dropdown is
-rendered only when at least one heat pump exists. When that
-dropdown was rendered AND the submit carries an empty value (or
-omits the key entirely — both shapes funnel through a sentinel
-check), the persisted `CONF_DEVICE_TO_PILOT_NAME` is removed.
-Without this distinction the merge in `_async_save_radiator_entry`
-would re-inject the stale name on the next edit.
+User-explicit pilot clear is handled by the **centralized
+clear-on-absence mechanism** (below), not a per-field hack: the
+heat-pump dropdown is a plain `vol.Optional(CONF_DEVICE_TO_PILOT_NAME)`
+selector, so when it was rendered and the submit omits it, the
+generic path drops the persisted name. `_async_save_radiator_entry`
+folds `_cleared_optional_keys(cleaned)` into its stale-key set so the
+single `async_update_entry` write excludes the cleared key. The
+genuinely-different `_radiator_orphan_pilot_keys` cleanup still runs
+for the case the generic mechanism cannot see — all heat pumps
+deleted, so the dropdown isn't even rendered — alongside the
+render-side stale-name surfacing and the submit-time revalidation
+against `home.get_heat_pumps()`.
+
+**Centralized clear-on-absence for optional fields**
+(`QSFlowHandlerMixin`, QS-251): clearing the ✕ on an optional
+selector makes Home Assistant omit the key from `user_input`, but the
+options-flow save is an additive merge
+(`merged = dict(config_entry.data); merged.update(user_input)`), so a
+missing key let the stale value survive — clearing nearly any optional
+field silently reverted on save. The mixin overrides `async_show_form`
+to record the optional marker keys of the rendered schema in
+`_last_optional_keys` (bare `CONF_*` strings extracted from each
+`vol.Optional` marker). The two terminal options-flow save sites then
+drop any optional key that was rendered but omitted:
+`QSOptionsFlowHandler._async_entry_next` calls `_merge_with_cleared`,
+and `_async_save_radiator_entry` adds `_cleared_optional_keys` to its
+stale set. Runtime-only keys (`measured_power`, `measured_charge_*`)
+never appear in a form schema, so they are never in the cleared set
+and survive the merge. Required fields and boolean `default=` fields
+are always submitted by HA, so they are never falsely cleared. The
+creation flow uses `async_create_entry(data=...)` with no merge, so the
+captured set is simply unused there. This replaced two per-field
+band-aids: the water-boiler `setdefault(CONF_WATER_BOILER_TEMPERATURE_SENSOR, "")`
+and the radiator `explicit_pilot_clear` sentinel block.
+
+**Known limitation:** the mechanism only corrects the two *terminal*
+save sites. The *intermediate* multi-pass persists (car dampening,
+climate/radiator HVAC reprompt, `_persist_radiator_pass1`) are
+transient writes overwritten by the final submit, so a field cleared
+mid-multi-pass may still re-suggest until the terminal save — a
+documented follow-up, not fixed here.
 
 **Home options-flow section editor** (`async_step_home`): the 8
 dashboard-section slot suggestions (`CONF_DASHBOARD_SECTION_NAME_<i>`
@@ -201,9 +235,9 @@ device.attach_ha_state_to_probe(...) for each tracked entity
   temperature entities OR a previously-configured id is stored** — the
   latter rule prevents a stranded entity id from becoming invisible
   after HA loses the sensor (the form's selector then includes the
-  stored id so the user can replace or keep it). When the field was
-  rendered, the per-step also `setdefault`s the key in `user_input`
-  to an empty string before submission so the OptionsFlow merge can
-  actually overwrite a stranded id with a cleared value
-  (`QSWaterBoiler.__init__` normalises the empty string back to
-  `None`).
+  stored id so the user can replace or keep it). Clearing the field is
+  now handled by the centralized clear-on-absence mechanism (see
+  "Centralized clear-on-absence" above) — the former per-step
+  `setdefault(..., "")` band-aid was removed in QS-251.
+  `QSWaterBoiler.__init__` still normalises a pre-existing stored `""`
+  back to `None` at construction time.

--- a/docs/stories/QS-251.story.md
+++ b/docs/stories/QS-251.story.md
@@ -16,8 +16,8 @@ old value is back. The clear does not persist. The reporter notes it affects
 ## Root cause
 
 Optional fields are rendered with `description={"suggested_value": <old>}` and
-**no** `default=` (see `QSFlowHandlerMixin.add_entity_selector`, config_flow.py
-~L311). When the user clears such a field, Home Assistant's frontend simply
+**no** `default=` (see `QSFlowHandlerMixin.add_entity_selector` in
+`config_flow.py`). When the user clears such a field, Home Assistant's frontend simply
 **omits the key** from `user_input`. The options-flow save then does an
 **additive merge**:
 
@@ -26,7 +26,7 @@ merged = dict(self.config_entry.data)
 merged.update(data)          # the cleared key is ABSENT → the stale value survives
 ```
 
-`QSFlowHandlerMixin.clean_data` (~L703) strips explicit `None` values but
+`QSFlowHandlerMixin.clean_data` strips explicit `None` values but
 cannot reintroduce a missing key, so the old value is re-persisted.
 
 - Required fields and boolean `default=` fields are **unaffected** — HA always
@@ -38,8 +38,7 @@ cannot reintroduce a missing key, so the old value is re-persisted.
 This is systemic: it hits every optional entity selector across every device
 step. Two pre-existing per-field band-aids confirm the pattern — the
 water-boiler step's `user_input.setdefault(CONF_WATER_BOILER_TEMPERATURE_SENSOR, "")`
-(~L1535) and the radiator step's bespoke `explicit_pilot_clear` block
-(~L1817-1845, used ~L1875-1879).
+and the radiator step's bespoke `explicit_pilot_clear` block.
 
 ## Design — centralized "clear-on-absence"
 
@@ -84,7 +83,7 @@ def async_show_form(self, *, step_id=None, data_schema=None, **kwargs):
   class-level annotation (no runtime default lookup) keeps coverage at 100%
   with no `getattr` fallback branch.
 - Running on **creation-flow** renders is harmless: the creation final save
-  (`QSFlowHandler._async_entry_next`, ~L2238) uses `async_create_entry(data=data)`
+  (`QSFlowHandler._async_entry_next`) uses `async_create_entry(data=data)`
   with **no merge**, so the captured set is simply unused there.
 
 ### 2. Helpers on the mixin
@@ -95,50 +94,57 @@ def _cleared_optional_keys(self, submitted: dict) -> set[str]:
     submission = the user cleared them."""
     return {k for k in self._last_optional_keys if k not in submitted}
 
-def _merge_with_cleared(self, submitted: dict) -> dict:
-    merged = dict(self.config_entry.data)
+def _merge_with_cleared(self, base: dict, submitted: dict) -> dict:
+    merged = dict(base)
     merged.update(submitted)
     for key in self._cleared_optional_keys(submitted):
         merged.pop(key, None)
     return merged
 ```
 
-### 3. Apply at the two TERMINAL save sites only
+`_merge_with_cleared` takes the merge `base` explicitly (it never reads
+`config_entry`), so it stays flow-agnostic and is reused by both the terminal
+saves and the intermediate persists.
 
-- **`QSOptionsFlowHandler._async_entry_next`** (~L2267): replace
-  `merged = dict(...); merged.update(data)` with `merged = self._merge_with_cleared(data)`.
-- **`_async_save_radiator_entry`** (~L1780, options branch only — the
+### 3. Apply at the terminal save sites
+
+- **`QSOptionsFlowHandler._async_entry_next`**: replace
+  `merged = dict(...); merged.update(data)` with
+  `merged = self._merge_with_cleared(self.config_entry.data, data)`.
+- **`_async_save_radiator_entry`** (options branch only — the
   `FakeConfigEntry`/creation branch keeps `async_create_entry(data=cleaned)`):
   fold cleared keys into the existing stale-key set:
   `stale_keys = self._stale_radiator_backing_keys(keep_climate) + tuple(extra_stale_keys) + tuple(self._cleared_optional_keys(cleaned))`
   (resulting tuple; `dict`/set dedup is naturally handled by the
   comprehension that builds `merged`).
 
-**Out of scope (review #1 — scope-guardian/critic):** the three *intermediate*
-multi-pass persists (car dampening ~L1169, climate HVAC reprompt ~L1614,
-`_persist_radiator_pass1` ~L1713) are **not** touched. They are transient
-writes whose only purpose is to let Pass 2 render derived dropdowns; the final
-submit overwrites them and goes through a terminal site. The reported bug
-(clearing the car tracker) does not trigger a multi-pass at all. Multi-pass
-intermediate re-suggest is recorded as a known limitation / follow-up, not
-fixed here.
+### 3b. Apply at the intermediate multi-pass persists (review-fix #01)
+
+The three *intermediate* multi-pass persists (car dampening, climate HVAC
+reprompt, `_persist_radiator_pass1`) also route their write through
+`_merge_with_cleared`. At an intermediate write, `_last_optional_keys` still
+reflects the just-submitted Pass-1 form (Pass 2 has not rendered yet), so the
+Pass-1 clear is dropped before Pass 2 can re-suggest it — no cross-pass key
+accumulation needed. Runtime-only keys survive exactly as at the terminal
+sites. (Originally deferred as a "known limitation"; the user decided clearing
+must work across multi-pass steps too.)
 
 ### 4. Remove the per-field band-aids
 
-- **Water boiler** (~L1523-1535): remove the
+- **Water boiler**: remove the
   `user_input.setdefault(CONF_WATER_BOILER_TEMPERATURE_SENSOR, "")` block; the
   generic path now clears it. **Keep** the WF-4 field re-surfacing
-  (~L1550-1565) that renders a stranded sensor so it *can* be cleared.
-- **Radiator** (~L1817-1845 + use ~L1875-1879): remove the entire
+  that renders a stranded sensor so it *can* be cleared.
+- **Radiator**: remove the entire
   `explicit_pilot_clear` machinery. The pilot dropdown is built as a plain
   `vol.Optional(CONF_DEVICE_TO_PILOT_NAME, description={"suggested_value": ...})`
-  (~L2118-2133) — identical to any other optional selector — so the generic
+  — identical to any other optional selector — so the generic
   "rendered + omitted → cleared" path handles it normally (matching how
   `async_step_climate` treats its fields). **Keep** the genuinely-different
   concerns: `_radiator_orphan_pilot_keys` (E2 — clears a persisted name when
   *all* heat pumps were deleted and the dropdown isn't even rendered, a case
   the generic mechanism cannot see), the render-side S8/B4 stale-name error
-  surfacing (~L2114), and the EH-B submitted-name validation (~L1887-1897).
+  surfacing, and the EH-B submitted-name validation.
 
 ### 5. clean_data / strip interaction (review #4)
 
@@ -206,13 +212,14 @@ covers both the "key omitted" and "key submitted as None/empty" shapes.
    - AC2 e2e: battery optional sensor clear round-trips to absent.
    - AC3: runtime-only keys survive an unrelated clear.
    - AC4: required + boolean-default fields not dropped.
-   - Keep the radiator pilot-clear tests green (`test_radiator_step_orphan_pilot_cleared_on_reedit`
-     L1595, `test_radiator_step_explicit_pilot_clear_with_absent_key` L1646,
-     `test_radiator_step_explicit_pilot_clear_removes_persisted_key` L1811) —
+   - Keep the radiator pilot-clear tests green
+     (`test_radiator_step_orphan_pilot_cleared_on_reedit`,
+     `test_radiator_step_explicit_pilot_clear_with_absent_key`,
+     `test_radiator_step_explicit_pilot_clear_removes_persisted_key`) —
      they become regression guards for the generic path.
-6. **Tests — `tests/ha_tests/`.** Update the water-boiler clear/normalization
-   test (`test_water_boiler.py` ~L197) to the missing-key semantics; sanity-check
-   `tests/ha_tests/test_options_flow_reload_qs204.py` still passes.
+6. **Tests — `tests/ha_tests/`.** Add a missing-key consumer regression test in
+   `test_water_boiler.py` (the absent-key shape the generic path now emits);
+   sanity-check `tests/ha_tests/test_options_flow_reload_qs204.py` still passes.
 7. **Docs.** Update `docs/agents/concepts/config-and-setup-flow.md`: document
    the centralized clear-on-absence mechanism (replacing the per-field
    workaround narrative) and bump `last_verified` to the implementation date.
@@ -233,10 +240,13 @@ rule does not apply.
 Four reviewers (critic, scope-guardian, dev-proxy, concrete-planner) ran in
 parallel against the draft. Decisions:
 
-- **#1 (critical, scope-guardian + critic) — multi-pass intermediate persists
-  out of scope.** Accepted: fix only the two terminal save sites; multi-pass
-  re-suggest documented as a known limitation. Shrinks the diff from 5 merge
-  sites to 2 and removes the `_last_optional_keys` desync risk.
+- **#1 (critical, scope-guardian + critic) — multi-pass intermediate persists.**
+  Originally deferred as a known limitation (terminal sites only). **Superseded
+  by review-fix #01:** the user decided clearing must work across multi-pass
+  steps, so the three intermediate persists now route through
+  `_merge_with_cleared` as well (see "3b. Apply at the intermediate multi-pass
+  persists"). At an intermediate write `_last_optional_keys` still reflects the
+  just-submitted Pass-1 form, so there is no `_last_optional_keys` desync.
 - **#2 (critical, concrete-planner + dev-proxy) — override placement / MRO /
   coverage.** Accepted: override on the mixin (all steps live there); creation
   flow interception is benign; class-level annotation avoids a `getattr`

--- a/docs/stories/QS-251.story.md
+++ b/docs/stories/QS-251.story.md
@@ -1,0 +1,266 @@
+# QS-251 — Option-flow cleared fields revert to previous value on save
+
+- **Issue:** #251
+- **Branch:** `QS_251`
+- **Next phase:** `implement-task` (product code under `custom_components/quiet_solar/`)
+
+## Problem
+
+When re-editing a Quiet Solar config element (car, battery, solar, charger,
+person, …) through the **options flow**, clearing an optional field by
+clicking the ✕ on its selector (e.g. the car device tracker) correctly
+empties the field in the UI — but after saving and re-opening the config the
+old value is back. The clear does not persist. The reporter notes it affects
+"nearly all of the fields I can reset this way."
+
+## Root cause
+
+Optional fields are rendered with `description={"suggested_value": <old>}` and
+**no** `default=` (see `QSFlowHandlerMixin.add_entity_selector`, config_flow.py
+~L311). When the user clears such a field, Home Assistant's frontend simply
+**omits the key** from `user_input`. The options-flow save then does an
+**additive merge**:
+
+```python
+merged = dict(self.config_entry.data)
+merged.update(data)          # the cleared key is ABSENT → the stale value survives
+```
+
+`QSFlowHandlerMixin.clean_data` (~L703) strips explicit `None` values but
+cannot reintroduce a missing key, so the old value is re-persisted.
+
+- Required fields and boolean `default=` fields are **unaffected** — HA always
+  submits them.
+- The merge intentionally exists to preserve **runtime-only** keys
+  (`measured_power`, `measured_charge_*`, `measured_car_custom_power_charge_values`)
+  that are never part of the form schema.
+
+This is systemic: it hits every optional entity selector across every device
+step. Two pre-existing per-field band-aids confirm the pattern — the
+water-boiler step's `user_input.setdefault(CONF_WATER_BOILER_TEMPERATURE_SENSOR, "")`
+(~L1535) and the radiator step's bespoke `explicit_pilot_clear` block
+(~L1817-1845, used ~L1875-1879).
+
+## Design — centralized "clear-on-absence"
+
+A single generic mechanism on `QSFlowHandlerMixin`, replacing the per-field
+hacks.
+
+### 1. Capture the rendered optional keys
+
+Override `async_show_form` on **`QSFlowHandlerMixin`** (every `async_step_*`
+and every `async_show_form` call lives on the mixin; placing the override here
+intercepts all of them). On each render, record the set of optional marker
+keys actually shown:
+
+```python
+_last_optional_keys: set[str]   # class-level annotation, no __init__ on the mixin
+
+def async_show_form(self, *, step_id=None, data_schema=None, **kwargs):
+    keys: set[str] = set()
+    if data_schema is not None:
+        for marker in data_schema.schema:
+            if isinstance(marker, vol.Optional):
+                key = marker.schema if isinstance(marker.schema, str) else str(marker.schema)
+                keys.add(key)
+    self._last_optional_keys = keys
+    return super().async_show_form(step_id=step_id, data_schema=data_schema, **kwargs)
+```
+
+- **Key-extraction contract (review #3):** `vol.Optional` subclasses
+  `vol.Marker`; `marker.schema` holds the wrapped key, which for every QS
+  field is a bare `CONF_*` **string**. The `isinstance(..., str)` guard is
+  defensive normalization. A unit test asserts `_last_optional_keys` contains
+  the bare string constants for a known step.
+- **MRO (review #2):** for both `QSFlowHandler(QSFlowHandlerMixin, ConfigFlow)`
+  and `QSOptionsFlowHandler(QSFlowHandlerMixin, OptionsFlow)` the mixin is
+  leftmost, so `super().async_show_form()` resolves to HA's
+  `FlowHandler.async_show_form`. Under `TYPE_CHECKING` the mixin base is
+  `ConfigEntryBaseFlow`, so mypy sees a valid override — the signature mirrors
+  HA's verbatim (`*, step_id, data_schema, errors, description_placeholders,
+  last_step, preview` as applicable; return `ConfigFlowResult`).
+- **No dead branch (review #2):** a form is *always* rendered before any
+  submit/merge, so `_last_optional_keys` is always set by merge time — the
+  class-level annotation (no runtime default lookup) keeps coverage at 100%
+  with no `getattr` fallback branch.
+- Running on **creation-flow** renders is harmless: the creation final save
+  (`QSFlowHandler._async_entry_next`, ~L2238) uses `async_create_entry(data=data)`
+  with **no merge**, so the captured set is simply unused there.
+
+### 2. Helpers on the mixin
+
+```python
+def _cleared_optional_keys(self, submitted: dict) -> set[str]:
+    """Optional keys that were rendered in the last form but omitted from the
+    submission = the user cleared them."""
+    return {k for k in self._last_optional_keys if k not in submitted}
+
+def _merge_with_cleared(self, submitted: dict) -> dict:
+    merged = dict(self.config_entry.data)
+    merged.update(submitted)
+    for key in self._cleared_optional_keys(submitted):
+        merged.pop(key, None)
+    return merged
+```
+
+### 3. Apply at the two TERMINAL save sites only
+
+- **`QSOptionsFlowHandler._async_entry_next`** (~L2267): replace
+  `merged = dict(...); merged.update(data)` with `merged = self._merge_with_cleared(data)`.
+- **`_async_save_radiator_entry`** (~L1780, options branch only — the
+  `FakeConfigEntry`/creation branch keeps `async_create_entry(data=cleaned)`):
+  fold cleared keys into the existing stale-key set:
+  `stale_keys = self._stale_radiator_backing_keys(keep_climate) + tuple(extra_stale_keys) + tuple(self._cleared_optional_keys(cleaned))`
+  (resulting tuple; `dict`/set dedup is naturally handled by the
+  comprehension that builds `merged`).
+
+**Out of scope (review #1 — scope-guardian/critic):** the three *intermediate*
+multi-pass persists (car dampening ~L1169, climate HVAC reprompt ~L1614,
+`_persist_radiator_pass1` ~L1713) are **not** touched. They are transient
+writes whose only purpose is to let Pass 2 render derived dropdowns; the final
+submit overwrites them and goes through a terminal site. The reported bug
+(clearing the car tracker) does not trigger a multi-pass at all. Multi-pass
+intermediate re-suggest is recorded as a known limitation / follow-up, not
+fixed here.
+
+### 4. Remove the per-field band-aids
+
+- **Water boiler** (~L1523-1535): remove the
+  `user_input.setdefault(CONF_WATER_BOILER_TEMPERATURE_SENSOR, "")` block; the
+  generic path now clears it. **Keep** the WF-4 field re-surfacing
+  (~L1550-1565) that renders a stranded sensor so it *can* be cleared.
+- **Radiator** (~L1817-1845 + use ~L1875-1879): remove the entire
+  `explicit_pilot_clear` machinery. The pilot dropdown is built as a plain
+  `vol.Optional(CONF_DEVICE_TO_PILOT_NAME, description={"suggested_value": ...})`
+  (~L2118-2133) — identical to any other optional selector — so the generic
+  "rendered + omitted → cleared" path handles it normally (matching how
+  `async_step_climate` treats its fields). **Keep** the genuinely-different
+  concerns: `_radiator_orphan_pilot_keys` (E2 — clears a persisted name when
+  *all* heat pumps were deleted and the dropdown isn't even rendered, a case
+  the generic mechanism cannot see), the render-side S8/B4 stale-name error
+  surfacing (~L2114), and the EH-B submitted-name validation (~L1887-1897).
+
+### 5. clean_data / strip interaction (review #4)
+
+At the main options site, `async_entry_next` runs `clean_data(data)` (strips
+`None`) **before** `_async_entry_next`. The radiator builds `cleaned` by
+stripping `""`/`None`. Either way a cleared field is **absent** from the
+submitted dict by the time `_cleared_optional_keys` runs, so the generic pop
+covers both the "key omitted" and "key submitted as None/empty" shapes.
+
+## Acceptance criteria
+
+- **AC1 — the reported bug.** *Given* a car whose `CONF_CAR_TRACKER` is set,
+  *when* the user clears it in the options flow and saves, *then* the reloaded
+  `config_entry.data` contains no `CONF_CAR_TRACKER` and re-opening the form
+  shows the field empty.
+- **AC2 — generality.** *Given* an optional entity field on another device
+  type (battery — e.g. `CONF_BATTERY_CHARGE_PERCENT_SENSOR`), *when* it is
+  cleared in the options flow and saved, *then* the key is absent from the
+  reloaded entry. (Mechanism is generic; one extra type proves it — not all
+  device types, per review #7.)
+- **AC3 — runtime keys survive.** *Given* an entry carrying runtime-only keys
+  (`measured_power`, `measured_charge_*`), *when* the user clears an unrelated
+  optional field and saves, *then* the runtime-only keys remain intact.
+- **AC4 — no false clears.** *Given* a saved entry, *when* the user saves
+  without touching a required field (`CONF_NAME`) or a boolean `default=` field
+  (e.g. `CONF_GRID_POWER_SENSOR_INVERTED`), *then* those values are never
+  dropped.
+- **AC5 — radiator pilot.** *Given* a radiator with `CONF_DEVICE_TO_PILOT_NAME`
+  set and heat pumps present, *when* the user clears the pilot dropdown and
+  saves, *then* the persisted pilot name is removed. The orphan-pilot cleanup
+  (all heat pumps deleted) and submitted-name validation behave unchanged —
+  the existing radiator pilot tests stay green.
+- **AC6 — water boiler.** *Given* a water boiler with
+  `CONF_WATER_BOILER_TEMPERATURE_SENSOR` set, *when* the user clears it and
+  saves, *then* the key is removed and `QSWaterBoiler` tolerates the missing
+  key (equivalent to its existing `""`→`None` WF-3 normalization).
+- **AC7 — quality gate.** `python scripts/qs/quality_gate.py` passes — 100%
+  coverage, ruff, mypy, translations. No `strings.json` change (no schema keys
+  added/removed → translations gate unaffected).
+
+## Task breakdown
+
+1. **`config_flow.py` — generic mechanism.** Add the `_last_optional_keys:
+   set[str]` class-level annotation, the `async_show_form` override, and the
+   `_cleared_optional_keys` / `_merge_with_cleared` helpers to
+   `QSFlowHandlerMixin`. Reference `CONF_*` constants only — no hardcoded
+   strings.
+2. **`config_flow.py` — wire terminal sites.** Use `_merge_with_cleared` in
+   `QSOptionsFlowHandler._async_entry_next`; fold `_cleared_optional_keys(cleaned)`
+   into `stale_keys` in `_async_save_radiator_entry` (options branch).
+3. **`config_flow.py` — remove band-aids.** Delete the water-boiler
+   `setdefault` block and the radiator `explicit_pilot_clear` block (and its
+   use). Keep WF-4 re-surfacing, `_radiator_orphan_pilot_keys`, S8/B4, EH-B.
+4. **Consumer audit (review #6).** Confirm `QSWaterBoiler.__init__` and the
+   `CONF_CAR_TRACKER` reader (and any other cleared optional field consumed via
+   `data[...]`) use `.get(...)` and tolerate a missing key. Fix any `KeyError`
+   risk surfaced.
+5. **Tests — `tests/test_integration_config_flow.py`.**
+   - Unit test for `_cleared_optional_keys` / `_merge_with_cleared`: a rendered
+     optional key omitted from the submission is popped; a present key and an
+     untouched runtime-only key survive (asserts via `CONF_*` constants).
+   - Unit test that `_last_optional_keys` holds bare `CONF_*` strings after a
+     known step renders (key-extraction contract).
+   - AC1 e2e: car tracker clear round-trips to absent.
+   - AC2 e2e: battery optional sensor clear round-trips to absent.
+   - AC3: runtime-only keys survive an unrelated clear.
+   - AC4: required + boolean-default fields not dropped.
+   - Keep the radiator pilot-clear tests green (`test_radiator_step_orphan_pilot_cleared_on_reedit`
+     L1595, `test_radiator_step_explicit_pilot_clear_with_absent_key` L1646,
+     `test_radiator_step_explicit_pilot_clear_removes_persisted_key` L1811) —
+     they become regression guards for the generic path.
+6. **Tests — `tests/ha_tests/`.** Update the water-boiler clear/normalization
+   test (`test_water_boiler.py` ~L197) to the missing-key semantics; sanity-check
+   `tests/ha_tests/test_options_flow_reload_qs204.py` still passes.
+7. **Docs.** Update `docs/agents/concepts/config-and-setup-flow.md`: document
+   the centralized clear-on-absence mechanism (replacing the per-field
+   workaround narrative) and bump `last_verified` to the implementation date.
+8. **Quality gate.** Iterate with `python scripts/qs/quality_gate.py --quick
+   tests/test_integration_config_flow.py tests/ha_tests`; run the full
+   `python scripts/qs/quality_gate.py` before commit.
+
+## Doc maintenance
+
+`scripts/qs/check_doc_drift.py --paths custom_components/quiet_solar/config_flow.py`
+flags `docs/agents/concepts/config-and-setup-flow.md` (covers `config_flow.py`,
+`last_verified=2026-05-29`) as stale → **Task 7** updates it. No
+`.<harness>/agents/*.md` files are touched, so the harness-sync co-modification
+rule does not apply.
+
+## Adversarial Review Notes
+
+Four reviewers (critic, scope-guardian, dev-proxy, concrete-planner) ran in
+parallel against the draft. Decisions:
+
+- **#1 (critical, scope-guardian + critic) — multi-pass intermediate persists
+  out of scope.** Accepted: fix only the two terminal save sites; multi-pass
+  re-suggest documented as a known limitation. Shrinks the diff from 5 merge
+  sites to 2 and removes the `_last_optional_keys` desync risk.
+- **#2 (critical, concrete-planner + dev-proxy) — override placement / MRO /
+  coverage.** Accepted: override on the mixin (all steps live there); creation
+  flow interception is benign; class-level annotation avoids a `getattr`
+  default dead branch because a form always renders before a submit.
+- **#3 (critical, dev-proxy + concrete) — `marker.schema` key extraction.**
+  Accepted: pinned the extraction contract with an `isinstance(str)`
+  normalization plus a dedicated unit test.
+- **#4 (improve, concrete + critic) — clean_data interaction.** Accepted:
+  documented the strip→absent→pop chain; both omitted and None/empty shapes are
+  covered.
+- **#5 (redesign, scope-guardian + critic) — removing radiator
+  `explicit_pilot_clear`.** Reviewers urged caution; **user override**: remove
+  it entirely. The pilot dropdown is a plain `vol.Optional` selector, so the
+  generic path clears it "normally" (as `async_step_climate` treats its
+  fields). Kept the orphan-pilot (E2, all-pumps-deleted case the generic
+  mechanism can't see), S8/B4 render-side surfacing, and EH-B validation;
+  existing radiator tests guard the behavior.
+- **#6 (improve, critic + concrete) — missing-key vs `""` semantics.**
+  Accepted: added a consumer-audit task for `QSWaterBoiler.__init__` and
+  `CONF_CAR_TRACKER` readers.
+- **#7 (improve, scope-guardian) — device-type test matrix.** Accepted: trimmed
+  to a direct helper unit test + car (issue example) + battery e2e, instead of
+  five device types.
+- **#8 (clarify, dev-proxy) — harness-sync.** Accepted: dropped; only the
+  `covers:` doc-drift co-modification of the concept doc applies.
+- **#9 (improve, critic) — runtime-key survival.** Accepted: AC3 + test that
+  clearing one field preserves `measured_*` keys.

--- a/docs/stories/QS-251.story_review_fix_#01.md
+++ b/docs/stories/QS-251.story_review_fix_#01.md
@@ -1,0 +1,141 @@
+# QS-251 — Review fix plan #01
+
+## Summary
+- Source PR: #252
+- Source story: docs/stories/QS-251.story.md
+- Findings to fix: 8 (1 must-fix, 5 should-fix, 2 nice-to-have)
+- Next implement phase: `implement-task`
+
+## Findings to fix
+
+### [must-fix] Multi-pass intermediate persists re-suggest cleared fields
+- File: `custom_components/quiet_solar/config_flow.py` (car-dampening intermediate persist ~L1238-1241; climate/radiator HVAC reprompt ~L1675-1677; `_persist_radiator_pass1`)
+- Severity: must-fix (upgraded from nice-to-have during triage)
+- Source: qs-review-edge-case-hunter
+- Description: The multi-pass option-flow steps perform a plain additive
+  `merged = dict(config_entry.data); merged.update(user_input)` at their
+  **intermediate** persist. A field the user cleared in Pass 1 therefore
+  survives into `config_entry.data`. Pass 2 then re-renders and overwrites
+  `_last_optional_keys` with its own schema, so the terminal save site never
+  sees the Pass-1-cleared key in `_cleared_optional_keys` — the clear is lost.
+  Originally documented as an accepted "known limitation"; the user has
+  decided clearing must work across multi-pass steps too.
+- Proposed fix:
+  - Route the intermediate persists through the same clear-on-absence path
+    (`_merge_with_cleared`, or the explicit `_cleared_optional_keys(...)`
+    drop used by the radiator save site). At the moment of an intermediate
+    write, `_last_optional_keys` still reflects the just-submitted Pass-1
+    form (Pass 2 has not rendered yet), so dropping the cleared keys there
+    closes the gap without needing to accumulate keys across passes.
+  - Apply to all three intermediate persist sites (car dampening, climate/
+    radiator HVAC reprompt, `_persist_radiator_pass1`), preserving the
+    runtime-only-key survival guarantee (same as the terminal sites).
+  - Remove the "Known limitation" paragraph in
+    `docs/agents/concepts/config-and-setup-flow.md` (~L261-266) and the
+    matching out-of-scope note (review #1) in `docs/stories/QS-251.story.md`;
+    replace with a short note that multi-pass clears are now handled.
+  - Add e2e coverage: clear an optional field in a step that triggers a
+    multi-pass (e.g. car tracker cleared while toggling dampening), save
+    through Pass 2, assert the cleared key is absent from the reloaded entry
+    AND that runtime-only keys survive.
+
+### [should-fix] Shared mutable `set()` class default for `_last_optional_keys`
+- File: `custom_components/quiet_solar/config_flow.py:~308`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `_last_optional_keys: set[str] = set()` is a single mutable
+  object shared across all flow-handler instances. Safe today only because it
+  is always reassigned, never mutated in place — a fragile invariant.
+- Proposed fix: Replace with a `None` sentinel default + per-instance
+  initialization (e.g. initialize to an empty set on first use / in the
+  handler), so no mutable state is shared at class level. Keep coverage at
+  100% and preserve the additive-merge behavior for the (test-covered)
+  no-prior-render path.
+
+### [should-fix] Options-flow-only `_merge_with_cleared` lives on the shared mixin without a guard
+- File: `custom_components/quiet_solar/config_flow.py:~73`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `_merge_with_cleared` reads `self.config_entry.data`, which only
+  exists on the options-flow handler, yet sits on the shared mixin next to the
+  `async_show_form` override. Only the options flow calls it today; a future
+  creation-flow caller would `AttributeError`.
+- Proposed fix: Either move `_merge_with_cleared` (and, if appropriate,
+  `_cleared_optional_keys`) onto the options-flow handler, or guard against a
+  missing `config_entry` so a creation-flow misuse fails loudly/safely. Keep
+  the `async_show_form` capture on the shared mixin (it is correctly flow-
+  agnostic).
+
+### [should-fix] AC6 missing-key consumer tolerance not regression-tested
+- File: `tests/ha_tests/test_water_boiler.py:~197` (+ consumer
+  `custom_components/quiet_solar/ha_model/water_boiler.py`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: Story Task 6 prescribed updating the water-boiler test to the
+  missing-key (key-entirely-absent) semantics the generic mechanism now
+  produces. The existing test only exercises the `""`→None path. The consumer
+  is in fact tolerant, but AC6's consumer half has no dedicated guard.
+- Proposed fix: Add a missing-key device-construction regression test (update
+  `test_water_boiler.py:~197` or add a sibling) asserting `QSWaterBoiler`
+  tolerates `CONF_WATER_BOILER_TEMPERATURE_SENSOR` being entirely absent
+  (equivalent behavior to its `""`→None WF-3 normalization).
+
+### [should-fix] Stale `~L...` line anchors in the story
+- File: `docs/stories/QS-251.story.md:42` (also ~L86-124)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: Several `config_flow.py` line references no longer match the
+  current file (`add_entity_selector` ~L380, `clean_data` ~L772,
+  `_async_entry_next` ~L2308), making the investigation trail untrustworthy.
+- Proposed fix: Drop the exact line numbers from the story (refer to symbols/
+  functions by name instead of `~L...`).
+
+### [nice-to-have] `str(marker.schema)` fallback is a dead/masking branch
+- File: `custom_components/quiet_solar/config_flow.py:~55`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter / qs-review-edge-case-hunter / qs-review-acceptance-auditor
+- Description: Every QS optional marker wraps a bare `CONF_*` string, so the
+  `else: str(marker.schema)` branch is unreachable and would also produce a
+  key that can never match a submission (masking, not normalizing).
+- Proposed fix: Capture only bare-string optional keys (skip non-string
+  markers) instead of coercing with `str(...)`. Ensure the change keeps 100%
+  line+branch coverage (no newly-uncovered branch).
+
+### [nice-to-have] Comments reference now-deleted machinery
+- File: `custom_components/quiet_solar/config_flow.py:~1590, ~1884, ~1922`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Explanatory comments still reference removed code (M3, WF-4,
+  EH5, BH-D), which may confuse future readers.
+- Proposed fix: Trim/refresh the comments so they describe the current
+  generic clear-on-absence path without dangling references to deleted
+  bespoke machinery.
+
+### [nice-to-have] Full quality gate not verified during review
+- File: (whole change set)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: Targeted tests pass, but the full
+  `python scripts/qs/quality_gate.py` (100% cov / ruff / mypy / translations)
+  was not run during review.
+- Proposed fix: Run the full quality gate and ensure it passes before commit
+  (standard implement-phase requirement; called out here explicitly because
+  the must-fix multi-pass change widens the diff).
+
+## Decisions log (skipped findings)
+
+- **SF1 — numeric/string optional false-clear, incl. boolean ambiguity:**
+  SKIPPED. The fix relies on HA's contract that an omitted key means the user
+  cleared it (untouched optionals are resubmitted with their suggested value);
+  reverting a cleared numeric field to its default is the intended outcome.
+  Verified every `cv.boolean` field is `vol.Optional(..., default=...)`, so
+  HA always submits booleans and they can never be falsely cleared.
+- **NH4 — hardcoded `measured_*` keys in tests:** SKIPPED. There is no
+  `const.py` symbol for these runtime-written keys, so routing through a
+  constant is not applicable.
+
+## How to apply
+
+Run `implement-task` against this fix plan. When done, return and run
+`/review-task` again (or open a fresh `claude --agent qs-review-task`
+session) to re-verify.

--- a/docs/stories/QS-251.story_review_fix_#02.md
+++ b/docs/stories/QS-251.story_review_fix_#02.md
@@ -1,0 +1,65 @@
+# QS-251 — Review fix plan #02
+
+## Summary
+- Source PR: #252
+- Source story: docs/stories/QS-251.story.md
+- Prior fix plan: docs/stories/QS-251.story_review_fix_#01.md (all 8 items verified resolved; full quality gate passes)
+- Findings to fix: 1 (should-fix)
+- Next implement phase: `implement-task`
+
+## Findings to fix
+
+### [should-fix] Radiator validation-error re-render revives a cleared pilot
+- File: `custom_components/quiet_solar/config_flow.py` (`_async_show_radiator_form._suggest`, ~L2074; the radiator XOR/validation-error re-render path)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: On a radiator XOR/validation-error re-render, `_suggest` returns
+  `explicit_pending.get(key) or self.config_entry.data.get(key)`. The rejected
+  `pending` (the user's submission) OMITS an optional key the user just
+  cleared, so `_suggest` falls back to the still-persisted stale value and
+  re-prefills the dropdown. The error re-render does NOT persist, so the clear
+  is only "remembered" in `_last_optional_keys`. When the user fixes the
+  unrelated backing error and resubmits, the revived value is now PRESENT in
+  the submission, so `_cleared_optional_keys` no longer flags it and the old
+  value re-persists — the clear is silently lost.
+  - Repro: edit a radiator with `CONF_DEVICE_TO_PILOT_NAME` set and heat pumps
+    present; clear the pilot dropdown AND submit a backing combination that
+    trips the XOR error (both climate+switch set, or both empty). On the error
+    re-render the pilot is pre-filled again; fix the backing and save → the
+    cleared pilot name is back.
+  - Scope note: only the radiator error-re-render path is affected. The car
+    and climate multi-pass intermediates persist the cleared state BEFORE
+    re-rendering (Pass 2 reads the now-absent key and renders empty), so they
+    are immune. This contradicts the PR's stated goal that "clearing must
+    work."
+- Proposed fix:
+  - On the radiator error re-render, do not let `_suggest` revive an optional
+    field the user cleared. Treat keys present in `_last_optional_keys` but
+    omitted from the rejected `pending`/`user_input` as cleared, and suppress
+    the `config_entry.data` fallback for those keys so the selector renders
+    empty (preserving the user's clear across the error round-trip).
+  - Keep the existing `_suggest` behavior intact for all other keys (rejected
+    input is still re-prefilled as before).
+  - Add e2e coverage: clear the radiator pilot AND submit an XOR-invalid
+    backing combo → assert the error re-render does NOT re-prefill the pilot;
+    then fix the backing and save → assert the persisted entry has no
+    `CONF_DEVICE_TO_PILOT_NAME`. Also assert unrelated rejected fields are
+    still re-prefilled on the error screen (no regression to `_suggest`).
+
+## Decisions log (skipped findings)
+
+- **RF2-NH1 — optional-key capture lost its `isinstance(marker.schema, str)`
+  type guard:** SKIPPED. Latent only — every current QS optional marker wraps
+  a bare `CONF_*` string. A future non-string marker would be captured
+  verbatim and wrongly treated as always-cleared, but no such marker exists
+  today.
+- **RF2-NH2 — `FakeConfigEntry` creation-path car-dampening intermediate
+  persist:** SKIPPED. Pre-existing; the PR only swapped the merge expression.
+  `_merge_with_cleared` copies via `dict(base)` so it does not mutate the
+  shared `FakeConfigEntry` dict — safe today. Out of strict QS-251 scope.
+
+## How to apply
+
+Run `implement-task` against this fix plan. When done, return and run
+`/review-task` again (or open a fresh `claude --agent qs-review-task`
+session) to re-verify.

--- a/tests/ha_tests/test_water_boiler.py
+++ b/tests/ha_tests/test_water_boiler.py
@@ -194,6 +194,51 @@ async def test_water_boiler_without_temperature_sensor(
     )
 
 
+async def test_water_boiler_missing_temperature_sensor_key_tolerated(
+    hass: HomeAssistant,
+    home_config_entry: ConfigEntry,
+) -> None:
+    """AC6 / QS-251 — construction tolerates the temp-sensor key being absent.
+
+    The centralized clear-on-absence mechanism now removes the key entirely
+    (rather than the old `setdefault("")` band-aid), so a cleared water boiler
+    persists with `CONF_WATER_BOILER_TEMPERATURE_SENSOR` missing. This is the
+    consumer half of AC6: `QSWaterBoiler.__init__` must treat the missing key
+    exactly like its `""`→`None` WF-3 normalization — `None`, no probe.
+    """
+    await hass.config_entries.async_setup(home_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The key is entirely absent (the missing-key shape the generic path emits).
+    config = dict(MOCK_WATER_BOILER_CONFIG_NO_TEMP)
+    assert CONF_WATER_BOILER_TEMPERATURE_SENSOR not in config
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config,
+        entry_id="water_boiler_missing_key_test",
+        title=f"water_boiler: {config['name']}",
+        unique_id="quiet_solar_water_boiler_missing_key_test",
+    )
+    entry.add_to_hass(hass)
+
+    real_attach = HADeviceMixin.attach_ha_state_to_probe
+    with patch.object(
+        HADeviceMixin,
+        "attach_ha_state_to_probe",
+        autospec=True,
+        wraps=real_attach,
+    ) as mock_probe:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device = hass.data[DOMAIN].get(entry.entry_id)
+    assert device is not None
+    assert device.water_boiler_temperature_sensor is None
+    # No probe attached for the (absent) temperature sensor entity id.
+    assert _matching_probe_calls(mock_probe, _TEMP_SENSOR_ID) == []
+
+
 async def test_water_boiler_empty_string_temperature_sensor_normalised_to_none(
     hass: HomeAssistant,
     home_config_entry: ConfigEntry,

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -42,6 +42,7 @@ from custom_components.quiet_solar.const import (
     CONF_CAR_ESTIMATED_RANGE_SENSOR,
     CONF_CAR_IS_CUSTOM_POWER_CHARGE_VALUES_3P,
     CONF_CAR_ODOMETER_SENSOR,
+    CONF_CAR_TRACKER,
     CONF_CHARGER_DEVICE_OCPP,
     CONF_CHARGER_DEVICE_WALLBOX,
     CONF_CHARGER_LATITUDE,
@@ -58,6 +59,7 @@ from custom_components.quiet_solar.const import (
     CONF_DEVICE_TO_PILOT_NAME,
     CONF_DYN_GROUP_MAX_PHASE_AMPS,
     CONF_GRID_POWER_SENSOR,
+    CONF_GRID_POWER_SENSOR_INVERTED,
     CONF_HOME_VOLTAGE,
     CONF_IS_3P,
     CONF_LOAD_IS_BOOST_ONLY,
@@ -90,10 +92,14 @@ from custom_components.quiet_solar.const import (
     FORECAST_SOLAR_DOMAIN,
     OPEN_METEO_SOLAR_DOMAIN,
     SOLCAST_SOLAR_DOMAIN,
+    CONF_TYPE_NAME_QSBattery,
+    CONF_TYPE_NAME_QSCar,
     CONF_TYPE_NAME_QSClimateDuration,
     CONF_TYPE_NAME_QSHeatPump,
     CONF_TYPE_NAME_QSHome,
     CONF_TYPE_NAME_QSRadiator,
+    CONF_TYPE_NAME_QSWaterBoiler,
+    CONF_WATER_BOILER_TEMPERATURE_SENSOR,
 )
 from custom_components.quiet_solar.ha_model.battery import QSBattery
 from custom_components.quiet_solar.ha_model.car import QSCar
@@ -1675,14 +1681,20 @@ async def test_radiator_step_explicit_pilot_clear_with_absent_key(
 
     flow = _init_options_flow(hass, config_entry)
 
+    # Render the form first so the generic clear-on-absence mechanism
+    # captures the rendered optional pilot key (this replaces the removed
+    # per-field `explicit_pilot_clear` machinery).
+    render = await flow.async_step_radiator()
+    assert render["type"] == FlowResultType.FORM
+
     with patch(
         "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
         new_callable=AsyncMock,
     ):
         # User submits WITHOUT the pilot key at all (HA omits absent
         # `vol.Optional` fields). The persisted pilot must still be
-        # cleared because we detect "form rendered the dropdown AND
-        # user submitted nothing for it AND a value was persisted".
+        # cleared because the form rendered the dropdown AND the user
+        # submitted nothing for it.
         result = await flow.async_step_radiator(
             {
                 CONF_NAME: "Pilot Absent Radiator",
@@ -1839,6 +1851,12 @@ async def test_radiator_step_explicit_pilot_clear_removes_persisted_key(
     mock_data_handler.home = mock_home
 
     flow = _init_options_flow(hass, config_entry)
+
+    # Render the form first so the generic clear-on-absence mechanism
+    # captures the rendered optional pilot key (this replaces the removed
+    # per-field `explicit_pilot_clear` machinery).
+    render = await flow.async_step_radiator()
+    assert render["type"] == FlowResultType.FORM
 
     with patch(
         "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
@@ -3282,3 +3300,327 @@ async def test_options_solar_step_forecast_provider_filtered_when_unavailable(
             break
     else:
         pytest.fail("CONF_SOLAR_FORECAST_PROVIDERS key not found in schema")
+
+
+# ---------------------------------------------------------------------------
+# QS-251 — centralized "clear-on-absence" for optional option-flow fields.
+#
+# Clearing an optional selector (the ✕ on an entity selector) makes HA omit
+# the key from `user_input`. The options-flow merge is additive, so without a
+# correction the stale value is re-persisted. `QSFlowHandlerMixin` now records
+# the optional keys rendered in the last form (`_last_optional_keys`) and the
+# terminal save sites drop any optional key that was rendered but omitted.
+# ---------------------------------------------------------------------------
+
+
+def test_cleared_optional_keys_identifies_omitted_rendered_keys(
+    hass: HomeAssistant, mock_config_entry
+):
+    """`_cleared_optional_keys` = rendered optional keys missing from the submit.
+
+    A key that was rendered AND omitted is "cleared"; a key that was
+    rendered AND present (or never rendered) is not.
+    """
+    flow = _init_options_flow(hass, mock_config_entry)
+    flow._last_optional_keys = {CONF_CAR_TRACKER, CONF_BATTERY_CHARGE_PERCENT_SENSOR}
+
+    submitted = {CONF_NAME: "Device", CONF_BATTERY_CHARGE_PERCENT_SENSOR: "sensor.pct"}
+
+    cleared = flow._cleared_optional_keys(submitted)
+
+    # The tracker was rendered but omitted → cleared. The percent sensor was
+    # rendered and present → not cleared.
+    assert cleared == {CONF_CAR_TRACKER}
+
+
+def test_merge_with_cleared_drops_cleared_keeps_present_and_runtime(
+    hass: HomeAssistant
+):
+    """`_merge_with_cleared` drops cleared optional keys but keeps runtime keys.
+
+    A rendered-then-omitted optional field disappears from the merged data,
+    while a runtime-only key that never appears in the form schema
+    (e.g. ``measured_power``) survives the additive merge.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_merge_with_cleared_123",
+        data={
+            CONF_NAME: "Device",
+            CONF_CAR_TRACKER: "device_tracker.old_car",
+            "measured_power": 1234,
+            "measured_charge_6": 4200,
+        },
+        title="car: Device",
+    )
+    config_entry.add_to_hass(hass)
+    flow = _init_options_flow(hass, config_entry)
+
+    # The car tracker was rendered in the last form; the submission omits it.
+    flow._last_optional_keys = {CONF_CAR_TRACKER}
+    submitted = {CONF_NAME: "Device"}
+
+    merged = flow._merge_with_cleared(submitted)
+
+    # Cleared optional field is gone.
+    assert CONF_CAR_TRACKER not in merged
+    # Runtime-only keys (never in the form schema) survive.
+    assert merged["measured_power"] == 1234
+    assert merged["measured_charge_6"] == 4200
+    assert merged[CONF_NAME] == "Device"
+
+
+@pytest.mark.asyncio
+async def test_last_optional_keys_holds_bare_conf_strings_after_render(
+    hass: HomeAssistant, mock_data_handler
+):
+    """Key-extraction contract — `_last_optional_keys` holds bare `CONF_*` strings.
+
+    `async_show_form` records every `vol.Optional` marker's wrapped key as a
+    plain string. The car step always renders `CONF_CAR_TRACKER` as an
+    optional selector, so it must appear verbatim in the captured set.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_last_optional_keys_123",
+        data={CONF_NAME: "Captured Car", DEVICE_TYPE: CONF_TYPE_NAME_QSCar},
+        title="car: Captured",
+    )
+    config_entry.add_to_hass(hass)
+    flow = _init_options_flow(hass, config_entry)
+
+    result = await flow.async_step_car()
+
+    assert result["type"] == FlowResultType.FORM
+    # Bare string constant — not a wrapped marker object.
+    assert CONF_CAR_TRACKER in flow._last_optional_keys
+    assert all(isinstance(key, str) for key in flow._last_optional_keys)
+
+
+@pytest.mark.asyncio
+async def test_options_flow_car_tracker_clear_round_trips_to_absent(
+    hass: HomeAssistant, mock_data_handler
+):
+    """AC1 — clearing `CONF_CAR_TRACKER` in the options flow persists as absent.
+
+    The reported bug: clearing the car device tracker reverted to the old
+    value on save. The form is rendered (capturing the optional key), then
+    re-submitted without the tracker; the persisted entry must drop it.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_car_tracker_clear_123",
+        data={
+            CONF_NAME: "Tracked Car",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSCar,
+            CONF_CAR_TRACKER: "device_tracker.my_car",
+        },
+        title="car: Tracked",
+    )
+    config_entry.add_to_hass(hass)
+    flow = _init_options_flow(hass, config_entry)
+
+    # Render the form first — this captures the rendered optional keys.
+    render = await flow.async_step_car()
+    assert render["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+        new_callable=AsyncMock,
+    ):
+        # Submit WITHOUT the tracker → user cleared it via the ✕.
+        result = await flow.async_step_car({CONF_NAME: "Tracked Car"})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_CAR_TRACKER not in config_entry.data
+
+
+@pytest.mark.asyncio
+async def test_options_flow_battery_sensor_clear_round_trips_to_absent(
+    hass: HomeAssistant, mock_data_handler
+):
+    """AC2 — generality: clearing a battery optional sensor also persists absent.
+
+    The mechanism is generic; proving it on a second device type
+    (`CONF_BATTERY_CHARGE_PERCENT_SENSOR`) shows it's not car-specific.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_battery_sensor_clear_123",
+        data={
+            CONF_NAME: "House Battery",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSBattery,
+            CONF_BATTERY_CHARGE_PERCENT_SENSOR: "sensor.battery_soc",
+            CONF_BATTERY_CAPACITY: 5000,
+        },
+        title="battery: House",
+    )
+    config_entry.add_to_hass(hass)
+
+    # A percent sensor must exist for the optional selector to be rendered.
+    hass.states.async_set(
+        "sensor.battery_soc",
+        "50",
+        {ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE},
+    )
+
+    flow = _init_options_flow(hass, config_entry)
+
+    render = await flow.async_step_battery()
+    assert render["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+        new_callable=AsyncMock,
+    ):
+        result = await flow.async_step_battery(
+            {
+                CONF_NAME: "House Battery",
+                CONF_BATTERY_CAPACITY: 5000,
+            }
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_BATTERY_CHARGE_PERCENT_SENSOR not in config_entry.data
+
+
+@pytest.mark.asyncio
+async def test_options_flow_clear_preserves_runtime_only_keys(
+    hass: HomeAssistant, mock_data_handler
+):
+    """AC3 — clearing an unrelated optional field keeps runtime-only keys.
+
+    `measured_power` / `measured_charge_*` are written at runtime and never
+    appear in the form schema; the merge must preserve them even as a cleared
+    optional field is dropped.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_runtime_keys_survive_123",
+        data={
+            CONF_NAME: "Runtime Car",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSCar,
+            CONF_CAR_TRACKER: "device_tracker.my_car",
+            "measured_power": 2200,
+            "measured_charge_10": 6900,
+        },
+        title="car: Runtime",
+    )
+    config_entry.add_to_hass(hass)
+    flow = _init_options_flow(hass, config_entry)
+
+    render = await flow.async_step_car()
+    assert render["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+        new_callable=AsyncMock,
+    ):
+        result = await flow.async_step_car({CONF_NAME: "Runtime Car"})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # Cleared optional field gone, runtime-only keys intact.
+    assert CONF_CAR_TRACKER not in config_entry.data
+    assert config_entry.data["measured_power"] == 2200
+    assert config_entry.data["measured_charge_10"] == 6900
+
+
+@pytest.mark.asyncio
+async def test_options_flow_save_does_not_drop_required_or_boolean_default(
+    hass: HomeAssistant, mock_data_handler
+):
+    """AC4 — required and boolean `default=` fields are never falsely cleared.
+
+    HA always submits required (`CONF_NAME`) and boolean `default=`
+    (`CONF_GRID_POWER_SENSOR_INVERTED`) fields, so they are never in the
+    cleared set even on an otherwise minimal submission.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_no_false_clear_123",
+        data={
+            CONF_NAME: "Inverted Grid Home",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSHome,
+            CONF_GRID_POWER_SENSOR_INVERTED: True,
+        },
+        title="home: Inverted Grid",
+    )
+    config_entry.add_to_hass(hass)
+
+    # A power sensor must exist for the inverted-grid boolean to be rendered.
+    hass.states.async_set(
+        "sensor.grid_power",
+        "1000",
+        {ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT},
+    )
+
+    flow = _init_options_flow(hass, config_entry)
+
+    render = await flow.async_step_home()
+    assert render["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+        new_callable=AsyncMock,
+    ):
+        # HA always submits required + boolean-default fields.
+        result = await flow.async_step_home(
+            {
+                CONF_NAME: "Inverted Grid Home",
+                CONF_GRID_POWER_SENSOR_INVERTED: True,
+            }
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert config_entry.data[CONF_NAME] == "Inverted Grid Home"
+    assert config_entry.data[CONF_GRID_POWER_SENSOR_INVERTED] is True
+
+
+@pytest.mark.asyncio
+async def test_options_flow_water_boiler_temperature_sensor_clear_round_trips_to_absent(
+    hass: HomeAssistant, mock_data_handler
+):
+    """AC6 — clearing the water-boiler temperature sensor persists as absent.
+
+    The former per-step `setdefault(..., "")` band-aid is gone; the generic
+    clear-on-absence path now removes the key. `QSWaterBoiler.__init__`
+    tolerates the missing key exactly like its `""`→`None` WF-3 case.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_water_boiler_temp_clear_123",
+        data={
+            CONF_NAME: "Tank",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSWaterBoiler,
+            CONF_SWITCH: "switch.tank",
+            CONF_WATER_BOILER_TEMPERATURE_SENSOR: "sensor.tank_temp",
+        },
+        title="water_boiler: Tank",
+    )
+    config_entry.add_to_hass(hass)
+
+    # A live temperature entity ensures the optional selector is rendered.
+    hass.states.async_set(
+        "sensor.tank_temp",
+        "55",
+        {ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS},
+    )
+
+    flow = _init_options_flow(hass, config_entry)
+
+    render = await flow.async_step_water_boiler()
+    assert render["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+        new_callable=AsyncMock,
+    ):
+        result = await flow.async_step_water_boiler(
+            {
+                CONF_NAME: "Tank",
+                CONF_SWITCH: "switch.tank",
+            }
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_WATER_BOILER_TEMPERATURE_SENSOR not in config_entry.data

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -3334,33 +3334,29 @@ def test_cleared_optional_keys_identifies_omitted_rendered_keys(
 
 
 def test_merge_with_cleared_drops_cleared_keeps_present_and_runtime(
-    hass: HomeAssistant
+    hass: HomeAssistant, mock_config_entry
 ):
     """`_merge_with_cleared` drops cleared optional keys but keeps runtime keys.
 
-    A rendered-then-omitted optional field disappears from the merged data,
-    while a runtime-only key that never appears in the form schema
-    (e.g. ``measured_power``) survives the additive merge.
+    The helper takes the merge `base` explicitly (it is flow-agnostic and does
+    not read `config_entry`). A rendered-then-omitted optional field
+    disappears from the merged data, while a runtime-only key that never
+    appears in the form schema (e.g. ``measured_power``) survives the additive
+    merge.
     """
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="test_merge_with_cleared_123",
-        data={
-            CONF_NAME: "Device",
-            CONF_CAR_TRACKER: "device_tracker.old_car",
-            "measured_power": 1234,
-            "measured_charge_6": 4200,
-        },
-        title="car: Device",
-    )
-    config_entry.add_to_hass(hass)
-    flow = _init_options_flow(hass, config_entry)
+    flow = _init_options_flow(hass, mock_config_entry)
 
+    base = {
+        CONF_NAME: "Device",
+        CONF_CAR_TRACKER: "device_tracker.old_car",
+        "measured_power": 1234,
+        "measured_charge_6": 4200,
+    }
     # The car tracker was rendered in the last form; the submission omits it.
     flow._last_optional_keys = {CONF_CAR_TRACKER}
     submitted = {CONF_NAME: "Device"}
 
-    merged = flow._merge_with_cleared(submitted)
+    merged = flow._merge_with_cleared(base, submitted)
 
     # Cleared optional field is gone.
     assert CONF_CAR_TRACKER not in merged
@@ -3368,6 +3364,8 @@ def test_merge_with_cleared_drops_cleared_keeps_present_and_runtime(
     assert merged["measured_power"] == 1234
     assert merged["measured_charge_6"] == 4200
     assert merged[CONF_NAME] == "Device"
+    # The base dict is not mutated.
+    assert base[CONF_CAR_TRACKER] == "device_tracker.old_car"
 
 
 @pytest.mark.asyncio
@@ -3574,6 +3572,75 @@ async def test_options_flow_save_does_not_drop_required_or_boolean_default(
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert config_entry.data[CONF_NAME] == "Inverted Grid Home"
     assert config_entry.data[CONF_GRID_POWER_SENSOR_INVERTED] is True
+
+
+@pytest.mark.asyncio
+async def test_options_flow_multipass_car_dampening_clears_tracker_at_intermediate_persist(
+    hass: HomeAssistant, mock_data_handler
+):
+    """Multi-pass clear — a field cleared in Pass 1 is dropped at the
+    intermediate persist (not revived in Pass 2 nor re-persisted).
+
+    Toggling car dampening triggers a Pass 1 → Pass 2 re-render whose
+    intermediate `async_update_entry` previously merged additively, reviving
+    a Pass-1-cleared `CONF_CAR_TRACKER`. The intermediate persist now routes
+    through the same clear-on-absence path as the terminal save; runtime-only
+    keys still survive.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_multipass_car_clear_123",
+        data={
+            CONF_NAME: "Multipass Car",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSCar,
+            CONF_CAR_TRACKER: "device_tracker.my_car",
+            CONF_CAR_CHARGER_MIN_CHARGE: 6,
+            CONF_CAR_CHARGER_MAX_CHARGE: 10,
+            "measured_power": 3300,
+        },
+        title="car: Multipass",
+    )
+    config_entry.add_to_hass(hass)
+    flow = _init_options_flow(hass, config_entry)
+
+    # Pass 1 render — captures CONF_CAR_TRACKER as a rendered optional key.
+    render = await flow.async_step_car()
+    assert render["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+        new_callable=AsyncMock,
+    ):
+        # Pass 1 submit: enable dampening (forces Pass 2) AND clear the tracker.
+        pass2 = await flow.async_step_car(
+            {
+                CONF_NAME: "Multipass Car",
+                CONF_CAR_CHARGER_MIN_CHARGE: 6,
+                CONF_CAR_CHARGER_MAX_CHARGE: 10,
+                CONF_CAR_CUSTOM_POWER_CHARGE_VALUES: True,
+            }
+        )
+
+        assert pass2["type"] == FlowResultType.FORM
+        # Intermediate persist dropped the cleared tracker (Pass 2 cannot
+        # re-suggest it)...
+        assert CONF_CAR_TRACKER not in config_entry.data
+        # ...while runtime-only keys survive the intermediate merge.
+        assert config_entry.data["measured_power"] == 3300
+
+        # Pass 2 submit (terminal): dampening stays on, tracker still cleared.
+        result = await flow.async_step_car(
+            {
+                CONF_NAME: "Multipass Car",
+                CONF_CAR_CHARGER_MIN_CHARGE: 6,
+                CONF_CAR_CHARGER_MAX_CHARGE: 10,
+                CONF_CAR_CUSTOM_POWER_CHARGE_VALUES: True,
+            }
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_CAR_TRACKER not in config_entry.data
+    assert config_entry.data["measured_power"] == 3300
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration_config_flow.py
+++ b/tests/test_integration_config_flow.py
@@ -1878,6 +1878,97 @@ async def test_radiator_step_explicit_pilot_clear_removes_persisted_key(
     assert CONF_DEVICE_TO_PILOT_NAME not in config_entry.data
 
 
+def _suggested_value(schema, key: str):
+    """Return the `suggested_value` for `key` in a rendered schema, or None."""
+    for item in schema.schema:
+        if getattr(item, "schema", None) == key:
+            return item.description.get("suggested_value") if item.description else None
+    return None
+
+
+def _schema_has_marker(schema, key: str) -> bool:
+    return any(getattr(item, "schema", None) == key for item in schema.schema)
+
+
+@pytest.mark.asyncio
+async def test_radiator_error_rerender_does_not_revive_cleared_pilot(
+    hass: HomeAssistant, mock_data_handler
+):
+    """Review-fix #02 — a cleared pilot is not re-prefilled on an XOR-error
+    re-render (which would otherwise silently re-persist the stale value).
+
+    Repro: clear the pilot AND submit an XOR-invalid backing combo (both
+    climate and switch set). The error re-render must render the pilot empty
+    (not fall back to the persisted name), while unrelated rejected fields are
+    still re-prefilled. Fixing the backing and saving then drops the pilot.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_radiator_rerender_pilot_123",
+        data={
+            CONF_NAME: "Rerender Radiator",
+            DEVICE_TYPE: CONF_TYPE_NAME_QSRadiator,
+            CONF_POWER: 1000,
+            CONF_SWITCH: "switch.r",
+            CONF_DEVICE_TO_PILOT_NAME: "Existing HP",
+        },
+        title="radiator: Rerender",
+    )
+    config_entry.add_to_hass(hass)
+
+    existing_hp = MagicMock()
+    existing_hp.name = "Existing HP"
+    mock_home = create_minimal_home_model()
+    mock_home._heat_pumps = [existing_hp]
+    mock_data_handler.home = mock_home
+
+    flow = _init_options_flow(hass, config_entry)
+
+    # Render the form first so `_last_optional_keys` captures the pilot key.
+    render = await flow.async_step_radiator()
+    assert render["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.quiet_solar.config_flow.get_hvac_modes",
+        return_value=["heat", "off"],
+    ):
+        # XOR error: BOTH climate and switch set, pilot cleared (omitted).
+        rerender = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Rerender Radiator",
+                CONF_POWER: 1000,
+                CONF_CLIMATE: "climate.r",
+                CONF_SWITCH: "switch.r",
+                # CONF_DEVICE_TO_PILOT_NAME intentionally cleared (omitted)
+            }
+        )
+
+    assert rerender["type"] == FlowResultType.FORM
+    assert rerender["errors"]["base"] == "exactly_one_backing_required"
+    schema = rerender["data_schema"]
+    # The cleared pilot must NOT be re-prefilled from the persisted value.
+    assert _schema_has_marker(schema, CONF_DEVICE_TO_PILOT_NAME)
+    assert _suggested_value(schema, CONF_DEVICE_TO_PILOT_NAME) is None
+    # No-regression: an unrelated rejected field is still re-prefilled.
+    assert _suggested_value(schema, CONF_SWITCH) == "switch.r"
+
+    # Fix the backing (switch only) and save — the pilot stays cleared.
+    with patch(
+        "custom_components.quiet_solar.config_flow.async_reload_quiet_solar",
+        new_callable=AsyncMock,
+    ):
+        result = await flow.async_step_radiator(
+            {
+                CONF_NAME: "Rerender Radiator",
+                CONF_POWER: 1000,
+                CONF_SWITCH: "switch.r",
+            }
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_DEVICE_TO_PILOT_NAME not in config_entry.data
+
+
 @pytest.mark.asyncio
 async def test_get_common_schema_dashboard_dropdown_reflects_home_sections(
     hass: HomeAssistant, mock_data_handler


### PR DESCRIPTION
## Summary
Centralize clear-on-absence: QSFlowHandlerMixin.async_show_form records rendered optional keys; terminal options-flow save sites drop optional keys rendered-but-omitted instead of re-persisting stale values.
Removes the water-boiler setdefault and radiator explicit_pilot_clear per-field band-aids in favor of the generic path.
Adds helper unit tests plus AC1-AC6 e2e coverage (car tracker, battery sensor, runtime-key survival, no false clears, water boiler); updates radiator pilot-clear tests to guard the generic path.

Fixes #251

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rendered-but-omitted optional fields (e.g., radiator pilot, water‑boiler temperature sensor, car tracker, battery sensor, inverted boolean) are no longer restored on save; cleared optional keys are removed at both intermediate persists and final saves.

* **Documentation**
  * Added/updated docs describing the centralized clear-on-absence behavior, radiator pilot semantics, water‑boiler tolerance, and multi-pass flow behavior; updated verification date.

* **Tests**
  * Added unit and end-to-end tests for cleared-key detection, merge behavior, runtime-only key preservation, and water‑boiler missing-key tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->