### PR TITLE
QS-253: Car card — keep reset/person/charger clickable when car disconnected

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -1094,22 +1094,19 @@ class QsCarCard extends QsCardBase {
       .secondary { background: rgba(255,255,255,.06); color: var(--primary-text-color); border:1px solid var(--divider-color); }
       /* Disconnected visual mode (greyscale) */
       .disabled .ring .target-value { color: var(--secondary-text-color); }
-      .disabled .primary { background: var(--divider-color); color: var(--primary-text-color); }
-      .disabled .secondary { background: rgba(255,255,255,.04); border-color: var(--divider-color); color: var(--secondary-text-color); }
-      .disabled .danger { background: var(--error-color); color: #fff; }
-      .disabled .danger.outline { background: transparent !important; color: var(--error-color) !important; border-color: var(--error-color) !important; }
-      .disabled .chip, .disabled .pill { border-color: var(--divider-color); }
-      .disabled .sun-btn { border-color: var(--divider-color); background: rgba(255,255,255,.03); box-shadow: none; }
-      .disabled .sun-btn ha-icon { color: var(--secondary-text-color); }
-      .disabled .sun-btn.on { border-color: var(--divider-color); background: rgba(255,255,255,.03); box-shadow: none; }
-      .disabled .sun-btn.on ha-icon { color: var(--secondary-text-color); }
-      .disabled .rabbit-btn { border-color: var(--divider-color); background: rgba(255,255,255,.03); box-shadow: none; }
-      .disabled .rabbit-btn ha-icon { color: var(--secondary-text-color); }
-      .disabled .rabbit-btn.on { border-color: var(--divider-color); background: rgba(255,255,255,.03); box-shadow: none; }
-      .disabled .rabbit-btn.on ha-icon { color: var(--secondary-text-color); }
-      .disabled .time-btn { border-color: var(--divider-color); background: rgba(255,255,255,.03); box-shadow: none; cursor: not-allowed; color: var(--secondary-text-color); }
+      /* QS-253: disabled greying is scoped to in-ring controls only. The
+         below-ring controls (person / charger selects, Reset) render at full
+         enabled fidelity even when the car is disconnected. */
+      .disabled .ring .sun-btn { border-color: var(--divider-color); background: rgba(255,255,255,.03); box-shadow: none; }
+      .disabled .ring .sun-btn ha-icon { color: var(--secondary-text-color); }
+      .disabled .ring .sun-btn.on { border-color: var(--divider-color); background: rgba(255,255,255,.03); box-shadow: none; }
+      .disabled .ring .sun-btn.on ha-icon { color: var(--secondary-text-color); }
+      .disabled .ring .rabbit-btn { border-color: var(--divider-color); background: rgba(255,255,255,.03); box-shadow: none; }
+      .disabled .ring .rabbit-btn ha-icon { color: var(--secondary-text-color); }
+      .disabled .ring .rabbit-btn.on { border-color: var(--divider-color); background: rgba(255,255,255,.03); box-shadow: none; }
+      .disabled .ring .rabbit-btn.on ha-icon { color: var(--secondary-text-color); }
+      .disabled .ring .time-btn { border-color: var(--divider-color); background: rgba(255,255,255,.03); box-shadow: none; cursor: not-allowed; color: var(--secondary-text-color); }
       .disabled .progress > div { background: var(--divider-color); }
-      .disabled #force, .disabled #schedule_inline { pointer-events: none; cursor: not-allowed; }
       .live { display:grid; gap:10px; }
       .fault .card-title { color: var(--error-color); }
       .fault .time-btn { color: var(--secondary-text-color); }

--- a/custom_components/quiet_solar/ui/resources/shared/qs-card-styles.js
+++ b/custom_components/quiet_solar/ui/resources/shared/qs-card-styles.js
@@ -77,8 +77,12 @@ export function baseCardCSS(palette, _options) {
       .ring .power-btn ha-icon { --mdc-icon-size: 20px; color: var(--secondary-text-color); display:block; line-height:1; }
       .ring .power-btn.on { border-color: rgba(33,150,243,.45); background: rgba(33,150,243,.14); box-shadow: 0 0 0 3px rgba(33,150,243,.20), 0 0 16px #2196F3; }
       .ring .power-btn.on ha-icon { color: #2196F3; }
-      .card.disabled { opacity: 0.5; pointer-events: none; filter: grayscale(0.8); }
-      .card.disabled .power-btn { pointer-events: auto; opacity: 1; filter: grayscale(0); }
+      /* QS-253: dim/disable only the central ring (gauge + in-ring buttons),
+         not the whole card. Below-ring controls (.below / .below-line — mode
+         select, Reset, the car's person/charger selects) stay clickable and
+         un-dimmed when the card is disabled/disconnected. */
+      .card.disabled .ring { opacity: 0.5; pointer-events: none; filter: grayscale(0.8); }
+      .card.disabled .ring .power-btn { pointer-events: auto; opacity: 1; filter: grayscale(0); }
       .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center; pointer-events: none; transform: translateY(-5px); }
       .ring .target-label { color: var(--secondary-text-color); font-weight:700; font-size: .95rem; text-shadow: var(--ring-text-shadow); }
       .ring .target-value { font-weight:800; font-size: 2.5rem; line-height: 1.1; text-shadow: var(--ring-text-shadow); }

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -17,7 +17,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/shared/qs-ring-duration-base.js
   - custom_components/quiet_solar/ui/resources/shared/qs-anim-flame.js
   - custom_components/quiet_solar/ui/resources/shared/qs-anim-wave.js
-last_verified: 2026-05-30
+last_verified: 2026-06-02
 ---
 
 # Dashboard generation and JS Lovelace cards
@@ -272,12 +272,40 @@ Cross-card hardening invariants worth knowing (review-fix #02): every
 entity-derived string interpolated into `innerHTML` is escaped via
 `_escapeHtml`; every custom `div` control that carries handlers is
 focusable (`role="button"` + `tabindex` + `_registerKeyActivation`),
-and a disconnected card drops its custom controls out of the tab order
-(`tabindex="-1"` + `aria-disabled`); time parsing goes through the
-hardened `_parseTimeToMinutes` (07:00 fallback for `unavailable`/
-`unknown`); and the radiator keeps its RAF loop alive until
-`QsFlameEngine.isIdle()` so an on→off transition settles to a clean
-still silhouette instead of freezing mid-flicker.
+and a disconnected/disabled card drops its **in-ring** custom controls
+out of the tab order (`tabindex="-1"` + `aria-disabled`); time parsing
+goes through the hardened `_parseTimeToMinutes` (07:00 fallback for
+`unavailable`/`unknown`); and the radiator keeps its RAF loop alive
+until `QsFlameEngine.isIdle()` so an on→off transition settles to a
+clean still silhouette instead of freezing mid-flicker.
+
+**QS-253 — disabled dimming is ring-scoped, not whole-card.** The
+shared `disabled`/disconnected dimming + `pointer-events:none` rule
+(`shared/qs-card-styles.js`) targets **`.card.disabled .ring`** (and
+the power-button exemption `.card.disabled .ring .power-btn`), *not* a
+bare whole-card `.card.disabled { … }`. Consequently the central ring
+(gauge SVG, big value, in-ring buttons) dims and goes inert when a card
+is disabled (car disconnected / device off), while the **below-ring**
+controls (`.below` / `.below-line` — the mode `<select>`, the Reset
+button, and the car's assigned-person and connected-charger selects)
+stay **clickable and rendered at full enabled fidelity** (no greyscale,
+no divider-color greying). Only the **in-ring custom** controls drop
+out of the tab order (`tabindex="-1"` + `aria-disabled`) — the native
+`<select>`/`<button>` below-ring controls were never part of that
+custom-div tab-order logic and stay focusable. The in-ring JS `.disabled`
+guards (`querySelector('.disabled')`, e.g. the rabbit / SOC-popup
+handlers) keep working because the `disabled` class stays on the
+`<ha-card>` root, not on `.ring`. This fixed the reported bug where a
+**disconnected** car blocked the Reset / person / charger controls,
+making it impossible to manually re-assign the charger from the
+dashboard.
+
+> **Authorization (issue #253):** the product owner explicitly
+> authorized modifying the JS Lovelace cards for this change, and
+> broadening the behavior beyond the car's three controls to "all
+> pills/buttons below the circle … even for other cards, which is in
+> fact desired" — mirroring the QS-200 authorization to touch the
+> otherwise hand-maintained card assets.
 
 Two subsystems were root-caused in review-fix #04 to stop a recurring
 edge-case cycle:

--- a/docs/stories/QS-253.story.md
+++ b/docs/stories/QS-253.story.md
@@ -1,0 +1,300 @@
+# QS-253 — Keep below-ring controls clickable when a QS card is disconnected/disabled
+
+- **Issue:** #253
+- **Branch:** QS_253
+- **Next phase:** `implement-task` (touches `custom_components/quiet_solar/`)
+
+## Problem
+
+On all six QS Lovelace cards, when a card enters its "disabled" visual
+state the shared CSS rule
+
+```css
+.card.disabled { opacity: 0.5; pointer-events: none; filter: grayscale(0.8); }
+```
+
+(`ui/resources/shared/qs-card-styles.js`) dims **and** disables the
+**entire** card. Only the power button is exempted by the next line.
+
+- For **`qs-car-card`**, the disabled state means the car is
+  **disconnected** — `charge_type` state is `Not Plugged` / `Unknown`
+  (`isDisconnected`, the value that adds the `disabled` class to
+  `<ha-card>`).
+- For the other five cards (`qs-pool-card`, `qs-climate-card`,
+  `qs-on-off-duration-card`, `qs-radiator-card`, `qs-water-boiler-card`)
+  the disabled state means the device is turned off (`!isEnabled`).
+
+Reported bug (#253): on a **disconnected** car the **Reset** button,
+the **assigned-person** selector, and the **connected-charger** selector
+cannot be clicked. The product owner's key need: when the system picks
+the wrong car, they must be able to **manually re-assign the charger
+from the dashboard** — which is impossible today while disconnected.
+
+## Decision
+
+Re-scope the disabled dimming/disabling so it applies **only to the
+central ring** (`.ring` — the gauge circle plus the buttons inside it),
+leaving every control **below the ring** (`.below` / `.below-line`
+containers) fully **clickable and visually un-dimmed** — uniformly
+across all six cards.
+
+The product owner explicitly authorized broadening the behavior beyond
+the car's three controls to "all pills/buttons below the circle … even
+for other cards, which is in fact desired" (issue #253 conversation),
+and asked for the ring-only-dimming option "if easy". It is — see the
+scope rationale below.
+
+### Why this is the right (and minimal) shape
+
+- **All six cards share the same structure**: `<ha-card class="card …">`
+  with `.ring` rendered as a **direct sibling** of the below-ring
+  control containers (`.below`, `.below-line`). Confirmed across all six
+  card files. In every card the gauge SVG and all in-ring buttons
+  (power / green / override / time on the duration & pool cards; sun /
+  rabbit / time on the car) live **inside** `.ring`; the mode/person/
+  charger `<select>`s and the Reset button live in `.below` /
+  `.below-line` **outside** `.ring`.
+- **The rescope is behavior-preserving inside the ring.** Per the CSS
+  `pointer-events` spec, a descendant with `pointer-events: auto` is
+  still a pointer target even under an ancestor set to
+  `pointer-events: none`. The in-ring buttons already declare their own
+  `pointer-events: auto` (`.ring .power-btn` / `.ring .green-btn` /
+  `.ring .override-btn`; the car's rabbit button sets it inline in JS),
+  and their *gating* is done by JS `.disabled` guards
+  (`querySelector('.disabled')`), **not** by the card-level
+  `pointer-events: none`. Re-scoping the shared rule from `.card.disabled`
+  to `.card.disabled .ring` therefore changes nothing about in-ring
+  controls — it only stops the **below-ring** controls (which have no
+  explicit `pointer-events` rule) from inheriting `none`.
+- **The below-ring controls are wired unconditionally.** None of
+  person / charger / reset (car) or mode-select / reset (other 5) is
+  gated on `isEnabled` or behind a `querySelector('.disabled')` JS
+  guard, and the shared `_wireResetButton` (`shared/qs-card-base.js`)
+  and `_wireBistateMode` (`shared/qs-ring-duration-base.js`) helpers
+  contain **no internal disabled bail**. So a **CSS-only** change is
+  sufficient to make them functional — including the charger-force
+  feature the owner called out as the core of the bug.
+- **Only the car card carries card-specific `.disabled` CSS overrides.**
+  The other five cards rely entirely on the shared rule, so the single
+  shared-rule change fixes all five for free; the car card needs its own
+  overrides re-scoped/cleaned.
+- **Same-or-smaller diff than the fallback.** The owner's simpler
+  fallback (lower the base opacity / re-enable only the three car
+  controls) would leave below-ring controls **greyscaled** (not
+  "visible") and would require car-specific exemptions. The ring-rescope
+  is one shared rule plus a tidy of the car overrides, and it delivers
+  the "clickable **and** visible" outcome the owner preferred.
+
+## Acceptance criteria
+
+### AC1 — Car: reset / person / charger clickable when disconnected
+- **Given** a car whose `charge_type` is `Not Plugged` / `Unknown` (so
+  `<ha-card>` carries the `disabled` class),
+- **When** the `qs-car-card` renders,
+- **Then** the **Reset** button, the **assigned-person** `<select>`, and
+  the **connected-charger** `<select>` are clickable (not blocked by
+  `pointer-events: none`) and keyboard-focusable, and choosing a charger
+  option fires the `select` service on `e.charger_select` (the change
+  handler is not gated on connection state).
+
+### AC2 — Car: in-ring controls stay disabled and dimmed when disconnected
+- **Given** the same disconnected car card,
+- **When** it renders,
+- **Then** the central ring (gauge SVG, big SOC value, sun / rabbit /
+  time in-ring buttons) stays dimmed (`opacity .5` + `grayscale`) and
+  its interactive controls remain inert — the rabbit and SOC-popup
+  handlers still no-op via their `querySelector('.disabled')` guards,
+  which keep working because the `disabled` class stays on the
+  `<ha-card>` root (not moved to `.ring`).
+
+### AC3 — All cards: below-ring controls clickable + un-dimmed when disabled
+- **Given** any of the five duration/pool cards with its device disabled
+  (`!isEnabled` → `disabled` class),
+- **When** it renders,
+- **Then** the mode `<select>` and the Reset button (below the ring) are
+  clickable and rendered at **full enabled fidelity** — no greyscale, no
+  divider-color border greying — while the ring (gauge, power button
+  exemption unchanged, green / override / time buttons) stays dimmed and
+  behaves exactly as before this change.
+
+### AC4 — "Full enabled fidelity" defined
+- Below-ring controls in the disabled state render **identically to the
+  enabled state**: no `grayscale`/`opacity .5`, no `.disabled`-driven
+  border/background greying. The car Reset keeps its normal
+  `.danger.outline` (red-outline) styling; the person/charger pills keep
+  their normal pill styling.
+
+### AC5 — Regression pin: disabled dimming is ring-scoped, not whole-card
+- **Given** `shared/qs-card-styles.js`,
+- **Then** the dimming/disabling rule targets `.card.disabled .ring`
+  (not a bare `.card.disabled { … }`), the power-button exemption is
+  `.card.disabled .ring .power-btn`, and **no** bare whole-card
+  `.card.disabled { … }` greying rule remains anywhere in the six card
+  files or the shared styles.
+
+### AC6 — Tests + docs
+- Pinning tests added to `tests/test_dashboard_rendering.py` (string/
+  regex assertions, mirroring `test_car_card_soc_editable_pointer_events`).
+- `docs/agents/concepts/dashboard-and-cards.md` updated (behavior note +
+  QS-253 authorization subsection + `last_verified` bump).
+
+### AC7 — Manual smoke verification (mandatory; the real acceptance gate)
+JS cards are outside the automated pipeline (no JS execution/lint/build
+— documented "KNOWN GAP"); the pin-tests guard the CSS **string**, not
+the rendered behavior. Therefore a manual smoke is required before merge:
+- On a **disconnected** car card: confirm the ring stays dimmed while
+  **Reset**, **person**, and **charger** are clickable, un-greyed, and
+  selecting a charger re-assigns it.
+- On a **disabled** card of each other type: confirm the ring + power
+  button dim while the **mode select** and **Reset** stay clickable and
+  un-greyed.
+
+## Task breakdown
+
+> Anchor edits on **symbol/selector names**, not line numbers — the
+> files shift.
+
+### 1. `custom_components/quiet_solar/ui/resources/shared/qs-card-styles.js`
+- Change the bare `.card.disabled { opacity:.5; pointer-events:none;
+  filter:grayscale(.8) }` rule to `.card.disabled .ring { … }`
+  (same declarations).
+- Change `.card.disabled .power-btn { … }` to
+  `.card.disabled .ring .power-btn { … }` (same declarations; power-btn
+  is in-ring).
+- Add a short comment noting that `.below` / `.below-line` controls stay
+  active and un-dimmed when the card is disabled.
+
+### 2. `custom_components/quiet_solar/ui/resources/qs-car-card.js`
+- **Rescope in-ring overrides** to `.disabled .ring .X`:
+  `.disabled .sun-btn`, `.disabled .sun-btn ha-icon`,
+  `.disabled .sun-btn.on`, `.disabled .sun-btn.on ha-icon`,
+  `.disabled .rabbit-btn` (+ `ha-icon` / `.on` / `.on ha-icon`),
+  `.disabled .time-btn`.
+- **Remove below-ring greying overrides** so person/charger/reset render
+  at full enabled fidelity (AC4): `.disabled .primary`,
+  `.disabled .secondary`, `.disabled .chip, .disabled .pill`, and the
+  now-redundant `.disabled .danger` / `.disabled .danger.outline`
+  re-assertions (base `.danger` / `.danger.outline` already style the
+  Reset button; confirm no **in-ring** element uses `.danger`/`.primary`/
+  `.secondary`/`.pill`/`.chip` before removing — none do).
+- **Remove the dead rule** `.disabled #force, .disabled #schedule_inline
+  { … }` — both elements live inside a `/* … */` comment block and never
+  render; removing it keeps the negative pin-test unambiguous.
+- **Leave as-is** (already ring-scoped): `.disabled .ring .target-value`,
+  `.disabled .ring .mini-range-target`.
+- **No JS changes.** The `if (selPerson)` / `if (selCharger)` change
+  handlers and the `_wireResetButton` call are ungated; the in-ring
+  rabbit (`rbtnAction`) and SOC-popup (`openSocDialog`) handlers keep
+  their `querySelector('.disabled')` guards (still valid — the class
+  stays on `<ha-card>`).
+
+### 3. The other five cards — **no edits required**
+`qs-pool-card.js`, `qs-climate-card.js`, `qs-on-off-duration-card.js`,
+`qs-radiator-card.js`, `qs-water-boiler-card.js` carry **no** card-specific
+`.disabled` CSS rules; they inherit the fix entirely through the shared
+`.card.disabled .ring` change. (Verified: their `isEnabled` only gates
+`canDragHandle`; `_wireBistateMode`/`_wireResetButton` are called
+unconditionally.)
+
+### 4. `tests/test_dashboard_rendering.py`
+Mirror the existing sync pattern (`source = (COMPONENT_ROOT / "ui" /
+"resources" / "<file>").read_text()` + `re.search`). Add:
+- **`test_disabled_state_dims_only_ring_not_whole_card`** — read
+  `shared/qs-card-styles.js`:
+  - positive: `re.search(r"\.card\.disabled\s+\.ring\s*\{[^}]*pointer-events:\s*none", css)`;
+  - positive: power-btn exemption `.card.disabled .ring .power-btn`;
+  - negative (regression pin): `not re.search(r"\.card\.disabled\s*\{", css)`
+    (matches **only** the bare whole-card rule, not `.card.disabled .ring {`).
+- **`test_car_card_below_ring_controls_active_when_disconnected`** — read
+  `qs-car-card.js`:
+  - positive: in-ring overrides are ring-scoped — `.disabled .ring .sun-btn`,
+    `.disabled .ring .rabbit-btn`, `.disabled .ring .time-btn` present;
+  - negative: no whole-card below-ring greying — e.g.
+    `not re.search(r"(?<!\.ring )\.disabled \.(primary|secondary|chip|pill)\b", source)`;
+  - precondition pin (J): the `disabled` class is applied to the
+    `<ha-card>` root (assert the `card ${isDisconnected ? 'disabled' …}`
+    template is on `ha-card`), so the in-ring JS guards keep working.
+- **`test_no_card_reintroduces_whole_card_disabled_greyer`** —
+  parametrized over all six card files: assert
+  `not re.search(r"\.card\.disabled\s*\{", source)` in each (cheap
+  guard against any card re-adding a whole-card disable; avoids six
+  redundant behavior tests per scope-guardian).
+
+### 5. `docs/agents/concepts/dashboard-and-cards.md`
+- Update the disconnected-card behavior note (the review-fix #02
+  invariant paragraph) so it says the `disabled`/disconnected dimming +
+  `pointer-events:none` is scoped to **`.ring`**, and that below-ring
+  controls (mode select, Reset, the car's person/charger selects) stay
+  **clickable and un-dimmed**; only the **in-ring custom** controls drop
+  out of the tab order (`tabindex="-1"` + `aria-disabled`) — the native
+  `<select>`/`<button>` below-ring controls were never in that custom-div
+  tab-order logic and stay focusable.
+- Add a short **QS-253** subsection recording the ring-scoped-dimming
+  behavior change **and** the explicit issue-#253 authorization to modify
+  the JS cards (mirroring the QS-200 authorization wording).
+- Bump `last_verified` to `2026-06-02`.
+
+## Doc maintenance
+
+`scripts/qs/check_doc_drift.py --paths
+custom_components/quiet_solar/ui/resources/qs-car-card.js
+tests/test_dashboard_rendering.py` flags
+`docs/agents/concepts/dashboard-and-cards.md` (it `covers:` both
+`qs-car-card.js` and `shared/qs-card-styles.js`). Task 5 satisfies the
+co-modification requirement.
+
+## Quality gate / coverage note
+
+No production `.py` changes — only JS/CSS assets under `ui/resources/**`,
+a new/extended test in `tests/test_dashboard_rendering.py`, the story,
+and a doc. The new test assertions are pure string/regex checks and are
+self-covering, so 100% coverage holds trivially. The mixed paths include
+`docs/…` and a test file, so the gate may run the full suite rather than
+the UI-only fast path — acceptable (slower, not a blocker).
+
+## Adversarial Review Notes
+
+Four reviewers ran in parallel (critic, concrete-planner, dev-proxy,
+scope-guardian). **No critical blockers, no redesign.** Dispositions:
+
+- **CSS source-order / specificity (concrete-planner, raised as the
+  "real ordering risk")** → **Resolved.** Analysis added (see "Why this
+  is the right shape"): the rescope is behavior-preserving inside the
+  ring because in-ring buttons already carry their own
+  `pointer-events: auto` and are gated by JS `.disabled` guards; only
+  below-ring controls (no explicit `pointer-events`) change. Tests use
+  precise negative regexes that don't match the rescoped rules.
+- **Verify below-ring wiring is ungated on all cards + charger-force
+  works via CSS alone (critic / scope / dev-proxy)** → **Fixed.**
+  Verified during planning (person/charger/reset + `_wireBistateMode`/
+  `_wireResetButton` carry no `.disabled`/`isEnabled` gate); recorded as
+  AC1/AC3 and in the rationale.
+- **String tests don't prove real clickability (critic)** → **Fixed.**
+  Added AC7 mandatory manual smoke as the real acceptance gate.
+- **Confirm 5 other cards inherit purely via shared change
+  (concrete/dev-proxy)** → **Fixed.** Task 3 states it explicitly
+  (only the car has card-specific `.disabled` CSS).
+- **Record issue-#253 authorization in the doc, mirror QS-200
+  (dev-proxy / scope)** → **Fixed.** Task 5 adds the QS-253 subsection
+  with the authorization sentence.
+- **Anchor on symbol names not line numbers (concrete)** → **Fixed.**
+  Plan uses selector/symbol names throughout.
+- **Remove dead `.disabled #force/#schedule_inline` rule (concrete)** →
+  **Fixed.** Task 2 removes it.
+- **Negative regexes must not match the rescoped rules (concrete)** →
+  **Fixed.** Exact regex shapes specified in Task 4.
+- **Define "full enabled fidelity" (critic)** → **Fixed.** AC4.
+- **Pin that `.disabled` stays on the card root (critic)** → **Fixed.**
+  Assertion added to the car test (Task 4).
+- **Verify `.ring` wraps all in-ring buttons on all 6 cards (critic)** →
+  **Resolved.** Confirmed by exploration; stated in the rationale.
+- **Tab-order doc wording — only in-ring custom controls drop out
+  (concrete/critic)** → **Fixed.** Task 5 corrects the wording.
+- **Ring-rescope vs base-opacity fallback (scope)** → **Resolved.**
+  Decision rule recorded: the rescope is the same-or-smaller diff and is
+  the only option that delivers "clickable **and** visible".
+- **Avoid redundant per-card tests (scope) vs guard the other 5
+  (critic)** → **Compromise.** The shared-rule test covers the five
+  inheritors; one parametrized "no card reintroduces a whole-card
+  disable" test guards regressions cheaply (Task 4) — no six redundant
+  behavior tests.

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -403,6 +403,82 @@ class TestDashboardTemplateRendering:
             "it closes the literal early and breaks render (Configuration error)."
         )
 
+    def test_disabled_state_dims_only_ring_not_whole_card(self):
+        """QS-253 AC5 — the shared disabled dimming/disabling rule is scoped to
+        `.card.disabled .ring` (and the power-btn exemption to
+        `.card.disabled .ring .power-btn`), so below-ring controls stay
+        clickable + un-dimmed. No bare whole-card `.card.disabled { ... }`
+        greying rule remains."""
+        css = (COMPONENT_ROOT / "ui" / "resources" / "shared" / "qs-card-styles.js").read_text()
+        # Positive: dimming/disabling now targets the ring only.
+        assert re.search(r"\.card\.disabled\s+\.ring\s*\{[^}]*pointer-events:\s*none", css), (
+            "qs-card-styles.js: missing ring-scoped `.card.disabled .ring "
+            "{ ... pointer-events: none }` rule (AC5)."
+        )
+        # Positive: the power-button exemption is also ring-scoped.
+        assert re.search(r"\.card\.disabled\s+\.ring\s+\.power-btn\s*\{", css), (
+            "qs-card-styles.js: power-btn exemption must be "
+            "`.card.disabled .ring .power-btn` (AC5)."
+        )
+        # Negative (regression pin): no bare whole-card disable rule.
+        assert not re.search(r"\.card\.disabled\s*\{", css), (
+            "qs-card-styles.js: bare whole-card `.card.disabled { ... }` rule "
+            "must be removed — it disabled below-ring controls (AC5)."
+        )
+
+    def test_car_card_below_ring_controls_active_when_disconnected(self):
+        """QS-253 AC1/AC4 — the car card's in-ring disabled overrides are
+        ring-scoped, the below-ring greying overrides are removed (full enabled
+        fidelity), and the `disabled` class stays on the `<ha-card>` root so the
+        in-ring JS `.disabled` guards keep working (AC2)."""
+        source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
+        # Positive: in-ring overrides are ring-scoped.
+        assert ".disabled .ring .sun-btn" in source, (
+            "qs-car-card.js: sun-btn disabled override must be ring-scoped."
+        )
+        assert ".disabled .ring .rabbit-btn" in source, (
+            "qs-car-card.js: rabbit-btn disabled override must be ring-scoped."
+        )
+        assert ".disabled .ring .time-btn" in source, (
+            "qs-car-card.js: time-btn disabled override must be ring-scoped."
+        )
+        # Negative: no whole-card below-ring greying overrides remain.
+        assert not re.search(r"(?<!\.ring )\.disabled \.(primary|secondary|chip|pill)\b", source), (
+            "qs-car-card.js: below-ring greying overrides (`.disabled .primary` "
+            "etc.) must be removed so controls render at full enabled fidelity (AC4)."
+        )
+        # Negative: dead #force / #schedule_inline rule removed.
+        assert ".disabled #force" not in source and ".disabled #schedule_inline" not in source, (
+            "qs-car-card.js: dead `.disabled #force, .disabled #schedule_inline` "
+            "rule must be removed."
+        )
+        # Precondition pin (AC2): `disabled` class is on the `<ha-card>` root.
+        assert re.search(r"<ha-card class=\"card \$\{isDisconnected \? 'disabled'", source), (
+            "qs-car-card.js: the `disabled` class must stay on the `<ha-card>` "
+            "root so in-ring JS `.disabled` guards keep working (AC2)."
+        )
+
+    @pytest.mark.parametrize(
+        "card_file",
+        [
+            "qs-car-card.js",
+            "qs-climate-card.js",
+            "qs-on-off-duration-card.js",
+            "qs-pool-card.js",
+            "qs-radiator-card.js",
+            "qs-water-boiler-card.js",
+        ],
+    )
+    def test_no_card_reintroduces_whole_card_disabled_greyer(self, card_file):
+        """QS-253 AC3/AC5 — no card re-adds a bare whole-card
+        `.card.disabled { ... }` greying rule (which would re-disable the
+        below-ring controls)."""
+        source = (COMPONENT_ROOT / "ui" / "resources" / card_file).read_text()
+        assert not re.search(r"\.card\.disabled\s*\{", source), (
+            f"{card_file}: bare whole-card `.card.disabled {{ ... }}` rule "
+            "re-introduced — it would re-disable below-ring controls (AC5)."
+        )
+
     def test_radiator_card_s14_safe_number_guards_against_nan(self):  # CR2 — sync (no hass)
         """A2 — pin S14 via regex, not a bare substring.
 


### PR DESCRIPTION
## Summary
- Re-scope the shared disabled dimming/disabling rule from the whole card to `.card.disabled .ring` (power-btn exemption likewise), so below-ring controls stay clickable + un-dimmed across all six cards.
- Car card: re-scope in-ring `.disabled` overrides to `.disabled .ring .X`, remove below-ring greying overrides (person/charger/reset render at full enabled fidelity), drop the dead `#force/#schedule_inline` rule.
- Add 3 string/regex pin tests + update dashboard-and-cards doc (QS-253 authorization, last_verified bump). Manual smoke (AC7) required before merge — JS isn't executed in the pipeline.

Fixes #253

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)