### PR TITLE
QS-286: completion signal for detached --seed-testmon baseline refresh

### DIFF
--- a/.claude/agents/qs-finish-task.md
+++ b/.claude/agents/qs-finish-task.md
@@ -148,9 +148,20 @@ The standard merge flow.
    QG_PY="$MAIN_DIR/venv/bin/python"
    [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
    if [ -n "$QG_PY" ]; then
+       # QS-286: delete any stale marker BEFORE launch (so a prior run's
+       # `ok` cannot survive into a run that dies before writing `running`),
+       # then run detached, redirecting (truncate) to a log the user can
+       # inspect. The run writes .testmondata.seed-status when done.
+       rm -f "$MAIN_DIR/.testmondata.seed-status"
        ( cd "$MAIN_DIR" && nohup "$QG_PY" \
-           scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
+           scripts/qs/quality_gate.py --seed-testmon \
+           >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
        echo "Baseline refresh started (detached, best-effort)."
+       echo "It writes .testmondata.seed-status when done; check status with:"
+       echo "  python scripts/qs/quality_gate.py --seed-testmon-status"
+       echo "  (run from the main checkout, $MAIN_DIR)"
+       echo "It is safe to close this terminal once that reports OK; the log"
+       echo "is at $MAIN_DIR/.testmondata.seed.log."
    else
        echo "Warning: no usable Python interpreter found — skipping baseline refresh."
    fi

--- a/.cursor/agents/qs-finish-task.md
+++ b/.cursor/agents/qs-finish-task.md
@@ -147,9 +147,20 @@ The standard merge flow.
    QG_PY="$MAIN_DIR/venv/bin/python"
    [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
    if [ -n "$QG_PY" ]; then
+       # QS-286: delete any stale marker BEFORE launch (so a prior run's
+       # `ok` cannot survive into a run that dies before writing `running`),
+       # then run detached, redirecting (truncate) to a log the user can
+       # inspect. The run writes .testmondata.seed-status when done.
+       rm -f "$MAIN_DIR/.testmondata.seed-status"
        ( cd "$MAIN_DIR" && nohup "$QG_PY" \
-           scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
+           scripts/qs/quality_gate.py --seed-testmon \
+           >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
        echo "Baseline refresh started (detached, best-effort)."
+       echo "It writes .testmondata.seed-status when done; check status with:"
+       echo "  python scripts/qs/quality_gate.py --seed-testmon-status"
+       echo "  (run from the main checkout, $MAIN_DIR)"
+       echo "It is safe to close this terminal once that reports OK; the log"
+       echo "is at $MAIN_DIR/.testmondata.seed.log."
    else
        echo "Warning: no usable Python interpreter found — skipping baseline refresh."
    fi

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ coverage.xml
 .testmondata
 .testmondata-wal
 .testmondata-shm
+# QS-286: sidecar completion marker for the detached --seed-testmon refresh.
+# (.testmondata.seed.log is already covered by the *.log rule below.)
+.testmondata.seed-status
 *.cover
 *.py,cover
 .hypothesis/

--- a/.opencode/agents/qs-finish-task.md
+++ b/.opencode/agents/qs-finish-task.md
@@ -180,9 +180,20 @@ The standard merge flow.
    QG_PY="$MAIN_DIR/venv/bin/python"
    [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
    if [ -n "$QG_PY" ]; then
+       # QS-286: delete any stale marker BEFORE launch (so a prior run's
+       # `ok` cannot survive into a run that dies before writing `running`),
+       # then run detached, redirecting (truncate) to a log the user can
+       # inspect. The run writes .testmondata.seed-status when done.
+       rm -f "$MAIN_DIR/.testmondata.seed-status"
        ( cd "$MAIN_DIR" && nohup "$QG_PY" \
-           scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
+           scripts/qs/quality_gate.py --seed-testmon \
+           >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
        echo "Baseline refresh started (detached, best-effort)."
+       echo "It writes .testmondata.seed-status when done; check status with:"
+       echo "  python scripts/qs/quality_gate.py --seed-testmon-status"
+       echo "  (run from the main checkout, $MAIN_DIR)"
+       echo "It is safe to close this terminal once that reports OK; the log"
+       echo "is at $MAIN_DIR/.testmondata.seed.log."
    else
        echo "Warning: no usable Python interpreter found — skipping baseline refresh."
    fi

--- a/docs/stories/QS-286.story.md
+++ b/docs/stories/QS-286.story.md
@@ -79,7 +79,7 @@ concurrent reader). The whole body is wrapped in a **best-effort
 signal; a write failure must never abort the detached baseline rebuild —
 this is the sanctioned `--seed-testmon` best-effort carve-out), with a
 `finally` that `unlink(..., missing_ok=True)`s the temp file. We do **not**
-`fsync`: the marker is read only after the process exits in the common
+`fsync`: the marker is read back only after the process exits in the common
 case, and a torn/partial write from a hard crash is already covered by the
 reader's `unparseable → 3` backstop — fsync durability would be
 mechanization inconsistent with a best-effort signal (Findings

--- a/docs/stories/QS-286.story.md
+++ b/docs/stories/QS-286.story.md
@@ -1,0 +1,474 @@
+# QS-286 — completion signal for the detached `--seed-testmon` baseline refresh
+
+- **Issue:** #286
+- **Branch:** QS_286
+- **Next phase:** implement-setup-task (all touched paths are dev-infrastructure)
+- **Story label:** v3
+
+## Problem
+
+In `finish-task` (QS-276) Case B step 6, after a merge the agent rebuilds
+the main-worktree testmon baseline by launching:
+
+```bash
+( cd "$MAIN_DIR" && nohup "$QG_PY" scripts/qs/quality_gate.py --seed-testmon >/dev/null 2>&1 & )
+echo "Baseline refresh started (detached, best-effort)."
+```
+
+The process is **detached with output to `/dev/null`**, and the agent
+immediately continues to delete the branch and remove the worktree. The
+user is left with a terminal running an invisible background job and **no
+way to know**:
+
+- (a) whether the `.testmondata` reseed has completed and succeeded, and
+- (b) therefore whether it is safe to close/kill that terminal.
+
+Killing it mid-seed leaves a partial `.testmondata`. QS-283 already made
+`--impacted` self-healing against a drifted/partial baseline (it
+over-selects once, then auto-rebuilds), so this is a **visibility**
+problem, not a correctness one: the user has no signal for "done / safe
+to close".
+
+## Goal
+
+Give the user a durable, pollable completion signal for the detached
+`--seed-testmon` run — without changing its non-blocking, detached,
+best-effort contract (cleanup must never wait on it). Concretely:
+
+- a **status-marker file** written by `seed_testmon()` (option A),
+- a **`--seed-testmon-status`** query subcommand that reports it in plain
+  language + a scriptable exit code (option B),
+- `finish-task` **redirects the detached run to a log file** and tells the
+  user exactly how to check status (option C).
+
+Explicitly **out of scope** (decided with the user): a foreground run
+option, and any desktop-notification mechanism.
+
+## Design
+
+### A. Status-marker sidecar — `.testmondata.seed-status`
+
+Add a module constant next to the existing `TESTMON_DATA = REPO_ROOT /
+".testmondata"` definition: `SEED_STATUS = REPO_ROOT /
+".testmondata.seed-status"`. `REPO_ROOT` is `Path(__file__).resolve()`-
+based (cwd- and symlink-resolved), so the marker always lands beside the
+main worktree's `.testmondata` regardless of the detached process's cwd
+(satisfies AC 6). Add `import time` to the module import block (currently
+absent — verified); `json` and `os` are already imported.
+
+Marker shape (fields present depend on state), JSON:
+
+```json
+{"state": "running|ok|incomplete|skipped",
+ "pid": 12345,
+ "started": "<epoch-seconds>",
+ "finished": "<epoch-seconds>",
+ "returncode": 0,
+ "reason": "<text, skipped only>"}
+```
+
+Timestamps come from `time.time()`.
+
+**Write helper `_write_seed_status(state, **fields)` — atomic +
+best-effort (revised from v2: the round-1 `fsync` is dropped).**
+Serialize `{"state": state, **fields}` via `json.dumps`, write to a temp
+sibling `SEED_STATUS.with_suffix(SEED_STATUS.suffix + ".tmp")`, then
+**`os.replace(tmp, SEED_STATUS)`** (atomic rename — no torn file for a
+concurrent reader). The whole body is wrapped in a **best-effort
+`try/except` that swallows and continues** (the marker is a courtesy
+signal; a write failure must never abort the detached baseline rebuild —
+this is the sanctioned `--seed-testmon` best-effort carve-out), with a
+`finally` that `unlink(..., missing_ok=True)`s the temp file. We do **not**
+`fsync`: the marker is read only after the process exits in the common
+case, and a torn/partial write from a hard crash is already covered by the
+reader's `unparseable → 3` backstop — fsync durability would be
+mechanization inconsistent with a best-effort signal (Findings
+scope-S2 / critic-C2,C6,C7 / dev-proxy-DP1 / delta-D4). Reference
+`os.replace` at module scope so a test can `monkeypatch.setattr(
+quality_gate.os, "replace", raiser)` to cover the except branch.
+
+`seed_testmon()` state machine (only the marker writes are new; the
+existing best-effort return semantics are unchanged). Anchor edits on the
+existing symbols, not line numbers:
+1. **not importable** — at the `if not _testmon_available():` early
+   return, *before* `return 3`, write
+   `{"state":"skipped","reason":"pytest-testmon not importable"}`. No
+   `running` marker is written on this path (Finding concrete-R1).
+2. after `_testmon_available()` passes and *before*
+   `_rebuild_testmon_baseline()` → write `{"state":"running",
+   "pid":os.getpid(),"started":time.time()}`.
+3. run pytest via `_stream_pytest(_build_seed_testmon_cmd())`.
+4. on completion reuse the existing `rc = result.get("returncode", 0)`
+   local:
+   - `rc < 2` (0 = clean, 1 = test failures but DB still written) →
+     `state="ok"`;
+   - `rc >= 2` (collection error / crash, DB may be partial) →
+     `state="incomplete"`.
+   Exit-code rationale: `rc < 2` means testmon wrote `.testmondata`
+   (0 = clean, 1 = failures but DB persisted — note `ok` means "baseline
+   written", NOT "tests passed"; the human message says so); `rc >= 2`
+   (usage/collection error, internal crash, or no-tests-collected) means
+   the baseline is suspect. We do not branch on individual pytest codes
+   2–5 — all are "suspect, rerun". Write the final marker
+   `{"state":..,"pid":..,"started":..,"finished":time.time(),
+   "returncode":rc}`. Return 0 (still best-effort — matches the existing
+   rc>=2 warning path).
+
+**Stale-marker guard (Finding critic-redesign, round 1).** So a stale
+`ok` marker from a prior run cannot survive into a new run that dies
+before writing `running`, `finish-task` deletes the marker synchronously
+*before* launching the detached run (see C). This `rm -f` fires **only on
+finish-task's launch path** — there is no separate GC subcommand
+(Finding scope-S4). A transient `missing → 3` read during the brief
+window between the `rm -f` and the detached process's first marker write
+is an accepted, documented best-effort behavior (Finding critic-C1) — not
+mechanized, since a pre-probe `running` marker would conflict with the
+"no running marker on the not-importable path" rule above.
+
+### B. `--seed-testmon-status` reader — `seed_testmon_status()`
+
+New **read-only** non-gate subcommand: it invokes **no pytest, no
+coverage, no testmon import** — it only stat/reads the marker and checks
+PID liveness, matching the `--seed-testmon` carve-out family. It reads
+the marker and prints a human answer plus a scriptable exit code.
+**Distinct human messages** (sentence case, second person, backticks
+around the command and `.testmondata.seed.log`; these are `print()` to
+the user, so the no-trailing-period *log* rule does not apply) mapped
+onto a **deliberately small 4-code contract** (Finding
+scope-guardian — the issue asks a ~3-way question; the messages carry the
+nuance, the exit codes stay simple):
+
+| Marker state                    | Message intent                                                                       | Exit |
+| ------------------------------- | ------------------------------------------------------------------------------------ | ---- |
+| `ok`                            | baseline written at `<finished>` (tests may have failed) — safe to close this terminal | 0  |
+| `running` + pid **alive**       | still running (pid `<pid>`, started `<started>`) — keep this terminal open           | 4    |
+| `running` + pid **not** alive   | interrupted (pid no longer running) — `.testmondata` may be partial; rerun           | 1    |
+| `incomplete`                    | finished with errors (exit `<rc>`) — `.testmondata` may be partial; rerun            | 1    |
+| `skipped`                       | refresh was skipped (`<reason>`) — no baseline was written; rerun if needed          | 1    |
+| marker missing                  | no baseline refresh recorded                                                         | 3    |
+| marker present but unparseable  | baseline refresh status is unreadable                                                | 3    |
+
+Note the `ok` message deliberately says "baseline written (tests may have
+failed)" not "succeeded" — `rc == 1` maps to `ok` because testmon still
+persisted `.testmondata` (Finding critic-C8).
+
+Exit-code contract (4 codes): `0` = ok / safe to close; `4` = still
+running / keep terminal open; `1` = not trustworthy, rerun (covers
+`incomplete`, interrupted, and `skipped`); `3` = no readable status
+(missing or unparseable). Each of the 7 originating marker conditions is
+still a **separate test branch**; because three of them share exit `1`,
+the tests disambiguate them by asserting the **distinct message string**,
+not the exit code alone (Finding delta-D1). Exit `2` does **not** appear
+in the *status* namespace (`skipped` is `1`, not `2`); the surviving
+`test_seed_testmon_mutex_exits_2` refers to the unrelated argparse-mutex
+namespace, which is unchanged (Finding delta-D2). The `skipped` state is
+retained (not collapsed into `missing`) because it maps to a **real**
+existing early-return branch and its message ("no baseline was written")
+is more honest than a bare `missing → 3` — the marginal cost is one write
++ one test (Finding scope-S1, kept).
+
+Liveness is done through a small patchable helper **`_pid_alive(pid)
+-> bool`** (Finding dev-proxy critical): `os.kill(pid, 0)` in try/except —
+`ProcessLookupError` → `False` (dead); `PermissionError` → `True`
+(alive-but-not-ours); success → `True`. Extracting the helper gives the
+tests a clean seam (patch `_pid_alive` for the status branches; patch
+`os.kill` to raise each exception for the helper's own branches) so all
+paths reach 100% changed-line coverage.
+
+The reader **trusts the marker** (best-effort) — it does not cross-check
+that `.testmondata` still exists for an `ok` verdict (out of scope). No
+`--json` — deliberately minimal.
+
+**Accepted best-effort limitations (documented, no mechanism):**
+- **PID reuse** — `_pid_alive` can false-positive if the OS recycled the
+  seed's PID; acceptable for a best-effort dev-infra signal (no boot-id /
+  heartbeat).
+- **Single writer** — `finish-task` runs one seed at a time; concurrent
+  seeds would clobber the shared marker. Documented assumption, not
+  guarded.
+- **Independent exit-code namespaces** — `seed_testmon` returns 3 for
+  "not importable"; `seed_testmon_status` returns 3 for "no readable
+  status". Different subcommands, independent contracts; `seed_testmon`
+  runs detached so its return code goes to the log, not to any consumer
+  (Finding critic-C4, confirmed — documented, no renumber).
+
+### C. `main()` wiring + `finish-task` messaging
+
+`main()` in `scripts/qs/quality_gate.py` (anchor on symbols, not line
+numbers):
+- add `--seed-testmon-status` (`action="store_true"`) with help text,
+  immediately after the existing `--seed-testmon` `add_argument` call;
+- extend the mutex: add a block mirroring the existing `if
+  args.seed_testmon and (...)` `parser.error(...)` block —
+  `--seed-testmon-status` cannot combine with
+  `--impacted / --quick / --cache / --no-cache / --full / --fix /
+  --seed-testmon` (usage error);
+- dispatch: `if args.seed_testmon_status: sys.exit(seed_testmon_status())`
+  immediately after the existing `if args.seed_testmon:
+  sys.exit(seed_testmon())` dispatch, so it short-circuits before
+  cache/scope detection like the other subcommands.
+
+`finish-task` agent step 6 (**all three harnesses** —
+`.claude/agents/qs-finish-task.md`, `.cursor/agents/qs-finish-task.md`,
+`.opencode/agents/qs-finish-task.md`; harness-sync rule). The seed-launch
+block is a **byte-identical shared body** across all three today (verified;
+the round-1/2 line-number citations were stale — anchor on the block's
+text: the `QG_PY=` probe, the `nohup "$QG_PY" ... --seed-testmon
+>/dev/null 2>&1 & )` invocation, and the `echo "Baseline refresh
+started..."`). Edit that shared block identically in all three:
+- **before** launching, delete any stale marker synchronously (absolute
+  path, runs outside the `( cd "$MAIN_DIR" && ... )` subshell):
+  `rm -f "$MAIN_DIR/.testmondata.seed-status"` (stale-marker guard);
+- change the redirect target from `>/dev/null 2>&1` to
+  `>"$MAIN_DIR/.testmondata.seed.log" 2>&1` (**truncate** per run,
+  `$MAIN_DIR`-absolute). `nohup` is retained, so the existing
+  `test_seed_testmon_refresh_present` guard still holds. Truncate is
+  deliberate: it bounds the log to the latest run (round-1 flagged
+  unbounded-growth for append); the tradeoff is that the prior run's log
+  is overwritten — acceptable for a best-effort signal;
+- replace the single "started" echo with guidance:
+  - the run writes `.testmondata.seed-status` when done;
+  - how to check: `python scripts/qs/quality_gate.py --seed-testmon-status`
+    (run from the main checkout);
+  - it is safe to close the terminal once that reports OK; the log is at
+    `.testmondata.seed.log`.
+- keep the interpreter-probe / warn-on-no-python fallback unchanged; keep
+  the run detached & best-effort (no blocking, no foreground path).
+
+Also update the Case B "Hard rules" carve-out note only if wording needs
+it (the DB-refresh-is-not-the-gate statement stays true).
+
+### D. `.gitignore`
+
+Add `.testmondata.seed-status` next to the existing `.testmondata` /
+`-wal` / `-shm` lines. (`.testmondata.seed.log` is already covered by the
+existing `*.log` rule — verified via `git check-ignore`.)
+
+### Doc maintenance
+
+- **Update `docs/workflow/phase-protocols.md`** (finish-task step 5,
+  ~L209-215): note that the detached refresh now emits a completion
+  signal and how to check it (`--seed-testmon-status`).
+- **Update `docs/workflow/project-rules.md`** (the `--seed-testmon`
+  carve-out block, ~L66-103): document `--seed-testmon-status` as the
+  companion sanctioned non-gate query subcommand and the
+  `.testmondata.seed-status` marker.
+- **Doc-OK:** `docs/agents/glossary.md`, `docs/agents/personas/the-dev.md`,
+  `docs/agents/concepts/testing-layers.md` — matched only on
+  `finish-task`/`testmondata` incidentally; they do not describe the
+  detached-refresh step or the `--seed-testmon` command surface, so no
+  change is needed. The drift checker surfaced no `covers:`-tracked doc
+  for the touched files (its warnings were pre-existing
+  `testing-layers.md` `covers:` entries outside
+  `custom_components/quiet_solar/`).
+- **Drift co-mod (Finding dev-proxy-DP5):** the implement phase must run
+  `python scripts/qs/check_doc_drift.py` and, if any `docs/agents/*.md`
+  declares `covers: scripts/qs/quality_gate.py`, co-modify that doc in the
+  same change (add it to the changed set). The round-1 `--paths` run
+  surfaced none, so this is a conditional guard, not an expected edit.
+
+## Acceptance criteria
+
+1. Running `--seed-testmon` writes `.testmondata.seed-status` with
+   `state="running"` (+ `pid`, `started`) after the testmon probe / before
+   the pytest pass, and overwrites it on completion with `state="ok"`
+   (rc < 2) or `state="incomplete"` (rc >= 2, incl. `returncode` +
+   `finished`).
+2. When pytest-testmon is not importable, `--seed-testmon` writes a
+   `state="skipped"` marker (with `reason`) at the early return and still
+   returns 3; no `running` marker is written on that path; the run
+   remains best-effort (returns 0 on rc>=2 as today).
+3. `_write_seed_status` writes atomically and best-effort: temp sibling
+   file + `os.replace` (no torn file for a concurrent reader), the whole
+   body wrapped in a `try/except` that swallows and continues (a write
+   failure never aborts the detached rebuild) with a `finally` unlinking
+   the temp file. No `fsync` (dropped from v2); the reader's
+   `unparseable → 3` branch is the torn-write backstop.
+4. `--seed-testmon-status` reports a distinct human message **and** the
+   correct 4-code exit for every originating state: `ok`→0,
+   `running`+alive→4, `running`+dead(interrupted)→1, `incomplete`→1,
+   `skipped`→1, missing marker→3, unparseable marker→3. It performs no
+   pytest / coverage / testmon import (read-only).
+5. `--seed-testmon-status` is mutually exclusive with
+   `--impacted/--quick/--cache/--no-cache/--full/--fix/--seed-testmon`
+   (argparse usage error), matching the existing `--seed-testmon` mutex.
+6. The marker path is the module constant `SEED_STATUS = REPO_ROOT /
+   ".testmondata.seed-status"` (REPO_ROOT is `__file__`-relative, not
+   cwd), so the detached run in `$MAIN_DIR` and a later status query from
+   `$MAIN_DIR` read the same file.
+7. `finish-task` (all three harness copies, byte-identical shared body)
+   deletes any stale marker before launch, then launches the detached
+   refresh redirecting (truncate) to `.testmondata.seed.log` with `nohup`
+   retained, and prints guidance naming the `--seed-testmon-status`
+   command, the log path, and the "safe to close" condition. The step
+   stays detached, non-blocking, best-effort.
+8. `.gitignore` has an exact `.testmondata.seed-status` line (the existing
+   `.testmondata` line is exact-match, not a glob); `.testmondata.seed.log`
+   is already covered by `*.log`.
+9. `docs/workflow/phase-protocols.md` (step 5) and
+   `docs/workflow/project-rules.md` (one-line addition of the
+   `--seed-testmon-status` companion subcommand to the command reference)
+   are updated per Doc maintenance.
+10. `python scripts/qs/quality_gate.py --impacted` passes with 100%
+    changed-line coverage for all new/changed lines; the three
+    harness agent bodies stay aligned (harness-sync); `check_doc_drift.py`
+    passes.
+
+## Task breakdown
+
+1. **Module constant + `_write_seed_status` helper** in
+   `scripts/qs/quality_gate.py`: add `SEED_STATUS` next to `TESTMON_DATA`
+   and `import time`; atomic best-effort write (temp `.tmp` + `os.replace`
+   via module-scope `os.replace`; serialize `{"state": state, **fields}`
+   via `json.dumps`; wrap body in `try/except`-swallow with `finally`
+   temp-unlink; no `fsync`).
+2. **`_pid_alive(pid)` helper**: `os.kill(pid, 0)` → `ProcessLookupError`
+   → False, `PermissionError` → True, success → True (patchable seam).
+3. **Instrument `seed_testmon()`**: `skipped` marker at the
+   `if not _testmon_available():` early return (before `return 3`);
+   `running` marker after that probe / before `_rebuild_testmon_baseline()`;
+   `ok`/`incomplete` marker on completion reusing the existing `rc` local.
+   Keep `return 0`.
+4. **`seed_testmon_status()`** reader: `SEED_STATUS.exists()` /
+   `json.loads` guard → missing/unparseable→3; per-state message + 4-code
+   exit via `_pid_alive` for `running`. Read-only.
+5. **`main()` wiring**: add `--seed-testmon-status` arg after the
+   `--seed-testmon` `add_argument`; mutex block mirroring the
+   `--seed-testmon` `parser.error` block; dispatch after the
+   `--seed-testmon` `sys.exit` dispatch.
+6. **`.gitignore`**: add exact `.testmondata.seed-status` line after the
+   WAL/SHM entries.
+7. **finish-task agents (×3)**: stale-marker `rm -f`, redirect to
+   `.testmondata.seed.log` (truncate, keep `nohup`), status/"safe to
+   close" guidance; keep detached/best-effort. Byte-identical shared body.
+8. **Docs**: update `docs/workflow/phase-protocols.md` step 5 and add the
+   one-line `--seed-testmon-status` entry to
+   `docs/workflow/project-rules.md`.
+9. **Tests** in `tests/test_quality_gate.py`:
+   - marker states: running (after probe), ok (rc<2), incomplete (rc>=2),
+     skipped (patch `_testmon_available` → False; assert no running marker
+     written before `return 3`);
+   - `_write_seed_status`: temp file removed after a successful write (no
+     leftover `.tmp`); **and** the best-effort except branch —
+     `monkeypatch.setattr(quality_gate.os, "replace", raiser)`, assert the
+     helper swallows (no raise) and the `.tmp` is still cleaned up;
+   - `_pid_alive`: patch `os.kill` to raise `ProcessLookupError` /
+     `PermissionError` / succeed (all three branches);
+   - `seed_testmon_status`: one test per originating marker condition
+     (7 branches — `ok`, running+alive, running+dead, incomplete, skipped,
+     missing, unparseable), asserting exit code **and** a message
+     substring (the three exit-`1` branches are distinguished by message,
+     not code); patch `_pid_alive` for the two `running` cases;
+   - argparse mutex modeled on `test_seed_testmon_mutex_exits_2`; CLI
+     passthrough modeled on `test_seed_testmon_cli_passthrough`;
+   - `test_seed_status_gitignored` mirroring the exact-line
+     `test_testmondata_gitignored` (add to `TestImpactedDeps`);
+   - extend/add a `TestFinishTaskRefreshesBaseline` guard asserting
+     `--seed-testmon-status` and `.testmondata.seed.log` appear in all
+     three harness files (and `nohup` still present).
+   Ensure 100% changed-line coverage.
+
+## Adversarial Review Notes
+
+### Round 1 (4 global reviewers: critic, concrete-planner, dev-proxy, scope-guardian)
+
+All findings triaged; user chose "apply full recommended set". State:
+
+**Resolved (folded into the plan):**
+- `resolved` critic-C2 — atomic write not crash-safe → added `flush()` +
+  `os.fsync()` before `os.replace` (Design A, AC 3).
+- `resolved` critic-redesign — stale `ok` marker can survive a crash →
+  `finish-task` deletes the marker synchronously before launch (Design A/C,
+  AC 7).
+- `resolved` dev-proxy-critical / concrete — `os.kill` liveness
+  uncoverable → extracted patchable `_pid_alive(pid)` helper (Design B,
+  tasks 2/9).
+- `resolved` concrete-R1 — `skipped` marker must be written at the L1492
+  early return, before any `running` marker (Design A step 1, AC 2).
+- `resolved` concrete-critical — gitignore exact-line convention →
+  explicit `.testmondata.seed-status` line + `test_seed_status_gitignored`
+  (Design D, AC 8, task 9).
+- `resolved` concrete concreteness set — `SEED_STATUS` constant, temp-path,
+  `time.time()` timestamps, CLI insertion points, harness line refs +
+  byte-identical body, message-string enumeration, read-only assertion,
+  existing-test templates → folded into Design/tasks.
+- `resolved` critic-improve — log truncates per run (`>`), documented
+  (Design C).
+- `resolved` dev-proxy-clarify — status output is `print` (user-facing
+  writing style, not the log no-period rule); `--seed-testmon-status` is
+  read-only, no pytest — stated in Design B.
+
+**Scope decision (accepted):**
+- `resolved` scope-guardian-improve — exit-code over-modeling → collapsed
+  to a **4-code** contract (0 / 4 / 1 / 3); distinct human messages kept;
+  `skipped` folded into exit 1; standalone `skipped→2` dropped. Marker
+  states retained. project-rules.md update kept but reduced to a one-line
+  command-reference addition (Design B, AC 4/9).
+
+**Rejected (documented, no mechanism — scope creep avoided):**
+- `rejected` critic-clarify — DB-presence cross-check for `ok` verdict:
+  reader trusts the marker (best-effort). Documented in Design B.
+- `rejected` critic-redesign (per-code) — individual pytest exit-code
+  2–5 handling: one-line `rc<2` vs `rc>=2` rationale instead (Design A).
+- `rejected` critic-critical (PID reuse), critic-improve (concurrent
+  writers), critic-clarify (exit-code namespaces): accepted as documented
+  best-effort limitations in Design B, no added mechanism.
+
+**Open criticals after triage: 0.**
+
+### Round 2 (4 global reviewers + delta-auditor)
+
+Delta-auditor confirmed **all round-1 findings F1–F9 genuinely resolved**
+in v2 (concrete mechanisms, not just mentions). New findings triaged;
+user chose "apply full recommended set". State:
+
+**Resolved (folded into v3):**
+- `resolved` critic-C2 / dev-proxy-DP1 (both critical) + scope-S2 +
+  critic-C6/C7 + delta-D4 — the round-1 `fsync` + "let it raise"
+  contradicted the best-effort carve-out. **Partial reversal of F1:**
+  dropped `fsync`; `_write_seed_status` is now atomic `os.replace` wrapped
+  in a best-effort `try/except`-swallow with `finally` temp-unlink; the
+  reader's `unparseable → 3` is the torn-write backstop (Design A, AC 3,
+  tasks 1/9).
+- `resolved` critic-C1 (critical) — rm→launch window → documented that a
+  transient `missing → 3` is acceptable; not mechanized (Design A).
+- `resolved` critic-C9 + concrete-planner (critical) — stale/incorrect
+  line numbers (verified `.claude` L151-153, `.cursor` L150-152,
+  `.opencode` L183-184) → re-anchored all edits on symbolic/content
+  anchors; harness edits anchor on the byte-identical seed-block text
+  (Design A/C).
+- `resolved` concrete-planner (critical) — `import time` missing → added
+  to task 1 / Design A.
+- `resolved` dev-proxy-DP4 — named the probe seam `_testmon_available()`
+  (Design A, task 3/9).
+- `resolved` delta-D1 — three exit-`1` branches disambiguated by message
+  string in tests, stated explicitly (Design B, task 9).
+- `resolved` delta-D2 — noted exit `2` gone from the status namespace;
+  `test_seed_testmon_mutex_exits_2` is the unrelated mutex namespace
+  (Design B).
+- `resolved` critic-C8 — `ok` message now says "baseline written (tests
+  may have failed)", not "succeeded" (Design B table).
+- `resolved` critic-C10 — harness guard test asserts the new tokens in all
+  three files; byte-identity via identical manual edit (Design C, task 9).
+- `resolved` dev-proxy-DP5 — conditional `check_doc_drift` co-mod note for
+  any `covers: scripts/qs/quality_gate.py` doc (Doc maintenance).
+- `resolved` critic-C5 / scope-S3 — log truncate tradeoff documented
+  (bounds growth; prior log overwritten) (Design C).
+- `resolved` scope-S4 — stale `rm -f` scoped to finish-task's launch path;
+  no GC subcommand (Design A).
+
+**Scope call (kept):**
+- `resolved` scope-S1 — `skipped` state retained (maps to a real
+  early-return branch; honest message; ~1 write + 1 test). User confirmed
+  keep.
+
+**Rejected (documented best-effort limitations, no mechanism — consistent
+with round 1):**
+- `rejected` critic-C3 — staleness/timeout bound for `running+dead` under
+  PID reuse: magic constant; PID reuse already documented.
+- `rejected` critic-C4 — overloaded exit `3`: `seed_testmon` runs detached
+  (rc → log, no consumer); documented as independent namespaces.
+- `rejected` critic-C11 — `reason` already surfaced by the `skipped`
+  message row; no change.
+
+**Open criticals after round-2 triage: 0.**

--- a/docs/stories/QS-286.story_review_fix_#01.md
+++ b/docs/stories/QS-286.story_review_fix_#01.md
@@ -1,0 +1,65 @@
+# QS-286 — Review fix plan #01
+
+## Summary
+- Source PR: #287
+- Source story: docs/stories/QS-286.story.md
+- Findings to fix: 7 (1 must-fix, 3 should-fix, 3 nice-to-have)
+- Next implement phase: `/implement-setup-task`
+
+## Findings to fix
+
+### [must-fix] `seed_testmon_status` crashes on malformed marker instead of returning exit 3
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_status`, marker read + `running` branch)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter (must-fix ×2), qs-review-coderabbit (should-fix), qs-review-blind-hunter (nice-to-have)
+- Description: The read guard only catches `(OSError, ValueError)`. Two malformed-but-parseable inputs slip past and crash the read-only status command with an uncaught traceback, violating the documented "unparseable/unreadable → exit 3" contract:
+  1. **Non-dict JSON** (`[1]`, `5`, `"x"`, `null`): `json.loads` succeeds, then `marker.get("state")` raises `AttributeError`.
+  2. **`running` marker with missing/non-int `pid`** (`{"state":"running"}`, `{"state":"running","pid":null}`, `"pid":"x"`): `marker.get("pid")` yields `None`/str, flows into `_pid_alive(...)` → `os.kill(None, 0)` → uncaught `TypeError` (`_pid_alive` only catches `ProcessLookupError`/`PermissionError`).
+- Proposed fix: After parsing, validate the marker shape before use. Treat a non-`dict` result as unreadable → return the `3`/"unreadable status" path (same message/exit as the existing unparseable branch). In the `running` branch, treat a missing or non-`int` `pid` as unreadable → `3` (or, if design prefers, as "interrupted" → `1`; pick one and document it). Do NOT pass a non-int into `_pid_alive`. Add regression tests in `tests/test_quality_gate.py` for: non-dict scalar, non-dict array, `running` with no `pid`, `running` with `pid: null`, `running` with non-int `pid`. Keep the reader read-only (no writes).
+
+### [should-fix] Typo "still" in the status-code note
+- File: `docs/workflow/phase-protocols.md:215-219`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The `--seed-testmon-status` guidance note contains a misspelling of "still", making user-facing guidance look sloppy.
+- Proposed fix: Correct the spelling of "still" in the status-code note.
+
+### [should-fix] "read only" → "read-only" grammar in story
+- File: `docs/stories/QS-286.story.md:81-82`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The marker is described as "read only" where the hyphenated adjective "read-only" is intended, inconsistent with the rest of the doc.
+- Proposed fix: Change "read only" → "read-only" at the flagged location for terminology consistency.
+
+### [should-fix] No content-guard test for the `--seed-testmon-status` doc edit
+- File: `tests/test_quality_gate.py` (extend `TestProjectRulesDocGuards`), covering `docs/workflow/project-rules.md`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The `project-rules.md` addition (AC 9) has no content-guard test, unlike AC 8's `test_seed_status_gitignored` (which pins the exact gitignore line) and the harness alignment guards. A drifted or reverted doc line would go unnoticed.
+- Proposed fix: Add a one-line content assertion (mirroring `test_seed_status_gitignored`) that asserts the `--seed-testmon-status` guidance text is present in `docs/workflow/project-rules.md`. Extend the existing `TestProjectRulesDocGuards`.
+
+### [nice-to-have] Torn marker prints `None` verbatim in status message
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_status` message formatting)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: An `ok`/`incomplete` marker missing its numeric fields prints e.g. "Baseline written at None" / "Finished with errors (exit None)". Not a crash; exit code stays correct.
+- Proposed fix: Largely subsumed by the must-fix schema validation — once malformed markers route to the unreadable path, this is unreachable via `_write_seed_status`. If any state still reads an optional field, fall back to a readable placeholder rather than emitting `None`. Add/adjust a test if the behavior changes.
+
+### [nice-to-have] Verbose docstring on `_write_seed_status`
+- File: `scripts/qs/quality_gate.py` (`_write_seed_status`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The helper's docstring is unusually long/prose-heavy (fsync rationale, "mechanization" phrasing) for a small helper.
+- Proposed fix: Trim the docstring to a terse summary of behavior (atomic write, best-effort swallow, temp cleanup); drop the narrative prose. No behavior change.
+
+### [nice-to-have] Fragile substring anchor in cross-harness block comparison
+- File: `tests/test_quality_gate.py:3651-3663`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: `body.index(".testmondata.seed.log.", start)` anchors on prose text ending in a literal period rather than the actual redirect target string; narrative text containing that substring could truncate the slice inconsistently.
+- Proposed fix: Anchor on a more specific, code-adjacent marker (e.g. the exact redirect line `.testmondata.seed.log`) so the cross-harness slice is robust to added prose.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify.

--- a/docs/stories/QS-286.story_review_fix_#02.md
+++ b/docs/stories/QS-286.story_review_fix_#02.md
@@ -1,0 +1,69 @@
+# QS-286 — Review fix plan #02
+
+## Summary
+- Source PR: #287
+- Source story: docs/stories/QS-286.story.md
+- Findings to fix: 3 (1 should-fix, 2 nice-to-have)
+- Next implement phase: `/implement-setup-task`
+
+Round-2 review context: fix plan #01 is applied and verified. CodeRabbit's
+round-2 output was stale (re-reported the pre-fix commit, rate-limited on the
+head commit) and is not carried here. Nice-to-have findings for PID reuse and
+the fixed `.tmp` sibling race were triaged as accepted-by-design (documented
+single-writer / best-effort limitations) and are intentionally NOT in scope.
+
+## Findings to fix
+
+### [should-fix] `pid <= 0` / `bool` slips past the `isinstance(pid, int)` guard
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_status` `running` branch / `_pid_alive`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Fix plan #01 added a guard to route malformed `running` markers to
+  the "unreadable → exit 3" path, but the guard `isinstance(pid, int)` still
+  accepts `0`, `-1`, and `True`/`False` (`bool` is an `int` subclass). These
+  flow into `_pid_alive` → `os.kill(pid, 0)`: `os.kill(0, 0)` targets the
+  caller's process *group* and `os.kill(-1, 0)` targets every signalable
+  process — both succeed, so a corrupt marker spuriously reports "still running
+  (pid 0/-1)" with exit 4 instead of the intended "unreadable → 3". Only
+  reachable via a torn/hand-edited marker (`seed_testmon()` always writes a
+  positive `os.getpid()`), but this is precisely the corrupt-marker case the
+  #01 hardening was meant to close.
+- Proposed fix: Tighten the `running`-branch pid validation to
+  `isinstance(pid, int) and not isinstance(pid, bool) and pid > 0`; anything
+  else routes to the existing unreadable/`3` message + exit path (do NOT call
+  `_pid_alive` with it). Add regression tests in `tests/test_quality_gate.py`
+  for `running` markers with `pid: 0`, `pid: -1`, and `pid: true` — each
+  asserting exit 3 and the unreadable message, and asserting `_pid_alive`/`os.kill`
+  is not invoked. Keep the reader read-only.
+
+### [nice-to-have] Epoch-float timestamps printed verbatim
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_status` message formatting)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `started`/`finished` are stored as raw `time.time()` epoch floats
+  and printed verbatim, so a normal successful run prints e.g. "Baseline written
+  at 1719878400.1234567" — not human-readable. Not a crash; exit code is correct.
+- Proposed fix: Format the epoch value into a readable local/UTC timestamp when
+  present (e.g. via `datetime.fromtimestamp(...).isoformat(timespec="seconds")`),
+  keeping the existing "an unknown time" placeholder when the field is absent.
+  Preserve the stored marker format (`time.time()`) — only change presentation.
+  Update/extend the relevant `TestSeedTestmonStatus` message assertions.
+
+### [nice-to-have] `_write_seed_status` swallows failures with no trace
+- File: `scripts/qs/quality_gate.py` (`_write_seed_status`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `except Exception: pass` silently swallows all marker-write
+  failures with no diagnostic output; intentional per the documented best-effort
+  carve-out, but a one-line debug trace would aid diagnosing a marker that never
+  appears.
+- Proposed fix: Emit a single best-effort debug/stderr line in the except branch
+  (reusing the module's existing emit/log helper if one exists) describing the
+  swallowed failure, WITHOUT changing the best-effort contract (still no raise,
+  temp still unlinked in `finally`). Add a test asserting the write path stays
+  best-effort (no raise) and that a diagnostic line is emitted on failure.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify.

--- a/docs/stories/QS-286.story_review_fix_#03.md
+++ b/docs/stories/QS-286.story_review_fix_#03.md
@@ -1,0 +1,50 @@
+# QS-286 — Review fix plan #03
+
+## Summary
+- Source PR: #287
+- Source story: docs/stories/QS-286.story.md
+- Findings to fix: 1 (1 must-fix)
+- Next implement phase: `/implement-setup-task`
+
+Round-3 review context: blind-hunter, acceptance-auditor (all 10 ACs
+implemented + tested), and CodeRabbit (no actionable head findings — stale /
+rate-limited) are clean. The one must-fix below is a regression introduced by
+fix plan #02's own new timestamp helper. The nice-to-have `.tmp` concurrent-writer
+race was triaged (again) as accepted-by-design (documented single-writer
+best-effort limitation) and is intentionally NOT in scope.
+
+## Findings to fix
+
+### [must-fix] `_fmt_seed_time` crashes the status query on a non-finite / out-of-range epoch
+- File: `scripts/qs/quality_gate.py` (`_fmt_seed_time`, called from `seed_testmon_status` for both `finished` and `started` fields)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: The timestamp-formatting helper added in fix plan #02 guards
+  `isinstance(value, (int, float)) and not isinstance(value, bool)` but does not
+  check finiteness or range. A numeric-but-non-finite or out-of-range epoch
+  (`Infinity`, `-Infinity`, `NaN`, or a huge magnitude such as `1e400`) passes
+  the guard, then `datetime.fromtimestamp(value, tz=UTC)` raises `OverflowError`
+  (`inf` / `1e400`) or `ValueError` (`NaN`) — uncaught — crashing the read-only
+  `seed_testmon_status()` query with a traceback. Python's `json.loads` accepts
+  `Infinity` / `-Infinity` / `NaN` literals by default, so a torn write or a
+  hand-edited/corrupt `.testmondata.seed-status` (e.g.
+  `{"state":"ok","finished":Infinity}` or
+  `{"state":"running","pid":<positive>,"started":NaN}`) reaches this line. This
+  is exactly the corrupt-marker class that fix plans #01/#02 were meant to close;
+  #02's new helper reopened it. The `running` branch's
+  `_fmt_seed_time(marker.get('started'))` on the same bad value crashes
+  identically before the pid/exit-4 result is printed.
+- Proposed fix: In `_fmt_seed_time`, reject non-finite values (add a
+  `math.isfinite(value)` check to the existing type guard) and/or wrap the
+  `datetime.fromtimestamp(...)` call in `try/except (OverflowError, ValueError,
+  OSError)`, falling back to the existing `"an unknown time"` placeholder on any
+  failure. Do not let the status query raise. Add regression tests in
+  `tests/test_quality_gate.py` covering `finished`/`started` values of `inf`,
+  `-inf`, `NaN`, and `1e400` for both the `ok`/`incomplete` and `running`
+  branches — each asserting the placeholder is used, no exception propagates,
+  and the exit code contract is unchanged. Keep the reader read-only.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify.

--- a/docs/stories/QS-286.story_review_fix_#04.md
+++ b/docs/stories/QS-286.story_review_fix_#04.md
@@ -1,0 +1,98 @@
+# QS-286 — Review fix plan #04
+
+## Summary
+- Source PR: #287
+- Source story: docs/stories/QS-286.story.md
+- Findings to fix: 5 (1 must-fix, 1 should-fix, 3 nice-to-have)
+- Next implement phase: `/implement-setup-task`
+
+Round-4 review context: blind-hunter clean; CodeRabbit skipped this round
+(stale / rate-limited every prior round). Acceptance-auditor confirms all 10
+ACs implemented + tested. This is the fourth corrupt-marker hardening round —
+implement the must-fix as a single robust guard so the `_pid_alive` /
+`_fmt_seed_time` "trust nothing from the marker" contract stops resurfacing
+one input at a time.
+
+## Findings to fix
+
+### [must-fix] Out-of-`pid_t`-range pid crashes the status query with `OverflowError`
+- File: `scripts/qs/quality_gate.py` (`_pid_alive`, `seed_testmon_status` running branch)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: The running-branch guard added in fix #02
+  (`not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0`) accepts any
+  positive non-bool int, including values beyond the platform `pid_t` (e.g.
+  `10**19`). Such a value flows into `_pid_alive(pid)` → `os.kill(pid, 0)`,
+  which raises `OverflowError` ("Python int too large to convert to C int").
+  `_pid_alive` only catches `ProcessLookupError` / `PermissionError`, so the
+  `OverflowError` propagates out of the read-only `seed_testmon_status()` and
+  crashes the query with a traceback — violating the documented
+  "unreadable → exit 3 / never crash the status query" contract. `json.loads`
+  parses the value fine, so a torn or hand-edited `.testmondata.seed-status`
+  (`{"state":"running","pid":10000000000000000000}`) reaches it. Same
+  corrupt-marker lineage as fix plans #01/#02/#03.
+- Proposed fix: Make `_pid_alive` total — catch `OverflowError` (alongside the
+  existing `ProcessLookupError`/`PermissionError`, and `ValueError`/`TypeError`
+  for defensiveness) and return `False` (treat as dead / not running) so the
+  running+dead branch reports "interrupted" (exit 1). This is preferable to
+  routing to unreadable, since an out-of-range pid is unambiguously not a live
+  process. Add a regression test for a huge positive pid (e.g. `10**19`)
+  asserting no exception propagates and the exit code is the interrupted/dead
+  contract. While here, review `_pid_alive`/`_fmt_seed_time` together and ensure
+  every "value came from the untrusted marker" path is total (no uncaught
+  exception can escape the status query) so this class of finding is closed in
+  one pass rather than incrementally.
+
+### [should-fix] No content-guard test on the `phase-protocols.md` step-5 edit
+- File: `tests/test_quality_gate.py` (extend `TestProjectRulesDocGuards` or a sibling), covering `docs/workflow/phase-protocols.md`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: Symmetric to the gap remediated in fix #01 for `project-rules.md`.
+  The `project-rules.md` `--seed-testmon-status` addition is pinned by
+  `test_seed_testmon_status_command_reference_present`, but the
+  `phase-protocols.md` step-5 addition (the `.testmondata.seed.log` /
+  `--seed-testmon-status` / exit-code note) has no content-guard test, so a
+  drift or revert of that doc line would go unnoticed.
+- Proposed fix: Add a one-line content assertion (mirroring the existing
+  project-rules guard) that asserts the step-5 `--seed-testmon-status` guidance
+  text is present in `docs/workflow/phase-protocols.md`.
+
+### [nice-to-have] Redundant `pid` in the completion marker
+- File: `scripts/qs/quality_gate.py` (`seed_testmon` final `ok`/`incomplete` write)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `seed_testmon` writes `pid=os.getpid()` in both the `running`
+  marker and the final `ok`/`incomplete` marker; the completion marker's `pid`
+  is redundant since the process is finishing.
+- Proposed fix: Drop `pid` from the final `ok`/`incomplete` marker write (keep it
+  in the `running` marker, which is what the reader's liveness check consumes).
+  Update any affected marker-field assertions in `tests/test_quality_gate.py`.
+  Do not change the `running` marker or the status-code contract.
+
+### [nice-to-have] Misleading `_fmt_seed_time` comment
+- File: `scripts/qs/quality_gate.py` (`_fmt_seed_time`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The comment claims `math.isfinite` "overflows on a huge int
+  (10**400 → float)"; in fact `math.isfinite(10**400)` raises `OverflowError`
+  (caught by the surrounding `try`). Behavior is correct and tested; only the
+  "→ float" phrasing is misleading.
+- Proposed fix: Reword the comment to accurately describe that a huge int raises
+  `OverflowError` (caught), not a float conversion. Comment-only change.
+
+### [nice-to-have] No dedicated test for `__file__`-relative marker path
+- File: `tests/test_quality_gate.py`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: AC 6 requires the marker path be resolved `__file__`-relative
+  (via `REPO_ROOT`), not cwd-relative. The constant is correct by construction
+  and all tests patch `SEED_STATUS`, but the cwd-independence property itself is
+  asserted only via the source comment.
+- Proposed fix: Add a small test asserting `SEED_STATUS` is anchored under
+  `REPO_ROOT` (i.e. resolves the same regardless of the process cwd), mirroring
+  the existing `TESTMON_DATA` convention.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify.

--- a/docs/workflow/phase-protocols.md
+++ b/docs/workflow/phase-protocols.md
@@ -212,7 +212,11 @@ as alternatives (see QS-175 OUT OF SCOPE).
    --ff-only`), then refresh the testmon DB via
    `quality_gate.py --seed-testmon` — detached/best-effort, never
    blocking cleanup. A failure or stale baseline is safe (new worktrees
-   just run more tests).
+   just run more tests). QS-286: the detached run now emits a completion
+   signal — it redirects to `.testmondata.seed.log` and writes a
+   `.testmondata.seed-status` marker when done; poll it from the main
+   checkout with `quality_gate.py --seed-testmon-status` (0 = safe to
+   close, 4 = still running, 1 = rerun, 3 = no readable status).
 6. Delete remote branch (safety check: refuse if branch is
    `main` / `master`).
 7. Run `python scripts/qs/cleanup_worktree.py --work-dir <wd>

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -70,6 +70,11 @@ python scripts/qs/quality_gate.py --quick tests/test_solver.py tests/test_constr
 # baseline fully re-fingerprints (never a "0 changed" dead end).
 python scripts/qs/quality_gate.py --seed-testmon
 
+# QS-286: companion read-only query — report the detached --seed-testmon
+# run's completion status (no pytest/coverage/testmon import). Exit codes:
+# 0 = ok/safe to close, 4 = still running, 1 = rerun, 3 = no readable status.
+python scripts/qs/quality_gate.py --seed-testmon-status
+
 # Ad-hoc single-node pytest — debugging only.
 source venv/bin/activate && pytest tests/test_solver.py::test_function_name -v
 ```
@@ -100,7 +105,11 @@ whole-suite-ish `pytest --testmon` invocation is routed through
 `quality_gate.py` the single pytest owner: it only refreshes
 `.testmondata` (no coverage, no pass/fail verdict) and is invoked
 detached/best-effort by `finish-task` to rebuild the main baseline
-after a merge. A bare `pytest --testmon` remains forbidden.
+after a merge. A bare `pytest --testmon` remains forbidden. QS-286: its
+companion `--seed-testmon-status` is the sanctioned **read-only** query
+subcommand (no pytest/coverage/testmon import) — it reads the
+`.testmondata.seed-status` marker the detached run writes and reports
+whether it is safe to close the terminal.
 
 **UI-only fast path.** When only `custom_components/quiet_solar/ui/*.j2`
 templates and `custom_components/quiet_solar/ui/resources/**` assets

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -1486,17 +1486,9 @@ def check_impacted() -> int:
 
 
 def _write_seed_status(state: str, **fields: object) -> None:
-    """Write the `--seed-testmon` completion marker atomically, best-effort.
-
-    QS-286: serializes ``{"state": state, **fields}`` to a temp sibling and
-    ``os.replace()``s it over `SEED_STATUS` (atomic rename — a concurrent
-    reader never sees a torn file). The whole body is best-effort: a write
-    failure must NEVER abort the detached baseline rebuild (the sanctioned
-    `--seed-testmon` carve-out), so it swallows and continues, with a
-    `finally` that unlinks the temp file. No `fsync` — the marker is read
-    after the process exits in the common case, and the reader's
-    `unparseable → 3` branch is the torn-write backstop; fsync durability
-    would be mechanization inconsistent with a best-effort signal.
+    """Write the `SEED_STATUS` marker atomically (temp sibling + os.replace),
+    best-effort (swallow any error so a write failure never aborts the
+    detached rebuild), cleaning up the temp file in a `finally`. No `fsync`.
     """
     tmp = SEED_STATUS.with_suffix(SEED_STATUS.suffix + ".tmp")
     try:
@@ -1619,29 +1611,44 @@ def seed_testmon_status() -> int:
     incomplete, or skipped); 3 = no readable status (missing or unparseable).
 
     The reader TRUSTS the marker (best-effort) — it does not cross-check that
-    `.testmondata` still exists for an `ok` verdict.
+    `.testmondata` still exists for an `ok` verdict. It defends against a
+    malformed marker (review-fix #01): a non-`dict` payload, an unrecognized
+    `state`, or a `running` marker whose `pid` is missing/non-int all route to
+    the "unreadable → 3" path rather than crashing, and display-only fields
+    that are absent print a readable placeholder instead of `None`.
     """
+    def _unreadable() -> int:
+        print("The baseline refresh status is unreadable.")
+        return 3
+
     if not SEED_STATUS.exists():
         print("No baseline refresh has been recorded.")
         return 3
     try:
         marker = json.loads(SEED_STATUS.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        print("The baseline refresh status is unreadable.")
-        return 3
+        return _unreadable()
+    # A parseable-but-non-object payload (`[1]`, `5`, `null`, `"x"`) has no
+    # `.get`; treat it as unreadable rather than letting `.get` raise.
+    if not isinstance(marker, dict):
+        return _unreadable()
 
     state = marker.get("state")
     if state == "ok":
         print(
-            f"Baseline written at {marker.get('finished')} "
+            f"Baseline written at {marker.get('finished', 'an unknown time')} "
             "(tests may have failed) — safe to close this terminal."
         )
         return 0
     if state == "running":
         pid = marker.get("pid")
+        # `_pid_alive` calls `os.kill(pid, 0)`, which raises TypeError on a
+        # non-int; a `running` marker without a usable pid is unreadable.
+        if not isinstance(pid, int):
+            return _unreadable()
         if _pid_alive(pid):
             print(
-                f"Still running (pid {pid}, started {marker.get('started')}) "
+                f"Still running (pid {pid}, started {marker.get('started', 'an unknown time')}) "
                 "— keep this terminal open."
             )
             return 4
@@ -1652,19 +1659,18 @@ def seed_testmon_status() -> int:
         return 1
     if state == "incomplete":
         print(
-            f"Finished with errors (exit {marker.get('returncode')}) — "
+            f"Finished with errors (exit {marker.get('returncode', 'unknown')}) — "
             "`.testmondata` may be partial; rerun the refresh."
         )
         return 1
     if state == "skipped":
         print(
-            f"Refresh was skipped ({marker.get('reason')}) — no baseline was "
+            f"Refresh was skipped ({marker.get('reason', 'unknown reason')}) — no baseline was "
             "written; rerun if needed."
         )
         return 1
     # Any other/absent state value is an unreadable status.
-    print("The baseline refresh status is unreadable.")
-    return 3
+    return _unreadable()
 
 
 def main() -> None:

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -51,6 +51,7 @@ import sqlite3
 import subprocess
 import sys
 import threading
+import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
@@ -902,6 +903,12 @@ def _output_results(
 # per-run temp path.
 COVERAGE_XML = REPO_ROOT / "coverage.xml"
 TESTMON_DATA = REPO_ROOT / ".testmondata"
+# QS-286: sidecar completion marker for the detached `--seed-testmon` run.
+# REPO_ROOT is `__file__`-relative (cwd- and symlink-resolved), so the marker
+# always lands beside the main worktree's `.testmondata` regardless of the
+# detached process's cwd — a later `--seed-testmon-status` query from
+# $MAIN_DIR reads the same file.
+SEED_STATUS = REPO_ROOT / ".testmondata.seed-status"
 # QS-278: the persistent coverage DATA file (coverage.py's default). The
 # `--impacted` gate runs testmon-selected tests with `--cov-append` so
 # coverage ACCUMULATES across inner-loop invocations. testmon 2.2.0
@@ -1478,6 +1485,47 @@ def check_impacted() -> int:
     return 1
 
 
+def _write_seed_status(state: str, **fields: object) -> None:
+    """Write the `--seed-testmon` completion marker atomically, best-effort.
+
+    QS-286: serializes ``{"state": state, **fields}`` to a temp sibling and
+    ``os.replace()``s it over `SEED_STATUS` (atomic rename — a concurrent
+    reader never sees a torn file). The whole body is best-effort: a write
+    failure must NEVER abort the detached baseline rebuild (the sanctioned
+    `--seed-testmon` carve-out), so it swallows and continues, with a
+    `finally` that unlinks the temp file. No `fsync` — the marker is read
+    after the process exits in the common case, and the reader's
+    `unparseable → 3` branch is the torn-write backstop; fsync durability
+    would be mechanization inconsistent with a best-effort signal.
+    """
+    tmp = SEED_STATUS.with_suffix(SEED_STATUS.suffix + ".tmp")
+    try:
+        tmp.write_text(json.dumps({"state": state, **fields}), encoding="utf-8")
+        os.replace(tmp, SEED_STATUS)
+    except Exception:  # noqa: BLE001 — courtesy marker; never abort the rebuild
+        pass
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if `pid` is a live process (QS-286).
+
+    `os.kill(pid, 0)` sends no signal but validates the target:
+    `ProcessLookupError` → the pid is gone (dead); `PermissionError` → the
+    pid exists but is owned by another user (alive-but-not-ours → alive);
+    success → alive. Extracted as a patchable seam so the status reader's
+    `running` branches are coverable without spawning real processes.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
 def seed_testmon() -> int:
     """Refresh `.testmondata` via `pytest --testmon`; no coverage, no verdict.
 
@@ -1486,11 +1534,18 @@ def seed_testmon() -> int:
     baseline after a merge. Returns 0 once the selection completes (a
     failing test still updates the DB — there is no pass/fail verdict);
     returns 3 when testmon is not importable.
+
+    QS-286: writes the `SEED_STATUS` completion marker so the detached
+    run (launched by `finish-task`) has a pollable signal — see
+    `seed_testmon_status`. The marker writes are the only additions here;
+    the best-effort return semantics are unchanged.
     """
     # QS-276 review-fix S2: probe ONLY testmon — seeding never invokes
     # diff-cover, so a missing diff-cover must not block the refresh.
     if not _testmon_available():
         _emit("seed-testmon", "pytest-testmon not importable — skipping")
+        # QS-286: record the skip (no `running` marker on this path).
+        _write_seed_status("skipped", reason="pytest-testmon not importable")
         return 3
     # QS-283 A3: rebuild from scratch. The old code ran `pytest --testmon`
     # against the EXISTING DB, so an already-advanced baseline yielded
@@ -1499,6 +1554,10 @@ def seed_testmon() -> int:
     # establishes the baseline the NEXT `--impacted` accumulates onto) forces
     # a true full re-fingerprint (select-all) and prevents a stale `.coverage`
     # from re-introducing the desync A1 fixes.
+    # QS-286: mark the run as started (after the probe, before the pytest
+    # pass) so a status query mid-run reports "still running".
+    started = time.time()
+    _write_seed_status("running", pid=os.getpid(), started=started)
     _rebuild_testmon_baseline()
     _emit("seed-testmon", "refreshing .testmondata (pytest --testmon)")
     result = _stream_pytest(_build_seed_testmon_cmd())
@@ -1511,6 +1570,17 @@ def seed_testmon() -> int:
     rc = result.get("returncode", 0)
     if rc >= 2:
         _emit("seed-testmon", f"warning: pytest exited {rc} (collection error/crash) — .testmondata may be incomplete")
+    # QS-286: overwrite the marker on completion. rc < 2 means testmon wrote
+    # `.testmondata` (0 = clean, 1 = failures but DB persisted — "ok" means
+    # "baseline written", NOT "tests passed"); rc >= 2 (usage/collection
+    # error, crash, or no-tests) means the baseline is suspect → "incomplete".
+    _write_seed_status(
+        "ok" if rc < 2 else "incomplete",
+        pid=os.getpid(),
+        started=started,
+        finished=time.time(),
+        returncode=rc,
+    )
     return 0
 
 
@@ -1536,6 +1606,65 @@ def _build_seed_testmon_cmd() -> list[str]:
         if workers is not None:
             cmd.extend(["-n", workers])
     return cmd
+
+
+def seed_testmon_status() -> int:
+    """Report the detached `--seed-testmon` run's status (QS-286).
+
+    Read-only non-gate subcommand — invokes NO pytest, coverage, or testmon
+    import; it only stat/reads the `SEED_STATUS` marker and checks PID
+    liveness. Prints a human answer and returns a scriptable exit code on a
+    deliberately small 4-code contract: 0 = ok / safe to close; 4 = still
+    running / keep the terminal open; 1 = not trustworthy, rerun (interrupted,
+    incomplete, or skipped); 3 = no readable status (missing or unparseable).
+
+    The reader TRUSTS the marker (best-effort) — it does not cross-check that
+    `.testmondata` still exists for an `ok` verdict.
+    """
+    if not SEED_STATUS.exists():
+        print("No baseline refresh has been recorded.")
+        return 3
+    try:
+        marker = json.loads(SEED_STATUS.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        print("The baseline refresh status is unreadable.")
+        return 3
+
+    state = marker.get("state")
+    if state == "ok":
+        print(
+            f"Baseline written at {marker.get('finished')} "
+            "(tests may have failed) — safe to close this terminal."
+        )
+        return 0
+    if state == "running":
+        pid = marker.get("pid")
+        if _pid_alive(pid):
+            print(
+                f"Still running (pid {pid}, started {marker.get('started')}) "
+                "— keep this terminal open."
+            )
+            return 4
+        print(
+            f"Interrupted (pid {pid} no longer running) — `.testmondata` "
+            "may be partial; rerun the refresh."
+        )
+        return 1
+    if state == "incomplete":
+        print(
+            f"Finished with errors (exit {marker.get('returncode')}) — "
+            "`.testmondata` may be partial; rerun the refresh."
+        )
+        return 1
+    if state == "skipped":
+        print(
+            f"Refresh was skipped ({marker.get('reason')}) — no baseline was "
+            "written; rerun if needed."
+        )
+        return 1
+    # Any other/absent state value is an unreadable status.
+    print("The baseline refresh status is unreadable.")
+    return 3
 
 
 def main() -> None:
@@ -1572,6 +1701,16 @@ def main() -> None:
             "Mutex with --impacted/--quick/--cache/--no-cache/--full/--fix."
         ),
     )
+    parser.add_argument(
+        "--seed-testmon-status",
+        action="store_true",
+        help=(
+            "Report the detached --seed-testmon run's completion status "
+            "(read-only; no pytest). Exit 0=ok/safe to close, 4=still running, "
+            "1=rerun, 3=no readable status. Mutex with the same modes as "
+            "--seed-testmon."
+        ),
+    )
     args = parser.parse_args()
 
     # --quick is mutually exclusive with cache/full/fix. argparse's nargs="+"
@@ -1602,6 +1741,23 @@ def main() -> None:
         parser.error(
             "you cannot combine --seed-testmon with --impacted, --quick, --cache, "
             "--no-cache, --full, or --fix"
+        )
+
+    # QS-286: --seed-testmon-status is a read-only query subcommand, not a
+    # gate mode. Mirror the --seed-testmon mutex so combining it with any
+    # execution mode (or the seed itself) is an explicit usage error.
+    if args.seed_testmon_status and (
+        args.impacted
+        or args.quick
+        or args.cache
+        or args.no_cache
+        or args.full
+        or args.fix
+        or args.seed_testmon
+    ):
+        parser.error(
+            "you cannot combine --seed-testmon-status with --impacted, --quick, "
+            "--cache, --no-cache, --full, --fix, or --seed-testmon"
         )
 
     # Review-fix #01 finding 8 — `--quick ""` would otherwise resolve to
@@ -1648,6 +1804,11 @@ def main() -> None:
     # and exit, never touching scope detection or the coverage gate.
     if args.seed_testmon:
         sys.exit(seed_testmon())
+
+    # QS-286: --seed-testmon-status is a read-only query — short-circuit
+    # before cache/scope detection like the other subcommands.
+    if args.seed_testmon_status:
+        sys.exit(seed_testmon_status())
 
     use_cache = args.cache and not args.fix and not args.no_cache
 

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import sqlite3
@@ -1609,9 +1610,21 @@ def _fmt_seed_time(value: object) -> str:
     for display only (the stored marker format is unchanged). A missing or
     non-numeric value (torn/hand-edited marker) yields the readable
     "an unknown time" placeholder rather than a bare float or `None`.
+
+    Non-finite (`inf`/`-inf`/`NaN` — `json.loads` accepts these literals) and
+    out-of-range epochs are also placeholdered rather than crashing the
+    read-only query: `math.isfinite` rejects the former and the `try/except`
+    catches `datetime.fromtimestamp` overflow on a huge finite magnitude
+    (review-fix #03).
     """
     if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return datetime.fromtimestamp(value, tz=UTC).isoformat(timespec="seconds")
+        try:
+            # `math.isfinite` itself overflows on a huge int (10**400 → float),
+            # so it lives inside the guard, not as a short-circuit condition.
+            if math.isfinite(value):
+                return datetime.fromtimestamp(value, tz=UTC).isoformat(timespec="seconds")
+        except (OverflowError, ValueError, OSError):
+            pass
     return "an unknown time"
 
 

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -1511,13 +1511,20 @@ def _pid_alive(pid: int) -> bool:
     pid exists but is owned by another user (alive-but-not-ours → alive);
     success → alive. Extracted as a patchable seam so the status reader's
     `running` branches are coverable without spawning real processes.
+
+    Total by design (review-fix #04): the pid comes from an untrusted marker,
+    so an out-of-`pid_t`-range value (`10**19` → `OverflowError`) or any other
+    bad input (`ValueError`/`TypeError`) is treated as dead rather than
+    escaping and crashing the read-only status query. An out-of-range pid is
+    unambiguously not a live process, so "dead" (→ interrupted, exit 1) is the
+    correct verdict.
     """
     try:
         os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
     except PermissionError:
         return True
+    except (ProcessLookupError, OverflowError, ValueError, TypeError):
+        return False
     return True
 
 
@@ -1569,9 +1576,11 @@ def seed_testmon() -> int:
     # `.testmondata` (0 = clean, 1 = failures but DB persisted — "ok" means
     # "baseline written", NOT "tests passed"); rc >= 2 (usage/collection
     # error, crash, or no-tests) means the baseline is suspect → "incomplete".
+    # No `pid` in the completion marker: the process is finishing, so the
+    # reader's liveness check only ever consumes the `running` marker's pid
+    # (review-fix #04).
     _write_seed_status(
         "ok" if rc < 2 else "incomplete",
-        pid=os.getpid(),
         started=started,
         finished=time.time(),
         returncode=rc,
@@ -1619,8 +1628,9 @@ def _fmt_seed_time(value: object) -> str:
     """
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         try:
-            # `math.isfinite` itself overflows on a huge int (10**400 → float),
-            # so it lives inside the guard, not as a short-circuit condition.
+            # A huge int raises `OverflowError` in `math.isfinite` itself
+            # (caught below), so the finiteness check lives inside the
+            # try/except rather than as a short-circuit guard condition.
             if math.isfinite(value):
                 return datetime.fromtimestamp(value, tz=UTC).isoformat(timespec="seconds")
         except (OverflowError, ValueError, OSError):

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -1494,8 +1494,10 @@ def _write_seed_status(state: str, **fields: object) -> None:
     try:
         tmp.write_text(json.dumps({"state": state, **fields}), encoding="utf-8")
         os.replace(tmp, SEED_STATUS)
-    except Exception:  # noqa: BLE001 — courtesy marker; never abort the rebuild
-        pass
+    except Exception as exc:  # noqa: BLE001 — courtesy marker; never abort the rebuild
+        # Best-effort still emits one diagnostic line so a marker that never
+        # appears is traceable (review-fix #02) — contract unchanged: no raise.
+        _emit("seed-testmon", f"warning: could not write status marker ({state}): {exc}")
     finally:
         tmp.unlink(missing_ok=True)
 
@@ -1600,6 +1602,19 @@ def _build_seed_testmon_cmd() -> list[str]:
     return cmd
 
 
+def _fmt_seed_time(value: object) -> str:
+    """Render a marker epoch timestamp as a readable UTC ISO string (QS-286).
+
+    `started`/`finished` are stored as raw `time.time()` floats; format them
+    for display only (the stored marker format is unchanged). A missing or
+    non-numeric value (torn/hand-edited marker) yields the readable
+    "an unknown time" placeholder rather than a bare float or `None`.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return datetime.fromtimestamp(value, tz=UTC).isoformat(timespec="seconds")
+    return "an unknown time"
+
+
 def seed_testmon_status() -> int:
     """Report the detached `--seed-testmon` run's status (QS-286).
 
@@ -1636,19 +1651,22 @@ def seed_testmon_status() -> int:
     state = marker.get("state")
     if state == "ok":
         print(
-            f"Baseline written at {marker.get('finished', 'an unknown time')} "
+            f"Baseline written at {_fmt_seed_time(marker.get('finished'))} "
             "(tests may have failed) — safe to close this terminal."
         )
         return 0
     if state == "running":
         pid = marker.get("pid")
-        # `_pid_alive` calls `os.kill(pid, 0)`, which raises TypeError on a
-        # non-int; a `running` marker without a usable pid is unreadable.
-        if not isinstance(pid, int):
+        # `_pid_alive` calls `os.kill(pid, 0)`; a `running` marker whose pid is
+        # not a positive, non-bool int is unreadable. Excluding bool (an int
+        # subclass) and pid <= 0 is deliberate: `os.kill(0, 0)` targets the
+        # caller's process group and `os.kill(-1, 0)` every signalable process
+        # — both would spuriously report "still running" (review-fix #02).
+        if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
             return _unreadable()
         if _pid_alive(pid):
             print(
-                f"Still running (pid {pid}, started {marker.get('started', 'an unknown time')}) "
+                f"Still running (pid {pid}, started {_fmt_seed_time(marker.get('started'))}) "
                 "— keep this terminal open."
             )
             return 4

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -3158,6 +3158,7 @@ class TestSeedTestmon:
         assert marker["state"] == "ok"
         assert marker["returncode"] == rc
         assert "finished" in marker and "started" in marker
+        assert "pid" not in marker  # review-fix #04: dropped from completion marker
 
     def test_incomplete_marker_on_rc_ge_2(self) -> None:
         """AC#1: rc >= 2 (suspect DB) → final marker state=incomplete."""
@@ -3170,6 +3171,7 @@ class TestSeedTestmon:
         marker = self._marker()
         assert marker["state"] == "incomplete"
         assert marker["returncode"] == 2
+        assert "pid" not in marker  # review-fix #04: dropped from completion marker
 
     def test_skipped_marker_and_no_running_when_tooling_missing(self) -> None:
         """AC#2: not-importable writes a `skipped` marker (with reason) and
@@ -3323,6 +3325,21 @@ class TestPidAlive:
             assert quality_gate._pid_alive(1234) is True
         mock_kill.assert_called_once_with(1234, 0)
 
+    # review-fix #04: `_pid_alive` is total — an untrusted pid that makes
+    # os.kill raise anything other than PermissionError is treated as dead,
+    # never propagating out of the read-only status query.
+    @pytest.mark.parametrize(
+        "exc", [OverflowError, ValueError, TypeError], ids=["overflow", "value", "type"]
+    )
+    def test_dead_on_other_os_kill_errors(self, exc: type[Exception]) -> None:
+        with patch.object(quality_gate.os, "kill", side_effect=exc):
+            assert quality_gate._pid_alive(10**19) is False
+
+    def test_out_of_range_pid_is_dead_no_raise(self) -> None:
+        """Real os.kill: a pid beyond pid_t (10**19) raises OverflowError, which
+        `_pid_alive` swallows → dead (no patching of the syscall)."""
+        assert quality_gate._pid_alive(10**19) is False
+
 
 class TestFmtSeedTime:
     """QS-286 review-fix #02: epoch marker fields render as readable UTC ISO."""
@@ -3459,6 +3476,16 @@ class TestSeedTestmonStatus:
         mock_alive.assert_not_called()  # bad pid never hits the syscall seam
         mock_kill.assert_not_called()
         assert "unreadable" in capsys.readouterr().out.lower()
+
+    def test_running_out_of_range_pid_interrupted_no_crash(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """review-fix #04 must-fix: a positive pid beyond pid_t (10**19) passes
+        the positivity guard, reaches the real os.kill (→ OverflowError), and is
+        treated as dead → interrupted (exit 1), never crashing the query."""
+        self._write({"state": "running", "pid": 10**19, "started": 1.0})
+        assert quality_gate.seed_testmon_status() == 1  # no OverflowError
+        assert "interrupted" in capsys.readouterr().out.lower()
 
     # review-fix #01 nice-to-have: a marker missing a display-only field prints
     # a readable placeholder, not literal "None" — and keeps its exit code.
@@ -3677,6 +3704,17 @@ class TestImpactedDeps:
         gi = (Path(__file__).resolve().parent.parent / ".gitignore").read_text()
         assert any(line.strip() == ".testmondata.seed-status" for line in gi.splitlines())
 
+    def test_seed_status_path_is_repo_root_relative(self) -> None:
+        """QS-286 AC#6 (review-fix #04): the marker constant is anchored under
+        REPO_ROOT (`__file__`-relative, cwd-independent), mirroring TESTMON_DATA
+        — so the detached run and a later status query resolve the same file."""
+        assert quality_gate.SEED_STATUS == quality_gate.REPO_ROOT / ".testmondata.seed-status"
+        assert quality_gate.SEED_STATUS.parent == quality_gate.REPO_ROOT
+        assert quality_gate.SEED_STATUS.is_absolute()
+        # Shares the main worktree's .testmondata directory (same relocation
+        # invariant as the testmon DB).
+        assert quality_gate.SEED_STATUS.parent == quality_gate.TESTMON_DATA.parent
+
 
 class TestProjectRulesDocGuards:
     """review-fix N2: content guard for the AC#12 doc edits (not just drift-checker)."""
@@ -3702,6 +3740,16 @@ class TestProjectRulesDocGuards:
         rules = self._rules()
         assert "quality_gate.py --seed-testmon-status" in rules
         assert "companion" in rules  # documented as the --seed-testmon companion
+
+    def test_phase_protocols_step5_completion_signal_present(self) -> None:
+        """review-fix #04 (AC#9): pin the phase-protocols.md step-5 completion
+        -signal note, symmetric to the project-rules guard above so a drift /
+        revert of the step-5 line is caught."""
+        proto = (
+            Path(__file__).resolve().parent.parent / "docs" / "workflow" / "phase-protocols.md"
+        ).read_text()
+        assert "quality_gate.py --seed-testmon-status" in proto
+        assert ".testmondata.seed.log" in proto
 
 
 class TestWorktreeSetupSeedsCaches:

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -3339,6 +3339,16 @@ class TestFmtSeedTime:
     def test_non_numeric_is_placeholder(self, value: object) -> None:
         assert quality_gate._fmt_seed_time(value) == "an unknown time"
 
+    # review-fix #03: non-finite / out-of-range epochs must not raise
+    # (json.loads accepts Infinity/-Infinity/NaN); they placeholder instead.
+    @pytest.mark.parametrize(
+        "value",
+        [float("inf"), float("-inf"), float("nan"), 1e400, 10**400, -(10**400)],
+        ids=["inf", "-inf", "nan", "1e400", "huge-int", "huge-neg-int"],
+    )
+    def test_non_finite_or_out_of_range_is_placeholder(self, value: object) -> None:
+        assert quality_gate._fmt_seed_time(value) == "an unknown time"
+
 
 class TestSeedTestmonStatus:
     """QS-286 AC#4: `seed_testmon_status` — distinct message + 4-code exit
@@ -3457,6 +3467,39 @@ class TestSeedTestmonStatus:
         assert quality_gate.seed_testmon_status() == 0
         out = capsys.readouterr().out
         assert "None" not in out
+        assert "an unknown time" in out
+
+    # review-fix #03 must-fix: a non-finite / out-of-range epoch in a marker
+    # must not crash the read-only status query — it placeholders and keeps
+    # its exit code. json.dumps emits Infinity/-Infinity/NaN literals that
+    # json.loads accepts, mirroring a torn / hand-edited marker.
+    @pytest.mark.parametrize(
+        "finished",
+        [float("inf"), float("-inf"), float("nan"), 10**400],
+        ids=["inf", "-inf", "nan", "huge-int"],
+    )
+    def test_ok_with_bad_epoch_placeholders_no_crash(
+        self, finished: object, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._write({"state": "ok", "finished": finished})
+        assert quality_gate.seed_testmon_status() == 0  # no OverflowError/ValueError
+        out = capsys.readouterr().out
+        assert "safe to close" in out.lower()
+        assert "an unknown time" in out
+
+    @pytest.mark.parametrize(
+        "started",
+        [float("inf"), float("-inf"), float("nan"), 10**400],
+        ids=["inf", "-inf", "nan", "huge-int"],
+    )
+    def test_running_with_bad_epoch_placeholders_no_crash(
+        self, started: object, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._write({"state": "running", "pid": 42, "started": started})
+        with patch.object(quality_gate, "_pid_alive", return_value=True):
+            assert quality_gate.seed_testmon_status() == 4  # no crash before exit 4
+        out = capsys.readouterr().out
+        assert "still running" in out.lower()
         assert "an unknown time" in out
 
     def test_incomplete_missing_returncode_prints_placeholder(

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -3110,13 +3110,76 @@ class TestSeedTestmon:
     """`seed_testmon` refreshes the DB with no pass/fail verdict."""
 
     @pytest.fixture(autouse=True)
-    def _stub_rebuild(self):
+    def _stub_rebuild(self, tmp_path: Path):
         """QS-283 A3: `seed_testmon` now calls `_rebuild_testmon_baseline`,
         which purges the real `.testmondata` and `.coverage`. Stub it by
         default so these mocked-seam tests never touch the real FS; the
-        dedicated ordering test re-patches it with its own spy."""
-        with patch.object(quality_gate, "_rebuild_testmon_baseline"):
+        dedicated ordering test re-patches it with its own spy.
+
+        QS-286: also redirect `SEED_STATUS` to a tmp sibling so the marker
+        writes never pollute the repo root, and tests can read it back."""
+        with (
+            patch.object(quality_gate, "_rebuild_testmon_baseline"),
+            patch.object(quality_gate, "SEED_STATUS", tmp_path / ".testmondata.seed-status"),
+        ):
             yield
+
+    def _marker(self) -> dict:
+        return json.loads(quality_gate.SEED_STATUS.read_text())
+
+    def test_running_marker_written_after_probe_before_pytest(self) -> None:
+        """AC#1: a `running` marker (with pid + started) exists by the time
+        the pytest pass runs — captured here from inside `_stream_pytest`."""
+        seen: dict = {}
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["SEED_CMD"]),
+            patch.object(
+                quality_gate,
+                "_stream_pytest",
+                side_effect=lambda *_a, **_k: (seen.update(self._marker()), {"returncode": 0})[1],
+            ),
+        ):
+            assert quality_gate.seed_testmon() == 0
+        assert seen["state"] == "running"
+        assert seen["pid"] == os.getpid()
+        assert "started" in seen
+
+    @pytest.mark.parametrize("rc", [0, 1], ids=["clean", "test-failures"])
+    def test_ok_marker_on_rc_lt_2(self, rc: int) -> None:
+        """AC#1: rc < 2 (DB written) → final marker state=ok with returncode/finished."""
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["SEED_CMD"]),
+            patch.object(quality_gate, "_stream_pytest", return_value={"returncode": rc}),
+        ):
+            assert quality_gate.seed_testmon() == 0
+        marker = self._marker()
+        assert marker["state"] == "ok"
+        assert marker["returncode"] == rc
+        assert "finished" in marker and "started" in marker
+
+    def test_incomplete_marker_on_rc_ge_2(self) -> None:
+        """AC#1: rc >= 2 (suspect DB) → final marker state=incomplete."""
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["SEED_CMD"]),
+            patch.object(quality_gate, "_stream_pytest", return_value={"returncode": 2}),
+        ):
+            assert quality_gate.seed_testmon() == 0
+        marker = self._marker()
+        assert marker["state"] == "incomplete"
+        assert marker["returncode"] == 2
+
+    def test_skipped_marker_and_no_running_when_tooling_missing(self) -> None:
+        """AC#2: not-importable writes a `skipped` marker (with reason) and
+        returns 3; NO `running` marker is written on that path."""
+        with patch.object(quality_gate, "_testmon_available", return_value=False):
+            assert quality_gate.seed_testmon() == 3
+        marker = self._marker()
+        assert marker["state"] == "skipped"
+        assert "not importable" in marker["reason"]
+        assert "pid" not in marker  # never reached the `running` write
 
     def test_tooling_missing_returns_3(self) -> None:
         # review-fix S2: gated on the testmon-only probe, NOT the full impacted set.
@@ -3202,6 +3265,128 @@ class TestSeedTestmon:
         with patch.object(quality_gate, "_pytest_workers", return_value=None):
             cmd = quality_gate._build_seed_testmon_cmd()
         assert "-n" not in cmd
+
+
+class TestWriteSeedStatus:
+    """QS-286 AC#3: `_write_seed_status` is atomic + best-effort."""
+
+    @pytest.fixture(autouse=True)
+    def _redirect(self, tmp_path: Path):
+        with patch.object(quality_gate, "SEED_STATUS", tmp_path / ".testmondata.seed-status"):
+            yield
+
+    def test_writes_state_and_fields_no_temp_leftover(self) -> None:
+        quality_gate._write_seed_status("running", pid=7, started=1.5)
+        marker = json.loads(quality_gate.SEED_STATUS.read_text())
+        assert marker == {"state": "running", "pid": 7, "started": 1.5}
+        tmp = quality_gate.SEED_STATUS.with_suffix(quality_gate.SEED_STATUS.suffix + ".tmp")
+        assert not tmp.exists(), "temp sibling must be cleaned up after a successful write"
+
+    def test_uses_atomic_os_replace(self) -> None:
+        with patch.object(quality_gate.os, "replace") as mock_replace:
+            quality_gate._write_seed_status("ok", returncode=0)
+        mock_replace.assert_called_once()
+
+    def test_best_effort_swallows_and_cleans_up_on_failure(self) -> None:
+        """A write failure must NOT raise (never abort the detached rebuild),
+        and the temp file must still be unlinked by the `finally`."""
+
+        def raiser(*_a, **_k):
+            raise OSError("boom")
+
+        with patch.object(quality_gate.os, "replace", side_effect=raiser):
+            quality_gate._write_seed_status("ok", returncode=0)  # must not raise
+        tmp = quality_gate.SEED_STATUS.with_suffix(quality_gate.SEED_STATUS.suffix + ".tmp")
+        assert not tmp.exists()
+        assert not quality_gate.SEED_STATUS.exists()  # replace never happened
+
+
+class TestPidAlive:
+    """QS-286: `_pid_alive` maps os.kill(pid, 0) outcomes to liveness."""
+
+    def test_dead_when_process_lookup_error(self) -> None:
+        with patch.object(quality_gate.os, "kill", side_effect=ProcessLookupError):
+            assert quality_gate._pid_alive(999999) is False
+
+    def test_alive_when_permission_error(self) -> None:
+        with patch.object(quality_gate.os, "kill", side_effect=PermissionError):
+            assert quality_gate._pid_alive(1) is True
+
+    def test_alive_on_success(self) -> None:
+        with patch.object(quality_gate.os, "kill", return_value=None) as mock_kill:
+            assert quality_gate._pid_alive(1234) is True
+        mock_kill.assert_called_once_with(1234, 0)
+
+
+class TestSeedTestmonStatus:
+    """QS-286 AC#4: `seed_testmon_status` — distinct message + 4-code exit
+    for every originating marker condition. Read-only."""
+
+    @pytest.fixture(autouse=True)
+    def _redirect(self, tmp_path: Path):
+        with patch.object(quality_gate, "SEED_STATUS", tmp_path / ".testmondata.seed-status"):
+            yield
+
+    def _write(self, marker: object) -> None:
+        quality_gate.SEED_STATUS.write_text(json.dumps(marker))
+
+    def test_ok_exits_0(self, capsys: pytest.CaptureFixture[str]) -> None:
+        self._write({"state": "ok", "finished": 100.0})
+        assert quality_gate.seed_testmon_status() == 0
+        assert "safe to close" in capsys.readouterr().out.lower()
+
+    def test_running_alive_exits_4(self, capsys: pytest.CaptureFixture[str]) -> None:
+        self._write({"state": "running", "pid": 42, "started": 1.0})
+        with patch.object(quality_gate, "_pid_alive", return_value=True):
+            assert quality_gate.seed_testmon_status() == 4
+        assert "still running" in capsys.readouterr().out.lower()
+
+    def test_running_dead_exits_1_interrupted(self, capsys: pytest.CaptureFixture[str]) -> None:
+        self._write({"state": "running", "pid": 42, "started": 1.0})
+        with patch.object(quality_gate, "_pid_alive", return_value=False):
+            assert quality_gate.seed_testmon_status() == 1
+        assert "interrupted" in capsys.readouterr().out.lower()
+
+    def test_incomplete_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        self._write({"state": "incomplete", "returncode": 2})
+        assert quality_gate.seed_testmon_status() == 1
+        assert "finished with errors" in capsys.readouterr().out.lower()
+
+    def test_skipped_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        self._write({"state": "skipped", "reason": "pytest-testmon not importable"})
+        assert quality_gate.seed_testmon_status() == 1
+        out = capsys.readouterr().out.lower()
+        assert "skipped" in out and "no baseline was written" in out
+
+    def test_missing_marker_exits_3(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert not quality_gate.SEED_STATUS.exists()
+        assert quality_gate.seed_testmon_status() == 3
+        assert "no baseline refresh" in capsys.readouterr().out.lower()
+
+    def test_unparseable_marker_exits_3(self, capsys: pytest.CaptureFixture[str]) -> None:
+        quality_gate.SEED_STATUS.write_text("{not json")
+        assert quality_gate.seed_testmon_status() == 3
+        assert "unreadable" in capsys.readouterr().out.lower()
+
+    def test_unknown_state_exits_3(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A parseable marker with an unexpected state is treated as unreadable."""
+        self._write({"state": "bogus"})
+        assert quality_gate.seed_testmon_status() == 3
+        assert "unreadable" in capsys.readouterr().out.lower()
+
+    def test_reader_is_read_only(self) -> None:
+        """AC#4: no pytest / coverage / testmon import — the reader touches
+        none of the heavy seams."""
+        self._write({"state": "ok", "finished": 1.0})
+        with (
+            patch.object(quality_gate, "_stream_pytest") as mock_stream,
+            patch.object(quality_gate, "_testmon_available") as mock_probe,
+            patch.object(quality_gate, "_rebuild_testmon_baseline") as mock_rebuild,
+        ):
+            quality_gate.seed_testmon_status()
+        mock_stream.assert_not_called()
+        mock_probe.assert_not_called()
+        mock_rebuild.assert_not_called()
 
 
 class TestImpactedCli:
@@ -3292,6 +3477,50 @@ class TestImpactedCli:
         mock_seed.assert_called_once_with()
         mock_scope.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "conflict",
+        [
+            ["--seed-testmon"],
+            ["--impacted"],
+            ["--cache"],
+            ["--no-cache"],
+            ["--full"],
+            ["--fix"],
+            ["--quick", "tests/test_x.py"],
+        ],
+        ids=["seed", "impacted", "cache", "no-cache", "full", "fix", "quick"],
+    )
+    def test_seed_testmon_status_mutex_exits_2(
+        self, conflict: list[str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """AC#5: --seed-testmon-status combined with any mode is a usage error."""
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon-status", *conflict]),
+            patch.object(quality_gate, "seed_testmon_status") as mock_status,
+            patch.object(quality_gate, "seed_testmon") as mock_seed,
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == 2
+        assert "you cannot combine --seed-testmon-status with" in capsys.readouterr().err
+        mock_status.assert_not_called()
+        mock_seed.assert_not_called()
+
+    @pytest.mark.parametrize("status_code", [0, 1, 3, 4], ids=["ok", "rerun", "no-status", "running"])
+    def test_seed_testmon_status_cli_passthrough(self, status_code: int) -> None:
+        """AC#4: --seed-testmon-status short-circuits before scope, returning
+        the reader's exit code verbatim."""
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon-status"]),
+            patch.object(quality_gate, "seed_testmon_status", return_value=status_code) as mock_status,
+            patch.object(quality_gate, "_detect_scope") as mock_scope,
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == status_code
+        mock_status.assert_called_once_with()
+        mock_scope.assert_not_called()
+
 
 class TestImpactedDeps:
     """Regression guards for requirements_test.txt + .gitignore (AC#1)."""
@@ -3304,6 +3533,12 @@ class TestImpactedDeps:
     def test_testmondata_gitignored(self) -> None:
         gi = (Path(__file__).resolve().parent.parent / ".gitignore").read_text()
         assert any(line.strip() == ".testmondata" for line in gi.splitlines())
+
+    def test_seed_status_gitignored(self) -> None:
+        """QS-286 AC#8: exact `.testmondata.seed-status` line (matches the
+        exact-match `.testmondata` convention, not a glob)."""
+        gi = (Path(__file__).resolve().parent.parent / ".gitignore").read_text()
+        assert any(line.strip() == ".testmondata.seed-status" for line in gi.splitlines())
 
 
 class TestProjectRulesDocGuards:
@@ -3400,6 +3635,31 @@ class TestFinishTaskRefreshesBaseline:
         assert "--seed-testmon" in body
         assert "git worktree list --porcelain" in body  # MAIN_DIR captured before cleanup
         assert "nohup" in body  # detached / best-effort
+
+    @pytest.mark.parametrize("harness", [".claude", ".cursor", ".opencode"])
+    def test_completion_signal_present(self, harness: str) -> None:
+        """QS-286 AC#7: the detached refresh deletes the stale marker, logs to
+        `.testmondata.seed.log`, and points the user at --seed-testmon-status."""
+        body = (Path(__file__).resolve().parent.parent / harness / "agents" / "qs-finish-task.md").read_text()
+        assert 'rm -f "$MAIN_DIR/.testmondata.seed-status"' in body  # stale-marker guard
+        assert '>"$MAIN_DIR/.testmondata.seed.log" 2>&1' in body  # truncate redirect
+        assert "--seed-testmon-status" in body  # how to check
+        assert "safe to close this terminal" in body
+        # the old silent seed redirect is gone (other >/dev/null uses remain)
+        assert "--seed-testmon >/dev/null 2>&1" not in body
+
+    def test_seed_launch_block_byte_identical_across_harnesses(self) -> None:
+        """Harness-sync: the QS-286 completion-signal block is identical in
+        all three finish-task copies."""
+        blocks = []
+        for harness in (".claude", ".cursor", ".opencode"):
+            body = (
+                Path(__file__).resolve().parent.parent / harness / "agents" / "qs-finish-task.md"
+            ).read_text()
+            start = body.index('rm -f "$MAIN_DIR/.testmondata.seed-status"')
+            end = body.index(".testmondata.seed.log.", start)
+            blocks.append(body[start:end])
+        assert blocks[0] == blocks[1] == blocks[2]
 
     @pytest.mark.parametrize("harness", [".claude", ".cursor", ".opencode"])
     def test_interpreter_is_probed_not_hardcoded(self, harness: str) -> None:

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -3374,6 +3374,59 @@ class TestSeedTestmonStatus:
         assert quality_gate.seed_testmon_status() == 3
         assert "unreadable" in capsys.readouterr().out.lower()
 
+    # review-fix #01 must-fix: malformed-but-parseable markers must route to
+    # the unreadable→3 path, never crash the read-only status command.
+    @pytest.mark.parametrize(
+        "payload",
+        [5, "x", None, [1], 3.14],
+        ids=["int", "str", "null", "array", "float"],
+    )
+    def test_non_dict_payload_exits_3(
+        self, payload: object, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._write(payload)
+        assert quality_gate.seed_testmon_status() == 3  # no AttributeError
+        assert "unreadable" in capsys.readouterr().out.lower()
+
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            {"state": "running"},
+            {"state": "running", "pid": None},
+            {"state": "running", "pid": "x"},
+            {"state": "running", "pid": 1.5},
+        ],
+        ids=["no-pid", "pid-null", "pid-str", "pid-float"],
+    )
+    def test_running_with_bad_pid_exits_3(
+        self, marker: dict, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A `running` marker without an int pid is unreadable — never reaches
+        `_pid_alive` (which would `os.kill(None/str, 0)` → TypeError)."""
+        self._write(marker)
+        with patch.object(quality_gate, "_pid_alive") as mock_alive:
+            assert quality_gate.seed_testmon_status() == 3  # no TypeError
+        mock_alive.assert_not_called()  # bad pid never hits the syscall seam
+        assert "unreadable" in capsys.readouterr().out.lower()
+
+    # review-fix #01 nice-to-have: a marker missing a display-only field prints
+    # a readable placeholder, not literal "None" — and keeps its exit code.
+    def test_ok_missing_finished_prints_placeholder(self, capsys: pytest.CaptureFixture[str]) -> None:
+        self._write({"state": "ok"})
+        assert quality_gate.seed_testmon_status() == 0
+        out = capsys.readouterr().out
+        assert "None" not in out
+        assert "an unknown time" in out
+
+    def test_incomplete_missing_returncode_prints_placeholder(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._write({"state": "incomplete"})
+        assert quality_gate.seed_testmon_status() == 1
+        out = capsys.readouterr().out
+        assert "None" not in out
+        assert "exit unknown" in out
+
     def test_reader_is_read_only(self) -> None:
         """AC#4: no pytest / coverage / testmon import — the reader touches
         none of the heavy seams."""
@@ -3559,6 +3612,13 @@ class TestProjectRulesDocGuards:
         assert "Local-vs-CI coverage invariant" in rules
         assert "`--impacted` is mutually exclusive" in rules
 
+    def test_seed_testmon_status_command_reference_present(self) -> None:
+        """review-fix #01 (AC#9): pin the --seed-testmon-status command-reference
+        addition, mirroring test_seed_status_gitignored's exact-line guard."""
+        rules = self._rules()
+        assert "quality_gate.py --seed-testmon-status" in rules
+        assert "companion" in rules  # documented as the --seed-testmon companion
+
 
 class TestWorktreeSetupSeedsCaches:
     """AC#8: worktree-setup.sh copies (never symlinks) .testmondata + .mypy_cache."""
@@ -3656,8 +3716,13 @@ class TestFinishTaskRefreshesBaseline:
             body = (
                 Path(__file__).resolve().parent.parent / harness / "agents" / "qs-finish-task.md"
             ).read_text()
+            # review-fix #01 nice-to-have: anchor the slice on code-adjacent
+            # markers (the stale-marker rm and the exact redirect line), not on
+            # prose ending in a literal period, so added narrative can't
+            # truncate the slice inconsistently.
             start = body.index('rm -f "$MAIN_DIR/.testmondata.seed-status"')
-            end = body.index(".testmondata.seed.log.", start)
+            redirect = '>"$MAIN_DIR/.testmondata.seed.log" 2>&1'
+            end = body.index(redirect, start) + len(redirect)
             blocks.append(body[start:end])
         assert blocks[0] == blocks[1] == blocks[2]
 

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -3287,9 +3287,12 @@ class TestWriteSeedStatus:
             quality_gate._write_seed_status("ok", returncode=0)
         mock_replace.assert_called_once()
 
-    def test_best_effort_swallows_and_cleans_up_on_failure(self) -> None:
+    def test_best_effort_swallows_and_cleans_up_on_failure(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """A write failure must NOT raise (never abort the detached rebuild),
-        and the temp file must still be unlinked by the `finally`."""
+        the temp file must still be unlinked by the `finally`, AND a single
+        diagnostic line is emitted (review-fix #02)."""
 
         def raiser(*_a, **_k):
             raise OSError("boom")
@@ -3299,6 +3302,9 @@ class TestWriteSeedStatus:
         tmp = quality_gate.SEED_STATUS.with_suffix(quality_gate.SEED_STATUS.suffix + ".tmp")
         assert not tmp.exists()
         assert not quality_gate.SEED_STATUS.exists()  # replace never happened
+        err = capsys.readouterr().err
+        assert "could not write status marker" in err
+        assert "boom" in err  # the swallowed exception is surfaced for tracing
 
 
 class TestPidAlive:
@@ -3318,6 +3324,22 @@ class TestPidAlive:
         mock_kill.assert_called_once_with(1234, 0)
 
 
+class TestFmtSeedTime:
+    """QS-286 review-fix #02: epoch marker fields render as readable UTC ISO."""
+
+    def test_numeric_renders_utc_iso(self) -> None:
+        # 1_700_000_000 == 2023-11-14T22:13:20+00:00 (UTC, seconds precision).
+        assert quality_gate._fmt_seed_time(1_700_000_000) == "2023-11-14T22:13:20+00:00"
+
+    def test_float_renders_seconds_precision(self) -> None:
+        out = quality_gate._fmt_seed_time(1_700_000_000.987654)
+        assert out == "2023-11-14T22:13:20+00:00"  # sub-second truncated
+
+    @pytest.mark.parametrize("value", [None, "x", True], ids=["none", "str", "bool"])
+    def test_non_numeric_is_placeholder(self, value: object) -> None:
+        assert quality_gate._fmt_seed_time(value) == "an unknown time"
+
+
 class TestSeedTestmonStatus:
     """QS-286 AC#4: `seed_testmon_status` — distinct message + 4-code exit
     for every originating marker condition. Read-only."""
@@ -3333,13 +3355,20 @@ class TestSeedTestmonStatus:
     def test_ok_exits_0(self, capsys: pytest.CaptureFixture[str]) -> None:
         self._write({"state": "ok", "finished": 100.0})
         assert quality_gate.seed_testmon_status() == 0
-        assert "safe to close" in capsys.readouterr().out.lower()
+        out = capsys.readouterr().out
+        assert "safe to close" in out.lower()
+        # review-fix #02: epoch is rendered as a readable UTC ISO string, not
+        # the raw float.
+        assert "100.0" not in out
+        assert quality_gate._fmt_seed_time(100.0) in out
 
     def test_running_alive_exits_4(self, capsys: pytest.CaptureFixture[str]) -> None:
         self._write({"state": "running", "pid": 42, "started": 1.0})
         with patch.object(quality_gate, "_pid_alive", return_value=True):
             assert quality_gate.seed_testmon_status() == 4
-        assert "still running" in capsys.readouterr().out.lower()
+        out = capsys.readouterr().out
+        assert "still running" in out.lower()
+        assert quality_gate._fmt_seed_time(1.0) in out  # started rendered readably
 
     def test_running_dead_exits_1_interrupted(self, capsys: pytest.CaptureFixture[str]) -> None:
         self._write({"state": "running", "pid": 42, "started": 1.0})
@@ -3388,6 +3417,11 @@ class TestSeedTestmonStatus:
         assert quality_gate.seed_testmon_status() == 3  # no AttributeError
         assert "unreadable" in capsys.readouterr().out.lower()
 
+    # review-fix #01 must-fix + #02 should-fix: a `running` marker whose pid is
+    # not a positive, non-bool int is unreadable → 3, and must never reach the
+    # `os.kill` seam. Covers missing/null/str/float pids (would TypeError) AND
+    # pid 0 / -1 / bool (would target the process group / all processes and
+    # spuriously report "still running").
     @pytest.mark.parametrize(
         "marker",
         [
@@ -3395,18 +3429,25 @@ class TestSeedTestmonStatus:
             {"state": "running", "pid": None},
             {"state": "running", "pid": "x"},
             {"state": "running", "pid": 1.5},
+            {"state": "running", "pid": 0},
+            {"state": "running", "pid": -1},
+            {"state": "running", "pid": True},
         ],
-        ids=["no-pid", "pid-null", "pid-str", "pid-float"],
+        ids=["no-pid", "pid-null", "pid-str", "pid-float", "pid-zero", "pid-neg", "pid-bool"],
     )
     def test_running_with_bad_pid_exits_3(
         self, marker: dict, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """A `running` marker without an int pid is unreadable — never reaches
-        `_pid_alive` (which would `os.kill(None/str, 0)` → TypeError)."""
+        """A `running` marker without a positive, non-bool int pid is
+        unreadable — never reaches `_pid_alive`/`os.kill`."""
         self._write(marker)
-        with patch.object(quality_gate, "_pid_alive") as mock_alive:
-            assert quality_gate.seed_testmon_status() == 3  # no TypeError
+        with (
+            patch.object(quality_gate, "_pid_alive") as mock_alive,
+            patch.object(quality_gate.os, "kill") as mock_kill,
+        ):
+            assert quality_gate.seed_testmon_status() == 3  # no TypeError, no false "running"
         mock_alive.assert_not_called()  # bad pid never hits the syscall seam
+        mock_kill.assert_not_called()
         assert "unreadable" in capsys.readouterr().out.lower()
 
     # review-fix #01 nice-to-have: a marker missing a display-only field prints


### PR DESCRIPTION
## Summary
- seed_testmon() writes a best-effort .testmondata.seed-status marker (running/ok/incomplete/skipped)
- new read-only --seed-testmon-status query subcommand reports a human message + 4-code exit (0/4/1/3)
- finish-task (×3 harnesses) deletes the stale marker, logs to .testmondata.seed.log, and points users at the status command

Fixes #286

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only status-check command for the detached test baseline refresh, showing whether it’s running, completed successfully, incomplete, or skipped.
  * The refresh flow now writes a persistent log for troubleshooting and provides step-by-step guidance for checking completion.

* **Bug Fixes**
  * Prevents stale completion status from carrying over between refresh runs.
  * Improves outcomes and reporting when runs are interrupted or incomplete.

* **Documentation**
  * Updated workflow/project guidance to describe the new status-check behavior and meaning of status codes.

* **Tests**
  * Expanded coverage for status-marker transitions, reader behavior, and harness expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->