### PR TITLE
QS-278: normal date formatting for car-charge origin line (+ impacted-gate robustness)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,11 @@ htmlcov/
 nosetests.xml
 coverage.xml
 
-# pytest-testmon test-impact DB (QS-276) — written during runs, never committed
+# pytest-testmon test-impact DB (QS-276) — written during runs, never committed.
+# QS-278: also ignore the SQLite WAL/SHM sidecars left by an interrupted run.
 .testmondata
+.testmondata-wal
+.testmondata-shm
 *.cover
 *.py,cover
 .hypothesis/
@@ -173,17 +176,20 @@ cython_debug/
 config/
 
 # Third-party custom components
-custom_components/hacs/
+# NOTE: no trailing slash — these are often symlinks into a sibling HA
+# checkout, and a trailing-slash pattern matches dirs but NOT symlinks,
+# leaving them untracked and crashing `diff-cover --include-untracked`.
+custom_components/hacs
 custom_components/netatmo
-custom_components/ocpp/
+custom_components/ocpp
 custom_components/renault
-custom_components/solcast_solar/
+custom_components/solcast_solar
 custom_components/volkswagencarnet
-/custom_components/hacs/
+/custom_components/hacs
 /custom_components/netatmo
-/custom_components/ocpp/
+/custom_components/ocpp
 /custom_components/renault
-/custom_components/solcast_solar/
+/custom_components/solcast_solar
 /custom_components/volkswagencarnet
 /custom_components/abetterrouteplanner
 

--- a/.gitignore
+++ b/.gitignore
@@ -175,23 +175,20 @@ cython_debug/
 # Home Assistant runtime config
 config/
 
-# Third-party custom components
+# Third-party custom components.
 # NOTE: no trailing slash — these are often symlinks into a sibling HA
 # checkout, and a trailing-slash pattern matches dirs but NOT symlinks,
 # leaving them untracked and crashing `diff-cover --include-untracked`.
+# A mid-path slash already anchors each pattern to the repo root, so the
+# old `/custom_components/*` leading-slash duplicates were redundant
+# (QS-278 review-fix #01-6) and have been dropped.
+custom_components/abetterrouteplanner
 custom_components/hacs
 custom_components/netatmo
 custom_components/ocpp
 custom_components/renault
 custom_components/solcast_solar
 custom_components/volkswagencarnet
-/custom_components/hacs
-/custom_components/netatmo
-/custom_components/ocpp
-/custom_components/renault
-/custom_components/solcast_solar
-/custom_components/volkswagencarnet
-/custom_components/abetterrouteplanner
 
 # Per-task OpenCode agent files (rendered dynamically, not tracked)
 .opencode/agents/qs-*-QS-*.md

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -407,13 +407,22 @@ class QSCar(HADeviceMixin, AbstractDevice):
                 self.current_forecasted_person.name,
             )
 
-    def get_car_person_readable_forecast_mileage(self):
+    def get_car_person_readable_forecast_mileage(self, for_small_standalone: bool = True):
+        """Person-forecast line ``"<name>: <forecast>"`` for the car card.
 
+        ``for_small_standalone`` (default ``True``) is forwarded to
+        ``QSPerson.get_forecast_readable_string`` and selects the leave-time date
+        formatting. The default preserves every existing direct caller (e.g. the
+        ``qs_car_person_forecast`` sensor) on the compact form; the origin line
+        (``get_car_charge_origin_readable_string``) passes ``False`` to get the
+        normal ``today HH:MM`` / ``tomorrow HH:MM`` / ``%Y-%m-%d %H:%M`` form.
+        """
         person = self.current_forecasted_person
         if person is None:
             return "No forecasted person"
         else:
-            forecast_str = person.get_forecast_readable_string()  # will update the forecast too if needed
+            # will update the forecast too if needed
+            forecast_str = person.get_forecast_readable_string(for_small_standalone=for_small_standalone)
             return f"{person.name}: {forecast_str}"
 
     def get_car_persons_options(self) -> list[str]:
@@ -1178,18 +1187,23 @@ class QSCar(HADeviceMixin, AbstractDevice):
                 return "Manual as fast as possible charge"
 
         # No charger, person-automated, or any other type: the person-forecast line.
-        return self.get_car_person_readable_forecast_mileage()
+        # QS-278: render the leave time with the normal date formatting.
+        return self.get_car_person_readable_forecast_mileage(for_small_standalone=False)
 
     @staticmethod
     def _origin_target_single_line(ct) -> str:
         """Target time for the single-line origin row.
 
-        Delegates to the shared formatter with ``allow_cr=False`` so a far-out
-        (>~24h) target renders as ``"%m-%d %H:%M"`` on a single line instead of
-        the two-line ``"%m-%d\\n%H:%M"`` form. Covered by the far-out
-        Calendar/Manual tests in ``tests/test_car_charge_origin.py``.
+        Uses the **normal** ``get_readable_date_string`` formatting
+        (``for_small_standalone=False``) so the target renders as
+        ``today HH:MM`` / ``tomorrow HH:MM`` / ``%Y-%m-%d %H:%M`` — the more
+        legible form wanted on the origin line, rather than the compact
+        ``for_small_standalone`` widget form. ``allow_cr=False`` is kept
+        explicit to state the single-line intent at the call site; the normal
+        formatting branch never emits a newline. Covered by the Calendar/Manual
+        tests in ``tests/test_car_charge_origin.py``.
         """
-        return ct.get_readable_next_target_date_string(for_small_standalone=True, allow_cr=False)
+        return ct.get_readable_next_target_date_string(for_small_standalone=False, allow_cr=False)
 
     async def convert_auto_constraint_to_manual_if_needed(self) -> bool:
 

--- a/custom_components/quiet_solar/ha_model/person.py
+++ b/custom_components/quiet_solar/ha_model/person.py
@@ -335,14 +335,21 @@ class QSPerson(HADeviceMixin, AbstractDevice):
 
         return self.predicted_leave_time, self.predicted_mileage
 
-    def get_forecast_readable_string(self, time: datetime | None = None) -> str:
-        """Get a human-readable string of the person's forecast."""
+    def get_forecast_readable_string(self, time: datetime | None = None, for_small_standalone: bool = True) -> str:
+        """Get a human-readable string of the person's forecast.
+
+        ``for_small_standalone`` (default ``True``) selects the leave-time date
+        formatting passed to ``get_readable_date_string``. The default preserves
+        every existing direct caller on the compact widget form (``HH:MM`` /
+        ``%m-%d %H:%M``); the car-card origin line passes ``False`` to get the
+        normal ``today HH:MM`` / ``tomorrow HH:MM`` / ``%Y-%m-%d %H:%M`` form.
+        """
         self.update_person_forecast(time)
 
         if self.predicted_mileage is None or self.predicted_leave_time is None:
             return PERSON_NO_FORECAST_STRING
         else:
-            return f"{int(self.predicted_mileage)}km {get_readable_date_string(self.predicted_leave_time, for_small_standalone=True, allow_cr=False)}"
+            return f"{int(self.predicted_mileage)}km {get_readable_date_string(self.predicted_leave_time, for_small_standalone=for_small_standalone, allow_cr=False)}"
 
     async def notify_of_forecast_if_needed(
         self,

--- a/docs/agents/concepts/car-soc-estimation.md
+++ b/docs/agents/concepts/car-soc-estimation.md
@@ -4,7 +4,7 @@ slug: car-soc-estimation
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/car.py
-last_verified: 2026-06-18
+last_verified: 2026-06-29
 ---
 
 # Car SOC estimation — the effective-SOC model

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
   - custom_components/quiet_solar/ha_model/person.py
-last_verified: 2026-05-23
+last_verified: 2026-06-29
 ---
 
 # Notification routing

--- a/docs/agents/concepts/person-trip-prediction.md
+++ b/docs/agents/concepts/person-trip-prediction.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/person.py
   - custom_components/quiet_solar/ha_model/car.py
-last_verified: 2026-06-18
+last_verified: 2026-06-29
 ---
 
 # Person, Car, and trip prediction
@@ -73,22 +73,29 @@ prediction_kWh + margin` is pushed for the car's charger.
   surface from `AbstractLoad`.
 - 31-day mileage ring (sensor-attribute restored).
 - Custom power-to-amperage lookup table on `QSCar`.
-- `QSCar.get_car_person_readable_forecast_mileage()` — raw forecast
-  string (`"<Person>: <km>km <HH:MM>"`); backs the `qs_car_person_forecast`
-  sensor. Unchanged by QS-274 (kept for history/automations).
+- `QSCar.get_car_person_readable_forecast_mileage(for_small_standalone=True)`
+  — raw forecast string (`"<Person>: <km>km <date>"`); backs the
+  `qs_car_person_forecast` sensor. The default `for_small_standalone=True`
+  keeps the compact widget date form (`HH:MM` / `%m-%d %H:%M`) for that
+  sensor and all other direct callers; QS-278 added the parameter so the
+  origin line can request the normal form. Unchanged by QS-274.
 - `QSCar.get_car_charge_origin_readable_string()` (QS-274) — the
   origin-responsive context line backing the new `qs_car_charge_origin`
   sensor. Pure / sync-safe: reads
   `self.charger.get_charge_type(return_charge_errors=False)` and the live
-  `current_forecasted_person`. Returns `"Calendar · HH:MM"`,
-  `"Manually set to HH:MM"`, or the two as-fast strings for those origins;
+  `current_forecasted_person`. QS-278: every date-bearing branch renders
+  with the **normal** `get_readable_date_string` formatting —
+  `today HH:MM` / `tomorrow HH:MM` / `%Y-%m-%d %H:%M` — not the compact
+  `for_small_standalone` form. Returns `"Calendar · <date>"`,
+  `"Manually set to <date>"`, or the two as-fast strings for those origins;
   for the person-automated, no-charger and any-other-type cases it
-  delegates to the single `get_car_person_readable_forecast_mileage()`
-  helper — i.e. the raw person line `"<Person>: <forecast>"` (including
-  `"<Person>: No forecast"` when there is no prediction) or
-  `"No forecasted person"` when no person is attached. Far-out
-  (>~24h) Calendar/Manual targets are collapsed to a single line. This is
-  the single source of truth for the car card's origin context row.
+  delegates to `get_car_person_readable_forecast_mileage(for_small_standalone=False)`
+  — i.e. the person line `"<Person>: <forecast>"` with the leave time in
+  the same normal form (including `"<Person>: No forecast"` when there is no
+  prediction) or `"No forecasted person"` when no person is attached. Every
+  branch stays single-line; far-out (>~24h) targets/leave times render the
+  full `%Y-%m-%d %H:%M` date on one line. This is the single source of
+  truth for the car card's origin context row.
 
 ## Lifecycle
 

--- a/docs/stories/QS-278.story.md
+++ b/docs/stories/QS-278.story.md
@@ -128,11 +128,12 @@ return self.get_car_person_readable_forecast_mileage(for_small_standalone=False)
 5. The as-fast strings and `get_car_charge_time_readable_name` are unchanged
    (existing `test_as_fast_origin` / `test_manual_as_fast_origin` serve as the
    guard; those branches are untouched).
-6. 100% coverage maintained; the **full** quality gate
-   (`python scripts/qs/quality_gate.py` — pytest + ruff + mypy + translations) is
-   a **hard gating criterion** before PR, not just `--impacted`. Both modified
-   methods must have explicit `for_small_standalone=True` **and** `=False`
-   coverage.
+6. 100% coverage maintained. The **`--impacted`** gate
+   (`python scripts/qs/quality_gate.py --impacted` — changed lines 100% covered)
+   is the local pre-PR gating criterion; the whole-repo 100% gate is enforced in
+   **CI** on every PR (do **not** force a local full run by default — that is the
+   QS-278 correction). Both modified methods must have explicit
+   `for_small_standalone=True` **and** `=False` coverage.
 
 ## Task breakdown
 
@@ -182,8 +183,10 @@ return self.get_car_person_readable_forecast_mileage(for_small_standalone=False)
    collapsed to single line" wording with the normal today/tomorrow/full-date
    description, and note the person fall-through now uses normal formatting via
    the threaded `for_small_standalone=False`.
-7. **Run** `python scripts/qs/quality_gate.py --impacted` during TDD, then the
-   full gate before PR.
+7. **Run** `python scripts/qs/quality_gate.py --impacted` during TDD and as the
+   pre-PR gate (CI runs the authoritative whole-repo gate). A local full run is
+   optional — only on explicit request or when you suspect coverage lost in
+   unchanged code.
 
 ## Doc maintenance
 

--- a/docs/stories/QS-278.story.md
+++ b/docs/stories/QS-278.story.md
@@ -31,6 +31,14 @@ the **normal** `get_readable_date_string` formatting — `today HH:MM` /
 compact form. Existing direct callers of the shared methods keep their current
 compact behavior. Pure string-formatting change; no logic change.
 
+**Scope note (review-fix #01-7).** This story also intentionally bundles a small
+`--impacted`-gate hardening workstream (`--cov-append` coverage accumulation +
+fresh-baseline/schema-mismatch reset, `.gitignore` symlink/WAL-SHM fixes,
+`project-rules.md`). It belongs in QS-278 rather than a separate ticket because
+it is the "QS-278 correction" referenced in acceptance criterion 6 — the gate
+behaviour that surfaced while validating this very change — and is fully
+self-tested in `tests/test_quality_gate.py`.
+
 ## Design
 
 ### Current signatures (the contract this plan edits)

--- a/docs/stories/QS-278.story.md
+++ b/docs/stories/QS-278.story.md
@@ -1,0 +1,234 @@
+# QS-278 — `get_car_charge_origin_readable_string` should use normal date formatting
+
+## Problem
+
+`QSCar.get_car_charge_origin_readable_string()` (`ha_model/car.py`) backs the
+assigned-person / car-card origin context line. It formats a date in **two**
+distinct branches, both of which currently use the compact
+`for_small_standalone=True` form:
+
+1. **Calendar / Manual** origins format the target time through the helper
+   `_origin_target_single_line(ct)`, which calls
+   `ct.get_readable_next_target_date_string(for_small_standalone=True, allow_cr=False)`.
+2. **Person-automated / no-charger / any-other-type** origins fall through to
+   `get_car_person_readable_forecast_mileage()` →
+   `QSPerson.get_forecast_readable_string()` (`ha_model/person.py:345`), which
+   formats the predicted leave time with
+   `get_readable_date_string(self.predicted_leave_time, for_small_standalone=True, allow_cr=False)`.
+
+The `for_small_standalone=True` branch of `get_readable_date_string`
+(`home_model/constraints.py:54`) yields a compact, time-only form (`HH:MM`, or
+`%m-%d %H:%M` for far-out targets). That compact form is appropriate for a tiny
+standalone widget, but for the origin line we want the **normal**, more legible
+formatting in **both** branches.
+
+## Goal
+
+Make **both** date-bearing branches of `get_car_charge_origin_readable_string`
+(Calendar/Manual target time, and the person-forecast leave time) render with
+the **normal** `get_readable_date_string` formatting — `today HH:MM` /
+`tomorrow HH:MM` / `%Y-%m-%d %H:%M` — instead of the `for_small_standalone`
+compact form. Existing direct callers of the shared methods keep their current
+compact behavior. Pure string-formatting change; no logic change.
+
+## Design
+
+### Current signatures (the contract this plan edits)
+
+```python
+# home_model/constraints.py
+def get_readable_date_string(time: datetime | None, for_small_standalone: bool = False, allow_cr: bool = True) -> str
+def get_readable_next_target_date_string(self, for_small_standalone: bool = False, allow_cr: bool = True) -> str  # forwards to get_readable_date_string
+
+# ha_model/person.py
+def get_forecast_readable_string(self, time: datetime | None = None) -> str  # ← add for_small_standalone
+
+# ha_model/car.py
+def get_car_person_readable_forecast_mileage(self)  # ← add for_small_standalone
+```
+
+In `get_readable_date_string`, `for_small_standalone=True` is the compact form
+(`HH:MM` / `%m-%d %H:%M`); `False` is the normal form (`today HH:MM` /
+`tomorrow HH:MM` / `%Y-%m-%d %H:%M`). The normal branch never emits a `\n`, so
+acceptance criterion 3 (single-line) holds for it.
+
+### 1. Calendar / Manual branch — `_origin_target_single_line` (`ha_model/car.py`)
+
+```python
+@staticmethod
+def _origin_target_single_line(ct) -> str:
+    return ct.get_readable_next_target_date_string(for_small_standalone=False, allow_cr=False)
+```
+
+- Only `for_small_standalone` flips to `False` (the today/tomorrow/full-date
+  branch). `allow_cr=False` is kept **explicit and unchanged** — we do not rely on
+  any assumption about which internal branch consults it; the single-line intent
+  is stated at the call site regardless of the formatter's internals.
+- Update the helper's docstring to reflect normal formatting.
+
+### 2. Person-forecast branch — thread a `for_small_standalone` parameter
+
+The fall-through path formats the leave time inside
+`QSPerson.get_forecast_readable_string`. Thread a new parameter through the two
+methods on that path, **defaulting to `True` so every existing direct caller is
+unchanged**, and pass `False` only from the origin path:
+
+```python
+# ha_model/person.py
+def get_forecast_readable_string(self, time: datetime | None = None,
+                                 for_small_standalone: bool = True) -> str:
+    ...
+    return f"{int(self.predicted_mileage)}km " \
+           f"{get_readable_date_string(self.predicted_leave_time, for_small_standalone=for_small_standalone, allow_cr=False)}"
+
+# ha_model/car.py
+def get_car_person_readable_forecast_mileage(self, for_small_standalone: bool = True):
+    ...
+    forecast_str = person.get_forecast_readable_string(for_small_standalone=for_small_standalone)
+    return f"{person.name}: {forecast_str}"
+
+# ha_model/car.py — get_car_charge_origin_readable_string fall-through
+return self.get_car_person_readable_forecast_mileage(for_small_standalone=False)
+```
+
+- Only `for_small_standalone` is threaded. `allow_cr=False` is left **explicit and
+  unchanged** at the `get_readable_date_string` call site — its value is not
+  altered and the plan makes no assumption about which internal branch reads it.
+
+**Scope boundaries (unchanged on purpose):**
+- The as-fast strings in `get_car_charge_origin_readable_string` are untouched.
+- `get_car_charge_time_readable_name` (`car.py:1218`) keeps
+  `for_small_standalone=True` — separate time-row widget.
+- Default `for_small_standalone=True` preserves the existing direct callers:
+  `sensor.py:202` (`qs_car_person_forecast` sensor →
+  `get_car_person_readable_forecast_mileage()`) and `person.py:516`
+  (`get_forecast_readable_string()`), plus all their tests.
+- `_origin_target_single_line` has exactly two callers, both inside
+  `get_car_charge_origin_readable_string` (Calendar, Manual).
+
+**Resulting strings (origin line only):**
+- Today Calendar target → `Calendar · today 14:30`
+- Tomorrow Manual target → `Manually set to tomorrow 09:00`
+- Far-out target → `Calendar · 2026-07-02 09:00`
+- Person leave time → `Magali: 30km tomorrow 09:00` (was `Magali: 30km 09:00`)
+
+## Acceptance criteria
+
+1. Calendar and Manual origin lines render the target via the **normal**
+   `get_readable_date_string` formatting (`today …` / `tomorrow …` /
+   `%Y-%m-%d %H:%M`), not the `for_small_standalone` compact form.
+2. The person-forecast fall-through (`get_car_charge_origin_readable_string` →
+   `get_car_person_readable_forecast_mileage(for_small_standalone=False)`) renders
+   the leave time with the same normal formatting.
+3. Both branches stay single-line (no `\n`), including far-out targets/leave
+   times.
+4. Existing direct callers are unchanged: the `qs_car_person_forecast` sensor
+   (`sensor.py:202`) and `person.py:516` still get the compact
+   `for_small_standalone=True` form (default arg).
+5. The as-fast strings and `get_car_charge_time_readable_name` are unchanged
+   (existing `test_as_fast_origin` / `test_manual_as_fast_origin` serve as the
+   guard; those branches are untouched).
+6. 100% coverage maintained; the **full** quality gate
+   (`python scripts/qs/quality_gate.py` — pytest + ruff + mypy + translations) is
+   a **hard gating criterion** before PR, not just `--impacted`. Both modified
+   methods must have explicit `for_small_standalone=True` **and** `=False`
+   coverage.
+
+## Task breakdown
+
+1. **Edit `_origin_target_single_line`** in
+   `custom_components/quiet_solar/ha_model/car.py`: call
+   `get_readable_next_target_date_string(for_small_standalone=False, allow_cr=False)`
+   (flip only `for_small_standalone`; keep `allow_cr=False` explicit); update the
+   docstring.
+2. **Add `for_small_standalone: bool = True`** to
+   `QSPerson.get_forecast_readable_string` (`ha_model/person.py`), forward it to
+   `get_readable_date_string`, and **document the new parameter** in the docstring
+   (purpose + default-preserves-callers rationale).
+3. **Add `for_small_standalone: bool = True`** to
+   `QSCar.get_car_person_readable_forecast_mileage` (`ha_model/car.py`), forward
+   it to `get_forecast_readable_string`, document the new parameter, and update
+   the origin fall-through call to pass `for_small_standalone=False`.
+4. **Update `tests/test_car_charge_origin.py`** — all date-dependent assertions
+   under `@freeze_time` with a fixed instant; far-out cases pick a date
+   deterministically beyond the tomorrow window:
+   - Edit `_near_term_constraint()` line 82 to compute its expected value with
+     `get_readable_date_string(end_time, for_small_standalone=False)` (keep the
+     expected derived from the formatter, not a literal, to avoid midnight-edge
+     flakiness in `test_calendar_origin` / `test_manual_origin`).
+   - Reframe the far-out Calendar/Manual tests to assert the **full
+     `%Y-%m-%d %H:%M` date substring** (the old `"\n" not in result` becomes
+     trivially true under normal formatting; the date substring is the meaningful
+     lock). The `_far_term_constraint()` `"\n" in …(for_small_standalone=True)`
+     sanity line may stay (it probes the raw compact form) or be dropped.
+   - Add exactly **two** wording-lock tests under `@freeze_time` (replacing the
+     vague "update three person tests" — the existing prefix-only person tests
+     pass under both forms and need no edit):
+     - `test_calendar_origin_uses_tomorrow_wording` → `Calendar · tomorrow HH:MM`.
+     - `test_person_origin_uses_tomorrow_wording` →
+       `<name>: <km>km tomorrow HH:MM`.
+5. **Fix the zero-arg mock that the new kwarg breaks (review C1):** in
+   `tests/ha_tests/test_car.py:1275` change
+   `get_forecast_readable_string=lambda: "50km tomorrow"` to accept the keyword
+   (`lambda **kwargs: "50km tomorrow"`). Confirm the remaining default-True
+   caller-tests still pass — they call with no arg and need no edit:
+   `tests/ha_tests/test_person.py:747`, `tests/test_ha_person_real.py:448/457`,
+   `tests/test_ha_person_comprehensive.py:343/353`, `tests/test_person_coverage.py:326`,
+   `tests/test_car_charger_person_integration.py:615`. Add a focused test that
+   `get_car_person_readable_forecast_mileage()` (no arg, default `True`) keeps the
+   compact form, so both methods have explicit `True`/`False` branch coverage.
+6. **Update `docs/agents/concepts/person-trip-prediction.md`** (lines ~83-91):
+   replace the `"Calendar · HH:MM"` / `"Manually set to HH:MM"` / "far-out
+   collapsed to single line" wording with the normal today/tomorrow/full-date
+   description, and note the person fall-through now uses normal formatting via
+   the threaded `for_small_standalone=False`.
+7. **Run** `python scripts/qs/quality_gate.py --impacted` during TDD, then the
+   full gate before PR.
+
+## Doc maintenance
+
+Drift checker run on `car.py`, `person.py`, `test_car_charge_origin.py`:
+
+- `docs/agents/concepts/person-trip-prediction.md` — **update** (task 6): it
+  documents the exact origin format strings being changed and the person
+  fall-through.
+- `docs/agents/concepts/car-soc-estimation.md` — **Doc-OK**: the drift hit was on
+  unrelated "Recovery" text; the doc does not cover the origin readable string.
+- `docs/agents/concepts/notification-routing.md` — **Doc-OK**: surfaced only
+  because `person.py` is modified; it does not mention
+  `get_forecast_readable_string` or readable date formatting.
+
+## Adversarial Review Notes
+
+### Round 1 — critic · concrete-planner · dev-proxy · scope-guardian
+
+**Accepted → folded in (resolved):**
+- `C1` (concrete-planner, **critical**): `tests/ha_tests/test_car.py:1275` zero-arg
+  `get_forecast_readable_string` mock would `TypeError` once called with the new
+  kwarg → **resolved** by task 5 (mock accepts `**kwargs`).
+- Test accuracy (concrete-planner): the three person tests are prefix-only no-ops;
+  far-out `"\n"` assertion is trivially true under normal formatting → **resolved**
+  by reframed task 4 (two targeted wording-lock tests + full-date substring).
+- Coverage trap + full-gate gating (dev-proxy) → **resolved** by acceptance #6
+  (full gate hard-gating; explicit True/False branch coverage on both methods).
+- Determinism / midnight edge (dev-proxy + concrete-planner) → **resolved** by
+  task 4 (`@freeze_time`; formatter-derived expecteds; deterministic far-out date).
+- Inline signatures, docstring-for-new-param, enumerate caller-tests
+  (critic + dev-proxy + concrete-planner, clarify) → **resolved** by the new
+  "Current signatures" block + tasks 2/3/5.
+- As-fast / `get_car_charge_time_readable_name` regression guard (dev-proxy) →
+  **resolved** by acceptance #5 (existing as-fast tests serve as guard).
+
+**Rejected (recorded, will not resurface):**
+- Threaded-parameter vs call-site flip (critic + scope-guardian, redesign):
+  **rejected** — user explicitly chose the threaded-parameter design; the person
+  leave-time cannot be reformatted at the origin boundary without it.
+- Person branch / doc update out of scope (scope-guardian, clarify):
+  **rejected** — user confirmed the person branch is in scope, and
+  `person-trip-prediction.md:83-91` documents the exact strings being changed, so
+  the doc task is required.
+- Drop wording-lock tests as gold-plating (scope-guardian, improve):
+  **rejected (partial)** — kept a trimmed two-test minimum; without one wording
+  assertion per branch the fix would be unverified.
+
+Open criticals after triage: **0**.

--- a/docs/stories/QS-278.story_review_fix_#01.md
+++ b/docs/stories/QS-278.story_review_fix_#01.md
@@ -1,0 +1,63 @@
+# QS-278 — Review fix plan #01
+
+## Summary
+- Source PR: #279
+- Source story: docs/stories/QS-278.story.md
+- Findings to fix: 7 (4 should-fix + 3 nice-to-have)
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [should-fix] Coverage reset misses testmon schema-version-mismatch select-all
+- File: `scripts/qs/quality_gate.py:1224` (the `--cov-append` reset gate; cross-ref `_ensure_testmon_db_safe` docstring ~1049-1054)
+- Severity: should-fix
+- Source: qs-review-coderabbit (Major) + qs-review-blind-hunter + qs-review-edge-case-hunter (3 reviewers)
+- Description: The `--cov-append` accumulation reset (`_reset_coverage_data()`) fires only when `.testmondata` is absent (fresh baseline). But testmon recovers from an on-disk **schema-version mismatch** on its own by rebuilding and selecting ALL tests while leaving `.testmondata` present. In that case `TESTMON_DATA.exists()` is True, the reset is skipped, testmon select-all runs, and fresh coverage is `--cov-append`-ed on top of stale accumulated `.coverage` — exactly the "stale coverage masks a genuine changed-line gap → spurious local PASS" failure the reset was added to prevent. Reproduces when the testmon pin moves off its current version and the next `--impacted` run rebuilds + select-all with the old `.coverage` still present.
+- Proposed fix: Tie `_reset_coverage_data()` to the same "full baseline / select-all" signal rather than only `.testmondata` absence. Detect the select-all/rebuild case (e.g. when testmon reports a full reselection, or when `_ensure_testmon_db_safe` observes a schema-mismatch rebuild) and reset accumulated coverage then too. Add a regression test in `tests/test_quality_gate.py` covering the schema-mismatch-present-file path asserting the reset is invoked.
+
+### [should-fix] Orphaned SQLite WAL/SHM sidecars not purged on corrupt-DB recovery
+- File: `scripts/qs/quality_gate.py:1081` (`_ensure_testmon_db_safe`, purge + `sqlite3.connect` probe ~1067-1074)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: When a genuinely corrupt `.testmondata` is unlinked, the `.testmondata-wal` / `.testmondata-shm` sidecars (which this PR newly recognizes in `.gitignore` as "left by an interrupted run") are NOT removed. On the next run, SQLite opening a freshly-created `.testmondata` against an orphaned `-wal` can replay stale WAL frames or raise. Additionally, the `sqlite3.connect` readability probe opens the corrupt DB with the orphaned WAL present, which can surface as `OperationalError` ("locked") and hit the leave-intact branch rather than the `DatabaseError` purge branch — so a genuinely broken DB-plus-WAL can be wrongly preserved. Reproduces when an `--impacted`/`--seed-testmon` run is killed mid-write leaving the three files, and the next run probes/recreates the main DB without clearing the sidecars.
+- Proposed fix: When purging a corrupt `.testmondata` (the `DatabaseError` branch), also unlink the `.testmondata-wal` and `.testmondata-shm` sidecars (`missing_ok=True`). Consider treating the `OperationalError`-with-orphaned-sidecars case as recoverable (purge all three) rather than leave-intact. Add a `tests/test_quality_gate.py` case that seeds a corrupt DB + sidecars and asserts all three are removed.
+
+### [should-fix] AC3 person far-out leave-time single-line not directly asserted
+- File: `tests/test_car_charge_origin.py` (near `test_person_origin_uses_tomorrow_wording`, ~666)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC3 explicitly calls out "including far-out targets/leave **times**." The existing far-out `"\n" not in result` single-line assertions cover only the Calendar/Manual target path (~617, 630). The person fall-through far-out case — a leave time >24h out exercising the `%Y-%m-%d %H:%M` branch via the person line — has no direct single-line assertion; `test_person_origin_uses_tomorrow_wording` only exercises a one-day-out (tomorrow) leave time. The AC's "leave times" clause is not directly locked.
+- Proposed fix: Add a test that drives the person fall-through with a >24h-out predicted leave time (full-date branch) and asserts both `"\n" not in result` and that the rendered date is the full `%Y-%m-%d %H:%M` form. Use `@freeze_time` for determinism (see next finding).
+
+### [should-fix] Far-out date tests not under `@freeze_time`
+- File: `tests/test_car_charge_origin.py` (`test_calendar_origin_far_out_target_is_single_line` and the manual variant, ~190 / far-out target tests)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The far-out tests assert `expected[:4].isdigit()` to confirm the full-date form, relying on a 3-day-out date never collapsing to today/tomorrow. They are NOT under `@freeze_time`, unlike the new wording-lock tests. While currently correct, the lack of `@freeze_time` is inconsistent with the stated determinism goal for date-dependent assertions and is fragile across run timing.
+- Proposed fix: Wrap the far-out date-dependent tests in `@freeze_time` (consistent with the new wording-lock tests) so the asserted full-date form is deterministic regardless of wall-clock time.
+
+### [nice-to-have] `_reset_coverage_data` glob/unlink coupling & atomicity
+- File: `scripts/qs/quality_gate.py:1097` (`_reset_coverage_data`, `.coverage.*` shard glob + unlink)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter
+- Description: (1) The function globs `.coverage.*` shards but the primary `.coverage` (`COVERAGE_DATA`) is a module-level constant resolved at import; tests patch `REPO_ROOT` and `COVERAGE_DATA` separately, so a future test patching only one could make glob and unlink target different dirs. (2) The glob-then-unlink is not atomic; a concurrent `--impacted` run could create a shard after the glob that survives the reset and later gets `--cov-append`-merged.
+- Proposed fix: Add a clarifying comment documenting the single-writer assumption and the `REPO_ROOT`/`COVERAGE_DATA` coupling. Resolve the shard directory from the same root used for `COVERAGE_DATA` so they cannot diverge.
+
+### [nice-to-have] Redundant `.gitignore` leading-slash variants
+- File: `.gitignore:176-190` (the `/custom_components/*` anchored variants)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: After dropping the trailing slashes, the anchored `/custom_components/hacs` etc. variants are now redundant with the non-anchored `custom_components/hacs` patterns.
+- Proposed fix: Deduplicate — drop the redundant leading-slash variants, keeping a single canonical (non-anchored, no-trailing-slash) entry per component, with a brief comment.
+
+### [nice-to-have] Scope note: infra changes bundled into a string-formatting story
+- File: PR body / `docs/stories/QS-278.story.md`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: PR #279 bundles a story-adjacent infra workstream (`--cov-append` accumulation, `.gitignore` WAL/SHM + symlink-pattern fixes, `project-rules.md`) into a story scoped as a "pure string-formatting change; no logic change." The infra changes are self-tested and plausibly the "QS-278 correction" alluded to in AC6, but exceed the stated scope.
+- Proposed fix: Add a one-line note to the story/PR body confirming the `--impacted`-gate hardening belongs in QS-278 (vs. a separate ticket), so the bundling is intentional and documented. No code change required.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -24,6 +24,11 @@ all four; use it only for ad-hoc single-node debugging.
 # before commit/PR. Runs only the testmon-selected tests under
 # --cov=<package>, then diff-cover --fail-under=100 on the CHANGED
 # lines. Guarantees the lines YOU changed are 100% covered in ~seconds.
+# QS-278: coverage ACCUMULATES across runs (--cov-append), so a no-op
+# re-run (testmon selects 0 tests) or a single-file edit (small subset)
+# still has every changed-vs-origin line covered — no spurious FAIL, and
+# the run stays fast. The accumulated data is reset only on a fresh
+# select-all baseline (missing/rebuilt .testmondata).
 python scripts/qs/quality_gate.py --impacted
 
 # Full quality gate (pytest 100% cov + ruff + mypy + translations).

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -902,6 +902,17 @@ def _output_results(
 # per-run temp path.
 COVERAGE_XML = REPO_ROOT / "coverage.xml"
 TESTMON_DATA = REPO_ROOT / ".testmondata"
+# QS-278: the persistent coverage DATA file (coverage.py's default). The
+# `--impacted` gate runs testmon-selected tests with `--cov-append` so
+# coverage ACCUMULATES across inner-loop invocations. testmon 2.2.0
+# correctly selects 0 tests for a no-op re-run (and only a small subset for
+# a single-file edit); without accumulation, pytest-cov would erase
+# `.coverage` and emit a report covering only THIS run, so any line changed
+# vs origin/main but not re-exercised this run would read as uncovered and
+# diff-cover would FAIL spuriously. Accumulation keeps prior coverage so the
+# changed-line verdict stays correct while the run stays fast. The data is
+# reset only on a fresh select-all baseline (see `_reset_coverage_data`).
+COVERAGE_DATA = REPO_ROOT / ".coverage"
 
 # QS-276 review-fix S1: cap the inner-loop `git fetch origin main` so a
 # dead/slow remote degrades to a stale base + warning instead of hanging
@@ -1070,6 +1081,24 @@ def _ensure_testmon_db_safe() -> None:
         TESTMON_DATA.unlink(missing_ok=True)
 
 
+def _reset_coverage_data() -> None:
+    """Erase the accumulated coverage data before a fresh select-all baseline.
+
+    QS-278: `--impacted` runs with `--cov-append`, so coverage accumulates
+    across inner-loop invocations (keeping the changed-line verdict correct
+    when testmon reselects 0 tests). That accumulation must be reset
+    whenever testmon is about to select *all* tests — i.e. a first-ever run
+    or a rebuilt/purged `.testmondata` — otherwise stale coverage from an
+    earlier branch state could mask a genuine gap. A select-all run rewrites
+    the full picture from scratch, so a clean slate here is both safe and
+    necessary. Removes the primary `.coverage` plus any leftover xdist
+    per-worker shards (`.coverage.*`).
+    """
+    COVERAGE_DATA.unlink(missing_ok=True)
+    for shard in REPO_ROOT.glob(".coverage.*"):
+        shard.unlink(missing_ok=True)
+
+
 def _build_testmon_cmd() -> list[str]:
     """Build the single-process testmon selection + coverage pytest argv.
 
@@ -1102,6 +1131,14 @@ def _build_testmon_cmd() -> list[str]:
         # verdict is unaffected) and leaves every domain test selectable.
         f"--ignore={TESTS_DIR / 'test_quality_gate.py'}",
         f"--cov={SRC_DIR}",
+        # QS-278: accumulate coverage across inner-loop runs. testmon
+        # reselects 0 tests for a no-op re-run and only an edit's subset for
+        # an incremental change; `--cov-append` keeps the prior runs'
+        # coverage so the diff-cover changed-line verdict (vs origin/main)
+        # stays correct without re-running the whole impacted set every
+        # time. The data is reset on a fresh select-all baseline so it can't
+        # grow stale across unrelated branch states.
+        "--cov-append",
         "--cov-report=",
         f"--cov-report=xml:{COVERAGE_XML}",
         "-q",
@@ -1184,6 +1221,13 @@ def check_impacted() -> int:
         return 0
 
     _ensure_testmon_db_safe()
+    # QS-278: a missing `.testmondata` here (first-ever run, or just purged
+    # as corrupt) means testmon is about to select ALL tests — a fresh
+    # baseline. Reset the accumulated `--cov-append` coverage data so it
+    # reflects only this clean full run, never stale lines from an earlier
+    # branch state. When the DB exists, accumulation is intentional.
+    if not TESTMON_DATA.exists():
+        _reset_coverage_data()
     # QS-276 review-fix SF1 (#05): delete any stale coverage.xml from a
     # previous run BEFORE the testmon/cov pass. Otherwise a pytest-cov
     # emission failure would be masked — the N7 exists-guard below would

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -1043,42 +1043,83 @@ def _resolve_diff_base() -> str | None:
     return None
 
 
+def _testmon_schema_version() -> int | None:
+    """The DB schema version (`PRAGMA user_version`) the installed testmon
+    expects, probed in VENV_PYTHON — the interpreter pytest actually runs
+    under (mirroring `_testmon_available`). Returns None when testmon is not
+    importable there or the constant is unreadable, so callers fall back to
+    leaving the DB untouched rather than purging on an unknown.
+    """
+    res = _run([VENV_PYTHON, "-c", "import testmon.db as d; print(int(d.DATA_VERSION))"])
+    if res.returncode != 0:
+        return None
+    try:
+        return int(res.stdout.strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _purge_testmon_db(reason: str) -> None:
+    """Unlink `.testmondata` AND its SQLite WAL/SHM sidecars so the next run
+    rebuilds from scratch (select-all).
+
+    QS-278 review-fix #01-2: the `-wal` / `-shm` sidecars must go too. A fresh
+    `.testmondata` opened against an orphaned `-wal` can replay stale WAL
+    frames or raise, so a corrupt-DB recovery that left them behind merely
+    relocated the breakage to the next run. `missing_ok=True` everywhere
+    (QS-276 N6): a file that vanishes between probe and unlink (a concurrent
+    run / another worktree) already satisfies the select-all intent.
+    """
+    _emit("impacted", f"{reason} — removing .testmondata (+WAL/SHM) to force select-all")
+    TESTMON_DATA.unlink(missing_ok=True)
+    for suffix in ("-wal", "-shm"):
+        (TESTMON_DATA.parent / (TESTMON_DATA.name + suffix)).unlink(missing_ok=True)
+
+
 def _ensure_testmon_db_safe() -> None:
-    """Delete `.testmondata` when it is not a readable SQLite database.
+    """Purge `.testmondata` (+WAL/SHM) when it is unusable as an INCREMENTAL
+    baseline, so testmon rebuilds cleanly and `check_impacted`'s absence→reset
+    branch clears the accumulated `--cov-append` coverage. Two purge triggers:
 
-    testmon recovers from a schema-version mismatch on its own (it
-    rebuilds and selects all tests), but a genuinely corrupt /
-    partially-written / non-SQLite file (a killed run, a dependency bump,
-    a path relocation) makes it raise `sqlite3.DatabaseError` mid-run
-    instead. Removing the file forces a clean rebuild → select-all,
-    honouring the 'never silently under-select' fail-safe.
+    1. **Not a readable SQLite DB** — a genuinely corrupt / partially-written
+       / non-SQLite file (a killed run, a path relocation) raises
+       `sqlite3.DatabaseError`. (QS-276)
+    2. **Schema-version mismatch** (QS-278 review-fix #01-1) — testmon normally
+       rebuilds IN PLACE on a `PRAGMA user_version` mismatch (e.g. after a
+       testmon version bump), leaving the file present, so
+       `TESTMON_DATA.exists()` stays True and the coverage reset would be
+       skipped while a select-all runs and `--cov-append`s fresh coverage onto
+       STALE accumulated `.coverage` — masking a genuine changed-line gap.
+       Detecting the mismatch up front and purging unifies every select-all
+       trigger behind the absence→reset path.
 
-    QS-276 review-fix SF1: `sqlite3.OperationalError` ("database is
-    locked") is a *subclass* of `sqlite3.DatabaseError`. A VALID DB that
-    is transiently locked by a concurrent `--seed-testmon` / `--impacted`
-    run must NOT be deleted — wiping it would discard a recoverable
-    baseline and force a needless select-all. So catch `OperationalError`
-    FIRST and leave the file intact; only a genuine, corruption-specific
-    `DatabaseError` triggers the unlink.
+    QS-276 review-fix SF1: `sqlite3.OperationalError` ("database is locked")
+    is a *subclass* of `sqlite3.DatabaseError`. A VALID DB that is transiently
+    locked by a concurrent `--seed-testmon` / `--impacted` run must NOT be
+    deleted — wiping it (and its sidecars) would corrupt that live run's
+    baseline. So catch `OperationalError` FIRST and leave everything intact;
+    the schema probe is skipped too (we could not read it under the lock
+    anyway). Only a genuine corruption or a confirmed schema mismatch purges.
     """
     if not TESTMON_DATA.exists():
         return
     try:
         conn = sqlite3.connect(str(TESTMON_DATA))
         try:
-            conn.execute("PRAGMA schema_version").fetchone()
+            stored = int(conn.execute("PRAGMA user_version").fetchone()[0])
         finally:
             conn.close()
     except sqlite3.OperationalError as exc:
         # Valid-but-busy (locked) — leave it; testmon handles the lock.
         _emit("impacted", f".testmondata is locked/busy — leaving intact ({exc})")
+        return
     except sqlite3.DatabaseError:
-        _emit("impacted", "corrupt .testmondata detected — removing to force select-all")
-        # QS-276 review-fix N6: `missing_ok=True` so a file that vanishes
-        # between the readability probe and the unlink (a concurrent run,
-        # another worktree) doesn't raise — an absent DB already satisfies
-        # the select-all fail-safe intent.
-        TESTMON_DATA.unlink(missing_ok=True)
+        _purge_testmon_db("corrupt .testmondata detected")
+        return
+
+    expected = _testmon_schema_version()
+    if expected is not None and stored != expected:
+        _purge_testmon_db(f"testmon schema-version mismatch (db={stored}, expected={expected})")
 
 
 def _reset_coverage_data() -> None:
@@ -1087,15 +1128,21 @@ def _reset_coverage_data() -> None:
     QS-278: `--impacted` runs with `--cov-append`, so coverage accumulates
     across inner-loop invocations (keeping the changed-line verdict correct
     when testmon reselects 0 tests). That accumulation must be reset
-    whenever testmon is about to select *all* tests — i.e. a first-ever run
-    or a rebuilt/purged `.testmondata` — otherwise stale coverage from an
-    earlier branch state could mask a genuine gap. A select-all run rewrites
-    the full picture from scratch, so a clean slate here is both safe and
-    necessary. Removes the primary `.coverage` plus any leftover xdist
-    per-worker shards (`.coverage.*`).
+    whenever testmon is about to select *all* tests — a first-ever run, a
+    rebuilt/purged `.testmondata`, or a schema-version mismatch (see
+    `_ensure_testmon_db_safe`) — otherwise stale coverage from an earlier
+    branch state could mask a genuine gap. A select-all run rewrites the full
+    picture from scratch, so a clean slate here is both safe and necessary.
+    Removes the primary `.coverage` plus any leftover xdist per-worker shards.
+
+    QS-278 review-fix #01-5: the shard glob is resolved from `COVERAGE_DATA`'s
+    OWN directory, never a separately-resolved root, so the primary file and
+    its `.coverage.*` shards can never target divergent dirs. Single-writer
+    assumption (see the `COVERAGE_XML` note): at most one `--impacted` runs per
+    worktree at a time, so the glob-then-unlink need not be atomic.
     """
     COVERAGE_DATA.unlink(missing_ok=True)
-    for shard in REPO_ROOT.glob(".coverage.*"):
+    for shard in COVERAGE_DATA.parent.glob(COVERAGE_DATA.name + ".*"):
         shard.unlink(missing_ok=True)
 
 

--- a/tests/ha_tests/test_car.py
+++ b/tests/ha_tests/test_car.py
@@ -1272,7 +1272,7 @@ async def test_car_person_forecast_readable_variants(
         name="Forecast Person",
         predicted_mileage=50.0,
         predicted_leave_time=datetime(2026, 1, 16, 8, 0, tzinfo=pytz.UTC),
-        get_forecast_readable_string=lambda: "50km tomorrow",
+        get_forecast_readable_string=lambda **kwargs: "50km tomorrow",
     )
     car_device.current_forecasted_person = person
     assert "Forecast Person" in car_device.get_car_person_readable_forecast_mileage()

--- a/tests/test_car_charge_origin.py
+++ b/tests/test_car_charge_origin.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import pytz
+from freezegun import freeze_time
 from homeassistant.const import CONF_NAME
 
 from custom_components.quiet_solar.const import (
@@ -76,20 +77,24 @@ def _make_person(fake_hass, mock_data_handler, *, mileage, leave_time) -> QSPers
 
 
 def _near_term_constraint():
-    """A real constraint with a near-term target so the real formatter yields HH:MM."""
+    """A real constraint with a near-term target so the real formatter yields the
+    normal ``today HH:MM`` form (QS-278: origin line uses normal formatting). The
+    expected value is derived from the formatter — not a literal — so the
+    today/tomorrow boundary at midnight cannot cause a flaky assertion."""
     end_time = datetime.now(pytz.UTC) + timedelta(hours=2)
     ct = create_real_constraint(load=None, end_time=end_time)
-    expected_hhmm = get_readable_date_string(end_time, for_small_standalone=True)
-    return ct, expected_hhmm
+    expected = get_readable_date_string(end_time, for_small_standalone=False)
+    return ct, expected
 
 
 def _far_term_constraint():
-    """A real constraint >24h out — the formatter returns a two-line date."""
+    """A real constraint >24h out. QS-278: the origin line renders the full
+    ``%Y-%m-%d %H:%M`` date on a single line. Returns the expected full-date
+    substring derived from the normal formatter."""
     end_time = datetime.now(pytz.UTC) + timedelta(days=3)
     ct = create_real_constraint(load=None, end_time=end_time)
-    # sanity: the raw formatter really does produce a two-line form here
-    assert "\n" in get_readable_date_string(end_time, for_small_standalone=True)
-    return ct
+    expected = get_readable_date_string(end_time, for_small_standalone=False)
+    return ct, expected
 
 
 # ── Person (real method, no mock — review-fix #01 finding 4) ─────────────────
@@ -164,21 +169,68 @@ def test_manual_origin(origin_car):
 
 
 def test_calendar_origin_far_out_target_is_single_line(origin_car):
-    """A >24h target must render on one line — no raw newline (review-fix #02)."""
-    ct = _far_term_constraint()
+    """A >24h target renders the full ``%Y-%m-%d %H:%M`` date on one line
+    (QS-278: normal formatting, no raw newline)."""
+    ct, expected = _far_term_constraint()
     _set_charge_type(origin_car, CAR_CHARGE_TYPE_CALENDAR, ct)
     result = origin_car.get_car_charge_origin_readable_string()
     assert "\n" not in result
-    assert result.startswith("Calendar · ")
+    assert result == f"Calendar · {expected}"
+    assert expected[:4].isdigit()  # full-date form "%Y-%m-%d %H:%M"
 
 
 def test_manual_origin_far_out_target_is_single_line(origin_car):
-    """A >24h manual target must render on one line — no raw newline."""
-    ct = _far_term_constraint()
+    """A >24h manual target renders the full ``%Y-%m-%d %H:%M`` date on one line."""
+    ct, expected = _far_term_constraint()
     _set_charge_type(origin_car, CAR_CHARGE_TYPE_MANUAL, ct)
     result = origin_car.get_car_charge_origin_readable_string()
     assert "\n" not in result
-    assert result.startswith("Manually set to ")
+    assert result == f"Manually set to {expected}"
+    assert expected[:4].isdigit()  # full-date form "%Y-%m-%d %H:%M"
+
+
+# ── QS-278 wording locks (normal today/tomorrow formatting) ──────────────────
+
+
+@freeze_time("2026-01-15 12:00:00")
+def test_calendar_origin_uses_tomorrow_wording(origin_car):
+    """QS-278 AC1: a Calendar target one day out renders ``tomorrow HH:MM`` —
+    the normal formatting, not the compact ``%m-%d %H:%M`` form."""
+    target = datetime.now(pytz.UTC) + timedelta(days=1)
+    ct = create_real_constraint(load=None, end_time=target)
+    _set_charge_type(origin_car, CAR_CHARGE_TYPE_CALENDAR, ct)
+    result = origin_car.get_car_charge_origin_readable_string()
+    expected = get_readable_date_string(target, for_small_standalone=False)
+    assert result == f"Calendar · {expected}"
+    assert result.startswith("Calendar · tomorrow ")
+
+
+@freeze_time("2026-01-15 12:00:00")
+def test_default_forecast_mileage_keeps_compact_form(origin_car, fake_hass, mock_data_handler):
+    """QS-278 AC4: direct callers (default ``for_small_standalone=True``) keep the
+    compact form — a one-day-out leave time stays ``%m-%d %H:%M``, never
+    ``tomorrow``. Locks the True branch of both threaded methods."""
+    leave_time = datetime.now(pytz.UTC) + timedelta(days=1)
+    person = _make_person(fake_hass, mock_data_handler, mileage=30.0, leave_time=leave_time)
+    origin_car.current_forecasted_person = person
+    result = origin_car.get_car_person_readable_forecast_mileage()
+    expected = get_readable_date_string(leave_time, for_small_standalone=True, allow_cr=False)
+    assert result == f"Magali: 30km {expected}"
+    assert "tomorrow" not in result
+
+
+@freeze_time("2026-01-15 12:00:00")
+def test_person_origin_uses_tomorrow_wording(origin_car, fake_hass, mock_data_handler):
+    """QS-278 AC2: the person fall-through renders the leave time with the normal
+    ``tomorrow HH:MM`` formatting (was the compact ``HH:MM`` form)."""
+    leave_time = datetime.now(pytz.UTC) + timedelta(days=1)
+    person = _make_person(fake_hass, mock_data_handler, mileage=30.0, leave_time=leave_time)
+    origin_car.current_forecasted_person = person
+    _set_charge_type(origin_car, CAR_CHARGE_TYPE_PERSON_AUTOMATED)
+    result = origin_car.get_car_charge_origin_readable_string()
+    expected = get_readable_date_string(leave_time, for_small_standalone=False)
+    assert result == f"Magali: 30km {expected}"
+    assert result.startswith("Magali: 30km tomorrow ")
 
 
 # ── ct-is-None fall-through (review-fix #01 finding 2) ───────────────────────

--- a/tests/test_car_charge_origin.py
+++ b/tests/test_car_charge_origin.py
@@ -117,21 +117,22 @@ def test_person_origin(origin_car, fake_hass, mock_data_handler):
     assert "30km" in result
 
 
+@freeze_time("2026-01-15 12:00:00")
 def test_person_origin_far_out_leave_time_is_single_line(origin_car, fake_hass, mock_data_handler):
-    """A person forecast with a >24h leave time must render on one line — no raw
-    newline (review-fix #05: allow_cr=False threaded through the person branch)."""
-    person = _make_person(
-        fake_hass,
-        mock_data_handler,
-        mileage=30.0,
-        leave_time=datetime.now(pytz.UTC) + timedelta(days=3),
-    )
+    """AC3 (review-fix #01-3): the person fall-through with a >24h leave time
+    renders the full ``%Y-%m-%d %H:%M`` date on a single line — directly locking
+    the "leave times" clause, not just the Calendar/Manual target path. Frozen
+    clock makes the full-date branch deterministic."""
+    leave_time = datetime.now(pytz.UTC) + timedelta(days=3)
+    person = _make_person(fake_hass, mock_data_handler, mileage=30.0, leave_time=leave_time)
     origin_car.current_forecasted_person = person
     _set_charge_type(origin_car, CAR_CHARGE_TYPE_PERSON_AUTOMATED)
 
     result = origin_car.get_car_charge_origin_readable_string()
+    expected = get_readable_date_string(leave_time, for_small_standalone=False)
     assert "\n" not in result
-    assert result.startswith("Magali: 30km ")
+    assert result == f"Magali: 30km {expected}"
+    assert expected[:4].isdigit()  # full-date form "%Y-%m-%d %H:%M", not compact
 
 
 def test_orphaned_person_origin(origin_car):
@@ -168,9 +169,11 @@ def test_manual_origin(origin_car):
     )
 
 
+@freeze_time("2026-01-15 12:00:00")
 def test_calendar_origin_far_out_target_is_single_line(origin_car):
     """A >24h target renders the full ``%Y-%m-%d %H:%M`` date on one line
-    (QS-278: normal formatting, no raw newline)."""
+    (QS-278: normal formatting, no raw newline). Frozen clock (review-fix
+    #01-4) keeps the full-date branch deterministic regardless of run timing."""
     ct, expected = _far_term_constraint()
     _set_charge_type(origin_car, CAR_CHARGE_TYPE_CALENDAR, ct)
     result = origin_car.get_car_charge_origin_readable_string()
@@ -179,6 +182,7 @@ def test_calendar_origin_far_out_target_is_single_line(origin_car):
     assert expected[:4].isdigit()  # full-date form "%Y-%m-%d %H:%M"
 
 
+@freeze_time("2026-01-15 12:00:00")
 def test_manual_origin_far_out_target_is_single_line(origin_car):
     """A >24h manual target renders the full ``%Y-%m-%d %H:%M`` date on one line."""
     ct, expected = _far_term_constraint()

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -2343,22 +2343,69 @@ class TestEnsureTestmonDbSafe:
             quality_gate._ensure_testmon_db_safe()  # must not raise
         assert not db.exists()
 
-    def test_valid_sqlite_is_kept(self, tmp_path: Path) -> None:
+    def test_valid_sqlite_matching_schema_is_kept(self, tmp_path: Path) -> None:
         db = tmp_path / ".testmondata"
         conn = sqlite3.connect(str(db))
         conn.execute("CREATE TABLE t (x)")
+        conn.execute("PRAGMA user_version = 14")
         conn.commit()
         conn.close()
-        with patch.object(quality_gate, "TESTMON_DATA", db):
+        with (
+            patch.object(quality_gate, "TESTMON_DATA", db),
+            # QS-278 #01-1: matching schema → valid incremental baseline → kept.
+            patch.object(quality_gate, "_testmon_schema_version", return_value=14),
+        ):
             quality_gate._ensure_testmon_db_safe()
-        assert db.exists(), "a valid SQLite DB must be preserved"
+        assert db.exists(), "a valid, schema-matching SQLite DB must be preserved"
 
-    def test_corrupt_db_is_removed(self, tmp_path: Path) -> None:
+    def test_schema_version_mismatch_is_removed_with_sidecars(self, tmp_path: Path) -> None:
+        """QS-278 #01-1: testmon rebuilds in place on a `user_version` mismatch,
+        leaving the file present. We must purge it (and its WAL/SHM sidecars)
+        so the select-all run resets the accumulated `--cov-append` coverage."""
+        db = tmp_path / ".testmondata"
+        conn = sqlite3.connect(str(db))
+        conn.execute("PRAGMA user_version = 13")  # stale (testmon expects 14)
+        conn.commit()
+        conn.close()
+        wal = tmp_path / ".testmondata-wal"
+        wal.write_bytes(b"stale-wal")
+        shm = tmp_path / ".testmondata-shm"
+        shm.write_bytes(b"stale-shm")
+        with (
+            patch.object(quality_gate, "TESTMON_DATA", db),
+            patch.object(quality_gate, "_testmon_schema_version", return_value=14),
+        ):
+            quality_gate._ensure_testmon_db_safe()
+        assert not db.exists(), "a schema-mismatched .testmondata must be purged"
+        assert not wal.exists() and not shm.exists(), "WAL/SHM sidecars must be purged too"
+
+    def test_unknown_schema_version_keeps_db(self, tmp_path: Path) -> None:
+        """QS-278 #01-1: when the expected schema can't be probed (testmon not
+        importable), fall back to leaving a readable DB intact, not purging."""
+        db = tmp_path / ".testmondata"
+        conn = sqlite3.connect(str(db))
+        conn.execute("PRAGMA user_version = 7")
+        conn.commit()
+        conn.close()
+        with (
+            patch.object(quality_gate, "TESTMON_DATA", db),
+            patch.object(quality_gate, "_testmon_schema_version", return_value=None),
+        ):
+            quality_gate._ensure_testmon_db_safe()
+        assert db.exists(), "an unknown expected schema must not trigger a purge"
+
+    def test_corrupt_db_is_removed_with_sidecars(self, tmp_path: Path) -> None:
+        """QS-278 #01-2: a corrupt DB AND its orphaned WAL/SHM sidecars are purged."""
         db = tmp_path / ".testmondata"
         db.write_bytes(b"this is not a sqlite database")
+        wal = tmp_path / ".testmondata-wal"
+        wal.write_bytes(b"orphan-wal")
+        shm = tmp_path / ".testmondata-shm"
+        shm.write_bytes(b"orphan-shm")
         with patch.object(quality_gate, "TESTMON_DATA", db):
             quality_gate._ensure_testmon_db_safe()
         assert not db.exists(), "corrupt .testmondata must be removed to force select-all"
+        assert not wal.exists() and not shm.exists(), "orphaned WAL/SHM sidecars must be removed"
 
     def test_unlink_missing_safe_when_db_vanishes(self, tmp_path: Path) -> None:
         """review-fix N6: the file disappearing between probe and unlink must not raise."""
@@ -2672,18 +2719,36 @@ class TestCheckImpacted:
         mock_reset.assert_not_called()
 
 
+class TestTestmonSchemaVersion:
+    """QS-278 #01-1: `_testmon_schema_version` probes VENV_PYTHON for testmon's DATA_VERSION."""
+
+    def test_parses_int_from_probe_stdout(self) -> None:
+        with patch.object(quality_gate, "_run", return_value=_cp(0, stdout="14\n")) as mock_run:
+            assert quality_gate._testmon_schema_version() == 14
+        assert mock_run.call_args.args[0][0] == quality_gate.VENV_PYTHON
+
+    def test_returns_none_when_probe_fails(self) -> None:
+        with patch.object(quality_gate, "_run", return_value=_cp(1, stderr="ModuleNotFoundError")):
+            assert quality_gate._testmon_schema_version() is None
+
+    def test_returns_none_on_unparseable_stdout(self) -> None:
+        with patch.object(quality_gate, "_run", return_value=_cp(0, stdout="not-an-int")):
+            assert quality_gate._testmon_schema_version() is None
+
+
 class TestResetCoverageData:
     """QS-278: `_reset_coverage_data` clears the persistent coverage data."""
 
     def test_removes_primary_data_and_xdist_shards(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # #01-5: shards are globbed from COVERAGE_DATA's own dir — patching it
+        # alone must clear both the primary file and the shards.
         data = tmp_path / ".coverage"
         data.write_text("primary")
         shard = tmp_path / ".coverage.host.12345"
         shard.write_text("shard")
         monkeypatch.setattr(quality_gate, "COVERAGE_DATA", data)
-        monkeypatch.setattr(quality_gate, "REPO_ROOT", tmp_path)
 
         quality_gate._reset_coverage_data()
 
@@ -2695,7 +2760,6 @@ class TestResetCoverageData:
     ) -> None:
         """Absent data must not raise (first-ever run)."""
         monkeypatch.setattr(quality_gate, "COVERAGE_DATA", tmp_path / ".coverage")
-        monkeypatch.setattr(quality_gate, "REPO_ROOT", tmp_path)
         quality_gate._reset_coverage_data()  # must not raise
 
 

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -2409,6 +2409,9 @@ class TestBuildImpactedCmds:
         cmd = quality_gate._build_testmon_cmd()
         assert cmd[:4] == [quality_gate.VENV_PYTHON, "-m", "pytest", "--testmon"]
         assert f"--cov={quality_gate.SRC_DIR}" in cmd
+        # QS-278: coverage accumulates across inner-loop runs so a 0/partial
+        # testmon reselection still covers every line changed vs origin/main.
+        assert "--cov-append" in cmd
         # Empty --cov-report= must precede the xml report (clears pytest.ini).
         assert cmd.index("--cov-report=") < cmd.index(f"--cov-report=xml:{quality_gate.COVERAGE_XML}")
         assert "--cov-fail-under=100" not in cmd  # verdict is diff-cover's job
@@ -2462,6 +2465,18 @@ class TestBuildImpactedCmds:
 
 class TestCheckImpacted:
     """`check_impacted` orchestrator + exit-code mapping (mocked seam)."""
+
+    @pytest.fixture(autouse=True)
+    def _testmon_db_present(self, tmp_path_factory: pytest.TempPathFactory):
+        """QS-278: by default point `TESTMON_DATA` at an existing file so the
+        fresh-baseline branch (which resets the real `.coverage` via
+        `--cov-append`) never fires against the real FS during these
+        mocked-seam tests. Dedicated tests below re-patch it to exercise the
+        branch explicitly."""
+        db = tmp_path_factory.mktemp("tmdb") / ".testmondata"
+        db.write_bytes(b"x")
+        with patch.object(quality_gate, "TESTMON_DATA", db):
+            yield
 
     def test_tooling_missing_returns_3(self) -> None:
         with patch.object(quality_gate, "_impacted_tooling_available", return_value=False):
@@ -2605,6 +2620,83 @@ class TestCheckImpacted:
             assert quality_gate.check_impacted() == 1
         assert not xml.exists(), "the stale coverage.xml must have been cleared before the run"
         mock_run.assert_not_called()  # diff-cover never scores against a stale report
+
+    def test_fresh_baseline_resets_accumulated_coverage(self, tmp_path: Path) -> None:
+        """QS-278: an absent `.testmondata` (testmon about to select ALL tests)
+        resets the accumulated `--cov-append` coverage data before the run."""
+        xml = tmp_path / "coverage.xml"
+        absent_db = tmp_path / ".testmondata"  # never created
+
+        def _emit_xml(*_a: object, **_k: object) -> dict:
+            xml.write_text("<coverage/>")
+            return {"name": "pytest", "passed": True}
+
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "TESTMON_DATA", absent_db),
+            patch.object(quality_gate, "COVERAGE_XML", xml),
+            patch.object(quality_gate, "_reset_coverage_data") as mock_reset,
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
+            patch.object(quality_gate, "_stream_pytest", side_effect=_emit_xml),
+            patch.object(quality_gate, "_run", return_value=_cp(0, stdout="Coverage: 100%")),
+        ):
+            assert quality_gate.check_impacted() == 0
+        mock_reset.assert_called_once()
+
+    def test_existing_baseline_keeps_accumulated_coverage(self, tmp_path: Path) -> None:
+        """QS-278: when `.testmondata` exists, coverage accumulation is
+        intentional — the reset must NOT fire (so a 0/partial reselection
+        keeps prior runs' coverage of changed-vs-origin lines)."""
+        xml = tmp_path / "coverage.xml"
+        present_db = tmp_path / ".testmondata"
+        present_db.write_bytes(b"x")
+
+        def _emit_xml(*_a: object, **_k: object) -> dict:
+            xml.write_text("<coverage/>")
+            return {"name": "pytest", "passed": True}
+
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "TESTMON_DATA", present_db),
+            patch.object(quality_gate, "COVERAGE_XML", xml),
+            patch.object(quality_gate, "_reset_coverage_data") as mock_reset,
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
+            patch.object(quality_gate, "_stream_pytest", side_effect=_emit_xml),
+            patch.object(quality_gate, "_run", return_value=_cp(0, stdout="Coverage: 100%")),
+        ):
+            assert quality_gate.check_impacted() == 0
+        mock_reset.assert_not_called()
+
+
+class TestResetCoverageData:
+    """QS-278: `_reset_coverage_data` clears the persistent coverage data."""
+
+    def test_removes_primary_data_and_xdist_shards(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        data = tmp_path / ".coverage"
+        data.write_text("primary")
+        shard = tmp_path / ".coverage.host.12345"
+        shard.write_text("shard")
+        monkeypatch.setattr(quality_gate, "COVERAGE_DATA", data)
+        monkeypatch.setattr(quality_gate, "REPO_ROOT", tmp_path)
+
+        quality_gate._reset_coverage_data()
+
+        assert not data.exists()
+        assert not shard.exists()
+
+    def test_is_noop_when_no_data_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Absent data must not raise (first-ever run)."""
+        monkeypatch.setattr(quality_gate, "COVERAGE_DATA", tmp_path / ".coverage")
+        monkeypatch.setattr(quality_gate, "REPO_ROOT", tmp_path)
+        quality_gate._reset_coverage_data()  # must not raise
 
 
 class TestTestmonAvailable:


### PR DESCRIPTION
## Summary
- Render both date-bearing branches of get_car_charge_origin_readable_string (Calendar/Manual target, person-forecast leave time) with normal today/tomorrow/full-date formatting instead of the compact for_small_standalone form; threaded the flag with default True to preserve existing direct callers.
- Fix the --impacted gate: gitignore the untracked symlinked dev-env dirs (+ testmon WAL sidecars) that crashed diff-cover --include-untracked, and accumulate coverage with --cov-append (reset on fresh baseline) so a 0/partial testmon reselection no longer false-FAILs on changed-line coverage. Verified incremental re-run ~12s.
- Docs: project-rules + story AC#6 make --impacted the local pre-PR default; whole-repo 100% gate stays authoritative in CI.

## Doc maintenance
person-trip-prediction.md updated (origin format strings). car-soc-estimation.md and notification-routing.md re-verified (Doc-OK per story analysis: neither covers the origin readable string or date formatting) and last_verified bumped.

Fixes #278

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forecast and charge-origin readable strings to consistently show the correct human-friendly date/time format (compact vs normal) across tomorrow and far-out scenarios.

* **Documentation**
  * Updated QS-278-related concepts/stories and project rules, including refreshed “last verified” metadata and clarified behavior.

* **Chores**
  * Refreshed ignore rules for local test artifacts and Home Assistant paths.
  * Updated quality gate coverage handling to accumulate across impacted runs, resetting only when a fresh baseline is selected.

* **Tests**
  * Expanded/adjusted car and quality gate tests to match the updated formatting and coverage reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->