### PR TITLE
QS-271: Car card buttons drop taps on mobile/iOS

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -797,7 +797,9 @@ class QsCarCard extends QsCardBase {
   set hass(hass) {
     this._hass = hass;
     if (!this._root) return;
-    if (this._isInteracting || this._isInteractingCharger || this._isInteractingPerson || this._modalOpen || this._isInteractingTarget) return;
+    // QS-271 — also defer the repaint while a tap is in flight (state is
+    // stored above; only the _render() repaint is deferred).
+    if (this._isInteracting || this._isInteractingCharger || this._isInteractingPerson || this._modalOpen || this._isInteractingTarget || this._isPressInFlight()) return;
     this._render();
   }
 
@@ -1559,6 +1561,8 @@ class QsCarCard extends QsCardBase {
                   if (ev.target.tagName === 'SELECT') return;
                   try { personSel.showPicker(); } catch (_) { personSel.focus(); }
               });
+              // QS-271 — defer re-render across the click→showPicker tap.
+              this._armPressGuard(personPill);
           }
       }
 
@@ -1587,6 +1591,8 @@ class QsCarCard extends QsCardBase {
                   if (ev.target.tagName === 'SELECT') return;
                   try { chargerSel.showPicker(); } catch (_) { chargerSel.focus(); }
               });
+              // QS-271 — defer re-render across the click→showPicker tap.
+              this._armPressGuard(chargerPill);
           }
       }
 
@@ -1650,7 +1656,6 @@ class QsCarCard extends QsCardBase {
       if (e.force_now) {
           const rbtn = ids('rabbit_btn');
           if (rbtn) {
-              rbtn.style.pointerEvents = 'auto';
               const rbtnAction = async () => {
                   if (this._root?.querySelector('.disabled')) return;
 
@@ -1685,10 +1690,10 @@ class QsCarCard extends QsCardBase {
                       });
                   }
               };
-              rbtn.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); rbtnAction(); });
-              rbtn.addEventListener('touchend', (ev) => { ev.preventDefault(); rbtnAction(); });
-              // S5: keyboard activation for the focusable div.
-              this._registerKeyActivation(rbtn, rbtnAction);
+              // QS-271 — chokepoint. stopPropagation:true so the tap
+              // doesn't bubble into the ring/center handlers; keyboard:true
+              // for the focusable div (S5).
+              this._wireTap(rbtn, rbtnAction, { keyboard: true, stopPropagation: true });
           }
       }
 
@@ -1751,8 +1756,8 @@ class QsCarCard extends QsCardBase {
                   ]
               });
           };
-          forceBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); forceAction(); });
-          forceBtn?.addEventListener('touchend', (ev) => { ev.preventDefault(); forceAction(); });
+          // QS-271 — chokepoint. keyboard:false (matches prior behaviour).
+          this._wireTap(forceBtn, forceAction, { keyboard: false, stopPropagation: true });
       }
 
       if (e.schedule) {
@@ -1774,8 +1779,8 @@ class QsCarCard extends QsCardBase {
                   ]
               });
           };
-          schedBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); schedAction(); });
-          schedBtn?.addEventListener('touchend', (ev) => { ev.preventDefault(); schedAction(); });
+          // QS-271 — chokepoint. keyboard:false (matches prior behaviour).
+          this._wireTap(schedBtn, schedAction, { keyboard: false, stopPropagation: true });
       }
 
       // QS-243 — the big SOC number opens a manual-charge popup with an
@@ -1820,9 +1825,8 @@ class QsCarCard extends QsCardBase {
               // all dismiss the popup — no explicit close needed here (N6).
               this._showDialog({ title: 'Set charge percent', customContent: content, buttons });
           };
-          socEl?.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); openSocDialog(); });
-          socEl?.addEventListener('touchend', (ev) => { ev.preventDefault(); openSocDialog(); });
-          this._registerKeyActivation(socEl, openSocDialog);
+          // QS-271 — chokepoint. keyboard:true, stopPropagation:true.
+          this._wireTap(socEl, openSocDialog, { keyboard: true, stopPropagation: true });
       }
 
       // QS-235 AC4 — the reset button adopts the shared `_wireResetButton`

--- a/custom_components/quiet_solar/ui/resources/qs-climate-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-climate-card.js
@@ -629,7 +629,9 @@ class QsClimateCard extends QsRingDurationCardBase {
   set hass(hass) {
     this._hass = hass;
     if (!this._root) return;
-    if (this._isInteractingMode || this._isInteractingStateOn || this._modalOpen || this._isInteractingTarget) return;
+    // QS-271 — also defer the repaint while a tap is in flight (state is
+    // stored above; only the _render() repaint is deferred).
+    if (this._isInteractingMode || this._isInteractingStateOn || this._modalOpen || this._isInteractingTarget || this._isPressInFlight()) return;
     this._render();
   }
 
@@ -1403,6 +1405,8 @@ class QsClimateCard extends QsRingDurationCardBase {
                   if (ev.target.tagName === 'SELECT') return;
                   try { stateOnSel.showPicker(); } catch (_) { stateOnSel.focus(); }
               });
+              // QS-271 — defer re-render across the click→showPicker tap.
+              this._armPressGuard(stateOnPill);
           }
       }
 

--- a/custom_components/quiet_solar/ui/resources/shared/qs-card-base.js
+++ b/custom_components/quiet_solar/ui/resources/shared/qs-card-base.js
@@ -92,6 +92,24 @@ export const RING_BOTTOM_CARVE_CX = 160;   // SVG x-centre of the ring
 export const RING_BOTTOM_CARVE_CY = 277;   // button-centre y (derived from CSS .*-btn position)
 export const RING_BOTTOM_CARVE_R = 35;     // cover radius (user-tunable)
 
+// QS-271 — press-in-flight guard windows. Non-exported module consts
+// (matching the RING_BOTTOM_CARVE_* style) so they stay card-internal.
+//
+// PRESS_GUARD_MS — render-defer window armed around a tap. Sized to
+// cover iOS Safari's ~300 ms synthetic-click delay plus margin for the
+// handler to fire and the service call to begin. A `hass` push landing
+// inside this window skips the `_render()` repaint (NOT the state store)
+// so the live button node isn't torn out mid-tap. The window
+// auto-expires (self-healing) so a tap whose up-event never fires — the
+// node was destroyed before it — can never wedge rendering forever.
+const PRESS_GUARD_MS = 600;
+
+// SYNTHETIC_CLICK_MS — window within which a `click` is treated as the
+// OS-synthesized twin of a just-fired `touchend` (and therefore ignored).
+// Deliberately SEPARATE from PRESS_GUARD_MS: it must NOT throttle genuine
+// rapid re-taps, only dedupe the single synthetic click per physical tap.
+const SYNTHETIC_CLICK_MS = 350;
+
 
 export class QsCardBase extends HTMLElement {
     // ----- Lifecycle -----
@@ -111,6 +129,12 @@ export class QsCardBase extends HTMLElement {
         this._isInteractingTarget = false;
         this._isProcessingModeChange = false;
         this._modalOpen = false;
+        // QS-271 S7: reset the press-in-flight window. Non-critical (the
+        // window auto-expires anyway), but keeps the flag clean on
+        // re-attach. An innerHTML rewrite of a CHILD does not fire this
+        // on the card element, so it can't clear an in-flight guard
+        // mid-tap.
+        this._pressInFlightUntil = 0;
     }
 
     setConfig(config) {
@@ -123,8 +147,12 @@ export class QsCardBase extends HTMLElement {
     set hass(hass) {
         this._hass = hass;
         if (!this._root) return;
-        // Avoid re-rendering while user is interacting with selects or a modal is open
-        if (this._isInteractingMode || this._modalOpen || this._isInteractingTarget) return;
+        // Avoid re-rendering while user is interacting with selects or a
+        // modal is open, or while a tap is in flight (QS-271 — so a hass
+        // push can't tear the button node out mid-tap). `this._hass` is
+        // stored above the gate, so no state is dropped — only the repaint
+        // is deferred, by at most the guard window.
+        if (this._isInteractingMode || this._modalOpen || this._isInteractingTarget || this._isPressInFlight()) return;
         this._render();
     }
 
@@ -335,6 +363,67 @@ export class QsCardBase extends HTMLElement {
         });
         this._root.appendChild(wrap);
         return wrap;
+    }
+
+    // ----- Press-in-flight guard (QS-271) -----
+    /*
+      The bug: every `hass` push runs `set hass → _render() → innerHTML`,
+      which destroys and rebuilds every button node. A plain button tap
+      set NONE of the `_isInteracting*` guards, so a push landing between
+      `pointerdown` and the (iOS-delayed ~300 ms) synthetic `click`
+      tore the node out mid-tap and the press was dropped.
+
+      The fix is a self-expiring TIMESTAMP window — not a boolean. A
+      boolean set on `pointerdown` and cleared on the up-event would
+      WEDGE rendering forever exactly when the node is destroyed before
+      the up-event fires (this bug). The window auto-expires instead.
+    */
+    _isPressInFlight() {
+        return Date.now() < (this._pressInFlightUntil || 0);
+    }
+
+    // _armPressGuard — low-level primitive: arms the render-defer window
+    // on `pointerdown` + `touchstart`. Both listeners are {passive:true}
+    // (they never preventDefault), so on the native-`<select>` pills they
+    // cannot interfere with the picker opening. Used directly on controls
+    // that keep their own activation handler (the pills); _wireTap calls
+    // it internally for plain action buttons.
+    _armPressGuard(el) {
+        if (!el) return;
+        const begin = () => { this._pressInFlightUntil = Date.now() + PRESS_GUARD_MS; };
+        el.addEventListener('pointerdown', begin, { passive: true });
+        el.addEventListener('touchstart', begin, { passive: true });
+    }
+
+    // _wireTap — the full button-wiring chokepoint for plain action
+    // buttons. Arms the press guard, then owns the touchend / click /
+    // keyboard binding so the guard can never be forgotten on a new
+    // button. Replaces the copy-pasted click+touchend boilerplate.
+    _wireTap(el, action, { keyboard = true, stopPropagation = true } = {}) {
+        if (!el) return;
+        el.style.pointerEvents = 'auto';
+        this._armPressGuard(el);
+        let lastTouchEnd = 0;
+        // touchend: NON-passive (no passive option) so preventDefault can
+        // suppress the OS's delayed synthetic click; fires the action
+        // immediately and records the time.
+        el.addEventListener('touchend', (ev) => {
+            if (stopPropagation) ev.stopPropagation();
+            ev.preventDefault();
+            lastTouchEnd = Date.now();
+            action();
+        });
+        // click: ignore ONLY the synthetic twin that follows a real
+        // touchend (event-aware dedup, not a blanket time latch). Genuine
+        // mouse/synthesized clicks (no recent touchend) still fire, and
+        // genuine rapid re-taps are NOT throttled.
+        el.addEventListener('click', (ev) => {
+            if (stopPropagation) ev.stopPropagation();
+            ev.preventDefault();
+            if (Date.now() - lastTouchEnd < SYNTHETIC_CLICK_MS) return;
+            action();
+        });
+        if (keyboard) this._registerKeyActivation(el, action);
     }
 
     // ----- Keyboard activation -----
@@ -652,10 +741,8 @@ export class QsCardBase extends HTMLElement {
             });
         };
 
