### PR TITLE
QS-281: Live estimated SOC while charging (slow car APIs)

### DIFF
--- a/custom_components/quiet_solar/const.py
+++ b/custom_components/quiet_solar/const.py
@@ -261,6 +261,7 @@ SENSOR_CONSTRAINT_SENSOR_NEXT_OR_CURRENT_START = "qs_next_or_current_constraint_
 SENSOR_CONSTRAINT_SENSOR_NEXT_OR_CURRENT_END = "qs_next_or_current_constraint_end_time"
 
 SENSOR_CAR_SOC_PERCENT = "qs_car_soc_percent"
+SENSOR_CAR_BEST_ESTIMATED_SOC_PERCENT = "qs_car_best_estimated_soc_percent"
 SENSOR_CAR_CHARGE_TYPE = "qs_car_charge_type"
 SENSOR_CAR_CHARGE_TIME = "qs_car_charge_time"
 SENSOR_CAR_PERSON_FORECAST = "qs_car_person_forecast"

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -642,6 +642,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         await super().update_states(time)
         self._update_car_api_staleness(time)
         self._update_soc_estimation(time)
+        self._capture_last_valid_base_soc(time)
         await self._check_departure_auto_reset(time)
 
     async def _check_departure_auto_reset(self, time: datetime) -> None:
@@ -860,13 +861,17 @@ class QSCar(HADeviceMixin, AbstractDevice):
         return ", ".join(parts)
 
     def _exit_stale_mode(self, preserve_inferred: bool = False) -> None:
-        """Clear all stale flags and exit stale-percent mode.
+        """Clear the stale flags and exit stale-percent mode.
 
-        Also clears the system-captured SOC base. When there is NO user
-        override, it clears the accumulator + cursor too so the live sensor
-        takes over. When a user override IS active, the override owns its own
-        accumulator lifecycle (the case-1/2 recovery in `_update_soc_estimation`),
-        so a transient stale blip must not wipe its accumulated delta.
+        QS-281: this clears ONLY genuinely stale-specific state. The SOC base
+        (`_last_valid_base_soc_value`) is no longer stale-specific — it is the
+        "last known good raw value" maintained every cycle by the re-anchor
+        (`_capture_last_valid_base_soc`), so exiting stale mode must not wipe it
+        nor the accumulator/cursor. On a real stale→healthy exit the SOC sensor
+        is fresh (that is why we exit), so the same-cycle re-anchor snaps the
+        base to the fresh raw and resets the delta only when it genuinely
+        differs — a real charge delta now survives stale-exit unless the API
+        reports a different value.
 
         ``preserve_inferred`` keeps the manual inferred home/plug override in
         place so the immediately-following per-cycle reconciliation
@@ -881,10 +886,6 @@ class QSCar(HADeviceMixin, AbstractDevice):
             self._car_api_inferred_home = False
             self._car_api_inferred_plugged = False
         self._car_api_stale_since = None
-        self._last_valid_base_soc_value = None
-        if self._user_base_soc_value is None:
-            self._computed_added_delta_soc_percent = None
-            self._delta_soc_last_integration_time = None
 
     def reset_car_api_stale_detection(self) -> None:
         """Reset the detected stale state so the live API gets a fresh chance.
@@ -1632,6 +1633,33 @@ class QSCar(HADeviceMixin, AbstractDevice):
             return self._estimated_soc_percent
         return self.get_car_charge_percent_raw_sensor(time, tolerance_seconds)
 
+    def get_best_estimated_car_charge_percent(self, time: datetime | None = None) -> float | None:
+        """Return the freshest SOC for display (QS-281) — a pure read, no mutation.
+
+        While the slow car APIs lag during a charge, this surfaces a live
+        estimate (`last known good raw value + charge added since`) that
+        re-anchors when the API finally delivers a fresh value:
+
+        1. while estimating (stale / no-sensor / manual override) → the existing
+           estimate `_estimated_soc_percent` (parity with `get_car_charge_percent`,
+           may be `None` for the pure-delta case);
+        2. else when a system base exists → `self._estimated_soc_percent`
+           (the canonical `clamp(base + delta, 0, 100)`);
+        3. else → the plain raw sensor value.
+
+        No "actively charging" check is needed: the delta only ever grows while
+        the charger callback runs, so when idle `base + delta` simply holds the
+        last accurate value until a genuinely different raw API reading
+        re-anchors it (the re-anchor lives in `update_states`, not here).
+        """
+        if time is None:
+            time = datetime.now(tz=pytz.UTC)
+        if self.is_in_soc_estimation_mode(time):
+            return self._estimated_soc_percent
+        if self._last_valid_base_soc_value is not None:
+            return self._estimated_soc_percent
+        return self.get_car_charge_percent_raw_sensor(time)
+
     def _update_soc_estimation(self, time: datetime) -> None:
         """Per-cycle recovery for a user manual override (4-case, keyed on entry state).
 
@@ -1680,25 +1708,39 @@ class QSCar(HADeviceMixin, AbstractDevice):
             self.reset_soc_estimate()
 
     def _capture_last_valid_base_soc(self, time: datetime) -> None:
-        """Capture the last valid sensor value as the system base at a fresh→stale edge."""
-        if self._user_base_soc_value is not None or self._last_valid_base_soc_value is not None:
+        """Re-anchor the SOC base to the last known good raw value (QS-281).
+
+        Runs once per cycle from `update_states`, independent of stale state.
+        `_last_valid_base_soc_value` tracks the freshest raw SOC the API has
+        reported. When the raw value genuinely *changes* — detected by an
+        **integer** comparison (mirroring the card's `Math.trunc`, so a
+        same-integer heartbeat does NOT re-anchor and float noise can't cause a
+        spurious reset) — the accumulated delta is reset to `0.0` and the
+        integration cursor re-anchored, so the live estimate snaps back to the
+        truth the API just reported.
+
+        No-op when the raw value is `None` (no reading yet / no-sensor car) and
+        skipped entirely when a manual override is active — that override owns
+        its delta lifecycle via `_update_soc_estimation`.
+        """
+        if self._user_base_soc_value is not None:
             return
         raw = self.get_car_charge_percent_raw_sensor(time)
-        if raw is not None:
+        if raw is None:
+            return
+        if self._last_valid_base_soc_value is None or int(raw) != int(self._last_valid_base_soc_value):
             self._last_valid_base_soc_value = raw
             self._computed_added_delta_soc_percent = 0.0
             self._delta_soc_last_integration_time = None
 
     def _enter_stale_percent_mode(self, time: datetime | None, for_init: bool = False) -> None:
-        """Set stale-percent mode and capture the last valid base on a genuine edge.
+        """Set stale-percent mode.
 
-        The `for_init` restore path must not capture — the persisted value is
-        the source of truth.
+        QS-281: the system base is now maintained every cycle by the per-cycle
+        re-anchor (`_capture_last_valid_base_soc`), so this no longer captures
+        the base on the stale edge — it just flips the mode flag.
         """
         self.car_api_stale_percent_mode = True
-        if for_init or time is None:
-            return
-        self._capture_last_valid_base_soc(time)
 
     async def user_set_manual_soc_percent(self, value: float, for_init: bool = False) -> None:
         """Set a manual SOC baseline. `for_init` (entity restore) is a no-op."""

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -1654,9 +1654,10 @@ class QSCar(HADeviceMixin, AbstractDevice):
         """
         if time is None:
             time = datetime.now(tz=pytz.UTC)
-        if self.is_in_soc_estimation_mode(time):
-            return self._estimated_soc_percent
-        if self._last_valid_base_soc_value is not None:
+        # Estimating (stale / no-sensor / manual override) OR a healthy sensor
+        # that already has a system base → the canonical clamped estimate (which
+        # is `None` only in the pure-delta no-base case). Otherwise the plain raw.
+        if self.is_in_soc_estimation_mode(time) or self._last_valid_base_soc_value is not None:
             return self._estimated_soc_percent
         return self.get_car_charge_percent_raw_sensor(time)
 
@@ -1712,23 +1713,32 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         Runs once per cycle from `update_states`, independent of stale state.
         `_last_valid_base_soc_value` tracks the freshest raw SOC the API has
-        reported. When the raw value genuinely *changes* — detected by an
-        **integer** comparison (mirroring the card's `Math.trunc`, so a
-        same-integer heartbeat does NOT re-anchor and float noise can't cause a
-        spurious reset) — the accumulated delta is reset to `0.0` and the
-        integration cursor re-anchored, so the live estimate snaps back to the
-        truth the API just reported.
+        reported. When the raw value changes at the **integer** level (mirroring
+        the card's `Math.trunc`, so a same-integer heartbeat does NOT re-anchor),
+        the accumulated delta is reset to `0.0` and the integration cursor
+        re-anchored, so the live estimate snaps back to the truth the API just
+        reported. (Sub-integer jitter is absorbed, but a raw oscillating across
+        an integer boundary — e.g. `44.9`↔`45.1` — will re-anchor on each flip;
+        the integer compare is a coarse de-bounce, not full hysteresis.)
 
-        No-op when the raw value is `None` (no reading yet / no-sensor car) and
-        skipped entirely when a manual override is active — that override owns
-        its delta lifecycle via `_update_soc_estimation`.
+        No-op when the raw value is `None` (no reading yet / no-sensor car) or
+        **non-finite** (`nan`/`inf` — a misbehaving template/SOC sensor whose
+        literal `"nan"`/`"inf"` survives numeric coercion: `int()` on those
+        raises, so the per-cycle `update_states` must not crash). Skipped
+        entirely when a manual override is active — that override owns its delta
+        lifecycle via `_update_soc_estimation`.
         """
         if self._user_base_soc_value is not None:
             return
         raw = self.get_car_charge_percent_raw_sensor(time)
-        if raw is None:
+        # No-op unless `raw` is a finite real number: `None` (no reading), a
+        # non-numeric sensor state (the raw read is typed `str | float | None`),
+        # or a non-finite `nan`/`inf` must never reach `int()` — it would raise
+        # and crash the per-cycle `update_states`.
+        if not isinstance(raw, (int, float)) or not math.isfinite(raw):
             return
-        if self._last_valid_base_soc_value is None or int(raw) != int(self._last_valid_base_soc_value):
+        base = self._last_valid_base_soc_value
+        if not isinstance(base, (int, float)) or not math.isfinite(base) or int(raw) != int(base):
             self._last_valid_base_soc_value = raw
             self._computed_added_delta_soc_percent = 0.0
             self._delta_soc_last_integration_time = None

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -79,6 +79,20 @@ def _round_half_up(value: float) -> int:
     return int(math.floor(value + 0.5))
 
 
+def _finite_soc_or_none(value: Any) -> float | None:
+    """Coerce a persisted SOC numeric to a finite float, or `None` (QS-281).
+
+    A legacy/corrupt blob can hold a non-numeric (`str`) or non-finite
+    (`nan`/`inf`) value. QS-281's healthy-path accessor reads the base
+    directly, so an unsanitized value would crash the new
+    `car_best_estimated_soc_percentage` sensor's `value_fn` or emit `nan`/`inf`
+    to HA. Mirrors the finite guard in `_capture_last_valid_base_soc`.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value):
+        return float(value)
+    return None
+
+
 class QSCar(HADeviceMixin, AbstractDevice):
     conf_type_name = CONF_TYPE_NAME_QSCar
 
@@ -331,10 +345,19 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         # Estimated-SOC model (Story QS-243). Pre-QS-243 saved blobs lack
         # these keys and default to None (all-None defaults, no exception).
-        self._user_base_soc_value = stored_load_info.get("user_base_soc_value", None)
-        self._last_valid_base_soc_value = stored_load_info.get("last_valid_base_soc_value", None)
-        self._computed_added_delta_soc_percent = stored_load_info.get("computed_added_delta_soc_percent", None)
-        self._user_base_soc_entry_sensor_value = stored_load_info.get("user_base_soc_entry_sensor_value", None)
+        # QS-281: the numeric SOC fields are sanitized through `_finite_soc_or_none`
+        # so a legacy/corrupt blob holding a `str`/`nan`/`inf` can never reach
+        # the healthy-path accessor's `base + delta` read (crash / `nan` emit).
+        self._user_base_soc_value = _finite_soc_or_none(stored_load_info.get("user_base_soc_value", None))
+        self._last_valid_base_soc_value = _finite_soc_or_none(
+            stored_load_info.get("last_valid_base_soc_value", None)
+        )
+        self._computed_added_delta_soc_percent = _finite_soc_or_none(
+            stored_load_info.get("computed_added_delta_soc_percent", None)
+        )
+        self._user_base_soc_entry_sensor_value = _finite_soc_or_none(
+            stored_load_info.get("user_base_soc_entry_sensor_value", None)
+        )
         self._user_base_soc_entry_api_stale = stored_load_info.get("user_base_soc_entry_api_stale", None)
         # Re-anchor the integration cursor so the next charge cycle does not
         # integrate energy "delivered" during downtime.
@@ -1634,23 +1657,12 @@ class QSCar(HADeviceMixin, AbstractDevice):
         return self.get_car_charge_percent_raw_sensor(time, tolerance_seconds)
 
     def get_best_estimated_car_charge_percent(self, time: datetime | None = None) -> float | None:
-        """Return the freshest SOC for display (QS-281) — a pure read, no mutation.
+        """Return the freshest SOC for display (QS-281) — a **pure read**.
 
-        While the slow car APIs lag during a charge, this surfaces a live
-        estimate (`last known good raw value + charge added since`) that
-        re-anchors when the API finally delivers a fresh value:
-
-        1. while estimating (stale / no-sensor / manual override) → the existing
-           estimate `_estimated_soc_percent` (parity with `get_car_charge_percent`,
-           may be `None` for the pure-delta case);
-        2. else when a system base exists → `self._estimated_soc_percent`
-           (the canonical `clamp(base + delta, 0, 100)`);
-        3. else → the plain raw sensor value.
-
-        No "actively charging" check is needed: the delta only ever grows while
-        the charger callback runs, so when idle `base + delta` simply holds the
-        last accurate value until a genuinely different raw API reading
-        re-anchors it (the re-anchor lives in `update_states`, not here).
+        The estimate while estimating or when a system base exists (parity with
+        `get_car_charge_percent` for the pure-delta `None` case), otherwise the
+        raw sensor. The re-anchor and accumulator updates live elsewhere; see
+        `docs/agents/concepts/car-soc-estimation.md` for the full rationale.
         """
         if time is None:
             time = datetime.now(tz=pytz.UTC)

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -1655,8 +1655,14 @@ class QSCar(HADeviceMixin, AbstractDevice):
         if time is None:
             time = datetime.now(tz=pytz.UTC)
         # Estimating (stale / no-sensor / manual override) OR a healthy sensor
-        # that already has a system base → the canonical clamped estimate (which
-        # is `None` only in the pure-delta no-base case). Otherwise the plain raw.
+        # that already has a system base → the canonical clamped estimate. The
+        # two cases share a return because `_estimated_soc_percent` is a
+        # computed-on-read property (`clamp(base + delta)`), so a re-anchor that
+        # zeroes the delta is reflected immediately — there is no stored value
+        # that could surface a stale one-cycle display. It is `None` only in the
+        # pure-delta no-base case. Otherwise the plain raw sensor value, read
+        # with the default tolerance (`None`) — identical to the canonical
+        # `get_car_charge_percent()` value_fn, which also passes no tolerance.
         if self.is_in_soc_estimation_mode(time) or self._last_valid_base_soc_value is not None:
             return self._estimated_soc_percent
         return self.get_car_charge_percent_raw_sensor(time)

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -1659,25 +1659,36 @@ class QSCar(HADeviceMixin, AbstractDevice):
     def get_best_estimated_car_charge_percent(self, time: datetime | None = None) -> float | None:
         """Return the freshest SOC for display (QS-281) — a **pure read**.
 
