### PR TITLE
QS-299: finish-task must stream detached --seed-testmon progress inline until completion (QS-286 follow-up)

### DIFF
--- a/.claude/agents/qs-finish-task.md
+++ b/.claude/agents/qs-finish-task.md
@@ -128,11 +128,12 @@ The standard merge flow.
    If the PR was already merged externally between steps 2 and 5, treat
    as success.
 
-6. Refresh the `--impacted` baseline on the main worktree (QS-276). The
-   merged code is now on the true `main`, so rebuild the testmon
+6. Refresh the `--impacted` baseline on the main worktree (QS-276/QS-299).
+   The merged code is now on the true `main`, so rebuild the testmon
    baseline **there** — the worktree's own `.testmondata` reflects its
    (possibly stale) base and is unsafe to copy back. Capture `MAIN_DIR`
-   **before** cleanup removes this worktree (it is NOT in `context.py`):
+   **before** cleanup removes this worktree (it is NOT in `context.py`),
+   then launch a **tokened, detached** seed:
    ```bash
    MAIN_DIR="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
    git -C "$MAIN_DIR" fetch origin
@@ -148,28 +149,46 @@ The standard merge flow.
    QG_PY="$MAIN_DIR/venv/bin/python"
    [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
    if [ -n "$QG_PY" ]; then
-       # QS-286: delete any stale marker BEFORE launch (so a prior run's
-       # `ok` cannot survive into a run that dies before writing `running`),
-       # then run detached, redirecting (truncate) to a log the user can
-       # inspect. The run writes .testmondata.seed-status when done.
-       rm -f "$MAIN_DIR/.testmondata.seed-status"
-       ( cd "$MAIN_DIR" && nohup "$QG_PY" \
-           scripts/qs/quality_gate.py --seed-testmon \
-           >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
-       echo "Baseline refresh started (detached, best-effort)."
-       echo "It writes .testmondata.seed-status when done; check status with:"
-       echo "  python scripts/qs/quality_gate.py --seed-testmon-status"
-       echo "  (run from the main checkout, $MAIN_DIR)"
-       echo "It is safe to close this terminal once that reports OK; the log"
-       echo "is at $MAIN_DIR/.testmondata.seed.log."
+       # QS-299: generate a per-run token, then launch the seed DETACHED
+       # (its own process group, so a later task's finish preempts the
+       # whole pytest tree) with </dev/null so it fully backgrounds. Do
+       # NOT `rm -f` the marker — the new seed must READ the predecessor's
+       # marker to preempt it; deleting it would blind the last-wins handoff.
+       SEED_TOKEN="$("$QG_PY" -c 'import uuid; print(uuid.uuid4().hex)')"
+       ( cd "$MAIN_DIR" && nohup "$QG_PY" scripts/qs/quality_gate.py \
+           --seed-testmon --detached --seed-token "$SEED_TOKEN" \
+           </dev/null >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
+       echo "Baseline refresh started (detached, token $SEED_TOKEN)."
    else
        echo "Warning: no usable Python interpreter found — skipping baseline refresh."
+       SEED_TOKEN=""
    fi
    ```
-   A failure or timeout here is harmless — a stale baseline is still
-   safe (new worktrees just run more tests). Proceed regardless. The
-   first refresh after a large merge may approach a near-full run;
-   acceptable because it is detached.
+   Then, **in this same session**, stream the follower until it exits. The
+   foreground form below is **conceptual only** — never run it foreground,
+   a full seed can exceed the foreground Bash cap:
+   ```bash
+   # conceptual only — wrap in the background+monitor mechanism below:
+   cd "$MAIN_DIR" && "$QG_PY" scripts/qs/quality_gate.py \
+       --seed-testmon-follow --seed-token "$SEED_TOKEN"
+   ```
+   **Run it (this harness):** launch that `--seed-testmon-follow` command
+   with `run_in_background`, then Monitor it on a ~15 s cadence
+   (deliberately ≥ the follower's 5 s poll — latest-line-wins, so
+   intermediate progress lines may be coalesced), relaying the latest
+   progress line inline. When the background task exits, report the
+   follower's final verdict line and move on. Skip both the seed launch and
+   the follower when `$SEED_TOKEN` is empty (no interpreter).
+
+   **The follower's exit code is a completion signal, not a gate.** Cleanup
+   already finished before seeding, so relay the final line and continue
+   normally **regardless of exit code** (0/5 → safe to close this terminal; 4 → keep open
+   or re-attach with the printed `--seed-testmon-follow --seed-token …`;
+   1/3 → advisory only). Never surface a non-zero follower exit as a failed
+   step. A failure or timeout here is harmless — a stale baseline is still
+   safe (new worktrees just run more tests). Proceed regardless. As an
+   optional scripting fallback, `--seed-testmon-status` (run from
+   `$MAIN_DIR`) gives a one-shot status without streaming.
 
 7. Delete the remote branch. The guard refuses `main` / `master` at
    the shell level — never rely on the agent alone:
@@ -213,7 +232,9 @@ The standard merge flow.
 - **Never run the quality gate.** Cleanup must succeed even if tests
   would fail. (Carve-out: the post-merge `--seed-testmon` baseline
   refresh in Case B step 6 is a non-gate DB refresh — no coverage, no
-  pass/fail verdict — run detached/best-effort. It is not the gate.)
+  pass/fail verdict — run detached/best-effort; and its companion
+  `--seed-testmon-follow` is a read-only, no-pytest streaming status
+  query whose exit code is informational only. Neither is the gate.)
 - No merge without explicit user authorization in this turn.
 - Never auto-chain to `/release` — it's a separate decision.
 - Refuse to delete `main` / `master` even if asked.

