### PR TITLE
QS-260: Can put a "no person forecast" to multiple cars

### DIFF
--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -469,12 +469,13 @@ class QSCar(HADeviceMixin, AbstractDevice):
             return
 
         if self.home:
-            for car in self.home._cars:
-                if car.name != self.name and car.get_user_originated("person_name") == new_value:
-                    # the person is being reassigned to self; the other car's
-                    # entire snapshot (charge targets, times, etc.) was tied
-                    # to that person, so clear everything.
-                    car.clear_all_user_originated()
+            if new_value != FORCE_CAR_NO_PERSON_ATTACHED:
+                for car in self.home._cars:
+                    if car.name != self.name and car.get_user_originated("person_name") == new_value:
+                        # the person is being reassigned to self; the other car's
+                        # entire snapshot (charge targets, times, etc.) was tied
+                        # to that person, so clear everything.
+                        car.clear_all_user_originated()
 
             await self.home.compute_and_set_best_persons_cars_allocations(force_update=True, do_notify=True)
 

--- a/docs/stories/QS-260.story.md
+++ b/docs/stories/QS-260.story.md
@@ -1,0 +1,206 @@
+# Story QS-260: Setting "no person" on a second car must not clear the first car's "no person"
+
+- **Issue**: [#260](https://github.com/tmenguy/quiet-solar/issues/260) — bug, `area:car`, `area:person`
+- **Branch**: `QS_260`
+- **Status**: Approved
+
+## Problem
+
+The user set two connected cars (Zoe and Twingo) to "no person forecast".
+While setting the second one, the first one snapped back to an assigned
+person.
+
+## Definitions
+
+- **User-originated selection**: the value stored via
+  `set_user_originated("person_name", ...)` on a car — either a real
+  person name or the sentinel `FORCE_CAR_NO_PERSON_ATTACHED`. This is a
+  *manual* choice that must persist.
+- **Forecasted person**: `car.current_forecasted_person` — the output of
+  the automatic allocator
+  (`QSHome.compute_and_set_best_persons_cars_allocations`), recomputed
+  from user-originated pins + the Hungarian algorithm.
+
+## Root cause
+
+`QSCar.user_set_person_for_car` in
+`custom_components/quiet_solar/ha_model/car.py` (lines ~471-479). After
+storing the new user-originated `person_name`, a loop iterates the other
+cars and calls `car.clear_all_user_originated()` on any car whose
+user-originated `person_name` equals the new value — intended to "steal"
+a real person being reassigned from another car. When the new value is
+`FORCE_CAR_NO_PERSON_ATTACHED`, the loop matches every other car the
+user already set to "no person" and wipes its entire user-originated
+state. The subsequent forced reallocation
+(`compute_and_set_best_persons_cars_allocations(force_update=True)`)
+then reassigns a person to the wiped car.
+
+Note: `None` and unknown person names are converted to
+`FORCE_CAR_NO_PERSON_ATTACHED` *before* the loop (car.py:441-448), so
+guarding on the sentinel covers all "no person" entry paths. Unauthorized
+person names return early and never reach the loop.
+
+## Desired behavior (confirmed with user)
+
+When assigning `FORCE_CAR_NO_PERSON_ATTACHED` to a car:
+
+- DO trigger reallocation of the other cars (the freed person may be
+  picked up by an unpinned car).
+- DO NOT touch cars that hold a user-originated selection — whether a
+  real person OR `FORCE_CAR_NO_PERSON_ATTACHED`; "no person" is itself a
+  manual value that must be kept.
+
+No allocator change is needed:
+`QSHome.compute_and_set_best_persons_cars_allocations`
+(home.py:2552-2577) already pins every car with a user-originated
+`person_name` (real person → allocation fixed; FORCE → covered with no
+person) before running the Hungarian algorithm on the remaining
+cars/persons. NOT clearing is sufficient.
+
+## Acceptance criteria
+
+**AC1 (regression — the reported bug).** Given Twingo auto-forecasted to
+Arthur and Zoe auto-forecasted to Magali (both cars *must* hold a
+forecasted person, otherwise the early-return at car.py:466 skips the
+loop and the test passes even on unfixed code), When the user sets
+Twingo to "no person" and then Zoe to "no person", Then:
+
+- intermediate (after Twingo only): Twingo's user-originated
+  `person_name` == `FORCE_CAR_NO_PERSON_ATTACHED` and
+  `twingo.current_forecasted_person is None`;
+- final (after Zoe too): Twingo *still* has user-originated
+  `FORCE_CAR_NO_PERSON_ATTACHED` and `current_forecasted_person is None`,
+  and Zoe has user-originated `FORCE_CAR_NO_PERSON_ATTACHED` and
+  `current_forecasted_person is None`.
+
+The second call is also the end-to-end proof that the allocator pins
+FORCE'd cars: it forces a full reallocation with Twingo pinned and
+asserts Twingo stays person-free.
+
+**AC2.** Given Twingo manually assigned (user-originated) to Arthur,
+When the user sets Zoe to "no person", Then Twingo keeps its
+user-originated "Arthur" and `current_forecasted_person` is Arthur after
+the forced reallocation.
+
+**AC3 (existing behavior preserved).** Given person P manually assigned
+to car A, When the user manually assigns P to car B, Then car A's entire
+user-originated state is cleared and reallocation runs. Covered by the
+existing test
+`tests/ha_tests/test_car.py::test_car_user_set_person_for_car_updates_other_cars`,
+which calls the real `user_set_person_for_car` with a real person name —
+**do not weaken or delete this test**: it is what keeps the non-FORCE
+branch (the clearing loop body) covered under the 100% gate.
+
+**AC4 (regression guard for "still reallocate the other cars").** Given
+Twingo auto-forecasted to Arthur, When the user sets Twingo to "no
+person", Then the forced reallocation reassigns Arthur to Zoe. This
+outcome is deterministic, not a Hungarian tie: with Twingo pinned
+(excluded from the car set), Zoe is Arthur's *only* remaining authorized
+car (`authorized_car_names=["Zoe", "Twingo"]` in `_build_scenario()`);
+all other columns are the forbidden-cost sentinel. Also assert Twingo's
+state (user-originated FORCE, forecast None) and where Magali —
+displaced from Zoe — lands, so a future cost-matrix change cannot
+silently weaken the test.
+
+## Task breakdown
+
+### T1 — Fix `user_set_person_for_car`
+
+File: `custom_components/quiet_solar/ha_model/car.py`, function
+`user_set_person_for_car` (~line 439). Guard ONLY the clearing loop; the
+`await` stays inside `if self.home:` but OUTSIDE the new guard. Literal
+target:
+
+```python
+        if self.home:
+            if new_value != FORCE_CAR_NO_PERSON_ATTACHED:
+                for car in self.home._cars:
+                    if car.name != self.name and car.get_user_originated("person_name") == new_value:
+                        # the person is being reassigned to self; the other car's
+                        # entire snapshot (charge targets, times, etc.) was tied
+                        # to that person, so clear everything.
+                        car.clear_all_user_originated()
+
+            await self.home.compute_and_set_best_persons_cars_allocations(force_update=True, do_notify=True)
+```
+
+`do_notify=True` is pre-existing — no notification behavior change.
+
+### T2 — Regression tests
+
+File: `tests/test_person_car_allocation.py`. New class
+`TestNoPersonMultipleCars` (classes follow this file's established
+convention — `TestSetUserPersonEdgeCases`, `TestPersonSwapNotification` —
+overriding the general plain-functions preference). Reuse
+`_build_scenario()` (4 fake cars / 4 fake persons binding the REAL
+`QSCar.user_set_person_for_car` and REAL
+`QSHome.compute_and_set_best_persons_cars_allocations`; auto-allocation
+yields Tesla→Thomas, Twingo→Arthur, Zoe→Magali, IDBuzz→None):
+
+- `test_no_person_on_two_cars_preserves_both` (AC1): run allocation;
+  set Twingo→FORCE; assert intermediate state; set Zoe→FORCE; assert
+  both cars keep user-originated FORCE and `current_forecasted_person is
+  None`. Against unfixed code the second call would
+  `clear_all_user_originated()` on Twingo — this test MUST fail before
+  the fix.
+- `test_no_person_preserves_other_manual_person` (AC2): set Twingo
+  manually to Arthur; set Zoe→FORCE; assert Twingo keeps user-originated
+  "Arthur" and forecast Arthur.
+- `test_no_person_frees_person_for_reallocation` (AC4): set
+  Twingo→FORCE; assert Arthur reallocated to Zoe (deterministic — see
+  AC4), Twingo stays FORCE/None, and assert Magali's displaced landing
+  spot.
+
+Coverage note: the FORCE branch (loop skipped) is covered by these
+tests; the non-FORCE branch (loop executed) stays covered by the AC3
+ha_test — both files run in the same gate invocation
+(`testpaths = tests`).
+
+### T3 — Quality gate
+
+- TDD loop: `python scripts/qs/quality_gate.py --quick tests/test_person_car_allocation.py`
+- Full gate before commit: `python scripts/qs/quality_gate.py`
+  (pytest 100% cov + ruff + mypy + translations).
+
+## Out of scope
+
+- Changing the intentional behavior that real-person reassignment clears
+  the other car's entire user-originated snapshot (charge targets etc.).
+- Any allocator / Hungarian algorithm changes.
+- `user_clean_and_reset` (car.py:2599) — explicit user reset, unrelated.
+
+## Doc maintenance
+
+Drift checker (`scripts/qs/check_doc_drift.py`) flagged two docs
+covering `car.py`:
+
+- Doc-OK: `docs/agents/concepts/car-soc-estimation.md` — the fix touches
+  person assignment only; no SOC estimation behavior changes.
+- Doc-OK: `docs/agents/concepts/person-trip-prediction.md` — the
+  concept-level person-car allocation description remains accurate; the
+  fix corrects a manual-selection clearing bug not described in the doc.
+
+## NEXT_PHASE
+
+`implement-task` (touches `custom_components/quiet_solar/ha_model/car.py`
+and `tests/`).
+
+## Adversarial Review Notes
+
+Four parallel reviewers (critic, concrete-planner, dev-proxy,
+scope-guardian) ran on the draft. Decisions:
+
+| Finding | Decision |
+| --- | --- |
+| critic/critical: AC4 "Arthur→Zoe" could be a Hungarian tie | Resolved — concrete-planner verified Zoe is Arthur's only authorized car once Twingo is pinned; outcome forced. Documented in AC4. |
+| concrete-planner: AC1 must use two *forecasted* cars or the bug never reproduces (early return car.py:466) | Accepted — test pinned to Twingo-then-Zoe ordering; must fail pre-fix. |
+| concrete-planner: AC4 should also assert Twingo state + Magali displacement | Accepted. |
+| concrete-planner: show literal post-fix code; guard wraps only the loop | Accepted — snippet inlined in T1. |
+| dev-proxy + critic: both guard branches must stay covered (100% gate) | Accepted — non-FORCE branch protected by AC3 ha_test; "do not weaken" note added. |
+| dev-proxy: test class vs plain-functions rule | Accepted with justification — file already uses class organization. |
+| critic: is `do_notify=True` a smuggled change? | Resolved — pre-existing, unchanged. |
+| critic: enumerate all `new_value` cases | Accepted — None/unknown convert to FORCE before the loop; documented in root cause. |
+| critic/redesign: standalone "allocator pins FORCE" test | Rejected — AC1's second call is the end-to-end pinning proof; a separate test duplicates it. |
+| scope-guardian: AC4 is gold-plating | Kept, reframed — it guards the user-required "still reallocate the other cars" half of the fix. |
+| scope-guardian: Doc-OK notes are churn | Rejected — pipeline mandates resolving drift-checker flags (project-rules.md "Doc maintenance"). |
+| critic: define terms, spell out AC1 intermediate asserts | Accepted — Definitions section + explicit intermediate assertion in AC1. |

--- a/tests/test_person_car_allocation.py
+++ b/tests/test_person_car_allocation.py
@@ -323,6 +323,81 @@ class TestPersonSwapNotification:
         assert "PersonY" in notified, "PersonY should be notified of the swap"
 
 
+class TestNoPersonMultipleCars:
+    """Regression tests for issue #260: setting "no person" on a second car
+    must not clear the first car's user-originated "no person" selection."""
+
+    @pytest.mark.asyncio
+    async def test_no_person_on_two_cars_preserves_both(self):
+        """AC1: setting FORCE_CAR_NO_PERSON_ATTACHED on Twingo and then Zoe
+        must keep BOTH cars pinned to "no person" — the second call must not
+        wipe the first car's user-originated state."""
+        home, tesla, twingo, zoe, idbuzz, arthur, magali, thomas, brice = _build_scenario()
+        await home.compute_and_set_best_persons_cars_allocations(force_update=True)
+
+        # Both cars must hold a forecasted person, otherwise the early
+        # return in user_set_person_for_car skips the clearing loop and the
+        # test would pass even on unfixed code.
+        assert _person_name(twingo) == "Arthur"
+        assert _person_name(zoe) == "Magali"
+
+        await twingo.user_set_person_for_car(FORCE_CAR_NO_PERSON_ATTACHED)
+
+        # Intermediate state: Twingo is pinned to "no person".
+        assert twingo.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
+        assert twingo.current_forecasted_person is None
+
+        await zoe.user_set_person_for_car(FORCE_CAR_NO_PERSON_ATTACHED)
+
+        # Final state: Twingo's manual "no person" survived the second call
+        # (the forced reallocation must keep it pinned), and Zoe is also
+        # pinned to "no person".
+        assert twingo.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
+        assert twingo.current_forecasted_person is None
+        assert zoe.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
+        assert zoe.current_forecasted_person is None
+
+    @pytest.mark.asyncio
+    async def test_no_person_preserves_other_manual_person(self):
+        """AC2: setting "no person" on Zoe must not touch Twingo's manual
+        real-person assignment."""
+        home, tesla, twingo, zoe, idbuzz, arthur, magali, thomas, brice = _build_scenario()
+        await home.compute_and_set_best_persons_cars_allocations(force_update=True)
+
+        await twingo.user_set_person_for_car("Arthur")
+        assert twingo.get_user_originated("person_name") == "Arthur"
+
+        await zoe.user_set_person_for_car(FORCE_CAR_NO_PERSON_ATTACHED)
+
+        assert twingo.get_user_originated("person_name") == "Arthur"
+        assert _person_name(twingo) == "Arthur"
+        assert zoe.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
+        assert zoe.current_forecasted_person is None
+
+    @pytest.mark.asyncio
+    async def test_no_person_frees_person_for_reallocation(self):
+        """AC4: setting "no person" on Twingo must still trigger a full
+        reallocation of the other cars. Arthur (displaced from Twingo) lands
+        on Zoe deterministically: with Twingo pinned out, Zoe is Arthur's
+        only remaining authorized car. Magali, displaced from Zoe, lands on
+        IDBuzz."""
+        home, tesla, twingo, zoe, idbuzz, arthur, magali, thomas, brice = _build_scenario()
+        await home.compute_and_set_best_persons_cars_allocations(force_update=True)
+
+        assert _person_name(twingo) == "Arthur"
+        assert _person_name(zoe) == "Magali"
+
+        await twingo.user_set_person_for_car(FORCE_CAR_NO_PERSON_ATTACHED)
+
+        # Twingo stays pinned to "no person".
+        assert twingo.get_user_originated("person_name") == FORCE_CAR_NO_PERSON_ATTACHED
+        assert twingo.current_forecasted_person is None
+        # Arthur was reallocated to Zoe (his only remaining authorized car).
+        assert _person_name(zoe) == "Arthur"
+        # Magali, displaced from Zoe, landed on IDBuzz.
+        assert _person_name(idbuzz) == "Magali"
+
+
 class TestCacheHitReApply:
     """Cover the cache-hit re-apply branch (home.py lines 2358-2367)."""
 


### PR DESCRIPTION
## Summary
- Guard the clearing loop in `QSCar.user_set_person_for_car`: assigning `FORCE_CAR_NO_PERSON_ATTACHED` no longer wipes other cars' user-originated "no person" pins, while the forced reallocation still runs so the freed person is reassigned.
- New `TestNoPersonMultipleCars` regression tests (AC1/AC2/AC4) in `tests/test_person_car_allocation.py`; AC1 verified failing pre-fix. Existing ha_test keeps the non-FORCE clearing branch covered (AC3).

## Doc maintenance

Drift checker flagged `docs/agents/concepts/car-soc-estimation.md` and `docs/agents/concepts/person-trip-prediction.md` (both cover `ha_model/car.py`). Both are unaffected: the fix touches person assignment only — no SOC estimation behavior changes, and the concept-level person-car allocation description remains accurate; the fix corrects a manual-selection clearing bug not described in either doc. Adjudicated Doc-OK in the approved story plan.

Fixes #260

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where setting "no person" on one car would incorrectly clear another car's existing "no person" state, ensuring each car's user-configured assignment is preserved independently.

## Tests
* Added regression test suite to verify correct behavior when managing "no person" assignments across multiple cars.

## Documentation
* Added development story documenting the bug and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->