### PR TITLE
QS-298: Improve people forecast.

### DIFF
--- a/custom_components/quiet_solar/const.py
+++ b/custom_components/quiet_solar/const.py
@@ -438,8 +438,8 @@ SOLAR_DUSK_EARLIEST_LOCAL_HOUR = 15
 SOLAR_DUSK_SUSTAIN_S = 90 * 60
 # 90 min sustained low-pv to commit dusk (filters cloud transients).
 
-MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS = 90  # count cap: keep at most 90 mileage records
-PERSON_HISTORY_BACKFILL_DAYS = 30  # boot-time recorder backfill depth (one query per day)
+MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS = 90  # count cap: max mileage records retained
+PERSON_HISTORY_BACKFILL_DAYS = 30  # boot-time recorder backfill depth in days
 
 # Outlier-resistant trip prediction tunables (defaults chosen in planning, not
 # user-validated — see docs/stories/QS-298.story.md Design §2).

--- a/custom_components/quiet_solar/const.py
+++ b/custom_components/quiet_solar/const.py
@@ -442,7 +442,7 @@ MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS = 90  # count cap: max mileage record
 PERSON_HISTORY_BACKFILL_DAYS = 30  # boot-time recorder backfill depth in days
 
 # Outlier-resistant trip prediction tunables (defaults chosen in planning, not
-# user-validated — see docs/stories/QS-298.story.md Design §2).
+# user-validated — see docs/agents/concepts/person-trip-prediction.md).
 PERSON_MILEAGE_OUTLIER_FACTOR = 2.5
 PERSON_MILEAGE_OUTLIER_MIN_KM = 100.0
 PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS = 21

--- a/custom_components/quiet_solar/const.py
+++ b/custom_components/quiet_solar/const.py
@@ -438,7 +438,18 @@ SOLAR_DUSK_EARLIEST_LOCAL_HOUR = 15
 SOLAR_DUSK_SUSTAIN_S = 90 * 60
 # 90 min sustained low-pv to commit dusk (filters cloud transients).
 
-MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS = 30  # keep last 14 days of data
+MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS = 90  # count cap: keep at most 90 mileage records
+PERSON_HISTORY_BACKFILL_DAYS = 30  # boot-time recorder backfill depth (one query per day)
+
+# Outlier-resistant trip prediction tunables (defaults chosen in planning, not
+# user-validated — see docs/stories/QS-298.story.md Design §2).
+PERSON_MILEAGE_OUTLIER_FACTOR = 2.5
+PERSON_MILEAGE_OUTLIER_MIN_KM = 100.0
+PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS = 21
+PERSON_MILEAGE_RECURRENCE_TOLERANCE = 0.2
+PERSON_MILEAGE_MIN_SAMPLES_FOR_OUTLIER_DETECTION = 4
+PERSON_MILEAGE_NUM_GOOD_SAMPLES = 2
+
 PERSON_NOTIFY_REASON_DAILY_CHARGER_CONSTRAINTS = "charger_constraints"
 PERSON_NOTIFY_REASON_DAILY_REMINDER_FOR_CAR_NO_CHARGER = "daily_reminder_no_charger_car"
 PERSON_NOTIFY_REASON_CHANGED_CAR = "changed_car"

