### PR TITLE
QS-262: reset car API stale detection on no-charger / manual reset

### DIFF
--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -824,6 +824,17 @@ class QSCar(HADeviceMixin, AbstractDevice):
             self._computed_added_delta_soc_percent = None
             self._delta_soc_last_integration_time = None
 
+    def reset_car_api_stale_detection(self) -> None:
+        """Reset the detected stale state so the live API gets a fresh chance.
+
+        Never touches `car_stale_mode_override`: an explicit Force stale /
+        Force not stale select override is preserved; only the detected
+        state is cleared.
+        """
+        _LOGGER.debug("Resetting detected car API stale state for %s", self.name)
+        self._exit_stale_mode()
+        self._was_car_api_stale = False
+
     def _charger_assignment_is_user_originated(self) -> bool:
         """Return True when the current charger assignment originates from the user.
 
@@ -2577,6 +2588,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         if charger_name == FORCE_CAR_NO_CHARGER_CONNECTED:
             self.set_user_originated(USER_ORIGINATED_CHARGER_NAME, FORCE_CAR_NO_CHARGER_CONNECTED)
             self.clear_inferred_flags()
+            self.reset_car_api_stale_detection()
         elif charger_name is not None:
             charger = None
             for c in self.home._chargers:
@@ -2603,6 +2615,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         self.current_forecasted_person = None
         self.reset_soc_estimate()
+        self.reset_car_api_stale_detection()
 
         self.reset(keep_commands=True)  # will detach the car
 

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -3047,7 +3047,9 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
     async def user_set_selected_car_by_name(self, car_name: str | None):
         self.set_user_originated(USER_ORIGINATED_CAR_NAME, car_name)
         if self.car is not None and self.car.name != car_name:
+            displaced_car = self.car
             self.detach_car()
+            displaced_car.reset_car_api_stale_detection()
 
         await self.update_charger_for_user_change()
 

--- a/docs/agents/concepts/car-soc-estimation.md
+++ b/docs/agents/concepts/car-soc-estimation.md
@@ -4,7 +4,7 @@ slug: car-soc-estimation
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/car.py
-last_verified: 2026-05-30
+last_verified: 2026-06-13
 ---
 
 # Car SOC estimation — the effective-SOC model
@@ -94,6 +94,17 @@ charger computes `inc` from `soc_integration_cursor` then calls
   override owns its own accumulator lifecycle, so a transient stale blip must
   not wipe its accumulated delta. The user base is never cleared by stale-mode
   exit.
+- **Manual stale-detection reset** (`reset_car_api_stale_detection`): three
+  manual user actions give the live API a fresh chance by calling
+  `_exit_stale_mode` and clearing `_was_car_api_stale` (the *detected* state
+  only — `car_stale_mode_override` is preserved, so a Force-stale override
+  still wins): the car's clean-and-reset button (`user_clean_and_reset`, which
+  also covers the departure auto-reset path), a manual
+  `FORCE_CAR_NO_CHARGER_CONNECTED` select on the car, and a manual
+  charger-side car allocation that displaces the currently attached car
+  (`user_set_selected_car_by_name`, including `CHARGER_NO_CAR_CONNECTED`).
+  Automatic detaches (`detach_car` on its own) deliberately do **not** reset —
+  they keep the stale episode.
 - Estimation is **orthogonal** to `is_car_effectively_stale`: a manual
   override on a healthy API marks the car *estimated* (asterisk) but **not**
   API-stale.

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -4,7 +4,7 @@ slug: charger-budgeting
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/charger.py
-last_verified: 2026-05-30
+last_verified: 2026-06-13
 ---
 
 # Charger Dynamic Budgeting — the tactical layer

--- a/docs/agents/concepts/person-trip-prediction.md
+++ b/docs/agents/concepts/person-trip-prediction.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/person.py
   - custom_components/quiet_solar/ha_model/car.py
-last_verified: 2026-05-30
+last_verified: 2026-06-13
 ---
 
 # Person, Car, and trip prediction

--- a/docs/stories/QS-262.story.md
+++ b/docs/stories/QS-262.story.md
@@ -1,0 +1,274 @@
+# Story QS-262: Reset car API stale state on "no charger" assignment and manual reset button
+
+- **Issue**: [#262](https://github.com/tmenguy/quiet-solar/issues/262) — `area:car`, `area:charger`
+- **Branch**: `QS_262`
+- **Status**: Approved
+
+## Problem
+
+A car flagged stale (Story 3.9 machinery in
+`custom_components/quiet_solar/ha_model/car.py`) stays in
+stale-percent mode even after the user takes an action that invalidates
+the stale premise: assigning the car to "no charger" removes the
+charger-assignment contradiction that flagged it, and pressing the
+car's clean-and-reset button is an explicit "start fresh" request — yet
+neither path clears the detected stale state today.
+
+- `user_set_selected_charger_by_name(FORCE_CAR_NO_CHARGER_CONNECTED)`
+  (car.py:2577-2579) only calls `clear_inferred_flags()`.
+- `user_clean_and_reset()` (car.py:2600) resets SOC estimate,
+  constraints, and charge targets — but not the stale flags.
+- A manual charger allocation that displaces the currently attached car
+  (`QSChargerGeneric.user_set_selected_car_by_name`, charger.py:3047-3052)
+  detaches the displaced car without resetting its stale state.
+
+## Scope (drastically simplified per product owner)
+
+Reset the **detected** car API stale state when, and only when:
+
+1. The car's clean-and-reset button is pressed (`user_clean_and_reset`).
+2. A manual "no charger" (`FORCE_CAR_NO_CHARGER_CONNECTED`) is set on
+   the car via its charger select.
+3. The car ends up with "no charger" because of a **manual charger
+   allocation** on another car — i.e. a manual charger-side car
+   selection displaces the currently attached car. This is one code
+   branch (`user_set_selected_car_by_name`, reached directly from the
+   charger's select or indirectly from another car's
+   `user_set_selected_charger_by_name` at car.py:2590) and also covers
+   the manual `CHARGER_NO_CAR_CONNECTED` selection, which flows through
+   the same displacement branch.
+
+**Explicitly out of scope** (owner decision — too many edge cases):
+the physical unplug edge, automatic re-allocation displacement
+(`get_best_car` / `check_load_activity_and_constraints` paths), any
+blanket hook in `detach_car()`, `home.remove_device` teardown, and all
+boot/restore paths. Automatic detaches keep today's behavior.
+
+## Design
+
+New method on `QSCar` in `custom_components/quiet_solar/ha_model/car.py`,
+placed directly after `_exit_stale_mode` (~line 826):
+
+```python
+def reset_car_api_stale_detection(self) -> None:
+    """Reset the detected stale state so the live API gets a fresh chance.
+
+    Never touches `car_stale_mode_override`: an explicit Force stale /
+    Force not stale select override is preserved; only the detected
+    state is cleared.
+    """
+    _LOGGER.debug("Resetting detected car API stale state for %s", self.name)
+    self._exit_stale_mode()
+    self._was_car_api_stale = False
+```
+
+Key facts (verified against source):
+
+- `_exit_stale_mode()` (car.py:808-825) is **unconditional** (no early
+  return when not stale). It clears `_car_api_stale`,
+  `car_api_stale_percent_mode`, `_car_api_inferred_home`,
+  `_car_api_inferred_plugged`, `_car_api_stale_since`,
+  `_last_valid_base_soc_value`, and — only when
+  `_user_base_soc_value is None` — the SOC accumulator
+  (`_computed_added_delta_soc_percent`) and integration cursor. A user
+  manual-SOC override keeps its accumulator (override owns its own
+  recovery lifecycle).
+- Clearing `_was_car_api_stale` makes the next periodic
+  `_update_car_api_staleness` cycle (car.py:696) start a genuinely
+  fresh evaluation.
+- `car_stale_mode_override` is NOT touched (owner clarification). With
+  `Force stale` active, `is_car_effectively_stale` stays True via the
+  override and the next cycle re-enters stale-percent mode silently —
+  the notification path (car.py:761) already skips FORCE_STALE.
+- **Accepted behavior**: a car whose API is genuinely dead (all sensors
+  older than `CAR_API_STALE_THRESHOLD_S`) re-enters stale on the next
+  cycle as a NEW episode with one new person notification. Confirmed
+  fresh-chance semantics; the three triggers are all manual user
+  actions, so there is no spam vector.
+- **Persistence**: detected stale state is not persisted — it is
+  recomputed from sensor history after a reboot (only
+  `user_base_soc_entry_api_stale` and the select override persist), so
+  no reboot resurrection concern.
+
+### Hook sites (3)
+
+1. **Reset button** — `QSCar.user_clean_and_reset` (car.py:2600): add
+   `self.reset_car_api_stale_detection()` directly after
+   `self.reset_soc_estimate()` (car.py:2605), before
+   `self.reset(keep_commands=True)` at 2607. Ordering is not
+   load-bearing: `QSCar.reset()` and the downstream
+   `charger.user_clean_and_reset()` → `detach_car()` →
+   `clear_inferred_flags()` chain never re-populate stale fields. The
+   departure auto-reset (`_check_departure_auto_reset`, car.py:656)
+   calls `user_clean_and_reset` and inherits the behavior — desired.
+2. **Manual no-charger on the car** —
+   `QSCar.user_set_selected_charger_by_name`, the
+   `FORCE_CAR_NO_CHARGER_CONNECTED` branch (car.py:2577-2579): **add**
+   `self.reset_car_api_stale_detection()` after the existing
+   `self.clear_inferred_flags()`. Add, don't replace: the redundancy
+   (the reset also clears the inferred flags) is accepted to keep the
+   diff additive — no existing behavior is removed.
+   The plain `charger_name is None` branch (car.py:2593-2595) keeps
+   `clear_inferred_flags()` only — deliberate: clearing the select is
+   not a "no charger" assignment.
+3. **Manual charger allocation displaces the car** —
+   `QSChargerGeneric.user_set_selected_car_by_name`
+   (`custom_components/quiet_solar/ha_model/charger.py`, ~line 3047), in
+   the `if self.car is not None and self.car.name != car_name:` branch:
+
+   ```python
+   displaced_car = self.car
+   self.detach_car()
+   displaced_car.reset_car_api_stale_detection()
+   ```
+
+   Capture before `detach_car()` (it sets `self.car = None`); calling
+   the reset after the detach is safe — `detach_car` only clears the
+   car's inferred flags and `charger` backref.
+
+## Acceptance criteria
+
+**AC1 — manual no-charger resets detection.** Given a car in detected
+stale state (contradiction-flagged: `_car_api_stale` True,
+`car_api_stale_percent_mode` True, `_car_api_stale_since` set, inferred
+home/plugged flags True), When the user selects
+`FORCE_CAR_NO_CHARGER_CONNECTED` via
+`user_set_selected_charger_by_name`, Then `_car_api_stale` is False,
+`car_api_stale_percent_mode` is False, `_car_api_stale_since` is None,
+`_was_car_api_stale` is False, both inferred flags are False,
+`_last_valid_base_soc_value` is None (intended side effect: the
+system-captured SOC base is wiped — fresh-chance semantics; a user
+manual-SOC base would be preserved), and
+`is_car_effectively_stale(time)` returns False in auto mode.
+
+**AC2 — explicit select override survives every reset path.**
+Parametrized over the three entry points (`user_clean_and_reset`,
+no-charger select, charger-side displacement): Given a car in detected
+stale state with `car_stale_mode_override == CAR_STALE_MODE_FORCE_STALE`,
+When the reset path runs, Then `car_stale_mode_override` is unchanged,
+`is_car_effectively_stale(time)` still returns True (override wins),
+and the detected fields of AC1 are cleared.
+
+**AC3 — clean-and-reset button resets detection.** Given a stale car,
+When `user_clean_and_reset()` runs, Then the detected stale state is
+reset (same field assertions as AC1). A second test drives the
+departure auto-reset path (`car_tracker` configured, raw home False for
+≥ `CAR_NOT_HOME_AUTO_RESET_S`, `_check_departure_auto_reset` fires) and
+asserts the same outcome.
+
+**AC4 — manual charger-side allocation resets the displaced car.**
+Given car Y attached to charger C and in detected stale state, When
+`C.user_set_selected_car_by_name("X")` runs (another car's name — also
+reached via car X's `user_set_selected_charger_by_name("C")`), Then Y
+is detached AND Y's detected stale state is reset. A variant asserts
+the same for `car_name == CHARGER_NO_CAR_CONNECTED` (same branch).
+
+**AC5 — boundary guard: automatic detach does NOT reset.** Given a
+stale car attached to a charger with `_car_api_stale_since == T0`, When
+`charger.detach_car()` is called directly (the primitive used by all
+automatic paths), Then `car_api_stale_percent_mode` is still True and
+`_car_api_stale_since == T0` (only the inferred flags are cleared —
+existing behavior, unchanged).
+
+## Task breakdown
+
+TDD: write each AC's test red-first, iterate with
+`python scripts/qs/quality_gate.py --quick tests/test_car_api_staleness.py`.
+
+### T1 — `reset_car_api_stale_detection()` method
+
+File: `custom_components/quiet_solar/ha_model/car.py`. Insert after
+`_exit_stale_mode` (body ends line 825). Exact body in the Design
+section (debug log: lazy `%s`, no trailing period).
+
+### T2 — Hook: manual no-charger branch
+
+Same file, `user_set_selected_charger_by_name`, after
+`self.clear_inferred_flags()` in the `FORCE_CAR_NO_CHARGER_CONNECTED`
+branch (car.py:2579): add `self.reset_car_api_stale_detection()`.
+
+### T3 — Hook: `user_clean_and_reset`
+
+Same file, after `self.reset_soc_estimate()` (car.py:2605): add
+`self.reset_car_api_stale_detection()`.
+
+### T4 — Hook: charger-side displacement
+
+File: `custom_components/quiet_solar/ha_model/charger.py`,
+`user_set_selected_car_by_name` (~3047): capture `displaced_car`
+before `self.detach_car()`, call
+`displaced_car.reset_car_api_stale_detection()` after it (exact snippet
+in Design).
+
+### T5 — Tests
+
+File: `tests/test_car_api_staleness.py`, new class
+`TestStaleResetTriggers` (class grouping follows this file's
+established convention — `TestContradictionDetection`,
+`TestStalePercentMode`, etc. — overriding the general plain-functions
+preference, same precedent as QS-260). Fixtures: `real_car`,
+`real_car_with_home`, `current_time`; for AC4 use the charger helpers
+(`create_charger_generic`, `create_mock_home`, ...) already imported by
+this file from `tests/test_charger_additional_coverage.py`.
+
+- `test_no_charger_select_resets_stale_detection` (AC1)
+- `test_reset_preserves_force_stale_override` (AC2, parametrized over
+  the three entry points)
+- `test_clean_and_reset_resets_stale_detection` (AC3)
+- `test_departure_auto_reset_resets_stale_detection` (AC3)
+- `test_charger_side_manual_allocation_resets_displaced_car` (AC4)
+- `test_charger_side_no_car_selection_resets_displaced_car` (AC4)
+- `test_plain_detach_car_does_not_reset_stale_detection` (AC5)
+
+To stage a stale car, set the detected fields directly or drive
+`check_charger_assignment_contradiction` (the existing
+`TestContradictionDetection` tests show the recipe); use
+`is_car_effectively_stale(time)` (method, takes `time`).
+
+### T6 — Docs
+
+- Update `docs/agents/concepts/car-soc-estimation.md`: add the three
+  new reset triggers to the stale-exit description, bump
+  `last_verified`.
+- Doc-OK: `docs/agents/concepts/charger-budgeting.md` — the single
+  charger.py hook is car-assignment plumbing in
+  `user_set_selected_car_by_name`, not amp-budget logic.
+- Doc-OK: `docs/agents/concepts/person-trip-prediction.md` — no
+  person/trip-prediction logic changes (the stale reset only touches
+  car API detection state).
+
+### T7 — Quality gate
+
+`python scripts/qs/quality_gate.py` — full suite, 100% coverage, ruff,
+mypy, translations.
+
+## Adversarial Review Notes
+
+Round 1 ran the 4 reviewers (critic, concrete-planner, dev-proxy,
+scope-guardian) on a broader draft that also hooked the physical unplug
+edge and the automatic re-allocation displacement. Dispositions:
+
+- **"Superset replacement" of `clear_inferred_flags()` risky**
+  (4 reviewers) → fixed: hook 2 *adds* the reset call instead of
+  replacing; `_exit_stale_mode` verified unconditional.
+- **SOC-base wipe is an unasserted side effect** (critic, concrete) →
+  fixed: documented as intended fresh-chance semantics; asserted in AC1.
+- **Persisted stale state could resurrect after reboot** (critic) →
+  rejected with evidence: detected stale state is recomputed from
+  sensor history at boot, never persisted as such.
+- **Test class violates plain-functions rule** (dev-proxy) → resolved:
+  the target file's established convention is class grouping (QS-260
+  precedent for following file convention); concrete test names pinned.
+- **AC2 "any path" untestable / AC observables vague** (critic,
+  concrete, dev-proxy) → fixed: AC2 parametrized over the three entry
+  points; AC5 asserts the unchanged `_car_api_stale_since` timestamp.
+- **Unplug-edge hook = notification regression for dead-API cars
+  unplugged daily; displacement hook contradicts the anti-shuffle
+  rationale; charger-side manual path arguably in scope** (critic,
+  scope-guardian) → resolved by the product owner in round 2:
+  requirement drastically simplified to the three manual triggers
+  above; unplug and automatic re-allocation hooks dropped; the manual
+  charger-side displacement pulled INTO scope as hook 3.
+- Smaller items adopted: debug log in the new method, exact insertion
+  anchors (branch conditions + line numbers), TDD red-first note,
+  `CAR_API_STALE_THRESHOLD_S` named, ordering rationale for T3/T4.

--- a/docs/stories/QS-262.story_review_fix_#01.md
+++ b/docs/stories/QS-262.story_review_fix_#01.md
@@ -1,0 +1,37 @@
+# QS-262 — Review fix plan #01
+
+## Summary
+- Source PR: #263
+- Source story: docs/stories/QS-262.story.md
+- Findings to fix: 1
+- Next implement phase: `/implement-setup-task`
+
+## Findings to fix
+
+### [must-fix] Doc-maintenance gate: drift-tracked docs left stale without justification
+- File: `docs/agents/concepts/person-trip-prediction.md:?` and
+  `docs/agents/concepts/charger-budgeting.md:?` (front-matter `last_verified`)
+- Severity: must-fix
+- Source: qs-review-task orchestrator (doc-maintenance audit)
+- Description: PR #263 modifies `custom_components/quiet_solar/ha_model/car.py`
+  and `custom_components/quiet_solar/ha_model/charger.py`. Both are drift-tracked:
+  `person-trip-prediction.md` covers `car.py` and `charger-budgeting.md` covers
+  `charger.py`. `python scripts/qs/check_doc_drift.py` exits 1 (both docs stale at
+  `last_verified=2026-05-30`). The PR body has a `## Docs` section but **no
+  `## Doc maintenance` heading** carrying a justification for leaving these two
+  tracked docs untouched. The story's T6 already determined both are "Doc-OK"
+  (the charger.py hook is car-assignment plumbing, not amp-budget logic; no
+  person/trip-prediction logic changed), so no content change is required — only
+  the verification metadata / drift gate must be satisfied.
+- Proposed fix: Bump `last_verified` to `2026-06-13` (today) in the front-matter
+  of both `docs/agents/concepts/person-trip-prediction.md` and
+  `docs/agents/concepts/charger-budgeting.md`. This asserts the docs were
+  re-verified as still accurate (matching the story's Doc-OK determination) and
+  clears the `check_doc_drift.py` gate. Do **not** alter doc body content — both
+  remain accurate as-is. (A `## Doc maintenance` note in the PR body alone would
+  not clear the CI drift gate, so the date-bump is the required fix.)
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify.

--- a/tests/ha_tests/test_charger.py
+++ b/tests/ha_tests/test_charger.py
@@ -4001,6 +4001,9 @@ async def test_charger_best_car_and_user_selection(
         def clear_user_originated(self, key):
             self._user_originated.pop(key, None)
 
+        def reset_car_api_stale_detection(self) -> None:
+            pass
+
         def __hash__(self) -> int:
             return id(self)
 

--- a/tests/test_car_api_staleness.py
+++ b/tests/test_car_api_staleness.py
@@ -28,6 +28,7 @@ from custom_components.quiet_solar.const import (
     CAR_STALE_MODE_AUTO,
     CAR_STALE_MODE_FORCE_NOT_STALE,
     CAR_STALE_MODE_FORCE_STALE,
+    CHARGER_NO_CAR_CONNECTED,
     FORCE_CAR_NO_CHARGER_CONNECTED,
     SELECT_CAR_STALE_MODE,
     USER_ORIGINATED_CAR_NAME,
@@ -1827,3 +1828,154 @@ class TestGuestToKnownCarTransition:
 
         best = charger.get_best_car(now)
         assert best.name == "Twingo"
+
+
+# ── QS-262: Stale-detection reset triggers ───────────────────────────
+
+
+class TestStaleResetTriggers:
+    """Reset of detected car API stale state on the three manual triggers.
+
+    Triggers: the clean-and-reset button (`user_clean_and_reset`), a manual
+    `FORCE_CAR_NO_CHARGER_CONNECTED` select on the car, and a manual
+    charger-side car allocation that displaces the currently attached car.
+    """
+
+    @staticmethod
+    def _stage_detected_stale(car, time):
+        """Stage a car in detected (contradiction-flagged) stale state."""
+        car._car_api_stale = True
+        car.car_api_stale_percent_mode = True
+        car._car_api_stale_since = time
+        car._car_api_inferred_home = True
+        car._car_api_inferred_plugged = True
+        car._was_car_api_stale = True
+        car._last_valid_base_soc_value = 55.0
+
+    @staticmethod
+    def _assert_detected_cleared(car):
+        """Assert all detected stale fields are reset (AC1 field set)."""
+        assert car._car_api_stale is False
+        assert car.car_api_stale_percent_mode is False
+        assert car._car_api_stale_since is None
+        assert car._was_car_api_stale is False
+        assert car._car_api_inferred_home is False
+        assert car._car_api_inferred_plugged is False
+        assert car._last_valid_base_soc_value is None
+
+    @staticmethod
+    def _make_charger_with_attached(car):
+        """Build a real charger with ``car`` attached (charger-side + backref)."""
+        from tests.test_charger_additional_coverage import (
+            create_charger_generic,
+            create_mock_hass,
+            create_mock_home,
+        )
+
+        hass = create_mock_hass()
+        home = create_mock_home(hass)
+        charger = create_charger_generic(hass, home)
+        charger.car = car
+        car.charger = charger
+        return charger
+
+    async def _run_reset_path(self, entry_point, car):
+        """Drive one of the three manual reset entry points on ``car``."""
+        if entry_point == "clean_and_reset":
+            await car.user_clean_and_reset()
+        elif entry_point == "no_charger_select":
+            await car.user_set_selected_charger_by_name(FORCE_CAR_NO_CHARGER_CONNECTED)
+        else:  # "charger_displacement"
+            charger = self._make_charger_with_attached(car)
+            with patch.object(charger, "update_charger_for_user_change", new_callable=AsyncMock):
+                await charger.user_set_selected_car_by_name("Some Other Car")
+
+    async def test_no_charger_select_resets_stale_detection(self, real_car, current_time):
+        """AC1: manual FORCE_CAR_NO_CHARGER_CONNECTED clears detected stale state."""
+        self._stage_detected_stale(real_car, current_time)
+
+        await real_car.user_set_selected_charger_by_name(FORCE_CAR_NO_CHARGER_CONNECTED)
+
+        self._assert_detected_cleared(real_car)
+        assert real_car.is_car_effectively_stale(current_time) is False
+
+    @pytest.mark.parametrize(
+        "entry_point",
+        ["clean_and_reset", "no_charger_select", "charger_displacement"],
+    )
+    async def test_reset_preserves_force_stale_override(self, entry_point, real_car, current_time):
+        """AC2: an explicit Force-stale override survives every reset path."""
+        self._stage_detected_stale(real_car, current_time)
+        real_car.car_stale_mode_override = CAR_STALE_MODE_FORCE_STALE
+
+        await self._run_reset_path(entry_point, real_car)
+
+        assert real_car.car_stale_mode_override == CAR_STALE_MODE_FORCE_STALE
+        assert real_car.is_car_effectively_stale(current_time) is True
+        self._assert_detected_cleared(real_car)
+
+    async def test_clean_and_reset_resets_stale_detection(self, real_car, current_time):
+        """AC3: the clean-and-reset button clears detected stale state."""
+        self._stage_detected_stale(real_car, current_time)
+
+        await real_car.user_clean_and_reset()
+
+        self._assert_detected_cleared(real_car)
+        assert real_car.is_car_effectively_stale(current_time) is False
+
+    async def test_departure_auto_reset_resets_stale_detection(self, real_car, current_time):
+        """AC3: the departure auto-reset path inherits the stale reset."""
+        fresh_time = current_time - timedelta(seconds=60)
+        real_car._entity_probed_last_valid_state[real_car.car_tracker] = (fresh_time, "not_home", {})
+        self._stage_detected_stale(real_car, current_time)
+
+        # First call starts the departure timer.
+        await real_car._check_departure_auto_reset(current_time)
+        assert real_car._car_not_home_since == current_time
+
+        # After the confirmation window the real user_clean_and_reset fires.
+        later_time = current_time + timedelta(seconds=CAR_NOT_HOME_AUTO_RESET_S)
+        await real_car._check_departure_auto_reset(later_time)
+
+        assert real_car._departure_auto_reset_done is True
+        self._assert_detected_cleared(real_car)
+        assert real_car.is_car_effectively_stale(later_time) is False
+
+    async def test_charger_side_manual_allocation_resets_displaced_car(self, real_car, current_time):
+        """AC4: a manual charger-side car pick resets the displaced car."""
+        charger = self._make_charger_with_attached(real_car)
+        self._stage_detected_stale(real_car, current_time)
+
+        with patch.object(charger, "update_charger_for_user_change", new_callable=AsyncMock):
+            await charger.user_set_selected_car_by_name("Another Car")
+
+        # Displaced car detached AND reset.
+        assert charger.car is None
+        assert real_car.charger is None
+        self._assert_detected_cleared(real_car)
+        assert real_car.is_car_effectively_stale(current_time) is False
+
+    async def test_charger_side_no_car_selection_resets_displaced_car(self, real_car, current_time):
+        """AC4 variant: selecting CHARGER_NO_CAR_CONNECTED resets the displaced car."""
+        charger = self._make_charger_with_attached(real_car)
+        self._stage_detected_stale(real_car, current_time)
+
+        with patch.object(charger, "update_charger_for_user_change", new_callable=AsyncMock):
+            await charger.user_set_selected_car_by_name(CHARGER_NO_CAR_CONNECTED)
+
+        assert charger.car is None
+        assert real_car.charger is None
+        self._assert_detected_cleared(real_car)
+
+    async def test_plain_detach_car_does_not_reset_stale_detection(self, real_car, current_time):
+        """AC5: a direct detach_car (the automatic primitive) keeps detected stale state."""
+        charger = self._make_charger_with_attached(real_car)
+        self._stage_detected_stale(real_car, current_time)
+
+        charger.detach_car()
+
+        # Only the inferred flags are cleared — the stale episode is preserved.
+        assert real_car.car_api_stale_percent_mode is True
+        assert real_car._car_api_stale_since == current_time
+        assert real_car._car_api_inferred_home is False
+        assert real_car._car_api_inferred_plugged is False


### PR DESCRIPTION
Closes #262.

## What
A car flagged stale stayed in stale-percent mode even after a user action that invalidates the stale premise. This resets the **detected** car API stale state on the three manual triggers:

1. The car's clean-and-reset button (`user_clean_and_reset`) — also covers the departure auto-reset path.
2. A manual `FORCE_CAR_NO_CHARGER_CONNECTED` select on the car.
3. A manual charger-side car allocation that displaces the attached car (`user_set_selected_car_by_name`, incl. `CHARGER_NO_CAR_CONNECTED`).

## How
- New `QSCar.reset_car_api_stale_detection()` → `_exit_stale_mode()` + clears `_was_car_api_stale` (detected state only).
- `car_stale_mode_override` is **preserved** — a Force-stale override still wins; the next cycle silently re-enters stale-percent mode.
- Automatic `detach_car()` deliberately keeps today's behavior (no reset).

## Scope
Per the product-owner decision in the story, the physical-unplug edge, automatic re-allocation displacement, blanket `detach_car()` hooks, and boot/restore paths are explicitly out of scope.

## Tests
- `TestStaleResetTriggers` (AC1–AC5) in `tests/test_car_api_staleness.py`, 9 cases incl. the AC5 boundary guard (plain `detach_car` does NOT reset).
- `DummyCar` stub in `tests/ha_tests/test_charger.py` gains the no-op method (interface parity for the charger-selection unit test).

## Docs
- `docs/agents/concepts/car-soc-estimation.md`: stale-exit triggers + `last_verified` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Stale detection state now resets when users select "no charger connected," perform clean-and-reset, or trigger charger-side car reallocation. Explicit stale overrides are preserved.

* **Tests**
  * Added comprehensive test coverage for stale detection reset behaviors across all user-triggered paths.

* **Documentation**
  * Updated stale detection documentation to reflect reset triggers and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->