### PR TITLE
QS-276: Make the quality gate run much faster (--impacted inner loop)

### DIFF
--- a/.claude/agents/qs-finish-task.md
+++ b/.claude/agents/qs-finish-task.md
@@ -141,9 +141,19 @@ The standard merge flow.
    # Detached + best-effort: must never block or hang cleanup.
    # `--seed-testmon` is the SANCTIONED non-gate subcommand (NOT a raw
    # pytest, NOT the quality gate) — it only refreshes .testmondata.
-   ( cd "$MAIN_DIR" && nohup "$MAIN_DIR/venv/bin/python" \
-       scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
-   echo "Baseline refresh started (detached, best-effort)."
+   # Probe for a usable interpreter (review-fix S3): the main venv may
+   # be missing (fresh clone, relocated checkout). Fall back to python3
+   # / python on PATH; if none is usable, WARN instead of printing a
+   # false success.
+   QG_PY="$MAIN_DIR/venv/bin/python"
+   [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
+   if [ -n "$QG_PY" ]; then
+       ( cd "$MAIN_DIR" && nohup "$QG_PY" \
+           scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
+       echo "Baseline refresh started (detached, best-effort)."
+   else
+       echo "Warning: no usable Python interpreter found — skipping baseline refresh."
+   fi
    ```
    A failure or timeout here is harmless — a stale baseline is still
    safe (new worktrees just run more tests). Proceed regardless. The

--- a/.claude/agents/qs-finish-task.md
+++ b/.claude/agents/qs-finish-task.md
@@ -128,7 +128,29 @@ The standard merge flow.
    If the PR was already merged externally between steps 2 and 5, treat
    as success.
 
-6. Delete the remote branch. The guard refuses `main` / `master` at
+6. Refresh the `--impacted` baseline on the main worktree (QS-276). The
+   merged code is now on the true `main`, so rebuild the testmon
+   baseline **there** — the worktree's own `.testmondata` reflects its
+   (possibly stale) base and is unsafe to copy back. Capture `MAIN_DIR`
+   **before** cleanup removes this worktree (it is NOT in `context.py`):
+   ```bash
+   MAIN_DIR="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+   git -C "$MAIN_DIR" fetch origin
+   git -C "$MAIN_DIR" checkout main
+   git -C "$MAIN_DIR" pull --ff-only
+   # Detached + best-effort: must never block or hang cleanup.
+   # `--seed-testmon` is the SANCTIONED non-gate subcommand (NOT a raw
+   # pytest, NOT the quality gate) — it only refreshes .testmondata.
+   ( cd "$MAIN_DIR" && nohup "$MAIN_DIR/venv/bin/python" \
+       scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
+   echo "Baseline refresh started (detached, best-effort)."
+   ```
+   A failure or timeout here is harmless — a stale baseline is still
+   safe (new worktrees just run more tests). Proceed regardless. The
+   first refresh after a large merge may approach a near-full run;
+   acceptable because it is detached.
+
+7. Delete the remote branch. The guard refuses `main` / `master` at
    the shell level — never rely on the agent alone:
    ```bash
    if [ "{{branch}}" = "main" ] || [ "{{branch}}" = "master" ]; then
@@ -138,7 +160,7 @@ The standard merge flow.
    git push origin --delete "{{branch}}"
    ```
 
-7. Remove the worktree (`--force` is safe — code is merged):
+8. Remove the worktree (`--force` is safe — code is merged):
    ```bash
    python scripts/qs/cleanup_worktree.py \
        --work-dir "{{worktree}}" \
@@ -146,7 +168,7 @@ The standard merge flow.
        --force
    ```
 
-8. Report:
+9. Report:
    ```text
    ✅ PR #{{pr_number}} merged into main.
    ✅ Remote branch {{branch}} deleted.
@@ -168,7 +190,9 @@ The standard merge flow.
 ## Hard rules
 
 - **Never run the quality gate.** Cleanup must succeed even if tests
-  would fail.
+  would fail. (Carve-out: the post-merge `--seed-testmon` baseline
+  refresh in Case B step 6 is a non-gate DB refresh — no coverage, no
+  pass/fail verdict — run detached/best-effort. It is not the gate.)
 - No merge without explicit user authorization in this turn.
 - Never auto-chain to `/release` — it's a separate decision.
 - Refuse to delete `main` / `master` even if asked.

--- a/.claude/agents/qs-implement-setup-task.md
+++ b/.claude/agents/qs-implement-setup-task.md
@@ -75,15 +75,26 @@ than dev tooling tests), STOP — this should have been routed to
 
 Present a summary, ask "Ready to run the quality gate?". Wait.
 
-### 4. Quality gate (dev-only fast path)
+### 4. Quality gate (impacted inner loop)
+
+Default to the **impacted** gate before commit/PR:
 
 ```bash
-python scripts/qs/quality_gate.py
+python scripts/qs/quality_gate.py --impacted
 ```
 
-Smart scope detection skips the full suite when only dev files changed —
-runs the modified test files only. To force the full suite, use
-`--full`. Pass on a green gate; fix on red.
+It runs the testmon-selected tests and verifies any changed lines
+under `custom_components/quiet_solar/` are 100% covered. Dev-only
+changes (`scripts/`, `docs/`, agent files) carry no production-coverage
+delta, so `--impacted` just runs the impacted tests fast. The
+whole-repo 100% gate is enforced in **CI** on every PR; run it locally
+only on explicit request:
+
+```bash
+python scripts/qs/quality_gate.py        # full gate, on request
+```
+
+Pass on a green gate; fix on red.
 
 **Doc-maintenance pre-commit sub-step.** After staging your
 intended changes (`git add` first so the diff is populated), run

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -65,8 +65,9 @@ Red → green → refactor. For every cycle:
 
 Verify with `python scripts/qs/quality_gate.py --quick <path>` during
 the inner loop (the canonical TDD command; accepts files,
-directories, or both). The full quality gate runs at step 4 before
-commit. See the `## Commands` section of
+directories, or both). The `--impacted` gate runs at step 4 before
+commit (changed lines 100%); the whole-repo 100% gate is enforced in
+CI on every PR. See the `## Commands` section of
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 for the full command grammar and the forbidden-vs-allowed raw-pytest
 rule.
@@ -86,13 +87,26 @@ Then ask: **"Ready to run the quality gate?"** Wait for confirmation.
 
 ### 4. Quality gate (non-negotiable)
 
+Default to the **impacted** inner-loop gate before commit/PR:
+
 ```bash
-python scripts/qs/quality_gate.py
+python scripts/qs/quality_gate.py --impacted
 ```
 
-Must exit 0: pytest 100% coverage + ruff + mypy + translations. If it
-fails, fix autonomously and re-run. Only ask the user for direction
-after 2–3 unsuccessful attempts.
+`--impacted` runs the testmon-selected tests and verifies the lines
+**you changed** are 100% covered (exit 0 required). The whole-repo
+100% gate (pytest + ruff + mypy + translations) stays authoritative in
+**CI** on every PR — that is what guarantees full coverage, not a local
+full run. Run the full gate locally only on explicit request, or when
+you suspect coverage lost in *unchanged* code (which `--impacted`
+cannot see):
+
+```bash
+python scripts/qs/quality_gate.py        # full gate, on request
+```
+
+If the gate fails, fix autonomously and re-run. Only ask the user for
+direction after 2–3 unsuccessful attempts.
 
 **Doc-maintenance pre-commit sub-step.** After staging your
 intended changes (`git add` first so the diff is populated), run

--- a/.cursor/agents/qs-finish-task.md
+++ b/.cursor/agents/qs-finish-task.md
@@ -127,7 +127,29 @@ The standard merge flow.
    If the PR was already merged externally between steps 2 and 5, treat
    as success.
 
-6. Delete the remote branch. The guard refuses `main` / `master` at
+6. Refresh the `--impacted` baseline on the main worktree (QS-276). The
+   merged code is now on the true `main`, so rebuild the testmon
+   baseline **there** — the worktree's own `.testmondata` reflects its
+   (possibly stale) base and is unsafe to copy back. Capture `MAIN_DIR`
+   **before** cleanup removes this worktree (it is NOT in `context.py`):
+   ```bash
+   MAIN_DIR="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+   git -C "$MAIN_DIR" fetch origin
+   git -C "$MAIN_DIR" checkout main
+   git -C "$MAIN_DIR" pull --ff-only
+   # Detached + best-effort: must never block or hang cleanup.
+   # `--seed-testmon` is the SANCTIONED non-gate subcommand (NOT a raw
+   # pytest, NOT the quality gate) — it only refreshes .testmondata.
+   ( cd "$MAIN_DIR" && nohup "$MAIN_DIR/venv/bin/python" \
+       scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
+   echo "Baseline refresh started (detached, best-effort)."
+   ```
+   A failure or timeout here is harmless — a stale baseline is still
+   safe (new worktrees just run more tests). Proceed regardless. The
+   first refresh after a large merge may approach a near-full run;
+   acceptable because it is detached.
+
+7. Delete the remote branch. The guard refuses `main` / `master` at
    the shell level — never rely on the agent alone:
    ```bash
    if [ "{{branch}}" = "main" ] || [ "{{branch}}" = "master" ]; then
@@ -137,7 +159,7 @@ The standard merge flow.
    git push origin --delete "{{branch}}"
    ```
 
-7. Remove the worktree (`--force` is safe — code is merged):
+8. Remove the worktree (`--force` is safe — code is merged):
    ```bash
    python scripts/qs/cleanup_worktree.py \
        --work-dir "{{worktree}}" \
@@ -145,7 +167,7 @@ The standard merge flow.
        --force
    ```
 
-8. Report:
+9. Report:
     ```text
     ✅ PR #{{pr_number}} merged into main.
     ✅ Remote branch {{branch}} deleted.
@@ -167,7 +189,9 @@ The standard merge flow.
 ## Hard rules
 
 - **Never run the quality gate.** Cleanup must succeed even if tests
-  would fail.
+  would fail. (Carve-out: the post-merge `--seed-testmon` baseline
+  refresh in Case B step 6 is a non-gate DB refresh — no coverage, no
+  pass/fail verdict — run detached/best-effort. It is not the gate.)
 - No merge without explicit user authorization in this turn.
 - Never auto-chain to `/release` — it's a separate decision.
 - Refuse to delete `main` / `master` even if asked.

--- a/.cursor/agents/qs-finish-task.md
+++ b/.cursor/agents/qs-finish-task.md
@@ -140,9 +140,19 @@ The standard merge flow.
    # Detached + best-effort: must never block or hang cleanup.
    # `--seed-testmon` is the SANCTIONED non-gate subcommand (NOT a raw
    # pytest, NOT the quality gate) — it only refreshes .testmondata.
-   ( cd "$MAIN_DIR" && nohup "$MAIN_DIR/venv/bin/python" \
-       scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
-   echo "Baseline refresh started (detached, best-effort)."
+   # Probe for a usable interpreter (review-fix S3): the main venv may
+   # be missing (fresh clone, relocated checkout). Fall back to python3
+   # / python on PATH; if none is usable, WARN instead of printing a
+   # false success.
+   QG_PY="$MAIN_DIR/venv/bin/python"
+   [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
+   if [ -n "$QG_PY" ]; then
+       ( cd "$MAIN_DIR" && nohup "$QG_PY" \
+           scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
+       echo "Baseline refresh started (detached, best-effort)."
+   else
+       echo "Warning: no usable Python interpreter found — skipping baseline refresh."
+   fi
    ```
    A failure or timeout here is harmless — a stale baseline is still
    safe (new worktrees just run more tests). Proceed regardless. The

--- a/.cursor/agents/qs-implement-setup-task.md
+++ b/.cursor/agents/qs-implement-setup-task.md
@@ -76,15 +76,26 @@ than dev tooling tests), STOP — this should have been routed to
 
 Present a summary, ask "Ready to run the quality gate?". Wait.
 
-### 4. Quality gate (dev-only fast path)
+### 4. Quality gate (impacted inner loop)
+
+Default to the **impacted** gate before commit/PR:
 
 ```bash
-python scripts/qs/quality_gate.py
+python scripts/qs/quality_gate.py --impacted
 ```
 
-Smart scope detection skips the full suite when only dev files changed —
-runs the modified test files only. To force the full suite, use
-`--full`. Pass on a green gate; fix on red.
+It runs the testmon-selected tests and verifies any changed lines
+under `custom_components/quiet_solar/` are 100% covered. Dev-only
+changes (`scripts/`, `docs/`, agent files) carry no production-coverage
+delta, so `--impacted` just runs the impacted tests fast. The
+whole-repo 100% gate is enforced in **CI** on every PR; run it locally
+only on explicit request:
+
+```bash
+python scripts/qs/quality_gate.py        # full gate, on request
+```
+
+Pass on a green gate; fix on red.
 
 **Doc-maintenance pre-commit sub-step.** After staging your
 intended changes (`git add` first so the diff is populated), run

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -66,8 +66,9 @@ Red → green → refactor. For every cycle:
 
 Verify with `python scripts/qs/quality_gate.py --quick <path>` during
 the inner loop (the canonical TDD command; accepts files,
-directories, or both). The full quality gate runs at step 4 before
-commit. See the `## Commands` section of
+directories, or both). The `--impacted` gate runs at step 4 before
+commit (changed lines 100%); the whole-repo 100% gate is enforced in
+CI on every PR. See the `## Commands` section of
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 for the full command grammar and the forbidden-vs-allowed raw-pytest
 rule.
@@ -87,13 +88,26 @@ Then ask: **"Ready to run the quality gate?"** Wait for confirmation.
 
 ### 4. Quality gate (non-negotiable)
 
+Default to the **impacted** inner-loop gate before commit/PR:
+
 ```bash
-python scripts/qs/quality_gate.py
+python scripts/qs/quality_gate.py --impacted
 ```
 
-Must exit 0: pytest 100% coverage + ruff + mypy + translations. If it
-fails, fix autonomously and re-run. Only ask the user for direction
-after 2–3 unsuccessful attempts.
+`--impacted` runs the testmon-selected tests and verifies the lines
+**you changed** are 100% covered (exit 0 required). The whole-repo
+100% gate (pytest + ruff + mypy + translations) stays authoritative in
+**CI** on every PR — that is what guarantees full coverage, not a local
+full run. Run the full gate locally only on explicit request, or when
+you suspect coverage lost in *unchanged* code (which `--impacted`
+cannot see):
+
+```bash
+python scripts/qs/quality_gate.py        # full gate, on request
+```
+
+If the gate fails, fix autonomously and re-run. Only ask the user for
+direction after 2–3 unsuccessful attempts.
 
 **Doc-maintenance pre-commit sub-step.** After staging your
 intended changes (`git add` first so the diff is populated), run

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+
+# pytest-testmon test-impact DB (QS-276) — written during runs, never committed
+.testmondata
 *.cover
 *.py,cover
 .hypothesis/

--- a/.opencode/agents/qs-finish-task.md
+++ b/.opencode/agents/qs-finish-task.md
@@ -173,9 +173,19 @@ The standard merge flow.
    # Detached + best-effort: must never block or hang cleanup.
    # `--seed-testmon` is the SANCTIONED non-gate subcommand (NOT a raw
    # pytest, NOT the quality gate) — it only refreshes .testmondata.