--- a/custom_components/quiet_solar/ha_model/home.py
+++ b/custom_components/quiet_solar/ha_model/home.py
@@ -47,7 +47,6 @@ from ..const import (
     HOME_CONSUMPTION_SENSOR,
     HOME_NON_CONTROLLED_CONSUMPTION_SENSOR,
     INTERVALS_MN,
-    MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS,
     MAX_POWER_INFINITE,
     NUM_INTERVAL_PER_HOUR,
     NUM_INTERVALS_PER_DAY,
@@ -56,6 +55,7 @@ from ..const import (
     OFF_GRID_MODE_FORCE_ON_GRID,
     OVERRIDE_STATE_NO_OVERRIDE,
     PASS1_PREFERRED_CAR_PENALTY_KWH,
+    PERSON_HISTORY_BACKFILL_DAYS,
     PERSON_NOTIFY_REASON_CHANGED_CAR,
     PREFERRED_CAR_ENERGY_THRESHOLD_KWH,
     SENSOR_CAR_CHARGE_ORIGIN,
@@ -2268,14 +2268,14 @@ class QSHome(QSDynamicGroup):
         if is_passed_limit is False:
             local_day_utc = local_day_utc - timedelta(days=1)
 
-        # we are after 4am of the current day, we can recompute the last MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS days
+        # we are after 4am of the current day, we can recompute the last PERSON_HISTORY_BACKFILL_DAYS days
         # we shift to 4am to have mileage from 4am to 4am,
 
         data_to_save = []  # list of (start, end, [(car_name, car_positions, car_odos)], [(person, person_positions)])
         min_start = None
         max_end = None
 
-        for d in range(0, MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS):
+        for d in range(0, PERSON_HISTORY_BACKFILL_DAYS):
             start = local_day_utc - timedelta(days=d + 1) + timedelta(hours=HOME_PERSON_CAR_DAY_JOURNEY_START_HOURS)
             end = local_day_utc - timedelta(days=d) + timedelta(hours=HOME_PERSON_CAR_DAY_JOURNEY_START_HOURS)
 
@@ -2349,7 +2349,7 @@ class QSHome(QSDynamicGroup):
                         has_person_to_recompute = True
 
                 if has_person_to_recompute:
-                    # we are after 4am of the current day, we can recompute the last MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS days
+                    # we are after 4am of the current day, we can recompute the last PERSON_HISTORY_BACKFILL_DAYS days
                     # we shift to 4am to have mileage from 4am to 4am,
                     await self.recompute_people_historical_data(time)
 
@@ -2390,7 +2390,7 @@ class QSHome(QSDynamicGroup):
             delta = 0
         else:
             delta = 1
-        for d in range(delta, MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS + delta):
+        for d in range(delta, PERSON_HISTORY_BACKFILL_DAYS + delta):
             await self._compute_and_store_person_car_forecasts(local_day_utc, day_shift=d)
 
         for person in self._persons:

--- a/custom_components/quiet_solar/ha_model/person.py
+++ b/custom_components/quiet_solar/ha_model/person.py
@@ -1,4 +1,5 @@
 import logging
+import statistics
 from bisect import bisect_left
 from datetime import datetime, timedelta
 from datetime import time as dt_time
@@ -18,6 +19,12 @@ from ..const import (
     CONF_PERSON_TRACKER,
     DEVICE_STATUS_CHANGE_NOTIFY,
     MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS,
+    PERSON_MILEAGE_MIN_SAMPLES_FOR_OUTLIER_DETECTION,
+    PERSON_MILEAGE_NUM_GOOD_SAMPLES,
+    PERSON_MILEAGE_OUTLIER_FACTOR,
+    PERSON_MILEAGE_OUTLIER_MIN_KM,
+    PERSON_MILEAGE_RECURRENCE_TOLERANCE,
+    PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS,
     PERSON_NO_FORECAST_STRING,
     PERSON_NOTIFY_REASON_CHANGED_CAR,
     PERSON_NOTIFY_REASON_DAILY_CHARGER_CONSTRAINTS,
@@ -140,7 +147,7 @@ class QSPerson(HADeviceMixin, AbstractDevice):
         while True:
             if (
                 len(self.historical_mileage_data) > MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS
-            ):  # keeps only 2 weeks of data
+            ):  # count cap: keep at most MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS records
                 self.historical_mileage_data.pop(0)
             else:
                 break
@@ -154,23 +161,86 @@ class QSPerson(HADeviceMixin, AbstractDevice):
             )
         self.serializable_historical_data = serialized_hist_data
 
+    def _is_suspicious_mileage(
+        self,
+        entry: tuple[datetime, float, datetime, int],
+        bucket: list[tuple[datetime, float, datetime, int]],
+    ) -> bool:
+        """Return True when ``entry`` is far above its same-weekday norm.
+
+        The baseline is the leave-one-out ``statistics.median`` of the bucket
+        mileages, excluding ``entry`` by its day key. Detection is disabled
+        (returns ``False``) when fewer than
+        ``PERSON_MILEAGE_MIN_SAMPLES_FOR_OUTLIER_DETECTION`` other samples
+        remain — identical to today's behavior on sparse buckets.
+        """
+        entry_day = entry[0]
+        others = [e[1] for e in bucket if e[0] != entry_day]
+        if len(others) < PERSON_MILEAGE_MIN_SAMPLES_FOR_OUTLIER_DETECTION:
+            return False
+        baseline = statistics.median(others)
+        return entry[1] > PERSON_MILEAGE_OUTLIER_FACTOR * baseline and entry[1] > PERSON_MILEAGE_OUTLIER_MIN_KM
+
+    def _is_mileage_outlier(self, entry: tuple[datetime, float, datetime, int]) -> bool:
+        """Return True when ``entry`` should be excluded from the prediction.
+
+        A record is an outlier when it is suspicious (magnitude test with its
+        own leave-one-out baseline) unless it is rescued by the live-pattern
+        recurrence rule: rescue applies only to the 2 most recent records of
+        the weekday bucket, and only when BOTH are suspicious, mutually
+        similar, and within ``PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS`` of each
+        other (inclusive).
+        """
+        week_day = entry[3]
+        bucket = [e for e in self.historical_mileage_data if e[3] == week_day]
+
+        if not self._is_suspicious_mileage(entry, bucket):
+            return False
+
+        # A suspicious record implies the bucket has at least
+        # PERSON_MILEAGE_MIN_SAMPLES_FOR_OUTLIER_DETECTION + 1 records, so the
+        # last-2 pair always exists.
+        older, newest = bucket[-2], bucket[-1]
+        if entry[0] != older[0] and entry[0] != newest[0]:
+            return True  # older suspicious record, never rescued
+
+        if not (self._is_suspicious_mileage(newest, bucket) and self._is_suspicious_mileage(older, bucket)):
+            return True  # the last-2 pair is not a live pattern
+
+        if abs(older[1] - newest[1]) > PERSON_MILEAGE_RECURRENCE_TOLERANCE * newest[1]:
+            return True  # not mutually similar
+
+        if abs((newest[0].date() - older[0].date()).days) > PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS:
+            return True  # too far apart to be a live pattern
+
+        return False  # rescued: a live recurring long trip
+
     def _get_best_week_day_guess(self, week_day: int) -> tuple[float | None, dt_time | None]:
-        """Get the best guess for mileage and leave time for a given weekday."""
+        """Get the best guess for mileage and leave time for a given weekday.
+
+        Walks the history most-recent-first, skipping outliers, until
+        ``PERSON_MILEAGE_NUM_GOOD_SAMPLES`` good same-weekday records are
+        collected. Prediction is the max mileage and earliest leave time of
+        the good records (outliers contribute neither).
+        """
         best_mileage = None
         best_leave_time = None
 
-        # Look for the last two entries for the given weekday
-        num_entries = 0
+        num_good = 0
         for entry in reversed(self.historical_mileage_data):
-            if entry[3] == week_day:
-                num_entries += 1
-                if best_mileage is None or entry[1] > best_mileage:
-                    best_mileage = entry[1]
-                if best_leave_time is None or entry[2].time() < best_leave_time:
-                    best_leave_time = entry[2].time()
+            if entry[3] != week_day:
+                continue
+            if self._is_mileage_outlier(entry):
+                continue
 
-                if num_entries >= 2:
-                    break
+            num_good += 1
+            if best_mileage is None or entry[1] > best_mileage:
+                best_mileage = entry[1]
+            if best_leave_time is None or entry[2].time() < best_leave_time:
+                best_leave_time = entry[2].time()
+
+            if num_good >= PERSON_MILEAGE_NUM_GOOD_SAMPLES:
+                break
 
         return best_mileage, best_leave_time
 

--- a/custom_components/quiet_solar/ha_model/person.py
+++ b/custom_components/quiet_solar/ha_model/person.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import statistics
 from bisect import bisect_left
 from datetime import datetime, timedelta
@@ -18,7 +19,7 @@ from ..const import (
     CONF_PERSON_PREFERRED_CAR,
     CONF_PERSON_TRACKER,
     DEVICE_STATUS_CHANGE_NOTIFY,
-    MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS,
+    MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS,
     PERSON_MILEAGE_MIN_SAMPLES_FOR_OUTLIER_DETECTION,
     PERSON_MILEAGE_NUM_GOOD_SAMPLES,
     PERSON_MILEAGE_OUTLIER_FACTOR,
@@ -122,6 +123,16 @@ class QSPerson(HADeviceMixin, AbstractDevice):
             _LOGGER.warning("add_to_mileage_history: Leave time not provided for person %s", self.name)
             return
 
+        # Single choke point for both the live and restore paths: reject
+        # non-finite (NaN/inf) or non-positive mileage. A NaN would make the
+        # outlier baseline median undefined; a negative would flip the
+        # magnitude test — both silently corrupt detection.
+        if not math.isfinite(mileage) or mileage <= 0:
+            _LOGGER.warning(
+                "add_to_mileage_history: rejecting invalid mileage %s for person %s", mileage, self.name
+            )
+            return
+
         day = day.replace(tzinfo=pytz.UTC).astimezone(tz=None)
         leave_time = leave_time.replace(tzinfo=pytz.UTC).astimezone(tz=None)
         week_day = day.weekday()
@@ -146,8 +157,8 @@ class QSPerson(HADeviceMixin, AbstractDevice):
 
         while True:
             if (
-                len(self.historical_mileage_data) > MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS
-            ):  # count cap: keep at most MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS records
+                len(self.historical_mileage_data) > MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS
+            ):  # count cap: keep at most MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS records
                 self.historical_mileage_data.pop(0)
             else:
                 break
@@ -181,25 +192,31 @@ class QSPerson(HADeviceMixin, AbstractDevice):
         baseline = statistics.median(others)
         return entry[1] > PERSON_MILEAGE_OUTLIER_FACTOR * baseline and entry[1] > PERSON_MILEAGE_OUTLIER_MIN_KM
 
-    def _is_mileage_outlier(self, entry: tuple[datetime, float, datetime, int]) -> bool:
+    def _is_mileage_outlier(
+        self,
+        entry: tuple[datetime, float, datetime, int],
+        bucket: list[tuple[datetime, float, datetime, int]],
+        now: datetime,
+    ) -> bool:
         """Return True when ``entry`` should be excluded from the prediction.
 
-        A record is an outlier when it is suspicious (magnitude test with its
-        own leave-one-out baseline) unless it is rescued by the live-pattern
-        recurrence rule: rescue applies only to the 2 most recent records of
-        the weekday bucket, and only when BOTH are suspicious, mutually
-        similar, and within ``PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS`` of each
-        other (inclusive).
+        ``bucket`` is the same-weekday record list (built once by the caller);
+        ``now`` is the local prediction time. A record is an outlier when it is
+        suspicious (magnitude test with its own leave-one-out baseline) unless
+        it is rescued by the live-pattern recurrence rule: rescue applies only
+        to the 2 most recent records of the weekday bucket, and only when BOTH
+        are suspicious, mutually similar, within
+        ``PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS`` of each other, AND the newest
+        of the pair is itself within that window of ``now`` (a dead habit
+        produces no records and must not keep predicting).
         """
-        week_day = entry[3]
-        bucket = [e for e in self.historical_mileage_data if e[3] == week_day]
-
         if not self._is_suspicious_mileage(entry, bucket):
             return False
 
         # A suspicious record implies the bucket has at least
         # PERSON_MILEAGE_MIN_SAMPLES_FOR_OUTLIER_DETECTION + 1 records, so the
-        # last-2 pair always exists.
+        # last-2 pair always exists. The rescue validates exactly a pair; this
+        # is tied to PERSON_MILEAGE_NUM_GOOD_SAMPLES == 2 (guarded in tests).
         older, newest = bucket[-2], bucket[-1]
         if entry[0] != older[0] and entry[0] != newest[0]:
             return True  # older suspicious record, never rescued
@@ -207,30 +224,43 @@ class QSPerson(HADeviceMixin, AbstractDevice):
         if not (self._is_suspicious_mileage(newest, bucket) and self._is_suspicious_mileage(older, bucket)):
             return True  # the last-2 pair is not a live pattern
 
-        if abs(older[1] - newest[1]) > PERSON_MILEAGE_RECURRENCE_TOLERANCE * newest[1]:
+        # Symmetric similarity: normalize by the larger of the pair.
+        if abs(older[1] - newest[1]) > PERSON_MILEAGE_RECURRENCE_TOLERANCE * max(older[1], newest[1]):
             return True  # not mutually similar
 
-        if abs((newest[0].date() - older[0].date()).days) > PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS:
+        # Ordering is enforced at ingestion (ascending, unique day keys), so
+        # newest[0] >= older[0] and now >= newest[0] in the normal case.
+        if (newest[0].date() - older[0].date()).days > PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS:
             return True  # too far apart to be a live pattern
+
+        if (now.date() - newest[0].date()).days > PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS:
+            return True  # pair is stale relative to now — habit likely stopped
 
         return False  # rescued: a live recurring long trip
 
-    def _get_best_week_day_guess(self, week_day: int) -> tuple[float | None, dt_time | None]:
+    def _get_best_week_day_guess(
+        self, week_day: int, now: datetime | None = None
+    ) -> tuple[float | None, dt_time | None]:
         """Get the best guess for mileage and leave time for a given weekday.
 
-        Walks the history most-recent-first, skipping outliers, until
-        ``PERSON_MILEAGE_NUM_GOOD_SAMPLES`` good same-weekday records are
-        collected. Prediction is the max mileage and earliest leave time of
-        the good records (outliers contribute neither).
+        Walks the same-weekday bucket most-recent-first, skipping outliers,
+        until ``PERSON_MILEAGE_NUM_GOOD_SAMPLES`` good records are collected.
+        Prediction is the max mileage and earliest leave time of the good
+        records (outliers contribute neither). ``now`` (local time) gates the
+        live-pattern recurrence recency check; it defaults to the current
+        local time.
         """
+        if now is None:
+            now = datetime.now(tz=pytz.UTC).astimezone(tz=None)
+
+        bucket = [e for e in self.historical_mileage_data if e[3] == week_day]
+
         best_mileage = None
         best_leave_time = None
 
         num_good = 0
-        for entry in reversed(self.historical_mileage_data):
-            if entry[3] != week_day:
-                continue
-            if self._is_mileage_outlier(entry):
+        for entry in reversed(bucket):
+            if self._is_mileage_outlier(entry, bucket, now):
                 continue
 
             num_good += 1
@@ -252,8 +282,12 @@ class QSPerson(HADeviceMixin, AbstractDevice):
         tomorrow_week_day = (today_week_day + 1) % 7
 
         # all below is in local time
-        predicted_mileage_today, predicted_leave_time_today = self._get_best_week_day_guess(today_week_day)
-        predicted_mileage_tomorrow, predicted_leave_time_tomorrow = self._get_best_week_day_guess(tomorrow_week_day)
+        predicted_mileage_today, predicted_leave_time_today = self._get_best_week_day_guess(
+            today_week_day, now=local_time
+        )
+        predicted_mileage_tomorrow, predicted_leave_time_tomorrow = self._get_best_week_day_guess(
+            tomorrow_week_day, now=local_time
+        )
 
         self.predicted_leave_time = None
         self.predicted_mileage = None
@@ -348,8 +382,12 @@ class QSPerson(HADeviceMixin, AbstractDevice):
                         _LOGGER.warning("device_post_home_init: QSPerson %s error in saved data %s", self.name, e)
                         continue
 
-                    day = datetime.fromisoformat(day_str).replace(tzinfo=None).astimezone(tz=pytz.UTC)
-                    leave_time = datetime.fromisoformat(leave_time_str).replace(tzinfo=None).astimezone(tz=pytz.UTC)
+                    # Keep the serialized offset: aware isoformat strings map
+                    # to the correct instant across TZ / DST changes; naive
+                    # legacy strings still fall back to system-local (unchanged
+                    # behavior).
+                    day = datetime.fromisoformat(day_str).astimezone(tz=pytz.UTC)
+                    leave_time = datetime.fromisoformat(leave_time_str).astimezone(tz=pytz.UTC)
 
                     self.add_to_mileage_history(day, float(mileage), leave_time)
                 except Exception as ex:

--- a/custom_components/quiet_solar/ha_model/person.py
+++ b/custom_components/quiet_solar/ha_model/person.py
@@ -128,9 +128,7 @@ class QSPerson(HADeviceMixin, AbstractDevice):
         # outlier baseline median undefined; a negative would flip the
         # magnitude test — both silently corrupt detection.
         if not math.isfinite(mileage) or mileage <= 0:
-            _LOGGER.warning(
-                "add_to_mileage_history: rejecting invalid mileage %s for person %s", mileage, self.name
-            )
+            _LOGGER.warning("add_to_mileage_history: rejecting invalid mileage %s for person %s", mileage, self.name)
             return
 
         day = day.replace(tzinfo=pytz.UTC).astimezone(tz=None)
@@ -218,7 +216,10 @@ class QSPerson(HADeviceMixin, AbstractDevice):
         # last-2 pair always exists. The rescue validates exactly a pair; this
         # is tied to PERSON_MILEAGE_NUM_GOOD_SAMPLES == 2 (guarded in tests).
         older, newest = bucket[-2], bucket[-1]
-        if entry[0] != older[0] and entry[0] != newest[0]:
+        # The rescue only ever applies to the 2 most recent bucket records.
+        # Day keys are unique, so membership is tested by day key.
+        last_two_days = {older[0], newest[0]}
+        if entry[0] not in last_two_days:
             return True  # older suspicious record, never rescued
 
         if not (self._is_suspicious_mileage(newest, bucket) and self._is_suspicious_mileage(older, bucket)):

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/__init__.py
   - custom_components/quiet_solar/data_handler.py
   - custom_components/quiet_solar/const.py
-last_verified: 2026-07-05
+last_verified: 2026-07-22
 ---
 
 # Config flow and setup

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/__init__.py
   - custom_components/quiet_solar/data_handler.py
   - custom_components/quiet_solar/const.py
-last_verified: 2026-06-02
+last_verified: 2026-07-04
 ---
 
 # Config flow and setup

--- a/docs/agents/concepts/config-and-setup-flow.md
+++ b/docs/agents/concepts/config-and-setup-flow.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/__init__.py
   - custom_components/quiet_solar/data_handler.py
   - custom_components/quiet_solar/const.py
-last_verified: 2026-07-04
+last_verified: 2026-07-05
 ---
 
 # Config flow and setup

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
   - custom_components/quiet_solar/ha_model/person.py
-last_verified: 2026-06-29
+last_verified: 2026-07-04
 ---
 
 # Notification routing

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
   - custom_components/quiet_solar/ha_model/person.py
-last_verified: 2026-07-04
+last_verified: 2026-07-05
 ---
 
 # Notification routing

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
   - custom_components/quiet_solar/ha_model/person.py
-last_verified: 2026-07-05
+last_verified: 2026-07-22
 ---
 
 # Notification routing

--- a/docs/agents/concepts/off-grid-mode.md
+++ b/docs/agents/concepts/off-grid-mode.md
@@ -4,7 +4,7 @@ slug: off-grid-mode
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
-last_verified: 2026-06-16
+last_verified: 2026-07-04
 ---
 
 # Off-grid mode

--- a/docs/agents/concepts/person-trip-prediction.md
+++ b/docs/agents/concepts/person-trip-prediction.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/person.py
   - custom_components/quiet_solar/ha_model/car.py
-last_verified: 2026-06-29
+last_verified: 2026-07-04
 ---
 
 # Person, Car, and trip prediction
@@ -13,7 +13,9 @@ last_verified: 2026-06-29
 ## TL;DR
 
 `QSPerson` (`ha_model/person.py`) tracks presence and predicts trips
-from GPS and historical mileage (31-day rolling window). `QSCar`
+from GPS and historical mileage (a count-capped ring of the last 90
+mileage records; boot-time recorder backfill is a separate 30-day
+window). `QSCar`
 (`ha_model/car.py`) tracks SOC, charger assignment, and a custom
 power→amperage lookup table per car. The two together produce the
 constraints behind the "Magali plugs in her car" magic moment: the
@@ -22,8 +24,8 @@ tomorrow's predicted trips with margin.
 
 ## When you need this concept
 
-- Modifying trip prediction, mileage estimation, or the 31-day
-  rolling window.
+- Modifying trip prediction, mileage estimation, or the retention /
+  backfill windows.
 - Adding a new car model with non-linear charging curves.
 - Working on person-car allocation (which car belongs to which
   person).
@@ -34,8 +36,52 @@ tomorrow's predicted trips with margin.
 **Person side**:
 
 - GPS-based presence detection (home / away / commuting).
-- Mileage history (31 days, sensor-attribute restored) →
-  per-day-of-week average → next-day prediction.
+- Mileage history (count cap of 90 records via
+  `MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS`, sensor-attribute restored;
+  boot-time recorder backfill uses the separate
+  `PERSON_HISTORY_BACKFILL_DAYS = 30` so a larger retention never
+  inflates the per-day recorder queries) → **outlier-resistant**
+  per-weekday guess → next-day prediction. The retention is a count cap,
+  not an age cutoff: with gap days the ring may span more than 90
+  calendar days.
+- **Per-weekday guess** (`_get_best_week_day_guess`): walk the history
+  most-recent-first, same weekday only, **skip outliers**, and take the
+  **max mileage** and **earliest leave time** of the last
+  `PERSON_MILEAGE_NUM_GOOD_SAMPLES = 2` non-outlier records. Outlier
+  records contribute neither mileage nor leave time. Whenever the bucket
+  is non-empty at least one good record provably exists, so there is no
+  all-outlier fallback branch.
+- **Outlier detection** (`_is_mileage_outlier` / `_is_suspicious_mileage`):
+  a record is *suspicious* when
+  `mileage > PERSON_MILEAGE_OUTLIER_FACTOR (2.5) ×` its **leave-one-out**
+  `statistics.median` same-weekday baseline (interpolated median; the
+  record under test is excluded by its day key) **and**
+  `mileage > PERSON_MILEAGE_OUTLIER_MIN_KM (100 km)` (absolute floor —
+  rejecting normal km for a low-mileage person under-charges, the worse
+  failure mode). Detection is disabled (record kept) when the
+  leave-one-out bucket has fewer than
+  `PERSON_MILEAGE_MIN_SAMPLES_FOR_OUTLIER_DETECTION = 4` samples —
+  identical to the pre-QS-298 behavior on sparse / cold-start data (3
+  samples → off, 4 → on).
+- **Live-pattern recurrence rescue**: a suspicious record is kept only
+  when it is one of the **2 most recent** records of its weekday bucket
+  and that last-2 pair is a *live pattern* — BOTH suspicious, mutually
+  similar (`abs(older − newest) ≤ PERSON_MILEAGE_RECURRENCE_TOLERANCE
+  (0.2) × newest`), and within
+  `PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS = 21` days of each other
+  (inclusive). This keeps a genuine weekly far commute while rejecting a
+  one-off. A single normal day in the bucket breaks liveness and reverts
+  the prediction immediately (minority regime).
+- **Documented trade-offs**: the *first* occurrence of a new recurring
+  long trip is rejected (bounded to one mispredicted week, until the
+  second occurrence makes the pattern live); non-weekly / alternating /
+  monthly cadences are rejected (calendar integration is the fix, a
+  separate story); out-and-back weekend round trips cannot self-validate
+  because corroboration is same-weekday only. In the **majority regime**
+  (a habit that dominates the bucket) the leave-one-out median itself
+  rises, the records stop being suspicious, and the prediction decays
+  over a few weeks after the habit ends — the immediate-reversion
+  guarantee applies to the minority regime only.
 - Prediction confidence: if history is sparse or pattern match is
   weak, fall back to a conservative (over-charged) target.
 
@@ -71,7 +117,9 @@ prediction_kWh + margin` is pushed for the car's charger.
 - `QSPerson(HADeviceMixin, AbstractDevice)` — person tracking class.
 - `QSCar(HADeviceMixin, AbstractLoad)` — car class. Inherits constraint
   surface from `AbstractLoad`.
-- 31-day mileage ring (sensor-attribute restored).
+- 90-record mileage ring (count cap, sensor-attribute restored;
+  serialized payload stays under the recorder's 16 KB attribute limit —
+  guarded by a permanent test).
 - Custom power-to-amperage lookup table on `QSCar`.
 - `QSCar.get_car_person_readable_forecast_mileage(for_small_standalone=True)`
   — raw forecast string (`"<Person>: <km>km <date>"`); backs the

--- a/docs/agents/concepts/person-trip-prediction.md
+++ b/docs/agents/concepts/person-trip-prediction.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/person.py
   - custom_components/quiet_solar/ha_model/car.py
-last_verified: 2026-07-05
+last_verified: 2026-07-22
 ---
 
 # Person, Car, and trip prediction

--- a/docs/agents/concepts/person-trip-prediction.md
+++ b/docs/agents/concepts/person-trip-prediction.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/person.py
   - custom_components/quiet_solar/ha_model/car.py
-last_verified: 2026-07-04
+last_verified: 2026-07-05
 ---
 
 # Person, Car, and trip prediction
@@ -37,7 +37,7 @@ tomorrow's predicted trips with margin.
 
 - GPS-based presence detection (home / away / commuting).
 - Mileage history (count cap of 90 records via
-  `MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS`, sensor-attribute restored;
+  `MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS`, sensor-attribute restored;
   boot-time recorder backfill uses the separate
   `PERSON_HISTORY_BACKFILL_DAYS = 30` so a larger retention never
   inflates the per-day recorder queries) → **outlier-resistant**
@@ -67,11 +67,18 @@ tomorrow's predicted trips with margin.
   when it is one of the **2 most recent** records of its weekday bucket
   and that last-2 pair is a *live pattern* — BOTH suspicious, mutually
   similar (`abs(older − newest) ≤ PERSON_MILEAGE_RECURRENCE_TOLERANCE
-  (0.2) × newest`), and within
+  (0.2) × max(older, newest)` — a **symmetric** denominator matching the
+  "mutually similar" wording), within
   `PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS = 21` days of each other