-        The estimate while estimating or when a system base exists (parity with
-        `get_car_charge_percent` for the pure-delta `None` case), otherwise the
-        raw sensor. The re-anchor and accumulator updates live elsewhere; see
-        `docs/agents/concepts/car-soc-estimation.md` for the full rationale.
+        - **Estimating** (stale / no-sensor / manual override): the pure
+          `_estimated_soc_percent` (parity with `get_car_charge_percent`; the
+          raw sensor is distrusted here so it must NOT clamp to it). `None` in
+          the pure-delta no-base case.
+        - **Healthy sensor with a system base**: the canonical estimate
+          (`clamp(base + delta)`, a computed-on-read property), but **never
+          below the genuine live raw** — the integer re-anchor de-bounce can
+          leave `base + delta` a hair behind a sub-integer API increase (base
+          `45.0` vs raw `45.9`), and the estimate is meant to *lead* the API,
+          never lag it (fix-plan #04 #02).
+        - **No base**: the raw sensor value, sanitized through
+          `_finite_soc_or_none` so a `str`/`nan`/`inf` live read never reaches
+          the BATTERY/MEASUREMENT sensor (fix-plan #04 #05) — consistent with
+          the load-path guard.
+
+        See `docs/agents/concepts/car-soc-estimation.md` for the full rationale.
         """
         if time is None:
             time = datetime.now(tz=pytz.UTC)
-        # Estimating (stale / no-sensor / manual override) OR a healthy sensor
-        # that already has a system base → the canonical clamped estimate. The
-        # two cases share a return because `_estimated_soc_percent` is a
-        # computed-on-read property (`clamp(base + delta)`), so a re-anchor that
-        # zeroes the delta is reflected immediately — there is no stored value
-        # that could surface a stale one-cycle display. It is `None` only in the
-        # pure-delta no-base case. Otherwise the plain raw sensor value, read
-        # with the default tolerance (`None`) — identical to the canonical
-        # `get_car_charge_percent()` value_fn, which also passes no tolerance.
-        if self.is_in_soc_estimation_mode(time) or self._last_valid_base_soc_value is not None:
+        if self.is_in_soc_estimation_mode(time):
             return self._estimated_soc_percent
-        return self.get_car_charge_percent_raw_sensor(time)
+        # Read with the default tolerance (`None`) — identical to the canonical
+        # `get_car_charge_percent()` value_fn, which also passes no tolerance.
+        raw = _finite_soc_or_none(self.get_car_charge_percent_raw_sensor(time))
+        if self._last_valid_base_soc_value is not None:
+            est = self._estimated_soc_percent
+            if est is not None and raw is not None and raw > est:
+                return raw
+            return est
+        return raw
 
     def _update_soc_estimation(self, time: datetime) -> None:
         """Per-cycle recovery for a user manual override (4-case, keyed on entry state).
@@ -1731,13 +1742,18 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         Runs once per cycle from `update_states`, independent of stale state.
         `_last_valid_base_soc_value` tracks the freshest raw SOC the API has
-        reported. When the raw value changes at the **integer** level (mirroring
-        the card's `Math.trunc`, so a same-integer heartbeat does NOT re-anchor),
-        the accumulated delta is reset to `0.0` and the integration cursor
-        re-anchored, so the live estimate snaps back to the truth the API just
-        reported. (Sub-integer jitter is absorbed, but a raw oscillating across
-        an integer boundary — e.g. `44.9`↔`45.1` — will re-anchor on each flip;
-        the integer compare is a coarse de-bounce, not full hysteresis.)
+        reported. The re-anchor fires when the raw value changes at the
+        **integer-truncation** (`int()`) level: a same-integer heartbeat does
+        NOT re-anchor (so a stuck-but-pinging slow API keeps the accumulated
+        delta), and on a genuine change the delta is reset to `0.0` and the
+        cursor re-anchored so the estimate snaps back to the truth the API just
+        reported. This `int()` de-bounce is purely a Python-side heartbeat
+        guard — it is **independent of** the card's display asterisk, which
+        uses `Math.round` (fix-plan #01 #03). It is coarse, not full hysteresis:
+        a raw oscillating across an integer boundary (`44.9`↔`45.1`) re-anchors
+        on each flip, and a sub-integer increase within the same integer does
+        not re-anchor — the display accessor clamps `>= raw` so the estimate
+        still never lags the live API (fix-plan #04 #02).
 
         No-op when the raw value is `None` (no reading yet / no-sensor car) or
         **non-finite** (`nan`/`inf` — a misbehaving template/SOC sensor whose
@@ -1766,7 +1782,11 @@ class QSCar(HADeviceMixin, AbstractDevice):
 
         QS-281: the system base is now maintained every cycle by the per-cycle
         re-anchor (`_capture_last_valid_base_soc`), so this no longer captures
-        the base on the stale edge — it just flips the mode flag.
+        the base on the stale edge — it just flips the mode flag. `time` and
+        `for_init` are now unused but **retained for call-site compatibility**:
+        callers still pass them (`_enter_stale_percent_mode(time)` and
+        `(None, for_init=True)`), and `for_init` is passed by keyword so it
+        cannot be renamed/dropped without touching those sites.
         """
         self.car_api_stale_percent_mode = True
 

--- a/custom_components/quiet_solar/ha_model/car.py
+++ b/custom_components/quiet_solar/ha_model/car.py
@@ -349,9 +349,7 @@ class QSCar(HADeviceMixin, AbstractDevice):
         # so a legacy/corrupt blob holding a `str`/`nan`/`inf` can never reach
         # the healthy-path accessor's `base + delta` read (crash / `nan` emit).
         self._user_base_soc_value = _finite_soc_or_none(stored_load_info.get("user_base_soc_value", None))
-        self._last_valid_base_soc_value = _finite_soc_or_none(
-            stored_load_info.get("last_valid_base_soc_value", None)
-        )
+        self._last_valid_base_soc_value = _finite_soc_or_none(stored_load_info.get("last_valid_base_soc_value", None))
         self._computed_added_delta_soc_percent = _finite_soc_or_none(
             stored_load_info.get("computed_added_delta_soc_percent", None)
         )

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -4704,20 +4704,28 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
 
             total_charge_duration = (ct.last_value_update - ct.first_value_update).total_seconds()
 
-            if estimating:
-                # Car-level float accumulator with a dedicated integration cursor:
-                # advances every cycle so sub-1%/cycle slices are never lost and
-                # never double-counted across solver / constraint churn. The car
-                # owns the running value; this callback is its sole writer and
-                # drives it through the car's public accessors.
-                cursor = self.car.soc_integration_cursor
-                if cursor is None:
-                    # first cycle / post-reboot / post-base-set: anchor only.
-                    inc = None
-                else:
-                    inc = self._compute_added_charge_update(start_time=cursor, end_time=time, is_target_percent=True)
-                result_calculus = self.car.accumulate_soc_delta(inc, time)
+            # QS-281: advance the unified SOC accumulator exactly ONCE per
+            # callback, hoisted out of the estimating-only branch so the car's
+            # live best-estimate tracks a HEALTHY charge too (not just the
+            # stale / no-sensor / manual-override "estimating" cases). The car
+            # owns the running value; this callback is its sole writer. The
+            # cursor advances on every call so a same-cycle re-entry integrates
+            # a zero slice — no loss, no double-count across solver / constraint
+            # churn or across a healthy↔stale mid-charge transition.
+            cursor = self.car.soc_integration_cursor
+            if cursor is None:
+                # first cycle / post-reboot / post-base-set: anchor only.
+                inc = None
             else:
+                inc = self._compute_added_charge_update(start_time=cursor, end_time=time, is_target_percent=True)
+            accumulator_estimate = self.car.accumulate_soc_delta(inc, time)
+
+            if estimating:
+                result_calculus = accumulator_estimate
+            else:
+                # Non-estimating (healthy sensor): the accumulator return is
+                # DISCARDED — the constraint value stays driven by the raw
+                # sensor / `delta_added` and is byte-identical to before QS-281.
                 delta_added = self._compute_added_charge_update(
                     start_time=ct.last_value_change_update, end_time=time, is_target_percent=is_target_percent
                 )

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -4705,20 +4705,29 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
             total_charge_duration = (ct.last_value_update - ct.first_value_update).total_seconds()
 
             # QS-281: advance the unified SOC accumulator exactly ONCE per
-            # callback, hoisted out of the estimating-only branch so the car's
-            # live best-estimate tracks a HEALTHY charge too (not just the
+            # PERCENT callback, hoisted out of the estimating-only branch so the
+            # car's live best-estimate tracks a HEALTHY charge too (not just the
             # stale / no-sensor / manual-override "estimating" cases). The car
             # owns the running value; this callback is its sole writer. The
             # cursor advances on every call so a same-cycle re-entry integrates
             # a zero slice — no loss, no double-count across solver / constraint
             # churn or across a healthy↔stale mid-charge transition.
-            cursor = self.car.soc_integration_cursor
-            if cursor is None:
-                # first cycle / post-reboot / post-base-set: anchor only.
-                inc = None
-            else:
-                inc = self._compute_added_charge_update(start_time=cursor, end_time=time, is_target_percent=True)
-            accumulator_estimate = self.car.accumulate_soc_delta(inc, time)
+            #
+            # The `is_target_percent` guard (fix-plan #02 #05) keeps the SOC
+            # accumulator out of the energy-mode callback. The `inc` is a SOC
+            # PERCENT slice; advancing it from the energy callback relied
+            # implicitly on `can_use_charge_percent_constraints()` ⇒ a usable
+            # battery capacity ⇒ `inc=None`, so the guard makes the safety
+            # explicit rather than coupling-dependent (no phantom SOC delta).
+            accumulator_estimate = None
+            if is_target_percent:
+                cursor = self.car.soc_integration_cursor
+                if cursor is None:
+                    # first cycle / post-reboot / post-base-set: anchor only.
+                    inc = None
+                else:
+                    inc = self._compute_added_charge_update(start_time=cursor, end_time=time, is_target_percent=True)
+                accumulator_estimate = self.car.accumulate_soc_delta(inc, time)
 
             if estimating:
                 result_calculus = accumulator_estimate

--- a/custom_components/quiet_solar/sensor.py
+++ b/custom_components/quiet_solar/sensor.py
@@ -37,6 +37,7 @@ from .const import (
     SENSOR_BISTATE_CURRENT_DURATION_H,
     SENSOR_BISTATE_CURRENT_ON_H,
     SENSOR_CAR_AUTONOMY_TO_TARGET_SOC_KM,
+    SENSOR_CAR_BEST_ESTIMATED_SOC_PERCENT,
     SENSOR_CAR_CHARGE_ORIGIN,
     SENSOR_CAR_CHARGE_TIME,
     SENSOR_CAR_CHARGE_TYPE,
@@ -157,6 +158,18 @@ def create_ha_sensor_for_QSCar(device: QSCar):
             value_fn=lambda device, key: device.get_car_charge_percent(),
         )
         entities.append(QSBaseSensor(data_handler=device.data_handler, device=device, description=load_current_command))
+
+        # QS-281 — live best-estimated SOC: re-anchors on each fresh raw value
+        # but extrapolates `base + charge added` while the slow API lags.
+        best_estimated_soc = QSSensorEntityDescription(
+            key="car_best_estimated_soc_percentage",
+            translation_key=SENSOR_CAR_BEST_ESTIMATED_SOC_PERCENT,
+            native_unit_of_measurement=PERCENTAGE,
+            device_class=SensorDeviceClass.BATTERY,
+            state_class=SensorStateClass.MEASUREMENT,
+            value_fn=lambda device, key: device.get_best_estimated_car_charge_percent(),
+        )
+        entities.append(QSBaseSensor(data_handler=device.data_handler, device=device, description=best_estimated_soc))
 
         # Estimated remaining range now
         load_current_command = QSSensorEntityDescription(

--- a/custom_components/quiet_solar/strings.json
+++ b/custom_components/quiet_solar/strings.json
@@ -870,6 +870,9 @@
       "qs_car_soc_percent": {
         "name": "Current Charge"
       },
+      "qs_car_best_estimated_soc_percent": {
+        "name": "Best estimated SOC"
+      },
       "qs_car_charge_type": {
         "name": "Charge Type"
       },

--- a/custom_components/quiet_solar/translations/en.json
+++ b/custom_components/quiet_solar/translations/en.json
@@ -656,6 +656,9 @@
             "qs_car_autonomy_to_target_soc_km": {
                 "name": "Autonomy to Target SOC (km)"
             },
+            "qs_car_best_estimated_soc_percent": {
+                "name": "Best estimated SOC"
+            },
             "qs_car_charge_origin": {
                 "name": "Charge Origin"
             },

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
@@ -88,8 +88,8 @@ views:
               {%-    set badges_list.badges = badges_list.badges + [(e.entity_id, device.name)] %}
               {{ "soc: " + e.entity_id }}
               {%- endif %}
-              {%- set e = ha.get("car_best_estimated_soc_percentage") %}
-              {% if e %}best_soc: {{ e.entity_id }}{% endif %}
+              {%- set best_e = ha.get("car_best_estimated_soc_percentage") %}
+              {% if best_e %}best_soc: {{ best_e.entity_id }}{% endif %}
               {% if ha.get("current_constraint_current_energy") %}current_inputed_energy: {{ ha.get("current_constraint_current_energy").entity_id }}{% endif %}
               {% if device.car_battery_capacity %}car_battery_capacity_kwh: {{ (device.car_battery_capacity / 1000)|round(1) }}{% endif %}
               {% if ha.get("best_power_value") %}power: {{ ha.get("best_power_value").entity_id }}{% endif %}

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2
@@ -88,6 +88,8 @@ views:
               {%-    set badges_list.badges = badges_list.badges + [(e.entity_id, device.name)] %}
               {{ "soc: " + e.entity_id }}
               {%- endif %}
+              {%- set e = ha.get("car_best_estimated_soc_percentage") %}
+              {% if e %}best_soc: {{ e.entity_id }}{% endif %}
               {% if ha.get("current_constraint_current_energy") %}current_inputed_energy: {{ ha.get("current_constraint_current_energy").entity_id }}{% endif %}
               {% if device.car_battery_capacity %}car_battery_capacity_kwh: {{ (device.car_battery_capacity / 1000)|round(1) }}{% endif %}
               {% if ha.get("best_power_value") %}power: {{ ha.get("best_power_value").entity_id }}{% endif %}

--- a/custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2
+++ b/custom_components/quiet_solar/ui/quiet_solar_dashboard_template_standard_ha.yaml.j2
@@ -105,6 +105,11 @@ views:
               {{ "  name: " + "\'" + ha_entity.name + "\'" }}
               {%- endif %}
               {%- endif %}
+              {%- set ha_entity = device.ha_entities.get("car_best_estimated_soc_percentage") %}
+              {%- if  ha_entity != None %}
+              {{ "- entity: " + ha_entity.entity_id }}
+              {{ "  name: " + "\'" + ha_entity.name + "\'" }}
+              {%- endif %}
               {%- set ha_entity = device.ha_entities.get("qs_car_is_soc_estimated") %}
               {%- if  ha_entity != None %}
               {{ "- entity: " + ha_entity.entity_id }}

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -836,6 +836,9 @@ class QsCarCard extends QsCardBase {
       // number entity (popup prefill + write target), and the reset button.
       const sIsSocEstimated = this._entity(e.is_soc_estimated);
       const sManualSoc = this._entity(e.manual_soc);
+      // QS-281 — live best-estimated SOC (re-anchors on each fresh raw value,
+      // extrapolates `base + charge added` while the slow car API lags).
+      const sBestSoc = this._entity(e.best_soc);
 
       const title = (cfg.title || cfg.name) || (sSoc ? (sSoc.attributes.friendly_name || sSoc.entity_id) : "Car");
 
@@ -844,6 +847,11 @@ class QsCarCard extends QsCardBase {
       // Check if car API data is stale
       const isStale = sCarIsStale?.state === 'on';
       let soc = this._percent(sSoc?.state);
+      // QS-281 N2 — capture the RAW SOC up front, before `soc` can be
+      // reassigned to the best-estimate below: the asterisk compares the
+      // estimate against this raw value, so it must never be the (possibly
+      // overwritten) display variable.
+      const rawSoc = this._percent(sSoc?.state);
       // QS-235 AC6 — guard-shaped sensor read via the shared `_safeNumber`
       // (trims, rejects unknown/unavailable/±Infinity) instead of the raw
       // `Number(sPower?.state || "0")` pattern.
@@ -981,12 +989,23 @@ class QsCarCard extends QsCardBase {
           // Override soc for display
           soc = Math.max(0, Math.min(100, socPct));
       } else {
+          // QS-281 — normal percent path: prefer the live best-estimated SOC
+          // (both while charging AND idle) whenever it is numeric, so the slow
+          // car API no longer makes the gauge look stuck. Fall back to the raw
+          // `rawSoc` when the best-estimate entity is unavailable.
+          const bestSocNumeric = isNumberLike(sBestSoc?.state);
+          const bestSocVal = bestSocNumeric ? this._percent(sBestSoc.state) : rawSoc;
+          soc = bestSocVal;
+          // The asterisk marks a live extrapolation running ahead of the API:
+          // shown iff the integer part of the estimate differs from the raw
+          // value (mirroring the per-cycle re-anchor's integer compare). It is
+          // purely visual and must not stack with QS-243's `hasSocEstimate`
+          // asterisk — at most a single `*` is ever shown.
+          const showEstimateStar = bestSocNumeric && Math.trunc(bestSocVal) !== Math.trunc(rawSoc);
           targetPct = parseTargetPercent(target);
           maxCircleValue = 100;
           displayTargetValue = `${this._fmt(targetPct ?? soc)}%`;
-          // QS-243 — append an asterisk when the SOC is estimated rather
-          // than read live from the car's sensor.
-          displaySocValue = `${this._fmt(soc)}%${hasSocEstimate ? '*' : ''}`;
+          displaySocValue = `${this._fmt(soc)}%${(hasSocEstimate || showEstimateStar) ? '*' : ''}`;
       }
 
       // QS-199 review-fix #02 S2 — use the inherited hardened

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -998,6 +998,11 @@ class QsCarCard extends QsCardBase {
           // best-estimate never poisons the displayed value.
           const bestSocNumeric = isNumberLike(sBestSoc?.state);
           const bestSocCandidate = bestSocNumeric ? this._percent(sBestSoc.state) : rawSoc;
+          // `_percent` already maps NaN→0 and clamps to [0,100], so the
+          // `Number.isFinite` guard is belt-and-suspenders today (it cannot
+          // currently fire when `bestSocNumeric` is true); it is kept so a
+          // future `_percent` change that could yield a non-finite value still
+          // falls back to `rawSoc` rather than poisoning the display.
           const bestSocUsable = bestSocNumeric && Number.isFinite(bestSocCandidate);
           const bestSocVal = bestSocUsable ? bestSocCandidate : rawSoc;
           soc = bestSocVal;

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -1005,9 +1005,14 @@ class QsCarCard extends QsCardBase {
           // shown iff the estimate and the raw value differ once rounded the
           // SAME way the gauge displays them (`_fmt` = `Math.round`), so a value
           // like 45.6 that displays as 46 is correctly flagged against a raw 45.
+          // Gated on a genuinely numeric raw state (fix-plan #02 #04): an
+          // unavailable/non-numeric raw coerces to `rawSoc=0` via `_percent`,
+          // which would otherwise light a misleading `*` on a transient SOC
+          // dropout even though the API is merely unavailable, not lagging.
           // Purely visual; must not stack with QS-243's `hasSocEstimate`
           // asterisk — at most a single `*` is ever shown.
-          const showEstimateStar = bestSocUsable && Math.round(bestSocVal) !== Math.round(rawSoc);
+          const rawSocNumeric = isNumberLike(sSoc?.state);
+          const showEstimateStar = bestSocUsable && rawSocNumeric && Math.round(bestSocVal) !== Math.round(rawSoc);
           targetPct = parseTargetPercent(target);
           maxCircleValue = 100;
           displayTargetValue = `${this._fmt(targetPct ?? soc)}%`;

--- a/custom_components/quiet_solar/ui/resources/qs-car-card.js
+++ b/custom_components/quiet_solar/ui/resources/qs-car-card.js
@@ -992,16 +992,22 @@ class QsCarCard extends QsCardBase {
           // QS-281 — normal percent path: prefer the live best-estimated SOC
           // (both while charging AND idle) whenever it is numeric, so the slow
           // car API no longer makes the gauge look stuck. Fall back to the raw
-          // `rawSoc` when the best-estimate entity is unavailable.
+          // `rawSoc` when the best-estimate entity is unavailable — OR when it
+          // is "numeric" per `isNumberLike` yet `_percent` yields a non-finite
+          // value (the two helpers can disagree on range/format), so a bad
+          // best-estimate never poisons the displayed value.
           const bestSocNumeric = isNumberLike(sBestSoc?.state);
-          const bestSocVal = bestSocNumeric ? this._percent(sBestSoc.state) : rawSoc;
+          const bestSocCandidate = bestSocNumeric ? this._percent(sBestSoc.state) : rawSoc;
+          const bestSocUsable = bestSocNumeric && Number.isFinite(bestSocCandidate);
+          const bestSocVal = bestSocUsable ? bestSocCandidate : rawSoc;
           soc = bestSocVal;
           // The asterisk marks a live extrapolation running ahead of the API:
-          // shown iff the integer part of the estimate differs from the raw
-          // value (mirroring the per-cycle re-anchor's integer compare). It is
-          // purely visual and must not stack with QS-243's `hasSocEstimate`
+          // shown iff the estimate and the raw value differ once rounded the
+          // SAME way the gauge displays them (`_fmt` = `Math.round`), so a value
+          // like 45.6 that displays as 46 is correctly flagged against a raw 45.
+          // Purely visual; must not stack with QS-243's `hasSocEstimate`
           // asterisk — at most a single `*` is ever shown.
-          const showEstimateStar = bestSocNumeric && Math.trunc(bestSocVal) !== Math.trunc(rawSoc);
+          const showEstimateStar = bestSocUsable && Math.round(bestSocVal) !== Math.round(rawSoc);
           targetPct = parseTargetPercent(target);
           maxCircleValue = 100;
           displayTargetValue = `${this._fmt(targetPct ?? soc)}%`;

--- a/docs/agents/concepts/car-soc-estimation.md
+++ b/docs/agents/concepts/car-soc-estimation.md
@@ -66,10 +66,14 @@ runtime reset (plug-in / reset button / recovery) is reflected in the card.
   base (pure-delta `+XX%`).
 - `get_best_estimated_car_charge_percent(time=None)` (QS-281) — a **pure read**
   for display: while estimating → `_estimated_soc_percent` (parity with
-  `get_car_charge_percent`); else when a system base exists →
-  `_estimated_soc_percent` (reusing the canonical clamp — a computed-on-read
-  property, so a re-anchor that zeroes the delta is reflected immediately, no
-  stale one-cycle value); else the raw sensor read with the default tolerance
+  `get_car_charge_percent`, raw distrusted so no clamp to it); else when a
+  system base exists → `_estimated_soc_percent` (the canonical clamp — a
+  computed-on-read property, so a re-anchor that zeroes the delta is reflected
+  immediately) **clamped `>= the live raw`** so the estimate is never displayed
+  *below* a genuine sub-integer API increase the integer re-anchor de-bounce
+  swallowed (`base 45.0` vs `raw 45.9` → returns `45.9`); else the raw sensor,
+  **sanitized through `_finite_soc_or_none`** so a `str`/`nan`/`inf` live read
+  never reaches the BATTERY/MEASUREMENT sensor. Read with the default tolerance
   (`None`), identical to the canonical `get_car_charge_percent()` value_fn.
   No "actively charging" check — the delta only grows in the charger callback,
   so `base + delta` self-holds when idle until a genuinely different raw value

--- a/docs/agents/concepts/car-soc-estimation.md
+++ b/docs/agents/concepts/car-soc-estimation.md
@@ -201,16 +201,20 @@ sensor reports unplugged) while the SOC sensor is live:
 `_capture_last_valid_base_soc(time)` runs **once per cycle** from
 `update_states` (beside `_update_soc_estimation`), independent of stale state.
 It anchors `_last_valid_base_soc_value` to the last known good raw value; on a
-genuinely *different* raw value — detected by an **integer** compare
-(`int(raw) != int(base)`, mirroring the card's `Math.trunc` so a same-integer
-heartbeat does NOT re-anchor and float noise can't cause a spurious reset) — it
-resets the delta to `0.0` and re-anchors the cursor, so the estimate snaps back
-to the truth the API just reported. It is a **no-op when raw is `None`** and is
-**skipped entirely when a manual override is active** (`_user_base_soc_value is
-not None`) — that override owns its delta lifecycle via `_update_soc_estimation`,
-so the re-anchor must not zero it. A genuine API change is trusted and may move
-the displayed value up **or** down; the only invariant is that it never
-decreases due to accumulation alone between real API updates.
+raw value that differs at the **integer** level (`int(raw) != int(base)`,
+mirroring the card's `Math.trunc` so a same-integer heartbeat does NOT
+re-anchor; sub-integer jitter is absorbed but a value oscillating across an
+integer boundary still re-anchors on each flip — a coarse de-bounce, not full
+hysteresis) — it resets the delta to `0.0` and re-anchors the cursor, so the
+estimate snaps back to the truth the API just reported. It is a **no-op when
+raw is `None`, non-numeric, or non-finite** (`nan`/`inf`: `int()` would raise
+and crash the per-cycle `update_states`, so they are skipped like a `None`
+read) and is **skipped entirely when a manual override is active**
+(`_user_base_soc_value is not None`) — that override owns its delta lifecycle
+via `_update_soc_estimation`, so the re-anchor must not zero it. A genuine API
+change is trusted and may move the displayed value up **or** down; the only
+invariant is that it never decreases due to accumulation alone between real API
+updates.
 
 `_enter_stale_percent_mode` now only flips the mode flag — it no longer
 captures the base (the re-anchor maintains it every cycle).

--- a/docs/agents/concepts/car-soc-estimation.md
+++ b/docs/agents/concepts/car-soc-estimation.md
@@ -64,7 +64,10 @@ runtime reset (plug-in / reset button / recovery) is reflected in the card.
 - `get_best_estimated_car_charge_percent(time=None)` (QS-281) — a **pure read**
   for display: while estimating → `_estimated_soc_percent` (parity with
   `get_car_charge_percent`); else when a system base exists →
-  `_estimated_soc_percent` (reusing the canonical clamp); else the raw sensor.
+  `_estimated_soc_percent` (reusing the canonical clamp — a computed-on-read
+  property, so a re-anchor that zeroes the delta is reflected immediately, no
+  stale one-cycle value); else the raw sensor read with the default tolerance
+  (`None`), identical to the canonical `get_car_charge_percent()` value_fn.
   No "actively charging" check — the delta only grows in the charger callback,
   so `base + delta` self-holds when idle until a genuinely different raw value
   re-anchors it. `time=None` resolves to now; stays synchronous (sensor

--- a/docs/agents/concepts/car-soc-estimation.md
+++ b/docs/agents/concepts/car-soc-estimation.md
@@ -38,7 +38,10 @@ the car card — the solver/constraint path is untouched.
 - `_user_base_soc_value` — manually-entered baseline.
 - `_last_valid_base_soc_value` — the **last known good raw value** (QS-281),
   independent of stale state. Maintained **every cycle** by the re-anchor
-  (`_capture_last_valid_base_soc`), not just at the fresh→stale edge.
+  (`_capture_last_valid_base_soc`), not just at the fresh→stale edge. On load
+  the persisted numeric SOC fields are sanitized through `_finite_soc_or_none`
+  (coerce a legacy/corrupt `str`/`nan`/`inf` → `None`), so the QS-281 healthy-
+  path accessor that reads the base directly can never crash or emit `nan`.
 - `_computed_added_delta_soc_percent` — accumulated, efficiency-aware
   percent added during the current plugged session (a **float**).
 - `_user_base_soc_entry_sensor_value` — raw sensor value at the instant the

--- a/docs/agents/concepts/car-soc-estimation.md
+++ b/docs/agents/concepts/car-soc-estimation.md
@@ -15,8 +15,16 @@ A car's *effective* SOC is unified behind one accessor,
 `QSCar.get_car_charge_percent`. When the SOC API is **failed**,
 **inaccurate**, or **absent**, the car estimates SOC as `base + charged
 energy since`, where the base is either a **manual entry** or the **last
-valid sensor reading** captured at the fresh→stale edge. A genuine new
-sensor reading always wins and clears the estimate.
+known good raw value**. A genuine new sensor reading always wins and
+re-anchors the estimate.
+
+**QS-281 — live best-estimate for slow-but-healthy APIs.** Renault / VW /
+Tesla SOC APIs lag during a charge, so the raw reading looks stuck. The
+**display-only** accessor `get_best_estimated_car_charge_percent` (a pure
+read) surfaces a live `base + charge added` estimate **even on a healthy
+API** and re-anchors whenever the API finally delivers a genuinely different
+value. It feeds a dedicated sensor (`car_best_estimated_soc_percentage`) and
+the car card — the solver/constraint path is untouched.
 
 ## When you need this concept
 
@@ -28,8 +36,9 @@ sensor reading always wins and clears the estimate.
 ## State model (persisted on `QSCar`)
 
 - `_user_base_soc_value` — manually-entered baseline.
-- `_last_valid_base_soc_value` — last valid real sensor value, captured at
-  the fresh→stale transition (only when no user base exists).
+- `_last_valid_base_soc_value` — the **last known good raw value** (QS-281),
+  independent of stale state. Maintained **every cycle** by the re-anchor
+  (`_capture_last_valid_base_soc`), not just at the fresh→stale edge.
 - `_computed_added_delta_soc_percent` — accumulated, efficiency-aware
   percent added during the current plugged session (a **float**).
 - `_user_base_soc_entry_sensor_value` — raw sensor value at the instant the
@@ -52,6 +61,14 @@ runtime reset (plug-in / reset button / recovery) is reflected in the card.
   learning and the charge callback use this so they never see the estimate.
 - `_estimated_soc_percent` — `clamp(base + delta, 0, 100)`, or `None` with no
   base (pure-delta `+XX%`).
+- `get_best_estimated_car_charge_percent(time=None)` (QS-281) — a **pure read**
+  for display: while estimating → `_estimated_soc_percent` (parity with
+  `get_car_charge_percent`); else when a system base exists →
+  `_estimated_soc_percent` (reusing the canonical clamp); else the raw sensor.
+  No "actively charging" check — the delta only grows in the charger callback,
+  so `base + delta` self-holds when idle until a genuinely different raw value
+  re-anchors it. `time=None` resolves to now; stays synchronous (sensor
+  `value_fn`).
 - `is_in_soc_estimation_mode` — True for a no-sensor car, in stale-percent
   mode, or with a manual base on a healthy API. **Drives the `*` /
   `is_soc_estimated` binary sensor**: the asterisk means "the SOC number is
@@ -75,6 +92,14 @@ first cycle (or post-reboot / post-base-set) only **anchors** the cursor. The
 charger computes `inc` from `soc_integration_cursor` then calls
 `accumulate_soc_delta(inc, time)`.
 
+**QS-281** hoisted this `accumulate_soc_delta` call to **exactly one per
+callback**, out of the `estimating`-only branch, so the accumulator advances
+during a **healthy** charge too (powering the live best-estimate). On the
+non-estimating branch the return is **discarded** — the constraint value stays
+sensor/`delta_added`-driven and byte-identical to before. Because there is one
+unified base + accumulator + cursor and one call site, the healthy↔stale
+mid-charge transition is a non-event (no double-advance).
+
 ## Recovery and orthogonality
 
 - **User-base recovery** (`_update_soc_estimation`, per cycle) is a 4-case
@@ -89,11 +114,16 @@ charger computes `inc` from `soc_integration_cursor` then calls
     when the SOC sensor is time-stale (the user has asserted it is reliable).
   The tolerant compare uses half-away-from-zero rounding (`_round_half_up`), not
   Python's banker's rounding, so an exact `.5` reading is not mis-binned.
-- **System-base recovery**: `_exit_stale_mode` clears the system base. It also
-  clears the accumulator + cursor **only when no user override is active** — an
-  override owns its own accumulator lifecycle, so a transient stale blip must
-  not wipe its accumulated delta. The user base is never cleared by stale-mode
-  exit.
+- **System-base recovery (QS-281)**: the per-cycle re-anchor is now the single
+  delta-reset mechanism. `_exit_stale_mode` clears **only** stale-specific state
+  (`_car_api_stale`, `car_api_stale_percent_mode`, `_car_api_stale_since`,
+  inferred flags) — it no longer touches the base / accumulator / cursor. On a
+  stale→healthy exit the SOC sensor is fresh, so the same-cycle re-anchor snaps
+  the base to the fresh raw and resets the delta only when it genuinely differs
+  (a real charge delta now survives stale-exit unless the API reports a
+  different value). Whether we are in/out of stale mode is read from
+  `car_api_stale_percent_mode` / the override — never inferred from whether a
+  base is set (staleness logic never reads the base).
 - **Manual stale-detection reset** (`reset_car_api_stale_detection`): three
   manual user actions give the live API a fresh chance by calling
   `_exit_stale_mode` and clearing `_was_car_api_stale` (the *detected* state
@@ -166,12 +196,24 @@ sensor reports unplugged) while the SOC sensor is live:
   that override is active — the manual home/plug override never outlives an
   explicit Force-Not-Stale, even for a never-stale car (R3-SF1).
 
-## Capture at the fresh→stale edge
+## Per-cycle re-anchor (QS-281)
 
-`_enter_stale_percent_mode(time)` wraps every stale-percent write site and
-captures the last valid raw SOC into `_last_valid_base_soc_value` (zeroing
-the accumulator) only on a genuine edge and only when no base exists. The
-`for_init` restore path never captures — the persisted value is the truth.
+`_capture_last_valid_base_soc(time)` runs **once per cycle** from
+`update_states` (beside `_update_soc_estimation`), independent of stale state.
+It anchors `_last_valid_base_soc_value` to the last known good raw value; on a
+genuinely *different* raw value — detected by an **integer** compare
+(`int(raw) != int(base)`, mirroring the card's `Math.trunc` so a same-integer
+heartbeat does NOT re-anchor and float noise can't cause a spurious reset) — it
+resets the delta to `0.0` and re-anchors the cursor, so the estimate snaps back
+to the truth the API just reported. It is a **no-op when raw is `None`** and is
+**skipped entirely when a manual override is active** (`_user_base_soc_value is
+not None`) — that override owns its delta lifecycle via `_update_soc_estimation`,
+so the re-anchor must not zero it. A genuine API change is trusted and may move
+the displayed value up **or** down; the only invariant is that it never
+decreases due to accumulation alone between real API updates.
+
+`_enter_stale_percent_mode` now only flips the mode flag — it no longer
+captures the base (the re-anchor maintains it every cycle).
 
 ## Gotchas
 

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -150,7 +150,10 @@ apply_budget_strategy()
 - [car-soc-estimation.md](car-soc-estimation.md) — `constraint_update_value_callback_soc`
   is the **sole writer** of the car's float SOC accumulator (QS-243); while
   the car is estimating it bypasses the raw sensor and seeds the constraint
-  from the effective estimate instead of a forced `0.0`. It drives the
+  from the effective estimate instead of a forced `0.0`. **QS-281** hoisted the
+  `accumulate_soc_delta` call to exactly one per callback so the accumulator
+  advances during a **healthy** charge too (return discarded on the
+  non-estimating branch — the constraint value is byte-identical). It drives the
   accumulator through the car's public `soc_integration_cursor` /
   `accumulate_soc_delta` accessors (no underscore reach-in), and gates the
   zero-power hardware-fault check on `car.is_soc_sensor_distrusted()` (stale /

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -151,9 +151,13 @@ apply_budget_strategy()
   is the **sole writer** of the car's float SOC accumulator (QS-243); while
   the car is estimating it bypasses the raw sensor and seeds the constraint
   from the effective estimate instead of a forced `0.0`. **QS-281** hoisted the
-  `accumulate_soc_delta` call to exactly one per callback so the accumulator
-  advances during a **healthy** charge too (return discarded on the
-  non-estimating branch — the constraint value is byte-identical). It drives the
+  `accumulate_soc_delta` call to exactly one per **percent** callback so the
+  accumulator advances during a **healthy** charge too (return discarded on the
+  non-estimating branch — the constraint value is byte-identical). The hoist is
+  guarded on `is_target_percent`: the energy-mode callback never advances the
+  SOC accumulator, so there is no phantom delta even if the
+  `can_use_charge_percent_constraints()` ⇒ capacity coupling is ever loosened.
+  It drives the
   accumulator through the car's public `soc_integration_cursor` /
   `accumulate_soc_delta` accessors (no underscore reach-in), and gates the
   zero-power hardware-fault check on `car.is_soc_sensor_distrusted()` (stale /

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -899,11 +899,15 @@ energy / not stale-percent mode) the card now reads the `best_soc` entity
 SOC value and the ring fill whenever numeric — **both while charging and
 idle** — so the slow car API no longer makes the gauge look stuck. It falls
 back to the raw SOC (`rawSoc`, captured *before* any reassignment) when
-`best_soc` is non-numeric. A purely **visual** `*` is appended iff the integer
-part of the estimate differs from the raw value
-(`Math.trunc(bestSocVal) !== Math.trunc(rawSoc)`) — it is OR-combined with the
-QS-243 `hasSocEstimate` asterisk so at most one `*` shows, and it does **not**
-touch `is_soc_estimated` or the degraded-box logic.
+`best_soc` is non-numeric **or** numeric-but-non-finite (the `isNumberLike` /
+`_percent` helpers can disagree, so a bad estimate never poisons the display).
+A purely **visual** `*` is appended iff the estimate and the raw value differ
+once rounded the **same way the gauge displays them** —
+`Math.round(bestSocVal) !== Math.round(rawSoc)`, matching `_fmt`'s `Math.round`
+so a `45.6`→`46` estimate is correctly flagged against a raw `45` (an earlier
+`Math.trunc` gate mismatched the displayed rounding). It is OR-combined with
+the QS-243 `hasSocEstimate` asterisk so at most one `*` shows, and it does
+**not** touch `is_soc_estimated` or the degraded-box logic.
 
 **Degraded state CSS filter.** When `degraded === true` (computed
 as `isDisconnected || isFaulted || isStale` — `isOffGrid` is

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -893,6 +893,18 @@ SOC number is clickable → a popup with an integer 0–100 input and **Save**
 `manual_soc`, and `reset_soc` into the card. See
 [car-soc-estimation.md](car-soc-estimation.md) for the backing model.
 
+**Live best-estimated SOC (QS-281).** On the **normal percent path** (not
+energy / not stale-percent mode) the card now reads the `best_soc` entity
+(sensor `car_best_estimated_soc_percentage`) and uses it for both the displayed
+SOC value and the ring fill whenever numeric — **both while charging and
+idle** — so the slow car API no longer makes the gauge look stuck. It falls
+back to the raw SOC (`rawSoc`, captured *before* any reassignment) when
+`best_soc` is non-numeric. A purely **visual** `*` is appended iff the integer
+part of the estimate differs from the raw value
+(`Math.trunc(bestSocVal) !== Math.trunc(rawSoc)`) — it is OR-combined with the
+QS-243 `hasSocEstimate` asterisk so at most one `*` shows, and it does **not**
+touch `is_soc_estimated` or the degraded-box logic.
+
 **Degraded state CSS filter.** When `degraded === true` (computed
 as `isDisconnected || isFaulted || isStale` — `isOffGrid` is
 explicitly excluded; the card-level pinkish `.off-grid` CSS class

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -905,9 +905,13 @@ A purely **visual** `*` is appended iff the estimate and the raw value differ
 once rounded the **same way the gauge displays them** —
 `Math.round(bestSocVal) !== Math.round(rawSoc)`, matching `_fmt`'s `Math.round`
 so a `45.6`→`46` estimate is correctly flagged against a raw `45` (an earlier
-`Math.trunc` gate mismatched the displayed rounding). It is OR-combined with
-the QS-243 `hasSocEstimate` asterisk so at most one `*` shows, and it does
-**not** touch `is_soc_estimated` or the degraded-box logic.
+`Math.trunc` gate mismatched the displayed rounding). It is additionally gated
+on a genuinely numeric raw state (`rawSocNumeric = isNumberLike(sSoc?.state)`):
+an unavailable raw coerces to `rawSoc=0` via `_percent`, which would otherwise
+light a misleading `*` on a transient SOC-sensor dropout even though the API is
+merely unavailable, not lagging. It is OR-combined with the QS-243
+`hasSocEstimate` asterisk so at most one `*` shows, and it does **not** touch
+`is_soc_estimated` or the degraded-box logic.
 
 **Degraded state CSS filter.** When `degraded === true` (computed
 as `isDisconnected || isFaulted || isStale` — `isOffGrid` is

--- a/docs/agents/concepts/dashboard-and-cards.md
+++ b/docs/agents/concepts/dashboard-and-cards.md
@@ -899,8 +899,10 @@ energy / not stale-percent mode) the card now reads the `best_soc` entity
 SOC value and the ring fill whenever numeric — **both while charging and
 idle** — so the slow car API no longer makes the gauge look stuck. It falls
 back to the raw SOC (`rawSoc`, captured *before* any reassignment) when
-`best_soc` is non-numeric **or** numeric-but-non-finite (the `isNumberLike` /
-`_percent` helpers can disagree, so a bad estimate never poisons the display).
+`best_soc` is non-numeric **or** numeric-but-non-finite — the latter is a
+belt-and-suspenders guard, since `_percent` already maps `NaN`→`0` and clamps
+to `[0,100]`, kept only to survive a future `_percent` change. The j2 reads the
+sensor into a dedicated `best_e` lookup variable (not the reused `e`).
 A purely **visual** `*` is appended iff the estimate and the raw value differ
 once rounded the **same way the gauge displays them** —
 `Math.round(bestSocVal) !== Math.round(rawSoc)`, matching `_fmt`'s `Math.round`

--- a/docs/stories/QS-281.story.md
+++ b/docs/stories/QS-281.story.md
@@ -1,0 +1,549 @@
+# QS-281 — Live estimated SOC while charging (slow car APIs)
+
+- Issue: #281
+- Branch: QS_281
+- Persona: Magali (household member / non-technical)
+
+## Problem
+
+The SOC (state-of-charge) APIs of Renault, Volkswagen and even Tesla are
+**slow**: during an active charge the value on the car card lags well
+behind reality, so the charging progress looks stuck / inaccurate.
+
+Quiet Solar already has a full estimated-SOC model (QS-243): a car's
+*effective* SOC is `base + accumulated charge delta`, surfaced through
+`QSCar.get_car_charge_percent()`. **But** that estimate is only used when
+`is_in_soc_estimation_mode()` is true — i.e. only when the SOC API is
+considered **broken**: no SOC sensor, stale-percent mode
+(`car_api_stale_percent_mode`), or a manual user override.
+
+The **healthy-but-slow** case is exactly the gap: the API is *not* stale
+(it will eventually return the right value), so no estimate is produced
+and the card shows the lagging raw reading. The accumulator
+(`_computed_added_delta_soc_percent`) is advanced by the charger callback
+**only on the `estimating` branch**, so during a healthy charge no live
+delta is tracked for display.
+
+## Goal
+
+While the car is **actively charging**, display a **live estimated current
+SOC** (`latest raw reading + charge added since that reading`) that
+re-anchors whenever the slow API finally delivers a fresh raw value — so
+progress looks live and never double-counts nor jumps backward.
+
+This is a **display-only** improvement surfaced through a **new dedicated
+sensor**. It must not change the solver / constraint SOC path.
+
+## Design
+
+### Key decisions (agreed in discussion)
+
+- **(B) Reuse the existing accumulator**, not a parallel one. The
+  `_computed_added_delta_soc_percent` / `accumulate_soc_delta()` machinery
+  was *designed* to track charge added and re-anchor on real raw SOC
+  changes — we complete that design rather than bolt on a second
+  integrator.
+- **New dedicated sensor**, not a flip of `is_soc_estimated`. Flipping
+  `is_soc_estimated` during a healthy charge would be semantically wrong
+  (the flag means "the SOC is extrapolated because the API is
+  distrusted/overridden") and would add the `*` asterisk to a normal
+  charge. A new sensor keeps that meaning clean. (Note: `is_soc_estimated`
+  drives **only** the asterisk — the grey "degraded" box is driven by
+  `car_is_stale`/disconnected/faulted, line 1215 of `qs-car-card.js`, and
+  is unaffected either way.)
+- **Display-only.** The solver/constraint path
+  (`get_car_charge_percent_raw_sensor` + the constraint's own
+  `delta_added`) is untouched. The card uses the new sensor on the normal
+  percent path whenever its value is numeric — **both charging and idle** —
+  falling back to `car_soc_percentage` otherwise (see AC5 and the
+  idle-semantics note below).
+
+### Accumulator: one unified "last known good raw value" anchor
+
+The core refactor (agreed in review triage): `_last_valid_base_soc_value`
+becomes **the last known good raw SOC value, full stop** — independent of
+stale state. Its real purpose is the **re-anchor**: when the raw sensor
+reports a genuinely *different* value, reset the accumulated delta so the
+estimate snaps back to the truth the API just reported. There is **one**
+base, **one** accumulator (`_computed_added_delta_soc_percent`), and **one**
+integration cursor (`_delta_soc_last_integration_time`), used identically
+whether the car is in stale-percent mode or charging on a healthy API. We
+deliberately do **not** add a second `_charging_base_soc_value` field — that
+would be misleading; the existing field already *is* this concept.
+
+Decoupling from stale mode (the conflation that was the real bug):
+
+- **`_exit_stale_mode` must stop clearing `_last_valid_base_soc_value`**
+  (car.py:884). The "last known good raw value" is not stale-specific, so
+  exiting stale mode only clears genuinely stale-specific state
+  (`_car_api_stale`, `car_api_stale_percent_mode`, `_car_api_stale_since`,
+  inferred flags). Whether we are in/out of stale mode is read from
+  `car_api_stale_percent_mode` / the override — never inferred from whether
+  a base happens to be set.
+
+Re-anchor rule (replaces the single fresh→stale-edge capture):
+
+- The base is refreshed to the latest raw reading **whenever the raw value
+  genuinely changes** — detected by an **integer** comparison of the current
+  raw value against `_last_valid_base_soc_value` (`int(raw) != int(base)`,
+  mirroring the card's `Math.trunc` so a same-integer heartbeat does NOT
+  re-anchor and float noise can't cause spurious resets). On a genuine
+  change: set `_last_valid_base_soc_value` ← new raw,
+  `_computed_added_delta_soc_percent` ← `0.0`, integration cursor ←
+  re-anchored. The raw value comes from
+  `get_sensor_latest_possible_valid_time_value_attr(...)` (device.py:815,
+  returns `(last_time, value, attr)`).
+- **No-op when the raw value is `None`** (no reading yet / no-sensor car):
+  do not set the base to `None`, do not reset the delta.
+- **Guard: the per-cycle re-anchor runs only when `_user_base_soc_value is
+  None`** — see the manual-override edge case in the drill-down below. When
+  a manual override is active the delta belongs to that override and its
+  reset is owned by `_update_soc_estimation`; the re-anchor must not touch
+  it.
+- A genuine API change is trusted: the displayed value may move **up or
+  down** with it (e.g. estimate ran ahead to 47%, API updates to 45% →
+  display follows to 45%). The only invariant is that the value never
+  decreases **due to accumulation alone** between real API updates.
+- `_capture_last_valid_base_soc` (car.py:1682) is refactored into this
+  general "anchor to the last known good raw value, reset delta on a real
+  change" updater (it now has **one** purpose, no longer the dual-purpose
+  fresh→stale-edge-only capture R1 warned about). The early-return guard
+  (`base already set → return`) is removed; the value-change comparison
+  replaces it.
+
+Accumulation during any charge:
+
+- **Exactly one `accumulate_soc_delta(inc, time)` call per callback**, hoisted
+  out of the `estimating`-only branch so it runs whenever the callback
+  reaches the active path (plugged + command active — `charger.py`:4690 already
+  early-returns otherwise; no new "is charging" predicate is needed, and
+  `inc≈0` when no energy flows). `inc` is computed from the **unified cursor**
+  exactly as the estimating branch does today
+  (`cursor = self.car.soc_integration_cursor`;
+  `inc = None if cursor is None else self._compute_added_charge_update(start_time=cursor, end_time=time, is_target_percent=True)`),
+  so it stays **percent** (the `is_target_percent=True` path of
+  `_compute_added_charge_update` returns percent via `car_battery_capacity`;
+  a `None`/0 capacity yields `inc=None` → no growth). Because there is now one
+  unified base+accumulator+cursor and one call site, the healthy↔stale
+  mid-charge transition is a non-event — no two-cursor arbitration, no
+  double-advance (resolves the R2 hazard).
+- **Constraint value is unchanged (AC4).** The non-estimating branch keeps
+  computing `delta_added` from `ct.last_value_change_update` and returns
+  `ct.current_value + int(delta_added)` (`charger.py`:4727) — unchanged. The
+  hoisted `accumulate_soc_delta` call's **return value is discarded** on the
+  non-estimating branch and it does **not** read `_computed_added_delta_soc_percent`.
+  The named regression test asserts the returned tuple equals a pre-change
+  baseline **and** that `_computed_added_delta_soc_percent` advanced (proving
+  the call ran).
+- Reset lifecycle (`reset_soc_estimate`, unplug edge, genuine plug-in)
+  clears the base + accumulator + cursor as today, so a new plug-in starts
+  clean and the persisted base survives a reboot re-attach (the fields are
+  already in `_serialize`/`_load`, car.py:320-321 / 334-335).
+
+### Refactor impact: redefining `_last_valid_base_soc_value` (drill-down)
+
+Because this redefines a QS-243 field, here is the full reference audit and
+the edge-case analysis (the field's *only* references are car.py:259 init,
+321 serialize, 335 load, 884 `_exit_stale_mode` clear, 1569-1570
+`_estimated_soc_percent`, 1684/1688 `_capture_last_valid_base_soc`, 1736
+`reset_soc_estimate`):
+
+- **Staleness never reads the base — the key clearance.** Every staleness
+  decision (`_is_soc_sensor_stale`:615, `is_car_api_stale`:691,
+  `is_car_effectively_stale`:715, `_update_car_api_staleness`:727,
+  `can_exit_stale_percent_mode`:1037) is computed from **sensor timestamps
+  and the stale flags** (`_car_api_stale`, `car_api_stale_percent_mode`,
+  `_was_car_api_stale`, `car_stale_mode_override`) — **never** from
+  `_last_valid_base_soc_value`. So redefining the base as "last known good
+  raw value" cannot affect stale detection/exit. *Nothing else needs to take
+  over a staleness role, because the base never had one.*
+- **Stale-mode estimate is preserved.** In stale-percent mode the SOC sensor
+  is by definition not producing fresh values, so the per-cycle re-anchor
+  reads the same last value and the integer compare is equal → it is
+  **dormant**; the base stays frozen exactly as the old fresh→stale-edge
+  capture left it. The estimate (`base + delta`) used by the solver-facing
+  `get_car_charge_percent` in stale mode is therefore unchanged.
+- **NEW edge case — manual override must not be stomped.** When
+  `_user_base_soc_value` is set the estimate prefers it (car.py:1567), and
+  its delta lifecycle is owned by `_update_soc_estimation`'s 4-case recovery.
+  An *unguarded* per-cycle re-anchor would reset that delta to 0 on a raw
+  change and wrongly zero the override's accumulated charge. **Resolution:**
+  the re-anchor is guarded on `_user_base_soc_value is None` (above), making
+  it the clean "no-override" counterpart to `_update_soc_estimation` (which
+  handles the override case). This also aligns with the accessor: a set user
+  base ⇒ `is_in_soc_estimation_mode` True ⇒ branch 1, so branch 2 only ever
+  reads `_last_valid_base_soc_value` when no override exists.
+- **`_exit_stale_mode` (car.py:884-887).** Remove the base clear **and** the
+  no-override accumulator/cursor clear. The continuous re-anchor is now the
+  single delta-reset mechanism: on stale→healthy exit the SOC sensor is fresh
+  (that is why we exit), so the same-cycle re-anchor snaps the base to the
+  fresh raw and resets the delta when it genuinely differs. The user-override
+  branch was already skipped by the old guard, so its behavior is unchanged.
+  *(This is a deliberate QS-243 behavior change: dropping a real charge delta
+  on stale-exit was arguably wrong; now a delta survives unless the API
+  actually reports a different value.)*
+- **`_enter_stale_percent_mode` (car.py:1701).** Its explicit
+  `_capture_last_valid_base_soc(time)` call becomes redundant (the base is
+  maintained every cycle), so it is removed; the `for_init` restore early
+  return is preserved. A stale-edge test locks the resulting behavior.
+- **No-SOC-sensor / no-reading car.** Raw is `None` → re-anchor no-op → base
+  stays `None` → `_estimated_soc_percent` returns `None` (pure-delta) →
+  unchanged.
+- **Idle vs unplug (N3).** "Idle" means **plugged-but-not-charging**: the
+  battery is not discharging, so holding `base + delta` is correct, and the
+  per-cycle re-anchor (which runs every cycle regardless of plug/charge
+  state) re-converges it on the next genuinely different API reading. On
+  **unplug**, `reset_soc_estimate` clears base+delta, so a driven (and thus
+  discharging) car shows the raw API value — never a stale-high estimate.
+
+### New accessor: best up-to-date SOC, no charging predicate needed
+
+Add `QSCar.get_best_estimated_car_charge_percent(time=None)` — a **pure
+read** returning the freshest SOC:
+
+1. If `is_in_soc_estimation_mode(time)` → the existing estimate
+   (`_estimated_soc_percent`, may be `None` for the pure-delta case) —
+   identical to `get_car_charge_percent` today.
+2. Else if a base exists → `self._estimated_soc_percent`
+   (`clamp(base + delta, 0, 100)`) — **reuse the canonical property**, do not
+   re-implement the clamp. (When no user override, that base is
+   `_last_valid_base_soc_value`.)
+3. Else → the plain raw sensor value
+   (`get_car_charge_percent_raw_sensor`).
+
+**No "actively charging" check is required** and none is added. The delta
+(`_computed_added_delta_soc_percent`) only ever grows while the charger
+callback runs (i.e. only while charging), so when the car is not charging
+`base + delta` simply *holds* the last accurate value (e.g. it stays at 47%
+after a charge ended) until a genuinely different raw API reading
+re-anchors it. Between API updates the value never decreases due to
+accumulation; a real API change is trusted and may move it up or down.
+
+`time=None` resolves to `datetime.now(tz=pytz.UTC)` inside the accessor
+(matching the existing `car_soc_percentage` value_fn); it stays synchronous
+(no await) since a sensor `value_fn` must not block.
+
+**Re-anchor runs once per cycle, not in the accessor.** Re-anchoring
+mutates state (resets the delta), so it must not live in a getter called by
+the sensor `value_fn` — otherwise the result would depend on read
+frequency. The per-cycle re-anchor (compare latest raw vs
+`_last_valid_base_soc_value`; on a genuinely *different* value set base ←
+raw, delta ← 0, cursor re-anchored) lives in `update_states`, next to the
+existing `_update_soc_estimation`. The accessor is a pure read of
+`base + delta`.
+
+### New sensor entity
+
+In `sensor.py` `create_ha_sensor_for_QSCar` (alongside `car_soc_percentage`
+~line 150), gated on `device.can_use_charge_percent_constraints()`:
+
+- `key="car_best_estimated_soc_percentage"` (the j2 `ha.get(...)` lookup key)
+- `translation_key=SENSOR_CAR_BEST_ESTIMATED_SOC_PERCENT` (new const in
+  `const.py`, value `"qs_car_best_estimated_soc_percent"`)
+- `device_class=SensorDeviceClass.BATTERY`, unit `PERCENTAGE`,
+  `state_class=SensorStateClass.MEASUREMENT` (mirroring the sibling
+  `car_soc_percentage`, sensor.py:156, so it records history)
+- `value_fn = lambda device, key: device.get_best_estimated_car_charge_percent()`
+  (same `(device, key)` signature as `car_soc_percentage`, which calls its
+  SOC getter synchronously — no await; the accessor stays synchronous)
+
+Add the matching entry to `strings.json` under
+`entity.sensor.qs_car_best_estimated_soc_percent.name` (mirroring the
+existing `qs_car_soc_percent` entry) with an English name such as
+`"Best estimated SOC"`, then regenerate translations via
+`bash scripts/generate-translations.sh` (never hand-edit `translations/en.json`).
+
+### Card wiring
+
+- `quiet_solar_dashboard_template.yaml.j2` (car card entities ~line 89):
+  add a `best_soc` entity whose lookup uses the **sensor key**
+  `car_best_estimated_soc_percentage` (the precedent `ha.get("car_soc_percentage")`
+  at j2:86 uses the sensor `key`, NOT the translation key). The
+  `quiet_solar_dashboard_template_standard_ha.yaml.j2` variant has **no**
+  qs-car-card (it renders a plain entity row); add the new sensor as a plain
+  entity row there — the ring/asterisk substitution does not apply.
+- `qs-car-card.js` `_render` (~line 818/846): read
+  `const sBestSoc = this._entity(e.best_soc);`. **Capture the raw value first
+  in a separate variable** — `const rawSoc = this._percent(sSoc?.state);` —
+  *before* any reassignment, because the asterisk compares against it
+  (N2: if `soc` is overwritten with `best_soc`, `Math.trunc(best_soc) !==
+  Math.trunc(soc)` is always false). Then, on the **normal percent path**
+  (not energy mode, not stale-percent mode), when
+  `isNumberLike(sBestSoc?.state)`, set the displayed SOC value and the ring
+  fill from `best_soc` **instead of** `car_soc_percentage` — **both while
+  charging and while idle**. Fall back to `rawSoc` when `best_soc` is
+  non-numeric. The stale-percent and energy-mode branches are unchanged.
+- **Estimate asterisk (requirement).** The card shows an `*` after the
+  displayed SOC **if and only if** the **integer part** of the
+  best-estimated value differs from the raw API value — i.e.
+  `Math.trunc(bestSocVal) !== Math.trunc(rawSoc)`, using the `rawSoc`
+  captured above (the `car_soc_percentage` value) — **not** the possibly-
+  reassigned display variable. No charging gate is needed: by construction the integer parts
+  differ only when the estimate is running ahead of the API (during/just
+  after a charge), and they re-converge once the slow API catches up. The
+  estimate is a **float** and the raw API value is effectively an **int**;
+  `Math.trunc` on both sides means a fractional raw value (if one ever
+  occurs) is compared on its integer part too. This is a **purely visual**
+  asterisk so Magali knows the number is a live extrapolation ahead of the
+  last API report. It must NOT touch the `is_soc_estimated` binary sensor,
+  must NOT change the degraded-box logic, and must coexist with (not double
+  up on) the existing `hasSocEstimate` asterisk — at most a single `*` is
+  shown.
+
+## Acceptance criteria
+
+1. A new sensor `car_best_estimated_soc_percentage` exists for cars that
+   `can_use_charge_percent_constraints()`, with battery device class and
+   `%` unit, value from `get_best_estimated_car_charge_percent()`.
+2. `get_best_estimated_car_charge_percent()` is a **pure read** (no state
+   mutation):
+   - returns the existing estimate when `is_in_soc_estimation_mode()` is
+     true (parity with `get_car_charge_percent`);
+   - else, when a base exists, returns `self._estimated_soc_percent`
+     (canonical `clamp(base + delta, 0, 100)`) — no charging predicate, no
+     re-implemented clamp;
+   - else returns the raw sensor value;
+   - returns `None` only where the underlying raw/estimate is `None`
+     (pure-delta / no-reading), and the card then falls back to
+     `car_soc_percentage`.
+3. The per-cycle re-anchor (in `update_states`) advances/holds the
+   accumulator and **re-anchors only on a genuinely *different* raw SOC
+   value** (a new `last_time` carrying the same value is a heartbeat and
+   must NOT reset the delta). The delta grows only while charging (sole
+   writer = charger callback), so when idle `base + delta` holds the last
+   accurate value until a real API change re-anchors it. Between real API
+   updates the value never decreases due to accumulation; a genuine API
+   change is trusted and may move the value up **or down**. No
+   double-counting after the slow API catches up. The re-anchor is a
+   **no-op when raw is `None`** and **runs only when `_user_base_soc_value
+   is None`** (it must not stomp a manual override's delta — see drill-down).
+3a. `_last_valid_base_soc_value` is the single "last known good raw value"
+   anchor, independent of stale state: `_exit_stale_mode` no longer clears
+   the base or the accumulator, and in/out-of-stale is read from
+   `car_api_stale_percent_mode` / override, never inferred from whether a
+   base is set. Staleness logic never reads the base (verified in the
+   drill-down), so stale detection/exit is unaffected; stale-mode estimate
+   is preserved (re-anchor is dormant when the sensor isn't fresh). The
+   `_enter_stale_percent_mode` explicit-capture call is removed (base is
+   maintained every cycle). Existing QS-243 stale/manual estimation tests
+   stay green or are deliberately updated for the documented behavior change
+   (a real charge delta now survives stale-exit unless the API reports a
+   different value).
+4. The solver/constraint SOC path is unchanged: the value returned to the
+   constraint from `constraint_update_value_callback_soc` on the
+   non-estimating branch is identical to before this change; estimation
+   mode (stale / no-sensor / manual) behaves exactly as in QS-243.
+5. On the normal percent path (not energy / not stale-percent), the car
+   card displays the new best-estimated SOC **whenever it is numeric**
+   (both charging and idle — *scope deliberately widened beyond the issue's
+   "only when charging"; see Adversarial Review Notes*), falling back to the
+   captured `rawSoc` when `best_soc` is non-numeric.
+5a. The card shows an `*` after the SOC **if and only if** the **integer
+   part** of the best-estimated value differs from the captured raw value:
+   `Math.trunc(bestSocVal) !== Math.trunc(rawSoc)` (rawSoc captured *before*
+   any reassignment). It is a visual-only marker: the `is_soc_estimated`
+   binary sensor and the degraded-box logic are unchanged, and never more
+   than one `*` is shown (the new asterisk and the existing `hasSocEstimate`
+   asterisk do not stack).
+6. Plug-in / unplug / reset (`reset_soc_estimate`) clears the unified
+   base + accumulator + cursor, so a new session starts clean; the
+   persisted base survives a reboot re-attach (`_serialize`/`_load`).
+7. Coverage: the Python `--impacted`/CI whole-repo gate covers every new
+   accessor and re-anchor branch — estimation-mode, base+delta (reusing
+   `_estimated_soc_percent`), no-base→raw, clamp@100, raw `None`→`None`,
+   heartbeat (same-int) no-re-anchor, genuine-change up, genuine-change
+   down, re-anchor no-op on `None` raw, the manual-override guard skip, and
+   `_exit_stale_mode`'s remaining stale-flag clears. The `qs-car-card.js`
+   asterisk/substitution branches are **not** measured by Python coverage;
+   the `tests/test_dashboard_rendering.py` render test is their backstop.
+
+## Task breakdown
+
+1. **const.py** — add `SENSOR_CAR_BEST_ESTIMATED_SOC_PERCENT =
+   "qs_car_best_estimated_soc_percent"`. (No charging-threshold constant —
+   the accessor needs no charging predicate.)
+2. **ha_model/car.py** —
+   - add `get_best_estimated_car_charge_percent(time=None)` as a **pure
+     read** (estimation-mode → `_estimated_soc_percent`; else base exists →
+     `_estimated_soc_percent`; else raw; resolves `time=None` to now;
+     synchronous; no charging check, no mutation);
+   - refactor `_capture_last_valid_base_soc` into the unified per-cycle
+     re-anchor: remove the base-already-set early return; integer-compare the
+     latest raw vs `_last_valid_base_soc_value`; **no-op on `None` raw**;
+     **skip entirely when `_user_base_soc_value is not None`** (manual
+     override owns its delta via `_update_soc_estimation`); on a genuine
+     change set base←raw, delta←0, cursor re-anchored. Call it once per cycle
+     from `update_states` (beside `_update_soc_estimation`), regardless of
+     plug/charge state;
+   - **`_exit_stale_mode` (car.py:884-887): remove the base clear AND the
+     no-override accumulator/cursor clear** — clear only stale-specific state
+     (`_car_api_stale`, `car_api_stale_percent_mode`, `_car_api_stale_since`,
+     inferred flags). The re-anchor is now the single delta-reset mechanism;
+   - **remove the `_capture_last_valid_base_soc(time)` call in
+     `_enter_stale_percent_mode`** (car.py:1701); keep the `for_init` early
+     return;
+   - ensure `reset_soc_estimate` / unplug clears base + accumulator +
+     cursor; confirm the base is in `_serialize`/`_load`.
+3. **ha_model/charger.py** — in `constraint_update_value_callback_soc`,
+   **hoist `accumulate_soc_delta(inc, time)` to exactly one call per
+   callback** (out of the `estimating`-only branch), computing `inc` from the
+   unified cursor exactly as the estimating branch does today
+   (`cursor = self.car.soc_integration_cursor`; `inc = None if cursor is None
+   else self._compute_added_charge_update(start_time=cursor, end_time=time,
+   is_target_percent=True)` — returns **percent**; `None`/0 capacity → `inc=None`).
+   On the non-estimating branch **discard** its return; keep `delta_added`
+   (from `ct.last_value_change_update`) and the constraint return
+   `ct.current_value + int(delta_added)` (charger.py:4727) byte-identical. No
+   new "is charging" predicate — the callback already early-returns when not
+   plugged / command idle.
+4. **sensor.py** — register `car_best_estimated_soc_percentage` with
+   `key="car_best_estimated_soc_percentage"`,
+   `translation_key=SENSOR_CAR_BEST_ESTIMATED_SOC_PERCENT`,
+   `device_class=BATTERY`, unit `PERCENTAGE`,
+   `state_class=SensorStateClass.MEASUREMENT` (mirror sensor.py:151-158).
+5. **strings.json** + `bash scripts/generate-translations.sh` — add
+   `entity.sensor.qs_car_best_estimated_soc_percent.name`; regenerate
+   `translations/en.json`.
+6. **ui/quiet_solar_dashboard_template.yaml.j2** — add the `best_soc`
+   entity using the **sensor key** `car_best_estimated_soc_percentage`. In
+   `quiet_solar_dashboard_template_standard_ha.yaml.j2` (no qs-car-card),
+   add a plain entity row — no ring/asterisk substitution.
+7. **ui/resources/qs-car-card.js** — capture `const rawSoc =
+   this._percent(sSoc?.state)` before any reassignment; on the normal percent
+   path use `best_soc` for the displayed SOC value/ring whenever numeric
+   (charging and idle), falling back to `rawSoc` otherwise; add the
+   visual-only `*` when `Math.trunc(bestSocVal) !== Math.trunc(rawSoc)`
+   (single asterisk, no stacking with `hasSocEstimate`); leave
+   `is_soc_estimated` + degraded logic intact.
+8. **Tests** — domain tests for `get_best_estimated_car_charge_percent`
+   (every AC7 branch: estimation-mode, base+delta via `_estimated_soc_percent`,
+   no-base→raw, clamp@100, raw `None`→`None`); accessor is a pure read (no
+   mutation). Re-anchor tests: genuine-change up, genuine-change **down**,
+   heartbeat (same-int → no reset), **no-op on `None` raw**, **manual-override
+   guard skip** (re-anchor must NOT zero a user-override's delta), idle hold
+   (delta does not grow when not charging), and the **stale→healthy
+   recovery** transition (retained base re-anchors on the first differing
+   healthy reading; equal reading does not). `_exit_stale_mode` no longer
+   wipes base/accumulator; `_enter_stale_percent_mode` no longer captures
+   (stale-edge test). A named charger-callback regression test
+   (`test_callback_constraint_value_unchanged_with_healthy_accumulator`)
+   asserting the returned tuple equals a pre-change baseline **and** that
+   `_computed_added_delta_soc_percent` advanced (proving the single call ran).
+   Sensor registration test; card render test
+   (`tests/test_dashboard_rendering.py`) for best_soc substitution on the
+   normal percent path **and the asterisk** (present when
+   `int(best_soc) != int(rawSoc)`, absent when integer parts equal, never
+   doubled with `hasSocEstimate`). Use factories (`create_test_car_double`,
+   etc.) and `MOCK_CAR_CONFIG`; no MagicMock for domain objects.
+9. **Docs**:
+   - Update `docs/agents/concepts/car-soc-estimation.md` — document the
+     healthy-charge accumulation + re-anchor, the new accessor, and the
+     display-only nature.
+   - Update `docs/agents/concepts/dashboard-and-cards.md` — the car card
+     now uses `best_soc` on the normal percent path (charging and idle) with
+     the integer-diff asterisk.
+   - Update `docs/agents/concepts/charger-budgeting.md` — note the
+     accumulator now advances during a healthy charge in the callback
+     (one-liner; do not rewrite the budgeting narrative).
+   - `Doc-OK: docs/agents/concepts/config-and-setup-flow.md` — only a new
+     sensor translation-key constant is added; no config-flow change.
+   - `Doc-OK: docs/agents/concepts/person-trip-prediction.md` — trip
+     prediction is unrelated to the SOC-display change.
+
+## Open questions / risks
+
+- Re-anchor correctness when raw readings arrive between solver cycles —
+  the unified cursor + the value-change comparison must avoid both gaps and
+  double-counting; covered by AC3 tests.
+- The unified-base refactor changes QS-243 internals; the drill-down
+  (above) cleared the staleness-coupling worry (staleness never reads the
+  base) and found the manual-override guard. Existing stale/manual
+  estimation tests must stay green or be deliberately updated to the unified
+  model (CI whole-repo coverage is the backstop).
+
+## Adversarial Review Notes
+
+### Round 1 (4 global reviewers: critic, concrete-planner, dev-proxy, scope-guardian)
+
+State: `resolved` = folded into the plan; `rejected` = deliberate decision.
+
+- **C1** (heartbeat re-anchor → backward jump) — **resolved**: re-anchor
+  only on a genuinely *different* raw value; same-value heartbeat does not
+  reset. (Design "Re-anchor rule"; AC3; test.)
+- **C2** (never-below-raw invariant unsatisfiable) — **rejected/relaxed**
+  by user: a real API change is trusted and may move the value down. The
+  kept invariant is "no decrease due to accumulation alone." (AC3.)
+- **C3** (base field owned by stale lifecycle) — **resolved**, differently
+  from the reviewer's suggestion: per user, do NOT add a second field;
+  instead `_last_valid_base_soc_value` becomes the single stale-independent
+  "last known good raw value" anchor and `_exit_stale_mode` stops wiping
+  it. (Design; AC3a; tasks 2.)
+- **R1** (don't overload `_capture_last_valid_base_soc`) — **resolved**:
+  refactored to a single-purpose anchor/updater (no dual control flow).
+- **R2** (two-cursor double-count across mode transition) — **resolved**:
+  one unified base+accumulator+cursor makes the healthy↔stale transition a
+  non-event.
+- **dev-proxy (JS edit authorization)** — **resolved**: the story
+  explicitly authorizes the `qs-car-card.js` edit (core to AC5/5a).
+- **I1** (single "actively charging" predicate) — **resolved by removal**
+  (post-review design simplification): the accessor needs **no** charging
+  predicate. The delta only grows while charging (sole writer = charger
+  callback), so `base + delta` self-holds when idle; the card uses
+  `best_soc` in both states. No threshold constant added.
+- **I2** (`None`/pure-delta path) — **resolved**: accessor returns `None`,
+  card falls back; AC2 + test.
+- **I3/I4** (persistence + `inc` units) — **resolved**: base in
+  `_serialize`/`_load`; `inc` documented as percent.
+- **I5** (standard_ha template) — **resolved**: plain entity row only.
+- **I6 + clarifies** (coverage enumeration, harness-sync/full-gate note,
+  j2 sensor-key, `isNumberLike` guard, `strings.json` path, callback
+  insertion + named regression test, `Math.trunc` fractional note) —
+  **resolved** across Design/ACs/tasks.
+- **scope-guardian: drop AC5a asterisk as scope creep** — **rejected**:
+  deliberate product decision, explicitly requested by the user.
+- **scope-guardian: doc scope** — **resolved**: charger-budgeting update
+  kept to a one-liner; two docs marked Doc-OK.
+
+**Post-round-1 design simplification (user-driven):** the accessor became a
+pure read with **no charging predicate** (the delta only grows while
+charging, so `base + delta` self-holds when idle), re-anchor moved to a
+once-per-cycle `update_states` step, and the card now uses `best_soc` on the
+normal percent path **both charging and idle** (asterisk ungated, shown
+whenever `int(best_soc) != int(soc)`). This is a material change to the
+plan since round 1.
+
+### Round 2 (4 global reviewers + delta-auditor)
+
+Delta-auditor: **all 11 round-1 findings verified resolved**, no
+regressions. New findings from the simplification:
+
+- **N1** (leftover "only when charging" contradiction in Design/doc note) —
+  **resolved**: wording updated to "both charging and idle."
+- **N2** (asterisk variable collapse — comparing `best_soc` against a
+  reassigned `soc` is always false) — **resolved**: capture `rawSoc` before
+  reassignment; compare `Math.trunc(bestSocVal) !== Math.trunc(rawSoc)`.
+- **N3** (idle-display hazard) — **resolved**: "idle" = plugged-but-not-
+  charging (battery not discharging → hold is correct); unplug fires
+  `reset_soc_estimate` so a driven/discharging car shows raw. Re-anchor runs
+  every cycle regardless of plug state. (Drill-down + AC3/5.)
+- **N5** (unified-base refactor is "self-imposed", largest blast radius) —
+  **kept by user decision** + **drill-down analysis added**: audited all 8
+  references of `_last_valid_base_soc_value`; **staleness never reads it**
+  (so nothing needs to take over a staleness role — the user's specific
+  worry is cleared); stale-mode estimate preserved (re-anchor dormant when
+  sensor not fresh). Found and fixed a **new edge case**: the re-anchor must
+  be **guarded on `_user_base_soc_value is None`** so it can't zero a manual
+  override's delta.
+- **N4** (charger callback) — **resolved**: exactly one hoisted
+  `accumulate_soc_delta` call using the unified cursor; non-estimating return
+  discarded; constraint return byte-identical; no new charging predicate.
+- **N6–N20** (synchronicity parity, `inc` percent, integer re-anchor compare,
+  `None` no-op, reuse `_estimated_soc_percent`, `_enter_stale_percent_mode`
+  call removed + test, `state_class=MEASUREMENT`, `key`/`translation_key`
+  pinned, standard_ha plain row, AC7 JS-coverage caveat, AC5 widened-scope
+  note, stale→healthy + override-guard tests, regression test asserts return
+  AND accumulator advanced) — **all resolved** across Design/drill-down/ACs/
+  tasks.
+
+No open criticals. `changed-since-last-review` = **false** (round-2 findings
+folded in). Ready to finalize unless further discussion is wanted.

--- a/docs/stories/QS-281.story.md
+++ b/docs/stories/QS-281.story.md
@@ -87,7 +87,11 @@ Re-anchor rule (replaces the single fresh→stale-edge capture):
   genuinely changes** — detected by an **integer** comparison of the current
   raw value against `_last_valid_base_soc_value` (`int(raw) != int(base)`,
   mirroring the card's `Math.trunc` so a same-integer heartbeat does NOT
-  re-anchor and float noise can't cause spurious resets). On a genuine
+  re-anchor and sub-integer jitter is absorbed). The integer compare is a
+  coarse de-bounce, not full hysteresis: a raw oscillating across an integer
+  boundary (e.g. `44.9`↔`45.1`) still re-anchors on each flip. A non-finite
+  raw (`nan`/`inf`) is treated as a no-op, like a `None` read, so `int()`
+  cannot crash the per-cycle `update_states`. On a genuine
   change: set `_last_valid_base_soc_value` ← new raw,
   `_computed_added_delta_soc_percent` ← `0.0`, integration cursor ←
   re-anchored. The raw value comes from

--- a/docs/stories/QS-281.story.md
+++ b/docs/stories/QS-281.story.md
@@ -270,29 +270,33 @@ existing `qs_car_soc_percent` entry) with an English name such as
   `const sBestSoc = this._entity(e.best_soc);`. **Capture the raw value first
   in a separate variable** — `const rawSoc = this._percent(sSoc?.state);` —
   *before* any reassignment, because the asterisk compares against it
-  (N2: if `soc` is overwritten with `best_soc`, `Math.trunc(best_soc) !==
-  Math.trunc(soc)` is always false). Then, on the **normal percent path**
+  (N2: if `soc` is overwritten with `best_soc`, `Math.round(best_soc) !==
+  Math.round(soc)` is always false). Then, on the **normal percent path**
   (not energy mode, not stale-percent mode), when
   `isNumberLike(sBestSoc?.state)`, set the displayed SOC value and the ring
   fill from `best_soc` **instead of** `car_soc_percentage` — **both while
   charging and while idle**. Fall back to `rawSoc` when `best_soc` is
-  non-numeric. The stale-percent and energy-mode branches are unchanged.
+  non-numeric (or numeric-but-non-finite). The stale-percent and energy-mode
+  branches are unchanged.
 - **Estimate asterisk (requirement).** The card shows an `*` after the
-  displayed SOC **if and only if** the **integer part** of the
-  best-estimated value differs from the raw API value — i.e.
-  `Math.trunc(bestSocVal) !== Math.trunc(rawSoc)`, using the `rawSoc`
+  displayed SOC **if and only if** the **displayed (rounded)** best-estimated
+  value differs from the raw API value — i.e.
+  `Math.round(bestSocVal) !== Math.round(rawSoc)`, using the `rawSoc`
   captured above (the `car_soc_percentage` value) — **not** the possibly-
-  reassigned display variable. No charging gate is needed: by construction the integer parts
+  reassigned display variable. (Fix-plan #01 #03: the gate uses `Math.round`,
+  **not** `Math.trunc`, so it matches the value the gauge actually shows —
+  `_fmt` = `Math.round` — and a `45.6`→`46` estimate is correctly flagged
+  against a raw `45`. The gate is also suppressed when `rawSoc` is not a
+  genuinely numeric raw state — fix-plan #02 #04 — so a transient SOC-sensor
+  dropout, which coerces `rawSoc` to `0`, does not light a misleading `*`.)
+  No charging gate is needed: by construction the rounded values
   differ only when the estimate is running ahead of the API (during/just
-  after a charge), and they re-converge once the slow API catches up. The
-  estimate is a **float** and the raw API value is effectively an **int**;
-  `Math.trunc` on both sides means a fractional raw value (if one ever
-  occurs) is compared on its integer part too. This is a **purely visual**
-  asterisk so Magali knows the number is a live extrapolation ahead of the
-  last API report. It must NOT touch the `is_soc_estimated` binary sensor,
-  must NOT change the degraded-box logic, and must coexist with (not double
-  up on) the existing `hasSocEstimate` asterisk — at most a single `*` is
-  shown.
+  after a charge), and they re-converge once the slow API catches up. This is
+  a **purely visual** asterisk so Magali knows the number is a live
+  extrapolation ahead of the last API report. It must NOT touch the
+  `is_soc_estimated` binary sensor, must NOT change the degraded-box logic,
+  and must coexist with (not double up on) the existing `hasSocEstimate`
+  asterisk — at most a single `*` is shown.
 
 ## Acceptance criteria
 
@@ -342,10 +346,14 @@ existing `qs_car_soc_percent` entry) with an English name such as
    (both charging and idle — *scope deliberately widened beyond the issue's
    "only when charging"; see Adversarial Review Notes*), falling back to the
    captured `rawSoc` when `best_soc` is non-numeric.
-5a. The card shows an `*` after the SOC **if and only if** the **integer
-   part** of the best-estimated value differs from the captured raw value:
-   `Math.trunc(bestSocVal) !== Math.trunc(rawSoc)` (rawSoc captured *before*
-   any reassignment). It is a visual-only marker: the `is_soc_estimated`
+5a. The card shows an `*` after the SOC **if and only if** the **displayed
+   (rounded)** best-estimated value differs from the captured raw value:
+   `Math.round(bestSocVal) !== Math.round(rawSoc)` (rawSoc captured *before*
+   any reassignment), and only when `rawSoc` is a genuinely numeric raw state.
+   (Fix-plan #01 #03 aligned the gate on `Math.round` — matching `_fmt`'s
+   displayed rounding rather than `Math.trunc`; fix-plan #02 #04 suppresses it
+   on an unavailable raw so a sensor dropout, coerced to `rawSoc=0`, does not
+   light a spurious `*`.) It is a visual-only marker: the `is_soc_estimated`
    binary sensor and the degraded-box logic are unchanged, and never more
    than one `*` is shown (the new asterisk and the existing `hasSocEstimate`
    asterisk do not stack).
@@ -416,9 +424,11 @@ existing `qs_car_soc_percent` entry) with an English name such as
    this._percent(sSoc?.state)` before any reassignment; on the normal percent
    path use `best_soc` for the displayed SOC value/ring whenever numeric
    (charging and idle), falling back to `rawSoc` otherwise; add the
-   visual-only `*` when `Math.trunc(bestSocVal) !== Math.trunc(rawSoc)`
-   (single asterisk, no stacking with `hasSocEstimate`); leave
-   `is_soc_estimated` + degraded logic intact.
+   visual-only `*` when `Math.round(bestSocVal) !== Math.round(rawSoc)` and the
+   raw state is genuinely numeric (fix-plan #01 #03 + #02 #04: `Math.round`
+   matches `_fmt`'s displayed rounding, and an unavailable raw — coerced to
+   `0` — must not light the `*`); (single asterisk, no stacking with
+   `hasSocEstimate`); leave `is_soc_estimated` + degraded logic intact.
 8. **Tests** — domain tests for `get_best_estimated_car_charge_percent`
    (every AC7 branch: estimation-mode, base+delta via `_estimated_soc_percent`,
    no-base→raw, clamp@100, raw `None`→`None`); accessor is a pure read (no
@@ -436,8 +446,9 @@ existing `qs_car_soc_percent` entry) with an English name such as
    Sensor registration test; card render test
    (`tests/test_dashboard_rendering.py`) for best_soc substitution on the
    normal percent path **and the asterisk** (present when
-   `int(best_soc) != int(rawSoc)`, absent when integer parts equal, never
-   doubled with `hasSocEstimate`). Use factories (`create_test_car_double`,
+   `Math.round(best_soc) != Math.round(rawSoc)`, absent when the rounded
+   values are equal or when the raw state is unavailable, never doubled with
+   `hasSocEstimate`). Use factories (`create_test_car_double`,
    etc.) and `MOCK_CAR_CONFIG`; no MagicMock for domain objects.
 9. **Docs**:
    - Update `docs/agents/concepts/car-soc-estimation.md` — document the
@@ -512,8 +523,9 @@ State: `resolved` = folded into the plan; `rejected` = deliberate decision.
 pure read with **no charging predicate** (the delta only grows while
 charging, so `base + delta` self-holds when idle), re-anchor moved to a
 once-per-cycle `update_states` step, and the card now uses `best_soc` on the
-normal percent path **both charging and idle** (asterisk ungated, shown
-whenever `int(best_soc) != int(soc)`). This is a material change to the
+normal percent path **both charging and idle** (asterisk shown whenever
+`Math.round(best_soc) != Math.round(soc)` and the raw state is numeric — see
+fix-plan #01 #03 / #02 #04). This is a material change to the
 plan since round 1.
 
 ### Round 2 (4 global reviewers + delta-auditor)
@@ -525,7 +537,8 @@ regressions. New findings from the simplification:
   **resolved**: wording updated to "both charging and idle."
 - **N2** (asterisk variable collapse — comparing `best_soc` against a
   reassigned `soc` is always false) — **resolved**: capture `rawSoc` before
-  reassignment; compare `Math.trunc(bestSocVal) !== Math.trunc(rawSoc)`.
+  reassignment; compare `Math.round(bestSocVal) !== Math.round(rawSoc)`
+  (rounding aligned with `_fmt` per fix-plan #01 #03).
 - **N3** (idle-display hazard) — **resolved**: "idle" = plugged-but-not-
   charging (battery not discharging → hold is correct); unplug fires
   `reset_soc_estimate` so a driven/discharging car shows raw. Re-anchor runs

--- a/docs/stories/QS-281.story_review_fix_#01.md
+++ b/docs/stories/QS-281.story_review_fix_#01.md
@@ -1,0 +1,116 @@
+# QS-281 — Review fix plan #01
+
+## Summary
+- Source PR: #284
+- Source story: docs/stories/QS-281.story.md
+- Findings to fix: 8
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [must-fix] Crash on non-finite raw SOC in `_capture_last_valid_base_soc`
+- File: `custom_components/quiet_solar/ha_model/car.py:1731`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: The new per-cycle integer compare
+  `int(raw) != int(self._last_valid_base_soc_value)` (called every cycle
+  from `update_states`) calls `int()` on the raw sensor value.
+  `int(float('nan'))` raises `ValueError` and `int(float('inf'))` raises
+  `OverflowError`. A SOC sensor (or feeding template sensor) reporting the
+  literal state `"nan"`/`"inf"` passes numeric coercion in
+  `device.py:_add_state_history`, then `_capture_last_valid_base_soc`
+  throws and crashes the per-cycle `update_states`. The pre-QS-281 code
+  stored the raw value without ever calling `int()`, so this is a newly
+  introduced crash path.
+- Proposed fix: Guard with `math.isfinite(raw)` (and on
+  `_last_valid_base_soc_value`) before performing the `int()` comparison;
+  treat non-finite raw as a no-op (skip re-anchor) consistent with the
+  `None` raw handling. Add a regression test feeding `"nan"`/`"inf"`.
+
+### [should-fix] No `rawSoc` fallback when `_percent` yields non-finite (JS)
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:~995`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: When `isNumberLike(sBestSoc.state)` is true but
+  `this._percent(sBestSoc.state)` returns null/NaN (the two helpers may
+  disagree on range/format), `bestSocVal` becomes null/NaN and is assigned
+  to `soc` with no `rawSoc` fallback — the fallback only triggers on
+  `bestSocNumeric === false`.
+- Proposed fix: Fall back to `rawSoc` when `bestSocVal` is not a finite
+  number (e.g. `Number.isFinite(bestSocVal)` check), not only when
+  `bestSocNumeric === false`. Confirm against `isNumberLike`/`_percent`
+  internals. Pin behavior with a dashboard render test.
+
+### [should-fix] Rounding-mode mismatch between display and asterisk gate (JS)
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1004 vs 1008`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The displayed SOC uses `_fmt(soc)` = `Math.round(bestSocVal)`
+  (qs-card-base.js:227) but `showEstimateStar` uses
+  `Math.trunc(bestSocVal) !== Math.trunc(rawSoc)`. With `bestSocVal=45.6`
+  and `rawSoc=45.0`, `Math.trunc` → `45===45` so NO asterisk, yet the gauge
+  displays `Math.round(45.6)=46` — visibly ahead of the raw `45` with no
+  `*` marking it as a live estimate.
+- Proposed fix: Align both sides on the same rounding mode (e.g. compare
+  `Math.round` on both `bestSocVal` and `rawSoc`, or display with
+  `Math.trunc`). Add/extend a render test covering the `.6`-style boundary.
+
+### [nice-to-have] Collapse duplicate return branches in accessor
+- File: `custom_components/quiet_solar/ha_model/car.py:1658-1662`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: In `get_best_estimated_car_charge_percent`, branch 1
+  (estimation mode) and branch 2 (base exists) both
+  `return self._estimated_soc_percent`; only branch 3 differs. Reads as
+  near-dead duplication.
+- Proposed fix: Optionally collapse to a single
+  `if is_in_soc_estimation_mode or _last_valid_base_soc_value is not None`
+  while preserving the documented intent (a comment if kept separate).
+
+### [nice-to-have] Clamp test does not pin the producing branch
+- File: `tests/test_car_best_estimated_soc.py:121`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `test_best_estimate_clamped_at_100` never asserts
+  `is_in_soc_estimation_mode(...) is False`, so it does not pin which branch
+  (1 vs 2) produced the clamp.
+- Proposed fix: Add an explicit branch assertion like its sibling test.
+
+### [nice-to-have] `MagicMock()` for `config_entry` in test
+- File: `tests/test_car_best_estimated_soc.py:14`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Uses `MagicMock()` for `config_entry`; project rule is "no
+  MagicMock for domain objects." Likely acceptable (HA infra, not a domain
+  object) but worth aligning with the `create_test_car_double` factory
+  convention the story recommends.
+- Proposed fix: Prefer the factory/double convention where practical; keep
+  MagicMock only for genuine HA infra and document why.
+
+### [nice-to-have] Integer compare still re-anchors on sub-1% boundary jitter
+- File: `custom_components/quiet_solar/ha_model/car.py:1731`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Raw oscillating across an integer boundary (e.g. `44.9` ↔
+  `45.1`) re-anchors and zeros the accumulated charge delta on each flip.
+  The docstring/story "float noise can't cause a spurious reset" claim
+  overstates the guarantee.
+- Proposed fix: Either soften the docstring/story wording to match the
+  integer-compare reality, or add hysteresis. Lowest-risk: correct the
+  wording.
+
+### [nice-to-have] Hardcoded entity-key literal in render test
+- File: `tests/test_dashboard_rendering.py:356`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: Line 356 hardcodes the entity-key string while adjacent
+  assertions resolve keys via `const.py` names. A future rename could
+  silently desync this assertion.
+- Proposed fix: Replace `'ha.get("car_best_estimated_soc_percentage")'`
+  with `f'ha.get("{SENSOR_CAR_BEST_ESTIMATED_SOC_PERCENT}")'` and import
+  the const.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/stories/QS-281.story_review_fix_#02.md
+++ b/docs/stories/QS-281.story_review_fix_#02.md
@@ -1,0 +1,87 @@
+# QS-281 — Review fix plan #02
+
+## Summary
+- Source PR: #284
+- Source story: docs/stories/QS-281.story.md
+- Findings to fix: 5
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [should-fix] Story AC5a text contradicts shipped asterisk gate
+- File: `docs/stories/QS-281.story.md` (AC5a + Design "Card wiring" / drill-down)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC5a and the Design/drill-down text literally specify
+  `Math.trunc(bestSocVal) !== Math.trunc(rawSoc)`, but fix-plan #01
+  finding #03 deliberately changed the shipped code to use `Math.round`
+  on both sides (to match the `_fmt`/`Math.round` displayed value).
+  The code is correct and tested; only the story source-of-truth still
+  references `Math.trunc`, leaving the contract contradicting the code.
+- Proposed fix: Update AC5a and the Card-wiring/drill-down references
+  from `Math.trunc` to `Math.round` so the story matches what shipped.
+  Add a short note referencing fix-plan #01 #03 for the rationale.
+
+### [nice-to-have] Duplicate return branches / computed-on-read sanity check
+- File: `custom_components/quiet_solar/ha_model/car.py:~1656`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `get_best_estimated_car_charge_percent` returns
+  `self._estimated_soc_percent` for both branch-1 (estimating) and
+  branch-2 (healthy with base). This is fine only if
+  `_estimated_soc_percent` is recomputed-on-read (`clamp(base+delta)`);
+  if it were a stored field refreshed only inside `accumulate_soc_delta`,
+  a re-anchor (which zeroes the delta) could surface a one-cycle stale
+  display.
+- Proposed fix: Confirm `_estimated_soc_percent` is computed-on-read; if
+  so, optionally collapse branches 1+2 with a clarifying comment. If it
+  is a stored field, ensure a re-anchor recomputes it.
+
+### [nice-to-have] Raw fallback drops the tolerance argument
+- File: `custom_components/quiet_solar/ha_model/car.py:~1635`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `get_best_estimated_car_charge_percent(time=None)` resolves
+  `time` to now but, unlike `get_car_charge_percent(time,
+  tolerance_seconds)`, drops the tolerance arg on the raw fallback path
+  (`get_car_charge_percent_raw_sensor(time)`). If the default tolerance
+  differs from the estimation path's effective tolerance, the displayed
+  raw value could lag/lead slightly versus the canonical accessor.
+- Proposed fix: Pass the same tolerance the canonical accessor uses on
+  the raw fallback path, or add a comment documenting the intentional
+  default.
+
+### [nice-to-have] Cosmetic asterisk drift when raw SOC is unavailable (JS)
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1011`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `rawSoc = this._percent(sSoc?.state)` coerces an
+  unavailable/non-numeric raw state to `0`, so
+  `showEstimateStar = Math.round(bestSocVal) !== Math.round(0)` lights the
+  `*` and the gauge shows e.g. `45%*` when the API is merely unavailable
+  (not lagging). Value shown is still correct; only the `*` is misleading.
+  Reproduces on a transient SOC-sensor dropout during a healthy session.
+- Proposed fix: Suppress the asterisk when `rawSoc` is not a finite number
+  (raw sensor unavailable), e.g. only set `showEstimateStar` when the raw
+  value is genuinely numeric. Add a render-test case.
+
+### [nice-to-have] Defensive guard for energy-mode hoisted accumulate
+- File: `custom_components/quiet_solar/ha_model/charger.py:4715`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: In energy mode (`is_target_percent=False`) the hoisted
+  `accumulate_soc_delta(inc, time)` now runs every callback. It is a
+  no-op today only because energy mode implies no usable battery capacity
+  (`_compute_added_charge_update(is_target_percent=True)` returns `None`).
+  The safety depends entirely on the
+  `can_use_charge_percent_constraints()` ⇒ capacity-present coupling; if
+  that coupling is ever loosened, this path would silently grow a phantom
+  SOC delta.
+- Proposed fix: Either guard the hoisted accumulate with `if
+  is_target_percent:`, or add a regression test pinning the coupling so a
+  future change that breaks it fails CI.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/stories/QS-281.story_review_fix_#03.md
+++ b/docs/stories/QS-281.story_review_fix_#03.md
@@ -1,0 +1,88 @@
+# QS-281 — Review fix plan #03
+
+## Summary
+- Source PR: #284
+- Source story: docs/stories/QS-281.story.md
+- Findings to fix: 5
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [should-fix] Legacy-persisted non-numeric/non-finite base crashes the new sensor on the healthy path
+- File: `custom_components/quiet_solar/ha_model/car.py:335` (load) / `car.py:1562-1574` (`_estimated_soc_percent`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `_load` restores `_last_valid_base_soc_value` verbatim with
+  no `isinstance`/`isfinite` sanitization, and `_estimated_soc_percent`
+  computes `base + delta` with no numeric/finite guard. Before QS-281 the
+  healthy API path never read the base; QS-281's new accessor
+  (`get_best_estimated_car_charge_percent`, car.py:1666) returns
+  `_estimated_soc_percent` whenever `_last_valid_base_soc_value is not
+  None`, including on a healthy sensor. QS-243's old
+  `_capture_last_valid_base_soc` stored `raw` WITHOUT the finite guard
+  this PR added, so a car that persisted a `nan`/`inf`/string base under
+  pre-QS-281 code and re-attaches on a now-healthy API would crash the new
+  `car_best_estimated_soc_percentage` sensor's `value_fn` (`TypeError` for
+  a `str` base) or emit `nan`/`inf` to HA. The per-cycle re-anchor only
+  overwrites the base after the next genuinely-different raw reading, so
+  the first cycle(s) post-restore are exposed.
+- Proposed fix: Sanitize `_last_valid_base_soc_value` on load (mirror the
+  `isinstance(raw, (int, float)) and math.isfinite(raw)` guard already
+  used in `_capture_last_valid_base_soc`; coerce invalid → `None`), and/or
+  guard the base read in `_estimated_soc_percent`. Add a regression test
+  loading a persisted blob with a `nan`/`inf`/string base and asserting
+  the accessor/value_fn returns a safe value (raw fallback or `None`)
+  rather than crashing.
+
+### [should-fix] AC6 coverage-traceability gap (reset + reboot persistence)
+- File: `tests/test_car_best_estimated_soc.py` (or `tests/test_car_api_staleness.py`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: No new test directly asserts `reset_soc_estimate()` zeroes
+  the unified base + accumulator + cursor in one shot, and the
+  "persisted base survives reboot re-attach" half of AC6 relies on
+  pre-existing QS-243 serialization tests not visible in this diff. The
+  reset path is genuinely unchanged by this PR, so risk is low — this is a
+  traceability gap, not a defect.
+- Proposed fix: Add a one-line assertion that after `reset_soc_estimate()`
+  all three fields (`_last_valid_base_soc_value`,
+  `_computed_added_delta_soc_percent`, accumulator cursor) are `None`, or
+  add a comment in the relevant test pointing at the QS-243 reset/serialize
+  tests that cover it.
+
+### [nice-to-have] j2 reuses the `e` lookup variable
+- File: `custom_components/quiet_solar/ui/quiet_solar_dashboard_template.yaml.j2:91`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The new line reassigns `e`
+  (`{%- set e = ha.get("car_best_estimated_soc_percentage") %}`), which was
+  previously the `qs_car_soc_percent` entity. Benign today (all following
+  lines use `ha.get(...)` directly), but a latent footgun if a later block
+  references `e`.
+- Proposed fix: Use a distinct name such as `best_e`.
+
+### [nice-to-have] Overly long / duplicated accessor docstring
+- File: `custom_components/quiet_solar/ha_model/car.py:1633-1666`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `get_best_estimated_car_charge_percent`'s docstring is 20+
+  lines of rationale duplicated across three concept docs.
+- Proposed fix: Trim the docstring to the essential contract and defer the
+  rationale to the concept docs (or leave as-is if intentional).
+
+### [nice-to-have] Dead defensive non-finite fallback in the card
+- File: `custom_components/quiet_solar/ui/resources/qs-car-card.js:1001`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The `bestSocUsable` "numeric-but-non-finite" fallback can
+  never fire because `_percent()` already returns `0` for `NaN` and clamps
+  to `[0,100]`, so `Number.isFinite(bestSocCandidate)` is always true when
+  `bestSocNumeric` is true. Not a bug; flag only so a future reader does
+  not assume the branch guards against a finite-but-bad estimate.
+- Proposed fix: Add a short comment noting `_percent` already neutralizes
+  non-finite input, or leave as-is (safe).
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/stories/QS-281.story_review_fix_#04.md
+++ b/docs/stories/QS-281.story_review_fix_#04.md
@@ -1,0 +1,89 @@
+# QS-281 — Review fix plan #04
+
+## Summary
+- Source PR: #284
+- Source story: docs/stories/QS-281.story.md
+- Findings to fix: 5
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [should-fix] Stale docstring references the card's `Math.trunc`
+- File: `custom_components/quiet_solar/ha_model/car.py:1735` (`_capture_last_valid_base_soc` docstring)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The docstring claims the `int()` re-anchor "mirrors the
+  card's `Math.trunc`", but the card's asterisk gate was deliberately
+  changed to `Math.round` (fix-plan #01 #03;
+  `Math.round(bestSocVal) !== Math.round(rawSoc)`). The two mechanisms no
+  longer use the same rounding, so the comment is stale/misleading. The
+  Python `int()` truncation behavior itself is correct — only the comment
+  needs correcting.
+- Proposed fix: Update the docstring to describe the Python `int()`
+  de-bounce on its own terms (integer-truncation heartbeat de-bounce) and
+  drop the inaccurate "mirrors the card's `Math.trunc`" claim (or note the
+  card independently uses `Math.round` for its display asterisk).
+
+### [should-fix] Sub-integer upward API move can leave the estimate below raw
+- File: `custom_components/quiet_solar/ha_model/car.py:1759` (`_capture_last_valid_base_soc`) / `car.py:1562-1574` (`_estimated_soc_percent`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: With the base re-anchored at raw `45.0` (delta ~0) on a
+  healthy charge, a genuine slow-API advance to `45.9` is swallowed by the
+  `int(raw) != int(base)` de-bounce, so the base stays `45.0` and
+  `_estimated_soc_percent` stays ~`45` while `car_soc_percentage` (raw,
+  healthy path) reports `45.9`. The best-estimate then sits *behind* the
+  raw API value and is flagged with a `*`, contrary to the feature's
+  intent. The story accepts integer de-bounce as "coarse" but only reasons
+  about the never-decrease-via-accumulation invariant; it does not cover
+  the estimate lagging *below* a real sub-integer API increase.
+- Proposed fix: Ensure the best-estimate never reads below the current
+  genuine raw value on the healthy path — e.g. clamp the healthy-path
+  estimate to `>= raw` when raw is numeric, or re-anchor the base on any
+  genuine upward raw change (not only an integer-boundary change) while
+  preserving the never-decrease invariant. Add a regression test for the
+  `45.0 → 45.9` healthy-charge case asserting the estimate is not below
+  raw (and the spurious `*` is not shown).
+
+### [nice-to-have] Unused parameters in `_enter_stale_percent_mode`
+- File: `custom_components/quiet_solar/ha_model/car.py:~1771`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: After the capture removal, `time` and `for_init` are unused
+  in the body (it only sets `car_api_stale_percent_mode = True`). Ruff
+  ARG002 may flag them; the signature is presumably kept for call-site
+  compatibility.
+- Proposed fix: Prefix the unused params with `_`, or add a short comment
+  documenting why the signature is retained.
+
+### [nice-to-have] Verify the "no tolerance" docstring claim
+- File: `custom_components/quiet_solar/ha_model/car.py:~1672` (`get_best_estimated_car_charge_percent` docstring)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The docstring asserts the raw fallback is "identical to the
+  canonical `get_car_charge_percent()` value_fn, which also passes no
+  tolerance." Confirm `get_car_charge_percent` is genuinely invoked with no
+  tolerance on the comparable path; correct the docstring if not.
+- Proposed fix: Verify and either keep the claim or amend it to match
+  actual behavior.
+
+### [nice-to-have] Raw-fallback branch can return a `str` to a measurement sensor
+- File: `custom_components/quiet_solar/ha_model/car.py:1680` (`get_best_estimated_car_charge_percent`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The third branch returns
+  `get_car_charge_percent_raw_sensor(time)` directly, whose type is
+  `str | float | None`. A `str` state reaching the new
+  `device_class=BATTERY`, `state_class=MEASUREMENT` sensor makes HA
+  reject/warn on a non-numeric measurement. This mirrors the pre-existing
+  `car_soc_percentage` sensor (so it is NOT a QS-281 regression), but the
+  new sensor re-introduces the same unsanitized live read that the load
+  path was just hardened against with `_finite_soc_or_none`.
+- Proposed fix: Wrap the raw branch in `_finite_soc_or_none(...)` (or
+  equivalent) so the new sensor is consistent with the new load-path guard;
+  add a test for a `str` raw value yielding a safe result.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/tests/ha_tests/snapshots/test_sensor.ambr
+++ b/tests/ha_tests/snapshots/test_sensor.ambr
@@ -16,6 +16,23 @@
     'state': 'unknown',
   })
 # ---
+# name: test_car_sensors[sensor.car_test_car_best_estimated_soc-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by QuietSolarAbstraction',
+      'device_class': 'battery',
+      'friendly_name': 'car Test Car Best estimated SOC',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.car_test_car_best_estimated_soc',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_car_sensors[sensor.car_test_car_charge_eta-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({

--- a/tests/test_car_api_staleness.py
+++ b/tests/test_car_api_staleness.py
@@ -2190,14 +2190,21 @@ class TestStaleResetTriggers:
 
     @staticmethod
     def _assert_detected_cleared(car):
-        """Assert all detected stale fields are reset (AC1 field set)."""
+        """Assert all detected stale fields are reset (AC1 field set).
+
+        QS-281: the SOC base (`_last_valid_base_soc_value`) is no longer a
+        *detected stale field* — it is the "last known good raw value"
+        maintained by the per-cycle re-anchor and its lifecycle is owned by
+        `reset_soc_estimate`, not by stale-detection clearance. The base
+        expectation therefore depends on the reset path and is asserted
+        explicitly by the individual tests, not here.
+        """
         assert car._car_api_stale is False
         assert car.car_api_stale_percent_mode is False
         assert car._car_api_stale_since is None
         assert car._was_car_api_stale is False
         assert car._car_api_inferred_home is False
         assert car._car_api_inferred_plugged is False
-        assert car._last_valid_base_soc_value is None
 
     @staticmethod
     def _make_charger_with_attached(car):
@@ -2233,6 +2240,8 @@ class TestStaleResetTriggers:
         await real_car.user_set_selected_charger_by_name(FORCE_CAR_NO_CHARGER_CONNECTED)
 
         self._assert_detected_cleared(real_car)
+        # QS-281 — a stale-detection-only reset preserves the SOC base.
+        assert real_car._last_valid_base_soc_value == 55.0
         assert real_car.is_car_effectively_stale(current_time) is False
 
     @pytest.mark.parametrize(
@@ -2257,6 +2266,8 @@ class TestStaleResetTriggers:
         await real_car.user_clean_and_reset()
 
         self._assert_detected_cleared(real_car)
+        # QS-281 — a full clean-and-reset clears the SOC base (reset_soc_estimate).
+        assert real_car._last_valid_base_soc_value is None
         assert real_car.is_car_effectively_stale(current_time) is False
 
     async def test_departure_auto_reset_resets_stale_detection(self, real_car, current_time):

--- a/tests/test_car_best_estimated_soc.py
+++ b/tests/test_car_best_estimated_soc.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.quiet_solar.const import CONF_CAR_CHARGE_PERCENT_SENSOR
-from custom_components.quiet_solar.ha_model.car import QSCar
+from custom_components.quiet_solar.ha_model.car import QSCar, _finite_soc_or_none
 
 
 def _make_car(fake_hass, mock_data_handler, **overrides) -> QSCar:
@@ -272,3 +272,61 @@ def test_reanchor_stale_to_healthy_recovery(est_car, current_time):
     est_car._capture_last_valid_base_soc(later)
     assert est_car._last_valid_base_soc_value == 63.0
     assert est_car._computed_added_delta_soc_percent == 0.0
+
+
+# ── Legacy/corrupt persisted-base sanitization (fix-plan #03 #01) ─────────────
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (55.0, 55.0),
+        (40, 40.0),
+        (None, None),
+        (float("nan"), None),
+        (float("inf"), None),
+        (float("-inf"), None),
+        ("55.0", None),  # numeric-looking string is still rejected
+        ("unavailable", None),
+        (True, None),  # bool is not a valid SOC numeric
+    ],
+)
+def test_finite_soc_or_none(value, expected):
+    """`_finite_soc_or_none` keeps only finite real numbers, else `None`."""
+    assert _finite_soc_or_none(value) == expected
+
+
+@pytest.mark.parametrize("bad_base", [float("nan"), float("inf"), "corrupt", "55.0"])
+def test_load_sanitizes_non_finite_persisted_base(est_car, current_time, bad_base):
+    """A legacy/corrupt persisted base is coerced to `None` on load, so the
+    healthy-path accessor can never crash or emit nan/inf (fix-plan #03 #01)."""
+    est_car.use_saved_extra_device_info(
+        {
+            "last_valid_base_soc_value": bad_base,
+            "computed_added_delta_soc_percent": float("inf"),
+            "user_base_soc_value": "bad",
+            "user_base_soc_entry_sensor_value": float("nan"),
+        }
+    )
+    assert est_car._last_valid_base_soc_value is None
+    assert est_car._computed_added_delta_soc_percent is None
+    assert est_car._user_base_soc_value is None
+    assert est_car._user_base_soc_entry_sensor_value is None
+    # The accessor (and thus the sensor value_fn) must not raise — a healthy raw
+    # sensor is present, so it falls back to the raw value.
+    _set_soc(est_car, 53.0, current_time)
+    assert est_car.get_best_estimated_car_charge_percent(current_time) == 53.0
+
+
+def test_reset_soc_estimate_clears_unified_base_accumulator_cursor(est_car):
+    """AC6 — `reset_soc_estimate` zeroes the unified base + accumulator + cursor
+    in one shot (fix-plan #03 #02 traceability). The "persisted base survives a
+    reboot re-attach" half of AC6 is covered by the QS-243 serialize round-trip
+    test (`test_persistence_round_trip` in `test_car_soc_estimation.py`)."""
+    est_car._last_valid_base_soc_value = 47.0
+    est_car._computed_added_delta_soc_percent = 5.0
+    est_car._delta_soc_last_integration_time = "cursor"
+    est_car.reset_soc_estimate()
+    assert est_car._last_valid_base_soc_value is None
+    assert est_car._computed_added_delta_soc_percent is None
+    assert est_car._delta_soc_last_integration_time is None

--- a/tests/test_car_best_estimated_soc.py
+++ b/tests/test_car_best_estimated_soc.py
@@ -19,6 +19,11 @@ from custom_components.quiet_solar.ha_model.car import QSCar
 
 
 def _make_car(fake_hass, mock_data_handler, **overrides) -> QSCar:
+    # A REAL `QSCar` domain object built from the standard `MOCK_CAR_CONFIG`
+    # (no MagicMock for the domain object, per project rules). Only
+    # `config_entry` is a MagicMock — it is genuine HA infrastructure (a config
+    # entry handle), not a domain object, and the same convention is used by the
+    # sibling `test_car_soc_estimation.py` fixtures.
     from tests.ha_tests.const import MOCK_CAR_CONFIG
 
     config = {
@@ -81,6 +86,7 @@ def test_best_estimate_base_plus_delta_when_not_estimating(est_car, current_time
 def test_best_estimate_clamped_at_100(est_car, current_time):
     """Branch 2 — base + delta clamps to 100 (reuses `_estimated_soc_percent`)."""
     _set_soc(est_car, 98.0, current_time)
+    assert est_car.is_in_soc_estimation_mode(current_time) is False  # pin branch 2, not 1
     est_car._last_valid_base_soc_value = 98.0
     est_car._computed_added_delta_soc_percent = 10.0
     assert est_car.get_best_estimated_car_charge_percent(current_time) == 100.0
@@ -187,6 +193,41 @@ def test_reanchor_noop_when_raw_none(est_car, current_time):
     est_car._capture_last_valid_base_soc(current_time)
     assert est_car._last_valid_base_soc_value == 40.0
     assert est_car._computed_added_delta_soc_percent == 6.0
+
+
+@pytest.mark.parametrize("bad_raw", [float("nan"), float("inf"), float("-inf")])
+def test_reanchor_noop_when_raw_non_finite(est_car, current_time, bad_raw):
+    """A non-finite raw (`nan`/`inf`) must be a no-op, never `int()`-crash the
+    per-cycle re-anchor (must-fix #01)."""
+    est_car._last_valid_base_soc_value = 40.0
+    est_car._computed_added_delta_soc_percent = 6.0
+    _set_soc(est_car, bad_raw, current_time)
+    # Must not raise (int(nan) → ValueError, int(inf) → OverflowError).
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value == 40.0
+    assert est_car._computed_added_delta_soc_percent == 6.0
+
+
+def test_reanchor_noop_when_raw_non_numeric_string(est_car, current_time):
+    """A non-numeric sensor state (raw is typed `str | float | None`) is a
+    no-op — `int("foo")` must never crash the per-cycle re-anchor."""
+    est_car._last_valid_base_soc_value = 40.0
+    est_car._computed_added_delta_soc_percent = 6.0
+    _set_soc(est_car, "unavailable", current_time)
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value == 40.0
+    assert est_car._computed_added_delta_soc_percent == 6.0
+
+
+def test_reanchor_recovers_when_base_non_finite(est_car, current_time):
+    """A previously-stored non-finite base re-anchors to the next good raw
+    rather than crashing the compare."""
+    est_car._last_valid_base_soc_value = float("nan")
+    est_car._computed_added_delta_soc_percent = 3.0
+    _set_soc(est_car, 50.0, current_time)
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value == 50.0
+    assert est_car._computed_added_delta_soc_percent == 0.0
 
 
 def test_reanchor_skips_when_user_override(est_car, current_time):

--- a/tests/test_car_best_estimated_soc.py
+++ b/tests/test_car_best_estimated_soc.py
@@ -92,11 +92,56 @@ def test_best_estimate_clamped_at_100(est_car, current_time):
     assert est_car.get_best_estimated_car_charge_percent(current_time) == 100.0
 
 
+def test_best_estimate_never_below_raw_on_sub_integer_increase(est_car, current_time):
+    """fix-plan #04 #02 — base re-anchored at 45.0 (delta 0); a genuine slow-API
+    advance to 45.9 is swallowed by the integer de-bounce (no re-anchor), but
+    the display accessor must clamp `>= raw` so the estimate never lags the live
+    API (and no behind-the-API `*`)."""
+    est_car._last_valid_base_soc_value = 45.0
+    est_car._computed_added_delta_soc_percent = 0.0
+    _set_soc(est_car, 45.9, current_time)
+    # the per-cycle re-anchor does NOT fire: int(45.9) == int(45.0)
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value == 45.0
+    # …but the display accessor clamps up to the genuine raw value
+    best = est_car.get_best_estimated_car_charge_percent(current_time)
+    assert best == 45.9
+    assert best >= est_car.get_car_charge_percent_raw_sensor(current_time)
+
+
+def test_best_estimate_ahead_of_raw_when_api_lags(est_car, current_time):
+    """The complement of the clamp: when the estimate genuinely LEADS the
+    (lagging) raw API, the estimate stands (no down-clamp to raw)."""
+    est_car._last_valid_base_soc_value = 45.0
+    est_car._computed_added_delta_soc_percent = 2.5  # charge added while API stuck
+    _set_soc(est_car, 45.0, current_time)
+    assert est_car.is_in_soc_estimation_mode(current_time) is False
+    assert est_car.get_best_estimated_car_charge_percent(current_time) == pytest.approx(47.5)
+
+
+def test_best_estimate_base_with_non_numeric_raw_returns_estimate(est_car, current_time):
+    """Branch 2 with a non-numeric/unavailable raw → the estimate stands (the
+    raw clamp is skipped and no `str` leaks into the comparison)."""
+    _set_soc(est_car, "unknown", current_time)
+    est_car._last_valid_base_soc_value = 50.0
+    est_car._computed_added_delta_soc_percent = 4.0
+    assert est_car.is_in_soc_estimation_mode(current_time) is False
+    assert est_car.get_best_estimated_car_charge_percent(current_time) == pytest.approx(54.0)
+
+
 def test_best_estimate_no_base_returns_raw(est_car, current_time):
     """Branch 3 — healthy sensor, no base → the plain raw sensor value."""
     _set_soc(est_car, 53.0, current_time)
     est_car._last_valid_base_soc_value = None
     assert est_car.get_best_estimated_car_charge_percent(current_time) == 53.0
+
+
+def test_best_estimate_no_base_str_raw_returns_none(est_car, current_time):
+    """Branch 3 — fix-plan #04 #05: a non-numeric raw live read is sanitized to
+    `None`, so the BATTERY/MEASUREMENT sensor never receives a `str`."""
+    _set_soc(est_car, "unavailable", current_time)
+    est_car._last_valid_base_soc_value = None
+    assert est_car.get_best_estimated_car_charge_percent(current_time) is None
 
 
 def test_best_estimate_no_base_raw_none(est_car, current_time):

--- a/tests/test_car_best_estimated_soc.py
+++ b/tests/test_car_best_estimated_soc.py
@@ -1,0 +1,233 @@
+"""Tests for the live best-estimated SOC display model (Story QS-281).
+
+Covers the pure-read accessor `get_best_estimated_car_charge_percent` (every
+AC2/AC7 branch), and the per-cycle re-anchor refactor of
+`_capture_last_valid_base_soc`: genuine-change up/down, same-integer heartbeat,
+`None`-raw no-op, manual-override guard, idle hold, and the stale→healthy
+recovery transition.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.quiet_solar.const import CONF_CAR_CHARGE_PERCENT_SENSOR
+from custom_components.quiet_solar.ha_model.car import QSCar
+
+
+def _make_car(fake_hass, mock_data_handler, **overrides) -> QSCar:
+    from tests.ha_tests.const import MOCK_CAR_CONFIG
+
+    config = {
+        **MOCK_CAR_CONFIG,
+        "hass": fake_hass,
+        "config_entry": MagicMock(),
+        "data_handler": mock_data_handler,
+        "home": mock_data_handler.home,
+    }
+    config.update(overrides)
+    return QSCar(**config)
+
+
+@pytest.fixture
+def est_car(fake_hass, mock_data_handler, current_time):
+    """A normal car: SOC sensor + battery capacity, not invited."""
+    return _make_car(fake_hass, mock_data_handler)
+
+
+@pytest.fixture
+def est_car_no_sensor(fake_hass, mock_data_handler, current_time):
+    """A real car with a true capacity but no SOC sensor."""
+    return _make_car(fake_hass, mock_data_handler, **{CONF_CAR_CHARGE_PERCENT_SENSOR: None})
+
+
+def _set_soc(car: QSCar, value, time):
+    car._entity_probed_last_valid_state[car.car_charge_percent_sensor] = (time, value, {})
+
+
+# ── get_best_estimated_car_charge_percent — AC2 / AC7 branches ───────────────
+
+
+def test_best_estimate_estimation_mode_returns_estimate(est_car, current_time):
+    """Branch 1 — while estimating, parity with `get_car_charge_percent`."""
+    est_car.car_api_stale_percent_mode = True  # → estimating
+    est_car._last_valid_base_soc_value = 40.0
+    est_car._computed_added_delta_soc_percent = 7.0
+    assert est_car.is_in_soc_estimation_mode(current_time) is True
+    assert est_car.get_best_estimated_car_charge_percent(current_time) == pytest.approx(47.0)
+    assert est_car.get_best_estimated_car_charge_percent(current_time) == est_car.get_car_charge_percent(current_time)
+
+
+def test_best_estimate_estimation_mode_pure_delta_none(est_car_no_sensor, current_time):
+    """Branch 1, pure-delta — no base while estimating → None (card falls back)."""
+    assert est_car_no_sensor.is_in_soc_estimation_mode(current_time) is True
+    est_car_no_sensor._last_valid_base_soc_value = None
+    est_car_no_sensor._computed_added_delta_soc_percent = 5.0
+    assert est_car_no_sensor.get_best_estimated_car_charge_percent(current_time) is None
+
+
+def test_best_estimate_base_plus_delta_when_not_estimating(est_car, current_time):
+    """Branch 2 — healthy sensor, a base exists → clamp(base + delta)."""
+    _set_soc(est_car, 45.0, current_time)
+    assert est_car.is_in_soc_estimation_mode(current_time) is False
+    est_car._last_valid_base_soc_value = 45.0
+    est_car._computed_added_delta_soc_percent = 2.5
+    assert est_car.get_best_estimated_car_charge_percent(current_time) == pytest.approx(47.5)
+
+
+def test_best_estimate_clamped_at_100(est_car, current_time):
+    """Branch 2 — base + delta clamps to 100 (reuses `_estimated_soc_percent`)."""
+    _set_soc(est_car, 98.0, current_time)
+    est_car._last_valid_base_soc_value = 98.0
+    est_car._computed_added_delta_soc_percent = 10.0
+    assert est_car.get_best_estimated_car_charge_percent(current_time) == 100.0
+
+
+def test_best_estimate_no_base_returns_raw(est_car, current_time):
+    """Branch 3 — healthy sensor, no base → the plain raw sensor value."""
+    _set_soc(est_car, 53.0, current_time)
+    est_car._last_valid_base_soc_value = None
+    assert est_car.get_best_estimated_car_charge_percent(current_time) == 53.0
+
+
+def test_best_estimate_no_base_raw_none(est_car, current_time):
+    """Branch 3 — no base and the raw sensor itself is None → None."""
+    est_car._entity_probed_last_valid_state[est_car.car_charge_percent_sensor] = None
+    est_car._last_valid_base_soc_value = None
+    assert est_car.get_best_estimated_car_charge_percent(current_time) is None
+
+
+def test_best_estimate_time_none_resolves_to_now(est_car):
+    """`time=None` resolves to now inside the accessor (no exception, returns raw)."""
+    import pytz
+
+    now = __import__("datetime").datetime.now(tz=pytz.UTC)
+    _set_soc(est_car, 61.0, now)
+    est_car._last_valid_base_soc_value = None
+    assert est_car.get_best_estimated_car_charge_percent() == 61.0
+
+
+def test_best_estimate_is_a_pure_read(est_car, current_time):
+    """AC2 — the accessor must NOT mutate any estimate field."""
+    _set_soc(est_car, 50.0, current_time)
+    est_car._last_valid_base_soc_value = 50.0
+    est_car._computed_added_delta_soc_percent = 3.0
+    est_car._delta_soc_last_integration_time = current_time
+    snapshot = (
+        est_car._last_valid_base_soc_value,
+        est_car._computed_added_delta_soc_percent,
+        est_car._delta_soc_last_integration_time,
+        est_car._user_base_soc_value,
+    )
+    est_car.get_best_estimated_car_charge_percent(current_time)
+    assert (
+        est_car._last_valid_base_soc_value,
+        est_car._computed_added_delta_soc_percent,
+        est_car._delta_soc_last_integration_time,
+        est_car._user_base_soc_value,
+    ) == snapshot
+
+
+# ── per-cycle re-anchor (_capture_last_valid_base_soc) ───────────────────────
+
+
+def test_reanchor_genuine_change_up(est_car, current_time):
+    """A genuinely higher raw value re-anchors the base and resets the delta."""
+    est_car._last_valid_base_soc_value = 40.0
+    est_car._computed_added_delta_soc_percent = 6.0
+    est_car._delta_soc_last_integration_time = current_time
+    _set_soc(est_car, 45.0, current_time)
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value == 45.0
+    assert est_car._computed_added_delta_soc_percent == 0.0
+    assert est_car._delta_soc_last_integration_time is None
+
+
+def test_reanchor_genuine_change_down(est_car, current_time):
+    """A genuine API change is trusted and may move the value DOWN (estimate ran
+    ahead, API corrects it)."""
+    est_car._last_valid_base_soc_value = 47.0
+    est_car._computed_added_delta_soc_percent = 3.0
+    _set_soc(est_car, 45.0, current_time)
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value == 45.0
+    assert est_car._computed_added_delta_soc_percent == 0.0
+
+
+def test_reanchor_same_integer_heartbeat_no_reset(est_car, current_time):
+    """A same-integer reading (float noise / heartbeat) must NOT re-anchor."""
+    est_car._last_valid_base_soc_value = 50.0
+    est_car._computed_added_delta_soc_percent = 4.0
+    est_car._delta_soc_last_integration_time = current_time
+    _set_soc(est_car, 50.4, current_time)  # int(50.4) == int(50.0)
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value == 50.0
+    assert est_car._computed_added_delta_soc_percent == 4.0
+    assert est_car._delta_soc_last_integration_time == current_time
+
+
+def test_reanchor_first_base_from_none(est_car, current_time):
+    """With no base yet, the first raw reading sets the base (delta cleared)."""
+    est_car._last_valid_base_soc_value = None
+    est_car._computed_added_delta_soc_percent = 9.0
+    _set_soc(est_car, 33.0, current_time)
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value == 33.0
+    assert est_car._computed_added_delta_soc_percent == 0.0
+
+
+def test_reanchor_noop_when_raw_none(est_car, current_time):
+    """No reading yet → no-op: base stays, delta untouched (AC3)."""
+    est_car._last_valid_base_soc_value = 40.0
+    est_car._computed_added_delta_soc_percent = 6.0
+    est_car._entity_probed_last_valid_state[est_car.car_charge_percent_sensor] = None
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value == 40.0
+    assert est_car._computed_added_delta_soc_percent == 6.0
+
+
+def test_reanchor_skips_when_user_override(est_car, current_time):
+    """Manual override owns its delta — the re-anchor must NOT zero it."""
+    est_car._user_base_soc_value = 70.0
+    est_car._last_valid_base_soc_value = 40.0
+    est_car._computed_added_delta_soc_percent = 6.0
+    est_car._delta_soc_last_integration_time = current_time
+    _set_soc(est_car, 55.0, current_time)  # would re-anchor if unguarded
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value == 40.0
+    assert est_car._computed_added_delta_soc_percent == 6.0
+    assert est_car._delta_soc_last_integration_time == current_time
+
+
+def test_reanchor_idle_holds_value(est_car, current_time):
+    """Idle (no charge → delta does not grow): repeated equal readings hold the
+    base + delta unchanged; only the charger callback grows the delta."""
+    est_car._last_valid_base_soc_value = 60.0
+    est_car._computed_added_delta_soc_percent = 5.0  # accrued during the prior charge
+    _set_soc(est_car, 60.0, current_time)
+    for _ in range(3):
+        est_car._capture_last_valid_base_soc(current_time)
+    # held: no re-anchor (same int), and the re-anchor never grows the delta
+    assert est_car._last_valid_base_soc_value == 60.0
+    assert est_car._computed_added_delta_soc_percent == 5.0
+    assert est_car.get_best_estimated_car_charge_percent(current_time) == pytest.approx(65.0)
+
+
+def test_reanchor_stale_to_healthy_recovery(est_car, current_time):
+    """Stale→healthy: a retained delta survives until the first DIFFERENT
+    healthy reading re-anchors; an equal reading does not (AC3a)."""
+    est_car._last_valid_base_soc_value = 60.0
+    est_car._computed_added_delta_soc_percent = 4.0
+    # equal reading on recovery → delta survives
+    _set_soc(est_car, 60.0, current_time)
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._computed_added_delta_soc_percent == 4.0
+    # first genuinely different healthy reading → re-anchor
+    later = current_time + timedelta(seconds=30)
+    _set_soc(est_car, 63.0, later)
+    est_car._capture_last_valid_base_soc(later)
+    assert est_car._last_valid_base_soc_value == 63.0
+    assert est_car._computed_added_delta_soc_percent == 0.0

--- a/tests/test_car_soc_estimation.py
+++ b/tests/test_car_soc_estimation.py
@@ -501,31 +501,33 @@ def test_recovery_raw_none_skips(est_car, current_time):
 
 
 def test_capture_last_valid_base(est_car, current_time):
+    """QS-281 — the per-cycle re-anchor captures the raw value as the base."""
     _set_soc(est_car, 64.0, current_time)
-    est_car._enter_stale_percent_mode(current_time)
-    assert est_car.car_api_stale_percent_mode is True
+    est_car._capture_last_valid_base_soc(current_time)
     assert est_car._last_valid_base_soc_value == 64.0
     assert est_car._computed_added_delta_soc_percent == 0.0
     assert est_car._delta_soc_last_integration_time is None
 
 
-def test_capture_skipped_when_user_base(est_car, current_time):
+def test_enter_stale_no_longer_captures(est_car, current_time):
+    """QS-281 — `_enter_stale_percent_mode` only flips the flag now; the base
+    is maintained every cycle by the re-anchor, not on the stale edge."""
     _set_soc(est_car, 64.0, current_time)
-    est_car._user_base_soc_value = 80.0
     est_car._enter_stale_percent_mode(current_time)
+    assert est_car.car_api_stale_percent_mode is True
     assert est_car._last_valid_base_soc_value is None
 
 
-def test_capture_skipped_when_system_base_exists(est_car, current_time):
+def test_reanchor_skipped_when_user_base(est_car, current_time):
     _set_soc(est_car, 64.0, current_time)
-    est_car._last_valid_base_soc_value = 30.0
-    est_car._enter_stale_percent_mode(current_time)
-    assert est_car._last_valid_base_soc_value == 30.0
+    est_car._user_base_soc_value = 80.0
+    est_car._capture_last_valid_base_soc(current_time)
+    assert est_car._last_valid_base_soc_value is None
 
 
-def test_capture_skipped_when_raw_none(est_car, current_time):
+def test_reanchor_skipped_when_raw_none(est_car, current_time):
     est_car._entity_probed_last_valid_state[est_car.car_charge_percent_sensor] = None
-    est_car._enter_stale_percent_mode(current_time)
+    est_car._capture_last_valid_base_soc(current_time)
     assert est_car._last_valid_base_soc_value is None
 
 
@@ -540,9 +542,10 @@ def test_enter_stale_for_init_no_capture(est_car, current_time):
 
 
 def test_end_to_end_stale_capture_and_recovery(est_car, current_time):
-    """Drive `_update_car_api_staleness` across a full fresh→stale→recover cycle:
-    capture fires exactly once on the genuine edge, then recovery hands SOC back
-    to the live sensor."""
+    """QS-281 — drive the full fresh→stale→recover cycle with the per-cycle
+    re-anchor: the base tracks the last known good raw value, is dormant while
+    the sensor is not fresh (stale), and re-anchors on the first genuinely
+    different healthy reading (a real charge delta survives until then)."""
     tracker = est_car.car_tracker
     plugged = est_car.car_plugged
     soc = est_car.car_charge_percent_sensor
@@ -551,56 +554,69 @@ def test_end_to_end_stale_capture_and_recovery(est_car, current_time):
         est_car._entity_probed_last_valid_state[tracker] = (t, "home", {})
         est_car._entity_probed_last_valid_state[plugged] = (t, "on", {})
 
-    # 1) Everything fresh, SOC = 60 → not stale.
+    def _cycle(t):
+        # Mirror update_states order: staleness, then the per-cycle re-anchor.
+        est_car._update_car_api_staleness(t)
+        est_car._capture_last_valid_base_soc(t)
+
+    # 1) Everything fresh, SOC = 60 → not stale; re-anchor sets base = 60.
     _fresh_non_soc(current_time)
     est_car._entity_probed_last_valid_state[soc] = (current_time, 60.0, {})
-    est_car._update_car_api_staleness(current_time)
+    _cycle(current_time)
     assert est_car.car_api_stale_percent_mode is False
+    assert est_car._last_valid_base_soc_value == 60.0
     assert est_car.get_car_charge_percent(current_time) == 60.0
 
-    # 2) SOC sensor goes stale (others fresh) → SOC-only stale edge captures L=60.
+    # 2) SOC sensor goes stale (others fresh): the re-anchor reads the same last
+    #    value → dormant, base stays 60, estimate = base + 0 delta = 60.
     stale_time = current_time - timedelta(seconds=CAR_SOC_STALE_THRESHOLD_S + 1)
     est_car._entity_probed_last_valid_state[soc] = (stale_time, 60.0, {})
     _fresh_non_soc(current_time)
-    est_car._update_car_api_staleness(current_time)
+    _cycle(current_time)
     assert est_car.car_api_stale_percent_mode is True
     assert est_car._last_valid_base_soc_value == 60.0
     assert est_car._computed_added_delta_soc_percent == 0.0
     assert est_car.get_car_charge_percent(current_time) == 60.0  # base + 0 delta
 
-    # 3) A second stale cycle must NOT re-capture (genuine-edge guard).
-    est_car._last_valid_base_soc_value = 999.0  # sentinel — must be left untouched
-    est_car._update_car_api_staleness(current_time)
-    assert est_car._last_valid_base_soc_value == 999.0
-    est_car._last_valid_base_soc_value = 60.0
+    # 3) A second stale cycle with the same value → no re-anchor (heartbeat); a
+    #    charge delta that accrued mid-stale survives.
+    est_car._computed_added_delta_soc_percent = 5.0
+    _cycle(current_time)
+    assert est_car._last_valid_base_soc_value == 60.0
+    assert est_car._computed_added_delta_soc_percent == 5.0
 
-    # 4) API recovers: SOC fresh again with a new value → live sensor takes over.
+    # 4) API recovers: SOC fresh with a DIFFERENT value → re-anchor snaps the
+    #    base to 65 and resets the delta; the live sensor takes over.
     recover_time = current_time + timedelta(seconds=10)
     _fresh_non_soc(recover_time)
     est_car._entity_probed_last_valid_state[soc] = (recover_time, 65.0, {})
-    est_car._update_car_api_staleness(recover_time)
+    _cycle(recover_time)
     assert est_car.car_api_stale_percent_mode is False
-    assert est_car._last_valid_base_soc_value is None
+    assert est_car._last_valid_base_soc_value == 65.0
+    assert est_car._computed_added_delta_soc_percent == 0.0
     assert est_car.get_car_charge_percent(recover_time) == 65.0
 
 
-# ── _exit_stale_mode clears system base ──────────────────────────────────
+# ── _exit_stale_mode no longer touches the base/accumulator (QS-281) ──────
 
 
-def test_exit_stale_clears_system_base_no_user_override(est_car):
-    # No user override: the system-base recovery clears base + accumulator.
+def test_exit_stale_preserves_base_no_user_override(est_car):
+    """QS-281 — exiting stale mode clears ONLY stale flags; the base/accumulator
+    are now owned by the per-cycle re-anchor and must survive a stale-exit."""
     est_car.car_api_stale_percent_mode = True
     est_car._last_valid_base_soc_value = 40.0
     est_car._computed_added_delta_soc_percent = 6.0
     est_car._delta_soc_last_integration_time = "x"
     est_car._exit_stale_mode()
-    assert est_car._last_valid_base_soc_value is None
-    assert est_car._computed_added_delta_soc_percent is None
-    assert est_car._delta_soc_last_integration_time is None
+    assert est_car.car_api_stale_percent_mode is False
+    assert est_car._last_valid_base_soc_value == 40.0
+    assert est_car._computed_added_delta_soc_percent == 6.0
+    assert est_car._delta_soc_last_integration_time == "x"
 
 
 def test_exit_stale_preserves_accumulator_with_user_override(est_car):
-    # M1 defect 2: a transient stale blip must NOT wipe an override's delta.
+    # M1 defect 2: a transient stale blip must NOT wipe an override's delta;
+    # QS-281: the system base is preserved too (re-anchor owns it).
     est_car.car_api_stale_percent_mode = True
     est_car._last_valid_base_soc_value = 40.0
     est_car._computed_added_delta_soc_percent = 6.0
@@ -610,9 +626,9 @@ def test_exit_stale_preserves_accumulator_with_user_override(est_car):
     # the override owns its accumulator lifecycle → delta + cursor preserved
     assert est_car._computed_added_delta_soc_percent == 6.0
     assert est_car._delta_soc_last_integration_time == "x"
-    # user base untouched; system base cleared
+    # user base untouched; system base now preserved (QS-281)
     assert est_car._user_base_soc_value == 88.0
-    assert est_car._last_valid_base_soc_value is None
+    assert est_car._last_valid_base_soc_value == 40.0
 
 
 # ── AC12: orthogonality ──────────────────────────────────────────────────

--- a/tests/test_charger_soc_estimation.py
+++ b/tests/test_charger_soc_estimation.py
@@ -271,3 +271,28 @@ async def test_real_efficiency_integral_within_1pct():
     assert abs(car._computed_added_delta_soc_percent - expected_delta) <= 0.01
 
 
+async def test_callback_constraint_value_unchanged_with_healthy_accumulator():
+    """QS-281 — the hoisted `accumulate_soc_delta` call must NOT change the
+    constraint value on the non-estimating (healthy sensor) branch, yet it must
+    advance the accumulator (proving the single hoisted call ran)."""
+    charger, car, now = _build_charger_and_car(no_sensor=False)
+    car._entity_probed_last_valid_state[car.car_charge_percent_sensor] = (now, 47.0, {})
+    car._last_valid_base_soc_value = 47.0
+    car._computed_added_delta_soc_percent = 0.0
+    car._delta_soc_last_integration_time = now - timedelta(minutes=15)
+    charger._compute_added_charge_update = MagicMock(return_value=2.0)
+    assert car.is_in_soc_estimation_mode(now) is False
+
+    # A zero-length window keeps the result equal to the raw sensor value — the
+    # deterministic pre-change baseline for the constraint return.
+    ct = _Ct(now, current_value=40.0, target_value=80.0)
+    ct.first_value_update = now
+
+    result, _cont = await charger.constraint_update_value_callback_soc(ct, now, is_target_percent=True)
+
+    # constraint value byte-identical to the sensor-driven baseline …
+    assert result == 47.0
+    # … and the hoisted accumulate advanced the accumulator by inc = 2.0.
+    assert car._computed_added_delta_soc_percent == pytest.approx(2.0)
+
+

--- a/tests/test_charger_soc_estimation.py
+++ b/tests/test_charger_soc_estimation.py
@@ -296,3 +296,26 @@ async def test_callback_constraint_value_unchanged_with_healthy_accumulator():
     assert car._computed_added_delta_soc_percent == pytest.approx(2.0)
 
 
+async def test_energy_callback_does_not_advance_soc_accumulator():
+    """QS-281 fix-plan #02 #05 — the SOC accumulator is advanced only on the
+    PERCENT callback. The energy-mode callback (`is_target_percent=False`) must
+    leave `_computed_added_delta_soc_percent` and its cursor untouched, so the
+    guard makes the no-phantom-delta safety explicit rather than relying on the
+    `can_use_charge_percent_constraints()` ⇒ capacity coupling."""
+    charger, car, now = _build_charger_and_car(no_sensor=False)
+    car._entity_probed_last_valid_state[car.car_charge_percent_sensor] = (now, 50.0, {})
+    car._last_valid_base_soc_value = 50.0
+    car._computed_added_delta_soc_percent = 0.0
+    anchor = now - timedelta(minutes=15)
+    car._delta_soc_last_integration_time = anchor
+    # A positive slice would advance the accumulator IF accumulate were called.
+    charger._compute_added_charge_update = MagicMock(return_value=2.0)
+
+    t1 = now + timedelta(minutes=15)
+    await charger.constraint_update_value_callback_soc(_Ct(t1), t1, is_target_percent=False)
+
+    # The energy callback never touches the SOC accumulator or its cursor.
+    assert car._computed_added_delta_soc_percent == 0.0
+    assert car._delta_soc_last_integration_time == anchor
+
+

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -394,6 +394,11 @@ class TestDashboardTemplateRendering:
         # (Math.round), not Math.trunc, so a 45.6→46 estimate is flagged vs 45.
         assert "Math.round(bestSocVal) !== Math.round(rawSoc)" in source
         assert "Math.trunc(bestSocVal)" not in source  # old mismatched gate removed
+        # Fix-plan #02 #04 — the asterisk is suppressed when the raw SOC state
+        # is not genuinely numeric (an unavailable raw coerces to rawSoc=0,
+        # which would otherwise light a misleading `*` on a sensor dropout).
+        assert "const rawSocNumeric = isNumberLike(sSoc?.state);" in source
+        assert "bestSocUsable && rawSocNumeric && Math.round(bestSocVal) !== Math.round(rawSoc)" in source
         # Single asterisk — the new flag is OR-combined, never stacked.
         assert "(hasSocEstimate || showEstimateStar) ? '*' : ''" in source
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -27,7 +27,6 @@ from custom_components.quiet_solar.const import (
     BUTTON_CAR_RESET_SOC_ESTIMATE,
     CONF_POOL_TEMPERATURE_SENSOR,
     CONF_POWER,
-    NUMBER_CAR_MANUAL_SOC_PERCENT,
     CONF_SOLAR_FORECAST_PROVIDERS,
     CONF_SOLAR_PROVIDER_DOMAIN,
     CONF_SOLAR_PROVIDER_NAME,
@@ -37,6 +36,7 @@ from custom_components.quiet_solar.const import (
     DEVICE_TYPE,
     DOMAIN,
     LOAD_TYPE_DASHBOARD_DEFAULT_SECTION,
+    NUMBER_CAR_MANUAL_SOC_PERCENT,
     SOLCAST_SOLAR_DOMAIN,
     CONF_TYPE_NAME_QSPool,
 )
@@ -351,9 +351,14 @@ class TestDashboardTemplateRendering:
         assert entities["is_soc_estimated"].startswith("binary_sensor.")
         assert entities["manual_soc"].startswith("number.")
         assert entities["reset_soc"].startswith("button.")
-        # QS-281 — the live best-estimated SOC sensor is wired via its sensor key.
+        # QS-281 — the live best-estimated SOC sensor is wired via its sensor
+        # key. This parsed end-to-end check (real sensor registration →
+        # `ha_entities` → j2 render) is intentionally NOT a hardcoded
+        # `ha.get("...")` literal: a rename of either the sensor `key` or the
+        # j2 lookup drops `best_soc` from the rendered card, so this `entities`
+        # subscript would raise — catching any desync without a brittle string
+        # (fix-plan #01, finding #8).
         assert entities["best_soc"].startswith("sensor.")
-        assert 'ha.get("car_best_estimated_soc_percentage")' in template_content
 
         # N5 — the template resolves those entities via the const.py keys
         # (never hardcoded ha.get("qs_car_...") string literals in the source).
@@ -374,16 +379,21 @@ class TestDashboardTemplateRendering:
     def test_car_card_uses_best_soc_on_normal_percent_path(self):
         """QS-281 — the card reads the `best_soc` entity, captures the raw SOC
         before any reassignment, substitutes the best-estimate on the normal
-        percent path, and renders the integer-diff asterisk without stacking it
-        on top of the existing `hasSocEstimate` asterisk."""
+        percent path (with a non-finite fallback), and renders the asterisk
+        rounded the same way the gauge displays it, without stacking it on top
+        of the existing `hasSocEstimate` asterisk."""
         source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
         # Reads the new entity and captures the raw value up front (N2).
         assert "e.best_soc" in source
         assert "const rawSoc = this._percent(sSoc?.state);" in source
-        # Substitutes best_soc on the normal percent path, falling back to rawSoc.
-        assert "const bestSocVal = bestSocNumeric ? this._percent(sBestSoc.state) : rawSoc;" in source
-        # Integer-diff asterisk compares the estimate against the captured raw.
-        assert "Math.trunc(bestSocVal) !== Math.trunc(rawSoc)" in source
+        # Fix-plan #01 #02 — falls back to rawSoc when best_soc is non-numeric
+        # OR numeric-but-non-finite (the two helpers can disagree).
+        assert "const bestSocUsable = bestSocNumeric && Number.isFinite(bestSocCandidate);" in source
+        assert "const bestSocVal = bestSocUsable ? bestSocCandidate : rawSoc;" in source
+        # Fix-plan #01 #03 — asterisk gate rounds the SAME way `_fmt` displays
+        # (Math.round), not Math.trunc, so a 45.6→46 estimate is flagged vs 45.
+        assert "Math.round(bestSocVal) !== Math.round(rawSoc)" in source
+        assert "Math.trunc(bestSocVal)" not in source  # old mismatched gate removed
         # Single asterisk — the new flag is OR-combined, never stacked.
         assert "(hasSocEstimate || showEstimateStar) ? '*' : ''" in source
 

--- a/tests/test_dashboard_rendering.py
+++ b/tests/test_dashboard_rendering.py
@@ -351,6 +351,9 @@ class TestDashboardTemplateRendering:
         assert entities["is_soc_estimated"].startswith("binary_sensor.")
         assert entities["manual_soc"].startswith("number.")
         assert entities["reset_soc"].startswith("button.")
+        # QS-281 — the live best-estimated SOC sensor is wired via its sensor key.
+        assert entities["best_soc"].startswith("sensor.")
+        assert 'ha.get("car_best_estimated_soc_percentage")' in template_content
 
         # N5 — the template resolves those entities via the const.py keys
         # (never hardcoded ha.get("qs_car_...") string literals in the source).
@@ -367,6 +370,22 @@ class TestDashboardTemplateRendering:
         assert "e.reset_soc" in source
         # The asterisk gating must be present.
         assert "hasSocEstimate" in source
+
+    def test_car_card_uses_best_soc_on_normal_percent_path(self):
+        """QS-281 — the card reads the `best_soc` entity, captures the raw SOC
+        before any reassignment, substitutes the best-estimate on the normal
+        percent path, and renders the integer-diff asterisk without stacking it
+        on top of the existing `hasSocEstimate` asterisk."""
+        source = (COMPONENT_ROOT / "ui" / "resources" / "qs-car-card.js").read_text()
+        # Reads the new entity and captures the raw value up front (N2).
+        assert "e.best_soc" in source
+        assert "const rawSoc = this._percent(sSoc?.state);" in source
+        # Substitutes best_soc on the normal percent path, falling back to rawSoc.
+        assert "const bestSocVal = bestSocNumeric ? this._percent(sBestSoc.state) : rawSoc;" in source
+        # Integer-diff asterisk compares the estimate against the captured raw.
+        assert "Math.trunc(bestSocVal) !== Math.trunc(rawSoc)" in source
+        # Single asterisk — the new flag is OR-combined, never stacked.
+        assert "(hasSocEstimate || showEstimateStar) ? '*' : ''" in source
 
     def test_car_card_soc_editable_pointer_events(self):
         """QS-243 #02 M1 — the editable SOC re-enables pointer events (it sits

--- a/tests/test_platform_sensor.py
+++ b/tests/test_platform_sensor.py
@@ -66,6 +66,35 @@ def test_create_ha_sensor_for_car():
     assert any("car_autonomy_to_target_soc_km" in e.entity_description.key for e in entities)
 
 
+def test_create_ha_sensor_for_car_best_estimated_soc():
+    """QS-281 — the best-estimated SOC sensor is registered with battery device
+    class, `%` unit, MEASUREMENT state class, and a value_fn wired to the
+    `get_best_estimated_car_charge_percent` accessor."""
+    from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+    from homeassistant.const import PERCENTAGE
+
+    from custom_components.quiet_solar.const import SENSOR_CAR_BEST_ESTIMATED_SOC_PERCENT
+
+    mock_car = create_mock_device("car", name="Test Car")
+    mock_car.data_handler = MagicMock()
+    mock_car.charger = None
+    mock_car.get_car_charge_percent = MagicMock(return_value=80)
+    mock_car.get_best_estimated_car_charge_percent = MagicMock(return_value=82.5)
+    mock_car.get_car_charge_type = MagicMock(return_value="Solar")
+    mock_car.get_car_charge_time_readable_name = MagicMock(return_value="2 hours")
+    mock_car.get_estimated_range_km = MagicMock(return_value=260)
+    mock_car.get_autonomy_to_target_soc_km = MagicMock(return_value=50)
+
+    entities = create_ha_sensor_for_QSCar(mock_car)
+    best = next(e for e in entities if e.entity_description.key == "car_best_estimated_soc_percentage")
+    desc = best.entity_description
+    assert desc.translation_key == SENSOR_CAR_BEST_ESTIMATED_SOC_PERCENT
+    assert desc.device_class == SensorDeviceClass.BATTERY
+    assert desc.native_unit_of_measurement == PERCENTAGE
+    assert desc.state_class == SensorStateClass.MEASUREMENT
+    assert desc.value_fn(mock_car, desc.key) == 82.5
+
+
 def test_create_ha_sensor_for_load():
     """Test creating sensors for load device."""
     from custom_components.quiet_solar.ha_model.device import HADeviceMixin


### PR DESCRIPTION
## Summary
- New display-only sensor `car_best_estimated_soc_percentage` + pure-read accessor `get_best_estimated_car_charge_percent`; the car card uses it on the normal percent path (charging **and** idle) with an integer-diff `*` marker, falling back to the raw SOC.
- Unify `_last_valid_base_soc_value` as the stale-independent *last known good raw value*: a per-cycle re-anchor in `update_states` (integer compare, no-op on `None` raw, skipped under a manual override), `_exit_stale_mode` no longer wipes the base/accumulator, `_enter_stale_percent_mode` no longer captures.
- Hoist `accumulate_soc_delta` to exactly one call per charger callback so the accumulator advances during a **healthy** charge too — the non-estimating constraint value is byte-identical (named regression test).

## Doc maintenance

`scripts/qs/check_doc_drift.py` flags two docs as stale; both are intentional `Doc-OK` per the story:
- `config-and-setup-flow.md` (covers `const.py`) — only a new sensor translation-key constant was added; no config-flow change.
- `person-trip-prediction.md` (covers `car.py`) — trip prediction is unrelated to this SOC-display change.

The substantive concept docs were updated: `car-soc-estimation.md`, `dashboard-and-cards.md`, `charger-budgeting.md`.

Fixes #281

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [x] CRITICAL (solver, constraints, charger budgeting)
- [x] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Best estimated SOC** car sensor (battery %), including UI/dashboard wiring when the entity is available.
  * Updated the car card to display best-estimate SOC on the normal percent path with safe fallback to the raw SOC.
* **Bug Fixes**
  * Improved SOC estimation robustness by handling corrupt/non-finite persisted SOC values without breaking display.
  * Refined stale-to-healthy SOC re-anchoring so estimates stay consistent.
  * Corrected SOC “asterisk” rendering to avoid duplicate/misleading indicators.
* **Documentation**
  * Updated QS-281 SOC estimation documentation.
* **Tests**
  * Added/expanded coverage for best-estimated SOC, re-anchoring behavior, and SOC accumulator callback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->