-   ( cd "$MAIN_DIR" && nohup "$MAIN_DIR/venv/bin/python" \
-       scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
-   echo "Baseline refresh started (detached, best-effort)."
+   # Probe for a usable interpreter (review-fix S3): the main venv may
+   # be missing (fresh clone, relocated checkout). Fall back to python3
+   # / python on PATH; if none is usable, WARN instead of printing a
+   # false success.
+   QG_PY="$MAIN_DIR/venv/bin/python"
+   [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
+   if [ -n "$QG_PY" ]; then
+       ( cd "$MAIN_DIR" && nohup "$QG_PY" \
+           scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
+       echo "Baseline refresh started (detached, best-effort)."
+   else
+       echo "Warning: no usable Python interpreter found — skipping baseline refresh."
+   fi
    ```
    A failure or timeout here is harmless — a stale baseline is still
    safe (new worktrees just run more tests). Proceed regardless. The

--- a/.opencode/agents/qs-finish-task.md
+++ b/.opencode/agents/qs-finish-task.md
@@ -25,6 +25,7 @@ permission:
     "git log*": allow
     "git diff*": allow
     "git fetch*": allow
+    "git pull*": allow
     "git add *": allow
     "git commit *": allow
     "git push*": allow
@@ -159,7 +160,29 @@ The standard merge flow.
    If the PR was already merged externally between steps 1 and 4, treat
    as success.
 
-5. Delete the remote branch. The guard refuses `main` / `master` at
+5. Refresh the `--impacted` baseline on the main worktree (QS-276). The
+   merged code is now on the true `main`, so rebuild the testmon
+   baseline **there** — the worktree's own `.testmondata` reflects its
+   (possibly stale) base and is unsafe to copy back. Capture `MAIN_DIR`
+   **before** cleanup removes this worktree (it is NOT in `context.py`):
+   ```bash
+   MAIN_DIR="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+   git -C "$MAIN_DIR" fetch origin
+   git -C "$MAIN_DIR" checkout main
+   git -C "$MAIN_DIR" pull --ff-only
+   # Detached + best-effort: must never block or hang cleanup.
+   # `--seed-testmon` is the SANCTIONED non-gate subcommand (NOT a raw
+   # pytest, NOT the quality gate) — it only refreshes .testmondata.
+   ( cd "$MAIN_DIR" && nohup "$MAIN_DIR/venv/bin/python" \
+       scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
+   echo "Baseline refresh started (detached, best-effort)."
+   ```
+   A failure or timeout here is harmless — a stale baseline is still
+   safe (new worktrees just run more tests). Proceed regardless. The
+   first refresh after a large merge may approach a near-full run;
+   acceptable because it is detached.
+
+6. Delete the remote branch. The guard refuses `main` / `master` at
    the shell level — never rely on the agent alone:
    ```bash
    if [ "{{branch}}" = "main" ] || [ "{{branch}}" = "master" ]; then
@@ -169,7 +192,7 @@ The standard merge flow.
    git push origin --delete "{{branch}}"
    ```
 
-6. Remove the worktree (`--force` is safe — code is merged):
+7. Remove the worktree (`--force` is safe — code is merged):
    ```bash
    python scripts/qs/cleanup_worktree.py \
        --work-dir "{{worktree}}" \
@@ -177,7 +200,7 @@ The standard merge flow.
        --force
    ```
 
-7. Report:
+8. Report:
    ```text
    ✅ PR #{{pr_number}} merged into main.
    ✅ Remote branch {{branch}} deleted.
@@ -199,7 +222,9 @@ The standard merge flow.
 ## Hard rules
 
 - **Never run the quality gate.** Cleanup must succeed even if tests
-  would fail.
+  would fail. (Carve-out: the post-merge `--seed-testmon` baseline
+  refresh in Case B step 5 is a non-gate DB refresh — no coverage, no
+  pass/fail verdict — run detached/best-effort. It is not the gate.)
 - No merge without explicit user authorization in this turn.
 - Never auto-chain to `release` — it's a separate decision.
 - Refuse to delete `main` / `master` even if asked.

--- a/.opencode/agents/qs-implement-setup-task.md
+++ b/.opencode/agents/qs-implement-setup-task.md
@@ -129,15 +129,26 @@ than dev tooling tests), STOP — this should have been routed to
 
 Present a summary, ask "Ready to run the quality gate?". Wait.
 
-### 4. Quality gate (dev-only fast path)
+### 4. Quality gate (impacted inner loop)
+
+Default to the **impacted** gate before commit/PR:
 
 ```bash
-python scripts/qs/quality_gate.py
+python scripts/qs/quality_gate.py --impacted
 ```
 
-Smart scope detection skips the full suite when only dev files changed —
-runs the modified test files only. To force the full suite, use
-`--full`. Pass on a green gate; fix on red.
+It runs the testmon-selected tests and verifies any changed lines
+under `custom_components/quiet_solar/` are 100% covered. Dev-only
+changes (`scripts/`, `docs/`, agent files) carry no production-coverage
+delta, so `--impacted` just runs the impacted tests fast. The
+whole-repo 100% gate is enforced in **CI** on every PR; run it locally
+only on explicit request:
+
+```bash
+python scripts/qs/quality_gate.py        # full gate, on request
+```
+
+Pass on a green gate; fix on red.
 
 **Doc-maintenance pre-commit sub-step.** After staging your
 intended changes (`git add` first so the diff is populated), run

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -104,8 +104,9 @@ Red → green → refactor. For every cycle:
 
 Verify with `python scripts/qs/quality_gate.py --quick <path>` during
 the inner loop (the canonical TDD command; accepts files,
-directories, or both). The full quality gate runs at step 4 before
-commit. See the `## Commands` section of
+directories, or both). The `--impacted` gate runs at step 4 before
+commit (changed lines 100%); the whole-repo 100% gate is enforced in
+CI on every PR. See the `## Commands` section of
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 for the full command grammar and the forbidden-vs-allowed raw-pytest
 rule.
@@ -125,13 +126,26 @@ Then ask: **"Ready to run the quality gate?"** Wait for confirmation.
 
 ### 4. Quality gate (non-negotiable)
 
+Default to the **impacted** inner-loop gate before commit/PR:
+
 ```bash
-python scripts/qs/quality_gate.py
+python scripts/qs/quality_gate.py --impacted
 ```
 
-Must exit 0: pytest 100% coverage + ruff + mypy + translations. If it
-fails, fix autonomously and re-run. Only ask the user for direction
-after 2–3 unsuccessful attempts.
+`--impacted` runs the testmon-selected tests and verifies the lines
+**you changed** are 100% covered (exit 0 required). The whole-repo
+100% gate (pytest + ruff + mypy + translations) stays authoritative in
+**CI** on every PR — that is what guarantees full coverage, not a local
+full run. Run the full gate locally only on explicit request, or when
+you suspect coverage lost in *unchanged* code (which `--impacted`
+cannot see):
+
+```bash
+python scripts/qs/quality_gate.py        # full gate, on request
+```
+
+If the gate fails, fix autonomously and re-run. Only ask the user for
+direction after 2–3 unsuccessful attempts.
 
 **Doc-maintenance pre-commit sub-step.** After staging your
 intended changes (`git add` first so the diff is populated), run

--- a/docs/agents/concepts/testing-layers.md
+++ b/docs/agents/concepts/testing-layers.md
@@ -88,6 +88,18 @@ worktrees seed `.testmondata` + `.mypy_cache` from the main worktree
 (`worktree-setup.sh`); `finish-task` refreshes the main baseline via
 `--seed-testmon` after a merge.
 
+**`integration` marker vs the two regimes (QS-276).** The slow
+real-subprocess `@pytest.mark.integration` tests (e.g. the throwaway-git
+testmon tests) are **deselected from the `--impacted` fast loop**
+(`pytest --testmon -m "not integration"`) so the inner loop stays fast;
+they never cover `custom_components/quiet_solar`, so deselecting them
+cannot change the diff-cover verdict. CI's whole-repo gate
+(`pr-quality.yml`, `pytest tests/ -n auto --cov-fail-under=100`) applies
+**no** `-m` deselection, so it *does* run the integration tests — they
+must run there for the 100% gate to pass. New `quality_gate.py` lines
+are therefore also covered independently by mocked-seam unit tests, not
+solely by the integration tests.
+
 ## Key types / structures
 
 - `FakeHass` — lightweight HA stand-in. Provides `services`,

--- a/docs/agents/concepts/testing-layers.md
+++ b/docs/agents/concepts/testing-layers.md
@@ -88,17 +88,21 @@ worktrees seed `.testmondata` + `.mypy_cache` from the main worktree
 (`worktree-setup.sh`); `finish-task` refreshes the main baseline via
 `--seed-testmon` after a merge.
 
-**`integration` marker vs the two regimes (QS-276).** The slow
-real-subprocess `@pytest.mark.integration` tests (e.g. the throwaway-git
-testmon tests) are **deselected from the `--impacted` fast loop**
-(`pytest --testmon -m "not integration"`) so the inner loop stays fast;
-they never cover `custom_components/quiet_solar`, so deselecting them
-cannot change the diff-cover verdict. CI's whole-repo gate
-(`pr-quality.yml`, `pytest tests/ -n auto --cov-fail-under=100`) applies
-**no** `-m` deselection, so it *does* run the integration tests — they
-must run there for the 100% gate to pass. New `quality_gate.py` lines
-are therefore also covered independently by mocked-seam unit tests, not
-solely by the integration tests.
+**Keeping the testmon SELF-tests out of the fast loop (QS-276).** The
+only tests the `--impacted` loop excludes are the slow real-subprocess
+testmon *self-tests* (the throwaway-git + nested-pytest cases that live
+in `tests/test_quality_gate.py`). They are excluded **by path**
+(`pytest --testmon --ignore=tests/test_quality_gate.py`), NOT by the
+shared `integration` marker — because ~9 **domain** integration files
+(charger rebalancing, solver forecast, constraint boundaries, …) carry
+that marker AND exercise `custom_components/quiet_solar`. Excluding them
+would let a production line covered *only* by a domain integration test
+report 0% and FAIL `--impacted` with no local remedy (review-fix MF1).
+The self-tests never cover `custom_components/quiet_solar`, so ignoring
+that one file cannot change the diff-cover verdict; it just keeps the
+loop fast. CI's whole-repo gate (`pr-quality.yml`, `pytest tests/ -n auto
+--cov-fail-under=100`) ignores nothing, so it runs every test — domain
+integration and self-tests alike — for the authoritative 100%.
 
 ## Key types / structures
 

--- a/docs/agents/concepts/testing-layers.md
+++ b/docs/agents/concepts/testing-layers.md
@@ -7,7 +7,7 @@ covers:
   - tests/factories.py
   - tests/ha_tests/conftest.py
   - tests/ha_tests/const.py
-last_verified: 2026-05-19
+last_verified: 2026-06-24
 ---
 
 # Testing layers — FakeHass, factories, and real HA fixtures
@@ -59,6 +59,34 @@ stay in sync or tests pass while testing the wrong thing.
 testing. A solver bug is a domain test; a config-flow bug is an HA
 test. Don't run the slow layer for logic that the fast layer can
 cover.
+
+## Test-impact inner loop — `--impacted` (QS-276)
+
+Orthogonal to the two *layers* above is a third *execution mode* for
+the dev loop: `python scripts/qs/quality_gate.py --impacted`. It uses
+`pytest-testmon` to run **only the tests impacted by your change set**
+(across both layers), under `--cov=custom_components/quiet_solar`, then
+`diff-cover --fail-under=100` asserts the **lines you changed** are
+100% covered. On a small diff this is seconds instead of minutes, so it
+is the implement-phase default before commit/PR.
+
+**The split that makes this safe.** Whole-repo "100% on every PR" is
+NON-NEGOTIABLE — and a test-impact subset can never prove it. So the
+guarantee is split: `--impacted` proves *changed lines* locally; the
+**whole-repo 100% gate runs authoritatively in CI** on every PR.
+
+**Hard limitation — read this.** `--impacted` guarantees the lines you
+*changed* are covered. It does **not** detect coverage lost in
+*unchanged* code — e.g. deleting a test that was the sole cover of an
+untouched line drops whole-repo coverage but changes no measured line,
+so `--impacted` stays green. Only CI's whole-repo gate catches that.
+Never treat a green `--impacted` as a substitute for the CI gate.
+
+Fail-safe: a corrupt / non-SQLite `.testmondata` makes the gate select
+*all* tests (rebuild from scratch), never silently under-select. New
+worktrees seed `.testmondata` + `.mypy_cache` from the main worktree
+(`worktree-setup.sh`); `finish-task` refreshes the main baseline via
+`--seed-testmon` after a merge.
 
 ## Key types / structures
 

--- a/docs/stories/QS-276.story.md
+++ b/docs/stories/QS-276.story.md
@@ -356,3 +356,31 @@ I1 rejected/descoped** by owner; **I2 carried → promoted to AC#13**.
 
 **Open after round 2:** none. Full-gate baseline measured (~564s); all
 findings resolved or owner-rejected. Finalized.
+
+### Review-fix #01 — measured `--impacted` wall-clock + kill-criterion (S7)
+
+Measured on the QS_276 worktree (10-core M-series), honoring AC#13's
+kill-criterion (Task 1):
+
+| Run | Wall-clock | Notes |
+|---|---|---|
+| Full gate (`-n auto` + sysmon) | **~564s** | baseline (AC#13) |
+| Full-suite `pytest --collect-only -q` | **3.24s** | the per-run floor testmon pays even when it selects **zero** tests (testmon deselects *after* collection) |
+| `--impacted`, first run on a fresh worktree whose diff vs the `main` testmon baseline is the **whole feature branch** | **2710.70s** (`real`, measured) | select-**all**, run **serially** (`_TESTMON_SUPPORTS_XDIST=False`) |
+| `--impacted` steady-state p50 (warm baseline, small incremental diff) | **~floor + a few tests + diff-cover ≈ 5–10s** | dominated by the 3.24s collect floor; the diff selects a handful of tests + one `diff-cover` pass (~1–2s) |
+
+**Go/no-go: GO.** The *steady-state inner-loop p50* (~5–10s) clears the
+≤~15s target and is ~50–100× faster than the full gate, which is the
+regime the feature optimizes (edit → re-run with a warm `.testmondata`).
+
+**Honest caveat surfaced by the measurement.** The **first** `--impacted`
+run on a fresh worktree (or after a large merge) is a select-all that
+runs **serially** and therefore *exceeds* the `-n auto` full gate
+(2710s > 564s). This is the design's documented "approaches a near-full
+run" worst case — mitigated, both in this PR, by (a) `worktree-setup.sh`
+seeding `.testmondata` from `main` so the baseline starts warm, and
+(b) `finish-task`'s post-merge `--seed-testmon` reseed. A stale/cold
+baseline never under-selects (fail-safe), it only costs that one slow
+first loop. Promoting testmon⊕xdist from the static `False` to parallel
+selection is tracked as out-of-scope (Design A: a runtime probe would
+add an uncoverable branch).

--- a/docs/stories/QS-276.story.md
+++ b/docs/stories/QS-276.story.md
@@ -1,0 +1,358 @@
+# QS-276 — Make the quality gate run much faster (test-impact inner loop)
+
+- **Issue:** #276
+- **Branch:** QS_276
+- **Status:** FINALIZED (story v3) — 2 review rounds, all findings resolved
+
+## Problem
+
+The quality gate (`python scripts/qs/quality_gate.py`) is slow, and that
+slowness sits on the critical path of every `implement-task` iteration —
+which pays for the **full** 100% coverage run even when only a handful of
+files changed.
+
+Measured breakdown (10-core M-series, this worktree):
+
+| Gate | Cold | Warm | Verdict |
+|---|---|---|---|
+| ruff lint | 0.03s | — | noise |
+| ruff format | 0.05s | — | noise |
+| translations | 0.09s | — | noise |
+| mypy | **16s** | **0.4s** | a `.mypy_cache` story |
+| pytest per-invocation startup floor | ~3.5s | — | fixed tax (HA plugin + conftest) |
+| pytest "collect all 6102 tests" | ~6s on top | — | importing every test module |
+| **full pytest + 100% cov (`-n auto`, sysmon)** | **~564s (9m23s)** | — | the headline — 6102 passed; slowest single test ~12s |
+
+Suite: **6102 collected tests** / ~32k LOC. At ~9.5 min/run (pytest+cov;
++16s cold mypy), the full gate is the entire cost — anything in the
+~10–15s range is a ~40× inner-loop win. The gate **already** uses
+`pytest-xdist` (`-n auto`) + `COVERAGE_CORE=sysmon` — parallelization is
+not the missing lever.
+
+Three facts: (1) cheap gates are noise (~0.15s); (2) mypy is a pure cache
+story (fresh worktree pays 16s — `worktree-setup.sh` symlinks the venv
+but not `.mypy_cache`); (3) pytest has a ~3.5s startup floor + ~6s
+collect-all cost. **testmon deselects *after* pytest collection**, so the
+~6s collect cost likely persists even when few tests run → the realistic
+inner-loop floor is ~9–10s, not ~3.5s. Task 1 measures this and decides
+whether the feature is worth building (kill-criterion, AC#13).
+
+## The constraint that splits the problem
+
+**"100% coverage is MANDATORY and NON-NEGOTIABLE on every PR"** ⇒
+test-impact selection can never satisfy the whole-repo 100% gate. Split:
+
+| Regime | Goal | Strategy |
+|---|---|---|
+| **Inner loop** (edit → re-run) | sub-~10s feedback | testmon selection + coverage scoped to the diff; no whole-repo gate |
+| **Gate / CI** (PR, release) | guarantee 100% | full suite stays authoritative; runs in CI (already does) |
+
+## Goal
+
+1. Add `--impacted` to `quality_gate.py`: run only the tests impacted by
+   the change set, and verify the **changed source lines are 100%
+   covered**.
+2. `implement-task` + `implement-setup-task` default to `--impacted`;
+   full gate on explicit request locally + authoritatively in CI.
+3. Kill cold-start penalties: `worktree-setup.sh` seeds `.testmondata` +
+   `.mypy_cache` from the main worktree; `finish-task` refreshes the main
+   baseline **against the true merged main** after merge.
+
+## Non-goals (descoped — future issues)
+
+1. **Full-gate wall-clock optimization** (coverage contexts,
+   collection-cost reduction, conftest import deferral) — a separate
+   future task; `xdist`+`sysmon` already parallelize. **One full-gate win
+   we *do* keep here**, because it's free with the seeding work: seeding
+   `.mypy_cache` kills the 16s cold-mypy on a fresh worktree.
+2. **Startup-floor *remediation*** — descoped; only the read-only
+   *sizing measurement* in Task 1 stays (it sizes the in-scope testmon
+   win; it builds nothing).
+3. **CI auto-files a GitHub issue on coverage regression** — unrelated to
+   speed, no safety beyond the existing PR hard-fail. Cut to a future
+   story.
+
+## Design
+
+### A. Inner loop — `--impacted` (single logical pass)
+
+`--impacted` is the **locked** flag name. It short-circuits early in
+`main()` (the `--quick` block returns before `_detect_scope`; `--impacted`
+gets a sibling block) and joins the mutex: **mutually exclusive with
+`--quick`/`--cache`/`--no-cache`/`--full`/`--fix`** → `parser.error`
+(exit 2). Concretely: add `args.impacted` to the existing `--quick` mutex
+condition and add a parallel `if args.impacted and (...)` guard.
+
+**Selection ⊇ coverage — the core property.** Run the **testmon-selected
+tests** under `--cov=custom_components/quiet_solar`. The `--cov` package
+sets the *measurement scope* (so a brand-new untested file appears at
+0%), while the *tests that execute* are exactly testmon's selection. A
+changed line is "covered" iff a selected test ran it — and testmon
+selects every test whose covered code changed, i.e. **a superset of the
+tests that cover the diff**. Therefore legitimately-tested changes pass
+and genuinely-untested changes (a new function/file with no selecting
+test) run zero times → 0% → fail. **This superset property is testmon's
+design; Task 1 must confirm it for the pinned version** (it is the whole
+correctness basis, and the `const.py`-zero-reruns / new-function-fails
+regressions, AC#5/#6, depend on it).
+
+**Invocation (concrete — resolves the testmon ⊕ pytest-cov conflict).**
+`pytest.ini` carries an unconditional `addopts = ... --cov-report=term-missing`,
+so pytest-cov is always active unless neutralized:
+
+- **Preferred — single process:** `pytest --testmon
+  --cov=custom_components/quiet_solar --cov-report= --cov-report=xml:<REPO_ROOT>/coverage.xml`
+  (the leading empty `--cov-report=` clears `pytest.ini`'s html/term
+  default first, exactly as `check_pytest` does; **no `--cov-fail-under`**
+  — the 100% verdict is delegated to diff-cover; whole-tree subset
+  coverage is always <100 and would otherwise fail before diff-cover
+  runs). xdist worker `.coverage.*` files are combined before the XML is
+  written.
+- **Fallback — if the pinned testmon ⊕ pytest-cov can't share one
+  process:** two passes over the **same testmon-selected set** (never the
+  whole suite): pass 1 `pytest --testmon -p no:cov` to resolve selection;
+  pass 2 the selected node ids under `--cov` as above. This pays the
+  startup floor twice (~7s) but not the suite twice.
+- **testmon ⊕ xdist** is a **static** decision (a module constant, not a
+  runtime probe — a probe would add an uncoverable branch): if the pinned
+  testmon supports `-n auto`, use it; else the selection runs serially.
+  Recorded in Task 3 with the measured worst case.
+
+**Diff base — fallback ladder (resolves spurious failures offline / fresh
+worktree).** Resolve the base in order: `origin/main` → `main` →
+merge-base with the tracked upstream. Detect with
+`git rev-parse --verify <ref>`. If a base resolves, run
+`diff-cover <REPO_ROOT>/coverage.xml --compare-branch=<base> --fail-under=100`.
+The base is **live git**, independent of the seeded `.testmondata`. If
+**no** base resolves: **warn-and-skip locally (exit 0 + notice)** so an
+offline dev isn't blocked; **exit 4 in CI** (where `origin/main` must
+exist). `origin/main` is fetched fresh before resolving so the local
+changed-line set matches CI's.
+
+**Fail-safe.** A corrupt / schema-incompatible / partially-written
+`.testmondata` (e.g. after a dependency bump or a killed run) must
+**fall back to selecting all tests**, never silently under-select.
+
+**Exit-code table** (each row bound to a dedicated test — AC#11):
+`0` pass · `1` test failure or diff-coverage <100% · `2` usage error
+(bad/mutex args, via `parser.error`) · `3` tooling missing (testmon /
+diff-cover not importable) · `4` no diff base resolvable in CI.
+
+**Code shape / test seam (AC#10 — 100% on the new code).** New functions,
+named so unit tests have explicit `patch.object` targets and mirror the
+existing pattern (`patch.object(quality_gate.subprocess, "Popen", …)` /
+`patch.object(quality_gate, "_stream_pytest", …)`):
+- `check_impacted()` — orchestrator (selection → cov → diff-cover →
+  exit-code mapping);
+- `_build_testmon_cmd()`, `_build_cov_cmd()`, `_build_diff_cover_cmd()` —
+  pure argv builders (unit-tested on argv, no subprocess);
+- reuse `_run` for git / diff-cover calls and `_stream_pytest` /
+  `_pytest_env` / `_pytest_workers` for the pytest passes;
+- the diff base is a parameter; `coverage.xml` is a fixture in tests.
+Every error branch (exit 1/3/4, corrupt-DB fallback, warn-skip) is driven
+by mocking that seam.
+
+**Contract (documented + tested).** `--impacted` guarantees the lines
+**you changed** are 100% covered. It does **not** detect coverage lost in
+*unchanged* code (e.g. deleting a test that solely covered an untouched
+line) — only CI's whole-repo gate catches that. Stated in
+`testing-layers.md`.
+
+### B. The gate stays authoritative — enforcement is CI
+
+- `implement-task` + `implement-setup-task`: default `--impacted` before
+  commit/PR; full gate only on explicit request.
+- **`review-task` unchanged** — pure orchestrator, never runs the gate.
+- `pr-quality.yml` already runs the full 100% suite on every PR and
+  hard-fails on <100% — **no change required**.
+- **CI required-status-check is load-bearing and must be verified
+  (Task 9).** The safety split assumes a PR cannot merge red; if branch
+  protection isn't configured to require the `Tests (100% Coverage)`
+  check, dropping the local whole-repo gate lets <100% merge silently.
+  Task 9 verifies/configures it and flags loudly if absent.
+- **Rule-doc edits are a precondition (same atomic commit), and must
+  reconcile *all* the existing "default" prose** so the source of truth
+  isn't internally contradictory:
+  - `project-rules.md` "Required before every commit" → new invariant
+    *"local commits run `--impacted` (changed lines 100%); whole-repo
+    100% is enforced in CI on every PR"*;
+  - reconcile `--cache` ("recommended default for repeated dev-loop
+    runs") and `--quick` ("canonical TDD command") prose with the new
+    `--impacted` agent default — state how the three relate so there
+    aren't competing "defaults";
+  - add a carve-out to the **raw-`pytest` grammar rule** for the
+    sanctioned non-gate `--seed-testmon` invocation (see C/N4);
+  - `project-context.md` "100% on every PR" framing updated to match.
+
+### C. Cold-start seeding + baseline refresh
+
+- **Seeding (new worktree):** `worktree-setup.sh` **copies** (not
+  symlinks) `$MAIN_DIR/.testmondata` and `$MAIN_DIR/.mypy_cache` into the
+  new worktree, after the existing symlink blocks, copy-if-present /
+  skip-if-absent. Copy (not symlink) because both are written during runs
+  — a shared symlink corrupts across concurrent worktrees. **Emit a
+  one-line warning when a cache is absent** so a slow first loop is
+  observable (cause: main never ran the gate / seed yet). A path-relocated
+  `.testmondata` degrades to "select more," never fewer. `.testmondata`
+  added to `.gitignore` (`.mypy_cache`/`coverage.xml`/`.coverage*` already
+  ignored). **Never git-commit `.testmondata`.**
+- **Baseline refresh (`finish-task`) — corrected + bounded:** copying the
+  *worktree's* `.testmondata` back to main is **unsafe** — it reflects the
+  worktree's base, but `main` may have advanced (other merges) before
+  yours. The baseline must reflect the **true merged main**. So **after
+  the PR merges and before cleanup**, `finish-task`:
+  1. **captures `MAIN_DIR` first** (it is *not* in `context.py`):
+     `MAIN_DIR="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"`
+     — must be read before `cleanup_worktree.py` deletes the worktree;
+  2. updates the main checkout: `git -C "$MAIN_DIR" fetch origin &&
+     git -C "$MAIN_DIR" checkout main && git -C "$MAIN_DIR" pull --ff-only`
+     (main is always checked out in the main worktree);
+  3. refreshes the baseline by invoking the **sanctioned non-gate
+     subcommand** `"$MAIN_DIR/venv/bin/python" scripts/qs/quality_gate.py
+     --seed-testmon` in `$MAIN_DIR` (NOT a raw `pytest` — that would
+     break the raw-`pytest` grammar rule and the "never run the gate"
+     hard rule; `--seed-testmon` keeps `quality_gate.py` the single
+     pytest owner and is explicitly carved out, see B). It runs
+     **detached / best-effort**: it must never block or hang cleanup; a
+     failure or timeout warns and proceeds. First refresh after a large
+     merge may approach a near-full suite run — acceptable because it's
+     detached and a stale baseline is still safe (new worktrees just run
+     more tests);
+  4. then proceeds with worktree/branch cleanup.
+
+  `--seed-testmon` (new `quality_gate.py` subcommand): runs `pytest
+  --testmon` to update `.testmondata` only; no coverage gate, no
+  pass/fail verdict; exit 0 unless the invocation itself errors.
+
+### Dependencies / version pinning
+
+`requirements_test.txt` pins exact versions (CI installs from it). Add
+`pytest-testmon` and `diff-cover` pinned to the latest versions
+**compatible with `pytest==9.0.3` / `pytest-cov==7.1.0`**; resolve the
+exact `==` pins in Task 2 by installing and confirming compatibility
+(including the testmon ⊕ pytest-cov single-process question, which
+decides Design A's preferred-vs-fallback path).
+
+## Acceptance criteria
+
+1. `requirements_test.txt` adds `pytest-testmon==<x>` + `diff-cover==<y>`
+   (exact pins); `.testmondata` added to `.gitignore`.
+2. `quality_gate.py` gains `--impacted`: testmon-selected tests under
+   `--cov=custom_components/quiet_solar` (no `--cov-fail-under`), emitting
+   `<REPO_ROOT>/coverage.xml`, then `diff-cover` `--fail-under=100`
+   against the resolved diff base.
+3. `--impacted` is mutually exclusive with
+   `--quick`/`--cache`/`--no-cache`/`--full`/`--fix` (exit 2) and
+   short-circuits before `_detect_scope`.
+4. Diff base resolves via the ladder (`origin/main`→`main`→upstream
+   merge-base, fetched fresh); no base → warn-skip (exit 0) locally,
+   exit 4 in CI.
+5. Adding a new constant to `const.py` selects **zero** impacted tests.
+6. Adding a new untested function causes `--impacted` to **fail** the
+   diff-scoped coverage check (whole-package `--cov` ⇒ 0% on the new
+   lines).
+7. Corrupt/incompatible `.testmondata` fails safe (selects all tests).
+8. `worktree-setup.sh` copies `.testmondata` + `.mypy_cache` from
+   `$MAIN_DIR` when present, warns when absent, never commits.
+9. `finish-task` (all 3 harness copies) captures `MAIN_DIR` before
+   cleanup, refreshes the baseline via `--seed-testmon`
+   detached/best-effort, then cleans up.
+10. `implement-task` + `implement-setup-task` (all 3 harness copies each)
+    default to `--impacted`; `review-task` untouched.
+11. New `quality_gate.py` code is 100%-covered via the named seam, with a
+    **dedicated test per exit-code row** (0/1/2/3/4); the change set
+    passes the full gate at 100%.
+12. `project-rules.md` + `project-context.md` updated **in this change**:
+    the local-vs-CI invariant, the `--cache`/`--quick` reconciliation,
+    and the `--seed-testmon` carve-out to the raw-`pytest` grammar rule.
+13. **Numeric target + kill-criterion (promotes I2):** baseline full gate
+    = **~564s** (measured: 6102 passed in 563.98s, `-n auto` + sysmon).
+    **Target:** `--impacted` p50 ≤ ~15s on a small diff (≈40× faster).
+    Task 1 records the measured `--impacted` wall-clock; if it is not
+    materially faster than the warm full gate (e.g. within ~30%), the
+    feature is reconsidered/abandoned **before** Tasks 2–8.
+14. Branch protection requires the CI 100%-coverage check (Task 9
+    verifies/configures; flags if absent).
+15. Docs updated (see doc-maintenance). All agent + doc + rule edits land
+    in a **single atomic commit** (drift-checker co-modification).
+
+**Regression-test strategy (AC#5/#6/#7):** unit tests mock the
+testmon/diff-cover **subprocess seam** and assert on argv + parsed
+results (fast, no stateful `.testmondata` in the repo). The genuine
+behaviors that depend on real testmon block-fingerprinting (const.py →
+zero; new function → fail; corrupt DB → select-all) are covered by **one
+integration test** building a throwaway git repo + `.testmondata` under
+`tmp_path`. Both named in Task 4.
+
+## Doc maintenance
+
+- `docs/agents/concepts/testing-layers.md` — document the TIA inner-loop
+  layer **and** the `--impacted` limitation (changed-lines only; CI is the
+  whole-repo backstop). Confirm/handle its `covers:` frontmatter vs
+  `quality_gate.py`.
+- `docs/workflow/project-rules.md` + `docs/workflow/project-context.md` —
+  the local-vs-CI invariant, `--cache`/`--quick` reconciliation,
+  `--seed-testmon` grammar carve-out (AC#12).
+- `docs/workflow/phase-protocols.md` — implement-phase contract (fast loop
+  default, full gate on request / CI).
+- **Harness-sync (same commit):** every edit to
+  `.claude/agents/qs-{implement-task,implement-setup-task,finish-task}.md`
+  lands its `.cursor/agents/` + `.opencode/agents/` mirrors. The 3 harness
+  roots: `.claude/agents/`, `.cursor/agents/`, `.opencode/agents/`.
+
+## Task breakdown
+
+1. **Profile + kill-criterion (measure-first).** Record full-suite
+   wall-clock + `--durations`; confirm testmon's superset property and
+   whether it skips collection (sets the real floor); decide go/no-go.
+2. Add `pytest-testmon` + `diff-cover` (exact pins); confirm testmon ⊕
+   pytest-cov single-process compatibility (picks Design A path); add
+   `.testmondata` to `.gitignore`.
+3. Implement `--impacted` + `--seed-testmon` in `quality_gate.py`:
+   short-circuit + mutex, single-pass (or fallback) invocation, diff-base
+   ladder, fail-safe, exit-code table, named seam; static xdist decision.
+4. Tests in `tests/test_quality_gate.py`: unit (mock seam) for
+   argv/mutex/exit-codes/missing-tooling/no-base; integration (tmp git
+   repo + `.testmondata`) for const-noop→zero, new-fn→fail, corrupt→all.
+5. Seed `.testmondata` + `.mypy_cache` in `worktree-setup.sh`
+   (copy-if-present after symlink blocks; warn-if-absent).
+6. `finish-task` (all 3 harnesses, same commit): capture `MAIN_DIR`
+   before cleanup; refresh via `--seed-testmon` detached/best-effort.
+7. Switch `implement-task` + `implement-setup-task` to `--impacted`
+   default (all 3 harnesses each, same commit). `review-task` untouched.
+8. Edit `project-rules.md` + `project-context.md` (invariant +
+   `--cache`/`--quick` reconciliation + grammar carve-out) +
+   `testing-layers.md` + `phase-protocols.md`.
+9. Verify/configure branch protection requires the CI 100% check.
+
+## Adversarial Review Notes
+
+### Round 1 (story v1) — see git history of this section; all 19 findings
+dispositioned. Delta-auditor (round 2) confirmed **18 resolved**; **C4,
+I1 rejected/descoped** by owner; **I2 carried → promoted to AC#13**.
+
+### Round 2 (story v2) — 4 globals + delta-auditor
+
+| # | Finding | Sev | State |
+|---|---|---|---|
+| N1 | whole-tree `--cov` over impacted subset is incoherent (coverage is runtime) | critical | **resolved** — single pass: testmon-selected tests under `--cov=<package>`; superset property (Task 1) |
+| N2 | `pytest.ini` `--cov-report=term-missing` addopts defeats cov-isolation | critical | **resolved** — empty `--cov-report=` first; no `--cov-fail-under`; `-p no:cov` on fallback selection pass |
+| N3 | `$MAIN_DIR` undefined in finish-task env | critical | **resolved** — derive via `git worktree list --porcelain`, capture before cleanup; main venv interpreter |
+| N4 | bare `pytest --testmon` breaks raw-pytest grammar + "never run gate" | redesign | **resolved** — routed via `quality_gate.py --seed-testmon` + grammar carve-out (AC#12) |
+| N5 | exit-3 on absent `origin/main` misfires offline/fresh worktree | redesign | **resolved** — fallback ladder + warn-skip local / exit 4 CI |
+| N6 | finish-task refresh unbounded on merge path | redesign | **resolved** — detached/best-effort, never blocks cleanup |
+| N7 | CI required-status-check asserted, not verified | critical | **resolved** — Task 9 verifies/configures (AC#14) |
+| — | static testmon⊕xdist decision (no uncoverable probe) | improve | **resolved** — module constant (Design A) |
+| — | bind each exit-code row to a test | improve | **resolved** — AC#11 |
+| — | single atomic commit (drift co-mod) | improve | **resolved** — AC#15 |
+| — | reconcile `--cache`/`--quick` "default" prose | improve | **resolved** — AC#12 |
+| — | corrupt `.testmondata` → select-all | improve | **resolved** — AC#7 |
+| — | warn when caches absent | improve | **resolved** — Design C / AC#8 |
+| — | fetch `origin/main` fresh before diff | improve | **resolved** — Design A |
+| — | promote I2 + Task-1 kill-criterion | improve | **resolved** — AC#13 |
+| — | name the new functions | improve | **resolved** — Design A seam |
+| — | tighten Non-goals wording (mypy seeding is a kept win) | improve/clarify | **resolved** — Non-goals #1/#2 |
+| I2 | numeric wall-clock target | improve | **resolved** — full gate measured at ~564s; target set in AC#13 |
+
+**Open after round 2:** none. Full-gate baseline measured (~564s); all
+findings resolved or owner-rejected. Finalized.

--- a/docs/stories/QS-276.story.md
+++ b/docs/stories/QS-276.story.md
@@ -366,21 +366,28 @@ kill-criterion (Task 1):
 |---|---|---|
 | Full gate (`-n auto` + sysmon) | **~564s** | baseline (AC#13) |
 | Full-suite `pytest --collect-only -q` | **3.24s** | the per-run floor testmon pays even when it selects **zero** tests (testmon deselects *after* collection) |
-| `--impacted`, first run on a fresh worktree whose diff vs the `main` testmon baseline is the **whole feature branch** | **2710.70s** (`real`, measured) | select-**all**, run **serially** (`_TESTMON_SUPPORTS_XDIST=False`) |
+| `--impacted`, first run on a fresh worktree whose diff vs the `main` testmon baseline is the **whole feature branch**, **serial** | **2710.70s** (`real`, measured) | select-**all** with the original `_TESTMON_SUPPORTS_XDIST=False` — this is what motivated the xdist fix below |
 | `--impacted` steady-state p50 (warm baseline, small incremental diff) | **~floor + a few tests + diff-cover ≈ 5–10s** | dominated by the 3.24s collect floor; the diff selects a handful of tests + one `diff-cover` pass (~1–2s) |
 
 **Go/no-go: GO.** The *steady-state inner-loop p50* (~5–10s) clears the
 ≤~15s target and is ~50–100× faster than the full gate, which is the
 regime the feature optimizes (edit → re-run with a warm `.testmondata`).
 
-**Honest caveat surfaced by the measurement.** The **first** `--impacted`
-run on a fresh worktree (or after a large merge) is a select-all that
-runs **serially** and therefore *exceeds* the `-n auto` full gate
-(2710s > 564s). This is the design's documented "approaches a near-full
-run" worst case — mitigated, both in this PR, by (a) `worktree-setup.sh`
-seeding `.testmondata` from `main` so the baseline starts warm, and
-(b) `finish-task`'s post-merge `--seed-testmon` reseed. A stale/cold
-baseline never under-selects (fail-safe), it only costs that one slow
-first loop. Promoting testmon⊕xdist from the static `False` to parallel
-selection is tracked as out-of-scope (Design A: a runtime probe would
-add an uncoverable branch).
+**testmon⊕xdist promoted to parallel (review-fix).** The 2710s serial
+select-all above made the *worst case* (fresh worktree / large diff /
+cold baseline) **slower** than the `-n auto` full gate (564s) — the
+inner-loop value is lost exactly when the baseline is cold. The original
+`_TESTMON_SUPPORTS_XDIST=False` was an over-conservative assumption.
+Re-checked empirically against the pins (`pytest-testmon==2.2.0`,
+`pytest-xdist==3.8.0`): testmon 2.2.0 ships first-class xdist support and,
+on a throwaway repo under `-n auto`, the superset property holds exactly
+(no-op→0, covered-edit→reselect, uncovered-edit→0) **and** testmon ⊕
+pytest-cov combine per-worker `.coverage` files into a valid
+`coverage.xml` that diff-cover reads at 100%. So `_TESTMON_SUPPORTS_XDIST`
+is now **True**, and `--seed-testmon` (the heaviest pass — a full
+select-all) also runs under `-n auto`. The select-all worst case now
+falls to roughly the `-n auto` full-gate ballpark instead of ~45 min
+serial. The cold-baseline first-loop cost is still further mitigated by
+(a) `worktree-setup.sh` seeding `.testmondata` from `main` and
+(b) `finish-task`'s post-merge `--seed-testmon` reseed; a stale/cold
+baseline never under-selects (fail-safe), it only costs more tests.

--- a/docs/stories/QS-276.story_review_fix_#01.md
+++ b/docs/stories/QS-276.story_review_fix_#01.md
@@ -1,0 +1,128 @@
+# QS-276 — Review fix plan #01
+
+## Summary
+- Source PR: #277
+- Source story: docs/stories/QS-276.story.md
+- Findings to fix: 15 (1 must-fix, 7 should-fix, 7 nice-to-have)
+- Next implement phase: `implement-setup-task`
+
+> Routing note: every required code edit is under `scripts/qs/`,
+> `scripts/`, `.claude|.cursor|.opencode/agents/`, or `docs/` —
+> `implement-setup-task` scope. The single `tests/test_quality_gate.py`
+> file is the quality gate's own test suite (dev-infra; authored under
+> the setup variant when the PR was built), so it travels with the
+> setup variant rather than triggering `implement-task` (whose scope
+> excludes `scripts/`).
+
+## Findings to fix
+
+### [must-fix] M1 — `--seed-testmon` not mutually exclusive with other execution modes
+- File: `scripts/qs/quality_gate.py:1040` (also `:1095-1104`); test in `tests/test_quality_gate.py:2359`
+- Severity: must-fix
+- Source: qs-review-coderabbit
+- Description: `--seed-testmon` is not validated against `--quick` / `--impacted` / `--full` / `--cache` / `--no-cache` / `--fix`. The `main()` dispatch order short-circuits `--impacted` before `--seed-testmon`, and `--seed-testmon` before cache/scope/full handling, so combinations like `--seed-testmon --quick tests/test_x.py` or `--seed-testmon --full` silently ignore the seeding request (and may skip the gate) instead of erroring. The help text presents `--seed-testmon` as its own subcommand.
+- Proposed fix: Add a parser-level mutex error so `--seed-testmon` combined with any other execution mode exits 2 (same pattern as the existing `--impacted` mutex guard). Add a conflict-matrix test for `--seed-testmon` in `tests/test_quality_gate.py` mirroring `test_impacted_mutex_exits_2`.
+
+### [should-fix] S1 — `_resolve_diff_base` unconditional `git fetch origin main` on the inner-loop hot path
+- File: `scripts/qs/quality_gate.py:~1130` (fetch); `_run` at `~122`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (×2)
+- Description: `_resolve_diff_base()` runs `git fetch origin main` on every `--impacted` invocation. Two problems: (a) `_run` has no `timeout=`, so a hung/slow remote (VPN drop, dead SSH host) can block the "sub-15s" gate indefinitely; (b) a silently-failed fetch (offline) leaves a *stale* `origin/main`, so the changed-line set no longer matches CI — yet nothing warns, making the "fetched fresh" design promise false.
+- Proposed fix: Add a subprocess timeout to the fetch (and/or `_run`), and emit a one-line warning when the fetch returns non-zero so the divergence is observable. Consider skipping/backgrounding the fetch when not in CI. Keep CI behavior authoritative.
+
+### [should-fix] S2 — `--seed-testmon` requires diff-cover it never uses
+- File: `scripts/qs/quality_gate.py:1004` (calls `_impacted_tooling_available()` at `~1002`)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: `--seed-testmon` reuses `_impacted_tooling_available()`, which also checks for `diff-cover`. So the maintenance subcommand exits 3 when diff-cover is missing, even though seeding never invokes diff-cover — this can needlessly block the post-merge baseline refresh.
+- Proposed fix: For the `--seed-testmon` path, check only for `pytest-testmon` availability (a narrower probe), not the full impacted tooling set.
+
+### [should-fix] S3 — finish-task hardcodes `$MAIN_DIR/venv/bin/python` for the detached refresh
+- File: `.claude/agents/qs-finish-task.md:~147`, plus `.cursor/agents/qs-finish-task.md` and `.opencode/agents/qs-finish-task.md` (keep all 3 harnesses in sync)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The post-merge baseline refresh launches `"$MAIN_DIR/venv/bin/python"`. If that interpreter path is missing, the refresh is silently skipped while the agent still prints a success message.
+- Proposed fix: Probe for a usable interpreter (prefer `python`/`python3` on PATH, or fall back) before announcing the refresh started; emit a warning instead of a false success if none is found. Apply identically across all three harness copies.
+
+### [should-fix] S4 — `worktree-setup.sh` cache seeding is fragile
+- File: `scripts/worktree-setup.sh:~317` (`cp -R`), `~336` (remediation message), `~344` (`[ ! -e "$dst" ]` guard)
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-coderabbit + qs-review-edge-case-hunter
+- Description: Three related issues in the seeding loop: (1) `cp -R "$src" "$dst"` has no error handling — a partial copy (disk full / permissions) can wedge `.mypy_cache` (a partial `.testmondata` is recoverable via the fail-safe, but `.mypy_cache` is not); (2) the cache-miss remediation message suggests `--seed-testmon` as if runnable standalone and applies it to `.mypy_cache` too, which is misleading / not executable; (3) when `$dst` already exists (re-run after an interrupted setup), the copy is skipped silently, leaving a possibly-truncated DB with no warning.
+- Proposed fix: Guard the copy (`cp -R ... || { rm -rf "$dst"; echo "warn: ..."; }`); make the cache-miss message cache-specific and actually executable; warn (or re-copy) when `$dst` already exists instead of silently skipping. Cover the copy-vs-skip and per-cache behavior in the existing `TestWorktreeSetupSeedsCaches` tests.
+
+### [should-fix] S5 — decoupled diff base produces confusing FAILs
+- File: `scripts/qs/quality_gate.py` (`check_impacted` failure path / diff-cover invocation)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: testmon selection runs against the seeded `.testmondata` baseline, while the diff-cover verdict runs against live `origin/main`. If `origin/main` advances past the testmon baseline, testmon may not select a test covering a changed line, yet diff-cover still demands 100% on that line — producing a FAIL whose real remedy is "reseed", not "add a test".
+- Proposed fix: Add a hint to the diff-cover failure message pointing at `--seed-testmon` / reseeding when coverage gaps may stem from a stale testmon baseline. (Doc-only / message-only; no behavior change required.)
+
+### [should-fix] S6 — AC#11 coverage risk: new lines may depend on skip-guarded integration tests
+- File: `tests/test_quality_gate.py` (`TestImpactedIntegrationRealTestmon`, `@pytest.mark.integration`); verify against `.github/workflows/pr-quality.yml` and pytest config
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The real-testmon integration tests are `@pytest.mark.integration` and skip when testmon/diff-cover are not importable. If the whole-repo CI coverage run deselects the `integration` marker (or runs without those tools), new module-level fallback lines could end up covered only by mocked-seam unit tests — risking <100% on the authoritative gate.
+- Proposed fix: Confirm the full CI gate actually executes the `integration`-marked tests (and the tools are installed there); if not guaranteed, ensure the mocked-seam unit tests independently cover every new line. Document the decision.
+
+### [should-fix] S7 — AC#13 kill-criterion: no recorded `--impacted` wall-clock / go-no-go
+- File: `docs/stories/QS-276.story.md` (or PR #277 body)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The story's kill-criterion (Task 1) required recording the measured `--impacted` wall-clock and a go/no-go decision. The change set carries the baseline (~564s) but no measured `--impacted` p50.
+- Proposed fix: Capture the measured `--impacted` wall-clock (p50) and the go/no-go decision in the story's review notes or the PR body to honor the kill-criterion.
+
+### [nice-to-have] N1 — test should assert each cache is copied, not symlinked
+- File: `tests/test_quality_gate.py:~2381`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: The regression passes even if only `.mypy_cache` is `cp -R`'d (with `.testmondata` only appearing in a warning), or if a symlink path is later introduced.
+- Proposed fix: Assert each cache is copied per-cache and reject `ln -s`/`ln -sf`.
+
+### [nice-to-have] N2 — add a doc-content guard test for the `--seed-testmon` carve-out (AC#12)
+- File: `tests/test_quality_gate.py`; asserts content of `docs/workflow/project-rules.md`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The `--cache`/`--quick` reconciliation and `--seed-testmon` carve-out doc edits have no content guard (unlike the other doc-touching ACs), relying solely on the drift-checker.
+- Proposed fix: Add a lightweight test asserting `project-rules.md` contains the `--seed-testmon` carve-out heading, matching the existing doc-guard pattern.
+
+### [nice-to-have] N3 — `_is_ci` CI detection is narrow
+- File: `scripts/qs/quality_gate.py` (`_is_ci`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Recognizes only `CI` in `{"1","true"}`; some CI systems use `CI=yes`/`on` or only provider vars (`GITHUB_ACTIONS`). Fine for GitHub Actions as scoped, but narrow.
+- Proposed fix: Broaden the truthy set and/or also honor `GITHUB_ACTIONS`.
+
+### [nice-to-have] N4 — inline `__import__("re")` despite top-level import
+- File: `tests/test_quality_gate.py` (`_selected_count`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Uses `__import__("re")` inline even though `re` is imported at module top.
+- Proposed fix: Use `re.search` directly.
+
+### [nice-to-have] N5 — confirm integration tests are excluded from the `--impacted` fast loop
+- File: `tests/test_quality_gate.py` (`TestImpactedIntegrationRealTestmon`); pytest config
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The real-subprocess integration tests (git init + two pytest subprocess runs each) are slower/flakier; they are correctly marked/skip-guarded but should be confirmed excluded from the `--impacted` loop they document.
+- Proposed fix: Verify (and document) that the `integration` marker is deselected by the `--impacted` path.
+
+### [nice-to-have] N6 — `_ensure_testmon_db_safe` unlink not missing-safe
+- File: `scripts/qs/quality_gate.py:~1164`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `TESTMON_DATA.unlink()` can raise `FileNotFoundError` if the file disappears between the check and the unlink. The fail-safe intent (force select-all) is already satisfied by an absent file.
+- Proposed fix: Use `unlink(missing_ok=True)` (or catch the error).
+
+### [nice-to-have] N7 — guard `COVERAGE_XML.exists()` before diff-cover
+- File: `scripts/qs/quality_gate.py:~1240` (`check_impacted`, before `_build_diff_cover_cmd`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The flow relies on pytest-cov writing `coverage.xml` even on zero-collection. If a future pytest-cov stops emitting it, diff-cover would read a stale/missing file with no guard. A code comment documents the current verified behavior; add a defensive existence check.
+- Proposed fix: Assert/`COVERAGE_XML.exists()` before invoking diff-cover, with a clear error if missing.
+
+## How to apply
+
+Run `implement-setup-task` against this fix plan. When done, return and
+run `/review-task` again (or open a fresh `claude --agent qs-review-task`
+session) to re-verify.

--- a/docs/stories/QS-276.story_review_fix_#02.md
+++ b/docs/stories/QS-276.story_review_fix_#02.md
@@ -1,0 +1,148 @@
+# QS-276 — Review fix plan #02
+
+## Summary
+- Source PR: #277
+- Source story: docs/stories/QS-276.story.md
+- Findings to fix: 9 (3 should-fix + 6 nice-to-have)
+- Next implement phase: `/implement-task`
+  (findings touch `tests/test_quality_gate.py`, which is outside
+  `implement-setup-task`'s edit scope → `implement-task`.)
+
+No must-fix findings. The edge-case-hunter's exit-code-5 must-fix was
+**debunked empirically** (testmon exits 0 on a zero-selection run, so
+`check_impacted` proceeds to diff-cover as designed). CodeRabbit's
+must-fix/should-fix items were already resolved by review-fix #01.
+
+All fixes must land with the full quality gate green and 100% coverage
+on changed lines.
+
+## Findings to fix
+
+### [should-fix] SF1 — `_ensure_testmon_db_safe` deletes a transiently-locked but valid DB
+- File: `scripts/qs/quality_gate.py:~1456` (`_ensure_testmon_db_safe`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The corruption probe catches `sqlite3.DatabaseError`,
+  but `sqlite3.OperationalError` ("database is locked") is a subclass.
+  A *valid* `.testmondata` that is transiently locked by a concurrent
+  `--seed-testmon`/`--impacted` run is therefore treated as corrupt and
+  `unlink`ed, wiping a recoverable baseline and forcing a full
+  select-all.
+- Proposed fix: Narrow the `except` so only genuine corruption deletes
+  the DB. Distinguish `sqlite3.OperationalError` ("database is locked")
+  — which should be left intact (skip the probe / proceed without
+  deletion) — from corruption-specific `DatabaseError`s that warrant
+  `unlink`. Add a unit test that a locked-but-valid DB is preserved and
+  a genuinely corrupt DB is still deleted.
+
+### [should-fix] SF2 — testmon-seeded baseline vs live `origin/main` diff-base decoupling
+- File: `scripts/qs/quality_gate.py` (`check_impacted` /
+  `_build_diff_cover_cmd`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter (S5), qs-review-acceptance-auditor (AC#4)
+- Description: testmon selects tests against the seeded `.testmondata`
+  baseline, while diff-cover compares changed lines against a
+  freshly-fetched `origin/main`. When main advances past the baseline,
+  the gate can false-FAIL. Currently mitigated only by an advisory
+  reseed hint. The failure direction is safe (false-fail, never
+  false-pass).
+- Proposed fix: Detect staleness rather than relying on prose. When
+  diff-cover fails, compare the testmon baseline commit (recorded in
+  `.testmondata`, or the worktree's last-seed marker) against the
+  resolved diff base; if the baseline is behind, surface a clear
+  "baseline stale — reseed" verdict (distinct exit message) instead of
+  a generic coverage failure. Keep the existing hint as the fallback.
+  Add a test covering the stale-baseline detection path.
+
+### [should-fix] SF3 — cross-worktree `.testmondata` relocation invariant is unverified
+- File: `scripts/worktree-setup.sh` (cache-seeding block)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The script asserts in a comment that a path-relocated
+  `.testmondata` "degrades to select-more, never fewer," but nothing
+  enforces or tests this. If the assumption were ever false, copying
+  the DB across worktrees could under-select impacted tests.
+- Proposed fix: Replace the bare comment with an enforced guard — add a
+  test (in `tests/test_quality_gate.py`'s `TestWorktreeSetupSeedsCaches`
+  or a sibling) that demonstrates a relocated DB selects a superset
+  (never a subset) of tests, OR have the seeding step record the source
+  path so a relocation can be detected and the DB re-fingerprinted on
+  first use. Document the verified invariant inline.
+
+### [nice-to-have] NH1 — diff-cover subprocess runs without a timeout
+- File: `scripts/qs/quality_gate.py:~1072` (`check_impacted` → `_run(_build_diff_cover_cmd(...))`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+- Description: The diff-cover call uses the unbounded `_run`, unlike the
+  hot-path `git fetch` which got `_FETCH_TIMEOUT_SECONDS`. A pathological
+  diff-cover hang breaks the sub-15s inner-loop promise.
+- Proposed fix: Pass a `timeout=` to the diff-cover `_run` call,
+  consistent with the fetch's S1 rationale. Add/extend a test asserting
+  the timeout is applied.
+
+### [nice-to-have] NH2 — `_resolve_diff_base` doesn't check merge-base reachability
+- File: `scripts/qs/quality_gate.py` (`_resolve_diff_base`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: A shallow CI clone (`fetch-depth: 1`) can resolve
+  `origin/main` to a commit with no common merge-base with HEAD, making
+  diff-cover diff against unrelated history and report a spuriously huge
+  changed-line set.
+- Proposed fix: After resolving the candidate base, verify a merge-base
+  exists (`git merge-base --is-ancestor` or `git merge-base <base>
+  HEAD`); if not, treat as "no base" (warn-skip locally / exit 4 in CI,
+  same as the no-base ladder). Add a test for the unreachable-base path.
+
+### [nice-to-have] NH3 — AC#11 exit-code-2 missing from the parametrized exit-code table
+- File: `tests/test_quality_gate.py:~2321`
+  (`test_impacted_exits_with_check_impacted_code`)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The exit-code passthrough test parametrizes `[0, 1, 3, 4]`,
+  omitting 2 (raised by `parser.error` before `check_impacted`). Exit 2
+  is covered by `test_impacted_mutex_exits_2` /
+  `test_seed_testmon_mutex_exits_2`, but a reader scanning the table
+  won't find it.
+- Proposed fix: Add a code comment/cross-reference at the parametrized
+  table pointing to the mutex exit-2 tests, so the "dedicated test per
+  exit-code row" guarantee is self-evident.
+
+### [nice-to-have] NH4 — `_is_ci` truthy set omits `y`/`t`
+- File: `scripts/qs/quality_gate.py` (`_is_ci`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The truthy set is `("1","true","yes","on")`; some CI
+  providers use `y`/`t`. Minor; current set covers GitHub Actions.
+- Proposed fix: Extend the truthy set to include `y`/`t` (and document
+  the accepted values). Update the `_is_ci` test parametrization.
+
+### [nice-to-have] NH5 — worktree-setup cache test should reject symlinks per-cache
+- File: `tests/test_quality_gate.py:~2381`
+  (`TestWorktreeSetupSeedsCaches`)
+- Severity: nice-to-have
+- Source: qs-review-coderabbit (nitpick)
+- Description: The current assertion can pass if only one cache is
+  copied while the other appears solely in a warning, or if a symlink
+  path is later introduced. Tighten the regression to assert each cache
+  is genuinely copied (`cp -R`) and reject `ln -s`/`ln -sf`.
+- Proposed fix: Assert copy handling per cache (`.testmondata` and
+  `.mypy_cache`) independently and assert the script does not symlink.
+
+### [nice-to-have] NH6 — AC#13 kill-criterion measurement is narrative-only
+- File: `docs/stories/QS-276.story.md` (and PR #277 body)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The measured `--impacted` wall-clock (p50 ~5–10s) and the
+  GO decision live only in story prose, not in the PR body's testing
+  section or a reproducible artifact.
+- Proposed fix: Mirror the measured number + go/no-go into the PR #277
+  body's Testing section (and/or a short note in the story's testing
+  summary) so the kill-criterion is independently visible. Docs-only; no
+  test.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. Apply each fix TDD-style
+(failing test first where a test is specified), keep the full quality
+gate green at 100% coverage, then return and run `/review-task` again to
+re-verify.

--- a/docs/stories/QS-276.story_review_fix_#03.md
+++ b/docs/stories/QS-276.story_review_fix_#03.md
@@ -1,0 +1,138 @@
+# QS-276 — Review fix plan #03
+
+## Summary
+- Source PR: #277
+- Source story: docs/stories/QS-276.story.md
+- Findings to fix: 7 (1 must-fix + 2 should-fix + 4 nice-to-have)
+- Next implement phase: `/implement-task`
+  (MF1/SF1/SF2 need new tests in `tests/test_quality_gate.py`, which is
+  outside `implement-setup-task`'s edit scope → `implement-task`.)
+
+Round-#02 fixes (SF1–SF3, NH1–NH6) all verified resolved. The
+exit-code-5 item stays debunked. Two new issues surfaced from the
+freshly-added code (CodeRabbit) plus one material correctness gap in
+the testmon selection filter (edge-case-hunter).
+
+All fixes must land with the full quality gate green and 100% coverage
+on changed lines.
+
+## Findings to fix
+
+### [must-fix] MF1 — `_build_testmon_cmd` deselects domain integration tests that cover production code
+- File: `scripts/qs/quality_gate.py:1055-1056` (`_build_testmon_cmd`)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter (verified by orchestrator)
+- Description: The `-m "not integration"` filter — added as review-fix
+  N5 to keep the slow testmon *self-tests* (real-subprocess git-init +
+  nested pytest in `tests/test_quality_gate.py`) out of the inner loop —
+  also deselects the ~48 **domain** integration tests across
+  `tests/test_charger_rebalancing_scenarios.py`,
+  `tests/test_constraint_interaction_boundaries.py`,
+  `tests/test_solver_forecast_scenarios.py`,
+  `tests/test_grid_transition_constraints.py`,
+  `tests/test_boost_only_devices.py`, `tests/test_green_only_devices.py`,
+  `tests/test_piloted_device.py`, `tests/test_external_control_detection.py`,
+  `tests/test_ha_dynamic_group.py`. These import and exercise
+  `custom_components/quiet_solar` (solver, constraints, charger
+  rebalancing). The inline comment at line 1052 ("They never cover
+  `custom_components/quiet_solar`") is FALSE for these domain tests —
+  verified: each imports `custom_components.quiet_solar` (5–26 import
+  sites per file).
+  Failure mode: when a changed production line is covered *only* by an
+  integration test, testmon selects that test → `-m "not integration"`
+  deselects it → the changed line runs zero times → 0% in coverage.xml
+  → `diff-cover --fail-under=100` returns 1. The developer cannot make
+  `--impacted` green locally; only CI's whole-repo gate (no `-m`
+  deselection) covers it. This defeats the inner-loop promise precisely
+  for the project's core domain logic.
+- Proposed fix: Narrow the deselection so it excludes ONLY the testmon
+  self-tests, not the shared `integration` marker. Options: deselect by
+  path (`--ignore tests/test_quality_gate.py` for the impacted run) or
+  introduce a dedicated marker/keyword for the slow real-subprocess
+  self-tests (e.g. `selftest`/`subprocess`) and filter on that instead.
+  Do NOT drop domain integration coverage from the impacted run. Add a
+  test asserting `_build_testmon_cmd` does not deselect the domain
+  `integration` marker (or asserts a production line covered only by an
+  integration test passes `--impacted`).
+
+### [should-fix] SF1 — `_run()` not pinned to UTF-8 decoding
+- File: `scripts/qs/quality_gate.py:139` (`_run`)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: `subprocess.run(..., text=True)` inherits the locale
+  codec, so non-ASCII output from `git`/`diff-cover` can raise
+  `UnicodeDecodeError` under `LANG=C`, bypassing the normal return-code
+  handling.
+- Proposed fix: Pass `encoding="utf-8", errors="replace"` to the
+  `subprocess.run` call in `_run`, matching `_stream_pytest()`. Add/extend
+  a test covering non-ASCII subprocess output.
+
+### [should-fix] SF2 — diff-cover timeout (124) misreported as coverage/staleness failure
+- File: `scripts/qs/quality_gate.py:1147` (`check_impacted`)
+- Severity: should-fix
+- Source: qs-review-coderabbit (follow-on from review-fix #02 NH1)
+- Description: The NH1 fix bounded diff-cover with a timeout; a timed-out
+  diff-cover now returns `124` from `_run`, but the current branches
+  report it as "changed lines <100% covered" or "baseline stale",
+  giving the wrong primary verdict for the failure actually hit.
+- Proposed fix: Detect the `124` timeout return first and emit a distinct
+  timeout verdict before the coverage/staleness messaging. Add a test for
+  the timeout-return path.
+
+### [nice-to-have] NH1 — `_run` discards partial output on `TimeoutExpired`
+- File: `scripts/qs/quality_gate.py` (`_run`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: On `subprocess.TimeoutExpired` the synthesized
+  `CompletedProcess` sets `stdout=""`, discarding `exc.stdout`/`exc.stderr`
+  partial output that could aid diagnosis.
+- Proposed fix: Populate the synthesized `CompletedProcess` with the
+  exception's partial `stdout`/`stderr` (decoded) when present.
+
+### [nice-to-have] NH2 — duplicate reseed hints in `check_impacted`
+- File: `scripts/qs/quality_gate.py` (`check_impacted`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The stale-baseline branch and the S5 branch emit
+  near-duplicate "reseed with --seed-testmon" guidance; maintenance drift
+  risk.
+- Proposed fix: Consolidate to a single shared hint constant/helper.
+
+### [nice-to-have] NH3 — `cp -R` mixes a single file and a directory
+- File: `scripts/worktree-setup.sh` (cache-seeding loop)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The loop runs `cp -R` over both `.testmondata` (a file)
+  and `.mypy_cache` (a dir); harmless but surprising.
+- Proposed fix: Add a brief inline note explaining the single-file vs dir
+  handling (no functional change required).
+
+### [nice-to-have] NH4 — `seed_testmon` returns 0 even on a pytest collection crash
+- File: `scripts/qs/quality_gate.py` (`seed_testmon`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `seed_testmon` discards `_stream_pytest`'s result and
+  returns 0 unconditionally, so a pytest collection error / internal
+  crash (exit 2/3, not a mere test failure) reports success while
+  `.testmondata` may be unwritten/partial. `finish-task` then prints
+  "Baseline refresh started" as if it succeeded. Impact is low (detached,
+  best-effort; a stale/absent baseline only over-selects), but the
+  docstring contract isn't enforced.
+- Proposed fix: Surface a non-zero `_stream_pytest` returncode as a
+  warning (still best-effort / non-fatal). Add a test for the
+  collection-crash path.
+
+## Merge-time note (not an implement item)
+
+- **AC#15 single atomic commit (NH5, acceptance-auditor):** the branch
+  has multiple commits across review rounds. The drift-prevention intent
+  is satisfied per-commit and in the merged tree. Resolve the literal
+  "single commit" wording by **squash-merging** in finish-task. No code
+  change.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. Apply each fix TDD-style
+(failing test first for MF1/SF1/SF2/NH4), keep the full quality gate
+green at 100% coverage, then return and run `/review-task` again to
+re-verify.

--- a/docs/stories/QS-276.story_review_fix_#04.md
+++ b/docs/stories/QS-276.story_review_fix_#04.md
@@ -1,0 +1,137 @@
+# QS-276 — Review fix plan #04
+
+## Summary
+- Source PR: #277
+- Source story: docs/stories/QS-276.story.md
+- Findings to fix: 6 (1 must-fix + 3 should-fix + 2 nice-to-have)
+- Next implement phase: `/implement-task`
+  (fixes touch `tests/test_quality_gate.py`, outside
+  `implement-setup-task`'s edit scope → `implement-task`.)
+
+Round-#03 fixes (MF1 testmon-deselection, SF1 UTF-8, SF2 124-timeout,
+NH1–NH4) all verified resolved. The exit-code-5 item stays debunked.
+But fix-plan #03's *new tests* regressed CI by hard-coding `VENV_PYTHON`,
+turning the required `Tests (100% Coverage)` check RED — that is the
+headline blocking finding this round.
+
+All fixes must land with the full quality gate green AND the CI
+`Tests (100% Coverage)` job green (the gate is currently red — see MF1).
+
+## Findings to fix
+
+### [must-fix] MF1 — round-3 tests hard-code `VENV_PYTHON`; CI `Tests (100% Coverage)` is RED
+- File: `tests/test_quality_gate.py` (+ `scripts/qs/quality_gate.py` `_run`/probes)
+- Severity: must-fix (BLOCKING — required check failing)
+- Source: qs-review-acceptance-auditor (confirmed live via `gh pr checks` + CI log)
+- Description: Fix-plan #03's new tests invoke `quality_gate.VENV_PYTHON`
+  (`venv/bin/python`), which does not exist on the CI runner →
+  `FileNotFoundError: .../venv/bin/python`. CI run 28111925293 shows
+  `5 failed, 5 errors` on the `Tests (100% Coverage)` job (whole-repo
+  coverage still hits 100%, but the suite does not pass). Offending tests:
+  - `TestRunTimeout::test_run_decodes_non_ascii_output_without_crashing`
+    — real subprocess to `VENV_PYTHON`, no guard.
+  - `TestBuildImpactedCmds::test_testmon_cmd_does_not_deselect_integration_marker`
+    and `::test_testmon_cmd_ignores_only_the_selftest_file` — call
+    `_build_testmon_cmd()` with the default `_TESTMON_SUPPORTS_XDIST=True`,
+    which calls `_pytest_workers()` → probes `VENV_PYTHON` and raises.
+  - `TestSeedTestmon::test_seed_not_blocked_when_only_diff_cover_missing`
+    — hits the real `_pytest_workers` → `VENV_PYTHON` probe.
+  - `TestImpactedIntegrationRealTestmon` (all 5) and
+    `TestTestmonRelocationInvariant::test_relocated_db_with_changed_content_reselects_never_underselects`
+    — guard via `_impacted_tooling_available()`, but that helper itself
+    runs `_run([VENV_PYTHON, ...])`, and `_run` does not catch
+    `FileNotFoundError` (only `TimeoutExpired`), so the intended
+    `pytest.skip` never fires and they ERROR.
+- Proposed fix:
+  1. Add a module-level skip guard (e.g. `_venv_python_available()` doing
+     `Path(VENV_PYTHON).exists()`) applied to every test that reaches a
+     real `VENV_PYTHON` invocation, so they SKIP cleanly on CI exactly
+     like the pre-round-3 `TestImpactedIntegrationRealTestmon` already did
+     (`SKIPPED ... venv python not available`).
+  2. For the argv-builder *unit* tests (`TestBuildImpactedCmds`,
+     `TestSeedTestmon`), patch `_pytest_workers` and/or
+     `_TESTMON_SUPPORTS_XDIST=False` so they never run the real venv probe.
+  3. Optionally harden `_run`/`_impacted_tooling_available` to tolerate a
+     missing interpreter (catch `FileNotFoundError` → treat as
+     unavailable) so the tooling probe degrades to "skip", not "crash".
+  - Verify by confirming `gh pr checks 277` shows `Tests (100% Coverage)`
+    green after the push.
+
+### [should-fix] SF-A — untracked new files produce a false PASS
+- File: `scripts/qs/quality_gate.py` (`_build_diff_cover_cmd`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: diff-cover 10.3.0 defaults to `include_untracked=False`, so
+  a brand-new untracked `custom_components/quiet_solar/foo.py` containing
+  an untested function contributes zero changed lines and scores vacuously
+  100% — `--impacted` reports PASS before `git add`. This is the dominant
+  inner-loop scenario (new code starts untracked) and defeats AC#6 locally.
+  CI's whole-repo gate is the backstop (untracked files can't be
+  committed), hence should-fix not must-fix. The AC#6 integration test
+  only exercises the committed-file path, so this gap is untested.
+- Proposed fix: Add `--include-untracked` to `_build_diff_cover_cmd`'s
+  argv. Add a regression test: a new untracked file with an uncovered
+  function makes `--impacted` (diff-cover) fail.
+
+### [should-fix] SF-B — "baseline stale" diagnostic misfires (wrong guidance)
+- File: `scripts/qs/quality_gate.py` (`_diff_base_ahead_of_head`, `check_impacted`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter, qs-review-blind-hunter
+- Description: The round-3 SF2 staleness branch assumes a two-dot diff,
+  but diff-cover's pinned default range notation is three-dot `...`
+  (`merge-base(base, HEAD)…HEAD`). So an advanced `origin/main` does NOT
+  inflate the changed-line set — the stale-baseline scenario the branch
+  was written for does not actually occur with this diff-cover version.
+  Consequence: whenever the branch fork point is behind upstream AND the
+  dev's own diff has a genuinely uncovered line, `_diff_base_ahead_of_head`
+  returns True and the gate prints "FAIL (baseline stale — reseed
+  required)" instead of pointing at the real uncovered line. Exit code (1)
+  is correct; the diagnostic is misleading.
+- Proposed fix: Either drop the stale-baseline branch (given the `...`
+  notation makes it a non-issue) or gate the "reseed" message on a signal
+  that actually distinguishes staleness from a genuine uncovered line.
+  Update/relax the associated test to match the corrected behavior.
+
+### [should-fix] SF-C — `_run` timeout note keeps a leading blank for whitespace-only stderr
+- File: `scripts/qs/quality_gate.py` (`_run`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: On `TimeoutExpired`, the note-building ternary treats a
+  whitespace-only `err` as truthy, yielding a mid-string blank line before
+  the timeout note.
+- Proposed fix: Use `err.strip()` in the truthiness condition so
+  whitespace-only stderr is treated as empty. Cover with a small assertion.
+
+### [nice-to-have] NH1 — shared `coverage.xml` path races under concurrent `--impacted` runs
+- File: `scripts/qs/quality_gate.py` (`COVERAGE_XML`, `check_impacted`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Two overlapping `--impacted` runs in one worktree both write
+  `REPO_ROOT/coverage.xml`; run A's diff-cover can read run B's
+  freshly-overwritten XML → verdict against the wrong selection. Low
+  likelihood (single-worktree concurrency).
+- Proposed fix: Write coverage to a per-run temp path (e.g.
+  `tempfile`-based) consumed by diff-cover, or document the single-run
+  constraint.
+
+### [nice-to-have] NH2 — `dc.stdout` flushed before the 124-timeout branch
+- File: `scripts/qs/quality_gate.py` (`check_impacted`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: On the diff-cover 124-timeout path, `dc.stdout` (the
+  partial/empty synthetic capture) is written before the timeout FAIL
+  message. Cosmetic.
+- Proposed fix: Skip flushing `dc.stdout` (or reorder) on the timeout path.
+
+## Merge-time note (not an implement item)
+
+- **AC#15 single atomic commit (NH, acceptance-auditor):** multiple
+  commits across review rounds; resolve by **squash-merging** in
+  finish-task. No code change.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. Fix MF1 FIRST and confirm
+`gh pr checks 277` shows `Tests (100% Coverage)` green. Apply each fix
+TDD-style, keep the full quality gate green at 100% coverage, then return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-276.story_review_fix_#05.md
+++ b/docs/stories/QS-276.story_review_fix_#05.md
@@ -1,0 +1,79 @@
+# QS-276 — Review fix plan #05
+
+## Summary
+- Source PR: #277
+- Source story: docs/stories/QS-276.story.md
+- Findings to fix: 3 (1 should-fix + 2 nice-to-have)
+- Next implement phase: `/implement-task`
+  (SF1 needs a test in `tests/test_quality_gate.py`, outside
+  `implement-setup-task`'s edit scope → `implement-task`.)
+
+Round-4 was essentially clean: CI `Tests (100% Coverage)` is green, all
+15 ACs trace green, and the edge-case-hunter found nothing (empirically
+re-verified every prior-round fix). Remaining items are minor hardening
+and observability.
+
+All fixes must land with the full quality gate green AND CI
+`Tests (100% Coverage)` green.
+
+## Findings to fix
+
+### [should-fix] SF1 — clear `coverage.xml` before writing the impacted report
+- File: `scripts/qs/quality_gate.py` (`check_impacted`, report-generation path)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: `check_impacted()` only verifies `COVERAGE_XML.exists()`
+  before invoking diff-cover. On sequential `--impacted` runs, a stale
+  `coverage.xml` left by a previous run can mask a pytest-cov emission
+  failure — diff-cover would then score the changed lines against the
+  old report instead of failing loudly. (Related to round-4 NH1's
+  shared-path concern, but distinct: this is staleness-masking, not
+  concurrency.)
+- Proposed fix: `COVERAGE_XML.unlink(missing_ok=True)` immediately before
+  the testmon/cov run, so the existing "coverage report not written"
+  exists-guard correctly catches a pytest-cov emission failure. Add a
+  regression test: a run where pytest-cov does not emit a fresh report
+  fails (return 1) even if a stale `coverage.xml` is present.
+
+### [nice-to-have] NH1 — `--seed-testmon` runs the slow testmon self-tests
+- File: `scripts/qs/quality_gate.py` (`_build_seed_testmon_cmd` / `seed_testmon`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The seed pass runs the whole suite under `--testmon`,
+  including `tests/test_quality_gate.py`, whose `@pytest.mark.integration`
+  cases spawn real nested `pytest --testmon` subprocesses. The inner-loop
+  `_build_testmon_cmd` deliberately `--ignore`s that file; seeding does
+  not. This is intentional (seeding is the full baseline) but could be
+  slow/surprising in finish-task's detached refresh.
+- Proposed fix: Leave behavior as-is (full baseline is correct) but add a
+  one-line inline comment in `_build_seed_testmon_cmd` documenting that
+  seeding intentionally includes the self-tests, so a future reader
+  doesn't "fix" it by mirroring the `--ignore`.
+
+### [nice-to-have] NH2 — `_resolve_diff_base` doesn't emit which base it chose
+- File: `scripts/qs/quality_gate.py` (`_resolve_diff_base`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The upstream-fallback branch (and the named-ref paths)
+  return silently on success without `_emit`-ing which base was selected,
+  a minor observability gap when debugging an unexpected diff-cover range.
+- Proposed fix: Emit a single informational line naming the resolved base
+  (origin/main vs main vs merge-base SHA) on success. Keep it terse.
+  Update/extend the `TestResolveDiffBase` assertions if they capture
+  output.
+
+## Merge-time / by-design notes (not implement items)
+
+- **AC#15 single atomic commit (acceptance-auditor):** multiple commits
+  across review rounds + a merge from origin/main; resolve by
+  **squash-merging** in finish-task. No code change.
+- **AC#13 wall-clock measurement (acceptance-auditor):** self-reported in
+  the story by design for a kill-criterion AC; no automated regression
+  guard expected. No action.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. Apply SF1 TDD-style (failing
+test first), keep the full quality gate green at 100% coverage and CI
+green, then return and run `/review-task` again to re-verify. This is
+expected to be the final fix round.

--- a/docs/workflow/phase-protocols.md
+++ b/docs/workflow/phase-protocols.md
@@ -107,8 +107,13 @@ auto-commits, pushes, opens PR after green quality gate.
 2. TDD: write failing tests → implement minimum code → refactor.
 3. Present implementation summary (files modified, design decisions,
    risks). Ask "Ready to run the quality gate?".
-4. Run quality gate (`python scripts/qs/quality_gate.py`). Fix
-   autonomously on failure; escalate only after 2–3 attempts.
+4. Run the impacted inner-loop gate
+   (`python scripts/qs/quality_gate.py --impacted`) before commit/PR —
+   it proves the *changed lines* are 100% covered in seconds. The
+   whole-repo 100% gate runs authoritatively in **CI** on every PR; run
+   the full gate locally only on explicit request or when coverage may
+   have been lost in *unchanged* code (which `--impacted` cannot see).
+   Fix autonomously on failure; escalate only after 2–3 attempts.
 5. Auto-commit, push, open PR. No confirmation prompt — authorized by
    the workflow.
 
@@ -197,11 +202,18 @@ as alternatives (see QS-175 OUT OF SCOPE).
    failed, STOP.
 3. Ask user for explicit merge authorization.
 4. Merge PR: `gh pr merge --merge`.
-5. Delete remote branch (safety check: refuse if branch is
+5. Refresh the `--impacted` baseline (QS-276): capture `MAIN_DIR` (via
+   `git worktree list --porcelain | head -1`) **before** cleanup,
+   update the main checkout (`fetch` + `checkout main` + `pull
+   --ff-only`), then refresh the testmon DB via
+   `quality_gate.py --seed-testmon` — detached/best-effort, never
+   blocking cleanup. A failure or stale baseline is safe (new worktrees
+   just run more tests).
+6. Delete remote branch (safety check: refuse if branch is
    `main` / `master`).
-6. Run `python scripts/qs/cleanup_worktree.py --work-dir <wd>
+7. Run `python scripts/qs/cleanup_worktree.py --work-dir <wd>
    --issue <N> --force` (force because code is safely on main).
-7. Report. If merged and production code touched, tell the user to run
+8. Report. If merged and production code touched, tell the user to run
    `/release` from main.
 
 **Hard rules**:

--- a/docs/workflow/project-context.md
+++ b/docs/workflow/project-context.md
@@ -147,8 +147,10 @@ When adding a new device type, agents must touch:
 
 ### Coverage
 
-- **100% test coverage is MANDATORY and NON-NEGOTIABLE.** Every PR must maintain 100% coverage.
-- `scripts/qs/quality_gate.py` is the single test entry point (owns cache, xdist, sysmon, scope detection). Raw `pytest` bypasses all four.
+- **100% test coverage is MANDATORY and NON-NEGOTIABLE.** Every PR must maintain 100% coverage — enforced authoritatively in **CI** on every PR (`pr-quality.yml`, whole-repo `--cov-fail-under=100`).
+- **Local-vs-CI split (QS-276).** Local commits run the `--impacted` inner loop (the lines *you changed* are 100% covered, in ~seconds); the whole-repo 100% guarantee lives in CI. `--impacted` deliberately cannot detect coverage lost in *unchanged* code — only CI's whole-repo gate catches that.
+- `scripts/qs/quality_gate.py` is the single test entry point (owns cache, xdist, sysmon, scope detection, `--impacted`/`--seed-testmon`). Raw `pytest` bypasses all of it.
+- Impacted inner-loop gate (implement-phase default before commit/PR): `python scripts/qs/quality_gate.py --impacted`.
 - Full gate (pytest 100% cov + ruff + mypy + translations): `python scripts/qs/quality_gate.py`. Add `--cache` for cheap repeat runs on a clean tree.
 - Fast iteration on a single file or directory during TDD: `python scripts/qs/quality_gate.py --quick tests/test_<file>.py` (also accepts `tests/ha_tests`, `tests/`, or multiple paths).
 - Ad-hoc single-node debugging only: `source venv/bin/activate && pytest tests/test_<file>.py::test_specific -v`.

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -20,12 +20,20 @@ it owns the cache, `pytest-xdist` parallelization,
 all four; use it only for ad-hoc single-node debugging.
 
 ```bash
+# Impacted-tests inner loop (QS-276) — the implement-phase default
+# before commit/PR. Runs only the testmon-selected tests under
+# --cov=<package>, then diff-cover --fail-under=100 on the CHANGED
+# lines. Guarantees the lines YOU changed are 100% covered in ~seconds.
+python scripts/qs/quality_gate.py --impacted
+
 # Full quality gate (pytest 100% cov + ruff + mypy + translations).
-# Required before every commit.
+# Authoritative whole-repo gate — enforced in CI on every PR; run
+# locally on explicit request or when you suspect coverage lost in
+# UNCHANGED code (which --impacted cannot see).
 python scripts/qs/quality_gate.py
 
-# Recommended default for repeated dev-loop runs — skips gates when
-# git state matches a previous pass on a clean tree.
+# Caching for repeated FULL-gate runs — skips gates when git state
+# matches a previous pass on a clean tree.
 python scripts/qs/quality_gate.py --cache
 
 # Auto-fix formatting and lint.
@@ -34,16 +42,32 @@ python scripts/qs/quality_gate.py --fix
 # JSON output for scripts.
 python scripts/qs/quality_gate.py --json
 
-# Fast iteration on one or more test paths (files or directories).
+# Fast iteration on one or more EXPLICIT test paths (files or dirs).
 # Uses xdist + sysmon, skips coverage / ruff / mypy / translations.
-# The canonical TDD red/green/refactor command.
+# The canonical TDD red/green/refactor command while you iterate on a
+# known test target; --impacted is the pre-commit gate that finds the
+# impacted tests for you.
 python scripts/qs/quality_gate.py --quick tests/test_solver.py
 python scripts/qs/quality_gate.py --quick tests/ha_tests
 python scripts/qs/quality_gate.py --quick tests/test_solver.py tests/test_constraints.py
 
+# Refresh the testmon baseline (no coverage, no verdict). Sanctioned
+# non-gate subcommand — used by finish-task after a merge.
+python scripts/qs/quality_gate.py --seed-testmon
+
 # Ad-hoc single-node pytest — debugging only.
 source venv/bin/activate && pytest tests/test_solver.py::test_function_name -v
 ```
+
+**Local-vs-CI coverage invariant (QS-276).** Local commits run
+`--impacted` (the lines you changed are 100% covered); the **whole-repo
+100% coverage** requirement is enforced in **CI on every PR** and is
+what actually guarantees full coverage. The three iteration commands
+relate as: `--impacted` is the pre-commit default (finds + runs the
+impacted tests, checks changed-line coverage); `--quick` is for hammering
+an explicit test path you already know; `--cache` accelerates repeated
+*full*-gate runs. `--impacted` is mutually exclusive with
+`--quick`/`--cache`/`--no-cache`/`--full`/`--fix`.
 
 **Raw-`pytest` grammar rule.** Allowed: `pytest <path>::<nodeid> [-v]`
 — the positional argument MUST contain `::`. Forbidden as a habitual
@@ -51,6 +75,14 @@ command: any `pytest` invocation whose positional argument lacks
 `::`, e.g., `pytest tests/`, `pytest tests/ha_tests`,
 `pytest tests/test_foo.py`. Use `--quick` on the enclosing file or
 directory instead.
+
+**Carve-out — `--seed-testmon` (QS-276).** The one sanctioned
+whole-suite-ish `pytest --testmon` invocation is routed through
+`quality_gate.py --seed-testmon`, never run as a raw `pytest`. It keeps
+`quality_gate.py` the single pytest owner: it only refreshes
+`.testmondata` (no coverage, no pass/fail verdict) and is invoked
+detached/best-effort by `finish-task` to rebuild the main baseline
+after a merge. A bare `pytest --testmon` remains forbidden.
 
 **UI-only fast path.** When only `custom_components/quiet_solar/ui/*.j2`
 templates and `custom_components/quiet_solar/ui/resources/**` assets

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,6 +5,8 @@ pytest-asyncio==1.3.0
 pytest-cov==7.1.0  # matches pytest-homeassistant-custom-component's own pin
 pytest-timeout==2.4.0
 pytest-xdist==3.8.0
+pytest-testmon==2.2.0  # QS-276: test-impact selection for the --impacted inner loop
+diff-cover==10.3.0     # QS-276: diff-scoped coverage verdict for --impacted
 
 # Mock and testing utilities
 pytest-homeassistant-custom-component==0.13.336

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -853,6 +853,12 @@ TESTMON_DATA = REPO_ROOT / ".testmondata"
 # the gate. CI re-fetches authoritatively, so a short bound is safe.
 _FETCH_TIMEOUT_SECONDS = 15.0
 
+# QS-276 review-fix NH1: bound the diff-cover subprocess too — a
+# pathological hang there would break the same sub-15s inner-loop promise
+# as an unbounded fetch (S1). diff-cover only parses an already-written
+# coverage.xml + a git diff, so a generous cap is safe.
+_DIFF_COVER_TIMEOUT_SECONDS = 60.0
+
 # Static decision (Design A): whether the pinned pytest-testmon attributes
 # per-test coverage correctly across xdist workers, so the selection /
 # seeding passes can run in parallel.
@@ -899,18 +905,20 @@ def _testmon_available() -> bool:
     return _run([VENV_PYTHON, "-c", probe]).returncode == 0
 
 
-# QS-276 review-fix N3: accept the common truthy spellings some CI systems
-# use (`CI=yes` / `on`) and also honor GitHub Actions' own provider var,
-# which it always sets to `true`.
-_CI_TRUTHY = ("1", "true", "yes", "on")
+# QS-276 review-fix N3/NH4: accept the common truthy spellings CI systems
+# use — `1`, `true`, `yes`, `on`, plus the single-letter `y` / `t` some
+# providers emit — and also honor GitHub Actions' own provider var, which
+# it always sets to `true`.
+_CI_TRUTHY = ("1", "true", "yes", "on", "y", "t")
 
 
 def _is_ci() -> bool:
     """Return True when running under CI.
 
-    Recognizes a truthy `CI` env var (GitHub Actions sets `CI=true`;
-    other providers use `yes` / `on`) and falls back to GitHub Actions'
-    own `GITHUB_ACTIONS=true` provider variable.
+    Recognizes a truthy `CI` env var (accepted values:
+    `1`/`true`/`yes`/`on`/`y`/`t`, case-insensitive; GitHub Actions sets
+    `CI=true`) and falls back to GitHub Actions' own `GITHUB_ACTIONS=true`
+    provider variable.
     """
     if os.environ.get("CI", "").strip().lower() in _CI_TRUTHY:
         return True
@@ -926,6 +934,14 @@ def _resolve_diff_base() -> str | None:
     None when nothing resolves (offline / fresh worktree with no
     upstream). The base is live git, independent of the seeded
     `.testmondata`.
+
+    QS-276 review-fix NH2: a candidate ref is only accepted if it shares
+    a merge-base with HEAD. A shallow CI clone (`fetch-depth: 1`) can
+    resolve `origin/main` to a commit with no common ancestor, which
+    would make diff-cover diff against unrelated history and report a
+    spuriously huge changed-line set. An unreachable ref is skipped (and
+    a warning emitted); if nothing reachable resolves, we return None and
+    the caller applies the no-base policy (warn-skip locally, exit 4 CI).
     """
     # Best-effort fresh fetch; ignore failure — an offline dev still
     # resolves a local `main` or the upstream merge-base below.
@@ -942,8 +958,12 @@ def _resolve_diff_base() -> str | None:
             "warning: `git fetch origin main` failed/timed out — diff base may be stale vs CI",
         )
     for ref in ("origin/main", "main"):
-        if _run(["git", "rev-parse", "--verify", ref]).returncode == 0:
+        if _run(["git", "rev-parse", "--verify", ref]).returncode != 0:
+            continue
+        # NH2: require a common ancestor with HEAD before trusting the ref.
+        if _run(["git", "merge-base", ref, "HEAD"]).returncode == 0:
             return ref
+        _emit("impacted", f"warning: {ref} has no merge-base with HEAD (shallow clone?) — skipping")
     upstream = _run(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
     tracked = upstream.stdout.strip()
     if upstream.returncode == 0 and tracked:
@@ -952,6 +972,24 @@ def _resolve_diff_base() -> str | None:
         if mb.returncode == 0 and sha:
             return sha
     return None
+
+
+def _diff_base_ahead_of_head(base: str) -> bool:
+    """Return True when `base` has commits not reachable from HEAD.
+
+    QS-276 review-fix SF2: testmon selects against the seeded
+    `.testmondata` baseline, while diff-cover compares changed lines
+    against the freshly-fetched diff base. When the base (`origin/main`)
+    has advanced past the branch's fork point — i.e. `HEAD..base` is
+    non-empty — the diff includes upstream changes the testmon baseline
+    never saw, so the gate can *false*-FAIL (safe direction; never a
+    false-pass). This turns that into an observable, distinct verdict
+    instead of a generic coverage failure. A non-zero `rev-list --count
+    HEAD..base` is the precise signal.
+    """
+    r = _run(["git", "rev-list", "--count", f"HEAD..{base}"])
+    count = r.stdout.strip()
+    return r.returncode == 0 and count.isdigit() and int(count) > 0
 
 
 def _ensure_testmon_db_safe() -> None:
@@ -963,6 +1001,14 @@ def _ensure_testmon_db_safe() -> None:
     a path relocation) makes it raise `sqlite3.DatabaseError` mid-run
     instead. Removing the file forces a clean rebuild → select-all,
     honouring the 'never silently under-select' fail-safe.
+
+    QS-276 review-fix SF1: `sqlite3.OperationalError` ("database is
+    locked") is a *subclass* of `sqlite3.DatabaseError`. A VALID DB that
+    is transiently locked by a concurrent `--seed-testmon` / `--impacted`
+    run must NOT be deleted — wiping it would discard a recoverable
+    baseline and force a needless select-all. So catch `OperationalError`
+    FIRST and leave the file intact; only a genuine, corruption-specific
+    `DatabaseError` triggers the unlink.
     """
     if not TESTMON_DATA.exists():
         return
@@ -972,6 +1018,9 @@ def _ensure_testmon_db_safe() -> None:
             conn.execute("PRAGMA schema_version").fetchone()
         finally:
             conn.close()
+    except sqlite3.OperationalError as exc:
+        # Valid-but-busy (locked) — leave it; testmon handles the lock.
+        _emit("impacted", f".testmondata is locked/busy — leaving intact ({exc})")
     except sqlite3.DatabaseError:
         _emit("impacted", "corrupt .testmondata detected — removing to force select-all")
         # QS-276 review-fix N6: `missing_ok=True` so a file that vanishes
@@ -1069,21 +1118,33 @@ def check_impacted() -> int:
         _emit("impacted", f"FAIL (coverage report not written: {COVERAGE_XML})")
         return 1
 
-    dc = _run(_build_diff_cover_cmd(base))
+    # NH1: bound diff-cover so a hang can't break the sub-15s promise.
+    dc = _run(_build_diff_cover_cmd(base), timeout=_DIFF_COVER_TIMEOUT_SECONDS)
     sys.stdout.write(dc.stdout)
     sys.stdout.flush()
     if dc.returncode != 0:
-        _emit("impacted", "FAIL (changed lines <100% covered)")
-        # QS-276 review-fix S5: testmon selection runs against the seeded
-        # baseline while diff-cover compares against live `origin/main`.
-        # If main advanced past the baseline, testmon may not select a
-        # test covering a changed line even though one exists — the real
-        # remedy is a reseed, not a new test. Point at it.
-        _emit(
-            "impacted",
-            "hint: if origin/main advanced past your testmon baseline, reseed with "
-            "`python scripts/qs/quality_gate.py --seed-testmon` and re-run",
-        )
+        # QS-276 review-fix SF2: distinguish a genuine missing-coverage
+        # failure from a stale-baseline false-FAIL. If the diff base has
+        # advanced past HEAD's fork point, testmon's seeded baseline can't
+        # have selected tests for those upstream-changed lines — surface a
+        # distinct "baseline stale → reseed" verdict rather than a generic
+        # coverage failure.
+        if _diff_base_ahead_of_head(base):
+            _emit("impacted", f"FAIL (baseline stale — {base} advanced past your branch; reseed required)")
+            _emit(
+                "impacted",
+                "baseline stale: reseed with `python scripts/qs/quality_gate.py --seed-testmon` "
+                "(or merge/rebase origin/main into your branch) and re-run",
+            )
+        else:
+            _emit("impacted", "FAIL (changed lines <100% covered)")
+            # S5 fallback hint: a reseed can also help if the baseline is
+            # subtly behind even when no upstream commits are detected.
+            _emit(
+                "impacted",
+                "hint: if origin/main advanced past your testmon baseline, reseed with "
+                "`python scripts/qs/quality_gate.py --seed-testmon` and re-run",
+            )
         sys.stderr.write(dc.stderr)
         sys.stderr.flush()
         return 1

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -1015,8 +1015,10 @@ def _resolve_diff_base() -> str | None:
     for ref in ("origin/main", "main"):
         if _run(["git", "rev-parse", "--verify", ref]).returncode != 0:
             continue
-        # NH2: require a common ancestor with HEAD before trusting the ref.
+        # NH2 (#02): require a common ancestor with HEAD before trusting the ref.
         if _run(["git", "merge-base", ref, "HEAD"]).returncode == 0:
+            # NH2 (#05): name the chosen base so an unexpected diff-cover range is debuggable.
+            _emit("impacted", f"diff base: {ref}")
             return ref
         _emit("impacted", f"warning: {ref} has no merge-base with HEAD (shallow clone?) — skipping")
     upstream = _run(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
@@ -1025,6 +1027,7 @@ def _resolve_diff_base() -> str | None:
         mb = _run(["git", "merge-base", "HEAD", tracked])
         sha = mb.stdout.strip()
         if mb.returncode == 0 and sha:
+            _emit("impacted", f"diff base: {sha} (merge-base with {tracked})")
             return sha
     return None
 
@@ -1181,6 +1184,12 @@ def check_impacted() -> int:
         return 0
 
     _ensure_testmon_db_safe()
+    # QS-276 review-fix SF1 (#05): delete any stale coverage.xml from a
+    # previous run BEFORE the testmon/cov pass. Otherwise a pytest-cov
+    # emission failure would be masked — the N7 exists-guard below would
+    # see the *old* report and diff-cover would score the changed lines
+    # against stale data instead of failing loudly.
+    COVERAGE_XML.unlink(missing_ok=True)
     _emit("impacted", f"selecting impacted tests (testmon) vs base {base}")
     result = _stream_pytest(_build_testmon_cmd())
     if not result["passed"]:
@@ -1190,7 +1199,8 @@ def check_impacted() -> int:
     # QS-276 review-fix N7: pytest-cov writes coverage.xml even on a
     # zero-collection run (verified for the pinned version), but guard
     # defensively — if a future pytest-cov stops emitting it, diff-cover
-    # would silently read a stale/missing file. Fail loudly instead.
+    # would silently read a stale/missing file. Combined with the SF1
+    # pre-delete above, a fresh report is guaranteed or we fail loudly.
     if not COVERAGE_XML.exists():
         _emit("impacted", f"FAIL (coverage report not written: {COVERAGE_XML})")
         return 1
@@ -1262,6 +1272,12 @@ def _build_seed_testmon_cmd() -> list[str]:
     the baseline is the heaviest testmon pass (a full select-all), so it
     benefits the most from `-n auto`. Honours `QS_QG_PYTEST_WORKERS` via
     the shared `_pytest_workers()` resolver.
+
+    NH1 (review-fix #05): unlike the inner-loop `_build_testmon_cmd`, this
+    deliberately does NOT `--ignore tests/test_quality_gate.py`. Seeding is
+    the FULL baseline — the testmon self-tests must be fingerprinted too,
+    or a later change to the gate would force a select-all. Do not mirror
+    the inner-loop `--ignore` here (it would leave the baseline incomplete).
     """
     cmd = [VENV_PYTHON, "-m", "pytest", "--testmon", "-q"]
     if _TESTMON_SUPPORTS_XDIST:

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -4,6 +4,8 @@
 Usage:
     python scripts/qs/quality_gate.py [--fix] [--json] [--cache] [--no-cache] [--full]
     python scripts/qs/quality_gate.py --quick PATH [PATH ...]
+    python scripts/qs/quality_gate.py --impacted
+    python scripts/qs/quality_gate.py --seed-testmon
 
 Options:
     --fix                    Auto-fix what can be fixed (ruff format, ruff check --fix)
@@ -15,6 +17,15 @@ Options:
                              or directories) with xdist + sysmon; skip ruff/mypy/
                              translations/coverage/cache/scope. Mutex with
                              --cache/--no-cache/--full/--fix.
+    --impacted               Inner-loop gate (QS-276): run only the testmon-selected
+                             tests under --cov=<package>, write coverage.xml, then
+                             diff-cover --fail-under=100 against the resolved diff
+                             base. Guarantees the lines YOU changed are 100% covered
+                             (the whole-repo 100% gate stays authoritative in CI).
+                             Mutex with --quick/--cache/--no-cache/--full/--fix.
+    --seed-testmon           Sanctioned non-gate subcommand: refresh .testmondata via
+                             `pytest --testmon` (no coverage, no pass/fail verdict).
+                             Used by finish-task to rebuild the main baseline.
 
 Smart scope detection:
     When only dev-infrastructure files are modified (tests/, legacy/, docs/,
@@ -24,8 +35,10 @@ Smart scope detection:
 
 Exit codes:
     0 = all gates pass
-    1 = one or more gates failed
+    1 = one or more gates failed (incl. --impacted changed-lines <100%)
     2 = argument parsing error (e.g., --quick with no paths, or mutex violation)
+    3 = required tooling missing (--impacted: testmon / diff-cover not importable)
+    4 = --impacted could not resolve a diff base in CI
 """
 
 from __future__ import annotations
@@ -34,6 +47,7 @@ import argparse
 import json
 import os
 import re
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -804,6 +818,195 @@ def _output_results(
                 print(f"FAILED gates: {', '.join(failed)}")
 
 
+# --- QS-276: impacted-tests inner loop (`--impacted`) + testmon seeding ---
+#
+# `--impacted` runs only the testmon-selected tests under
+# `--cov=custom_components/quiet_solar`, writes `coverage.xml`, and lets
+# `diff-cover` assert the CHANGED lines are 100% covered. The whole-repo
+# 100% gate stays authoritative in CI; this is the sub-~15s inner loop.
+
+COVERAGE_XML = REPO_ROOT / "coverage.xml"
+TESTMON_DATA = REPO_ROOT / ".testmondata"
+
+# Static decision (Design A): pytest-testmon 2.2.0 does not reliably
+# attribute per-test coverage across xdist workers, so the selection pass
+# runs serially. Measured worst case (a full select against a cold
+# `.testmondata`) approaches the warm full suite; a small diff selects a
+# handful of tests and finishes in seconds. A *runtime* probe would add an
+# uncoverable branch, so this is a module constant by design.
+_TESTMON_SUPPORTS_XDIST = False
+
+
+def _impacted_tooling_available() -> bool:
+    """Return True iff `testmon` AND `diff_cover` import from VENV_PYTHON.
+
+    Probes the venv interpreter (same reasoning as `_has_xdist`) so the
+    check reflects the environment pytest / diff-cover actually run in,
+    not the orchestrator's.
+    """
+    probe = (
+        "import importlib.util as u, sys; "
+        "sys.exit(0 if u.find_spec('testmon') and u.find_spec('diff_cover') else 1)"
+    )
+    return _run([VENV_PYTHON, "-c", probe]).returncode == 0
+
+
+def _is_ci() -> bool:
+    """Return True when running under CI (GitHub Actions sets `CI=true`)."""
+    return os.environ.get("CI", "").strip().lower() in ("1", "true")
+
+
+def _resolve_diff_base() -> str | None:
+    """Resolve the `--impacted` diff base via the fallback ladder.
+
+    Order: `origin/main` → `main` → merge-base of HEAD with the tracked
+    upstream. `origin/main` is fetched fresh first so the local
+    changed-line set matches CI's. Returns the resolved ref / sha, or
+    None when nothing resolves (offline / fresh worktree with no
+    upstream). The base is live git, independent of the seeded
+    `.testmondata`.
+    """
+    # Best-effort fresh fetch; ignore failure — an offline dev still
+    # resolves a local `main` or the upstream merge-base below.
+    _run(["git", "fetch", "origin", "main"])
+    for ref in ("origin/main", "main"):
+        if _run(["git", "rev-parse", "--verify", ref]).returncode == 0:
+            return ref
+    upstream = _run(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
+    tracked = upstream.stdout.strip()
+    if upstream.returncode == 0 and tracked:
+        mb = _run(["git", "merge-base", "HEAD", tracked])
+        sha = mb.stdout.strip()
+        if mb.returncode == 0 and sha:
+            return sha
+    return None
+
+
+def _ensure_testmon_db_safe() -> None:
+    """Delete `.testmondata` when it is not a readable SQLite database.
+
+    testmon recovers from a schema-version mismatch on its own (it
+    rebuilds and selects all tests), but a genuinely corrupt /
+    partially-written / non-SQLite file (a killed run, a dependency bump,
+    a path relocation) makes it raise `sqlite3.DatabaseError` mid-run
+    instead. Removing the file forces a clean rebuild → select-all,
+    honouring the 'never silently under-select' fail-safe.
+    """
+    if not TESTMON_DATA.exists():
+        return
+    try:
+        conn = sqlite3.connect(str(TESTMON_DATA))
+        try:
+            conn.execute("PRAGMA schema_version").fetchone()
+        finally:
+            conn.close()
+    except sqlite3.DatabaseError:
+        _emit("impacted", "corrupt .testmondata detected — removing to force select-all")
+        TESTMON_DATA.unlink()
+
+
+def _build_testmon_cmd() -> list[str]:
+    """Build the single-process testmon selection + coverage pytest argv.
+
+    Design A preferred path (Task 2 confirmed testmon ⊕ pytest-cov share
+    one process): the testmon-selected tests run under `--cov=<package>`,
+    the leading empty `--cov-report=` clears pytest.ini's term default
+    before the XML report, and there is NO `--cov-fail-under` — the 100%
+    verdict is delegated to diff-cover on the changed lines only (a
+    whole-tree subset run is always <100% and would otherwise fail before
+    diff-cover runs). xdist is gated on the static `_TESTMON_SUPPORTS_XDIST`
+    constant.
+    """
+    cmd = [
+        VENV_PYTHON,
+        "-m",
+        "pytest",
+        "--testmon",
+        f"--cov={SRC_DIR}",
+        "--cov-report=",
+        f"--cov-report=xml:{COVERAGE_XML}",
+        "-q",
+    ]
+    if _TESTMON_SUPPORTS_XDIST:
+        workers = _pytest_workers()
+        if workers is not None:
+            cmd.extend(["-n", workers])
+    return cmd
+
+
+def _build_diff_cover_cmd(base: str) -> list[str]:
+    """Build the diff-cover argv asserting changed lines are 100% covered."""
+    return [
+        _venv_tool("diff-cover"),
+        str(COVERAGE_XML),
+        f"--compare-branch={base}",
+        "--fail-under=100",
+    ]
+
+
+def check_impacted() -> int:
+    """Run the `--impacted` inner-loop gate; return the process exit code.
+
+    Pipeline: tooling probe → diff-base ladder → testmon-selected tests
+    under `--cov` (writes coverage.xml) → diff-cover --fail-under=100 on
+    the changed lines.
+
+    Exit codes: 0 pass · 1 selected-test failure OR diff-coverage <100% ·
+    3 testmon / diff-cover not importable · 4 no diff base resolvable in
+    CI (warn-and-skip → 0 locally so an offline dev isn't blocked).
+
+    Fail-safe: a corrupt / schema-incompatible `.testmondata` makes
+    testmon select *all* tests (its native recovery), never silently
+    under-select.
+    """
+    if not _impacted_tooling_available():
+        _emit("impacted", "pytest-testmon / diff-cover not importable — install requirements_test.txt")
+        return 3
+
+    base = _resolve_diff_base()
+    if base is None:
+        if _is_ci():
+            _emit("impacted", "no diff base (origin/main) resolvable in CI")
+            return 4
+        _emit("impacted", "no diff base resolvable — skipping diff-coverage check (offline/fresh worktree)")
+        return 0
+
+    _ensure_testmon_db_safe()
+    _emit("impacted", f"selecting impacted tests (testmon) vs base {base}")
+    result = _stream_pytest(_build_testmon_cmd())
+    if not result["passed"]:
+        _emit("impacted", "FAIL (selected tests failed)")
+        return 1
+
+    dc = _run(_build_diff_cover_cmd(base))
+    sys.stdout.write(dc.stdout)
+    sys.stdout.flush()
+    if dc.returncode != 0:
+        _emit("impacted", "FAIL (changed lines <100% covered)")
+        sys.stderr.write(dc.stderr)
+        sys.stderr.flush()
+        return 1
+    _emit("impacted", "PASS (changed lines 100% covered)")
+    return 0
+
+
+def seed_testmon() -> int:
+    """Refresh `.testmondata` via `pytest --testmon`; no coverage, no verdict.
+
+    Sanctioned non-gate subcommand (see the project-rules raw-`pytest`
+    carve-out) used by `finish-task` to rebuild the main-worktree
+    baseline after a merge. Returns 0 once the selection completes (a
+    failing test still updates the DB — there is no pass/fail verdict);
+    returns 3 when testmon is not importable.
+    """
+    if not _impacted_tooling_available():
+        _emit("seed-testmon", "pytest-testmon not importable — skipping")
+        return 3
+    _emit("seed-testmon", "refreshing .testmondata (pytest --testmon)")
+    _stream_pytest([VENV_PYTHON, "-m", "pytest", "--testmon", "-q"])
+    return 0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run quality gates")
     parser.add_argument("--fix", action="store_true", help="Auto-fix formatting/lint issues")
@@ -821,6 +1024,20 @@ def main() -> None:
             "translations/coverage."
         ),
     )
+    parser.add_argument(
+        "--impacted",
+        action="store_true",
+        help=(
+            "Inner-loop gate: testmon-selected tests under --cov, then "
+            "diff-cover --fail-under=100 on the changed lines. Mutex with "
+            "--quick/--cache/--no-cache/--full/--fix."
+        ),
+    )
+    parser.add_argument(
+        "--seed-testmon",
+        action="store_true",
+        help="Refresh .testmondata via `pytest --testmon` (no coverage, no verdict).",
+    )
     args = parser.parse_args()
 
     # --quick is mutually exclusive with cache/full/fix. argparse's nargs="+"
@@ -830,6 +1047,14 @@ def main() -> None:
     if args.quick and (args.cache or args.no_cache or args.full or args.fix):
         parser.error(
             "you cannot combine --quick with --cache, --no-cache, --full, or --fix"
+        )
+
+    # --impacted joins the same mutex: it is a self-contained inner-loop
+    # gate with its own selection + coverage semantics, incompatible with
+    # the cache/scope/fix machinery and with --quick's bare-pytest run.
+    if args.impacted and (args.quick or args.cache or args.no_cache or args.full or args.fix):
+        parser.error(
+            "you cannot combine --impacted with --quick, --cache, --no-cache, --full, or --fix"
         )
 
     # Review-fix #01 finding 8 — `--quick ""` would otherwise resolve to
@@ -866,6 +1091,16 @@ def main() -> None:
             scope="quick",
         )
         sys.exit(0 if result["passed"] else 1)
+
+    # --impacted short-circuits before scope detection / caching, exactly
+    # like --quick: it is its own gate with a bespoke exit-code table.
+    if args.impacted:
+        sys.exit(check_impacted())
+
+    # --seed-testmon is a non-gate maintenance subcommand: refresh the DB
+    # and exit, never touching scope detection or the coverage gate.
+    if args.seed_testmon:
+        sys.exit(seed_testmon())
 
     use_cache = args.cache and not args.fix and not args.no_cache
 

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -119,8 +119,28 @@ def _venv_tool(name: str) -> str:
     return str(VENV_BIN / name)
 
 
-def _run(cmd: list[str], cwd: str | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, capture_output=True, text=True, cwd=cwd or str(REPO_ROOT))
+def _run(
+    cmd: list[str], cwd: str | None = None, timeout: float | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess, capturing stdout/stderr.
+
+    `timeout` (QS-276 review-fix S1) bounds calls on the inner-loop hot
+    path (e.g. the `--impacted` `git fetch`): a hung/slow remote (VPN
+    drop, dead SSH host) must not block the sub-15s gate indefinitely. A
+    timeout is surfaced as a non-zero `CompletedProcess` (returncode
+    124, matching the shell convention) rather than a raised
+    `TimeoutExpired`, so callers handle it via the normal returncode
+    path. Callers that omit `timeout` keep the original unbounded
+    behavior.
+    """
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, cwd=cwd or str(REPO_ROOT), timeout=timeout
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=124, stdout="", stderr=f"timed out after {timeout}s"
+        )
 
 
 def _emit(name: str, line: str) -> None:
@@ -828,6 +848,11 @@ def _output_results(
 COVERAGE_XML = REPO_ROOT / "coverage.xml"
 TESTMON_DATA = REPO_ROOT / ".testmondata"
 
+# QS-276 review-fix S1: cap the inner-loop `git fetch origin main` so a
+# dead/slow remote degrades to a stale base + warning instead of hanging
+# the gate. CI re-fetches authoritatively, so a short bound is safe.
+_FETCH_TIMEOUT_SECONDS = 15.0
+
 # Static decision (Design A): pytest-testmon 2.2.0 does not reliably
 # attribute per-test coverage across xdist workers, so the selection pass
 # runs serially. Measured worst case (a full select against a cold
@@ -851,9 +876,34 @@ def _impacted_tooling_available() -> bool:
     return _run([VENV_PYTHON, "-c", probe]).returncode == 0
 
 
+def _testmon_available() -> bool:
+    """Return True iff `testmon` imports from VENV_PYTHON.
+
+    Narrower probe than `_impacted_tooling_available` (QS-276 review-fix
+    S2): `--seed-testmon` only runs `pytest --testmon` — it never invokes
+    diff-cover — so the post-merge baseline refresh must not be blocked
+    when diff-cover happens to be absent.
+    """
+    probe = "import importlib.util as u, sys; sys.exit(0 if u.find_spec('testmon') else 1)"
+    return _run([VENV_PYTHON, "-c", probe]).returncode == 0
+
+
+# QS-276 review-fix N3: accept the common truthy spellings some CI systems
+# use (`CI=yes` / `on`) and also honor GitHub Actions' own provider var,
+# which it always sets to `true`.
+_CI_TRUTHY = ("1", "true", "yes", "on")
+
+
 def _is_ci() -> bool:
-    """Return True when running under CI (GitHub Actions sets `CI=true`)."""
-    return os.environ.get("CI", "").strip().lower() in ("1", "true")
+    """Return True when running under CI.
+
+    Recognizes a truthy `CI` env var (GitHub Actions sets `CI=true`;
+    other providers use `yes` / `on`) and falls back to GitHub Actions'
+    own `GITHUB_ACTIONS=true` provider variable.
+    """
+    if os.environ.get("CI", "").strip().lower() in _CI_TRUTHY:
+        return True
+    return os.environ.get("GITHUB_ACTIONS", "").strip().lower() in _CI_TRUTHY
 
 
 def _resolve_diff_base() -> str | None:
@@ -868,7 +918,18 @@ def _resolve_diff_base() -> str | None:
     """
     # Best-effort fresh fetch; ignore failure — an offline dev still
     # resolves a local `main` or the upstream merge-base below.
-    _run(["git", "fetch", "origin", "main"])
+    #
+    # QS-276 review-fix S1: bound the fetch so a hung/slow remote can't
+    # block the sub-15s inner loop, and WARN on a non-zero result so a
+    # silently-failed fetch (offline / timeout) — which leaves a stale
+    # `origin/main` whose changed-line set may diverge from CI's — is
+    # observable instead of pretending the base was fetched fresh.
+    fetch = _run(["git", "fetch", "origin", "main"], timeout=_FETCH_TIMEOUT_SECONDS)
+    if fetch.returncode != 0:
+        _emit(
+            "impacted",
+            "warning: `git fetch origin main` failed/timed out — diff base may be stale vs CI",
+        )
     for ref in ("origin/main", "main"):
         if _run(["git", "rev-parse", "--verify", ref]).returncode == 0:
             return ref
@@ -902,7 +963,11 @@ def _ensure_testmon_db_safe() -> None:
             conn.close()
     except sqlite3.DatabaseError:
         _emit("impacted", "corrupt .testmondata detected — removing to force select-all")
-        TESTMON_DATA.unlink()
+        # QS-276 review-fix N6: `missing_ok=True` so a file that vanishes
+        # between the readability probe and the unlink (a concurrent run,
+        # another worktree) doesn't raise — an absent DB already satisfies
+        # the select-all fail-safe intent.
+        TESTMON_DATA.unlink(missing_ok=True)
 
 
 def _build_testmon_cmd() -> list[str]:
@@ -922,6 +987,13 @@ def _build_testmon_cmd() -> list[str]:
         "-m",
         "pytest",
         "--testmon",
+        # QS-276 review-fix N5: keep the slow real-subprocess integration
+        # tests (git-init + nested pytest runs each) out of the inner
+        # loop. They never cover `custom_components/quiet_solar`, so
+        # deselecting them cannot affect the diff-cover verdict — it only
+        # keeps the fast loop fast. CI's whole-repo gate still runs them.
+        "-m",
+        "not integration",
         f"--cov={SRC_DIR}",
         "--cov-report=",
         f"--cov-report=xml:{COVERAGE_XML}",
@@ -978,11 +1050,29 @@ def check_impacted() -> int:
         _emit("impacted", "FAIL (selected tests failed)")
         return 1
 
+    # QS-276 review-fix N7: pytest-cov writes coverage.xml even on a
+    # zero-collection run (verified for the pinned version), but guard
+    # defensively — if a future pytest-cov stops emitting it, diff-cover
+    # would silently read a stale/missing file. Fail loudly instead.
+    if not COVERAGE_XML.exists():
+        _emit("impacted", f"FAIL (coverage report not written: {COVERAGE_XML})")
+        return 1
+
     dc = _run(_build_diff_cover_cmd(base))
     sys.stdout.write(dc.stdout)
     sys.stdout.flush()
     if dc.returncode != 0:
         _emit("impacted", "FAIL (changed lines <100% covered)")
+        # QS-276 review-fix S5: testmon selection runs against the seeded
+        # baseline while diff-cover compares against live `origin/main`.
+        # If main advanced past the baseline, testmon may not select a
+        # test covering a changed line even though one exists — the real
+        # remedy is a reseed, not a new test. Point at it.
+        _emit(
+            "impacted",
+            "hint: if origin/main advanced past your testmon baseline, reseed with "
+            "`python scripts/qs/quality_gate.py --seed-testmon` and re-run",
+        )
         sys.stderr.write(dc.stderr)
         sys.stderr.flush()
         return 1
@@ -999,7 +1089,9 @@ def seed_testmon() -> int:
     failing test still updates the DB — there is no pass/fail verdict);
     returns 3 when testmon is not importable.
     """
-    if not _impacted_tooling_available():
+    # QS-276 review-fix S2: probe ONLY testmon — seeding never invokes
+    # diff-cover, so a missing diff-cover must not block the refresh.
+    if not _testmon_available():
         _emit("seed-testmon", "pytest-testmon not importable — skipping")
         return 3
     _emit("seed-testmon", "refreshing .testmondata (pytest --testmon)")
@@ -1036,7 +1128,10 @@ def main() -> None:
     parser.add_argument(
         "--seed-testmon",
         action="store_true",
-        help="Refresh .testmondata via `pytest --testmon` (no coverage, no verdict).",
+        help=(
+            "Refresh .testmondata via `pytest --testmon` (no coverage, no verdict). "
+            "Mutex with --impacted/--quick/--cache/--no-cache/--full/--fix."
+        ),
     )
     args = parser.parse_args()
 
@@ -1055,6 +1150,19 @@ def main() -> None:
     if args.impacted and (args.quick or args.cache or args.no_cache or args.full or args.fix):
         parser.error(
             "you cannot combine --impacted with --quick, --cache, --no-cache, --full, or --fix"
+        )
+
+    # --seed-testmon (QS-276 review-fix M1) is a self-contained maintenance
+    # subcommand, not a gate mode: combining it with any execution mode
+    # silently dropped the seeding request (the main() dispatch order
+    # short-circuited --impacted before it, and it before cache/scope/full).
+    # Make the conflict an explicit usage error instead.
+    if args.seed_testmon and (
+        args.impacted or args.quick or args.cache or args.no_cache or args.full or args.fix
+    ):
+        parser.error(
+            "you cannot combine --seed-testmon with --impacted, --quick, --cache, "
+            "--no-cache, --full, or --fix"
         )
 
     # Review-fix #01 finding 8 — `--quick ""` would otherwise resolve to

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -137,6 +137,13 @@ def _run(
     (matching `_stream_pytest`) so non-ASCII output from git / diff-cover
     can't raise `UnicodeDecodeError` under `LANG=C` / `LC_ALL=POSIX` and
     bypass the normal return-code handling.
+
+    QS-276 review-fix MF1 (#04): a missing executable (e.g. the venv
+    interpreter absent on a CI runner) is surfaced as returncode 127
+    (shell "command not found"), NOT a raised `FileNotFoundError`. This
+    lets the tooling probes (`_impacted_tooling_available`,
+    `_testmon_available`, `_has_xdist`) degrade to "unavailable" → the
+    integration tests skip cleanly instead of erroring.
     """
     try:
         return subprocess.run(
@@ -158,8 +165,15 @@ def _run(
             args=cmd,
             returncode=124,
             stdout=out,
-            stderr=f"{err}\n{timeout_note}".strip() if err else timeout_note,
+            # SF-C (#04): use `err.strip()` so a whitespace-only stderr is
+            # treated as empty and doesn't inject a leading blank line.
+            stderr=f"{err}\n{timeout_note}".strip() if err.strip() else timeout_note,
         )
+    except FileNotFoundError as exc:
+        # MF1: executable not found — degrade to a non-zero result so
+        # callers handle it via the normal return-code path (probes treat
+        # 127 as "tool unavailable").
+        return subprocess.CompletedProcess(args=cmd, returncode=127, stdout="", stderr=str(exc))
 
 
 def _decode_maybe(value: bytes | str | None) -> str:
@@ -878,6 +892,14 @@ def _output_results(
 # `diff-cover` assert the CHANGED lines are 100% covered. The whole-repo
 # 100% gate stays authoritative in CI; this is the sub-~15s inner loop.
 
+# NH1 (review-fix #04): `--impacted` writes a single fixed coverage.xml at
+# the repo root and immediately consumes it with diff-cover. This assumes
+# ONE `--impacted` run per worktree at a time — two overlapping runs in the
+# same worktree would race on this path (run A's diff-cover could read run
+# B's freshly-overwritten XML). The implement agents never run `--impacted`
+# concurrently in one worktree (each task has its own worktree), so this
+# documented single-run constraint is the accepted resolution rather than a
+# per-run temp path.
 COVERAGE_XML = REPO_ROOT / "coverage.xml"
 TESTMON_DATA = REPO_ROOT / ".testmondata"
 
@@ -1007,24 +1029,6 @@ def _resolve_diff_base() -> str | None:
     return None
 
 
-def _diff_base_ahead_of_head(base: str) -> bool:
-    """Return True when `base` has commits not reachable from HEAD.
-
-    QS-276 review-fix SF2: testmon selects against the seeded
-    `.testmondata` baseline, while diff-cover compares changed lines
-    against the freshly-fetched diff base. When the base (`origin/main`)
-    has advanced past the branch's fork point — i.e. `HEAD..base` is
-    non-empty — the diff includes upstream changes the testmon baseline
-    never saw, so the gate can *false*-FAIL (safe direction; never a
-    false-pass). This turns that into an observable, distinct verdict
-    instead of a generic coverage failure. A non-zero `rev-list --count
-    HEAD..base` is the precise signal.
-    """
-    r = _run(["git", "rev-list", "--count", f"HEAD..{base}"])
-    count = r.stdout.strip()
-    return r.returncode == 0 and count.isdigit() and int(count) > 0
-
-
 def _ensure_testmon_db_safe() -> None:
     """Delete `.testmondata` when it is not a readable SQLite database.
 
@@ -1107,40 +1111,46 @@ def _build_testmon_cmd() -> list[str]:
 
 
 def _build_diff_cover_cmd(base: str) -> list[str]:
-    """Build the diff-cover argv asserting changed lines are 100% covered."""
+    """Build the diff-cover argv asserting changed lines are 100% covered.
+
+    QS-276 review-fix SF-A (#04): `--include-untracked` so a brand-new,
+    not-yet-`git add`-ed source file with an untested function is counted
+    as changed lines (diff-cover 10.3.0 defaults to excluding untracked
+    files, which made the dominant inner-loop case — new code starts
+    untracked — score a vacuous 100% PASS before staging, defeating AC#6
+    locally).
+    """
     return [
         _venv_tool("diff-cover"),
         str(COVERAGE_XML),
         f"--compare-branch={base}",
+        "--include-untracked",
         "--fail-under=100",
     ]
 
 
-# QS-276 review-fix NH2 (#03): single source of truth for the reseed
-# command so the two failure-path hints can't drift apart.
+# QS-276 review-fix NH2 (#03): single source of truth for the reseed command.
 _SEED_TESTMON_CMD = "python scripts/qs/quality_gate.py --seed-testmon"
 
 
-def _emit_reseed_guidance(*, stale: bool) -> None:
-    """Emit reseed guidance on a diff-cover failure (consolidated, NH2).
+def _emit_reseed_guidance() -> None:
+    """Emit the reseed hint on a diff-cover coverage failure.
 
-    `stale=True` is the confirmed stale-baseline branch (the diff base
-    advanced past HEAD); `stale=False` is the generic-coverage-failure
-    fallback where a reseed *might* still help. Both reference the single
-    `_SEED_TESTMON_CMD` constant.
+    QS-276 review-fix SF-B (#04): the previous "baseline stale" branch was
+    removed. diff-cover's pinned default uses three-dot range notation
+    (`merge-base(base, HEAD)...HEAD`), so an advanced `origin/main` does
+    NOT inflate the changed-line set — the staleness false-FAIL it guarded
+    against cannot occur, and the branch only mislabeled genuine
+    uncovered-line failures. This single hint remains useful because
+    testmon's *selection* (vs the seeded baseline) is independent of
+    diff-cover's range: a stale baseline can still under-select, so a
+    reseed is a reasonable thing to suggest on any coverage failure.
     """
-    if stale:
-        _emit(
-            "impacted",
-            f"baseline stale: reseed with `{_SEED_TESTMON_CMD}` "
-            "(or merge/rebase origin/main into your branch) and re-run",
-        )
-    else:
-        _emit(
-            "impacted",
-            f"hint: if origin/main advanced past your testmon baseline, reseed with "
-            f"`{_SEED_TESTMON_CMD}` and re-run",
-        )
+    _emit(
+        "impacted",
+        f"hint: if a changed line looks covered but failed, your testmon baseline "
+        f"may be stale — reseed with `{_SEED_TESTMON_CMD}` and re-run",
+    )
 
 
 def check_impacted() -> int:
@@ -1187,26 +1197,27 @@ def check_impacted() -> int:
 
     # NH1: bound diff-cover so a hang can't break the sub-15s promise.
     dc = _run(_build_diff_cover_cmd(base), timeout=_DIFF_COVER_TIMEOUT_SECONDS)
+
+    # QS-276 review-fix SF2 (#03) + NH2 (#04): a timed-out diff-cover
+    # returns the synthetic 124 from `_run`. Report THAT as the primary
+    # verdict FIRST — before writing dc.stdout (which is empty/partial on
+    # timeout, NH2) and before the coverage messaging (which would
+    # mislabel a timeout as "<100% covered", SF2).
+    if dc.returncode == 124:
+        _emit("impacted", f"FAIL (diff-cover timed out after {_DIFF_COVER_TIMEOUT_SECONDS}s)")
+        sys.stderr.write(dc.stderr)
+        sys.stderr.flush()
+        return 1
+
     sys.stdout.write(dc.stdout)
     sys.stdout.flush()
     if dc.returncode != 0:
-        # QS-276 review-fix SF2 (#03): a timed-out diff-cover returns the
-        # synthetic 124 from `_run`. Report THAT as the primary verdict
-        # first — otherwise the coverage/staleness branches below would
-        # mislabel a timeout as "<100% covered" or "baseline stale".
-        if dc.returncode == 124:
-            _emit("impacted", f"FAIL (diff-cover timed out after {_DIFF_COVER_TIMEOUT_SECONDS}s)")
-        # SF2 (#02): distinguish a genuine missing-coverage failure from a
-        # stale-baseline false-FAIL. If the diff base advanced past HEAD's
-        # fork point, testmon's seeded baseline can't have selected tests
-        # for those upstream-changed lines — surface a distinct
-        # "baseline stale → reseed" verdict rather than a generic failure.
-        elif _diff_base_ahead_of_head(base):
-            _emit("impacted", f"FAIL (baseline stale — {base} advanced past your branch; reseed required)")
-            _emit_reseed_guidance(stale=True)
-        else:
-            _emit("impacted", "FAIL (changed lines <100% covered)")
-            _emit_reseed_guidance(stale=False)
+        # SF-B (#04): the "baseline stale" branch was removed (diff-cover's
+        # three-dot range means an advanced origin/main can't inflate the
+        # changed-line set, so that scenario never occurs). A non-zero,
+        # non-timeout diff-cover is a genuine changed-line coverage gap.
+        _emit("impacted", "FAIL (changed lines <100% covered)")
+        _emit_reseed_guidance()
         sys.stderr.write(dc.stderr)
         sys.stderr.flush()
         return 1

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -853,13 +853,24 @@ TESTMON_DATA = REPO_ROOT / ".testmondata"
 # the gate. CI re-fetches authoritatively, so a short bound is safe.
 _FETCH_TIMEOUT_SECONDS = 15.0
 
-# Static decision (Design A): pytest-testmon 2.2.0 does not reliably
-# attribute per-test coverage across xdist workers, so the selection pass
-# runs serially. Measured worst case (a full select against a cold
-# `.testmondata`) approaches the warm full suite; a small diff selects a
-# handful of tests and finishes in seconds. A *runtime* probe would add an
-# uncoverable branch, so this is a module constant by design.
-_TESTMON_SUPPORTS_XDIST = False
+# Static decision (Design A): whether the pinned pytest-testmon attributes
+# per-test coverage correctly across xdist workers, so the selection /
+# seeding passes can run in parallel.
+#
+# QS-276 review-fix: empirically verified TRUE for pytest-testmon==2.2.0 +
+# pytest-xdist==3.8.0. testmon 2.2.0 ships first-class xdist support
+# (`TestmonXdistSync`, `pytest_xdist_node_collection_finished`,
+# controller↔worker `workerinput` plumbing). Probed on a throwaway repo:
+# under `-n auto` the superset property holds exactly (no-op → 0 selected,
+# covered edit → reselect, uncovered edit → 0) AND testmon ⊕ pytest-cov
+# combine the per-worker `.coverage` files into a valid `coverage.xml`
+# that diff-cover reads at 100%. Leaving this serial made the select-all
+# worst case (~45 min) *slower* than the `-n auto` full gate — the whole
+# point of the inner loop is lost. A *runtime* probe of testmon's own
+# xdist support would add an uncoverable branch, so this stays a module
+# constant; `_pytest_workers()` (already probed + tested) still decides
+# the actual worker count and honours `QS_QG_PYTEST_WORKERS`.
+_TESTMON_SUPPORTS_XDIST = True
 
 
 def _impacted_tooling_available() -> bool:
@@ -1095,8 +1106,26 @@ def seed_testmon() -> int:
         _emit("seed-testmon", "pytest-testmon not importable — skipping")
         return 3
     _emit("seed-testmon", "refreshing .testmondata (pytest --testmon)")
-    _stream_pytest([VENV_PYTHON, "-m", "pytest", "--testmon", "-q"])
+    _stream_pytest(_build_seed_testmon_cmd())
     return 0
+
+
+def _build_seed_testmon_cmd() -> list[str]:
+    """Build the `--seed-testmon` baseline-refresh pytest argv.
+
+    Runs the whole suite under `--testmon` to (re)build `.testmondata`;
+    no coverage, no verdict. Parallelized with xdist (QS-276 review-fix)
+    when `_TESTMON_SUPPORTS_XDIST` is set and workers resolve — seeding
+    the baseline is the heaviest testmon pass (a full select-all), so it
+    benefits the most from `-n auto`. Honours `QS_QG_PYTEST_WORKERS` via
+    the shared `_pytest_workers()` resolver.
+    """
+    cmd = [VENV_PYTHON, "-m", "pytest", "--testmon", "-q"]
+    if _TESTMON_SUPPORTS_XDIST:
+        workers = _pytest_workers()
+        if workers is not None:
+            cmd.extend(["-n", workers])
+    return cmd
 
 
 def main() -> None:

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -132,15 +132,43 @@ def _run(
     `TimeoutExpired`, so callers handle it via the normal returncode
     path. Callers that omit `timeout` keep the original unbounded
     behavior.
+
+    QS-276 review-fix SF1: pins `encoding="utf-8", errors="replace"`
+    (matching `_stream_pytest`) so non-ASCII output from git / diff-cover
+    can't raise `UnicodeDecodeError` under `LANG=C` / `LC_ALL=POSIX` and
+    bypass the normal return-code handling.
     """
     try:
         return subprocess.run(
-            cmd, capture_output=True, text=True, cwd=cwd or str(REPO_ROOT), timeout=timeout
+            cmd,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=cwd or str(REPO_ROOT),
+            timeout=timeout,
         )
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as exc:
+        # NH1: preserve any partial output captured before the timeout —
+        # it aids diagnosis. `exc.stdout`/`.stderr` may be bytes (decode),
+        # str (already decoded), or None.
+        out = _decode_maybe(exc.stdout)
+        err = _decode_maybe(exc.stderr)
+        timeout_note = f"timed out after {timeout}s"
         return subprocess.CompletedProcess(
-            args=cmd, returncode=124, stdout="", stderr=f"timed out after {timeout}s"
+            args=cmd,
+            returncode=124,
+            stdout=out,
+            stderr=f"{err}\n{timeout_note}".strip() if err else timeout_note,
         )
+
+
+def _decode_maybe(value: bytes | str | None) -> str:
+    """Return `value` as text — decode bytes (utf-8/replace), pass through str, "" for None."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return value
 
 
 def _emit(name: str, line: str) -> None:
@@ -603,6 +631,11 @@ def _stream_pytest(
     return {
         "name": "pytest",
         "passed": passed,
+        # QS-276 review-fix NH4 (#03): expose the raw pytest exit code so
+        # callers (e.g. seed_testmon) can distinguish a mere test failure
+        # (1, DB still updated) from a collection error / internal crash
+        # (>=2, .testmondata may be partial).
+        "returncode": proc.returncode,
         "coverage": coverage,
         "missing": missing_lines[:10],
         "detail": stdout_text[-500:] if not passed else "",
@@ -1047,13 +1080,20 @@ def _build_testmon_cmd() -> list[str]:
         "-m",
         "pytest",
         "--testmon",
-        # QS-276 review-fix N5: keep the slow real-subprocess integration
-        # tests (git-init + nested pytest runs each) out of the inner
-        # loop. They never cover `custom_components/quiet_solar`, so
-        # deselecting them cannot affect the diff-cover verdict — it only
-        # keeps the fast loop fast. CI's whole-repo gate still runs them.
-        "-m",
-        "not integration",
+        # QS-276 review-fix MF1: keep the slow testmon SELF-tests (the
+        # real-subprocess git-init + nested-pytest cases in
+        # tests/test_quality_gate.py) out of the inner loop WITHOUT
+        # deselecting the shared `integration` marker. The earlier
+        # `-m "not integration"` (review-fix N5) was wrong: ~9 DOMAIN
+        # integration test files (charger rebalancing, solver forecast,
+        # constraint boundaries, …) carry that marker AND exercise
+        # `custom_components/quiet_solar`. Deselecting them meant a
+        # production line covered ONLY by a domain integration test ran
+        # zero times → 0% in coverage.xml → diff-cover FAIL the dev could
+        # never clear locally. Ignoring by PATH targets only the
+        # self-tests (which never cover production code, so the diff-cover
+        # verdict is unaffected) and leaves every domain test selectable.
+        f"--ignore={TESTS_DIR / 'test_quality_gate.py'}",
         f"--cov={SRC_DIR}",
         "--cov-report=",
         f"--cov-report=xml:{COVERAGE_XML}",
@@ -1074,6 +1114,33 @@ def _build_diff_cover_cmd(base: str) -> list[str]:
         f"--compare-branch={base}",
         "--fail-under=100",
     ]
+
+
+# QS-276 review-fix NH2 (#03): single source of truth for the reseed
+# command so the two failure-path hints can't drift apart.
+_SEED_TESTMON_CMD = "python scripts/qs/quality_gate.py --seed-testmon"
+
+
+def _emit_reseed_guidance(*, stale: bool) -> None:
+    """Emit reseed guidance on a diff-cover failure (consolidated, NH2).
+
+    `stale=True` is the confirmed stale-baseline branch (the diff base
+    advanced past HEAD); `stale=False` is the generic-coverage-failure
+    fallback where a reseed *might* still help. Both reference the single
+    `_SEED_TESTMON_CMD` constant.
+    """
+    if stale:
+        _emit(
+            "impacted",
+            f"baseline stale: reseed with `{_SEED_TESTMON_CMD}` "
+            "(or merge/rebase origin/main into your branch) and re-run",
+        )
+    else:
+        _emit(
+            "impacted",
+            f"hint: if origin/main advanced past your testmon baseline, reseed with "
+            f"`{_SEED_TESTMON_CMD}` and re-run",
+        )
 
 
 def check_impacted() -> int:
@@ -1123,28 +1190,23 @@ def check_impacted() -> int:
     sys.stdout.write(dc.stdout)
     sys.stdout.flush()
     if dc.returncode != 0:
-        # QS-276 review-fix SF2: distinguish a genuine missing-coverage
-        # failure from a stale-baseline false-FAIL. If the diff base has
-        # advanced past HEAD's fork point, testmon's seeded baseline can't
-        # have selected tests for those upstream-changed lines — surface a
-        # distinct "baseline stale → reseed" verdict rather than a generic
-        # coverage failure.
-        if _diff_base_ahead_of_head(base):
+        # QS-276 review-fix SF2 (#03): a timed-out diff-cover returns the
+        # synthetic 124 from `_run`. Report THAT as the primary verdict
+        # first — otherwise the coverage/staleness branches below would
+        # mislabel a timeout as "<100% covered" or "baseline stale".
+        if dc.returncode == 124:
+            _emit("impacted", f"FAIL (diff-cover timed out after {_DIFF_COVER_TIMEOUT_SECONDS}s)")
+        # SF2 (#02): distinguish a genuine missing-coverage failure from a
+        # stale-baseline false-FAIL. If the diff base advanced past HEAD's
+        # fork point, testmon's seeded baseline can't have selected tests
+        # for those upstream-changed lines — surface a distinct
+        # "baseline stale → reseed" verdict rather than a generic failure.
+        elif _diff_base_ahead_of_head(base):
             _emit("impacted", f"FAIL (baseline stale — {base} advanced past your branch; reseed required)")
-            _emit(
-                "impacted",
-                "baseline stale: reseed with `python scripts/qs/quality_gate.py --seed-testmon` "
-                "(or merge/rebase origin/main into your branch) and re-run",
-            )
+            _emit_reseed_guidance(stale=True)
         else:
             _emit("impacted", "FAIL (changed lines <100% covered)")
-            # S5 fallback hint: a reseed can also help if the baseline is
-            # subtly behind even when no upstream commits are detected.
-            _emit(
-                "impacted",
-                "hint: if origin/main advanced past your testmon baseline, reseed with "
-                "`python scripts/qs/quality_gate.py --seed-testmon` and re-run",
-            )
+            _emit_reseed_guidance(stale=False)
         sys.stderr.write(dc.stderr)
         sys.stderr.flush()
         return 1
@@ -1167,7 +1229,16 @@ def seed_testmon() -> int:
         _emit("seed-testmon", "pytest-testmon not importable — skipping")
         return 3
     _emit("seed-testmon", "refreshing .testmondata (pytest --testmon)")
-    _stream_pytest(_build_seed_testmon_cmd())
+    result = _stream_pytest(_build_seed_testmon_cmd())
+    # QS-276 review-fix NH4 (#03): a pytest exit code >= 2 means a
+    # collection error / internal crash (NOT a mere test failure, which is
+    # 1 and still updates the DB). Surface it as a warning so a partial /
+    # unwritten `.testmondata` is observable — but stay best-effort:
+    # finish-task runs this detached and a stale/absent baseline only
+    # over-selects, so we still return 0.
+    rc = result.get("returncode", 0)
+    if rc >= 2:
+        _emit("seed-testmon", f"warning: pytest exited {rc} (collection error/crash) — .testmondata may be incomplete")
     return 0
 
 

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -333,6 +333,10 @@ fi
 # tests/test_quality_gate.py::TestTestmonRelocationInvariant
 # (real testmon: relocate a seeded DB, change a covered file, prove the
 # covering test is reselected).
+# NH3 (review-fix #03): the loop handles BOTH a directory (.mypy_cache)
+# and a single file (.testmondata). `cp -R` is deliberately used for both
+# — for a regular file it behaves like a plain copy, so one code path
+# covers both kinds without a per-cache branch.
 for cache in .mypy_cache .testmondata; do
     src="${MAIN_DIR}/${cache}"
     dst="${WORKTREE_DIR}/${cache}"

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -326,16 +326,36 @@ fi
 for cache in .mypy_cache .testmondata; do
     src="${MAIN_DIR}/${cache}"
     dst="${WORKTREE_DIR}/${cache}"
+    # Cache-specific remediation (review-fix S4): each line is an actually
+    # runnable command, not a generic suggestion.
+    case "$cache" in
+        .testmondata) populate="python scripts/qs/quality_gate.py --seed-testmon" ;;
+        *)            populate="python scripts/qs/quality_gate.py" ;;
+    esac
     if [ -e "$src" ]; then
-        if [ ! -e "$dst" ]; then
-            cp -R "$src" "$dst"
+        # review-fix S4: re-copy (don't silently skip) when $dst already
+        # exists — a re-run after an interrupted setup may have left a
+        # truncated DB. Remove it first so the copy is clean.
+        if [ -e "$dst" ]; then
+            echo "Note: ${cache} already present in worktree — refreshing from main"
+            rm -rf "$dst"
+        fi
+        # review-fix S4: guard the copy. A partial copy (disk full /
+        # permissions) can wedge .mypy_cache irrecoverably; on failure,
+        # remove the partial result and warn rather than leave it broken.
+        if cp -R "$src" "$dst"; then
             echo "Seeded ${cache} from main worktree"
+        else
+            rm -rf "$dst"
+            echo "Warning: failed to copy ${cache} from main worktree — first inner-loop run will be slower"
+            echo "  (run '${populate}' in ${MAIN_DIR}, then re-run setup, to populate it)"
         fi
     else
         echo "Warning: ${cache} absent in main worktree — first inner-loop run will be slower"
-        echo "  (run 'python scripts/qs/quality_gate.py' or '--seed-testmon' in ${MAIN_DIR} to populate it)"
+        echo "  (run '${populate}' in ${MAIN_DIR} to populate it)"
     fi
 done
+# QS-276 end: cache seeding
 
 # Verify the worktree's HEAD landed on the expected branch. A downstream
 # session (e.g. Claude Desktop auto-isolation) that creates its own

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -315,6 +315,28 @@ if [ -d "${MAIN_DIR}/custom_components" ]; then
     done
 fi
 
+# QS-276: seed cold-start caches from the main worktree so the first
+# inner-loop run is fast. COPY (never symlink) — both are written during
+# runs, and a shared symlink would corrupt across concurrent worktrees:
+#   - .mypy_cache kills the ~16s cold-mypy on a fresh worktree;
+#   - .testmondata gives `--impacted` a warm test-impact baseline (a
+#     path-relocated DB degrades to "select more", never fewer).
+# Copy-if-present / warn-if-absent: a missing cache means main never ran
+# the gate / `--seed-testmon` yet, which only costs a slow first loop.
+for cache in .mypy_cache .testmondata; do
+    src="${MAIN_DIR}/${cache}"
+    dst="${WORKTREE_DIR}/${cache}"
+    if [ -e "$src" ]; then
+        if [ ! -e "$dst" ]; then
+            cp -R "$src" "$dst"
+            echo "Seeded ${cache} from main worktree"
+        fi
+    else
+        echo "Warning: ${cache} absent in main worktree — first inner-loop run will be slower"
+        echo "  (run 'python scripts/qs/quality_gate.py' or '--seed-testmon' in ${MAIN_DIR} to populate it)"
+    fi
+done
+
 # Verify the worktree's HEAD landed on the expected branch. A downstream
 # session (e.g. Claude Desktop auto-isolation) that creates its own
 # worktree on top of this one inherits HEAD — if HEAD is wrong here, the

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -319,10 +319,20 @@ fi
 # inner-loop run is fast. COPY (never symlink) — both are written during
 # runs, and a shared symlink would corrupt across concurrent worktrees:
 #   - .mypy_cache kills the ~16s cold-mypy on a fresh worktree;
-#   - .testmondata gives `--impacted` a warm test-impact baseline (a
-#     path-relocated DB degrades to "select more", never fewer).
+#   - .testmondata gives `--impacted` a warm test-impact baseline.
 # Copy-if-present / warn-if-absent: a missing cache means main never ran
 # the gate / `--seed-testmon` yet, which only costs a slow first loop.
+#
+# SAFETY INVARIANT (review-fix SF3): copying `.testmondata` across
+# worktrees can NEVER under-select impacted tests. testmon keys on
+# rootdir-RELATIVE paths + file-content checksums (not absolute paths or
+# mtimes), so in the relocated worktree any file whose content differs
+# from the seeded baseline is reselected; an identical file selects zero
+# (the intended warm-baseline speedup). It "selects more, never fewer".
+# This is enforced, not asserted: see
+# tests/test_quality_gate.py::TestTestmonRelocationInvariant
+# (real testmon: relocate a seeded DB, change a covered file, prove the
+# covering test is reselected).
 for cache in .mypy_cache .testmondata; do
     src="${MAIN_DIR}/${cache}"
     dst="${WORKTREE_DIR}/${cache}"

--- a/tests/test_car_card_smoke.py
+++ b/tests/test_car_card_smoke.py
@@ -35,11 +35,14 @@ def test_dropped_icons_absent(card_source: str) -> None:
 
 
 def test_charge_origin_wired_into_context_row(card_source: str) -> None:
-    """The new ``charge_origin`` entity feeds the ``.forecast-row`` string."""
+    """The ``charge_origin`` entity feeds the ``.forecast-row`` string."""
     assert "this._entity(e.charge_origin)" in card_source
     assert "chargeOriginStr" in card_source
-    # the row is driven by the origin string and a leading Mode icon
-    assert 'class="forecast-row">${chargeIcon' in card_source
+    # The row is driven by the origin string (``forecastDisplay``). The
+    # leading Mode icon was intentionally removed (main commit "removed
+    # icon on car js"), so the row no longer carries a ``${chargeIcon`` prefix.
+    assert 'class="forecast-row">${forecastDisplay}' in card_source
+    assert 'class="forecast-row">${chargeIcon' not in card_source
 
 
 def test_forecast_prefix_dropped(card_source: str) -> None:

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import re
 import sqlite3
 import subprocess
 import sys
@@ -2091,19 +2092,38 @@ class TestImpactedToolingAvailable:
 
 
 class TestIsCi:
-    """`_is_ci` recognizes the GitHub Actions `CI` env var."""
+    """`_is_ci` recognizes the `CI` env var and the GitHub Actions provider var."""
 
     @pytest.mark.parametrize(
         ("value", "expected"),
-        [("true", True), ("1", True), ("TRUE", True), ("  true ", True), ("false", False), ("0", False), ("", False)],
+        [
+            ("true", True),
+            ("1", True),
+            ("TRUE", True),
+            ("  true ", True),
+            # review-fix N3: broaden the truthy set beyond {1, true}.
+            ("yes", True),
+            ("on", True),
+            ("false", False),
+            ("0", False),
+            ("", False),
+        ],
     )
     def test_ci_env(self, value: str, expected: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
         monkeypatch.setenv("CI", value)
         assert quality_gate._is_ci() is expected
 
     def test_ci_unset_is_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("CI", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
         assert quality_gate._is_ci() is False
+
+    def test_github_actions_provider_var_honored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """review-fix N3: GitHub Actions sets GITHUB_ACTIONS=true even if CI is unset."""
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        assert quality_gate._is_ci() is True
 
 
 class TestResolveDiffBase:
@@ -2165,6 +2185,48 @@ class TestResolveDiffBase:
         with patch.object(quality_gate, "_run", side_effect=router):
             assert quality_gate._resolve_diff_base() is None
 
+    def test_fetch_is_bounded_by_timeout(self) -> None:
+        """review-fix S1: the hot-path fetch must pass a subprocess timeout."""
+        with patch.object(quality_gate, "_run", side_effect=self._router({"origin/main": 0})) as mock_run:
+            quality_gate._resolve_diff_base()
+        fetch_call = mock_run.call_args_list[0]
+        assert fetch_call.args[0] == ["git", "fetch", "origin", "main"]
+        assert fetch_call.kwargs.get("timeout") == quality_gate._FETCH_TIMEOUT_SECONDS
+
+    def test_fetch_failure_emits_warning(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """review-fix S1: a non-zero/timed-out fetch warns so a stale base is observable."""
+
+        def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
+            if cmd[:2] == ["git", "fetch"]:
+                return _cp(124, stderr="timed out after 15.0s")  # simulate a hung remote
+            if cmd[:3] == ["git", "rev-parse", "--verify"] and cmd[3] == "origin/main":
+                return _cp(0)
+            return _cp(1)
+
+        with patch.object(quality_gate, "_run", side_effect=_side_effect):
+            base = quality_gate._resolve_diff_base()
+        assert base == "origin/main"  # stale local origin/main still resolves
+        assert "git fetch origin main` failed/timed out" in capsys.readouterr().err
+
+
+class TestRunTimeout:
+    """`_run` (review-fix S1) surfaces a subprocess timeout as a non-zero result."""
+
+    def test_timeout_returns_nonzero_completed_process(self) -> None:
+        with patch.object(
+            quality_gate.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["git", "fetch"], timeout=5.0),
+        ):
+            result = quality_gate._run(["git", "fetch"], timeout=5.0)
+        assert result.returncode == 124
+        assert "timed out" in result.stderr
+
+    def test_timeout_is_forwarded_to_subprocess_run(self) -> None:
+        with patch.object(quality_gate.subprocess, "run", return_value=_cp(0)) as mock_run:
+            quality_gate._run(["git", "status"], timeout=3.0)
+        assert mock_run.call_args.kwargs.get("timeout") == 3.0
+
 
 class TestEnsureTestmonDbSafe:
     """`_ensure_testmon_db_safe` deletes only a non-SQLite `.testmondata`."""
@@ -2192,6 +2254,22 @@ class TestEnsureTestmonDbSafe:
             quality_gate._ensure_testmon_db_safe()
         assert not db.exists(), "corrupt .testmondata must be removed to force select-all"
 
+    def test_unlink_missing_safe_when_db_vanishes(self, tmp_path: Path) -> None:
+        """review-fix N6: the file disappearing between probe and unlink must not raise."""
+        db = tmp_path / ".testmondata"
+        db.write_bytes(b"corrupt")
+
+        def _boom(*_a: object, **_k: object) -> None:
+            db.unlink()  # simulate a concurrent run removing it first
+            raise sqlite3.DatabaseError("file is not a database")
+
+        with (
+            patch.object(quality_gate, "TESTMON_DATA", db),
+            patch.object(quality_gate.sqlite3, "connect", side_effect=_boom),
+        ):
+            quality_gate._ensure_testmon_db_safe()  # must NOT raise FileNotFoundError
+        assert not db.exists()
+
 
 class TestBuildImpactedCmds:
     """Pure argv builders for the `--impacted` seam."""
@@ -2205,6 +2283,11 @@ class TestBuildImpactedCmds:
         assert cmd.index("--cov-report=") < cmd.index(f"--cov-report=xml:{quality_gate.COVERAGE_XML}")
         assert "--cov-fail-under=100" not in cmd  # verdict is diff-cover's job
         assert "-n" not in cmd  # static serial decision
+        # review-fix N5: integration tests are deselected from the fast loop.
+        # (`-m` appears twice — `python -m pytest` and the marker — so locate
+        # the marker value and assert it is preceded by a `-m` flag.)
+        assert "not integration" in cmd
+        assert cmd[cmd.index("not integration") - 1] == "-m"
 
     def test_testmon_cmd_adds_workers_when_xdist_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(quality_gate, "_TESTMON_SUPPORTS_XDIST", True)
@@ -2262,21 +2345,45 @@ class TestCheckImpacted:
             assert quality_gate.check_impacted() == 1
         mock_run.assert_not_called()  # diff-cover never runs if tests failed
 
-    def test_diff_coverage_below_100_returns_1(self) -> None:
+    def test_diff_coverage_below_100_returns_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        xml = tmp_path / "coverage.xml"
+        xml.write_text("<coverage/>")
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "COVERAGE_XML", xml),
             patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
             patch.object(quality_gate, "_run", return_value=_cp(1, stdout="Coverage: 50%", stderr="fail")),
         ):
             assert quality_gate.check_impacted() == 1
+        # review-fix S5: failure points at a reseed when the baseline may be stale.
+        assert "--seed-testmon" in capsys.readouterr().err
 
-    def test_pass_returns_0(self) -> None:
+    def test_missing_coverage_xml_returns_1(self, tmp_path: Path) -> None:
+        """review-fix N7: if pytest-cov fails to emit coverage.xml, fail loudly (don't diff-cover a stale file)."""
+        missing = tmp_path / "coverage.xml"  # never created
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "COVERAGE_XML", missing),
+            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
+            patch.object(quality_gate, "_run") as mock_run,
+        ):
+            assert quality_gate.check_impacted() == 1
+        mock_run.assert_not_called()  # diff-cover never runs without a coverage report
+
+    def test_pass_returns_0(self, tmp_path: Path) -> None:
+        xml = tmp_path / "coverage.xml"
+        xml.write_text("<coverage/>")
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe") as mock_safe,
+            patch.object(quality_gate, "COVERAGE_XML", xml),
             patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
             patch.object(quality_gate, "_run", return_value=_cp(0, stdout="Coverage: 100%")) as mock_run,
         ):
@@ -2286,17 +2393,45 @@ class TestCheckImpacted:
         assert dc_cmd[2] == "--compare-branch=origin/main"
 
 
+class TestTestmonAvailable:
+    """review-fix S2: `_testmon_available` probes ONLY testmon, never diff-cover."""
+
+    @pytest.mark.parametrize(
+        ("probe_rc", "expected"),
+        [(0, True), (1, False)],
+        ids=["importable", "missing"],
+    )
+    def test_probe_result_maps_to_bool(self, probe_rc: int, expected: bool) -> None:
+        with patch.object(quality_gate, "_run", return_value=_cp(probe_rc)) as mock_run:
+            assert quality_gate._testmon_available() is expected
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == quality_gate.VENV_PYTHON
+        assert "testmon" in cmd[-1]
+        assert "diff_cover" not in cmd[-1]  # narrower than _impacted_tooling_available
+
+
 class TestSeedTestmon:
     """`seed_testmon` refreshes the DB with no pass/fail verdict."""
 
     def test_tooling_missing_returns_3(self) -> None:
-        with patch.object(quality_gate, "_impacted_tooling_available", return_value=False):
+        # review-fix S2: gated on the testmon-only probe, NOT the full impacted set.
+        with patch.object(quality_gate, "_testmon_available", return_value=False):
             assert quality_gate.seed_testmon() == 3
+
+    def test_seed_not_blocked_when_only_diff_cover_missing(self) -> None:
+        """review-fix S2: seeding never calls diff-cover, so a missing diff-cover must not block it."""
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=False) as mock_full,
+            patch.object(quality_gate, "_stream_pytest", return_value={"passed": True}),
+        ):
+            assert quality_gate.seed_testmon() == 0
+        mock_full.assert_not_called()  # the full (diff-cover-inclusive) probe is never consulted
 
     def test_success_returns_0_regardless_of_test_outcome(self) -> None:
         # Even a failing selection still updates the DB → seed returns 0.
         with (
-            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_testmon_available", return_value=True),
             patch.object(quality_gate, "_stream_pytest", return_value={"passed": False}) as mock_stream,
         ):
             assert quality_gate.seed_testmon() == 0
@@ -2345,6 +2480,35 @@ class TestImpactedCli:
         assert exc.value.code == 2
         assert "you cannot combine --impacted with" in capsys.readouterr().err
 
+    @pytest.mark.parametrize(
+        "conflict",
+        [
+            ["--impacted"],
+            ["--cache"],
+            ["--no-cache"],
+            ["--full"],
+            ["--fix"],
+            ["--quick", "tests/test_x.py"],
+        ],
+        ids=["impacted", "cache", "no-cache", "full", "fix", "quick"],
+    )
+    def test_seed_testmon_mutex_exits_2(
+        self, conflict: list[str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """review-fix M1: --seed-testmon combined with any execution mode is a usage error."""
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon", *conflict]),
+            patch.object(quality_gate, "seed_testmon") as mock_seed,
+            patch.object(quality_gate, "check_impacted") as mock_impacted,
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == 2
+        assert "you cannot combine --seed-testmon with" in capsys.readouterr().err
+        # The conflicting request must NOT silently execute either mode.
+        mock_seed.assert_not_called()
+        mock_impacted.assert_not_called()
+
     @pytest.mark.parametrize("seed_code", [0, 3], ids=["ok", "tooling-missing"])
     def test_seed_testmon_cli_passthrough(self, seed_code: int) -> None:
         with (
@@ -2372,16 +2536,68 @@ class TestImpactedDeps:
         assert any(line.strip() == ".testmondata" for line in gi.splitlines())
 
 
+class TestProjectRulesDocGuards:
+    """review-fix N2: content guard for the AC#12 doc edits (not just drift-checker)."""
+
+    def _rules(self) -> str:
+        return (
+            Path(__file__).resolve().parent.parent / "docs" / "workflow" / "project-rules.md"
+        ).read_text()
+
+    def test_seed_testmon_carveout_heading_present(self) -> None:
+        rules = self._rules()
+        assert "Carve-out — `--seed-testmon`" in rules
+        assert "single pytest owner" in rules  # the carve-out's rationale
+
+    def test_cache_quick_impacted_reconciliation_present(self) -> None:
+        rules = self._rules()
+        assert "Local-vs-CI coverage invariant" in rules
+        assert "`--impacted` is mutually exclusive" in rules
+
+
 class TestWorktreeSetupSeedsCaches:
     """AC#8: worktree-setup.sh copies (never symlinks) .testmondata + .mypy_cache."""
 
     def _script(self) -> str:
         return (Path(__file__).resolve().parent.parent / "scripts" / "worktree-setup.sh").read_text()
 
-    def test_copies_both_caches(self) -> None:
+    def _seed_block(self) -> str:
+        """Return only the QS-276 cache-seeding block (review-fix N1).
+
+        Scoping the symlink-rejection assertions to this block is essential:
+        the rest of the script legitimately uses `ln -s` for config /
+        custom_components links.
+        """
         body = self._script()
-        assert ".mypy_cache" in body and ".testmondata" in body
-        assert "cp -R" in body, "caches must be copied, not symlinked"
+        start = body.index("# QS-276: seed cold-start caches")
+        end = body.index("# QS-276 end: cache seeding")
+        return body[start:end]
+
+    def test_copies_both_caches(self) -> None:
+        block = self._seed_block()
+        assert ".mypy_cache" in block and ".testmondata" in block
+        assert "cp -R" in block, "caches must be copied, not symlinked"
+
+    def test_seeding_never_symlinks(self) -> None:
+        """review-fix N1: reject any symlink in the seeding block (copy, not link)."""
+        block = self._seed_block()
+        assert "ln -s" not in block and "ln -sf" not in block
+
+    def test_copy_is_error_guarded(self) -> None:
+        """review-fix S4: a failed copy must clean up the partial result, not wedge the cache."""
+        block = self._seed_block()
+        assert "rm -rf" in block
+        assert "failed to copy" in block
+
+    def test_existing_dst_is_refreshed_not_silently_skipped(self) -> None:
+        """review-fix S4: a pre-existing (possibly truncated) cache is refreshed, not skipped silently."""
+        block = self._seed_block()
+        assert "already present" in block
+
+    def test_absent_remediation_is_cache_specific_and_runnable(self) -> None:
+        """review-fix S4: the cache-miss hint cites a real command, --seed-testmon for the DB."""
+        block = self._seed_block()
+        assert "--seed-testmon" in block  # .testmondata remediation is executable
 
     def test_warns_when_absent(self) -> None:
         assert "Warning:" in self._script() and "absent in main worktree" in self._script()
@@ -2396,6 +2612,13 @@ class TestFinishTaskRefreshesBaseline:
         assert "--seed-testmon" in body
         assert "git worktree list --porcelain" in body  # MAIN_DIR captured before cleanup
         assert "nohup" in body  # detached / best-effort
+
+    @pytest.mark.parametrize("harness", [".claude", ".cursor", ".opencode"])
+    def test_interpreter_is_probed_not_hardcoded(self, harness: str) -> None:
+        """review-fix S3: probe for a usable interpreter; warn instead of a false success if none."""
+        body = (Path(__file__).resolve().parent.parent / harness / "agents" / "qs-finish-task.md").read_text()
+        assert "command -v python3" in body or "command -v python" in body
+        assert "no usable Python interpreter" in body
 
 
 class TestImplementAgentsDefaultImpacted:
@@ -2434,7 +2657,7 @@ def _selected_count(result: subprocess.CompletedProcess[str]) -> int:
     out = result.stdout
     if "no tests ran" in out:
         return 0
-    m = __import__("re").search(r"(\d+) passed", out)
+    m = re.search(r"(\d+) passed", out)
     return int(m.group(1)) if m else -1
 
 

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -2277,12 +2277,32 @@ class TestRunTimeout:
         assert mock_run.call_args.kwargs.get("errors") == "replace"
 
     def test_run_decodes_non_ascii_output_without_crashing(self) -> None:
-        """review-fix SF1: real non-ASCII subprocess output round-trips, never raises."""
-        result = quality_gate._run(
-            [quality_gate.VENV_PYTHON, "-c", "import sys; sys.stdout.write('café—✓ déjà')"]
-        )
+        """review-fix SF1: real non-ASCII subprocess output round-trips, never raises.
+
+        review-fix MF1 (#04): use `sys.executable` (always present) rather
+        than `VENV_PYTHON` (absent on CI runners) so this real-subprocess
+        test runs everywhere — `_run` is interpreter-agnostic.
+        """
+        result = quality_gate._run([sys.executable, "-c", "import sys; sys.stdout.write('café—✓ déjà')"])
         assert result.returncode == 0
         assert "café" in result.stdout and "déjà" in result.stdout
+
+    def test_missing_executable_returns_127(self) -> None:
+        """review-fix MF1 (#04): a missing interpreter degrades to rc 127, not a raised FileNotFoundError."""
+        with patch.object(quality_gate.subprocess, "run", side_effect=FileNotFoundError("no such file")):
+            result = quality_gate._run(["/nonexistent/venv/bin/python", "-c", "pass"])
+        assert result.returncode == 127
+        assert "no such file" in result.stderr
+
+    def test_timeout_whitespace_only_stderr_has_no_leading_blank(self) -> None:
+        """review-fix SF-C (#04): whitespace-only stderr must not inject a leading blank line."""
+        with patch.object(
+            quality_gate.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["x"], timeout=5.0, output="", stderr="   \n  "),
+        ):
+            result = quality_gate._run(["x"], timeout=5.0)
+        assert result.stderr == "timed out after 5.0s"  # not "...\ntimed out..."
 
     def test_timeout_preserves_partial_output(self) -> None:
         """review-fix NH1: partial stdout/stderr captured before the timeout is retained."""
@@ -2308,26 +2328,6 @@ class TestRunTimeout:
         ):
             result = quality_gate._run(["x"], timeout=5.0)
         assert result.stdout == "café"
-
-
-class TestDiffBaseAheadOfHead:
-    """`_diff_base_ahead_of_head` (review-fix SF2) detects an advanced diff base."""
-
-    @pytest.mark.parametrize(
-        ("rc", "stdout", "expected"),
-        [
-            (0, "3\n", True),  # base has 3 commits not in HEAD → stale
-            (0, "0\n", False),  # base fully merged → not stale
-            (0, "", False),  # empty output → defensive False
-            (0, "garbage", False),  # non-numeric → defensive False
-            (1, "5", False),  # rev-list failed → don't claim staleness
-        ],
-        ids=["ahead", "level", "empty", "nonnumeric", "rev-list-failed"],
-    )
-    def test_count_maps_to_bool(self, rc: int, stdout: str, expected: bool) -> None:
-        with patch.object(quality_gate, "_run", return_value=_cp(rc, stdout=stdout)) as mock_run:
-            assert quality_gate._diff_base_ahead_of_head("origin/main") is expected
-        assert mock_run.call_args.args[0] == ["git", "rev-list", "--count", "HEAD..origin/main"]
 
 
 class TestEnsureTestmonDbSafe:
@@ -2415,14 +2415,20 @@ class TestBuildImpactedCmds:
         assert f"--ignore={quality_gate.TESTS_DIR / 'test_quality_gate.py'}" in cmd
 
     def test_testmon_cmd_does_not_deselect_integration_marker(self) -> None:
-        """review-fix MF1: must NOT carry `-m "not integration"` — that dropped domain coverage."""
-        cmd = quality_gate._build_testmon_cmd()
+        """review-fix MF1: must NOT carry `-m "not integration"` — that dropped domain coverage.
+
+        review-fix MF1 (#04): patch `_pytest_workers` so this argv unit test
+        never reaches the real `VENV_PYTHON` xdist probe (absent on CI).
+        """
+        with patch.object(quality_gate, "_pytest_workers", return_value=None):
+            cmd = quality_gate._build_testmon_cmd()
         assert "not integration" not in cmd
         assert "-m" not in cmd[3:]  # no marker filter beyond `python -m pytest`
 
     def test_testmon_cmd_ignores_only_the_selftest_file(self) -> None:
         """review-fix MF1: exactly one --ignore, targeting the testmon self-tests."""
-        cmd = quality_gate._build_testmon_cmd()
+        with patch.object(quality_gate, "_pytest_workers", return_value=None):
+            cmd = quality_gate._build_testmon_cmd()
         ignores = [a for a in cmd if a.startswith("--ignore=")]
         assert ignores == [f"--ignore={quality_gate.TESTS_DIR / 'test_quality_gate.py'}"]
 
@@ -2444,6 +2450,8 @@ class TestBuildImpactedCmds:
             quality_gate._venv_tool("diff-cover"),
             str(quality_gate.COVERAGE_XML),
             "--compare-branch=origin/main",
+            # review-fix SF-A (#04): untracked new files must count as changes.
+            "--include-untracked",
             "--fail-under=100",
         ]
 
@@ -2496,8 +2504,6 @@ class TestCheckImpacted:
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "COVERAGE_XML", xml),
             patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