--- a/.claude/agents/qs-finish-task.md
+++ b/.claude/agents/qs-finish-task.md
@@ -148,20 +148,24 @@ The standard merge flow.
    # false success.
    QG_PY="$MAIN_DIR/venv/bin/python"
    [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
+   # QS-299: generate a per-run token, then launch the seed DETACHED (its own
+   # process group, so a later task's finish preempts the whole pytest tree)
+   # with </dev/null so it fully backgrounds. Do NOT `rm -f` the marker — the
+   # new seed must READ the predecessor's marker to preempt it; deleting it
+   # would blind the last-wins handoff.
+   SEED_TOKEN=""
    if [ -n "$QG_PY" ]; then
-       # QS-299: generate a per-run token, then launch the seed DETACHED
-       # (its own process group, so a later task's finish preempts the
-       # whole pytest tree) with </dev/null so it fully backgrounds. Do
-       # NOT `rm -f` the marker — the new seed must READ the predecessor's
-       # marker to preempt it; deleting it would blind the last-wins handoff.
        SEED_TOKEN="$("$QG_PY" -c 'import uuid; print(uuid.uuid4().hex)')"
+   else
+       echo "Warning: no usable Python interpreter found — skipping baseline refresh."
+   fi
+   # review-fix #02 (finding #8): only launch with a NON-EMPTY token — the CLI
+   # rejects an empty --seed-token (exit 2), which would be a silent no-op.
+   if [ -n "$SEED_TOKEN" ]; then
        ( cd "$MAIN_DIR" && nohup "$QG_PY" scripts/qs/quality_gate.py \
            --seed-testmon --detached --seed-token "$SEED_TOKEN" \
            </dev/null >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
        echo "Baseline refresh started (detached, token $SEED_TOKEN)."
-   else
-       echo "Warning: no usable Python interpreter found — skipping baseline refresh."
-       SEED_TOKEN=""
    fi
    ```
    Then, **in this same session**, stream the follower until it exits. The

--- a/.cursor/agents/qs-finish-task.md
+++ b/.cursor/agents/qs-finish-task.md
@@ -127,11 +127,12 @@ The standard merge flow.
    If the PR was already merged externally between steps 2 and 5, treat
    as success.
 
-6. Refresh the `--impacted` baseline on the main worktree (QS-276). The
-   merged code is now on the true `main`, so rebuild the testmon
+6. Refresh the `--impacted` baseline on the main worktree (QS-276/QS-299).
+   The merged code is now on the true `main`, so rebuild the testmon
    baseline **there** — the worktree's own `.testmondata` reflects its
    (possibly stale) base and is unsafe to copy back. Capture `MAIN_DIR`
-   **before** cleanup removes this worktree (it is NOT in `context.py`):
+   **before** cleanup removes this worktree (it is NOT in `context.py`),
+   then launch a **tokened, detached** seed:
    ```bash
    MAIN_DIR="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
    git -C "$MAIN_DIR" fetch origin
@@ -147,28 +148,46 @@ The standard merge flow.
    QG_PY="$MAIN_DIR/venv/bin/python"
    [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
    if [ -n "$QG_PY" ]; then
-       # QS-286: delete any stale marker BEFORE launch (so a prior run's
-       # `ok` cannot survive into a run that dies before writing `running`),
-       # then run detached, redirecting (truncate) to a log the user can
-       # inspect. The run writes .testmondata.seed-status when done.
-       rm -f "$MAIN_DIR/.testmondata.seed-status"
-       ( cd "$MAIN_DIR" && nohup "$QG_PY" \
-           scripts/qs/quality_gate.py --seed-testmon \
-           >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
-       echo "Baseline refresh started (detached, best-effort)."
-       echo "It writes .testmondata.seed-status when done; check status with:"
-       echo "  python scripts/qs/quality_gate.py --seed-testmon-status"
-       echo "  (run from the main checkout, $MAIN_DIR)"
-       echo "It is safe to close this terminal once that reports OK; the log"
-       echo "is at $MAIN_DIR/.testmondata.seed.log."
+       # QS-299: generate a per-run token, then launch the seed DETACHED
+       # (its own process group, so a later task's finish preempts the
+       # whole pytest tree) with </dev/null so it fully backgrounds. Do
+       # NOT `rm -f` the marker — the new seed must READ the predecessor's
+       # marker to preempt it; deleting it would blind the last-wins handoff.
+       SEED_TOKEN="$("$QG_PY" -c 'import uuid; print(uuid.uuid4().hex)')"
+       ( cd "$MAIN_DIR" && nohup "$QG_PY" scripts/qs/quality_gate.py \
+           --seed-testmon --detached --seed-token "$SEED_TOKEN" \
+           </dev/null >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
+       echo "Baseline refresh started (detached, token $SEED_TOKEN)."
    else
        echo "Warning: no usable Python interpreter found — skipping baseline refresh."
+       SEED_TOKEN=""
    fi
    ```
-   A failure or timeout here is harmless — a stale baseline is still
-   safe (new worktrees just run more tests). Proceed regardless. The
-   first refresh after a large merge may approach a near-full run;
-   acceptable because it is detached.
+   Then, **in this same session**, stream the follower until it exits. The
+   foreground form below is **conceptual only** — never run it foreground,
+   a full seed can exceed the foreground command cap:
+   ```bash
+   # conceptual only — wrap in the background+poll mechanism below:
+   cd "$MAIN_DIR" && "$QG_PY" scripts/qs/quality_gate.py \
+       --seed-testmon-follow --seed-token "$SEED_TOKEN"
+   ```
+   **Run it (this harness):** start that `--seed-testmon-follow` command as
+   a background process/terminal, then poll its output on a ~15 s cadence
+   (deliberately ≥ the follower's 5 s poll — latest-line-wins, so
+   intermediate progress lines may be coalesced), relaying the latest
+   progress line inline, until the process exits; then report the
+   follower's final verdict line and move on. Skip both the seed launch and
+   the follower when `$SEED_TOKEN` is empty (no interpreter).
+
+   **The follower's exit code is a completion signal, not a gate.** Cleanup
+   already finished before seeding, so relay the final line and continue
+   normally **regardless of exit code** (0/5 → safe to close this terminal; 4 → keep open
+   or re-attach with the printed `--seed-testmon-follow --seed-token …`;
+   1/3 → advisory only). Never surface a non-zero follower exit as a failed
+   step. A failure or timeout here is harmless — a stale baseline is still
+   safe (new worktrees just run more tests). Proceed regardless. As an
+   optional scripting fallback, `--seed-testmon-status` (run from
+   `$MAIN_DIR`) gives a one-shot status without streaming.
 
 7. Delete the remote branch. The guard refuses `main` / `master` at
    the shell level — never rely on the agent alone:
@@ -212,7 +231,9 @@ The standard merge flow.
 - **Never run the quality gate.** Cleanup must succeed even if tests
   would fail. (Carve-out: the post-merge `--seed-testmon` baseline
   refresh in Case B step 6 is a non-gate DB refresh — no coverage, no
-  pass/fail verdict — run detached/best-effort. It is not the gate.)
+  pass/fail verdict — run detached/best-effort; and its companion
+  `--seed-testmon-follow` is a read-only, no-pytest streaming status
+  query whose exit code is informational only. Neither is the gate.)
 - No merge without explicit user authorization in this turn.
 - Never auto-chain to `/release` — it's a separate decision.
 - Refuse to delete `main` / `master` even if asked.

--- a/.cursor/agents/qs-finish-task.md
+++ b/.cursor/agents/qs-finish-task.md
@@ -147,20 +147,24 @@ The standard merge flow.
    # false success.
    QG_PY="$MAIN_DIR/venv/bin/python"
    [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
+   # QS-299: generate a per-run token, then launch the seed DETACHED (its own
+   # process group, so a later task's finish preempts the whole pytest tree)
+   # with </dev/null so it fully backgrounds. Do NOT `rm -f` the marker — the
+   # new seed must READ the predecessor's marker to preempt it; deleting it
+   # would blind the last-wins handoff.
+   SEED_TOKEN=""
    if [ -n "$QG_PY" ]; then
-       # QS-299: generate a per-run token, then launch the seed DETACHED
-       # (its own process group, so a later task's finish preempts the
-       # whole pytest tree) with </dev/null so it fully backgrounds. Do
-       # NOT `rm -f` the marker — the new seed must READ the predecessor's
-       # marker to preempt it; deleting it would blind the last-wins handoff.
        SEED_TOKEN="$("$QG_PY" -c 'import uuid; print(uuid.uuid4().hex)')"
+   else
+       echo "Warning: no usable Python interpreter found — skipping baseline refresh."
+   fi
+   # review-fix #02 (finding #8): only launch with a NON-EMPTY token — the CLI
+   # rejects an empty --seed-token (exit 2), which would be a silent no-op.
+   if [ -n "$SEED_TOKEN" ]; then
        ( cd "$MAIN_DIR" && nohup "$QG_PY" scripts/qs/quality_gate.py \
            --seed-testmon --detached --seed-token "$SEED_TOKEN" \
            </dev/null >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
        echo "Baseline refresh started (detached, token $SEED_TOKEN)."
-   else
-       echo "Warning: no usable Python interpreter found — skipping baseline refresh."
-       SEED_TOKEN=""
    fi
    ```
    Then, **in this same session**, stream the follower until it exits. The

--- a/.opencode/agents/qs-finish-task.md
+++ b/.opencode/agents/qs-finish-task.md
@@ -160,11 +160,12 @@ The standard merge flow.
    If the PR was already merged externally between steps 1 and 4, treat
    as success.
 
-5. Refresh the `--impacted` baseline on the main worktree (QS-276). The
-   merged code is now on the true `main`, so rebuild the testmon
+5. Refresh the `--impacted` baseline on the main worktree (QS-276/QS-299).
+   The merged code is now on the true `main`, so rebuild the testmon
    baseline **there** — the worktree's own `.testmondata` reflects its
    (possibly stale) base and is unsafe to copy back. Capture `MAIN_DIR`
-   **before** cleanup removes this worktree (it is NOT in `context.py`):
+   **before** cleanup removes this worktree (it is NOT in `context.py`),
+   then launch a **tokened, detached** seed:
    ```bash
    MAIN_DIR="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
    git -C "$MAIN_DIR" fetch origin
@@ -180,28 +181,46 @@ The standard merge flow.
    QG_PY="$MAIN_DIR/venv/bin/python"
    [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
    if [ -n "$QG_PY" ]; then
-       # QS-286: delete any stale marker BEFORE launch (so a prior run's
-       # `ok` cannot survive into a run that dies before writing `running`),
-       # then run detached, redirecting (truncate) to a log the user can
-       # inspect. The run writes .testmondata.seed-status when done.
-       rm -f "$MAIN_DIR/.testmondata.seed-status"
-       ( cd "$MAIN_DIR" && nohup "$QG_PY" \
-           scripts/qs/quality_gate.py --seed-testmon \
-           >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
-       echo "Baseline refresh started (detached, best-effort)."
-       echo "It writes .testmondata.seed-status when done; check status with:"
-       echo "  python scripts/qs/quality_gate.py --seed-testmon-status"
-       echo "  (run from the main checkout, $MAIN_DIR)"
-       echo "It is safe to close this terminal once that reports OK; the log"
-       echo "is at $MAIN_DIR/.testmondata.seed.log."
+       # QS-299: generate a per-run token, then launch the seed DETACHED
+       # (its own process group, so a later task's finish preempts the
+       # whole pytest tree) with </dev/null so it fully backgrounds. Do
+       # NOT `rm -f` the marker — the new seed must READ the predecessor's
+       # marker to preempt it; deleting it would blind the last-wins handoff.
+       SEED_TOKEN="$("$QG_PY" -c 'import uuid; print(uuid.uuid4().hex)')"
+       ( cd "$MAIN_DIR" && nohup "$QG_PY" scripts/qs/quality_gate.py \
+           --seed-testmon --detached --seed-token "$SEED_TOKEN" \
+           </dev/null >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
+       echo "Baseline refresh started (detached, token $SEED_TOKEN)."
    else
        echo "Warning: no usable Python interpreter found — skipping baseline refresh."
+       SEED_TOKEN=""
    fi
    ```
-   A failure or timeout here is harmless — a stale baseline is still
-   safe (new worktrees just run more tests). Proceed regardless. The
-   first refresh after a large merge may approach a near-full run;
-   acceptable because it is detached.
+   Then, **in this same session**, stream the follower until it exits. The
+   foreground form below is **conceptual only** — never run it foreground,
+   a full seed can exceed the foreground command cap:
+   ```bash
+   # conceptual only — wrap in the background+poll mechanism below:
+   cd "$MAIN_DIR" && "$QG_PY" scripts/qs/quality_gate.py \
+       --seed-testmon-follow --seed-token "$SEED_TOKEN"
+   ```
+   **Run it (this harness):** start that `--seed-testmon-follow` command as
+   a background process, then poll its output on a ~15 s cadence
+   (deliberately ≥ the follower's 5 s poll — latest-line-wins, so
+   intermediate progress lines may be coalesced), relaying the latest
+   progress line inline, until the process exits; then report the
+   follower's final verdict line and move on. Skip both the seed launch and
+   the follower when `$SEED_TOKEN` is empty (no interpreter).
+
+   **The follower's exit code is a completion signal, not a gate.** Cleanup
+   already finished before seeding, so relay the final line and continue
+   normally **regardless of exit code** (0/5 → safe to close this terminal; 4 → keep open
+   or re-attach with the printed `--seed-testmon-follow --seed-token …`;
+   1/3 → advisory only). Never surface a non-zero follower exit as a failed
+   step. A failure or timeout here is harmless — a stale baseline is still
+   safe (new worktrees just run more tests). Proceed regardless. As an
+   optional scripting fallback, `--seed-testmon-status` (run from
+   `$MAIN_DIR`) gives a one-shot status without streaming.
 
 6. Delete the remote branch. The guard refuses `main` / `master` at
    the shell level — never rely on the agent alone:
@@ -245,7 +264,9 @@ The standard merge flow.
 - **Never run the quality gate.** Cleanup must succeed even if tests
   would fail. (Carve-out: the post-merge `--seed-testmon` baseline
   refresh in Case B step 5 is a non-gate DB refresh — no coverage, no
-  pass/fail verdict — run detached/best-effort. It is not the gate.)
+  pass/fail verdict — run detached/best-effort; and its companion
+  `--seed-testmon-follow` is a read-only, no-pytest streaming status
+  query whose exit code is informational only. Neither is the gate.)
 - No merge without explicit user authorization in this turn.
 - Never auto-chain to `release` — it's a separate decision.
 - Refuse to delete `main` / `master` even if asked.

--- a/.opencode/agents/qs-finish-task.md
+++ b/.opencode/agents/qs-finish-task.md
@@ -180,20 +180,24 @@ The standard merge flow.
    # false success.
    QG_PY="$MAIN_DIR/venv/bin/python"
    [ -x "$QG_PY" ] || QG_PY="$(command -v python3 || command -v python || true)"
+   # QS-299: generate a per-run token, then launch the seed DETACHED (its own
+   # process group, so a later task's finish preempts the whole pytest tree)
+   # with </dev/null so it fully backgrounds. Do NOT `rm -f` the marker — the
+   # new seed must READ the predecessor's marker to preempt it; deleting it
+   # would blind the last-wins handoff.
+   SEED_TOKEN=""
    if [ -n "$QG_PY" ]; then
-       # QS-299: generate a per-run token, then launch the seed DETACHED
-       # (its own process group, so a later task's finish preempts the
-       # whole pytest tree) with </dev/null so it fully backgrounds. Do
-       # NOT `rm -f` the marker — the new seed must READ the predecessor's
-       # marker to preempt it; deleting it would blind the last-wins handoff.
        SEED_TOKEN="$("$QG_PY" -c 'import uuid; print(uuid.uuid4().hex)')"
+   else
+       echo "Warning: no usable Python interpreter found — skipping baseline refresh."
+   fi
+   # review-fix #02 (finding #8): only launch with a NON-EMPTY token — the CLI
+   # rejects an empty --seed-token (exit 2), which would be a silent no-op.
+   if [ -n "$SEED_TOKEN" ]; then
        ( cd "$MAIN_DIR" && nohup "$QG_PY" scripts/qs/quality_gate.py \
            --seed-testmon --detached --seed-token "$SEED_TOKEN" \
            </dev/null >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
        echo "Baseline refresh started (detached, token $SEED_TOKEN)."
-   else
-       echo "Warning: no usable Python interpreter found — skipping baseline refresh."
-       SEED_TOKEN=""
    fi
    ```
    Then, **in this same session**, stream the follower until it exits. The

--- a/docs/stories/QS-299.story.md
+++ b/docs/stories/QS-299.story.md
@@ -38,10 +38,12 @@ invocation**:
 - **Surface the baseline-refresh progress inline** — a progress line
   (`N/M tests (pct%)` + elapsed, **plain ASCII** so a piped non-UTF-8 stdout can
   never raise) that updates as the refresh proceeds and culminates in an
-  unambiguous terminal verdict: **"[OK] … safe to close this terminal"** (done),
-  **"a fresher baseline refresh is now running - this one was stopped, safe to
-  close this terminal"** (superseded), or a rerun advisory.
-- **Best-effort last-wins preemption** (review-fix #01, finding #4 — stated
+  unambiguous terminal verdict: **"[OK] baseline refresh complete - safe to close
+  this terminal"** (done); on the own-token→foreign path, the honest
+  **"another baseline refresh now holds the marker; this run either completed or
+  was superseded - check `--seed-testmon-status`. Safe to close this terminal."**
+  (`_FOLLOW_MSG_TAKEN_OVER`, exit 5); or a rerun advisory (`incomplete`/`skipped`).
+- **Best-effort last-wins preemption** (review-fix #01/#04, finding #4 — stated
   consistently, not as a hard guarantee): when a new seed starts on main it
   SIGTERMs any still-running seed from a previous task (killing its pytest tree)
   under an advisory lock, and the completion write is token-guarded so a
@@ -49,11 +51,14 @@ invocation**:
   unordered and pull-time vs lock-claim-time are not globally serialized, which
   seed ends up the surviving winner is **not** globally guaranteed — but
   correctness never depends on it (a stale baseline only over-selects tests,
-  which is safe). A follower whose own run is genuinely superseded prints the
-  "superseded - safe to close" line; at **startup**, a stale foreign-token marker
-  left by a previous task (seen before this session's seed has claimed the
+  which is safe). A follower that owned the marker and then sees a foreign token
+  reports the honest `_FOLLOW_MSG_TAKEN_OVER` line (it cannot tell "completed then
+  overwritten" from "preempted"; see AC 17); at **startup**, a stale foreign-token
+  marker left by a previous task (seen before this session's seed has claimed the
   marker) is tolerated within a grace window rather than misreported as a
-  supersession.
+  supersession, and if it persists the whole grace the follower reports the
+  honest `_FOLLOW_MSG_UNCONFIRMED` line (exit 5). Both exit-5 messages end with
+  "safe to close this terminal".
 
 **Honest mechanism note (soft, best-effort — not a hard guarantee).** The
 *follower CLI* (`--seed-testmon-follow`) deterministically emits a fresh
@@ -186,14 +191,18 @@ apply to it. Follower user-facing lines go through `print()`.
 loop that reads the marker (via `_read_seed_marker()`) and the `SEED_LOG` tail,
 printing one progress line per poll and returning a terminal exit code:
 
+(All printed lines are **plain ASCII** — AC 13 — so the table below shows the
+shipped `_FOLLOW_MSG_*` wording, not glyphs.)
+
 | exit | condition | printed |
 | ---- | --------- | ------- |
-| 0 | my token, `ok` | ✅ baseline refresh complete — safe to close this terminal |
-| 5 | marker token ≠ my token (superseded) | a fresher baseline refresh is now running — this one was stopped, safe to close this terminal |
-| 1 | my token `incomplete`, or `running` with a re-poll-confirmed dead pid (interrupted) | `.testmondata` may be partial — rerun the refresh |
-| 1 | my token `skipped` | refresh was skipped (`reason`) — no baseline was written; safe to close this terminal, rerun if needed |
-| 4 | my token still `running` past `_SEED_FOLLOW_MAX_WAIT_S` | still running after 45m — keep this terminal open, or re-attach: `python scripts/qs/quality_gate.py --seed-testmon-follow --seed-token <T>` |
-| 3 | marker missing past the startup grace, or unreadable after a one-poll re-read | the baseline refresh status is unreadable |
+| 0 | my token, `ok` | `[OK] baseline refresh complete - safe to close this terminal.` |
+| 5 | owned the marker, then a foreign token owns it (`_FOLLOW_MSG_TAKEN_OVER`) | `Another baseline refresh now holds the marker; this run either completed or was superseded - check ...--seed-testmon-status. Safe to close this terminal.` |
+| 5 | foreign token persists the whole startup grace (`_FOLLOW_MSG_UNCONFIRMED`) | `Could not confirm this baseline refresh started; another refresh holds the marker - check ...--seed-testmon-status. Safe to close this terminal.` |
+| 1 | my token `incomplete`, or `running` with a re-poll-confirmed dead pid (interrupted) | `` `.testmondata` may be partial - rerun the refresh. `` |
+| 1 | my token `skipped` | `Refresh was skipped (reason) - no baseline was written; safe to close this terminal, rerun if needed.` |
+| 4 | no terminal state within `_SEED_FOLLOW_MAX_WAIT_S` (checked at loop top) | `Still running after 45m - keep this terminal open, or re-attach: python scripts/qs/quality_gate.py --seed-testmon-follow --seed-token <T>` |
+| 3 | marker missing/unreadable past the startup grace | `The baseline refresh status is unreadable.` |
 
 Details:
 - **Progress line** (each poll while `running` with my token): read the `SEED_LOG`
@@ -202,8 +211,9 @@ Details:
   `_stream_pytest` synthesizes; **verified live under `-n auto`**, the log
   contains e.g. `  pytest: 21% (72/330) | passed=72 failed=0 errors=0` (and the
   regex correctly does not match the sibling `  pytest: done (…)` line). Print
-  `refreshing baseline: N/M tests (pct%) · elapsed mm:ss`; degrade to
-  `refreshing baseline: elapsed mm:ss` when unparseable. Tests use a fixture
+  `refreshing baseline: N/M tests (pct%) - elapsed mm:ss` (plain ASCII, AC 13);
+  degrade to `refreshing baseline: elapsed mm:ss` when unparseable. Tests use a
+  fixture
   derived from that real captured line and assert the exact production format
   parses (so a future `_stream_pytest` format drift breaks the test rather than
   silently degrading).
@@ -307,10 +317,12 @@ Prose points for all three:
 
 1. `--seed-testmon-follow --seed-token T` exists, is read-only (no
    pytest/coverage/testmon import), emits **plain-ASCII** lines only, and returns
-   **0** (my token `ok`), **5** (superseded — a different token owns the marker
-   *after* T was observed owning it, OR a foreign token persists past the startup
-   grace; single message), **1** (`incomplete`; `running` with a re-poll-confirmed
-   dead pid — interrupted; or `skipped` with its own benign message), **4**
+   **0** (my token `ok`), **5** (a different token owns the marker *after* T was
+   observed owning it → `_FOLLOW_MSG_TAKEN_OVER`, OR a foreign token persists past
+   the startup grace → `_FOLLOW_MSG_UNCONFIRMED`; **two exit-5 messages
+   (taken-over / unconfirmed-start), one exit code** — see AC 19/22), **1**
+   (`incomplete`; `running` with a re-poll-confirmed dead pid — interrupted; or
+   `skipped` with its own benign message), **4**
    (`running` past `_SEED_FOLLOW_MAX_WAIT_S`), **3** (marker missing/unreadable
    past the startup grace). **Startup-grace covers a stale foreign-token marker**
    (review-fix #01, finding #1): until T has been observed owning the marker, a

--- a/docs/stories/QS-299.story.md
+++ b/docs/stories/QS-299.story.md
@@ -387,6 +387,32 @@ Prose points for all three:
     with finding #1's grace); the pid-reuse liveness limitation is documented in a
     code comment (no functional change — advisory-only, not over-engineered).
 
+### Review-fix #02 acceptance criteria
+
+17. **(finding #1, should-fix) Completed run is not misreported as superseded.**
+    A run that reached `ok(T)` whose marker was then overwritten by a parallel
+    `running(U)` reports **completion** (exit 0), not "stopped": on the
+    own-token→foreign path the follower re-reads once and honors a MY-token
+    terminal state. Tests: (a) own `ok` overwritten by foreign `running` → exit 0;
+    (b) own `running` then foreign `running` (never completed) → exit 5.
+18. **(finding #2, should-fix) Symmetric seed-mode mutex.** `--seed-testmon`,
+    `--seed-testmon-status`, `--seed-testmon-follow` are pairwise mutually
+    exclusive via ONE centralized, order-independent check (exit 2). Tested from
+    both directions for all three pairs.
+19. **(finding #3, nice-to-have) Softened grace-elapsed message.** A foreign token
+    that holds the marker for the whole startup grace yields exit 5 with an
+    uncertainty message ("could not confirm this baseline refresh started … check
+    `--seed-testmon-status`"), not a definite supersession claim. Tested.
+20. **(finding #4, nice-to-have) Universal deadline.** `_SEED_FOLLOW_MAX_WAIT_S`
+    is enforced at the TOP of the poll loop, so every path (startup wait, no-marker
+    re-poll, running-alive) honors it and a flapping/no-progress marker eventually
+    returns exit 4. Tested.
+21. **(findings #5/#6/#9, nice-to-have)** shared startup-wait poll block extracted
+    (no duplication); marker `state` strings are module constants
+    (`_SEED_STATE_*`) used by every producer/consumer; the `running`+my-token+alive
+    re-poll branch is covered by a test. (finding #7: `io` import confirmed present
+    in the test module — no change needed.)
+
 ## Task breakdown (TDD)
 
 1. **Marker + token core.** Add `SEED_LOG` constant; extract

--- a/docs/stories/QS-299.story.md
+++ b/docs/stories/QS-299.story.md
@@ -2,7 +2,7 @@
 
 - Issue: #299 (follow-up to QS-286, which followed QS-276)
 - Branch: `QS_299`
-- Story version: v3
+- Story version: v8 (v3 + review-fix rounds #01–#05 folded, ACs 12–25)
 - Next phase: **implement-task** — the change set is test-authoring
   (`tests/test_quality_gate.py`) plus agent-file edits that need the full
   TDD + doc-drift/harness-sync wiring, which is implement-task's job.
@@ -40,9 +40,10 @@ invocation**:
   never raise) that updates as the refresh proceeds and culminates in an
   unambiguous terminal verdict: **"[OK] baseline refresh complete - safe to close
   this terminal"** (done); on the own-token→foreign path, the honest
-  **"another baseline refresh now holds the marker; this run either completed or
+  **"Another baseline refresh now holds the marker; this run either completed or
   was superseded - check `--seed-testmon-status`. Safe to close this terminal."**
-  (`_FOLLOW_MSG_TAKEN_OVER`, exit 5); or a rerun advisory (`incomplete`/`skipped`).
+  (`_FOLLOW_MSG_TAKEN_OVER`, exit 5; byte-exact with the shipped constant); or a
+  rerun advisory (`incomplete`/`skipped`).
 - **Best-effort last-wins preemption** (review-fix #01/#04, finding #4 — stated
   consistently, not as a hard guarantee): when a new seed starts on main it
   SIGTERMs any still-running seed from a previous task (killing its pytest tree)
@@ -408,8 +409,8 @@ Prose points for all three:
     `running(T) → running(U)` on preemption). The follower therefore cannot
     distinguish "completed then overwritten" from "preempted mid-run"; on the
     own-token→foreign path it reports HONEST uncertainty (exit 5,
-    `_FOLLOW_MSG_TAKEN_OVER`: "another baseline refresh now holds the marker; this
-    run either completed or was superseded — check `--seed-testmon-status`"),
+    `_FOLLOW_MSG_TAKEN_OVER`: "Another baseline refresh now holds the marker; this
+    run either completed or was superseded - check `--seed-testmon-status`"),
     never a false "this run was stopped" and never a fabricated completion. The
     round-2 synchronous-re-read "recovery" was dead code under the token guard
     (the `running(U) → ok(T)` transition it relied on is forbidden) and is
@@ -546,7 +547,8 @@ rejected items correctly absent. New findings, all **resolved in v3**:
   rules coverage carve-out; AC#11 now states no `scripts/qs` coverage gate exists
   or is added.
 
-- changed-since-last-review: true (v3 folds Round 2)
-- last review: round 2 (all findings folded; the only open item is the owner-
-  rejected coverage-enforcement suggestion)
+- changed-since-last-review: true (folds review-fix round #05 — ACs 22–25 plus
+  the #05 doc/docstring-consistency fixes)
+- last review: implementation review round #05 (review-fix plans #01–#05 all
+  folded; ACs 12–25). Earlier: plan adversarial review round 2.
 - open criticals: 0

--- a/docs/stories/QS-299.story.md
+++ b/docs/stories/QS-299.story.md
@@ -389,12 +389,20 @@ Prose points for all three:
 
 ### Review-fix #02 acceptance criteria
 
-17. **(finding #1, should-fix) Completed run is not misreported as superseded.**
-    A run that reached `ok(T)` whose marker was then overwritten by a parallel
-    `running(U)` reports **completion** (exit 0), not "stopped": on the
-    own-token→foreign path the follower re-reads once and honors a MY-token
-    terminal state. Tests: (a) own `ok` overwritten by foreign `running` → exit 0;
-    (b) own `running` then foreign `running` (never completed) → exit 5.
+17. **(finding #1, should-fix — REVISED in review-fix #03) Own-token→foreign is
+    honest best-effort.** The single shared marker is token-guarded, so a run's
+    `ok(T)` is unrecoverable once a parallel `running(U)` claims the marker (the
+    reachable on-disk histories are `running(T) → ok(T) → running(U)` or
+    `running(T) → running(U)` on preemption). The follower therefore cannot
+    distinguish "completed then overwritten" from "preempted mid-run"; on the
+    own-token→foreign path it reports HONEST uncertainty (exit 5,
+    `_FOLLOW_MSG_TAKEN_OVER`: "another baseline refresh now holds the marker; this
+    run either completed or was superseded — check `--seed-testmon-status`"),
+    never a false "this run was stopped" and never a fabricated completion. The
+    round-2 synchronous-re-read "recovery" was dead code under the token guard
+    (the `running(U) → ok(T)` transition it relied on is forbidden) and is
+    removed; the test now drives only the reachable ordering. Outcome is safe
+    either way — a valid baseline exists (ours or the winner's).
 18. **(finding #2, should-fix) Symmetric seed-mode mutex.** `--seed-testmon`,
     `--seed-testmon-status`, `--seed-testmon-follow` are pairwise mutually
     exclusive via ONE centralized, order-independent check (exit 2). Tested from
@@ -412,6 +420,21 @@ Prose points for all three:
     (`_SEED_STATE_*`) used by every producer/consumer; the `running`+my-token+alive
     re-poll branch is covered by a test. (finding #7: `io` import confirmed present
     in the test module — no change needed.)
+
+### Review-fix #03 acceptance criteria
+
+22. **(finding #2, nice-to-have)** The follower docstring exit table documents that
+    exit 5 covers BOTH the own-token→foreign "taken over" case AND the
+    grace-elapsed "unconfirmed start" case.
+23. **(finding #3, nice-to-have)** The lock-busy (contention) branch of
+    `_claim_and_preempt` documents the possible cosmetic progress-line jitter from
+    two concurrent seeds sharing `SEED_LOG` (no functional change).
+24. **(finding #4, nice-to-have)** `docs/workflow/harness.md` notes that the
+    seed/follow launch block is intentionally byte-identical across the three
+    `qs-finish-task.md` files and must be edited in lockstep (guarded by
+    `test_seed_launch_block_byte_identical_across_harnesses`).
+25. **(finding #5, nice-to-have)** A test asserts each `qs-finish-task.md` contains
+    the `[ -n "$SEED_TOKEN" ]` empty-token launch guard.
 
 ## Task breakdown (TDD)
 

--- a/docs/stories/QS-299.story.md
+++ b/docs/stories/QS-299.story.md
@@ -1,0 +1,451 @@
+# QS-299 — finish-task streams detached `--seed-testmon` progress inline, with last-wins preemption across parallel tasks
+
+- Issue: #299 (follow-up to QS-286, which followed QS-276)
+- Branch: `QS_299`
+- Story version: v3
+- Next phase: **implement-task** — the change set is test-authoring
+  (`tests/test_quality_gate.py`) plus agent-file edits that need the full
+  TDD + doc-drift/harness-sync wiring, which is implement-task's job.
+
+## Problem
+
+QS-286 shipped a solution the user explicitly rejected. Today `finish-task`,
+after a merge, launches the `--seed-testmon` baseline refresh **detached**
+(`nohup`) on the main checkout and then tells the user to *manually* run
+`python scripts/qs/quality_gate.py --seed-testmon-status` **from a different
+cwd, as a second command**, to find out when the refresh finished. That means:
+
+1. **No inline completion signal.** The user cannot see, in the same
+   finish-task session, when it is safe to close the terminal. They must
+   context-switch to the main checkout and poll by hand.
+
+2. **No coordination across parallel tasks.** Seeding the testmon baseline is
+   *slow* (a near-full `pytest --testmon` select-all). A developer commonly
+   runs 2–4 tasks in parallel; each task's finish-task fires its own
+   `--seed-testmon` against the **same** main checkout and the **same**
+   `.testmondata`. They stack up, competing for CPU. Only the **last** one to
+   start is authoritative — by construction its `main` already contains every
+   earlier task's merge — yet the earlier, now-obsolete runs keep grinding, and
+   their finish-task sessions give the user no signal that they've been made
+   redundant and can be closed.
+
+## Goal
+
+After finish-task announces "PR merged / branch deleted / worktree removed", it
+must, **in the same session, with no separate command / cwd / second
+invocation**:
+
+- **Surface the baseline-refresh progress inline** — a progress line
+  (`N/M tests (pct%)` + elapsed) that updates as the refresh proceeds and
+  culminates in an unambiguous terminal verdict: **"✅ safe to close this
+  terminal"** (done), **"a fresher baseline refresh is now running — this one
+  was stopped, safe to close this terminal"** (superseded), or a rerun advisory.
+- **Preempt earlier runs automatically:** when a new seed starts on main it
+  stops any still-running seed from a previous task (killing its pytest tree),
+  and every superseded task's finish-task session prints the "superseded — safe
+  to close" line. Only the newest seed keeps running.
+
+**Honest mechanism note (soft, best-effort — not a hard guarantee).** The
+*follower CLI* (`--seed-testmon-follow`) deterministically emits a fresh
+progress line every poll to its stdout and returns a terminal verdict — that
+part is unit-tested. Making those lines appear *inline in the session* relies on
+the LLM harness running the follower as a monitored background task and relaying
+its output; that is agent-prose behavior, not a mechanism we can unit-test. The
+issue's actual requirement — the completion signal appears in the same session,
+with no separate command/cwd — is met; we do not claim a guaranteed
+frame-by-frame live viewport.
+
+Non-goals: no change to what `--seed-testmon` actually computes; no change to
+the `--impacted`/full-gate machinery; **no coverage gate for `scripts/qs`** (the
+project deliberately does not enforce utility-script coverage — see §8); keep
+the whole thing **best-effort** — a failed/timed-out/duplicate refresh must
+never block finish-task's cleanup, because a stale baseline is always safe (new
+worktrees just over-select tests).
+
+## Design
+
+All parallel seeds run against the **one** main checkout, so they already share
+`.testmondata`, the seed log, and the status marker. We coordinate through that
+status marker, made **token-aware**, with an OS-level lock serializing the
+whole read → claim → kill critical section.
+
+**Precondition / authoritativeness (softened per review).** Case B step 6
+already does `git -C "$MAIN_DIR" checkout main` + `pull --ff-only` before
+seeding, so each seed sees the merges present at *its* pull. The last seed to
+**claim the lock** wins and keeps running; because pull-time and lock-claim-time
+are not serialized against each other, the surviving winner is *usually* — but
+not provably — the one with the freshest `main`. **Correctness never depends on
+this:** a stale baseline only over-selects tests, which is safe (a non-goal).
+We therefore drop any hard "last-started is authoritative" guarantee.
+
+### 1. Per-run token + token-aware marker
+
+Each finish-task session generates a unique **token** (uuid4 hex) and passes it
+to both the seed and the follower via a new `--seed-token <T>` option. Rationale
+(recorded): the detached `( … & )` subshell hides `$!`, and the follower must
+identify *its own* run to detect supersession — the marker's `pid` alone cannot
+(a superseded winner has a different pid; a finished winner has no pid). The
+single marker file `.testmondata.seed-status` (constant `SEED_STATUS`, unchanged
+path) always carries the owning run's `token`:
+
+- `running`  → `{"state","token","pid","pgid","started"}` (`pgid` present only
+  when this run owns its own process group — see §2)
+- `ok`/`incomplete` → `{"state","token","started","finished","returncode"}`
+- `skipped`  → `{"state","token","reason"}`
+
+**Required invariant:** every marker has a well-formed `token`. `--seed-token`
+is optional for `--seed-testmon`; when absent (an ad-hoc manual run)
+`seed_testmon()` generates its own uuid4 so all readers/preemptor comparisons
+are well-defined.
+
+New/changed symbols:
+- Add module constant `SEED_LOG = REPO_ROOT / ".testmondata.seed.log"` beside
+  `SEED_STATUS` (the follower reads it; today it is only a shell redirect target).
+- Extract `_read_seed_marker() -> dict | None` from the inline `json.loads` in
+  `seed_testmon_status()` (missing / `OSError` / `ValueError` / non-`dict` →
+  `None`). **`seed_testmon_status()` keeps its two distinct messages** by
+  re-checking `SEED_STATUS.exists()` for "No baseline refresh has been
+  recorded." vs "…unreadable." — the extraction must not collapse them.
+- `_write_seed_status()` threads a `token` field from **every** call site
+  (running claim, ok/incomplete completion, skipped early-return). It already
+  writes **atomically** (temp sibling + `os.replace`, best-effort), so concurrent
+  follower reads can never see a partial JSON.
+
+### 2. Detach into its own process group — gated on an explicit `--detached` flag
+
+Rather than sniff the tty (unreliable: BSD `nohup` on macOS does not redirect
+stdin and job-control keeps the tty), `seed_testmon()` detaches **only when
+launched with the new `--detached` flag**, which finish-task passes on the
+`nohup` launch and manual/foreground runs omit (so a hand-run `--seed-testmon`
+keeps Ctrl-C / job control). `_detach_session()`:
+- calls `os.setsid()`;
+- records `pgid = os.getpgrp()` **when we are the group leader** —
+  `os.getpgrp() == os.getpid()` — covering both "setsid succeeded" **and** the
+  "setsid raised `EPERM` because we were *already* a group leader" branch (in
+  the `( … & )` subshell the child often already leads its group; the xdist
+  workers it spawns are still ours, so record that group);
+- records **no** `pgid` only if we are genuinely not a group leader — then
+  preemption falls back to a single-pid `os.kill`. `pgid` matters because xdist
+  workers are separate processes a bare controller kill would orphan; the
+  residual single-pid case is rare and harmless (orphaned workers finish and
+  exit on their own).
+
+### 3. Automatic last-wins preemption (lock-serialized, kill inside the lock)
+
+The whole read → claim → **kill** critical section at the start of
+`seed_testmon()` runs **under** an OS advisory lock (`fcntl.flock` on a sidecar
+lock file `SEED_STATUS.with_suffix(".seed-status.lock")`; portable on
+macOS/Linux). Holding the lock **across the kill** (not just the claim) is what
+makes the invariant hold for N≥3 concurrent starters: each claimant, serialized,
+reads the single immediately-previous claimant as its predecessor and terminates
+it before the next claimant runs — so no middle run is left orphaned. Under the
+lock, in order:
+
+1. `_read_seed_marker()` → capture any predecessor that is `running`, has a
+   different `token`, and whose process is alive (`_pid_alive`); remember its
+   `pid`/`pgid`.
+2. `_write_seed_status("running", token=mine, pid=…, pgid=…, started=…)` — claim
+   (written **before** the kill, so the marker never shows a foreign-token-dead
+   state → no false "interrupted").
+3. `_terminate_process_group(pgid, pid)` on the predecessor — `os.killpg(pgid,
+   SIGTERM)` when a `pgid` was recorded, else `os.kill(pid, SIGTERM)`; fully
+   best-effort (dead / foreign / out-of-range pid never raises) and emits one
+   `_emit()` diagnostic line.
+4. Release the lock.
+
+**On lock-acquire failure (rare):** do **not** race — skip preemption entirely,
+best-effort write the claim, and leave any predecessor running. Last-wins
+degrades to "possibly two seeds run", which is safe (duplicate/stale baseline is
+harmless). The lock is what upgrades best-effort to a real guarantee; without it
+we stay best-effort rather than introduce the C2 TOCTOU.
+
+**Token-guarded completion write (kept — round-1 finding S-I2).** A preempted
+predecessor is SIGTERM'd and normally dies before its completion write; as
+belt-and-suspenders `seed_testmon()` re-acquires the lock, re-reads the marker,
+and writes `ok`/`incomplete` **only if the marker's `token` is still mine**. This
+prevents a racing killed predecessor from stamping its old token and making the
+live winner's *own* follower falsely report itself superseded.
+
+`_emit()` is the existing stderr **print** helper (not `_LOGGER`), so its
+f-string style is fine; the lazy-`%s`/no-trailing-period logging rules do not
+apply to it. Follower user-facing lines go through `print()`.
+
+### 4. Inline follower — new `--seed-testmon-follow --seed-token <T>`
+
+`seed_testmon_follow(token)` — a read-only, no-pytest/coverage/testmon-import
+loop that reads the marker (via `_read_seed_marker()`) and the `SEED_LOG` tail,
+printing one progress line per poll and returning a terminal exit code:
+
+| exit | condition | printed |
+| ---- | --------- | ------- |
+| 0 | my token, `ok` | ✅ baseline refresh complete — safe to close this terminal |
+| 5 | marker token ≠ my token (superseded) | a fresher baseline refresh is now running — this one was stopped, safe to close this terminal |
+| 1 | my token `incomplete`, or `running` with a re-poll-confirmed dead pid (interrupted) | `.testmondata` may be partial — rerun the refresh |
+| 1 | my token `skipped` | refresh was skipped (`reason`) — no baseline was written; safe to close this terminal, rerun if needed |
+| 4 | my token still `running` past `_SEED_FOLLOW_MAX_WAIT_S` | still running after 45m — keep this terminal open, or re-attach: `python scripts/qs/quality_gate.py --seed-testmon-follow --seed-token <T>` |
+| 3 | marker missing past the startup grace, or unreadable after a one-poll re-read | the baseline refresh status is unreadable |
+
+Details:
+- **Progress line** (each poll while `running` with my token): read the `SEED_LOG`
+  tail and take the **last** match of regex `pytest:\s+(\d+)%\s+\((\d+)/(\d+)\)`
+  → `pct`, `current` (N), `total` (M) directly (no `round()`). This is the line
+  `_stream_pytest` synthesizes; **verified live under `-n auto`**, the log
+  contains e.g. `  pytest: 21% (72/330) | passed=72 failed=0 errors=0` (and the
+  regex correctly does not match the sibling `  pytest: done (…)` line). Print
+  `refreshing baseline: N/M tests (pct%) · elapsed mm:ss`; degrade to
+  `refreshing baseline: elapsed mm:ss` when unparseable. Tests use a fixture
+  derived from that real captured line and assert the exact production format
+  parses (so a future `_stream_pytest` format drift breaks the test rather than
+  silently degrading).
+- **elapsed** is wall-clock `time.time() - marker["started"]` (seed-relative, so
+  a later re-attach still shows the true age), **not** the follower's
+  `monotonic` start. `time.monotonic` is used only for the `max_wait` deadline.
+- **Log/token safety:** a preempting seed truncates the shared `SEED_LOG`, but the
+  follower only ever parses progress *after* confirming the marker still carries
+  its own token; a superseded run returns exit 5 before parsing, so it never
+  mis-reads the winner's log tail.
+- **Re-poll defenses:** (a) R1 — on `running` + my token + `_pid_alive` False,
+  sleep one interval and re-read once before concluding `interrupted` (cosmetic
+  polish: prevents a rare, harmless "rerun" line in the sub-poll window between a
+  preemptor's claim and the observed marker flip; not correctness-critical since
+  claim-before-kill already carries R1). (b) On an unreadable marker, re-read
+  once before concluding exit 3.
+- **Startup grace:** while the marker is missing, print "waiting for baseline
+  refresh to start…" for a small bounded number of polls, then exit 3 — covers
+  the window before the seed writes its `running` marker.
+- **Constants (plain module constants — no env knobs):**
+  `_SEED_FOLLOW_INTERVAL_S = 5`, `_SEED_FOLLOW_MAX_WAIT_S = 2700` (45 min).
+- **Seams for full branch coverage without real processes/sleep:** `time.sleep`,
+  `time.monotonic`, `time.time`, `_read_seed_marker`, `_pid_alive`, and the
+  log-tail read are all patchable.
+
+### 5. `--seed-testmon-status` retained
+
+Kept as a scriptable one-shot fallback (issue answer #1). Reuses
+`_read_seed_marker()` while preserving its distinct missing-vs-unreadable
+messages (§1); 0/4/1/3 exit contract unchanged.
+
+### 6. xdist for seeding — verified, asserted (user-requested)
+
+`_build_seed_testmon_cmd()` appends `-n <workers>` from `_pytest_workers()`
+(default `auto`); the user explicitly asked to ensure this. Keep the existing
+`test_seed_cmd_parallelizes_when_xdist_enabled` assertion — no new code.
+
+### 7. finish-task agent change (all three harnesses, harness-sync)
+
+Rewrite Case B step 6 in `.claude`, `.cursor`, `.opencode` `qs-finish-task.md`.
+After the existing `MAIN_DIR` capture + `checkout main` + `pull --ff-only` +
+`QG_PY` probe, launch the tokened detached seed — **no `rm -f` of the marker**
+(that would erase the predecessor the new seed must read to preempt it):
+
+```bash
+SEED_TOKEN="$("$QG_PY" -c 'import uuid; print(uuid.uuid4().hex)')"
+( cd "$MAIN_DIR" && nohup "$QG_PY" scripts/qs/quality_gate.py \
+    --seed-testmon --detached --seed-token "$SEED_TOKEN" \
+    </dev/null >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )
+```
+
+Then, **the actual step** (the foreground form below is conceptual only — a full
+seed can exceed the foreground Bash cap): run the follower via the harness's
+background-run + monitor mechanism and relay its progress inline until it exits.
+
+```bash
+# conceptual — each harness wraps this in its background+monitor mechanism,
+# never runs it foreground:
+cd "$MAIN_DIR" && "$QG_PY" scripts/qs/quality_gate.py \
+    --seed-testmon-follow --seed-token "$SEED_TOKEN"
+```
+
+Per-harness mechanism (core behavior identical; harness tool adapted, per the
+harness-sync rule):
+- **`.claude`:** run the follower via `run_in_background` + Monitor. Poll its
+  output on a cadence (~15 s; note the monitor cadence is deliberately ≥ the
+  follower's 5 s interval — latest-line-wins, so intermediate lines may be
+  coalesced), relay the latest progress line inline, stop when the background
+  task exits, then report the follower's final verdict line.
+- **`.cursor` / `.opencode`:** the equivalent background-run + poll-until-exit
+  mechanism for that harness (not a verbatim copy of Claude tool names).
+
+Prose points for all three:
+- The seed stays `nohup`-detached so it survives a closed window (and the next
+  task's finish preempts it anyway).
+- **The follower's exit code is a completion signal, not a gate** — cleanup has
+  already finished before seeding, so relay the final line and finish normally
+  **regardless of exit code** (0/5 → safe to close; 4/1 → advisory only; never
+  surface a non-zero follower exit as a failed step).
+- Remove the old "run `--seed-testmon-status` yourself from the main checkout" as
+  the primary path (keep only as an optional scripting note). Update the
+  Hard-rules carve-out bullet to name the follower as a read-only non-gate
+  subcommand.
+
+### CLI wiring
+
+- `--seed-testmon-follow` (store_true) joins the existing subcommand mutex
+  (incompatible with `--impacted/--quick/--cache/--no-cache/--full/--fix` and
+  with `--seed-testmon`/`--seed-testmon-status`).
+- `--seed-token <str>` (default `None`) is only meaningful with `--seed-testmon`
+  or `--seed-testmon-follow`; elsewhere → `parser.error`.
+  `--seed-testmon-follow` **requires** `--seed-token` (else it cannot detect
+  supersession) → `parser.error`.
+- `--detached` (store_true) is only meaningful with `--seed-testmon`; elsewhere
+  → `parser.error`.
+- `main()` dispatch: `--seed-testmon-follow` short-circuits before cache/scope →
+  `sys.exit(seed_testmon_follow(args.seed_token))`; `seed_testmon()` receives
+  `args.seed_token` and `args.detached`.
+
+## Acceptance criteria
+
+1. `--seed-testmon-follow --seed-token T` exists, is read-only (no
+   pytest/coverage/testmon import), and returns **0** (my token `ok`), **5**
+   (marker token ≠ T — superseded, single message), **1** (`incomplete`;
+   `running` with a re-poll-confirmed dead pid — interrupted; or `skipped` with
+   its own benign message), **4** (`running` past `_SEED_FOLLOW_MAX_WAIT_S`),
+   **3** (marker missing past grace, or unreadable after a one-poll re-read).
+2. While `running` with my token, each poll prints `N/M tests (pct%)` + elapsed
+   parsed from the **last** real `pytest: NN% (cur/total)` line in `SEED_LOG`
+   (fixture derived from the live-captured format; exact-format assertion),
+   elapsed = wall-clock `now - marker["started"]`, degrading to elapsed-only when
+   unparseable. `time.sleep`/`time.monotonic`/`time.time` patched (no real sleep).
+3. `--seed-testmon --detached --seed-token T2` **automatically** SIGTERMs a
+   still-`running` predecessor whose token ≠ T2 — `os.killpg(pgid)` when a pgid
+   was recorded, else `os.kill(pid)` — best-effort (dead/foreign/out-of-range pid
+   never raises), with read→claim→**kill all under the flock** and the claim
+   written before the kill; on lock-acquire failure preemption is skipped (claim
+   best-effort written, predecessor left running).
+4. `_detach_session()` runs `os.setsid()` **only** when `--detached` is passed;
+   records `pgid` when `os.getpgrp() == os.getpid()` — covering both setsid-
+   success and setsid-`EPERM`-already-leader — and records **no** pgid otherwise;
+   a run without `--detached` neither detaches nor records a pgid. All branches
+   covered.
+5. A preempted run does not clobber the winner's marker: the completion write
+   re-acquires the lock, re-reads, and writes only if the marker's `token` is
+   still mine.
+6. `--seed-token` is optional for `--seed-testmon` (uuid4 generated when absent —
+   required invariant that every marker has a `token`) and **required** for
+   `--seed-testmon-follow`; `--detached` is valid only with `--seed-testmon`; the
+   mutex + usage-error checks cover follow-without-token, stray `--seed-token`,
+   and stray `--detached`.
+7. `--seed-testmon-status` still returns its unchanged 0/4/1/3 contract **and**
+   its distinct "no baseline recorded" vs "unreadable" messages (the
+   `_read_seed_marker()` extraction preserves both).
+8. Seeding still parallelizes: `_build_seed_testmon_cmd()` includes `-n auto`
+   when xdist is available (existing test preserved + asserted).
+9. All three `qs-finish-task.md` (`.claude`, `.cursor`, `.opencode`) updated in
+   lockstep: post-merge step launches the tokened detached seed with `--detached`
+   and `</dev/null` (no `rm -f` marker) and streams the follower inline via each
+   harness's background+monitor mechanism (the foreground form is conceptual
+   only); the follower's exit code is documented as informational and never fails
+   cleanup; Hard-rules carve-out names the follower; no residual primary
+   "run `--seed-testmon-status` yourself from the main checkout".
+10. `docs/workflow/project-rules.md` documents `--seed-testmon-follow` in **both**
+    the `--seed-testmon*` command-help block **and** the carve-out prose
+    paragraph.
+11. New/changed `quality_gate.py` code is exercised by thorough, per-branch unit
+    tests in `tests/test_quality_gate.py`; ruff + mypy clean. **No coverage gate
+    for `scripts/qs` exists or is added** — `--impacted`, the full gate, and CI
+    all measure `--cov=custom_components/quiet_solar` only, and enforcing
+    utility-script coverage is explicitly out of scope (owner decision). Tests
+    are written for good practice, not to satisfy a `scripts/qs` coverage gate.
+
+## Task breakdown (TDD)
+
+1. **Marker + token core.** Add `SEED_LOG` constant; extract
+   `_read_seed_marker()` (preserving `seed_testmon_status()`'s distinct
+   missing-vs-unreadable messages); thread `token` through every
+   `_write_seed_status()` call site (running/ok/incomplete/skipped). Tests first.
+2. **Detach + preemption.** Add `_detach_session()` (flag-gated setsid; pgid when
+   group-leader incl. EPERM-already-leader), `_terminate_process_group()`
+   (killpg-when-pgid else kill; best-effort), and lock-serialized
+   `_preempt_previous_seed()` with the **kill inside the lock** and the lock-fail
+   skip-preemption path; wire into `seed_testmon()` (accept `token`+`detached`;
+   uuid4 when token absent; read→claim→kill order; token-guarded completion
+   write). Tests: preempt live foreign-token run; skip dead/same-token; best-
+   effort on bad pid; no-`--detached` path skips setsid/pgid; setsid-EPERM-
+   already-leader records pgid; concurrent-claim serialization; lock-fail skips
+   preemption; guarded completion write skipped when preempted.
+3. **Follower.** Add `seed_testmon_follow()` with the sleep/clock/marker/log
+   seams, startup grace, R1 re-poll, unreadable re-poll, wall-clock elapsed,
+   last-match xdist-format progress parse, and the 0/5/1/4/3 table (incl. the
+   benign `skipped` message). Exhaustive per-branch tests.
+4. **CLI wiring.** Add `--seed-testmon-follow`, `--seed-token`, `--detached`;
+   mutex; usage errors (stray token, follow-without-token, stray `--detached`);
+   `main()` dispatch. Tests.
+5. **Verify xdist.** Keep/strengthen `test_seed_cmd_parallelizes_when_xdist_enabled`
+   (AC#8).
+6. **finish-task agents (×3).** Rewrite Case B step 6 + Hard-rules carve-out in
+   `.claude`, `.cursor`, `.opencode` in lockstep (per-harness background+monitor;
+   `--detached` + `</dev/null`; follower-exit-informational note; no `rm -f`;
+   foreground form labeled conceptual).
+7. **Docs.** Update the `--seed-testmon*` command-help block **and** the carve-out
+   prose paragraph in `docs/workflow/project-rules.md`.
+8. **Gate.** `python scripts/qs/quality_gate.py --impacted` green before PR (it
+   passes trivially w.r.t. `scripts/qs`, which is outside its `--cov` scope — no
+   scoped coverage self-check is run or required).
+
+## Doc maintenance
+
+`scripts/qs/check_doc_drift.py --paths <planned files>` surfaced **no**
+`docs/agents/` doc requiring co-modification (only unrelated `covers:`-outside-
+`custom_components/` warnings for `testing-layers.md`).
+
+- **Doc-OK:** `docs/agents/**` — no `custom_components/quiet_solar/` source is
+  touched, so no drift-tracked `covers:` doc is affected.
+- **In scope anyway (not drift-tracked):** `docs/workflow/project-rules.md`
+  command-help block **and** carve-out prose (Task 7, AC#10).
+
+## Adversarial Review Notes
+
+State legend: resolved = folded in · rejected = deliberately not done.
+
+### Round 1 (critic, concrete-planner, dev-proxy, scope-guardian) — all resolved in v2
+- C1 `rm -f` marker destroyed preemption; C2 TOCTOU (no lock); C3 streaming
+  over-promised; R1 superseded-as-interrupted; R2 wrong progress-parse target;
+  R3 killpg after swallowed setsid; R-dev setsid detaches foreground tty — all
+  **resolved**. Improve/clarify bundle (env knobs→constants, MAIN_DIR
+  precondition, carve-out prose, call-site enumeration, per-harness phrasing,
+  `_emit`, NEXT_PHASE note, exit-4 re-attach) **resolved**.
+- **Rejected (still not applied):** drop the token-guarded completion write
+  (kept, §3); drop the xdist AC (kept, §6).
+
+### Round 2 (same four + delta-auditor)
+Delta-auditor confirmed all 10 round-1 accepted findings resolved and both
+rejected items correctly absent. New findings, all **resolved in v3**:
+- **critical** — §7 foreground bash contradicted "background+monitor required"
+  (critic + delta-auditor + dev-proxy) → foreground form labeled conceptual;
+  background+monitor is the real step (§7, AC#9). · N≥3 orphan: kill-after-
+  release let a middle claimant die before killing its predecessor (critic) →
+  **kill moved inside the lock** (§3, AC#3). · tty-sniff `_is_detached_launch()`
+  unreliable on macOS → no setsid → orphaned workers (dev-proxy) → **explicit
+  `--detached` flag** (§2, AC#4).
+- **redesign** — setsid `EPERM`-already-leader dropped the pgid (dev-proxy) →
+  record the existing group when `getpgrp()==getpid()` (§2, AC#4). · "last-
+  started authoritative" conflated lock-order with pull-order (critic) →
+  authoritativeness claim **softened/dropped**, correctness rests on "stale is
+  safe" (Precondition).
+- **improve/clarify — resolved** — flock-unlocked reintroduced C2 → lock-fail
+  now **skips preemption** (§3). · `skipped` wrong message → split benign line
+  (§4, AC#1). · shared-log truncation → token-gates-parse note (§4). · partial-
+  JSON read → `_write_seed_status` is already atomic + follower unreadable re-poll
+  (§1, §4). · follower non-zero exit looked like a failed step → documented
+  informational (§7, AC#9). · inline progress is soft harness behavior →
+  acknowledged (Goal). · missing `SEED_LOG` constant → added (§1). · missing-vs-
+  unreadable message split preserved (§1, §5, AC#7). · elapsed made wall-clock
+  from `started` (§4, AC#2). · tail-parse takes last match (§4). · progress
+  fixture from the **live-captured** line — verified `pytest: 21% (72/330)` under
+  `-n auto` (§4). · `_emit` clarified as stderr print helper (§3). · NEXT_PHASE
+  rationale tightened (header). · monitor-cadence ≥ interval note (§7).
+- **scope-guardian trims — resolved** — exit-5 pid/"newer run" two-branch
+  **collapsed to one message** (removed the prior AC#7 + branch + tests). · R1
+  re-poll **reframed as cosmetic polish** (kept, cheap). · token auto-gen stated
+  as a **required invariant** (§1).
+- **rejected (owner decision, this round)** — enforce `scripts/qs` coverage
+  (dev-proxy #12 grammar tension + critic CI-gate suggestion): the owner does
+  **not** want utility-test coverage enforced. Removed the 100%-coverage mandate,
+  the forbidden-grammar `--cov=scripts/qs` self-verify command, and any project-
+  rules coverage carve-out; AC#11 now states no `scripts/qs` coverage gate exists
+  or is added.
+
+- changed-since-last-review: true (v3 folds Round 2)
+- last review: round 2 (all findings folded; the only open item is the owner-
+  rejected coverage-enforcement suggestion)
+- open criticals: 0

--- a/docs/stories/QS-299.story.md
+++ b/docs/stories/QS-299.story.md
@@ -36,14 +36,24 @@ must, **in the same session, with no separate command / cwd / second
 invocation**:
 
 - **Surface the baseline-refresh progress inline** — a progress line
-  (`N/M tests (pct%)` + elapsed) that updates as the refresh proceeds and
-  culminates in an unambiguous terminal verdict: **"✅ safe to close this
-  terminal"** (done), **"a fresher baseline refresh is now running — this one
-  was stopped, safe to close this terminal"** (superseded), or a rerun advisory.
-- **Preempt earlier runs automatically:** when a new seed starts on main it
-  stops any still-running seed from a previous task (killing its pytest tree),
-  and every superseded task's finish-task session prints the "superseded — safe
-  to close" line. Only the newest seed keeps running.
+  (`N/M tests (pct%)` + elapsed, **plain ASCII** so a piped non-UTF-8 stdout can
+  never raise) that updates as the refresh proceeds and culminates in an
+  unambiguous terminal verdict: **"[OK] … safe to close this terminal"** (done),
+  **"a fresher baseline refresh is now running - this one was stopped, safe to
+  close this terminal"** (superseded), or a rerun advisory.
+- **Best-effort last-wins preemption** (review-fix #01, finding #4 — stated
+  consistently, not as a hard guarantee): when a new seed starts on main it
+  SIGTERMs any still-running seed from a previous task (killing its pytest tree)
+  under an advisory lock, and the completion write is token-guarded so a
+  preempted run never clobbers the winner's marker. Because uuid4 tokens are
+  unordered and pull-time vs lock-claim-time are not globally serialized, which
+  seed ends up the surviving winner is **not** globally guaranteed — but
+  correctness never depends on it (a stale baseline only over-selects tests,
+  which is safe). A follower whose own run is genuinely superseded prints the
+  "superseded - safe to close" line; at **startup**, a stale foreign-token marker
+  left by a previous task (seen before this session's seed has claimed the
+  marker) is tolerated within a grace window rather than misreported as a
+  supersession.
 
 **Honest mechanism note (soft, best-effort — not a hard guarantee).** The
 *follower CLI* (`--seed-testmon-follow`) deterministically emits a fresh
@@ -296,11 +306,16 @@ Prose points for all three:
 ## Acceptance criteria
 
 1. `--seed-testmon-follow --seed-token T` exists, is read-only (no
-   pytest/coverage/testmon import), and returns **0** (my token `ok`), **5**
-   (marker token ≠ T — superseded, single message), **1** (`incomplete`;
-   `running` with a re-poll-confirmed dead pid — interrupted; or `skipped` with
-   its own benign message), **4** (`running` past `_SEED_FOLLOW_MAX_WAIT_S`),
-   **3** (marker missing past grace, or unreadable after a one-poll re-read).
+   pytest/coverage/testmon import), emits **plain-ASCII** lines only, and returns
+   **0** (my token `ok`), **5** (superseded — a different token owns the marker
+   *after* T was observed owning it, OR a foreign token persists past the startup
+   grace; single message), **1** (`incomplete`; `running` with a re-poll-confirmed
+   dead pid — interrupted; or `skipped` with its own benign message), **4**
+   (`running` past `_SEED_FOLLOW_MAX_WAIT_S`), **3** (marker missing/unreadable
+   past the startup grace). **Startup-grace covers a stale foreign-token marker**
+   (review-fix #01, finding #1): until T has been observed owning the marker, a
+   missing OR foreign-token marker is tolerated within the grace window — it never
+   yields an immediate exit 5.
 2. While `running` with my token, each poll prints `N/M tests (pct%)` + elapsed
    parsed from the **last** real `pytest: NN% (cur/total)` line in `SEED_LOG`
    (fixture derived from the live-captured format; exact-format assertion),
@@ -346,6 +361,31 @@ Prose points for all three:
     all measure `--cov=custom_components/quiet_solar` only, and enforcing
     utility-script coverage is explicitly out of scope (owner decision). Tests
     are written for good practice, not to satisfy a `scripts/qs` coverage gate.
+
+### Review-fix #01 acceptance criteria
+
+12. **(finding #1, must-fix) Startup grace covers a foreign-token marker.** The
+    follower does not exit 5 on a stale foreign-token marker seen before its own
+    seed has claimed the marker; supersession is concluded only after T is seen
+    owning the marker and is then replaced, or the startup grace elapses with a
+    foreign token still present. Tests: (a) stale foreign marker at startup → own
+    seed claims within grace → streams own progress, no spurious exit 5; (b)
+    foreign token persists past grace → exit 5; (c) own token then a newer token
+    → exit 5.
+13. **(finding #2, should-fix) ASCII-only follower output.** Every follower
+    verdict/progress line is plain ASCII (no `✅`/`—`/`·`/`…`), so a harness that
+    pipes stdout under `LANG=C` never raises `UnicodeEncodeError`. Tested.
+14. **(finding #3, should-fix) Blank `--seed-token` rejected.** An empty or
+    whitespace-only `--seed-token` is a usage error (exit 2) for BOTH
+    `--seed-testmon` and `--seed-testmon-follow`, so `""`/`"  "` is never silently
+    treated as absent (seed) vs literal (follow). Tested.
+15. **(finding #5, nice-to-have) Log tail, not whole file.** `_read_seed_log_tail`
+    reads only the trailing `_SEED_LOG_TAIL_BYTES`; the last progress line still
+    parses. Tested against a log far larger than the window.
+16. **(findings #6/#7/#8, nice-to-have)** `_read_seed_marker` docstring reworded;
+    `_SEED_STARTUP_GRACE_POLLS` widened to ~60 s for slow cold-starts (coordinated
+    with finding #1's grace); the pid-reuse liveness limitation is documented in a
+    code comment (no functional change — advisory-only, not over-engineered).
 
 ## Task breakdown (TDD)
 

--- a/docs/stories/QS-299.story_review_fix_#01.md
+++ b/docs/stories/QS-299.story_review_fix_#01.md
@@ -1,0 +1,143 @@
+# QS-299 — Review fix plan #01
+
+## Summary
+- Source PR: #300
+- Source story: docs/stories/QS-299.story.md
+- Findings to fix: 8
+- Next implement phase: `/implement-setup-task`
+
+## Findings to fix
+
+### [must-fix] Foreign-token marker at follower startup → premature exit 5
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_follow`, startup-grace logic)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: The follower's startup grace only covers a **missing** marker. If a
+  previous task's `.testmondata.seed-status` marker is still on disk (the common
+  case for every run after the first), the follower reads it before this
+  session's `nohup`-launched seed has claimed the marker (the seed must do
+  interpreter start + `import quality_gate` + `_testmon_available()` +
+  `_detach_session()` before reaching `_claim_and_preempt`). The follower sees a
+  foreign uuid token, treats it as "superseded", prints the fresher-run line, and
+  exits 5 — never streaming this run's progress. Tokens are uuid4 (unordered), so
+  a foreign token is indistinguishable from a genuinely fresher one. This defeats
+  the PR's primary feature and misreports a supersession that never happened.
+  Cleanup safety is preserved (a baseline is still built), so this is
+  feature-defeating + misleading, not data-losing.
+- Proposed fix: Extend the startup grace so that a **foreign-token** marker seen
+  before this follower's own seed has claimed the marker is treated the same as a
+  missing marker (keep polling within the grace window), not as immediate
+  supersession. Only conclude "superseded" once either (a) the follower has
+  observed its own token claim the marker at least once and *then* a different
+  token appears, or (b) the startup grace elapses with a foreign token still
+  present. Add per-branch tests: (1) foreign marker present at startup, own seed
+  claims within grace → follower streams own progress (no spurious exit 5);
+  (2) foreign marker persists past grace (own seed never claims) → still exits 5
+  as before; (3) own token observed then replaced by a newer foreign token
+  mid-run → exits 5 (genuine supersession). Update the story ACs to describe the
+  grace-covers-foreign-marker behavior.
+
+### [should-fix] Non-ASCII glyphs in follower output → UnicodeEncodeError under non-UTF-8 locale
+- File: `scripts/qs/quality_gate.py` (`_print_seed_progress` / `seed_testmon_follow` verdict lines)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The follower prints non-ASCII glyphs (`✅`, em-dash `—`, middle-dot
+  `·`, ellipsis `…`). The follower's stdout is captured/piped by the harness
+  (non-tty). Under a non-UTF-8 locale (`LANG=C`), `print()` raises
+  `UnicodeEncodeError`, replacing the clean verdict line with a traceback and
+  crashing the follower.
+- Proposed fix: Replace the non-ASCII glyphs with ASCII equivalents (e.g.
+  `[OK]`/`[done]`, `-`, `-`, `...`) OR force UTF-8 encoding on the follower's
+  stdout with error-tolerant fallback. Prefer plain ASCII for the streamed lines
+  to keep output robust across locales. Add a test that exercises the verdict/
+  progress print under a simulated non-UTF-8 stdout encoding without raising.
+
+### [should-fix] Empty/whitespace `--seed-token` handled inconsistently
+- File: `scripts/qs/quality_gate.py` (`main` arg validation, `seed_testmon`, `seed_testmon_follow`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `seed_testmon("")` does `token = token or uuid.uuid4().hex`, so an
+  empty token is treated as **absent** and a fresh uuid is generated. But
+  `seed_testmon_follow("")` compares `marker.get("token") != ""`, which is always
+  true against a real uuid marker → instant exit 5. The follow requirement check
+  (`args.seed_testmon_follow and args.seed_token is None`) passes for
+  `--seed-token ""`. The two subcommands interpret `""` inconsistently (absent vs
+  literal), so a follower launched with an empty/blank token can never match its
+  own seed.
+- Proposed fix: Reject an empty or whitespace-only `--seed-token` in argument
+  validation (usage error, exit 2) for both subcommands, so `""`/`"   "` is never
+  silently accepted. Add tests: `--seed-token ""` and `--seed-token "  "` → exit
+  2 for both `--seed-testmon --detached` and `--seed-testmon-follow`.
+
+### [should-fix] Story preemption contract is self-contradictory
+- File: `docs/stories/QS-299.story.md` (lines ~30, ~43-46, ~72-80, ~156-160)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The story promises deterministic "last-wins" behavior and that
+  every superseded session prints the stopped/superseded line, but later retracts
+  that guarantee and makes the winner only "usually" the freshest run. The
+  acceptance criteria are left ambiguous and could allow an older run to survive
+  as the winner.
+- Proposed fix: Rewrite the goal + affected ACs to state a single consistent
+  contract. Given tokens are unordered uuid4 and preemption is lock-serialized
+  best-effort, describe it as **best-effort last-wins preemption** everywhere:
+  a newly-launched seed SIGTERMs a still-running predecessor under the lock, and
+  the completion write is token-guarded so a preempted run never clobbers the
+  winner — but ordering is not globally guaranteed. Remove the deterministic
+  "every superseded session prints the stopped line" absolute guarantee, or scope
+  it to the observable cases the implementation actually delivers. Keep this
+  consistent with the foreign-marker grace fix above.
+
+### [nice-to-have] `_read_seed_log_tail` reads the whole file, not a tail
+- File: `scripts/qs/quality_gate.py:~1948` (`_read_seed_log_tail`, `_parse_seed_progress`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter, qs-review-coderabbit (3×)
+- Description: Despite the name, `_read_seed_log_tail` `read_text()`s the entire
+  `SEED_LOG`, and `_parse_seed_progress` runs `findall` over the whole content on
+  every poll (~every 5s for up to 45min). For a long full-suite refresh the log
+  can grow large, so the follower repeatedly re-reads/re-scans the whole file
+  (O(filesize) per poll). Correctness is unaffected.
+- Proposed fix: Seek to and read only the trailing bytes (e.g. last few KB, enough
+  to contain the latest `pytest: NN% (…)` progress line), making the name
+  accurate. Preserve existing parse behavior (last match wins). Add/adjust a test
+  asserting only the tail is read and the latest progress is still parsed.
+
+### [nice-to-have] `_read_seed_marker` docstring grammar
+- File: `scripts/qs/quality_gate.py` (`_read_seed_marker` docstring)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The docstring ("Extracted from the inline `json.loads`
+  `seed_testmon_status()` used") reads awkwardly.
+- Proposed fix: Reword the docstring for clarity. No behavior change.
+
+### [nice-to-have] `_SEED_STARTUP_GRACE_POLLS` (30s) may be short for slow cold-start
+- File: `scripts/qs/quality_gate.py` (`_SEED_STARTUP_GRACE_POLLS`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The follower launches immediately after the seed's `nohup` launch;
+  the seed writes its `running` marker only after import + `_testmon_available()`
+  + `_detach_session()`. 30s is almost certainly enough, but a very slow
+  interpreter cold-start could exhaust the grace and yield a spurious (harmless)
+  exit 3. Note: the foreign-marker grace fix (must-fix #1) may naturally widen /
+  reshape this window — coordinate the two.
+- Proposed fix: Consider raising the startup grace modestly (or tie it to the same
+  window used by the foreign-marker grace fix) so slow cold-starts don't yield a
+  spurious exit 3. Keep it informational-only. Adjust the relevant grace test if
+  the constant changes.
+
+### [nice-to-have] pid-reuse on the `running` liveness path
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_follow`, `_pid_alive` liveness check)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: If the detached seed dies and the OS reuses its pid,
+  `_pid_alive(pid)` returns True and the follower streams stale-marker "progress"
+  until the 45-min deadline, then exits 4 advising re-attach. Inherent limitation
+  of pid-based liveness; low likelihood, benign (advisory only).
+- Proposed fix: Document the pid-reuse limitation with a code comment near the
+  liveness check (no functional change required). Optionally note it as a known
+  limitation in the story. Do not over-engineer a pid-generation guard.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/stories/QS-299.story_review_fix_#02.md
+++ b/docs/stories/QS-299.story_review_fix_#02.md
@@ -1,0 +1,159 @@
+# QS-299 — Review fix plan #02
+
+## Summary
+- Source PR: #300
+- Source story: docs/stories/QS-299.story.md
+- Findings to fix: 9
+- Next implement phase: `/implement-setup-task`
+
+Round-2 review (after fix plan #01). The round-1 must-fix (foreign-token
+startup grace) is confirmed closed by all four reviewers. No must-fix remains.
+This plan addresses 2 should-fix + 7 nice-to-have items.
+
+## Findings to fix
+
+### [should-fix] Completed run misreported as "superseded/stopped"
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_follow`, ~2140-2146)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Every seed unconditionally claims `running(mytoken)` at start
+  (`_claim_and_preempt` writes the running marker regardless of the predecessor's
+  state), so the marker flips even when the predecessor already finished `ok`.
+  Race: this session's seed writes `ok(T)`, then a newly-started parallel task's
+  finish-task seed claims `running(U)` in the ≤5s gap between the follower's last
+  `running(T)` poll and its next poll. The follower never observes the `ok(T)`
+  state, hits the `own_token_seen` branch, and prints "a fresher baseline refresh
+  is now running - this one was stopped" for a run that actually **completed** and
+  wrote a valid baseline. Outcome safety is preserved (both verdicts end with
+  "safe to close this terminal"), so this is a misleading terminal verdict, not a
+  correctness/data problem.
+- Proposed fix: Before concluding "superseded" on the `own_token_seen` path,
+  re-read the marker one more time and check whether this follower's own token
+  reached a **terminal** state (`ok`/`incomplete`/`skipped`) at any point — track
+  the last-observed own-token terminal state as the follower polls. If the
+  follower ever observed its own token complete (`ok`), report the completion
+  verdict (exit 0) rather than "superseded", even if the marker has since flipped
+  to a foreign `running`. Only report "superseded/stopped" when the own token was
+  observed *running* and then replaced without ever reaching a terminal state.
+  Add per-branch tests: (a) own token observed `ok`, then foreign `running`
+  appears in the gap → follower reports completion (exit 0), not superseded;
+  (b) own token observed `running`, then foreign `running` without ever completing
+  → superseded (exit 5) as before.
+
+### [should-fix] Asymmetric `--seed-testmon` mutex guard
+- File: `scripts/qs/quality_gate.py` (`main()` arg validation, ~2265)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The `--seed-testmon --seed-testmon-follow` combination is only
+  rejected because the follow-mutex list happens to include `args.seed_testmon`;
+  there is no symmetric mutex on the seed side. It is correct today, but the guard
+  is asymmetric — if the follow-mutex is ever refactored, `--seed-testmon` would
+  silently win via `main()`'s dispatch ordering rather than raising a usage error.
+- Proposed fix: Add a symmetric, explicit mutual-exclusion check so that
+  `--seed-testmon`, `--seed-testmon-follow`, and `--seed-testmon-status` are
+  pairwise mutually exclusive regardless of dispatch order (usage error exit 2).
+  Prefer a single centralized check over exactly one of the three seed modes.
+  Add tests covering each disallowed pairing from the seed side (not just the
+  follow side).
+
+### [nice-to-have] Startup grace (~60s) exhaustible in the target parallel scenario
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_follow`, `_SEED_STARTUP_GRACE_POLLS`, ~2150-2158)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter, qs-review-blind-hunter
+- Description: Under 2-4 saturating parallel `pytest -n auto` seeds, this
+  session's seed cold-start (interpreter + `import quality_gate` +
+  `_testmon_available()`'s testmon import + `_detach_session()`) can exceed the
+  ~60s grace, so the follower never observes its own token, the grace elapses with
+  a stale foreign token present, and it prints "superseded/stopped" though its own
+  seed was merely slow to claim — a *misleading* exit 5 (unlike the missing-marker
+  path, which exits 3 benignly).
+- Proposed fix: On the foreign-marker-past-grace path, soften the messaging to
+  reflect uncertainty (e.g. "could not confirm this run started within N s;
+  another baseline refresh holds the marker — check
+  `--seed-testmon-status`") rather than asserting a definite supersession.
+  Optionally raise the grace modestly for the saturated-parallel case. Keep it
+  informational-only (follower exit stays advisory). Adjust the relevant grace
+  test if the constant or message changes.
+
+### [nice-to-have] `_SEED_FOLLOW_MAX_WAIT_S` deadline only checked in one branch
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_follow`, ~2160-2168)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The `_SEED_FOLLOW_MAX_WAIT_S` deadline is only checked in the
+  `running`+my-token+alive branch (~2127). The no-marker-after-`own_token_seen`
+  re-poll and the startup-wait paths never check it, so a theoretical flapping
+  marker (`None` at top of loop, non-`None` on re-read) could `continue`
+  indefinitely at 5s intervals and never return exit 4. Extremely low likelihood
+  (atomic `os.replace` writes), and each cycle sleeps (not a busy-loop) — purely a
+  missing upper bound.
+- Proposed fix: Enforce the `_SEED_FOLLOW_MAX_WAIT_S` deadline at the top of the
+  main poll loop so every path (startup wait, no-marker re-poll, running-alive)
+  honors the same upper bound and returns exit 4 when exceeded. Add a test for a
+  flapping/no-progress marker eventually hitting the deadline (exit 4).
+
+### [nice-to-have] Duplicated "waiting for baseline refresh to start" poll block
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_follow`, ~2150-2154 & ~2170-2174)
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: The startup-wait poll block is duplicated verbatim across the
+  foreign-marker and missing-marker branches; the two could drift apart on a
+  future edit.
+- Proposed fix: Extract the shared poll/sleep/grace-decrement logic into a small
+  helper used by both branches. No behavior change; keep existing tests green.
+
+### [nice-to-have] State-string literals compared directly
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_follow`/marker handling, ~2073-2176)
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: The marker state strings (`"ok"`, `"incomplete"`, `"skipped"`,
+  `"running"`) are compared directly across the new function; a typo in any one
+  silently falls through to "unreadable status" rather than failing loudly. Per
+  coding guidelines, prefer named constants over hardcoded strings.
+- Proposed fix: Define module-level constants for the seed marker states and use
+  them everywhere they are compared or written (seed writer + follower + status
+  reader), so all producers and consumers share one definition. No behavior
+  change; adjust tests only if they reference the literals.
+
+### [nice-to-have] Verify `io` import for `test_output_is_ascii_only`
+- File: `tests/test_quality_gate.py` (`test_output_is_ascii_only`, ~3600)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The test uses `io.StringIO()`; the reviewer could only see
+  `import signal` added in the diff and flagged (without repo context) that `io`
+  must already be imported or the test raises `NameError`. Almost certainly a
+  false positive.
+- Proposed fix: Confirm `io` is imported at the top of `tests/test_quality_gate.py`
+  (the suite already passed the quality gate, so it is). If for any reason it is
+  not, add the import. No change if already present.
+
+### [nice-to-have] Agent bash launch: empty `SEED_TOKEN` on uuid failure → exit 2 silent no-op
+- File: `.claude/agents/qs-finish-task.md` (bash launch block, ~155) + `.cursor` + `.opencode` mirrors
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: If `$QG_PY` exists but uuid generation somehow fails, `SEED_TOKEN`
+  stays empty (only the no-interpreter `else` sets `SEED_TOKEN=""`), and the
+  detached seed is launched with `--seed-token ""`, which the CLI now rejects with
+  exit 2 — a silent no-op baseline refresh. Extremely unlikely (uuid never fails
+  if the interpreter runs) and best-effort by design.
+- Proposed fix: Guard the launch so an empty `SEED_TOKEN` skips the seed launch
+  (or generates a shell-side fallback token) rather than invoking the CLI with an
+  empty token. Apply the identical change to all three harness files
+  (`.claude`, `.cursor`, `.opencode`) to preserve byte-identical lockstep, and
+  keep the `test_seed_launch_block_byte_identical_across_harnesses` /
+  `TestFinishTaskFollowerAgents` assertions green (update them to match).
+
+### [nice-to-have] Untested re-poll branch (running + my-token + pid-alive)
+- File: `tests/test_quality_gate.py` (`TestSeedTestmonFollow`)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The re-poll branch where the re-read marker is `running` + my token
+  + pid *alive* (falls through to `continue` and re-loops) has no explicit test.
+  There is deliberately no `scripts/qs` coverage gate (AC 11), so this is a
+  completeness nit.
+- Proposed fix: Add a test that drives one `running`+my-token+alive re-poll cycle
+  and then a terminal `ok`, asserting the follower loops once and exits 0.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/stories/QS-299.story_review_fix_#03.md
+++ b/docs/stories/QS-299.story_review_fix_#03.md
@@ -1,0 +1,115 @@
+# QS-299 — Review fix plan #03
+
+## Summary
+- Source PR: #300
+- Source story: docs/stories/QS-299.story.md
+- Findings to fix: 5
+- Next implement phase: `/implement-setup-task`
+
+Round-3 review (after fix plans #01 and #02). No must-fix remains. Blind-hunter,
+acceptance-auditor and CodeRabbit are clean; the round-2 mutex and deadline
+findings are confirmed resolved. This plan addresses 1 should-fix (a previously
+"fixed" item that was only papered over) + 4 nice-to-have items.
+
+## Findings to fix
+
+### [should-fix] "Completed run misreported as superseded" fix (AC 17) is illusory; test validates an unreachable state
+- File: `scripts/qs/quality_gate.py:2210-2223` (`seed_testmon_follow` own-token→foreign re-read); test `tests/test_quality_gate.py` (`test_own_token_ok_overwritten_by_foreign_reports_completion`, ~2614-2632); `_claim_and_preempt` (~1699), `_write_completion_if_owner` (~1723)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The round-2 fix for "completed run misreported as superseded" (AC 17)
+  added a single synchronous re-read on the own-token→foreign path and honors a
+  MY-token terminal state. But the re-read runs microseconds after the top-of-loop
+  read (no sleep between), so in production it returns the **same** on-disk marker.
+  Under the real write ordering the on-disk history is
+  `running(T) → ok(T) → running(U)`: this run writes `ok(T)` via the token-guarded
+  `_write_completion_if_owner`, and only afterward a parallel task's
+  `_claim_and_preempt` overwrites it with `running(U)`. So `ok(T)` is already gone
+  by the time the follower's poll lands on `running(U)`. The token guard also makes
+  the reverse (`running(U)` then `ok(T)`) unreachable — `_write_completion_if_owner`
+  refuses to write `ok(T)` once the marker token is `U`. The recovery branch
+  (`repoll.get("token") == token`) is therefore effectively **dead code** in
+  production. The "proof" test drives the on-disk sequence
+  `running(T) → running(U) → ok(T)`, which cannot occur under the production
+  token-guard, so it passes against an unreachable state and does not exercise the
+  real race. Outcome is still safe (a valid baseline exists; both verdicts end with
+  "safe to close this terminal"), so this is a misleading terminal verdict, not
+  data loss — but it must not be reported as resolved.
+- Proposed fix: Choose ONE of the two genuine remedies below (prefer the lighter
+  option (b) unless option (a) is cheap and clean):
+  - **(a) Structural fix** — In `_claim_and_preempt`, only overwrite a marker whose
+    state is `running` (a live predecessor). If the existing marker is already in a
+    terminal state (`ok`/`incomplete`/`skipped`), do **not** clobber it with the new
+    `running(U)` claim; let it be superseded lazily / leave the terminal record
+    intact so a follower can still observe the predecessor's true completion.
+    Ensure preemption (SIGTERM of a live predecessor) still happens. Add a test
+    driving the real ordering `running(T) → ok(T)` then a parallel `claim(U)` and
+    assert the terminal `ok(T)` is preserved and the follower reports completion
+    (exit 0).
+  - **(b) Honest best-effort fix** — Remove the dead recovery re-read branch (or
+    keep only what is reachable), and reword the verdict + story/ACs so the
+    completed-then-superseded race is documented as a known best-effort limitation
+    (the follower may print "unconfirmed / another refresh now holds the marker —
+    check `--seed-testmon-status`" rather than asserting this run was "stopped").
+    Rewrite `test_own_token_ok_overwritten_by_foreign_reports_completion` to reflect
+    the reachable production ordering (`running(T) → ok(T) → running(U)`) and assert
+    the actual, honest verdict rather than an unreachable recovery.
+  - Either way: update AC 17 in the story to state exactly what is guaranteed, and
+    make sure no test asserts an on-disk marker transition that the token-guard
+    forbids.
+
+### [nice-to-have] Exit code 5 overloaded (supersession vs unconfirmed-start)
+- File: `scripts/qs/quality_gate.py` (`seed_testmon_follow` docstring exit table)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Exit code `5` covers two semantically different outcomes — genuine
+  supersession (`_FOLLOW_MSG_SUPERSEDED`) and unconfirmed-start (foreign marker past
+  grace, `_FOLLOW_MSG_UNCONFIRMED`). The docstring exit table only labels `5` as
+  "supersession".
+- Proposed fix: Update the docstring exit table (and any user-facing help) to note
+  that `5` also covers the unconfirmed-start case. No behavior change. If this
+  interacts with the option chosen for finding #1, keep the two consistent.
+
+### [nice-to-have] Lock-busy branch: concurrent seeds interleave shared SEED_LOG
+- File: `scripts/qs/quality_gate.py` (`_claim_and_preempt` lock-busy branch)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: On `flock` contention two seeds run concurrently and both
+  truncate/append to the shared `SEED_LOG`, which can interleave lines the
+  follower's `_parse_seed_progress` scans. Safety is preserved (documented
+  "duplicate seed is safe"); only the streamed progress line could momentarily
+  jitter. Cosmetic.
+- Proposed fix: Add a short code comment documenting the possible progress-line
+  jitter on lock contention (no functional change required). Do not over-engineer
+  per-process log isolation unless trivial.
+
+### [nice-to-have] Three qs-finish-task.md specs duplicate the seed/follow block verbatim
+- File: `.claude/agents/qs-finish-task.md`, `.cursor/agents/qs-finish-task.md`, `.opencode/agents/qs-finish-task.md`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The three agent specs duplicate a long, near-identical seed/follow
+  block verbatim; any future edit must be applied in three places. Not
+  diff-introduced drift (they match here) — a maintenance smell.
+- Proposed fix: No code change required now; the existing
+  `test_seed_launch_block_byte_identical_across_harnesses` already guards drift.
+  Optionally add a brief note in the docs/workflow harness reference pointing out
+  that the seed/follow block is intentionally mirrored byte-for-byte and must be
+  edited in lockstep. Keep all three byte-identical.
+
+### [nice-to-have] Agent bash guard `if [ -n "$SEED_TOKEN" ]` has no direct test
+- File: `tests/test_quality_gate.py` (`TestFinishTaskFollowerAgents` / agent-prose assertions)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The empty-token skip guard `if [ -n "$SEED_TOKEN" ]` is present in all
+  three `qs-finish-task.md` files and inside the byte-identical slice, but no test
+  directly asserts its presence — `test_seed_launch_block_byte_identical_across_harnesses`
+  only asserts the three copies match, and `test_empty_or_whitespace_token_exits_2`
+  tests the CLI rejection, not the shell guard. Grep-coverage nit.
+- Proposed fix: Add a small assertion that each `qs-finish-task.md` contains the
+  `[ -n "$SEED_TOKEN" ]` guard around the detached seed launch (grep-style prose
+  check), so a future edit that drops the guard is caught.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/stories/QS-299.story_review_fix_#04.md
+++ b/docs/stories/QS-299.story_review_fix_#04.md
@@ -1,0 +1,79 @@
+# QS-299 — Review fix plan #04
+
+## Summary
+- Source PR: #300
+- Source story: docs/stories/QS-299.story.md
+- Findings to fix: 4
+- Next implement phase: `/implement-setup-task`
+
+Round-4 review (after fix plans #01–#03). No must-fix. The round-3 should-fix
+(the "illusory" completed-run fix) is confirmed **genuinely resolved via option
+(b)** by edge-case-hunter. Blind-hunter and edge-case-hunter are otherwise clean;
+CodeRabbit's should-fix (a caution against fix-plan option (a)) is moot because
+option (b) was taken, and CodeRabbit's nitpicks are stale re-surfaced comments
+already resolved by AC 15/21. This plan addresses 1 should-fix + 3 nice-to-have
+items, all documentation/consistency drift plus one harmless code polish.
+
+## Findings to fix
+
+### [should-fix] Story Goal prose contradicts AC 17 (retired "this run was stopped" verdict)
+- File: `docs/stories/QS-299.story.md` (~line 42 and ~line 52)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The Goal section still lists the retired superseded verdict
+  *"a fresher baseline refresh is now running - this one was stopped, safe to close
+  this terminal"*, and line ~52 says a genuinely-superseded follower *"prints the
+  'superseded - safe to close' line."* No such message exists in the shipped code:
+  the only exit-5 messages are `_FOLLOW_MSG_TAKEN_OVER` and
+  `_FOLLOW_MSG_UNCONFIRMED`, and AC 17 explicitly forbids "this run was stopped."
+  The Goal directly contradicts the authoritative revised AC. Code + tests are
+  correct; the Goal/preemption-contract prose was not updated in lockstep with
+  review-fix #03.
+- Proposed fix: Update the Goal verdict list and line ~52 to the honest
+  `_FOLLOW_MSG_TAKEN_OVER` ("this run either completed or was superseded - check
+  `--seed-testmon-status`. Safe to close this terminal.") / `_FOLLOW_MSG_UNCONFIRMED`
+  wording. Ensure the Goal describes best-effort last-wins preemption consistently
+  with AC 17 and the exit-5 dual-message design (AC 19/22). No code change.
+
+### [nice-to-have] Story §4 design exit table is stale
+- File: `docs/stories/QS-299.story.md` (~line 501, `### 4.` exit table)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The §4 design exit table still shows exit 5 = "a fresher baseline
+  refresh is now running — this one was stopped..." and uses non-ASCII glyphs
+  (`✅`, `—`, `·`) in the exit-0/progress rows — both retired by AC 13 (ASCII-only)
+  and AC 17. It is a design-section table (not stdout), so harmless, but it no
+  longer describes the shipped behavior.
+- Proposed fix: Align the §4 exit table with the `_FOLLOW_MSG_*` constants and the
+  ASCII-only output (AC 13): replace glyphs with the shipped ASCII markers and
+  update the exit-5 row to the taken-over/unconfirmed wording.
+
+### [nice-to-have] AC 1's "single message" parenthetical for exit 5 is stale
+- File: `docs/stories/QS-299.story.md` (AC 1)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: AC 1 says exit 5 uses a "single message," but review-fix #02/#03
+  deliberately split exit 5 into two distinct messages (`_FOLLOW_MSG_TAKEN_OVER`
+  vs `_FOLLOW_MSG_UNCONFIRMED`), as documented by AC 19 and AC 22. The code is
+  correct; AC 1's parenthetical is stale.
+- Proposed fix: Reword AC 1's parenthetical to "two exit-5 messages (taken-over /
+  unconfirmed-start), one exit code." Keep it consistent with AC 19/22.
+
+### [nice-to-have] `--seed-token` validated for empty/whitespace but not trimmed
+- File: `scripts/qs/quality_gate.py` (`main()` `--seed-token` validation)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `--seed-token` is rejected when empty/whitespace-only, but a token
+  with surrounding whitespace is passed through verbatim. Harmless in practice
+  since seed + follow both read the same `$SEED_TOKEN` shell var (identical value),
+  so no mismatch can arise.
+- Proposed fix: Trim the token (`.strip()`) after the empty/blank rejection so the
+  stored/compared token has no surrounding whitespace, keeping seed and follow
+  strictly consistent. Add/extend a test that a padded token is accepted and
+  compared trimmed (or, if preferred, that a padded token is normalized). Minimal
+  change; keep existing `test_empty_or_whitespace_token_exits_2` green.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/stories/QS-299.story_review_fix_#05.md
+++ b/docs/stories/QS-299.story_review_fix_#05.md
@@ -1,0 +1,108 @@
+# QS-299 — Review fix plan #05
+
+## Summary
+- Source PR: #300
+- Source story: docs/stories/QS-299.story.md
+- Findings to fix: 7
+- Next implement phase: `/implement-setup-task`
+
+Round-5 review (after fix plans #01–#04). No must-fix. Blind-hunter,
+edge-case-hunter, and acceptance-auditor found no code-level must/should-fix — all
+substantive concerns from rounds 1–4 are confirmed closed. The only should-fix is
+a one-character doc case-mismatch from CodeRabbit. This plan folds in that fix plus
+the remaining doc/docstring-consistency nice-to-haves so the next round is clean.
+
+## Findings to fix
+
+### [should-fix] Story exit-5 text case mismatch (`Another` vs `another`)
+- File: `docs/stories/QS-299.story.md:200`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The §4 exit table capitalizes `Another`, but AC 17 and
+  `scripts/qs/quality_gate.py` (`_FOLLOW_MSG_*`) use lowercase `another`. Documented
+  output should match the shipped string exactly.
+- Proposed fix: Change `Another` → `another` at line 200 so the documented exit-5
+  text is byte-exact with the `_FOLLOW_MSG_TAKEN_OVER` / `_FOLLOW_MSG_UNCONFIRMED`
+  constant wording. No code change.
+
+### [nice-to-have] Module docstring exit-code list is incomplete
+- File: `scripts/qs/quality_gate.py:~46-50` (module docstring exit-code summary)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The top-of-file exit-code summary adds only `5 = ... superseded`, but
+  `--seed-testmon-follow` also reuses exit `4` (still running), `3` (unreadable),
+  `1` (rerun) with meanings different from the `--impacted` entries above them.
+  Fully documented in the follower docstring/help, but the top summary reads
+  incomplete.
+- Proposed fix: Expand the module docstring exit-code summary to note the
+  follower's reuse of `4`/`3`/`1` (with their follower-specific meanings) alongside
+  the new `5`, so the top-level summary matches the follower docstring/help. No
+  behavior change.
+
+### [nice-to-have] Module docstring exit-5 narrower than actual behavior
+- File: `scripts/qs/quality_gate.py` (module docstring, exit `5` line)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The summary says exit 5 = "this run was superseded by a fresher
+  baseline refresh," but the code also returns 5 for the unconfirmed-start case
+  (`_FOLLOW_MSG_UNCONFIRMED`, a foreign token held the whole startup grace).
+- Proposed fix: Reword the module docstring exit-5 line to cover both cases
+  (superseded / taken-over AND unconfirmed-start), consistent with the follower
+  docstring exit table (AC 22) and the story §4 table.
+
+### [nice-to-have] Hardcoded "45m" wait string vs `_SEED_FOLLOW_MAX_WAIT_S`
+- File: `scripts/qs/quality_gate.py:2045-2049` (`seed_testmon_follow` exit-4 message)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The exit-4 message hardcodes the literal `"Still running after 45m"`
+  while the duration comes from `_SEED_FOLLOW_MAX_WAIT_S = 2700`. If that constant
+  is ever retuned, the message drifts silently. Cosmetic (exit 4 is advisory).
+- Proposed fix: Derive the human-readable duration in the exit-4 message from
+  `_SEED_FOLLOW_MAX_WAIT_S` (e.g. compute minutes from the constant) so the message
+  can never drift from the actual deadline. Keep the wording ASCII-only (AC 13).
+  Adjust the relevant test assertion if it matches the literal string.
+
+### [nice-to-have] Startup-grace exit 3 under CPU saturation — record only
+- File: `scripts/qs/quality_gate.py:2100-2106` + `:1962` (`_SEED_STARTUP_GRACE_POLLS = 12`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: A missing marker that persists the whole ~60s grace returns exit 3
+  ("unreadable"), which could abandon a seed whose detached interpreter cold-start
+  hasn't yet claimed the marker under 3-4 parallel saturating seeds. This is a
+  deliberate tuned design choice from review-fix #01 (findings #6/#7); consequence
+  is only a mildly-misleading advisory line (cleanup already finished, the seed
+  still completes safely).
+- Proposed fix: No behavior change intended. Ensure the ~60s grace / exit-3
+  trade-off is captured in a brief code comment near `_SEED_STARTUP_GRACE_POLLS` (if
+  not already), so future readers know the value is intentional. Record-only;
+  do not retune.
+
+### [nice-to-have] Stale story-metadata footer
+- File: `docs/stories/QS-299.story.md:5, 550-551`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The story footer still reads `Story version: v3` and
+  `last review: round 2` / `changed-since-last-review: true (v3 folds Round 2)`,
+  even though four review-fix rounds (ACs 12–25) have since been folded in. Purely
+  story-bookkeeping drift; fulfills no AC and affects no code.
+- Proposed fix: Update the version/last-review footer fields to reflect the actual
+  review history (current story version and the latest folded review round). No code
+  change.
+
+### [nice-to-have] Verify test line-length / ruff E501 handling for tests/
+- File: `tests/test_quality_gate.py` (assorted parametrize / patch.object lines >100 chars)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Some added test lines run 101-124 chars while all added production
+  lines stay ≤100. If ruff's line-length is 100 and `tests/` is not per-file-ignored
+  for E501, they'd trip the linter. Almost certainly already per-file-ignored (the
+  suite passes the quality gate).
+- Proposed fix: Confirm the quality gate / ruff config per-file-ignores E501 (or
+  equivalent) for `tests/`; the gate already passes, so this is a verification. If
+  for any reason it does not, wrap the offending lines. No change if already
+  handled.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and run
+`/review-task` again to re-verify.

--- a/docs/workflow/harness.md
+++ b/docs/workflow/harness.md
@@ -137,6 +137,18 @@ two copies is low; the cost of a missed sync is high. A diff lint script
 (`scripts/qs/lint_agents.py`, future) can verify the bodies stay
 aligned.
 
+**Byte-identical blocks must be edited in lockstep.** Some agent
+passages are intentionally mirrored byte-for-byte across all three
+harness files and guarded by a test. The clearest example is the QS-299
+post-merge **seed/follow launch block** in `qs-finish-task.md` (the
+`--seed-testmon --detached --seed-token …` launch plus the empty-token
+guard), pinned by
+`tests/test_quality_gate.py::TestFinishTaskRefreshesBaseline::test_seed_launch_block_byte_identical_across_harnesses`.
+Any edit to such a block must be applied identically to `.claude`,
+`.cursor`, and `.opencode` in the same change, or that test fails. The
+surrounding per-harness prose (e.g. the background+monitor mechanism)
+deliberately differs and is not part of the pinned slice.
+
 ## Adding a new harness
 
 1. Add a detection branch to `scripts/qs/harness.py::detect()`.

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -75,6 +75,13 @@ python scripts/qs/quality_gate.py --seed-testmon
 # 0 = ok/safe to close, 4 = still running, 1 = rerun, 3 = no readable status.
 python scripts/qs/quality_gate.py --seed-testmon-status
 
+# QS-299: companion read-only FOLLOWER — stream the detached --seed-testmon
+# run's progress inline (a `N/M tests (pct%)` line per poll) until it reaches
+# a terminal state; used by finish-task after a merge. Requires --seed-token.
+# Exit codes: 0 = ok/safe to close, 5 = superseded by a fresher refresh,
+# 1 = rerun, 4 = still running after 45m, 3 = no readable status.
+python scripts/qs/quality_gate.py --seed-testmon-follow --seed-token "$TOKEN"
+
 # Ad-hoc single-node pytest — debugging only.
 source venv/bin/activate && pytest tests/test_solver.py::test_function_name -v
 ```
@@ -109,7 +116,17 @@ after a merge. A bare `pytest --testmon` remains forbidden. QS-286: its
 companion `--seed-testmon-status` is the sanctioned **read-only** query
 subcommand (no pytest/coverage/testmon import) — it reads the
 `.testmondata.seed-status` marker the detached run writes and reports
-whether it is safe to close the terminal.
+whether it is safe to close the terminal. QS-299: a second companion,
+`--seed-testmon-follow --seed-token <T>`, is the sanctioned **read-only**
+streaming follower (also no pytest/coverage/testmon import) — it tails the
+same marker plus the `.testmondata.seed.log` and prints one progress line
+per poll until a terminal verdict, so finish-task can surface completion
+inline in the same session; its exit code (0 ok / 5 superseded / 4 still
+running / 1 rerun / 3 unreadable) is a **completion signal, not a gate**.
+The detached seed accepts `--detached` (own process group) and
+`--seed-token <T>` (per-run identity); a newer seed automatically preempts
+an earlier still-running one (last-wins), and a stale baseline is always
+safe (new worktrees just over-select tests).
 
 **UI-only fast path.** When only `custom_components/quiet_solar/ui/*.j2`
 templates and `custom_components/quiet_solar/ui/resources/**` assets

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -927,6 +927,15 @@ SEED_STATUS = REPO_ROOT / ".testmondata.seed-status"
 # constant the follower reads to synthesize its progress line). Anchored under
 # REPO_ROOT for the same cwd-independent relocation invariant as SEED_STATUS.
 SEED_LOG = REPO_ROOT / ".testmondata.seed.log"
+# QS-299 review-fix #02 (finding #6): named constants for the seed marker's
+# `state` field, shared by every producer (`seed_testmon`) and consumer
+# (`seed_testmon_status`, `seed_testmon_follow`, `_find_running_predecessor`) so
+# a typo can't silently fall through to "unreadable" and the states have one
+# definition.
+_SEED_STATE_RUNNING = "running"
+_SEED_STATE_OK = "ok"
+_SEED_STATE_INCOMPLETE = "incomplete"
+_SEED_STATE_SKIPPED = "skipped"
 # QS-278: the persistent coverage DATA file (coverage.py's default). The
 # `--impacted` gate runs testmon-selected tests with `--cov-append` so
 # coverage ACCUMULATES across inner-loop invocations. testmon 2.2.0
@@ -1666,7 +1675,7 @@ def _find_running_predecessor(my_token: str) -> tuple[int, int | None] | None:
     marker = _read_seed_marker()
     if marker is None:
         return None
-    if marker.get("state") != "running" or marker.get("token") == my_token:
+    if marker.get("state") != _SEED_STATE_RUNNING or marker.get("token") == my_token:
         return None
     pid = marker.get("pid")
     if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
@@ -1702,10 +1711,10 @@ def _claim_and_preempt(token: str, pid: int, pgid: int | None, started: float) -
     with _seed_lock() as locked:
         if not locked:
             _emit("seed-testmon", "seed lock busy — skipping preemption (best-effort claim)")
-            _write_seed_status("running", **_running_fields(token, pid, pgid, started))
+            _write_seed_status(_SEED_STATE_RUNNING, **_running_fields(token, pid, pgid, started))
             return
         predecessor = _find_running_predecessor(token)
-        _write_seed_status("running", **_running_fields(token, pid, pgid, started))
+        _write_seed_status(_SEED_STATE_RUNNING, **_running_fields(token, pid, pgid, started))
         if predecessor is not None:
             pred_pid, pred_pgid = predecessor
             _terminate_process_group(pred_pgid, pred_pid)
@@ -1756,7 +1765,7 @@ def seed_testmon(token: str | None = None, detached: bool = False) -> int:
         _emit("seed-testmon", "pytest-testmon not importable — skipping")
         # QS-286: record the skip (no `running` marker on this path).
         # QS-299: the skip marker still carries the token (invariant).
-        _write_seed_status("skipped", token=token, reason="pytest-testmon not importable")
+        _write_seed_status(_SEED_STATE_SKIPPED, token=token, reason="pytest-testmon not importable")
         return 3
     # QS-299: detach into our own process group FIRST (only when --detached) so
     # the pgid we record covers the pytest/xdist tree a later preemptor kills.
@@ -1797,7 +1806,7 @@ def seed_testmon(token: str | None = None, detached: bool = False) -> int:
     # token over the live winner's marker.
     _write_completion_if_owner(
         token,
-        "ok" if rc < 2 else "incomplete",
+        _SEED_STATE_OK if rc < 2 else _SEED_STATE_INCOMPLETE,
         started=started,
         finished=time.time(),
         returncode=rc,
@@ -1890,13 +1899,13 @@ def seed_testmon_status() -> int:
         return _unreadable()
 
     state = marker.get("state")
-    if state == "ok":
+    if state == _SEED_STATE_OK:
         print(
             f"Baseline written at {_fmt_seed_time(marker.get('finished'))} "
             "(tests may have failed) — safe to close this terminal."
         )
         return 0
-    if state == "running":
+    if state == _SEED_STATE_RUNNING:
         pid = marker.get("pid")
         # `_pid_alive` calls `os.kill(pid, 0)`; a `running` marker whose pid is
         # not a positive, non-bool int is unreadable. Excluding bool (an int
@@ -1916,13 +1925,13 @@ def seed_testmon_status() -> int:
             "may be partial; rerun the refresh."
         )
         return 1
-    if state == "incomplete":
+    if state == _SEED_STATE_INCOMPLETE:
         print(
             f"Finished with errors (exit {marker.get('returncode', 'unknown')}) — "
             "`.testmondata` may be partial; rerun the refresh."
         )
         return 1
-    if state == "skipped":
+    if state == _SEED_STATE_SKIPPED:
         print(
             f"Refresh was skipped ({marker.get('reason', 'unknown reason')}) — no baseline was "
             "written; rerun if needed."
@@ -2042,6 +2051,51 @@ def _print_seed_progress(marker: dict) -> None:
         print(f"refreshing baseline: elapsed {elapsed}")
 
 
+# QS-299 follower verdict lines (plain ASCII — review-fix #01 finding #2 — so a
+# harness piping stdout under a non-UTF-8 locale never raises UnicodeEncodeError).
+_FOLLOW_MSG_OK = "[OK] baseline refresh complete - safe to close this terminal."
+_FOLLOW_MSG_PARTIAL = "`.testmondata` may be partial - rerun the refresh."
+_FOLLOW_MSG_UNREADABLE = "The baseline refresh status is unreadable."
+_FOLLOW_MSG_SUPERSEDED = (
+    "A fresher baseline refresh is now running - this one was stopped, "
+    "safe to close this terminal."
+)
+# QS-299 review-fix #02 (finding #3): a foreign marker that persists the whole
+# startup grace might just mean this run's seed was slow to claim (saturated
+# parallel cold-start), so the verdict is phrased as uncertainty, not a definite
+# supersession.
+_FOLLOW_MSG_UNCONFIRMED = (
+    "Could not confirm this baseline refresh started; another refresh holds the "
+    "marker - check `python scripts/qs/quality_gate.py --seed-testmon-status`. "
+    "Safe to close this terminal."
+)
+
+
+def _follow_own_terminal_verdict(marker: dict) -> int | None:
+    """Map a MY-token marker in a terminal state to its follower exit code,
+    printing the verdict line; return None for a non-terminal (`running`) or
+    unknown state (QS-299).
+
+    Shared by the main poll and the supersession re-read (review-fix #02 finding
+    #1) so a completed run is never misreported as superseded.
+    """
+    state = marker.get("state")
+    if state == _SEED_STATE_OK:
+        print(_FOLLOW_MSG_OK)
+        return 0
+    if state == _SEED_STATE_INCOMPLETE:
+        print(_FOLLOW_MSG_PARTIAL)
+        return 1
+    if state == _SEED_STATE_SKIPPED:
+        reason = marker.get("reason", "unknown reason")
+        print(
+            f"Refresh was skipped ({reason}) - no baseline was written; "
+            "safe to close this terminal, rerun if needed."
+        )
+        return 1
+    return None
+
+
 def seed_testmon_follow(token: str) -> int:
     """Stream the detached `--seed-testmon` run's progress inline until it reaches
     a terminal state, returning a completion exit code (QS-299).
@@ -2054,51 +2108,57 @@ def seed_testmon_follow(token: str) -> int:
       0  my token `ok`                          - refresh complete, safe to close
       5  supersession (see below)               - a fresher refresh took over
       1  my token `incomplete` / `running`-dead / `skipped`
-      4  my token still `running` past max wait - keep terminal open / re-attach
+      4  no terminal state within max wait      - keep terminal open / re-attach
       3  marker missing/unreadable past the startup grace
 
-    Supersession vs startup (QS-299 review-fix #01, finding #1): tokens are
-    unordered uuid4, so a foreign token is indistinguishable from a genuinely
-    fresher one. Until this follower has observed its OWN token own the marker at
-    least once (`own_token_seen`), a missing OR foreign-token marker just means
-    "my seed hasn't claimed yet" — poll within the startup grace instead of
-    declaring supersession. Exit 5 fires only when either (a) our token was seen
-    and is THEN replaced by a different token, or (b) the startup grace elapses
-    with a foreign token still present.
+    Supersession vs startup (review-fix #01, finding #1): tokens are unordered
+    uuid4, so a foreign token is indistinguishable from a genuinely fresher one.
+    Until this follower has observed its OWN token own the marker at least once
+    (`own_token_seen`), a missing OR foreign-token marker just means "my seed
+    hasn't claimed yet" — poll within the startup grace instead of declaring
+    supersession.
 
-    Every heavy operation (`time.sleep`/`time.monotonic`/`time.time`,
-    `_read_seed_marker`, `_pid_alive`, the log-tail read) is a patchable seam so
-    the whole loop is unit-testable without real processes or sleeps.
+    Completed-not-superseded (review-fix #02, finding #1): a new parallel seed
+    unconditionally re-claims `running(U)`, so it can overwrite this run's
+    `ok(T)` in the ≤5 s gap between polls. Before concluding "superseded" on the
+    own-token path, re-read once and honor a MY-token terminal state, so a run
+    that actually completed reports completion (exit 0), not "stopped".
+
+    The `_SEED_FOLLOW_MAX_WAIT_S` deadline is enforced at the TOP of the loop
+    (review-fix #02, finding #4) so EVERY path — startup wait, no-marker re-poll,
+    running-alive — honors the same upper bound. Every heavy operation
+    (`time.sleep`/`time.monotonic`/`time.time`, `_read_seed_marker`,
+    `_pid_alive`, the log-tail read) is a patchable seam so the whole loop is
+    unit-testable without real processes or sleeps.
     """
-    superseded = (
-        "A fresher baseline refresh is now running - this one was "
-        "stopped, safe to close this terminal."
-    )
-    unreadable = "The baseline refresh status is unreadable."
+
+    def _startup_wait() -> None:
+        """Emit the startup-wait line + sleep one interval (review-fix #02 #5:
+        one definition shared by the foreign- and missing-marker grace paths)."""
+        print("waiting for baseline refresh to start...")
+        time.sleep(_SEED_FOLLOW_INTERVAL_S)
+
     deadline = time.monotonic() + _SEED_FOLLOW_MAX_WAIT_S
     startup_polls = 0
     own_token_seen = False
     while True:
+        # Finding #4: universal upper bound — no path can loop past the deadline.
+        if time.monotonic() >= deadline:
+            print(
+                f"Still running after 45m - keep this terminal open, or re-attach: "
+                f"python scripts/qs/quality_gate.py --seed-testmon-follow --seed-token {token}"
+            )
+            return 4
+
         marker = _read_seed_marker()
 
         # --- The marker carries MY token: I own it now. ---
         if marker is not None and marker.get("token") == token:
             own_token_seen = True
-            state = marker.get("state")
-            if state == "ok":
-                print("[OK] baseline refresh complete - safe to close this terminal.")
-                return 0
-            if state == "incomplete":
-                print("`.testmondata` may be partial - rerun the refresh.")
-                return 1
-            if state == "skipped":
-                reason = marker.get("reason", "unknown reason")
-                print(
-                    f"Refresh was skipped ({reason}) - no baseline was written; "
-                    "safe to close this terminal, rerun if needed."
-                )
-                return 1
-            if state == "running":
+            verdict = _follow_own_terminal_verdict(marker)
+            if verdict is not None:
+                return verdict
+            if marker.get("state") == _SEED_STATE_RUNNING:
                 pid = _marker_pid(marker)
                 if pid is None or not _pid_alive(pid):
                     # R1 re-poll (cosmetic polish): a preemptor claims BEFORE the
@@ -2111,69 +2171,63 @@ def seed_testmon_follow(token: str) -> int:
                         # The marker flipped (superseded / completed / vanished) —
                         # let the top of the loop re-classify it.
                         continue
-                    if repoll.get("state") == "running":
+                    if repoll.get("state") == _SEED_STATE_RUNNING:
                         repoll_pid = _marker_pid(repoll)
                         if repoll_pid is None or not _pid_alive(repoll_pid):
-                            print("`.testmondata` may be partial - rerun the refresh.")
+                            print(_FOLLOW_MSG_PARTIAL)
                             return 1
-                    # State changed to a terminal value under my token — re-loop.
+                    # Still running+alive, or flipped to a terminal state under my
+                    # token — re-loop and let the top re-classify.
                     continue
                 # NOTE (finding #8): `_pid_alive` is pid-based, so in the rare
                 # event the detached seed dies and the OS reuses its pid, this
-                # streams stale "progress" until the 45-min deadline, then exits 4
+                # streams stale "progress" until the deadline, then exits 4
                 # advising re-attach. Benign (advisory only); a pid-generation
                 # guard would be over-engineering for this low-likelihood case.
                 _print_seed_progress(marker)
-                if time.monotonic() >= deadline:
-                    print(
-                        f"Still running after 45m - keep this terminal open, or "
-                        f"re-attach: python scripts/qs/quality_gate.py "
-                        f"--seed-testmon-follow --seed-token {token}"
-                    )
-                    return 4
                 time.sleep(_SEED_FOLLOW_INTERVAL_S)
                 continue
             # Any other/absent state under my token is an unreadable status.
-            print(unreadable)
+            print(_FOLLOW_MSG_UNREADABLE)
             return 3
 
-        # --- A DIFFERENT token owns the marker. ---
-        if marker is not None:
-            if own_token_seen:
-                # We owned the marker and a fresher run has now taken over —
-                # genuine supersession.
-                print(superseded)
-                return 5
-            # Startup: my seed hasn't claimed the marker yet. A stale foreign
-            # marker from a previous task is expected here — wait it out within
-            # the grace window rather than mis-reporting a supersession.
+        # --- Startup phase: our seed hasn't been observed owning the marker. ---
+        if not own_token_seen:
             if startup_polls < _SEED_STARTUP_GRACE_POLLS:
                 startup_polls += 1
-                print("waiting for baseline refresh to start...")
-                time.sleep(_SEED_FOLLOW_INTERVAL_S)
+                _startup_wait()
                 continue
-            # Grace elapsed with a foreign token still present — our seed never
-            # claimed; treat the persistent foreign run as the winner.
-            print(superseded)
+            # Grace elapsed without our claim.
+            if marker is not None:
+                # A foreign token held the marker the whole window: possibly a
+                # genuinely fresher run, possibly just our own slow cold-start.
+                # Report the uncertainty rather than a definite supersession.
+                print(_FOLLOW_MSG_UNCONFIRMED)
+                return 5
+            print(_FOLLOW_MSG_UNREADABLE)
+            return 3
+
+        # --- We owned the marker before; it is no longer ours. ---
+        if marker is not None:
+            # A different token now owns it. Re-read once and honor a MY-token
+            # terminal state (finding #1): a completed run whose `ok(T)` was
+            # overwritten by a parallel `running(U)` must report completion.
+            repoll = _read_seed_marker()
+            if repoll is not None and repoll.get("token") == token:
+                verdict = _follow_own_terminal_verdict(repoll)
+                if verdict is not None:
+                    return verdict
+                # Back to our own running marker — keep following.
+                continue
+            print(_FOLLOW_MSG_SUPERSEDED)
             return 5
 
-        # --- No readable marker (missing or unreadable JSON). ---
-        if own_token_seen:
-            # Our marker vanished/became unreadable after we owned it — re-read
-            # once before concluding.
-            time.sleep(_SEED_FOLLOW_INTERVAL_S)
-            if _read_seed_marker() is None:
-                print(unreadable)
-                return 3
-            continue
-        # Startup: no marker yet — wait within the grace window.
-        if startup_polls < _SEED_STARTUP_GRACE_POLLS:
-            startup_polls += 1
-            print("waiting for baseline refresh to start...")
-            time.sleep(_SEED_FOLLOW_INTERVAL_S)
-            continue
-        print(unreadable)
-        return 3
+        # --- No readable marker after we owned it — re-read once, else exit 3. ---
+        time.sleep(_SEED_FOLLOW_INTERVAL_S)
+        if _read_seed_marker() is None:
+            print(_FOLLOW_MSG_UNREADABLE)
+            return 3
+        continue
 
 
 def main() -> None:
@@ -2270,11 +2324,23 @@ def main() -> None:
             "you cannot combine --impacted with --quick, --cache, --no-cache, --full, or --fix"
         )
 
+    # QS-299 review-fix #02 (finding #2): the three seed subcommands are pairwise
+    # mutually exclusive. ONE centralized, symmetric check (order-independent)
+    # rather than relying on each mode's list happening to name the others — so a
+    # future refactor of any single list can't let one silently win via main()'s
+    # dispatch ordering.
+    if sum((args.seed_testmon, args.seed_testmon_status, args.seed_testmon_follow)) > 1:
+        parser.error(
+            "--seed-testmon, --seed-testmon-status, and --seed-testmon-follow are "
+            "mutually exclusive"
+        )
+
     # --seed-testmon (QS-276 review-fix M1) is a self-contained maintenance
     # subcommand, not a gate mode: combining it with any execution mode
     # silently dropped the seeding request (the main() dispatch order
     # short-circuited --impacted before it, and it before cache/scope/full).
-    # Make the conflict an explicit usage error instead.
+    # Make the conflict an explicit usage error instead. (Cross-seed pairs are
+    # already handled by the centralized check above.)
     if args.seed_testmon and (
         args.impacted or args.quick or args.cache or args.no_cache or args.full or args.fix
     ):
@@ -2284,38 +2350,23 @@ def main() -> None:
         )
 
     # QS-286: --seed-testmon-status is a read-only query subcommand, not a
-    # gate mode. Mirror the --seed-testmon mutex so combining it with any
-    # execution mode (or the seed itself) is an explicit usage error.
+    # gate mode. Mirror the --seed-testmon execution-mode mutex.
     if args.seed_testmon_status and (
-        args.impacted
-        or args.quick
-        or args.cache
-        or args.no_cache
-        or args.full
-        or args.fix
-        or args.seed_testmon
-        or args.seed_testmon_follow
+        args.impacted or args.quick or args.cache or args.no_cache or args.full or args.fix
     ):
         parser.error(
             "you cannot combine --seed-testmon-status with --impacted, --quick, "
-            "--cache, --no-cache, --full, --fix, --seed-testmon, or --seed-testmon-follow"
+            "--cache, --no-cache, --full, or --fix"
         )
 
     # QS-299: --seed-testmon-follow is a read-only streaming query subcommand.
-    # Same mutex family as --seed-testmon-status.
+    # Same execution-mode mutex.
     if args.seed_testmon_follow and (
-        args.impacted
-        or args.quick
-        or args.cache
-        or args.no_cache
-        or args.full
-        or args.fix
-        or args.seed_testmon
-        or args.seed_testmon_status
+        args.impacted or args.quick or args.cache or args.no_cache or args.full or args.fix
     ):
         parser.error(
             "you cannot combine --seed-testmon-follow with --impacted, --quick, "
-            "--cache, --no-cache, --full, --fix, --seed-testmon, or --seed-testmon-status"
+            "--cache, --no-cache, --full, or --fix"
         )
 
     # QS-299: --seed-token is meaningful only with --seed-testmon (identifies the

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -42,11 +42,17 @@ Smart scope detection:
 
 Exit codes:
     0 = all gates pass
-    1 = one or more gates failed (incl. --impacted changed-lines <100%)
+    1 = one or more gates failed (incl. --impacted changed-lines <100%;
+        --seed-testmon-follow: baseline incomplete/interrupted/skipped — rerun)
     2 = argument parsing error (e.g., --quick with no paths, or mutex violation)
-    3 = required tooling missing (--impacted: testmon / diff-cover not importable)
+    3 = required tooling missing (--impacted: testmon / diff-cover not importable;
+        --seed-testmon-follow: marker missing/unreadable past the startup grace)
     4 = --impacted could not resolve a diff base in CI
-    5 = --seed-testmon-follow: this run was superseded by a fresher baseline refresh
+        (--seed-testmon-follow: no terminal state within the max wait — re-attach)
+    5 = --seed-testmon-follow: a foreign token owns the marker — this run was
+        superseded / taken over, OR its start could not be confirmed (both
+        safe-to-close). Exit codes 1/3/4 are REUSED by --seed-testmon-follow with
+        the follower-specific meanings noted above.
 """
 
 from __future__ import annotations
@@ -1958,6 +1964,13 @@ _SEED_FOLLOW_INTERVAL_S = 5
 # claimed yet" — keep polling within this window rather than mis-reporting a
 # supersession. Widened to 12 polls (~60 s) so a slow interpreter cold-start
 # can't exhaust the grace.
+#
+# review-fix #05 (finding #5), record-only: this ~60 s is a DELIBERATE tuned
+# trade-off. A missing marker that persists the whole grace returns exit 3
+# ("unreadable"); under 3-4 saturating parallel seeds a detached interpreter
+# cold-start could in theory exceed 60 s and yield a mildly-misleading exit-3
+# advisory — but cleanup has already finished and the seed still completes
+# safely, so the consequence is cosmetic. Do NOT retune without re-measuring.
 _SEED_FOLLOW_MAX_WAIT_S = 2700  # 45 min
 _SEED_STARTUP_GRACE_POLLS = 12  # ~60 s at the 5 s poll interval
 # The progress line `_stream_pytest` synthesizes (verified live under `-n auto`):
@@ -2156,13 +2169,16 @@ def seed_testmon_follow(token: str) -> int:
         time.sleep(_SEED_FOLLOW_INTERVAL_S)
 
     deadline = time.monotonic() + _SEED_FOLLOW_MAX_WAIT_S
+    # review-fix #05 (finding #4): derive the human-readable wait from the
+    # constant so the exit-4 message can never drift if it is retuned.
+    max_wait_min = _SEED_FOLLOW_MAX_WAIT_S // 60
     startup_polls = 0
     own_token_seen = False
     while True:
         # Finding #4: universal upper bound — no path can loop past the deadline.
         if time.monotonic() >= deadline:
             print(
-                f"Still running after 45m - keep this terminal open, or re-attach: "
+                f"Still running after {max_wait_min}m - keep this terminal open, or re-attach: "
                 f"python scripts/qs/quality_gate.py --seed-testmon-follow --seed-token {token}"
             )
             return 4

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -2396,6 +2396,12 @@ def main() -> None:
     # from. Fail loudly at the CLI instead of silently mismatching.
     if args.seed_token is not None and not args.seed_token.strip():
         parser.error("--seed-token must not be empty or whitespace")
+    # QS-299 review-fix #04 (finding #4): normalize the token by trimming
+    # surrounding whitespace so the seed and its follower compare strictly
+    # identical values (harmless today — both read the same shell var — but keeps
+    # the marker token clean and the equality robust).
+    if args.seed_token is not None:
+        args.seed_token = args.seed_token.strip()
     if args.seed_testmon_follow and args.seed_token is None:
         parser.error("--seed-testmon-follow requires --seed-token")
     if args.detached and not args.seed_testmon:

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -5,7 +5,8 @@ Usage:
     python scripts/qs/quality_gate.py [--fix] [--json] [--cache] [--no-cache] [--full]
     python scripts/qs/quality_gate.py --quick PATH [PATH ...]
     python scripts/qs/quality_gate.py --impacted
-    python scripts/qs/quality_gate.py --seed-testmon
+    python scripts/qs/quality_gate.py --seed-testmon [--detached --seed-token T]
+    python scripts/qs/quality_gate.py --seed-testmon-follow --seed-token T
 
 Options:
     --fix                    Auto-fix what can be fixed (ruff format, ruff check --fix)
@@ -26,6 +27,12 @@ Options:
     --seed-testmon           Sanctioned non-gate subcommand: refresh .testmondata via
                              `pytest --testmon` (no coverage, no pass/fail verdict).
                              Used by finish-task to rebuild the main baseline.
+                             QS-299: accepts --detached (own process group, for the
+                             nohup launch) and --seed-token T (per-run identity).
+    --seed-testmon-follow    QS-299: read-only. Stream the detached --seed-testmon
+                             run's progress inline until a terminal state. Requires
+                             --seed-token T. Exit 0=ok, 5=superseded, 1=rerun,
+                             4=still running, 3=no readable status.
 
 Smart scope detection:
     When only dev-infrastructure files are modified (tests/, legacy/, docs/,
@@ -39,21 +46,26 @@ Exit codes:
     2 = argument parsing error (e.g., --quick with no paths, or mutex violation)
     3 = required tooling missing (--impacted: testmon / diff-cover not importable)
     4 = --impacted could not resolve a diff base in CI
+    5 = --seed-testmon-follow: this run was superseded by a fresher baseline refresh
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import json
 import math
 import os
 import re
+import signal
 import sqlite3
 import subprocess
 import sys
 import threading
 import time
-from collections.abc import Callable
+import uuid
+from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from pathlib import Path
@@ -910,6 +922,11 @@ TESTMON_DATA = REPO_ROOT / ".testmondata"
 # detached process's cwd — a later `--seed-testmon-status` query from
 # $MAIN_DIR reads the same file.
 SEED_STATUS = REPO_ROOT / ".testmondata.seed-status"
+# QS-299: the shared seed log the detached `--seed-testmon` run redirects its
+# stdout/stderr to (previously only a shell redirect target; now a first-class
+# constant the follower reads to synthesize its progress line). Anchored under
+# REPO_ROOT for the same cwd-independent relocation invariant as SEED_STATUS.
+SEED_LOG = REPO_ROOT / ".testmondata.seed.log"
 # QS-278: the persistent coverage DATA file (coverage.py's default). The
 # `--impacted` gate runs testmon-selected tests with `--cov-append` so
 # coverage ACCUMULATES across inner-loop invocations. testmon 2.2.0
@@ -1528,7 +1545,189 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
-def seed_testmon() -> int:
+def _read_seed_marker() -> dict | None:
+    """Parse the `SEED_STATUS` marker; return the dict, or None when it is
+    missing / unreadable / not a JSON object (QS-299).
+
+    Extracted from the inline `json.loads` `seed_testmon_status()` used, so the
+    follower and the preemptor share ONE tolerant reader. Callers that need to
+    tell "missing" apart from "unreadable" (e.g. `seed_testmon_status`'s two
+    distinct messages) re-check `SEED_STATUS.exists()` themselves — this helper
+    deliberately collapses both to None.
+    """
+    try:
+        marker = json.loads(SEED_STATUS.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(marker, dict):
+        return None
+    return marker
+
+
+def _seed_lock_path() -> Path:
+    """Sidecar advisory-lock file beside `SEED_STATUS` (QS-299).
+
+    Derived from `SEED_STATUS` at call time (not a frozen module constant) so a
+    test that repoints `SEED_STATUS` to a tmp path gets a matching lock path,
+    mirroring `_write_seed_status`'s temp-sibling convention.
+    """
+    return SEED_STATUS.with_suffix(SEED_STATUS.suffix + ".lock")
+
+
+@contextlib.contextmanager
+def _seed_lock() -> Iterator[bool]:
+    """Best-effort OS advisory lock (`fcntl.flock`, non-blocking) serializing the
+    seed marker read→claim→kill critical section (QS-299).
+
+    Yields True when the exclusive lock was acquired, False otherwise (lock busy,
+    or the lock file could not even be opened). A False yield tells the caller to
+    degrade to an unlocked best-effort claim WITHOUT preemption — never to race —
+    so a contended lock can only cost a duplicate seed (safe), never the C2
+    TOCTOU. The yield sits in a plain try/finally (no `except` around it) so an
+    exception raised inside the `with` body propagates cleanly and the lock is
+    still released.
+    """
+    lock_fh = None
+    acquired = False
+    try:
+        lock_fh = open(_seed_lock_path(), "a", encoding="utf-8")  # noqa: SIM115 — released in finally
+    except OSError:
+        lock_fh = None
+    if lock_fh is not None:
+        try:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            acquired = True
+        except OSError:
+            acquired = False
+    try:
+        yield acquired
+    finally:
+        if lock_fh is not None:
+            if acquired:
+                try:
+                    fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+            lock_fh.close()
+
+
+def _detach_session() -> int | None:
+    """Detach the current process into its own session/process group (QS-299).
+
+    Called ONLY when `--detached` is passed (finish-task's `nohup` launch); a
+    hand-run foreground `--seed-testmon` skips this so Ctrl-C / job control keep
+    working. `os.setsid()` may raise `EPERM` when we are *already* a group leader
+    (common in the `( … & )` subshell). Either way we then record `pgid` iff we
+    genuinely lead our own group (`os.getpgrp() == os.getpid()`) — covering both
+    the setsid-success and the setsid-`EPERM`-already-leader branches — so a
+    later preemptor can `killpg` the whole tree (controller + xdist workers).
+    Returns None when we are not a group leader, in which case preemption falls
+    back to a single-pid kill (rare, harmless: orphaned workers exit on their own).
+    """
+    try:
+        os.setsid()
+    except OSError:
+        # EPERM: already a session/group leader — harmless, we may still lead
+        # our own group (checked below).
+        pass
+    if os.getpgrp() == os.getpid():
+        return os.getpgrp()
+    return None
+
+
+def _terminate_process_group(pgid: int | None, pid: int) -> None:
+    """Best-effort SIGTERM a preempted predecessor seed (QS-299).
+
+    `os.killpg(pgid, SIGTERM)` when a `pgid` was recorded (kills the controller
+    AND its xdist workers), else a single-pid `os.kill(pid, SIGTERM)`. Fully
+    best-effort: a dead / foreign / out-of-`pid_t`-range target never raises out
+    of here (mirrors `_pid_alive`'s totality). Emits one diagnostic line.
+    """
+    target = f"pgid {pgid}" if pgid is not None else f"pid {pid}"
+    _emit("seed-testmon", f"preempting previous baseline refresh ({target})")
+    try:
+        if pgid is not None:
+            os.killpg(pgid, signal.SIGTERM)
+        else:
+            os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OverflowError, ValueError, TypeError, OSError):
+        # Dead / foreign / out-of-range — nothing to preempt; stay best-effort.
+        pass
+
+
+def _find_running_predecessor(my_token: str) -> tuple[int, int | None] | None:
+    """Return `(pid, pgid)` of a live predecessor seed to preempt, or None (QS-299).
+
+    A predecessor qualifies only when the current marker is `running`, carries a
+    DIFFERENT token, and its `pid` is a live positive int. `pgid` is returned
+    when the marker recorded one (its own process group), else None (single-pid
+    kill fallback). Must be called under `_seed_lock()`.
+    """
+    marker = _read_seed_marker()
+    if marker is None:
+        return None
+    if marker.get("state") != "running" or marker.get("token") == my_token:
+        return None
+    pid = marker.get("pid")
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return None
+    if not _pid_alive(pid):
+        return None
+    pgid = marker.get("pgid")
+    if not (isinstance(pgid, int) and not isinstance(pgid, bool) and pgid > 0):
+        pgid = None
+    return pid, pgid
+
+
+def _running_fields(token: str, pid: int, pgid: int | None, started: float) -> dict:
+    """Assemble the `running` marker fields, including `pgid` only when set (QS-299)."""
+    fields: dict = {"token": token, "pid": pid, "started": started}
+    if pgid is not None:
+        fields["pgid"] = pgid
+    return fields
+
+
+def _claim_and_preempt(token: str, pid: int, pgid: int | None, started: float) -> None:
+    """Under the seed lock: read the predecessor, CLAIM the marker (before the
+    kill), then SIGTERM the predecessor — all inside the same lock (QS-299).
+
+    Holding the lock across the kill (not just the claim) is what makes last-wins
+    hold for N≥3 concurrent starters: each claimant, serialized, sees exactly the
+    single immediately-previous claimant and terminates it before the next
+    claimant runs, so no middle run is orphaned. Claiming BEFORE the kill means
+    the marker never momentarily shows a foreign-token-dead state (no false
+    "interrupted"). On lock-acquire failure we skip preemption entirely and just
+    best-effort claim — a duplicate seed is safe; racing the kill is not.
+    """
+    with _seed_lock() as locked:
+        if not locked:
+            _emit("seed-testmon", "seed lock busy — skipping preemption (best-effort claim)")
+            _write_seed_status("running", **_running_fields(token, pid, pgid, started))
+            return
+        predecessor = _find_running_predecessor(token)
+        _write_seed_status("running", **_running_fields(token, pid, pgid, started))
+        if predecessor is not None:
+            pred_pid, pred_pgid = predecessor
+            _terminate_process_group(pred_pgid, pred_pid)
+
+
+def _write_completion_if_owner(token: str, state: str, **fields: object) -> None:
+    """Write the `ok`/`incomplete` completion marker ONLY if the marker's token is
+    still ours (QS-299, round-1 finding S-I2).
+
+    A preempted predecessor is SIGTERM'd and normally dies before completing, but
+    as belt-and-suspenders we re-acquire the lock, re-read, and refuse to stamp
+    our (old) token over a live winner's marker — which would make the winner's
+    own follower falsely report itself superseded. On a lock-acquire failure we
+    still re-read unlocked and apply the same token guard (best-effort).
+    """
+    with _seed_lock():
+        marker = _read_seed_marker()
+        if marker is not None and marker.get("token") == token:
+            _write_seed_status(state, token=token, **fields)
+
+
+def seed_testmon(token: str | None = None, detached: bool = False) -> int:
     """Refresh `.testmondata` via `pytest --testmon`; no coverage, no verdict.
 
     Sanctioned non-gate subcommand (see the project-rules raw-`pytest`
@@ -1539,16 +1738,29 @@ def seed_testmon() -> int:
 
     QS-286: writes the `SEED_STATUS` completion marker so the detached
     run (launched by `finish-task`) has a pollable signal — see
-    `seed_testmon_status`. The marker writes are the only additions here;
-    the best-effort return semantics are unchanged.
+    `seed_testmon_status`.
+
+    QS-299: `token` (a per-run uuid4 hex — auto-generated when the caller omits
+    it, the required "every marker has a token" invariant) identifies THIS run
+    so the follower can detect supersession. `detached` gates `os.setsid()`
+    (finish-task's `nohup` launch passes it; a foreground manual run omits it to
+    keep job control). At start-up the run claims the marker and preempts any
+    still-running predecessor from an earlier task, all under an advisory lock;
+    the completion write is token-guarded so a preempted run never clobbers the
+    winner's marker.
     """
+    token = token or uuid.uuid4().hex
     # QS-276 review-fix S2: probe ONLY testmon — seeding never invokes
     # diff-cover, so a missing diff-cover must not block the refresh.
     if not _testmon_available():
         _emit("seed-testmon", "pytest-testmon not importable — skipping")
         # QS-286: record the skip (no `running` marker on this path).
-        _write_seed_status("skipped", reason="pytest-testmon not importable")
+        # QS-299: the skip marker still carries the token (invariant).
+        _write_seed_status("skipped", token=token, reason="pytest-testmon not importable")
         return 3
+    # QS-299: detach into our own process group FIRST (only when --detached) so
+    # the pgid we record covers the pytest/xdist tree a later preemptor kills.
+    pgid = _detach_session() if detached else None
     # QS-283 A3: rebuild from scratch. The old code ran `pytest --testmon`
     # against the EXISTING DB, so an already-advanced baseline yielded
     # "0 changed" and the reseed did nothing — the QS_281 recovery dead end.
@@ -1558,8 +1770,10 @@ def seed_testmon() -> int:
     # from re-introducing the desync A1 fixes.
     # QS-286: mark the run as started (after the probe, before the pytest
     # pass) so a status query mid-run reports "still running".
+    # QS-299: claim the marker and preempt any earlier still-running seed under
+    # the lock (read→claim→kill), then rebuild.
     started = time.time()
-    _write_seed_status("running", pid=os.getpid(), started=started)
+    _claim_and_preempt(token, os.getpid(), pgid, started)
     _rebuild_testmon_baseline()
     _emit("seed-testmon", "refreshing .testmondata (pytest --testmon)")
     result = _stream_pytest(_build_seed_testmon_cmd())
@@ -1579,7 +1793,10 @@ def seed_testmon() -> int:
     # No `pid` in the completion marker: the process is finishing, so the
     # reader's liveness check only ever consumes the `running` marker's pid
     # (review-fix #04).
-    _write_seed_status(
+    # QS-299: token-guarded — a preempted predecessor must NOT stamp its old
+    # token over the live winner's marker.
+    _write_completion_if_owner(
+        token,
         "ok" if rc < 2 else "incomplete",
         started=started,
         finished=time.time(),
@@ -1659,16 +1876,17 @@ def seed_testmon_status() -> int:
         print("The baseline refresh status is unreadable.")
         return 3
 
+    # QS-299: `_read_seed_marker()` collapses missing/unreadable/non-dict to
+    # None, so re-check `exists()` first to keep the two DISTINCT messages
+    # ("no baseline recorded" vs "unreadable") this command is contracted on.
     if not SEED_STATUS.exists():
         print("No baseline refresh has been recorded.")
         return 3
-    try:
-        marker = json.loads(SEED_STATUS.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return _unreadable()
-    # A parseable-but-non-object payload (`[1]`, `5`, `null`, `"x"`) has no
-    # `.get`; treat it as unreadable rather than letting `.get` raise.
-    if not isinstance(marker, dict):
+    marker = _read_seed_marker()
+    # Missing (raced away), unreadable JSON, or a parseable-but-non-object
+    # payload (`[1]`, `5`, `null`, `"x"`) all route to the unreadable path
+    # rather than letting `.get` raise.
+    if marker is None:
         return _unreadable()
 
     state = marker.get("state")
@@ -1712,6 +1930,186 @@ def seed_testmon_status() -> int:
         return 1
     # Any other/absent state value is an unreadable status.
     return _unreadable()
+
+
+# QS-299: inline follower constants (plain module constants — no env knobs).
+_SEED_FOLLOW_INTERVAL_S = 5
+_SEED_FOLLOW_MAX_WAIT_S = 2700  # 45 min
+# How many missing-marker polls to tolerate before the seed's `running` claim
+# lands (the startup grace window) before concluding "unreadable".
+_SEED_STARTUP_GRACE_POLLS = 6
+# The progress line `_stream_pytest` synthesizes (verified live under `-n auto`):
+#   `  pytest: 21% (72/330) | passed=72 failed=0 errors=0`
+# Capture pct / current / total; deliberately does NOT match the sibling
+# `  pytest: done (…)` completion line.
+_SEED_PROGRESS_RE = re.compile(r"pytest:\s+(\d+)%\s+\((\d+)/(\d+)\)")
+
+
+def _read_seed_log_tail() -> str:
+    """Read the shared `SEED_LOG` (QS-299), best-effort — "" when missing/unreadable.
+
+    A preempting seed truncates this shared log, but the follower only parses it
+    AFTER confirming the marker still carries its own token, so it never
+    mis-reads a winner's log tail. Patchable seam for tests.
+    """
+    try:
+        return SEED_LOG.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _parse_seed_progress(log_text: str) -> tuple[int, int, int] | None:
+    """Return `(pct, current, total)` from the LAST `pytest: NN% (cur/total)` line
+    in `log_text`, or None when none match (QS-299).
+
+    Takes the last match so the freshest milestone wins; values are taken
+    directly (no `round()`).
+    """
+    matches = _SEED_PROGRESS_RE.findall(log_text)
+    if not matches:
+        return None
+    pct, current, total = matches[-1]
+    return int(pct), int(current), int(total)
+
+
+def _fmt_elapsed(seconds: float) -> str:
+    """Render a wall-clock elapsed span as `mm:ss` (QS-299)."""
+    total = max(0, int(seconds))
+    return f"{total // 60:02d}:{total % 60:02d}"
+
+
+def _marker_elapsed(marker: dict) -> float:
+    """Wall-clock age of the seed from its `started` epoch: `now - started`
+    (QS-299), so a later re-attach still shows the true age. 0.0 for a
+    missing / non-finite `started`."""
+    started = marker.get("started")
+    if isinstance(started, (int, float)) and not isinstance(started, bool):
+        try:
+            if math.isfinite(started):
+                return max(0.0, time.time() - float(started))
+        except (OverflowError, ValueError):
+            pass
+    return 0.0
+
+
+def _marker_pid(marker: dict) -> int | None:
+    """Positive, non-bool int `pid` from a marker, else None (QS-299)."""
+    pid = marker.get("pid")
+    if isinstance(pid, int) and not isinstance(pid, bool) and pid > 0:
+        return pid
+    return None
+
+
+def _print_seed_progress(marker: dict) -> None:
+    """Print one progress line for a `running` poll (QS-299).
+
+    `refreshing baseline: N/M tests (pct%) · elapsed mm:ss` when the log tail is
+    parseable, degrading to `refreshing baseline: elapsed mm:ss` otherwise.
+    """
+    elapsed = _fmt_elapsed(_marker_elapsed(marker))
+    prog = _parse_seed_progress(_read_seed_log_tail())
+    if prog is not None:
+        pct, current, total = prog
+        print(f"refreshing baseline: {current}/{total} tests ({pct}%) · elapsed {elapsed}")
+    else:
+        print(f"refreshing baseline: elapsed {elapsed}")
+
+
+def seed_testmon_follow(token: str) -> int:
+    """Stream the detached `--seed-testmon` run's progress inline until it reaches
+    a terminal state, returning a completion exit code (QS-299).
+
+    Read-only — NO pytest / coverage / testmon import; it only reads the
+    `SEED_STATUS` marker (`_read_seed_marker`) and the `SEED_LOG` tail. The exit
+    table (`token` = my `--seed-token`):
+
+      0  my token `ok`                          — refresh complete, safe to close
+      5  marker token ≠ mine (superseded)       — a fresher refresh took over
+      1  my token `incomplete` / `running`-dead / `skipped`
+      4  my token still `running` past max wait — keep terminal open / re-attach
+      3  marker missing past grace, or unreadable after a one-poll re-read
+
+    Every heavy operation (`time.sleep`/`time.monotonic`/`time.time`,
+    `_read_seed_marker`, `_pid_alive`, the log-tail read) is a patchable seam so
+    the whole loop is unit-testable without real processes or sleeps.
+    """
+    deadline = time.monotonic() + _SEED_FOLLOW_MAX_WAIT_S
+    startup_polls = 0
+    while True:
+        marker = _read_seed_marker()
+        if marker is None:
+            # Distinguish "not written yet" (startup grace) from "unreadable".
+            if not SEED_STATUS.exists():
+                if startup_polls < _SEED_STARTUP_GRACE_POLLS:
+                    startup_polls += 1
+                    print("waiting for baseline refresh to start…")
+                    time.sleep(_SEED_FOLLOW_INTERVAL_S)
+                    continue
+                print("The baseline refresh status is unreadable.")
+                return 3
+            # Present but unreadable — re-read once before concluding.
+            time.sleep(_SEED_FOLLOW_INTERVAL_S)
+            if _read_seed_marker() is None:
+                print("The baseline refresh status is unreadable.")
+                return 3
+            continue
+
+        # A different token means a fresher seed claimed the marker: superseded.
+        if marker.get("token") != token:
+            print(
+                "A fresher baseline refresh is now running — this one was "
+                "stopped, safe to close this terminal."
+            )
+            return 5
+
+        state = marker.get("state")
+        if state == "ok":
+            print("✅ baseline refresh complete — safe to close this terminal.")
+            return 0
+        if state == "incomplete":
+            print("`.testmondata` may be partial — rerun the refresh.")
+            return 1
+        if state == "skipped":
+            reason = marker.get("reason", "unknown reason")
+            print(
+                f"Refresh was skipped ({reason}) — no baseline was written; "
+                "safe to close this terminal, rerun if needed."
+            )
+            return 1
+        if state == "running":
+            pid = _marker_pid(marker)
+            if pid is None or not _pid_alive(pid):
+                # R1 re-poll (cosmetic polish): a preemptor claims BEFORE the
+                # kill, so a `running`+dead observation is almost always a
+                # transient sub-poll race. Sleep one interval and re-read once
+                # before concluding "interrupted".
+                time.sleep(_SEED_FOLLOW_INTERVAL_S)
+                repoll = _read_seed_marker()
+                if repoll is None or repoll.get("token") != token:
+                    # The marker flipped (superseded / completed / vanished) —
+                    # let the top of the loop re-classify it.
+                    continue
+                if repoll.get("state") == "running":
+                    repoll_pid = _marker_pid(repoll)
+                    if repoll_pid is None or not _pid_alive(repoll_pid):
+                        print("`.testmondata` may be partial — rerun the refresh.")
+                        return 1
+                # State changed to a terminal value under my token — re-loop.
+                continue
+            _print_seed_progress(marker)
+            if time.monotonic() >= deadline:
+                print(
+                    f"Still running after 45m — keep this terminal open, or "
+                    f"re-attach: python scripts/qs/quality_gate.py "
+                    f"--seed-testmon-follow --seed-token {token}"
+                )
+                return 4
+            time.sleep(_SEED_FOLLOW_INTERVAL_S)
+            continue
+
+        # Any other/absent state under my token is an unreadable status.
+        print("The baseline refresh status is unreadable.")
+        return 3
 
 
 def main() -> None:
@@ -1758,6 +2156,37 @@ def main() -> None:
             "--seed-testmon."
         ),
     )
+    parser.add_argument(
+        "--seed-testmon-follow",
+        action="store_true",
+        help=(
+            "QS-299: stream the detached --seed-testmon run's progress inline "
+            "until it reaches a terminal state (read-only; no pytest). Requires "
+            "--seed-token. Exit 0=ok/safe to close, 5=superseded, 1=rerun, "
+            "4=still running, 3=no readable status. Mutex with the same modes as "
+            "--seed-testmon."
+        ),
+    )
+    parser.add_argument(
+        "--seed-token",
+        default=None,
+        metavar="T",
+        help=(
+            "QS-299: per-run token (uuid4 hex) tying a --seed-testmon run to its "
+            "--seed-testmon-follow so supersession is detectable. Only valid with "
+            "--seed-testmon or --seed-testmon-follow."
+        ),
+    )
+    parser.add_argument(
+        "--detached",
+        action="store_true",
+        help=(
+            "QS-299: detach --seed-testmon into its own session/process group "
+            "(os.setsid) so a later run can preempt the whole pytest tree. "
+            "finish-task passes this on the nohup launch; omit it for a "
+            "foreground manual run. Only valid with --seed-testmon."
+        ),
+    )
     args = parser.parse_args()
 
     # --quick is mutually exclusive with cache/full/fix. argparse's nargs="+"
@@ -1801,11 +2230,41 @@ def main() -> None:
         or args.full
         or args.fix
         or args.seed_testmon
+        or args.seed_testmon_follow
     ):
         parser.error(
             "you cannot combine --seed-testmon-status with --impacted, --quick, "
-            "--cache, --no-cache, --full, --fix, or --seed-testmon"
+            "--cache, --no-cache, --full, --fix, --seed-testmon, or --seed-testmon-follow"
         )
+
+    # QS-299: --seed-testmon-follow is a read-only streaming query subcommand.
+    # Same mutex family as --seed-testmon-status.
+    if args.seed_testmon_follow and (
+        args.impacted
+        or args.quick
+        or args.cache
+        or args.no_cache
+        or args.full
+        or args.fix
+        or args.seed_testmon
+        or args.seed_testmon_status
+    ):
+        parser.error(
+            "you cannot combine --seed-testmon-follow with --impacted, --quick, "
+            "--cache, --no-cache, --full, --fix, --seed-testmon, or --seed-testmon-status"
+        )
+
+    # QS-299: --seed-token is meaningful only with --seed-testmon (identifies the
+    # run) or --seed-testmon-follow (identifies the run to track); elsewhere it is
+    # a usage error. --seed-testmon-follow REQUIRES it (it cannot detect
+    # supersession without knowing its own token). --detached is valid only with
+    # --seed-testmon (it gates the setsid detach of the seeding process).
+    if args.seed_token is not None and not (args.seed_testmon or args.seed_testmon_follow):
+        parser.error("--seed-token is only valid with --seed-testmon or --seed-testmon-follow")
+    if args.seed_testmon_follow and args.seed_token is None:
+        parser.error("--seed-testmon-follow requires --seed-token")
+    if args.detached and not args.seed_testmon:
+        parser.error("--detached is only valid with --seed-testmon")
 
     # Review-fix #01 finding 8 — `--quick ""` would otherwise resolve to
     # REPO_ROOT and silently collect the whole suite. Reject before any
@@ -1847,10 +2306,16 @@ def main() -> None:
     if args.impacted:
         sys.exit(check_impacted())
 
+    # QS-299: --seed-testmon-follow is a read-only streaming query — short-circuit
+    # before cache/scope, like the other subcommands. `--seed-token` is guaranteed
+    # present by the usage-error check above.
+    if args.seed_testmon_follow:
+        sys.exit(seed_testmon_follow(args.seed_token))
+
     # --seed-testmon is a non-gate maintenance subcommand: refresh the DB
     # and exit, never touching scope detection or the coverage gate.
     if args.seed_testmon:
-        sys.exit(seed_testmon())
+        sys.exit(seed_testmon(token=args.seed_token, detached=args.detached))
 
     # QS-286: --seed-testmon-status is a read-only query — short-circuit
     # before cache/scope detection like the other subcommands.

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -1710,6 +1710,12 @@ def _claim_and_preempt(token: str, pid: int, pgid: int | None, started: float) -
     """
     with _seed_lock() as locked:
         if not locked:
+            # review-fix #03 (finding #3): on lock contention two seeds run
+            # concurrently and both truncate/append the shared SEED_LOG, so the
+            # follower's parsed progress line may momentarily jitter (e.g. jump
+            # between the two runs' percentages). Purely cosmetic — outcome safety
+            # is preserved (a duplicate/stale baseline is safe), so we accept the
+            # jitter rather than add per-process log isolation.
             _emit("seed-testmon", "seed lock busy — skipping preemption (best-effort claim)")
             _write_seed_status(_SEED_STATE_RUNNING, **_running_fields(token, pid, pgid, started))
             return
@@ -2056,9 +2062,16 @@ def _print_seed_progress(marker: dict) -> None:
 _FOLLOW_MSG_OK = "[OK] baseline refresh complete - safe to close this terminal."
 _FOLLOW_MSG_PARTIAL = "`.testmondata` may be partial - rerun the refresh."
 _FOLLOW_MSG_UNREADABLE = "The baseline refresh status is unreadable."
-_FOLLOW_MSG_SUPERSEDED = (
-    "A fresher baseline refresh is now running - this one was stopped, "
-    "safe to close this terminal."
+# QS-299 review-fix #03 (finding #1): once a foreign token owns the marker after
+# THIS run owned it, we genuinely cannot tell whether our run completed `ok(T)`
+# (then got overwritten by a parallel `running(U)`) or was preempted mid-run —
+# the token-guarded completion write means `ok(T)` is already gone by the time
+# the poll lands on `running(U)`, and the reverse is forbidden. So the verdict is
+# honest uncertainty, not a definite "this run was stopped".
+_FOLLOW_MSG_TAKEN_OVER = (
+    "Another baseline refresh now holds the marker; this run either completed or "
+    "was superseded - check `python scripts/qs/quality_gate.py --seed-testmon-status`. "
+    "Safe to close this terminal."
 )
 # QS-299 review-fix #02 (finding #3): a foreign marker that persists the whole
 # startup grace might just mean this run's seed was slow to claim (saturated
@@ -2075,9 +2088,6 @@ def _follow_own_terminal_verdict(marker: dict) -> int | None:
     """Map a MY-token marker in a terminal state to its follower exit code,
     printing the verdict line; return None for a non-terminal (`running`) or
     unknown state (QS-299).
-
-    Shared by the main poll and the supersession re-read (review-fix #02 finding
-    #1) so a completed run is never misreported as superseded.
     """
     state = marker.get("state")
     if state == _SEED_STATE_OK:
@@ -2106,7 +2116,10 @@ def seed_testmon_follow(token: str) -> int:
     The exit table (`token` = my `--seed-token`):
 
       0  my token `ok`                          - refresh complete, safe to close
-      5  supersession (see below)               - a fresher refresh took over
+      5  a foreign token owns the marker        - either (a) it owned it AFTER our
+         token did (this run completed or was superseded — indistinguishable, see
+         below), or (b) a foreign token held it for the whole startup grace
+         (unconfirmed start); BOTH cases are safe-to-close, exit 5
       1  my token `incomplete` / `running`-dead / `skipped`
       4  no terminal state within max wait      - keep terminal open / re-attach
       3  marker missing/unreadable past the startup grace
@@ -2118,11 +2131,15 @@ def seed_testmon_follow(token: str) -> int:
     hasn't claimed yet" — poll within the startup grace instead of declaring
     supersession.
 
-    Completed-not-superseded (review-fix #02, finding #1): a new parallel seed
-    unconditionally re-claims `running(U)`, so it can overwrite this run's
-    `ok(T)` in the ≤5 s gap between polls. Before concluding "superseded" on the
-    own-token path, re-read once and honor a MY-token terminal state, so a run
-    that actually completed reports completion (exit 0), not "stopped".
+    Completed-vs-superseded is BEST-EFFORT (review-fix #03, finding #1): the
+    single shared marker is token-guarded, so the on-disk history is
+    `running(T) → ok(T) → running(U)` (a parallel task overwrites our completed
+    marker) or `running(T) → running(U)` (we were preempted mid-run). Either way
+    `ok(T)` is gone by the time a poll lands on `running(U)`, and the follower
+    cannot tell the two apart — so on the own-token→foreign path it reports honest
+    uncertainty (`_FOLLOW_MSG_TAKEN_OVER`, exit 5), never a false "this run was
+    stopped". The outcome is safe regardless: a valid baseline exists (ours or the
+    winner's, which is still rebuilding).
 
     The `_SEED_FOLLOW_MAX_WAIT_S` deadline is enforced at the TOP of the loop
     (review-fix #02, finding #4) so EVERY path — startup wait, no-marker re-poll,
@@ -2207,19 +2224,15 @@ def seed_testmon_follow(token: str) -> int:
             print(_FOLLOW_MSG_UNREADABLE)
             return 3
 
-        # --- We owned the marker before; it is no longer ours. ---
+        # --- We owned the marker before; a foreign token now owns it. ---
         if marker is not None:
-            # A different token now owns it. Re-read once and honor a MY-token
-            # terminal state (finding #1): a completed run whose `ok(T)` was
-            # overwritten by a parallel `running(U)` must report completion.
-            repoll = _read_seed_marker()
-            if repoll is not None and repoll.get("token") == token:
-                verdict = _follow_own_terminal_verdict(repoll)
-                if verdict is not None:
-                    return verdict
-                # Back to our own running marker — keep following.
-                continue
-            print(_FOLLOW_MSG_SUPERSEDED)
+            # review-fix #03 (finding #1): the token-guarded single marker makes
+            # our completed `ok(T)` unrecoverable once `running(U)` is claimed
+            # (and the reverse write is forbidden), so we cannot distinguish
+            # "completed then overwritten" from "preempted mid-run". Report honest
+            # uncertainty (exit 5) rather than a false "this run was stopped".
+            # Both are safe-to-close: a valid baseline exists either way.
+            print(_FOLLOW_MSG_TAKEN_OVER)
             return 5
 
         # --- No readable marker after we owned it — re-read once, else exit 3. ---

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -1549,11 +1549,11 @@ def _read_seed_marker() -> dict | None:
     """Parse the `SEED_STATUS` marker; return the dict, or None when it is
     missing / unreadable / not a JSON object (QS-299).
 
-    Extracted from the inline `json.loads` `seed_testmon_status()` used, so the
-    follower and the preemptor share ONE tolerant reader. Callers that need to
-    tell "missing" apart from "unreadable" (e.g. `seed_testmon_status`'s two
-    distinct messages) re-check `SEED_STATUS.exists()` themselves — this helper
-    deliberately collapses both to None.
+    A single tolerant reader shared by the follower, the preemptor, and
+    `seed_testmon_status` (which previously parsed the marker inline). Callers
+    that need to tell "missing" apart from "unreadable" (e.g.
+    `seed_testmon_status`'s two distinct messages) re-check `SEED_STATUS.exists()`
+    themselves — this helper deliberately collapses both to None.
     """
     try:
         marker = json.loads(SEED_STATUS.read_text(encoding="utf-8"))
@@ -1934,28 +1934,51 @@ def seed_testmon_status() -> int:
 
 # QS-299: inline follower constants (plain module constants — no env knobs).
 _SEED_FOLLOW_INTERVAL_S = 5
+# QS-299 review-fix #01 (findings #1/#7): the startup grace now also covers a
+# stale FOREIGN-token marker left by a previous task — the follower launches
+# right after the seed's `nohup`, but the seed only claims the marker after
+# interpreter start + `import quality_gate` + `_testmon_available()` +
+# `_detach_session()`. Until this follower has observed its OWN token claim the
+# marker at least once, a missing OR foreign-token marker means "my seed hasn't
+# claimed yet" — keep polling within this window rather than mis-reporting a
+# supersession. Widened to 12 polls (~60 s) so a slow interpreter cold-start
+# can't exhaust the grace.
 _SEED_FOLLOW_MAX_WAIT_S = 2700  # 45 min
-# How many missing-marker polls to tolerate before the seed's `running` claim
-# lands (the startup grace window) before concluding "unreadable".
-_SEED_STARTUP_GRACE_POLLS = 6
+_SEED_STARTUP_GRACE_POLLS = 12  # ~60 s at the 5 s poll interval
 # The progress line `_stream_pytest` synthesizes (verified live under `-n auto`):
 #   `  pytest: 21% (72/330) | passed=72 failed=0 errors=0`
 # Capture pct / current / total; deliberately does NOT match the sibling
 # `  pytest: done (…)` completion line.
 _SEED_PROGRESS_RE = re.compile(r"pytest:\s+(\d+)%\s+\((\d+)/(\d+)\)")
+# QS-299 review-fix #01 (finding #5): only the trailing slice of the (possibly
+# large, growing) seed log is scanned each poll — enough to hold the latest
+# `pytest: NN% (…)` milestone line, so the follower stays O(1)-per-poll instead
+# of O(filesize).
+_SEED_LOG_TAIL_BYTES = 8192
 
 
 def _read_seed_log_tail() -> str:
-    """Read the shared `SEED_LOG` (QS-299), best-effort — "" when missing/unreadable.
+    """Read the TAIL of the shared `SEED_LOG` (QS-299), best-effort — "" when
+    missing/unreadable.
 
-    A preempting seed truncates this shared log, but the follower only parses it
-    AFTER confirming the marker still carries its own token, so it never
-    mis-reads a winner's log tail. Patchable seam for tests.
+    Seeks to the last `_SEED_LOG_TAIL_BYTES` and decodes only that slice, so a
+    long full-suite refresh (a log that grows for up to 45 min) does not cost an
+    O(filesize) re-read + re-scan on every 5 s poll. `_parse_seed_progress` takes
+    the last match, and the newest milestone line is always well within the tail,
+    so the trailing window preserves the parse result. A preempting seed
+    truncates this shared log, but the follower only parses it AFTER confirming
+    the marker still carries its own token, so it never mis-reads a winner's log
+    tail. Patchable seam for tests.
     """
     try:
-        return SEED_LOG.read_text(encoding="utf-8", errors="replace")
+        with open(SEED_LOG, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - _SEED_LOG_TAIL_BYTES))
+            data = fh.read()
     except OSError:
         return ""
+    return data.decode("utf-8", "replace")
 
 
 def _parse_seed_progress(log_text: str) -> tuple[int, int, int] | None:
@@ -2003,14 +2026,18 @@ def _marker_pid(marker: dict) -> int | None:
 def _print_seed_progress(marker: dict) -> None:
     """Print one progress line for a `running` poll (QS-299).
 
-    `refreshing baseline: N/M tests (pct%) · elapsed mm:ss` when the log tail is
+    `refreshing baseline: N/M tests (pct%) - elapsed mm:ss` when the log tail is
     parseable, degrading to `refreshing baseline: elapsed mm:ss` otherwise.
+
+    QS-299 review-fix #01 (finding #2): the line is plain ASCII (no `·`) so it
+    can never raise `UnicodeEncodeError` when the harness pipes the follower's
+    stdout under a non-UTF-8 locale (`LANG=C`).
     """
     elapsed = _fmt_elapsed(_marker_elapsed(marker))
     prog = _parse_seed_progress(_read_seed_log_tail())
     if prog is not None:
         pct, current, total = prog
-        print(f"refreshing baseline: {current}/{total} tests ({pct}%) · elapsed {elapsed}")
+        print(f"refreshing baseline: {current}/{total} tests ({pct}%) - elapsed {elapsed}")
     else:
         print(f"refreshing baseline: elapsed {elapsed}")
 
@@ -2020,95 +2047,132 @@ def seed_testmon_follow(token: str) -> int:
     a terminal state, returning a completion exit code (QS-299).
 
     Read-only — NO pytest / coverage / testmon import; it only reads the
-    `SEED_STATUS` marker (`_read_seed_marker`) and the `SEED_LOG` tail. The exit
-    table (`token` = my `--seed-token`):
+    `SEED_STATUS` marker (`_read_seed_marker`) and the `SEED_LOG` tail. All
+    printed lines are plain ASCII so piping under a non-UTF-8 locale can't raise.
+    The exit table (`token` = my `--seed-token`):
 
-      0  my token `ok`                          — refresh complete, safe to close
-      5  marker token ≠ mine (superseded)       — a fresher refresh took over
+      0  my token `ok`                          - refresh complete, safe to close
+      5  supersession (see below)               - a fresher refresh took over
       1  my token `incomplete` / `running`-dead / `skipped`
-      4  my token still `running` past max wait — keep terminal open / re-attach
-      3  marker missing past grace, or unreadable after a one-poll re-read
+      4  my token still `running` past max wait - keep terminal open / re-attach
+      3  marker missing/unreadable past the startup grace
+
+    Supersession vs startup (QS-299 review-fix #01, finding #1): tokens are
+    unordered uuid4, so a foreign token is indistinguishable from a genuinely
+    fresher one. Until this follower has observed its OWN token own the marker at
+    least once (`own_token_seen`), a missing OR foreign-token marker just means
+    "my seed hasn't claimed yet" — poll within the startup grace instead of
+    declaring supersession. Exit 5 fires only when either (a) our token was seen
+    and is THEN replaced by a different token, or (b) the startup grace elapses
+    with a foreign token still present.
 
     Every heavy operation (`time.sleep`/`time.monotonic`/`time.time`,
     `_read_seed_marker`, `_pid_alive`, the log-tail read) is a patchable seam so
     the whole loop is unit-testable without real processes or sleeps.
     """
+    superseded = (
+        "A fresher baseline refresh is now running - this one was "
+        "stopped, safe to close this terminal."
+    )
+    unreadable = "The baseline refresh status is unreadable."
     deadline = time.monotonic() + _SEED_FOLLOW_MAX_WAIT_S
     startup_polls = 0
+    own_token_seen = False
     while True:
         marker = _read_seed_marker()
-        if marker is None:
-            # Distinguish "not written yet" (startup grace) from "unreadable".
-            if not SEED_STATUS.exists():
-                if startup_polls < _SEED_STARTUP_GRACE_POLLS:
-                    startup_polls += 1
-                    print("waiting for baseline refresh to start…")
-                    time.sleep(_SEED_FOLLOW_INTERVAL_S)
-                    continue
-                print("The baseline refresh status is unreadable.")
-                return 3
-            # Present but unreadable — re-read once before concluding.
-            time.sleep(_SEED_FOLLOW_INTERVAL_S)
-            if _read_seed_marker() is None:
-                print("The baseline refresh status is unreadable.")
-                return 3
-            continue
 
-        # A different token means a fresher seed claimed the marker: superseded.
-        if marker.get("token") != token:
-            print(
-                "A fresher baseline refresh is now running — this one was "
-                "stopped, safe to close this terminal."
-            )
+        # --- The marker carries MY token: I own it now. ---
+        if marker is not None and marker.get("token") == token:
+            own_token_seen = True
+            state = marker.get("state")
+            if state == "ok":
+                print("[OK] baseline refresh complete - safe to close this terminal.")
+                return 0
+            if state == "incomplete":
+                print("`.testmondata` may be partial - rerun the refresh.")
+                return 1
+            if state == "skipped":
+                reason = marker.get("reason", "unknown reason")
+                print(
+                    f"Refresh was skipped ({reason}) - no baseline was written; "
+                    "safe to close this terminal, rerun if needed."
+                )
+                return 1
+            if state == "running":
+                pid = _marker_pid(marker)
+                if pid is None or not _pid_alive(pid):
+                    # R1 re-poll (cosmetic polish): a preemptor claims BEFORE the
+                    # kill, so a `running`+dead observation is almost always a
+                    # transient sub-poll race. Sleep one interval and re-read once
+                    # before concluding "interrupted".
+                    time.sleep(_SEED_FOLLOW_INTERVAL_S)
+                    repoll = _read_seed_marker()
+                    if repoll is None or repoll.get("token") != token:
+                        # The marker flipped (superseded / completed / vanished) —
+                        # let the top of the loop re-classify it.
+                        continue
+                    if repoll.get("state") == "running":
+                        repoll_pid = _marker_pid(repoll)
+                        if repoll_pid is None or not _pid_alive(repoll_pid):
+                            print("`.testmondata` may be partial - rerun the refresh.")
+                            return 1
+                    # State changed to a terminal value under my token — re-loop.
+                    continue
+                # NOTE (finding #8): `_pid_alive` is pid-based, so in the rare
+                # event the detached seed dies and the OS reuses its pid, this
+                # streams stale "progress" until the 45-min deadline, then exits 4
+                # advising re-attach. Benign (advisory only); a pid-generation
+                # guard would be over-engineering for this low-likelihood case.
+                _print_seed_progress(marker)
+                if time.monotonic() >= deadline:
+                    print(
+                        f"Still running after 45m - keep this terminal open, or "
+                        f"re-attach: python scripts/qs/quality_gate.py "
+                        f"--seed-testmon-follow --seed-token {token}"
+                    )
+                    return 4
+                time.sleep(_SEED_FOLLOW_INTERVAL_S)
+                continue
+            # Any other/absent state under my token is an unreadable status.
+            print(unreadable)
+            return 3
+
+        # --- A DIFFERENT token owns the marker. ---
+        if marker is not None:
+            if own_token_seen:
+                # We owned the marker and a fresher run has now taken over —
+                # genuine supersession.
+                print(superseded)
+                return 5
+            # Startup: my seed hasn't claimed the marker yet. A stale foreign
+            # marker from a previous task is expected here — wait it out within
+            # the grace window rather than mis-reporting a supersession.
+            if startup_polls < _SEED_STARTUP_GRACE_POLLS:
+                startup_polls += 1
+                print("waiting for baseline refresh to start...")
+                time.sleep(_SEED_FOLLOW_INTERVAL_S)
+                continue
+            # Grace elapsed with a foreign token still present — our seed never
+            # claimed; treat the persistent foreign run as the winner.
+            print(superseded)
             return 5
 
-        state = marker.get("state")
-        if state == "ok":
-            print("✅ baseline refresh complete — safe to close this terminal.")
-            return 0
-        if state == "incomplete":
-            print("`.testmondata` may be partial — rerun the refresh.")
-            return 1
-        if state == "skipped":
-            reason = marker.get("reason", "unknown reason")
-            print(
-                f"Refresh was skipped ({reason}) — no baseline was written; "
-                "safe to close this terminal, rerun if needed."
-            )
-            return 1
-        if state == "running":
-            pid = _marker_pid(marker)
-            if pid is None or not _pid_alive(pid):
-                # R1 re-poll (cosmetic polish): a preemptor claims BEFORE the
-                # kill, so a `running`+dead observation is almost always a
-                # transient sub-poll race. Sleep one interval and re-read once
-                # before concluding "interrupted".
-                time.sleep(_SEED_FOLLOW_INTERVAL_S)
-                repoll = _read_seed_marker()
-                if repoll is None or repoll.get("token") != token:
-                    # The marker flipped (superseded / completed / vanished) —
-                    # let the top of the loop re-classify it.
-                    continue
-                if repoll.get("state") == "running":
-                    repoll_pid = _marker_pid(repoll)
-                    if repoll_pid is None or not _pid_alive(repoll_pid):
-                        print("`.testmondata` may be partial — rerun the refresh.")
-                        return 1
-                # State changed to a terminal value under my token — re-loop.
-                continue
-            _print_seed_progress(marker)
-            if time.monotonic() >= deadline:
-                print(
-                    f"Still running after 45m — keep this terminal open, or "
-                    f"re-attach: python scripts/qs/quality_gate.py "
-                    f"--seed-testmon-follow --seed-token {token}"
-                )
-                return 4
+        # --- No readable marker (missing or unreadable JSON). ---
+        if own_token_seen:
+            # Our marker vanished/became unreadable after we owned it — re-read
+            # once before concluding.
+            time.sleep(_SEED_FOLLOW_INTERVAL_S)
+            if _read_seed_marker() is None:
+                print(unreadable)
+                return 3
+            continue
+        # Startup: no marker yet — wait within the grace window.
+        if startup_polls < _SEED_STARTUP_GRACE_POLLS:
+            startup_polls += 1
+            print("waiting for baseline refresh to start...")
             time.sleep(_SEED_FOLLOW_INTERVAL_S)
             continue
-
-        # Any other/absent state under my token is an unreadable status.
-        print("The baseline refresh status is unreadable.")
+        print(unreadable)
         return 3
 
 
@@ -2261,6 +2325,13 @@ def main() -> None:
     # --seed-testmon (it gates the setsid detach of the seeding process).
     if args.seed_token is not None and not (args.seed_testmon or args.seed_testmon_follow):
         parser.error("--seed-token is only valid with --seed-testmon or --seed-testmon-follow")
+    # QS-299 review-fix #01 (finding #3): reject an empty / whitespace-only token
+    # for BOTH subcommands. `seed_testmon("")` would treat it as absent (fresh
+    # uuid), while `seed_testmon_follow("")` could never match a real uuid marker
+    # — an inconsistency a follower launched with a blank token can never recover
+    # from. Fail loudly at the CLI instead of silently mismatching.
+    if args.seed_token is not None and not args.seed_token.strip():
+        parser.error("--seed-token must not be empty or whitespace")
     if args.seed_testmon_follow and args.seed_token is None:
         parser.error("--seed-testmon-follow requires --seed-token")
     if args.detached and not args.seed_testmon:

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -4148,40 +4148,30 @@ class TestSeedTestmonFollow:
         mock_prog.assert_called_once()  # streamed our own progress
         assert "safe to close" in out
 
-    def test_own_token_then_foreign_exits_5(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """review-fix #01/#02 (finding #1): our token owned the marker, then a
-        newer run replaced it (still `running`, never our terminal) → genuine
-        supersession (exit 5). The superseded-path re-read (finding #1, #02) also
-        sees the foreign token."""
+    def test_own_token_then_foreign_reports_taken_over(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """review-fix #03 (finding #1): our token owned the marker (`running(T)`),
+        then a foreign token owns it (`running(U)`) — the reachable production
+        ordering `running(T) → ok(T) → running(U)` OR `running(T) → running(U)`.
+        The token-guarded single marker means `ok(T)` is unrecoverable, so the
+        follower reports HONEST uncertainty (exit 5), never a false "was
+        stopped"/"fresher" claim, and never a fabricated completion."""
         mine = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
-        newer = {"token": "newer", "state": "running", "pid": 99}
+        foreign = {"token": "U", "state": "running", "pid": 99}
         with (
-            patch.object(quality_gate, "_read_seed_marker", side_effect=[mine, newer, newer]),
+            # only 2 reads now — the dead recovery re-read was removed.
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[mine, foreign]),
             patch.object(quality_gate, "_pid_alive", return_value=True),
             patch.object(quality_gate, "_print_seed_progress"),
         ):
             assert quality_gate.seed_testmon_follow("t") == 5
-        assert "fresher baseline refresh" in capsys.readouterr().out.lower()
-
-    def test_own_token_ok_overwritten_by_foreign_reports_completion(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """review-fix #02 (finding #1) SHOULD-FIX: a run that completed `ok(T)`
-        but whose marker was overwritten by a parallel `running(U)` before the
-        next poll must report COMPLETION (exit 0), not "superseded" — the
-        superseded-path re-read observes our own terminal `ok`."""
-        mine_running = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
-        foreign = {"token": "U", "state": "running", "pid": 99}
-        mine_ok = {"token": "t", "state": "ok"}
-        with (
-            patch.object(quality_gate, "_read_seed_marker", side_effect=[mine_running, foreign, mine_ok]),
-            patch.object(quality_gate, "_pid_alive", return_value=True),
-            patch.object(quality_gate, "_print_seed_progress"),
-        ):
-            assert quality_gate.seed_testmon_follow("t") == 0
         out = capsys.readouterr().out.lower()
-        assert "safe to close" in out
-        assert "fresher baseline" not in out  # NOT misreported as superseded
+        assert "another baseline refresh now holds the marker" in out
+        assert "either completed or was superseded" in out
+        assert "--seed-testmon-status" in out and "safe to close" in out
+        # honest — neither a false "stopped" nor a fabricated completion:
+        assert "was stopped" not in out
+        assert "[ok]" not in out
+        assert out.isascii()
 
     def test_incomplete_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch.object(quality_gate, "_read_seed_marker", return_value={"token": "t", "state": "incomplete"}):
@@ -4261,11 +4251,11 @@ class TestSeedTestmonFollow:
 
     def test_running_dead_then_superseded(self) -> None:
         """R1 re-poll: token flips (superseded) → exit 5. Reads: initial dead,
-        R1 re-read (new), loop-top (new), superseded-path re-read (new)."""
+        R1 re-read (new), loop-top (new) → own-token→foreign taken-over verdict."""
         dead = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
         new = {"token": "new", "state": "running"}
         with (
-            patch.object(quality_gate, "_read_seed_marker", side_effect=[dead, new, new, new]),
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[dead, new, new]),
             patch.object(quality_gate, "_pid_alive", return_value=False),
         ):
             assert quality_gate.seed_testmon_follow("t") == 5
@@ -4716,6 +4706,13 @@ class TestFinishTaskFollowerAgents:
         body = self._text(rel)
         assert "--seed-testmon --detached --seed-token" in body
         assert "</dev/null" in body  # fully backgrounded
+
+    @pytest.mark.parametrize("rel", _AGENTS)
+    def test_empty_seed_token_guard_present(self, rel: str) -> None:
+        """review-fix #03 (finding #5): the launch is guarded by a non-empty
+        SEED_TOKEN check so a uuid failure can't invoke the CLI with an empty
+        --seed-token (which it rejects with exit 2 — a silent no-op)."""
+        assert '[ -n "$SEED_TOKEN" ]' in self._text(rel)
 
     @pytest.mark.parametrize("rel", _AGENTS)
     def test_no_rm_f_marker(self, rel: str) -> None:

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -4225,7 +4225,9 @@ class TestSeedTestmonFollow:
         ):
             assert quality_gate.seed_testmon_follow("t") == 4
         out = capsys.readouterr().out.lower()
-        assert "still running after 45m" in out and "--seed-token t" in out
+        # review-fix #05 (finding #4): the minutes are derived from the constant.
+        mins = quality_gate._SEED_FOLLOW_MAX_WAIT_S // 60
+        assert f"still running after {mins}m" in out and "--seed-token t" in out
 
     def test_running_dead_confirmed_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
         """R1 re-poll: dead pid confirmed on re-read → interrupted."""
@@ -4300,7 +4302,8 @@ class TestSeedTestmonFollow:
             patch.object(quality_gate, "_print_seed_progress"),
         ):
             assert quality_gate.seed_testmon_follow("t") == 4
-        assert "still running after 45m" in capsys.readouterr().out.lower()
+        mins = quality_gate._SEED_FOLLOW_MAX_WAIT_S // 60
+        assert f"still running after {mins}m" in capsys.readouterr().out.lower()
 
     def test_startup_grace_then_exit_3(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch.object(quality_gate, "_read_seed_marker", return_value=None):

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -4025,7 +4025,9 @@ class TestPrintSeedProgress:
         ):
             quality_gate._print_seed_progress({"started": 1.0})
         out = capsys.readouterr().out
-        assert "refreshing baseline: 72/330 tests (21%) · elapsed 01:05" in out
+        # QS-299 review-fix #01 (finding #2): plain-ASCII separator (no `·`).
+        assert "refreshing baseline: 72/330 tests (21%) - elapsed 01:05" in out
+        assert "·" not in out
 
     def test_degraded_when_unparseable(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
@@ -4039,7 +4041,7 @@ class TestPrintSeedProgress:
 
 
 class TestReadSeedLogTail:
-    """QS-299: `_read_seed_log_tail` — best-effort read."""
+    """QS-299: `_read_seed_log_tail` — best-effort TAIL read (review-fix #01 #5)."""
 
     def test_reads_content(self, tmp_path: Path) -> None:
         log = tmp_path / "seed.log"
@@ -4050,6 +4052,25 @@ class TestReadSeedLogTail:
     def test_missing_returns_empty(self, tmp_path: Path) -> None:
         with patch.object(quality_gate, "SEED_LOG", tmp_path / "nope.log"):
             assert quality_gate._read_seed_log_tail() == ""
+
+    def test_reads_only_the_tail(self, tmp_path: Path) -> None:
+        """A large log is not read whole: only ~`_SEED_LOG_TAIL_BYTES` come back,
+        and the freshest progress line (at the end) survives + parses."""
+        log = tmp_path / "seed.log"
+        head = "OLD 0% (0/330)\n" * 5000  # far bigger than the tail window
+        tail_line = "  pytest: 99% (327/330) | passed=327 failed=0 errors=0\n"
+        log.write_text(head + tail_line)
+        with patch.object(quality_gate, "SEED_LOG", log):
+            out = quality_gate._read_seed_log_tail()
+        assert len(out) <= quality_gate._SEED_LOG_TAIL_BYTES
+        assert len(out) < len(head)  # NOT the whole file
+        assert quality_gate._parse_seed_progress(out) == (99, 327, 330)
+
+    def test_tail_smaller_than_window_returns_all(self, tmp_path: Path) -> None:
+        log = tmp_path / "seed.log"
+        log.write_text("short content")
+        with patch.object(quality_gate, "SEED_LOG", log):
+            assert quality_gate._read_seed_log_tail() == "short content"
 
 
 class TestSeedTestmonFollow:
@@ -4069,13 +4090,72 @@ class TestSeedTestmonFollow:
     def test_ok_exits_0(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch.object(quality_gate, "_read_seed_marker", return_value={"token": "t", "state": "ok"}):
             assert quality_gate.seed_testmon_follow("t") == 0
-        assert "safe to close" in capsys.readouterr().out.lower()
+        out = capsys.readouterr().out.lower()
+        assert "safe to close" in out
+        assert out.isascii()  # review-fix #01 (#2): no non-ASCII glyphs
 
-    def test_superseded_exits_5(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_output_is_ascii_only(self) -> None:
+        """review-fix #01 (finding #2): every verdict/progress line is plain
+        ASCII, so piping under a non-UTF-8 locale can never raise."""
+        markers = [
+            {"token": "t", "state": "ok"},
+            {"token": "t", "state": "incomplete"},
+            {"token": "t", "state": "skipped", "reason": "x"},
+            {"token": "other", "state": "running"},
+        ]
+        for m in markers:
+            with patch.object(quality_gate, "_read_seed_marker", return_value=m):
+                buf = io.StringIO()
+                with patch("sys.stdout", buf):
+                    quality_gate.seed_testmon_follow("t")
+                assert buf.getvalue().isascii(), m
+
+    def test_foreign_marker_past_grace_exits_5(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """review-fix #01 (finding #1): a foreign token that persists the whole
+        startup grace (our seed never claims) → supersession."""
         with patch.object(quality_gate, "_read_seed_marker", return_value={"token": "other", "state": "running"}):
             assert quality_gate.seed_testmon_follow("t") == 5
         out = capsys.readouterr().out.lower()
+        assert "waiting for baseline refresh" in out  # grace polled first
         assert "fresher baseline refresh" in out and "safe to close" in out
+
+    def test_stale_foreign_marker_then_own_claim_streams_progress(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """review-fix #01 (finding #1) MUST-FIX: a stale foreign marker present at
+        startup must NOT trigger a spurious exit 5 — once our own seed claims the
+        marker within the grace window we stream our own progress to completion."""
+        stale = {"token": "prev-task", "state": "running", "pid": 7}
+        mine_running = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
+        mine_ok = {"token": "t", "state": "ok"}
+        with (
+            patch.object(
+                quality_gate,
+                "_read_seed_marker",
+                side_effect=[stale, stale, mine_running, mine_ok],
+            ),
+            patch.object(quality_gate, "_pid_alive", return_value=True),
+            patch.object(quality_gate, "_print_seed_progress") as mock_prog,
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 0
+        out = capsys.readouterr().out.lower()
+        assert "waiting for baseline refresh" in out  # tolerated the stale marker
+        assert "fresher baseline" not in out  # no spurious supersession
+        mock_prog.assert_called_once()  # streamed our own progress
+        assert "safe to close" in out
+
+    def test_own_token_then_foreign_exits_5(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """review-fix #01 (finding #1): our token owned the marker, then a newer
+        run replaced it → genuine supersession (exit 5)."""
+        mine = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
+        newer = {"token": "newer", "state": "running", "pid": 99}
+        with (
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[mine, newer]),
+            patch.object(quality_gate, "_pid_alive", return_value=True),
+            patch.object(quality_gate, "_print_seed_progress"),
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 5
+        assert "fresher baseline refresh" in capsys.readouterr().out.lower()
 
     def test_incomplete_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch.object(quality_gate, "_read_seed_marker", return_value={"token": "t", "state": "incomplete"}):
@@ -4246,6 +4326,29 @@ class TestSeedFollowCli:
             quality_gate.main()
         assert exc.value.code == 2
         assert "--seed-testmon-follow requires --seed-token" in capsys.readouterr().err
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t"], ids=["empty", "spaces", "tab"])
+    @pytest.mark.parametrize(
+        "mode",
+        [["--seed-testmon", "--detached"], ["--seed-testmon-follow"]],
+        ids=["seed", "follow"],
+    )
+    def test_empty_or_whitespace_token_exits_2(
+        self, blank: str, mode: list[str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """review-fix #01 (finding #3): a blank --seed-token is rejected for BOTH
+        subcommands (never silently treated as absent vs literal)."""
+        with (
+            patch("sys.argv", ["quality_gate.py", *mode, "--seed-token", blank]),
+            patch.object(quality_gate, "seed_testmon") as mock_seed,
+            patch.object(quality_gate, "seed_testmon_follow") as mock_follow,
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == 2
+        assert "--seed-token must not be empty or whitespace" in capsys.readouterr().err
+        mock_seed.assert_not_called()
+        mock_follow.assert_not_called()
 
     @pytest.mark.parametrize(
         "argv",

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -4110,14 +4110,18 @@ class TestSeedTestmonFollow:
                     quality_gate.seed_testmon_follow("t")
                 assert buf.getvalue().isascii(), m
 
-    def test_foreign_marker_past_grace_exits_5(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """review-fix #01 (finding #1): a foreign token that persists the whole
-        startup grace (our seed never claims) → supersession."""
+    def test_foreign_marker_past_grace_exits_5_unconfirmed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """review-fix #01/#02 (findings #1/#3): a foreign token that persists the
+        whole startup grace (our seed never claims) → exit 5 with the SOFTENED
+        "could not confirm" message (it may just be a slow cold-start), not a
+        definite supersession."""
         with patch.object(quality_gate, "_read_seed_marker", return_value={"token": "other", "state": "running"}):
             assert quality_gate.seed_testmon_follow("t") == 5
         out = capsys.readouterr().out.lower()
         assert "waiting for baseline refresh" in out  # grace polled first
-        assert "fresher baseline refresh" in out and "safe to close" in out
+        assert "could not confirm" in out and "--seed-testmon-status" in out
+        assert "safe to close" in out
+        assert out.isascii()
 
     def test_stale_foreign_marker_then_own_claim_streams_progress(
         self, capsys: pytest.CaptureFixture[str]
@@ -4145,17 +4149,39 @@ class TestSeedTestmonFollow:
         assert "safe to close" in out
 
     def test_own_token_then_foreign_exits_5(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """review-fix #01 (finding #1): our token owned the marker, then a newer
-        run replaced it → genuine supersession (exit 5)."""
+        """review-fix #01/#02 (finding #1): our token owned the marker, then a
+        newer run replaced it (still `running`, never our terminal) → genuine
+        supersession (exit 5). The superseded-path re-read (finding #1, #02) also
+        sees the foreign token."""
         mine = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
         newer = {"token": "newer", "state": "running", "pid": 99}
         with (
-            patch.object(quality_gate, "_read_seed_marker", side_effect=[mine, newer]),
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[mine, newer, newer]),
             patch.object(quality_gate, "_pid_alive", return_value=True),
             patch.object(quality_gate, "_print_seed_progress"),
         ):
             assert quality_gate.seed_testmon_follow("t") == 5
         assert "fresher baseline refresh" in capsys.readouterr().out.lower()
+
+    def test_own_token_ok_overwritten_by_foreign_reports_completion(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """review-fix #02 (finding #1) SHOULD-FIX: a run that completed `ok(T)`
+        but whose marker was overwritten by a parallel `running(U)` before the
+        next poll must report COMPLETION (exit 0), not "superseded" — the
+        superseded-path re-read observes our own terminal `ok`."""
+        mine_running = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
+        foreign = {"token": "U", "state": "running", "pid": 99}
+        mine_ok = {"token": "t", "state": "ok"}
+        with (
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[mine_running, foreign, mine_ok]),
+            patch.object(quality_gate, "_pid_alive", return_value=True),
+            patch.object(quality_gate, "_print_seed_progress"),
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 0
+        out = capsys.readouterr().out.lower()
+        assert "safe to close" in out
+        assert "fresher baseline" not in out  # NOT misreported as superseded
 
     def test_incomplete_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch.object(quality_gate, "_read_seed_marker", return_value={"token": "t", "state": "incomplete"}):
@@ -4234,11 +4260,12 @@ class TestSeedTestmonFollow:
         assert "safe to close" in capsys.readouterr().out.lower()
 
     def test_running_dead_then_superseded(self) -> None:
-        """R1 re-poll: token flips (superseded) → exit 5, handled at loop top."""
+        """R1 re-poll: token flips (superseded) → exit 5. Reads: initial dead,
+        R1 re-read (new), loop-top (new), superseded-path re-read (new)."""
         dead = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
         new = {"token": "new", "state": "running"}
         with (
-            patch.object(quality_gate, "_read_seed_marker", side_effect=[dead, new, new]),
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[dead, new, new, new]),
             patch.object(quality_gate, "_pid_alive", return_value=False),
         ):
             assert quality_gate.seed_testmon_follow("t") == 5
@@ -4252,6 +4279,38 @@ class TestSeedTestmonFollow:
             assert quality_gate.seed_testmon_follow("t") == 1
         # a missing pid never reaches the syscall seam in the first observation.
         mock_alive.assert_not_called()
+
+    def test_repoll_running_alive_loops_then_completes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """review-fix #02 (finding #9): the R1 re-poll branch where the re-read is
+        running + my token + pid ALIVE falls through to `continue`; the follower
+        loops once more and then exits 0 on a terminal `ok`."""
+        running = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
+        ok = {"token": "t", "state": "ok"}
+        with (
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[running, running, ok]),
+            # initial observation dead → R1 re-poll; re-read alive → continue.
+            patch.object(quality_gate, "_pid_alive", side_effect=[False, True]),
+            patch.object(quality_gate, "_print_seed_progress"),
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 0
+        assert "safe to close" in capsys.readouterr().out.lower()
+
+    def test_deadline_enforced_on_all_paths_exits_4(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """review-fix #02 (finding #4): the max-wait deadline is checked at the TOP
+        of the loop, so even a flapping marker (None <-> running) that never
+        reaches a terminal state eventually returns exit 4."""
+        running = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
+        big = quality_gate._SEED_FOLLOW_MAX_WAIT_S + 1
+        with (
+            # deadline calc(0), iter1 top(0), iter2 top(0), iter3 top(big)->exit 4
+            patch.object(quality_gate.time, "monotonic", side_effect=[0.0, 0.0, 0.0, big]),
+            # iter1: running(alive) → progress; iter2: None(owned) → re-read running → continue
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[running, None, running]),
+            patch.object(quality_gate, "_pid_alive", return_value=True),
+            patch.object(quality_gate, "_print_seed_progress"),
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 4
+        assert "still running after 45m" in capsys.readouterr().out.lower()
 
     def test_startup_grace_then_exit_3(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch.object(quality_gate, "_read_seed_marker", return_value=None):
@@ -4373,8 +4432,6 @@ class TestSeedFollowCli:
     @pytest.mark.parametrize(
         "conflict",
         [
-            ["--seed-testmon"],
-            ["--seed-testmon-status"],
             ["--impacted"],
             ["--cache"],
             ["--no-cache"],
@@ -4382,9 +4439,11 @@ class TestSeedFollowCli:
             ["--fix"],
             ["--quick", "tests/test_x.py"],
         ],
-        ids=["seed", "status", "impacted", "cache", "no-cache", "full", "fix", "quick"],
+        ids=["impacted", "cache", "no-cache", "full", "fix", "quick"],
     )
     def test_follow_mutex_exits_2(self, conflict: list[str], capsys: pytest.CaptureFixture[str]) -> None:
+        """--seed-testmon-follow vs an execution mode (seed-mode pairs are covered
+        by test_seed_modes_pairwise_mutex_exits_2)."""
         with (
             patch("sys.argv", ["quality_gate.py", "--seed-testmon-follow", "--seed-token", "T", *conflict]),
             patch.object(quality_gate, "seed_testmon_follow") as mock_follow,
@@ -4392,9 +4451,40 @@ class TestSeedFollowCli:
         ):
             quality_gate.main()
         assert exc.value.code == 2
-        # the error may come from an earlier subcommand's mutex, but must be a
-        # usage error that prevents the follower from running.
-        assert "you cannot combine" in capsys.readouterr().err
+        assert "you cannot combine --seed-testmon-follow with" in capsys.readouterr().err
+        mock_follow.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "pair",
+        [
+            ["--seed-testmon", "--seed-testmon-status"],
+            ["--seed-testmon", "--seed-testmon-follow", "--seed-token", "T"],
+            ["--seed-testmon-status", "--seed-testmon-follow", "--seed-token", "T"],
+            # reversed order — the centralized check is order-independent.
+            ["--seed-testmon-status", "--seed-testmon"],
+            ["--seed-testmon-follow", "--seed-token", "T", "--seed-testmon"],
+            ["--seed-testmon-follow", "--seed-token", "T", "--seed-testmon-status"],
+        ],
+        ids=["seed+status", "seed+follow", "status+follow", "status+seed", "follow+seed", "follow+status"],
+    )
+    def test_seed_modes_pairwise_mutex_exits_2(
+        self, pair: list[str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """review-fix #02 (finding #2): the three seed subcommands are pairwise
+        mutually exclusive via ONE centralized, order-independent check — neither
+        the seed side nor the follow side silently wins."""
+        with (
+            patch("sys.argv", ["quality_gate.py", *pair]),
+            patch.object(quality_gate, "seed_testmon") as mock_seed,
+            patch.object(quality_gate, "seed_testmon_status") as mock_status,
+            patch.object(quality_gate, "seed_testmon_follow") as mock_follow,
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == 2
+        assert "mutually exclusive" in capsys.readouterr().err
+        mock_seed.assert_not_called()
+        mock_status.assert_not_called()
         mock_follow.assert_not_called()
 
 
@@ -4490,7 +4580,6 @@ class TestImpactedCli:
     @pytest.mark.parametrize(
         "conflict",
         [
-            ["--seed-testmon"],
             ["--impacted"],
             ["--cache"],
             ["--no-cache"],
@@ -4498,12 +4587,13 @@ class TestImpactedCli:
             ["--fix"],
             ["--quick", "tests/test_x.py"],
         ],
-        ids=["seed", "impacted", "cache", "no-cache", "full", "fix", "quick"],
+        ids=["impacted", "cache", "no-cache", "full", "fix", "quick"],
     )
     def test_seed_testmon_status_mutex_exits_2(
         self, conflict: list[str], capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """AC#5: --seed-testmon-status combined with any mode is a usage error."""
+        """AC#5: --seed-testmon-status combined with an execution mode is a usage
+        error (seed-mode pairs → test_seed_modes_pairwise_mutex_exits_2)."""
         with (
             patch("sys.argv", ["quality_gate.py", "--seed-testmon-status", *conflict]),
             patch.object(quality_gate, "seed_testmon_status") as mock_status,

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import sqlite3
 import subprocess
 import sys
@@ -3553,6 +3554,747 @@ class TestSeedTestmonStatus:
         mock_rebuild.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# QS-299 — inline follower + last-wins preemption
+# ---------------------------------------------------------------------------
+
+
+import contextlib as _contextlib  # noqa: E402 — local alias for the fake-lock helper
+
+
+@_contextlib.contextmanager
+def _fake_lock(acquired: bool):
+    """A stand-in for `quality_gate._seed_lock()` yielding a fixed acquired flag."""
+    yield acquired
+
+
+def _fake_lock_factory(acquired: bool):
+    """Return a no-arg callable producing a `_fake_lock(acquired)` context manager."""
+    return lambda: _fake_lock(acquired)
+
+
+class TestReadSeedMarker:
+    """QS-299: `_read_seed_marker` — tolerant JSON-object reader (None otherwise)."""
+
+    @pytest.fixture(autouse=True)
+    def _redirect(self, tmp_path: Path):
+        with patch.object(quality_gate, "SEED_STATUS", tmp_path / ".testmondata.seed-status"):
+            yield
+
+    def test_missing_returns_none(self) -> None:
+        assert quality_gate._read_seed_marker() is None
+
+    def test_unparseable_returns_none(self) -> None:
+        quality_gate.SEED_STATUS.write_text("{not json")
+        assert quality_gate._read_seed_marker() is None
+
+    @pytest.mark.parametrize("payload", [5, "x", None, [1], 3.14], ids=["int", "str", "null", "arr", "float"])
+    def test_non_dict_returns_none(self, payload: object) -> None:
+        quality_gate.SEED_STATUS.write_text(json.dumps(payload))
+        assert quality_gate._read_seed_marker() is None
+
+    def test_valid_dict_returned(self) -> None:
+        quality_gate.SEED_STATUS.write_text(json.dumps({"state": "ok", "token": "t"}))
+        assert quality_gate._read_seed_marker() == {"state": "ok", "token": "t"}
+
+    def test_status_keeps_distinct_missing_vs_unreadable(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """AC#7: the extraction must NOT collapse the two distinct messages."""
+        assert quality_gate.seed_testmon_status() == 3
+        assert "no baseline refresh" in capsys.readouterr().out.lower()
+        quality_gate.SEED_STATUS.write_text("{not json")
+        assert quality_gate.seed_testmon_status() == 3
+        assert "unreadable" in capsys.readouterr().out.lower()
+
+
+class TestSeedLock:
+    """QS-299: `_seed_lock` — best-effort advisory lock (yields acquired flag)."""
+
+    @pytest.fixture(autouse=True)
+    def _redirect(self, tmp_path: Path):
+        with patch.object(quality_gate, "SEED_STATUS", tmp_path / ".testmondata.seed-status"):
+            yield
+
+    def test_lock_path_tracks_seed_status(self) -> None:
+        assert quality_gate._seed_lock_path() == quality_gate.SEED_STATUS.with_suffix(
+            quality_gate.SEED_STATUS.suffix + ".lock"
+        )
+
+    def test_acquires_when_free(self) -> None:
+        with quality_gate._seed_lock() as locked:
+            assert locked is True
+
+    def test_yields_false_when_flock_busy(self) -> None:
+        with (
+            patch.object(quality_gate.fcntl, "flock", side_effect=OSError("busy")),
+            quality_gate._seed_lock() as locked,
+        ):
+            assert locked is False
+
+    def test_yields_false_when_lockfile_unopenable(self, tmp_path: Path) -> None:
+        bad = tmp_path / "nonexistent-dir" / "x.seed-status"
+        with (
+            patch.object(quality_gate, "SEED_STATUS", bad),
+            quality_gate._seed_lock() as locked,
+        ):
+            assert locked is False
+
+    def test_releases_and_propagates_body_exception(self) -> None:
+        """A body exception must propagate (lock still released via finally)."""
+        with pytest.raises(ValueError):  # noqa: PT011
+            with quality_gate._seed_lock() as locked:
+                assert locked is True
+                raise ValueError("boom")
+        # Lock is free again — can re-acquire.
+        with quality_gate._seed_lock() as locked:
+            assert locked is True
+
+
+class TestDetachSession:
+    """QS-299 AC#4: `_detach_session` — setsid + pgid-when-group-leader."""
+
+    def test_records_pgid_on_setsid_success(self) -> None:
+        with (
+            patch.object(quality_gate.os, "setsid") as mock_setsid,
+            patch.object(quality_gate.os, "getpgrp", return_value=4242),
+            patch.object(quality_gate.os, "getpid", return_value=4242),
+        ):
+            assert quality_gate._detach_session() == 4242
+        mock_setsid.assert_called_once_with()
+
+    def test_records_pgid_on_setsid_eperm_already_leader(self) -> None:
+        """setsid raises EPERM when we already lead a group — still record it."""
+        with (
+            patch.object(quality_gate.os, "setsid", side_effect=OSError("EPERM")),
+            patch.object(quality_gate.os, "getpgrp", return_value=99),
+            patch.object(quality_gate.os, "getpid", return_value=99),
+        ):
+            assert quality_gate._detach_session() == 99
+
+    def test_no_pgid_when_not_group_leader(self) -> None:
+        with (
+            patch.object(quality_gate.os, "setsid"),
+            patch.object(quality_gate.os, "getpgrp", return_value=1),
+            patch.object(quality_gate.os, "getpid", return_value=2),
+        ):
+            assert quality_gate._detach_session() is None
+
+
+class TestTerminateProcessGroup:
+    """QS-299 AC#3: `_terminate_process_group` — killpg-when-pgid else kill; best-effort."""
+
+    def test_killpg_when_pgid(self) -> None:
+        with patch.object(quality_gate.os, "killpg") as mock_killpg:
+            quality_gate._terminate_process_group(500, 501)
+        mock_killpg.assert_called_once_with(500, signal.SIGTERM)
+
+    def test_kill_when_no_pgid(self) -> None:
+        with patch.object(quality_gate.os, "kill") as mock_kill:
+            quality_gate._terminate_process_group(None, 777)
+        mock_kill.assert_called_once_with(777, signal.SIGTERM)
+
+    @pytest.mark.parametrize(
+        "exc", [ProcessLookupError, PermissionError, OverflowError, ValueError, TypeError, OSError]
+    )
+    def test_best_effort_never_raises(self, exc: type[Exception]) -> None:
+        with patch.object(quality_gate.os, "killpg", side_effect=exc):
+            quality_gate._terminate_process_group(1, 2)  # must not raise
+        with patch.object(quality_gate.os, "kill", side_effect=exc):
+            quality_gate._terminate_process_group(None, 2)  # must not raise
+
+    def test_emits_one_diagnostic(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(quality_gate.os, "killpg"):
+            quality_gate._terminate_process_group(3, 4)
+        assert "preempting previous baseline refresh" in capsys.readouterr().err
+
+
+class TestFindRunningPredecessor:
+    """QS-299: `_find_running_predecessor` selection rules."""
+
+    @pytest.fixture(autouse=True)
+    def _redirect(self, tmp_path: Path):
+        with patch.object(quality_gate, "SEED_STATUS", tmp_path / ".testmondata.seed-status"):
+            yield
+
+    def _write(self, marker: object) -> None:
+        quality_gate.SEED_STATUS.write_text(json.dumps(marker))
+
+    def test_none_when_no_marker(self) -> None:
+        assert quality_gate._find_running_predecessor("me") is None
+
+    def test_live_foreign_running_returns_pid_pgid(self) -> None:
+        self._write({"state": "running", "token": "other", "pid": 42, "pgid": 40})
+        with patch.object(quality_gate, "_pid_alive", return_value=True):
+            assert quality_gate._find_running_predecessor("me") == (42, 40)
+
+    def test_no_pgid_field_returns_pid_none(self) -> None:
+        self._write({"state": "running", "token": "other", "pid": 42})
+        with patch.object(quality_gate, "_pid_alive", return_value=True):
+            assert quality_gate._find_running_predecessor("me") == (42, None)
+
+    def test_same_token_returns_none(self) -> None:
+        self._write({"state": "running", "token": "me", "pid": 42})
+        with patch.object(quality_gate, "_pid_alive", return_value=True):
+            assert quality_gate._find_running_predecessor("me") is None
+
+    def test_dead_pid_returns_none(self) -> None:
+        self._write({"state": "running", "token": "other", "pid": 42})
+        with patch.object(quality_gate, "_pid_alive", return_value=False):
+            assert quality_gate._find_running_predecessor("me") is None
+
+    def test_non_running_state_returns_none(self) -> None:
+        self._write({"state": "ok", "token": "other", "pid": 42})
+        assert quality_gate._find_running_predecessor("me") is None
+
+    @pytest.mark.parametrize("pid", [None, "x", 0, -1, True, 1.5], ids=["none", "str", "zero", "neg", "bool", "float"])
+    def test_bad_pid_returns_none(self, pid: object) -> None:
+        self._write({"state": "running", "token": "other", "pid": pid})
+        assert quality_gate._find_running_predecessor("me") is None
+
+    @pytest.mark.parametrize("pgid", [0, -1, True, "x", 1.5], ids=["zero", "neg", "bool", "str", "float"])
+    def test_bad_pgid_falls_back_to_none(self, pgid: object) -> None:
+        self._write({"state": "running", "token": "other", "pid": 42, "pgid": pgid})
+        with patch.object(quality_gate, "_pid_alive", return_value=True):
+            assert quality_gate._find_running_predecessor("me") == (42, None)
+
+
+class TestClaimAndPreempt:
+    """QS-299 AC#3: read→claim→kill under the lock; lock-fail skips preemption."""
+
+    @pytest.fixture(autouse=True)
+    def _redirect(self, tmp_path: Path):
+        with patch.object(quality_gate, "SEED_STATUS", tmp_path / ".testmondata.seed-status"):
+            yield
+
+    def _marker(self) -> dict:
+        return json.loads(quality_gate.SEED_STATUS.read_text())
+
+    def test_claims_and_preempts_in_order(self) -> None:
+        order: list[str] = []
+        with (
+            patch.object(quality_gate, "_seed_lock", _fake_lock_factory(True)),
+            patch.object(quality_gate, "_find_running_predecessor", return_value=(42, 40)),
+            patch.object(
+                quality_gate,
+                "_write_seed_status",
+                side_effect=lambda *a, **k: order.append("claim"),
+            ),
+            patch.object(
+                quality_gate,
+                "_terminate_process_group",
+                side_effect=lambda *a, **k: order.append("kill"),
+            ) as mock_kill,
+        ):
+            quality_gate._claim_and_preempt("me", 100, 90, 1.0)
+        assert order == ["claim", "kill"], "claim must be written BEFORE the kill"
+        mock_kill.assert_called_once_with(40, 42)
+
+    def test_no_predecessor_no_kill(self) -> None:
+        with (
+            patch.object(quality_gate, "_seed_lock", _fake_lock_factory(True)),
+            patch.object(quality_gate, "_find_running_predecessor", return_value=None),
+            patch.object(quality_gate, "_terminate_process_group") as mock_kill,
+        ):
+            quality_gate._claim_and_preempt("me", 100, 90, 1.0)
+        mock_kill.assert_not_called()
+        marker = self._marker()
+        assert marker["state"] == "running" and marker["token"] == "me"
+        assert marker["pid"] == 100 and marker["pgid"] == 90
+
+    def test_no_pgid_field_when_pgid_none(self) -> None:
+        with (
+            patch.object(quality_gate, "_seed_lock", _fake_lock_factory(True)),
+            patch.object(quality_gate, "_find_running_predecessor", return_value=None),
+        ):
+            quality_gate._claim_and_preempt("me", 100, None, 1.0)
+        assert "pgid" not in self._marker()
+
+    def test_lock_busy_skips_preemption_but_claims(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch.object(quality_gate, "_seed_lock", _fake_lock_factory(False)),
+            patch.object(quality_gate, "_find_running_predecessor") as mock_find,
+            patch.object(quality_gate, "_terminate_process_group") as mock_kill,
+        ):
+            quality_gate._claim_and_preempt("me", 100, 90, 1.0)
+        mock_find.assert_not_called()
+        mock_kill.assert_not_called()
+        assert self._marker()["state"] == "running"
+        assert "skipping preemption" in capsys.readouterr().err
+
+
+class TestWriteCompletionIfOwner:
+    """QS-299 AC#5: token-guarded completion write."""
+
+    @pytest.fixture(autouse=True)
+    def _redirect(self, tmp_path: Path):
+        with patch.object(quality_gate, "SEED_STATUS", tmp_path / ".testmondata.seed-status"):
+            yield
+
+    def test_writes_when_token_matches(self) -> None:
+        quality_gate.SEED_STATUS.write_text(json.dumps({"state": "running", "token": "me"}))
+        with patch.object(quality_gate, "_seed_lock", _fake_lock_factory(True)):
+            quality_gate._write_completion_if_owner("me", "ok", returncode=0)
+        marker = json.loads(quality_gate.SEED_STATUS.read_text())
+        assert marker == {"state": "ok", "token": "me", "returncode": 0}
+
+    def test_skips_when_token_differs(self) -> None:
+        quality_gate.SEED_STATUS.write_text(json.dumps({"state": "running", "token": "winner"}))
+        with patch.object(quality_gate, "_seed_lock", _fake_lock_factory(True)):
+            quality_gate._write_completion_if_owner("me", "ok", returncode=0)
+        # Winner's marker untouched.
+        assert json.loads(quality_gate.SEED_STATUS.read_text())["token"] == "winner"
+
+    def test_skips_when_marker_missing(self) -> None:
+        with patch.object(quality_gate, "_seed_lock", _fake_lock_factory(True)):
+            quality_gate._write_completion_if_owner("me", "ok", returncode=0)
+        assert not quality_gate.SEED_STATUS.exists()
+
+
+class TestSeedTestmonTokenPreemption:
+    """QS-299: `seed_testmon(token, detached)` wiring — token invariant,
+    detach gating, preemption, token-guarded completion."""
+
+    @pytest.fixture(autouse=True)
+    def _stub(self, tmp_path: Path):
+        with (
+            patch.object(quality_gate, "_rebuild_testmon_baseline"),
+            patch.object(quality_gate, "SEED_STATUS", tmp_path / ".testmondata.seed-status"),
+            patch.object(quality_gate, "_seed_lock", _fake_lock_factory(True)),
+        ):
+            yield
+
+    def _marker(self) -> dict:
+        return json.loads(quality_gate.SEED_STATUS.read_text())
+
+    def test_uses_given_token_end_to_end(self) -> None:
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["S"]),
+            patch.object(quality_gate, "_find_running_predecessor", return_value=None),
+            patch.object(quality_gate, "_stream_pytest", return_value={"returncode": 0}),
+        ):
+            assert quality_gate.seed_testmon(token="tok123") == 0
+        assert self._marker()["token"] == "tok123"
+
+    def test_generates_token_when_absent(self) -> None:
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["S"]),
+            patch.object(quality_gate, "_find_running_predecessor", return_value=None),
+            patch.object(quality_gate, "_stream_pytest", return_value={"returncode": 0}),
+        ):
+            assert quality_gate.seed_testmon() == 0
+        token = self._marker()["token"]
+        assert isinstance(token, str) and len(token) == 32  # uuid4().hex
+
+    def test_skipped_marker_carries_token(self) -> None:
+        with patch.object(quality_gate, "_testmon_available", return_value=False):
+            assert quality_gate.seed_testmon(token="tokX") == 3
+        marker = self._marker()
+        assert marker["state"] == "skipped" and marker["token"] == "tokX"
+
+    def test_detached_true_calls_setsid_and_records_pgid(self) -> None:
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["S"]),
+            patch.object(quality_gate, "_find_running_predecessor", return_value=None),
+            patch.object(quality_gate, "_detach_session", return_value=555) as mock_detach,
+            patch.object(quality_gate, "_stream_pytest", return_value={"returncode": 0}),
+        ):
+            # capture the running marker mid-pass (completion marker drops pgid).
+            seen: dict = {}
+            with patch.object(
+                quality_gate,
+                "_stream_pytest",
+                side_effect=lambda *a, **k: (seen.update(self._marker()), {"returncode": 0})[1],
+            ):
+                assert quality_gate.seed_testmon(token="t", detached=True) == 0
+        mock_detach.assert_called_once_with()
+        assert seen["pgid"] == 555
+
+    def test_detached_false_skips_setsid(self) -> None:
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["S"]),
+            patch.object(quality_gate, "_find_running_predecessor", return_value=None),
+            patch.object(quality_gate, "_detach_session") as mock_detach,
+            patch.object(quality_gate, "_stream_pytest", return_value={"returncode": 0}),
+        ):
+            assert quality_gate.seed_testmon(token="t", detached=False) == 0
+        mock_detach.assert_not_called()
+
+    def test_preempts_live_predecessor(self) -> None:
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["S"]),
+            patch.object(quality_gate, "_find_running_predecessor", return_value=(42, 40)),
+            patch.object(quality_gate, "_terminate_process_group") as mock_kill,
+            patch.object(quality_gate, "_stream_pytest", return_value={"returncode": 0}),
+        ):
+            assert quality_gate.seed_testmon(token="t2") == 0
+        mock_kill.assert_called_once_with(40, 42)
+
+    def test_completion_write_is_token_guarded(self) -> None:
+        """AC#5: a preempted run (marker flipped to a foreign token during the
+        pass) must NOT clobber the winner's marker on completion."""
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_build_seed_testmon_cmd", return_value=["S"]),
+            patch.object(quality_gate, "_find_running_predecessor", return_value=None),
+            patch.object(
+                quality_gate,
+                "_stream_pytest",
+                # a fresher seed claims the marker while we run.
+                side_effect=lambda *a, **k: (
+                    quality_gate.SEED_STATUS.write_text(
+                        json.dumps({"state": "running", "token": "winner"})
+                    ),
+                    {"returncode": 0},
+                )[1],
+            ),
+        ):
+            assert quality_gate.seed_testmon(token="loser") == 0
+        assert json.loads(quality_gate.SEED_STATUS.read_text())["token"] == "winner"
+
+
+class TestParseSeedProgress:
+    """QS-299 AC#2: last-match parse of the live `_stream_pytest` progress format."""
+
+    def test_parses_live_captured_format(self) -> None:
+        # The exact line _stream_pytest synthesizes under -n auto (captured live).
+        line = "  pytest: 21% (72/330) | passed=72 failed=0 errors=0\n"
+        assert quality_gate._parse_seed_progress(line) == (21, 72, 330)
+
+    def test_takes_last_match(self) -> None:
+        log = (
+            "  pytest: 21% (72/330) | passed=72 failed=0 errors=0\n"
+            "  pytest: 65% (216/330) | passed=216 failed=0 errors=0\n"
+        )
+        assert quality_gate._parse_seed_progress(log) == (65, 216, 330)
+
+    def test_does_not_match_done_line(self) -> None:
+        assert quality_gate._parse_seed_progress("  pytest: done (330/330) | passed=329\n") is None
+
+    def test_none_when_empty(self) -> None:
+        assert quality_gate._parse_seed_progress("") is None
+
+    def test_production_format_still_parses(self) -> None:
+        """Regression tripwire: if `_stream_pytest`'s format drifts, this breaks."""
+        # Reconstruct the exact production f-string.
+        pct, current, total, lp, lf, le = 43, 144, 330, 144, 0, 0
+        line = f"  pytest: {pct}% ({current}/{total}) | passed={lp} failed={lf} errors={le}\n"
+        assert quality_gate._parse_seed_progress(line) == (43, 144, 330)
+
+
+class TestFmtElapsed:
+    """QS-299: `_fmt_elapsed` renders mm:ss."""
+
+    @pytest.mark.parametrize(
+        ("seconds", "expected"),
+        [(0, "00:00"), (5, "00:05"), (65, "01:05"), (3661, "61:01"), (-3, "00:00")],
+    )
+    def test_formats(self, seconds: float, expected: str) -> None:
+        assert quality_gate._fmt_elapsed(seconds) == expected
+
+
+class TestMarkerElapsed:
+    """QS-299 AC#2: wall-clock elapsed from `started`."""
+
+    def test_now_minus_started(self) -> None:
+        with patch.object(quality_gate.time, "time", return_value=100.0):
+            assert quality_gate._marker_elapsed({"started": 40.0}) == 60.0
+
+    @pytest.mark.parametrize(
+        "started", [None, "x", True, float("inf"), float("nan"), 10**400], ids=["none", "str", "bool", "inf", "nan", "huge"]
+    )
+    def test_bad_started_is_zero(self, started: object) -> None:
+        with patch.object(quality_gate.time, "time", return_value=100.0):
+            assert quality_gate._marker_elapsed({"started": started}) == 0.0
+
+    def test_never_negative(self) -> None:
+        with patch.object(quality_gate.time, "time", return_value=10.0):
+            assert quality_gate._marker_elapsed({"started": 40.0}) == 0.0
+
+
+class TestPrintSeedProgress:
+    """QS-299 AC#2: progress line format + degraded fallback."""
+
+    def test_full_format(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch.object(quality_gate, "_read_seed_log_tail", return_value="  pytest: 21% (72/330) | x\n"),
+            patch.object(quality_gate, "_marker_elapsed", return_value=65.0),
+        ):
+            quality_gate._print_seed_progress({"started": 1.0})
+        out = capsys.readouterr().out
+        assert "refreshing baseline: 72/330 tests (21%) · elapsed 01:05" in out
+
+    def test_degraded_when_unparseable(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch.object(quality_gate, "_read_seed_log_tail", return_value="no progress here"),
+            patch.object(quality_gate, "_marker_elapsed", return_value=5.0),
+        ):
+            quality_gate._print_seed_progress({"started": 1.0})
+        out = capsys.readouterr().out
+        assert "refreshing baseline: elapsed 00:05" in out
+        assert "tests" not in out
+
+
+class TestReadSeedLogTail:
+    """QS-299: `_read_seed_log_tail` — best-effort read."""
+
+    def test_reads_content(self, tmp_path: Path) -> None:
+        log = tmp_path / "seed.log"
+        log.write_text("hello")
+        with patch.object(quality_gate, "SEED_LOG", log):
+            assert quality_gate._read_seed_log_tail() == "hello"
+
+    def test_missing_returns_empty(self, tmp_path: Path) -> None:
+        with patch.object(quality_gate, "SEED_LOG", tmp_path / "nope.log"):
+            assert quality_gate._read_seed_log_tail() == ""
+
+
+class TestSeedTestmonFollow:
+    """QS-299 AC#1/#2: the inline follower's exit table + progress line."""
+
+    @pytest.fixture(autouse=True)
+    def _seams(self, tmp_path: Path):
+        """Redirect SEED_STATUS + neutralize sleep; each test drives the clock
+        and marker reads via its own patches."""
+        with (
+            patch.object(quality_gate, "SEED_STATUS", tmp_path / ".testmondata.seed-status"),
+            patch.object(quality_gate.time, "sleep"),
+            patch.object(quality_gate.time, "monotonic", return_value=0.0),
+        ):
+            yield
+
+    def test_ok_exits_0(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(quality_gate, "_read_seed_marker", return_value={"token": "t", "state": "ok"}):
+            assert quality_gate.seed_testmon_follow("t") == 0
+        assert "safe to close" in capsys.readouterr().out.lower()
+
+    def test_superseded_exits_5(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(quality_gate, "_read_seed_marker", return_value={"token": "other", "state": "running"}):
+            assert quality_gate.seed_testmon_follow("t") == 5
+        out = capsys.readouterr().out.lower()
+        assert "fresher baseline refresh" in out and "safe to close" in out
+
+    def test_incomplete_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(quality_gate, "_read_seed_marker", return_value={"token": "t", "state": "incomplete"}):
+            assert quality_gate.seed_testmon_follow("t") == 1
+        assert "may be partial" in capsys.readouterr().out.lower()
+
+    def test_skipped_exits_1_benign(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(
+            quality_gate,
+            "_read_seed_marker",
+            return_value={"token": "t", "state": "skipped", "reason": "no testmon"},
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 1
+        out = capsys.readouterr().out.lower()
+        assert "skipped" in out and "no baseline was written" in out and "safe to close" in out
+
+    def test_unknown_state_exits_3(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(quality_gate, "_read_seed_marker", return_value={"token": "t", "state": "bogus"}):
+            assert quality_gate.seed_testmon_follow("t") == 3
+        assert "unreadable" in capsys.readouterr().out.lower()
+
+    def test_running_alive_prints_progress_then_completes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        markers = [
+            {"token": "t", "state": "running", "pid": 42, "started": 1.0},
+            {"token": "t", "state": "ok"},
+        ]
+        with (
+            patch.object(quality_gate, "_read_seed_marker", side_effect=markers),
+            patch.object(quality_gate, "_pid_alive", return_value=True),
+            patch.object(quality_gate, "_print_seed_progress") as mock_prog,
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 0
+        mock_prog.assert_called_once()
+        assert "safe to close" in capsys.readouterr().out.lower()
+
+    def test_running_past_max_wait_exits_4(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # deadline = monotonic()[0] + MAX_WAIT; make the in-loop check exceed it.
+        with (
+            patch.object(
+                quality_gate.time,
+                "monotonic",
+                side_effect=[0.0, quality_gate._SEED_FOLLOW_MAX_WAIT_S + 1],
+            ),
+            patch.object(
+                quality_gate,
+                "_read_seed_marker",
+                return_value={"token": "t", "state": "running", "pid": 42, "started": 1.0},
+            ),
+            patch.object(quality_gate, "_pid_alive", return_value=True),
+            patch.object(quality_gate, "_print_seed_progress"),
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 4
+        out = capsys.readouterr().out.lower()
+        assert "still running after 45m" in out and "--seed-token t" in out
+
+    def test_running_dead_confirmed_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """R1 re-poll: dead pid confirmed on re-read → interrupted."""
+        dead = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
+        with (
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[dead, dead]),
+            patch.object(quality_gate, "_pid_alive", return_value=False),
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 1
+        assert "may be partial" in capsys.readouterr().out.lower()
+
+    def test_running_dead_then_ok_recovers(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """R1 re-poll: marker flips to ok before we conclude interrupted (the
+        re-poll re-read + the top-of-loop re-classify both read the marker)."""
+        dead = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
+        ok = {"token": "t", "state": "ok"}
+        with (
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[dead, ok, ok]),
+            patch.object(quality_gate, "_pid_alive", return_value=False),
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 0
+        assert "safe to close" in capsys.readouterr().out.lower()
+
+    def test_running_dead_then_superseded(self) -> None:
+        """R1 re-poll: token flips (superseded) → exit 5, handled at loop top."""
+        dead = {"token": "t", "state": "running", "pid": 42, "started": 1.0}
+        new = {"token": "new", "state": "running"}
+        with (
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[dead, new, new]),
+            patch.object(quality_gate, "_pid_alive", return_value=False),
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 5
+
+    def test_running_missing_pid_treated_dead(self, capsys: pytest.CaptureFixture[str]) -> None:
+        no_pid = {"token": "t", "state": "running", "started": 1.0}
+        with (
+            patch.object(quality_gate, "_read_seed_marker", side_effect=[no_pid, no_pid]),
+            patch.object(quality_gate, "_pid_alive") as mock_alive,
+        ):
+            assert quality_gate.seed_testmon_follow("t") == 1
+        # a missing pid never reaches the syscall seam in the first observation.
+        mock_alive.assert_not_called()
+
+    def test_startup_grace_then_exit_3(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(quality_gate, "_read_seed_marker", return_value=None):
+            # SEED_STATUS never created → missing → grace exhausts → exit 3.
+            assert quality_gate.seed_testmon_follow("t") == 3
+        out = capsys.readouterr().out.lower()
+        assert "waiting for baseline refresh" in out and "unreadable" in out
+
+    def test_startup_grace_then_marker_appears(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(quality_gate, "_read_seed_marker", side_effect=[None, {"token": "t", "state": "ok"}]):
+            assert quality_gate.seed_testmon_follow("t") == 0
+        out = capsys.readouterr().out.lower()
+        assert "waiting for baseline refresh" in out and "safe to close" in out
+
+    def test_present_but_unreadable_reread_exits_3(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # marker file exists (so not startup grace) but reads as None twice.
+        quality_gate.SEED_STATUS.write_text("{not json")
+        with patch.object(quality_gate, "_read_seed_marker", return_value=None):
+            assert quality_gate.seed_testmon_follow("t") == 3
+        assert "unreadable" in capsys.readouterr().out.lower()
+
+    def test_present_but_unreadable_then_recovers(self) -> None:
+        quality_gate.SEED_STATUS.write_text("{not json")
+        ok = {"token": "t", "state": "ok"}
+        # None (present→re-read), non-None on re-read, then re-classify at loop top.
+        with patch.object(quality_gate, "_read_seed_marker", side_effect=[None, ok, ok]):
+            assert quality_gate.seed_testmon_follow("t") == 0
+
+    def test_is_read_only(self) -> None:
+        """AC#1: no pytest/coverage/testmon seam is touched."""
+        with (
+            patch.object(quality_gate, "_read_seed_marker", return_value={"token": "t", "state": "ok"}),
+            patch.object(quality_gate, "_stream_pytest") as mock_stream,
+            patch.object(quality_gate, "_testmon_available") as mock_probe,
+            patch.object(quality_gate, "_rebuild_testmon_baseline") as mock_rebuild,
+        ):
+            quality_gate.seed_testmon_follow("t")
+        mock_stream.assert_not_called()
+        mock_probe.assert_not_called()
+        mock_rebuild.assert_not_called()
+
+
+class TestSeedFollowCli:
+    """QS-299 AC#6: CLI wiring for --seed-testmon-follow/--seed-token/--detached."""
+
+    def test_follow_passthrough(self) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon-follow", "--seed-token", "T"]),
+            patch.object(quality_gate, "seed_testmon_follow", return_value=5) as mock_follow,
+            patch.object(quality_gate, "_detect_scope") as mock_scope,
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == 5
+        mock_follow.assert_called_once_with("T")
+        mock_scope.assert_not_called()
+
+    def test_seed_testmon_threads_token_and_detached(self) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon", "--detached", "--seed-token", "T"]),
+            patch.object(quality_gate, "seed_testmon", return_value=0) as mock_seed,
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+        mock_seed.assert_called_once_with(token="T", detached=True)
+
+    def test_follow_requires_token(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon-follow"]),
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == 2
+        assert "--seed-testmon-follow requires --seed-token" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--seed-token", "T"],
+            ["--seed-token", "T", "--impacted"],
+            ["--detached"],
+            ["--detached", "--seed-testmon-follow", "--seed-token", "T"],
+        ],
+        ids=["stray-token", "token-with-impacted", "stray-detached", "detached-with-follow"],
+    )
+    def test_stray_token_or_detached_exits_2(self, argv: list[str], capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", *argv]),
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        assert "only valid with" in err
+
+    @pytest.mark.parametrize(
+        "conflict",
+        [
+            ["--seed-testmon"],
+            ["--seed-testmon-status"],
+            ["--impacted"],
+            ["--cache"],
+            ["--no-cache"],
+            ["--full"],
+            ["--fix"],
+            ["--quick", "tests/test_x.py"],
+        ],
+        ids=["seed", "status", "impacted", "cache", "no-cache", "full", "fix", "quick"],
+    )
+    def test_follow_mutex_exits_2(self, conflict: list[str], capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon-follow", "--seed-token", "T", *conflict]),
+            patch.object(quality_gate, "seed_testmon_follow") as mock_follow,
+            pytest.raises(SystemExit) as exc,
+        ):
+            quality_gate.main()
+        assert exc.value.code == 2
+        # the error may come from an earlier subcommand's mutex, but must be a
+        # usage error that prevents the follower from running.
+        assert "you cannot combine" in capsys.readouterr().err
+        mock_follow.assert_not_called()
+
+
 class TestImpactedCli:
     """`main()` wiring: short-circuit, exit-code passthrough, mutex."""
 
@@ -3638,7 +4380,8 @@ class TestImpactedCli:
         ):
             quality_gate.main()
         assert exc.value.code == seed_code
-        mock_seed.assert_called_once_with()
+        # QS-299: token + detached are threaded from the CLI (defaults here).
+        mock_seed.assert_called_once_with(token=None, detached=False)
         mock_scope.assert_not_called()
 
     @pytest.mark.parametrize(
@@ -3751,6 +4494,65 @@ class TestProjectRulesDocGuards:
         assert "quality_gate.py --seed-testmon-status" in proto
         assert ".testmondata.seed.log" in proto
 
+    def test_seed_testmon_follow_documented_in_both_places(self) -> None:
+        """QS-299 AC#10: `--seed-testmon-follow` appears in BOTH the command-help
+        block AND the carve-out prose paragraph."""
+        rules = self._rules()
+        # command-help block (the runnable command line).
+        assert "quality_gate.py --seed-testmon-follow --seed-token" in rules
+        # carve-out prose: named as a read-only companion + exit-5 supersession.
+        assert "streaming follower" in rules
+        assert "superseded" in rules
+
+
+class TestFinishTaskFollowerAgents:
+    """QS-299 AC#9: all three qs-finish-task.md agents launch the tokened
+    detached seed + stream the follower inline, in lockstep."""
+
+    _AGENTS = (
+        ".claude/agents/qs-finish-task.md",
+        ".cursor/agents/qs-finish-task.md",
+        ".opencode/agents/qs-finish-task.md",
+    )
+
+    def _text(self, rel: str) -> str:
+        return (Path(__file__).resolve().parent.parent / rel).read_text()
+
+    @pytest.mark.parametrize("rel", _AGENTS)
+    def test_launches_tokened_detached_seed(self, rel: str) -> None:
+        body = self._text(rel)
+        assert "--seed-testmon --detached --seed-token" in body
+        assert "</dev/null" in body  # fully backgrounded
+
+    @pytest.mark.parametrize("rel", _AGENTS)
+    def test_no_rm_f_marker(self, rel: str) -> None:
+        """The new seed must READ the predecessor marker to preempt it — never rm."""
+        assert "rm -f \"$MAIN_DIR/.testmondata.seed-status\"" not in self._text(rel)
+
+    @pytest.mark.parametrize("rel", _AGENTS)
+    def test_streams_follower_inline(self, rel: str) -> None:
+        body = self._text(rel)
+        assert "--seed-testmon-follow --seed-token" in body
+        # foreground form is labeled conceptual only.
+        assert "conceptual only" in body
+
+    @pytest.mark.parametrize("rel", _AGENTS)
+    def test_follower_exit_is_informational(self, rel: str) -> None:
+        body = self._text(rel)
+        assert "completion signal, not a gate" in body
+
+    @pytest.mark.parametrize("rel", _AGENTS)
+    def test_hard_rules_carveout_names_follower(self, rel: str) -> None:
+        body = self._text(rel)
+        assert "`--seed-testmon-follow` is a read-only" in body
+
+    @pytest.mark.parametrize("rel", _AGENTS)
+    def test_no_residual_primary_status_instruction(self, rel: str) -> None:
+        """The old 'run --seed-testmon-status yourself from the main checkout'
+        primary path must be gone (kept only as an optional scripting fallback)."""
+        body = self._text(rel)
+        assert "run from the main checkout, $MAIN_DIR)" not in body
+
 
 class TestWorktreeSetupSeedsCaches:
     """AC#8: worktree-setup.sh copies (never symlinks) .testmondata + .mypy_cache."""
@@ -3830,30 +4632,33 @@ class TestFinishTaskRefreshesBaseline:
 
     @pytest.mark.parametrize("harness", [".claude", ".cursor", ".opencode"])
     def test_completion_signal_present(self, harness: str) -> None:
-        """QS-286 AC#7: the detached refresh deletes the stale marker, logs to
-        `.testmondata.seed.log`, and points the user at --seed-testmon-status."""
+        """QS-299 (supersedes QS-286): the detached refresh logs to
+        `.testmondata.seed.log`, streams the follower inline, and culminates in
+        a "safe to close this terminal" verdict — WITHOUT the old rm -f marker
+        or the manual --seed-testmon-status primary path."""
         body = (Path(__file__).resolve().parent.parent / harness / "agents" / "qs-finish-task.md").read_text()
-        assert 'rm -f "$MAIN_DIR/.testmondata.seed-status"' in body  # stale-marker guard
-        assert '>"$MAIN_DIR/.testmondata.seed.log" 2>&1' in body  # truncate redirect
-        assert "--seed-testmon-status" in body  # how to check
+        assert '>"$MAIN_DIR/.testmondata.seed.log" 2>&1' in body  # log redirect
+        assert "--seed-testmon-follow --seed-token" in body  # inline streaming
         assert "safe to close this terminal" in body
+        # QS-299: the stale-marker rm is gone (it would blind preemption).
+        assert 'rm -f "$MAIN_DIR/.testmondata.seed-status"' not in body
         # the old silent seed redirect is gone (other >/dev/null uses remain)
         assert "--seed-testmon >/dev/null 2>&1" not in body
 
     def test_seed_launch_block_byte_identical_across_harnesses(self) -> None:
-        """Harness-sync: the QS-286 completion-signal block is identical in
-        all three finish-task copies."""
+        """Harness-sync: the QS-299 tokened-detached seed LAUNCH block (bash) is
+        byte-identical in all three finish-task copies (the per-harness
+        background+monitor prose is allowed to differ)."""
         blocks = []
         for harness in (".claude", ".cursor", ".opencode"):
             body = (
                 Path(__file__).resolve().parent.parent / harness / "agents" / "qs-finish-task.md"
             ).read_text()
-            # review-fix #01 nice-to-have: anchor the slice on code-adjacent
-            # markers (the stale-marker rm and the exact redirect line), not on
-            # prose ending in a literal period, so added narrative can't
-            # truncate the slice inconsistently.
-            start = body.index('rm -f "$MAIN_DIR/.testmondata.seed-status"')
-            redirect = '>"$MAIN_DIR/.testmondata.seed.log" 2>&1'
+            # Anchor on the token generation and the exact detached-launch
+            # redirect line — both code-adjacent, so per-harness follower prose
+            # after the fence can't truncate the slice inconsistently.
+            start = body.index('SEED_TOKEN="$("$QG_PY"')
+            redirect = '</dev/null >"$MAIN_DIR/.testmondata.seed.log" 2>&1 & )'
             end = body.index(redirect, start) + len(redirect)
             blocks.append(body[start:end])
         assert blocks[0] == blocks[1] == blocks[2]

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -4367,6 +4367,28 @@ class TestSeedFollowCli:
             quality_gate.main()
         mock_seed.assert_called_once_with(token="T", detached=True)
 
+    def test_padded_token_is_trimmed_seed(self) -> None:
+        """review-fix #04 (finding #4): a token with surrounding whitespace is
+        accepted and normalized (trimmed) before dispatch."""
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon", "--seed-token", "  abc  "]),
+            patch.object(quality_gate, "seed_testmon", return_value=0) as mock_seed,
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+        mock_seed.assert_called_once_with(token="abc", detached=False)
+
+    def test_padded_token_is_trimmed_follow(self) -> None:
+        """review-fix #04 (finding #4): the follower receives the trimmed token so
+        it compares strictly identical to the seed's."""
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon-follow", "--seed-token", "\tabc\n"]),
+            patch.object(quality_gate, "seed_testmon_follow", return_value=0) as mock_follow,
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+        mock_follow.assert_called_once_with("abc")
+
     def test_follow_requires_token(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch("sys.argv", ["quality_gate.py", "--seed-testmon-follow"]),


### PR DESCRIPTION
## Summary
Add a read-only `--seed-testmon-follow` follower that streams the detached baseline refresh's progress inline until a terminal verdict, so finish-task surfaces completion in the same session (no separate command/cwd).
Add lock-serialized last-wins preemption: a new tokened, detached seed SIGTERMs any still-running predecessor from an earlier parallel task; the completion write is token-guarded so a preempted run never clobbers the winner's marker.
Update all three qs-finish-task.md agents (tokened `--detached` seed, no `rm -f` marker, per-harness background+monitor streaming, follower-exit-informational) and project-rules.md; ~40 per-branch unit tests.

Fixes #299

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tokenized, detached baseline refresh on the true main checkout with inline progress streaming.
  * Added a companion read-only follower mode that streams refresh progress/completion, including superseded outcomes.
* **Bug Fixes**
  * Prevented older refresh runs from overwriting newer results through token-guarded coordination.
  * Improved tolerance of baseline status/log data and clarified follower exit codes as informational (non-gating).
* **Documentation**
  * Updated workflow and project rules to cover the detached seed + follower streaming flow and semantics.
  * Added guidance to keep key agent text byte-identical across harnesses.
* **Tests**
  * Added extensive coverage for detachment, preemption, follower streaming, and exit-code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->