-        buttonEl.style.pointerEvents = 'auto';
-        buttonEl.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); timeAction(); });
-        buttonEl.addEventListener('touchend', (ev) => { ev.preventDefault(); timeAction(); });
-        this._registerKeyActivation(buttonEl, timeAction);
+        // QS-271 — chokepoint: arms the press guard + owns touchend/click/keyboard.
+        this._wireTap(buttonEl, timeAction, { keyboard: true, stopPropagation: true });
     }
 
     /*
@@ -685,8 +772,9 @@ export class QsCardBase extends HTMLElement {
                 ],
             });
         };
-        buttonEl.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); resetAction(); });
-        buttonEl.addEventListener('touchend', (ev) => { ev.preventDefault(); resetAction(); });
+        // QS-271 — chokepoint. N6: native `<button id="reset">` is
+        // keyboard-native, so no `_registerKeyActivation` (keyboard:false).
+        this._wireTap(buttonEl, resetAction, { keyboard: false, stopPropagation: true });
     }
 
     /*
@@ -712,10 +800,9 @@ export class QsCardBase extends HTMLElement {
                 // ignore; HA state will resync UI on next render
             }
         };
-        buttonEl.style.pointerEvents = 'auto';
-        buttonEl.addEventListener('click', togglePower);
-        buttonEl.addEventListener('touchend', (ev) => { ev.preventDefault(); togglePower(); });
-        this._registerKeyActivation(buttonEl, togglePower);
+        // QS-271 — chokepoint. stopPropagation:false preserves the
+        // power button's current behaviour (no parent delegation relied on).
+        this._wireTap(buttonEl, togglePower, { keyboard: true, stopPropagation: false });
     }
 
     /*
@@ -739,10 +826,9 @@ export class QsCardBase extends HTMLElement {
                 // ignore; HA state will resync UI on next render
             }
         };
-        buttonEl.style.pointerEvents = 'auto';
-        buttonEl.addEventListener('click', toggleGreen);
-        buttonEl.addEventListener('touchend', (ev) => { ev.preventDefault(); toggleGreen(); });
-        this._registerKeyActivation(buttonEl, toggleGreen);
+        // QS-271 — chokepoint. stopPropagation:false preserves the
+        // green button's current behaviour (no parent delegation relied on).
+        this._wireTap(buttonEl, toggleGreen, { keyboard: true, stopPropagation: false });
     }
 
     // ----- Ring builder -----

--- a/custom_components/quiet_solar/ui/resources/shared/qs-card-base.js
+++ b/custom_components/quiet_solar/ui/resources/shared/qs-card-base.js
@@ -412,10 +412,14 @@ export class QsCardBase extends HTMLElement {
     _armPressGuard(el) {
         if (!el) return;
         const begin = () => {
-            // QS-271 fix #01 N4: a disabled control's action no-ops, so
-            // arming the guard (deferring the next repaint by up to
-            // PRESS_GUARD_MS) would be pure waste — skip it.
-            if (el.getAttribute('aria-disabled') === 'true' || el.classList.contains('disabled')) return;
+            // QS-271 fix #01 N4 + fix #02 N1: a disabled control's action
+            // no-ops, so arming the guard (deferring the next repaint by up
+            // to PRESS_GUARD_MS) would be pure waste — skip it. Consult both
+            // the element's own `aria-disabled` AND a `.disabled` ancestor
+            // (`closest` walks the control + its wrappers), so an inline
+            // action that reflects disabled state only on the card-level
+            // `.disabled` container is covered too.
+            if (el.getAttribute('aria-disabled') === 'true' || el.closest('.disabled')) return;
             this._pressInFlightUntil = performance.now() + PRESS_GUARD_MS;
             // QS-271 fix #01 N5: schedule a single catch-up render for when
             // the window expires, so a `hass` push dropped during the
@@ -430,6 +434,11 @@ export class QsCardBase extends HTMLElement {
                 if (this.isConnected && this._root && this._hass != null) this.hass = this._hass;
             }, PRESS_GUARD_MS + 50);
         };
+        // QS-271 fix #02 N2: intentional idempotent double-arm — on touch,
+        // BOTH `pointerdown` and `touchstart` fire, so `begin` runs twice
+        // per tap. That is harmless: it re-stamps the same window and
+        // resets the single coalesced flush timer (no double scheduling).
+        // Binding both covers pointer-capable and touch-only browsers.
         el.addEventListener('pointerdown', begin, { passive: true });
         el.addEventListener('touchstart', begin, { passive: true });
     }
@@ -461,10 +470,17 @@ export class QsCardBase extends HTMLElement {
             swallowNextClick = true;
             action();
         });
-        // click: swallow the synthetic twin via the one-shot latch (S2),
-        // with SYNTHETIC_CLICK_MS as a belt-and-suspenders secondary.
-        // Genuine mouse clicks (no preceding touchend) and rapid touch
-        // re-taps (each fired by its own touchend) are unaffected.
+        // click: swallow the synthetic twin via a one-shot latch that is
+        // only honored WITHIN the SYNTHETIC_CLICK_MS window of the
+        // touchend (QS-271 fix #02 S1). The window bound matters because
+        // touchend's preventDefault usually suppresses the synthetic click
+        // outright, so the latch is often never consumed — leaving it
+        // stuck `true` would silently swallow a LATER unrelated genuine
+        // click (hybrid touch+mouse, programmatic `.click()`, assistive
+        // tech). Gating on the window means a click after it is treated as
+        // genuine and the stale latch is reset. Genuine mouse clicks (no
+        // preceding touchend) and rapid touch re-taps (each fired by its
+        // own touchend) are unaffected.
         // S1/N2 — `preventDefault()` here is OPTION-GATED: power/green
         // buttons historically bound a bare `click` with no
         // preventDefault, so routing them through `_wireTap` must not
@@ -473,10 +489,14 @@ export class QsCardBase extends HTMLElement {
         el.addEventListener('click', (ev) => {
             if (stopPropagation) ev.stopPropagation();
             if (preventDefaultClick) ev.preventDefault();
-            if (swallowNextClick || (performance.now() - lastTouchEnd < SYNTHETIC_CLICK_MS)) {
-                swallowNextClick = false;
+            const withinSyntheticWindow = (performance.now() - lastTouchEnd) < SYNTHETIC_CLICK_MS;
+            if (swallowNextClick && withinSyntheticWindow) {
+                swallowNextClick = false;  // consume the synthetic twin (once)
                 return;
             }
+            // A click outside the window is genuine — clear any stale latch
+            // so it can't swallow a future click, then fire.
+            swallowNextClick = false;
             action();
         });
         if (keyboard) this._registerKeyActivation(el, action);

--- a/custom_components/quiet_solar/ui/resources/shared/qs-card-base.js
+++ b/custom_components/quiet_solar/ui/resources/shared/qs-card-base.js
@@ -104,10 +104,13 @@ export const RING_BOTTOM_CARVE_R = 35;     // cover radius (user-tunable)
 // node was destroyed before it — can never wedge rendering forever.
 const PRESS_GUARD_MS = 600;
 
-// SYNTHETIC_CLICK_MS — window within which a `click` is treated as the
-// OS-synthesized twin of a just-fired `touchend` (and therefore ignored).
-// Deliberately SEPARATE from PRESS_GUARD_MS: it must NOT throttle genuine
-// rapid re-taps, only dedupe the single synthetic click per physical tap.
+// SYNTHETIC_CLICK_MS — belt-and-suspenders secondary window backing the
+// one-shot synthetic-click latch (QS-271 fix #01 S2). A `click` landing
+// within this window of a touchend is treated as the OS-synthesized twin
+// even if the latch was already consumed. Deliberately SEPARATE from
+// PRESS_GUARD_MS: it must NOT throttle genuine rapid re-taps, only dedupe
+// the synthetic twin. >= 300 to cover iOS Safari's synthetic-click delay
+// (pinned by `test_synthetic_click_ms_has_lower_bound`).
 const SYNTHETIC_CLICK_MS = 350;
 
 
@@ -117,6 +120,10 @@ export class QsCardBase extends HTMLElement {
     connectedCallback() {
         // RAF intentionally NOT started here — _render() decides when to
         // start the dashed-arc animation via _startArcDashAnimation().
+        // QS-271 fix #01 N1: initialize the press-guard window for clarity
+        // (the defensive `|| 0` in `_isPressInFlight` still covers a guard
+        // armed before any connect).
+        this._pressInFlightUntil = 0;
     }
 
     disconnectedCallback() {
@@ -135,6 +142,12 @@ export class QsCardBase extends HTMLElement {
         // on the card element, so it can't clear an in-flight guard
         // mid-tap.
         this._pressInFlightUntil = 0;
+        // QS-271 fix #01 N5: cancel any pending catch-up flush render so it
+        // can't fire against a torn-down shadow root after detach.
+        if (this._pressGuardFlushTimer) {
+            clearTimeout(this._pressGuardFlushTimer);
+            this._pressGuardFlushTimer = null;
+        }
     }
 
     setConfig(config) {
@@ -377,9 +390,17 @@ export class QsCardBase extends HTMLElement {
       boolean set on `pointerdown` and cleared on the up-event would
       WEDGE rendering forever exactly when the node is destroyed before
       the up-event fires (this bug). The window auto-expires instead.
+
+      QS-271 fix #01 S3: the window is measured against the MONOTONIC
+      clock (`performance.now()`), NOT `Date.now()`. A backward
+      wall-clock step (NTP correction, manual change, mobile DST/timezone
+      re-sync) while a press is in flight would otherwise keep
+      `_isPressInFlight()` true for the magnitude of the jump (minutes)
+      and silently drop every `hass` push — defeating the "self-healing"
+      guarantee. `performance.now()` only moves forward.
     */
     _isPressInFlight() {
-        return Date.now() < (this._pressInFlightUntil || 0);
+        return performance.now() < (this._pressInFlightUntil || 0);
     }
 
     // _armPressGuard — low-level primitive: arms the render-defer window