-            # SF2: not stale → generic missing-coverage verdict + S5 hint.
-            patch.object(quality_gate, "_diff_base_ahead_of_head", return_value=False),
             patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
             patch.object(quality_gate, "_run", return_value=_cp(1, stdout="Coverage: 50%", stderr="fail")),
         ):
@@ -2507,31 +2513,10 @@ class TestCheckImpacted:
         # review-fix S5: failure points at a reseed when the baseline may be stale.
         assert "--seed-testmon" in err
 
-    def test_stale_baseline_emits_distinct_verdict_returns_1(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """review-fix SF2: when the diff base advanced past HEAD, surface a stale-baseline verdict."""
-        xml = tmp_path / "coverage.xml"
-        xml.write_text("<coverage/>")
-        with (
-            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
-            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
-            patch.object(quality_gate, "_ensure_testmon_db_safe"),
-            patch.object(quality_gate, "COVERAGE_XML", xml),
-            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
-            patch.object(quality_gate, "_diff_base_ahead_of_head", return_value=True),
-            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
-            patch.object(quality_gate, "_run", return_value=_cp(1, stdout="Coverage: 50%", stderr="fail")),
-        ):
-            assert quality_gate.check_impacted() == 1
-        err = capsys.readouterr().err
-        assert "baseline stale" in err
-        assert "advanced past your branch" in err
-
     def test_diff_cover_timeout_returns_1_with_distinct_verdict(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """review-fix SF2 (#03): a timed-out diff-cover (124) reports a timeout, not a coverage/stale verdict."""
+        """review-fix SF2 (#03): a timed-out diff-cover (124) reports a timeout, not a coverage verdict."""
         xml = tmp_path / "coverage.xml"
         xml.write_text("<coverage/>")
         with (
@@ -2540,8 +2525,6 @@ class TestCheckImpacted:
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "COVERAGE_XML", xml),
             patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
-            # If the staleness probe were consulted, the verdict would be wrong.
-            patch.object(quality_gate, "_diff_base_ahead_of_head") as mock_ahead,
             patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
             patch.object(quality_gate, "_run", return_value=_cp(124, stderr="timed out after 60.0s")),
         ):
@@ -2549,8 +2532,6 @@ class TestCheckImpacted:
         err = capsys.readouterr().err
         assert "diff-cover timed out" in err
         assert "changed lines <100%" not in err
-        assert "baseline stale" not in err
-        mock_ahead.assert_not_called()  # timeout verdict short-circuits the staleness probe
 
     def test_missing_coverage_xml_returns_1(self, tmp_path: Path) -> None:
         """review-fix N7: if pytest-cov fails to emit coverage.xml, fail loudly (don't diff-cover a stale file)."""
@@ -2613,11 +2594,16 @@ class TestSeedTestmon:
             assert quality_gate.seed_testmon() == 3
 
     def test_seed_not_blocked_when_only_diff_cover_missing(self) -> None:
-        """review-fix S2: seeding never calls diff-cover, so a missing diff-cover must not block it."""
+        """review-fix S2: seeding never calls diff-cover, so a missing diff-cover must not block it.
+
+        review-fix MF1 (#04): stub `_build_seed_testmon_cmd` so this unit test
+        never reaches the real `VENV_PYTHON` xdist probe (absent on CI).
+        """
         with (
             patch.object(quality_gate, "_testmon_available", return_value=True),
             patch.object(quality_gate, "_impacted_tooling_available", return_value=False) as mock_full,
-            patch.object(quality_gate, "_stream_pytest", return_value={"passed": True}),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["SEED_CMD"]),
+            patch.object(quality_gate, "_stream_pytest", return_value={"passed": True, "returncode": 0}),
         ):
             assert quality_gate.seed_testmon() == 0
         mock_full.assert_not_called()  # the full (diff-cover-inclusive) probe is never consulted
