### PR TITLE
QS-280: The rabbit (as fast as possible) button is not showing a UI change

### DIFF
--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -885,6 +885,16 @@ class QsCarCard extends QsCardBase {
           "Person Automated": "mdi:account-clock",
       };
       const iconForChargeType = (str) => carChargeTypeIcons[str];
+      // QS-280: the rabbit (charge-as-fast-as-possible) button covers both
+      // as-fast charge-type strings — solver-driven "As Fast As Possible" and
+      // user-force "Manual As Fast As Possible" (what get_charge_type() returns
+      // after a user press). The set is matched directly here, decoupled from
+      // the icon map, so the icon for either state can change independently
+      // without silently breaking the button's lit state or its Stop dialog.
+      // These are the rendered values of the CAR_CHARGE_TYPE_*AS_FAST_AS_POSSIBLE
+      // constants in const.py and must stay in sync with them.
+      const AS_FAST_STATES = ['As Fast As Possible', 'Manual As Fast As Possible'];
+      const isAsFastState = (s) => AS_FAST_STATES.includes(s);
       const chargeIcon = iconForChargeType(sChargeType?.state);
       const chargeTime = sChargeTime?.state || '';
       const chargeIconLabel = 'Mode';
@@ -1387,7 +1397,7 @@ class QsCarCard extends QsCardBase {
                   <div class="mini-title">${useEnergyMode ? 'Target Energy' : 'Target SOC'}</div>
                   <div class="mini-title">${chargeTimeLabel}</div>
 
-                  ${e.force_now ? `<div id="rabbit_btn" class="rabbit-btn ${sChargeType?.state === 'As Fast As Possible' ? 'on' : ''}" role="button" ${ctrlTabAttrs} aria-label="Charge as fast as possible"><ha-icon icon="mdi:rabbit"></ha-icon></div>` : ''}
+                  ${e.force_now ? `<div id="rabbit_btn" class="rabbit-btn ${isAsFastState(sChargeType?.state) ? 'on' : ''}" role="button" ${ctrlTabAttrs} aria-label="Charge as fast as possible"><ha-icon icon="mdi:rabbit"></ha-icon></div>` : ''}
                   <div class="target-cell">
                     <div id="target_value" class="target-value">${displayTargetValue}</div>
                     ${useEnergyMode ? '' : `<div class="mini-range-target" aria-label="range at target">${rangeTargetStr}</div>`}
@@ -1663,7 +1673,7 @@ class QsCarCard extends QsCardBase {
                   if (this._root?.querySelector('.disabled')) return;
 
                   // Check if already in "As Fast As Possible" mode
-                  const isAlreadyForcing = sChargeType?.state === 'As Fast As Possible';
+                  const isAlreadyForcing = isAsFastState(sChargeType?.state);
 
                   if (isAlreadyForcing && e.clean_constraints) {
                       this._showDialog({

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -17,7 +17,7 @@ covers:
   - custom_components/quiet_solar/ui/resources/shared/qs-ring-duration-base.js
   - custom_components/quiet_solar/ui/resources/shared/qs-anim-flame.js
   - custom_components/quiet_solar/ui/resources/shared/qs-anim-wave.js
-last_verified: 2026-06-18
+last_verified: 2026-06-30
 ---
 
 # Dashboard generation and JS Lovelace cards
@@ -420,8 +420,8 @@ origin-aware charge types:
 
 | charge type (sensor state) | icon |
 |---|---|
-| `As Fast As Possible` | `mdi:rabbit` |
-| `Manual As Fast As Possible` | `mdi:rabbit` (the context row differentiates user vs automation) |
+| `As Fast As Possible` | `mdi:rabbit` (solver-driven as-fast) |
+| `Manual As Fast As Possible` | `mdi:rabbit` (user-force; context row differentiates user vs automation) |
 | `Manual` | `mdi:hand-back-right` |
 | `Calendar` | `mdi:calendar` |
 | `Person Automated` | `mdi:account-clock` |
@@ -433,6 +433,24 @@ origin-aware charge types:
 old `mdi:auto-fix` person icon were **removed**. The JS map keys are the
 rendered string values of the `CAR_CHARGE_TYPE_*` constants — they must
 stay in sync with `const.py`.
+
+**QS-280 — rabbit button covers both as-fast states.** There are two
+distinct as-fast charge types: solver-driven `"As Fast As Possible"` and
+user-force `"Manual As Fast As Possible"` (the latter is what
+`get_charge_type()` returns after a user presses the rabbit). The rabbit
+button's lit `on` class and the Stop-vs-Start dialog gate
+(`isAlreadyForcing`) now test against an explicit
+`const AS_FAST_STATES = ['As Fast As Possible', 'Manual As Fast As Possible']`
+set via a render-local predicate
+`const isAsFastState = (s) => AS_FAST_STATES.includes(s)`, rather than the
+old bare `=== 'As Fast As Possible'` literal that missed the manual
+variant. The set is matched **directly on the charge-type strings**
+(decoupled from `carChargeTypeIcons`) so the icon for either state can be
+changed independently without breaking the button. `AS_FAST_STATES` mirrors
+the `CAR_CHARGE_TYPE_*AS_FAST_AS_POSSIBLE` constants and must stay in sync
+with `const.py`. This fixes the bug where a user-pressed rabbit
+(`"Manual As Fast As Possible"`) left the button unlit and offered Start
+instead of Stop.
 
 The card's `.forecast-row` is now an **origin context row**: it renders
 the new `qs_car_charge_origin` sensor (wired through the template as

--- a/docs/stories/QS-280.story.md
+++ b/docs/stories/QS-280.story.md
@@ -48,7 +48,7 @@ map at lines 881–882 and a comment at line 1665):
   `sChargeType?.state === 'As Fast As Possible'` → false for the Manual
   variant → **button never lights**.
 - **`isAlreadyForcing`** (~line 1666), which gates the Stop-vs-Start
-  dialog: same exact check → false → shows the **Start** dialog → user
+  dialog: same check → false → shows the **Start** dialog → user
   **cannot stop** the charge.
 
 The icon map (lines 881–882) already maps **both** strings to
@@ -172,16 +172,17 @@ variant produced by a user press.
    style) — do **not** grep for `"Manual As Fast As Possible"` alone,
    which is already present via the icon map (line 882) and would pass
    pre-fix, defeating red-first.
-2. **Fix (green):** Add the `carChargeTypeIcons`-derived `isAsFastState`
-   predicate and apply it at the two expression sites per Design.
+2. **Fix (green):** Add the direct-string `isAsFastState` predicate
+   backed by an explicit `AS_FAST_STATES` set and apply it at the two
+   expression sites per Design.
 3. **Doc maintenance (required — drift co-modification):**
    `docs/agents/concepts/dashboard-and-cards.md` `covers:` `qs-car-card.js`
    and is flagged stale by `check_doc_drift.py`. Update the rabbit /
    charge-type section (around the `carChargeTypeIcons` description,
    ~line 418, and the rabbit-button rows ~lines 423–424) to note that
    the rabbit lit state and the Stop dialog cover **both** as-fast
-   strings via the icon-map-derived `isAsFastState` predicate, and bump
-   `last_verified`.
+   strings via the direct-string `isAsFastState` predicate (backed by an
+   explicit `AS_FAST_STATES` set), and bump `last_verified`.
 4. **Gate:** Run `python scripts/qs/quality_gate.py --impacted` as the
    pre-commit inner loop (it selects the changed
    `test_car_card_smoke.py` and checks changed-line coverage). The
@@ -197,8 +198,10 @@ variant produced by a user press.
 **Accepted → folded into story (resolved):**
 
 - **R1 (critic redesign):** Hardcoding two literals re-introduces drift.
-  → Predicate now derived from the icon map (`carChargeTypeIcons[s] ===
-  'mdi:rabbit'`). *resolved*
+  → Predicate tests the charge-type strings directly via an explicit
+  `AS_FAST_STATES` set (`isAsFastState`), decoupled from the icon map.
+  (An interim icon-map-derived idea was itself later superseded on user
+  direction — see the Design-change note.) *resolved*
 - **R2 (concrete + dev-proxy improve):** Grep test must be red-first /
   not collide with the icon-map line. → Test spec now pins the
   `isAsFastState` predicate + both call sites and the removal of the

--- a/docs/stories/QS-280.story.md
+++ b/docs/stories/QS-280.story.md
@@ -1,0 +1,226 @@
+# QS-280: The rabbit (as-fast-as-possible) button is not showing a UI change
+
+story v2 · status: DISCUSS · last review: round 1 · changed-since-last-review: false · open criticals: 0
+
+## Problem
+
+When the user presses the **rabbit button** (charge as fast as possible)
+on a connected car's `qs-car-card`:
+
+- the charge does start at max power (the constraint is correctly set),
+- the **car-charge-type text sensor correctly shows the as-fast state**,
+- but the **rabbit button does not light up** (no "on" highlight), and
+- pressing the rabbit again offers **"Start full-speed charge"** instead
+  of **"Stop Force Charging"**, so the user **cannot stop** the charge
+  from the rabbit.
+
+## Root cause
+
+The bug is a **string-match mismatch in the JS card**, not a state /
+timing problem (the sensor text proves state propagates correctly).
+
+The issue carries an `area:solver` label and the reporter speculates
+about a "Broken sensor or switch". That hypothesis was **considered and
+rejected**: the reporter confirms the charge-type text sensor is correct,
+so the solver and the `get_charge_type()` Python logic are right — only
+the card's UI predicate is wrong. No solver/sensor change is warranted.
+
+There are two distinct as-fast charge-type strings (`const.py`
+lines 386–387):
+
+- `CAR_CHARGE_TYPE_AS_FAST_AS_POSSIBLE = "As Fast As Possible"` —
+  solver-driven mandatory as-fast.
+- `CAR_CHARGE_TYPE_MANUAL_AS_FAST_AS_POSSIBLE = "Manual As Fast As Possible"`
+  — user-originated force.
+
+When the **user** presses the rabbit, `QSCar.user_force_charge_now()`
+sets `from_user=True` / `CONSTRAINT_ORIGINATOR_USER_OVERRIDE`, so
+`QSChargerGeneric.get_charge_type()` returns the **`"Manual As Fast As
+Possible"`** variant (`charger.py` ~line 4384), not `"As Fast As
+Possible"`.
+
+But `custom_components/quiet_solar/ui/resources/qs-car-card.js` compares
+against the **non-manual string only** in the **two (and only two) live
+comparison sites** (verified: the only other occurrences are the icon
+map at lines 881–882 and a comment at line 1665):
+
+- **The rabbit's lit `on` CSS class** (~line 1390):
+  `sChargeType?.state === 'As Fast As Possible'` → false for the Manual
+  variant → **button never lights**.
+- **`isAlreadyForcing`** (~line 1666), which gates the Stop-vs-Start
+  dialog: same exact check → false → shows the **Start** dialog → user
+  **cannot stop** the charge.
+
+The icon map (lines 881–882) already maps **both** strings to
+`mdi:rabbit`, and **only** those two states map to `mdi:rabbit` —
+confirming both are legitimate as-fast states. The two comparison sites
+just weren't updated to match the Manual variant.
+
+## Goal
+
+Make the rabbit button's **lit state** and its **stop/start dialog
+gate** treat **both** `"As Fast As Possible"` and `"Manual As Fast As
+Possible"` as the as-fast (rabbit-active) state, so:
+
+- the rabbit lights up whenever the car is in either as-fast state, and
+- pressing the lit rabbit offers **Stop Force Charging** (resets the
+  constraint via `e.clean_constraints`).
+
+## Design
+
+UI-only change to `custom_components/quiet_solar/ui/resources/qs-car-card.js`,
+inside `_render()` (which spans from ~line 814 to the end of the
+method; both edit sites are lexically within it, so a render-local
+`const` is in scope at both).
+
+1. **Derive the predicate from the existing icon map** rather than
+   re-typing the two display literals (avoids re-introducing the exact
+   literal-drift that caused this bug, and auto-covers any future
+   as-fast variant added to the map). Declare it near the existing
+   `sChargeType` read / `carChargeTypeIcons` map:
+
+   ```js
+   const isAsFastState = (s) => carChargeTypeIcons[s] === 'mdi:rabbit';
+   ```
+
+   Both as-fast strings — and only those — map to `mdi:rabbit`, so this
+   is exactly the as-fast set. For a missing/undefined state,
+   `carChargeTypeIcons[undefined]` is `undefined !== 'mdi:rabbit'` →
+   `false` (correct: unlit + Start path).
+
+2. **Rabbit lit `on` class** — find the expression
+   `sChargeType?.state === 'As Fast As Possible'` used for the
+   `rabbit-btn ... 'on'` class (~line 1390) and replace it with
+   `isAsFastState(sChargeType?.state)`.
+
+3. **Stop-vs-Start gate** — find
+   `const isAlreadyForcing = sChargeType?.state === 'As Fast As Possible';`
+   (~line 1666) and replace the right-hand side with
+   `isAsFastState(sChargeType?.state)`.
+
+Edits are anchored to the **exact expression text** above, not to line
+numbers (line numbers are indicative and may drift). No Python,
+template, `const.py`, or `strings.json` changes. Behavior for the
+existing non-manual `"As Fast As Possible"` state is preserved (it
+already lit / offered Stop); the fix additionally covers the Manual
+variant produced by a user press.
+
+### Documented non-issues / explicitly out of scope
+
+- **`clean_constraints` always present for cars.** The Stop dialog is
+  gated on `e.clean_constraints` (a pre-existing condition, unchanged by
+  this fix). The clean-command button
+  (`BUTTON_DEVICE_CLEAN_COMMAND_AND_CONSTRAINTS`) is created for every
+  `AbstractDevice`, so a car card always wires `clean_constraints`
+  (template line 95). A lit-rabbit-without-Stop state therefore cannot
+  occur for a car.
+- **Legacy inline `force` button** — the `id="force"` button (lines
+  1532–1534) lives inside a `/* ... */` comment, so it is never
+  rendered. Its event-wiring block (~lines 1745–1764) is **live JS** but
+  calls `ids('force')`, which returns `null` for the non-existent
+  element, so `_wireTap(null, …)` no-ops. Left untouched — removing dead
+  wiring would be scope creep on a bug fix.
+- **No JS DOM test harness exists** in the repo; card behavior is
+  verified by grep-based card-smoke tests (the established pattern, e.g.
+  `tests/test_car_card_smoke.py` lines 26–27). Adding a DOM/render
+  harness for ACs 1–4 would be over-engineering, so ACs 1–4 are
+  behavioral intent and AC 6 is the gate-enforced proxy.
+- **Manual verification** of the lit/dialog behavior requires a resource
+  refresh (HA restart or hard browser reload), since only resources are
+  updated on startup. The automated proof is the grep smoke test.
+
+## Acceptance criteria
+
+1. When the user presses the rabbit and the car enters
+   `"Manual As Fast As Possible"`, the rabbit button renders with the
+   `on` class (lit). *(behavioral intent)*
+2. The rabbit also stays lit for the solver-driven
+   `"As Fast As Possible"` state (unchanged behavior, both states lit).
+   *(behavioral intent)*
+3. When the rabbit is in either as-fast state and `e.clean_constraints`
+   is present, pressing it opens the **Stop Force Charging** dialog (not
+   the Start dialog). *(behavioral intent)*
+4. When the car is in any non-as-fast state — including a missing /
+   `undefined` charge-type state — the rabbit is unlit and a press opens
+   the **Force charge now / Start** dialog (unchanged). *(behavioral
+   intent)*
+5. The as-fast predicate is **derived from the icon map** (not hardcoded
+   literals), so a future as-fast charge-type added to the icon map is
+   automatically covered.
+6. **Gate-enforced:** the card source defines `isAsFastState` and uses
+   it at *both* the rabbit lit-class site and the `isAlreadyForcing`
+   gate, and the bare `sChargeType?.state === 'As Fast As Possible'`
+   comparison no longer gates either of those two sites (asserted by the
+   card-smoke test).
+
+## Task breakdown
+
+1. **Test (red):** Extend `tests/test_car_card_smoke.py` so that it
+   asserts (a) `isAsFastState` is defined in the card source, (b) it is
+   used at the rabbit lit-class site and at the `isAlreadyForcing` gate,
+   and (c) the bare `sChargeType?.state === 'As Fast As Possible'`
+   no longer appears as the rabbit-lit / stop-gate condition. Match on
+   the predicate name and call-site substrings (robust to quote/spacing
+   style) — do **not** grep for `"Manual As Fast As Possible"` alone,
+   which is already present via the icon map (line 882) and would pass
+   pre-fix, defeating red-first.
+2. **Fix (green):** Add the `carChargeTypeIcons`-derived `isAsFastState`
+   predicate and apply it at the two expression sites per Design.
+3. **Doc maintenance (required — drift co-modification):**
+   `docs/agents/concepts/dashboard-and-cards.md` `covers:` `qs-car-card.js`
+   and is flagged stale by `check_doc_drift.py`. Update the rabbit /
+   charge-type section (around the `carChargeTypeIcons` description,
+   ~line 418, and the rabbit-button rows ~lines 423–424) to note that
+   the rabbit lit state and the Stop dialog cover **both** as-fast
+   strings via the icon-map-derived `isAsFastState` predicate, and bump
+   `last_verified`.
+4. **Gate:** Run `python scripts/qs/quality_gate.py --impacted` as the
+   pre-commit inner loop (it selects the changed
+   `test_car_card_smoke.py` and checks changed-line coverage). The
+   authoritative whole-repo 100%-coverage gate runs in CI. Note: the
+   `.js` file is **not** in Python coverage scope, so it neither raises
+   nor lowers coverage; the change is guarded by the Python card-smoke
+   grep test (itself covered), and whole-repo coverage is unaffected.
+
+## Adversarial Review Notes
+
+### Round 1 — 4 global reviewers (critic, concrete-planner, dev-proxy, scope-guardian)
+
+**Accepted → folded into story (resolved):**
+
+- **R1 (critic redesign):** Hardcoding two literals re-introduces drift.
+  → Predicate now derived from the icon map (`carChargeTypeIcons[s] ===
+  'mdi:rabbit'`). *resolved*
+- **R2 (concrete + dev-proxy improve):** Grep test must be red-first /
+  not collide with the icon-map line. → Test spec now pins the
+  `isAsFastState` predicate + both call sites and the removal of the
+  bare comparison. *resolved*
+- **R3 (critic improve):** Undefined `sChargeType.state`. → AC 4 covers
+  missing/undefined → unlit + Start; predicate returns false. *resolved*
+- **R4 (dev-proxy critical #2 + #1):** Gate command conflated `--impacted`
+  with UI-only fast path; coverage reasoning. → Task 4 corrected;
+  coverage note added. *resolved (downgraded — wording, not a defect)*
+- **R5 (all, clarify):** Line numbers load-bearing. → Edits anchored to
+  exact expression text. *resolved*
+- **R6 (critic + scope, clarify):** Doc content unspecified / solver
+  hypothesis. → Doc content specified; solver/sensor hypothesis
+  recorded as considered-and-rejected. *resolved*
+- **R7 (critic improve):** Lit-but-no-`clean_constraints`. → Documented
+  non-issue: clean button exists for every device; gate pre-existing.
+  *resolved*
+- **R8 (concrete clarify):** "Dead wiring" mischaracterized. → Reworded:
+  live JS referencing a commented-out element; no-ops. *resolved*
+
+**Rejected (with reason):**
+
+- **(critic critical) Possible third comparison site.** Rejected —
+  verified only two live sites (1390, 1666); other occurrences are the
+  icon map (881–882) and a comment (1665).
+- **(critic redesign / scope improve) Add DOM tests for ACs 1–4 / drop
+  the grep AC.** Rejected — no JS test harness exists; grep card-smoke
+  is the established pattern. ACs 1–4 are behavioral intent; AC 6 is the
+  gate-enforced grep proxy.
+- **(scope improve) Drop the doc task.** Rejected — the doc `covers:`
+  `qs-car-card.js`, so drift co-modification is mandatory.
+
+**Open criticals:** 0.

--- a/docs/stories/QS-280.story.md
+++ b/docs/stories/QS-280.story.md
@@ -73,20 +73,26 @@ inside `_render()` (which spans from ~line 814 to the end of the
 method; both edit sites are lexically within it, so a render-local
 `const` is in scope at both).
 
-1. **Derive the predicate from the existing icon map** rather than
-   re-typing the two display literals (avoids re-introducing the exact
-   literal-drift that caused this bug, and auto-covers any future
-   as-fast variant added to the map). Declare it near the existing
-   `sChargeType` read / `carChargeTypeIcons` map:
+1. **Match the as-fast charge-type strings directly** via an explicit
+   set, declared near the existing `sChargeType` read /
+   `carChargeTypeIcons` map:
 
    ```js
-   const isAsFastState = (s) => carChargeTypeIcons[s] === 'mdi:rabbit';
+   const AS_FAST_STATES = ['As Fast As Possible', 'Manual As Fast As Possible'];
+   const isAsFastState = (s) => AS_FAST_STATES.includes(s);
    ```
 
-   Both as-fast strings — and only those — map to `mdi:rabbit`, so this
-   is exactly the as-fast set. For a missing/undefined state,
-   `carChargeTypeIcons[undefined]` is `undefined !== 'mdi:rabbit'` →
-   `false` (correct: unlit + Start path).
+   **Design-change note (post-review, on user direction):** an earlier
+   draft derived the predicate from the icon map
+   (`carChargeTypeIcons[s] === 'mdi:rabbit'`). That was rejected by the
+   user because it couples the as-fast logic to the icon — changing the
+   icon for either as-fast state would silently break the button. The
+   predicate now tests the charge-type strings directly, decoupled from
+   the icon. `AS_FAST_STATES` mirrors the
+   `CAR_CHARGE_TYPE_*AS_FAST_AS_POSSIBLE` constants and must stay in sync
+   with `const.py`. For a missing/undefined state,
+   `AS_FAST_STATES.includes(undefined)` is `false` (correct: unlit +
+   Start path).
 
 2. **Rabbit lit `on` class** — find the expression
    `sChargeType?.state === 'As Fast As Possible'` used for the
@@ -144,9 +150,11 @@ variant produced by a user press.
    `undefined` charge-type state — the rabbit is unlit and a press opens
    the **Force charge now / Start** dialog (unchanged). *(behavioral
    intent)*
-5. The as-fast predicate is **derived from the icon map** (not hardcoded
-   literals), so a future as-fast charge-type added to the icon map is
-   automatically covered.
+5. The as-fast predicate tests an **explicit `AS_FAST_STATES` set of the
+   charge-type strings** (decoupled from the icon map), so the icon for
+   either as-fast state can be changed independently without breaking the
+   rabbit button. *(amended post-review on user direction; the earlier
+   icon-map-derived approach was rejected — see Design note.)*
 6. **Gate-enforced:** the card source defines `isAsFastState` and uses
    it at *both* the rabbit lit-class site and the `isAlreadyForcing`
    gate, and the bare `sChargeType?.state === 'As Fast As Possible'`

--- a/docs/stories/QS-280.story_review_fix_#01.md
+++ b/docs/stories/QS-280.story_review_fix_#01.md
@@ -1,0 +1,63 @@
+# QS-280 — Review fix plan #01
+
+## Summary
+- Source PR: #282
+- Source story: docs/stories/QS-280.story.md
+- Findings to fix: 4
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [should-fix] F1 — Task breakdown mislabels predicate as "icon-map-derived"
+- File: `docs/stories/QS-280.story.md:184`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: Task 3 in the Task breakdown describes the predicate as the
+  "icon-map-derived `isAsFastState`". The final Design (lines ~85–95) explicitly
+  rejected the icon-map-derived approach in favor of testing the charge-type
+  strings directly via an explicit `AS_FAST_STATES` set. The wording contradicts
+  what shipped.
+- Proposed fix: Replace "icon-map-derived `isAsFastState` predicate" with
+  "direct-string `isAsFastState` predicate backed by an explicit `AS_FAST_STATES`
+  set" (and remove the parenthetical implying derivation from `carChargeTypeIcons`).
+
+### [should-fix] F2 — Adversarial note R1 resolution describes rejected approach
+- File: `docs/stories/QS-280.story.md:201`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: Round-1 note R1's resolution reads "Predicate now derived from the
+  icon map (`carChargeTypeIcons[s] === 'mdi:rabbit'`)". That approach was later
+  rejected (see Design-change note). The recorded resolution should reflect the
+  final direct-string `AS_FAST_STATES` design.
+- Proposed fix: Update the R1 resolution to state the predicate tests the
+  charge-type strings directly via an explicit `AS_FAST_STATES` set, decoupled
+  from the icon map (note that the interim icon-map-derived idea was itself
+  superseded — cross-reference the Design-change note).
+
+### [nice-to-have] F3 — Redundant phrasing "same exact"
+- File: `docs/stories/QS-280.story.md:51`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: "same exact check" is redundant.
+- Proposed fix: "same exact check" → "same check".
+
+### [nice-to-have] F4 — Fragile bare-comparison smoke assertion
+- File: `tests/test_car_card_smoke.py:88`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `test_bare_as_fast_comparison_no_longer_gates` asserts the full
+  comparison `sChargeType?.state === 'As Fast As Possible'` is absent. This passes
+  today, but the new comment block in the card still contains the substring
+  `'As Fast As Possible'` (inside `AS_FAST_STATES`). The assertion is correct only
+  because it matches the full `=== ` expression; it would be fragile if someone
+  later added an inline comparison example to a comment.
+- Proposed fix: Add a brief clarifying comment in the test explaining it must match
+  the full comparison expression (not the bare literal, which legitimately appears
+  in the `AS_FAST_STATES` set and the doc comment). Keep the assertion as-is —
+  no behavioral change, just guard against future misedits. Optionally also assert
+  the literal still appears (in the set) to make the intent explicit.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/tests/test_car_card_smoke.py
+++ b/tests/test_car_card_smoke.py
@@ -48,3 +48,44 @@ def test_charge_origin_wired_into_context_row(card_source: str) -> None:
 def test_forecast_prefix_dropped(card_source: str) -> None:
     """The old ``Forecast:`` prefix is no longer rendered."""
     assert "Forecast: ${forecastDisplay}" not in card_source
+
+
+def test_is_as_fast_state_predicate_defined(card_source: str) -> None:
+    """QS-280: the as-fast predicate checks the charge-type strings directly.
+
+    It is backed by an explicit ``AS_FAST_STATES`` set of both as-fast
+    charge-type strings, so the icon mapping can change independently without
+    silently breaking the rabbit button. The single-quoted literals here are
+    distinct from the double-quoted ``carChargeTypeIcons`` keys, so this is
+    not satisfied by the icon map alone.
+    """
+    assert "const isAsFastState" in card_source
+    assert "const AS_FAST_STATES" in card_source
+    assert "'As Fast As Possible'" in card_source
+    assert "'Manual As Fast As Possible'" in card_source
+
+
+def test_rabbit_lit_class_uses_predicate(card_source: str) -> None:
+    """QS-280: the rabbit lit ``on`` class is gated by ``isAsFastState``."""
+    assert (
+        "class=\"rabbit-btn ${isAsFastState(sChargeType?.state) ? 'on' : ''}\""
+        in card_source
+    )
+
+
+def test_is_already_forcing_uses_predicate(card_source: str) -> None:
+    """QS-280: the Stop-vs-Start gate is driven by ``isAsFastState``."""
+    assert (
+        "const isAlreadyForcing = isAsFastState(sChargeType?.state);"
+        in card_source
+    )
+
+
+def test_bare_as_fast_comparison_no_longer_gates(card_source: str) -> None:
+    """QS-280: the bare display-literal comparison is gone from both sites.
+
+    Both the rabbit lit-class site and the ``isAlreadyForcing`` gate
+    previously compared ``sChargeType?.state === 'As Fast As Possible'``,
+    which missed the ``"Manual As Fast As Possible"`` user-force variant.
+    """
+    assert "sChargeType?.state === 'As Fast As Possible'" not in card_source

--- a/tests/test_car_card_smoke.py
+++ b/tests/test_car_card_smoke.py
@@ -87,5 +87,13 @@ def test_bare_as_fast_comparison_no_longer_gates(card_source: str) -> None:
     Both the rabbit lit-class site and the ``isAlreadyForcing`` gate
     previously compared ``sChargeType?.state === 'As Fast As Possible'``,
     which missed the ``"Manual As Fast As Possible"`` user-force variant.
+
+    NOTE: this matches the *full* comparison expression (with ``=== ``), not
+    the bare ``'As Fast As Possible'`` literal — that literal legitimately
+    still appears in the ``AS_FAST_STATES`` set and in the explanatory card
+    comment, so asserting its absence would be wrong. The companion assertion
+    below pins that the literal *is* still present (in the set), making the
+    intent explicit and guarding against a future misedit that drops it.
     """
     assert "sChargeType?.state === 'As Fast As Possible'" not in card_source
+    assert "'As Fast As Possible'" in card_source


### PR DESCRIPTION
## Summary
- Fix the rabbit button so it lights up and offers Stop Force Charging for BOTH as-fast charge types: solver-driven 'As Fast As Possible' and user-force 'Manual As Fast As Possible' (previously only the former).
- Introduce a render-local isAsFastState predicate backed by an explicit AS_FAST_STATES string set (decoupled from the icon map, so the icon for either state can change independently), applied at the rabbit lit-class site and the isAlreadyForcing Stop/Start gate.
- Add grep card-smoke tests (no JS DOM harness exists) and update the dashboard-and-cards concept doc.

Fixes #280

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The car card now correctly recognizes both “As Fast As Possible” and “Manual As Fast As Possible” as active fast-charging states.
  * The rabbit button now shows the correct active state and offers the right action when fast charging is already enabled.
* **Documentation**
  * Updated dashboard/card guidance to clarify the two fast-charging states and the button behavior.
  * Added a new story describing the UI issue and expected behavior.
* **Tests**
  * Expanded smoke checks to cover the updated button logic and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->