@@ -390,7 +411,25 @@ export class QsCardBase extends HTMLElement {
     // it internally for plain action buttons.
     _armPressGuard(el) {
         if (!el) return;
-        const begin = () => { this._pressInFlightUntil = Date.now() + PRESS_GUARD_MS; };
+        const begin = () => {
+            // QS-271 fix #01 N4: a disabled control's action no-ops, so
+            // arming the guard (deferring the next repaint by up to
+            // PRESS_GUARD_MS) would be pure waste — skip it.
+            if (el.getAttribute('aria-disabled') === 'true' || el.classList.contains('disabled')) return;
+            this._pressInFlightUntil = performance.now() + PRESS_GUARD_MS;
+            // QS-271 fix #01 N5: schedule a single catch-up render for when
+            // the window expires, so a `hass` push dropped during the
+            // window (the gate returned before `_render()`) isn't stranded
+            // until the next organic push (~4 s). Re-running `set hass` via
+            // the stored state replays the FULL gate (all `_isInteracting*`
+            // / `_modalOpen` / press-in-flight checks), so it only paints
+            // when genuinely idle. Coalesced: each new press resets it.
+            if (this._pressGuardFlushTimer) clearTimeout(this._pressGuardFlushTimer);
+            this._pressGuardFlushTimer = setTimeout(() => {
+                this._pressGuardFlushTimer = null;
+                if (this.isConnected && this._root && this._hass != null) this.hass = this._hass;
+            }, PRESS_GUARD_MS + 50);
+        };
         el.addEventListener('pointerdown', begin, { passive: true });
         el.addEventListener('touchstart', begin, { passive: true });
     }
@@ -399,28 +438,45 @@ export class QsCardBase extends HTMLElement {
     // buttons. Arms the press guard, then owns the touchend / click /
     // keyboard binding so the guard can never be forgotten on a new
     // button. Replaces the copy-pasted click+touchend boilerplate.
-    _wireTap(el, action, { keyboard = true, stopPropagation = true } = {}) {
+    _wireTap(el, action, { keyboard = true, stopPropagation = true, preventDefaultClick = true } = {}) {
         if (!el) return;
         el.style.pointerEvents = 'auto';
         this._armPressGuard(el);
         let lastTouchEnd = 0;
+        // QS-271 fix #01 S2 — one-shot latch: the single `click` that
+        // follows a real `touchend` is the OS synthetic twin. Swallow
+        // exactly that one click, regardless of how late it arrives, so a
+        // slow device whose synthetic click lands after SYNTHETIC_CLICK_MS
+        // can never double-fire `action()`.
+        let swallowNextClick = false;
         // touchend: NON-passive (no passive option) so preventDefault can
-        // suppress the OS's delayed synthetic click; fires the action
-        // immediately and records the time.
+        // suppress the OS's delayed synthetic click. This preventDefault is
+        // ALWAYS-ON (unlike the click path) precisely because suppressing
+        // that synthetic twin is the whole point — fires the action
+        // immediately, records the time, and arms the latch.
         el.addEventListener('touchend', (ev) => {
             if (stopPropagation) ev.stopPropagation();
             ev.preventDefault();
-            lastTouchEnd = Date.now();
+            lastTouchEnd = performance.now();
+            swallowNextClick = true;
             action();
         });
-        // click: ignore ONLY the synthetic twin that follows a real
-        // touchend (event-aware dedup, not a blanket time latch). Genuine
-        // mouse/synthesized clicks (no recent touchend) still fire, and
-        // genuine rapid re-taps are NOT throttled.
+        // click: swallow the synthetic twin via the one-shot latch (S2),
+        // with SYNTHETIC_CLICK_MS as a belt-and-suspenders secondary.
+        // Genuine mouse clicks (no preceding touchend) and rapid touch
+        // re-taps (each fired by its own touchend) are unaffected.
+        // S1/N2 — `preventDefault()` here is OPTION-GATED: power/green
+        // buttons historically bound a bare `click` with no
+        // preventDefault, so routing them through `_wireTap` must not
+        // silently suppress a native default. touchend's preventDefault
+        // stays unconditional (see above).
         el.addEventListener('click', (ev) => {
             if (stopPropagation) ev.stopPropagation();
-            ev.preventDefault();
-            if (Date.now() - lastTouchEnd < SYNTHETIC_CLICK_MS) return;
+            if (preventDefaultClick) ev.preventDefault();
+            if (swallowNextClick || (performance.now() - lastTouchEnd < SYNTHETIC_CLICK_MS)) {
+                swallowNextClick = false;
+                return;
+            }
             action();
         });
         if (keyboard) this._registerKeyActivation(el, action);
@@ -800,9 +856,9 @@ export class QsCardBase extends HTMLElement {
                 // ignore; HA state will resync UI on next render
             }
         };
-        // QS-271 — chokepoint. stopPropagation:false preserves the
-        // power button's current behaviour (no parent delegation relied on).
-        this._wireTap(buttonEl, togglePower, { keyboard: true, stopPropagation: false });
+        // QS-271 — chokepoint. stopPropagation:false + preventDefaultClick:false
+        // preserve the power button's original bare-click behaviour (fix #01 S1).
+        this._wireTap(buttonEl, togglePower, { keyboard: true, stopPropagation: false, preventDefaultClick: false });
     }
 
     /*
@@ -826,9 +882,9 @@ export class QsCardBase extends HTMLElement {
                 // ignore; HA state will resync UI on next render
             }
         };
-        // QS-271 — chokepoint. stopPropagation:false preserves the
-        // green button's current behaviour (no parent delegation relied on).
-        this._wireTap(buttonEl, toggleGreen, { keyboard: true, stopPropagation: false });
+        // QS-271 — chokepoint. stopPropagation:false + preventDefaultClick:false
+        // preserve the green button's original bare-click behaviour (fix #01 S1).
+        this._wireTap(buttonEl, toggleGreen, { keyboard: true, stopPropagation: false, preventDefaultClick: false });
     }
 
     // ----- Ring builder -----

--- a/custom_components/quiet_solar/ui/resources/shared/qs-ring-duration-base.js
+++ b/custom_components/quiet_solar/ui/resources/shared/qs-ring-duration-base.js
@@ -107,9 +107,9 @@ export class QsRingDurationCardBase extends QsCardBase {
                 ],
             });
         };
-        buttonEl.addEventListener('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); obtnAction(); });
-        buttonEl.addEventListener('touchend', (ev) => { ev.preventDefault(); obtnAction(); });
-        this._registerKeyActivation(buttonEl, obtnAction);
+        // QS-271 — chokepoint. stopPropagation:true so a tap doesn't
+        // bubble into the ring/center handlers.
+        this._wireTap(buttonEl, obtnAction, { keyboard: true, stopPropagation: true });
     }
 
     /*
@@ -162,6 +162,9 @@ export class QsRingDurationCardBase extends QsCardBase {
                 if (ev.target.tagName === 'SELECT') return;
                 try { selectEl.showPicker(); } catch (_) { selectEl.focus(); }
             });
+            // QS-271 — defer re-render across the click→showPicker tap so
+            // a hass push can't destroy the pill before the picker opens.
+            this._armPressGuard(modePill);
         }
     }
 }

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -17,7 +17,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/shared/qs-ring-duration-base.js
   - custom_components/quiet_solar/ui/resources/shared/qs-anim-flame.js
   - custom_components/quiet_solar/ui/resources/shared/qs-anim-wave.js
-last_verified: 2026-06-17
+last_verified: 2026-06-18
 ---
 
 # Dashboard generation and JS Lovelace cards
@@ -1038,22 +1038,32 @@ patterns after the cross-card audit:
     > `addEventListener('click'…)` rule scoped to action buttons, kept
     > clear of the pill/`<select>` handlers). Until then the dual-binding
     > pattern — the dominant bug surface — is fully covered.
-  - **Robustness hardening (QS-271 review-fix #01).** The guard window
-    is measured with the **monotonic** `performance.now()` (not
+  - **Robustness hardening (QS-271 review-fix #01 + #02).** The guard
+    window is measured with the **monotonic** `performance.now()` (not
     `Date.now()`), so a backward wall-clock step can't wedge rendering
-    (S3). The synthetic-click dedup is a **one-shot latch** —
-    `touchend` arms `swallowNextClick`; the next `click` is swallowed
-    regardless of how late it arrives — with `SYNTHETIC_CLICK_MS` kept
-    as a belt-and-suspenders secondary, so a slow device's late
-    synthetic click can't double-fire the action (S2). `_wireTap`'s
-    **click** `preventDefault()` is option-gated (`preventDefaultClick`,
-    default true; power/green pass `false`) so routing a bare-click
-    button through the chokepoint doesn't silently suppress a native
-    default — `touchend`'s `preventDefault` stays unconditional (S1/N2).
-    `_armPressGuard` skips arming for a `.disabled` / `aria-disabled`
-    control (N4), and schedules a single coalesced catch-up
-    `_render()` (via re-running `set hass` over the stored state) when
-    the window expires so a dropped push isn't stranded (N5).
+    (#01 S3). The synthetic-click dedup is a **window-bounded one-shot
+    latch**: `touchend` arms `swallowNextClick`, and the next `click` is
+    swallowed only when it lands **within `SYNTHETIC_CLICK_MS`** of the
+    touchend (#02 S1) — so the latch can't stay stuck `true` and
+    silently swallow a later unrelated genuine click (hybrid
+    touch+mouse, programmatic `.click()`, assistive tech); a click
+    outside the window is treated as genuine and resets the latch.
+    `SYNTHETIC_CLICK_MS` (>= 300) sizes that window to cover the iOS
+    synthetic-click delay (#01 S2). `_wireTap`'s **click**
+    `preventDefault()` is option-gated (`preventDefaultClick`, default
+    true; power/green pass `false`) so routing a bare-click button
+    through the chokepoint doesn't silently suppress a native default —
+    `touchend`'s `preventDefault` stays unconditional (#01 S1/N2).
+    `_armPressGuard` skips arming for a control disabled on its own node
+    (`aria-disabled`) **or** via a `.disabled` ancestor
+    (`closest('.disabled')` — #02 N1, covering inline actions gated only
+    by the card-level `.disabled` container) (#01 N4), and schedules a
+    single coalesced catch-up `_render()` (via re-running `set hass`
+    over the stored state) when the window expires so a dropped push
+    isn't stranded (#01 N5). The dual `pointerdown` + `touchstart`
+    arming is an intentional idempotent double-arm (#02 N2): both fire
+    on touch but re-stamp the same window and reset the one coalesced
+    flush timer.
 
 ### Ring text readability — uniform shadow (QS-228)
 

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -17,7 +17,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/shared/qs-ring-duration-base.js
   - custom_components/quiet_solar/ui/resources/shared/qs-anim-flame.js
   - custom_components/quiet_solar/ui/resources/shared/qs-anim-wave.js
-last_verified: 2026-06-02
+last_verified: 2026-06-17
 ---
 
 # Dashboard generation and JS Lovelace cards
@@ -980,6 +980,57 @@ patterns after the cross-card audit:
   `buttons` is empty, and the per-button `activate` closure wraps
   `b.onClick?.()` in `try/finally` so a synchronous throw can't
   leave the modal locked open.
+- **Press-in-flight guard + `_wireTap` / `_armPressGuard` chokepoint
+  (QS-271).** Every `hass` push runs `set hass → _render() →
+  innerHTML`, which destroys and rebuilds every button node. A plain
+  button tap set none of the `_isInteracting*` guards, so a push
+  landing between `pointerdown` and the (iOS-delayed ~300 ms)
+  synthetic `click` tore the node out mid-tap and dropped the press.
+  The fix lives in `shared/qs-card-base.js`:
+  - A self-expiring **timestamp window** (`_pressInFlightUntil`,
+    `_isPressInFlight()`) — *not* a boolean, which would wedge
+    rendering forever when the node is destroyed before the up-event.
+    `PRESS_GUARD_MS` (non-exported module const, ≥ 300 to cover the
+    iOS synthetic-click delay) sizes the window. All three `set hass`
+    overrides (`qs-card-base.js`, `qs-car-card.js`, `qs-climate-card.js`)
+    add `|| this._isPressInFlight()` to their interaction gate. State
+    is never dropped — `this._hass = hass` is assigned *above* the
+    gate; only the `_render()` repaint is deferred (the RAF animation
+    loop is independent of `_render()`, so visuals keep moving).
+    `disconnectedCallback` resets `_pressInFlightUntil = 0` (S7).
+  - **`_armPressGuard(el)`** — low-level primitive that arms the window
+    on `pointerdown` + `touchstart`, both `{passive:true}` (so it can
+    never `preventDefault` / interfere with a native picker). Used
+    directly on the native-`<select>` **pills** (`personPill` /
+    `chargerPill` in car, `stateOnPill` in climate, `modePill` in
+    ring-duration base): a pill's tap is click-only and merely opens
+    `showPicker()`, so it needs the render deferred across the
+    synthetic-click window but must keep its own handler — `_wireTap`
+    would be wrong there.
+  - **`_wireTap(el, action, {keyboard, stopPropagation})`** — the full
+    button-wiring **chokepoint** for plain action buttons. Calls
+    `_armPressGuard` internally, then owns the binding: a **non-passive**
+    `touchend` (so `preventDefault` suppresses the synthetic click) that
+    fires the action and records `lastTouchEnd`; a `click` that fires
+    *unless* within `SYNTHETIC_CLICK_MS` (a separate const, ~350 ms —
+    event-aware dedup of the synthetic twin, **not** a blanket re-tap
+    throttle); optional keyboard activation. The four base wire-helpers
+    (`_wireTimePicker`, `_wireResetButton`, `_wirePowerButton`,
+    `_wireGreenButton`), `_wireOverrideButton` (ring-duration base) and
+    the four car inline buttons (`rbtn`, `forceBtn`, `schedBtn`,
+    `socEl`) all route through it — their raw `click`/`touchend`
+    bindings were **replaced**, not augmented. `_showDialog`'s modal
+    buttons are intentionally left unchanged (already `_modalOpen`-
+    guarded + double-fire latched).
+  - **Enforced going forward** by
+    `test_no_card_uses_bare_touchend_outside_shared_helpers`: every
+    element-level `addEventListener('touchend'…)` must live inside
+    `_wireTap` / `_wireTargetHandle` / `_showDialog` (the latter's
+    occurrence count is pinned). The canary is `touchend`-only by
+    design — a source-text rule can't distinguish a click-only action
+    button from the legitimate pill/`<select>` click handlers without
+    false positives, so a future *click-only* action button could
+    still slip past.
 
 ### Ring text readability — uniform shadow (QS-228)
 

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -1031,6 +1031,29 @@ patterns after the cross-card audit:
     button from the legitimate pill/`<select>` click handlers without
     false positives, so a future *click-only* action button could
     still slip past.
+    > **Tracked follow-up (QS-271 review-fix #01 N3):** the
+    > `touchend`-only canary gap is a known limitation, not an
+    > oversight. If a click-only action-button pattern ever lands, open a
+    > follow-up issue to extend the canary (e.g. an allowlist-based
+    > `addEventListener('click'…)` rule scoped to action buttons, kept
+    > clear of the pill/`<select>` handlers). Until then the dual-binding
+    > pattern — the dominant bug surface — is fully covered.
+  - **Robustness hardening (QS-271 review-fix #01).** The guard window
+    is measured with the **monotonic** `performance.now()` (not
+    `Date.now()`), so a backward wall-clock step can't wedge rendering
+    (S3). The synthetic-click dedup is a **one-shot latch** —
+    `touchend` arms `swallowNextClick`; the next `click` is swallowed
+    regardless of how late it arrives — with `SYNTHETIC_CLICK_MS` kept
+    as a belt-and-suspenders secondary, so a slow device's late
+    synthetic click can't double-fire the action (S2). `_wireTap`'s
+    **click** `preventDefault()` is option-gated (`preventDefaultClick`,
+    default true; power/green pass `false`) so routing a bare-click
+    button through the chokepoint doesn't silently suppress a native
+    default — `touchend`'s `preventDefault` stays unconditional (S1/N2).
+    `_armPressGuard` skips arming for a `.disabled` / `aria-disabled`
+    control (N4), and schedules a single coalesced catch-up
+    `_render()` (via re-running `set hass` over the stored state) when
+    the window expires so a dropped push isn't stranded (N5).
 
 ### Ring text readability — uniform shadow (QS-228)
 

--- a/docs/stories/QS-271.story.md
+++ b/docs/stories/QS-271.story.md
@@ -51,6 +51,19 @@ without explicit instruction" rule.
 
 ## Design
 
+> **Note (post-merge accuracy).** The pseudocode in this section reflects
+> the *original* design. The **shipped** implementation was hardened during
+> code review — see `QS-271.story_review_fix_#01.md` and
+> `QS-271.story_review_fix_#02.md`. In particular: the guard window uses the
+> **monotonic** `performance.now()` (not `Date.now()`); the synthetic-click
+> dedup is a **window-bounded one-shot latch** (`swallowNextClick`, honored
+> only within `SYNTHETIC_CLICK_MS`); `_wireTap`'s click `preventDefault()` is
+> option-gated via `preventDefaultClick` (power/green opt out);
+> `_armPressGuard` skips disabled controls (own node **or** `.disabled`
+> ancestor) and schedules a catch-up flush render. The acceptance criteria
+> and `docs/agents/concepts/dashboard-and-cards.md` describe the final
+> behaviour.
+
 Chosen approach: **Option 1 (a self-expiring "press-in-flight" guard)**,
 delivered through **two shared primitives** on `QsCardBase`:
 

--- a/docs/stories/QS-271.story.md
+++ b/docs/stories/QS-271.story.md
@@ -1,0 +1,437 @@
+# QS-271 — Car card buttons drop taps on mobile/iOS
+
+> Story label: **v3** · Next phase: **implement-task**
+
+## Problem
+
+The QS Lovelace cards (notably `qs-car-card`) **drop taps on mobile**,
+worst on iPhone/iOS Safari — a button often needs several presses before
+the action registers. The retry behaviour also makes accidental presses
+plausible (surfaced while investigating #270, where a legitimate-but-
+repeated `qs_next_car_charge_add_default` tap looked unexpected).
+
+**Root cause (confirmed in code).** Every HA `hass` state push runs
+`set hass` → `_render()` → `this._root.innerHTML = …`, which **destroys
+and rebuilds every button DOM node**:
+
+- `qs-car-card.js:797-802` — `set hass` calls `_render()` on each push,
+  guarded only by `_isInteracting / _isInteractingCharger /
+  _isInteractingPerson / _modalOpen / _isInteractingTarget`.
+- `qs-card-base.js:123-129` — the base `set hass` (inherited by the five
+  duration cards) has the same shape with `_isInteractingMode /
+  _modalOpen / _isInteractingTarget`.
+- `qs-car-card.js:1352` / each card's `_render()` — full `innerHTML`
+  rewrite.
+
+Those guards are set **only** during select / slider / time-picker
+interactions. A **plain button tap sets none of them**, so a push landing
+between `pointerdown` and the synthesized `click` / `touchend` tears the
+node out mid-tap. iOS Safari's ~300 ms synthetic-click delay makes the
+race hit far more often. The existing dual `click` + `touchend`
+mitigation (documented at `qs-car-card.js:1635-1640`) does not help when
+the re-render lands *before* the handler fires on the live node.
+
+The deeper cause is structural: button wiring is **scattered and
+inconsistent** — some sites set interaction guards, some do not; the dual
+`click` + `touchend` boilerplate is copy-pasted across ~9 sites with
+subtle per-site variations. A point fix leaves the same trap for the next
+button added later.
+
+## Goal
+
+Stop a `hass` push from re-rendering a card out from under an in-flight
+tap, for **every tappable action control** on **every** QS card — and
+prevent the bug class from recurring when new buttons are added later.
+The fix must live in the shared plumbing (`shared/qs-card-base.js`) so all
+cards benefit, not just the car card.
+
+This is an **authorized JS-card change** — issue #271 carries the
+explicit instruction that overrides the standard "don't modify JS cards
+without explicit instruction" rule.
+
+## Design
+
+Chosen approach: **Option 1 (a self-expiring "press-in-flight" guard)**,
+delivered through **two shared primitives** on `QsCardBase`:
+
+- `_armPressGuard(el)` — the low-level primitive that arms the guard on
+  `pointerdown` + `touchstart` (passive). Used directly on controls that
+  keep their own activation handler (the native-`<select>` pills).
+- `_wireTap(el, action, opts)` — the full button-wiring **chokepoint** for
+  plain action buttons; it calls `_armPressGuard(el)` internally and owns
+  the `touchend` / `click` / keyboard binding.
+
+Rejected alternatives:
+- **Option 2 (diff / targeted DOM update)** — rewrites all six cards'
+  `_render()`; large regression surface, out of scope.
+- **Option 3 (debounce / coalesce renders)** — non-deterministic; a tap
+  can still coincide with a debounced render.
+
+### Why a timestamp window, not a boolean
+
+A plain boolean set on `pointerdown` and cleared on `touchend`/`pointerup`
+would **wedge rendering forever** when the node is destroyed before the
+up-event fires — which is exactly this bug. So the guard is a **timestamp
+window** that auto-expires (self-healing): it blocks re-render for a
+bounded window around the tap, then expires on its own.
+
+**No state is dropped.** Both `set hass` overrides already assign
+`this._hass = hass` **before** the interaction gate (`qs-card-base.js:124`,
+`qs-car-card.js:798`) — the gate only skips the `_render()` repaint, never
+the state store. So the latest state is always retained; the guard merely
+defers *painting* by at most the guard window.
+
+**What the freeze does and does not affect.** A tap defers the card's
+**discrete-value repaint** (SOC %, power text, target label) for at most
+the guard window — the same whole-card behaviour the existing
+`_isInteracting*` guards already have during a select/drag interaction.
+The **RAF animation loop is independent of `_render()`** (it animates the
+electron-soup / wave / flame layers from accumulators set at the last
+render and does not re-read `hass`), so visuals keep moving during the
+freeze. Discrete values refresh on the next `hass` push — state polling
+runs ≈ every 4 s, and a tap that calls a service typically triggers its
+own state push shortly after. No explicit flush-render is therefore
+needed; this matches existing guard semantics.
+
+### The two primitives
+
+New on `QsCardBase` (`custom_components/quiet_solar/ui/resources/shared/qs-card-base.js`):
+
+```js
+// PRESS_GUARD_MS — render-defer window around a tap. Sized to cover iOS
+// Safari's ~300 ms synthetic-click delay plus margin for the handler to
+// fire and the service call to begin. Non-exported module const at the
+// top of the file (matching the RING_BOTTOM_CARVE_* const style). Tests
+// pin the NAME and a >= 300 lower bound; the exact value is user-tunable.
+const PRESS_GUARD_MS = 600;
+
+// SYNTHETIC_CLICK_MS — window within which a `click` is treated as the
+// OS-synthesized twin of a just-fired `touchend` (and therefore ignored).
+// Deliberately SEPARATE from PRESS_GUARD_MS: it must NOT throttle genuine
+// rapid re-taps, only dedupe the single synthetic click per physical tap.
+const SYNTHETIC_CLICK_MS = 350;
+
+_isPressInFlight() { return Date.now() < this._pressInFlightUntil; }
+
+_armPressGuard(el) {
+  if (!el) return;
+  const begin = () => { this._pressInFlightUntil = Date.now() + PRESS_GUARD_MS; };
+  el.addEventListener('pointerdown', begin, { passive: true });
+  el.addEventListener('touchstart', begin, { passive: true });
+}
+
+_wireTap(el, action, { keyboard = true, stopPropagation = true } = {}) {
+  if (!el) return;
+  el.style.pointerEvents = 'auto';
+  this._armPressGuard(el);
+  let lastTouchEnd = 0;
+  // touchend: NON-passive (no passive option) so preventDefault can
+  // suppress the OS's delayed synthetic click; fires the action
+  // immediately and records the time.
+  el.addEventListener('touchend', (ev) => {
+    if (stopPropagation) ev.stopPropagation();
+    ev.preventDefault();
+    lastTouchEnd = Date.now();
+    action();
+  });
+  // click: ignore ONLY the synthetic twin that follows a real touchend.
+  // Genuine mouse/synthesized clicks (no recent touchend) still fire, and
+  // rapid genuine re-taps are NOT throttled — only the per-tap synthetic
+  // twin is dropped (event-aware dedup, not a blanket time latch).
+  el.addEventListener('click', (ev) => {
+    if (stopPropagation) ev.stopPropagation();
+    ev.preventDefault();
+    if (Date.now() - lastTouchEnd < SYNTHETIC_CLICK_MS) return;
+    action();
+  });
+  if (keyboard) this._registerKeyActivation(el, action);
+}
+```
+
+- `_pressInFlightUntil` is initialized to `0` and reset to `0` in the base
+  `disconnectedCallback` (`qs-card-base.js:104-114`, the S7
+  interaction-flag-reset pattern). Verified: every card override
+  (`qs-car-card.js:745`, `qs-climate-card.js:593`, plus pool / radiator /
+  water-boiler) calls `super.disconnectedCallback()`, so the reset runs
+  everywhere. (Non-critical anyway — the window auto-expires and the
+  `lastTouchEnd` closure is recreated with each node.) An `innerHTML`
+  rewrite of a child does **not** fire `disconnectedCallback` on the card
+  element, so the reset cannot clear an in-flight guard mid-tap.
+- The three `set hass` overrides gate on `|| this._isPressInFlight()`:
+  base (`qs-card-base.js:127`), car (`qs-car-card.js:800`), and climate
+  (`qs-climate-card.js:632`). Verified these are the **only** three
+  overrides — pool / radiator / on-off-duration / water-boiler inherit the
+  base `set hass`, so gating the base line covers them for free. Climate is
+  gated because it has a guarded tappable control (its `stateOnPill`, armed
+  via `_armPressGuard`) plus the inherited override / reset buttons.
+
+### Routing every tappable action control
+
+**Plain action buttons → `_wireTap`.** The refactor **replaces** each
+site's existing `click` + `touchend` (+ `_registerKeyActivation`) lines
+with a single `_wireTap(...)` call — it does **not** add `_wireTap`
+alongside the old bindings. After the refactor, no raw element-level
+`touchend` remains in these helpers, which is what makes the chokepoint
+test (below) self-enforcing. Each call passes `keyboard` /
+`stopPropagation` to match the site's current behaviour:
+
+- `shared/qs-card-base.js` wire-helpers: `_wireTimePicker` (L655-658),
+  `_wireResetButton` (L688-689, `keyboard: false` — native `<button
+  id="reset">` is keyboard-native, per the existing N6 note),
+  `_wirePowerButton` (L715-718, `stopPropagation: false`),
+  `_wireGreenButton` (L742-745, `stopPropagation: false`).
+- `shared/qs-ring-duration-base.js`: `_wireOverrideButton` (L110-111,
+  `stopPropagation: true` — it must not bubble into ring/center handlers).
+- `custom_components/quiet_solar/ui/resources/qs-car-card.js` inline
+  buttons, by real variable name (each replaces a 2-3 line click/touchend
+  (+ key) block): `rbtn` (rabbit, L1688-1691, `keyboard: true`,
+  `stopPropagation: true`), `forceBtn` (L1754-1755, `keyboard: false`),
+  `schedBtn` (schedule_inline, L1777-1778, `keyboard: false`), `socEl`
+  (soc_pct, L1823-1825, `keyboard: true`, `stopPropagation: true`).
+
+`stopPropagation` rationale: the car inline buttons and the override
+button sit inside the ring/center and rely on `stopPropagation` so a tap
+does not bubble into ring/center handlers; `_wirePowerButton` /
+`_wireGreenButton` keep `stopPropagation: false` to preserve their current
+behaviour (no parent delegation relied upon).
+
+**Native-`<select>` pills → `_armPressGuard` only.** Keep each pill's
+existing `click` → `showPicker()` handler (and its
+`ev.target.tagName === 'SELECT'` re-entry guard); add `_armPressGuard(pill)`
+as a *separate* listener pair.
+
+- `qs-car-card.js`: `personPill` (L1556-1562), `chargerPill` (L1584-1590).
+- `qs-climate-card.js`: `stateOnPill` (L1400-1406).
+- `shared/qs-ring-duration-base.js`: `modePill` (L159-165).
+
+**Pill rationale (why `_armPressGuard`, not `_wireTap`).** A pill's tap is
+*click-only* and merely opens the native `<select>` picker; the actual
+write happens later on the `<select>`'s `change` event (already
+`_isInteracting*`-guarded). On mobile, the synthesized `click` fires
+~300 ms after `touchend`; if a `hass` push re-renders the card in that
+window the pill node is destroyed and the **opening tap is lost**.
+`_armPressGuard` defers the render across that window so the existing
+click→`showPicker` survives — which is exactly and only what the pill
+needs. Routing a pill through `_wireTap` would be **wrong**: its
+`preventDefault` on `touchend`/`click` and its synthetic-click dedup could
+interfere with the native `<select>` opening and double-handle the
+`SELECT`-target re-entry case. The arming listeners are `{passive: true}`,
+so they can never `preventDefault` and never interfere with the picker.
+
+**Left unchanged (already safe):**
+
+- `_showDialog` modal action buttons (`qs-card-base.js:328-333`) — already
+  protected by `_modalOpen` (no re-render while a dialog is open) and
+  already carry the per-button `activated` double-fire latch + N13
+  try/finally. Rewiring would be consistency-only churn with no
+  correctness gain. (The chokepoint test whitelists this one site.)
+- `_wireTargetHandle` ring drag (`qs-card-base.js`, incl. its legacy
+  `document`-level `touchend` at L548) — already sets `_isInteractingTarget`.
+- The select / time-picker `change` / `focus` / `blur` handlers — already
+  set `_isInteracting*`.
+
+**Dropped from scope (v2 → v3).** The car `.chip[data-pct]` quick-percent
+chips, briefly added in v2, are **dead code**: only a CSS rule
+(`qs-car-card.js:1117`) and a reader handler (`L1885`) reference `.chip`;
+**no code ever emits chip markup**, so `querySelectorAll('.chip[data-pct]')`
+matches zero elements and the handler never runs. Routing dead code through
+`_wireTap` would wire nothing and a source-text test for it would assert
+nothing observable. Removed. (That chips are defined-but-never-rendered is
+a separate latent oddity, out of scope for QS-271.)
+
+### Enforcing the chokepoint going forward
+
+A regression test asserts that every **element-level**
+`addEventListener('touchend'…)` binding in the card files lives inside one
+of the allowlisted shared sites — `_wireTap`, `_wireTargetHandle` (its
+legacy `document`-level `touchend`), and `_showDialog` (its latch-bearing
+modal buttons). Because the refactor *replaces* the raw bindings in the
+wire-helpers and the four car inline sites with `_wireTap` calls, the only
+surviving `touchend` registrations post-refactor are inside those three
+methods — so the test passes and any *future* raw element-level `touchend`
+fails the gate. The test pins the `_showDialog` `touchend` occurrence count
+(currently one) so a new bare `touchend` added elsewhere in `_showDialog`
+is still caught. This mirrors the existing
+`test_no_card_reintroduces_whole_card_disabled_greyer` convention.
+
+**Scope limitation (documented honestly):** the canary is `touchend`-only.
+It deliberately does **not** forbid bare `addEventListener('click'…)`,
+because legitimate click-only handlers exist that are not the bug surface
+(the pills' `showPicker` handlers, `<select>` `change` handlers) and a
+source-text rule cannot distinguish a click-only *action* button from
+those without false positives. So a future *click-only* action button
+could still slip past — the canary catches the dominant dual-binding
+pattern, not every conceivable case.
+
+### Scope note (deliberate, for the scope-guardian)
+
+This is intentionally a refactor beyond the minimal point fix. It is the
+explicit user direction — "be sure all clicks and buttons everywhere work
+better … shared across the cards and future-proof." The `_wireTap`
+chokepoint plus the `_armPressGuard` primitive give a single guarantee
+that the guard cannot be forgotten on a new button, and the regression
+test makes that enforceable. The refactor is bounded (the codebase already
+funnels most wiring into the two shared base files), and modal buttons —
+which do not drop taps — are explicitly excluded to avoid consistency-only
+churn. This is a conscious decision, not creep.
+
+### Testing reality
+
+The JS cards are **outside the executable test pipeline** (no JS test
+harness, no JS linter, no build step — see
+`docs/agents/concepts/dashboard-and-cards.md` "the cards are outside the
+quality pipeline", a documented KNOWN GAP). Tests are therefore
+**source-text / structural assertions** in
+`tests/test_dashboard_rendering.py`, matching the established convention
+(e.g. `test_card_mode_change_wrapped_in_try_finally`,
+`test_no_card_reintroduces_whole_card_disabled_greyer`). We do **not**
+introduce a jsdom/JS harness — that is a large infrastructure investment
+out of scope for this bug; the timing race itself is verified by a manual
+iOS-Safari smoke test (steps below). There are **no Python production-code
+changes**, so full-suite coverage is unaffected, and under the UI fast
+path coverage is not measured at all.
+
+**Manual smoke test (the only verification of the actual race):** on an
+iPhone (iOS Safari or the HA companion app), open a QS car card receiving
+regular updates (car charging, SOC ticking). Rapidly tap the inside-disc
+buttons (time / sun / rabbit), the person/charger pills, and the inline
+force/schedule/SOC controls ~once per second for ~30 s each; every tap
+should register on the first press. Repeat on a duration card (pool /
+radiator) for the inherited override / reset / mode-pill controls.
+
+**Quality-gate scope (verified against `scripts/qs/quality_gate.py`).**
+`docs/` and the `.md` extension are dev-only patterns; JS under
+`ui/resources/` is a UI asset; `tests/*.py` is captured as a changed-test
+file. With this file set, `_detect_scope` returns **`ui-only`**, running
+`tests/test_dashboard_rendering.py` plus any changed test files (skipping
+ruff / mypy / translations / full coverage). The new tests live in
+`test_dashboard_rendering.py` (the fast-path file itself), so they run. No
+`strings.json` / translations impact. The harness-sync rule does not apply
+(no `.<harness>/agents/*.md` files touched).
+
+## Acceptance criteria
+
+1. `QsCardBase` defines non-exported module consts `PRESS_GUARD_MS` and
+   `SYNTHETIC_CLICK_MS`, an `_isPressInFlight()` method, an
+   `_armPressGuard(el)` method that arms the guard on **both**
+   `pointerdown` and `touchstart` with `{passive: true}`, and a
+   `_wireTap(el, action, opts)` method that: sets `pointer-events: auto`,
+   calls `_armPressGuard(el)`, binds a **non-passive** `touchend` that
+   fires `action` and records `lastTouchEnd`, binds a `click` that fires
+   `action` **unless** within `SYNTHETIC_CLICK_MS` of the last `touchend`
+   (event-aware synthetic-click dedup, not a blanket throttle), applies
+   `preventDefault` on both and optional `stopPropagation`, and optionally
+   registers keyboard activation.
+2. All three `set hass` overrides — `qs-card-base.js`, `qs-car-card.js`,
+   `qs-climate-card.js` — gate re-render on `_isPressInFlight()`, and each
+   still assigns `this._hass` before the gate.
+3. Every plain-action button wires through `_wireTap`, with its raw
+   `click`/`touchend` bindings **removed**: the four base wire-helpers
+   (`_wireTimePicker`, `_wireResetButton`, `_wirePowerButton`,
+   `_wireGreenButton`), `_wireOverrideButton` (ring-duration base), and the
+   four car inline buttons (`rbtn`, `forceBtn`, `schedBtn`, `socEl`).
+4. The native-`<select>` pills (`personPill`, `chargerPill` in car,
+   `stateOnPill` in climate, `modePill` in ring-duration base) add
+   `_armPressGuard` while keeping their existing click→`showPicker`
+   handler.
+5. `_showDialog` modal buttons are **unchanged**.
+6. `disconnectedCallback` (base) resets `_pressInFlightUntil` to `0`.
+7. A regression test asserts every element-level `addEventListener('touchend'`
+   in the card files lives inside `_wireTap` / `_wireTargetHandle` /
+   `_showDialog`, and pins the `_showDialog` occurrence count.
+8. `tests/test_dashboard_rendering.py` pins AC 1-7 via source-text
+   assertions (tolerant of single/double quotes and whitespace), including:
+   `PRESS_GUARD_MS` exists with a `>= 300` numeric lower bound,
+   `SYNTHETIC_CLICK_MS` exists, the `touchend` listener in `_wireTap` is
+   non-passive, and the three `set hass` overrides contain
+   `_isPressInFlight`. The quality gate passes via the `ui-only` fast path;
+   100% coverage is unaffected (no Python production changes).
+
+## Task breakdown
+
+1. **`custom_components/quiet_solar/ui/resources/shared/qs-card-base.js`**
+   — add `PRESS_GUARD_MS`, `SYNTHETIC_CLICK_MS`, `_isPressInFlight`,
+   `_armPressGuard`, `_wireTap` (event-aware synthetic-click dedup,
+   non-passive `touchend`); initialize `_pressInFlightUntil` and reset it
+   in `disconnectedCallback`; gate base `set hass` on `_isPressInFlight`;
+   **replace** the raw bindings in `_wireTimePicker` / `_wireResetButton` /
+   `_wirePowerButton` / `_wireGreenButton` with `_wireTap` calls. **Leave
+   `_showDialog` unchanged.**
+2. **`custom_components/quiet_solar/ui/resources/shared/qs-ring-duration-base.js`**
+   — replace `_wireOverrideButton`'s raw bindings with a `_wireTap` call;
+   add `_armPressGuard(modePill)`.
+3. **`custom_components/quiet_solar/ui/resources/qs-car-card.js`** — gate
+   `set hass` on `_isPressInFlight`; replace `rbtn` / `forceBtn` /
+   `schedBtn` / `socEl` raw bindings with `_wireTap` calls; add
+   `_armPressGuard(personPill)` and `_armPressGuard(chargerPill)`.
+4. **`custom_components/quiet_solar/ui/resources/qs-climate-card.js`** —
+   gate `set hass` on `_isPressInFlight`; add `_armPressGuard(stateOnPill)`.
+5. **`tests/test_dashboard_rendering.py`** — add source-text AC tests with
+   concrete names, e.g. `test_card_base_defines_press_guard_primitives`
+   (asserts `_armPressGuard(`, `_wireTap(`, `_isPressInFlight`,
+   `PRESS_GUARD_MS` with `>= 300`, `SYNTHETIC_CLICK_MS`),
+   `test_wire_tap_touchend_is_non_passive`,
+   `test_all_set_hass_overrides_gate_on_press_in_flight`,
+   `test_wire_helpers_and_inline_buttons_route_through_wire_tap`,
+   `test_select_pills_arm_press_guard`,
+   `test_disconnected_callback_resets_press_guard`,
+   `test_no_card_uses_bare_touchend_outside_shared_helpers` (allowlist +
+   `_showDialog` count pin). Use quote/whitespace-tolerant matching.
+6. **`docs/agents/concepts/dashboard-and-cards.md`** — document the
+   press-in-flight guard + `_armPressGuard` / `_wireTap` chokepoint (and
+   the `_armPressGuard`-only pill treatment) under "Hardened JS-card
+   patterns (QS-194 review-fix #03)"; set `last_verified: 2026-06-17`.
+   (Required — the drift checker flags this doc as the `covers:` owner of
+   the touched JS files.)
+
+## Doc maintenance
+
+`scripts/qs/check_doc_drift.py` flags
+`docs/agents/concepts/dashboard-and-cards.md` (stale; `covers:`
+`qs-car-card.js`, `qs-climate-card.js`, `qs-card-base.js`). → Task 6
+updates it. No other docs are surfaced.
+
+## Adversarial Review Notes
+
+### Round 1 — 4 global reviewers (critic, concrete-planner, dev-proxy, scope-guardian)
+
+**Accepted → folded into story v2:**
+
+- `resolved` [concrete · critical] Card file paths were bare/ambiguous → fully-qualified (cards under `ui/resources/`, not `shared/`).
+- `superseded` [concrete · critical] "Route `.chip[data-pct]` chips through `_wireTap`" → added in v2, then **reversed in round 2** (the chips are dead code; never rendered). Removed in v3. See round 2.
+- `resolved` [concrete · critical] Native-`<select>` pills lose the opening tap → covered via new `_armPressGuard` primitive (AC4).
+- `resolved` [scope-guardian · redesign] `_showDialog` modal-button rewiring was consistency-only churn → dropped; modal buttons unchanged (AC5).
+- `resolved` [critic · critical] Double-fire risk → latch added in `_wireTap` (v2), then redesigned event-aware in v3 (see round 2).
+- `resolved` [critic · critical/clarify] Guard "drops state" / RAF assumption → clarified: `this._hass` stored before the gate (no drop); RAF independent of `_render`; documented.
+- `resolved` [critic · redesign] `PRESS_GUARD_MS` magic number → derivation documented; v3 adds a `>= 300` test lower bound.
+- `resolved` [dev-proxy · critical] UI fast-path triggering → verified against `quality_gate.py` (scope `ui-only`).
+- `resolved` [dev-proxy/concrete · improve] Test-spec precision → concrete test names, quote/whitespace-tolerant matching, `last_verified: 2026-06-17`, real inline-button variable names.
+- `resolved` [dev-proxy · improve] `disconnectedCallback` vs innerHTML → noted; v3 also verified subclasses call `super`.
+
+**Rejected (round 1):** "Drop `_wireTap`, use only `_armPressGuard`" (user chose the chokepoint; synthesized — kept both); "don't gate climate `set hass`" (climate has guarded controls); "source-text tests are theater / add jsdom" (no JS harness by design — KNOWN GAP); "extend chokepoint to click/pointerdown" (false-positives); "try/finally + opt-in pointer-events in `_wireTap`" (actions own errors; matches existing helpers).
+
+### Round 2 — 4 global reviewers + delta-auditor (on the v1→v2 diff)
+
+**Accepted → folded into story v3:**
+
+- `resolved` [concrete · critical] **Percent chips are dead code** (`.chip[data-pct]` matches zero rendered elements) → reverses the round-1 chip finding; all chip work dropped from design / AC3 / task 3. Verified in code.
+- `resolved` [critic + delta-auditor · critical] Single-fire latch reused `PRESS_GUARD_MS` (600 ms) as an inter-tap throttle, dropping genuine rapid re-taps → redesigned **event-aware** with a separate `SYNTHETIC_CLICK_MS` (~350 ms): `touchend` fires + records time, `click` ignores only its synthetic twin; genuine re-taps and desktop clicks unaffected (AC1).
+- `resolved` [concrete · critical] Chokepoint allowlist would fail unless the wire-helpers' raw `touchend` is **replaced** (not augmented) by `_wireTap` → made explicit in design/AC3/tasks; post-refactor only `_wireTap`/`_wireTargetHandle`/`_showDialog` retain `touchend`.
+- `resolved` [dev-proxy + critic · improve] `_wireTap`'s `touchend` must be **non-passive** (so `preventDefault` works) while `_armPressGuard` listeners are `{passive:true}` → stated + asserted (AC1, AC8, task 5).
+- `resolved` [concrete + delta-auditor + scope-guardian · clarify] Precise **pill rationale** (click-only tap lost via synthetic click; `_armPressGuard` defers render so click→`showPicker` survives; `_wireTap` would be wrong; passive arming can't interfere with native picker) → documented.
+- `resolved` [critic · improve] `PRESS_GUARD_MS` could be silently lowered → test asserts a `>= 300` lower bound (AC8, task 5).
+- `resolved` [critic · redesign/clarify] Whole-card freeze for the window → acknowledged (matches `_isInteracting*` semantics); RAF wording made precise.
+- `resolved` [critic · clarify] `stopPropagation:false` for power/green → rationale documented (preserve current behaviour; car/override buttons use `true` to avoid bubbling).
+- `resolved` [delta-auditor · improve] Chokepoint test pins the `_showDialog` `touchend` occurrence count so a new bare one elsewhere is caught (AC7, task 5).
+- `resolved` [dev-proxy · clarify] List literal asserted substrings → enumerated in task 5.
+- `resolved` [critic · improve] Manual smoke-test repro steps documented.
+- `verified` [concrete] Only three `set hass` overrides exist (water-boiler inherits base); all `disconnectedCallback` overrides call `super`. Confirmed in code.
+
+**Rejected (round 2):**
+
+- `rejected` [critic · improve] Stronger chokepoint (forbid bare `click` / assert every service closure uses `_wireTap`). — not robustly expressible via source-text; brittle / false-positives on pills + `<select>` `change` handlers. Touchend canary + documented limitation kept (scope-guardian concurred it is appropriately scoped).
+- `rejected` [scope-guardian · improve] "`_armPressGuard` is one primitive too many." — pills genuinely need guard-without-activation; scope-guardian called it borderline/defensible. Kept with documented rationale.
+
+**Delta-auditor resolution check:** 8/10 round-1 findings fully resolved by v2; #3 (pills) upgraded to fully resolved in v3 via the documented rationale; #5 (latch) resolved in v3 via the event-aware redesign. The one genuinely new defect the v2 edits introduced (latch window) is fixed in v3.
+
+**State:** open criticals: 0 · changed-since-last-review: true (story v2 → v3; the chip removal + latch redesign + chokepoint "replace" clarification are post-review edits).

--- a/docs/stories/QS-271.story_review_fix_#01.md
+++ b/docs/stories/QS-271.story_review_fix_#01.md
@@ -1,0 +1,126 @@
+# QS-271 — Review fix plan #01
+
+## Summary
+- Source PR: #273
+- Source story: docs/stories/QS-271.story.md
+- Findings to fix: 8 (3 should-fix, 5 nice-to-have)
+- Next implement phase: `/implement-task`
+
+> CodeRabbit was unavailable for this round (rate-limited / out of credits,
+> zero findings). The three manual reviewers covered the same files. An
+> optional re-review can pull CodeRabbit's pass on the next `/review-task`.
+
+## Findings to fix
+
+### [should-fix] S1 — `_wireTap` adds unconditional `preventDefault()` on click
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js` (`_wireTap`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: Power/green buttons previously bound a bare
+  `addEventListener('click', togglePower)` with no `preventDefault`. Routing
+  them through `_wireTap` silently adds `ev.preventDefault()` on every click —
+  a behavioral change not covered by the `stopPropagation` option.
+- Proposed fix: Gate the click-path `preventDefault()` behind a `_wireTap`
+  option (e.g. `preventDefaultClick`, default preserving today's behavior for
+  the buttons that already relied on it) OR confirm via the affected buttons
+  that no native default matters and document that explicitly. Add/extend a
+  source-text test pinning the chosen contract so the asymmetry can't silently
+  regress. Touchend's `preventDefault` (needed to suppress the synthetic click)
+  stays unconditional.
+
+### [should-fix] S2 — double-fire if synthetic click lands after `SYNTHETIC_CLICK_MS`
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js` (`_wireTap`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: Both `touchend` and the synthetic `click` invoke `action()`,
+  deduped only by the hardcoded `SYNTHETIC_CLICK_MS` (350 ms) window recorded
+  in `lastTouchEnd`. On a slow device whose synthetic click arrives later than
+  that window, `action()` fires twice. `PRESS_GUARD_MS` has a `>= 300`
+  lower-bound test; `SYNTHETIC_CLICK_MS` has no guard test.
+- Proposed fix: Make the dedup robust — either widen/justify
+  `SYNTHETIC_CLICK_MS` with a documented rationale and a lower-bound source
+  test, or switch to a one-shot latch (consume the next synthetic click after a
+  touchend rather than relying purely on a time window). Add a regression test
+  asserting the dedup contract (single `action()` per tap, and the bound's
+  lower limit).
+
+### [should-fix] S3 — `_isPressInFlight` uses non-monotonic `Date.now()`
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js`
+  (`_isPressInFlight`, `_armPressGuard`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The guard compares `Date.now() < this._pressInFlightUntil`. A
+  backward wall-clock step (NTP correction, manual change, DST/timezone
+  re-sync on mobile) while a press is in flight keeps `_isPressInFlight()` true
+  for the full magnitude of the jump (potentially minutes), silently dropping
+  every `hass` push (`set hass` returns before `_render()`) and freezing the
+  card's discrete values. The story's "self-healing / auto-expires" guarantee
+  assumes monotonic time, which `Date.now()` is not.
+- Proposed fix: Use a monotonic clock (`performance.now()`) for arming and
+  checking the guard window so backward wall-clock steps cannot wedge
+  rendering. Keep `disconnectedCallback` reset semantics. Add a test that the
+  guard expires within `PRESS_GUARD_MS` of arming regardless of wall-clock
+  movement (or at minimum that the monotonic source is used).
+
+### [nice-to-have] N1 — initialize `_pressInFlightUntil` in the constructor
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `_pressInFlightUntil` is only assigned in `disconnectedCallback`
+  (= 0) and inside `_armPressGuard`. First-call safety relies on the defensive
+  `(this._pressInFlightUntil || 0)` in `_isPressInFlight()`.
+- Proposed fix: Initialize the field in the constructor/`connectedCallback` for
+  clarity (defensive `|| 0` may remain).
+
+### [nice-to-have] N2 — comment why `preventDefault` is unconditional
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js` (`_wireTap`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `stopPropagation` is option-gated while `preventDefault` is
+  always-on; the asymmetry is easy to misread.
+- Proposed fix: Add a brief comment explaining the rationale (resolve jointly
+  with S1's chosen contract).
+
+### [nice-to-have] N3 — tracked follow-up for the touchend-only canary gap
+- File: `docs/agents/concepts/dashboard-and-cards.md` /
+  `tests/test_dashboard_rendering.py`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The regression canary is `touchend`-only by design; a future
+  click-only action button could slip past it (acknowledged in the doc).
+- Proposed fix: Record an explicit tracked follow-up (issue reference or doc
+  TODO) so the gap is not lost; optionally extend the canary to cover
+  click-only bindings.
+
+### [nice-to-have] N4 — disabled control still arms the render-defer guard
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js`
+  (`rbtnAction` and the other inline buttons via `_wireTap`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `_armPressGuard` fires on `pointerdown`/`touchstart`
+  unconditionally, but the action early-returns when `.disabled`. So tapping a
+  disabled control defers the next repaint by up to `PRESS_GUARD_MS` for no
+  benefit (auto-expires; low impact).
+- Proposed fix: Skip arming (or short-circuit the guard) when the control is in
+  a `.disabled` state, so no-op taps don't defer repaints.
+
+### [nice-to-have] N5 — no terminal flush render when the guard window expires
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js`
+  (`_wireTap` / press-guard lifecycle)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Unlike the `_isInteracting*` guards (which call `_render()` on
+  blur/change/timer-clear), the press guard has no catch-up flush. If exactly
+  one `hass` push lands inside the window and none follows, the dropped repaint
+  isn't replayed until the next organic push (~4 s). Acknowledged story
+  tradeoff; the divergence from every other guard is the concern.
+- Proposed fix: On guard expiry, schedule a single catch-up `_render()` if a
+  `hass` push was dropped during the window (mirroring the other guards'
+  flush), or document explicitly why no flush is warranted.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.
+</content>
+</invoke>

--- a/docs/stories/QS-271.story_review_fix_#02.md
+++ b/docs/stories/QS-271.story_review_fix_#02.md
@@ -1,0 +1,102 @@
+# QS-271 — Review fix plan #02
+
+## Summary
+- Source PR: #273
+- Source story: docs/stories/QS-271.story.md
+- Findings to fix: 5 (1 must-fix, 1 should-fix, 3 nice-to-have)
+- Next implement phase: `/implement-task`
+
+> Round-2 re-review after fix plan #01 (commit `517c54ac`). The prior
+> should-fix items (S1 click-preventDefault gating, S2 dedup, S3 monotonic
+> clock) and nice-to-haves (N1 init, N4 disabled-skip, N5 catch-up flush) are
+> all RESOLVED and pinned by tests. CodeRabbit produced no findings (its
+> incremental engine treats the commits as already reviewed from the earlier
+> rate-limited run; a fresh commit will reset its baseline for a future pass).
+
+## Findings to fix
+
+### [must-fix] M1 — doc drift on `dashboard-and-cards.md` not re-verified
+- File: `docs/agents/concepts/dashboard-and-cards.md` (and/or PR #273 body)
+- Severity: must-fix
+- Source: orchestrator doc-maintenance audit (`check_doc_drift.py` exits 1)
+- Description: The review-fix commit `517c54ac` changed docs-tracked source
+  (`shared/qs-card-base.js`, `qs-car-card.js`, `qs-climate-card.js`,
+  `shared/qs-ring-duration-base.js`) — introducing the monotonic
+  `performance.now()` guard, the `swallowNextClick` one-shot latch + lower-bound
+  `SYNTHETIC_CLICK_MS`, the `_pressGuardFlushTimer` catch-up render, the
+  `preventDefaultClick` option, and the disabled-skip — but
+  `docs/agents/concepts/dashboard-and-cards.md` (`last_verified=2026-06-17`)
+  was not re-verified, and the PR body carries no `## Doc maintenance` heading.
+- Proposed fix: Update `docs/agents/concepts/dashboard-and-cards.md` to describe
+  the hardened press-in-flight guard design and bump its `last_verified`
+  date so `check_doc_drift.py` exits 0 — OR, if the doc already covers the
+  behavior at the right level of abstraction, re-verify it and add a
+  `## Doc maintenance` justification to the PR body. Re-run
+  `python scripts/qs/check_doc_drift.py` against the changed source files and
+  confirm exit 0.
+
+### [should-fix] S1 — `swallowNextClick` one-shot latch can stay stuck `true`
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js`
+  (`_wireTap`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter (new this round)
+- Description: `swallowNextClick` is set `true` on every `touchend`, but
+  touchend's unconditional `preventDefault()` normally suppresses the synthetic
+  `click`, so the latch is never consumed and stays stuck `true`. A subsequent
+  *unrelated* genuine click (hybrid touch+mouse device, programmatic `.click()`,
+  assistive tech) would then be silently swallowed. The `SYNTHETIC_CLICK_MS`
+  window is doing the real dedup; the never-cleared latch is a latent
+  false-swallow.
+- Proposed fix: Expire/clear the latch on the same `SYNTHETIC_CLICK_MS` window
+  (e.g. only honor `swallowNextClick` when the click lands within
+  `SYNTHETIC_CLICK_MS` of `lastTouchEnd`, otherwise treat it as a genuine
+  click and reset the latch). Add a regression test asserting a genuine click
+  arriving after the window is NOT swallowed.
+
+### [nice-to-have] N1 — disabled-skip checks own element, not card-level ancestor
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js`
+  (`_armPressGuard.begin`), `custom_components/quiet_solar/ui/resources/qs-car-card.js`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (merged)
+- Description: `_armPressGuard.begin()` skips arming based on `aria-disabled` /
+  `.disabled` on the control's own element, but the inline car action handlers
+  gate on the card-level `.disabled` ancestor
+  (`this._root?.querySelector('.disabled')`). A future inline action button
+  rendered WITHOUT its own `aria-disabled`/`.disabled` (relying solely on the
+  card-level gate) would still arm the guard on a disconnected card and defer
+  the next repaint for a no-op action. Latent today — all current controls
+  carry `aria-disabled`.
+- Proposed fix: Also consult the card-level `.disabled` ancestor in the
+  arm-time skip (or document that controls must reflect disabled state on their
+  own node). Self-healing either way; low priority.
+
+### [nice-to-have] N2 — comment the intentional double-arm
+- File: `custom_components/quiet_solar/ui/resources/shared/qs-card-base.js`
+  (`_armPressGuard`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `begin()` runs for both `pointerdown` and `touchstart`, which
+  both fire on touch, so `begin` executes twice per tap. It is idempotent
+  (coalesced timer, same timestamp), but the intent isn't obvious.
+- Proposed fix: Add a brief comment noting the intentional, idempotent
+  double-arm.
+
+### [nice-to-have] N3 — main story body reads stale vs merged code
+- File: `docs/stories/QS-271.story.md`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The committed story still shows pre-hardening pseudocode
+  (`Date.now()`, time-only dedup, no `swallowNextClick` / `performance.now()` /
+  `preventDefaultClick`). The shipped code uses the review-fix design. The
+  divergence is captured in the fix-plan files, but the main story body reads
+  stale relative to the merged code.
+- Proposed fix: Add a short note/pointer in the story body indicating the
+  press-guard implementation was hardened per the review-fix plans (or update
+  the pseudocode to match), so the story isn't misleading.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify (a fresh commit will also reset CodeRabbit's
+incremental baseline for a clean automated pass).
+</content>

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -8776,3 +8776,156 @@ def test_no_card_uses_bare_touchend_outside_shared_helpers():
             "found — route the control through `_wireTap` / `_armPressGuard` "
             "(shared chokepoint) instead."
         )
+
+
+# ---------------------------------------------------------------------------
+# QS-271 review-fix #01 — robustness hardening of the press-in-flight guard.
+# ---------------------------------------------------------------------------
+
+
+def test_wire_tap_click_prevent_default_is_option_gated():
+    """QS-271 fix #01 S1/N2 — `_wireTap` gates the click-path
+    `preventDefault()` behind a `preventDefaultClick` option (default
+    preserves the buttons that relied on it). Power/green buttons —
+    which historically bound a bare `click` with no preventDefault —
+    wire with `preventDefaultClick: false`. touchend's preventDefault
+    stays unconditional (it must suppress the synthetic click)."""
+    base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+    body = _extract_js_function_body(base, r"_wireTap\([^\n]*\)\s*\{")
+    assert body is not None, "could not extract `_wireTap` body."
+
+    # The option exists in the destructured opts (default true). This
+    # lives in the SIGNATURE (param list), not the extracted body.
+    assert re.search(r"_wireTap\([^\n]*preventDefaultClick\s*=\s*true[^\n]*\)\s*\{", base), (
+        "_wireTap must accept `preventDefaultClick` (default true) in its signature."
+    )
+    # The click handler's preventDefault is gated on the option.
+    assert re.search(r"if\s*\(\s*preventDefaultClick\s*\)\s*ev\.preventDefault\(\)", body), (
+        "_wireTap's click `preventDefault()` must be gated on `preventDefaultClick`."
+    )
+
+    # Power and green buttons opt out (preserve their original bare-click
+    # behaviour — no native default suppressed).
+    for helper in ("_wirePowerButton", "_wireGreenButton"):
+        hbody = _extract_js_function_body(base, rf"{helper}\(params\)\s*\{{")
+        assert hbody is not None, f"could not extract `{helper}` body."
+        assert re.search(r"preventDefaultClick\s*:\s*false", hbody), (
+            f"{helper} must wire `_wireTap` with `preventDefaultClick: false`."
+        )
+
+
+def test_wire_tap_uses_one_shot_latch_for_synthetic_click_dedup():
+    """QS-271 fix #01 S2 — the synthetic-click dedup is a one-shot latch
+    (swallow the single click that follows a touchend, regardless of how
+    late it arrives), not a pure time window — so a slow device whose
+    synthetic click lands after SYNTHETIC_CLICK_MS can't double-fire."""
+    base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+    body = _extract_js_function_body(base, r"_wireTap\([^\n]*\)\s*\{")
+    assert body is not None, "could not extract `_wireTap` body."
+
+    # A one-shot latch variable is armed on touchend and cleared on the
+    # swallowed click.
+    assert "swallowNextClick" in body, "_wireTap must use a one-shot latch."
+    assert re.search(r"swallowNextClick\s*=\s*true", body), (
+        "_wireTap must arm the latch (`swallowNextClick = true`) on touchend."
+    )
+    assert re.search(r"swallowNextClick\s*=\s*false", body), (
+        "_wireTap must clear the latch (`swallowNextClick = false`) when the "
+        "synthetic click is swallowed."
+    )
+    # The click handler swallows when the latch is set (independent of the
+    # time window — that stays as a belt-and-suspenders secondary).
+    assert re.search(r"if\s*\(\s*swallowNextClick", body), (
+        "_wireTap's click handler must swallow when the latch is set."
+    )
+
+
+def test_synthetic_click_ms_has_lower_bound():
+    """QS-271 fix #01 S2 — SYNTHETIC_CLICK_MS carries a `>= 300` lower
+    bound (mirrors PRESS_GUARD_MS) so the belt-and-suspenders window
+    can't be silently shrunk below the iOS synthetic-click delay."""
+    executable = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+    m = re.search(r"const\s+SYNTHETIC_CLICK_MS\s*=\s*(\d+)", executable)
+    assert m is not None, "SYNTHETIC_CLICK_MS const must exist."
+    assert int(m.group(1)) >= 300, (
+        f"SYNTHETIC_CLICK_MS must be >= 300 (iOS synthetic-click delay); got {m.group(1)}."
+    )
+
+
+def test_press_guard_uses_monotonic_clock():
+    """QS-271 fix #01 S3 — the guard arms/checks against a MONOTONIC
+    clock (`performance.now()`), not the wall-clock `Date.now()`, so a
+    backward wall-clock step (NTP / DST / manual change) can't wedge
+    rendering for the magnitude of the jump."""
+    base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+
+    # Anchor on the method DEFINITIONS (`name() {` / `name(el) {`), not the
+    # earlier call-sites in `set hass` / `_wireTap`.
+    for method in (r"_isPressInFlight\(\)\s*\{", r"_armPressGuard\(el\)\s*\{"):
+        body = _extract_js_function_body(base, method)
+        assert body is not None, f"could not extract body for /{method}/."
+        assert "performance.now()" in body, (
+            f"/{method}/ must use the monotonic `performance.now()`."
+        )
+        assert "Date.now()" not in body, (
+            f"/{method}/ must NOT use the non-monotonic `Date.now()` for the guard."
+        )
+
+    # The _wireTap timestamp (lastTouchEnd) is also monotonic for
+    # consistency with the guard window.
+    wire_tap = _extract_js_function_body(base, r"_wireTap\([^\n]*\)\s*\{")
+    assert wire_tap is not None
+    assert "Date.now()" not in wire_tap, (
+        "_wireTap must use `performance.now()` (monotonic), not `Date.now()`."
+    )
+
+
+def test_connected_callback_initializes_press_guard_field():
+    """QS-271 fix #01 N1 — `_pressInFlightUntil` is initialized (= 0) in
+    `connectedCallback` for clarity (the defensive `|| 0` may remain)."""
+    base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+    body = _extract_js_function_body(base, r"connectedCallback\s*\(")
+    assert body is not None, "could not extract `connectedCallback` body."
+    assert re.search(r"this\._pressInFlightUntil\s*=\s*0", body), (
+        "connectedCallback must initialize `this._pressInFlightUntil = 0`."
+    )
+
+
+def test_arm_press_guard_skips_disabled_controls():
+    """QS-271 fix #01 N4 — `_armPressGuard` does not arm the render-defer
+    window for a disabled control (its action no-ops, so deferring
+    repaints would be pure waste)."""
+    base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+    body = _extract_js_function_body(base, r"_armPressGuard\s*\(")
+    assert body is not None, "could not extract `_armPressGuard` body."
+    # Skips arming when the element is disabled (aria-disabled or the
+    # `.disabled` class used by the in-ring custom controls).
+    assert "aria-disabled" in body or "disabled" in body, (
+        "_armPressGuard must short-circuit for a disabled control."
+    )
+
+
+def test_press_guard_schedules_catch_up_flush_render():
+    """QS-271 fix #01 N5 — when the guard window expires the card
+    schedules a single catch-up render (re-running the full `set hass`
+    gate via the stored state) so a `hass` push dropped during the
+    window isn't stranded until the next organic push. The timer is
+    cleared on disconnect."""
+    base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+
+    arm_body = _extract_js_function_body(base, r"_armPressGuard\s*\(")
+    assert arm_body is not None
+    assert "_pressGuardFlushTimer" in arm_body, (
+        "_armPressGuard must schedule a `_pressGuardFlushTimer` catch-up render."
+    )
+    assert "setTimeout(" in arm_body, "_armPressGuard must schedule the flush via setTimeout."
+    # The flush re-runs the full gate by re-assigning the stored state.
+    assert re.search(r"this\.hass\s*=\s*this\._hass", arm_body), (
+        "the catch-up flush must re-run `set hass` via `this.hass = this._hass`."
+    )
+
+    disc_body = _extract_js_function_body(base, r"disconnectedCallback\s*\(")
+    assert disc_body is not None
+    assert "_pressGuardFlushTimer" in disc_body and "clearTimeout(" in disc_body, (
+        "disconnectedCallback must clear the `_pressGuardFlushTimer`."
+    )

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -8815,10 +8815,11 @@ def test_wire_tap_click_prevent_default_is_option_gated():
 
 
 def test_wire_tap_uses_one_shot_latch_for_synthetic_click_dedup():
-    """QS-271 fix #01 S2 — the synthetic-click dedup is a one-shot latch
-    (swallow the single click that follows a touchend, regardless of how
-    late it arrives), not a pure time window — so a slow device whose
-    synthetic click lands after SYNTHETIC_CLICK_MS can't double-fire."""
+    """QS-271 fix #01 S2 + fix #02 S1 — the synthetic-click dedup is a
+    one-shot latch armed on touchend, but the latch is only honored
+    WITHIN `SYNTHETIC_CLICK_MS` of the touchend (fix #02 S1) so it can't
+    stay stuck `true` and silently swallow a later unrelated genuine
+    click."""
     base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
     body = _extract_js_function_body(base, r"_wireTap\([^\n]*\)\s*\{")
     assert body is not None, "could not extract `_wireTap` body."
@@ -8830,13 +8831,37 @@ def test_wire_tap_uses_one_shot_latch_for_synthetic_click_dedup():
         "_wireTap must arm the latch (`swallowNextClick = true`) on touchend."
     )
     assert re.search(r"swallowNextClick\s*=\s*false", body), (
-        "_wireTap must clear the latch (`swallowNextClick = false`) when the "
-        "synthetic click is swallowed."
+        "_wireTap must clear the latch (`swallowNextClick = false`)."
     )
-    # The click handler swallows when the latch is set (independent of the
-    # time window — that stays as a belt-and-suspenders secondary).
+    # The click handler swallows when the latch is set.
     assert re.search(r"if\s*\(\s*swallowNextClick", body), (
         "_wireTap's click handler must swallow when the latch is set."
+    )
+
+
+def test_wire_tap_latch_only_honored_within_window():
+    """QS-271 fix #02 S1 — the latch is gated by the
+    `SYNTHETIC_CLICK_MS` window (`swallowNextClick && <within window>`),
+    NOT an unconditional `swallowNextClick ||` that could stay stuck
+    `true` forever. A genuine click arriving after the window must NOT
+    be swallowed."""
+    base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+    body = _extract_js_function_body(base, r"_wireTap\([^\n]*\)\s*\{")
+    assert body is not None, "could not extract `_wireTap` body."
+
+    # The swallow decision must AND the latch with a window condition …
+    assert re.search(r"swallowNextClick\s*&&", body), (
+        "the latch must be ANDed with the time-window check, not honored "
+        "unconditionally (`swallowNextClick && <within window>`)."
+    )
+    # … the window is computed from SYNTHETIC_CLICK_MS …
+    assert "SYNTHETIC_CLICK_MS" in body, (
+        "the swallow window must be derived from SYNTHETIC_CLICK_MS."
+    )
+    # … and must NOT use the stuck-prone unconditional `swallowNextClick ||`.
+    assert not re.search(r"swallowNextClick\s*\|\|", body), (
+        "the latch must NOT be honored unconditionally (`swallowNextClick ||`) "
+        "— that leaves it stuck `true` and swallows later genuine clicks."
     )
 
 
@@ -8892,16 +8917,24 @@ def test_connected_callback_initializes_press_guard_field():
 
 
 def test_arm_press_guard_skips_disabled_controls():
-    """QS-271 fix #01 N4 — `_armPressGuard` does not arm the render-defer
-    window for a disabled control (its action no-ops, so deferring
-    repaints would be pure waste)."""
+    """QS-271 fix #01 N4 + fix #02 N1 — `_armPressGuard` does not arm the
+    render-defer window for a disabled control (its action no-ops). The
+    skip consults BOTH the element's own `aria-disabled` AND a
+    card-level `.disabled` ancestor (`closest('.disabled')`), so a
+    control that reflects disabled state only on a wrapping ancestor is
+    still covered (fix #02 N1)."""
     base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
-    body = _extract_js_function_body(base, r"_armPressGuard\s*\(")
+    body = _extract_js_function_body(base, r"_armPressGuard\(el\)\s*\{")
     assert body is not None, "could not extract `_armPressGuard` body."
-    # Skips arming when the element is disabled (aria-disabled or the
-    # `.disabled` class used by the in-ring custom controls).
-    assert "aria-disabled" in body or "disabled" in body, (
-        "_armPressGuard must short-circuit for a disabled control."
+    # The element's own disabled state.
+    assert "aria-disabled" in body, (
+        "_armPressGuard must short-circuit on the element's `aria-disabled`."
+    )
+    # The card-level `.disabled` ancestor (fix #02 N1) — `closest` walks
+    # up from the control through its wrappers.
+    assert re.search(r"closest\(\s*['\"]\.disabled['\"]\s*\)", body), (
+        "_armPressGuard must also consult a `.disabled` ancestor via "
+        "`closest('.disabled')` (fix #02 N1)."
     )
 
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -561,19 +561,29 @@ class TestDashboardTemplateRendering:
         # and is wired into every action via the shared wire-helpers.
         union = card_source_union("qs-radiator-card.js")
         assert "_registerKeyActivation(" in union
-        # QS-199 review-fix #02 S12 — count CALL-SITES only. The method
-        # DEFINITION `_registerKeyActivation(el, action) {` in
-        # qs-card-base.js would otherwise inflate the count, letting the
-        # test pass with fewer wired actions than expected. `this.` and
-        # bare-call forms are call-sites; the `(el, action)` signature is
-        # the definition.
-        call_sites = re.findall(r"_registerKeyActivation\(", union)
-        definitions = re.findall(r"_registerKeyActivation\(el,\s*action\)", union)
-        wired = len(call_sites) - len(definitions)
-        assert wired >= 4, (
-            f"expected ≥4 _registerKeyActivation call-sites across the union, "
-            f"got {wired} (calls={len(call_sites)}, defs={len(definitions)})"
+        # QS-271 — keyboard activation was centralized into the shared
+        # `_wireTap` chokepoint: it now calls `_registerKeyActivation`
+        # once (for keyboard:true controls) instead of every wire-helper
+        # calling it directly. So the assertion is now structural:
+        #   (a) `_wireTap` calls `_registerKeyActivation` (the chokepoint
+        #       wires keyboard activation for every routed control), and
+        #   (b) the radiator's four action helpers route through `_wireTap`
+        #       (so each action div still gets keyboard activation).
+        executable = _strip_js_comments(union)
+        wire_tap_body = _extract_js_function_body(executable, r"_wireTap\([^\n]*\)\s*\{")
+        assert wire_tap_body is not None and "_registerKeyActivation(" in wire_tap_body, (
+            "_wireTap chokepoint must call _registerKeyActivation so every "
+            "routed control gets keyboard activation."
         )
+        for helper in ("_wirePowerButton", "_wireGreenButton", "_wireTimePicker", "_wireOverrideButton"):
+            # Anchor on the `(params)` DEFINITION, not the `({ ... })`
+            # call-site (the radiator card text precedes the shared
+            # modules in the union, so a bare-name match would grab the
+            # call's object-literal arg instead of the method body).
+            body = _extract_js_function_body(executable, rf"{helper}\(params\)\s*\{{")
+            assert body is not None and "_wireTap(" in body, (
+                f"{helper} must route through `_wireTap` (keyboard activation chokepoint)."
+            )
 
     def test_radiator_card_s17_async_calls_wrapped_in_try_finally(self):  # CR2 — sync (no hass)
         """A2 — pin S17: each `_select` / `_setNumber` await is wrapped.
@@ -8523,4 +8533,246 @@ def test_car_disconnected_controls_leave_tab_order():
     for el_id in ("sun_btn", "rabbit_btn", "time_btn"):
         assert re.search(rf'id="{el_id}"[^>]*\$\{{ctrlTabAttrs\}}', car), (
             f"CR1: car `{el_id}` must use `${{ctrlTabAttrs}}` (conditional tab order)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# QS-271 — press-in-flight guard + _wireTap / _armPressGuard chokepoint.
+#
+# The JS cards live outside the executable test pipeline (no jsdom / JS
+# harness — a documented KNOWN GAP). These are therefore source-text /
+# structural assertions, tolerant of single/double quotes and whitespace,
+# matching the established convention in this module.
+# ---------------------------------------------------------------------------
+
+_CARD_BASE_JS = COMPONENT_ROOT / "ui" / "resources" / "shared" / "qs-card-base.js"
+_RING_DURATION_JS = COMPONENT_ROOT / "ui" / "resources" / "shared" / "qs-ring-duration-base.js"
+_CAR_CARD_JS = COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js"
+_CLIMATE_CARD_JS = COMPONENT_ROOT / "ui" / "resources" / "qs-climate-card.js"
+
+# Every JS file that wires tappable controls (the six cards + the two
+# shared base classes). Used by the touchend chokepoint canary.
+_ALL_CARD_JS_FILES = [
+    "qs-car-card.js",
+    "qs-climate-card.js",
+    "qs-on-off-duration-card.js",
+    "qs-pool-card.js",
+    "qs-radiator-card.js",
+    "qs-water-boiler-card.js",
+    "shared/qs-card-base.js",
+    "shared/qs-ring-duration-base.js",
+]
+
+
+def test_card_base_defines_press_guard_primitives():
+    """QS-271 AC1 — `QsCardBase` defines the two press-guard module
+    consts and the three guard methods."""
+    src = _CARD_BASE_JS.read_text(encoding="utf-8")
+    executable = _strip_js_comments(src)
+
+    # PRESS_GUARD_MS module const with a numeric value >= 300 (covers
+    # iOS Safari's ~300 ms synthetic-click delay). The exact value is
+    # user-tunable; only the >= 300 lower bound is pinned.
+    m = re.search(r"const\s+PRESS_GUARD_MS\s*=\s*(\d+)", executable)
+    assert m is not None, "qs-card-base.js must define `const PRESS_GUARD_MS = <int>`."
+    assert int(m.group(1)) >= 300, (
+        f"PRESS_GUARD_MS must be >= 300 (iOS synthetic-click window); got {m.group(1)}."
+    )
+
+    # SYNTHETIC_CLICK_MS module const (separate from PRESS_GUARD_MS).
+    assert re.search(r"const\s+SYNTHETIC_CLICK_MS\s*=\s*\d+", executable), (
+        "qs-card-base.js must define `const SYNTHETIC_CLICK_MS = <int>`."
+    )
+
+    # The three guard methods.
+    assert "_isPressInFlight(" in executable, "missing `_isPressInFlight(` method."
+    assert "_armPressGuard(" in executable, "missing `_armPressGuard(` method."
+    assert "_wireTap(" in executable, "missing `_wireTap(` method."
+
+    # _armPressGuard arms on BOTH pointerdown and touchstart, passive.
+    arm_body = _extract_js_function_body(executable, r"_armPressGuard\s*\(")
+    assert arm_body is not None, "could not extract `_armPressGuard` body."
+    assert "pointerdown" in arm_body and "touchstart" in arm_body, (
+        "_armPressGuard must arm on both `pointerdown` and `touchstart`."
+    )
+    assert re.search(r"passive\s*:\s*true", arm_body), (
+        "_armPressGuard listeners must be registered `{ passive: true }`."
+    )
+    # The guard sets the timestamp window from PRESS_GUARD_MS.
+    assert "PRESS_GUARD_MS" in arm_body, (
+        "_armPressGuard must arm the window using PRESS_GUARD_MS."
+    )
+
+
+def test_wire_tap_touchend_is_non_passive_with_synthetic_click_dedup():
+    """QS-271 AC1/AC8 — `_wireTap`'s touchend is non-passive (so
+    preventDefault works), records the touchend time, and the click
+    handler dedups only the synthetic twin via SYNTHETIC_CLICK_MS."""
+    executable = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+    # `_wireTap`'s signature carries a destructuring default `{ ... } = {}`
+    # in its param list, so anchor on the body-opening brace (after the
+    # closing `)`) rather than the first `{` the walker would otherwise hit.
+    body = _extract_js_function_body(executable, r"_wireTap\([^\n]*\)\s*\{")
+    assert body is not None, "could not extract `_wireTap` body."
+
+    # Calls the low-level primitive internally.
+    assert "_armPressGuard(" in body, "_wireTap must call `_armPressGuard(el)`."
+    # Sets pointer-events auto.
+    assert re.search(r"pointerEvents\s*=\s*['\"]auto['\"]", body), (
+        "_wireTap must set `el.style.pointerEvents = 'auto'`."
+    )
+    # touchend listener present and NON-passive (no `passive: true` on it).
+    tm = re.search(r"addEventListener\(\s*['\"]touchend['\"][\s\S]*?\)\s*;", body)
+    assert tm is not None, "_wireTap must register a `touchend` listener."
+    # The touchend registration must not opt into passive — otherwise
+    # preventDefault (needed to suppress the synthetic click) is a no-op.
+    assert "passive" not in tm.group(0), (
+        "_wireTap's `touchend` listener must be NON-passive so preventDefault works."
+    )
+    assert "preventDefault" in body, "_wireTap handlers must call preventDefault."
+    # Records the last touchend time and dedups the synthetic click.
+    assert "lastTouchEnd" in body, "_wireTap must record `lastTouchEnd`."
+    assert "SYNTHETIC_CLICK_MS" in body, (
+        "_wireTap's click handler must dedup the synthetic twin via SYNTHETIC_CLICK_MS."
+    )
+    # Optional keyboard activation.
+    assert "_registerKeyActivation(" in body, (
+        "_wireTap must optionally register keyboard activation."
+    )
+
+
+@pytest.mark.parametrize(
+    "card_file",
+    ["shared/qs-card-base.js", "qs-car-card.js", "qs-climate-card.js"],
+)
+def test_all_set_hass_overrides_gate_on_press_in_flight(card_file):
+    """QS-271 AC2 — each of the three `set hass` overrides gates the
+    re-render on `_isPressInFlight()` AND still assigns `this._hass`
+    before the gate (so no state is dropped)."""
+    src = (COMPONENT_ROOT / "ui" / "resources" / card_file).read_text(encoding="utf-8")
+    executable = _strip_js_comments(src)
+    body = _extract_js_function_body(executable, r"set\s+hass\s*\(")
+    assert body is not None, f"{card_file}: could not extract `set hass` body."
+
+    assert "_isPressInFlight" in body, (
+        f"{card_file}: `set hass` must gate re-render on `_isPressInFlight()`."
+    )
+    # `this._hass = hass` must appear before the first interaction gate
+    # (the first `return`), so the latest state is always stored.
+    hass_idx = body.find("this._hass")
+    gate_idx = body.find("return")
+    assert hass_idx != -1, f"{card_file}: `set hass` must assign `this._hass`."
+    assert gate_idx != -1, f"{card_file}: `set hass` must have a guard `return`."
+    assert hass_idx < gate_idx, (
+        f"{card_file}: `this._hass = hass` must be assigned BEFORE the guard return."
+    )
+
+
+def test_wire_helpers_and_inline_buttons_route_through_wire_tap():
+    """QS-271 AC3 — the four base wire-helpers, the ring-duration
+    override button, and the four car inline buttons route through
+    `_wireTap`."""
+    base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+    for helper in ("_wireTimePicker", "_wireResetButton", "_wirePowerButton", "_wireGreenButton"):
+        body = _extract_js_function_body(base, rf"{helper}\s*\(")
+        assert body is not None, f"could not extract `{helper}` body."
+        assert "_wireTap(" in body, f"{helper} must route through `_wireTap(`."
+
+    ring = _strip_js_comments(_RING_DURATION_JS.read_text(encoding="utf-8"))
+    override_body = _extract_js_function_body(ring, r"_wireOverrideButton\s*\(")
+    assert override_body is not None, "could not extract `_wireOverrideButton` body."
+    assert "_wireTap(" in override_body, "_wireOverrideButton must route through `_wireTap(`."
+
+    car = _strip_js_comments(_CAR_CARD_JS.read_text(encoding="utf-8"))
+    # Each inline button is wired via `_wireTap(<var>, ...)`.
+    for var in ("rbtn", "forceBtn", "schedBtn", "socEl"):
+        assert re.search(rf"_wireTap\(\s*{var}\b", car), (
+            f"car inline button `{var}` must route through `_wireTap({var}, ...)`."
+        )
+
+
+def test_select_pills_arm_press_guard():
+    """QS-271 AC4 — the native-`<select>` pills add `_armPressGuard`
+    while keeping their existing click->showPicker handler."""
+    car = _strip_js_comments(_CAR_CARD_JS.read_text(encoding="utf-8"))
+    for pill in ("personPill", "chargerPill"):
+        assert re.search(rf"_armPressGuard\(\s*{pill}\b", car), (
+            f"car `{pill}` must add `_armPressGuard({pill})`."
+        )
+        # The existing click->showPicker handler is preserved.
+        assert "showPicker(" in car, "car pills must keep their showPicker handler."
+
+    climate = _strip_js_comments(_CLIMATE_CARD_JS.read_text(encoding="utf-8"))
+    assert re.search(r"_armPressGuard\(\s*stateOnPill\b", climate), (
+        "climate `stateOnPill` must add `_armPressGuard(stateOnPill)`."
+    )
+
+    ring = _strip_js_comments(_RING_DURATION_JS.read_text(encoding="utf-8"))
+    assert re.search(r"_armPressGuard\(\s*modePill\b", ring), (
+        "ring-duration `modePill` must add `_armPressGuard(modePill)`."
+    )
+
+
+def test_disconnected_callback_resets_press_guard():
+    """QS-271 AC6 — base `disconnectedCallback` resets
+    `_pressInFlightUntil` to 0 (S7 interaction-flag-reset pattern)."""
+    base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+    body = _extract_js_function_body(base, r"disconnectedCallback\s*\(")
+    assert body is not None, "could not extract base `disconnectedCallback` body."
+    assert re.search(r"this\._pressInFlightUntil\s*=\s*0", body), (
+        "base disconnectedCallback must reset `this._pressInFlightUntil = 0`."
+    )
+
+
+def test_no_card_uses_bare_touchend_outside_shared_helpers():
+    """QS-271 AC7 — chokepoint canary: every element-level
+    `addEventListener('touchend'...)` in the card files must live inside
+    one of the allowlisted shared sites (`_wireTap`, `_wireTargetHandle`,
+    `_showDialog`). Pins the `_showDialog` occurrence count so a new bare
+    touchend added elsewhere in that method is still caught.
+
+    Mirrors `test_no_card_reintroduces_whole_card_disabled_greyer`.
+    """
+    pat = re.compile(r"addEventListener\(\s*['\"]touchend['\"]")
+
+    # Only qs-card-base.js may contain element-level touchend bindings —
+    # and only inside the three allowlisted methods. Every other card
+    # file must contain ZERO.
+    base = _strip_js_comments(_CARD_BASE_JS.read_text(encoding="utf-8"))
+    base_total = len(pat.findall(base))
+
+    allowlisted_total = 0
+    # `_wireTap`'s param list contains a destructuring default brace, so
+    # anchor its extraction on the body-opening brace (see above).
+    for method in (r"_wireTap\([^\n]*\)\s*\{", r"_wireTargetHandle\s*\(", r"_showDialog\s*\("):
+        body = _extract_js_function_body(base, method)
+        assert body is not None, f"could not extract body for /{method}/."
+        allowlisted_total += len(pat.findall(body))
+
+    assert base_total == allowlisted_total, (
+        "qs-card-base.js has element-level `addEventListener('touchend'...)` "
+        f"OUTSIDE the allowlisted methods (_wireTap / _wireTargetHandle / "
+        f"_showDialog): {base_total} total vs {allowlisted_total} allowlisted."
+    )
+
+    # Pin the _showDialog occurrence count (currently one) so a NEW bare
+    # touchend added inside _showDialog is still caught.
+    show_dialog = _extract_js_function_body(base, r"_showDialog\s*\(")
+    assert len(pat.findall(show_dialog)) == 1, (
+        "_showDialog must contain exactly one `touchend` binding (its "
+        "latch-bearing modal-button wiring); a new bare one was added."
+    )
+
+    # Every OTHER card file must have no element-level touchend at all —
+    # they all route through `_wireTap` / `_armPressGuard` now.
+    for card_file in _ALL_CARD_JS_FILES:
+        if card_file == "shared/qs-card-base.js":
+            continue
+        src = _strip_js_comments(
+            (COMPONENT_ROOT / "ui" / "resources" / card_file).read_text(encoding="utf-8")
+        )
+        assert pat.search(src) is None, (
+            f"{card_file}: bare element-level `addEventListener('touchend'...)` "
+            "found — route the control through `_wireTap` / `_armPressGuard` "
+            "(shared chokepoint) instead."
         )


### PR DESCRIPTION
## Summary
- Add a self-expiring press-in-flight guard + _wireTap / _armPressGuard primitives on QsCardBase so a hass push can't re-render a card out from under an in-flight tap.
- Route every plain action button (4 base wire-helpers, ring-duration override, 4 car inline buttons) through the _wireTap chokepoint; arm the native-<select> pills (person/charger/stateOn/mode) via _armPressGuard.
- Gate all three set hass overrides on _isPressInFlight(); add a regression test enforcing the touchend chokepoint going forward.

Fixes #271

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

## Doc maintenance

`docs/agents/concepts/dashboard-and-cards.md` is the `covers:` owner of the
touched JS files (`shared/qs-card-base.js`, `qs-car-card.js`,
`qs-climate-card.js`, `shared/qs-ring-duration-base.js`). It was
co-modified in every implementation commit and re-verified for the
review-fix #01/#02 hardening (monotonic guard clock, window-bounded
one-shot synthetic-click latch, `preventDefaultClick` option, card-level
`.disabled` skip, idempotent double-arm, catch-up flush render);
`last_verified` is bumped to 2026-06-18. `python scripts/qs/check_doc_drift.py`
exits 0.