@@ -2981,6 +2967,35 @@ class TestImpactedIntegrationRealTestmon:
             text=True,
         )
         assert dc.returncode != 0, f"diff-cover should fail on the untested function:\n{dc.stdout}"
+
+    def test_untracked_new_file_fails_only_with_include_untracked(self, repo: Path) -> None:
+        """review-fix SF-A (#04): a brand-new UNTRACKED file with an uncovered function.
+
+        Proves the dominant inner-loop case (new code starts untracked):
+        without `--include-untracked` diff-cover scores a vacuous 100% PASS;
+        with it (the argv `_build_diff_cover_cmd` now emits) it FAILs.
+        """
+        base = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(repo), check=True, capture_output=True, text=True
+        ).stdout.strip()
+        # New file, NEVER `git add`-ed, with an untested function.
+        (repo / "pkg" / "untracked_mod.py").write_text("def untracked_fn(z):\n    return z * 99\n")
+        xml = repo / "coverage.xml"
+        _run_testmon(repo, cov=True, xml=xml)
+        assert xml.exists()
+
+        def _dc(*extra: str) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [quality_gate._venv_tool("diff-cover"), str(xml), f"--compare-branch={base}", *extra, "--fail-under=100"],
+                cwd=str(repo),
+                capture_output=True,
+                text=True,
+            )
+
+        # Without the flag: untracked file ignored → vacuous PASS (the bug).
+        assert _dc().returncode == 0
+        # With the flag (what we now emit): the uncovered new lines FAIL.
+        assert _dc("--include-untracked").returncode != 0
 
     def test_corrupt_db_selects_all(self, repo: Path) -> None:
         """AC#7: a corrupt .testmondata → fail-safe deletes it → select-all."""

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import sqlite3
+import subprocess
 import sys
 import threading
 import time
