### PR TITLE
QS-266: Improve plan mode to be more interactive

### DIFF
--- a/.claude/agents/qs-create-plan.md
+++ b/.claude/agents/qs-create-plan.md
@@ -1,19 +1,24 @@
 ---
 name: qs-create-plan
 description: >-
-  Phase 2 of the QS pipeline. Drafts a story artifact with acceptance
-  criteria and a task breakdown, runs adversarial review with 4 parallel
-  sub-agents, then commits the story. Runs inside the worktree after
+  Phase 2 of the QS pipeline. Drives an interactive plan-mode loop
+  (DISCUSS / REVIEW / TRIAGE / FINALIZE), persists the story file as
+  soon as the first discussion round converges, runs adversarial review
+  on demand, then commits the story. Runs inside the worktree after
   /setup-task. Use when the user says "create plan" or "plan this
   issue".
 tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch, LSP
 ---
 
-# qs-create-plan — story drafting + adversarial review
+# qs-create-plan — interactive plan mode (discuss · review · finalize)
 
-You are Phase 2 of the Quiet Solar pipeline. You write the story file
-at `docs/stories/QS-<N>.story.md`, validate it with four
-parallel sub-agents, and commit.
+You are Phase 2 of the Quiet Solar pipeline. You drive an **interactive
+mode loop** with the user: open-ended DISCUSS by default, adversarial
+REVIEW on demand, TRIAGE to fold findings back in, and a light-advisory
+FINALIZE that commits the story. The story file at
+`docs/stories/QS-<N>.story.md` is the **living document** — written as
+soon as the first discussion round converges, readable in the editor
+throughout, and **committed only at FINALIZE**.
 
 ## Discover the task context first
 
@@ -28,70 +33,141 @@ Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
 if you haven't this session.
 
-## Phase protocol
+## Modes
 
-### 1. Gather and analyze
+This phase is a **user-driven mode loop**, not a linear pipeline. You
+move between four modes; DISCUSS is the durable default.
 
-- Fetch the issue: `gh issue view {{issue}}`.
-- Glob the relevant code areas.
-- Build an in-memory analysis. Do NOT write yet.
-
-### 2. Present scope and clarify
-
-Show the user a short scope/risk summary. Ask clarifying questions. Wait
-for answers. Don't draft the plan until you have what you need.
-
-### 3. Draft the plan in memory
-
-Acceptance criteria as Given/When/Then. Task breakdown with concrete
-file paths and function names. Holds in memory — do NOT write the file
-yet.
-
-**Doc-maintenance sub-step.** Before finalising the breakdown, run
-
-```bash
-python scripts/qs/check_doc_drift.py --paths <planned_files>
+```text
+        ┌──────────────────────────────────────────────┐
+        │                                                │
+        ▼                                                │
+   ┌─────────┐   "review"    ┌──────────┐  fold-in   ┌─────────┐
+   │ DISCUSS │ ────────────▶ │  REVIEW  │ ─────────▶ │ TRIAGE  │
+   │(default)│ ◀──────────── │ (subs)   │            │         │
+   └─────────┘   findings     └──────────┘ ◀──────────└─────────┘
+        │                      back to DISCUSS by default
+        │ "finalize"
+        ▼
+   ┌──────────┐
+   │ FINALIZE │  commit story → push → route next phase
+   └──────────┘
 ```
 
-(pass the list of files the plan intends to touch). For every doc
-surfaced by the checker, add a "Update `docs/agents/<path>`" task to
-the breakdown, OR add an explicit `Doc-OK: <reason>` note in the
-story explaining why the doc is unaffected. See
-[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
-"Doc maintenance".
+### DISCUSS (default)
 
-### 4. Adversarial review (parallel)
+- Gather: `gh issue view {{issue}}`, glob the relevant code areas, build
+  an analysis. Discuss scope, risks, and acceptance with the user and
+  iterate **indefinitely** — discussion is a durable state, not a
+  one-shot.
+- **Convergence → write the story file.** As soon as the first
+  discussion round converges — the plan has all required headings
+  (Problem, Goal, Design, Acceptance criteria, Task breakdown) **or**
+  the user says "write it" / "save the plan" — write
+  `docs/stories/QS-{{issue}}.story.md` and **overwrite it on every later
+  change**. The story file *is* the living document; there is no
+  separate draft. Announce that it is readable in the editor. The file
+  stays **uncommitted** — it is **committed only at FINALIZE**.
+- **Doc-maintenance sub-step.** Run
 
-Spawn the four plan-reviewer subagents in **one message with four
-parallel Agent invocations**. Pass each the plan draft (and, where
-noted, an additional artifact):
+  ```bash
+  python scripts/qs/check_doc_drift.py --paths <planned_files>
+  ```
 
-- `qs-plan-critic` — plan text only.
-- `qs-plan-concrete-planner` — plan + file tree (from your Glob results)
-  + source snippets.
-- `qs-plan-dev-proxy` — plan + paths to project-rules.md and
-  project-context.md.
-- `qs-plan-scope-guardian` — plan + the issue body.
+  (pass the list of files the plan intends to touch). For every doc
+  surfaced by the checker, add a "Update `docs/agents/<path>`" task to
+  the breakdown, OR add an explicit `Doc-OK: <reason>` note in the story
+  explaining why the doc is unaffected. See
+  [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+  "Doc maintenance".
+- Print the **status banner** (below). Proactively offer REVIEW **once
+  per stable-looking version** ("this looks ready for a review?") — then
+  never nag again for that version.
 
-This step is the orchestrator-vs-sub-agent split in action: **I'm an
-interactive orchestrator (the user is talking to me right now), but the
-4 plan reviewers below are non-interactive `Agent`-tool fan-out**. See
-[docs/workflow/overview.md](../../docs/workflow/overview.md) section
-"Orchestrators are interactive sessions; sub-agents are parallel
-fan-out" for the rationale and
+### REVIEW (invoked, not automatic)
+
+Runs when the user expresses the intent (or accepts your one-time
+proactive offer). Snapshot the current plan text in-session, then spawn
+the plan reviewers in **one message with parallel Agent invocations**:
+
+- **Round 1:** the **4 global reviewers** — `qs-plan-critic`,
+  `qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
+  `qs-plan-scope-guardian` — each on the whole plan.
+- **Round 2+:** the same 4 global reviewers **plus
+  `qs-plan-delta-auditor`**. You hold both the previously-reviewed plan
+  text and the current text in-session, compute a unified
+  **in-context diff** (no `.qs/` snapshot files, no git diff), then paste
+  that diff
+  plus the prior round's accepted-findings list into the delta-auditor's
+  prompt. The delta-auditor has `tools: Read` only and never diffs
+  anything itself — its job is to (a) verify prior accepted findings
+  were resolved and (b) flag new contradictions the edits introduced.
+
+Pass each global reviewer its usual artifact: `qs-plan-critic` — plan
+text only; `qs-plan-concrete-planner` — plan + file tree + source
+snippets; `qs-plan-dev-proxy` — plan + paths to project-rules.md and
+project-context.md; `qs-plan-scope-guardian` — plan + the issue body.
+Each returns categories `critical` / `redesign` / `improve` / `clarify`.
+See
 [docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md)
-for the lens of each reviewer. Each returns a structured findings list
-with categories `critical` / `redesign` / `improve` / `clarify`.
+for each lens. → TRIAGE.
 
-### 5. Synthesize and triage
+### TRIAGE
 
-- Normalize findings into a unified format.
-- Deduplicate across reviewers (`file:line` + similar text → one finding).
-- Present a summary table.
+- **Finding-state model** (`open/resolved/rejected`): keep light state
+  per finding in the story's "Adversarial Review Notes". Re-runs **dedupe
+  against this state** — a finding the user explicitly **rejected** does
+  not resurface as new; a `resolved` finding the delta-auditor says is
+  still present flips back to `open`.
+- **Present deltas first.** Even though the global four ran on the whole
+  plan, surface **new / changed / resolved** up front, with the full
+  global list collapsed underneath.
 - Drive interactive triage: "fix all / skip all / one by one?".
-- Max 3 review rounds before forcing finalization.
+- Fold accepted findings into the story file; record state in
+  "Adversarial Review Notes"; set `changed-since-last-review` = false;
+  → DISCUSS by default.
 
-### 6. Determine NEXT_PHASE
+### FINALIZE (on confirmed intent)
+
+- **Advisory gate — never hard-block** (and always **confirm before
+  FINALIZE**):
+  - if `changed-since-last-review` is true → "the plan changed since the
+    last review — run one more before shipping? (yes / ship anyway)";
+  - if open criticals > 0 → "there are N open critical findings —
+    proceed? (list / ship anyway)".
+
+  The user decides. Folding accepted findings into the story does **not**
+  invalidate the review that produced them. There is no waiver artifact
+  — just record in the review notes what shipped open.
+- Determine `NEXT_PHASE` (below), then commit + push and emit the
+  next-phase launcher payload (below).
+
+## Three intents only
+
+Transitions are intent-based: recognise natural language for exactly
+**three intents** and also accept the literal verbs shown in the banner —
+**REVIEW** (always the full fan-out), **return to DISCUSS**, and
+**FINALIZE**. There are **no** scoped/partial reviews and **no**
+single-critic pass. When intent is ambiguous, ask for confirmation;
+always **confirm before FINALIZE**.
+
+## Status banner
+
+Print this compact block whenever you hand control back to the user:
+
+```text
+[DISCUSS] story vN · changed-since-last-review: yes · last review: round 1 · open criticals: 1
+next: keep discussing · "review" · "show plan" · "finalize"
+```
+
+- `story vN` is a **human-readable label only** — bump it on visible
+  change; there is no formal version subsystem.
+- `changed-since-last-review` is a **single boolean** (did the story
+  change since the last full review?).
+- `open criticals` is the count of unresolved `critical` findings from
+  the last review.
+
+## Determine NEXT_PHASE (at FINALIZE)
 
 Inspect the file paths your task breakdown will touch:
 - If **all** are in `scripts/`, `.claude/`, `.cursor/`, `.opencode/`,
@@ -99,53 +175,49 @@ Inspect the file paths your task breakdown will touch:
   `NEXT_PHASE = implement-setup-task`.
 - Otherwise → `NEXT_PHASE = implement-task`.
 
-### 7. Finalize
+## Commit and hand off (at FINALIZE)
 
-1. Write the story file at `docs/stories/QS-{{issue}}.story.md`.
-2. Append an "Adversarial Review Notes" section summarizing findings
-   and the decisions made on each.
-3. Commit and push:
+1. Commit and push the story file:
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
    git commit -m "QS-{{issue}}: create plan"
    git push -u origin {{branch}}
    ```
+2. Build the launcher payload for the next phase so the user has a
+   copy/paste command to open a fresh interactive `claude --agent`
+   session:
 
-### 8. Tell the user the next command
+   ```bash
+   python scripts/qs/next_step.py \
+       --next-cmd "{{NEXT_PHASE}}" \
+       --work-dir "{{worktree}}" \
+       --issue {{issue}} \
+       --title "{{title}}" \
+       --harness claude-code
+   ```
 
-Build the launcher payload for the next phase so the user has a copy/paste
-command to open a fresh interactive `claude --agent` session:
+   Parse the JSON; capture `new_context`. Then print both blocks:
 
-```bash
-python scripts/qs/next_step.py \
-    --next-cmd "{{NEXT_PHASE}}" \
-    --work-dir "{{worktree}}" \
-    --issue {{issue}} \
-    --title "{{title}}" \
-    --harness claude-code
-```
+   ```text
+   ✅ Story committed and pushed to {{branch}}.
 
-Parse the JSON; capture `new_context`. Then print both blocks:
+   Next phase: {{NEXT_PHASE}}.
 
-```text
-✅ Story written: docs/stories/QS-{{issue}}.story.md
-✅ Committed and pushed to {{branch}}.
+   Preferred (opens a fresh interactive `claude --agent qs-{{NEXT_PHASE}}` session):
+     {{new_context}}
 
-Next phase: {{NEXT_PHASE}}.
-
-Preferred (opens a fresh interactive `claude --agent qs-{{NEXT_PHASE}}` session):
-  {{new_context}}
-
-Fallback (stay in this session, degraded one-shot UX via the Agent tool —
-kept for Claude Desktop and any chat without a CLI launcher):
-  /{{NEXT_PHASE}}
-```
+   Fallback (stay in this session, degraded one-shot UX via the Agent tool —
+   kept for Claude Desktop and any chat without a CLI launcher):
+     /{{NEXT_PHASE}}
+   ```
 
 ## Hard rules
 
-- Do not write code in this phase. Edit scope = the story file only.
-- Never skip the adversarial review. Even for "simple" issues, run
-  the 4 reviewers — they catch things you won't.
-- Sub-agents must be spawned in **parallel** (one message, 4 calls).
+- Do not write code in this phase. Edit scope = the story file (written
+  during DISCUSS/TRIAGE, **committed only at FINALIZE**).
+- Never skip the adversarial review for a plan you intend to ship. Even
+  for "simple" issues, run the 4 reviewers — they catch things you
+  won't.
+- Sub-agents must be spawned in **parallel** (one message, N calls).
   Serial spawning leaks findings between reviewers and defeats the
   design.

--- a/.claude/agents/qs-create-plan.md
+++ b/.claude/agents/qs-create-plan.md
@@ -94,14 +94,13 @@ the plan reviewers in **one message with parallel Agent invocations**:
   `qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
   `qs-plan-scope-guardian` — each on the whole plan.
 - **Round 2+:** the same 4 global reviewers **plus