-  (inclusive). This keeps a genuine weekly far commute while rejecting a
-  one-off. A single normal day in the bucket breaks liveness and reverts
-  the prediction immediately (minority regime).
+  (inclusive), **and** the pair's newest record itself within that same
+  window of the prediction time (*now*). The recency-vs-now clause stops
+  a dead habit — two similar long trips then that weekday goes
+  driving-silent (no records are ever written for zero-mileage days) —
+  from predicting stale ~400 km indefinitely; the prediction reverts to
+  the non-outlier records once the pair ages past the window. This keeps
+  a genuine weekly far commute while rejecting a one-off. A single normal
+  day in the bucket breaks liveness and reverts the prediction
+  immediately (minority regime).
 - **Documented trade-offs**: the *first* occurrence of a new recurring
   long trip is rejected (bounded to one mispredicted week, until the
   second occurrence makes the pattern live); non-weekly / alternating /

--- a/docs/agents/concepts/qs-home-orchestrator.md
+++ b/docs/agents/concepts/qs-home-orchestrator.md
@@ -4,7 +4,7 @@ slug: qs-home-orchestrator
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/home.py
-last_verified: 2026-05-23
+last_verified: 2026-07-04
 ---
 
 # QSHome — the orchestrator

--- a/docs/stories/QS-298.story.md
+++ b/docs/stories/QS-298.story.md
@@ -51,7 +51,8 @@ smarter.
 
 ### 1. Retention vs backfill split (`const.py`, `home.py`)
 