@@ -1670,10 +1673,9 @@ class TestQuickMode:
             quality_gate.main()
         assert exc_info.value.code == 2
         err = capsys.readouterr().err
-        assert (
-            "you cannot combine --quick with --cache, --no-cache, --full, or --fix"
-            in err
-        ), f"mutex message missing/changed: {err!r}"
+        assert "you cannot combine --quick with --cache, --no-cache, --full, or --fix" in err, (
+            f"mutex message missing/changed: {err!r}"
+        )
 
     @pytest.mark.parametrize(
         ("workers_value", "expected_in_cmd"),
@@ -1708,9 +1710,7 @@ class TestQuickMode:
         )
         if expected_in_cmd:
             n_idx = cmd.index("-n")
-            assert cmd[n_idx + 1] == workers_value, (
-                f"-n value mismatch; want {workers_value!r}, got {cmd[n_idx + 1]!r}"
-            )
+            assert cmd[n_idx + 1] == workers_value, f"-n value mismatch; want {workers_value!r}, got {cmd[n_idx + 1]!r}"
 
     def test_quick_collect_only_uses_cited_paths_not_tests_dir(
         self,
@@ -1754,9 +1754,7 @@ class TestQuickMode:
         # The cited file (resolved against REPO_ROOT) must appear in the count
         # cmd; the full tests/ tree path must NOT.
         cited = str(quality_gate.REPO_ROOT / "tests/test_factories_pytest_opt_out.py")
-        assert cited in collect_cmd, (
-            f"collect-only cmd must include the cited path {cited!r}; got {collect_cmd!r}"
-        )
+        assert cited in collect_cmd, f"collect-only cmd must include the cited path {cited!r}; got {collect_cmd!r}"
         assert str(quality_gate.TESTS_DIR) not in collect_cmd, (
             f"collect-only cmd must NOT walk full TESTS_DIR; got {collect_cmd!r}"
         )
@@ -1822,9 +1820,7 @@ class TestQuickMode:
             quality_gate.main()
         assert exc_info.value.code == 2
         err = capsys.readouterr().err
-        assert "must be inside the repo" in err, (
-            f"path-escape message missing/changed: {err!r}"
-        )
+        assert "must be inside the repo" in err, f"path-escape message missing/changed: {err!r}"
         assert bad_path in err, f"offending path must appear in error: {err!r}"
 
     @pytest.mark.parametrize(
@@ -1851,9 +1847,7 @@ class TestQuickMode:
             quality_gate.main()
         assert exc_info.value.code == 2
         err = capsys.readouterr().err
-        assert "must be non-empty" in err, (
-            f"empty-path message missing/changed: {err!r}"
-        )
+        assert "must be non-empty" in err, f"empty-path message missing/changed: {err!r}"
 
 
 # --- QS-208 T1.1: _is_ui_asset detector ---
@@ -1865,17 +1859,9 @@ class TestIsUIAsset:
     def test_recognizes_j2_template_anywhere_under_ui(self) -> None:
         """Both top-level and nested `.j2` files under `ui/` count as UI assets."""
         assert (
-            quality_gate._is_ui_asset(
-                "custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2"
-            )
-            is True
+            quality_gate._is_ui_asset("custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2") is True
         )
-        assert (
-            quality_gate._is_ui_asset(
-                "custom_components/quiet_solar/ui/subdir/partial.j2"
-            )
-            is True
-        )
+        assert quality_gate._is_ui_asset("custom_components/quiet_solar/ui/subdir/partial.j2") is True
 
     def test_recognizes_any_file_under_resources(self) -> None:
         """Any file under `ui/resources/` is a UI asset, regardless of extension.
@@ -1884,48 +1870,21 @@ class TestIsUIAsset:
         `.py` file there is treated as a UI asset (and would be a category error
         — Python code belongs outside `resources/`).
         """
-        assert (
-            quality_gate._is_ui_asset(
-                "custom_components/quiet_solar/ui/resources/qs-car-card.js"
-            )
-            is True
-        )
-        assert (
-            quality_gate._is_ui_asset(
-                "custom_components/quiet_solar/ui/resources/sub/nested.css"
-            )
-            is True
-        )
+        assert quality_gate._is_ui_asset("custom_components/quiet_solar/ui/resources/qs-car-card.js") is True
+        assert quality_gate._is_ui_asset("custom_components/quiet_solar/ui/resources/sub/nested.css") is True
         # Convention-documenting test: nothing should be .py here, but if it
         # is, it still routes through the UI fast path. Users should move it.
-        assert (
-            quality_gate._is_ui_asset(
-                "custom_components/quiet_solar/ui/resources/hypothetical.py"
-            )
-            is True
-        )
+        assert quality_gate._is_ui_asset("custom_components/quiet_solar/ui/resources/hypothetical.py") is True
 
     def test_rejects_python_at_ui_root(self) -> None:
         """`.py` files directly under `ui/` are Python production code, not UI assets."""
-        assert (
-            quality_gate._is_ui_asset("custom_components/quiet_solar/ui/dashboard.py")
-            is False
-        )
-        assert (
-            quality_gate._is_ui_asset("custom_components/quiet_solar/ui/__init__.py")
-            is False
-        )
+        assert quality_gate._is_ui_asset("custom_components/quiet_solar/ui/dashboard.py") is False
+        assert quality_gate._is_ui_asset("custom_components/quiet_solar/ui/__init__.py") is False
 
     def test_rejects_paths_outside_ui(self) -> None:
         """Files outside `custom_components/quiet_solar/ui/` are never UI assets."""
-        assert (
-            quality_gate._is_ui_asset("custom_components/quiet_solar/home_model/foo.py")
-            is False
-        )
-        assert (
-            quality_gate._is_ui_asset("custom_components/quiet_solar/ha_model/bar.py")
-            is False
-        )
+        assert quality_gate._is_ui_asset("custom_components/quiet_solar/home_model/foo.py") is False
+        assert quality_gate._is_ui_asset("custom_components/quiet_solar/ha_model/bar.py") is False
         assert quality_gate._is_ui_asset("tests/test_baz.py") is False
         assert quality_gate._is_ui_asset("scripts/qs/quality_gate.py") is False
 
@@ -1938,9 +1897,7 @@ class TestDetectScopeUIOnly:
 
     def test_returns_ui_only_when_only_j2_changed(self) -> None:
         """Diff of one `.j2` template → scope is `"ui-only"`."""
-        info = quality_gate._detect_scope(
-            ["custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2"]
-        )
+        info = quality_gate._detect_scope(["custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2"])
         assert info["scope"] == "ui-only"
         assert info["changed_test_files"] == []
 
@@ -2074,9 +2031,7 @@ class TestUIOnlyMainBranch:
         ):
             quality_gate.main()
 
-        mock_pytest_files.assert_called_once_with(
-            ["tests/test_dashboard_rendering.py", "tests/test_other.py"]
-        )
+        mock_pytest_files.assert_called_once_with(["tests/test_dashboard_rendering.py", "tests/test_other.py"])
 
     def test_full_flag_overrides_ui_only_scope(
         self,
@@ -2106,3 +2061,461 @@ class TestUIOnlyMainBranch:
             m.assert_called()
         # The UI fast-path pytest must NOT have been called.
         mock_pytest_files.assert_not_called()
+
+
+# ===========================================================================
+# QS-276 — `--impacted` inner loop + `--seed-testmon`
+# ===========================================================================
+
+
+def _cp(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    """Build a CompletedProcess stand-in for mocking `quality_gate._run`."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestImpactedToolingAvailable:
+    """`_impacted_tooling_available` probes the venv for testmon + diff_cover."""
+
+    @pytest.mark.parametrize(
+        ("probe_rc", "expected"),
+        [(0, True), (1, False)],
+        ids=["both-importable", "missing"],
+    )
+    def test_probe_result_maps_to_bool(self, probe_rc: int, expected: bool) -> None:
+        with patch.object(quality_gate, "_run", return_value=_cp(probe_rc)) as mock_run:
+            assert quality_gate._impacted_tooling_available() is expected
+        # Probes the venv interpreter, not the orchestrator.
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == quality_gate.VENV_PYTHON
+        assert "diff_cover" in cmd[-1] and "testmon" in cmd[-1]
+
+
+class TestIsCi:
+    """`_is_ci` recognizes the GitHub Actions `CI` env var."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("true", True), ("1", True), ("TRUE", True), ("  true ", True), ("false", False), ("0", False), ("", False)],
+    )
+    def test_ci_env(self, value: str, expected: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CI", value)
+        assert quality_gate._is_ci() is expected
+
+    def test_ci_unset_is_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CI", raising=False)
+        assert quality_gate._is_ci() is False
+
+
+class TestResolveDiffBase:
+    """`_resolve_diff_base` walks origin/main → main → upstream merge-base."""
+
+    @staticmethod
+    def _router(
+        rev_parse: dict[str, int], *, upstream: tuple[int, str] = (1, ""), merge_base: tuple[int, str] = (1, "")
+    ):
+        """Build a `_run` side_effect keyed on the git subcommand."""
+
+        def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
+            if cmd[:2] == ["git", "fetch"]:
+                return _cp(0)
+            if cmd[:3] == ["git", "rev-parse", "--verify"]:
+                return _cp(rev_parse.get(cmd[3], 1))
+            if cmd[:2] == ["git", "rev-parse"]:  # @{u} upstream lookup
+                return _cp(upstream[0], stdout=upstream[1])
+            if cmd[:2] == ["git", "merge-base"]:
+                return _cp(merge_base[0], stdout=merge_base[1])
+            raise AssertionError(f"unexpected cmd {cmd!r}")
+
+        return _side_effect
+
+    def test_origin_main_wins(self) -> None:
+        with patch.object(quality_gate, "_run", side_effect=self._router({"origin/main": 0, "main": 0})):
+            assert quality_gate._resolve_diff_base() == "origin/main"
+
+    def test_fetches_origin_main_first(self) -> None:
+        with patch.object(quality_gate, "_run", side_effect=self._router({"origin/main": 0})) as mock_run:
+            quality_gate._resolve_diff_base()
+        first = mock_run.call_args_list[0].args[0]
+        assert first == ["git", "fetch", "origin", "main"]
+
+    def test_falls_back_to_local_main(self) -> None:
+        with patch.object(quality_gate, "_run", side_effect=self._router({"origin/main": 1, "main": 0})):
+            assert quality_gate._resolve_diff_base() == "main"
+
+    def test_falls_back_to_upstream_merge_base(self) -> None:
+        router = self._router(
+            {"origin/main": 1, "main": 1},
+            upstream=(0, "origin/feature"),
+            merge_base=(0, "deadbeefcafe"),
+        )
+        with patch.object(quality_gate, "_run", side_effect=router):
+            assert quality_gate._resolve_diff_base() == "deadbeefcafe"
+
+    def test_none_when_no_upstream(self) -> None:
+        router = self._router({"origin/main": 1, "main": 1}, upstream=(1, ""))
+        with patch.object(quality_gate, "_run", side_effect=router):
+            assert quality_gate._resolve_diff_base() is None
+
+    def test_none_when_merge_base_fails(self) -> None:
+        router = self._router(
+            {"origin/main": 1, "main": 1},
+            upstream=(0, "origin/feature"),
+            merge_base=(1, ""),
+        )
+        with patch.object(quality_gate, "_run", side_effect=router):
+            assert quality_gate._resolve_diff_base() is None
+
+
+class TestEnsureTestmonDbSafe:
+    """`_ensure_testmon_db_safe` deletes only a non-SQLite `.testmondata`."""
+
+    def test_absent_is_noop(self, tmp_path: Path) -> None:
+        db = tmp_path / ".testmondata"
+        with patch.object(quality_gate, "TESTMON_DATA", db):
+            quality_gate._ensure_testmon_db_safe()  # must not raise
+        assert not db.exists()
+
+    def test_valid_sqlite_is_kept(self, tmp_path: Path) -> None:
+        db = tmp_path / ".testmondata"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE t (x)")
+        conn.commit()
+        conn.close()
+        with patch.object(quality_gate, "TESTMON_DATA", db):
+            quality_gate._ensure_testmon_db_safe()
+        assert db.exists(), "a valid SQLite DB must be preserved"
+
+    def test_corrupt_db_is_removed(self, tmp_path: Path) -> None:
+        db = tmp_path / ".testmondata"
+        db.write_bytes(b"this is not a sqlite database")
+        with patch.object(quality_gate, "TESTMON_DATA", db):
+            quality_gate._ensure_testmon_db_safe()
+        assert not db.exists(), "corrupt .testmondata must be removed to force select-all"
+
+
+class TestBuildImpactedCmds:
+    """Pure argv builders for the `--impacted` seam."""
+
+    def test_testmon_cmd_default_serial(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(quality_gate, "_TESTMON_SUPPORTS_XDIST", False)
+        cmd = quality_gate._build_testmon_cmd()
+        assert cmd[:4] == [quality_gate.VENV_PYTHON, "-m", "pytest", "--testmon"]
+        assert f"--cov={quality_gate.SRC_DIR}" in cmd
+        # Empty --cov-report= must precede the xml report (clears pytest.ini).
+        assert cmd.index("--cov-report=") < cmd.index(f"--cov-report=xml:{quality_gate.COVERAGE_XML}")
+        assert "--cov-fail-under=100" not in cmd  # verdict is diff-cover's job
+        assert "-n" not in cmd  # static serial decision
+
+    def test_testmon_cmd_adds_workers_when_xdist_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(quality_gate, "_TESTMON_SUPPORTS_XDIST", True)
+        with patch.object(quality_gate, "_pytest_workers", return_value="auto"):
+            cmd = quality_gate._build_testmon_cmd()
+        assert cmd[cmd.index("-n") + 1] == "auto"
+
+    def test_testmon_cmd_serial_when_xdist_enabled_but_workers_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(quality_gate, "_TESTMON_SUPPORTS_XDIST", True)
+        with patch.object(quality_gate, "_pytest_workers", return_value=None):
+            cmd = quality_gate._build_testmon_cmd()
+        assert "-n" not in cmd
+
+    def test_diff_cover_cmd(self) -> None:
+        cmd = quality_gate._build_diff_cover_cmd("origin/main")
+        assert cmd == [
+            quality_gate._venv_tool("diff-cover"),
+            str(quality_gate.COVERAGE_XML),
+            "--compare-branch=origin/main",
+            "--fail-under=100",
+        ]
+
+
+class TestCheckImpacted:
+    """`check_impacted` orchestrator + exit-code mapping (mocked seam)."""
+
+    def test_tooling_missing_returns_3(self) -> None:
+        with patch.object(quality_gate, "_impacted_tooling_available", return_value=False):
+            assert quality_gate.check_impacted() == 3
+
+    def test_no_base_in_ci_returns_4(self) -> None:
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value=None),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+        ):
+            assert quality_gate.check_impacted() == 4
+
+    def test_no_base_locally_warns_and_passes(self) -> None:
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value=None),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+        ):
+            assert quality_gate.check_impacted() == 0
+
+    def test_selected_tests_fail_returns_1(self) -> None:
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": False}),
+            patch.object(quality_gate, "_run") as mock_run,
+        ):
+            assert quality_gate.check_impacted() == 1
+        mock_run.assert_not_called()  # diff-cover never runs if tests failed
+
+    def test_diff_coverage_below_100_returns_1(self) -> None:
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
+            patch.object(quality_gate, "_run", return_value=_cp(1, stdout="Coverage: 50%", stderr="fail")),
+        ):
+            assert quality_gate.check_impacted() == 1
+
+    def test_pass_returns_0(self) -> None:
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe") as mock_safe,
+            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
+            patch.object(quality_gate, "_run", return_value=_cp(0, stdout="Coverage: 100%")) as mock_run,
+        ):
+            assert quality_gate.check_impacted() == 0
+        mock_safe.assert_called_once()
+        dc_cmd = mock_run.call_args.args[0]
+        assert dc_cmd[2] == "--compare-branch=origin/main"
+
+
+class TestSeedTestmon:
+    """`seed_testmon` refreshes the DB with no pass/fail verdict."""
+
+    def test_tooling_missing_returns_3(self) -> None:
+        with patch.object(quality_gate, "_impacted_tooling_available", return_value=False):
+            assert quality_gate.seed_testmon() == 3
+
+    def test_success_returns_0_regardless_of_test_outcome(self) -> None:
+        # Even a failing selection still updates the DB → seed returns 0.
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_stream_pytest", return_value={"passed": False}) as mock_stream,
+        ):
+            assert quality_gate.seed_testmon() == 0
+        cmd = mock_stream.call_args.args[0]
+        assert cmd == [quality_gate.VENV_PYTHON, "-m", "pytest", "--testmon", "-q"]
+
+
+class TestImpactedCli:
+    """`main()` wiring: short-circuit, exit-code passthrough, mutex."""
+
+    @pytest.mark.parametrize("exit_code", [0, 1, 3, 4], ids=["pass", "fail", "tooling", "no-base"])
+    def test_impacted_exits_with_check_impacted_code(self, exit_code: int) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--impacted"]),
+            patch.object(quality_gate, "check_impacted", return_value=exit_code) as mock_check,
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == exit_code
+        mock_check.assert_called_once_with()
+
+    def test_impacted_short_circuits_before_scope_and_cache(self) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--impacted"]),
+            patch.object(quality_gate, "check_impacted", return_value=0),
+            patch.object(quality_gate, "_detect_scope") as mock_scope,
+            patch.object(quality_gate, "_read_cache") as mock_cache,
+            patch.object(quality_gate, "_get_changed_files") as mock_changed,
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+        for m in (mock_scope, mock_cache, mock_changed):
+            m.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "conflict",
+        [["--cache"], ["--no-cache"], ["--full"], ["--fix"], ["--quick", "tests/test_x.py"]],
+        ids=["cache", "no-cache", "full", "fix", "quick"],
+    )
+    def test_impacted_mutex_exits_2(self, conflict: list[str], capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--impacted", *conflict]),
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == 2
+        assert "you cannot combine --impacted with" in capsys.readouterr().err
+
+    @pytest.mark.parametrize("seed_code", [0, 3], ids=["ok", "tooling-missing"])
+    def test_seed_testmon_cli_passthrough(self, seed_code: int) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon"]),
+            patch.object(quality_gate, "seed_testmon", return_value=seed_code) as mock_seed,
+            patch.object(quality_gate, "_detect_scope") as mock_scope,
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == seed_code
+        mock_seed.assert_called_once_with()
+        mock_scope.assert_not_called()
+
+
+class TestImpactedDeps:
+    """Regression guards for requirements_test.txt + .gitignore (AC#1)."""
+
+    def test_testmon_and_diff_cover_pinned(self) -> None:
+        reqs = (Path(__file__).resolve().parent.parent / "requirements_test.txt").read_text()
+        assert "pytest-testmon==" in reqs
+        assert "diff-cover==" in reqs
+
+    def test_testmondata_gitignored(self) -> None:
+        gi = (Path(__file__).resolve().parent.parent / ".gitignore").read_text()
+        assert any(line.strip() == ".testmondata" for line in gi.splitlines())
+
+
+class TestWorktreeSetupSeedsCaches:
+    """AC#8: worktree-setup.sh copies (never symlinks) .testmondata + .mypy_cache."""
+
+    def _script(self) -> str:
+        return (Path(__file__).resolve().parent.parent / "scripts" / "worktree-setup.sh").read_text()
+
+    def test_copies_both_caches(self) -> None:
+        body = self._script()
+        assert ".mypy_cache" in body and ".testmondata" in body
+        assert "cp -R" in body, "caches must be copied, not symlinked"
+
+    def test_warns_when_absent(self) -> None:
+        assert "Warning:" in self._script() and "absent in main worktree" in self._script()
+
+
+class TestFinishTaskRefreshesBaseline:
+    """AC#9: all three finish-task harness copies refresh via --seed-testmon."""
+
+    @pytest.mark.parametrize("harness", [".claude", ".cursor", ".opencode"])
+    def test_seed_testmon_refresh_present(self, harness: str) -> None:
+        body = (Path(__file__).resolve().parent.parent / harness / "agents" / "qs-finish-task.md").read_text()
+        assert "--seed-testmon" in body
+        assert "git worktree list --porcelain" in body  # MAIN_DIR captured before cleanup
+        assert "nohup" in body  # detached / best-effort
+
+
+class TestImplementAgentsDefaultImpacted:
+    """AC#10: implement agents default to --impacted; review-task untouched."""
+
+    @pytest.mark.parametrize("harness", [".claude", ".cursor", ".opencode"])
+    @pytest.mark.parametrize("agent", ["qs-implement-task", "qs-implement-setup-task"])
+    def test_implement_agents_use_impacted(self, harness: str, agent: str) -> None:
+        body = (Path(__file__).resolve().parent.parent / harness / "agents" / f"{agent}.md").read_text()
+        assert "quality_gate.py --impacted" in body
+
+    @pytest.mark.parametrize("harness", [".claude", ".cursor", ".opencode"])
+    def test_review_task_untouched_by_impacted(self, harness: str) -> None:
+        body = (Path(__file__).resolve().parent.parent / harness / "agents" / "qs-review-task.md").read_text()
+        assert "--impacted" not in body
+
+
+def _run_testmon(repo: Path, *, cov: bool = False, xml: Path | None = None) -> subprocess.CompletedProcess[str]:
+    """Run `pytest --testmon` in an isolated subprocess inside `repo`.
+
+    Plugin autoload is disabled so the host's pytest-homeassistant /
+    asyncio plugin stack can't crash collection in the throwaway repo;
+    testmon (and pytest-cov when measuring) are loaded explicitly.
+    cacheprovider is a pytest builtin and stays loaded.
+    """
+    env = {**os.environ, "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1"}
+    cmd = [quality_gate.VENV_PYTHON, "-m", "pytest", "--testmon", "-q", "-p", "testmon.pytest_testmon"]
+    if cov:
+        assert xml is not None
+        cmd += ["-p", "pytest_cov", "--cov=pkg", "--cov-report=", f"--cov-report=xml:{xml}"]
+    return subprocess.run(cmd, cwd=str(repo), capture_output=True, text=True, env=env)
+
+
+def _selected_count(result: subprocess.CompletedProcess[str]) -> int:
+    """Parse the number of tests testmon actually ran from pytest output."""
+    out = result.stdout
+    if "no tests ran" in out:
+        return 0
+    m = __import__("re").search(r"(\d+) passed", out)
+    return int(m.group(1)) if m else -1
+
+
+@pytest.mark.integration
+class TestImpactedIntegrationRealTestmon:
+    """AC#5/#6/#7: genuine testmon block-fingerprinting in a throwaway repo.
+
+    These exercise REAL pytest-testmon + diff-cover (no mocks) to prove
+    the correctness basis of `--impacted`: a changed line is "covered"
+    iff a selected test ran it, and testmon selects a superset of the
+    tests that cover the diff.
+    """
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        if not quality_gate._impacted_tooling_available():
+            pytest.skip("pytest-testmon / diff-cover not importable")
+        repo = tmp_path / "repo"
+        (repo / "pkg").mkdir(parents=True)
+        (repo / "tests").mkdir()
+        (repo / "pkg" / "__init__.py").write_text("")
+        (repo / "pkg" / "calc.py").write_text("X = 1\n\n\ndef add(a, b):\n    return a + b\n")
+        (repo / "pkg" / "isolated_const.py").write_text("UNUSED = 1\n")
+        (repo / "tests" / "test_calc.py").write_text(
+            "from pkg.calc import add\n\n\ndef test_add():\n    assert add(1, 2) == 3\n"
+        )
+        for args in (
+            ["init", "-q"],
+            ["config", "user.email", "t@t.co"],
+            ["config", "user.name", "t"],
+            ["add", "-A"],
+            ["commit", "-qm", "base"],
+        ):
+            subprocess.run(["git", *args], cwd=str(repo), check=True, capture_output=True, text=True)
+        # Seed the testmon baseline (selects all → records coverage).
+        seed = _run_testmon(repo)
+        assert _selected_count(seed) == 1, seed.stdout + seed.stderr
+        return repo
+
+    def test_noop_selects_zero(self, repo: Path) -> None:
+        """Nothing changed since the seed → testmon selects zero tests."""
+        assert _selected_count(_run_testmon(repo)) == 0
+
+    def test_edit_to_uncovered_code_selects_zero(self, repo: Path) -> None:
+        """AC#5: a new constant in a module no test exercises selects zero."""
+        (repo / "pkg" / "isolated_const.py").write_text("UNUSED = 1\nNEW_CONST = 2\n")
+        assert _selected_count(_run_testmon(repo)) == 0
+
+    def test_edit_to_covered_code_reselects_its_test(self, repo: Path) -> None:
+        """Superset property: editing a covered function reselects its test."""
+        (repo / "pkg" / "calc.py").write_text("X = 1\n\n\ndef add(a, b):\n    return a + b + 0\n")
+        assert _selected_count(_run_testmon(repo)) == 1
+
+    def test_new_untested_function_fails_diff_cover(self, repo: Path) -> None:
+        """AC#6: a new untested function → 0% on the new lines → diff-cover fails."""
+        base = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(repo), check=True, capture_output=True, text=True
+        ).stdout.strip()
+        (repo / "pkg" / "calc.py").write_text(
+            "X = 1\n\n\ndef add(a, b):\n    return a + b\n\n\ndef untested(z):\n    return z * 99\n"
+        )
+        subprocess.run(["git", "add", "-A"], cwd=str(repo), check=True, capture_output=True, text=True)
+        subprocess.run(["git", "commit", "-qm", "untested"], cwd=str(repo), check=True, capture_output=True, text=True)
+        xml = repo / "coverage.xml"
+        _run_testmon(repo, cov=True, xml=xml)
+        assert xml.exists()
+        dc = subprocess.run(
+            [quality_gate._venv_tool("diff-cover"), str(xml), f"--compare-branch={base}", "--fail-under=100"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+        )
+        assert dc.returncode != 0, f"diff-cover should fail on the untested function:\n{dc.stdout}"
+
+    def test_corrupt_db_selects_all(self, repo: Path) -> None:
+        """AC#7: a corrupt .testmondata → fail-safe deletes it → select-all."""
+        db = repo / ".testmondata"
+        db.write_bytes(b"not a sqlite database")
+        # Mirror check_impacted's fail-safe against the throwaway DB.
+        with patch.object(quality_gate, "TESTMON_DATA", db):
+            quality_gate._ensure_testmon_db_safe()
+        assert not db.exists()
+        # With the corrupt DB gone, testmon rebuilds and selects all tests.
+        assert _selected_count(_run_testmon(repo)) == 1

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -2269,6 +2269,46 @@ class TestRunTimeout:
             quality_gate._run(["git", "status"], timeout=3.0)
         assert mock_run.call_args.kwargs.get("timeout") == 3.0
 
+    def test_run_pins_utf8_replace_decoding(self) -> None:
+        """review-fix SF1: _run must decode as utf-8/replace, not the locale codec."""
+        with patch.object(quality_gate.subprocess, "run", return_value=_cp(0)) as mock_run:
+            quality_gate._run(["git", "status"])
+        assert mock_run.call_args.kwargs.get("encoding") == "utf-8"
+        assert mock_run.call_args.kwargs.get("errors") == "replace"
+
+    def test_run_decodes_non_ascii_output_without_crashing(self) -> None:
+        """review-fix SF1: real non-ASCII subprocess output round-trips, never raises."""
+        result = quality_gate._run(
+            [quality_gate.VENV_PYTHON, "-c", "import sys; sys.stdout.write('café—✓ déjà')"]
+        )
+        assert result.returncode == 0
+        assert "café" in result.stdout and "déjà" in result.stdout
+
+    def test_timeout_preserves_partial_output(self) -> None:
+        """review-fix NH1: partial stdout/stderr captured before the timeout is retained."""
+        with patch.object(
+            quality_gate.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(
+                cmd=["x"], timeout=5.0, output="partial out", stderr="partial err"
+            ),
+        ):
+            result = quality_gate._run(["x"], timeout=5.0)
+        assert result.returncode == 124
+        assert result.stdout == "partial out"
+        assert "partial err" in result.stderr
+        assert "timed out" in result.stderr  # the timeout marker is still appended
+
+    def test_timeout_decodes_bytes_partial_output(self) -> None:
+        """review-fix NH1: bytes partial output is decoded utf-8/replace."""
+        with patch.object(
+            quality_gate.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["x"], timeout=5.0, output=b"caf\xc3\xa9"),
+        ):
+            result = quality_gate._run(["x"], timeout=5.0)
+        assert result.stdout == "café"
+
 
 class TestDiffBaseAheadOfHead:
     """`_diff_base_ahead_of_head` (review-fix SF2) detects an advanced diff base."""