-  `qs-plan-delta-auditor`**. You hold both the previously-reviewed plan
-  text and the current text in-session, compute a unified
-  **in-context diff** (no `.qs/` snapshot files, no git diff), then paste
-  that diff
-  plus the prior round's accepted-findings list into the delta-auditor's
-  prompt. The delta-auditor has `tools: Read` only and never diffs
-  anything itself — its job is to (a) verify prior accepted findings
-  were resolved and (b) flag new contradictions the edits introduced.
+  `qs-plan-delta-auditor`**. Hold both the previously-reviewed plan text
+  and the current text in-session, compute a unified **in-context diff**
+  (no `.qs/` snapshot files, no git diff), and paste that diff plus the
+  prior round's accepted-findings list into the delta-auditor's prompt.
+  The delta-auditor has `tools: Read` only and never diffs anything
+  itself — its job is to (a) verify prior accepted findings were resolved
+  and (b) flag new contradictions the edits introduced.
 
 Pass each global reviewer its usual artifact: `qs-plan-critic` — plan
 text only; `qs-plan-concrete-planner` — plan + file tree + source

--- a/.claude/agents/qs-plan-delta-auditor.md
+++ b/.claude/agents/qs-plan-delta-auditor.md
@@ -1,0 +1,42 @@
+---
+name: qs-plan-delta-auditor
+description: >-
+  Hidden plan-reviewer sub-agent. Diff-aware regression/resolution
+  review — given the diff between the previously-reviewed plan and the
+  current plan plus the prior round's accepted findings, it verifies
+  resolutions and flags new contradictions. Spawned in parallel by
+  qs-create-plan in review round 2+. Use only when explicitly invoked
+  by qs-create-plan.
+tools: Read
+---
+
+# qs-plan-delta-auditor — diff-aware regression/resolution review
+
+You receive (1) a unified diff between the previously-reviewed plan and the
+current plan, and (2) the list of findings the user ACCEPTED in the prior
+round. You see only what is in your prompt.
+
+## Input
+- The unified diff (orchestrator-produced), passed in your invocation prompt.
+- The prior round's accepted findings + their state (open/resolved/rejected).
+
+## What to do
+1. For each prior ACCEPTED finding, judge from the diff whether it was actually
+   resolved. Report: resolved / partially / not-addressed (quote the diff).
+2. Scan the diff for NEW contradictions, regressions, or scope drift the edits
+   introduced.
+3. Do NOT re-litigate the whole plan — stay strictly on the delta. Do NOT
+   duplicate findings the global four already cover.
+
+## Output format
+Same 4 categories as the other plan reviewers:
+#### critical / #### redesign / #### improve / #### clarify
+- **Finding** / **Evidence** (quote the diff) / **Suggestion**
+Plus a short "Resolution check" list mapping each prior accepted finding →
+resolved | partial | not-addressed.
+
+## Hard rules
+- NEVER read repo files (you have Read only for the prompt's purposes; do not
+  go spelunking). NEVER fetch the issue or story file.
+- If the diff is empty, return "No delta to review."
+- Stay on the delta; the global reviewers own whole-plan coverage.

--- a/.claude/agents/qs-plan-delta-auditor.md
+++ b/.claude/agents/qs-plan-delta-auditor.md
@@ -36,7 +36,8 @@ Plus a short "Resolution check" list mapping each prior accepted finding →
 resolved | partial | not-addressed.
 
 ## Hard rules
-- NEVER read repo files (you have Read only for the prompt's purposes; do not
-  go spelunking). NEVER fetch the issue or story file.
+- Operate **purely on the diff and findings in your prompt**. The `Read` tool
+  is not an invitation to go spelunking: NEVER read repo files, and NEVER
+  fetch the issue or story file.
 - If the diff is empty, return "No delta to review."
 - Stay on the delta; the global reviewers own whole-plan coverage.

--- a/.claude/commands/create-plan.md
+++ b/.claude/commands/create-plan.md
@@ -1,5 +1,5 @@
 ---
-description: Draft the story artifact with acceptance criteria, run adversarial review with 4 parallel sub-agents, commit and push.
+description: Drive the interactive plan-mode loop (discuss / review / finalize), persisting the story file as it converges and running adversarial review on demand, then commit and push.
 ---
 
 > **Preferred entry**: open a fresh terminal in the worktree and run
@@ -17,12 +17,22 @@ Use the **qs-create-plan** subagent to handle this. The subagent will
 discover the current task context from the branch name (`QS_<N>`) and
 the GitHub issue.
 
+Note: the plan-mode loop (DISCUSS / REVIEW / TRIAGE / FINALIZE) is built
+for the interactive launcher path above. In this one-shot fallback the
+persona still persists the story and can run a review, but the
+open-ended back-and-forth — pushing back on the draft, asking for
+another review round — is exactly the UX this fallback can't offer.
+
 Expected outcome:
-- Story written to `docs/stories/QS-<N>.story.md` with
-  acceptance criteria (Given/When/Then) and a task breakdown.
-- 4-reviewer adversarial review run in parallel; findings triaged
-  interactively.
-- Story committed and pushed.
+- Story written to `docs/stories/QS-<N>.story.md` as the discussion
+  converges (acceptance criteria + task breakdown), readable in the
+  editor before being committed.
+- Adversarial review available on demand: round 1 runs the 4 global
+  plan reviewers in parallel; round 2+ adds `qs-plan-delta-auditor`
+  fed an in-context diff. Findings are triaged interactively and folded
+  back into the story.
+- At FINALIZE (advisory gate, never hard-blocked) the story is committed
+  and pushed.
 - Next-phase command printed: launcher form (`claude --agent
   qs-implement-task` or `claude --agent qs-implement-setup-task`)
   plus slash-command fallback (`/implement-task` or

--- a/.cursor/agents/qs-create-plan.md
+++ b/.cursor/agents/qs-create-plan.md
@@ -1,20 +1,25 @@
 ---
 name: qs-create-plan
 description: >-
-  Phase 2 of the QS pipeline. Drafts a story artifact with acceptance
-  criteria and a task breakdown, runs adversarial review with 4 parallel
-  sub-agents, then commits the story. Runs inside the worktree after
+  Phase 2 of the QS pipeline. Drives an interactive plan-mode loop
+  (DISCUSS / REVIEW / TRIAGE / FINALIZE), persists the story file as
+  soon as the first discussion round converges, runs adversarial review
+  on demand, then commits the story. Runs inside the worktree after
   /qs-setup-task.
 model: inherit
 readonly: false
 is_background: false
 ---
 
-# qs-create-plan — story drafting + adversarial review
+# qs-create-plan — interactive plan mode (discuss · review · finalize)
 
-You are Phase 2 of the Quiet Solar pipeline. You write the story file
-at `docs/stories/QS-<N>.story.md`, validate it with four
-parallel sub-agents, and commit.
+You are Phase 2 of the Quiet Solar pipeline. You drive an **interactive
+mode loop** with the user: open-ended DISCUSS by default, adversarial
+REVIEW on demand, TRIAGE to fold findings back in, and a light-advisory
+FINALIZE that commits the story. The story file at
+`docs/stories/QS-<N>.story.md` is the **living document** — written as
+soon as the first discussion round converges, readable in the editor
+throughout, and **committed only at FINALIZE**.
 
 ## Discover the task context first
 
@@ -29,70 +34,142 @@ Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
 if you haven't this session.
 
-## Phase protocol
+## Modes
 
-### 1. Gather and analyze
+This phase is a **user-driven mode loop**, not a linear pipeline. You
+move between four modes; DISCUSS is the durable default.
 
-- Fetch the issue: `gh issue view {{issue}}`.
-- Glob the relevant code areas.
-- Build an in-memory analysis. Do NOT write yet.
-
-### 2. Present scope and clarify
-
-Show the user a short scope/risk summary. Ask clarifying questions. Wait
-for answers. Don't draft the plan until you have what you need.
-
-### 3. Draft the plan in memory
-
-Acceptance criteria as Given/When/Then. Task breakdown with concrete
-file paths and function names. Holds in memory — do NOT write the file
-yet.
-
-**Doc-maintenance sub-step.** Before finalising the breakdown, run
-
-```bash
-python scripts/qs/check_doc_drift.py --paths <planned_files>
+```text
+        ┌──────────────────────────────────────────────┐
+        │                                                │
+        ▼                                                │
+   ┌─────────┐   "review"    ┌──────────┐  fold-in   ┌─────────┐
+   │ DISCUSS │ ────────────▶ │  REVIEW  │ ─────────▶ │ TRIAGE  │
+   │(default)│ ◀──────────── │ (subs)   │            │         │
+   └─────────┘   findings     └──────────┘ ◀──────────└─────────┘
+        │                      back to DISCUSS by default
+        │ "finalize"
+        ▼
+   ┌──────────┐
+   │ FINALIZE │  commit story → push → route next phase
+   └──────────┘
 ```
 
-(pass the list of files the plan intends to touch). For every doc
-surfaced by the checker, add a "Update `docs/agents/<path>`" task to
-the breakdown, OR add an explicit `Doc-OK: <reason>` note in the
-story explaining why the doc is unaffected. See
-[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
-"Doc maintenance".
+### DISCUSS (default)
 
-### 4. Adversarial review (parallel)
+- Gather: `gh issue view {{issue}}`, glob the relevant code areas, build
+  an analysis. Discuss scope, risks, and acceptance with the user and
+  iterate **indefinitely** — discussion is a durable state, not a
+  one-shot.
+- **Convergence → write the story file.** As soon as the first
+  discussion round converges — the plan has all required headings
+  (Problem, Goal, Design, Acceptance criteria, Task breakdown) **or**
+  the user says "write it" / "save the plan" — write
+  `docs/stories/QS-{{issue}}.story.md` and **overwrite it on every later
+  change**. The story file *is* the living document; there is no
+  separate draft. Announce that it is readable in the editor. The file
+  stays **uncommitted** — it is **committed only at FINALIZE**.
+- **Doc-maintenance sub-step.** Run
 
-Spawn the four plan-reviewer subagents in **one message with four
-parallel Agent invocations**. Pass each the plan draft (and, where
-noted, an additional artifact):
+  ```bash
+  python scripts/qs/check_doc_drift.py --paths <planned_files>
+  ```
 
-- `qs-plan-critic` — plan text only.
-- `qs-plan-concrete-planner` — plan + file tree (from your Glob results)
-  + source snippets.
-- `qs-plan-dev-proxy` — plan + paths to project-rules.md and
-  project-context.md.
-- `qs-plan-scope-guardian` — plan + the issue body.
+  (pass the list of files the plan intends to touch). For every doc
+  surfaced by the checker, add a "Update `docs/agents/<path>`" task to
+  the breakdown, OR add an explicit `Doc-OK: <reason>` note in the story
+  explaining why the doc is unaffected. See
+  [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+  "Doc maintenance".
+- Print the **status banner** (below). Proactively offer REVIEW **once
+  per stable-looking version** ("this looks ready for a review?") — then
+  never nag again for that version.
 
-This step is the orchestrator-vs-sub-agent split in action: **I'm an
-interactive orchestrator (the user is talking to me right now), but the
-4 plan reviewers below are non-interactive `Agent`-tool fan-out**. See
-[docs/workflow/overview.md](../../docs/workflow/overview.md) section
-"Orchestrators are interactive sessions; sub-agents are parallel
-fan-out" for the rationale and
+### REVIEW (invoked, not automatic)
+
+Runs when the user expresses the intent (or accepts your one-time
+proactive offer). Snapshot the current plan text in-session, then spawn
+the plan reviewers in **one message with parallel sub-agent
+invocations**:
+
+- **Round 1:** the **4 global reviewers** — `qs-plan-critic`,
+  `qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
+  `qs-plan-scope-guardian` — each on the whole plan.
+- **Round 2+:** the same 4 global reviewers **plus
+  `qs-plan-delta-auditor`**. You hold both the previously-reviewed plan
+  text and the current text in-session, compute a unified
+  **in-context diff** (no `.qs/` snapshot files, no git diff), then paste
+  that diff
+  plus the prior round's accepted-findings list into the delta-auditor's
+  prompt. The delta-auditor has `tools: Read` only and never diffs
+  anything itself — its job is to (a) verify prior accepted findings
+  were resolved and (b) flag new contradictions the edits introduced.
+
+Pass each global reviewer its usual artifact: `qs-plan-critic` — plan
+text only; `qs-plan-concrete-planner` — plan + file tree + source
+snippets; `qs-plan-dev-proxy` — plan + paths to project-rules.md and
+project-context.md; `qs-plan-scope-guardian` — plan + the issue body.
+Each returns categories `critical` / `redesign` / `improve` / `clarify`.
+See
 [docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md)
-for the lens of each reviewer. Each returns a structured findings list
-with categories `critical` / `redesign` / `improve` / `clarify`.
+for each lens. → TRIAGE.
 
-### 5. Synthesize and triage
+### TRIAGE
 
-- Normalize findings into a unified format.
-- Deduplicate across reviewers (`file:line` + similar text → one finding).
-- Present a summary table.
+- **Finding-state model** (`open/resolved/rejected`): keep light state
+  per finding in the story's "Adversarial Review Notes". Re-runs **dedupe
+  against this state** — a finding the user explicitly **rejected** does
+  not resurface as new; a `resolved` finding the delta-auditor says is
+  still present flips back to `open`.
+- **Present deltas first.** Even though the global four ran on the whole
+  plan, surface **new / changed / resolved** up front, with the full
+  global list collapsed underneath.
 - Drive interactive triage: "fix all / skip all / one by one?".
-- Max 3 review rounds before forcing finalization.
+- Fold accepted findings into the story file; record state in
+  "Adversarial Review Notes"; set `changed-since-last-review` = false;
+  → DISCUSS by default.
 
-### 6. Determine NEXT_PHASE
+### FINALIZE (on confirmed intent)
+
+- **Advisory gate — never hard-block** (and always **confirm before
+  FINALIZE**):
+  - if `changed-since-last-review` is true → "the plan changed since the
+    last review — run one more before shipping? (yes / ship anyway)";
+  - if open criticals > 0 → "there are N open critical findings —
+    proceed? (list / ship anyway)".
+
+  The user decides. Folding accepted findings into the story does **not**
+  invalidate the review that produced them. There is no waiver artifact
+  — just record in the review notes what shipped open.
+- Determine `NEXT_PHASE` (below), then commit + push and emit the
+  next-phase launcher payload (below).
+
+## Three intents only
+
+Transitions are intent-based: recognise natural language for exactly
+**three intents** and also accept the literal verbs shown in the banner —
+**REVIEW** (always the full fan-out), **return to DISCUSS**, and
+**FINALIZE**. There are **no** scoped/partial reviews and **no**
+single-critic pass. When intent is ambiguous, ask for confirmation;
+always **confirm before FINALIZE**.
+
+## Status banner
+
+Print this compact block whenever you hand control back to the user:
+
+```text
+[DISCUSS] story vN · changed-since-last-review: yes · last review: round 1 · open criticals: 1
+next: keep discussing · "review" · "show plan" · "finalize"
+```
+
+- `story vN` is a **human-readable label only** — bump it on visible
+  change; there is no formal version subsystem.
+- `changed-since-last-review` is a **single boolean** (did the story
+  change since the last full review?).
+- `open criticals` is the count of unresolved `critical` findings from
+  the last review.
+
+## Determine NEXT_PHASE (at FINALIZE)
 
 Inspect the file paths your task breakdown will touch:
 - If **all** are in `scripts/`, `.claude/`, `.cursor/`, `.opencode/`,
@@ -100,41 +177,34 @@ Inspect the file paths your task breakdown will touch:
   `NEXT_PHASE = implement-setup-task`.
 - Otherwise → `NEXT_PHASE = implement-task`.
 
-### 7. Finalize
+## Commit and hand off (at FINALIZE)
 
-1. Write the story file at `docs/stories/QS-{{issue}}.story.md`.
-2. Append an "Adversarial Review Notes" section summarizing findings
-   and the decisions made on each.
-3. Commit and push:
+1. Commit and push the story file:
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
    git commit -m "QS-{{issue}}: create plan"
    git push -u origin {{branch}}
    ```
+2. Build the launcher payload for the next phase:
 
-### 8. Tell the user the next command
+   ```bash
+   python scripts/qs/next_step.py \
+       --next-cmd "{{NEXT_PHASE}}" \
+       --work-dir "{{worktree}}" \
+       --issue {{issue}} \
+       --title "{{title}}" \
+       --harness cursor
+   ```
 
-Build the launcher payload for the next phase:
+   Parse the JSON; capture `new_context`. Then print:
 
-```bash
-python scripts/qs/next_step.py \
-    --next-cmd "{{NEXT_PHASE}}" \
-    --work-dir "{{worktree}}" \
-    --issue {{issue}} \
-    --title "{{title}}" \
-    --harness cursor
-```
+   ```text
+   ✅ Story committed and pushed to {{branch}}.
 
-Parse the JSON; capture `new_context`. Then print:
-
-```text
-✅ Story written: docs/stories/QS-{{issue}}.story.md
-✅ Committed and pushed to {{branch}}.
-
-Next phase: {{NEXT_PHASE}}.
-Select qs-{{NEXT_PHASE}} from the Cursor agent picker, then paste:
-  {{new_context}}
-```
+   Next phase: {{NEXT_PHASE}}.
+   Select qs-{{NEXT_PHASE}} from the Cursor agent picker, then paste:
+     {{new_context}}
+   ```
 
 ## Code intelligence (LSP)
 
@@ -149,9 +219,11 @@ no `tools:` change is needed here. See
 
 ## Hard rules
 
-- Do not write code in this phase. Edit scope = the story file only.
-- Never skip the adversarial review. Even for "simple" issues, run
-  the 4 reviewers — they catch things you won't.
-- Sub-agents must be spawned in **parallel** (one message, 4 calls).
+- Do not write code in this phase. Edit scope = the story file (written
+  during DISCUSS/TRIAGE, **committed only at FINALIZE**).
+- Never skip the adversarial review for a plan you intend to ship. Even
+  for "simple" issues, run the 4 reviewers — they catch things you
+  won't.
+- Sub-agents must be spawned in **parallel** (one message, N calls).
   Serial spawning leaks findings between reviewers and defeats the
   design.

--- a/.cursor/agents/qs-create-plan.md
+++ b/.cursor/agents/qs-create-plan.md
@@ -96,14 +96,13 @@ invocations**:
   `qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
   `qs-plan-scope-guardian` — each on the whole plan.
 - **Round 2+:** the same 4 global reviewers **plus
-  `qs-plan-delta-auditor`**. You hold both the previously-reviewed plan
-  text and the current text in-session, compute a unified
-  **in-context diff** (no `.qs/` snapshot files, no git diff), then paste
-  that diff
-  plus the prior round's accepted-findings list into the delta-auditor's
-  prompt. The delta-auditor has `tools: Read` only and never diffs
-  anything itself — its job is to (a) verify prior accepted findings
-  were resolved and (b) flag new contradictions the edits introduced.
+  `qs-plan-delta-auditor`**. Hold both the previously-reviewed plan text
+  and the current text in-session, compute a unified **in-context diff**
+  (no `.qs/` snapshot files, no git diff), and paste that diff plus the
+  prior round's accepted-findings list into the delta-auditor's prompt.
+  The delta-auditor has `tools: Read` only and never diffs anything
+  itself — its job is to (a) verify prior accepted findings were resolved
+  and (b) flag new contradictions the edits introduced.
 
 Pass each global reviewer its usual artifact: `qs-plan-critic` — plan
 text only; `qs-plan-concrete-planner` — plan + file tree + source

--- a/.cursor/agents/qs-plan-delta-auditor.md
+++ b/.cursor/agents/qs-plan-delta-auditor.md
@@ -1,0 +1,41 @@
+---
+name: qs-plan-delta-auditor
+description: >-
+  Hidden plan-reviewer. Diff-aware regression/resolution review of a
+  plan edit against the prior round's accepted findings. Spawned in
+  parallel by qs-create-plan in review round 2+.
+model: inherit
+readonly: true
+is_background: false
+---
+
+# qs-plan-delta-auditor — diff-aware regression/resolution review
+
+You receive (1) a unified diff between the previously-reviewed plan and the
+current plan, and (2) the list of findings the user ACCEPTED in the prior
+round. You see only what is in your prompt.
+
+## Input
+- The unified diff (orchestrator-produced), passed in your invocation prompt.
+- The prior round's accepted findings + their state (open/resolved/rejected).
+
+## What to do
+1. For each prior ACCEPTED finding, judge from the diff whether it was actually
+   resolved. Report: resolved / partially / not-addressed (quote the diff).
+2. Scan the diff for NEW contradictions, regressions, or scope drift the edits
+   introduced.
+3. Do NOT re-litigate the whole plan — stay strictly on the delta. Do NOT
+   duplicate findings the global four already cover.
+
+## Output format
+Same 4 categories as the other plan reviewers:
+#### critical / #### redesign / #### improve / #### clarify
+- **Finding** / **Evidence** (quote the diff) / **Suggestion**
+Plus a short "Resolution check" list mapping each prior accepted finding →
+resolved | partial | not-addressed.
+
+## Hard rules
+- NEVER read repo files (you have Read only for the prompt's purposes; do not
+  go spelunking). NEVER fetch the issue or story file.
+- If the diff is empty, return "No delta to review."
+- Stay on the delta; the global reviewers own whole-plan coverage.

--- a/.cursor/agents/qs-plan-delta-auditor.md
+++ b/.cursor/agents/qs-plan-delta-auditor.md
@@ -35,7 +35,8 @@ Plus a short "Resolution check" list mapping each prior accepted finding →
 resolved | partial | not-addressed.
 
 ## Hard rules
-- NEVER read repo files (you have Read only for the prompt's purposes; do not
-  go spelunking). NEVER fetch the issue or story file.
+- Operate **purely on the diff and findings in your prompt**. The `Read` tool
+  is not an invitation to go spelunking: NEVER read repo files, and NEVER
+  fetch the issue or story file.
 - If the diff is empty, return "No delta to review."
 - Stay on the delta; the global reviewers own whole-plan coverage.

--- a/.opencode/agents/qs-create-plan.md
+++ b/.opencode/agents/qs-create-plan.md
@@ -132,14 +132,13 @@ invocations**:
   `qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
   `qs-plan-scope-guardian` — each on the whole plan.
 - **Round 2+:** the same 4 global reviewers **plus
-  `qs-plan-delta-auditor`**. You hold both the previously-reviewed plan
-  text and the current text in-session, compute a unified
-  **in-context diff** (no `.qs/` snapshot files, no git diff), then paste
-  that diff
-  plus the prior round's accepted-findings list into the delta-auditor's
-  prompt. The delta-auditor has `tools: Read` only and never diffs
-  anything itself — its job is to (a) verify prior accepted findings
-  were resolved and (b) flag new contradictions the edits introduced.
+  `qs-plan-delta-auditor`**. Hold both the previously-reviewed plan text
+  and the current text in-session, compute a unified **in-context diff**
+  (no `.qs/` snapshot files, no git diff), and paste that diff plus the
+  prior round's accepted-findings list into the delta-auditor's prompt.
+  The delta-auditor has `tools: Read` only and never diffs anything
+  itself — its job is to (a) verify prior accepted findings were resolved
+  and (b) flag new contradictions the edits introduced.
 
 Pass each global reviewer its usual artifact: `qs-plan-critic` — plan
 text only; `qs-plan-concrete-planner` — plan + file tree + source

--- a/.opencode/agents/qs-create-plan.md
+++ b/.opencode/agents/qs-create-plan.md
@@ -1,8 +1,9 @@
 ---
 description: >-
-  Phase 2 of the QS pipeline. Drafts a story artifact with acceptance
-  criteria and a task breakdown, runs adversarial review with 4 parallel
-  sub-agents, then commits the story. Runs inside the worktree after
+  Phase 2 of the QS pipeline. Drives an interactive plan-mode loop
+  (DISCUSS / REVIEW / TRIAGE / FINALIZE), persists the story file as
+  soon as the first discussion round converges, runs adversarial review
+  on demand, then commits the story. Runs inside the worktree after
   setup-task. Use when the user says "create plan" or "plan this
   issue".
 mode: primary
@@ -46,11 +47,15 @@ permission:
   webfetch: ask
 ---
 
-# qs-create-plan — story drafting + adversarial review
+# qs-create-plan — interactive plan mode (discuss · review · finalize)
 
-You are Phase 2 of the Quiet Solar pipeline. You write the story file
-at `docs/stories/QS-<N>.story.md`, validate it with four
-parallel sub-agents, and commit.
+You are Phase 2 of the Quiet Solar pipeline. You drive an **interactive
+mode loop** with the user: open-ended DISCUSS by default, adversarial
+REVIEW on demand, TRIAGE to fold findings back in, and a light-advisory
+FINALIZE that commits the story. The story file at
+`docs/stories/QS-<N>.story.md` is the **living document** — written as
+soon as the first discussion round converges, readable in the editor
+throughout, and **committed only at FINALIZE**.
 
 ## Discover the task context first
 
@@ -65,71 +70,142 @@ Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
 if you haven't this session.
 
-## Phase protocol
+## Modes
 
-### 1. Gather and analyze
+This phase is a **user-driven mode loop**, not a linear pipeline. You
+move between four modes; DISCUSS is the durable default.
 
-- Fetch the issue: `gh issue view {{issue}}`.
-- Glob the relevant code areas.
-- Build an in-memory analysis. Do NOT write yet.
-
-### 2. Present scope and clarify
-
-Show the user a short scope/risk summary. Ask clarifying questions. Wait
-for answers. Don't draft the plan until you have what you need.
-
-### 3. Draft the plan in memory
-
-Acceptance criteria as Given/When/Then. Task breakdown with concrete
-file paths and function names. Holds in memory — do NOT write the file
-yet.
-
-**Doc-maintenance sub-step.** Before finalising the breakdown, run
-
-```bash
-python scripts/qs/check_doc_drift.py --paths <planned_files>
+```text
+        ┌──────────────────────────────────────────────┐
+        │                                                │
+        ▼                                                │
+   ┌─────────┐   "review"    ┌──────────┐  fold-in   ┌─────────┐
+   │ DISCUSS │ ────────────▶ │  REVIEW  │ ─────────▶ │ TRIAGE  │
+   │(default)│ ◀──────────── │ (subs)   │            │         │
+   └─────────┘   findings     └──────────┘ ◀──────────└─────────┘
+        │                      back to DISCUSS by default
+        │ "finalize"
+        ▼
+   ┌──────────┐
+   │ FINALIZE │  commit story → push → route next phase
+   └──────────┘
 ```
 
-(pass the list of files the plan intends to touch). For every doc
-surfaced by the checker, add a "Update `docs/agents/<path>`" task to
-the breakdown, OR add an explicit `Doc-OK: <reason>` note in the
-story explaining why the doc is unaffected. See
-[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
-"Doc maintenance".
+### DISCUSS (default)
 
-### 4. Adversarial review (parallel)
+- Gather: `gh issue view {{issue}}`, glob the relevant code areas, build
+  an analysis. Discuss scope, risks, and acceptance with the user and
+  iterate **indefinitely** — discussion is a durable state, not a
+  one-shot.
+- **Convergence → write the story file.** As soon as the first
+  discussion round converges — the plan has all required headings
+  (Problem, Goal, Design, Acceptance criteria, Task breakdown) **or**
+  the user says "write it" / "save the plan" — write
+  `docs/stories/QS-{{issue}}.story.md` and **overwrite it on every later
+  change**. The story file *is* the living document; there is no
+  separate draft. Announce that it is readable in the editor. The file
+  stays **uncommitted** — it is **committed only at FINALIZE**.
+- **Doc-maintenance sub-step.** Run
 
-Spawn the four plan-reviewer subagents in **one message with four
-parallel sub-agent invocations**. Pass each the plan draft (and, where
-noted, an additional artifact):
+  ```bash
+  python scripts/qs/check_doc_drift.py --paths <planned_files>
+  ```
 
-- `qs-plan-critic` — plan text only.
-- `qs-plan-concrete-planner` — plan + file tree (from your Glob results)
-  + source snippets.
-- `qs-plan-dev-proxy` — plan + paths to project-rules.md and
-  project-context.md.
-- `qs-plan-scope-guardian` — plan + the issue body.
+  (pass the list of files the plan intends to touch). For every doc
+  surfaced by the checker, add a "Update `docs/agents/<path>`" task to
+  the breakdown, OR add an explicit `Doc-OK: <reason>` note in the story
+  explaining why the doc is unaffected. See
+  [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+  "Doc maintenance".
+- Print the **status banner** (below). Proactively offer REVIEW **once
+  per stable-looking version** ("this looks ready for a review?") — then
+  never nag again for that version.
 
-This step is the orchestrator-vs-sub-agent split in action: **I'm an
-interactive orchestrator (the user is talking to me right now), but the
-4 plan reviewers below are non-interactive parallel sub-agent fan-out**.
+### REVIEW (invoked, not automatic)
+
+Runs when the user expresses the intent (or accepts your one-time
+proactive offer). Snapshot the current plan text in-session, then spawn
+the plan reviewers in **one message with parallel sub-agent
+invocations**:
+
+- **Round 1:** the **4 global reviewers** — `qs-plan-critic`,
+  `qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
+  `qs-plan-scope-guardian` — each on the whole plan.
+- **Round 2+:** the same 4 global reviewers **plus
+  `qs-plan-delta-auditor`**. You hold both the previously-reviewed plan
+  text and the current text in-session, compute a unified
+  **in-context diff** (no `.qs/` snapshot files, no git diff), then paste
+  that diff
+  plus the prior round's accepted-findings list into the delta-auditor's
+  prompt. The delta-auditor has `tools: Read` only and never diffs
+  anything itself — its job is to (a) verify prior accepted findings
+  were resolved and (b) flag new contradictions the edits introduced.
+
+Pass each global reviewer its usual artifact: `qs-plan-critic` — plan
+text only; `qs-plan-concrete-planner` — plan + file tree + source
+snippets; `qs-plan-dev-proxy` — plan + paths to project-rules.md and
+project-context.md; `qs-plan-scope-guardian` — plan + the issue body.
+Each returns categories `critical` / `redesign` / `improve` / `clarify`.
 See
-[docs/workflow/overview.md](../../docs/workflow/overview.md) section
-"Orchestrators are interactive sessions; sub-agents are parallel
-fan-out" for the rationale and
 [docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md)
-for the lens of each reviewer. Each returns a structured findings list
-with categories `critical` / `redesign` / `improve` / `clarify`.
+for each lens. → TRIAGE.
 
-### 5. Synthesize and triage
+### TRIAGE
 
-- Normalize findings into a unified format.
-- Deduplicate across reviewers (`file:line` + similar text → one finding).
-- Present a summary table.
+- **Finding-state model** (`open/resolved/rejected`): keep light state
+  per finding in the story's "Adversarial Review Notes". Re-runs **dedupe
+  against this state** — a finding the user explicitly **rejected** does
+  not resurface as new; a `resolved` finding the delta-auditor says is
+  still present flips back to `open`.
+- **Present deltas first.** Even though the global four ran on the whole
+  plan, surface **new / changed / resolved** up front, with the full
+  global list collapsed underneath.
 - Drive interactive triage: "fix all / skip all / one by one?".
-- Max 3 review rounds before forcing finalization.
+- Fold accepted findings into the story file; record state in
+  "Adversarial Review Notes"; set `changed-since-last-review` = false;
+  → DISCUSS by default.
 
-### 6. Determine NEXT_PHASE
+### FINALIZE (on confirmed intent)
+
+- **Advisory gate — never hard-block** (and always **confirm before
+  FINALIZE**):
+  - if `changed-since-last-review` is true → "the plan changed since the
+    last review — run one more before shipping? (yes / ship anyway)";
+  - if open criticals > 0 → "there are N open critical findings —
+    proceed? (list / ship anyway)".
+
+  The user decides. Folding accepted findings into the story does **not**
+  invalidate the review that produced them. There is no waiver artifact
+  — just record in the review notes what shipped open.
+- Determine `NEXT_PHASE` (below), then commit + push and emit the
+  next-phase launcher payload (below).
+
+## Three intents only
+
+Transitions are intent-based: recognise natural language for exactly
+**three intents** and also accept the literal verbs shown in the banner —
+**REVIEW** (always the full fan-out), **return to DISCUSS**, and
+**FINALIZE**. There are **no** scoped/partial reviews and **no**
+single-critic pass. When intent is ambiguous, ask for confirmation;
+always **confirm before FINALIZE**.
+
+## Status banner
+
+Print this compact block whenever you hand control back to the user:
+
+```text
+[DISCUSS] story vN · changed-since-last-review: yes · last review: round 1 · open criticals: 1
+next: keep discussing · "review" · "show plan" · "finalize"
+```
+
+- `story vN` is a **human-readable label only** — bump it on visible
+  change; there is no formal version subsystem.
+- `changed-since-last-review` is a **single boolean** (did the story
+  change since the last full review?).
+- `open criticals` is the count of unresolved `critical` findings from
+  the last review.
+
+## Determine NEXT_PHASE (at FINALIZE)
 
 Inspect the file paths your task breakdown will touch:
 - If **all** are in `scripts/`, `.claude/`, `.cursor/`, `.opencode/`,
@@ -137,22 +213,16 @@ Inspect the file paths your task breakdown will touch:
   `NEXT_PHASE = implement-setup-task`.
 - Otherwise → `NEXT_PHASE = implement-task`.
 
-### 7. Finalize
+## Commit and hand off (at FINALIZE)
 
-1. Write the story file at `docs/stories/QS-{{issue}}.story.md`.
-2. Append an "Adversarial Review Notes" section summarizing findings
-   and the decisions made on each.
-3. Commit and push:
+1. Commit and push the story file:
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
    git commit -m "QS-{{issue}}: create plan"
    git push -u origin {{branch}}
    ```
-
-### 8. Tell the user the next command
-
-Build the launcher payload for the next phase so the user has a copy/paste
-command to open a fresh session bound to the next agent:
+2. Build the launcher payload for the next phase so the user has a
+   copy/paste command to open a fresh session bound to the next agent.
 
 **Before running** — substitute `{{NEXT_PHASE}}` with the next phase
 name you determined above (one of: `implement-task`,
@@ -223,9 +293,11 @@ explicit `LSP` tool (diagnostics + navigation). See
 
 ## Hard rules
 
-- Do not write code in this phase. Edit scope = the story file only.
-- Never skip the adversarial review. Even for "simple" issues, run
-  the 4 reviewers — they catch things you won't.
-- Sub-agents must be spawned in **parallel** (one message, 4 calls).
+- Do not write code in this phase. Edit scope = the story file (written
+  during DISCUSS/TRIAGE, **committed only at FINALIZE**).
+- Never skip the adversarial review for a plan you intend to ship. Even
+  for "simple" issues, run the 4 reviewers — they catch things you
+  won't.
+- Sub-agents must be spawned in **parallel** (one message, N calls).
   Serial spawning leaks findings between reviewers and defeats the
   design.

--- a/.opencode/agents/qs-plan-delta-auditor.md
+++ b/.opencode/agents/qs-plan-delta-auditor.md
@@ -46,8 +46,12 @@ Plus a short "Resolution check" list mapping each prior accepted finding →
 resolved | partial | not-addressed.
 
 ## Hard rules
-- NEVER read repo files. Treat `grep`/`rg`/`ls`/`wc` as a safety net, not as
-  inputs to your review — your lens is the prompt's diff only. NEVER fetch the
-  issue or story file (`webfetch: deny` enforces this at the tool layer).
+- Operate **purely on the diff and findings in your prompt**. NEVER read repo
+  files, and NEVER fetch the issue or story file (`webfetch: deny` enforces
+  this at the tool layer).
+- The `grep`/`rg`/`ls`/`wc` bash grant in the frontmatter is an intentional
+  OpenCode harness accommodation (mirroring `qs-plan-critic`'s OpenCode copy —
+  OpenCode grants read-only shell verbs) — treat it as a safety net, NOT as an
+  input to your review. The Claude/Cursor twins carry `Read`/`readonly` only.
 - If the diff is empty, return "No delta to review."
 - Stay on the delta; the global reviewers own whole-plan coverage.

--- a/.opencode/agents/qs-plan-delta-auditor.md
+++ b/.opencode/agents/qs-plan-delta-auditor.md
@@ -1,0 +1,53 @@
+---
+description: >-
+  Hidden plan-reviewer sub-agent. Diff-aware regression/resolution
+  review of a plan edit against the prior round's accepted findings.
+  Spawned in parallel by qs-create-plan in review round 2+. Use only
+  when explicitly invoked by qs-create-plan.
+mode: subagent
+color: "#3B82F6"
+hidden: true
+# model: github-copilot/claude-sonnet-4.5  # uncomment to override project default
+permission:
+  read: allow
+  edit: deny
+  bash:
+    "*": ask
+    "grep *": allow
+    "rg *": allow
+    "ls *": allow
+    "wc *": allow
+  webfetch: deny
+---
+
+# qs-plan-delta-auditor — diff-aware regression/resolution review
+
+You receive (1) a unified diff between the previously-reviewed plan and the
+current plan, and (2) the list of findings the user ACCEPTED in the prior
+round. You see only what is in your prompt.
+
+## Input
+- The unified diff (orchestrator-produced), passed in your invocation prompt.
+- The prior round's accepted findings + their state (open/resolved/rejected).
+
+## What to do
+1. For each prior ACCEPTED finding, judge from the diff whether it was actually
+   resolved. Report: resolved / partially / not-addressed (quote the diff).
+2. Scan the diff for NEW contradictions, regressions, or scope drift the edits
+   introduced.
+3. Do NOT re-litigate the whole plan — stay strictly on the delta. Do NOT
+   duplicate findings the global four already cover.
+
+## Output format
+Same 4 categories as the other plan reviewers:
+#### critical / #### redesign / #### improve / #### clarify
+- **Finding** / **Evidence** (quote the diff) / **Suggestion**
+Plus a short "Resolution check" list mapping each prior accepted finding →
+resolved | partial | not-addressed.
+
+## Hard rules
+- NEVER read repo files. Treat `grep`/`rg`/`ls`/`wc` as a safety net, not as
+  inputs to your review — your lens is the prompt's diff only. NEVER fetch the
+  issue or story file (`webfetch: deny` enforces this at the tool layer).
+- If the diff is empty, return "No delta to review."
+- Stay on the delta; the global reviewers own whole-plan coverage.

--- a/docs/stories/QS-266.story.md
+++ b/docs/stories/QS-266.story.md
@@ -1,0 +1,381 @@
+# QS-266 — Improve plan mode to be more interactive
+
+> **Status: working draft v3.1 — DISCUSS mode. Round 1 adversarial review done
+> and triaged, then concrete repo-mechanics claims verified directly (see
+> "Adversarial Review Notes"). The design below is the post-triage *minimal*
+> shape.**
+> This file is persisted early on purpose: the point of QS-266 is that you can
+> read the plan in your editor before/between reviews instead of it living in
+> the agent's memory. It is **not committed** until FINALIZE.
+
+## Problem
+
+`qs-create-plan` is today a **linear pipeline disguised as a conversation**:
+gather → a few clarifying questions (once) → draft in memory → adversarial
+fan-out (4 subs) → big findings dump → triage → write + commit.
+
+Pain points:
+
+1. **Discussion is a one-shot, not a state** — questions happen once, then the
+   agent barrels into draft + review.
+2. **The plan is invisible until the end** — held in memory only; the user
+   cannot read it before the adversarial phase.
+3. **Adversarial review fires on a half-baked draft** and returns a wall of
+   findings about things the user would have changed anyway.
+4. **The loop is hostile** — "max 3 review rounds before forcing finalization"
+   is a turn-counter; re-running review re-dumps the same findings.
+
+## Goal
+
+Reshape `qs-create-plan` from a linear pipeline into a **user-driven mode
+loop** like vanilla / Cursor "plan mode": open-ended discussion by default,
+adversarial review as a *repeatable, on-demand tool*, the plan **persisted to
+the story file as soon as the first discussion round ends** (readable in the
+editor, committed only at the end), and a *light advisory* finalize step.
+
+Stays compatible across harnesses (Claude Code, Cursor, OpenCode; Codex
+follows the same agent-body files when present). Only the agent *body* and
+workflow docs change.
+
+## Design (minimal — post round-1 triage)
+
+### Mode loop (replaces the linear steps 2–7)
+
+```
+        ┌──────────────────────────────────────────────┐
+        │                                                │
+        ▼                                                │
+   ┌─────────┐   "review"    ┌──────────┐  fold-in   ┌─────────┐
+   │ DISCUSS │ ────────────▶ │  REVIEW  │ ─────────▶ │ TRIAGE  │
+   │(default)│ ◀──────────── │ (subs)   │            │         │
+   └─────────┘   findings     └──────────┘ ◀──────────└─────────┘
+        │                      back to DISCUSS by default
+        │ "finalize"
+        ▼
+   ┌──────────┐
+   │ FINALIZE │  commit story → push → route next phase
+   └──────────┘
+```
+
+- **DISCUSS — durable default.** Agent proposes/revises, user pushes back,
+  repeat indefinitely. **As soon as the first discussion round converges, the
+  agent writes `docs/stories/QS-<N>.story.md`** and overwrites it on every
+  subsequent change. The story file *is* the living document — no separate
+  draft file. **Convergence trigger (concrete, resolves F-clarify):** the
+  agent has produced a story containing all required headings (Problem, Goal,
+  Design, Acceptance criteria, Task breakdown) **or** the user says "write
+  it"/"save the plan". The agent announces the file is readable.
+- **REVIEW — invoked, not automatic.** Runs when the user expresses the
+  intent, or when the agent **proactively asks "this looks ready for a
+  review?" once per stable-looking version** (never nags again for that
+  version).
+- **TRIAGE — fold accepted findings into the story file**, then return to
+  DISCUSS by default.
+- **FINALIZE — commit + push + route to next phase.** Light advisory gate
+  (below).
+
+### Three intents only (cut scoped reviews + quick-check)
+
+Transitions are **intent-based**: the agent recognises natural language for
+exactly three transitions and also accepts the literal verbs shown in the
+banner:
+
+1. **REVIEW** (always the full fan-out),
+2. **return to DISCUSS**,
+3. **FINALIZE**.
+
+There are **no** scoped/partial reviews and **no** "quick check" single-critic
+pass (cut as scope creep). When intent is ambiguous the agent asks for
+confirmation; it **always confirms before FINALIZE**.
+
+### Status banner on every hand-back
+
+Compact block printed whenever the agent returns control:
+
+```
+[DISCUSS] story v3 · changed-since-last-review: yes · last review: round 1 · open criticals: 1
+next: keep discussing · "review" · "show plan" · "finalize"
+```
+
+- `story vN` is a **human-readable label only** — bumped on visible change, no
+  formal version subsystem.
+- `changed-since-last-review` is a **single boolean** (not per-version
+  staleness math).
+- `open criticals` is the count of un-resolved `critical` findings from the
+  last review.
+
+### Plan-changed-since-last-review (single boolean — replaces version/staleness machinery)
+
+The agent tracks one boolean: did the story change since the last full review?
+That's all the banner and the advisory gate need. No "material change"
+classification, no per-version staleness computation.
+
+### Adversarial review: global-always + diff-aware delta auditor
+
+- **Round 1:** the 4 global reviewers only — `qs-plan-critic`,
+  `qs-plan-concrete-planner`, `qs-plan-dev-proxy`, `qs-plan-scope-guardian` —
+  each on the whole plan, spawned **in parallel** (one message, N invocations).
+- **Round 2+:** the same 4 global reviewers re-run on the whole plan **plus a
+  new `qs-plan-delta-auditor`** (full body in Appendix A). Its only job: (a)
+  verify prior **accepted** findings were resolved by the new plan, and (b)
+  flag new contradictions introduced by the edits.
+- **How the delta-auditor sees "the diff" (resolves F4):** the **orchestrator**
+  holds both the previous-reviewed plan text and the current plan text
+  in-session. It computes a unified diff **in-context** (no `.qs/` snapshot
+  files, no gitignore changes) and pastes that diff + the prior round's
+  accepted-findings list into the delta-auditor's prompt. The sub-agent has
+  `tools: Read` only and never diffs anything itself.
+- **Finding-state model (resolves F13):** the orchestrator keeps a light state
+  per finding — `open` / `resolved` / `rejected` — in the "Adversarial Review
+  Notes" section. Re-runs **dedupe against this state**: a finding the user
+  explicitly **rejected** does not re-surface as new; a `resolved` finding the
+  delta-auditor says is still present flips back to `open`.
+- **Orchestrator presents deltas first.** Even though the global four ran on
+  the whole plan, the agent surfaces **new / changed / resolved** up front with
+  the full global list collapsed underneath.
+
+### Advisory finalize gate (replaces the max-3-rounds cap; no livelock, no waiver)
+
+FINALIZE is **never hard-blocked** (resolving F1's livelock). On "finalize" the
+agent shows an advisory check:
+
+- if `changed-since-last-review` is true → "the plan changed since the last
+  review — run one more before shipping? (yes / ship anyway)";
+- if open criticals > 0 → "there are N open critical findings — proceed? (list
+  / ship anyway)".
+
+The user decides. Folding accepted findings into the story does **not**
+invalidate the review that produced them (no version-bump-invalidates-review
+livelock). There is **no waiver artifact**; the agent simply records in the
+review notes what was shipped open.
+
+### Early persistence — commit boundary (resolves F9)
+
+- The story file is **written/overwritten during DISCUSS/REVIEW but left
+  uncommitted**. It is committed and pushed **only at FINALIZE** (unchanged
+  from today's commit timing).
+- Implement task must **audit consumers of `scripts/qs/context.py`
+  `story_exists`** (grep `scripts/qs/` + agent bodies) and confirm that a story
+  file existing mid-DISCUSS does not falsely signal "plan phase complete" to
+  any downstream router. If a consumer relies on it, add an explicit
+  in-progress note rather than overload `story_exists`.
+
+## Acceptance criteria (phrased as body-content pins — resolves F11)
+
+The repo tests agent bodies by **static substring pinning** (see
+`tests/qs/agents/`), not by executing personas. Each AC is therefore a literal
+marker that must appear in the relevant agent body / docs.
+
+- **AC1 — mode loop present.** `qs-create-plan.md` (all 3 harness copies)
+  contains a `## Modes` (or equivalent) section defining `DISCUSS`, `REVIEW`,
+  `TRIAGE`, `FINALIZE`.
+- **AC2 — early persistence rule.** The body contains the instruction to write
+  the story after the first discussion round and the **"committed only at
+  FINALIZE"** rule; the old "Do NOT write yet" / "do NOT write the file yet"
+  strings are **gone** (resolves F10).
+- **AC3 — status banner template.** The body contains the literal banner
+  template (the `[DISCUSS] story vN · changed-since-last-review:` line).
+- **AC4 — three intents, no scoped reviews.** The body documents exactly the
+  three transitions and contains **no** "review scope" / "quick check"
+  language.
+- **AC5 — delta-auditor wired.** The body describes round-1 (4 reviewers) vs
+  round-2+ (4 + `qs-plan-delta-auditor`), the in-context diff mechanism, and
+  the finding-state model.
+- **AC6 — advisory finalize.** The body contains the advisory-gate prompts and
+  the "never hard-block / confirm before FINALIZE" rule.
+- **AC7 — new sub-agent exists in all harnesses.** `qs-plan-delta-auditor.md`
+  exists in `.claude/agents/`, `.cursor/agents/`, `.opencode/agents/` with the
+  body in Appendix A (modulo per-harness frontmatter).
+- **AC8 — docs updated.** `overview.md`, `adversarial-review.md`,
+  `phase-protocols.md` describe the mode loop + the 5th reviewer + round
+  asymmetry; the hard-coded "4 plan reviewers" count is reconciled in each
+  (resolves F8).
+- **AC9 — harness parity green.** `python scripts/qs/check_doc_drift.py` exits
+  0; a pinning test in `tests/qs/agents/` covers the new agent (resolves F6);
+  `test_opencode_agents.py` includes `qs-plan-delta-auditor` in the reviewer
+  list; `test_lsp_tool_enabled.py` lists it in the **blind** group (no LSP);
+  all `tests/qs/agents/` pass.
+- **AC10 — quality gate green.** `python scripts/qs/quality_gate.py` passes on
+  the dev-only fast path.
+
+## Task breakdown (for implement-setup-task)
+
+> All paths are dev-environment → **NEXT_PHASE = implement-setup-task**.
+> Tasks 4–9 touch agent bodies across harnesses and should land as **one
+> atomic change-set**. Verified nuance: `check_doc_drift.py`'s co-modification
+> rule **forces** the 3 copies of `qs-create-plan` together (it exists in all
+> harnesses), but a **brand-new** single-harness agent is *exempt* from that
+> rule — so parity for the new `qs-plan-delta-auditor` is enforced by the
+> **pinning test (task 9)**, not the drift checker. Commit all together anyway.
+
+1. **`docs/workflow/phase-protocols.md`** — replace the linear `create-plan`
+   protocol (steps 1–8, ~lines 53–80) with the mode loop + advisory finalize.
+   Reword the "Edit scope is the story file only" hard rule to the early-
+   persistence/commit-at-FINALIZE rule.
+2. **`docs/workflow/adversarial-review.md`** — add `qs-plan-delta-auditor` to
+   the plan-reviewers section; document round-1 vs round-2+, the in-context
+   diff, the finding-state model, and delta-first presentation; update the
+   "Triage model" + the "4-reviewer" framing (lines 1, 30–60).
+3. **`docs/workflow/overview.md`** — update the create-plan one-liner and the
+   adversarial-review bullets (lines 41–48, 73–77) for the loop + 5th reviewer.
+4. **`.claude/agents/qs-create-plan.md`** — rewrite `## Phase protocol` into
+   the mode-loop state machine (Appendix B sketch): DISCUSS/REVIEW/TRIAGE/
+   FINALIZE, status banner, early persistence, three intents, global+delta
+   reviewers, finding-state model, advisory gate. Remove every "Do NOT write
+   yet" / "do NOT write the file yet" line; reword the "Edit scope = the story
+   file only" hard rule. **Must retain the doc-maintenance sub-step** (running
+   `check_doc_drift.py` during DISCUSS/draft) — it is pinned by
+   `tests/qs/agents/test_doc_maintenance_parity.py`, which would fail if the
+   rewrite drops it.
+5. **`.claude/agents/qs-plan-delta-auditor.md`** — NEW (body in Appendix A;
+   `tools: Read`). Decide `covers:` frontmatter: the existing reviewers carry
+   none, so the new agent carries **no `covers:` block** and is classified as a
+   hidden sub-agent exempt from the drift checker's covers-path validation
+   (resolves F14) — confirm against `check_doc_drift.py`.
+6. **`.cursor/agents/qs-create-plan.md` + `.cursor/agents/qs-plan-delta-auditor.md`**
+   — mirror #4/#5 with Cursor frontmatter (`readonly:` tool grant style used by
+   the other `.cursor` reviewers).
+7. **`.opencode/agents/qs-create-plan.md` + `.opencode/agents/qs-plan-delta-auditor.md`**
+   — mirror #4/#5 with OpenCode frontmatter; keep core body byte-aligned with
+   `.claude` modulo frontmatter/spawn sections.
+8. **`.claude/commands/create-plan.md`** — update the "Expected outcome" prose
+   to describe the loop (still flagged degraded fallback). **No** `.cursor`/
+   `.opencode` command mirror — those dirs do not exist (resolves F7).
+9. **Harness parity + tests (resolves F6).** Run
+   `python scripts/qs/check_doc_drift.py` (co-modification enforcement) and add
+   a pinning test under `tests/qs/agents/` (mirror
+   `test_doc_maintenance_parity.py`) asserting the new markers (AC1–AC6) exist
+   in all 3 harness copies of `qs-create-plan` and that `qs-plan-delta-auditor`
+   exists in all 3 dirs. **Verified concrete test updates required:**
+   - `tests/qs/agents/test_opencode_agents.py:79-82` — add `qs-plan-delta-auditor`
+     to the pinned plan-reviewer list (**definite**, not conditional).
+   - `tests/qs/agents/test_lsp_tool_enabled.py` — add `qs-plan-delta-auditor`
+     to the **blind / context-starved** group (lines ~59-64): it is `tools:
+     Read` only, **no `LSP`**, so it must NOT be in the LSP-enabled list.
+   - re-check `test_orchestrator_handoff.py` / `test_slash_command_preambles.py`
+     only if the create-plan rewrite changes pinned handoff/preamble strings.
+10. **`scripts/qs/context.py` (resolves F9 — verified).** Direct grep confirmed
+    `story_exists` has **no consumer** beyond its own definition at
+    `context.py:68` (no script or agent body branches on it). Early persistence
+    is therefore safe; **no code change needed** — this task is a one-line
+    confirmation in the implement PR, not a fix.
+
+**Codex (resolves F12):** there is no Codex agent directory in the repo today;
+AC7/parity applies to `.claude`/`.cursor`/`.opencode`. If a Codex surface is
+added later it follows the same agent-body files. AC8's "identical" means the
+**core protocol body is byte-aligned across harness copies modulo frontmatter
+and harness-specific spawn sections** — enforced by `check_doc_drift.py` +
+pinning tests, not by a (non-existent) standalone parity script.
+
+## Doc maintenance
+
+Run `python scripts/qs/check_doc_drift.py --paths <files in tasks 1–9>` in
+implement-setup-task. This story pre-lists the workflow docs that must change
+(tasks 1–3) and the agent/test co-modifications (4–9). Any additional doc the
+checker surfaces gets a task or a `Doc-OK:` note then.
+
+`Doc-OK:` `docs/agents/*` concept docs are unaffected — this change is purely
+about the create-plan workflow agent and its reviewers, not the car/charger
+domain concepts those docs cover.
+
+## Appendix A — `qs-plan-delta-auditor` agent body (to embed in task 5)
+
+Frontmatter (Claude): `name: qs-plan-delta-auditor`, hidden-sub-agent
+description, `tools: Read`. (Cursor/OpenCode: same body, harness frontmatter.)
+
+```
+# qs-plan-delta-auditor — diff-aware regression/resolution review
+
+You receive (1) a unified diff between the previously-reviewed plan and the
+current plan, and (2) the list of findings the user ACCEPTED in the prior
+round. You see only what is in your prompt.
+
+## Input
+- The unified diff (orchestrator-produced), passed in your invocation prompt.
+- The prior round's accepted findings + their state (open/resolved/rejected).
+
+## What to do
+1. For each prior ACCEPTED finding, judge from the diff whether it was actually
+   resolved. Report: resolved / partially / not-addressed (quote the diff).
+2. Scan the diff for NEW contradictions, regressions, or scope drift the edits
+   introduced.
+3. Do NOT re-litigate the whole plan — stay strictly on the delta. Do NOT
+   duplicate findings the global four already cover.
+
+## Output format
+Same 4 categories as the other plan reviewers:
+#### critical / #### redesign / #### improve / #### clarify
+- **Finding** / **Evidence** (quote the diff) / **Suggestion**
+Plus a short "Resolution check" list mapping each prior accepted finding →
+resolved | partial | not-addressed.
+
+## Hard rules
+- NEVER read repo files (you have Read only for the prompt's purposes; do not
+  go spelunking). NEVER fetch the issue or story file.
+- If the diff is empty, return "No delta to review."
+- Stay on the delta; the global reviewers own whole-plan coverage.
+```
+
+## Appendix B — `qs-create-plan` Phase-protocol sketch (to embed in task 4)
+
+Replace the current numbered protocol with a `## Modes` state machine:
+
+- **DISCUSS (default):** gather (context.py, issue, rules, glob); discuss
+  scope/risks; iterate. On convergence → write story file (uncommitted),
+  announce it's readable. **Run the doc-maintenance sub-step**
+  (`check_doc_drift.py` on planned paths) — *retained from today's protocol,
+  pinned by `test_doc_maintenance_parity.py`*. Print banner. Proactively offer
+  REVIEW once per stable version.
+- **REVIEW:** snapshot current plan text in-session; spawn reviewers in
+  parallel (round 1 = 4 global; round 2+ = 4 global + delta-auditor fed the
+  in-context diff + accepted findings). → TRIAGE.
+- **TRIAGE:** dedupe via finding-state (open/resolved/rejected); present deltas
+  first; drive fix-all/skip-all/one-by-one; fold accepted findings into the
+  story; record state in "Adversarial Review Notes"; set
+  changed-since-last-review=false; → DISCUSS.
+- **FINALIZE (on confirmed intent):** advisory check (changed-since-review? /
+  open criticals?); determine NEXT_PHASE by touched paths; commit + push;
+  emit next-phase launcher payload (unchanged from today).
+
+Keep today's `## Discover the task context first`, NEXT_PHASE routing, and the
+next-command emission verbatim.
+
+## Adversarial Review Notes
+
+### Round 1 — 4 global reviewers (on story v2), triaged into v3
+
+16 findings, deduped. Triage decision: **adopt the minimal direction + all
+must-fixes** (user: "your proposal").
+
+| ID | Finding | Sev | State | Disposition |
+|----|---------|-----|-------|-------------|
+| F1 | Finalize-gate livelock + unrequested waiver | critical | resolved | Gate made **advisory**, never blocks; resolving findings doesn't invalidate review; waiver dropped. |
+| F2 | Versioning + staleness over-engineered/undefined | redesign | resolved | Replaced with single `changed-since-last-review` boolean + human `vN` label. |
+| F3 | Scoped reviews + quick-check = scope creep | redesign | resolved | **Cut both.** Three intents only. |
+| F4 | `.qs/` snapshot + git-diff + gitignore infra unrequested/undefined | redesign | resolved | **Dropped `.qs/`.** Orchestrator computes diff in-context. `.qs/` artifact deleted. |
+| F5 | Delta-auditor body underspecified | critical | resolved | Full body embedded (Appendix A), `tools: Read`, all 3 harness dirs. |
+| F6 | "Body-parity script" doesn't exist | critical | resolved | Task 9 names real mechanisms: `check_doc_drift.py` + pinning test in `tests/qs/agents/`. |
+| F7 | `.cursor/.opencode` command mirrors target phantom dirs | critical | resolved | Dropped; only `.claude/commands/create-plan.md` updated. |
+| F8 | Reviewer count hard-coded in 4 docs | should-fix | resolved | Explicit subtasks in tasks 2,3,9. |
+| F9 | Early-persist commit boundary + `story_exists` misroute risk | should-fix | resolved | Uncommitted until FINALIZE; task 10 audits `story_exists`. |
+| F10 | "Do NOT write yet" rules contradict early persistence | should-fix | resolved | Enumerated in tasks 1,4; AC2 pins their removal. |
+| F11 | Behavioral ACs not testable | should-fix | resolved | All ACs reframed as body-content pins. |
+| F12 | Codex unlisted / AC8 "identical" vague | clarify | resolved | Codex note added; "identical" defined as byte-aligned core body modulo frontmatter. |
+| F13 | Round 2+ re-dump risk; needs finding identity/state | clarify | resolved | Added open/resolved/rejected finding-state model. |
+| F14 | `covers:` frontmatter for new agent | clarify | resolved | New agent carries no `covers:` (matches existing reviewers); confirm against drift checker. |
+| F15 | Intent disambiguation | clarify | resolved | Verbs accepted literally + via intent; confirm before FINALIZE. |
+| F16 | Quality-gate fast-path / task atomicity | clarify | resolved | Noted: dev-only fast path; tasks 4–9 commit together (atomicity nuance corrected in V1 below). |
+
+### Round 1.5 — direct verification of concrete repo-mechanics claims (no sub-agents)
+
+Instead of a full round 2 (critic/scope lenses were spent; risk was concentrated
+in the concrete/dev-proxy lane), the orchestrator verified the risky claims
+directly via grep. Result: 3 corrections + 1 de-risk, folded into v3.1.
+
+| ID | Claim verified | Outcome | Story change |
+|----|----------------|---------|--------------|
+| V1 | Drift-checker forces all harness copies | **Corrected.** `_check_harness_sync` exempts brand-new single-harness agents; only `qs-create-plan` (exists in all 3) is force-co-modified. New delta-auditor parity relies on the **pinning test**, not the checker. | Breakdown atomicity note + task 9 reworded. |
+| V2 | Reviewer-set test pinning | **Expanded.** `test_opencode_agents.py:79-82` pins the 4-reviewer list (definite update); `test_lsp_tool_enabled.py:62-64` requires delta-auditor in the **blind** group (Read-only, no LSP). | Task 9 + AC9 updated. |
+| V3 | Doc-maintenance step survives rewrite | **Gap closed.** `test_doc_maintenance_parity.py` pins that `qs-create-plan` invokes `check_doc_drift.py`; Appendix B sketch had dropped it. | Task 4 + Appendix B now require retaining it. |
+| V4 | `story_exists` misroute risk (F9) | **De-risked.** Only consumer is `context.py:68` (its own definition); nothing branches on it. | Task 10 downgraded to a confirmation; no code change. |
+| V5 | `covers:` exemption (F14) | **Confirmed.** No agent persona uses `covers:`; it's `docs/agents/` only. Delta-auditor correctly carries none. | No change. |

--- a/docs/stories/QS-266.story_review_fix_#01.md
+++ b/docs/stories/QS-266.story_review_fix_#01.md
@@ -1,0 +1,86 @@
+# QS-266 — Review fix plan #01
+
+## Summary
+- Source PR: #267
+- Source story: docs/stories/QS-266.story.md
+- Findings to fix: 6 (2 should-fix, 4 nice-to-have)
+- Next implement phase: `/implement-setup-task`
+
+## Findings to fix
+
+### [should-fix] Raw `pytest -k` example in test docstring
+- File: `tests/qs/agents/test_plan_mode_loop.py:79`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The test docstring documents `pytest -k claude`, which conflicts
+  with the `tests/**/*.py` test-entrypoint policy ("use
+  `scripts/qs/quality_gate.py` as the single test entry point; avoid raw
+  `pytest` commands except `::`-scoped ad-hoc single-node debugging").
+- Proposed fix: Replace the `pytest -k claude` guidance in the docstring with
+  `scripts/qs/quality_gate.py`. If a pytest example must remain, use a
+  `::`-scoped node invocation (e.g. `pytest tests/qs/agents/test_plan_mode_loop.py::<node>`).
+
+### [should-fix] No content-pinning test for AC8 doc strings
+- File: `docs/workflow/overview.md`, `docs/workflow/adversarial-review.md`,
+  `docs/workflow/phase-protocols.md` (+ new assertions in
+  `tests/qs/agents/test_plan_mode_loop.py`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC1–AC7 have literal marker pins in `test_plan_mode_loop.py`, but
+  AC8 (the 5th-reviewer / round-asymmetry doc updates across the three workflow
+  docs) has no content-pin — only `check_doc_drift.py` co-modification
+  enforcement, which checks co-edit, not content. A future edit could silently
+  drop the round-asymmetry paragraph or the 5th-reviewer mention without any
+  test failing.
+- Proposed fix: Add parametrized required-marker assertions (mirroring the
+  existing `test_plan_mode_loop.py` pattern) pinning the 5th-reviewer /
+  round-asymmetry strings in `overview.md`, `adversarial-review.md`, and
+  `phase-protocols.md`.
+
+### [nice-to-have] Self-contradictory phrasing in delta-auditor Hard rule
+- File: `.claude/agents/qs-plan-delta-auditor.md:39` (mirror into
+  `.cursor/agents/qs-plan-delta-auditor.md` and
+  `.opencode/agents/qs-plan-delta-auditor.md`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The Hard rule reads "NEVER read repo files (you have Read only
+  for the prompt's purposes...)", which is misleading — the `Read` tool reads
+  files, not the prompt.
+- Proposed fix: Reword to make clear the agent must operate purely on the
+  in-prompt diff, and apply the same wording to all three harness copies.
+
+### [nice-to-have] Awkward line-wrapping in REVIEW round-2 paragraph
+- File: `.claude/agents/qs-create-plan.md:111-115` (and mirrored
+  `.cursor`/`.opencode` copies if affected)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The REVIEW round-2 paragraph wraps as a broken sentence ("then
+  paste / that diff / plus the prior round's..."); cosmetic only.
+- Proposed fix: Reflow the paragraph into clean sentence wrapping; keep parity
+  across harness copies.
+
+### [nice-to-have] Confirm OpenCode delta-auditor bash divergence is intentional
+- File: `.opencode/agents/qs-plan-delta-auditor.md`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The OpenCode copy adds grep/rg/ls/wc bash permissions and a
+  reworded "NEVER read repo files. Treat grep/rg/ls/wc as a safety net..." rule
+  not present in the `.claude`/`.cursor` copies or Appendix A. Likely a
+  deliberate harness-frontmatter accommodation (OpenCode grants bash), but the
+  agent's whole point is to see only the prompt's diff.
+- Proposed fix: Confirm the extra bash grant + reworded rule is intentional. If
+  intended, add a one-line note explaining the divergence; if not, align it with
+  the `.claude`/`.cursor` copies and Appendix A.
+
+### [nice-to-have] Stale reviewer-count comment
+- File: `tests/qs/agents/test_lsp_tool_enabled.py:12`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The docstring says "the 7 context-starved reviewers" but
+  `LSP_EXCLUDE_AGENTS` now lists 8 after adding `qs-plan-delta-auditor`.
+- Proposed fix: Update the comment to "8" (or phrase it count-agnostically).
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/stories/QS-266.story_review_fix_#02.md
+++ b/docs/stories/QS-266.story_review_fix_#02.md
@@ -1,0 +1,27 @@
+# QS-266 — Review fix plan #02
+
+## Summary
+- Source PR: #267
+- Source story: docs/stories/QS-266.story.md
+- Findings to fix: 1 (1 should-fix)
+- Next implement phase: `/implement-setup-task`
+
+## Findings to fix
+
+### [should-fix] Broken `ids` lambda yields empty test IDs
+- File: `tests/qs/agents/test_plan_mode_loop.py:144-148`
+- Severity: should-fix
+- Source: qs-review-coderabbit (+ qs-review-blind-hunter, same issue)
+- Description: In `test_workflow_docs_describe_fifth_reviewer`, the
+  `ids=lambda v: v if isinstance(v, str) else ""` lambda receives each full
+  `(doc_rel, markers)` parametrize tuple before pytest unpacks it. The
+  `isinstance(tuple, str)` check is always False, so every test ID renders
+  empty (or as a trailing-dash `overview.md-`), making the IDs useless for
+  filtering and debugging.
+- Proposed fix: Replace with `ids=lambda pair: pair[0]` so the doc path is used
+  as the test ID. Confirm the resulting IDs render cleanly (one per doc).
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/workflow/adversarial-review.md
+++ b/docs/workflow/adversarial-review.md
@@ -1,15 +1,22 @@
-# Adversarial review — the 4-reviewer pattern
+# Adversarial review — the parallel-reviewer pattern
 
-Two phases — `create-plan` and `review-task` — fan out into four parallel
+Two phases — `create-plan` and `review-task` — fan out into parallel
 sub-agents, each examining the same input through a different lens. The
 goal is to catch issues a single reviewer would miss because lens bias is
 real: a "completeness" reviewer doesn't think about scope creep; a "scope"
 reviewer doesn't enumerate edge cases.
 
+`review-task` always fans out into **four** code reviewers.
+`create-plan` is a **repeatable, on-demand** review inside its mode loop:
+**round 1** runs the **four global plan reviewers**; **round 2+** runs
+those four **plus a fifth, diff-aware** reviewer
+(`qs-plan-delta-auditor`) — see "Round asymmetry" below.
+
 ## Why parallel, not serial
 
-All four subagents must be spawned in **one message with four parallel
-invocations**, not one-by-one in sequence. Two reasons:
+All the round's subagents must be spawned in **one message with parallel
+invocations** (four for a code review or a round-1 plan review; five for
+a round-2+ plan review), not one-by-one in sequence. Two reasons:
 
 1. **Independence**: serial spawning leaks earlier findings into later
    reviewers' context. They start agreeing instead of disagreeing.
@@ -59,6 +66,36 @@ never read source code. Simulate not having codebase access.
 expansion, abstractions not justified by the issue. **Hard rule**: never
 read repo. Compare plan's scope to issue's stated scope exactly.
 
+### `qs-plan-delta-auditor` (round 2+ only)
+**Lens**: diff-aware regression/resolution. **Input**: a unified diff
+between the previously-reviewed plan and the current plan (computed
+**in-context** by the orchestrator — no snapshot files), plus the prior
+round's accepted findings. **Looks for**: (a) whether each prior
+accepted finding was actually resolved by the edits, and (b) new
+contradictions, regressions, or scope drift the edits introduced.
+**Hard rule**: `tools: Read` only; never diffs anything itself, never
+reads repo files, stays strictly on the delta (the global four own
+whole-plan coverage). Returns "No delta to review." on an empty diff.
+
+### Round asymmetry (plan reviews only)
+
+- **Round 1**: the **4 global reviewers** above, each on the whole plan.
+- **Round 2+**: the same 4 global reviewers (re-run on the whole plan)
+  **plus `qs-plan-delta-auditor`**. The orchestrator holds both the
+  previous-reviewed plan text and the current text in-session, computes
+  the unified diff **in-context**, and pastes that diff + the prior
+  round's accepted-findings list into the delta-auditor's prompt.
+
+### Finding-state model
+
+The orchestrator keeps light per-finding state —
+`open` / `resolved` / `rejected` — in the story's "Adversarial Review
+Notes". Re-runs **dedupe against this state**: a finding the user
+explicitly **rejected** does not resurface as new; a `resolved` finding
+the delta-auditor reports as still present flips back to `open`. The
+orchestrator presents **deltas first** (new / changed / resolved) with
+the full global list collapsed underneath.
+
 ## Code reviewers (used by `qs-review-task`)
 
 Spawned with the PR diff. Each returns findings categorized as
@@ -96,14 +133,21 @@ The orchestrator (the parent agent, not the reviewers) consolidates
 findings:
 
 1. **Normalize**: deduplicate identical findings across reviewers
-   (`file:line` + similar text).
+   (`file:line` + similar text). For plan reviews, also dedupe against
+   the **finding-state model** (`open`/`resolved`/`rejected`) so a
+   rejected finding doesn't resurface and a regressed `resolved` finding
+   flips back to `open`.
 2. **Bucket**: critical → must-fix; vague/inapplicable → invalid.
-3. **Present**: show a summary table to the user.
+3. **Present**: show a summary table to the user. For plan reviews,
+   present **deltas first** (new / changed / resolved).
 4. **Triage**: ask "fix all / skip all / one by one?". If one by one,
    walk each finding and ask "fix or skip?". Collect all decisions, then
    confirm before acting.
-5. **Loop** (review only): if fixes were applied, re-run the review
-   (loop back to step 1). Loop until clean or user says "proceed".
+5. **Loop**: re-running review is **on-demand and repeatable**, not a
+   capped counter. In `create-plan` the user re-enters REVIEW whenever
+   they want; FINALIZE is an **advisory** gate that never hard-blocks.
+   In `review-task` the loop runs until clean or the user says
+   "proceed".
 
 ## Don't confuse the patterns
 

--- a/docs/workflow/overview.md
+++ b/docs/workflow/overview.md
@@ -15,7 +15,7 @@ isolated in `scripts/qs/launchers/`.
 | Phase            | Where it runs        | What it produces                            |
 | ---------------- | -------------------- | ------------------------------------------- |
 | `setup-task`     | main checkout        | issue, branch `QS_<N>`, worktree            |
-| `create-plan`    | worktree             | story file at `docs/stories/QS-<N>.story.md`, committed |
+| `create-plan`    | worktree             | story file at `docs/stories/QS-<N>.story.md` via an interactive discuss/review/finalize loop, committed at finalize |
 | `implement-task` | worktree             | TDD code, green quality gate, PR opened     |
 | `review-task`    | worktree             | parallel adversarial review, fix-plan loop  |
 | `finish-task`    | worktree             | PR merged, worktree removed                 |
@@ -38,17 +38,23 @@ under `legacy/`; this is the only supported model going forward.
 
 ## Adversarial review (parallel sub-agents)
 
-Two phases fan out into four parallel sub-agents that each look at the
-same input through a different lens:
+Two phases fan out into parallel sub-agents that each look at the same
+input through a different lens:
 
-- **create-plan** spawns: `qs-plan-critic`, `qs-plan-concrete-planner`,
-  `qs-plan-dev-proxy`, `qs-plan-scope-guardian`.
-- **review-task** spawns: `qs-review-blind-hunter`,
+- **create-plan** is an on-demand, repeatable review inside its mode
+  loop. **Round 1** spawns the 4 global plan reviewers —
+  `qs-plan-critic`, `qs-plan-concrete-planner`, `qs-plan-dev-proxy`,
+  `qs-plan-scope-guardian`. **Round 2+** spawns those four **plus
+  `qs-plan-delta-auditor`**, a fifth diff-aware reviewer fed an
+  in-context diff of the plan's edits + the prior round's accepted
+  findings.
+- **review-task** always spawns four: `qs-review-blind-hunter`,
   `qs-review-edge-case-hunter`, `qs-review-acceptance-auditor`,
   `qs-review-coderabbit`.
 
-All four must be spawned in **one message with four parallel sub-agent
-invocations** — serial spawning defeats the design (later reviewers see
+All of a round's reviewers must be spawned in **one message with
+parallel sub-agent invocations** (four, or five for a round-2+ plan
+review) — serial spawning defeats the design (later reviewers see
 earlier findings and conform to them). See
 [adversarial-review.md](adversarial-review.md) for the full pattern.
 

--- a/docs/workflow/phase-protocols.md
+++ b/docs/workflow/phase-protocols.md
@@ -41,7 +41,8 @@ the user runs to open a new session on the worktree.
 **Runs on**: worktree.
 **Inputs**: branch `QS_<N>` (issue resolves from there).
 **Side effects**: writes story file to
-`docs/stories/QS-<N>.story.md`, commits and pushes.
+`docs/stories/QS-<N>.story.md` (written as soon as the first discussion
+round converges, **committed only at FINALIZE**).
 **Output**: story file with acceptance criteria + task breakdown +
 adversarial review notes appended.
 **Next phase**: `claude --agent qs-implement-task` or
@@ -50,33 +51,43 @@ fresh interactive session), or `/implement-task` /
 `/implement-setup-task` as fallback. The agent decides which based on
 the file paths in its task breakdown.
 
-**Phase protocol**:
-1. Read the issue (`gh issue view`). Read `docs/workflow/project-rules.md`
-   and `docs/workflow/project-context.md`. Glob the relevant code areas.
-2. Present a scope/risk summary; ask clarifying questions; wait for user
-   answers.
-3. Draft the plan in memory — acceptance criteria (Given/When/Then) and
-   task breakdown.
-4. **Adversarial review**: spawn the 4 plan-reviewer subagents in
-   parallel (one message, 4 sub-agent invocations). See
-   [adversarial-review.md](adversarial-review.md).
-5. Synthesize and triage findings interactively with the user. Max 3
-   review rounds before forcing finalization.
-6. Determine `NEXT_PHASE`: `implement-setup-task` if all touched files
-   are in `scripts/`, `.claude/`, `.cursor/`, `.opencode/`,
-   `legacy/`, `docs/`, `.github/`, or top-level config;
-   otherwise `implement-task`.
-7. Write the story file. Append "Adversarial Review Notes". Commit and
-   push.
-8. Tell the user the next command — emit the launcher payload (preferred,
-   `claude --agent qs-implement-task` or `claude --agent
-   qs-implement-setup-task`) plus the slash-command fallback
-   (`/implement-task` or `/implement-setup-task`).
+**Phase protocol** — a **user-driven mode loop** (DISCUSS / REVIEW /
+TRIAGE / FINALIZE), not a linear pipeline. DISCUSS is the durable
+default; REVIEW is invoked on demand and repeatable; the story file is
+the living document:
+
+- **DISCUSS (default)**: read the issue (`gh issue view`), read
+  `project-rules.md` / `project-context.md`, glob the relevant code,
+  and discuss scope/risks/acceptance with the user — iterate
+  indefinitely. As soon as the first round **converges** (the plan has
+  all required headings, or the user says "write it"), write the story
+  file and overwrite it on every later change; announce it is readable.
+  Run the doc-maintenance sub-step (`check_doc_drift.py --paths`). Print
+  the status banner and offer REVIEW once per stable version. The story
+  stays uncommitted.
+- **REVIEW (invoked)**: spawn the plan reviewers in parallel (one
+  message). Round 1 = the **4 global reviewers**; round 2+ = the same 4
+  **plus `qs-plan-delta-auditor`** fed an in-context diff + the prior
+  round's accepted findings. See [adversarial-review.md](adversarial-review.md).
+- **TRIAGE**: dedupe via the finding-state model
+  (`open`/`resolved`/`rejected`), present deltas first, drive
+  interactive triage, fold accepted findings into the story, then return
+  to DISCUSS.
+- **FINALIZE (on confirmed intent)**: an **advisory** gate (never
+  hard-blocks) — if the plan changed since the last review, or open
+  criticals remain, the agent asks but the user decides. Determine
+  `NEXT_PHASE` (`implement-setup-task` if all touched files are in
+  `scripts/`, `.claude/`, `.cursor/`, `.opencode/`, `legacy/`,
+  `docs/`, `.github/`, or top-level config; otherwise `implement-task`),
+  commit + push, then emit the launcher payload (preferred,
+  `claude --agent qs-implement-task` / `qs-implement-setup-task`) plus
+  the slash-command fallback.
 
 **Hard rules**:
 - Do not write code in this phase.
-- Edit scope is the story file only.
-- Never skip the adversarial review.
+- Edit scope is the story file — written during DISCUSS/TRIAGE,
+  committed only at FINALIZE.
+- Never skip the adversarial review for a plan you intend to ship.
 
 ---
 

--- a/tests/qs/agents/test_lsp_tool_enabled.py
+++ b/tests/qs/agents/test_lsp_tool_enabled.py
@@ -62,6 +62,7 @@ LSP_EXCLUDE_AGENTS: tuple[str, ...] = (
     "qs-plan-critic",
     "qs-plan-dev-proxy",
     "qs-plan-scope-guardian",
+    "qs-plan-delta-auditor",
     "qs-review-blind-hunter",
     "qs-review-coderabbit",
     "qs-finish-task",

--- a/tests/qs/agents/test_lsp_tool_enabled.py
+++ b/tests/qs/agents/test_lsp_tool_enabled.py
@@ -9,7 +9,7 @@ split and the plugin-enablement schema cannot silently regress:
   ``code.claude.com/docs/en/sub-agents``), the ``LSP`` tool — and its
   auto post-edit diagnostics, which are a behavior of the same tool —
   stays inactive for any agent that omits it.
-- ``test_lsp_excluded_on_blind_and_merge_agents`` — the 7
+- ``test_lsp_excluded_on_blind_and_merge_agents`` — the 8
   context-starved reviewers / merge / release agents do **not** list
   ``LSP``. The blind reviewers' design forbids reading the codebase, so
   granting them code navigation would be a direct hard-rule violation.

--- a/tests/qs/agents/test_opencode_agents.py
+++ b/tests/qs/agents/test_opencode_agents.py
@@ -80,6 +80,7 @@ SUB_AGENT_NAMES: tuple[str, ...] = (
     "qs-plan-concrete-planner",
     "qs-plan-dev-proxy",
     "qs-plan-scope-guardian",
+    "qs-plan-delta-auditor",
     "qs-review-blind-hunter",
     "qs-review-edge-case-hunter",
     "qs-review-acceptance-auditor",

--- a/tests/qs/agents/test_plan_mode_loop.py
+++ b/tests/qs/agents/test_plan_mode_loop.py
@@ -73,10 +73,39 @@ CREATE_PLAN_FORBIDDEN_MARKERS: tuple[str, ...] = (
 DELTA_AUDITOR_NAME = "qs-plan-delta-auditor"
 
 
+# AC8 — the three workflow docs must describe the 5th reviewer and the
+# round asymmetry (review-fix #01 should-fix). ``check_doc_drift.py``
+# only enforces co-modification (that the docs were *edited* alongside
+# the agents), not content, so without these pins a future edit could
+# silently drop the round-asymmetry paragraph. Per-doc marker sets
+# (each doc phrases it slightly differently — see the doc bodies).
+DOC_AC8_MARKERS: dict[str, tuple[str, ...]] = {
+    "docs/workflow/overview.md": (
+        "qs-plan-delta-auditor",
+        "Round 2+",
+        "diff-aware",
+        "in-context diff",
+    ),
+    "docs/workflow/adversarial-review.md": (
+        "qs-plan-delta-auditor",
+        "Round asymmetry",
+        "round 2+",
+        "diff-aware",
+    ),
+    "docs/workflow/phase-protocols.md": (
+        "qs-plan-delta-auditor",
+        "round 2+",
+        "in-context diff",
+    ),
+}
+
+
 def _harness_id(p: Path) -> str:
-    # Mirror test_doc_maintenance_parity: strip the leading dot so
-    # ``pytest -k claude`` works without the dot being read as a regex
-    # meta-char.
+    # Mirror test_doc_maintenance_parity: strip the leading dot so the
+    # parametrize id is ``claude`` rather than ``.claude`` (a leading dot
+    # is awkward in test-selection filters). Run these via
+    # ``python scripts/qs/quality_gate.py --quick tests/qs/agents`` — the
+    # single test entry point.
     return p.parent.name.lstrip(".")
 
 
@@ -110,6 +139,32 @@ def test_create_plan_body_drops_linear_pipeline_marker(
         f"linear protocol with early persistence (F10) and cuts scoped / "
         f"quick-check reviews (F3)."
     )
+
+
+@pytest.mark.parametrize(
+    ("doc_rel", "markers"),
+    list(DOC_AC8_MARKERS.items()),
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+def test_workflow_docs_describe_fifth_reviewer(
+    doc_rel: str, markers: tuple[str, ...],
+) -> None:
+    """AC8 — the workflow docs pin the 5th reviewer + round asymmetry.
+
+    Content pin (review-fix #01): ``check_doc_drift.py`` enforces only
+    that these docs are co-edited with the agents, not what they say.
+    These markers fail loudly if the round-asymmetry / delta-auditor
+    prose is dropped on a future edit.
+    """
+    path = REPO_ROOT / doc_rel
+    assert path.is_file(), f"Missing workflow doc: {path}"
+    body = path.read_text(encoding="utf-8")
+    for marker in markers:
+        assert marker in body, (
+            f"{doc_rel}: missing AC8 marker {marker!r} — the doc must keep "
+            f"describing the 5th reviewer (qs-plan-delta-auditor) and the "
+            f"round-1 vs round-2+ asymmetry."
+        )
 
 
 @pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)

--- a/tests/qs/agents/test_plan_mode_loop.py
+++ b/tests/qs/agents/test_plan_mode_loop.py
@@ -144,7 +144,11 @@ def test_create_plan_body_drops_linear_pipeline_marker(
 @pytest.mark.parametrize(
     ("doc_rel", "markers"),
     list(DOC_AC8_MARKERS.items()),
-    ids=lambda v: v if isinstance(v, str) else "",
+    # Explicit id list (one per doc) — a callable ``ids`` is invoked
+    # per-arg (doc_rel AND markers), so the markers tuple rendered an
+    # empty trailing-dash segment (review-fix #02). The doc path alone
+    # is the clean, filterable id.
+    ids=list(DOC_AC8_MARKERS.keys()),
 )
 def test_workflow_docs_describe_fifth_reviewer(
     doc_rel: str, markers: tuple[str, ...],

--- a/tests/qs/agents/test_plan_mode_loop.py
+++ b/tests/qs/agents/test_plan_mode_loop.py
@@ -1,0 +1,124 @@
+"""Pin the QS-266 interactive plan-mode loop across all three harnesses.
+
+QS-266 reshapes ``qs-create-plan`` from a linear pipeline into a
+user-driven **mode loop** (DISCUSS / REVIEW / TRIAGE / FINALIZE) and
+adds a fifth, diff-aware plan reviewer (``qs-plan-delta-auditor``).
+
+The repo tests agent bodies by **static substring pinning** (see the
+sibling ``test_doc_maintenance_parity.py``), not by executing the
+personas. Each QS-266 acceptance criterion (AC1–AC6) is therefore a
+literal marker that must appear in every harness copy of
+``qs-create-plan`` — and AC7 is the existence of the new sub-agent in
+all three harness directories.
+
+Pattern follows ``test_doc_maintenance_parity.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Three harnesses to mirror across.
+HARNESS_DIRS: tuple[Path, ...] = (
+    REPO_ROOT / ".claude" / "agents",
+    REPO_ROOT / ".cursor" / "agents",
+    REPO_ROOT / ".opencode" / "agents",
+)
+
+# Markers that pin AC1–AC6 in the body of every ``qs-create-plan`` copy.
+# Each entry is a literal substring that the mode-loop rewrite must
+# contain. They are byte-aligned across harnesses (the core protocol
+# body differs only in frontmatter + the harness-specific spawn/handoff
+# and LSP sections — see project-rules.md "Harness sync").
+CREATE_PLAN_REQUIRED_MARKERS: tuple[str, ...] = (
+    # AC1 — mode loop present.
+    "## Modes",
+    "DISCUSS",
+    "REVIEW",
+    "TRIAGE",
+    "FINALIZE",
+    # AC2 — early persistence rule.
+    "committed only at FINALIZE",
+    # AC3 — status banner template.
+    "[DISCUSS] story vN · changed-since-last-review:",
+    "changed-since-last-review",
+    # AC4 — three intents.
+    "three intents",
+    # AC5 — delta-auditor wired (round asymmetry + in-context diff +
+    # finding-state model).
+    "qs-plan-delta-auditor",
+    "in-context diff",
+    "open/resolved/rejected",
+    # AC6 — advisory finalize.
+    "never hard-block",
+    "confirm before FINALIZE",
+    "ship anyway",
+)
+
+# AC2 / AC4 — strings that the rewrite must REMOVE. The old linear
+# protocol told the agent to defer writing the story (contradicts early
+# persistence, F10) and there are no scoped/quick reviews (F3).
+CREATE_PLAN_FORBIDDEN_MARKERS: tuple[str, ...] = (
+    "Do NOT write yet",
+    "do NOT write the file yet",
+    "review scope",
+    "quick check",
+)
+
+# AC7 — the new diff-aware reviewer exists in all three harnesses.
+DELTA_AUDITOR_NAME = "qs-plan-delta-auditor"
+
+
+def _harness_id(p: Path) -> str:
+    # Mirror test_doc_maintenance_parity: strip the leading dot so
+    # ``pytest -k claude`` works without the dot being read as a regex
+    # meta-char.
+    return p.parent.name.lstrip(".")
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+@pytest.mark.parametrize("marker", CREATE_PLAN_REQUIRED_MARKERS)
+def test_create_plan_body_contains_mode_loop_marker(
+    harness_dir: Path, marker: str,
+) -> None:
+    """Every ``qs-create-plan`` copy pins the AC1–AC6 mode-loop markers."""
+    path = harness_dir / "qs-create-plan.md"
+    assert path.is_file(), f"Missing agent file: {path}"
+    body = path.read_text(encoding="utf-8")
+    assert marker in body, (
+        f"{path}: missing QS-266 mode-loop marker {marker!r}. AC1–AC6 are "
+        f"pinned as literal substrings in every harness copy of "
+        f"qs-create-plan; the mode-loop rewrite must keep this marker aligned "
+        f"across .claude/, .cursor/, and .opencode/."
+    )
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+@pytest.mark.parametrize("marker", CREATE_PLAN_FORBIDDEN_MARKERS)
+def test_create_plan_body_drops_linear_pipeline_marker(
+    harness_dir: Path, marker: str,
+) -> None:
+    """The linear-pipeline / scoped-review strings are gone (AC2/AC4, F10/F3)."""
+    body = (harness_dir / "qs-create-plan.md").read_text(encoding="utf-8")
+    assert marker not in body, (
+        f"{harness_dir / 'qs-create-plan.md'}: stale string {marker!r} must be "
+        f"removed. QS-266 replaces the 'draft in memory, do not write yet' "
+        f"linear protocol with early persistence (F10) and cuts scoped / "
+        f"quick-check reviews (F3)."
+    )
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_delta_auditor_exists_in_every_harness(harness_dir: Path) -> None:
+    """AC7 — ``qs-plan-delta-auditor`` ships in all three harness dirs."""
+    path = harness_dir / f"{DELTA_AUDITOR_NAME}.md"
+    assert path.is_file(), (
+        f"Missing new sub-agent file: {path}. AC7 requires "
+        f"qs-plan-delta-auditor in .claude/, .cursor/, and .opencode/ "
+        f"(parity enforced by this pinning test, not the drift checker — a "
+        f"brand-new single-harness agent is exempt from co-modification)."
+    )


### PR DESCRIPTION
## Summary
Update workflow docs (phase-protocols, adversarial-review, overview) + the create-plan slash command for the loop and round asymmetry; add a pinning test (tests/qs/agents/test_plan_mode_loop.py) and wire the new reviewer into the OpenCode reviewer list and the LSP blind group.

Fixes #266

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned plan creation as an interactive mode loop (DISCUSS, REVIEW, TRIAGE, FINALIZE) with persistent story drafts during iteration.
  * Added on-demand adversarial review with delta-aware regression/resolution checks in later rounds.
  * FINALIZE is now an advisory, intent-confirmed gate (not a hard blocker) that publishes when you confirm.

* **Documentation**
  * Updated workflow and phase protocol docs to reflect the new mode loop and review rounds.

* **Tests**
  * Added/expanded consistency tests to ensure the plan-mode loop and delta-auditor behavior match across harnesses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->