-- `MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS`: **30 → 90**. Semantics are
+- `MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS` (renamed from
+  `..._DAYS` in review fix #01, N1): **30 → 90**. Semantics are
   a **count cap of 90 records** (the existing pop-oldest loop in
   `add_to_mileage_history`), not an age cutoff — for a person with gap
   days the retained records may span more than 90 calendar days, which
@@ -126,12 +127,17 @@ New helper `QSPerson._is_mileage_outlier(entry) -> bool` operating on
    forms a *live pattern* when BOTH are suspicious (per step 2, each
    with its own LOO baseline/gate) AND mutually similar
    (`abs(older_km − newest_km) ≤ PERSON_MILEAGE_RECURRENCE_TOLERANCE ×
-   newest_km`) AND their days are within
-   `PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS` of each other (**inclusive**:
-   exactly 21 days apart still qualifies — tolerates up to two missed
-   weeks). In that case both are treated as good records (prediction =
-   their max mileage, earliest leave time). In every other
-   configuration, suspicious records are outliers.
+   max(older_km, newest_km)` — **symmetric denominator, amended in
+   review fix #01, N2**; the story previously pinned `newest_km`) AND
+   their days are within `PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS` of each
+   other (**inclusive**: exactly 21 days apart still qualifies —
+   tolerates up to two missed weeks) AND the pair's **newest record is
+   itself within `PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS` of the
+   prediction time (*now*)** (recency clause, **added in review fix #01,
+   S1** — a dead habit produces no records and must not keep predicting;
+   see the reversion note below). In that case both are treated as good
+   records (prediction = their max mileage, earliest leave time). In
+   every other configuration, suspicious records are outliers.
 
    The 21-day pair window is **deliberately kept** even though the
    user's tightened rule didn't mention one (round-2 scope question,
@@ -157,6 +163,16 @@ New helper `QSPerson._is_mileage_outlier(entry) -> bool` operating on
      same-weekday only, so a one-off weekend round trip (~200 km out
      Friday, ~200 km back Sunday) can never self-validate — the two
      records live in different buckets.
+   - **Dead-habit reversion (recency clause, review fix #01 S1)**: once
+     a live pair's newest record ages past
+     `PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS` relative to *now* the rescue
+     stops and the prediction reverts to the non-outlier records. Zero-
+     mileage days write no record (ingestion requires `mileage > 0`), so
+     without this clause a habit that simply stops (WFH, car sold,
+     tracker off) would keep the stale pair as `bucket[-2:]` and predict
+     ~400 km until ~90 other-day records evict it — a regression vs. the
+     pre-PR 30-day self-heal. The recency check restores bounded
+     self-healing (≤ the window).
 
 **Documented trade-offs** (accepted in review rounds 1–2 + discussion):
 
@@ -299,7 +315,7 @@ weekday guess.
 All tasks land as **one commit** after a single `--impacted` run — the
 intermediate states (e.g. task-2 red tests) are never committed.
 
-1. **`const.py`** — bump `MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS` to 90
+1. **`const.py`** — bump `MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS` to 90
    (fix comment); add `PERSON_HISTORY_BACKFILL_DAYS` and the 6 outlier
    constants listed in Design §2.
 2. **Tests first** — new file `tests/test_person_outlier.py`. The

--- a/docs/stories/QS-298.story.md
+++ b/docs/stories/QS-298.story.md
@@ -1,0 +1,402 @@
+# QS-298 — Improve people forecast (outlier-resistant trip prediction)
+
+- **Issue**: [#298](https://github.com/tmenguy/quiet-solar/issues/298)
+- **Branch**: `QS_298`
+- **Status**: draft (story v4 — review rounds 1 & 2 folded in)
+- **Persona**: Magali (household member / non-technical)
+
+## Problem
+
+The person trip forecast reuses any past trip blindly. The prediction in
+`QSPerson._get_best_week_day_guess()` (`ha_model/person.py:157`) takes the
+**max mileage of the last 2 same-weekday records** and — independently —
+the **earliest leave time of those same 2 records** (the leave-time rule
+is already "earliest of the considered records" today), with no outlier
+rejection. A single one-off long trip (e.g. Valbonne→Marseille, ~400 km
+on a Wednesday) becomes that weekday's prediction and stays there for up
+to ~4 weeks — until it ages out of the 30-day retention window
+(`MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS = 30`, `const.py:441`). The car
+then gets over-charged for a trip that will not happen.
+
+History record schema (`QSPerson.historical_mileage_data`): a
+date-ordered `list[tuple[datetime, float, datetime, int]]` =
+`(day, mileage_km, leave_time, weekday)`, all in **local time**, one
+record per (4 am–4 am) day, unique day keys. Records with a `None` leave
+time or non-positive mileage are rejected at ingestion
+(`add_to_mileage_history:114`, `home.py:2410-2417`), so every retained
+record has a positive mileage and a leave time.
+
+Additional latent issues discovered during analysis:
+
+- `MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS` is double-duty: it caps the
+  retained history in `person.py` **and** sizes the boot-time backfill
+  loops in `home.py` (defs at `recompute_people_historical_data:2379`
+  and `dump_person_car_data_for_debug:2265`; the loops themselves at
+  `:2393` and `:2278`), which run one recorder history query per day.
+  The HA recorder typically only keeps ~10 days, so a larger retention
+  must NOT inflate the backfill loop.
+- `docs/agents/concepts/person-trip-prediction.md` describes the
+  algorithm as a "per-day-of-week average"; the code is max-of-last-2.
+  Pre-existing doc drift to fix here.
+
+## Goal
+
+A one-off unusually-long trip is excluded from the prediction, while
+genuinely recurring long trips (e.g. a weekly far commute) are kept.
+History depth grows to 3 months so recurrence and medians are meaningful.
+No new config-flow options — invisible to Magali; the forecast just gets
+smarter.
+
+## Design
+
+### 1. Retention vs backfill split (`const.py`, `home.py`)
+
+- `MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS`: **30 → 90**. Semantics are
+  a **count cap of 90 records** (the existing pop-oldest loop in
+  `add_to_mileage_history`), not an age cutoff — for a person with gap
+  days the retained records may span more than 90 calendar days, which
+  is acceptable (more bucket samples, never fewer). Fix the stale
+  "keep last 14 days" comment.
+  Estimated ~90 records × ~100 bytes ≈ 9 KB of sensor attributes — under
+  the recorder's 16 KB attribute limit with margin; **the estimate is
+  verified by a test** that serializes 90 realistic records (full ISO
+  datetimes, real key names, alongside the sensor's other attributes) and
+  asserts the JSON payload stays < 16 KB. The test is kept as a
+  **permanent guard** so any future retention bump (e.g. the deferred
+  6-month option) trips it consciously. 6 months was considered but
+  requires compacting the serialization (18 KB > 16 KB) — deferred, see
+  Out of scope.
+- New constant `PERSON_HISTORY_BACKFILL_DAYS = 30` used by the two
+  `home.py` loops (`recompute_people_historical_data`,
+  `dump_person_car_data_for_debug`) instead of the retention constant.
+  Rationale for keeping 30 (not lowering to ~10): it matches today's
+  boot-time query load exactly (no regression either way) and still
+  serves users with extended recorder `purge_keep_days`.
+- **Restore vs recompute interaction** (why the 90-day history survives
+  restarts): `recompute_people_historical_data` clears and rebuilds
+  history from recorder data, but it only runs when
+  `person.should_recompute_history()` is true, i.e. when the person is
+  **uninitialized**. Restoring any record via the
+  `QSBaseSensorRestore` attribute round-trip
+  (`device_post_home_init:244` sets `has_been_initialized = True` at
+  `:316-317`) means a normal restart never triggers the wipe — restored
+  records older than the backfill window are preserved and history keeps
+  accumulating day-by-day via `_compute_and_store_person_car_forecasts`
+  (which merges by day key). Pinned by acceptance criterion 7.
+
+### 2. Outlier detection (`ha_model/person.py`)
+
+New constants in `const.py` (values are **tunable defaults chosen in
+planning, not user-validated** — the Magali scenario, 400 km vs ~40 km
+median, passes with wide margin; revisit against real data if needed):
+
+- `PERSON_MILEAGE_OUTLIER_FACTOR = 2.5`
+- `PERSON_MILEAGE_OUTLIER_MIN_KM = 100.0`
+- `PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS = 21`
+- `PERSON_MILEAGE_RECURRENCE_TOLERANCE = 0.2`
+- `PERSON_MILEAGE_MIN_SAMPLES_FOR_OUTLIER_DETECTION = 4`
+- `PERSON_MILEAGE_NUM_GOOD_SAMPLES = 2`
+
+New helper `QSPerson._is_mileage_outlier(entry) -> bool` operating on
+`historical_mileage_data`:
+
+1. **Baseline**: `statistics.median` (the interpolated median — on an
+   even-sized bucket like `[40, 40, 400, 400]` it yields 220, which is
+   the intended, forgiving behavior) of the same-weekday bucket
+   mileages, **excluding the record under test by its day key
+   (`entry[0]`)** — leave-one-out. If the bucket (after exclusion) has
+   fewer than `PERSON_MILEAGE_MIN_SAMPLES_FOR_OUTLIER_DETECTION` (4)
+   samples, detection is disabled for that record (return `False` —
+   behavior identical to today on cold start / sparse data). Boundary:
+   3 remaining samples → detection **off**; exactly 4 → detection
+   **on**. There is no global-median fallback (dropped in round 1 as
+   YAGNI).
+2. **Magnitude test** (applied per record, each with its **own**
+   leave-one-out baseline and its own step-1 gate): a record is
+   suspicious only if `mileage > PERSON_MILEAGE_OUTLIER_FACTOR ×
+   baseline` **and** `mileage > PERSON_MILEAGE_OUTLIER_MIN_KM` (the
+   absolute floor prevents rejecting normal 40 km days for a
+   low-mileage person whose median is ~10 km — rejecting too much means
+   under-charging, the worse failure mode).
+3. **Recurrence escape hatch — live-pattern rule**: rescue applies
+   **only to the 2 most recent records of the weekday bucket** — an
+   older suspicious record is never rescued (immaterial to the
+   prediction, which consumes the newest 2 good records, but it pins
+   the helper's truth table for direct unit tests). The last-2 pair
+   forms a *live pattern* when BOTH are suspicious (per step 2, each
+   with its own LOO baseline/gate) AND mutually similar
+   (`abs(older_km − newest_km) ≤ PERSON_MILEAGE_RECURRENCE_TOLERANCE ×
+   newest_km`) AND their days are within
+   `PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS` of each other (**inclusive**:
+   exactly 21 days apart still qualifies — tolerates up to two missed
+   weeks). In that case both are treated as good records (prediction =
+   their max mileage, earliest leave time). In every other
+   configuration, suspicious records are outliers.
+
+   The 21-day pair window is **deliberately kept** even though the
+   user's tightened rule didn't mention one (round-2 scope question,
+   user-confirmed): without it, a sparse bucket whose last 2 records are
+   two big trips months apart would wrongly count as a live pattern.
+
+   Properties of this rule:
+   - A weekly Marseille commute (last 2 Wednesdays both ~400 km) is
+     kept; the one-off is rejected.
+   - **Reversion when the habit stops — minority regime**: while the
+     long trips are a bucket *minority* (still classified suspicious),
+     one normal day in the bucket (last 2 = `[400, 40]`) breaks the
+     live pattern and the prediction reverts to normal at once.
+   - **Majority regime (intended, documented)**: once a weekly habit
+     has run long enough to dominate the bucket (~7+ of ~13 samples),
+     the LOO median itself rises toward 400 km, the records stop being
+     "suspicious", and they are kept as plain good records — at that
+     point 400 km *is* the person's norm, and when the habit ends the
+     prediction decays over a few weeks exactly as today's algorithm
+     would. The immediate-reversion guarantee applies to the minority
+     regime only; AC 2's fixture is constrained accordingly.
+   - **Out-and-back loophole closed structurally**: corroboration is
+     same-weekday only, so a one-off weekend round trip (~200 km out
+     Friday, ~200 km back Sunday) can never self-validate — the two
+     records live in different buckets.
+
+**Documented trade-offs** (accepted in review rounds 1–2 + discussion):
+
+- **Non-weekly cadences are rejected**: an alternating pattern (e.g.
+  400 km every *other* Wednesday) never has 2 consecutive big bucket
+  records, so it is always treated as outlier. Accepted — stricter is
+  safer against stale predictions; calendar integration is the fix for
+  irregular long trips.
+- **Monthly cadence is out of reach**: same reasoning — a weekday-based
+  model cannot predict a monthly trip anyway (today it only inflates
+  the forecast for the weeks *after* the trip, which is exactly the
+  reported bug); calendar integration (separate story) is the real fix.
+  See Out of scope.
+- **Ramp-in of a new recurring trip**: the *first* occurrence of a new
+  weekly long commute has no corroborating record yet and is rejected —
+  bounded to **one mispredicted week**, since the second occurrence
+  makes the pattern live from then on. Pinned by a dedicated test.
+- **A single recorded normal day breaks liveness** (mirror image of
+  ramp-in): a sick day or holiday inside a live weekly pattern makes
+  last 2 = `[400, 40]`, so the next big trip is rejected as ramp-in
+  before the pattern re-establishes — a 1–2 week under-prediction.
+  Accepted (data gaps of up to two weeks are tolerated by the 21-day
+  pair window; a *present* normal record is treated as evidence the
+  habit changed). Pinned by the pattern-stop + ramp-in tests together.
+
+### 3. Selection: last 2 *good* samples (`_get_best_week_day_guess`)
+
+Rework `_get_best_week_day_guess(week_day)`:
+
+- Walk `historical_mileage_data` in reverse (most recent first), same
+  weekday only, **skipping outliers**, until
+  `PERSON_MILEAGE_NUM_GOOD_SAMPLES = 2` good records are collected (or
+  the history is exhausted).
+- Prediction = **max mileage** of the good records and **earliest leave
+  time** of the good records (outlier records contribute neither mileage
+  nor leave time — an anomalous trip usually has an anomalous departure
+  too). Every stored record has a leave time (enforced at ingestion), so
+  no missing-leave-time branch is needed.
+- **No all-outlier fallback branch** (round-2 finding C3): whenever the
+  bucket is non-empty, at least one good record provably exists, so
+  "some prediction" is never lost. Proof: the bucket's smallest record
+  has a leave-one-out median ≥ its own value, so it can never exceed
+  `2.5 ×` that median (all mileages are > 0 by ingestion); the
+  recurrence rule only rescues, never rejects; and below the 4-sample
+  gate detection is off entirely. A defensive branch would be dead code
+  that the 100 % coverage gate could only reach via monkeypatching.
+
+`_compute_person_next_need()`, the cache wrapper
+`update_person_forecast()`, serialization, restore, and all consumers
+(`car.get_best_person_next_need`, `charger.py` constraint build, `home.py`
+allocation matrix) are unchanged — the improvement is entirely inside the
+weekday guess.
+
+### 4. Doc maintenance
+
+- **Update** `docs/agents/concepts/person-trip-prediction.md`: replace the
+  incorrect "31-day window / per-day-of-week average" description with the
+  real algorithm (90-record retention, 30-day backfill, max of last 2
+  non-outlier same-weekday samples, earliest leave time, outlier +
+  live-pattern recurrence rules, the cadence/ramp-in/majority-regime
+  trade-offs); bump `last_verified`.
+- The drift checker requires **co-modification** (a Doc-OK note alone
+  does not make it pass), so the four Doc-OK docs below get a
+  `last_verified` bump as their co-modification:
+  - Doc-OK: `docs/agents/concepts/config-and-setup-flow.md` (covers
+    `const.py`) — only plain algorithm constants added/changed; no config
+    keys, no setup-flow change.
+  - Doc-OK: `docs/agents/concepts/notification-routing.md` (covers
+    `person.py`, `home.py`) — notification logic untouched.
+  - Doc-OK: `docs/agents/concepts/off-grid-mode.md` (covers `home.py`) —
+    off-grid logic untouched.
+  - Doc-OK: `docs/agents/concepts/qs-home-orchestrator.md` (covers
+    `home.py`) — doc doesn't describe the backfill loop internals;
+    accessor surface unchanged.
+
+## Acceptance criteria
+
+1. **One-off outlier rejected**: with ~12 weeks of ~30–60 km same-weekday
+   records and a single 400 km record last week, the prediction for that
+   weekday is the max of the last 2 non-outlier records (≤ 60 km), and
+   the predicted leave time is the earliest of those 2 good records.
+2. **Live recurring long trip kept (minority regime)**: with a bucket
+   where big records are a minority (e.g. ≥ 4 normal ~40 km records plus
+   the last 2 records at ~400 km on consecutive same weekdays, within
+   the ±20 % tolerance relative to the newest) → that weekday's
+   prediction is ~400 km. **Pattern-stop reversion**: as soon as a
+   normal (~40 km) day lands in that bucket, the prediction reverts to
+   normal immediately. A big record on a *different* weekday never
+   corroborates. (Majority-regime behavior — habit dominates the
+   median — is documented in Design §2 and intentionally NOT immediate
+   reversion.)
+3. **Out-and-back loophole closed**: a one-off weekend round trip
+   (~200 km on Friday, ~200 km on Sunday, otherwise ~40 km days) → both
+   records are rejected as outliers (different weekday buckets cannot
+   corroborate each other).
+4. **Absolute floor respected**: a person with a ~10 km median and a
+   40 km record → 40 km is NOT treated as an outlier
+   (`< PERSON_MILEAGE_OUTLIER_MIN_KM`).
+5. **Sparse data unchanged, boundary pinned**: with 3 leave-one-out
+   bucket samples, detection is **off** and prediction outputs (mileage
+   and leave time) are identical to today's algorithm; with exactly 4,
+   detection is **on**. Median is `statistics.median` (interpolated) —
+   pinned by an even-sized-bucket test. Recurrence pair window is
+   inclusive at exactly 21 days.
+6. **Ramp-in bounded**: the first occurrence of a new recurring long
+   trip is rejected (documented trade-off); once the second same-weekday
+   occurrence lands (within 21 days), the pattern is live and it is
+   kept. Rejection reasons are each pinned: similarity failure
+   (400 km + 250 km pair) and window failure (28 days apart) both
+   reject.
+7. **Restore/backfill safety**: retention is a count cap of 90 records
+   (`add_to_mileage_history`); the two backfill loops run
+   `PERSON_HISTORY_BACKFILL_DAYS` (30) days (update only the two
+   existing count tests — no new count-assertion tests); a restart with
+   restored records older than 30 days does **not** trigger
+   `recompute_people_historical_data` and preserves them (serialize →
+   restore round-trip reproduces the same prediction, existing format,
+   no migration).
+8. **Attribute size verified**: 90 realistic serialized records total
+   < 16 KB (recorder attribute limit) — asserted by a test kept as a
+   permanent guard for future retention bumps.
+9. **Exact-value regression oracle**:
+   `test_process_all_14_days_with_stored_local_day_utc`
+   (`tests/test_persons_car_forecast.py:875`) asserts 57 km (Thomas),
+   76 km (Arthur), 37 km (Magali), `None` (Brice) from real pickled
+   history. With ~14 days of fixture history every weekday bucket is
+   below the 4-sample leave-one-out gate, so detection is provably off
+   and **all four values must pass unchanged** — any change indicates a
+   bug in the gate. The same policy (change only with a named,
+   justified outlier record; fixture data never edited) extends to any
+   other pre-existing exact-value assertion affected by the new rules.
+10. `docs/agents/concepts/person-trip-prediction.md` matches the shipped
+    algorithm; the four Doc-OK docs get `last_verified` bumps;
+    `scripts/qs/check_doc_drift.py` passes.
+11. `quality_gate.py --impacted` passes (100 % coverage on changed
+    lines); full gate green in CI.
+
+## Task breakdown (TDD order)
+
+All tasks land as **one commit** after a single `--impacted` run — the
+intermediate states (e.g. task-2 red tests) are never committed.
+
+1. **`const.py`** — bump `MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS` to 90
+   (fix comment); add `PERSON_HISTORY_BACKFILL_DAYS` and the 6 outlier
+   constants listed in Design §2.
+2. **Tests first** — new file `tests/test_person_outlier.py`. The
+   outlier-behavior tests are **red until task 4** (not task 3); the
+   tests marked *(char.)* are characterization tests expected green
+   from task 1 — that is intentional, don't force artificial redness:
+   - `test_one_off_long_trip_rejected` (AC 1)
+   - `test_live_recurring_weekly_long_trip_kept` (AC 2)
+   - `test_pattern_stop_reverts_prediction_immediately` (AC 2)
+   - `test_different_weekday_big_record_does_not_corroborate` (AC 2)
+   - `test_out_and_back_weekend_trip_rejected` (AC 3)
+   - `test_absolute_floor_keeps_normal_trip_for_low_mileage_person` (AC 4)
+   - `test_sparse_weekday_bucket_disables_outlier_detection` (AC 5,
+     3-vs-4 LOO-sample boundary; *(char.)* for the 3-sample side)
+   - `test_median_interpolated_on_even_bucket` (AC 5)
+   - `test_older_suspicious_record_never_rescued` (Design §2 step 3
+     truth table)
+   - `test_first_occurrence_rejected_pattern_live_after_second` (AC 6)
+   - `test_recurrence_tolerance_exceeded_rejects` (AC 6)
+   - `test_recurrence_window_exceeded_rejects` (AC 6; inclusive-at-21
+     boundary)
+   - `test_leave_time_ignores_outlier_records` (AC 1 leave-time half)
+   - `test_serialized_history_90_records_under_recorder_limit` (AC 8,
+     *(char.)*)
+   - `test_restored_old_records_survive_when_initialized` (AC 7 restart
+     half, *(char.)*; extend existing restore tests if a better home
+     exists)
+3. **`ha_model/home.py` + its count tests (atomic)** — switch the two
+   backfill loops (loop lines `home.py:2393` in
+   `recompute_people_historical_data` and `:2278` in
+   `dump_person_car_data_for_debug`) to `PERSON_HISTORY_BACKFILL_DAYS`;
+   swap the `home.py:50` import accordingly; **in the same task**,
+   update the two count tests and their imports —
+   `tests/ha_tests/test_home_coverage.py:4139` (imports the constant
+   *through* `ha_model.home`; leaving it breaks collection with an
+   ImportError, masking task-2 redness) and `:4160`;
+   `tests/test_persons_car_forecast.py:18` and `:977`. Fix **both**
+   stale comments: `home.py:2271` and `home.py:2352` (the latter is in
+   `update_forecast_probers` — kept in scope because it literally names
+   the constant whose semantics this story changes).
+4. **`ha_model/person.py`** — add `_is_mileage_outlier()` (leave-one-out
+   `statistics.median` by day key + per-record magnitude test +
+   last-2-only live-pattern rescue); rework `_get_best_week_day_guess()`
+   to collect the last 2 good samples (no all-outlier fallback branch —
+   see Design §3 proof); fix the stale "keeps only 2 weeks of data"
+   comment in `add_to_mileage_history`. Task-2 outlier tests green.
+5. **Existing-test verification** — the two retention-cap tests
+   (`tests/test_person_coverage.py:136-141`,
+   `tests/test_ha_person_comprehensive.py:165-176`) are parametrized on
+   the constant and self-adapt — **verify they pass unchanged, do not
+   edit them**. Verify AC 9's exact-value oracle (all four person
+   assertions unchanged).
+6. **Docs** — update
+   `docs/agents/concepts/person-trip-prediction.md` per Design §4; bump
+   `last_verified` on the four Doc-OK docs.
+
+## Out of scope
+
+- **Calendar integration** (reading trip destinations from person
+  calendars) — explicitly deferred to a separate story, per the issue and
+  discussion. Also the designated fix for **monthly- or alternating-
+  cadence trips**, which the live-pattern recurrence rule deliberately
+  does not recognize (review rounds 1–2 + discussion, accepted
+  trade-off).
+- **6-month retention** — requires a compacted serialization format
+  (date-only `day`, `HH:MM` `leave_time`) with backward-compatible
+  parsing to stay under the recorder's 16 KB attribute limit. Follow-up
+  candidate if 3 months proves insufficient in real data. The AC 8 size
+  guard is the tripwire for this follow-up.
+- Any config-flow / UI options for the thresholds — constants only.
+
+## Adversarial Review Notes
+
+**Round 1** (4 reviewers: critic, concrete-planner, dev-proxy,
+scope-guardian) — 22 deduped findings, all triaged "fix all":
+
+| # | Finding (short) | Source | State |
+|---|---|---|---|
+| C1 | Restore↔backfill restart interaction unspecified | critic | resolved — Design §1 note + AC 7 |
+| C2 | Out-and-back one-off self-validates as recurring | critic | resolved — initially min-gap 4 days; **superseded in v3** by the same-weekday live-pattern rule (structural fix) + AC 3 |
+| R1 | Monthly recurrence blind spot | critic | resolved — accepted as designed, documented in Design §2 + Out of scope (calendar story is the fix) |
+| R2 | First occurrence of new recurring trip rejected | critic, dev-proxy | resolved — documented trade-off, bounded to 1 week, AC 6 |
+| R3 | Wrong exact-value regression test named (57/76 km test at :875) | concrete-planner | resolved — AC 9 with strict change policy |
+| R4 | Doc-OK docs mechanically fail drift checker (co-modification required) | dev-proxy | resolved — `last_verified` bumps, task 6 |
+| D1 | Global-median fallback is YAGNI | scope-guardian | resolved — dropped; single bucket-threshold rule |
+| U1 | Stale recurrence: after a 2-occurrence pattern stops, the newer big record stays "corroborated" and over-predicts one extra week | user (discussion after round 1) | resolved — v3 live-pattern rule: recurrence applies only when the last 2 same-weekday records are both big + similar; pattern break reverts the prediction immediately (AC 2) |
+| — | 18-item improve/clarify batch (leave-one-out median; tolerance formula; entry schema; leave-time rule; 16 KB test; debug log; TDD order; import churn; self-adapting tests; stale comments; named tests; AC wording; tunable defaults; provenance flags; backfill rationale; no new count tests) | all | resolved — folded into Design/AC/tasks |
+
+**Round 2** (4 reviewers + delta-auditor on the v1→v3 diff) — delta
+auditor verified **all round-1 findings resolved**, no contradictions
+introduced; new findings all triaged "fix all":
+
+| # | Finding (short) | Source | State |
+|---|---|---|---|
+| C3 | All-outlier fallback is mathematically unreachable (dead code vs 100 % coverage) | critic + scope-guardian (converged) | resolved — branch, AC and test dropped; proof recorded in Design §3 |
+| R5 | "Immediate reversion" invariant false in the majority regime (habit dominates the median) | critic | resolved — qualified to minority regime; majority regime documented as intended; AC 2 fixture constrained |
+| D2 | 21-day pair window not part of the user's tightened rule | scope-guardian | resolved — kept deliberately (stale-pair protection on sparse buckets), user-confirmed, rationale recorded in Design §2 |
+| — | Improve/clarify batch: task-3 atomicity with count tests (ImportError window); single-commit note; 2 new rejection-reason tests; green-from-start characterization annotations; last-2-only rescue scope pinned; per-record LOO baseline + gate pinned; `statistics.median` pinned + even-bucket test; LOO exclusion by day key; AC 5 boundary both sides + inclusive 21; count-cap vs days semantics; AC 9 extended to all four assertions + concrete oracle + policy generalized; single-normal-day trade-off documented; 16 KB test framed as permanent guard; `home.py:2352` comment kept with justification; def-vs-loop line refs labeled | all + delta-auditor | resolved — folded into Design/AC/tasks |
+
+Nothing shipped open; no rejected findings.

--- a/docs/stories/QS-298.story_review_fix_#01.md
+++ b/docs/stories/QS-298.story_review_fix_#01.md
@@ -1,0 +1,224 @@
+# QS-298 — Review fix plan #01
+
+## Summary
+- Source PR: #301
+- Source story: docs/stories/QS-298.story.md
+- Findings to fix: 12
+- Next implement phase: `/implement-task`
+
+Review context: 4-reviewer adversarial pass (blind-hunter,
+edge-case-hunter, acceptance-auditor; CodeRabbit rate-limited this
+round). CI fully green at review time, doc drift check clean. Two
+blind-hunter findings were verified as false positives (count-cap
+off-by-one; ordering invariant — both are actually enforced in
+`add_to_mileage_history`) and are NOT in this plan.
+
+User-confirmed decisions: fix ALL findings below, including S/N
+caveats — N2 amends the story's pinned tolerance-denominator
+semantics, and N6's fix touches the pre-existing production restore
+path in addition to the test.
+
+## Findings to fix
+
+### [should-fix] Live-pattern rescue has no recency bound relative to now
+- File: `custom_components/quiet_solar/ha_model/person.py:213` (`_is_mileage_outlier`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The 21-day recurrence window only checks pair spacing
+  (`newest[0] − older[0]`), never `now − newest[0]`. Zero-driving days
+  produce no records (ingestion requires `mileage > 0`), so a dead
+  habit — two similar >100 km trips on consecutive same weekdays, then
+  that weekday goes driving-silent (WFH, car sold, tracker stops) —
+  stays `bucket[-2:]` and keeps predicting ~400 km until ~90 other-day
+  records push the pair out of the ring (~15 weeks at 6 driving
+  days/week; indefinitely for a low-driving person). Pre-PR, the
+  30-day retention self-healed this in ≤4 weeks, so this corner is a
+  regression vs. the story's own goal.
+- Proposed fix: Additionally require the pair's `newest[0]` to be
+  within `PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS` (or a dedicated
+  constant if a different bound is warranted) of the prediction time.
+  Thread `time` from `_compute_person_next_need` →
+  `_get_best_week_day_guess` → `_is_mileage_outlier` →
+  the rescue check. Add tests: (a) live pair within window of now →
+  rescued; (b) same pair but prediction time > window after `newest`
+  → rejected (prediction reverts to non-outlier records); (c) boundary
+  at exactly the window (pin inclusive/exclusive to match the pair-
+  spacing rule's inclusivity). Update
+  `docs/agents/concepts/person-trip-prediction.md` (live-pattern rule
+  gains a "pair must be recent relative to now" clause) and the story's
+  documented trade-offs if worded there.
+
+### [should-fix] Sparse-boundary test does not actually pin leave time
+- File: `tests/test_person_outlier.py:141-153`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC 5 requires that with 3 leave-one-out samples
+  (detection off) the prediction outputs — mileage AND leave time —
+  are identical to today's algorithm, but the test only asserts
+  `leave_off is not None`, and all fixture records share the default
+  `leave_hour=8`, so even an equality assertion would be vacuous.
+- Proposed fix: Give the 400 km outlier record a distinct earlier
+  leave hour (e.g. `leave_hour=5`) in the detection-off fixture and
+  assert `leave_off.hour == 5` (the undetected outlier's leave time is
+  consumed exactly as today); in the detection-on fixture assert
+  `leave.hour == 8` (the outlier contributes neither mileage nor leave
+  time).
+
+### [nice-to-have] Rename MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS to reflect count semantics
+- File: `custom_components/quiet_solar/const.py:441` (+ all usages)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The constant now semantically means "record count",
+  not days (the doc even warns the ring "may span more than 90
+  calendar days"). The `_DAYS` suffix is actively misleading.
+- Proposed fix: Rename to `MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS`
+  (or similar) across `const.py`, `person.py`, tests, and docs. Keep
+  any serialized attribute names unchanged (the constant name is not
+  serialized — verify).
+
+### [nice-to-have] Symmetric similarity denominator for the recurrence tolerance
+- File: `custom_components/quiet_solar/ha_model/person.py:208` (`_is_mileage_outlier`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `abs(older − newest) > TOLERANCE × newest[1]` is
+  asymmetric — a larger `newest` is more lenient — and doesn't match
+  the "mutually similar" wording. NOTE: the story pins
+  "denominator = newest"; the user explicitly approved amending that
+  pin.
+- Proposed fix: Use `max(older[1], newest[1])` as the denominator.
+  Update the story's pinned semantics (Design §2), the docstring, the
+  concept doc, and any test that pins the 400/250 similarity-failure
+  boundary (recheck the pinned pair still fails: 150 > 0.2×400=80 —
+  yes, still rejected).
+
+### [nice-to-have] Hoist weekday-bucket build out of the per-entry outlier check
+- File: `custom_components/quiet_solar/ha_model/person.py:~195`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `_is_mileage_outlier` rebuilds the weekday bucket with
+  a full history scan for every entry visited, and
+  `_is_suspicious_mileage` re-runs a median per call — O(n²·median)
+  per prediction. Trivial at n=90 but easy to avoid.
+- Proposed fix: Build the weekday bucket once in
+  `_get_best_week_day_guess` and pass it to `_is_mileage_outlier`
+  (which already receives it for `_is_suspicious_mileage`). Pure
+  refactor; behavior identical, existing tests must stay green.
+
+### [nice-to-have] const.py comments hardcode tunable values
+- File: `custom_components/quiet_solar/const.py:441-442`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Comments say "keep at most 90 mileage records" and
+  "one query per day" for 30 — they will silently drift on the next
+  retention bump.
+- Proposed fix: Reword comments to be value-free ("count cap: max
+  mileage records retained", "boot-time recorder backfill depth in
+  days").
+
+### [nice-to-have] Dead abs() in the pair-spacing window check
+- File: `custom_components/quiet_solar/ha_model/person.py:211`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `abs((newest[0].date() − older[0].date()).days)` — the
+  `abs()` is dead: `add_to_mileage_history` enforces ascending order
+  with unique day keys, so `newest ≥ older` always.
+- Proposed fix: Drop the `abs()` and add a short comment that ordering
+  is enforced at ingestion.
+
+### [nice-to-have] Restore parsing strips the serialized offset (production + test)
+- Files: `custom_components/quiet_solar/ha_model/person.py:351-352`
+  (pre-existing `device_post_home_init` restore loop) and
+  `tests/test_person_outlier.py:~287`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter (downgraded by orchestrator)
+- Description: `datetime.fromisoformat(s).replace(tzinfo=None)
+  .astimezone(tz=pytz.UTC)` discards the serialized offset and
+  reinterprets the wall time in the system TZ. Correct when serialize
+  and restore share the same TZ (the normal case), but fragile across
+  TZ changes / DST-transition instants. The test mirrors production
+  verbatim. User approved fixing BOTH.
+- Proposed fix: In both places, keep the parsed offset:
+  `datetime.fromisoformat(s).astimezone(pytz.UTC)` (fromisoformat
+  output is aware here because serialization writes aware local
+  isoformat; guard/fallback for naive legacy strings if needed —
+  preserve current behavior for offset-less input). Update/extend the
+  round-trip test accordingly.
+
+### [nice-to-have] Restore path accepts non-finite / non-positive mileage
+- File: `custom_components/quiet_solar/ha_model/person.py`
+  (`add_to_mileage_history:119`, restore loop `:354`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The `mileage > 0` guard exists only on the live
+  ingestion path (`home.py`); the restore loop feeds any parseable
+  float into history. A `NaN` makes `statistics.median` ordering
+  undefined — the baseline becomes `NaN`, every comparison silently
+  returns False, and outlier detection turns off for that weekday
+  with no log; a negative mileage drags `2.5 × baseline` negative,
+  flagging normal >100 km records as suspicious.
+- Proposed fix: Reject `mileage <= 0` or non-finite
+  (`math.isfinite`) values in `add_to_mileage_history` — the single
+  choke point covering both restore and live paths — with a warning
+  log. Add a test restoring a `NaN` and a negative record and
+  asserting they are dropped and detection still works.
+
+### [nice-to-have] Rescue pair size hardcoded vs PERSON_MILEAGE_NUM_GOOD_SAMPLES
+- File: `custom_components/quiet_solar/ha_model/person.py:203`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The rescue hardcodes a last-2 pair
+  (`bucket[-2], bucket[-1]`) while `PERSON_MILEAGE_NUM_GOOD_SAMPLES`
+  is a separate tunable used for the walk depth. Bumping the tunable
+  to 3 would silently mix a rescued pair with a third record while
+  rescue still only validates pairs.
+- Proposed fix: Add a comment plus a module-level guard (e.g.
+  `assert PERSON_MILEAGE_NUM_GOOD_SAMPLES == 2` adjacent to the rescue,
+  or a static check in tests) tying the rescue's pair size to the
+  constant. Do NOT generalize the rescue to N-tuples (YAGNI — scope
+  guarded).
+
+### [nice-to-have] Restart test exercises the flag, not the real restore path
+- File: `tests/test_person_outlier.py:272-296`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: `test_restored_old_records_survive_when_initialized`
+  sets `restored.has_been_initialized = True` by hand and asserts
+  `should_recompute_history(...) is False`, rather than driving the
+  `QSBaseSensorRestore` attribute round-trip /
+  `device_post_home_init` path. Story permits this, but an
+  integration-level restore test pins the actual restart wiring.
+- Proposed fix: Extend an existing restore test in the ha_tests layer
+  (or add one) that restores >30-day-old records through the sensor
+  attributes and asserts history length and prediction are preserved
+  after `device_post_home_init`. Coordinate with the N6/N7 fixes above
+  (same code region).
+
+### [nice-to-have] 16 KB size guard duplicates the attribute dict
+- File: `tests/test_person_outlier.py:260-267`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: `test_serialized_history_90_records_under_recorder_limit`
+  hand-builds `{"historical_data", "predicted_mileage",
+  "predicted_leave_time", "has_been_initialized"}`. The keys match
+  `get_person_mileage_serialized_prediction`
+  (`person.py:604-609`) today, but the "permanent guard" silently
+  under-measures if the sensor ever gains attributes.
+- Proposed fix: Build the payload by calling
+  `get_person_mileage_serialized_prediction()` (or a shared helper)
+  so the guard tracks the real serialized surface.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify.
+
+Notes for the implementer:
+- S1 changes prediction semantics: update
+  `docs/agents/concepts/person-trip-prediction.md` and the story's
+  trade-off section in the same commit (doc-maintenance rule).
+- N2 amends a story-pinned choice — user-approved; amend the story
+  text, don't silently contradict it.
+- N6 touches pre-existing production code (`device_post_home_init`);
+  keep the behavior identical for the normal same-TZ case.
+- Quality gate: `python scripts/qs/quality_gate.py --impacted`
+  (100% coverage, ruff, mypy) before commit/push.

--- a/docs/stories/QS-298.story_review_fix_#02.md
+++ b/docs/stories/QS-298.story_review_fix_#02.md
@@ -1,0 +1,84 @@
+# QS-298 — Review fix plan #02
+
+## Summary
+- Source PR: #301
+- Source story: docs/stories/QS-298.story.md
+- Findings to fix: 3
+- Next implement phase: `/implement-task`
+
+Review context: round-2 4-reviewer adversarial pass over commit
+`0b1b9a8f` ("apply review fix plan #01"). The acceptance auditor
+confirmed all 11 story ACs and all 12 round-1 fix-plan findings are
+implemented and tested, and both deliberate story amendments (S1
+recency clause, N2 symmetric denominator) were correctly folded into
+the story + concept doc. The blind-hunter and edge-case-hunter both
+verified the four round-1 fixes hold up with no regressions.
+
+CodeRabbit was unavailable both rounds (rate-limited, then its
+incremental engine refused to re-review the already-registered
+commit); pushing this round's fix will force a fresh CodeRabbit run.
+
+User-confirmed decisions: fix M1, N4, N5 below. Explicitly SKIPPED
+(reviewer nice-to-haves, deliberately not in this plan): recency-bound
+future-date clamp (`person.py:236`), `len(bucket) < 2` explicit guard
+(`person.py:~190`), and hoisting the per-call median out of
+`_is_suspicious_mileage`.
+
+## Findings to fix
+
+### [must-fix] Ruff format check fails in CI
+- File: `custom_components/quiet_solar/ha_model/person.py:131`
+- Severity: must-fix
+- Source: CI ("Ruff Lint & Format" job red) / orchestrator
+- Description: The `_LOGGER.warning(...)` call added by review fix #01
+  is over-wrapped across three lines; `ruff format` collapses it to a
+  single line. CI fails and `ruff format --check` reproduces locally
+  ("1 file would be reformatted, 37 already formatted"). This is the
+  only blocking item this round.
+- Proposed fix: Run `python -m ruff format
+  custom_components/quiet_solar/ha_model/person.py` (collapses the
+  `_LOGGER.warning("add_to_mileage_history: rejecting invalid mileage
+  %s for person %s", mileage, self.name)` call to one line). Confirm
+  `ruff format --check` and the full `quality_gate.py --impacted` are
+  green before commit.
+
+### [nice-to-have] Const comment references transient story file
+- File: `custom_components/quiet_solar/const.py:445`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The production constant comment points at
+  `docs/stories/QS-298.story.md Design §2`. Story files are transient;
+  the durable home for the rationale is the concept doc.
+- Proposed fix: Repoint the comment to
+  `docs/agents/concepts/person-trip-prediction.md` (the durable
+  concept doc that already documents the outlier tunables). Verify the
+  concept doc actually covers the referenced rationale; if a specific
+  section anchor is cited, make sure it exists.
+
+### [nice-to-have] Pair-size coupling test is a bare constant assertion
+- File: `tests/test_person_outlier.py`
+  (`test_rescue_pair_size_matches_num_good_samples`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The test is a bare `assert PERSON_MILEAGE_NUM_GOOD_SAMPLES
+  == 2` with no behavior exercised — it tells a future editor "change
+  me too" but not *why* the rescue breaks for N != 2.
+- Proposed fix: Add (or convert to) a behavioral guard that exercises
+  the rescue with the last-2 pair semantics — e.g. a weekday bucket
+  whose 3 most-recent records include a rescued similar pair plus a
+  distinct third record, asserting the third record does NOT alter the
+  rescue decision (the rescue only ever validates `bucket[-2:]`). Keep
+  the static `== 2` assertion too if useful as a tripwire, but the
+  behavioral test is the primary carrier of the coupling. Do NOT
+  generalize the rescue to N-tuples (YAGNI — scope guarded).
+
+## How to apply
+
+Run `/implement-task` against this fix plan. M1 is a pure reformat; N4
+is a comment-only change; N5 is a test change. No production logic
+changes are in scope this round. When done, return and run
+`/review-task` again to re-verify (the new commit will also unblock a
+fresh CodeRabbit run).
+
+Quality gate: `python scripts/qs/quality_gate.py --impacted` (100%
+coverage, ruff, mypy) must be green before commit/push.

--- a/tests/ha_tests/test_home_coverage.py
+++ b/tests/ha_tests/test_home_coverage.py
@@ -4136,7 +4136,7 @@ async def test_dump_person_car_data_pickle_save(
     from os.path import join
 
     from custom_components.quiet_solar.ha_model.home import (
-        MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS,
+        PERSON_HISTORY_BACKFILL_DAYS,
     )
 
     await hass.config_entries.async_setup(home_config_entry.entry_id)
@@ -4157,7 +4157,7 @@ async def test_dump_person_car_data_pickle_save(
 
     assert "full_range" in data
     assert "per_day" in data
-    assert len(data["per_day"]) == MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS
+    assert len(data["per_day"]) == PERSON_HISTORY_BACKFILL_DAYS
 
 
 async def test_mileage_person_only_pre_start_segments(

--- a/tests/test_ha_person_comprehensive.py
+++ b/tests/test_ha_person_comprehensive.py
@@ -32,7 +32,7 @@ from custom_components.quiet_solar.const import (
     CONF_PERSON_PREFERRED_CAR,
     DATA_HANDLER,
     DOMAIN,
-    MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS,
+    MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS,
     PERSON_NOTIFY_REASON_CHANGED_CAR,
 )
 from custom_components.quiet_solar.ha_model.person import (
@@ -162,18 +162,18 @@ class TestQSPersonMileageHistory:
         assert person.historical_mileage_data[2][1] == 75.0
 
     def test_add_to_mileage_history_limits_size(self, create_person):
-        """Test history is limited to MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS."""
+        """Test history is limited to MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS."""
         person = create_person()
 
         base = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
         leave = datetime.datetime(2024, 1, 1, 8, 0, 0, tzinfo=pytz.UTC)
 
         # Add more than the maximum
-        for i in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS + 5):
+        for i in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS + 5):
             day = base + timedelta(days=i)
             person.add_to_mileage_history(day, float(i * 10), leave + timedelta(days=i))
 
-        assert len(person.historical_mileage_data) <= MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS
+        assert len(person.historical_mileage_data) <= MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS
 
     def test_add_to_mileage_history_none_leave_time(self, create_person):
         """Test handling of None leave time."""

--- a/tests/test_person_coverage.py
+++ b/tests/test_person_coverage.py
@@ -20,7 +20,7 @@ from custom_components.quiet_solar.const import (
     CONF_PERSON_PERSON_ENTITY,
     CONF_PERSON_PREFERRED_CAR,
     DOMAIN,
-    MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS,
+    MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS,
     PERSON_NOTIFY_REASON_CHANGED_CAR,
     PERSON_NOTIFY_REASON_DAILY_REMINDER_FOR_CAR_NO_CHARGER,
 )
@@ -133,12 +133,12 @@ def test_add_to_mileage_history_insert_update_and_trim(hass: HomeAssistant) -> N
     assert len(person.historical_mileage_data) == 3
     assert person.historical_mileage_data[1][1] == 15.0
 
-    for idx in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS + 1):
+    for idx in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS + 1):
         day = base + timedelta(days=3 + idx)
         person.add_to_mileage_history(day, 1.0, day + timedelta(hours=8))
 
-    assert len(person.historical_mileage_data) == MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS
-    assert len(person.serializable_historical_data) == MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS
+    assert len(person.historical_mileage_data) == MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS
+    assert len(person.serializable_historical_data) == MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS
 
 
 def test_should_recompute_history_empty_authorized_cars(hass: HomeAssistant) -> None:
@@ -247,6 +247,36 @@ async def test_device_post_home_init_restores_history(hass: HomeAssistant) -> No
 
     assert len(person.historical_mileage_data) == 1
     assert person.has_been_initialized is True
+
+
+async def test_device_post_home_init_preserves_old_records_and_prediction(hass: HomeAssistant) -> None:
+    """Restore >30-day-old records through the real sensor-attribute round-trip
+    (device_post_home_init): history length and prediction are preserved and an
+    initialized person never triggers recompute (QS-298 AC 7, N9)."""
+    hass, _, person = _make_person(hass, person_authorized_cars=["Car A"])
+    person.ha_entities["person_mileage_prediction"] = SimpleNamespace(entity_id="sensor.person_mileage_prediction")
+
+    now = datetime(2026, 4, 1, 6, 0, tzinfo=pytz.UTC)
+    base = now - timedelta(days=MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS - 1)  # spans > 30 days
+
+    _, _, source = _make_person(hass, person_authorized_cars=["Car A"])
+    for i in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS):
+        d = base + timedelta(days=i)
+        source.add_to_mileage_history(d, 40.0 + (i % 3) * 5.0, d + timedelta(hours=8))
+    serialized = list(source.serializable_historical_data)
+    source_pred = source._get_best_week_day_guess(now.weekday(), now.astimezone(tz=None))
+
+    hass.states.async_set(
+        "sensor.person_mileage_prediction",
+        "ok",
+        {"historical_data": serialized, "has_been_initialized": True},
+    )
+
+    person.device_post_home_init(now)
+
+    assert len(person.historical_mileage_data) == MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS
+    assert person.should_recompute_history(now) is False
+    assert person._get_best_week_day_guess(now.weekday(), now.astimezone(tz=None)) == source_pred
 
 
 def test_device_post_home_init_missing_sensor_entity(hass: HomeAssistant) -> None:

--- a/tests/test_person_outlier.py
+++ b/tests/test_person_outlier.py
@@ -1,0 +1,295 @@
+"""Outlier-resistant trip-prediction tests (QS-298).
+
+These exercise ``QSPerson._is_mileage_outlier`` and the reworked
+``QSPerson._get_best_week_day_guess`` directly by building
+``historical_mileage_data`` tuples with full control over the weekday
+buckets. Tuples are ``(day, mileage_km, leave_time, weekday)`` in local
+time, date-ordered ascending — the same schema the ingestion path
+produces.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+
+import pytz
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.quiet_solar.const import (
+    CONF_PERSON_PERSON_ENTITY,
+    DOMAIN,
+    MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS,
+    PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS,
+)
+from custom_components.quiet_solar.ha_model.home import QSHome
+from custom_components.quiet_solar.ha_model.person import QSPerson
+
+# Reference weekdays (2026-01-01 is a Thursday).
+WED = datetime(2026, 1, 7, 12, 0, tzinfo=pytz.UTC)  # Wednesday
+TUE = datetime(2026, 1, 6, 12, 0, tzinfo=pytz.UTC)  # Tuesday
+FRI = datetime(2026, 1, 9, 12, 0, tzinfo=pytz.UTC)  # Friday
+SUN = datetime(2026, 1, 11, 12, 0, tzinfo=pytz.UTC)  # Sunday
+
+
+def _make_person(hass: HomeAssistant, **overrides) -> QSPerson:
+    hass.data.setdefault(DOMAIN, {})
+    config_entry = MockConfigEntry(domain=DOMAIN, data={"name": "Test Home"}, title="Test Home")
+    home = QSHome(hass=hass, config_entry=config_entry, name="Test Home")
+    return QSPerson(
+        hass=hass,
+        home=home,
+        config_entry=None,
+        name="Test Person",
+        **{CONF_PERSON_PERSON_ENTITY: "person.test_person", **overrides},
+    )
+
+
+def _entry(base: datetime, weeks: int, km: float, leave_hour: int = 8):
+    """Build one same-weekday record ``weeks`` after ``base``."""
+    day = base + timedelta(weeks=weeks)
+    leave = day.replace(hour=leave_hour, minute=0)
+    return (day, float(km), leave, day.weekday())
+
+
+def _set_history(person: QSPerson, entries: list) -> None:
+    person.historical_mileage_data = sorted(entries, key=lambda e: e[0])
+
+
+def test_one_off_long_trip_rejected(hass: HomeAssistant) -> None:
+    """AC 1: a single 400 km record among ~12 weeks of 30-60 km days is
+    rejected; prediction is the max of the last 2 non-outlier records."""
+    person = _make_person(hass)
+    entries = [_entry(WED, w, 30 + (w % 2) * 30) for w in range(11)]  # 30 / 60 km
+    entries.append(_entry(WED, 11, 400.0))  # one-off last week
+    _set_history(person, entries)
+
+    mileage, leave = person._get_best_week_day_guess(WED.weekday())
+    assert mileage is not None and mileage <= 60.0
+    assert leave is not None
+
+
+def test_live_recurring_weekly_long_trip_kept(hass: HomeAssistant) -> None:
+    """AC 2 (minority regime): last 2 same-weekday records both ~400 km on
+    consecutive weeks, within tolerance, with a normal-day majority → kept."""
+    person = _make_person(hass)
+    entries = [_entry(WED, w, 40.0) for w in range(6)]
+    entries.append(_entry(WED, 6, 400.0))
+    entries.append(_entry(WED, 7, 390.0))  # newest, within 20% of 400
+    _set_history(person, entries)
+
+    mileage, _leave = person._get_best_week_day_guess(WED.weekday())
+    assert mileage is not None and mileage >= 390.0
+
+
+def test_pattern_stop_reverts_prediction_immediately(hass: HomeAssistant) -> None:
+    """AC 2: a normal day landing after a live pattern reverts at once."""
+    person = _make_person(hass)
+    entries = [_entry(WED, w, 40.0) for w in range(6)]
+    entries.append(_entry(WED, 6, 400.0))
+    entries.append(_entry(WED, 7, 390.0))
+    entries.append(_entry(WED, 8, 40.0))  # normal day breaks liveness
+    _set_history(person, entries)
+
+    mileage, _leave = person._get_best_week_day_guess(WED.weekday())
+    assert mileage is not None and mileage <= 60.0
+
+
+def test_different_weekday_big_record_does_not_corroborate(hass: HomeAssistant) -> None:
+    """AC 2: a big record on a different weekday never rescues an outlier."""
+    person = _make_person(hass)
+    entries = [_entry(WED, w, 40.0) for w in range(6)]
+    entries.append(_entry(WED, 6, 400.0))  # one-off Wednesday
+    # a big Tuesday record that must not corroborate the Wednesday one-off
+    entries += [_entry(TUE, w, 40.0) for w in range(6)]
+    entries.append(_entry(TUE, 6, 400.0))
+    _set_history(person, entries)
+
+    mileage, _leave = person._get_best_week_day_guess(WED.weekday())
+    assert mileage is not None and mileage <= 60.0
+
+
+def test_out_and_back_weekend_trip_rejected(hass: HomeAssistant) -> None:
+    """AC 3: a one-off ~200 km Friday-out / Sunday-back trip is rejected on
+    both weekdays (different buckets cannot corroborate)."""
+    person = _make_person(hass)
+    entries = []
+    for base in (FRI, SUN):
+        entries += [_entry(base, w, 40.0) for w in range(6)]
+        entries.append(_entry(base, 6, 200.0))
+    _set_history(person, entries)
+
+    fri_mileage, _ = person._get_best_week_day_guess(FRI.weekday())
+    sun_mileage, _ = person._get_best_week_day_guess(SUN.weekday())
+    assert fri_mileage is not None and fri_mileage <= 60.0
+    assert sun_mileage is not None and sun_mileage <= 60.0
+
+
+def test_absolute_floor_keeps_normal_trip_for_low_mileage_person(hass: HomeAssistant) -> None:
+    """AC 4: a 40 km record for a ~10 km-median person is not an outlier."""
+    person = _make_person(hass)
+    entries = [_entry(WED, w, 10.0) for w in range(6)]
+    entries.append(_entry(WED, 6, 40.0))  # 4x median but under the 100 km floor
+    _set_history(person, entries)
+
+    mileage, _leave = person._get_best_week_day_guess(WED.weekday())
+    assert mileage == 40.0
+
+
+def test_sparse_weekday_bucket_disables_outlier_detection(hass: HomeAssistant) -> None:
+    """AC 5: 3 leave-one-out samples → detection off (char.); exactly 4 → on."""
+    person = _make_person(hass)
+
+    # 4 records total → LOO others for the 400 record = 3 → detection off.
+    sparse = [_entry(WED, w, 40.0) for w in range(3)] + [_entry(WED, 3, 400.0)]
+    _set_history(person, sparse)
+    mileage_off, leave_off = person._get_best_week_day_guess(WED.weekday())
+    assert mileage_off == 400.0  # identical to today's max-of-last-2
+    assert leave_off is not None
+
+    # 5 records total → LOO others = 4 → detection on → 400 rejected.
+    dense = [_entry(WED, w, 40.0) for w in range(4)] + [_entry(WED, 4, 400.0)]
+    _set_history(person, dense)
+    mileage_on, _leave = person._get_best_week_day_guess(WED.weekday())
+    assert mileage_on == 40.0
+
+
+def test_median_interpolated_on_even_bucket(hass: HomeAssistant) -> None:
+    """AC 5: baseline uses statistics.median (interpolated) — on an even
+    leave-one-out bucket [40,40,400,400] the baseline is 220, so a 500 km
+    record is NOT suspicious (500 <= 2.5 * 220)."""
+    person = _make_person(hass)
+    others = [
+        _entry(WED, 0, 40.0),
+        _entry(WED, 1, 40.0),
+        _entry(WED, 2, 400.0),
+        _entry(WED, 3, 400.0),
+    ]
+    target = _entry(WED, 4, 500.0)
+    _set_history(person, others + [target])
+
+    # baseline = median([40,40,400,400]) = 220 ; 500 <= 2.5*220 = 550
+    assert person._is_mileage_outlier(target) is False
+
+
+def test_older_suspicious_record_never_rescued(hass: HomeAssistant) -> None:
+    """Design §2 step 3 truth table: rescue only applies to the last 2 bucket
+    records; an older suspicious record is always an outlier."""
+    person = _make_person(hass)
+    entries = [
+        _entry(WED, 0, 40.0),
+        _entry(WED, 1, 400.0),  # older big pair (consecutive + similar)
+        _entry(WED, 2, 400.0),
+        _entry(WED, 3, 40.0),
+        _entry(WED, 4, 40.0),  # last 2 are normal
+    ]
+    _set_history(person, entries)
+
+    older_big = entries[1]
+    assert person._is_mileage_outlier(older_big) is True
+
+
+def test_first_occurrence_rejected_pattern_live_after_second(hass: HomeAssistant) -> None:
+    """AC 6: first occurrence of a new recurring trip rejected; second
+    occurrence within 21 days makes the pattern live and kept."""
+    person = _make_person(hass)
+    normals = [_entry(WED, w, 40.0) for w in range(5)]
+
+    _set_history(person, normals + [_entry(WED, 5, 400.0)])
+    mileage_first, _ = person._get_best_week_day_guess(WED.weekday())
+    assert mileage_first is not None and mileage_first <= 60.0
+
+    _set_history(person, normals + [_entry(WED, 5, 400.0), _entry(WED, 6, 400.0)])
+    mileage_second, _ = person._get_best_week_day_guess(WED.weekday())
+    assert mileage_second == 400.0
+
+
+def test_recurrence_tolerance_exceeded_rejects(hass: HomeAssistant) -> None:
+    """AC 6: a 400/250 last-2 pair fails the similarity test → both rejected."""
+    person = _make_person(hass)
+    entries = [_entry(WED, w, 40.0) for w in range(5)]
+    entries.append(_entry(WED, 5, 400.0))
+    entries.append(_entry(WED, 6, 250.0))  # |400-250|=150 > 0.2*250=50
+    _set_history(person, entries)
+
+    mileage, _ = person._get_best_week_day_guess(WED.weekday())
+    assert mileage is not None and mileage <= 60.0
+
+
+def test_recurrence_window_exceeded_rejects(hass: HomeAssistant) -> None:
+    """AC 6: window is inclusive at exactly 21 days; 28 days apart rejects."""
+    assert PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS == 21
+    person = _make_person(hass)
+    normals = [_entry(WED, w, 40.0) for w in range(5)]
+
+    # exactly 21 days apart (3 weeks) → inclusive → live pattern kept
+    _set_history(person, normals + [_entry(WED, 5, 400.0), _entry(WED, 8, 400.0)])
+    mileage_in, _ = person._get_best_week_day_guess(WED.weekday())
+    assert mileage_in == 400.0
+
+    # 28 days apart (4 weeks) → outside window → rejected
+    _set_history(person, normals + [_entry(WED, 5, 400.0), _entry(WED, 9, 400.0)])
+    mileage_out, _ = person._get_best_week_day_guess(WED.weekday())
+    assert mileage_out is not None and mileage_out <= 60.0
+
+
+def test_leave_time_ignores_outlier_records(hass: HomeAssistant) -> None:
+    """AC 1 (leave-time half): an outlier contributes neither mileage nor
+    leave time — the predicted leave time is the earliest of the good ones."""
+    person = _make_person(hass)
+    entries = [_entry(WED, w, 40.0, leave_hour=8 + (w % 2)) for w in range(6)]  # 08:00 / 09:00
+    entries.append(_entry(WED, 6, 400.0, leave_hour=5))  # anomalous early departure
+    _set_history(person, entries)
+
+    mileage, leave = person._get_best_week_day_guess(WED.weekday())
+    assert mileage is not None and mileage <= 60.0
+    assert leave is not None and leave.hour == 8  # never the 05:00 outlier
+
+
+def test_serialized_history_90_records_under_recorder_limit(hass: HomeAssistant) -> None:
+    """AC 8 (char., permanent guard): 90 realistic serialized records plus the
+    sensor's other attributes stay under the recorder's 16 KB limit."""
+    person = _make_person(hass)
+    day = datetime(2026, 1, 1, 6, 30, 15, tzinfo=pytz.UTC)
+    for i in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS):
+        d = day + timedelta(days=i)
+        person.add_to_mileage_history(d, 123.45, d + timedelta(hours=13, minutes=27))
+
+    assert len(person.serializable_historical_data) == 90
+
+    attributes = {
+        "historical_data": person.serializable_historical_data,
+        "predicted_mileage": 123.45,
+        "predicted_leave_time": (day + timedelta(hours=13, minutes=27)).isoformat(),
+        "has_been_initialized": True,
+    }
+    payload = json.dumps(attributes)
+    assert len(payload) < 16 * 1024
+
+
+def test_restored_old_records_survive_when_initialized(hass: HomeAssistant) -> None:
+    """AC 7 (restart half, char.): a serialize→restore round-trip preserves
+    records older than the backfill window and reproduces the prediction; an
+    initialized person never triggers recompute."""
+    person = _make_person(hass, person_authorized_cars=["Car A"])
+    day = datetime(2026, 1, 1, 6, 0, tzinfo=pytz.UTC)
+    for i in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS):
+        d = day + timedelta(days=i)
+        person.add_to_mileage_history(d, 40.0 + (i % 3) * 5.0, d + timedelta(hours=8 + (i % 2)))
+
+    serialized = list(person.serializable_historical_data)
+    assert len(serialized) == 90
+    original = person._get_best_week_day_guess(WED.weekday())
+
+    restored = _make_person(hass, person_authorized_cars=["Car A"])
+    for e in serialized:
+        rec_day = datetime.fromisoformat(e["day"]).replace(tzinfo=None).astimezone(tz=pytz.UTC)
+        rec_leave = datetime.fromisoformat(e["leave_time"]).replace(tzinfo=None).astimezone(tz=pytz.UTC)
+        restored.add_to_mileage_history(rec_day, float(e["mileage"]), rec_leave)
+
+    assert len(restored.historical_mileage_data) == len(person.historical_mileage_data)
+    assert restored._get_best_week_day_guess(WED.weekday()) == original
+
+    restored.has_been_initialized = True
+    assert restored.should_recompute_history(datetime.now(tz=pytz.UTC)) is False

--- a/tests/test_person_outlier.py
+++ b/tests/test_person_outlier.py
@@ -11,6 +11,7 @@ produces.
 from __future__ import annotations
 
 import json
+import math
 from datetime import datetime, timedelta
 
 import pytz
@@ -20,7 +21,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.quiet_solar.const import (
     CONF_PERSON_PERSON_ENTITY,
     DOMAIN,
-    MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS,
+    MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS,
+    PERSON_MILEAGE_NUM_GOOD_SAMPLES,
     PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS,
 )
 from custom_components.quiet_solar.ha_model.home import QSHome
@@ -57,6 +59,12 @@ def _set_history(person: QSPerson, entries: list) -> None:
     person.historical_mileage_data = sorted(entries, key=lambda e: e[0])
 
 
+def _recent_now(person: QSPerson, days_after: int = 1) -> datetime:
+    """A prediction time just after the most recent stored record."""
+    last = max(e[0] for e in person.historical_mileage_data)
+    return last + timedelta(days=days_after)
+
+
 def test_one_off_long_trip_rejected(hass: HomeAssistant) -> None:
     """AC 1: a single 400 km record among ~12 weeks of 30-60 km days is
     rejected; prediction is the max of the last 2 non-outlier records."""
@@ -65,7 +73,7 @@ def test_one_off_long_trip_rejected(hass: HomeAssistant) -> None:
     entries.append(_entry(WED, 11, 400.0))  # one-off last week
     _set_history(person, entries)
 
-    mileage, leave = person._get_best_week_day_guess(WED.weekday())
+    mileage, leave = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage is not None and mileage <= 60.0
     assert leave is not None
 
@@ -79,7 +87,7 @@ def test_live_recurring_weekly_long_trip_kept(hass: HomeAssistant) -> None:
     entries.append(_entry(WED, 7, 390.0))  # newest, within 20% of 400
     _set_history(person, entries)
 
-    mileage, _leave = person._get_best_week_day_guess(WED.weekday())
+    mileage, _leave = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage is not None and mileage >= 390.0
 
 
@@ -92,8 +100,37 @@ def test_pattern_stop_reverts_prediction_immediately(hass: HomeAssistant) -> Non
     entries.append(_entry(WED, 8, 40.0))  # normal day breaks liveness
     _set_history(person, entries)
 
-    mileage, _leave = person._get_best_week_day_guess(WED.weekday())
+    mileage, _leave = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage is not None and mileage <= 60.0
+
+
+def test_live_pattern_requires_recency_relative_to_now(hass: HomeAssistant) -> None:
+    """S1: a live pair is only rescued while its newest record is within the
+    recurrence window of *now* — a dead habit stops predicting."""
+    person = _make_person(hass)
+    entries = [_entry(WED, w, 40.0) for w in range(6)]
+    entries.append(_entry(WED, 6, 400.0))
+    entries.append(_entry(WED, 7, 390.0))
+    _set_history(person, entries)
+    newest_day = entries[-1][0]
+
+    # (a) recent now → rescued
+    mileage_recent, _ = person._get_best_week_day_guess(
+        WED.weekday(), newest_day + timedelta(days=3)
+    )
+    assert mileage_recent is not None and mileage_recent >= 390.0
+
+    # (c) exactly at the window boundary → inclusive → still rescued
+    mileage_boundary, _ = person._get_best_week_day_guess(
+        WED.weekday(), newest_day + timedelta(days=PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS)
+    )
+    assert mileage_boundary is not None and mileage_boundary >= 390.0
+
+    # (b) one day past the window → stale → rejected, reverts to normal
+    mileage_stale, _ = person._get_best_week_day_guess(
+        WED.weekday(), newest_day + timedelta(days=PERSON_MILEAGE_RECURRENCE_WINDOW_DAYS + 1)
+    )
+    assert mileage_stale is not None and mileage_stale <= 60.0
 
 
 def test_different_weekday_big_record_does_not_corroborate(hass: HomeAssistant) -> None:
@@ -106,7 +143,7 @@ def test_different_weekday_big_record_does_not_corroborate(hass: HomeAssistant) 
     entries.append(_entry(TUE, 6, 400.0))
     _set_history(person, entries)
 
-    mileage, _leave = person._get_best_week_day_guess(WED.weekday())
+    mileage, _leave = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage is not None and mileage <= 60.0
 
 
@@ -119,9 +156,10 @@ def test_out_and_back_weekend_trip_rejected(hass: HomeAssistant) -> None:
         entries += [_entry(base, w, 40.0) for w in range(6)]
         entries.append(_entry(base, 6, 200.0))
     _set_history(person, entries)
+    now = _recent_now(person)
 
-    fri_mileage, _ = person._get_best_week_day_guess(FRI.weekday())
-    sun_mileage, _ = person._get_best_week_day_guess(SUN.weekday())
+    fri_mileage, _ = person._get_best_week_day_guess(FRI.weekday(), now)
+    sun_mileage, _ = person._get_best_week_day_guess(SUN.weekday(), now)
     assert fri_mileage is not None and fri_mileage <= 60.0
     assert sun_mileage is not None and sun_mileage <= 60.0
 
@@ -133,26 +171,37 @@ def test_absolute_floor_keeps_normal_trip_for_low_mileage_person(hass: HomeAssis
     entries.append(_entry(WED, 6, 40.0))  # 4x median but under the 100 km floor
     _set_history(person, entries)
 
-    mileage, _leave = person._get_best_week_day_guess(WED.weekday())
+    mileage, _leave = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage == 40.0
 
 
 def test_sparse_weekday_bucket_disables_outlier_detection(hass: HomeAssistant) -> None:
-    """AC 5: 3 leave-one-out samples → detection off (char.); exactly 4 → on."""
+    """AC 5: 3 leave-one-out samples → detection off (char.); exactly 4 → on.
+
+    With detection off, both mileage AND leave time are consumed exactly as
+    today's algorithm — the undetected 400 km outlier's 05:00 departure is the
+    earliest, so it wins.
+    """
     person = _make_person(hass)
 
     # 4 records total → LOO others for the 400 record = 3 → detection off.
-    sparse = [_entry(WED, w, 40.0) for w in range(3)] + [_entry(WED, 3, 400.0)]
+    sparse = [_entry(WED, w, 40.0, leave_hour=8) for w in range(3)] + [
+        _entry(WED, 3, 400.0, leave_hour=5)
+    ]
     _set_history(person, sparse)
-    mileage_off, leave_off = person._get_best_week_day_guess(WED.weekday())
+    mileage_off, leave_off = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage_off == 400.0  # identical to today's max-of-last-2
-    assert leave_off is not None
+    assert leave_off is not None and leave_off.hour == 5  # outlier's leave time consumed as today
 
-    # 5 records total → LOO others = 4 → detection on → 400 rejected.
-    dense = [_entry(WED, w, 40.0) for w in range(4)] + [_entry(WED, 4, 400.0)]
+    # 5 records total → LOO others = 4 → detection on → 400 rejected, and its
+    # 05:00 leave time is ignored (falls back to the good 08:00 records).
+    dense = [_entry(WED, w, 40.0, leave_hour=8) for w in range(4)] + [
+        _entry(WED, 4, 400.0, leave_hour=5)
+    ]
     _set_history(person, dense)
-    mileage_on, _leave = person._get_best_week_day_guess(WED.weekday())
+    mileage_on, leave_on = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage_on == 40.0
+    assert leave_on is not None and leave_on.hour == 8
 
 
 def test_median_interpolated_on_even_bucket(hass: HomeAssistant) -> None:
@@ -170,7 +219,10 @@ def test_median_interpolated_on_even_bucket(hass: HomeAssistant) -> None:
     _set_history(person, others + [target])
 
     # baseline = median([40,40,400,400]) = 220 ; 500 <= 2.5*220 = 550
-    assert person._is_mileage_outlier(target) is False
+    assert (
+        person._is_mileage_outlier(target, person.historical_mileage_data, _recent_now(person))
+        is False
+    )
 
 
 def test_older_suspicious_record_never_rescued(hass: HomeAssistant) -> None:
@@ -187,7 +239,10 @@ def test_older_suspicious_record_never_rescued(hass: HomeAssistant) -> None:
     _set_history(person, entries)
 
     older_big = entries[1]
-    assert person._is_mileage_outlier(older_big) is True
+    assert (
+        person._is_mileage_outlier(older_big, person.historical_mileage_data, _recent_now(person))
+        is True
+    )
 
 
 def test_first_occurrence_rejected_pattern_live_after_second(hass: HomeAssistant) -> None:
@@ -197,23 +252,26 @@ def test_first_occurrence_rejected_pattern_live_after_second(hass: HomeAssistant
     normals = [_entry(WED, w, 40.0) for w in range(5)]
 
     _set_history(person, normals + [_entry(WED, 5, 400.0)])
-    mileage_first, _ = person._get_best_week_day_guess(WED.weekday())
+    mileage_first, _ = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage_first is not None and mileage_first <= 60.0
 
     _set_history(person, normals + [_entry(WED, 5, 400.0), _entry(WED, 6, 400.0)])
-    mileage_second, _ = person._get_best_week_day_guess(WED.weekday())
+    mileage_second, _ = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage_second == 400.0
 
 
 def test_recurrence_tolerance_exceeded_rejects(hass: HomeAssistant) -> None:
-    """AC 6: a 400/250 last-2 pair fails the similarity test → both rejected."""
+    """AC 6: a 400/250 last-2 pair fails the similarity test → both rejected.
+
+    Symmetric denominator: 150 > 0.2 * max(400, 250) = 80 → still rejected.
+    """
     person = _make_person(hass)
     entries = [_entry(WED, w, 40.0) for w in range(5)]
     entries.append(_entry(WED, 5, 400.0))
-    entries.append(_entry(WED, 6, 250.0))  # |400-250|=150 > 0.2*250=50
+    entries.append(_entry(WED, 6, 250.0))  # |400-250|=150 > 0.2*400=80
     _set_history(person, entries)
 
-    mileage, _ = person._get_best_week_day_guess(WED.weekday())
+    mileage, _ = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage is not None and mileage <= 60.0
 
 
@@ -225,13 +283,19 @@ def test_recurrence_window_exceeded_rejects(hass: HomeAssistant) -> None:
 
     # exactly 21 days apart (3 weeks) → inclusive → live pattern kept
     _set_history(person, normals + [_entry(WED, 5, 400.0), _entry(WED, 8, 400.0)])
-    mileage_in, _ = person._get_best_week_day_guess(WED.weekday())
+    mileage_in, _ = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage_in == 400.0
 
     # 28 days apart (4 weeks) → outside window → rejected
     _set_history(person, normals + [_entry(WED, 5, 400.0), _entry(WED, 9, 400.0)])
-    mileage_out, _ = person._get_best_week_day_guess(WED.weekday())
+    mileage_out, _ = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage_out is not None and mileage_out <= 60.0
+
+
+def test_rescue_pair_size_matches_num_good_samples(hass: HomeAssistant) -> None:
+    """N8: the live-pattern rescue validates exactly a pair, so it is tied to
+    PERSON_MILEAGE_NUM_GOOD_SAMPLES == 2. Guard the tunable here."""
+    assert PERSON_MILEAGE_NUM_GOOD_SAMPLES == 2
 
 
 def test_leave_time_ignores_outlier_records(hass: HomeAssistant) -> None:
@@ -242,54 +306,78 @@ def test_leave_time_ignores_outlier_records(hass: HomeAssistant) -> None:
     entries.append(_entry(WED, 6, 400.0, leave_hour=5))  # anomalous early departure
     _set_history(person, entries)
 
-    mileage, leave = person._get_best_week_day_guess(WED.weekday())
+    mileage, leave = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
     assert mileage is not None and mileage <= 60.0
     assert leave is not None and leave.hour == 8  # never the 05:00 outlier
 
 
-def test_serialized_history_90_records_under_recorder_limit(hass: HomeAssistant) -> None:
-    """AC 8 (char., permanent guard): 90 realistic serialized records plus the
-    sensor's other attributes stay under the recorder's 16 KB limit."""
+def test_add_to_mileage_history_rejects_non_finite_and_non_positive(hass: HomeAssistant) -> None:
+    """N7: the single choke point drops NaN / inf / <= 0 mileage on both the
+    live and restore paths, and detection still works on valid records."""
+    person = _make_person(hass)
+    day = datetime(2026, 1, 1, 6, 0, tzinfo=pytz.UTC)
+    person.add_to_mileage_history(day, math.nan, day + timedelta(hours=8))
+    person.add_to_mileage_history(day + timedelta(days=1), math.inf, day + timedelta(hours=8))
+    person.add_to_mileage_history(day + timedelta(days=2), -5.0, day + timedelta(hours=8))
+    person.add_to_mileage_history(day + timedelta(days=3), 0.0, day + timedelta(hours=8))
+    assert person.historical_mileage_data == []
+
+    # valid records still ingested and outlier detection still functions
+    entries = [_entry(WED, w, 40.0) for w in range(5)] + [_entry(WED, 5, 400.0)]
+    _set_history(person, entries)
+    mileage, _ = person._get_best_week_day_guess(WED.weekday(), _recent_now(person))
+    assert mileage == 40.0  # the one-off 400 is rejected
+
+
+async def test_serialized_history_90_records_under_recorder_limit(hass: HomeAssistant) -> None:
+    """AC 8 (char., permanent guard): the real serialized sensor payload for
+    90 records stays under the recorder's 16 KB attribute limit."""
     person = _make_person(hass)
     day = datetime(2026, 1, 1, 6, 30, 15, tzinfo=pytz.UTC)
-    for i in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS):
+    for i in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS):
         d = day + timedelta(days=i)
         person.add_to_mileage_history(d, 123.45, d + timedelta(hours=13, minutes=27))
 
     assert len(person.serializable_historical_data) == 90
 