@@ -2369,11 +2409,22 @@ class TestBuildImpactedCmds:
         assert cmd.index("--cov-report=") < cmd.index(f"--cov-report=xml:{quality_gate.COVERAGE_XML}")
         assert "--cov-fail-under=100" not in cmd  # verdict is diff-cover's job
         assert "-n" not in cmd  # serial only when testmon⊕xdist is disabled
-        # review-fix N5: integration tests are deselected from the fast loop.
-        # (`-m` appears twice — `python -m pytest` and the marker — so locate
-        # the marker value and assert it is preceded by a `-m` flag.)
-        assert "not integration" in cmd
-        assert cmd[cmd.index("not integration") - 1] == "-m"
+        # review-fix MF1: the self-test file is excluded BY PATH, not by the
+        # shared `integration` marker (domain integration tests cover
+        # production code and must stay selected).
+        assert f"--ignore={quality_gate.TESTS_DIR / 'test_quality_gate.py'}" in cmd
+
+    def test_testmon_cmd_does_not_deselect_integration_marker(self) -> None:
+        """review-fix MF1: must NOT carry `-m "not integration"` — that dropped domain coverage."""
+        cmd = quality_gate._build_testmon_cmd()
+        assert "not integration" not in cmd
+        assert "-m" not in cmd[3:]  # no marker filter beyond `python -m pytest`
+
+    def test_testmon_cmd_ignores_only_the_selftest_file(self) -> None:
+        """review-fix MF1: exactly one --ignore, targeting the testmon self-tests."""
+        cmd = quality_gate._build_testmon_cmd()
+        ignores = [a for a in cmd if a.startswith("--ignore=")]
+        assert ignores == [f"--ignore={quality_gate.TESTS_DIR / 'test_quality_gate.py'}"]
 
     def test_testmon_cmd_adds_workers_when_xdist_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(quality_gate, "_TESTMON_SUPPORTS_XDIST", True)
@@ -2477,6 +2528,30 @@ class TestCheckImpacted:
         assert "baseline stale" in err
         assert "advanced past your branch" in err
 
+    def test_diff_cover_timeout_returns_1_with_distinct_verdict(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """review-fix SF2 (#03): a timed-out diff-cover (124) reports a timeout, not a coverage/stale verdict."""
+        xml = tmp_path / "coverage.xml"
+        xml.write_text("<coverage/>")
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "COVERAGE_XML", xml),
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
+            # If the staleness probe were consulted, the verdict would be wrong.
+            patch.object(quality_gate, "_diff_base_ahead_of_head") as mock_ahead,
+            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
+            patch.object(quality_gate, "_run", return_value=_cp(124, stderr="timed out after 60.0s")),
+        ):
+            assert quality_gate.check_impacted() == 1
+        err = capsys.readouterr().err
+        assert "diff-cover timed out" in err
+        assert "changed lines <100%" not in err
+        assert "baseline stale" not in err
+        mock_ahead.assert_not_called()  # timeout verdict short-circuits the staleness probe
+
     def test_missing_coverage_xml_returns_1(self, tmp_path: Path) -> None:
         """review-fix N7: if pytest-cov fails to emit coverage.xml, fail loudly (don't diff-cover a stale file)."""
         missing = tmp_path / "coverage.xml"  # never created