-    attributes = {
-        "historical_data": person.serializable_historical_data,
-        "predicted_mileage": 123.45,
-        "predicted_leave_time": (day + timedelta(hours=13, minutes=27)).isoformat(),
-        "has_been_initialized": True,
-    }
+    # Build the payload via the real serializer so the guard tracks any future
+    # attribute added to the sensor surface.
+    _state, attributes = person.get_person_mileage_serialized_prediction()
+    await hass.async_block_till_done()
+    assert len(attributes["historical_data"]) == 90
     payload = json.dumps(attributes)
     assert len(payload) < 16 * 1024
 
 
 def test_restored_old_records_survive_when_initialized(hass: HomeAssistant) -> None:
     """AC 7 (restart half, char.): a serialize→restore round-trip preserves
-    records older than the backfill window and reproduces the prediction; an
-    initialized person never triggers recompute."""
+    records older than the backfill window, reproduces the prediction, and the
+    parsed instants are identical (offset preserved); an initialized person
+    never triggers recompute."""
     person = _make_person(hass, person_authorized_cars=["Car A"])
     day = datetime(2026, 1, 1, 6, 0, tzinfo=pytz.UTC)
-    for i in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS):
+    for i in range(MAX_PERSON_MILEAGE_HISTORICAL_DATA_RECORDS):
         d = day + timedelta(days=i)
         person.add_to_mileage_history(d, 40.0 + (i % 3) * 5.0, d + timedelta(hours=8 + (i % 2)))
 
     serialized = list(person.serializable_historical_data)
     assert len(serialized) == 90
-    original = person._get_best_week_day_guess(WED.weekday())
+    now = _recent_now(person)
+    original = person._get_best_week_day_guess(WED.weekday(), now)
 
     restored = _make_person(hass, person_authorized_cars=["Car A"])
     for e in serialized:
-        rec_day = datetime.fromisoformat(e["day"]).replace(tzinfo=None).astimezone(tz=pytz.UTC)
-        rec_leave = datetime.fromisoformat(e["leave_time"]).replace(tzinfo=None).astimezone(tz=pytz.UTC)
+        # mirror device_post_home_init parsing (offset preserved)
+        rec_day = datetime.fromisoformat(e["day"]).astimezone(tz=pytz.UTC)
+        rec_leave = datetime.fromisoformat(e["leave_time"]).astimezone(tz=pytz.UTC)
         restored.add_to_mileage_history(rec_day, float(e["mileage"]), rec_leave)
 
     assert len(restored.historical_mileage_data) == len(person.historical_mileage_data)
-    assert restored._get_best_week_day_guess(WED.weekday()) == original
+    # instants preserved (aware equality compares the underlying instant)
+    assert [e[0] for e in restored.historical_mileage_data] == [
+        e[0] for e in person.historical_mileage_data
+    ]
+    assert restored._get_best_week_day_guess(WED.weekday(), now) == original
 
     restored.has_been_initialized = True
     assert restored.should_recompute_history(datetime.now(tz=pytz.UTC)) is False

--- a/tests/test_person_outlier.py
+++ b/tests/test_person_outlier.py
@@ -292,9 +292,35 @@ def test_recurrence_window_exceeded_rejects(hass: HomeAssistant) -> None:
     assert mileage_out is not None and mileage_out <= 60.0
 
 
-def test_rescue_pair_size_matches_num_good_samples(hass: HomeAssistant) -> None:
-    """N8: the live-pattern rescue validates exactly a pair, so it is tied to
-    PERSON_MILEAGE_NUM_GOOD_SAMPLES == 2. Guard the tunable here."""
+def test_rescue_only_validates_last_two_records(hass: HomeAssistant) -> None:
+    """N8 / N5: the live-pattern rescue validates exactly ``bucket[-2:]``.
+
+    A third, distinct most-recent record must not change the rescue decision
+    for the pair — the rescue only ever inspects the last two records, which
+    is why it is coupled to ``PERSON_MILEAGE_NUM_GOOD_SAMPLES == 2`` (kept as a
+    tripwire below). Here the live pair is rescued whether or not an older
+    third big record precedes it, proving the third record is inert.
+    """
+    person = _make_person(hass)
+    normals = [_entry(WED, w, 40.0) for w in range(5)]  # weeks 0-4
+    live_pair = [_entry(WED, 6, 400.0), _entry(WED, 7, 390.0)]
+
+    # Baseline: just normals + the live pair → rescued (~400 km kept).
+    _set_history(person, normals + live_pair)
+    now = _recent_now(person)
+    baseline_pair = person._is_mileage_outlier(live_pair[-1], person.historical_mileage_data, now)
+    assert baseline_pair is False
+    assert person._get_best_week_day_guess(WED.weekday(), now)[0] >= 390.0
+
+    # Add a distinct older big record BEFORE the pair (week 5): the newest
+    # record's rescue decision is unchanged (rescue inspects only bucket[-2:]).
+    with_third = normals + [_entry(WED, 5, 500.0)] + live_pair
+    _set_history(person, with_third)
+    now = _recent_now(person)
+    assert person._is_mileage_outlier(live_pair[-1], person.historical_mileage_data, now) is False
+    assert person._get_best_week_day_guess(WED.weekday(), now)[0] >= 390.0
+
+    # Tripwire: the rescue's pair semantics are tied to this tunable.
     assert PERSON_MILEAGE_NUM_GOOD_SAMPLES == 2
 
 

--- a/tests/test_persons_car_forecast.py
+++ b/tests/test_persons_car_forecast.py
@@ -15,7 +15,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.quiet_solar.const import (
     DOMAIN,
-    MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS,
+    PERSON_HISTORY_BACKFILL_DAYS,
 )
 from custom_components.quiet_solar.ha_model.car import QSCar
 from custom_components.quiet_solar.ha_model.home import QSHome, get_time_from_state
@@ -974,7 +974,7 @@ class TestPersonsCarForecast:
             # for d in range(0, 14):
             #     await self._compute_and_store_person_car_forecasts(local_day_utc, day_shift=d)
 
-            num_days = min(MAX_PERSON_MILEAGE_HISTORICAL_DATA_DAYS, len(per_day_data))
+            num_days = min(PERSON_HISTORY_BACKFILL_DAYS, len(per_day_data))
             print(f"\nProcessing {num_days} days with day_shift from 0 to {num_days - 1}:")
 
             local_day_2, local_day_shifted_2, local_day_utc_2, is_passed = (


### PR DESCRIPTION
## Summary
- Outlier-resistant per-weekday trip prediction: leave-one-out median magnitude test + last-2 live-pattern recurrence rescue, so a one-off long trip is rejected while a genuine weekly far commute is kept.
- Retention grown to a 90-record count cap; boot-time recorder backfill split to a dedicated PERSON_HISTORY_BACKFILL_DAYS=30 window so larger retention never inflates per-day queries.
- Docs: rewrote person-trip-prediction concept to the shipped algorithm; bumped last_verified on the four Doc-OK docs.

Fixes #298

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [x] HIGH (load base, constants, orchestration)
- [x] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)