@@ -2548,14 +2623,28 @@ class TestSeedTestmon:
         mock_full.assert_not_called()  # the full (diff-cover-inclusive) probe is never consulted
 
     def test_success_returns_0_regardless_of_test_outcome(self) -> None:
-        # Even a failing selection still updates the DB → seed returns 0.
+        # A failing test (rc=1) still updates the DB → seed returns 0, no warning.
         with (
             patch.object(quality_gate, "_testmon_available", return_value=True),
             patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["SEED_CMD"]),
-            patch.object(quality_gate, "_stream_pytest", return_value={"passed": False}) as mock_stream,
+            patch.object(
+                quality_gate, "_stream_pytest", return_value={"passed": False, "returncode": 1}
+            ) as mock_stream,
         ):
             assert quality_gate.seed_testmon() == 0
         assert mock_stream.call_args.args[0] == ["SEED_CMD"]
+
+    def test_collection_crash_warns_but_stays_best_effort(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """review-fix NH4 (#03): a pytest exit >=2 (collection error/crash) warns but still returns 0."""
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["SEED_CMD"]),
+            patch.object(quality_gate, "_stream_pytest", return_value={"passed": False, "returncode": 2}),
+        ):
+            assert quality_gate.seed_testmon() == 0  # best-effort: never fatal
+        err = capsys.readouterr().err
+        assert "exited 2" in err
+        assert ".testmondata may be incomplete" in err
 
     def test_seed_cmd_parallelizes_when_xdist_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """review-fix: seeding is the heaviest testmon pass, so it runs under -n auto."""
@@ -2733,6 +2822,11 @@ class TestWorktreeSetupSeedsCaches:
         # The copy is keyed on the loop variable (applies to every cache),
         # not hard-coded for a single cache name.
         assert 'cp -R "$src" "$dst"' in block
+
+    def test_documents_file_vs_dir_cp(self) -> None:
+        """review-fix NH3: the block notes that cp -R handles both a file and a directory."""
+        block = self._seed_block()
+        assert "directory (.mypy_cache)" in block and "single file (.testmondata)" in block
 
     def test_seeding_never_symlinks(self) -> None:
         """review-fix N1: reject any symlink in the seeding block (copy, not link)."""

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -2274,7 +2274,11 @@ class TestEnsureTestmonDbSafe:
 class TestBuildImpactedCmds:
     """Pure argv builders for the `--impacted` seam."""
 
-    def test_testmon_cmd_default_serial(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_testmon_supports_xdist_enabled_by_default(self) -> None:
+        """review-fix: testmon 2.2.0 attributes coverage across xdist workers, so we parallelize."""
+        assert quality_gate._TESTMON_SUPPORTS_XDIST is True
+
+    def test_testmon_cmd_shape_when_xdist_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(quality_gate, "_TESTMON_SUPPORTS_XDIST", False)
         cmd = quality_gate._build_testmon_cmd()
         assert cmd[:4] == [quality_gate.VENV_PYTHON, "-m", "pytest", "--testmon"]
@@ -2282,7 +2286,7 @@ class TestBuildImpactedCmds:
         # Empty --cov-report= must precede the xml report (clears pytest.ini).
         assert cmd.index("--cov-report=") < cmd.index(f"--cov-report=xml:{quality_gate.COVERAGE_XML}")
         assert "--cov-fail-under=100" not in cmd  # verdict is diff-cover's job
-        assert "-n" not in cmd  # static serial decision
+        assert "-n" not in cmd  # serial only when testmon⊕xdist is disabled
         # review-fix N5: integration tests are deselected from the fast loop.
         # (`-m` appears twice — `python -m pytest` and the marker — so locate
         # the marker value and assert it is preceded by a `-m` flag.)
@@ -2339,6 +2343,9 @@ class TestCheckImpacted:
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            # Isolate _run to the diff-cover call: the cmd builder probes
+            # xdist via _run, so stub it (it is unit-tested separately).
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
             patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": False}),
             patch.object(quality_gate, "_run") as mock_run,
         ):
@@ -2355,6 +2362,7 @@ class TestCheckImpacted:
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "COVERAGE_XML", xml),
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
             patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
             patch.object(quality_gate, "_run", return_value=_cp(1, stdout="Coverage: 50%", stderr="fail")),
         ):
@@ -2370,6 +2378,7 @@ class TestCheckImpacted:
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "COVERAGE_XML", missing),
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
             patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
             patch.object(quality_gate, "_run") as mock_run,
         ):
@@ -2384,6 +2393,7 @@ class TestCheckImpacted:
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe") as mock_safe,
             patch.object(quality_gate, "COVERAGE_XML", xml),
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
             patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
             patch.object(quality_gate, "_run", return_value=_cp(0, stdout="Coverage: 100%")) as mock_run,
         ):
@@ -2432,11 +2442,30 @@ class TestSeedTestmon:
         # Even a failing selection still updates the DB → seed returns 0.
         with (
             patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["SEED_CMD"]),
             patch.object(quality_gate, "_stream_pytest", return_value={"passed": False}) as mock_stream,
         ):
             assert quality_gate.seed_testmon() == 0
-        cmd = mock_stream.call_args.args[0]
+        assert mock_stream.call_args.args[0] == ["SEED_CMD"]
+
+    def test_seed_cmd_parallelizes_when_xdist_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """review-fix: seeding is the heaviest testmon pass, so it runs under -n auto."""
+        monkeypatch.setattr(quality_gate, "_TESTMON_SUPPORTS_XDIST", True)
+        with patch.object(quality_gate, "_pytest_workers", return_value="auto"):
+            cmd = quality_gate._build_seed_testmon_cmd()
+        assert cmd[:5] == [quality_gate.VENV_PYTHON, "-m", "pytest", "--testmon", "-q"]
+        assert cmd[cmd.index("-n") + 1] == "auto"
+
+    def test_seed_cmd_serial_when_xdist_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(quality_gate, "_TESTMON_SUPPORTS_XDIST", False)
+        cmd = quality_gate._build_seed_testmon_cmd()
         assert cmd == [quality_gate.VENV_PYTHON, "-m", "pytest", "--testmon", "-q"]
+
+    def test_seed_cmd_serial_when_workers_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(quality_gate, "_TESTMON_SUPPORTS_XDIST", True)
+        with patch.object(quality_gate, "_pytest_workers", return_value=None):
+            cmd = quality_gate._build_seed_testmon_cmd()
+        assert "-n" not in cmd
 
 
 class TestImpactedCli:

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -2168,9 +2168,11 @@ class TestResolveDiffBase:
 
         return _side_effect
 
-    def test_origin_main_wins(self) -> None:
+    def test_origin_main_wins(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch.object(quality_gate, "_run", side_effect=self._router({"origin/main": 0, "main": 0})):
             assert quality_gate._resolve_diff_base() == "origin/main"
+        # review-fix NH2 (#05): the chosen base is announced for debuggability.
+        assert "diff base: origin/main" in capsys.readouterr().err
 
     def test_fetches_origin_main_first(self) -> None:
         with patch.object(quality_gate, "_run", side_effect=self._router({"origin/main": 0})) as mock_run:
@@ -2182,7 +2184,7 @@ class TestResolveDiffBase:
         with patch.object(quality_gate, "_run", side_effect=self._router({"origin/main": 1, "main": 0})):
             assert quality_gate._resolve_diff_base() == "main"
 
-    def test_falls_back_to_upstream_merge_base(self) -> None:
+    def test_falls_back_to_upstream_merge_base(self, capsys: pytest.CaptureFixture[str]) -> None:
         router = self._router(
             {"origin/main": 1, "main": 1},
             upstream=(0, "origin/feature"),
@@ -2190,6 +2192,8 @@ class TestResolveDiffBase:
         )
         with patch.object(quality_gate, "_run", side_effect=router):
             assert quality_gate._resolve_diff_base() == "deadbeefcafe"
+        # review-fix NH2 (#05): the merge-base sha + tracked ref are announced.
+        assert "diff base: deadbeefcafe (merge-base with origin/feature)" in capsys.readouterr().err
 
     def test_none_when_no_upstream(self) -> None:
         router = self._router({"origin/main": 1, "main": 1}, upstream=(1, ""))
@@ -2497,14 +2501,18 @@ class TestCheckImpacted:
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         xml = tmp_path / "coverage.xml"
-        xml.write_text("<coverage/>")
+
+        def _emit_xml(*_a: object, **_k: object) -> dict:
+            xml.write_text("<coverage/>")  # simulate pytest-cov writing a fresh report
+            return {"name": "pytest", "passed": True}
+
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "COVERAGE_XML", xml),
             patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
-            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
+            patch.object(quality_gate, "_stream_pytest", side_effect=_emit_xml),
             patch.object(quality_gate, "_run", return_value=_cp(1, stdout="Coverage: 50%", stderr="fail")),
         ):
             assert quality_gate.check_impacted() == 1
@@ -2518,14 +2526,18 @@ class TestCheckImpacted:
     ) -> None:
         """review-fix SF2 (#03): a timed-out diff-cover (124) reports a timeout, not a coverage verdict."""
         xml = tmp_path / "coverage.xml"
-        xml.write_text("<coverage/>")
+
+        def _emit_xml(*_a: object, **_k: object) -> dict:
+            xml.write_text("<coverage/>")
+            return {"name": "pytest", "passed": True}
+
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "COVERAGE_XML", xml),
             patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
-            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
+            patch.object(quality_gate, "_stream_pytest", side_effect=_emit_xml),
             patch.object(quality_gate, "_run", return_value=_cp(124, stderr="timed out after 60.0s")),
         ):
             assert quality_gate.check_impacted() == 1
@@ -2550,14 +2562,18 @@ class TestCheckImpacted:
 
     def test_pass_returns_0(self, tmp_path: Path) -> None:
         xml = tmp_path / "coverage.xml"
-        xml.write_text("<coverage/>")
+
+        def _emit_xml(*_a: object, **_k: object) -> dict:
+            xml.write_text("<coverage/>")  # fresh report, written AFTER the SF1 pre-delete
+            return {"name": "pytest", "passed": True}
+
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe") as mock_safe,
             patch.object(quality_gate, "COVERAGE_XML", xml),
             patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
-            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
+            patch.object(quality_gate, "_stream_pytest", side_effect=_emit_xml),
             patch.object(quality_gate, "_run", return_value=_cp(0, stdout="Coverage: 100%")) as mock_run,
         ):
             assert quality_gate.check_impacted() == 0
@@ -2566,6 +2582,29 @@ class TestCheckImpacted:
         assert dc_cmd[2] == "--compare-branch=origin/main"
         # review-fix NH1: the diff-cover subprocess is bounded by a timeout.
         assert mock_run.call_args.kwargs.get("timeout") == quality_gate._DIFF_COVER_TIMEOUT_SECONDS
+
+    def test_stale_coverage_xml_cleared_so_emission_failure_fails(self, tmp_path: Path) -> None:
+        """review-fix SF1 (#05): a stale coverage.xml must not mask a pytest-cov emission failure.
+
+        A previous run's report is present, but this run's (mocked) pytest
+        does NOT emit a fresh one. The pre-run unlink + exists-guard must
+        still FAIL (return 1) and never run diff-cover against stale data.
+        """
+        xml = tmp_path / "coverage.xml"
+        xml.write_text("<coverage>STALE from a previous run</coverage>")
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "COVERAGE_XML", xml),
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
+            # pytest runs but does NOT (re)write coverage.xml this time.
+            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
+            patch.object(quality_gate, "_run") as mock_run,
+        ):
+            assert quality_gate.check_impacted() == 1
+        assert not xml.exists(), "the stale coverage.xml must have been cleared before the run"
+        mock_run.assert_not_called()  # diff-cover never scores against a stale report
 
 
 class TestTestmonAvailable:

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -6,6 +6,7 @@ import io
 import json
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -2104,8 +2105,13 @@ class TestIsCi:
             # review-fix N3: broaden the truthy set beyond {1, true}.
             ("yes", True),
             ("on", True),
+            # review-fix NH4: single-letter spellings some providers emit.
+            ("y", True),
+            ("t", True),
+            ("T", True),
             ("false", False),
             ("0", False),
+            ("n", False),
             ("", False),
         ],
     )
@@ -2131,9 +2137,19 @@ class TestResolveDiffBase:
 
     @staticmethod
     def _router(
-        rev_parse: dict[str, int], *, upstream: tuple[int, str] = (1, ""), merge_base: tuple[int, str] = (1, "")
+        rev_parse: dict[str, int],
+        *,
+        upstream: tuple[int, str] = (1, ""),
+        merge_base: tuple[int, str] = (1, ""),
+        reachable: dict[str, int] | None = None,
     ):
-        """Build a `_run` side_effect keyed on the git subcommand."""
+        """Build a `_run` side_effect keyed on the git subcommand.
+
+        `reachable` (NH2) maps a candidate ref → returncode for the
+        `git merge-base <ref> HEAD` reachability probe; default 0
+        (reachable) so the pre-NH2 tests keep passing unchanged.
+        """
+        reachable = reachable or {}
 
         def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
             if cmd[:2] == ["git", "fetch"]:
@@ -2143,6 +2159,10 @@ class TestResolveDiffBase:
             if cmd[:2] == ["git", "rev-parse"]:  # @{u} upstream lookup
                 return _cp(upstream[0], stdout=upstream[1])
             if cmd[:2] == ["git", "merge-base"]:
+                # NH2 reachability probe is `merge-base <ref> HEAD`; the
+                # upstream-path call is `merge-base HEAD <tracked>`.
+                if cmd[3] == "HEAD":
+                    return _cp(reachable.get(cmd[2], 0))
                 return _cp(merge_base[0], stdout=merge_base[1])
             raise AssertionError(f"unexpected cmd {cmd!r}")
 
@@ -2201,12 +2221,34 @@ class TestResolveDiffBase:
                 return _cp(124, stderr="timed out after 15.0s")  # simulate a hung remote
             if cmd[:3] == ["git", "rev-parse", "--verify"] and cmd[3] == "origin/main":
                 return _cp(0)
+            if cmd[:2] == ["git", "merge-base"]:  # NH2 reachability probe — reachable
+                return _cp(0)
             return _cp(1)
 
         with patch.object(quality_gate, "_run", side_effect=_side_effect):
             base = quality_gate._resolve_diff_base()
         assert base == "origin/main"  # stale local origin/main still resolves
         assert "git fetch origin main` failed/timed out" in capsys.readouterr().err
+
+    def test_skips_origin_main_without_merge_base(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """review-fix NH2: a resolvable but unreachable ref (shallow clone) is skipped."""
+        router = self._router(
+            {"origin/main": 0, "main": 0},
+            reachable={"origin/main": 1},  # origin/main has no common ancestor
+        )
+        with patch.object(quality_gate, "_run", side_effect=router):
+            assert quality_gate._resolve_diff_base() == "main"  # falls through to reachable main
+        assert "no merge-base with HEAD" in capsys.readouterr().err
+
+    def test_none_when_no_ref_is_reachable(self) -> None:
+        """review-fix NH2: both refs resolve but neither is reachable, and no upstream → None."""
+        router = self._router(
+            {"origin/main": 0, "main": 0},
+            reachable={"origin/main": 1, "main": 1},
+            upstream=(1, ""),
+        )
+        with patch.object(quality_gate, "_run", side_effect=router):
+            assert quality_gate._resolve_diff_base() is None
 
 
 class TestRunTimeout:
@@ -2226,6 +2268,26 @@ class TestRunTimeout:
         with patch.object(quality_gate.subprocess, "run", return_value=_cp(0)) as mock_run:
             quality_gate._run(["git", "status"], timeout=3.0)
         assert mock_run.call_args.kwargs.get("timeout") == 3.0
+
+
+class TestDiffBaseAheadOfHead:
+    """`_diff_base_ahead_of_head` (review-fix SF2) detects an advanced diff base."""
+
+    @pytest.mark.parametrize(
+        ("rc", "stdout", "expected"),
+        [
+            (0, "3\n", True),  # base has 3 commits not in HEAD → stale
+            (0, "0\n", False),  # base fully merged → not stale
+            (0, "", False),  # empty output → defensive False
+            (0, "garbage", False),  # non-numeric → defensive False
+            (1, "5", False),  # rev-list failed → don't claim staleness
+        ],
+        ids=["ahead", "level", "empty", "nonnumeric", "rev-list-failed"],
+    )
+    def test_count_maps_to_bool(self, rc: int, stdout: str, expected: bool) -> None:
+        with patch.object(quality_gate, "_run", return_value=_cp(rc, stdout=stdout)) as mock_run:
+            assert quality_gate._diff_base_ahead_of_head("origin/main") is expected
+        assert mock_run.call_args.args[0] == ["git", "rev-list", "--count", "HEAD..origin/main"]
 
 
 class TestEnsureTestmonDbSafe:
@@ -2269,6 +2331,26 @@ class TestEnsureTestmonDbSafe:
         ):
             quality_gate._ensure_testmon_db_safe()  # must NOT raise FileNotFoundError
         assert not db.exists()
+
+    def test_locked_but_valid_db_is_preserved(self, tmp_path: Path) -> None:
+        """review-fix SF1: 'database is locked' (OperationalError) must NOT delete a valid baseline.
+
+        OperationalError is a subclass of DatabaseError, so the corruption
+        probe would otherwise wipe a recoverable DB that is merely busy
+        with a concurrent --seed-testmon/--impacted run.
+        """
+        db = tmp_path / ".testmondata"
+        db.write_bytes(b"placeholder-valid-baseline")
+
+        def _locked(*_a: object, **_k: object) -> None:
+            raise sqlite3.OperationalError("database is locked")
+
+        with (
+            patch.object(quality_gate, "TESTMON_DATA", db),
+            patch.object(quality_gate.sqlite3, "connect", side_effect=_locked),
+        ):
+            quality_gate._ensure_testmon_db_safe()
+        assert db.exists(), "a locked-but-valid .testmondata must be left intact"
 
 
 class TestBuildImpactedCmds:
@@ -2363,12 +2445,37 @@ class TestCheckImpacted:
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "COVERAGE_XML", xml),
             patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
+            # SF2: not stale → generic missing-coverage verdict + S5 hint.
+            patch.object(quality_gate, "_diff_base_ahead_of_head", return_value=False),
             patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
             patch.object(quality_gate, "_run", return_value=_cp(1, stdout="Coverage: 50%", stderr="fail")),
         ):
             assert quality_gate.check_impacted() == 1
+        err = capsys.readouterr().err
+        assert "changed lines <100% covered" in err
         # review-fix S5: failure points at a reseed when the baseline may be stale.
-        assert "--seed-testmon" in capsys.readouterr().err
+        assert "--seed-testmon" in err
+
+    def test_stale_baseline_emits_distinct_verdict_returns_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """review-fix SF2: when the diff base advanced past HEAD, surface a stale-baseline verdict."""
+        xml = tmp_path / "coverage.xml"
+        xml.write_text("<coverage/>")
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "COVERAGE_XML", xml),
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
+            patch.object(quality_gate, "_diff_base_ahead_of_head", return_value=True),
+            patch.object(quality_gate, "_stream_pytest", return_value={"name": "pytest", "passed": True}),
+            patch.object(quality_gate, "_run", return_value=_cp(1, stdout="Coverage: 50%", stderr="fail")),
+        ):
+            assert quality_gate.check_impacted() == 1
+        err = capsys.readouterr().err
+        assert "baseline stale" in err
+        assert "advanced past your branch" in err
 
     def test_missing_coverage_xml_returns_1(self, tmp_path: Path) -> None:
         """review-fix N7: if pytest-cov fails to emit coverage.xml, fail loudly (don't diff-cover a stale file)."""
@@ -2401,6 +2508,8 @@ class TestCheckImpacted:
         mock_safe.assert_called_once()
         dc_cmd = mock_run.call_args.args[0]
         assert dc_cmd[2] == "--compare-branch=origin/main"
+        # review-fix NH1: the diff-cover subprocess is bounded by a timeout.
+        assert mock_run.call_args.kwargs.get("timeout") == quality_gate._DIFF_COVER_TIMEOUT_SECONDS
 
 
 class TestTestmonAvailable:
@@ -2471,6 +2580,11 @@ class TestSeedTestmon:
 class TestImpactedCli:
     """`main()` wiring: short-circuit, exit-code passthrough, mutex."""
 
+    # review-fix NH3: this table covers the codes `check_impacted` itself
+    # returns (0/1/3/4). Exit code 2 (usage/mutex error) is raised by
+    # `parser.error` BEFORE `check_impacted` runs, so its dedicated rows
+    # live in `test_impacted_mutex_exits_2` and `test_seed_testmon_mutex_exits_2`
+    # — together they give the "dedicated test per exit-code row" guarantee.
     @pytest.mark.parametrize("exit_code", [0, 1, 3, 4], ids=["pass", "fail", "tooling", "no-base"])
     def test_impacted_exits_with_check_impacted_code(self, exit_code: int) -> None:
         with (
@@ -2606,6 +2720,19 @@ class TestWorktreeSetupSeedsCaches:
         block = self._seed_block()
         assert ".mypy_cache" in block and ".testmondata" in block
         assert "cp -R" in block, "caches must be copied, not symlinked"
+
+    def test_loop_enumerates_each_cache_explicitly(self) -> None:
+        """review-fix NH5: both caches are handled by the same copy loop, not one-off.
+
+        Asserts the loop header names BOTH caches, so the regression can't
+        pass with only one cache genuinely copied and the other appearing
+        solely in a warning line.
+        """
+        block = self._seed_block()
+        assert "for cache in .mypy_cache .testmondata; do" in block
+        # The copy is keyed on the loop variable (applies to every cache),
+        # not hard-coded for a single cache name.
+        assert 'cp -R "$src" "$dst"' in block
 
     def test_seeding_never_symlinks(self) -> None:
         """review-fix N1: reject any symlink in the seeding block (copy, not link)."""
@@ -2771,3 +2898,59 @@ class TestImpactedIntegrationRealTestmon:
         assert not db.exists()
         # With the corrupt DB gone, testmon rebuilds and selects all tests.
         assert _selected_count(_run_testmon(repo)) == 1
+
+
+@pytest.mark.integration
+class TestTestmonRelocationInvariant:
+    """review-fix SF3: enforce the cross-worktree `.testmondata` relocation invariant.
+
+    `worktree-setup.sh` COPIES `.testmondata` from the main worktree into
+    a freshly-created one. The safety claim — "selects more, never fewer"
+    — must be *enforced*, not just asserted in a comment: copying the DB
+    across worktrees may never cause testmon to UNDER-select impacted
+    tests. testmon keys on rootdir-relative paths + file-content
+    checksums, so a relocated DB still reselects any file whose content
+    differs from the baseline. This proves it with real testmon.
+    """
+
+    def _make_repo(self, root: Path, *, calc_body: str) -> Path:
+        if not quality_gate._impacted_tooling_available():
+            pytest.skip("pytest-testmon / diff-cover not importable")
+        (root / "pkg").mkdir(parents=True)
+        (root / "tests").mkdir()
+        (root / "pkg" / "__init__.py").write_text("")
+        (root / "pkg" / "calc.py").write_text(calc_body)
+        (root / "tests" / "test_calc.py").write_text(
+            "from pkg.calc import add\n\n\ndef test_add():\n    assert add(1, 2) == 3\n"
+        )
+        for args in (
+            ["init", "-q"],
+            ["config", "user.email", "t@t.co"],
+            ["config", "user.name", "t"],
+            ["add", "-A"],
+            ["commit", "-qm", "base"],
+        ):
+            subprocess.run(["git", *args], cwd=str(root), check=True, capture_output=True, text=True)
+        return root
+
+    def test_relocated_db_with_changed_content_reselects_never_underselects(self, tmp_path: Path) -> None:
+        base_body = "def add(a, b):\n    return a + b\n"
+        # "main" worktree: seed the baseline against the original content.
+        main = self._make_repo(tmp_path / "main", calc_body=base_body)
+        seed = _run_testmon(main)
+        assert _selected_count(seed) == 1, seed.stdout + seed.stderr
+        # A noop re-run in the SAME repo selects zero (warm baseline).
+        assert _selected_count(_run_testmon(main)) == 0
+
+        # "worktree": identical repo, but the COVERED file has different
+        # content than the seeded baseline. Relocate (copy) the DB in.
+        work = self._make_repo(tmp_path / "work", calc_body="def add(a, b):\n    return a + b + 0\n")
+        shutil.copy2(main / ".testmondata", work / ".testmondata")
+
+        # Invariant: the relocated DB must NOT skip the test covering the
+        # changed file — it reselects it (selects more, never fewer).
+        selected = _selected_count(_run_testmon(work))
+        assert selected == 1, (
+            "relocated .testmondata under-selected a changed-content test "
+            f"(got {selected}); the 'never fewer' invariant is violated"
+        )


### PR DESCRIPTION
## Summary
Add a testmon-driven `--impacted` inner-loop gate to quality_gate.py: runs only the tests impacted by the change set under `--cov=<package>` and verifies the changed lines are 100% covered via diff-cover — sub-~15s feedback vs the ~9min full suite. The whole-repo 100% guarantee stays authoritative in CI (branch protection on main now requires the `Tests (100% Coverage)` check). Adds `--seed-testmon`, cold-start cache seeding in worktree-setup.sh, a post-merge baseline refresh in finish-task, and switches both implement agents (all 3 harnesses) to the `--impacted` default.

Fixes #276

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

### Kill-criterion measurement (AC#13, review-fix NH6)
Measured on a 10-core M-series (worktree QS_276):

| Run | Wall-clock |
|---|---|
| Full gate (`-n auto` + sysmon) — baseline | **~564s** (6102 passed in 563.98s) |
| Full-suite `pytest --collect-only -q` (testmon's per-run floor) | **3.24s** |
| `--impacted` steady-state p50 (warm baseline, small diff) | **~5–10s** (collect floor + a few selected tests + one diff-cover pass) |
| `--impacted` select-all worst case (cold/large-branch baseline) | **2710.7s** serial — motivated promoting testmon⊕xdist to `-n auto` |

**Go/no-go: GO.** The steady-state inner-loop p50 (~5–10s) clears the ≤~15s target (~50–100× faster than the full gate). testmon⊕xdist was empirically verified for the pinned `pytest-testmon==2.2.0` / `pytest-xdist==3.8.0` (superset property holds under `-n auto`; worker `.coverage` files combine into a valid `coverage.xml`), so selection and `--seed-testmon` now parallelize. Full detail in `docs/stories/QS-276.story.md`.

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an impacted-only quality-gate mode for faster local verification (`--impacted`, 100% coverage for changed lines) and a baseline refresher (`--seed-testmon`).
  * Added a best-effort, non-blocking post-merge baseline refresh on the real `main` worktree.
* **Bug Fixes**
  * Improved fail-safe behavior when test-impact data is missing/corrupt to avoid under-selecting tests.
* **Documentation**
  * Updated workflow guidance to default to `--impacted`, reserve the full gate for CI/explicit requests, and clarify `--seed-testmon` isn’t a quality gate.
* **Chores**
  * Seeded cold-start cache artifacts into new worktrees, ignored refreshed baseline data, pinned required test tooling, and expanded quality-gate coverage tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
