### PR TITLE
QS-305: facade drives both channels, reports fail-safe

### DIFF
--- a/config/configuration.jinja
+++ b/config/configuration.jinja
@@ -1,24 +1,24 @@
 {## ============================================================ ##}
 {## LEGRAND FAÇADE SWITCHES - per-device list to map             ##}
 {## ============================================================ ##}
-{## Add one entry per Legrand switch you want to expose as a     ##}
-{## resilient (HK-with-cloud-fallback) façade.                   ##}
-{## Each entry is a dict with two required keys + one optional:  ##}
-{##   slug          : (required) short snake_case id. Generates   ##}
-{##                   input_boolean.<slug>_state,                 ##}
-{##                   input_boolean.<slug>_command,               ##}
-{##                   switch.<slug>_facade.                       ##}
-{##                   Pick a slug that does NOT collide with any  ##}
-{##                   Netatmo cloud entity name.                  ##}
-{##   name          : (required) friendly name shown in HA UI and ##}
-{##                   (with the "HA <name> Mirror"/"HA <name> Cmd"##}
-{##                   prefix) in Apple Home.                      ##}
-{##   cloud_entity  : (optional) the existing Netatmo cloud       ##}
-{##                   switch entity_id used as the fallback leg.  ##}
-{##                   If omitted, the façade is HK-only: it will  ##}
-{##                   be unavailable whenever either health sensor##}
-{##                   is off, and turn_on/turn_off only drive the ##}
-{##                   HK command boolean.                         ##}
+{## Add one entry per Legrand switch to expose as a façade whose ##}
+{## reported state can be trusted.                               ##}
+{## Each entry is a dict with two required keys + one optional:   ##}
+{##   slug          : (required) short snake_case id. Generates    ##}
+{##                   input_boolean.<slug>_state, _command, and    ##}
+{##                   switch.<slug>_facade. Must NOT collide with  ##}
+{##                   any Netatmo cloud entity name.               ##}
+{##   name          : (required) friendly name. Any characters are ##}
+{##                   safe -- every use is | tojson escaped.       ##}
+{##   cloud_entity  : (OPTIONAL) a Netatmo cloud switch entity_id, ##}
+{##                   driven as a SECOND actuation channel in      ##}
+{##                   parallel with the HomeKit boolean. NEVER     ##}
+{##                   read -- writing actuates, but reading only   ##}
+{##                   echoes Netatmo's last command. When absent   ##}
+{##                   the device is HomeKit-only and gets the SAME ##}
+{##                   façade (same trust, wait, notify, dismiss),  ##}
+{##                   just no cloud channel. No separate variant.  ##}
+{## The façade is NEVER unavailable: untrusted reports unknown.    ##}
 {## ============================================================ ##}
 {%- set legrand_switches_to_map = namespace(switches = []) %}
 
@@ -159,9 +159,9 @@ input_boolean:
     name: "HomeKit Hub Alive"
 {%- for s in legrand_switches_to_map.switches %}
   {{ s.slug }}_state:
-    name: "{{ s.name }} - HK Mirror (read)"
+    name: {{ (s.name ~ " - HK Mirror (read)") | tojson }}
   {{ s.slug }}_command:
-    name: "{{ s.name }} - HK Command (write)"
+    name: {{ (s.name ~ " - HK Command (write)") | tojson }}
 {%- endfor %}
 
 template:
@@ -278,79 +278,65 @@ template:
         state: {{ "'{{ is_state(''climate.salle_de_bains_darthur'', ''heat'') }}'" }}
 {##  --- BEGIN: generated Legrand façade switches --- ##}
 {#- ================================================================================ -#}
-{#- RULE: Never trust a value you just wrote. Never report a value you can't trust.   -#}
+{#- RULE: Never trust a value you just wrote. Never report a value you can't trust.  -#}
 {#-                                                                                  -#}
-{#- We write input_boolean.<slug>_command and we write the Netatmo cloud switch, so   -#}
-{#- NEITHER can be evidence -- they only parrot back what we told them. The Netatmo   -#}
-{#- switch writes its state optimistically, and it read 'off' all day on 2026-07-27   -#}
-{#- while the boiler drew 2353 W. Reading it back after our own write is guaranteed   -#}
-{#- to return the target, so a wait that consults it is VACUOUSLY TRUE and the        -#}
-{#- notification branch unreachable.                                                  -#}
+{#- We write input_boolean.<slug>_command and we write the Netatmo cloud switch, so  -#}
+{#- NEITHER can be evidence -- they only echo what we told them. The Netatmo switch  -#}
+{#- writes state optimistically and read 'off' all day on 2026-07-27 while the       -#}
+{#- boiler drew 2353 W. input_boolean.<slug>_state (the mirror) is written only by   -#}
+{#- Apple Home from watching the real device: the ONLY honest witness, and the only  -#}
+{#- leg used for state and for both waits. Do not "restore symmetry" by re-adding a  -#}
+{#- cloud term -- a backup that lies is worse than no backup.                        -#}
 {#-                                                                                  -#}
-{#- input_boolean.<slug>_state (the mirror) is written only by Apple Home from        -#}
-{#- watching the real device, and follows a real change in 2-3 s. It is the only      -#}
-{#- honest witness, so it is the only leg used for state and for both waits. Do NOT   -#}
-{#- "restore symmetry" by re-adding the cloud term anywhere below: a backup that lies -#}
-{#- is worse than no backup, because it sits at 'off' and reports it with full        -#}
-{#- confidence. Going dark honestly is better.                                        -#}
+{#- FOUR THINGS HERE LOOK TIDYABLE. NONE ARE:                                        -#}
+{#-  1. There is deliberately NO availability: key. A falsy availability makes HA    -#}
+{#-     drop the entity from entity-service calls with only a warning, silently      -#}
+{#-     swallowing every actuation -- and the health sensors force themselves off    -#}
+{#-     for 120 s after each HA restart. Untrusted must stay AVAILABLE.              -#}
+{#-  2. The untrusted branch emits none, not the string 'unknown'. cv.boolean is     -#}
+{#-     applied without none_on_unknown_unavailable, so a string logs an ERROR on    -#}
+{#-     every evaluation.                                                            -#}
+{#-  3. The cloud write sits alone in a parallel: branch because pyatmo raises       -#}
+{#-     plain Exception subclasses, which continue_on_error does NOT swallow.        -#}
+{#-  4. Do NOT reorder hk_ok = is_state(link) and is_state(hub). Jinja               -#}
+{#-     short-circuits, so WHICH ENTITIES GET TRACKED DEPENDS ON THE RENDER PATH:    -#}
+{#-     while the link reads off the hub is never evaluated, so it is not            -#}
+{#-     subscribed. Benign here (link recovery re-renders), but reordering or        -#}
+{#-     splitting this can strand the template on a sensor it never subscribed to    -#}
+{#-     -- the most common cause of "my template switch doesn't update".             -#}
 {#-                                                                                  -#}
-{#- Three things below look like they could be tidied. None of them can:              -#}
-{#-  1. There is deliberately NO availability: key. A falsy availability makes HA     -#}
-{#-     filter the entity out of entity-service calls with only a warning, so every   -#}
-{#-     actuation would be SILENTLY SWALLOWED -- and both health sensors force        -#}
-{#-     themselves off for 120 s after an HA restart. Untrusted must stay AVAILABLE.  -#}
-{#-  2. The untrusted branch emits {{ none }}, not the string 'unknown'. cv.boolean   -#}
-{#-     is applied without none_on_unknown_unavailable, so a string logs an ERROR on  -#}
-{#-     every single evaluation.                                                       -#}
-{#-  3. The cloud write sits alone in a parallel: branch because pyatmo raises plain  -#}
-{#-     Exception subclasses, which continue_on_error does NOT swallow. Inline, a 429  -#}
-{#-     would abort the script before the diagnostic could fire.                       -#}
+{#- THE APPLE-SIDE HALF, OUTSIDE THIS REPO. HA never writes the mirror; TWO Apple    -#}
+{#- Home automations do, and BOTH must exist for every device above:                 -#}
+{#-  (1) EDGE, one pair per device -- the fast path:                                 -#}
+{#-        <homekit_device> ON  -> set <slug>_state ON                               -#}
+{#-        <homekit_device> OFF -> set <slug>_state OFF                              -#}
+{#-      Follows a real change in 2-3 s, which is what the 10 s waits rely on.       -#}
+{#-      Driven by HomeKit change events, which can stop arriving silently.          -#}
+{#-  (2) PERIODIC RESYNC, one Shortcut for all devices -- the safety net:            -#}
+{#-        input_boolean.legrand_ticker switches ON -> Shortcut that, per device:    -#}
+{#-            if <homekit_device> is on -> set <slug>_state ON                      -#}
+{#-            else                      -> set <slug>_state OFF                     -#}
+{#-      Writes the observed value EVERY tick, changed or not, making the mirror     -#}
+{#-      polled rather than event-driven. Within one ticker period it heals: a       -#}
+{#-      mirror frozen by a lost subscription; staleness after HA downtime; a NEW    -#}
+{#-      device whose mirror Apple never wrote (it reads off, and would otherwise    -#}
+{#-      be trusted as a confident off -- the incident signature); and a stray tap   -#}
+{#-      or scene sweep. The cadence is set in automations.yaml, NOT here, and it    -#}
+{#-      bounds all of the above.                                                    -#}
 {#-                                                                                  -#}
-{#- Full derivation and source citations: docs/stories/QS-305.story.md and its two    -#}
-{#- review fix plans. Do not re-derive from memory.                                    -#}
+{#- ADDING A DEVICE: add its mirror to BOTH automations. With (1) only it is fine    -#}
+{#- until the first freeze; with (2) only, every command times out and notifies;     -#}
+{#- with neither, the facade trusts a mirror nobody writes -- which reads off.       -#}
 {#-                                                                                  -#}
-{#- -------------------------------------------------------------------------------- -#}
-{#- THE APPLE-SIDE HALF, WHICH LIVES OUTSIDE THIS REPO                                -#}
+{#- NEITHER AUTOMATION IS OBSERVABLE FROM HA and Apple has no execution log, so a    -#}
+{#- Shortcut that silently stops degrades this to event-driven only, unnoticed.      -#}
 {#-                                                                                  -#}
-{#- HA never writes input_boolean.<slug>_state. TWO Apple Home automations do, and    -#}
-{#- both must exist for every device in the inventory above:                          -#}
+{#- Because (2) rewrites unchanged values, HA advances the mirror's last_reported    -#}
+{#- each tick while last_changed does not, making last_reported a usable freshness   -#}
+{#- signal. NOT used yet -- see the story's Issue D.                                 -#}
 {#-                                                                                  -#}
-{#-  (1) EDGE, one pair per device -- the fast path.                                  -#}
-{#-      when <homekit_device> switches ON  -> set <slug>_state ON                     -#}
-{#-      when <homekit_device> switches OFF -> set <slug>_state OFF                    -#}
-{#-      Follows a real change in 2-3 s, which is what the 10 s waits below rely on.   -#}
-{#-      It is driven by HomeKit change events, and those can stop arriving silently.  -#}
-{#-                                                                                  -#}
-{#-  (2) PERIODIC RESYNC, one Shortcut for all devices -- the safety net.              -#}
-{#-      when input_boolean.legrand_ticker switches ON -> run a Shortcut that, for     -#}
-{#-      each device, does:                                                            -#}
-{#-          if <homekit_device> is on  -> set <slug>_state ON                         -#}
-{#-          else                       -> set <slug>_state OFF                        -#}
-{#-      This writes the observed value EVERY tick, changed or not. That is what makes -#}
-{#-      the mirror polled rather than event-driven, so all four of these self-heal    -#}
-{#-      within one ticker period instead of persisting indefinitely:                  -#}
-{#-        - a mirror frozen by a lost HomeKit subscription;                           -#}
-{#-        - a stale mirror after HA was down while the device was switched;            -#}
-{#-        - a NEW device whose mirror Apple has never written (it reads off, and       -#}
-{#-          would otherwise be trusted as a confident off -- the incident signature); -#}
-{#-        - a stray hand tap on the mirror in Apple Home, or a scene sweeping it.     -#}
-{#-      The ticker cadence is set in automations.yaml, NOT here, and it is the bound  -#}
-{#-      on every one of those mitigations.                                            -#}
-{#-                                                                                  -#}
-{#- WHEN YOU ADD A DEVICE: add its mirror to BOTH automations. With (1) only, a new    -#}
-{#- device is fine until the first HomeKit freeze; with (2) only, confirmation is as   -#}
-{#- slow as the ticker and the 10 s waits will time out and notify on every command.   -#}
-{#- With neither, the facade trusts a mirror nobody writes -- which reads off.         -#}
-{#-                                                                                  -#}
-{#- NEITHER AUTOMATION IS OBSERVABLE FROM HA, and Apple's Home app has no automation   -#}
-{#- execution log. If the Shortcut in (2) silently stops running, behaviour degrades   -#}
-{#- back to event-driven-only and nothing here can tell you. A liveness check for it   -#}
-{#- is the highest-value watchdog target -- see the story's follow-up Issue A.         -#}
-{#-                                                                                  -#}
-{#- Because (2) rewrites the value even when it has not changed, HA advances the       -#}
-{#- mirror's last_reported on every tick, while last_changed does NOT move on a        -#}
-{#- no-op write. So last_reported is a usable freshness signal for the trust           -#}
-{#- predicate. NOT used yet: see the story's Issue D.                                  -#}
+{#- Derivation, citations and residuals: docs/stories/QS-305.story.md and its three  -#}
+{#- review fix plans. Do not re-derive from memory.                                  -#}
 {#- ================================================================================ -#}
 {%- for s in legrand_switches_to_map.switches %}
 {##  --- Dual-channel actuation, mirror-only trust --- ##}
@@ -373,11 +359,13 @@ template:
               entity_id: input_boolean.{{ s.slug }}_command
             continue_on_error: true
           - parallel:
+{%- if s.cloud_entity is defined %}
               - sequence:
                   - action: switch.turn_on
                     target:
                       entity_id: {{ s.cloud_entity }}
                     continue_on_error: true
+{%- endif %}
               - sequence:
                   - wait_template: >-
                       {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
@@ -391,23 +379,28 @@ template:
                             data:
                               title: {{ (s.name ~ " - turn_on not confirmed") | tojson }}
                               message: >-
-                                {{ "{{ 'Both channels were driven but the mirror did not confirm on within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' at ' ~ now().isoformat() }}" }}
+                                {{ "{{ 'Commanded on via the HomeKit boolean" ~ (" and the Netatmo cloud," if s.cloud_entity is defined else " (this device has no cloud channel),") ~ " but the mirror did not confirm on within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' at ' ~ now().isoformat() }}" }}
                               notification_id: {{ s.slug }}_facade_on_unconfirmed
                     default:
                       - action: persistent_notification.dismiss
                         data:
                           notification_id: {{ s.slug }}_facade_on_unconfirmed
+                      - action: persistent_notification.dismiss
+                        data:
+                          notification_id: {{ s.slug }}_facade_off_unconfirmed
         turn_off:
           - action: input_boolean.turn_off
             target:
               entity_id: input_boolean.{{ s.slug }}_command
             continue_on_error: true
           - parallel:
+{%- if s.cloud_entity is defined %}
               - sequence:
                   - action: switch.turn_off
                     target:
                       entity_id: {{ s.cloud_entity }}
                     continue_on_error: true
+{%- endif %}
               - sequence:
                   - wait_template: >-
                       {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'off') }}" }}
@@ -421,9 +414,12 @@ template:
                             data:
                               title: {{ (s.name ~ " - turn_off not confirmed") | tojson }}
                               message: >-
-                                {{ "{{ 'Both channels were driven but the mirror did not confirm off within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' at ' ~ now().isoformat() }}" }}
+                                {{ "{{ 'Commanded off via the HomeKit boolean" ~ (" and the Netatmo cloud," if s.cloud_entity is defined else " (this device has no cloud channel),") ~ " but the mirror did not confirm off within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' at ' ~ now().isoformat() }}" }}
                               notification_id: {{ s.slug }}_facade_off_unconfirmed
                     default:
+                      - action: persistent_notification.dismiss
+                        data:
+                          notification_id: {{ s.slug }}_facade_on_unconfirmed
                       - action: persistent_notification.dismiss
                         data:
                           notification_id: {{ s.slug }}_facade_off_unconfirmed
@@ -625,9 +621,9 @@ homekit:
         name: TV Salon
 {%- for s in legrand_switches_to_map.switches %}
       input_boolean.{{ s.slug }}_state:
-        name: LHK {{ s.name }} Mirror
+        name: {{ ("LHK " ~ s.name ~ " Mirror") | tojson }}
       input_boolean.{{ s.slug }}_command:
-        name: LHK {{ s.name }} Cmd
+        name: {{ ("LHK " ~ s.name ~ " Cmd") | tojson }}
 {%- endfor %}
 
 

--- a/config/configuration.jinja
+++ b/config/configuration.jinja
@@ -282,27 +282,39 @@ template:
 {#-                                                                                  -#}
 {#- We write input_boolean.<slug>_command and we write the Netatmo cloud switch, so   -#}
 {#- NEITHER can be evidence -- they only parrot back what we told them. The Netatmo   -#}
-{#- switch sets _attr_is_on optimistically and writes state immediately              -#}
-{#- (custom_components/netatmo/switch.py:77-90 -- a FORK, symlinked into              -#}
-{#- custom_components/, that shadows the core integration), and on 2026-07-27 it read -#}
-{#- 'off' all day while the boiler drew 2353 W. Reading it back after our own write   -#}
-{#- is guaranteed to return the target, so a wait that consults it is VACUOUSLY TRUE  -#}
-{#- and the notification branch unreachable.                                          -#}
+{#- switch writes its state optimistically, and it read 'off' all day on 2026-07-27   -#}
+{#- while the boiler drew 2353 W. Reading it back after our own write is guaranteed   -#}
+{#- to return the target, so a wait that consults it is VACUOUSLY TRUE and the        -#}
+{#- notification branch unreachable.                                                  -#}
 {#-                                                                                  -#}
 {#- input_boolean.<slug>_state (the mirror) is written only by Apple Home from        -#}
 {#- watching the real device, and follows a real change in 2-3 s. It is the only      -#}
-{#- honest witness, so it is the only leg used for state, availability and both       -#}
-{#- waits. Do NOT "restore symmetry" by re-adding the cloud term anywhere below: a    -#}
-{#- backup that lies is worse than no backup, because it sits at 'off' and reports it -#}
-{#- with full confidence. Going dark honestly is better.                              -#}
+{#- honest witness, so it is the only leg used for state and for both waits. Do NOT   -#}
+{#- "restore symmetry" by re-adding the cloud term anywhere below: a backup that lies -#}
+{#- is worse than no backup, because it sits at 'off' and reports it with full        -#}
+{#- confidence. Going dark honestly is better.                                        -#}
+{#-                                                                                  -#}
+{#- Three things below look like they could be tidied. None of them can:              -#}
+{#-  1. There is deliberately NO availability: key. A falsy availability makes HA     -#}
+{#-     filter the entity out of entity-service calls with only a warning, so every   -#}
+{#-     actuation would be SILENTLY SWALLOWED -- and both health sensors force        -#}
+{#-     themselves off for 120 s after an HA restart. Untrusted must stay AVAILABLE.  -#}
+{#-  2. The untrusted branch emits {{ none }}, not the string 'unknown'. cv.boolean   -#}
+{#-     is applied without none_on_unknown_unavailable, so a string logs an ERROR on  -#}
+{#-     every single evaluation.                                                       -#}
+{#-  3. The cloud write sits alone in a parallel: branch because pyatmo raises plain  -#}
+{#-     Exception subclasses, which continue_on_error does NOT swallow. Inline, a 429  -#}
+{#-     would abort the script before the diagnostic could fire.                       -#}
+{#-                                                                                  -#}
+{#- Full derivation and source citations: docs/stories/QS-305.story.md and its two    -#}
+{#- review fix plans. Do not re-derive from memory.                                    -#}
 {#- ================================================================================ -#}
 {%- for s in legrand_switches_to_map.switches %}
-{%- if s.cloud_entity is defined %}
 {##  --- Dual-channel actuation, mirror-only trust --- ##}
   - switch:
       - unique_id: {{ s.slug }}_facade
         default_entity_id: switch.{{ s.slug }}_facade
-        name: {{ s.name }}
+        name: {{ s.name | tojson }}
         state: >
           {{ "{% set hk_ok = is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') %}" }}
           {{ "{% set mirror = states('input_boolean." ~ s.slug ~ "_state') %}" }}
@@ -310,80 +322,68 @@ template:
           {{ "{% if mirror_valid %}" }}
             {{ "{{ mirror == 'on' }}" }}
           {{ "{% else %}" }}
-            unknown
+            {{ "{{ none }}" }}
           {{ "{% endif %}" }}
-        availability: >
-          {{ "{{ is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') and states('input_boolean." ~ s.slug ~ "_state') in ['on','off'] }}" }}
         turn_on:
           - action: input_boolean.turn_on
             target:
               entity_id: input_boolean.{{ s.slug }}_command
             continue_on_error: true
-          - action: switch.turn_on
-            target:
-              entity_id: {{ s.cloud_entity }}
-            continue_on_error: true
-          - wait_template: >-
-              {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
-            timeout: "00:00:10"
-            continue_on_timeout: true
-          - choose:
-              - conditions: >-
-                  {{ "{{ not is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
-                sequence:
-                  - action: persistent_notification.create
-                    data:
-                      title: "{{ s.name }} - turn_on not confirmed"
-                      message: >-
-                        {{ "{{ 'Both channels were driven but the mirror did not confirm on within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' cloud=' ~ states('" ~ s.cloud_entity ~ "') ~ ' at ' ~ now().isoformat() }}" }}
-                      notification_id: {{ s.slug }}_facade_on_unconfirmed
+          - parallel:
+              - sequence:
+                  - action: switch.turn_on
+                    target:
+                      entity_id: {{ s.cloud_entity }}
+                    continue_on_error: true
+              - sequence:
+                  - wait_template: >-
+                      {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
+                    timeout: "00:00:10"
+                    continue_on_timeout: true
+                  - choose:
+                      - conditions: >-
+                          {{ "{{ not is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
+                        sequence:
+                          - action: persistent_notification.create
+                            data:
+                              title: {{ (s.name ~ " - turn_on not confirmed") | tojson }}
+                              message: >-
+                                {{ "{{ 'Both channels were driven but the mirror did not confirm on within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' at ' ~ now().isoformat() }}" }}
+                              notification_id: {{ s.slug }}_facade_on_unconfirmed
+                    default:
+                      - action: persistent_notification.dismiss
+                        data:
+                          notification_id: {{ s.slug }}_facade_on_unconfirmed
         turn_off:
           - action: input_boolean.turn_off
             target:
               entity_id: input_boolean.{{ s.slug }}_command
             continue_on_error: true
-          - action: switch.turn_off
-            target:
-              entity_id: {{ s.cloud_entity }}
-            continue_on_error: true
-          - wait_template: >-
-              {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'off') }}" }}
-            timeout: "00:00:10"
-            continue_on_timeout: true
-          - choose:
-              - conditions: >-
-                  {{ "{{ not is_state('input_boolean." ~ s.slug ~ "_state', 'off') }}" }}
-                sequence:
-                  - action: persistent_notification.create
-                    data:
-                      title: "{{ s.name }} - turn_off not confirmed"
-                      message: >-
-                        {{ "{{ 'Both channels were driven but the mirror did not confirm off within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' cloud=' ~ states('" ~ s.cloud_entity ~ "') ~ ' at ' ~ now().isoformat() }}" }}
-                      notification_id: {{ s.slug }}_facade_off_unconfirmed
-{%- else %}
-{##  --- HK-only variant: no cloud fallback --- ##}
-  - switch:
-      - unique_id: {{ s.slug }}_facade
-        default_entity_id: switch.{{ s.slug }}_facade
-        name: {{ s.name }}
-        state: >
-          {{ "{% set hk_ok = is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') %}" }}
-          {{ "{% if hk_ok and states('input_boolean." ~ s.slug ~ "_state') in ['on','off'] %}" }}
-            {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
-          {{ "{% else %}" }}
-            unknown
-          {{ "{% endif %}" }}
-        availability: >
-          {{ "{{ is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') }}" }}
-        turn_on:
-          - action: input_boolean.turn_on
-            target:
-              entity_id: input_boolean.{{ s.slug }}_command
-        turn_off:
-          - action: input_boolean.turn_off
-            target:
-              entity_id: input_boolean.{{ s.slug }}_command
-{%- endif %}
+          - parallel:
+              - sequence:
+                  - action: switch.turn_off
+                    target:
+                      entity_id: {{ s.cloud_entity }}
+                    continue_on_error: true
+              - sequence:
+                  - wait_template: >-
+                      {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'off') }}" }}
+                    timeout: "00:00:10"
+                    continue_on_timeout: true
+                  - choose:
+                      - conditions: >-
+                          {{ "{{ not is_state('input_boolean." ~ s.slug ~ "_state', 'off') }}" }}
+                        sequence:
+                          - action: persistent_notification.create
+                            data:
+                              title: {{ (s.name ~ " - turn_off not confirmed") | tojson }}
+                              message: >-
+                                {{ "{{ 'Both channels were driven but the mirror did not confirm off within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' at ' ~ now().isoformat() }}" }}
+                              notification_id: {{ s.slug }}_facade_off_unconfirmed
+                    default:
+                      - action: persistent_notification.dismiss
+                        data:
+                          notification_id: {{ s.slug }}_facade_off_unconfirmed
 {%- endfor %}
 {## --- END: generated Legrand façade switches --- ##}
   - binary_sensor:

--- a/config/configuration.jinja
+++ b/config/configuration.jinja
@@ -277,68 +277,88 @@ template:
         name: QS Radiateur Serviette Arthur
         state: {{ "'{{ is_state(''climate.salle_de_bains_darthur'', ''heat'') }}'" }}
 {##  --- BEGIN: generated Legrand façade switches --- ##}
+{#- ================================================================================ -#}
+{#- RULE: Never trust a value you just wrote. Never report a value you can't trust.   -#}
+{#-                                                                                  -#}
+{#- We write input_boolean.<slug>_command and we write the Netatmo cloud switch, so   -#}
+{#- NEITHER can be evidence -- they only parrot back what we told them. The Netatmo   -#}
+{#- switch sets _attr_is_on optimistically and writes state immediately              -#}
+{#- (custom_components/netatmo/switch.py:77-90 -- a FORK, symlinked into              -#}
+{#- custom_components/, that shadows the core integration), and on 2026-07-27 it read -#}
+{#- 'off' all day while the boiler drew 2353 W. Reading it back after our own write   -#}
+{#- is guaranteed to return the target, so a wait that consults it is VACUOUSLY TRUE  -#}
+{#- and the notification branch unreachable.                                          -#}
+{#-                                                                                  -#}
+{#- input_boolean.<slug>_state (the mirror) is written only by Apple Home from        -#}
+{#- watching the real device, and follows a real change in 2-3 s. It is the only      -#}
+{#- honest witness, so it is the only leg used for state, availability and both       -#}
+{#- waits. Do NOT "restore symmetry" by re-adding the cloud term anywhere below: a    -#}
+{#- backup that lies is worse than no backup, because it sits at 'off' and reports it -#}
+{#- with full confidence. Going dark honestly is better.                              -#}
+{#- ================================================================================ -#}
 {%- for s in legrand_switches_to_map.switches %}
 {%- if s.cloud_entity is defined %}
-{##  --- Cloud-backed variant: HK preferred, cloud fallback --- ##}
+{##  --- Dual-channel actuation, mirror-only trust --- ##}
   - switch:
       - unique_id: {{ s.slug }}_facade
         default_entity_id: switch.{{ s.slug }}_facade
         name: {{ s.name }}
         state: >
+          {{ "{% set hk_ok = is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') %}" }}
           {{ "{% set mirror = states('input_boolean." ~ s.slug ~ "_state') %}" }}
-          {{ "{% set cloud = states('" ~ s.cloud_entity ~ "') %}" }}
-          {{ "{% set mirror_valid = mirror in ['on','off'] %}" }}
-          {{ "{% set cloud_valid = cloud in ['on','off'] %}" }}
-          {{ "{% if mirror_valid or cloud_valid %}" }}
-            {{ "{{ mirror == 'on' or cloud == 'on' }}" }}
+          {{ "{% set mirror_valid = hk_ok and mirror in ['on','off'] %}" }}
+          {{ "{% if mirror_valid %}" }}
+            {{ "{{ mirror == 'on' }}" }}
           {{ "{% else %}" }}
             unknown
           {{ "{% endif %}" }}
         availability: >
-          {{ "{{ (is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on')) or states('" ~ s.cloud_entity ~ "') in ['on','off'] }}" }}
+          {{ "{{ is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') and states('input_boolean." ~ s.slug ~ "_state') in ['on','off'] }}" }}
         turn_on:
           - action: input_boolean.turn_on
             target:
               entity_id: input_boolean.{{ s.slug }}_command
+            continue_on_error: true
           - action: switch.turn_on
             target:
               entity_id: {{ s.cloud_entity }}
             continue_on_error: true
           - wait_template: >-
-              {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on') }}" }}
+              {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
             timeout: "00:00:10"
             continue_on_timeout: true
           - choose:
               - conditions: >-
-                  {{ "{{ not (is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on')) }}" }}
+                  {{ "{{ not is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
                 sequence:
                   - action: persistent_notification.create
                     data:
                       title: "{{ s.name }} - turn_on not confirmed"
                       message: >-
-                        {{ "{{ 'Both channels were driven but the load did not report on within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' cloud=' ~ states('" ~ s.cloud_entity ~ "') ~ ' at ' ~ now().isoformat() }}" }}
+                        {{ "{{ 'Both channels were driven but the mirror did not confirm on within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' cloud=' ~ states('" ~ s.cloud_entity ~ "') ~ ' at ' ~ now().isoformat() }}" }}
                       notification_id: {{ s.slug }}_facade_on_unconfirmed
         turn_off:
           - action: input_boolean.turn_off
             target:
               entity_id: input_boolean.{{ s.slug }}_command
+            continue_on_error: true
           - action: switch.turn_off
             target:
               entity_id: {{ s.cloud_entity }}
             continue_on_error: true
           - wait_template: >-
-              {{ "{{ not (is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on')) }}" }}
+              {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'off') }}" }}
             timeout: "00:00:10"
             continue_on_timeout: true
           - choose:
               - conditions: >-
-                  {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on') }}" }}
+                  {{ "{{ not is_state('input_boolean." ~ s.slug ~ "_state', 'off') }}" }}
                 sequence:
                   - action: persistent_notification.create
                     data:
                       title: "{{ s.name }} - turn_off not confirmed"
                       message: >-
-                        {{ "{{ 'Both channels were driven but the load did not report off within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' cloud=' ~ states('" ~ s.cloud_entity ~ "') ~ ' at ' ~ now().isoformat() }}" }}
+                        {{ "{{ 'Both channels were driven but the mirror did not confirm off within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' cloud=' ~ states('" ~ s.cloud_entity ~ "') ~ ' at ' ~ now().isoformat() }}" }}
                       notification_id: {{ s.slug }}_facade_off_unconfirmed
 {%- else %}
 {##  --- HK-only variant: no cloud fallback --- ##}

--- a/config/configuration.jinja
+++ b/config/configuration.jinja
@@ -308,6 +308,49 @@ template:
 {#-                                                                                  -#}
 {#- Full derivation and source citations: docs/stories/QS-305.story.md and its two    -#}
 {#- review fix plans. Do not re-derive from memory.                                    -#}
+{#-                                                                                  -#}
+{#- -------------------------------------------------------------------------------- -#}
+{#- THE APPLE-SIDE HALF, WHICH LIVES OUTSIDE THIS REPO                                -#}
+{#-                                                                                  -#}
+{#- HA never writes input_boolean.<slug>_state. TWO Apple Home automations do, and    -#}
+{#- both must exist for every device in the inventory above:                          -#}
+{#-                                                                                  -#}
+{#-  (1) EDGE, one pair per device -- the fast path.                                  -#}
+{#-      when <homekit_device> switches ON  -> set <slug>_state ON                     -#}
+{#-      when <homekit_device> switches OFF -> set <slug>_state OFF                    -#}
+{#-      Follows a real change in 2-3 s, which is what the 10 s waits below rely on.   -#}
+{#-      It is driven by HomeKit change events, and those can stop arriving silently.  -#}
+{#-                                                                                  -#}
+{#-  (2) PERIODIC RESYNC, one Shortcut for all devices -- the safety net.              -#}
+{#-      when input_boolean.legrand_ticker switches ON -> run a Shortcut that, for     -#}
+{#-      each device, does:                                                            -#}
+{#-          if <homekit_device> is on  -> set <slug>_state ON                         -#}
+{#-          else                       -> set <slug>_state OFF                        -#}
+{#-      This writes the observed value EVERY tick, changed or not. That is what makes -#}
+{#-      the mirror polled rather than event-driven, so all four of these self-heal    -#}
+{#-      within one ticker period instead of persisting indefinitely:                  -#}
+{#-        - a mirror frozen by a lost HomeKit subscription;                           -#}
+{#-        - a stale mirror after HA was down while the device was switched;            -#}
+{#-        - a NEW device whose mirror Apple has never written (it reads off, and       -#}
+{#-          would otherwise be trusted as a confident off -- the incident signature); -#}
+{#-        - a stray hand tap on the mirror in Apple Home, or a scene sweeping it.     -#}
+{#-      The ticker cadence is set in automations.yaml, NOT here, and it is the bound  -#}
+{#-      on every one of those mitigations.                                            -#}
+{#-                                                                                  -#}
+{#- WHEN YOU ADD A DEVICE: add its mirror to BOTH automations. With (1) only, a new    -#}
+{#- device is fine until the first HomeKit freeze; with (2) only, confirmation is as   -#}
+{#- slow as the ticker and the 10 s waits will time out and notify on every command.   -#}
+{#- With neither, the facade trusts a mirror nobody writes -- which reads off.         -#}
+{#-                                                                                  -#}
+{#- NEITHER AUTOMATION IS OBSERVABLE FROM HA, and Apple's Home app has no automation   -#}
+{#- execution log. If the Shortcut in (2) silently stops running, behaviour degrades   -#}
+{#- back to event-driven-only and nothing here can tell you. A liveness check for it   -#}
+{#- is the highest-value watchdog target -- see the story's follow-up Issue A.         -#}
+{#-                                                                                  -#}
+{#- Because (2) rewrites the value even when it has not changed, HA advances the       -#}
+{#- mirror's last_reported on every tick, while last_changed does NOT move on a        -#}
+{#- no-op write. So last_reported is a usable freshness signal for the trust           -#}
+{#- predicate. NOT used yet: see the story's Issue D.                                  -#}
 {#- ================================================================================ -#}
 {%- for s in legrand_switches_to_map.switches %}
 {##  --- Dual-channel actuation, mirror-only trust --- ##}

--- a/config/configuration.jinja
+++ b/config/configuration.jinja
@@ -285,88 +285,61 @@ template:
         default_entity_id: switch.{{ s.slug }}_facade
         name: {{ s.name }}
         state: >
-          {{ "{% set hk_ok = is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') %}" }}
           {{ "{% set mirror = states('input_boolean." ~ s.slug ~ "_state') %}" }}
           {{ "{% set cloud = states('" ~ s.cloud_entity ~ "') %}" }}
-          {{ "{% set mirror_valid = hk_ok and mirror in ['on','off'] %}" }}
+          {{ "{% set mirror_valid = mirror in ['on','off'] %}" }}
           {{ "{% set cloud_valid = cloud in ['on','off'] %}" }}
-          {{ "{% if mirror_valid and cloud_valid and mirror != cloud %}" }}
-            {{ "{% set m_t = states['input_boolean." ~ s.slug ~ "_state'].last_changed %}" }}
-            {{ "{% set c_t = states['" ~ s.cloud_entity ~ "'].last_changed %}" }}
-            {{ "{{ (mirror if m_t > c_t else cloud) == 'on' }}" }}
-          {{ "{% elif mirror_valid %}" }}
-            {{ "{{ mirror == 'on' }}" }}
-          {{ "{% elif cloud_valid %}" }}
-            {{ "{{ cloud == 'on' }}" }}
+          {{ "{% if mirror_valid or cloud_valid %}" }}
+            {{ "{{ mirror == 'on' or cloud == 'on' }}" }}
           {{ "{% else %}" }}
             unknown
           {{ "{% endif %}" }}
         availability: >
           {{ "{{ (is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on')) or states('" ~ s.cloud_entity ~ "') in ['on','off'] }}" }}
         turn_on:
-          - variables:
-              hk_ok: >
-                {{ "{{ is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') }}" }}
+          - action: input_boolean.turn_on
+            target:
+              entity_id: input_boolean.{{ s.slug }}_command
+          - action: switch.turn_on
+            target:
+              entity_id: {{ s.cloud_entity }}
+            continue_on_error: true
+          - wait_template: >-
+              {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on') }}" }}
+            timeout: "00:00:10"
+            continue_on_timeout: true
           - choose:
-              - conditions: {{ '"{{ hk_ok }}"' }}
+              - conditions: >-
+                  {{ "{{ not (is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on')) }}" }}
                 sequence:
-                  - action: input_boolean.turn_on
-                    target:
-                      entity_id: input_boolean.{{ s.slug }}_command
-                  - wait_template: >-
-                      {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on') }}" }}
-                    timeout: "00:00:10"
-                    continue_on_timeout: true
-                  - choose:
-                      - conditions: >-
-                          {{ "{{ not (is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on')) }}" }}
-                        sequence:
-                          - action: persistent_notification.create
-                            data:
-                              title: "{{ s.name }} - HK turn_on timed out"
-                              message: "Mirror did not confirm in 10 s; falling back to cloud."
-                          - action: switch.turn_on
-                            target:
-                              entity_id: {{ s.cloud_entity }}
-            default:
-              - action: switch.turn_on
-                target:
-                  entity_id: {{ s.cloud_entity }}
-              - action: input_boolean.turn_on
-                target:
-                  entity_id: input_boolean.{{ s.slug }}_command
+                  - action: persistent_notification.create
+                    data:
+                      title: "{{ s.name }} - turn_on not confirmed"
+                      message: >-
+                        {{ "{{ 'Both channels were driven but the load did not report on within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' cloud=' ~ states('" ~ s.cloud_entity ~ "') ~ ' at ' ~ now().isoformat() }}" }}
+                      notification_id: {{ s.slug }}_facade_on_unconfirmed
         turn_off:
-          - variables:
-              hk_ok: >
-                {{ "{{ is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') }}" }}
+          - action: input_boolean.turn_off
+            target:
+              entity_id: input_boolean.{{ s.slug }}_command
+          - action: switch.turn_off
+            target:
+              entity_id: {{ s.cloud_entity }}
+            continue_on_error: true
+          - wait_template: >-
+              {{ "{{ not (is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on')) }}" }}
+            timeout: "00:00:10"
+            continue_on_timeout: true
           - choose:
-              - conditions: {{ '"{{ hk_ok }}"' }}
+              - conditions: >-
+                  {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on') }}" }}
                 sequence:
-                  - action: input_boolean.turn_off
-                    target:
-                      entity_id: input_boolean.{{ s.slug }}_command
-                  - wait_template: >-
-                      {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'off') or is_state('" ~ s.cloud_entity ~ "', 'off') }}" }}
-                    timeout: "00:00:10"
-                    continue_on_timeout: true
-                  - choose:
-                      - conditions: >-
-                          {{ "{{ not (is_state('input_boolean." ~ s.slug ~ "_state', 'off') or is_state('" ~ s.cloud_entity ~ "', 'off')) }}" }}
-                        sequence:
-                          - action: persistent_notification.create
-                            data:
-                              title: "{{ s.name }} - HK turn_off timed out"
-                              message: "Mirror did not confirm in 10 s; falling back to cloud."
-                          - action: switch.turn_off
-                            target:
-                              entity_id: {{ s.cloud_entity }}
-            default:
-              - action: switch.turn_off
-                target:
-                  entity_id: {{ s.cloud_entity }}
-              - action: input_boolean.turn_off
-                target:
-                  entity_id: input_boolean.{{ s.slug }}_command
+                  - action: persistent_notification.create
+                    data:
+                      title: "{{ s.name }} - turn_off not confirmed"
+                      message: >-
+                        {{ "{{ 'Both channels were driven but the load did not report off within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' cloud=' ~ states('" ~ s.cloud_entity ~ "') ~ ' at ' ~ now().isoformat() }}" }}
+                      notification_id: {{ s.slug }}_facade_off_unconfirmed
 {%- else %}
 {##  --- HK-only variant: no cloud fallback --- ##}
   - switch:

--- a/docs/stories/QS-305.story.md
+++ b/docs/stories/QS-305.story.md
@@ -993,3 +993,61 @@ controller — which would also supply a genuinely independent second leg.
   the two control planes are permanently independent, that is worth documenting.
 - **Issue D — mirror resync (user-requested).** A way to reset the mirror to the real HomeKit
   state, closing B2 and residual 8. See the constraint noted under B2.
+
+---
+
+# Update — periodic Apple-side mirror sync (2026-07-30, user)
+
+The user implemented an **Apple Shortcuts script that runs periodically and syncs each device's
+real state into its mirror boolean**. This is a deployment-side change, outside this repo.
+
+It is a **strict improvement over anything achievable in-template**, because it converts the
+mirror from *event-driven* (write on accessory change) to *polled* (write every tick). That
+weakens the single-leg design's worst failure modes at the source rather than working around them.
+
+## Effect on the recorded residuals
+
+| Residual | New status |
+| --- | --- |
+| **B2** — a never-written mirror reads `off` and is trusted | **Mitigated, bounded by one sync period.** After the first tick the mirror carries a real observation. The manual "set the mirror when adding a device" step is reduced to "wait one sync period before relying on the facade". |
+| **1** — a mirror freeze between commands is undetectable | **Substantially mitigated.** The documented freeze modes (hub never re-subscribing, a `No Response` episode cancelling subscriptions, a bridge using `setCharacteristic`) all stop *change events* from arriving. A periodic write does not depend on change events, so a frozen mirror self-heals within one period. |
+| **8** — mirror staleness across HA downtime | **Mitigated, bounded by one sync period.** Nothing re-published the mirror at HA start; now something does. |
+| **9** — the mirror is writable from HomeKit | **Mitigated.** A stray hand tap or a scene sweep is corrected within one sync period instead of persisting indefinitely. |
+
+## What it does NOT close — stated so it is not assumed
+
+- **The template cannot verify the sync exists.** Nothing in this repo can assert it is installed
+  or running, so none of the above is enforced by a test. They are mitigated by an operational
+  practice, not fixed in code.
+- **The sync has the same observability blind spot as the automation it supplements.** Apple's Home
+  app has no automation execution log, so a Shortcuts automation that silently stops running is
+  undetectable from the Apple side — which is residual 1's original problem, moved up one level. If
+  the sync stops, behaviour degrades silently to the pre-sync design. A liveness check belongs with
+  Issue A's watchdog.
+- **The exposure window is now the sync period**, not zero. Every mitigation above is "within one
+  period", so the period is the design parameter that matters.
+
+## New opportunity — `last_reported` becomes a real freshness signal
+
+Verified in HA core: *"If the state is unchanged, the existing state will be mutated with an
+updated `last_reported`"* (`core.py:1814`; see also `:1888-1892`). A same-value write therefore
+advances `last_reported` even though `last_changed` does **not** move (which is also why a no-op
+`input_boolean.turn_*` fires no `state_changed` — residual 6).
+
+**If the periodic sync writes the mirror unconditionally on every tick**, then
+`states.input_boolean.<slug>_state.last_reported` answers *"has this mirror been refreshed
+recently?"* — the positive freshness evidence B2's option 1 wanted, with **no extra helpers**. It
+also does not breach §1.6's `last_changed` ban, which targets `last_changed` as a *race arbiter*
+(the issue's A3); this is a different signal answering a different question.
+
+That would let the trust predicate become "HomeKit healthy **and** mirror valid **and** mirror
+refreshed within N periods", closing B2 and residual 8 properly rather than by convention. **Not
+implemented here** — it depends on two facts about the shortcut that must be confirmed first (see
+Issue D), and it is a spec change beyond fix plan #02.
+
+## Follow-up changes
+
+- **Issue D is re-scoped.** No longer "build a resync" — that exists. It becomes: (a) confirm the
+  sync writes unconditionally every tick, (b) if so, add a `last_reported` freshness conjunct to
+  the trust predicate, and (c) add a liveness signal so a stopped sync is visible.
+- **Issue A** gains the sync-liveness check as its most valuable watchdog target.

--- a/docs/stories/QS-305.story.md
+++ b/docs/stories/QS-305.story.md
@@ -1041,13 +1041,24 @@ also does not breach §1.6's `last_changed` ban, which targets `last_changed` as
 (the issue's A3); this is a different signal answering a different question.
 
 That would let the trust predicate become "HomeKit healthy **and** mirror valid **and** mirror
-refreshed within N periods", closing B2 and residual 8 properly rather than by convention. **Not
-implemented here** — it depends on two facts about the shortcut that must be confirmed first (see
-Issue D), and it is a spec change beyond fix plan #02.
+refreshed within N periods", closing B2 and residual 8 properly rather than by convention.
+
+**Precondition confirmed (user, 2026-07-30).** The Shortcut is triggered by
+`input_boolean.legrand_ticker` switching **on**, and for each device performs
+`if <homekit_device> is on -> set <slug>_state on, else -> set <slug>_state off`. That is an
+**unconditional write of the observed value on every tick**, changed or not, so `last_reported`
+does advance each period. The sync period is therefore the ticker's rising-edge cadence, which is
+defined in `automations.yaml` (outside this story's file scope).
+
+**Still not implemented here**, because it is a spec change beyond fix plan #02: it adds a
+conjunct to the trust predicate, needs the freshness window `N` chosen against the real ticker
+cadence, and needs its own row coverage. Carried by Issue D.
 
 ## Follow-up changes
 
-- **Issue D is re-scoped.** No longer "build a resync" — that exists. It becomes: (a) confirm the
-  sync writes unconditionally every tick, (b) if so, add a `last_reported` freshness conjunct to
-  the trust predicate, and (c) add a liveness signal so a stopped sync is visible.
+- **Issue D is re-scoped.** No longer "build a resync" — that exists, and its unconditional-write
+  precondition is confirmed. It becomes: (a) read the ticker cadence out of `automations.yaml` and
+  pick a freshness window `N` against it, (b) add a `last_reported` freshness conjunct to the trust
+  predicate with row coverage, and (c) add a liveness signal so a stopped Shortcut is visible.
+  Both Apple-side automations are now documented inline in `config/configuration.jinja`.
 - **Issue A** gains the sync-liveness check as its most valuable watchdog target.

--- a/docs/stories/QS-305.story.md
+++ b/docs/stories/QS-305.story.md
@@ -5,16 +5,18 @@
 - **Files touched**: `config/configuration.jinja`, `tests/test_config_jinja_rendering.py`
 - **Story version**: v7 — design chosen by the user; five adversarial review rounds folded in
 
-> # ⚠️ SUPERSEDED — read `QS-305.story_review_fix_#01.md` Part 1 first
+> # ⚠️ SUPERSEDED — read `QS-305.story_review_fix_%2301.md` Part 1 first
 >
 > The design below (D1/D2/D3 — dual-channel actuation with **fail-safe OR reporting**) was
 > **replaced during review triage on 2026-07-30**. What shipped is
-> [`QS-305.story_review_fix_#01.md`](QS-305.story_review_fix_#01.md) Part 1:
-> **dual-channel actuation with mirror-only trust**. Where this story and Part 1 disagree,
+> [`QS-305.story_review_fix_%2301.md`](QS-305.story_review_fix_%2301.md) Part 1
+> **as amended by [`QS-305.story_review_fix_%2302.md`](QS-305.story_review_fix_%2302.md)
+> Part A**: dual-channel actuation with mirror-only trust, reporting `unknown` (never
+> `unavailable`) when the mirror cannot be trusted. Where this story and Part 1 disagree,
 > **Part 1 wins and this document is void on that point** — including its Design section, its
 > acceptance criteria, and its residuals. This file is retained for its incident evidence and
 > design history only. See "Supersession record" at the end.
-
+>
 > **Home Assistant citations.** Core-HA citations in this story refer to
 > `venv/lib/python3.14/site-packages/homeassistant/`, not a system install. (v6 cited the
 > system install and three line numbers were wrong; the conclusions were unaffected but the
@@ -737,7 +739,7 @@ every AC value and line count in this version was produced by executing the edit
 
 The design in this story was replaced. This section records what changed, why, and the
 residuals the new design carries. Authoritative spec:
-[`QS-305.story_review_fix_#01.md`](QS-305.story_review_fix_#01.md) Part 1.
+[`QS-305.story_review_fix_%2301.md`](QS-305.story_review_fix_%2301.md) Part 1.
 
 ## What replaced what
 
@@ -834,3 +836,160 @@ A1-A5 in this story are void. The shipped criteria are Part 1 §1.3-§1.6, pinne
 and the old A3 identity `wait == ¬state` are deliberately gone**: `state:` answers "is the load
 on?" and consults `hk_ok`, while the wait answers "did the mirror confirm the target?" and does
 not. That divergence is intentional — do not "fix" it back.
+
+---
+
+# Supersession record — review fix plan #02 (2026-07-30)
+
+Plan #01 Part 1 stands, **except its §1.5 disposition of the untrusted case**, which plan #02
+§A1 replaces. Round 2 found no mis-implementation of plan #01; everything here is either a case
+plan #01's spec did not anticipate, or the one place it was **wrong**.
+
+## §A1 — plan #01's "untrusted → `unavailable`" was wrong, and dangerous
+
+**Corrected rule: untrusted → report `unknown`, and stay AVAILABLE. The facade must never become
+`unavailable`.**
+
+The reason is not the obvious one. `STATE_UNKNOWN` and `STATE_UNAVAILABLE` are
+**indistinguishable to quiet-solar** — `probe_if_command_set` returns `None` for both
+(`ha_model/bistate_duration.py:550`), and `UNAVAILABLE_STATE_VALUES = [STATE_UNKNOWN,
+STATE_UNAVAILABLE]` (`ha_model/device.py:52`). So any argument based on QS's acknowledgement path
+is unfounded.
+
+**The decisive difference is in HA core.** `helpers/service.py:763`, inside the resolver used by
+`entity_service_call`:
+
+```python
+entity_candidates = [e for e in entity_candidates if e.available]
+```
+
+then one WARNING via `log_missing`, no exception. `switch.turn_on`/`turn_off`/`toggle` are
+registered as **entity services** (`components/switch/__init__.py:67-69`), so they pass through
+that filter. **An `unavailable` facade therefore silently swallows every actuation quiet-solar
+issues** — both channels undriven, and because the action script never runs, no diagnostic
+notification either. That is the 2026-07-27 failure shape reconstructed by a different route.
+
+It would have fired **on every HA restart**: both health sensors force themselves `off` for 120 s
+after start (`configuration.jinja` warming guard), a window that comfortably exceeds the ~70 s QS
+needs to give up on a command (`home_model/load.py:707-717`).
+
+### §A1.1 — emit `{{ none }}`, not the string `unknown`
+
+`components/template/switch.py` calls `template_validators.boolean(self, CONF_STATE)` **without**
+`none_on_unknown_unavailable`, so `check_result_for_none` only accepts a real `None`
+(`validators.py:47-50`). Rendering the literal `unknown` fails `cv.boolean`, takes the error path
+and **logs an ERROR on every evaluation**. Verified empirically:
+
+| Rendered | Parses to | `check_result_for_none` | Result |
+| --- | --- | --- | --- |
+| `{{ none }}` | `None` | **True** | clean `unknown`, no log |
+| ` unknown ` | `'unknown'` | **False** | ERROR every evaluation |
+
+The old `{% else %} unknown {% endif %}` was harmless only because the branch was dead — plan
+#01's `availability:` blocked `state:` from rendering at all. §A1 makes it live.
+
+## B1 — `continue_on_error` does not contain a Netatmo failure
+
+`continue_on_error` only swallows `HomeAssistantError` subclasses (`helpers/script.py` —
+*"Only Home Assistant errors can be ignored"*, then `raise exception`). pyatmo raises `ApiError`,
+`ApiThrottlingError` and `ApiTooManyRequestError`, all plain `Exception` subclasses
+(`custom_components/netatmo/pyatmo/exceptions.py:24-45`). So on a 429/throttle — a documented
+operating condition for this fork, which inflates poll intervals under rate pressure — the raw
+exception aborted the script **at the cloud step**: the relay did not actuate *and no notification
+was raised*. **The single failure the diagnostic exists to report was the one that silenced it.**
+
+**Fix: the cloud write moved into its own `parallel:` branch.** `_async_step_parallel` gathers
+with `return_exceptions=True` and re-raises only **after every branch completes**
+(`helpers/script.py:686-694`), so the wait and the notification still run. Pinned by a test that
+runs the real rendered sequence through HA's `Script` with a raising cloud service and asserts the
+notification still fires.
+
+The rejected alternative was delegating the cloud write to a `script:` entity (fire-and-forget).
+It is blocked here: the config already has `script: !include scripts.yaml`, so inline script
+entities would require editing `scripts.yaml` — outside the one-file `config/` grant — or
+restructuring that include, which would change non-facade rendered lines.
+
+## B2 — a never-written mirror reads `off` and is fully trusted (ACCEPTED, option 3)
+
+`input_boolean.<slug>_state` is declared with no `initial:`, and `input_boolean` sets
+`_attr_is_on = state is not None and state.state == STATE_ON` — i.e. **`off` when there is no
+restore data** (`components/input_boolean/__init__.py:196-204`). So a mirror Apple Home has never
+written reads `off`, satisfies `mirror in ['on','off']`, and the facade reports a **confident
+`off`**. Worse, `turn_off`'s positive-confirmation wait is then satisfied instantly with zero
+observation, so no notification either. The trust predicate **cannot distinguish "Apple has never
+written me" from "the device is off"** — the incident signature, on the one leg now trusted alone.
+
+**User decision (2026-07-30): accept and document (option 3).** The companion-freshness-marker fix
+(option 1) was deferred because it changes the HomeKit deployment. The `last_changed` carve-out
+(option 2) was **rejected on the merits**: a restored mirror also carries `last_changed` = HA start
+time, so it cannot distinguish "never written" from "restored and still correct" — it looks like a
+fix without being one.
+
+**Mandatory deployment step:** when adding a device to `legrand_switches_to_map`, on a fresh
+install, after restoring a backup without `.storage/core.restore_state`, or after
+`input_boolean.reload`, **manually set the mirror boolean to match reality before the facade is
+used.** All of these are operator-initiated events; none occurs spontaneously.
+
+The user's stated preference is a **proper mirror resync from real HomeKit state**. Recorded as
+follow-up Issue D. One constraint to design around: HA cannot read the Legrand accessory directly
+— HA is the HomeKit *bridge* publishing these booleans, while the gateway is an accessory Apple
+Home controls. A resync must therefore be Apple-driven (the existing
+`legrand_pumpkin`/`homekit_hub_alive` ticker is the precedent: HA toggles a boolean, an Apple
+automation reacts), unless `homekit_controller` is added so HA talks to the gateway as a
+controller — which would also supply a genuinely independent second leg.
+
+## Also applied
+
+- **C1 — the HK-only facade variant was deleted.** It was still on the superseded design
+  (`availability:` = `hk_ok` alone, no wait, no notification) and mutating it to report a
+  confident `off` left all 26 tests green. It was unreachable dead code — all five inventory
+  entries define `cloud_entity`. Deleting it also means a missing `cloud_entity` now fails the
+  render loudly under `StrictUndefined` instead of silently degrading to one channel.
+- **C2 — notification message templates are now evaluated**, not just substring-checked. A broken
+  template there raises at runtime on a step with no `continue_on_error`, converting the
+  diagnostic into a silent script failure.
+- **C5 — the success path dismisses the notification**, so a transient failure no longer leaves a
+  permanent stale alarm.
+- **C7 — `cloud=` was dropped from the message.** The fork writes state optimistically and ignores
+  the API's return value, so the field echoed our own command (or a stale pre-command value) and
+  could never tell the operator whether the write was accepted.
+- **C8** is moot: with the HK-only branch gone, `cloud_entity_of` cannot meet a block without one.
+- Part D: `%23`-encoded fix-plan links, MD001/MD028 fixes, dead test imports removed, the header
+  comment no longer hardcodes an external path and line range, and **`| tojson` on `name:` and the
+  notification `title:`** — a device name containing `"`, `:` or a leading `{`/`[`/`*`/`&` would
+  otherwise break the render, and a malformed render fails **all** of HA's startup.
+
+## Additional residuals (plan #02 C3, C4, C6)
+
+7. **`mode: single` now has a real 10 s window that discards commands.** Template action scripts
+   are built with HA defaults, so `script_mode` is single with `max_exceeded="WARNING"`. A second
+   same-direction call while the first is in its wait is discarded **before either actuation write
+   executes**, which undercuts the "the writes always happen" guarantee at the run level.
+   Previously the wait was vacuously true and runs finished in milliseconds, so this window did not
+   exist. Not fixable in-template (template entities accept no `mode:` key). QS's own relaunch
+   cadence (>50 s) does not hit it; the exposure is a double tap in the UI, or a user override
+   racing a solver command.
+8. **Mirror staleness across HA downtime is trusted with no age check.** `input_boolean` restores
+   its last value with no age check, Apple's automation writes the mirror only on an accessory
+   *change*, and nothing re-publishes it at HA start. The health sensors prove only that
+   `legrand_pumpkin`/`homekit_hub_alive` moved within 90 s — nothing about *this* accessory's
+   mirror being fresh. Switch the device while HA is down and never switch it again: the facade
+   reports the pre-restart value with full confidence, indefinitely. Overlaps B2; both are "the
+   mirror's value carries no freshness evidence", and Issue D would address both.
+9. **The mirror is bridged to HomeKit as a writable switch.** `input_boolean.<slug>_state` is
+   exposed as `LHK <name> Mirror`. It must be writable for Apple to drive it, but that also means a
+   hand tap in Apple Home — or the mirror being swept into a HomeKit scene — writes the facade's
+   **only** witness and **only** confirmation source. The cloud leg used to supply a second
+   opinion; mirror-only trust removed it.
+
+## Follow-ups after merge
+
+- **Issue A — out-of-band watchdog:** re-check the mirror against the last commanded state out of
+  band, and dismiss stale notifications. (The power-sensor third leg is **withdrawn** — the
+  template generates zero per-device power sensors.)
+- **Issue B — docs:** `project-context.md:150` misdescribes CI coverage as whole-repo; it is scoped
+  to `custom_components/quiet_solar`.
+- **Issue C — investigate** why Netatmo's cloud never observes HomeKit-initiated state changes. If
+  the two control planes are permanently independent, that is worth documenting.
+- **Issue D — mirror resync (user-requested).** A way to reset the mirror to the real HomeKit
+  state, closing B2 and residual 8. See the constraint noted under B2.

--- a/docs/stories/QS-305.story.md
+++ b/docs/stories/QS-305.story.md
@@ -1,0 +1,716 @@
+# QS-305 — Legrand/Netatmo facade: drive both channels, report fail-safe
+
+- **Issue**: [#305](https://github.com/tmenguy/quiet-solar/issues/305) (split out of [#304](https://github.com/tmenguy/quiet-solar/issues/304))
+- **Branch**: `QS_305` · **Next phase**: `qs-implement-task`
+- **Files touched**: `config/configuration.jinja`, `tests/test_config_jinja_rendering.py`
+- **Story version**: v7 — design chosen by the user; five adversarial review rounds folded in
+
+> **All Home Assistant citations in this story refer to
+> `venv/lib/python3.14/site-packages/homeassistant/`**, not a system install. (v6 cited the
+> system install and three line numbers were wrong; the conclusions were unaffected but the
+> references were unusable.)
+
+## Blocking dependencies — read before T1
+
+This story cannot be completed without the user at two distinct points. They are listed together
+so the phase owner meets neither by surprise:
+
+1. **T0** — in-session confirmation of (a) the `config/configuration.jinja` edit-scope grant and
+   (b) the fail-safe-direction decision. **If either is declined, stop** — there is no
+   committable subset.
+2. **T8** — if `--impacted` fails as a zero-changed-lines artifact, escalate immediately rather
+   than retrying.
+
+(An earlier version listed a third stop — a user-run P6 check. It was **resolved from source**
+instead; see P6.)
+
+> **Edit-scope authorization (one-off, user-granted).** `config/**` is in **neither** implement
+> agent's edit scope (`docs/workflow/phase-protocols.md:131-137`). The user authorized a one-off
+> extension **narrowed to `config/configuration.jinja`** — read+write on that file only; every
+> other path under `config/` is off-limits for read and write. `git add -f` is not needed
+> **because the file is already tracked** (verified: `git ls-files --error-unmatch
+> config/configuration.jinja` and `git cat-file -e origin/main:config/configuration.jinja` both
+> succeed — the latter is also what makes T8's baseline valid). Note `-f` would be required for
+> any *ignored* path regardless of whether it is new. Verified safe: the template has **no** Jinja
+> `{% include %}`/`{% import %}`, so `FileSystemLoader(CONFIG_DIR)` never opens a sibling.
+
+## Problem
+
+`config/configuration.jinja` generates a facade switch per Legrand device
+(`switch.<slug>_facade`) that prefers a HomeKit mirror leg and is supposed to fall back to the
+Netatmo cloud leg. In the incident the boiler ran ~7 hours after being commanded off.
+
+The root cause is **structural**: the template *predicts* whether actuation succeeded by reading
+a leg, then decides whether to drive the cloud channel based on that prediction. Any leg can lie,
+so the prediction can be wrong — and when it is wrong, the one channel that worked is never
+driven.
+
+Three defects in the cloud-backed branch (`configuration.jinja:280-369`):
+
+1. **Three predicates that disagree.** `state:` (key 287, tail 293-303) elects a winner via a
+   `last_changed` race, while `wait_template:` (316-317, 348-349) and the fallback condition
+   (321-322, 353-354) test `not (mirror at target **or** cloud at target)`. The fallback fires
+   only when *neither* leg confirms — but the real failure is *one leg confirms and it is lying*.
+2. **`last_changed` is the wrong arbiter** (read 294-295, compared 296).
+3. **Retries cannot reach HomeKit** (313, 345). Re-calling `input_boolean.turn_off` on a boolean
+   already `off` produces no edge, so an edge-triggered Apple Home automation never re-fires.
+
+### Incident evidence (verified in `home-assistant-3.log`, 311 MB, plus the HA instance)
+
+- **7 `turn_off` executions** on the boiler facade, 12:12:19 → 12:30:11 on 2026-07-27 (initial +
+  **6** relaunches). Every one took `choice 1`; the trace **stops at
+  `Executing step wait template (timeout: 0:00:10)`**.
+- **The wait was satisfied every time.** HA logs nothing for a `choose` whose conditions all fail
+  and which has no `default:` (the visible `Choose at step 2: choice 1` lines come from the chosen
+  **sub-script's** name; there is no "Executing step choose" line even for the outer one). Had the
+  wait timed out, the inner condition — the negation of the wait predicate — would have been
+  **true**, producing the notification and the cloud write. Both are absent.
+- **The load then wedged**: from 12:36:01, every ~7 s, `check_loads_commands: Command for load
+  Cumulus Pool House has been relaunched 6 times and is still not acked or good … Last command was
+  LoadCommand(command='on', power_consign=2353.0)`.
+- **No `netatmo`/`pyatmo` errors** in 11:50-12:40 — which rules out an `unavailable` bounce
+  **only**, and says nothing about staleness (a stale leg produces no log noise; that is the point).
+- **From the HA instance**: the command boolean went `on` at 12:01 and correctly `off` at
+  12:12:19; **the mirror read `on` from 12:01 until past 19:00**; the facade never went `off`;
+  **the load was never physically switched off**.
+
+**Two corrections to the issue's premise.** #304 does *not* make QS "retry forever" —
+`ha_model/home.py:2871-2877` bounds relaunches at **6** (spacing `50 × (n+1)` s,
+`home.py:2871`), exactly as the log shows. The issue's "24 times" is the three-day total, not this
+incident (7).
+
+### Task 0 — executed, and the limit of what it establishes
+
+The mirror read `on` while the command read `off`, so **the mirror is not a command echo**. The
+wait was satisfied while the mirror read `on`, so **the cloud leg read `off`** — while the boiler
+ran. The facade stayed `on`, so the race picked the mirror, so the cloud's `last_changed` predated
+12:01.
+
+**What it does not establish:** whether the mirror was *truthful* or had **frozen at `on`** after
+correctly following the 12:01 `turn_on`. Both produce identical observables, and HA has no
+independent device image to break the tie (the per-device power sensor could, but was not
+sampled). **This is why the design does not bet on a leg for reporting.** It is *not* fully
+sidestepped, though: D3's diagnostic can only fire while some leg disagrees with the target, and
+during the optimistic-cloud window the mirror is the only leg that can disagree — so **whether the
+diagnostic can ever fire still depends on mirror truthfulness.** Stated here rather than buried in
+a residual. Version history is in the review notes.
+
+### Entity data flow
+
+| Entity | Written by | Read by |
+| --- | --- | --- |
+| `input_boolean.<slug>_command` | **HA** (these scripts); exposed to HomeKit (559-560) | the Apple Home automation that actuates the device |
+| `input_boolean.<slug>_state` (mirror) | **Apple Home automation only** — never by HA | `state:`, the diagnostic predicates |
+| `<cloud_entity>` | Netatmo integration, **and these scripts** | `state:`, `availability:`, the diagnostic predicates |
+| `switch.<slug>_facade` | — (template switch) | **QS**, as the load's `bistate_entity` |
+
+### Pre-implementation validation (user-run)
+
+- **P0.** Calling `switch.turn_on/off` on the Netatmo entity **does actuate the device**, and the
+  mirror follows within ~1 s. The log shows this call had **never executed once in three days**, so
+  the channel this design relies on was entirely unproven before the check.
+- **P1/P2.** The mirror appears reliable and follows a successful command within a few seconds; the
+  existing 10 s timeout is left unchanged. User impressions, no sample size — they justify *not
+  changing* the timeout, nothing more.
+- **P3/P4.** `legrand_homekit_link_healthy` flapped 3× on 07-26, none on 07-27, and the mirror was
+  not stale during them. Weak evidence; v7 does not act on it beyond leaving `availability:` alone.
+- **P5.** The current render is valid in production. `config/configuration.yaml` is **not** the
+  render output (1115 bytes of dev config vs ~41 700 chars rendered). The **edited** render still
+  needs one config check — see Deployment.
+- **P6 — resolved from source, no user check needed.** The question was whether a cloud write
+  actuates when the cloud entity **already reads the target** — because the parallel with Defect 3
+  is exact: Defect 3 is "a redundant command produces no edge", and in the incident the cloud
+  entity read `off` while the boiler ran, so D1's `switch.turn_off` is a **no-change command** from
+  the integration's point of view. Had `pyatmo` or the HA platform short-circuited it, **D1 would
+  be Defect 3 wearing a different hat and would fix nothing.**
+
+  **There is no state guard anywhere in the chain**, verified end to end:
+  `async_turn_off` (`netatmo/switch.py:80-85`) unconditionally awaits `device.async_off()` →
+  `async_set_switch(False)` (`pyatmo/modules/module.py:388-391`) → an unconditional
+  `{"modules": [{"id": …, "on": False, …}]}` POST (`:369-379`). No early return, no comparison
+  against current state. So the command **is** dispatched regardless of what the entity reads.
+
+  Residual: whether Netatmo's *server* ignores an `on: false` for a module it believes is already
+  off. Unknowable from here, and P0's evidence (a cloud write did actuate the device) is the
+  relevant counter-evidence. Accepted without further checking.
+
+## Goal
+
+**Actuation is unconditional within the script** — no predicate can suppress a command — and
+**reporting is biased toward `on`**, so false-`off` is *narrowed* from "any one leg stuck at `off`"
+to "*all* valid legs stuck at `off`". It is **not eliminated**: see residual 2. A lying leg can
+still suppress a command one layer up, where QS reads the facade and stops commanding — that is
+the incident's causal chain, and this story narrows rather than closes it.
+
+Out of scope: the Legrand / Netatmo / HomeKit devices and integrations; the QS-side deadlock
+(#304). **QS-305 does not resolve the QS-side deadlock or the phantom-load bookkeeping** — D1's
+first unconditional `switch.turn_off` does physically stop the boiler (given P0/P6), but how long
+QS keeps driving, and what it does with a load pinned `on`, is #304's territory.
+
+## Design
+
+Every edit was verified by performing it on a scratch copy and rendering: `wc -l` **598 → 567**
+(delta **−31**, which reproduces exactly: D2 replaces 17 lines with 10 = −7; D1+D3 replace 32 with
+20 per direction = −24), output parses, `last_changed` and `hk_ok` both absent from `state:`, and
+every A1/A3 value reproduced on the real rendered output.
+
+### D1 — Actuation: drive both channels, always (supersedes the issue's F1 and F3)
+
+Replace each script's `variables:` → `choose:` → `default:` apparatus (306-337 / 338-369). D3
+appends two further steps to each; the actuation head is:
+
+```yaml
+        turn_off:
+          - action: input_boolean.turn_off
+            target:
+              entity_id: input_boolean.{{ s.slug }}_command
+          - action: switch.turn_off
+            target:
+              entity_id: {{ s.cloud_entity }}
+            continue_on_error: true
+```
+
+`turn_on` is the exact polarity flip (`input_boolean.turn_on`, `switch.turn_on`). **This is the
+fix** — it deletes the decision that caused the incident, so no predicate can conclude "already
+done, no need to drive the cloud".
+
+- **Defect 1 is eliminated by construction**: there is no fallback decision, so no predicates can
+  disagree about one. Stronger than F1, which kept the decision and patched its predicate — and
+  F1's own `default_entity_id`-collision caveat never arises.
+- **Defect 3's intent is met**: every command *and every relaunch* reaches the cloud channel. This
+  is **not** F3's mechanism: the HK leg is **not** skipped. The no-op boolean write is deliberately
+  **retained**, because skipping it needs a condition — the construct being removed.
+- The local boolean is written **first**, so it happens even if the cloud call fails. **Accepted
+  ordering limit:** the steps are sequential, so an exception at step `[0]` means the cloud is
+  never driven. `parallel:` was considered and rejected (it complicates the accessor indices every
+  AC depends on for a failure mode — a missing `input_boolean` helper — that would break the
+  template far more visibly).
+- **`continue_on_error: true` on the cloud step.** This flag has flipped four times across
+  versions; this position is the first resting on verified behaviour.
+  `helpers/script.py:556-578`: `_handle_exception` **logs** the exception, then with the flag set
+  re-raises only `_StopScript`, `vol.Invalid`, `TemplateError`, `ServiceNotFound`,
+  `InvalidEntityFormatError`, `NoEntitySpecifiedError`. So:
+
+  | cloud call raises | with the flag | without |
+  | --- | --- | --- |
+  | `HomeAssistantError` | logged, script continues → D3's wait times out (a leg still disagrees) → **notification fires** | script aborts → log only, **no notification** |
+  | non-`HomeAssistantError` | aborts anyway | aborts, log only |
+
+  It is therefore **strictly better for observability and never worse**. The earlier "actively
+  harmful" claim rested on a false premise (that a cloud leg left at `off` would satisfy the wait —
+  it does not, unless the mirror also reads the target, which is residual 2 and holds either way).
+  Pinned by A2 so a later edit cannot drop it silently.
+- Cost: **Netatmo write volume goes from ~0 to one per command plus one per relaunch (≤6), across
+  5 devices.** Rate limits were **not** checked; a throttle response would land in the
+  non-`HomeAssistantError` abort path. Recorded in T9.
+
+### D2 — State: fail-safe direction (the issue's F2, redesigned)
+
+Pre-edit, for reference (so this story is checkable without opening the file):
+
+```jinja
+        state: >
+          {{ "{% set hk_ok = is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') %}" }}   <- 288, deleted
+          … mirror / cloud …                                                                                                                              <- 289-290, kept
+          {{ "{% set mirror_valid = hk_ok and mirror in ['on','off'] %}" }}                                                                               <- 291, hk_ok dropped
+          {{ "{% set cloud_valid = cloud in ['on','off'] %}" }}                                                                                            <- 292, kept
+          {{ "{% if mirror_valid and cloud_valid and mirror != cloud %}" }} … m_t/c_t last_changed … {{ "{% endif %}" }}                                    <- 293-303, replaced
+```
+
+Delete 288, drop `hk_ok` from 291, replace the tail 293-303, giving:
+
+```jinja
+        state: >
+          {{ "{% set mirror = states('input_boolean." ~ s.slug ~ "_state') %}" }}
+          {{ "{% set cloud = states('" ~ s.cloud_entity ~ "') %}" }}
+          {{ "{% set mirror_valid = mirror in ['on','off'] %}" }}
+          {{ "{% set cloud_valid = cloud in ['on','off'] %}" }}
+          {{ "{% if mirror_valid or cloud_valid %}" }}
+            {{ "{{ mirror == 'on' or cloud == 'on' }}" }}
+          {{ "{% else %}" }}
+            unknown
+          {{ "{% endif %}" }}
+```
+
+*Report `off` only when no valid leg says `on`.* No `last_changed` (the issue's A3 satisfied
+**strictly**), no `hk_ok`, no timestamps, no timers — so F2's blockers 1-2 do not arise and
+`MIRROR_FOLLOW_TIMEOUT_S` is unnecessary (**the issue's A6 is dropped**). The validity guards are
+deliberately not repeated inside the boolean: `mirror == 'on'` already implies `mirror_valid`.
+
+**Why this direction — a trade, not a win:**
+
+| Error | Cause | Status |
+| --- | --- | --- |
+| **False `off`** | **narrowed**, not removed — was "any one leg stuck at `off`" (the observed incident: the cloud sat `off` for 7 h); now "*all* valid legs stuck at `off`" (residual 2) | still silent when it happens |
+| **False `on`** | **introduced** — any leg stuck at `on` | D3 raises a notification; steady-state cost is **mispriced**, see residual 1 |
+
+**The asymmetry rests on D3's notification, not on the log.** The `check_loads_commands` ERROR
+fired every ~7 s from 12:36 to past 19:00 in this very incident and changed nothing — a log line
+is demonstrably not a signal. **This is the weakest load-bearing claim in the story**: a
+`persistent_notification` is only better if it is *seen*, nothing dismisses it, and after 6
+relaunches QS stops invoking the script, so a stale notification can sit there carrying no
+information — exactly the failure mode of the ERROR it replaced. If you want this to be a real
+signal, route it to a `notify.*` mobile channel; that is a deployment choice, not a template one.
+
+**Residual 1 — a leg stuck at `on` pins the facade `on`, with no recovery path in this story.**
+The old race would have let a freshly-driven leg win. QS retries 6× then gives up
+(`home.py:2871-2877`), leaving a permanently un-acked command and a load treated as a permanent
+phantom consumer in the power budget. Only the Apple Home automation, or a manual write to the
+mirror boolean, can clear a stuck mirror.
+
+**Residual 2 — single-leg redundancy, not immunity.** The precise guarantee is *"never report `off`
+while some leg says `on`"*. If **all** valid legs read `off` while the device runs, the facade
+reports `off` and D3 stays quiet. That window is guaranteed: the Netatmo write is optimistic
+(`netatmo/switch.py:77,84` sets `_attr_is_on` then writes state immediately), so the cloud leg
+reports `off` right after every `turn_off` — **for that interval the mirror is the only leg that can
+raise the alarm**, and a mirror stuck at `off` therefore hides a running load. Note "all *valid*
+legs" also covers a leg that is `unavailable`: `(mirror=off, cloud=unavailable)` is a confident
+`off` with one leg known dead. This is the exact dual of the observed incident, was equally broken
+before, and is why the diagnostic's reachability still depends on mirror truthfulness. Verified:
+`(mirror=off, cloud=off)` → state `False`, wait satisfied, no notification.
+
+**The principled closure is the per-device power sensor** (`sensor.<device>_power`, harvested at
+67-84): the only signal that cannot echo a command. Out of scope — recommended follow-up in T9.
+
+**`availability:` (304-305) is deliberately left untouched.** It re-inlines the two health-sensor
+checks rather than referencing the `hk_ok` variable, so deleting line 288 cannot break it. Keeping
+it means that when the HomeKit link is down *and* the cloud leg is invalid, the facade goes
+**`unavailable`** rather than reporting a confident false value — strictly safer than replacing it,
+and it is why the two health binary sensors (185-198) and the
+`legrand_pumpkin`/`homekit_hub_alive` ticker plumbing (154-159, 179-183, 555-557) **retain a
+consumer and must not be pruned as dead**.
+
+### D3 — Diagnostics: a wait that complains instead of deciding (the issue's F4)
+
+Both channels are already driven, so the 10 s timer has no actuation decision left. Appended to
+each script. The two directions are **not** a simple polarity flip, so both are verbatim:
+
+```yaml
+          # turn_off
+          - wait_template: >-
+              {{ "{{ not (is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on')) }}" }}
+            timeout: "00:00:10"
+            continue_on_timeout: true
+          - choose:
+              - conditions: >-
+                  {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on') }}" }}
+                sequence:
+                  - action: persistent_notification.create
+                    data:
+                      title: "{{ s.name }} - turn_off not confirmed"
+                      message: >-
+                        {{ "{{ 'Both channels were driven but the load did not report off within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' cloud=' ~ states('" ~ s.cloud_entity ~ "') ~ ' at ' ~ now().isoformat() }}" }}
+                      notification_id: {{ s.slug }}_facade_off_unconfirmed
+```
+
+```yaml
+          # turn_on
+          - wait_template: >-
+              {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on') }}" }}
+            timeout: "00:00:10"
+            continue_on_timeout: true
+          - choose:
+              - conditions: >-
+                  {{ "{{ not (is_state('input_boolean." ~ s.slug ~ "_state', 'on') or is_state('" ~ s.cloud_entity ~ "', 'on')) }}" }}
+                sequence:
+                  - action: persistent_notification.create
+                    data:
+                      title: "{{ s.name }} - turn_on not confirmed"
+                      message: >-
+                        {{ "{{ 'Both channels were driven but the load did not report on within 10 s. mirror=' ~ states('input_boolean." ~ s.slug ~ "_state') ~ ' cloud=' ~ states('" ~ s.cloud_entity ~ "') ~ ' at ' ~ now().isoformat() }}" }}
+                      notification_id: {{ s.slug }}_facade_on_unconfirmed
+```
+
+Let `S` be the `state:` boolean (`mirror == 'on' or cloud == 'on'`). Then
+**`wait(turn_off) = ¬S`, `wait(turn_on) = S`, `complain = ¬wait` in both directions** — so the
+three predicates agree with reporting by construction, and no facade self-reference is needed.
+
+- **The message reports both leg states and a timestamp.** This is the only cheap step toward
+  resolving mirror-truthful-vs-frozen — the question that refuted four earlier designs and still
+  governs residual 2.
+- **`continue_on_timeout: true` is load-bearing** (without it a timeout errors the script and the
+  `choose` never runs) and **`timeout: "00:00:10"`** is unchanged from pre-edit. Both are pinned by
+  A2.
+- **Per-direction ids** so a `turn_off` cannot erase a `turn_on` failure. Nothing dismisses them.
+- **Residual 3 — the diagnostic is unreachable in one failure mode.** A non-`HomeAssistantError`
+  from the cloud call aborts the script at step `[1]`, before the wait, so the cloud leg is
+  undriven *and* no notification is raised — UI-silent by this story's own standard, leaving only
+  the log line D2 argues is not a signal. `continue_on_error` closes the `HomeAssistantError` half
+  of this (see D1); this half stays open.
+- **Accepted assumption — `mode: single`.** Template entity action scripts are built by
+  `components/template/entity.py:178-192` as `Script(self.hass, config, f"{name} {script_id}",
+  domain)` with **no `script_mode`**, so they inherit `DEFAULT_SCRIPT_MODE = SCRIPT_MODE_SINGLE`
+  (`helpers/script.py:119,126`), and `mode:` is not settable (`components/template/switch.py`
+  types the actions as `cv.SCRIPT_SCHEMA`, which has no `mode:` key). A second invocation inside
+  the 10 s wait is **dropped in full — including the two actuation steps.** Pre-existing (the old
+  `hk_ok`-true path had the same wait) but **widened to every path**, and widest exactly when a leg
+  is stuck. QS's own relaunches are spaced `50 × (n+1)` s (`home.py:2871`) so they never collide,
+  but **three other invokers can**: a human toggling the facade in the UI, another automation, and
+  **QS reversing direction within 10 s** — where the earlier direction's script is still parked and
+  will post a "not confirmed" notification for a command that was deliberately superseded.
+  Accepted; the alternative (moving the diagnostic into a trigger-based `binary_sensor` +
+  automation) needs `automations.yaml`, which is outside this story's file scope.
+- The wait is **stricter** than pre-edit (*either* leg at target used to satisfy it; now *neither*
+  may be `on`), so a stuck leg makes every command sit the full 10 s. This does **not** stall QS:
+  `ha_model/bistate_transport.py:238-242` calls `hass.services.async_call(...)` with no
+  `blocking=`, so it defaults to `False`.
+
+### D4 — The HK-only `{%- else %}` branch is untouched
+
+Lines 370-392 (no `cloud_entity`) have no cloud channel, so D1/D3 do not apply. All five mapped
+devices define `cloud_entity` — **hard-coded at 26-50, not derived from `integration_entities()`**
+— so this branch never renders. Per the issue's own choice of "scope the AC" over "add a synthetic
+fixture entry", the ACs quantify over all rendered facade blocks, and `test_facade_block_inventory`
+is what keeps that non-vacuous.
+
+**No structural cloud-backed filter is used.** An earlier draft filtered on
+`b["turn_on"][1]["action"] == "switch.turn_on"`, which matches only the **post-edit** shape — so
+pre-edit it selected zero blocks and every AC passed **vacuously**. The inventory test asserts
+cloud-backedness with a predicate true on both sides of the edit: `"switch."` appears in
+`blk["availability"]` (verified — the HK-only branch's `availability:` at 383-384 references only
+the two health sensors, so it yields no match).
+
+### D5 — Test strategy
+
+New `tests/test_config_jinja_rendering.py`. Its **module docstring** carries the issue's
+"permanent" gate note: *`config/configuration.jinja` is a non-Python file; testmon cannot select
+this test — run `--quick tests/test_config_jinja_rendering.py` in any PR touching the template.*
+(Pinning the template in the `tests/qs` pinning test would make that rule enforceable and is
+in-scope, but it changes a shared test governing other agents' gates — **considered and deferred**
+to the T9 follow-up.)
+
+**Layer 1 — render.** `REPO_ROOT = Path(__file__).resolve().parent.parent`,
+`CONFIG_DIR = REPO_ROOT / "config"` (never cwd-relative):
+
+```python
+env = jinja2.Environment(loader=jinja2.FileSystemLoader(CONFIG_DIR), undefined=jinja2.StrictUndefined)
+env.globals["integration_entities"] = lambda domain: FIXTURE_NETATMO_ENTITIES
+rendered = env.get_template("configuration.jinja").render()
+```
+
+`integration_entities` is the **only** generator-layer global the file needs (verified). Fixture:
+
+```python
+FIXTURE_NETATMO_ENTITIES = [
+    "sensor.cumulus_pool_house_power",   # passes both filters
+    "sensor.not_a_power_entity",         # fails endswith('_power')
+    "switch.cumulus_pool_house",         # fails startswith('sensor.')
+]
+```
+
+Precedent: `tests/test_dashboard_rendering.py` gives the path-anchoring idiom (`:60`) and the
+render→parse→assert shape (`:247-253`). Deliberate divergences: plain `jinja2` rather than HA's
+`Template` (a pure text transform — no `hass` fixture, no async), and plain functions rather than
+that file's `TestDashboardTemplateRendering` class (`:240`).
+
+**Layer 2 — parse.** `class _TagTolerantLoader(yaml.SafeLoader)`, then
+**`_TagTolerantLoader.add_multi_constructor("!", lambda loader, suffix, node: f"!{suffix}")`** —
+register on the *subclass*; calling it on `yaml.SafeLoader` would silently make every other test's
+`yaml.safe_load` tag-tolerant.
+
+Helpers, paths **verified against the real post-edit render**:
+
+- `facade_blocks(parsed) -> dict[str, dict]` — walk `parsed["template"]` (dicts keyed by platform;
+  some items also carry `trigger:`, e.g. 168-175 and 176-202, so never assert `len(item) == 1`),
+  take `item.get("switch", [])`, keep `unique_id` ending `_facade`, key by `removesuffix("_facade")`.
+  Only precondition assert: **non-empty**.
+- `cloud_entity_of(blk)` — `re.findall(r"states\('([^']+)'\)", blk["availability"])`, keep matches
+  starting `switch.`, **assert exactly one**, return it. Shape-independent, so it works pre- and
+  post-edit; this is what makes T2's red real. (Verified: `is_state('` never contains `states('`,
+  so the health checks do not match — but assert the count anyway, because a silent misselection
+  would put the wrong key in every layer-3 `states` dict and turn the intended `UndefinedError`
+  into a stub `KeyError`.)
+- `wait_of(blk, d)` → `blk[d][2]["wait_template"]`.
+- `complain_of(blk, d)` → `blk[d][3]["choose"][0]["conditions"]`.
+- `notification_of(blk, d)` → `blk[d][3]["choose"][0]["sequence"][0]["data"]`.
+- `all_notification_data(parsed)` — recursive walk keeping every dict whose
+  `action == "persistent_notification.create"`, returning its `data`.
+- `_negate(rendered: str) -> str` — total mapping `{"True": "False", "False": "True"}`, so A3
+  compares **rendered strings**, not Python bools. Both keys are exercised by the row table, so it
+  has no unreachable arm.
+
+Verified post-edit item shapes for both directions: `[0]` = `{action, target}` (boolean), `[1]` =
+`{action, target, continue_on_error}` (cloud), `[2]` =
+`{wait_template, timeout, continue_on_timeout}`, `[3]` = `{choose}`, `len == 4`.
+
+`test_facade_block_inventory` (a named test, **not** a shared-helper assert, so it reds once and
+informatively): the slug set equals the set from `parsed["input_boolean"]` keys ending `_command`
+with that suffix stripped (verified: the only other keys are `legrand_ticker`, `legrand_pumpkin`,
+`homekit_hub_alive`), and every block is cloud-backed via the `availability:` predicate. **This
+test is what makes A1-A4 non-vacuous** — do not prune it.
+
+**Layer 3 — evaluate the emitted runtime layer.**
+
+```python
+def eval_ha_template(text: str, states: dict[str, str]) -> str:
+    """Render an emitted HA-runtime template with stubbed HA globals, whitespace-collapsed."""
+```
+
+A fresh `jinja2.Environment(undefined=jinja2.StrictUndefined)` with one accessor `_state_of(e)`
+returning `states[e]` and **raising on an absent id** (so a typo'd entity is a loud red, not a
+silent `False`), exposed as both `states=_state_of` and `is_state=lambda e, v: _state_of(e) == v`.
+Return `" ".join(out.split())` — not merely `.strip()` — since `state:` is a `>` folded scalar
+whose more-indented body lines keep their newlines. **No `variables` parameter is needed**: the
+scripts have no `variables:` step and `state:` sets its own locals.
+
+**Every row's `states` dict has four keys** — `input_boolean.<slug>_state`, `cloud_entity_of(blk)`,
+`binary_sensor.legrand_homekit_link_healthy` and `binary_sensor.homekit_hub_healthy` (both `'on'`).
+The health sensors are required for the *pre-edit* red to be the real one: pre-edit `state:` reads
+them at line 288, before the race tail, so a two-key dict would raise `KeyError` on every row and
+mask the failure under test. Because they are seeded, A1 also asserts **positively** that the
+post-edit `state:` contains neither health-sensor entity id — otherwise "no `hk_ok`" is only a name
+check that a re-inlined health test would survive.
+
+**No unexecuted line in this file.** `_state_of`'s raise arm gets a one-line `pytest.raises` test
+(a genuine guard test), and `_negate` is total. This makes the CI-coverage-scope question moot
+regardless of whether `project-context.md:150` or `pr-quality.yml:70` is right.
+
+Assert the single `action:` key the template uses (no defensive `action:`/`service:` walker). The
+planning-time probe counts (12 top-level keys, 26 `template:` items, 9 `- switch:` blocks pre-edit)
+are **evidence only — do not assert them**.
+
+**Test names:** `test_config_jinja_renders_and_parses` (A5), `test_facade_block_inventory`,
+`test_facade_state_is_fail_safe` + `test_facade_state_never_reads_last_changed` (A1),
+`test_both_channels_driven_unconditionally` (A2),
+`test_diagnostic_predicates_agree_with_state` (A3),
+`test_notifications_have_per_direction_id` (A4), `test_state_stub_raises_on_unknown_entity`.
+
+**Conventions** (unenforced — ruff/mypy cover only `custom_components/quiet_solar` **both locally
+and in CI**: `quality_gate.py:83,752,785`, `pr-quality.yml:26,29,48`): `from __future__ import
+annotations`, full type hints, docstrings on helpers, plain pytest functions, American English.
+`qs-review-blind-hunter` and CodeRabbit **will** enforce these at review, so write it clean; T7
+offers the user a scoped lint pass.
+
+## Acceptance criteria
+
+A1-A3 quantify over all blocks in `facade_blocks(parsed)` and both directions; A4 combines a
+whole-render walk with per-block checks; A5 is file-level.
+
+- **A1 — Fail-safe reporting.** The emitted `state:` contains **no `last_changed`**, **no
+  `hk_ok`**, and **neither health-sensor entity id**. Rows are **named, not numbered**, so A3 and
+  T3 cannot drift:
+
+  | Row | mirror | cloud | state | Why it is here |
+  | --- | --- | --- | --- | --- |
+  | `R_both_on` | `on` | `on` | `"True"` | **The normal state of a running load, and the row that makes the OR non-negotiable.** Without it an XOR implementation (`(mirror=='on') != (cloud=='on')`) passes every other row while reporting `off` with both legs `on` — verified: XOR passes all seven others |
+  | `R_incident` | `on` | `off` | `"True"` | the observed incident state, and the row that would have **reported** it (not prevented or recovered it — see residual 1) |
+  | `R_cloud_only` | `off` | `on` | `"True"` | a stale-`on` cloud cannot be overruled by an `off` mirror |
+  | `R_both_off` | `off` | `off` | `"False"` | the only agreed-`off` case |
+  | `R_mirror_invalid_on` | `unknown` | `on` | `"True"` | one valid leg decides |
+  | `R_mirror_invalid_off` | `unknown` | `off` | `"False"` | the reachable shape of residual 2 — pinned so a future "improvement" cannot silently change it |
+  | `R_cloud_unavailable` | `off` | `unavailable` | `"False"` | a confident `off` with one leg known dead. Unlike the mirror, a Netatmo entity **does** go `unavailable` routinely |
+  | `R_none_valid` | `unknown` | `unknown` | `"unknown"` | the `{% else %}` branch. Unit-level only — with `availability:` unchanged the facade may publish `unavailable` here. After an HA restart this makes every `turn_on` time out and notify once per device (benign but surprising) |
+
+  (`unknown` for the mirror, not `unavailable`: an `input_boolean` never goes unavailable.)
+- **A2 — Unconditional actuation.** Split across two task pairs so each closes green:
+  - **after T4**: for each direction `len(blk[d]) == 2`;
+    `blk[d][0]["action"] == "input_boolean.turn_<dir>"` targeting `<slug>_command`;
+    `blk[d][1]["action"] == "switch.turn_<dir>"` targeting `cloud_entity_of(blk)` with
+    `continue_on_error is True`; **no step has a `variables` key**.
+  - **after T6**: `len(blk[d]) == 4`; `blk[d][2]["timeout"] == "00:00:10"` and
+    `blk[d][2]["continue_on_timeout"] is True`; `choose` appears **only** at index 3.
+- **A3 — Diagnostics agree with reporting.** For every row whose `state` is a boolean (all but
+  `R_none_valid`): `wait_of(blk,"turn_off") == _negate(S)`, `wait_of(blk,"turn_on") == S`, and
+  `complain_of(blk,d) == _negate(wait_of(blk,d))` in both directions. For `R_none_valid`, assert
+  all five literals: `state -> "unknown"`, `wait_of(turn_off) -> "True"`,
+  `wait_of(turn_on) -> "False"`, `complain_of(turn_off) -> "False"`,
+  `complain_of(turn_on) -> "True"`. For `R_incident` and `turn_off`: `wait_of -> "False"`,
+  `complain_of -> "True"`.
+- **A4 — Notifications.** `all_notification_data(parsed)` returns **10** entries (note the count
+  alone is **non-discriminating** — pre-edit there are also 10; the pre-edit red comes from the
+  absent `notification_id` and the `"falling back"` message). Each entry has a `notification_id`
+  whose suffix is `_facade_on_unconfirmed` or `_facade_off_unconfirmed` with a slug in the inventory
+  set, and no `title` or `message` contains `"falling back"` or `"Mirror did not confirm"` or
+  `"HK turn"`. **Direction attribution is asserted through `notification_of(blk, d)`** — a flat
+  walk cannot tell direction, so ten *swapped* ids would otherwise pass, which is precisely the F4
+  failure the AC exists to prevent.
+- **A5 — Render and parse.** The template renders under the stubbed environment and parses with the
+  tag-tolerant loader.
+
+### Issue AC / remedy → story mapping
+
+The issue prescribed **patching** the fallback (F1 + F2 + F3, keeping the architecture); at the
+user's direction this story **deletes** the fallback decision instead. That substitution is the
+largest deviation here.
+
+| Issue item | Status | Why |
+| --- | --- | --- |
+| **F1** (predicates test the facade's resolved state) | **superseded, stronger** | D1 removes the decision the predicates gated; F1's `default_entity_id`-collision caveat never arises |
+| **F2** (mirror wins when HK is trustworthy) | **replaced** | D2 picks a fail-safe *direction* instead of a trustworthy *leg* — no timestamps, no timers, so F2's blockers 1-2 do not arise |
+| **F3** (skip the no-op HK leg) | **intent met, mechanism rejected** | every relaunch reaches the cloud, but the no-op boolean write is **retained** — skipping it needs a condition |
+| **F4** (stable `notification_id`) | **kept, sharpened** | D3 — per-direction ids, plus the now-required text change |
+| A1 (Task 0 gates F2) | **executed; hypothesis refuted; direction confirmed by the user** | Task 0 was run and **refuted** the issue's reading. Literal descoping of F2 would leave the `last_changed` race in place, which the issue's **own A3 forbids** — the issue's ACs conflict, so some F2 replacement was mandatory. The clause's intent ("rather than guessed") **is** honoured: this design guesses no arbiter. T0 confirms the fail-safe direction in-session |
+| A2 (fallback condition references the resolved state) | **superseded** | there is no fallback condition; the cloud channel is driven 100% of the time, which dominates any predicate fix |
+| A3 (no mirror-vs-cloud `last_changed`) | **kept, strengthened** | A1 — no `last_changed` at all |
+| A4 → A4, A5 → A5 | **kept** | per-direction ids; render+parse verbatim |
+| A6 (`MIRROR_FOLLOW_TIMEOUT_S`) | **dropped** | the identifier appears nowhere in the template (proven by the scratch render succeeding under `StrictUndefined`), so satisfying A6 would mean *introducing* dead config |
+| — | **added** | A1/A3 **evaluate** the emitted templates; three round-1 reviewers found the issue's ACs unverifiable by a purely structural test |
+
+## Gates
+
+```bash
+python scripts/qs/quality_gate.py --quick tests/test_config_jinja_rendering.py   # red/green loop
+python scripts/qs/quality_gate.py --impacted                                     # mandatory pre-commit
+python scripts/qs/check_doc_drift.py --paths tests/test_config_jinja_rendering.py config/configuration.jinja
+```
+
+- `--impacted` **will** select the new test (a new Python file); the "testmon cannot see `.jinja`"
+  caveat applies to *future* template-only PRs. Expected verdict: **PASS with no measurable changed
+  lines** — zero lines change under `custom_components/quiet_solar/`, and `tests/**` carries no
+  coverage data. **If it fails as a zero-changed-lines artifact, escalate immediately with the gate
+  output — do not retry.** That is a **deliberate narrowing of `phase-protocols.md` step 4** for
+  this failure class only (there is no code/test defect to fix, and QS-283's rebuild-and-recheck
+  already happens inside the gate); **any other `--impacted` failure follows step 4 normally** —
+  fix code/tests, escalate after 2-3 attempts, never substitute the full gate.
+- **CI is the durable net** (`project-rules.md:90-94`): `pr-quality.yml:70` runs the whole suite,
+  so future template-only PRs are covered. It is `--cov=custom_components/quiet_solar`, **not**
+  whole-repo — `project-context.md:150` misdescribes this; fixing it needs `docs/**`, outside this
+  story's scope, so T9 emits it as a follow-up.
+- `--quick tests/qs` is **not run**: `config/` is absent from the pinned non-Python list
+  (`project-rules.md:96-101`) and no test there pins `config/**`, so it would assert nothing about
+  this change. (See D5 on why pinning was deferred.)
+- Doc-drift: pass **both** paths and expect **exit 0**. The Doc-OK note argues a `config/` artifact
+  cannot be `covers:`-tracked; passing the path is then harmless and strictly more informative than
+  omitting it.
+- Do not add progress notes to this story file; the PR body (T9) is the record.
+- `project-context.md`'s "never submit tests without running the full suite" conflicts with
+  `project-rules.md`/QS-276; this story follows **`project-rules.md`**.
+
+## Deployment (out of scope, stated so it is not assumed)
+
+There is **no in-repo render target**. Re-rendering into the production HA config and reloading is
+**manual, user-owned, post-merge**, and **the fix has zero effect until then**. **No release is
+needed** — `config/configuration.jinja` is not part of the HACS component. For the `review-task`
+auditor: the deliverable is *the emitted configuration is corrected and pinned by tests*.
+
+- **Run HA's config check on the edited render before reloading.** PyYAML (A5) is far weaker than
+  HA's template-platform schema, and a malformed block fails the reload of the **entire `template:`
+  section** — all five facades plus the health sensors. **A5 is the only automated validity gate,
+  and it renders under plain `jinja2`; how the production render is produced is not recorded** — if
+  it goes through HA's sandboxed `Template`, plain `jinja2` may accept constructs HA rejects.
+- **The revert artifact is the operator's own copy of the live rendered config**, taken before
+  reload. T8's diff cannot serve this purpose — it renders under the test fixture, not production's
+  entity set.
+- **Dismiss the pre-existing facade notifications by title** (`… - HK turn_on timed out` /
+  `… - HK turn_off timed out`). The pre-edit calls set **no `notification_id` at all**, so they have
+  HA-generated ids and the new ids can never replace them. (There is no "rename" — an earlier draft
+  of this story said so incorrectly.)
+- Consider routing the diagnostic to a `notify.*` mobile channel — see D2 on why a UI notification
+  may not be a real signal.
+- Confirm one real `turn_off` afterwards: both channels driven, the load actually stopping, no
+  notification. Exercising D3 requires an **induced** failure — e.g. hold the mirror boolean at its
+  pre-command value.
+
+## Task breakdown
+
+Line numbers are **pre-edit** and shift as tasks land — **anchor edits by content.** Four
+byte-identical pairs exist between the directions: `308-309 ≡ 340-341`, `311 ≡ 343`,
+`318-319 ≡ 350-351`, `327 ≡ 359`. T4 replaces whole ranges, so **anchor each block on its unique
+`        turn_on:` / `        turn_off:` line and its unique `title:` line**. Each red/green pair
+ends with `--quick tests/test_config_jinja_rendering.py`.
+
+1. **T0** — capture, verbatim in working notes at the moment given (not in this file): the user's
+   confirmation of the `config/configuration.jinja` grant **and** of the fail-safe direction. Stop
+   if either is declined. Then verify `git ls-files --error-unmatch config/configuration.jinja` and
+   `git cat-file -e origin/main:config/configuration.jinja` (both known to succeed).
+2. **T1 — scaffold** (A5): layers 1-2, `facade_blocks()`, `cloud_entity_of()`, `wait_of`,
+   `complain_of`, `notification_of`, `all_notification_data()`, `_negate()`, `eval_ha_template()`,
+   the module docstring, `test_facade_block_inventory`, `test_state_stub_raises_on_unknown_entity`.
+   **Green on arrival** — test-only, and every helper is shape-independent.
+3. **T2 → T3 — A1**: assert no `last_changed`/`hk_ok`/health-sensor ids plus the eight-row table →
+   red; then delete 288, drop `hk_ok` from 291, replace the tail 293-303 per D2 → green.
+   **Pre-edit, `R_both_on`, `R_incident` and `R_cloud_only` red** via `jinja2.UndefinedError` —
+   raised at `{% set m_t = states['…'].last_changed %}` (line 294) because `Undefined.__getattr__`
+   (`jinja2/runtime.py:862-868`) raises on attribute access, **not** at the `m_t > c_t` comparison,
+   which never executes. The remaining rows pass pre-edit. Expect an **error**, not an assertion
+   mismatch; do **not** wrap the helper in `try`/`except`. After green, mutate the boolean to XOR
+   once and confirm `R_both_on` reds — the table's whole purpose.
+5. **T4 — A2 (first half)**: assert the two-step shape → red (pre-edit `len(blk[d]) == 2` as well,
+   so the red is an **`AssertionError`** on a step-content assert, not an `IndexError`); then
+   replace 306-337 / 338-369 with D1's actuation head per direction → green. `availability:`
+   (304-305) is **not** touched.
+6. **T5 → T6 — A2 (second half) + A3 + A4**: assert `len == 4`, the `[2]` timeout keys, the
+   predicate identities, and the ten notification ids and texts → red; then append D3's wait +
+   `choose` to each direction → green.
+7. **T7 — summary checkpoint** (`phase-protocols.md:112-113`): present files modified, design
+   decisions and risks; ask "Ready to run the quality gate?". Also ask the user to authorize one
+   scoped lint pass over the new test file (the sanctioned route, since `--quick` skips
+   ruff/mypy and the full gate is user-request-only); if declined, say so in the PR body.
+8. **T8 — gates and the review diff**: the three commands above. Then a scratchpad script (outside
+   the repo, never committed; run with `venv/bin/python`, re-declaring `FIXTURE_NETATMO_ENTITIES`
+   locally, after `git fetch origin`) that renders `origin/main:config/configuration.jinja` and the
+   working copy.
+
+   **Pass criterion — coalescing-independent.** Diff at **`n=0`** (`difflib.unified_diff(...,
+   n=0)`, or `diff -U0`) and assert: (1) every changed line falls inside one of the five facade
+   regions — between a `state: >` line whose block `unique_id` ends `_facade` and the end of that
+   block's `turn_off:`; (2) **zero** changed lines in the health sensors, the `homekit:` filter, or
+   the power sensors; (3) `wc -l config/configuration.jinja` (the **template**, not the render):
+   **598 → 567**. Hunk *counts* are informational only — they depend on `difflib`'s context
+   coalescing (`get_grouped_opcodes` splits only when an equal run exceeds `2n`) and on `autojunk`
+   heuristics; two earlier drafts of this story predicted "4 per device" and "exactly 5", and the
+   measured answer at default context is **1**. Put the single-device excerpt in the PR body.
+9. **T9 — PR body**: the two T0 confirmations (verbatim); P6's result; that Task 0 was executed
+   and **refuted** the issue's hypothesis, that mirror-truthful-vs-frozen is **unresolved**, and
+   that literal descoping was impossible because the issue's own A3 forbids the race; D2's
+   error-direction table with **false-`off` narrowed, not removed**; **residuals 1-3**, naming
+   explicitly that residual 2 is undetectable and residual 1 has no recovery path; that the
+   asymmetry rests on a notification whose signal value is itself uncertain; the `mode: single`
+   widening and its three non-QS invokers; the **Netatmo write volume going 0 → one per command
+   plus one per relaunch across 5 devices with rate limits unchecked**; the two corrections to the
+   issue's premise; that **#304 is also required**; and the manual re-render/reload with its revert
+   and notification-dismissal steps. Then, since filing issues is `setup-task`'s side effect
+   (`phase-protocols.md:24`) and it **passes text through verbatim** from the **main checkout**,
+   emit two **paste-ready** issue bodies for the user to run through `qs-setup-task`:
+   (a) use `sensor.<device>_power` (harvested at 67-84) as a third, command-independent leg to
+   close residuals 2-3, and pin `config/configuration.jinja` in the `tests/qs` pinning test;
+   (b) correct `project-context.md:150`'s description of CI coverage scope.
+
+**Doc-OK:** no `docs/agents/` file has a `covers:` entry pointing at `config/configuration.jinja`,
+and the drift checker only tracks `covers:` paths under `custom_components/quiet_solar/`, so a
+deployment artifact cannot be tracked by it. Verified — only pre-existing unrelated `tests/`
+warnings. No doc task required.
+
+## Adversarial Review Notes
+
+**Five rounds, four global reviewers each, plus the delta-auditor in rounds 2-5.** The valuable
+findings were the ones that **destroyed** things rather than polished them:
+
+- **R1** — a facade self-reference leaves `turn_on` as broken as the original; the ACs asserted
+  runtime semantics a structural test cannot verify (three reviewers), producing layer 3.
+- **R2** — `config/**` is in no agent's edit scope and a story cannot self-authorize; the Task 0
+  guardrail cannot be waved away (scope-guardian, first of three times).
+- **R3** — the story contradicted itself about which leg lied; the frozen-mirror hypothesis was
+  never excluded, so **no arbiter choice was safe** — which led to removing the bet entirely.
+- **R4** — "loud" was refuted by the story's own evidence; the cloud-backed filter matched only the
+  post-edit shape, so every AC would have passed **vacuously** at the red step (two reviewers
+  independently); A3's negation identity was direction-blind and unsatisfiable for `turn_on` (two
+  reviewers independently).
+- **R5** — **A1's row table did not pin its own semantics**: an XOR implementation passed all six
+  rows while reporting `off` with both legs `on`, because no row had both legs `on`. Five rounds
+  missed it. Also: the A2 pair could not close green; `continue_on_timeout`/`timeout` were pinned by no AC;
+  the `continue_on_error` rejection rested on a false premise; the "dismiss the renamed
+  notifications" step described a rename that never existed (the pre-edit calls have no
+  `notification_id` at all); and three HA citations pointed at a **system install** rather than
+  `venv/`.
+
+**Design history — do not resurrect.** v1 pessimistic OR + facade self-reference; v2
+mirror-preference; v3 pessimistic OR + all-legs-agree; v4 mirror-preference + mirror-only
+predicates; v5-v7 unconditional dual-channel actuation + fail-safe reporting. Each of the first four
+was refuted by the next piece of evidence — twice because the author *inferred* which leg lied
+instead of deriving it (a "command echo" reading, corrected by the user's instance data).
+
+**Rejected, with evidence (5):** "`unknown` coerces to `off`" — `components/template/validators.py:116-158`
+returns `None` → state `unknown`. "A4's whole-file scope is an unfixable red" — only two source
+sites, both cloud-backed. "`config/home-assistant_v2.db` is absent" — it is a symlink. "The fixture
+reds the inventory test because `cloud_entity` comes from `integration_entities()`" — hard-coded at
+26-50. "Silence after the wait step means the script never left it" — HA logs nothing for a
+non-matching `choose` with no `default:`, and a timeout would have produced the notification.
+
+**Self-caught by running the edits, not by reasoning about them:** v4's "delete 293-296, keep
+297-303 verbatim" would have orphaned an `{% elif %}` and failed to render; v5's "never hides a
+running load" was too strong (→ residual 2); v6's "exactly 5 hunks" was wrong (measured: 1). The
+pattern is that **the design stabilised two rounds before the verification scaffolding did** — so
+every AC value and line count in this version was produced by executing the edit, not by inference.
+
+**Not yet reviewed: v7.**

--- a/docs/stories/QS-305.story.md
+++ b/docs/stories/QS-305.story.md
@@ -350,7 +350,7 @@ three predicates agree with reporting by construction, and no facade self-refere
   `choose` never runs) and **`timeout: "00:00:10"`** is unchanged from pre-edit. Both are pinned by
   A2.
 - **Per-direction ids** so a `turn_off` cannot erase a `turn_on` failure. Nothing dismisses them.
-- **Residual 3 — the diagnostic is unreachable in one failure mode.** A non-`HomeAssistantError`
+- **Residual 3 (CLOSED by plan #02 B1 — the cloud write is now isolated in a `parallel:` branch) — the diagnostic is unreachable in one failure mode.** A non-`HomeAssistantError`
   from the cloud call aborts the script at step `[1]`, before the wait, so the cloud leg is
   undriven *and* no notification is raised — UI-silent by this story's own standard, leaving only
   the log line D2 argues is not a signal. `continue_on_error` closes the `HomeAssistantError` half
@@ -815,8 +815,11 @@ occur, and in doing so introduced the false-`on` risk it then had to argue away.
    phone re-read the accessory and back-sync the value to the hub over iCloud
    ([homebridge#2622](https://github.com/homebridge/homebridge/issues/2622)), so the value can
    look correct *because it was inspected*. "The Home app shows the right state" is not evidence.
-5. **QS will now see `unavailable` where it previously saw a value**, whenever HomeKit is down.
-   Intended, and a real behaviour change for the consuming load.
+5. **QS will now see `unknown` where it previously saw a value**, whenever HomeKit is down.
+   Intended. Note the facade is **never** `unavailable` (plan #02 §A1) — that distinction is
+   invisible to quiet-solar, which lists both in the same collection
+   (`ha_model/bistate_duration.py:550`, `ha_model/device.py:52`), but decisive to HA core, which
+   drops unavailable entities from entity-service calls.
 6. **A no-op `input_boolean.turn_*` produces no `state_changed`** (`core.py:2414-2431`), so the
    Apple automation never re-fires on relaunch. Accepted in-template; the real fix is the Apple
    automation's trigger, which is deployment-side.
@@ -886,7 +889,7 @@ and **logs an ERROR on every evaluation**. Verified empirically:
 | ` unknown ` | `'unknown'` | **False** | ERROR every evaluation |
 
 The old `{% else %} unknown {% endif %}` was harmless only because the branch was dead — plan
-#01's `availability:` blocked `state:` from rendering at all. §A1 makes it live.
+plan #01's `availability:` blocked `state:` from rendering at all. §A1 makes it live.
 
 ## B1 — `continue_on_error` does not contain a Netatmo failure
 
@@ -1062,3 +1065,129 @@ cadence, and needs its own row coverage. Carried by Issue D.
   predicate with row coverage, and (c) add a liveness signal so a stopped Shortcut is visible.
   Both Apple-side automations are now documented inline in `config/configuration.jinja`.
 - **Issue A** gains the sync-liveness check as its most valuable watchdog target.
+
+---
+
+# Supersession record — review fix plan #03 (2026-07-31)
+
+Plans #01 Part 1 and #02 Part A stand. §A2 below is a user-specified design change that
+supersedes plan #02's C1.
+
+## §A2 — `cloud_entity` is optional again (supersedes plan #02 C1)
+
+**Plan #02 deleted the HomeKit-only variant on my recommendation. That recommendation was
+wrong**, and all three round-3 reviewers independently flagged the result as a must-fix: the
+`{%- if s.cloud_entity is defined %}` guard was gone while the header still documented the key
+as optional. Following the documentation would have produced, under HA's own Jinja
+(`strict=None`, **not** the tests' `StrictUndefined`): empty render → `entity_id: null` →
+`cv.SCRIPT_SCHEMA` coerces to the string `'none'` → that is `ENTITY_MATCH_NONE`, so
+`helpers/target.py:64` selects nothing **and logs nothing**. Config validates, the facade loads,
+and the cloud channel is silently gone.
+
+**The rule now:** `cloud_entity` is optional. A device without one is a pure-HomeKit device and
+gets the **full** facade — mirror-only trust, positive confirmation, the diagnostic, the dismiss
+— differing only in that no cloud channel is driven.
+
+**Not by reintroducing a duplicated variant block.** The old `{% else %}` branch was a second
+copy of the whole switch definition and was worse on every axis: no wait, no notification, no
+dismiss, and an `availability:` key that could take the entity offline. That is why a mutation
+making it report a confident `off` passed all 26 tests. There is now **one code path**: the cloud
+actuation step is conditionally emitted inside the existing `parallel:`, and the diagnostic is
+always the **last** branch so every test accessor stays variant-independent.
+
+This was cheap only because the mirror-only rework left `cloud_entity` in exactly one place —
+the actuation target. `state:` never referenced it, `availability:` no longer exists, neither
+wait touches it, and plan #02 C7 removed `cloud=` from the message.
+
+## B1 — `| tojson` was incomplete, and the previous commit's claim was false
+
+Commit `c65ab731` claimed a name containing `"` or `:` "cannot break the render". **It still
+could.** `| tojson` had been applied to three of **seven** `s.name` interpolations; the two
+`input_boolean` helper names and the two HomeKit `entity_config` names were left raw, and
+`'name': 'po"ol: pump'` broke the YAML parse. A malformed render fails **all** of HA's startup,
+not just the facade — a whole-instance outage triggered by a rename.
+
+All seven sites are now escaped, and a parametrised test renders five hostile names (embedded
+quote, colon, brace, YAML indicators, trailing backslash) and asserts the whole document still
+parses **and** that each name round-trips to its exact value. The "drop `| tojson`" mutation was
+the only survivor of the auditor's 17; it is now caught at three separate sites.
+
+## B2 — the restore-clobber residual (accepted; do not fix in code)
+
+`AbstractTemplateSwitch` is a `RestoreEntity` with `_restore_state_properties = ("_attr_is_on",)`
+(`components/template/switch.py:115,121`), and `async_restore_last_state`
+(`components/template/entity.py:243-273`) restores **only when the property is `None`** — i.e.
+exactly when our template says "I don't know". So when the platform is set up while hass is
+already running, the template renders `None` and HA then substitutes the last known `on`/`off`.
+
+Runtime-verified, three scenarios:
+
+| scenario | published state |
+| --- | --- |
+| hass **running** at setup, no `availability:` (the shipped shape) | **`on`** — restored, stale |
+| hass not running (cold boot) | `unknown` — correct |
+| hass running, with plan #01's `availability:` | `unavailable` — previously masked this |
+
+**There is no fix.** Restore fires precisely when `_attr_is_on is None`, which is the same
+condition as "we are reporting unknown" — from YAML you cannot have one without the other.
+Reinstating `availability:` is off the table: it reintroduces plan #02 §A1's bug, where HA drops
+the entity from entity-service calls (`helpers/service.py:763`) and **silently swallows every
+actuation**. That is strictly worse than a stale reading.
+
+**The exposure is bounded.** A *genuine* `EVENT_STATE_CHANGED` on a tracked entity re-renders and
+clears the stale value. The template always collects the mirror and the link sensor, so HomeKit
+recovery (link `off`→`on`) or any real device change corrects it. The window is therefore **a
+config reload that lands during a HomeKit outage, lasting until HomeKit returns** — not permanent.
+
+**What does NOT help — recorded so it is not re-proposed.** The Apple-side periodic resync does
+**not** rescue this. `TrackTemplateResultInfo` subscribes only to `EVENT_STATE_CHANGED`
+(`helpers/event.py:1031-1032`); a same-value write fires `EVENT_STATE_REPORTED` instead
+(`core.py:2414-2431`), and nothing in `helpers/template/` or `components/template/` listens for
+it. Empirically: 3 no-op writes → 0 `state_changed`, 3 `state_reported`, and the facade's state
+object not even re-written. **This is the same asymmetry that makes `last_reported` a freshness
+signal (Issue D) yet useless as a re-render trigger.**
+
+## Also applied
+
+- **C1** — the "no ERROR logged" assertion was **decorative** where it sat: it attached a handler
+  to the validators logger but the test only called `Template(...).async_render()` directly, never
+  invoking `template_validators.boolean`, so it could not fail. Moved into
+  `test_actuation_reaches_the_entity_while_untrusted`, which stands up the real platform.
+  Demonstrated load-bearing: under the string-`unknown` mutation it now fails with the platform's
+  own `Received invalid switch state: unknown for entity switch.lhk_filtration_facade`.
+- **C2** — "Both channels were driven" was reachable and false in three ways (the cloud write
+  raised; `cloud=` was removed so the operator cannot tell which case; and a HomeKit-only device
+  has no second channel). Reworded to name the channels actually commanded, conditionally.
+- **C3** — the `continue_on_error` on the cloud step is commented as what it is: it covers
+  `HomeAssistantError` only, so it does **not** catch pyatmo's plain exceptions; the `parallel:`
+  branch is what protects the diagnostic. **Deliberate decision not to swallow after the
+  diagnostic fires** — the re-raised exception is the *only* trace a permanently dead cloud leg
+  leaves, and suppressing it would make that failure completely invisible. See residual 10.
+- **C4** — both notification ids are dismissed on either success path, so a timed-out `turn_off`
+  no longer leaves an alarm standing through every later successful `turn_on`.
+- **C5** — the module-scoped `blocks` fixture is deep-copied before `async_setup_component`, which
+  mutates config mappings in place (template strings → `Template` objects).
+- **C6** — residual 5 above corrected from `unavailable` to `unknown`.
+- **Part D** — the `not ` substring check became a `\bnot\s+is_state` regex (the old form would
+  reject a legitimate future `is_not`/`not_home`); the Jinja short-circuit hazard is documented in
+  the template; the comment box trimmed 75 → 61 lines with terminators aligned; markdown fixes.
+
+## Additional residuals
+
+10. **A permanently dead cloud leg is invisible.** `_async_step_parallel` re-raises after the
+    gather, so a raw `ApiError` escapes `switch.turn_on` on the facade — but quiet-solar calls
+    with the default `blocking=False` (`ha_model/bistate_transport.py:238-242`), so it is only
+    logged by the task runner. Meanwhile the mirror confirms via HomeKit and the `default:` branch
+    dismisses the notification, so the operator sees a healthy facade. **The dual-channel
+    guarantee can be lost for months with one traceback per command as the only trace.** Nothing
+    raises a diagnostic for "the cloud channel is failing" — the diagnostic is wired solely to
+    mirror non-confirmation, and the two `parallel:` branches cannot communicate in-template.
+11. **The diagnostic flaps rather than latches.** The `choose` condition reads the mirror's
+    *current* value, not whether the wait observed a transition. A mirror already sitting at the
+    target satisfies the wait instantly with zero observation and then dismisses a notification
+    that was raised on real evidence. An operator needs a latch; this is the opposite.
+12. **The `parallel:` restructure moved the confirmation window.** Plan #01 §1.3 sequenced the
+    cloud write *before* the wait; under `parallel:` the wait starts **concurrently with** it, so
+    the window is 10 s minus the pyatmo round-trip rather than 10 s after it. Authorised by plan
+    #02 B1, so not a violation — but it erodes the 3× margin measured against the mirror's 2-3 s
+    latency, and was recorded nowhere until now.

--- a/docs/stories/QS-305.story.md
+++ b/docs/stories/QS-305.story.md
@@ -5,10 +5,26 @@
 - **Files touched**: `config/configuration.jinja`, `tests/test_config_jinja_rendering.py`
 - **Story version**: v7 — design chosen by the user; five adversarial review rounds folded in
 
-> **All Home Assistant citations in this story refer to
-> `venv/lib/python3.14/site-packages/homeassistant/`**, not a system install. (v6 cited the
+> # ⚠️ SUPERSEDED — read `QS-305.story_review_fix_#01.md` Part 1 first
+>
+> The design below (D1/D2/D3 — dual-channel actuation with **fail-safe OR reporting**) was
+> **replaced during review triage on 2026-07-30**. What shipped is
+> [`QS-305.story_review_fix_#01.md`](QS-305.story_review_fix_#01.md) Part 1:
+> **dual-channel actuation with mirror-only trust**. Where this story and Part 1 disagree,
+> **Part 1 wins and this document is void on that point** — including its Design section, its
+> acceptance criteria, and its residuals. This file is retained for its incident evidence and
+> design history only. See "Supersession record" at the end.
+
+> **Home Assistant citations.** Core-HA citations in this story refer to
+> `venv/lib/python3.14/site-packages/homeassistant/`, not a system install. (v6 cited the
 > system install and three line numbers were wrong; the conclusions were unaffected but the
 > references were unusable.)
+>
+> **⚠️ Every `netatmo`/`pyatmo` citation in this story is WRONG.** They point at
+> `venv/.../homeassistant/components/netatmo/`, which **is not the code that runs**.
+> `custom_components/netatmo` is a **symlink to a forked integration that shadows the core
+> one**, and HA loads `custom_components` first. Corrected citations are in the supersession
+> record below.
 
 ## Blocking dependencies — read before T1
 
@@ -714,3 +730,107 @@ pattern is that **the design stabilised two rounds before the verification scaff
 every AC value and line count in this version was produced by executing the edit, not by inference.
 
 **Not yet reviewed: v7.**
+
+---
+
+# Supersession record — review fix plan #01 (2026-07-30)
+
+The design in this story was replaced. This section records what changed, why, and the
+residuals the new design carries. Authoritative spec:
+[`QS-305.story_review_fix_#01.md`](QS-305.story_review_fix_#01.md) Part 1.
+
+## What replaced what
+
+| This story shipped | Part 1 replaced it with | Why |
+| --- | --- | --- |
+| `state:` = fail-safe OR over both legs, no `hk_ok` | **mirror-only**, `hk_ok` restored; untrusted → `unavailable` | The Netatmo leg is **inert**, not merely unreliable — a backup that lies is worse than no backup |
+| `availability:` untouched (`hk_ok or cloud valid`) | **the trust predicate** (`hk_ok and mirror valid`) | An inert cloud parked at `off` is a *valid* state, so the old second disjunct was **permanently true**: the facade advertised itself available with HomeKit entirely down |
+| waits/conditions read `mirror or cloud` | **mirror only, positive confirmation of the target** | See the vacuous-wait defect below |
+| `continue_on_error` on the cloud step only | on **both** actuation steps | An exception on the local boolean aborted before the cloud — the verified-working actuator — was ever driven |
+
+## The defect this story shipped
+
+Service steps run with `blocking=True` (`helpers/script.py:1035-1044`), and the forked Netatmo
+switch sets `_attr_is_on` optimistically then writes state immediately. So **our own cloud write
+at step 2 satisfied the cloud term of the wait before the wait was ever evaluated.** The wait
+was vacuously true, the notification branch was **unreachable**, and an un-actuated `turn_on`
+was never reported. This story replaced a fallback that could not fire with a diagnostic that
+could not fire.
+
+**The same mechanism explains the incident.** The pre-existing wait was
+`is_state(mirror,'off') or is_state(cloud,'off')`; with the cloud pinned at `off`, that
+predicate was **vacuously true from the very first execution** — which is why the trace stops
+at the wait template on all 7 attempts and the fallback never fired.
+
+## Corrected `netatmo` / `pyatmo` citations (C6)
+
+`custom_components/netatmo` is a symlink to a fork that shadows core. It has its own
+coordinator (`coordinator.py`, replacing `data_handler.py`), its own webhook layer, and a
+vendored pyatmo aliased into `sys.modules["pyatmo"]` (`__init__.py:8-25`).
+
+| Claim | Correct citation (the fork) | Verified |
+| --- | --- | --- |
+| Optimistic write | `custom_components/netatmo/switch.py:77-90` — `async_turn_on/off` set `_attr_is_on` then `async_write_ha_state()` | yes |
+| No state guard on the write (P6 still holds) | `switch.py:85-90` — `async_turn_off` unconditionally awaits `device.async_off()` | yes |
+| Unreachable module pins the optimistic value | `switch.py:71-75` — `if self.device.reachable is not False: self._attr_is_on = self.device.on` | yes |
+| `update_entity` is a **no-op** for this entity | no `async_update`/`update` anywhere in the MRO, so `helpers/entity.py:1377-1382` returns immediately | yes |
+| Poll cadence is credential-dependent | `coordinator.py:127,131` (own-app: 10/10) vs `:114,119` (Nabu Casa: 60/300), inflated under rate pressure at `:535-546` | yes |
+
+**Consequence for this story's P6:** the conclusion survives (the write is dispatched
+unconditionally), but it was reached from the wrong file. The **reading** side is what the story
+got wrong: it treated the cloud as a witness when the cloud has no push path for switch state
+(`iot_class: cloud_polling`, zero webhook subscriptions) and therefore reports only Netatmo's
+own last command.
+
+## What this story got right, and one thing it diagnosed wrongly
+
+Right: D1's unconditional dual-channel actuation is the fix, and it survives intact. The
+`last_changed` arbiter had to go (the issue's A3), and it stays gone.
+
+**Wrong: the incident was not a reporting failure.** The facade reported `on` throughout and the
+boiler *was* on — **the mirror was correct all day.** The incident was an actuation failure plus
+a vacuous wait predicate. This story's entire `state:` redesign addressed a defect that did not
+occur, and in doing so introduced the false-`on` risk it then had to argue away.
+
+## Residuals of the shipped (Part 1) design
+
+1. **A mirror freeze between commands is undetectable.** The wait tests mirror liveness at
+   command time only. Three documented, silent, non-self-healing ways exist for HomeKit
+   characteristic events to stop arriving: a hub never re-subscribing after election or
+   hand-off; a `No Response` episode cancelling subscriptions permanently; a bridge emitting via
+   `setCharacteristic` instead of `updateCharacteristic`. Apple's Home app has **no automation
+   execution log**, so these are unobservable by design. **No evidence any of this occurred on
+   07-27.** A known risk of a single-leg design, not a diagnosis.
+2. **`hk_ok` may not cover per-accessory subscription loss.** It gates on
+   `input_boolean.legrand_pumpkin` moving within 90 s. If HomeKit subscriptions are
+   per-accessory, the cumulus could lose its subscription while the pumpkin keeps ticking. The
+   cumulus accessory lives on the Legrand gateway, not HA's HomeKit bridge, so its subscription
+   state is **not observable from HA at all**.
+3. **HomeKit actuation failed in the incident and this work does not fix it.** The command
+   boolean went `off` correctly at 12:12:19 and the device kept running. The design works
+   around it by always driving the cloud; the HomeKit actuation path itself is untouched.
+4. **Manual verification of the mirror is self-invalidating.** Opening a HomeKit app makes the
+   phone re-read the accessory and back-sync the value to the hub over iCloud
+   ([homebridge#2622](https://github.com/homebridge/homebridge/issues/2622)), so the value can
+   look correct *because it was inspected*. "The Home app shows the right state" is not evidence.
+5. **QS will now see `unavailable` where it previously saw a value**, whenever HomeKit is down.
+   Intended, and a real behaviour change for the consuming load.
+6. **A no-op `input_boolean.turn_*` produces no `state_changed`** (`core.py:2414-2431`), so the
+   Apple automation never re-fires on relaunch. Accepted in-template; the real fix is the Apple
+   automation's trigger, which is deployment-side.
+
+## Withdrawn follow-up
+
+The **per-device power sensor** third leg proposed in this story (and in the PR body) is
+**withdrawn**: the user ruled it out as unreliable, and investigation confirmed the template
+generates **zero** per-device power sensors — the emitting loop iterates
+`all_power_to_be_corrected.sensors`, which is explicitly reset to empty (`:131-133`) — while the
+device↔sensor mapping for the towel rails is not derivable from the slug.
+
+## Superseded acceptance criteria
+
+A1-A5 in this story are void. The shipped criteria are Part 1 §1.3-§1.6, pinned by
+`tests/test_config_jinja_rendering.py`. Notably **the old A1 row table (fail-safe OR, 8 rows)
+and the old A3 identity `wait == ¬state` are deliberately gone**: `state:` answers "is the load
+on?" and consults `hk_ok`, while the wait answers "did the mirror confirm the target?" and does
+not. That divergence is intentional — do not "fix" it back.

--- a/docs/stories/QS-305.story_review_fix_#01.md
+++ b/docs/stories/QS-305.story_review_fix_#01.md
@@ -109,7 +109,7 @@ false `off` this work exists to eliminate. Going dark honestly is better.
 The current PR implements a different design. Each item below is the delta from what is on
 `QS_305` today to Part 1.
 
-### C1 — Waits and notification conditions become mirror-only, positively confirmed
+## C1 — Waits and notification conditions become mirror-only, positively confirmed
 - File: `config/configuration.jinja:307-320` (`turn_on`), `:329-342` (`turn_off`)
 - Implements: §1.3 step 3-4, §1.4
 - Reviewer source: qs-review-edge-case-hunter and qs-review-blind-hunter, independently
@@ -138,7 +138,7 @@ condition. Retain the 10 s timeout — measured latency is 2-3 s.
 Add a template comment stating the rule from §1.2, so a later reader does not "restore
 symmetry" by re-adding the cloud term.
 
-### C2 — `state:` becomes mirror-only, with `hk_ok` restored
+## C2 — `state:` becomes mirror-only, with `hk_ok` restored
 - File: `config/configuration.jinja:287-296`
 - Implements: §1.5
 
@@ -158,7 +158,7 @@ symmetry" by re-adding the cloud term.
 left for the single leg being trusted. The `unknown` branch is defensive only — C3 makes the
 entity `unavailable` in that case.
 
-### C3 — `availability:` becomes the trust predicate
+## C3 — `availability:` becomes the trust predicate
 - File: `config/configuration.jinja:297-298`
 - Implements: §1.5
 
@@ -176,7 +176,7 @@ Target — availability is exactly the §1.5 trust predicate:
 The story declared `availability:` out of scope. That decision predates the evidence in Part 3
 and is superseded per the clause above.
 
-### C4 — `continue_on_error` on the first actuation step
+## C4 — `continue_on_error` on the first actuation step
 - File: `config/configuration.jinja:299-302`, `:321-324`
 - Implements: §1.3 step 1 ("on error, keep going")
 - Reviewer source: qs-review-blind-hunter
@@ -186,7 +186,7 @@ aborts before the cloud — the verified-working actuator — is ever driven. Ad
 `continue_on_error: true` to both first steps. This preserves the 4-step indices the tests
 assert.
 
-### C5 — Tests must reject disabled actuation steps
+## C5 — Tests must reject disabled actuation steps
 - File: `tests/test_config_jinja_rendering.py:329-345`
 - Implements: §1.6 first bullet
 - Reviewer source: qs-review-coderabbit
@@ -194,7 +194,7 @@ assert.
 HA honours `enabled: false` on script actions, and the current test passes even if an
 actuation step is disabled. Assert steps `[0]` and `[1]` carry no `enabled` key.
 
-### C6 — Correct every Netatmo citation to the fork
+## C6 — Correct every Netatmo citation to the fork
 - Files: `docs/stories/QS-305.story.md`, template comments, PR body
 - See Part 3, E1.
 
@@ -202,7 +202,7 @@ actuation step is disabled. Assert steps `[0]` and `[1]` carry no `enabled` key.
 
 # PART 3 — Evidence (why Part 1 is what it is)
 
-### E1 — The story and all four reviewers read the wrong Netatmo integration
+## E1 — The story and all four reviewers read the wrong Netatmo integration
 
 `custom_components/netatmo` is a **symlink to a forked integration that shadows the core
 one**. HA loads `custom_components` first, so the venv copy cited throughout the story and PR
@@ -219,7 +219,7 @@ the optimistic value indefinitely; poll cadence is credential-dependent, `SCAN_I
 (`coordinator.py:114,119`), dynamically inflated under rate pressure
 (`coordinator.py:535-546`).
 
-### E2 — The Netatmo leg is inert, not merely unreliable
+## E2 — The Netatmo leg is inert, not merely unreliable
 
 User-verified in HA history: **`switch.cumulus_pool_house` read `off` for the entire day of
 2026-07-27**, while the boiler drew 2353 W from 12:01 to past 19:00. The log shows
@@ -240,7 +240,7 @@ Supporting source facts:
 
 **Conclusion: the cloud entity reports Netatmo's own last command, not the device.**
 
-### E3 — The mirror is a genuine observer, at 2-3 s
+## E3 — The mirror is a genuine observer, at 2-3 s
 
 User experiment run during review:
 
@@ -258,7 +258,7 @@ within 2-3 s. The 10 s timeout carries ~3× margin.
 relay. A wall-button actuation test would close this. Minor — P0 established the cloud write
 physically actuates the device, so the observed value was correct either way.
 
-### E4 — Corrected causal chain for the incident
+## E4 — Corrected causal chain for the incident
 
 The old wait was `is_state(mirror,'off') or is_state(cloud,'off')`. With the cloud pinned at
 `off` (E2), **that predicate was vacuously true from the very first execution** — which is

--- a/docs/stories/QS-305.story_review_fix_#01.md
+++ b/docs/stories/QS-305.story_review_fix_#01.md
@@ -1,0 +1,384 @@
+# QS-305 — Review fix plan #01
+
+## Summary
+- Source PR: #310
+- Source story: `docs/stories/QS-305.story.md`
+- Next implement phase: `/implement-task`
+- Edit scope: `config/configuration.jinja` (one-off user grant, already in force for this
+  task) and `tests/test_config_jinja_rendering.py`
+
+---
+
+# PART 1 — THE SPECIFICATION (authoritative)
+
+> **This section is the user-approved design. It was agreed verbatim during review triage on
+> 2026-07-30 and it overrides everything else.**
+>
+> **Supersession clause — read this before anything else.** Where *any* other document
+> contradicts Part 1, Part 1 wins and the other document is void on that point. This
+> explicitly includes:
+> - `docs/stories/QS-305.story.md` — the original story, all versions, including its Design
+>   section, its acceptance criteria, and its residuals
+> - the body of PR #310 and everything currently implemented on branch `QS_305`
+> - the original issue #305's proposed fixes and acceptance criteria (F1, F2, F3, A1-A6)
+> - every reviewer finding, and every earlier remark made anywhere in review discussion
+>
+> Do **not** attempt to reconcile Part 1 with the old design, and do not preserve an old
+> behaviour merely because a story sentence or an existing test asserts it. If it contradicts
+> Part 1, delete it. Parts 2-5 exist only to explain and support Part 1; if they ever appear
+> to disagree with it, Part 1 is correct.
+
+## 1.1 The three entities
+
+| Entity | Who writes it | What it actually tells you |
+| --- | --- | --- |
+| `input_boolean.<slug>_command` | **we do** | Nothing. It is our outbox. HomeKit watches it and an Apple automation actuates the device from it. |
+| `input_boolean.<slug>_state` (the mirror) | **Apple Home only — never HA** | The truth. Apple writes it from watching the real device; it followed a real change in 2-3 s under test. This is the only honest witness available. |
+| `switch.<cloud_entity>` (Netatmo) | **we do**, and Netatmo does | Writing it physically switches the device. *Reading* it tells you only what Netatmo last commanded — on 2026-07-27 it read `off` all day while the boiler ran. Good arm, blind eye. |
+
+## 1.2 The rule everything derives from
+
+> **Never trust a value you just wrote. Never report a value you can't trust.**
+
+## 1.3 Switching ON
+
+1. **Write the command boolean to `on`.** Fires the HomeKit path. On error, keep going.
+2. **Write the cloud switch to `on`.** Fires the Netatmo path. On error, keep going.
+3. **Wait up to 10 s for the mirror to read `on`.** Positive confirmation of the target value.
+4. **If after 10 s the mirror does not read `on`, raise a notification.**
+
+Steps 1 and 2 are **unconditional and always both executed**. There is no predicate, no
+`choose`, no `variables`, and no short-circuit anywhere between the start of the script and
+the end of step 2. We cannot know in advance which channel will work, and *deciding* is
+exactly what caused the incident.
+
+Step 3 watches **only the mirror**. We wrote the command boolean and the cloud switch, so
+neither can be evidence — they can only parrot back what we told them. The mirror is the one
+leg we never write.
+
+## 1.4 Switching OFF
+
+Identical, with `off` throughout: write the command boolean `off`, write the cloud switch
+`off`, wait up to 10 s for the mirror to read **`off`**, notify if it does not.
+
+**Positive confirmation in both directions.** The wait must test for the *target value
+itself* — `is_state(mirror, 'off')` — and **must not** be expressed as "the mirror is not
+`on`". An unavailable or unknown mirror satisfies "not `on`" and would let us silently
+conclude the turn-off succeeded. Confirm the target; never accept the absence of its
+opposite.
+
+## 1.5 Reading the state
+
+The mirror is the only source that watches the device, so it is the only source used.
+
+**Trust predicate** — the mirror may be believed when both hold:
+
+- the HomeKit link is healthy (`binary_sensor.legrand_homekit_link_healthy` **and**
+  `binary_sensor.homekit_hub_healthy` are `on`), and
+- the mirror actually reads `on` or `off` (not `unknown`, not `unavailable`).
+
+Then:
+
+- **trusted → `state` is the mirror**, i.e. `mirror == 'on'`
+- **not trusted → the facade is `unavailable`**
+
+**Never report `off` when the mirror cannot be trusted.** An entity confidently reporting
+`off` while a boiler ran is the entire incident. If we cannot see, we say we cannot see.
+
+**The Netatmo leg is not a fallback for state.** Not as a secondary, not as a tie-breaker,
+not as a last resort. A backup that lies is worse than no backup: it sits at `off` and reports
+it with full confidence, so falling back to it turns every HomeKit outage into exactly the
+false `off` this work exists to eliminate. Going dark honestly is better.
+
+## 1.6 Explicitly forbidden
+
+- Any condition, `choose`, `variables` block, or template that can prevent either actuation
+  write from executing.
+- The cloud entity appearing in `state:`, in `availability:`, in either wait template, or in
+  either notification condition. It appears **only** as the target of the actuation write in
+  step 2, and in the notification's message text as diagnostic context.
+- `last_changed` anywhere (the issue's A3, which survives intact).
+- Any wait expressed as the negation of the opposite value rather than as positive
+  confirmation of the target.
+- Reporting `off`, `on`, or any confident value when the trust predicate is false.
+
+---
+
+# PART 2 — What must change on the branch
+
+The current PR implements a different design. Each item below is the delta from what is on
+`QS_305` today to Part 1.
+
+### C1 — Waits and notification conditions become mirror-only, positively confirmed
+- File: `config/configuration.jinja:307-320` (`turn_on`), `:329-342` (`turn_off`)
+- Implements: §1.3 step 3-4, §1.4
+- Reviewer source: qs-review-edge-case-hunter and qs-review-blind-hunter, independently
+
+The shipped `turn_on` wait is `is_state(mirror,'on') or is_state(cloud,'on')`. Service steps
+run with `blocking=True` (`helpers/script.py:1035-1044`) and the Netatmo switch writes
+`_attr_is_on` optimistically, so **our own write at step 2 satisfies the cloud term before the
+wait is ever evaluated**. The wait always succeeds, the notification branch is unreachable,
+and an un-actuated `turn_on` is never reported.
+
+Target:
+
+```yaml
+          - wait_template: >-
+              {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
+            timeout: "00:00:10"
+            continue_on_timeout: true
+          - choose:
+              - conditions: >-
+                  {{ "{{ not is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
+```
+
+and for `turn_off`, `is_state(..., 'off')` in the wait and `not is_state(..., 'off')` in the
+condition. Retain the 10 s timeout — measured latency is 2-3 s.
+
+Add a template comment stating the rule from §1.2, so a later reader does not "restore
+symmetry" by re-adding the cloud term.
+
+### C2 — `state:` becomes mirror-only, with `hk_ok` restored
+- File: `config/configuration.jinja:287-296`
+- Implements: §1.5
+
+```jinja
+        state: >
+          {{ "{% set hk_ok = is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') %}" }}
+          {{ "{% set mirror = states('input_boolean." ~ s.slug ~ "_state') %}" }}
+          {{ "{% set mirror_valid = hk_ok and mirror in ['on','off'] %}" }}
+          {{ "{% if mirror_valid %}" }}
+            {{ "{{ mirror == 'on' }}" }}
+          {{ "{% else %}" }}
+            unknown
+          {{ "{% endif %}" }}
+```
+
+`hk_ok` returns because with the cloud gone, HomeKit link health is the only staleness signal
+left for the single leg being trusted. The `unknown` branch is defensive only — C3 makes the
+entity `unavailable` in that case.
+
+### C3 — `availability:` becomes the trust predicate
+- File: `config/configuration.jinja:297-298`
+- Implements: §1.5
+
+Currently `(hk_ok and hub_healthy) or states(cloud) in ['on','off']`. An inert cloud leg
+parked at `off` is a *valid* state, so the second disjunct is **permanently true**: the facade
+advertises itself available even with HomeKit entirely down.
+
+Target — availability is exactly the §1.5 trust predicate:
+
+```jinja
+        availability: >
+          {{ "{{ is_state('binary_sensor.legrand_homekit_link_healthy', 'on') and is_state('binary_sensor.homekit_hub_healthy', 'on') and states('input_boolean." ~ s.slug ~ "_state') in ['on','off'] }}" }}
+```
+
+The story declared `availability:` out of scope. That decision predates the evidence in Part 3
+and is superseded per the clause above.
+
+### C4 — `continue_on_error` on the first actuation step
+- File: `config/configuration.jinja:299-302`, `:321-324`
+- Implements: §1.3 step 1 ("on error, keep going")
+- Reviewer source: qs-review-blind-hunter
+
+Only the cloud step carries the flag today. An exception at step 1 (e.g. a missing helper)
+aborts before the cloud — the verified-working actuator — is ever driven. Add
+`continue_on_error: true` to both first steps. This preserves the 4-step indices the tests
+assert.
+
+### C5 — Tests must reject disabled actuation steps
+- File: `tests/test_config_jinja_rendering.py:329-345`
+- Implements: §1.6 first bullet
+- Reviewer source: qs-review-coderabbit
+
+HA honours `enabled: false` on script actions, and the current test passes even if an
+actuation step is disabled. Assert steps `[0]` and `[1]` carry no `enabled` key.
+
+### C6 — Correct every Netatmo citation to the fork
+- Files: `docs/stories/QS-305.story.md`, template comments, PR body
+- See Part 3, E1.
+
+---
+
+# PART 3 — Evidence (why Part 1 is what it is)
+
+### E1 — The story and all four reviewers read the wrong Netatmo integration
+
+`custom_components/netatmo` is a **symlink to a forked integration that shadows the core
+one**. HA loads `custom_components` first, so the venv copy cited throughout the story and PR
+body (`venv/.../homeassistant/components/netatmo/switch.py:73-85`) **is not the code that
+runs**. The fork has its own coordinator (`custom_components/netatmo/coordinator.py`,
+replacing `data_handler.py`), its own webhook layer, and a vendored pyatmo aliased into
+`sys.modules["pyatmo"]` (`custom_components/netatmo/__init__.py:8-25`).
+
+Differences that matter: the fork's switch *does* call `async_write_ha_state()` on its update
+callback (`switch.py:69-75`); it gates on reachability — `if self.device.reachable is not
+False: self._attr_is_on = self.device.on` (`switch.py:73-74`), so an unreachable module pins
+the optimistic value indefinitely; poll cadence is credential-dependent, `SCAN_INTERVAL: 10` /
+`HOME: 10` on own-app credentials (`coordinator.py:127,131`) versus `60` / `300` on Nabu Casa
+(`coordinator.py:114,119`), dynamically inflated under rate pressure
+(`coordinator.py:535-546`).
+
+### E2 — The Netatmo leg is inert, not merely unreliable
+
+User-verified in HA history: **`switch.cumulus_pool_house` read `off` for the entire day of
+2026-07-27**, while the boiler drew 2353 W from 12:01 to past 19:00. The log shows
+`switch.turn_on/off` was never called once in three days — Netatmo never commanded the device,
+so Netatmo's view never moved.
+
+Supporting source facts:
+
+- **No push path for switch state.** `netatmo/switch.py` subscribes to zero webhook signals in
+  either tree; `EVENT_TYPE_ON`/`EVENT_TYPE_OFF` are camera-monitoring only. `iot_class` is
+  `cloud_polling`.
+- **`homeassistant.update_entity` is a verified no-op** for this entity: `NetatmoSwitch` has
+  neither `async_update` nor `update` anywhere in its MRO, so `helpers/entity.py:1377-1382`
+  returns immediately and re-publishes the cached value. No service-exposed force-poll exists
+  in either tree.
+- pyatmo's `async_set_switch` never mutates `self.on`, so a poll callback arriving before the
+  server catches up **reverts** the entity to the stale value.
+
+**Conclusion: the cloud entity reports Netatmo's own last command, not the device.**
+
+### E3 — The mirror is a genuine observer, at 2-3 s
+
+User experiment run during review:
+
+- Actuate the **cloud** entity → the mirror follows in **2-3 s, both directions**. HA never
+  wrote `input_boolean.<slug>_command` during this, so the mirror cannot be echoing the command
+  boolean. **This closes the original story's Task 0 open question: the mirror observes device
+  state.**
+- Actuate via **HomeKit** → the cloud does not follow "before a long time", consistent with E2.
+
+This is what makes §1.3 step 3 an *acknowledgement* and not merely a liveness check: driving
+the cloud actuates the device, and the mirror independently observes the relay having moved,
+within 2-3 s. The 10 s timeout carries ~3× margin.
+
+*Residual:* the Legrand gateway could in principle relay Netatmo's command rather than read the
+relay. A wall-button actuation test would close this. Minor — P0 established the cloud write
+physically actuates the device, so the observed value was correct either way.
+
+### E4 — Corrected causal chain for the incident
+
+The old wait was `is_state(mirror,'off') or is_state(cloud,'off')`. With the cloud pinned at
+`off` (E2), **that predicate was vacuously true from the very first execution** — which is
+exactly why the trace stops at the wait template on all 7 attempts and the fallback never
+fired.
+
+Note what was *not* wrong: the facade reported `on` throughout, and the boiler *was* on. The
+mirror was correct all day. **The incident was an actuation failure plus a vacuous wait
+predicate — not a reporting failure.** The original story's state redesign addressed a defect
+that did not occur.
+
+---
+
+# PART 4 — Test rework (not optional)
+
+The current suite pins the design being replaced and will red wholesale. That is expected.
+Rewrite rather than patch.
+
+- **`STATE_ROWS`** — the 8-row table encodes the fail-safe OR. Rebuild for §1.5: vary
+  `mirror` × `hk_ok`, and assert the cloud leg has **no effect whatsoever** on `state:`. Include
+  an explicit row proving a cloud leg at `on` does not move a facade whose mirror reads `off`,
+  and the converse. That pair is the regression guard for §1.6.
+- **Availability** — currently untested. Add rows for HK down and for an invalid mirror; both
+  must yield unavailable, never a confident value.
+- **`test_diagnostic_predicates_agree_with_state`** — the old identity (`wait == ¬state`) no
+  longer holds, deliberately: `state:` answers "is the load on?" while the wait answers "did the
+  mirror confirm the target?". Replace with direct per-predicate assertions and record in a
+  comment that the divergence is intentional, so it is not "fixed" back.
+- **Positive-confirmation guard** — assert each wait tests `is_state(mirror, <target>)` and
+  that neither wait is expressed as a negation of the opposite value (§1.4).
+- **`cloud_entity_of`** (`:124-137`) derives the cloud entity id from `availability:`, which C3
+  removes. Re-source it from the actuation step's `target.entity_id`.
+- **`test_facade_block_inventory`** — keep it. It is what makes every other assertion
+  non-vacuous. Re-base its cloud-backedness predicate per the point above.
+- Keep the three-layer approach (render → tag-tolerant parse → evaluate the emitted runtime
+  templates) and the raising accessor stub. Keep the `_TagTolerantLoader` **subclass**
+  registration — registering the multi-constructor on `yaml.SafeLoader` would silently make
+  every other test's `yaml.safe_load` tag-tolerant.
+
+---
+
+# PART 5 — Out of scope, residuals, follow-ups
+
+## Deferred — do NOT fix in this PR
+
+| Finding | Why deferred |
+| --- | --- |
+| Superseded-command false notification (`turn_on`/`turn_off` are separate `Script` objects, so `mode: single` does not make them mutually exclusive) | Real, pre-existing, unchanged by this work. At a 10 s timeout with 2-3 s typical latency the window is small. Needs a design decision, not a patch. |
+| Notification is never dismissed or re-checked; a slow confirmation leaves a permanent stale alarm | Same. Wants an out-of-band watchdog — see Issue A. |
+| A renamed or missing `cloud_entity` silently degrades to a single channel | Pre-existing. Wants an inventory-validation test. |
+| The HK-only inventory variant breaks the new suite | All five entries define `cloud_entity`, so that branch is currently **dead code**. Latent, not live. |
+| `input_boolean.turn_*` on a boolean already at target produces no `state_changed` (`core.py:2414-2431`), so the Apple automation never re-fires on relaunch | Accept in-template and document. Cloud actuation is verified and §1.3 drives it every time. The real fix is the Apple automation's trigger — deployment-side. |
+
+## Invalid — do not action
+
+- ruff `E501` / mypy `warn_return_any` on the new test file. Both tools are scoped to
+  `custom_components/quiet_solar` in `pyproject.toml` and in CI (`pr-quality.yml:70`); `tests/`
+  is not linted.
+- CodeRabbit's "define configuration keys in `const.py`". Misapplied — `template`, `switch` and
+  `unique_id` are Home Assistant YAML schema keys inside a rendering test, not quiet-solar
+  config-entry keys.
+
+## Residuals to record in the story
+
+1. **A mirror freeze between commands is undetectable.** The §1.3 wait tests mirror liveness at
+   command time only. Research during review surfaced three documented, silent,
+   non-self-healing ways for HomeKit characteristic events to stop arriving: a hub never
+   re-subscribing after election or hand-off; a `No Response` episode cancelling subscriptions
+   permanently; a bridge emitting via `setCharacteristic` instead of `updateCharacteristic`.
+   Apple's Home app has **no automation execution log**, so these are unobservable by design.
+   **No evidence any of this occurred on 07-27 — the mirror was correct all day.** Recorded as a
+   known risk of a single-leg design, not as a diagnosis.
+2. **`hk_ok` may not cover per-accessory subscription loss.** It gates on
+   `input_boolean.legrand_pumpkin` moving within 90 s. If HomeKit subscriptions are
+   per-accessory, the cumulus could lose its subscription while the pumpkin keeps ticking. The
+   cumulus accessory lives on the Legrand gateway, not HA's HomeKit bridge, so its subscription
+   state is not observable from HA at all.
+3. **HomeKit actuation failed in the incident and this work does not fix it.** The command
+   boolean went `off` correctly at 12:12:19 and the device kept running. §1.3 works around it by
+   always driving the cloud; the HomeKit actuation path itself is untouched.
+4. **Manual verification of the mirror is self-invalidating.** Opening a HomeKit app makes the
+   phone re-read the accessory and back-sync the value to the hub over iCloud
+   ([homebridge#2622](https://github.com/homebridge/homebridge/issues/2622)), so the value can
+   look correct *because it was inspected*. "The Home app shows the right state" is not
+   evidence.
+5. **QS will now see `unavailable` where it previously saw a value**, whenever HomeKit is down.
+   That is intended per §1.5, and is a real behaviour change for the consuming load.
+
+## Follow-ups to open after merge
+
+- **Issue A — out-of-band watchdog.** The power-sensor approach proposed in the PR body is
+  **withdrawn**: the user ruled it out as unreliable, and investigation confirmed the template
+  generates zero per-device power sensors (the emitting loop at `configuration.jinja:444-459`
+  iterates a list explicitly reset to empty at `:131-133`), while the device↔sensor mapping for
+  the towel rails is not derivable from the slug. Re-scope around the two deferred diagnostic
+  items: re-check the mirror against the last commanded state out of band, and dismiss stale
+  notifications.
+- **Issue B — docs.** `docs/workflow/project-context.md:150` misdescribes CI coverage as
+  whole-repo; it is scoped to `custom_components/quiet_solar` (`pr-quality.yml:70`).
+- **Issue C — new.** Investigate why Netatmo's cloud never observes HomeKit-initiated state
+  changes (E2/E3). If the two control planes are permanently independent, that is worth
+  documenting for every future decision involving these devices.
+
+---
+
+# Verification before commit
+
+- Render at `n=0` and diff against `origin/main`: only the five facade regions may change; the
+  non-facade remainder must remain byte-identical.
+- Grep the rendered output: the cloud entity id must appear **only** in the two actuation steps
+  and in notification message text — never in `state:`, `availability:`, a wait, or a
+  notification condition.
+- Confirm `last_changed` is absent from `state:`.
+- Confirm both waits use positive confirmation of the target value (§1.4).
+- Run the five YAML-consuming test files together to re-check loader contamination (the PR's
+  803-test targeted run).
+- `git add -f docs/stories/ config/configuration.jinja` — `.gitignore:182` contains `config/`,
+  so plain `git add` warns and **exits 1**, silently breaking any `add && commit` chain.
+
+# How to apply
+
+Run `/implement-task` against this fix plan. Implement Part 1 exactly; use Parts 2-5 as
+support. When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-305.story_review_fix_#02.md
+++ b/docs/stories/QS-305.story_review_fix_#02.md
@@ -27,8 +27,7 @@ authoritative except where §A1 below amends it.
 > §A1 replaces. Same supersession rules: where any other document disagrees, §A1 wins.
 > User-approved 2026-07-30.
 
-## §A1 — Untrusted ⇒ report `unknown` and stay AVAILABLE (replaces plan #01 §1.5's
-## "not trusted → the facade is `unavailable`")
+## §A1 — Untrusted ⇒ report `unknown` and stay AVAILABLE (replaces plan #01 §1.5's "not trusted → the facade is `unavailable`")
 
 **Plan #01 said:** *"not trusted → the facade is `unavailable`"*. **That was wrong. Do not
 implement it.**

--- a/docs/stories/QS-305.story_review_fix_#02.md
+++ b/docs/stories/QS-305.story_review_fix_#02.md
@@ -1,0 +1,360 @@
+# QS-305 — Review fix plan #02
+
+## Summary
+- Source PR: #310
+- Source story: `docs/stories/QS-305.story.md`
+- Previous fix plan: `docs/stories/QS-305.story_review_fix_%2301.md` (plan #01)
+- Next implement phase: `/implement-task`
+- Edit scope: `config/configuration.jinja`, `tests/test_config_jinja_rendering.py`,
+  `docs/stories/QS-305*.md`
+
+## Standing on plan #01
+
+Round 2 of adversarial review found **no mis-implementation of plan #01**. Every Part 1
+requirement traced green, all six deltas C1-C6 are implemented and tested, 19 of 22 mutations
+are caught, and both CodeRabbit (fresh review `4822637567` against head `5374314f`) and the
+acceptance auditor returned **zero must-fix** on the code.
+
+Everything in this plan is either (a) a case plan #01's *specification* did not anticipate, or
+(b) one place where plan #01's specification was **wrong**. Plan #01 Part 1 remains
+authoritative except where §A1 below amends it.
+
+---
+
+# PART A — AMENDMENT TO THE SPECIFICATION (authoritative)
+
+> Plan #01 Part 1 stays in force, **except** §1.5's disposition of the untrusted case, which
+> §A1 replaces. Same supersession rules: where any other document disagrees, §A1 wins.
+> User-approved 2026-07-30.
+
+## §A1 — Untrusted ⇒ report `unknown` and stay AVAILABLE (replaces plan #01 §1.5's
+## "not trusted → the facade is `unavailable`")
+
+**Plan #01 said:** *"not trusted → the facade is `unavailable`"*. **That was wrong. Do not
+implement it.**
+
+**Corrected rule:**
+
+- **Trusted** (HomeKit link healthy **and** mirror reads `on`/`off`) → `state` is the mirror.
+- **Not trusted** → `state` is **`unknown`**, and the entity **remains available**.
+- The facade must **never** become `unavailable` through the `availability:` template.
+
+### Why — the reason matters, because the obvious one is wrong
+
+`STATE_UNKNOWN` and `STATE_UNAVAILABLE` are **indistinguishable to quiet-solar**. Every
+functional read site lists them in the same collection: `probe_if_command_set` returns `None`
+for both (`custom_components/quiet_solar/ha_model/bistate_duration.py:550`), the
+override-interception block falls through for both (`:579`), override detection yields `None`
+for both (`:761`), and `UNAVAILABLE_STATE_VALUES = [STATE_UNKNOWN, STATE_UNAVAILABLE]`
+(`custom_components/quiet_solar/ha_model/device.py:52`). Solver, budget and constraint
+membership depend only on `qs_enable_device` and a non-empty constraint list
+(`home_model/load.py:1163-1168`) — never on entity state. **So acknowledgement behaviour is
+byte-for-byte identical between the two.** Any argument for `unknown` based on QS's
+acknowledgement path is unfounded.
+
+**The decisive difference is in Home Assistant core.** `helpers/service.py:763`, inside the
+resolver used by `entity_service_call`:
+
+```python
+entity_candidates = [e for e in entity_candidates if e.available]
+```
+
+then `referenced.log_missing(...)` → `helpers/target.py:152-155`, one WARNING, no exception.
+`switch.turn_on` / `turn_off` / `toggle` are registered as **entity services**
+(`components/switch/__init__.py:67-69`), so they pass through that filter.
+
+**Therefore an `unavailable` facade silently swallows every actuation quiet-solar issues.**
+Both channels go undriven, and because the action script never runs, the diagnostic
+notification cannot fire either. That is the 2026-07-27 failure shape reconstructed by a
+different route — and it would trigger on every HA restart, since both health sensors force
+themselves `off` for 120 s after start (`config/configuration.jinja:188-190`, `:195-197`), a
+window that comfortably exceeds the ~70 s quiet-solar needs to give up on a command
+(`home_model/load.py:707-717`, `NUM_MAX_INVALID_PROBES_COMMANDS`, 7 s loop tick at
+`data_handler.py:30,84`).
+
+An `unknown` state is not an availability, so the service call executes normally
+(`helpers/entity.py:1063-1068` shows the ordering: not-available → `"unavailable"`, else
+`state is None` → `"unknown"`).
+
+### §A1.1 — How to emit it: render `none`, NOT the string `unknown`
+
+`components/template/switch.py:129-131` calls
+`template_validators.boolean(self, CONF_STATE)` **without** `none_on_unknown_unavailable`. So:
+
+- rendering the literal string `unknown` (or `unavailable`) fails `cv.boolean`, takes the
+  error path (`components/template/validators.py:20-38`, `:116-158`), yields `None` **and logs
+  an ERROR on every evaluation**;
+- rendering `none` hits `check_result_for_none` (`validators.py:47-50`) and yields `None`
+  cleanly, no log.
+
+The current `{% else %} unknown {% endif %}` was harmless only because the branch was dead
+(availability blocked rendering). §A1 makes it live, so it must change.
+
+**Emit `{{ none }}` in the runtime template** — Jinja renders Python `None` as `"None"`, which
+HA's `_parse_result` literal-evals back to `None`.
+
+> **Verify this end-to-end rather than trusting the derivation above.** Confirm the rendered
+> facade actually publishes state `unknown` with **no** ERROR in the HA log, and add a test
+> asserting the untrusted rows evaluate to `None` — not to the string `"unknown"`. If `{{ none }}`
+> does not produce a clean `None`, find the construct that does and record what you found.
+
+### §A1.2 — `availability:`
+
+Because §A1 forbids ever becoming unavailable, the `availability:` template introduced by plan
+#01 C3 must go. Either drop the key entirely, or set it to a constant true — prefer dropping
+it, and leave a comment recording **why** it must not come back (a falsy `availability:` makes
+HA swallow actuation, `service.py:763`).
+
+Note this also removes the super-template gating that currently blocks `state:` from rendering
+(`components/template/template_entity.py:206`, `:231-236`), which is what makes §A1.1 matter.
+
+### §A1.3 — What does NOT change
+
+Plan #01 §1.1-§1.4 and §1.6 stand unaltered: dual unconditional actuation, mirror-only
+positively-confirmed waits, cloud never read for state or confirmation, no `last_changed`, no
+predicate able to suppress a write. **`hk_ok` stays in the trust predicate** — it is still what
+decides `mirror` vs `unknown`; it simply no longer decides availability.
+
+---
+
+# PART B — must-fix
+
+## B1 — `continue_on_error` does not contain a Netatmo failure, which suppresses the notification
+
+- File: `config/configuration.jinja:325`, `:348`
+- Source: qs-review-edge-case-hunter
+
+`continue_on_error` only swallows `HomeAssistantError` subclasses — `helpers/script.py:598-600`
+ends with *"Only Home Assistant errors can be ignored"* then `raise exception`, and
+`ServiceNotFound` / `vol.Invalid` / `TemplateError` are re-raised explicitly (`:586-595`).
+pyatmo raises `ApiError`, `ApiThrottlingError`, `ApiTooManyRequestError` — all plain
+`Exception` subclasses (`custom_components/netatmo/pyatmo/exceptions.py:24-41`) — via
+`custom_components/netatmo/switch.py:77-90` → `pyatmo/modules/module.py:421-441` →
+`pyatmo/home.py:380-401` → `auth.async_post_api_request`. Steps run `blocking=True`
+(`helpers/script.py:1037-1044`) and HA does not wrap entity-method exceptions
+(`helpers/service.py:819-833`), so the raw `ApiError` reaches `_async_step` (`:540-547`) and
+**aborts the script at step 2**.
+
+Consequence: on a 429/throttle (documented operating condition for this fork, which inflates
+poll intervals under rate pressure — `custom_components/netatmo/coordinator.py:535-546`) or a
+dropped connection (`pyatmo/auth.py:133-136`, `:295-297`, `:308-310`), the cloud relay does not
+actuate **and no notification is raised**. The single failure the diagnostic exists to report
+is the one that silences it.
+
+**Two candidate fixes, neither violating §1.6's ban on gating conditions:**
+
+1. **`parallel:`** — put the cloud write in one branch and the wait+notify in another.
+   `helpers/script.py:688-694` gathers with `return_exceptions=True` and re-raises only after
+   all branches complete, so the wait and notification still run. Cost: changes the step
+   indices that several tests assert.
+2. **Delegate the cloud write to a `script:` entity** invoked as `action: script.turn_on`,
+   which is fire-and-forget, so an exception inside it cannot abort the caller. Cost: one extra
+   script entity per device in the generated config.
+
+Pick one, state the reasoning in the commit, and **test the abort path** — a test that proves
+the notification still fires when the cloud step raises a non-`HomeAssistantError` is the point
+of this fix. If neither approach survives contact, escalate rather than silently reverting to
+the current behaviour.
+
+## B2 — A never-written mirror reads `off` and is fully trusted
+
+- File: `config/configuration.jinja:308-316` (trust predicate)
+- Source: qs-review-edge-case-hunter
+
+`input_boolean.<slug>_state` is declared with no `initial:` (`config/configuration.jinja:161-162`),
+and `input_boolean` sets `_attr_is_on = state is not None and state.state == STATE_ON`, i.e.
+**`False` when there is no restore data** (`homeassistant/components/input_boolean/__init__.py:196-204`).
+So a mirror Apple Home has never written reads `off`, satisfies `mirror in ['on','off']`, and the
+facade reports a **confident `off`**. Worse, `turn_off`'s positive-confirmation wait is then
+satisfied instantly with zero observation, so no notification either.
+
+**The trust predicate cannot distinguish "Apple has never written me" from "the device is
+off"** — the incident signature, on the one leg the design now trusts alone.
+
+Reproduces on: a sixth entry added to `legrand_switches_to_map` (`:26-49`); a fresh install;
+restore-from-backup without `.storage/core.restore_state`; a helper recreated via
+`input_boolean.reload`.
+
+**This violates plan #01 §1.2 directly** (*never report a value you can't trust*), so it must be
+addressed. The awkwardness is that an `input_boolean` cannot hold `unknown`, so "never written"
+is not expressible in the value itself. Options, in preference order:
+
+1. **A companion freshness marker.** Have the Apple Home automation also write a second helper
+   (e.g. `input_boolean.<slug>_mirror_seen`, or an `input_datetime`) so the trust predicate can
+   require positive evidence that the mirror has ever been written. Deployment cost: one more
+   helper and one more Apple automation action per device.
+2. **A narrow `last_changed` carve-out for freshness only.** §1.6 bans `last_changed`, but that
+   ban targets its use as a *race arbiter* (the issue's A3). Using `last_changed` to answer *"has
+   this ever moved since HA started?"* is a different function. **This requires explicit user
+   approval before implementing** — do not assume the carve-out.
+3. **Accept and document**, with a mandatory deployment step: when adding a device, manually set
+   the mirror to match reality before the facade is used.
+
+Option 1 is the only one that is both spec-compliant and self-maintaining, but it changes the
+HomeKit deployment. **Raise the choice with the user rather than picking unilaterally.**
+
+---
+
+# PART C — should-fix
+
+## C1 — The HK-only facade variant was never brought to Part 1, and is wholly untested
+- File: `config/configuration.jinja:363-385`
+- Source: qs-review-acceptance-auditor
+
+Its `availability:` is `hk_ok` alone with no mirror-validity conjunct, and it has no wait and no
+notification at all. Mutating it to unconditionally report a confident `off` **leaves all 26
+tests green**. Plan #01 Part 5 deferred "the HK-only variant breaks the new suite" as latent —
+but that deferral was about the *tests*, not about leaving the branch on the superseded design.
+
+Unreachable today (all five inventory entries define `cloud_entity`). **Prefer deleting the
+branch** — that removes the dead-code coverage gap outright. If it is kept, align it with §A1
+and cover it.
+
+## C2 — Notification message templates are never evaluated, only substring-checked
+- File: `tests/test_config_jinja_rendering.py:510-517`
+- Source: qs-review-acceptance-auditor
+
+A `last_changed` read — or any broken template — inside the message text passes every test. At
+runtime a failing template in service data raises, and that step has no `continue_on_error`, so
+the mutation converts the diagnostic notification into a **silent script failure**: precisely the
+"diagnostic that cannot fire" class this whole task exists to eliminate. This is one of the three
+surviving mutations.
+
+Extend `test_state_and_availability_never_read_last_changed` (`:368-374`) to all four facade
+sub-templates plus message text, and evaluate the message through `eval_ha_template` with a
+stubbed `now()`.
+
+## C3 — `mode: single` now has a real 10 s window that discards commands
+- File: `config/configuration.jinja:317`, `:340`
+- Source: qs-review-edge-case-hunter
+
+Template action scripts are built with HA defaults (`components/template/entity.py:186-191`), so
+`script_mode = DEFAULT_SCRIPT_MODE` = single and `max_exceeded="WARNING"`. A second
+same-direction call while the first is in its wait is discarded at `helpers/script.py:1822-1826`
+**before either actuation write executes** — undercutting the "the writes always happen"
+guarantee at the run level. Previously the wait was vacuously true, runs finished in
+milliseconds, and this window did not exist.
+
+Not fixable in-template (template entities accept no `mode:` key). **Record it as a residual**,
+and note QS's own relaunch cadence (>50 s, `ha_model/home.py:2871`) does not hit it — the
+exposure is a double tap in the UI, or a user override racing a solver command.
+
+## C4 — Mirror staleness across HA downtime is trusted with no age check
+- Source: qs-review-edge-case-hunter
+
+`input_boolean` restores its last value with no age check
+(`input_boolean/__init__.py:203-204`), Apple's automation writes the mirror only on an accessory
+*change*, and nothing re-publishes it at HA start. The health sensors prove only that
+`legrand_pumpkin` / `homekit_hub_alive` moved within 90 s — nothing about *this* accessory's
+mirror being fresh. Switch the device while HA is down and never switch it again: the facade
+reports the pre-restart value with full confidence, indefinitely.
+
+Overlaps B2 (both are "the mirror's value carries no freshness evidence"). If B2 is solved by
+option 1 or 2, this likely falls out with it. **Record it either way** — currently recorded
+nowhere.
+
+## C5 — Nothing dismisses the unconfirmed notifications
+- File: `config/configuration.jinja:330-339`, `:353-362`
+- Source: qs-review-blind-hunter (also plan #01, deferred)
+
+After a transient failure the notification persists indefinitely, even once the mirror confirms.
+A `persistent_notification.dismiss` on the success path would keep the signal honest. Cheap now
+that the wait is meaningful; deferred in plan #01 only because the wait was not.
+
+## C6 — The mirror is bridged to HomeKit as a writable switch
+- File: `config/configuration.jinja:552`, `:584-585`
+- Source: qs-review-edge-case-hunter
+
+`input_boolean.<slug>_state` is exposed to HomeKit as `LHK <name> Mirror`. It must be writable
+for Apple to drive it, but that also means a hand tap in Apple Home — or the mirror being swept
+into a HomeKit scene — writes the facade's **only** witness and **only** confirmation source.
+The cloud leg used to supply a second opinion; §1.5 removed it. **Record as a residual of the
+single-leg design.**
+
+## C7 — `cloud=` in the notification message can never carry information
+- File: `config/configuration.jinja:338`, `:361`
+- Source: qs-review-edge-case-hunter
+
+The fork sets `_attr_is_on` and writes state unconditionally, ignoring `async_set_state`'s return
+value (`custom_components/netatmo/switch.py:77-90`; `pyatmo/home.py:393-401` can return `False`).
+So `cloud=` echoes what we just commanded — or, if a poll lands inside the 10 s window
+(`coordinator.py:127,131`), the *pre-command* stale value, since pyatmo never mutates `self.on`.
+The operator cannot tell a rejected cloud write from an accepted one, which is the first thing
+they will want to know. Either drop the field or replace it with something that carries signal.
+
+## C8 — `cloud_entity_of` raises on an HK-only entry
+- File: `tests/test_config_jinja_rendering.py` (`facade_blocks` / `cloud_entity_of`)
+- Source: qs-review-blind-hunter
+
+`facade_blocks()` collects every `*_facade` block including the HK-only variant, and
+`cloud_entity_of()` then indexes `blk["turn_on"][1]["target"]["entity_id"]`, so an entry without
+`cloud_entity` dies with `KeyError`/`IndexError` rather than a meaningful assertion. Moot if C1
+deletes the branch.
+
+---
+
+# PART D — nice-to-have
+
+- **Broken doc links (CodeRabbit).** `#` starts a fragment in a Markdown link destination, so
+  `QS-305.story_review_fix_#01.md` does not resolve. Percent-encode as `%23` in
+  `docs/stories/QS-305.story.md:12` and `:740`, and anywhere else a fix plan is linked.
+- **markdownlint MD028 (CodeRabbit)** — blank lines inside blockquotes,
+  `docs/stories/QS-305.story.md:9,17`.
+- **markdownlint MD001 (CodeRabbit)** — `C1`-`C6` and `E1`-`E4` in plan #01 are `###` under `#`
+  Part headings; should be `##`. 10 locations.
+- **Dead code in the test file** — `import re` (unused since `cloud_entity_of` became a dict
+  lookup) and `HEALTH_SENSORS` (`:63`, never referenced). Not gate failures (see Part E), just
+  tidiness.
+- **Correct the test count.** The commit message and PR body say "805 tests pass"; the real
+  figure is **853** across the five YAML-consuming files (26 + 245 + 20 + 480 + 82), all green in
+  355 s. Independently reproduced by the auditor.
+- **The header comment hardcodes an external path, line range and date**
+  (`custom_components/netatmo/switch.py:77-90`), which will rot. Consider pointing at the story
+  instead. Keep the *rule* itself inline — that is the part that must not be lost.
+- **YAML injection via inventory `name`** (pre-existing, unchanged from `origin/main`, but inside
+  the rewritten block): `name: {{ s.name }}` is unquoted and `title: "{{ s.name }} - …"` sits in a
+  double-quoted scalar with no escaping. A name containing `"`, `:`, or a leading `{`/`[`/`*`/`&`
+  breaks the render — and a malformed render fails **all** of HA's startup, not just the facade.
+  `| tojson` on both sites is the cheap guard.
+
+---
+
+# PART E — Invalid, do not action
+
+- **ruff `F401` on the unused `import re`, reported as must-fix.** CI runs
+  `ruff check custom_components/quiet_solar/` (`.github/workflows/pr-quality.yml:26,29,48`);
+  **`tests/` is not linted**, locally or in CI. Remove the import as tidiness (Part D), not as a
+  gate fix.
+- **ruff `E501` on ~95-character lines.** Wrong twice: `pyproject.toml:3` sets
+  `line-length = 120`, and `tests/` is not linted anyway.
+- **CodeRabbit's three stale comments** from review `4812287720` (2026-07-29, against
+  `72d1f09f`). They target the superseded design. The fresh review is `4822637567` against
+  `5374314f`.
+
+---
+
+# PART F — Verification before commit
+
+- The facade must **never** publish `unavailable`. Confirm no `availability:` key remains on the
+  cloud-backed facade (or that it is a constant true), and that an untrusted mirror yields state
+  `unknown`.
+- Confirm the untrusted branch produces a clean `None` with **no ERROR log** (§A1.1). This is the
+  single most likely thing to be silently wrong.
+- Confirm `switch.turn_on` on the facade reaches the entity while the mirror is untrusted — i.e.
+  the §A1 regression is actually closed, not just described.
+- A test must prove the notification still fires when the cloud step raises a
+  non-`HomeAssistantError` (B1).
+- Re-run the mutation set. The three known survivors must be reduced: HK-only confident-`off`
+  (C1), `last_changed` in message text (C2). The third — `mirror == 'on'` → `mirror != 'off'` — is
+  an equivalent mutant inside the validity guard and needs no action.
+- Render diff at `n=0`: only the five facade regions may change; the non-facade remainder must stay
+  byte-identical.
+- Run the five YAML-consuming test files together to re-check loader contamination.
+- `git add -f config/configuration.jinja` — `.gitignore:182` contains `config/`, so plain
+  `git add` warns and **exits 1**, silently breaking any `add && commit` chain.
+
+# How to apply
+
+Run `/implement-task` against this fix plan. Part A is authoritative and amends plan #01 §1.5;
+plan #01 Part 1 otherwise stands. **B2 and B1 both contain a choice that needs the user** — raise
+them in-session rather than picking unilaterally. When done, return and run `/review-task`.

--- a/docs/stories/QS-305.story_review_fix_#03.md
+++ b/docs/stories/QS-305.story_review_fix_#03.md
@@ -1,0 +1,343 @@
+# QS-305 — Review fix plan #03
+
+## Summary
+- Source PR: #310
+- Source story: `docs/stories/QS-305.story.md`
+- Previous fix plans: `QS-305.story_review_fix_%2301.md`, `QS-305.story_review_fix_%2302.md`
+- Next implement phase: `/implement-task`
+- Edit scope: `config/configuration.jinja`, `tests/test_config_jinja_rendering.py`,
+  `docs/stories/QS-305*.md`
+
+## Standing on plans #01 and #02
+
+Round 3 found **no must-fix from CodeRabbit and none from blind-hunter**. Plan #02's two
+must-fixes (B1 the `parallel:` isolation, and §A1's `unknown`-not-`unavailable`) are both
+**verified closed with real runtime coverage**, not structural assertions. 16 of 17 mutations
+are caught.
+
+Specification precedence is unchanged and cumulative:
+
+1. **Part A of this plan** (§B1 below is a design change, user-specified)
+2. **Part A (§A1) of plan #02** — untrusted ⇒ `unknown`, entity stays AVAILABLE
+3. **Part 1 of plan #01** — everything except §1.5
+
+`docs/stories/QS-305.story.md` and issue #305's A1-A6 remain void where they disagree.
+
+---
+
+# PART A — DESIGN CHANGE (authoritative)
+
+## §A2 — `cloud_entity` is optional again, by conditional emission
+
+**User-specified, 2026-07-31. This supersedes plan #02 C1 ("delete the HK-only variant"),
+which was my recommendation and was wrong.** It also supersedes all three reviewers'
+proposal to make `cloud_entity` a required key.
+
+### The rule
+
+`cloud_entity` is **optional**. A device without one is a pure-HomeKit device and must still
+be mappable in HA. It gets the **full** facade design — mirror-only trust, positive
+confirmation, the diagnostic, the dismiss — differing only in that no cloud channel is driven.
+
+**Do not reintroduce a duplicated HK-only variant block.** The old `{% else %}` branch was a
+second copy of the whole switch definition, and it was worse on every axis: no wait, no
+notification, no dismiss, and an `availability:` key that could take the entity offline. That
+is why a mutation making it report a confident `off` passed all 26 tests. One code path, one
+set of semantics.
+
+### Why this is now cheap
+
+After the mirror-only rework, `cloud_entity` survives in exactly **one** place: the two
+actuation targets. `state:` does not reference it, `availability:` no longer exists, neither
+wait touches it, and plan #02 C7 removed `cloud=` from the message. So the conditional is a
+single wrapped step per direction:
+
+```jinja
+        turn_on:
+          - action: input_boolean.turn_on
+            target:
+              entity_id: input_boolean.{{ s.slug }}_command
+            continue_on_error: true
+          - parallel:
+{%- if s.cloud_entity is defined %}
+              - sequence:
+                  - action: switch.turn_on
+                    target:
+                      entity_id: {{ s.cloud_entity }}
+                    continue_on_error: true
+{%- endif %}
+              - sequence:
+                  - wait_template: >-
+                      {{ "{{ is_state('input_boolean." ~ s.slug ~ "_state', 'on') }}" }}
+                    timeout: "00:00:10"
+                    continue_on_timeout: true
+                  - choose: …
+```
+
+and the polarity flip for `turn_off`. Whether a single-branch `parallel:` is retained for a
+HomeKit-only device, or the wait sequence is emitted flat, is the implementer's call — but
+**keep the emitted step count and shape uniform across both variants if possible**, because
+several tests assert step roles by index.
+
+### What this fixes
+
+It closes the round-3 must-fix found independently by **all three** code reviewers. Currently
+the guard `{%- if s.cloud_entity is defined %}` is gone but the header still documents
+`cloud_entity` as optional, so following the documentation yields, under HA's own Jinja
+(`strict=None`, **not** the tests' `StrictUndefined`): empty render → `entity_id: null` →
+`cv.SCRIPT_SCHEMA` coerces to the string `'none'` → that is `ENTITY_MATCH_NONE`, so
+`helpers/target.py:64` selects nothing **and logs nothing**. Config validates, the facade
+loads, the cloud channel is silently gone.
+
+### Consequences to handle in the same change
+
+1. **The notification message must be conditional.** "Both channels were driven" is false for
+   a HomeKit-only device. See C2, which fixes the same string for a second reason.
+2. **The inventory header (`config/configuration.jinja:6`, `:16-21`) must be corrected.** The
+   "optional" clause becomes true again, but the rest is still false — there is no HK-only
+   variant any more, and the facade can **never** be unavailable. Rewrite; do not delete.
+3. **Add a HomeKit-only entry to the test inventory.** This path was previously dead code and
+   wholly untested. It is now live, so `facade_blocks`, `cloud_entity_of`, the parallel-branch
+   count and the message wording must all be exercised for a device without `cloud_entity`.
+   This also closes blind-hunter's `KeyError` finding properly rather than by moot-ness.
+
+---
+
+# PART B — must-fix
+
+## B1 — `| tojson` is incomplete and its claim is false
+
+- Files: `config/configuration.jinja:162`, `:164`, `:628`, `:630`
+- Source: qs-review-acceptance-auditor (demonstrated, not theorised)
+
+`| tojson` was applied at `:360`, `:392`, `:422` only. **Four other `s.name` interpolations
+remain unescaped** — `:162` and `:164` inside double-quoted scalars, `:628` and `:630` as bare
+scalars. Rendered with `'name': 'po"ol: pump'`:
+
+```
+YAML PARSE FAILS: while parsing a block mapping
+    name: "po"ol: pump - HK Mirror (read)"
+    name: LHK po"ol: pump Mirror
+```
+
+Commit `c65ab731` claims such a name "cannot break the render". It still can, and a malformed
+render fails **all** of HA's startup, not just the facade.
+
+**Fix:** extend `| tojson` to all seven sites. **And add a test** — mutation "drop `| tojson`
+from `name:`" currently leaves all 34 tests green, so nothing pins this. It is the only
+surviving mutation of the auditor's 17.
+
+## B2 — Record the restore-clobber residual (documentation, not a code fix)
+
+- Source: qs-review-edge-case-hunter (runtime-verified), confirmed by dedicated investigation
+- **User decision 2026-07-31: accept and document. Do not attempt a code fix.**
+
+`AbstractTemplateSwitch` is a `RestoreEntity` with `_restore_state_properties =
+("_attr_is_on",)` (`components/template/switch.py:115,121`). `async_restore_last_state`
+(`components/template/entity.py:243-273`) restores **only when the property is `None`** — i.e.
+exactly when our template says "I don't know". So when the platform is set up while hass is
+already running, the template renders `None` first and HA then substitutes the last known
+`on`/`off`.
+
+Verified at runtime, three scenarios:
+
+| scenario | published state |
+| --- | --- |
+| hass **running** at setup, no `availability:` (the shipped shape) | **`on`** — restored, stale |
+| hass not running (cold boot) | `unknown` — correct |
+| hass running, with plan #01's `availability:` | `unavailable` — previously masked |
+
+**Why there is no fix.** Restore fires precisely when `_attr_is_on is None`, which is the same
+condition as "we are reporting unknown" — from YAML you cannot have one without the other.
+Reinstating `availability:` is off the table: it reintroduces plan #02 §A1's bug, where HA
+filters the entity out of entity-service calls (`helpers/service.py:763`) and **silently
+swallows every actuation**. That is strictly worse.
+
+**Why the exposure is bounded.** A *genuine* `EVENT_STATE_CHANGED` on a tracked entity does
+re-render and clear the stale value (counter-test confirmed: restored `on` → `unknown`). The
+template always collects the mirror and the link sensor, so HomeKit recovery (link `off`→`on`)
+or any real device change corrects it. The window is therefore: **a config reload that lands
+during a HomeKit outage, lasting until HomeKit returns.** Not permanent.
+
+**What does NOT help — record this explicitly so it is not re-proposed.** The Apple-side
+periodic resync does **not** rescue it. `TrackTemplateResultInfo` subscribes only to
+`EVENT_STATE_CHANGED` (`helpers/event.py:1031-1032`); a same-value write fires
+`EVENT_STATE_REPORTED` instead (`core.py:2414-2431`), and nothing in `helpers/template/` or
+`components/template/` listens for it (`async_track_state_report_event` exists at
+`helpers/event.py:391-405` but has only four unrelated consumers). Empirically: 3 no-op writes
+→ 0 `state_changed`, 3 `state_reported`, facade state object not even re-written.
+
+**Deliverable:** a residual in the story's *live* residuals section stating the trigger, the
+bound, why there is no fix, and why `availability:` must not come back.
+
+---
+
+# PART C — should-fix
+
+## C1 — The "no ERROR log" assertion cannot fail
+- File: `tests/test_config_jinja_rendering.py:465`
+- Source: qs-review-acceptance-auditor
+
+`assert not records` attaches a handler to `homeassistant.components.template.validators`, but
+the test only calls `Template(...).async_render()` and `check_result_for_none()` directly. It
+never invokes `template_validators.boolean(...)`, so `records` can never be non-empty. The
+`{{ none }}` vs string-`unknown` mutation is still caught — but by `assert result is None` at
+`:454`, not by the log assertion, which is decorative.
+
+**Fix:** move the assertion into `test_actuation_reaches_the_entity_while_untrusted` (`:468`),
+which already stands up the real platform. Verified load-bearing there: under the string
+mutation the real platform logs `Received invalid switch state: unknown …`; under `{{ none }}`
+it logs nothing.
+
+## C2 — "Both channels were driven" is now reachable and false
+- File: `config/configuration.jinja:394`, `:424`
+- Source: qs-review-edge-case-hunter
+
+Two independent reasons the string lies, and §A2 adds a third:
+
+1. The `parallel:` restructure made the notification reachable when the cloud write **raised**
+   — which is exactly the case B1-of-plan-#02 was added to cover. In round 2 the exception
+   aborted the script first, so it could not be emitted with an undriven cloud.
+2. Plan #02 C7 removed the `cloud=` field in the same commit, so the operator has no way to
+   tell which case they are looking at.
+3. Under §A2 a HomeKit-only device has no second channel at all.
+
+**Fix:** reword to something true in all three cases, and reconsider restoring a cloud-status
+hint — but not the bare `cloud=` state, which C4 explains is uninformative.
+
+## C3 — A permanently dead cloud leg is invisible
+- File: `config/configuration.jinja:375-380`, `:405-410`
+- Source: qs-review-edge-case-hunter, and independently qs-review-blind-hunter
+
+`_async_step_parallel` re-raises after the gather (`helpers/script.py:688-694`), so a raw
+`ApiError` escapes `switch.turn_on` on the facade. Quiet-solar calls with the default
+`blocking=False` (`ha_model/bistate_transport.py:238-242`), so it is only logged by the task
+runner. Meanwhile the mirror confirms via HomeKit, the `default:` branch dismisses the
+notification, and the operator sees a healthy facade. **The dual-channel guarantee can be lost
+for months with one traceback per command as the only trace.** Nothing raises a diagnostic for
+"the cloud channel is failing" — the diagnostic is wired solely to mirror non-confirmation.
+
+Blind-hunter's related point: **`continue_on_error: true` on the cloud step is a no-op for the
+failure mode it sits next to**, and the test itself asserts `pytest.raises(_CloudApiError)`.
+The flag *reads* as protection and is not. At minimum, comment it; better, decide deliberately
+whether to swallow after the diagnostic has fired.
+
+## C4 — Dismiss only clears the same-direction notification
+- File: `config/configuration.jinja:396-399`, `:426-429`
+- Source: qs-review-edge-case-hunter
+
+`turn_on`'s success path dismisses `<slug>_facade_on_unconfirmed` and nothing else. A
+`turn_off` that timed out leaves `<slug>_facade_off_unconfirmed` standing through every
+subsequent successful `turn_on` — for a solar-scheduled load, potentially many hours — showing
+a stale alarm for a device that has demonstrably just confirmed. Dismiss both ids on either
+success path.
+
+## C5 — Module-scoped fixture passed into `async_setup_component`
+- File: `tests/test_config_jinja_rendering.py:496`
+- Source: qs-review-blind-hunter
+
+`async_setup_component(hass, "template", {"template": [{"switch": [blk]}]})` passes the
+**module-scoped** `blocks` dict straight into HA config validation, which mutates mappings in
+place (template strings → `Template` objects). Later tests in the module can see a contaminated
+fixture — an order-dependent flake waiting to happen. Line 634 already does `copy.deepcopy`;
+`:496` must too.
+
+## C6 — `story.md:818-819` contradicts §A1, in a live section
+- Source: qs-review-acceptance-auditor
+
+It still reads *"QS will now see `unavailable` where it previously saw a value…"*. That is in
+**"Residuals of the shipped design"** — a live section, not the void story body — and §A1 makes
+it false. Rewrite to `unknown`, ideally noting §A1's finding that quiet-solar cannot distinguish
+the two anyway (`bistate_duration.py:550`, `device.py:52`).
+
+## C7 — Record the `parallel:` timing change
+- Source: qs-review-acceptance-auditor
+
+Plan #01 §1.3 sequenced the cloud write *before* the wait. Under `parallel:` the wait now starts
+**concurrently with** the cloud write, so the confirmation window is 10 s minus the pyatmo
+round-trip rather than 10 s after it. Authorised by plan #02 B1, so not a violation — but it
+erodes the 3× margin measured in E3 and is recorded nowhere.
+
+## C8 — Correct the test count, and stop asserting unverified numbers
+- Source: qs-review-acceptance-auditor
+
+Commit `c65ab731` says "813 tests pass across the five YAML-consuming files". Measured: **861**
+(34 + 245 + 20 + 480 + 82, 247.6 s, green). Plan #02 Part D existed specifically to correct this
+figure once already (805 → 853).
+
+**This is the third unverified claim in three rounds** — alongside `c65ab731`'s "`| tojson` …
+cannot break the render" (false, B1) and "9/9 mutations caught" (unfalsifiable as written; the
+set is not enumerated). **Measure before writing a number into a commit message, or omit it.**
+
+---
+
+# PART D — nice-to-have
+
+- **The dismiss path is not evidence-gated the way the create path is.** The `choose` condition
+  reads the mirror's *current* value, not whether the wait observed a transition. A mirror
+  already sitting at the target satisfies the wait instantly with zero observation and then
+  dismisses a notification raised on real evidence — so the diagnostic **flaps rather than
+  latches**, which is the opposite of what an operator needs. (edge-case-hunter)
+- `tests/test_config_jinja_rendering.py:661` — `assert "not " not in wait` would also reject a
+  legitimate future wait containing `is_not` / `not_home`. A regex on `not\s+is_state` is less
+  brittle. (blind-hunter)
+- **Record the Jinja short-circuit gotcha in the template comment.** `{% if %}` short-circuits,
+  so *which entities get tracked depends on the render path*: in
+  `hk_ok = is_state(link) and is_state(hub)`, the hub sensor is **not tracked** while the link
+  is `off`. Benign here — link recovery re-renders and re-collects — but it is a sharp edge, and
+  the investigation notes it is a far more common cause of "my template switch doesn't update"
+  than anything else. Add a warning so nobody reorders that expression casually.
+- Four `-#}` terminators in the comment box are off by one column; and the ~70-line header now
+  dwarfs the block it annotates and restates the fix plans nearly verbatim. Consider trimming to
+  the invariants plus the pointer. (blind-hunter)
+- `docs/stories/QS-305.story.md:353-357` (residual 3, "the diagnostic is unreachable in one
+  failure mode") is closed by plan #02 B1 but still reads as open. It sits in the void story
+  body, so cosmetic — a "closed by plan #02 B1" pointer stops a future reader re-opening it.
+- `tests/test_config_jinja_rendering.py:370-371` asserts a `StrictUndefined` render guarantee
+  that holds only in the test harness; the repo has no production renderer. Word it as a
+  test-harness property. (auditor + blind-hunter; and §A2 makes it moot for the `cloud_entity`
+  case specifically)
+- **Markdown, from CodeRabbit.** `QS-305.story_review_fix_%2302.md:31` — the §A1 heading is split
+  across two lines both starting with `##`, so it renders as two H2s, the second a nonsensical
+  fragment. My drafting error; join into one line. And `story.md:889` — `#01's` at column one
+  triggers MD018; prefix with `plan `.
+- 53 added markdown lines exceed 120 chars. Harmless unless a length rule is enforced.
+
+---
+
+# PART E — Answered or invalid, do not action
+
+- **"Every command now blocks up to 10 s and stalls the caller."** Answered: quiet-solar calls
+  with the default `blocking=False` (`ha_model/bistate_transport.py:238-242`), confirmed by two
+  independent investigations. The control loop is not stalled.
+- **"Make `cloud_entity` required."** Proposed by all three code reviewers; **overruled by §A2.**
+- **ruff `F401` / `E501` on the test file.** CI runs `ruff check custom_components/quiet_solar/`
+  (`pr-quality.yml:26,29,48`); `tests/` is not linted, and `pyproject.toml:3` sets
+  `line-length = 120`.
+- **CodeRabbit reviews `4812287720` and `4822637567`** target superseded designs. Note also that
+  CodeRabbit **auto-reviewed round 3** (`4823145115` against `c65ab731`, `4823526528` against
+  head `84a606dc`) and its 22:10Z full pass auto-resolved both round-3 Major findings as
+  addressed. No CodeRabbit code findings remain.
+
+---
+
+# PART F — Verification before commit
+
+- Render with an inventory entry that has **no** `cloud_entity`: it must produce a complete,
+  valid facade with the wait, the notification and the dismiss, and **no** `entity_id:` with an
+  empty or `'none'` value anywhere. Assert this in a test, not by eye.
+- Render with `'name': 'po"ol: pump'`: the full output must still parse as YAML (B1).
+- Re-run the mutation set. "Drop `| tojson`" must now be **caught**.
+- The moved no-ERROR assertion (C1) must be shown to actually fail under the string-`unknown`
+  mutation — otherwise it is decorative again.
+- Render diff at `n=0`: only the facade regions may change; the non-facade remainder byte-identical.
+- Run the five YAML-consuming test files together (loader contamination), and **report the
+  measured count, not an estimate** (C8).
+- `git add -f config/configuration.jinja` — `.gitignore:182` contains `config/`, so plain
+  `git add` warns and exits 1, silently breaking any `add && commit` chain.
+
+# How to apply
+
+Run `/implement-task` against this fix plan. §A2 is a design change and is authoritative; B2 is
+a documentation task with an explicit "do not fix in code" instruction. When done, return and run
+`/review-task`.

--- a/tests/test_config_jinja_rendering.py
+++ b/tests/test_config_jinja_rendering.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -127,14 +128,50 @@ ROWS: dict[str, Row] = {
 # ============================================================================
 
 
+def _environment(loader: jinja2.BaseLoader) -> jinja2.Environment:
+    """Build the generator-layer environment with the one global the template needs.
+
+    ``StrictUndefined`` is a **test-harness** choice, not a production guarantee: this repo
+    has no renderer, and HA's own Jinja runs with ``strict=None``. It is used here so a typo
+    in the inventory fails loudly in tests rather than rendering an empty string.
+    """
+    env = jinja2.Environment(loader=loader, undefined=jinja2.StrictUndefined)
+    env.globals["integration_entities"] = lambda domain: FIXTURE_NETATMO_ENTITIES
+    return env
+
+
 def render_config() -> str:
     """Render ``config/configuration.jinja`` with the generator-layer globals stubbed."""
-    env = jinja2.Environment(
-        loader=jinja2.FileSystemLoader(CONFIG_DIR),
-        undefined=jinja2.StrictUndefined,
+    return _environment(jinja2.FileSystemLoader(CONFIG_DIR)).get_template(
+        "configuration.jinja"
+    ).render()
+
+
+# The marker that closes the hand-edited device inventory.
+_INVENTORY_END = "{## --- END EDIT --- ##}"
+
+
+def render_config_with_extra_device(slug: str, name: str, cloud_entity: str | None) -> str:
+    """Render the real template with one extra device appended to the inventory.
+
+    The inventory is hardcoded in the template rather than injected, so exercising a
+    HomeKit-only device (no ``cloud_entity``) or an awkward ``name`` means adding an entry.
+    Done by source injection at the inventory's own end marker, so the block under test is
+    the real one -- no forked copy of the facade definition to drift.
+    """
+    source = (CONFIG_DIR / "configuration.jinja").read_text()
+    assert source.count(_INVENTORY_END) == 1, "inventory end marker moved"
+    entry = {"slug": slug, "name": name}
+    if cloud_entity is not None:
+        entry["cloud_entity"] = cloud_entity
+    injected = (
+        "{%- set legrand_switches_to_map.switches = "
+        f"legrand_switches_to_map.switches + [{entry!r}] %}}\n" + _INVENTORY_END
     )
-    env.globals["integration_entities"] = lambda domain: FIXTURE_NETATMO_ENTITIES
-    return env.get_template("configuration.jinja").render()
+    patched = source.replace(_INVENTORY_END, injected)
+    return _environment(jinja2.DictLoader({"configuration.jinja": patched})).get_template(
+        "configuration.jinja"
+    ).render()
 
 
 # ============================================================================
@@ -173,15 +210,19 @@ def facade_blocks(parsed: dict[str, Any]) -> dict[str, dict[str, Any]]:
 
 # --- step accessors -------------------------------------------------------------------
 #
-# Post-B1 shape per direction:
-#   [0] input_boolean.turn_<dir>            (continue_on_error)
+# Shape per direction, identical for both variants:
+#   [0] input_boolean.turn_<dir>              (continue_on_error)
 #   [1] parallel:
-#         [0] sequence: [ switch.turn_<dir> (continue_on_error) ]
-#         [1] sequence: [ wait_template, choose(+default) ]
+#         [0] sequence: [ switch.turn_<dir> ] -- ONLY when `cloud_entity` is defined
+#         [-1] sequence: [ wait_template, choose(+default) ]
 #
-# The cloud write is isolated in its own parallel branch so a plain-Exception failure cannot
-# abort the diagnostic branch: `_async_step_parallel` gathers with `return_exceptions=True`
-# and re-raises only after every branch has completed.
+# The diagnostic is always the LAST parallel branch, so every accessor below is uniform
+# across a cloud-backed and a HomeKit-only device. `cloud_entity` is optional: a device
+# without one gets the same facade with no cloud branch emitted.
+#
+# The cloud write is isolated in its own branch so a plain-Exception failure cannot abort
+# the diagnostic: `_async_step_parallel` gathers with `return_exceptions=True` and re-raises
+# only after every branch has completed.
 
 
 def boolean_step_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
@@ -189,19 +230,38 @@ def boolean_step_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
     return blk[direction][0]
 
 
+def parallel_of(blk: dict[str, Any], direction: str) -> list[dict[str, Any]]:
+    """Return the parallel branches of a direction script."""
+    return blk[direction][1]["parallel"]
+
+
+def has_cloud(blk: dict[str, Any]) -> bool:
+    """Whether this facade drives a Netatmo cloud channel."""
+    counts = {len(parallel_of(blk, d)) for d in DIRECTIONS}
+    assert counts in ({1}, {2}), f"inconsistent branch counts across directions: {counts}"
+    return counts == {2}
+
+
 def cloud_step_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
     """Return the Netatmo cloud actuation step, inside its own parallel branch."""
-    return blk[direction][1]["parallel"][0]["sequence"][0]
+    assert has_cloud(blk), "this facade has no cloud channel"
+    return parallel_of(blk, direction)[0]["sequence"][0]
 
 
 def diagnostic_of(blk: dict[str, Any], direction: str) -> list[dict[str, Any]]:
-    """Return the diagnostic branch's sequence: ``[wait_template, choose]``."""
-    return blk[direction][1]["parallel"][1]["sequence"]
+    """Return the diagnostic branch's sequence: ``[wait_template, choose]``.
+
+    Always the last parallel branch, so this is variant-independent.
+    """
+    return parallel_of(blk, direction)[-1]["sequence"]
 
 
 def actuation_steps_of(blk: dict[str, Any], direction: str) -> list[dict[str, Any]]:
-    """Return both actuation writes."""
-    return [boolean_step_of(blk, direction), cloud_step_of(blk, direction)]
+    """Return every actuation write: the boolean, plus the cloud when there is one."""
+    steps = [boolean_step_of(blk, direction)]
+    if has_cloud(blk):
+        steps.append(cloud_step_of(blk, direction))
+    return steps
 
 
 def cloud_entity_of(blk: dict[str, Any]) -> str:
@@ -236,9 +296,16 @@ def notification_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
     return choose_of(blk, direction)["choose"][0]["sequence"][0]["data"]
 
 
-def dismiss_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
-    """Return the success-path ``persistent_notification.dismiss`` step."""
-    return choose_of(blk, direction)["default"][0]
+def dismiss_ids_of(blk: dict[str, Any], direction: str) -> set[str]:
+    """Return the notification ids the success path dismisses.
+
+    Both directions are dismissed on either success path: a ``turn_off`` that timed out would
+    otherwise leave its alarm standing through every later successful ``turn_on`` -- for hours
+    on a solar-scheduled load -- showing a stale alarm for a device that just confirmed.
+    """
+    steps = choose_of(blk, direction)["default"]
+    assert all(s["action"] == "persistent_notification.dismiss" for s in steps), steps
+    return {s["data"]["notification_id"] for s in steps}
 
 
 def all_notification_data(parsed: dict[str, Any]) -> list[dict[str, Any]]:
@@ -432,37 +499,25 @@ async def test_untrusted_state_parses_to_none_without_error(
 
     Asserted through Home Assistant's own ``Template`` and the template platform's validator
     rather than the layer-3 stub, because this is the single most likely thing to be silently
-    wrong: a string here would still *look* like ``unknown`` in the UI while logging an error
-    on every state evaluation.
+    wrong. The companion *no-ERROR-logged* assertion lives in
+    ``test_actuation_reaches_the_entity_while_untrusted``, which stands up the real platform --
+    the validator is never invoked by rendering a ``Template`` directly, so asserting it here
+    would be decorative.
     """
-    records: list[logging.LogRecord] = []
+    for slug, blk in blocks.items():
+        # Untrusted: HomeKit link down.
+        hass.states.async_set(LINK_SENSOR, "off")
+        hass.states.async_set(HUB_SENSOR, "on")
+        hass.states.async_set(f"input_boolean.{slug}_state", "on")
+        result = Template(blk["state"], hass).async_render(parse_result=True)
+        assert result is None, f"{slug} rendered {result!r} instead of None"
+        # This is the check the template platform actually applies to `state:`.
+        assert template_validators.check_result_for_none(result) is True, slug
 
-    class _Capture(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            records.append(record)
-
-    handler = _Capture(level=logging.ERROR)
-    validators_logger = logging.getLogger(template_validators.__name__)
-    validators_logger.addHandler(handler)
-    try:
-        for slug, blk in blocks.items():
-            # Untrusted: HomeKit link down.
-            hass.states.async_set(LINK_SENSOR, "off")
-            hass.states.async_set(HUB_SENSOR, "on")
-            hass.states.async_set(f"input_boolean.{slug}_state", "on")
-            result = Template(blk["state"], hass).async_render(parse_result=True)
-            assert result is None, f"{slug} rendered {result!r} instead of None"
-            # This is the check the template platform actually applies to `state:`.
-            assert template_validators.check_result_for_none(result) is True, slug
-
-            # Trusted: the same template must still yield a real boolean.
-            hass.states.async_set(LINK_SENSOR, "on")
-            trusted = Template(blk["state"], hass).async_render(parse_result=True)
-            assert trusted is True, f"{slug} rendered {trusted!r} instead of True"
-    finally:
-        validators_logger.removeHandler(handler)
-
-    assert not records, f"validator logged errors: {[r.getMessage() for r in records]}"
+        # Trusted: the same template must still yield a real boolean.
+        hass.states.async_set(LINK_SENSOR, "on")
+        trusted = Template(blk["state"], hass).async_render(parse_result=True)
+        assert trusted is True, f"{slug} rendered {trusted!r} instead of True"
 
 
 async def test_actuation_reaches_the_entity_while_untrusted(
@@ -487,7 +542,24 @@ async def test_actuation_reaches_the_entity_while_untrusted(
     driven = async_mock_service(hass, "input_boolean", "turn_on")
     async_mock_service(hass, "persistent_notification", "dismiss")
 
-    assert await async_setup_component(hass, "template", {"template": [{"switch": [blk]}]})
+    # C1: the real platform DOES invoke `template_validators.boolean` on `state:`, so this is
+    # where a no-ERROR assertion is load-bearing. Under a string-`unknown` mutation the
+    # platform logs "Received invalid switch state: unknown"; under `{{ none }}` it is silent.
+    errors: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            errors.append(record)
+
+    handler = _Capture(level=logging.ERROR)
+    validators_logger = logging.getLogger(template_validators.__name__)
+    validators_logger.addHandler(handler)
+
+    # `async_setup_component` runs config validation, which mutates mappings in place
+    # (template strings -> Template objects). `blocks` is module-scoped, so pass a copy or
+    # later tests in this module see a contaminated fixture.
+    config = {"template": [{"switch": [copy.deepcopy(blk)]}]}
+    assert await async_setup_component(hass, "template", config)
     await hass.async_block_till_done()
 
     facade = next(e for e in hass.states.async_entity_ids("switch") if e.endswith("_facade"))
@@ -498,8 +570,11 @@ async def test_actuation_reaches_the_entity_while_untrusted(
     )
     await hass.async_block_till_done()
 
+    validators_logger.removeHandler(handler)
+
     assert len(driven) == 1, "the untrusted facade swallowed the actuation"
     assert driven[0].data["entity_id"] == [f"input_boolean.{slug}_command"]
+    assert not errors, f"the platform rejected the state template: {[r.getMessage() for r in errors]}"
 
 
 def test_cloud_leg_cannot_move_the_facade(blocks: dict[str, dict[str, Any]]) -> None:
@@ -652,7 +727,9 @@ def test_wait_positively_confirms_the_target_value(
     for slug, blk in blocks.items():
         wait = wait_of(blk, direction)
         assert f"'{target}'" in wait, f"{slug}/{direction} does not mention {target!r}"
-        assert "not " not in wait, f"{slug}/{direction} is expressed as a negation: {wait}"
+        assert not re.search(r"\bnot\s+is_state", wait), (
+            f"{slug}/{direction} is expressed as a negation: {wait}"
+        )
 
         for mirror in ("unknown", "unavailable"):
             states = trusted_states(slug, Row(mirror, "on", "on", "", "probe"))
@@ -716,11 +793,158 @@ def test_success_path_dismisses_the_notification(
     confirmed -- the same "a stale signal carries no information" problem as the log line this
     notification replaced.
     """
-    suffix = TARGET_OF[direction]
     for slug, blk in blocks.items():
-        step = dismiss_of(blk, direction)
-        assert step["action"] == "persistent_notification.dismiss", f"{slug}/{direction}"
-        assert step["data"]["notification_id"] == f"{slug}_facade_{suffix}_unconfirmed"
+        assert dismiss_ids_of(blk, direction) == {
+            f"{slug}_facade_on_unconfirmed",
+            f"{slug}_facade_off_unconfirmed",
+        }, f"{slug}/{direction} must clear the other direction's stale alarm too"
+
+
+# ============================================================================
+# `cloud_entity` is optional (plan #03 section A2)
+# ============================================================================
+
+
+def test_homekit_only_device_gets_the_full_facade() -> None:
+    """A device without ``cloud_entity`` gets the same facade, minus the cloud channel.
+
+    Previously this was a duplicated ``{% else %}`` block with no wait, no notification and
+    no dismiss, plus an ``availability:`` key that could take the entity offline -- which is
+    why a mutation making it report a confident ``off`` passed the whole suite. There is now
+    one code path, so a HomeKit-only device inherits every guarantee automatically.
+    """
+    parsed = parse_config(render_config_with_extra_device("lhk_hk_only", "hk only", None))
+    blocks = facade_blocks(parsed)
+    assert "lhk_hk_only" in blocks, "the HomeKit-only device produced no facade"
+    blk = blocks["lhk_hk_only"]
+
+    assert not has_cloud(blk)
+    assert "availability" not in blk
+    assert eval_ha_template(
+        blk["state"], trusted_states("lhk_hk_only", ROWS["R_mirror_on_trusted"])
+    ) == "True"
+
+    for direction in DIRECTIONS:
+        assert len(blk[direction]) == 2, direction
+        assert len(parallel_of(blk, direction)) == 1, "a cloud branch was emitted anyway"
+        assert boolean_step_of(blk, direction)["action"] == f"input_boolean.{direction}"
+        # The full diagnostic apparatus must still be present.
+        assert wait_step_of(blk, direction)["timeout"] == "00:00:10"
+        assert wait_step_of(blk, direction)["continue_on_timeout"] is True
+        assert complain_of(blk, direction)
+        assert notification_of(blk, direction)["notification_id"] == (
+            f"lhk_hk_only_facade_{TARGET_OF[direction]}_unconfirmed"
+        )
+        assert dismiss_ids_of(blk, direction) == {
+            "lhk_hk_only_facade_on_unconfirmed",
+            "lhk_hk_only_facade_off_unconfirmed",
+        }
+
+
+def test_homekit_only_device_emits_no_empty_entity_id() -> None:
+    """No ``entity_id`` may render empty, ``null`` or ``'none'``.
+
+    Under HA's own Jinja (``strict=None``, unlike this harness) an undefined ``cloud_entity``
+    would render as an empty string, become ``entity_id: null``, and be coerced by
+    ``cv.SCRIPT_SCHEMA`` to the string ``'none'`` -- which is ``ENTITY_MATCH_NONE``, so the
+    call selects nothing **and logs nothing**. The cloud channel would vanish in silence.
+    """
+    rendered = render_config_with_extra_device("lhk_hk_only", "hk only", None)
+    lines = rendered.splitlines()
+    offenders = []
+    for index, line in enumerate(lines):
+        match = re.match(r"^(\s*)entity_id:\s*(.*)$", line)
+        if not match:
+            continue
+        indent, value = match.group(1), match.group(2).strip()
+        if value in ("null", "none", "'none'", '"none"', "~"):
+            offenders.append(line.strip())
+        elif not value:
+            # A bare `entity_id:` is legitimate when a block list follows (several triggers do
+            # this); it is an offender only when nothing does. A block sequence may be indented
+            # at or beyond its key's column, so accept either.
+            following = next((v for v in lines[index + 1 :] if v.strip()), "")
+            is_list = following.lstrip().startswith("- ") and (
+                len(following) - len(following.lstrip()) >= len(indent)
+            )
+            if not is_list:
+                offenders.append(f"{line.strip()} (no value, no list)")
+    assert not offenders, offenders
+
+    # Belt and braces: the parsed form must not contain such a target either.
+    for slug, blk in facade_blocks(parse_config(rendered)).items():
+        for direction in DIRECTIONS:
+            for step in actuation_steps_of(blk, direction):
+                target = step["target"]["entity_id"]
+                assert target and target not in ("none", "null"), f"{slug}/{direction}"
+
+
+def test_homekit_only_notification_does_not_claim_two_channels() -> None:
+    """The message must not say both channels were driven when there is only one.
+
+    The wording is now reachable with an undriven cloud in three separate cases: the cloud
+    write raised (which the ``parallel:`` split made reportable), the ``cloud=`` field was
+    removed so the operator cannot tell which case they are in, and a HomeKit-only device has
+    no second channel at all.
+    """
+    hk_only = facade_blocks(
+        parse_config(render_config_with_extra_device("lhk_hk_only", "hk only", None))
+    )["lhk_hk_only"]
+    for direction in DIRECTIONS:
+        message = notification_of(hk_only, direction)["message"]
+        assert "no cloud channel" in message, message
+        assert "Netatmo" not in message, message
+        assert "Both channels" not in message, message
+
+
+def test_cloud_backed_notification_names_both_channels(
+    blocks: dict[str, dict[str, Any]],
+) -> None:
+    """A cloud-backed device's message says which channels were commanded."""
+    for slug, blk in blocks.items():
+        for direction in DIRECTIONS:
+            message = notification_of(blk, direction)["message"]
+            assert "Netatmo cloud" in message, f"{slug}/{direction}"
+            assert "no cloud channel" not in message, f"{slug}/{direction}"
+            assert "Both channels" not in message, f"{slug}/{direction}"
+
+
+# ============================================================================
+# Name escaping (plan #03 B1)
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "hostile_name",
+    [
+        'po"ol: pump',  # double quote inside a quoted scalar, plus a colon
+        "pump: {weird}",  # leading brace after a colon
+        "a'b",  # single quote
+        "*anchor & alias",  # YAML indicators
+        "trailing backslash \\",
+    ],
+)
+def test_hostile_device_name_still_renders_valid_yaml(hostile_name: str) -> None:
+    """Every ``s.name`` interpolation is escaped, so no name can break the render.
+
+    There are seven interpolation sites: the two ``input_boolean`` helper names, the facade
+    ``name:``, the two notification titles, and the two HomeKit ``entity_config`` names. A
+    malformed render fails the load of **all** of HA's startup, not just the facade -- so a
+    single unescaped site is a whole-instance outage triggered by a rename.
+    """
+    rendered = render_config_with_extra_device("lhk_hostile", hostile_name, "switch.hostile")
+    parsed = parse_config(rendered)  # must not raise
+    assert "lhk_hostile" in facade_blocks(parsed)
+    assert parsed["input_boolean"]["lhk_hostile_state"]["name"] == (
+        f"{hostile_name} - HK Mirror (read)"
+    )
+    assert parsed["input_boolean"]["lhk_hostile_command"]["name"] == (
+        f"{hostile_name} - HK Command (write)"
+    )
+    entity_config = parsed["homekit"][0]["entity_config"]
+    assert entity_config["input_boolean.lhk_hostile_state"]["name"] == f"LHK {hostile_name} Mirror"
+    assert entity_config["input_boolean.lhk_hostile_command"]["name"] == f"LHK {hostile_name} Cmd"
+    assert facade_blocks(parsed)["lhk_hostile"]["name"] == hostile_name
 
 
 def test_state_stub_raises_on_unknown_entity() -> None:

--- a/tests/test_config_jinja_rendering.py
+++ b/tests/test_config_jinja_rendering.py
@@ -1,0 +1,446 @@
+"""Tests for the Legrand/Netatmo facade switches in ``config/configuration.jinja``.
+
+These tests catch bugs where:
+
+- The facade's ``state:`` template reports ``off`` while some leg still reports ``on``
+  (the QS-305 incident: a boiler ran ~7 hours after being commanded off).
+- A predicate suppresses actuation on one of the two channels, so the channel that
+  actually works is never driven.
+- The wait / complain predicates disagree with what ``state:`` reports.
+- ``persistent_notification`` calls lose their per-direction ``notification_id``.
+
+**Permanent gate note.** ``config/configuration.jinja`` is a non-Python file, so
+testmon cannot select this test: ``--impacted`` is blind to a template-only change.
+Run ``python scripts/qs/quality_gate.py --quick tests/test_config_jinja_rendering.py``
+in any PR that touches the template. CI's whole-suite run is the durable net.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import jinja2
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_DIR = REPO_ROOT / "config"
+
+# Exercises both generator-side filters at lines 67-84: only the first entry
+# passes `startswith('sensor.')` and `endswith('_power')`.
+FIXTURE_NETATMO_ENTITIES = [
+    "sensor.cumulus_pool_house_power",  # passes both filters
+    "sensor.not_a_power_entity",  # fails endswith('_power')
+    "switch.cumulus_pool_house",  # fails startswith('sensor.')
+]
+
+HEALTH_SENSORS = (
+    "binary_sensor.legrand_homekit_link_healthy",
+    "binary_sensor.homekit_hub_healthy",
+)
+
+DIRECTIONS = ("turn_on", "turn_off")
+
+# The A1 fail-safe reporting table. Rows are NAMED, not numbered, so A1 and A3
+# cannot drift apart. Each entry is (mirror, cloud, expected rendered state).
+#
+# `R_both_on` is load-bearing: without a both-legs-on row, an XOR implementation
+# (`(mirror=='on') != (cloud=='on')`) passes every other row while reporting `off`
+# with both legs on. The mirror uses `unknown`, never `unavailable`, because an
+# `input_boolean` never goes unavailable.
+STATE_ROWS: dict[str, tuple[str, str, str]] = {
+    "R_both_on": ("on", "on", "True"),
+    "R_incident": ("on", "off", "True"),
+    "R_cloud_only": ("off", "on", "True"),
+    "R_both_off": ("off", "off", "False"),
+    "R_mirror_invalid_on": ("unknown", "on", "True"),
+    "R_mirror_invalid_off": ("unknown", "off", "False"),
+    "R_cloud_unavailable": ("off", "unavailable", "False"),
+    "R_none_valid": ("unknown", "unknown", "unknown"),
+}
+
+
+# ============================================================================
+# Layer 1: render the generator template
+# ============================================================================
+
+
+def render_config() -> str:
+    """Render ``config/configuration.jinja`` with the generator-layer globals stubbed.
+
+    ``integration_entities`` is the only global the template needs at generation time.
+    """
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(CONFIG_DIR),
+        undefined=jinja2.StrictUndefined,
+    )
+    env.globals["integration_entities"] = lambda domain: FIXTURE_NETATMO_ENTITIES
+    return env.get_template("configuration.jinja").render()
+
+
+# ============================================================================
+# Layer 2: parse the emitted YAML
+# ============================================================================
+
+
+class _TagTolerantLoader(yaml.SafeLoader):
+    """SafeLoader that degrades unknown ``!tag`` nodes to plain strings.
+
+    The rendered config uses ``!include``, which ``yaml.SafeLoader`` rejects. The
+    multi-constructor is registered on this subclass rather than on
+    ``yaml.SafeLoader`` so every other test's ``yaml.safe_load`` stays strict.
+    """
+
+
+_TagTolerantLoader.add_multi_constructor(
+    "!", lambda loader, suffix, node: f"!{suffix}"
+)
+
+
+def parse_config(rendered: str) -> dict[str, Any]:
+    """Parse a rendered config with the tag-tolerant loader."""
+    return yaml.load(rendered, Loader=_TagTolerantLoader)
+
+
+def facade_blocks(parsed: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return the generated Legrand facade switch blocks, keyed by device slug.
+
+    Walks ``template:`` items (some also carry ``trigger:``, so no item-shape
+    assumption is made) and keeps ``- switch:`` entries whose ``unique_id`` ends
+    with ``_facade``.
+    """
+    blocks: dict[str, dict[str, Any]] = {}
+    for item in parsed["template"]:
+        for blk in item.get("switch", []):
+            unique_id = blk.get("unique_id", "")
+            if unique_id.endswith("_facade"):
+                blocks[unique_id.removesuffix("_facade")] = blk
+    assert blocks, "no facade blocks found; the inventory would be vacuous"
+    return blocks
+
+
+def cloud_entity_of(blk: dict[str, Any]) -> str:
+    """Return the Netatmo cloud entity id a facade block falls back to.
+
+    Read out of ``availability:``, which is untouched by QS-305, so this helper
+    works identically before and after the edit.
+    """
+    matches = [
+        entity_id
+        for entity_id in re.findall(r"states\('([^']+)'\)", blk["availability"])
+        if entity_id.startswith("switch.")
+    ]
+    assert len(matches) == 1, f"expected exactly one cloud entity, got {matches}"
+    return matches[0]
+
+
+def wait_of(blk: dict[str, Any], direction: str) -> str:
+    """Return the ``wait_template`` of a facade block's direction script."""
+    return blk[direction][2]["wait_template"]
+
+
+def complain_of(blk: dict[str, Any], direction: str) -> str:
+    """Return the diagnostic ``choose`` condition of a direction script."""
+    return blk[direction][3]["choose"][0]["conditions"]
+
+
+def notification_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
+    """Return the notification ``data`` mapping of a direction script."""
+    return blk[direction][3]["choose"][0]["sequence"][0]["data"]
+
+
+def all_notification_data(parsed: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the ``data`` of every ``persistent_notification.create`` in the config."""
+    found: list[dict[str, Any]] = []
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if node.get("action") == "persistent_notification.create":
+                found.append(node["data"])
+            for value in node.values():
+                _walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                _walk(value)
+
+    _walk(parsed)
+    return found
+
+
+# ============================================================================
+# Layer 3: evaluate the emitted HA-runtime templates
+# ============================================================================
+
+
+def _negate(rendered: str) -> str:
+    """Flip a rendered boolean string. Total over the two values it is used with."""
+    return {"True": "False", "False": "True"}[rendered]
+
+
+def eval_ha_template(text: str, states: dict[str, str]) -> str:
+    """Render an emitted HA-runtime template with stubbed HA globals.
+
+    Whitespace is collapsed rather than merely stripped, because ``state:`` is a
+    ``>`` folded scalar whose more-indented body lines keep their newlines.
+    """
+
+    def _state_of(entity_id: str) -> str:
+        if entity_id not in states:
+            raise KeyError(f"template read unstubbed entity {entity_id!r}")
+        return states[entity_id]
+
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    env.globals["states"] = _state_of
+    env.globals["is_state"] = lambda entity_id, value: _state_of(entity_id) == value
+    return " ".join(env.from_string(text).render().split())
+
+
+def leg_states(blk: dict[str, Any], slug: str, mirror: str, cloud: str) -> dict[str, str]:
+    """Build a four-key ``states`` dict for one row of the A1 table.
+
+    The two health sensors are seeded because the *pre-edit* ``state:`` reads them
+    before the race tail; a two-key dict would raise ``KeyError`` on every row and
+    mask the failure under test.
+    """
+    return {
+        f"input_boolean.{slug}_state": mirror,
+        cloud_entity_of(blk): cloud,
+        HEALTH_SENSORS[0]: "on",
+        HEALTH_SENSORS[1]: "on",
+    }
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def rendered() -> str:
+    """The rendered ``config/configuration.jinja`` output."""
+    return render_config()
+
+
+@pytest.fixture(scope="module")
+def parsed(rendered: str) -> dict[str, Any]:
+    """The parsed rendered config."""
+    return parse_config(rendered)
+
+
+@pytest.fixture(scope="module")
+def blocks(parsed: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """The generated Legrand facade switch blocks, keyed by device slug."""
+    return facade_blocks(parsed)
+
+
+# ============================================================================
+# A5: render and parse
+# ============================================================================
+
+
+def test_config_jinja_renders_and_parses(parsed: dict[str, Any]) -> None:
+    """The template renders under the stubbed environment and parses as YAML."""
+    assert isinstance(parsed, dict)
+    assert "template" in parsed
+    assert "input_boolean" in parsed
+
+
+def test_facade_block_inventory(parsed: dict[str, Any], blocks: dict[str, dict[str, Any]]) -> None:
+    """Every mapped Legrand device yields exactly one cloud-backed facade block.
+
+    This is what keeps A1-A4 non-vacuous: it pins the set the other tests quantify
+    over, and asserts cloud-backedness with a predicate that holds both before and
+    after the QS-305 edit. Do not prune it.
+    """
+    expected_slugs = {
+        key.removesuffix("_command")
+        for key in parsed["input_boolean"]
+        if key.endswith("_command")
+    }
+    assert expected_slugs, "no command booleans found; the template changed shape"
+    assert set(blocks) == expected_slugs
+
+    for slug, blk in blocks.items():
+        assert "switch." in blk["availability"], f"{slug} is not cloud-backed"
+        assert cloud_entity_of(blk).startswith("switch."), slug
+
+
+# ============================================================================
+# A1: fail-safe reporting
+# ============================================================================
+
+
+def test_facade_state_never_reads_last_changed(blocks: dict[str, dict[str, Any]]) -> None:
+    """The facade ``state:`` elects no winner and trusts no health sensor.
+
+    ``last_changed`` was the wrong arbiter (a stale leg keeps an old timestamp), and
+    gating mirror validity on ``hk_ok`` let a healthy-looking link vouch for a frozen
+    mirror. The health-sensor entity ids are asserted absent *positively*, so a
+    re-inlined health test cannot survive as a mere name change.
+    """
+    for slug, blk in blocks.items():
+        state = blk["state"]
+        assert "last_changed" not in state, slug
+        assert "hk_ok" not in state, slug
+        for sensor in HEALTH_SENSORS:
+            assert sensor not in state, f"{slug} still reads {sensor}"
+
+
+@pytest.mark.parametrize("row", list(STATE_ROWS))
+def test_facade_state_is_fail_safe(blocks: dict[str, dict[str, Any]], row: str) -> None:
+    """The facade reports ``off`` only when no valid leg says ``on``.
+
+    False-``off`` is the incident's failure mode and is narrowed to "all valid legs
+    stuck at ``off``"; false-``on`` is the accepted cost and is what D3 reports on.
+    """
+    mirror, cloud, expected = STATE_ROWS[row]
+    for slug, blk in blocks.items():
+        states = leg_states(blk, slug, mirror, cloud)
+        assert eval_ha_template(blk["state"], states) == expected, f"{slug} / {row}"
+
+
+# ============================================================================
+# A2: unconditional actuation
+# ============================================================================
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_both_channels_driven_unconditionally(
+    blocks: dict[str, dict[str, Any]], direction: str
+) -> None:
+    """Both the HomeKit command boolean and the Netatmo cloud entity are always driven.
+
+    This is the QS-305 fix. The old script *predicted* whether the HomeKit leg had
+    worked and drove the cloud leg only if it concluded otherwise; any leg can lie, so
+    a wrong prediction meant the one channel that worked was never driven. There is no
+    longer a decision to get wrong: no ``variables:``, no ``choose:`` in the actuation
+    head, and therefore no predicate that can suppress a command.
+
+    The local boolean is written *first* so it still happens if the cloud call fails.
+    ``continue_on_error`` on the cloud step keeps a ``HomeAssistantError`` from aborting
+    the script before the diagnostic wait can report the failure.
+    """
+    for slug, blk in blocks.items():
+        steps = blk[direction]
+        assert len(steps) == 4, f"{slug} / {direction}: expected actuation head + diagnostic"
+
+        assert steps[0].get("action") == f"input_boolean.{direction}", f"{slug} / {direction}"
+        assert steps[0]["target"]["entity_id"] == f"input_boolean.{slug}_command"
+
+        assert steps[1].get("action") == f"switch.{direction}", f"{slug} / {direction}"
+        assert steps[1]["target"]["entity_id"] == cloud_entity_of(blk)
+        assert steps[1].get("continue_on_error") is True, f"{slug} / {direction}"
+
+        # `continue_on_timeout` is load-bearing: without it a timeout errors the script
+        # and the diagnostic `choose` never runs.
+        assert steps[2]["timeout"] == "00:00:10", f"{slug} / {direction}"
+        assert steps[2]["continue_on_timeout"] is True, f"{slug} / {direction}"
+
+        for index, step in enumerate(steps):
+            assert "variables" not in step, f"{slug} / {direction}: step {index} is conditional"
+            assert ("choose" in step) == (index == 3), (
+                f"{slug} / {direction}: step {index} must not branch"
+            )
+
+
+# ============================================================================
+# A3: the diagnostic predicates agree with reporting
+# ============================================================================
+
+
+@pytest.mark.parametrize("row", list(STATE_ROWS))
+def test_diagnostic_predicates_agree_with_state(
+    blocks: dict[str, dict[str, Any]], row: str
+) -> None:
+    """The wait and complain predicates are derived from what ``state:`` reports.
+
+    Letting ``state:``, ``wait_template:`` and the fallback condition disagree was the
+    QS-305 incident's first defect. With ``S`` the reported state, this pins
+    ``wait(turn_off) = not S``, ``wait(turn_on) = S`` and ``complain = not wait`` in both
+    directions, so the three predicates cannot drift apart again.
+    """
+    mirror, cloud, expected = STATE_ROWS[row]
+    for slug, blk in blocks.items():
+        states = leg_states(blk, slug, mirror, cloud)
+        waits = {d: eval_ha_template(wait_of(blk, d), states) for d in DIRECTIONS}
+        complains = {d: eval_ha_template(complain_of(blk, d), states) for d in DIRECTIONS}
+
+        if row == "R_none_valid":
+            # `state:` reports `unknown`, which is not a boolean, so the identities are
+            # pinned as literals instead. Both legs invalid reads as "not on".
+            assert expected == "unknown", row
+            assert waits["turn_off"] == "True", slug
+            assert waits["turn_on"] == "False", slug
+            assert complains["turn_off"] == "False", slug
+            assert complains["turn_on"] == "True", slug
+        else:
+            assert waits["turn_off"] == _negate(expected), f"{slug} / {row}"
+            assert waits["turn_on"] == expected, f"{slug} / {row}"
+
+        for direction in DIRECTIONS:
+            assert complains[direction] == _negate(waits[direction]), f"{slug} / {row} / {direction}"
+
+
+def test_diagnostic_reports_the_incident_state(blocks: dict[str, dict[str, Any]]) -> None:
+    """In the observed incident state, a ``turn_off`` complains instead of going silent.
+
+    ``R_incident`` (mirror ``on``, cloud ``off``) is what the boiler actually reported
+    while it ran for ~7 hours. Pre-fix the wait was satisfied by the cloud leg alone and
+    nothing was raised; now the wait fails and the notification fires.
+    """
+    mirror, cloud, _ = STATE_ROWS["R_incident"]
+    for slug, blk in blocks.items():
+        states = leg_states(blk, slug, mirror, cloud)
+        assert eval_ha_template(wait_of(blk, "turn_off"), states) == "False", slug
+        assert eval_ha_template(complain_of(blk, "turn_off"), states) == "True", slug
+
+
+# ============================================================================
+# A4: notifications
+# ============================================================================
+
+
+def test_notifications_have_per_direction_id(
+    parsed: dict[str, Any], blocks: dict[str, dict[str, Any]]
+) -> None:
+    """Every facade notification carries a stable, per-direction ``notification_id``.
+
+    Without an id HA generates a fresh one per call, so repeated failures pile up
+    duplicates that cannot be replaced. Per-direction ids also stop a ``turn_off``
+    result from erasing a ``turn_on`` failure.
+
+    Direction attribution is asserted through ``notification_of``, because a flat walk
+    cannot tell direction: ten *swapped* ids would pass a whole-render check alone.
+    """
+    stale_phrases = ("falling back", "Mirror did not confirm", "HK turn")
+    suffixes = {"turn_on": "_facade_on_unconfirmed", "turn_off": "_facade_off_unconfirmed"}
+    valid_ids = {f"{slug}{suffix}" for slug in blocks for suffix in suffixes.values()}
+
+    entries = all_notification_data(parsed)
+    assert len(entries) == len(blocks) * len(DIRECTIONS)
+
+    for entry in entries:
+        assert entry["notification_id"] in valid_ids, entry
+        for phrase in stale_phrases:
+            assert phrase not in entry["title"], entry
+            assert phrase not in entry["message"], entry
+
+    for slug, blk in blocks.items():
+        for direction, suffix in suffixes.items():
+            data = notification_of(blk, direction)
+            assert data["notification_id"] == f"{slug}{suffix}", f"{slug} / {direction}"
+            # The message carries both leg states, the only cheap evidence that
+            # distinguishes a truthful mirror from one frozen at its old value.
+            assert f"input_boolean.{slug}_state" in data["message"], f"{slug} / {direction}"
+            assert cloud_entity_of(blk) in data["message"], f"{slug} / {direction}"
+
+
+def test_state_stub_raises_on_unknown_entity() -> None:
+    """The layer-3 accessor raises on an unstubbed entity id.
+
+    A typo'd entity id must be a loud red, never a silent falsy read.
+    """
+    with pytest.raises(KeyError, match="unstubbed entity"):
+        eval_ha_template("{{ states('sensor.never_stubbed') }}", {})

--- a/tests/test_config_jinja_rendering.py
+++ b/tests/test_config_jinja_rendering.py
@@ -1,38 +1,44 @@
 """Tests for the Legrand/Netatmo facade switches in ``config/configuration.jinja``.
 
-The design these tests pin is stated in ``docs/stories/QS-305.story_review_fix_#01.md``
-Part 1, which supersedes the original story. The rule everything derives from:
+The design pinned here is ``docs/stories/QS-305.story_review_fix_%2301.md`` Part 1 as amended
+by ``docs/stories/QS-305.story_review_fix_%2302.md`` Part A. The rule everything derives from:
 
     **Never trust a value you just wrote. Never report a value you can't trust.**
 
-We write ``input_boolean.<slug>_command`` and we write the Netatmo cloud switch, so neither
-can be evidence -- they only parrot back what we told them. The Netatmo switch in particular
-sets ``_attr_is_on`` optimistically and writes state immediately
-(``custom_components/netatmo/switch.py:77-90``, a **fork** that shadows the core integration),
-so reading it back after our own write is guaranteed to return the target value. The mirror,
-``input_boolean.<slug>_state``, is written only by Apple Home from watching the real device,
-and is therefore the only honest witness.
+We write ``input_boolean.<slug>_command`` and we write the Netatmo cloud switch, so neither can
+be evidence -- they only parrot back what we told them. The mirror,
+``input_boolean.<slug>_state``, is written only by Apple Home from watching the real device, so
+it is the only honest witness. See the story for the forked-integration source citations.
 
 These tests catch bugs where:
 
+- The facade becomes ``unavailable``. HA filters unavailable entities out of entity-service
+  calls (``helpers/service.py:763``) and only logs a warning, and ``switch.turn_on/off`` are
+  entity services -- so an unavailable facade **silently swallows every actuation**, with no
+  script run and therefore no diagnostic either. That is the incident's shape by another route,
+  and it would fire on every HA restart while the health sensors warm up.
+- The untrusted branch emits the *string* ``unknown`` instead of ``none``. ``cv.boolean`` is
+  applied without ``none_on_unknown_unavailable``, so a string logs an ERROR on every
+  evaluation; only a real ``None`` is accepted cleanly.
 - A wait or notification condition consults the cloud leg, making the wait vacuously true and
-  the notification branch unreachable (the shipped-then-reverted defect: an un-actuated
-  ``turn_on`` was never reported).
+  the notification unreachable.
 - A wait is expressed as "the mirror is not ``on``" instead of positively confirming the
   target, so an ``unknown``/``unavailable`` mirror silently satisfies a turn-off.
-- ``state:`` or ``availability:`` reports a confident value while the mirror cannot be
-  trusted -- an entity confidently reporting ``off`` while a boiler ran is the whole incident.
-- A predicate or ``enabled: false`` can prevent either actuation write from executing.
+- A cloud-side exception aborts the script before the diagnostic can fire. ``pyatmo`` raises
+  plain ``Exception`` subclasses, which ``continue_on_error`` does **not** swallow, so the cloud
+  write lives in its own ``parallel:`` branch.
+- A predicate, or ``enabled: false``, can prevent either actuation write from executing.
 
-**Permanent gate note.** ``config/configuration.jinja`` is a non-Python file, so testmon
-cannot select this test: ``--impacted`` is blind to a template-only change. Run
+**Permanent gate note.** ``config/configuration.jinja`` is a non-Python file, so testmon cannot
+select this test: ``--impacted`` is blind to a template-only change. Run
 ``python scripts/qs/quality_gate.py --quick tests/test_config_jinja_rendering.py``
 in any PR that touches the template. CI's whole-suite run is the durable net.
 """
 
 from __future__ import annotations
 
-import re
+import copy
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -40,6 +46,13 @@ from typing import Any
 import jinja2
 import pytest
 import yaml
+from homeassistant.components.template import validators as template_validators
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.script import Script
+from homeassistant.helpers.template import Template
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import async_mock_service
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONFIG_DIR = REPO_ROOT / "config"
@@ -54,7 +67,6 @@ FIXTURE_NETATMO_ENTITIES = [
 
 LINK_SENSOR = "binary_sensor.legrand_homekit_link_healthy"
 HUB_SENSOR = "binary_sensor.homekit_hub_healthy"
-HEALTH_SENSORS = (LINK_SENSOR, HUB_SENSOR)
 
 DIRECTIONS = ("turn_on", "turn_off")
 
@@ -62,48 +74,49 @@ DIRECTIONS = ("turn_on", "turn_off")
 TARGET_OF = {"turn_on": "on", "turn_off": "off"}
 
 
+class _CloudApiError(Exception):
+    """Stand-in for pyatmo's ``ApiError``.
+
+    Verified: ``ApiError``, ``ApiThrottlingError`` and ``ApiTooManyRequestError`` are plain
+    ``Exception`` subclasses (``custom_components/netatmo/pyatmo/exceptions.py``), **not**
+    ``HomeAssistantError``, so ``continue_on_error`` does not swallow them
+    (``helpers/script.py`` -- "Only Home Assistant errors can be ignored", then ``raise``).
+    Declared locally to keep this test hermetic.
+    """
+
+
 @dataclass(frozen=True)
 class Row:
-    """One scenario for the emitted ``state:`` and ``availability:`` templates."""
+    """One scenario for the emitted ``state:`` template."""
 
     mirror: str
     link: str
     hub: str
     state: str
-    available: str
     why: str
 
 
-# Rows are NAMED, not numbered, so the state and availability expectations cannot drift.
+# Rows are NAMED, not numbered, so expectations cannot drift.
 #
-# The trust predicate is `hk_ok and mirror in ['on','off']`. `R_link_down` and `R_hub_down`
-# vary the two health sensors independently, which pins `hk_ok` as an AND -- an OR
-# implementation would pass if only one of them were ever exercised.
+# `R_link_down` and `R_hub_down` vary the two health sensors independently, which pins `hk_ok`
+# as an AND -- an OR implementation would survive if only one were ever exercised.
+#
+# "None" is the *rendered* form of `{{ none }}`; HA literal-evals it back to Python None, which
+# publishes state `unknown` while the entity stays AVAILABLE.
 ROWS: dict[str, Row] = {
-    "R_mirror_on_trusted": Row(
-        "on", "on", "on", "True", "True", "the normal running state"
-    ),
+    "R_mirror_on_trusted": Row("on", "on", "on", "True", "the normal running state"),
     "R_mirror_off_trusted": Row(
-        "off", "on", "on", "False", "True", "the only case that may report a confident off"
+        "off", "on", "on", "False", "the only case that may report a confident off"
     ),
-    "R_mirror_unknown": Row(
-        "unknown", "on", "on", "unknown", "False", "mirror not yet restored -> go dark"
-    ),
-    "R_mirror_unavailable": Row(
-        "unavailable", "on", "on", "unknown", "False", "mirror invalid -> go dark"
-    ),
-    "R_link_down": Row(
-        "on", "off", "on", "unknown", "False", "pins hk_ok as AND on the link sensor"
-    ),
-    "R_hub_down": Row(
-        "on", "on", "off", "unknown", "False", "pins hk_ok as AND on the hub sensor"
-    ),
+    "R_mirror_unknown": Row("unknown", "on", "on", "None", "mirror not restored -> report nothing"),
+    "R_mirror_unavailable": Row("unavailable", "on", "on", "None", "mirror invalid"),
+    "R_link_down": Row("on", "off", "on", "None", "pins hk_ok as AND on the link sensor"),
+    "R_hub_down": Row("on", "on", "off", "None", "pins hk_ok as AND on the hub sensor"),
     "R_health_down_mirror_off": Row(
         "off",
         "off",
         "off",
-        "unknown",
-        "False",
+        "None",
         "THE incident class: never report a confident off when we cannot see",
     ),
 }
@@ -138,9 +151,7 @@ class _TagTolerantLoader(yaml.SafeLoader):
     """
 
 
-_TagTolerantLoader.add_multi_constructor(
-    "!", lambda loader, suffix, node: f"!{suffix}"
-)
+_TagTolerantLoader.add_multi_constructor("!", lambda loader, suffix, node: f"!{suffix}")
 
 
 def parse_config(rendered: str) -> dict[str, Any]:
@@ -160,31 +171,74 @@ def facade_blocks(parsed: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return blocks
 
 
-def cloud_entity_of(blk: dict[str, Any]) -> str:
-    """Return the Netatmo cloud entity id a facade block actuates.
+# --- step accessors -------------------------------------------------------------------
+#
+# Post-B1 shape per direction:
+#   [0] input_boolean.turn_<dir>            (continue_on_error)
+#   [1] parallel:
+#         [0] sequence: [ switch.turn_<dir> (continue_on_error) ]
+#         [1] sequence: [ wait_template, choose(+default) ]
+#
+# The cloud write is isolated in its own parallel branch so a plain-Exception failure cannot
+# abort the diagnostic branch: `_async_step_parallel` gathers with `return_exceptions=True`
+# and re-raises only after every branch has completed.
 
-    Sourced from the actuation step's target, because the cloud entity is deliberately
-    absent from ``availability:`` (it may appear only as an actuation target and as
-    diagnostic text in a notification message).
-    """
-    entity_id = blk["turn_on"][1]["target"]["entity_id"]
+
+def boolean_step_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
+    """Return the local command-boolean actuation step."""
+    return blk[direction][0]
+
+
+def cloud_step_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
+    """Return the Netatmo cloud actuation step, inside its own parallel branch."""
+    return blk[direction][1]["parallel"][0]["sequence"][0]
+
+
+def diagnostic_of(blk: dict[str, Any], direction: str) -> list[dict[str, Any]]:
+    """Return the diagnostic branch's sequence: ``[wait_template, choose]``."""
+    return blk[direction][1]["parallel"][1]["sequence"]
+
+
+def actuation_steps_of(blk: dict[str, Any], direction: str) -> list[dict[str, Any]]:
+    """Return both actuation writes."""
+    return [boolean_step_of(blk, direction), cloud_step_of(blk, direction)]
+
+
+def cloud_entity_of(blk: dict[str, Any]) -> str:
+    """Return the Netatmo cloud entity id a facade block actuates."""
+    entity_id = cloud_step_of(blk, "turn_on")["target"]["entity_id"]
     assert entity_id.startswith("switch."), entity_id
     return entity_id
 
 
 def wait_of(blk: dict[str, Any], direction: str) -> str:
     """Return the ``wait_template`` of a facade block's direction script."""
-    return blk[direction][2]["wait_template"]
+    return diagnostic_of(blk, direction)[0]["wait_template"]
+
+
+def wait_step_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
+    """Return the whole wait step, for timeout assertions."""
+    return diagnostic_of(blk, direction)[0]
+
+
+def choose_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
+    """Return the diagnostic ``choose`` step."""
+    return diagnostic_of(blk, direction)[1]
 
 
 def complain_of(blk: dict[str, Any], direction: str) -> str:
     """Return the diagnostic ``choose`` condition of a direction script."""
-    return blk[direction][3]["choose"][0]["conditions"]
+    return choose_of(blk, direction)["choose"][0]["conditions"]
 
 
 def notification_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
     """Return the notification ``data`` mapping of a direction script."""
-    return blk[direction][3]["choose"][0]["sequence"][0]["data"]
+    return choose_of(blk, direction)["choose"][0]["sequence"][0]["data"]
+
+
+def dismiss_of(blk: dict[str, Any], direction: str) -> dict[str, Any]:
+    """Return the success-path ``persistent_notification.dismiss`` step."""
+    return choose_of(blk, direction)["default"][0]
 
 
 def all_notification_data(parsed: dict[str, Any]) -> list[dict[str, Any]]:
@@ -205,6 +259,21 @@ def all_notification_data(parsed: dict[str, Any]) -> list[dict[str, Any]]:
     return found
 
 
+def sub_templates_of(blk: dict[str, Any]) -> dict[str, str]:
+    """Return every template string a facade block evaluates at runtime.
+
+    Includes the notification *message* templates: a broken template there raises at runtime
+    on a step with no ``continue_on_error``, turning the diagnostic into a silent script
+    failure -- exactly the class this task exists to eliminate.
+    """
+    out = {"state": blk["state"]}
+    for direction in DIRECTIONS:
+        out[f"{direction}.wait"] = wait_of(blk, direction)
+        out[f"{direction}.conditions"] = complain_of(blk, direction)
+        out[f"{direction}.message"] = notification_of(blk, direction)["message"]
+    return out
+
+
 # ============================================================================
 # Layer 3: evaluate the emitted HA-runtime templates
 # ============================================================================
@@ -218,8 +287,8 @@ def _negate(rendered: str) -> str:
 def eval_ha_template(text: str, states: dict[str, str]) -> str:
     """Render an emitted HA-runtime template with stubbed HA globals.
 
-    Whitespace is collapsed rather than merely stripped, because ``state:`` is a ``>``
-    folded scalar whose more-indented body lines keep their newlines.
+    Whitespace is collapsed rather than merely stripped, because ``state:`` is a ``>`` folded
+    scalar whose more-indented body lines keep their newlines.
     """
 
     def _state_of(entity_id: str) -> str:
@@ -227,19 +296,27 @@ def eval_ha_template(text: str, states: dict[str, str]) -> str:
             raise KeyError(f"template read unstubbed entity {entity_id!r}")
         return states[entity_id]
 
+    class _FixedNow:
+        """Stub for ``now()`` so message templates are evaluable off a real hass."""
+
+        @staticmethod
+        def isoformat() -> str:
+            return "2026-07-30T12:00:00+02:00"
+
     env = jinja2.Environment(undefined=jinja2.StrictUndefined)
     env.globals["states"] = _state_of
     env.globals["is_state"] = lambda entity_id, value: _state_of(entity_id) == value
+    env.globals["now"] = lambda: _FixedNow()
     return " ".join(env.from_string(text).render().split())
 
 
 def trusted_states(slug: str, row: Row) -> dict[str, str]:
     """Build the ``states`` dict for one row.
 
-    The cloud entity is **deliberately absent**. Every template under test must consult
-    only the mirror and the two health sensors, so if a future edit reintroduces the cloud
-    leg into ``state:``, ``availability:``, a wait or a notification condition, the raising
-    accessor turns it into a loud ``KeyError`` rather than a silent pass.
+    The cloud entity is **deliberately absent**. Every template under test must consult only
+    the mirror and the two health sensors, so if a future edit reintroduces the cloud leg into
+    ``state:``, a wait or a notification condition, the raising accessor turns it into a loud
+    ``KeyError`` rather than a silent pass.
     """
     return {
         f"input_boolean.{slug}_state": row.mirror,
@@ -288,8 +365,10 @@ def test_facade_block_inventory(
 ) -> None:
     """Every mapped Legrand device yields exactly one cloud-actuating facade block.
 
-    This is what keeps every other assertion non-vacuous: it pins the set they quantify
-    over. Do not prune it.
+    This is what keeps every other assertion non-vacuous: it pins the set they quantify over.
+    Do not prune it. There is no longer an HK-only variant -- that branch was dead code on the
+    superseded design and was deleted, so ``cloud_entity`` is now effectively required and a
+    missing one fails the render loudly under ``StrictUndefined``.
     """
     expected_slugs = {
         key.removesuffix("_command")
@@ -304,96 +383,181 @@ def test_facade_block_inventory(
 
 
 # ============================================================================
-# Reporting: state and availability (Part 1 section 1.5)
+# Reporting (plan #02 section A1)
 # ============================================================================
+
+
+def test_facade_is_never_unavailable(blocks: dict[str, dict[str, Any]]) -> None:
+    """No ``availability:`` template may exist on the facade.
+
+    HA filters unavailable entities out of entity-service calls and only logs a warning, and
+    ``switch.turn_on/off`` are entity services -- so an unavailable facade silently swallows
+    every actuation quiet-solar issues, with no script run and therefore no diagnostic either.
+    Both health sensors force themselves ``off`` for 120 s after an HA restart, which exceeds
+    the ~70 s quiet-solar needs to give up on a command. Do not reintroduce this key.
+    """
+    for slug, blk in blocks.items():
+        assert "availability" not in blk, f"{slug} would swallow actuation when untrusted"
 
 
 @pytest.mark.parametrize("row_name", list(ROWS))
 def test_facade_reports_only_what_the_mirror_can_prove(
     blocks: dict[str, dict[str, Any]], row_name: str
 ) -> None:
-    """``state:`` is the mirror when trusted, and nothing at all when it is not.
-
-    Never report ``off`` when the mirror cannot be trusted. The Netatmo leg is not a
-    fallback: a backup that lies is worse than no backup, because it sits at ``off`` and
-    reports it with full confidence, turning every HomeKit outage into exactly the false
-    ``off`` this work exists to eliminate. Going dark honestly is better.
-    """
+    """``state:`` is the mirror when trusted, and ``none`` when it is not."""
     row = ROWS[row_name]
     for slug, blk in blocks.items():
         states = trusted_states(slug, row)
         assert eval_ha_template(blk["state"], states) == row.state, f"{slug} / {row_name}"
-        assert (
-            eval_ha_template(blk["availability"], states) == row.available
-        ), f"{slug} / {row_name} availability"
 
 
-def test_facade_never_reports_confident_off_while_untrusted(
+def test_untrusted_state_emits_none_not_the_string_unknown(
     blocks: dict[str, dict[str, Any]],
 ) -> None:
-    """The incident class, asserted directly rather than only via the row table.
+    """The untrusted branch must emit ``none``, never the literal ``unknown``.
 
-    An entity confidently reporting ``off`` while a boiler ran is the entire incident.
+    ``cv.boolean`` is applied without ``none_on_unknown_unavailable``, so the string
+    ``unknown`` fails validation, takes the error path and logs an ERROR on **every**
+    evaluation. Only a real ``None`` is accepted cleanly.
     """
-    for row_name, row in ROWS.items():
-        if row.available == "True":
-            continue
+    for slug, blk in blocks.items():
+        assert "unknown" not in blk["state"], f"{slug} still emits a literal state string"
+        assert "unavailable" not in blk["state"], slug
+
+
+async def test_untrusted_state_parses_to_none_without_error(
+    hass: HomeAssistant, blocks: dict[str, dict[str, Any]]
+) -> None:
+    """End-to-end: HA parses the untrusted branch to ``None``, with no ERROR logged.
+
+    Asserted through Home Assistant's own ``Template`` and the template platform's validator
+    rather than the layer-3 stub, because this is the single most likely thing to be silently
+    wrong: a string here would still *look* like ``unknown`` in the UI while logging an error
+    on every state evaluation.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Capture(level=logging.ERROR)
+    validators_logger = logging.getLogger(template_validators.__name__)
+    validators_logger.addHandler(handler)
+    try:
         for slug, blk in blocks.items():
-            reported = eval_ha_template(blk["state"], trusted_states(slug, row))
-            assert reported == "unknown", f"{slug} / {row_name} leaked {reported!r}"
+            # Untrusted: HomeKit link down.
+            hass.states.async_set(LINK_SENSOR, "off")
+            hass.states.async_set(HUB_SENSOR, "on")
+            hass.states.async_set(f"input_boolean.{slug}_state", "on")
+            result = Template(blk["state"], hass).async_render(parse_result=True)
+            assert result is None, f"{slug} rendered {result!r} instead of None"
+            # This is the check the template platform actually applies to `state:`.
+            assert template_validators.check_result_for_none(result) is True, slug
+
+            # Trusted: the same template must still yield a real boolean.
+            hass.states.async_set(LINK_SENSOR, "on")
+            trusted = Template(blk["state"], hass).async_render(parse_result=True)
+            assert trusted is True, f"{slug} rendered {trusted!r} instead of True"
+    finally:
+        validators_logger.removeHandler(handler)
+
+    assert not records, f"validator logged errors: {[r.getMessage() for r in records]}"
+
+
+async def test_actuation_reaches_the_entity_while_untrusted(
+    hass: HomeAssistant, blocks: dict[str, dict[str, Any]]
+) -> None:
+    """The §A1 regression, closed by demonstration rather than by argument.
+
+    Sets up the real facade through the ``template`` integration with the HomeKit link down, so
+    the facade publishes ``unknown``, then calls ``switch.turn_on`` on it and asserts the local
+    actuation actually executed. Had an ``availability:`` template made the entity unavailable,
+    HA would have filtered it out of the service call with only a warning and this would fail --
+    which is precisely how every actuation would be lost for 120 s after each HA restart.
+    """
+    slug, blk = next(iter(blocks.items()))
+    mirror = f"input_boolean.{slug}_state"
+
+    # Untrusted (link down) but the turn_on wait is immediately satisfied, so the script is fast.
+    hass.states.async_set(LINK_SENSOR, "off")
+    hass.states.async_set(HUB_SENSOR, "on")
+    hass.states.async_set(mirror, "on")
+
+    driven = async_mock_service(hass, "input_boolean", "turn_on")
+    async_mock_service(hass, "persistent_notification", "dismiss")
+
+    assert await async_setup_component(hass, "template", {"template": [{"switch": [blk]}]})
+    await hass.async_block_till_done()
+
+    facade = next(e for e in hass.states.async_entity_ids("switch") if e.endswith("_facade"))
+    assert hass.states.get(facade).state == "unknown", "expected the untrusted scenario"
+
+    await hass.services.async_call(
+        "switch", "turn_on", {"entity_id": facade}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert len(driven) == 1, "the untrusted facade swallowed the actuation"
+    assert driven[0].data["entity_id"] == [f"input_boolean.{slug}_command"]
 
 
 def test_cloud_leg_cannot_move_the_facade(blocks: dict[str, dict[str, Any]]) -> None:
-    """The cloud leg has no effect whatsoever on what the facade reports.
-
-    Seeds the cloud entity at ``on`` and at ``off`` against a mirror reading the opposite
-    and asserts the reported state and availability are identical. This is the regression
-    guard for "the Netatmo leg is not a fallback for state".
-    """
+    """The cloud leg has no effect whatsoever on what the facade reports."""
     for slug, blk in blocks.items():
         cloud = cloud_entity_of(blk)
         for mirror in ("on", "off"):
-            row = Row(mirror, "on", "on", "", "", "probe")
-            base = trusted_states(slug, row)
-            results = set()
-            avail = set()
-            for cloud_value in ("on", "off", "unavailable"):
-                probe = dict(base) | {cloud: cloud_value}
-                results.add(eval_ha_template(blk["state"], probe))
-                avail.add(eval_ha_template(blk["availability"], probe))
+            base = trusted_states(slug, Row(mirror, "on", "on", "", "probe"))
+            results = {
+                eval_ha_template(blk["state"], dict(base) | {cloud: value})
+                for value in ("on", "off", "unavailable")
+            }
             assert results == {"True" if mirror == "on" else "False"}, f"{slug}/{mirror}"
-            assert avail == {"True"}, f"{slug}/{mirror}"
 
 
-def test_state_and_availability_never_read_last_changed(
-    blocks: dict[str, dict[str, Any]],
-) -> None:
-    """No ``last_changed`` anywhere: a stale leg keeps an old timestamp."""
+def test_no_sub_template_reads_last_changed(blocks: dict[str, dict[str, Any]]) -> None:
+    """No ``last_changed`` in any evaluated template, including message text.
+
+    A stale leg keeps an old timestamp, so ``last_changed`` is never a validity signal.
+    Message text is included because a broken template there fails silently at runtime.
+    """
     for slug, blk in blocks.items():
-        assert "last_changed" not in blk["state"], slug
-        assert "last_changed" not in blk["availability"], slug
+        for name, text in sub_templates_of(blk).items():
+            assert "last_changed" not in text, f"{slug} / {name}"
 
 
-def test_cloud_entity_confined_to_actuation_and_message(
-    blocks: dict[str, dict[str, Any]],
-) -> None:
-    """The cloud entity id appears only where Part 1 section 1.6 permits it.
+def test_every_sub_template_evaluates(blocks: dict[str, dict[str, Any]]) -> None:
+    """Every runtime template renders, including the notification messages.
 
-    Allowed: the target of the actuation write, and the notification message as diagnostic
-    context. Forbidden: ``state:``, ``availability:``, either wait, either notification
-    condition.
+    Substring checks alone would let a broken message template through; at runtime that raises
+    on a step with no ``continue_on_error``, converting the diagnostic into a silent failure.
+    """
+    for slug, blk in blocks.items():
+        states = trusted_states(slug, ROWS["R_mirror_on_trusted"])
+        for name, text in sub_templates_of(blk).items():
+            out = eval_ha_template(text, states)
+            assert out, f"{slug} / {name} rendered empty"
+
+
+def test_cloud_entity_confined_to_actuation(blocks: dict[str, dict[str, Any]]) -> None:
+    """The cloud entity id appears only as an actuation target.
+
+    It is no longer quoted in the notification message either: the fork writes state
+    optimistically and ignores the API's return value, so ``cloud=`` echoed our own command (or
+    a stale pre-command value) and could never tell the operator whether the write was accepted.
     """
     for slug, blk in blocks.items():
         cloud = cloud_entity_of(blk)
         assert cloud not in blk["state"], f"{slug}: cloud leaked into state"
-        assert cloud not in blk["availability"], f"{slug}: cloud leaked into availability"
         for direction in DIRECTIONS:
             assert cloud not in wait_of(blk, direction), f"{slug}/{direction} wait"
             assert cloud not in complain_of(blk, direction), f"{slug}/{direction} condition"
+            message = notification_of(blk, direction)["message"]
+            assert cloud not in message, f"{slug}/{direction} message quotes an inert leg"
 
 
 # ============================================================================
-# Actuation: unconditional, both channels (Part 1 sections 1.3, 1.6)
+# Actuation (plan #01 sections 1.3, 1.6; plan #02 B1)
 # ============================================================================
 
 
@@ -401,41 +565,81 @@ def test_cloud_entity_confined_to_actuation_and_message(
 def test_both_channels_driven_unconditionally(
     blocks: dict[str, dict[str, Any]], direction: str
 ) -> None:
-    """Both channels are driven every time, and nothing can suppress either write.
-
-    We cannot know in advance which channel will work, and *deciding* is exactly what
-    caused the incident. Both steps carry ``continue_on_error`` so a failure of one still
-    drives the other -- notably, an exception on the local boolean must not abort before
-    the cloud, which is the verified-working actuator.
-    """
+    """Both channels are driven every time, and nothing can suppress either write."""
     for slug, blk in blocks.items():
         steps = blk[direction]
-        assert len(steps) == 4, f"{slug} / {direction}: expected actuation head + diagnostic"
+        assert len(steps) == 2, f"{slug}/{direction}: expected boolean write + parallel"
 
-        assert steps[0].get("action") == f"input_boolean.{direction}", f"{slug}/{direction}"
-        assert steps[0]["target"]["entity_id"] == f"input_boolean.{slug}_command"
+        boolean_step = boolean_step_of(blk, direction)
+        assert boolean_step.get("action") == f"input_boolean.{direction}", f"{slug}/{direction}"
+        assert boolean_step["target"]["entity_id"] == f"input_boolean.{slug}_command"
 
-        assert steps[1].get("action") == f"switch.{direction}", f"{slug}/{direction}"
-        assert steps[1]["target"]["entity_id"] == cloud_entity_of(blk)
+        cloud_step = cloud_step_of(blk, direction)
+        assert cloud_step.get("action") == f"switch.{direction}", f"{slug}/{direction}"
+        assert cloud_step["target"]["entity_id"] == cloud_entity_of(blk)
 
-        for index in (0, 1):
-            assert steps[index].get("continue_on_error") is True, f"{slug}/{direction}/{index}"
-            # HA honours `enabled: false` on a script action, which would silently
-            # disable an actuation write while every other assertion still passed.
-            assert "enabled" not in steps[index], f"{slug}/{direction}: step {index} disabled"
+        for index, step in enumerate(actuation_steps_of(blk, direction)):
+            assert step.get("continue_on_error") is True, f"{slug}/{direction}/{index}"
+            # HA honours `enabled: false` on a script action, which would silently disable an
+            # actuation write while every other assertion still passed.
+            assert "enabled" not in step, f"{slug}/{direction}: actuation {index} disabled"
+            assert "variables" not in step, f"{slug}/{direction}: actuation {index} conditional"
+            assert "choose" not in step, f"{slug}/{direction}: actuation {index} branches"
 
-        assert steps[2]["timeout"] == "00:00:10", f"{slug}/{direction}"
-        assert steps[2]["continue_on_timeout"] is True, f"{slug}/{direction}"
+        # The cloud write is isolated so its exceptions cannot abort the diagnostic.
+        branches = steps[1]["parallel"]
+        assert len(branches) == 2, f"{slug}/{direction}"
+        assert len(branches[0]["sequence"]) == 1, f"{slug}/{direction}: cloud branch not isolated"
 
-        for index, step in enumerate(steps):
-            assert "variables" not in step, f"{slug}/{direction}: step {index} is conditional"
-            assert ("choose" in step) == (index == 3), (
-                f"{slug}/{direction}: step {index} must not branch"
-            )
+        wait_step = wait_step_of(blk, direction)
+        assert wait_step["timeout"] == "00:00:10", f"{slug}/{direction}"
+        assert wait_step["continue_on_timeout"] is True, f"{slug}/{direction}"
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+async def test_notification_fires_when_cloud_write_raises(
+    hass: HomeAssistant, blocks: dict[str, dict[str, Any]], direction: str
+) -> None:
+    """B1: a non-``HomeAssistantError`` from the cloud step must not suppress the diagnostic.
+
+    ``continue_on_error`` only swallows ``HomeAssistantError`` subclasses, but pyatmo raises
+    plain ``Exception`` subclasses on a 429/throttle or a dropped connection -- a documented
+    operating condition for this fork. Before the ``parallel:`` split that aborted the script
+    at the cloud step, so the single failure the diagnostic exists to report was the one that
+    silenced it.
+
+    Runs the real rendered sequence through HA's ``Script`` helper.
+    """
+    slug, blk = next(iter(blocks.items()))
+    mirror = f"input_boolean.{slug}_state"
+
+    # Mirror parked at the value that does NOT confirm this direction, so the wait must fail.
+    hass.states.async_set(mirror, "on" if direction == "turn_off" else "off")
+
+    async_mock_service(hass, "input_boolean", direction)
+    created = async_mock_service(hass, "persistent_notification", "create")
+    async_mock_service(hass, "persistent_notification", "dismiss")
+
+    async def _raise(call: Any) -> None:
+        raise _CloudApiError("429 throttled")
+
+    hass.services.async_register("switch", direction, _raise)
+
+    sequence = copy.deepcopy(blk[direction])
+    # Shorten the wait so the test is fast; the 10 s value is asserted structurally above.
+    diagnostic_of({direction: sequence}, direction)[0]["timeout"] = {"seconds": 0.05}
+
+    script = Script(hass, cv.SCRIPT_SCHEMA(sequence), f"{slug} {direction}", "template")
+    with pytest.raises(_CloudApiError):
+        await script.async_run(context=Context())
+    await hass.async_block_till_done()
+
+    assert len(created) == 1, "the cloud exception suppressed the diagnostic notification"
+    assert created[0].data["notification_id"] == f"{slug}_facade_{TARGET_OF[direction]}_unconfirmed"
 
 
 # ============================================================================
-# Diagnostics: positive confirmation on the mirror (Part 1 sections 1.3, 1.4)
+# Diagnostics (plan #01 sections 1.3, 1.4)
 # ============================================================================
 
 
@@ -443,20 +647,15 @@ def test_both_channels_driven_unconditionally(
 def test_wait_positively_confirms_the_target_value(
     blocks: dict[str, dict[str, Any]], direction: str
 ) -> None:
-    """Each wait confirms the target value itself, never the absence of its opposite.
-
-    ``not is_state(mirror,'on')`` is satisfied by an ``unavailable`` or ``unknown`` mirror,
-    which would let us silently conclude a turn-off succeeded. Confirm the target.
-    """
+    """Each wait confirms the target value itself, never the absence of its opposite."""
     target = TARGET_OF[direction]
     for slug, blk in blocks.items():
         wait = wait_of(blk, direction)
         assert f"'{target}'" in wait, f"{slug}/{direction} does not mention {target!r}"
         assert "not " not in wait, f"{slug}/{direction} is expressed as a negation: {wait}"
 
-        # An invalid mirror must NOT satisfy either direction's wait.
         for mirror in ("unknown", "unavailable"):
-            states = trusted_states(slug, Row(mirror, "on", "on", "", "", "probe"))
+            states = trusted_states(slug, Row(mirror, "on", "on", "", "probe"))
             assert eval_ha_template(wait, states) == "False", f"{slug}/{direction}/{mirror}"
 
 
@@ -466,9 +665,9 @@ def test_wait_and_complain_track_the_mirror_only(
 ) -> None:
     """The wait is satisfied exactly when the mirror reads the target value.
 
-    Deliberately **not** the old ``wait == not state`` identity. ``state:`` answers "is the
-    load on?" and consults ``hk_ok``; the wait answers "did the mirror confirm the target?"
-    and does not. The divergence is intentional -- do not "fix" it back.
+    Deliberately **not** the old ``wait == not state`` identity. ``state:`` answers "is the load
+    on?" and consults ``hk_ok``; the wait answers "did the mirror confirm the target?" and does
+    not. The divergence is intentional -- do not "fix" it back.
     """
     row = ROWS[row_name]
     for slug, blk in blocks.items():
@@ -477,7 +676,6 @@ def test_wait_and_complain_track_the_mirror_only(
             expected = "True" if row.mirror == TARGET_OF[direction] else "False"
             wait = eval_ha_template(wait_of(blk, direction), states)
             assert wait == expected, f"{slug}/{row_name}/{direction}"
-            # We complain exactly when the wait was not satisfied.
             complain = eval_ha_template(complain_of(blk, direction), states)
             assert complain == _negate(wait), f"{slug}/{row_name}/{direction} condition"
 
@@ -485,15 +683,9 @@ def test_wait_and_complain_track_the_mirror_only(
 def test_notifications_have_per_direction_id(
     parsed: dict[str, Any], blocks: dict[str, dict[str, Any]]
 ) -> None:
-    """Every facade notification carries a stable, per-direction ``notification_id``.
-
-    Without an id HA generates a fresh one per call, so repeated failures pile up
-    duplicates that cannot be replaced. Direction attribution is asserted through
-    ``notification_of``, because a flat walk cannot tell direction: ten *swapped* ids
-    would otherwise pass.
-    """
-    # "Mirror did not confirm" is absent from this list on purpose: under the mirror-only
-    # design the message legitimately says the mirror did not confirm.
+    """Every facade notification carries a stable, per-direction ``notification_id``."""
+    # "Mirror did not confirm" is absent on purpose: under the mirror-only design the message
+    # legitimately says the mirror did not confirm.
     stale_phrases = ("falling back", "HK turn")
     suffixes = {"turn_on": "_facade_on_unconfirmed", "turn_off": "_facade_off_unconfirmed"}
     valid_ids = {f"{slug}{suffix}" for slug in blocks for suffix in suffixes.values()}
@@ -511,10 +703,24 @@ def test_notifications_have_per_direction_id(
         for direction, suffix in suffixes.items():
             data = notification_of(blk, direction)
             assert data["notification_id"] == f"{slug}{suffix}", f"{slug}/{direction}"
-            # Both leg states are reported: the cheapest evidence that distinguishes a
-            # truthful mirror from one frozen at its old value.
             assert f"input_boolean.{slug}_state" in data["message"], f"{slug}/{direction}"
-            assert cloud_entity_of(blk) in data["message"], f"{slug}/{direction}"
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_success_path_dismisses_the_notification(
+    blocks: dict[str, dict[str, Any]], direction: str
+) -> None:
+    """A confirmed command clears any stale notification for that direction.
+
+    Otherwise a transient failure leaves an alarm standing forever, even once the mirror has
+    confirmed -- the same "a stale signal carries no information" problem as the log line this
+    notification replaced.
+    """
+    suffix = TARGET_OF[direction]
+    for slug, blk in blocks.items():
+        step = dismiss_of(blk, direction)
+        assert step["action"] == "persistent_notification.dismiss", f"{slug}/{direction}"
+        assert step["data"]["notification_id"] == f"{slug}_facade_{suffix}_unconfirmed"
 
 
 def test_state_stub_raises_on_unknown_entity() -> None:

--- a/tests/test_config_jinja_rendering.py
+++ b/tests/test_config_jinja_rendering.py
@@ -1,23 +1,39 @@
 """Tests for the Legrand/Netatmo facade switches in ``config/configuration.jinja``.
 
+The design these tests pin is stated in ``docs/stories/QS-305.story_review_fix_#01.md``
+Part 1, which supersedes the original story. The rule everything derives from:
+
+    **Never trust a value you just wrote. Never report a value you can't trust.**
+
+We write ``input_boolean.<slug>_command`` and we write the Netatmo cloud switch, so neither
+can be evidence -- they only parrot back what we told them. The Netatmo switch in particular
+sets ``_attr_is_on`` optimistically and writes state immediately
+(``custom_components/netatmo/switch.py:77-90``, a **fork** that shadows the core integration),
+so reading it back after our own write is guaranteed to return the target value. The mirror,
+``input_boolean.<slug>_state``, is written only by Apple Home from watching the real device,
+and is therefore the only honest witness.
+
 These tests catch bugs where:
 
-- The facade's ``state:`` template reports ``off`` while some leg still reports ``on``
-  (the QS-305 incident: a boiler ran ~7 hours after being commanded off).
-- A predicate suppresses actuation on one of the two channels, so the channel that
-  actually works is never driven.
-- The wait / complain predicates disagree with what ``state:`` reports.
-- ``persistent_notification`` calls lose their per-direction ``notification_id``.
+- A wait or notification condition consults the cloud leg, making the wait vacuously true and
+  the notification branch unreachable (the shipped-then-reverted defect: an un-actuated
+  ``turn_on`` was never reported).
+- A wait is expressed as "the mirror is not ``on``" instead of positively confirming the
+  target, so an ``unknown``/``unavailable`` mirror silently satisfies a turn-off.
+- ``state:`` or ``availability:`` reports a confident value while the mirror cannot be
+  trusted -- an entity confidently reporting ``off`` while a boiler ran is the whole incident.
+- A predicate or ``enabled: false`` can prevent either actuation write from executing.
 
-**Permanent gate note.** ``config/configuration.jinja`` is a non-Python file, so
-testmon cannot select this test: ``--impacted`` is blind to a template-only change.
-Run ``python scripts/qs/quality_gate.py --quick tests/test_config_jinja_rendering.py``
+**Permanent gate note.** ``config/configuration.jinja`` is a non-Python file, so testmon
+cannot select this test: ``--impacted`` is blind to a template-only change. Run
+``python scripts/qs/quality_gate.py --quick tests/test_config_jinja_rendering.py``
 in any PR that touches the template. CI's whole-suite run is the durable net.
 """
 
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -28,37 +44,68 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONFIG_DIR = REPO_ROOT / "config"
 
-# Exercises both generator-side filters at lines 67-84: only the first entry
-# passes `startswith('sensor.')` and `endswith('_power')`.
+# Exercises both generator-side filters: only the first entry passes
+# `startswith('sensor.')` and `endswith('_power')`.
 FIXTURE_NETATMO_ENTITIES = [
     "sensor.cumulus_pool_house_power",  # passes both filters
     "sensor.not_a_power_entity",  # fails endswith('_power')
     "switch.cumulus_pool_house",  # fails startswith('sensor.')
 ]
 
-HEALTH_SENSORS = (
-    "binary_sensor.legrand_homekit_link_healthy",
-    "binary_sensor.homekit_hub_healthy",
-)
+LINK_SENSOR = "binary_sensor.legrand_homekit_link_healthy"
+HUB_SENSOR = "binary_sensor.homekit_hub_healthy"
+HEALTH_SENSORS = (LINK_SENSOR, HUB_SENSOR)
 
 DIRECTIONS = ("turn_on", "turn_off")
 
-# The A1 fail-safe reporting table. Rows are NAMED, not numbered, so A1 and A3
-# cannot drift apart. Each entry is (mirror, cloud, expected rendered state).
+# The value each direction positively confirms on the mirror.
+TARGET_OF = {"turn_on": "on", "turn_off": "off"}
+
+
+@dataclass(frozen=True)
+class Row:
+    """One scenario for the emitted ``state:`` and ``availability:`` templates."""
+
+    mirror: str
+    link: str
+    hub: str
+    state: str
+    available: str
+    why: str
+
+
+# Rows are NAMED, not numbered, so the state and availability expectations cannot drift.
 #
-# `R_both_on` is load-bearing: without a both-legs-on row, an XOR implementation
-# (`(mirror=='on') != (cloud=='on')`) passes every other row while reporting `off`
-# with both legs on. The mirror uses `unknown`, never `unavailable`, because an
-# `input_boolean` never goes unavailable.
-STATE_ROWS: dict[str, tuple[str, str, str]] = {
-    "R_both_on": ("on", "on", "True"),
-    "R_incident": ("on", "off", "True"),
-    "R_cloud_only": ("off", "on", "True"),
-    "R_both_off": ("off", "off", "False"),
-    "R_mirror_invalid_on": ("unknown", "on", "True"),
-    "R_mirror_invalid_off": ("unknown", "off", "False"),
-    "R_cloud_unavailable": ("off", "unavailable", "False"),
-    "R_none_valid": ("unknown", "unknown", "unknown"),
+# The trust predicate is `hk_ok and mirror in ['on','off']`. `R_link_down` and `R_hub_down`
+# vary the two health sensors independently, which pins `hk_ok` as an AND -- an OR
+# implementation would pass if only one of them were ever exercised.
+ROWS: dict[str, Row] = {
+    "R_mirror_on_trusted": Row(
+        "on", "on", "on", "True", "True", "the normal running state"
+    ),
+    "R_mirror_off_trusted": Row(
+        "off", "on", "on", "False", "True", "the only case that may report a confident off"
+    ),
+    "R_mirror_unknown": Row(
+        "unknown", "on", "on", "unknown", "False", "mirror not yet restored -> go dark"
+    ),
+    "R_mirror_unavailable": Row(
+        "unavailable", "on", "on", "unknown", "False", "mirror invalid -> go dark"
+    ),
+    "R_link_down": Row(
+        "on", "off", "on", "unknown", "False", "pins hk_ok as AND on the link sensor"
+    ),
+    "R_hub_down": Row(
+        "on", "on", "off", "unknown", "False", "pins hk_ok as AND on the hub sensor"
+    ),
+    "R_health_down_mirror_off": Row(
+        "off",
+        "off",
+        "off",
+        "unknown",
+        "False",
+        "THE incident class: never report a confident off when we cannot see",
+    ),
 }
 
 
@@ -68,10 +115,7 @@ STATE_ROWS: dict[str, tuple[str, str, str]] = {
 
 
 def render_config() -> str:
-    """Render ``config/configuration.jinja`` with the generator-layer globals stubbed.
-
-    ``integration_entities`` is the only global the template needs at generation time.
-    """
+    """Render ``config/configuration.jinja`` with the generator-layer globals stubbed."""
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(CONFIG_DIR),
         undefined=jinja2.StrictUndefined,
@@ -89,8 +133,8 @@ class _TagTolerantLoader(yaml.SafeLoader):
     """SafeLoader that degrades unknown ``!tag`` nodes to plain strings.
 
     The rendered config uses ``!include``, which ``yaml.SafeLoader`` rejects. The
-    multi-constructor is registered on this subclass rather than on
-    ``yaml.SafeLoader`` so every other test's ``yaml.safe_load`` stays strict.
+    multi-constructor is registered on this subclass rather than on ``yaml.SafeLoader``
+    so every other test's ``yaml.safe_load`` stays strict.
     """
 
 
@@ -105,35 +149,27 @@ def parse_config(rendered: str) -> dict[str, Any]:
 
 
 def facade_blocks(parsed: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """Return the generated Legrand facade switch blocks, keyed by device slug.
-
-    Walks ``template:`` items (some also carry ``trigger:``, so no item-shape
-    assumption is made) and keeps ``- switch:`` entries whose ``unique_id`` ends
-    with ``_facade``.
-    """
+    """Return the generated Legrand facade switch blocks, keyed by device slug."""
     blocks: dict[str, dict[str, Any]] = {}
     for item in parsed["template"]:
         for blk in item.get("switch", []):
             unique_id = blk.get("unique_id", "")
             if unique_id.endswith("_facade"):
                 blocks[unique_id.removesuffix("_facade")] = blk
-    assert blocks, "no facade blocks found; the inventory would be vacuous"
+    assert blocks, "no facade blocks found; every other assertion would be vacuous"
     return blocks
 
 
 def cloud_entity_of(blk: dict[str, Any]) -> str:
-    """Return the Netatmo cloud entity id a facade block falls back to.
+    """Return the Netatmo cloud entity id a facade block actuates.
 
-    Read out of ``availability:``, which is untouched by QS-305, so this helper
-    works identically before and after the edit.
+    Sourced from the actuation step's target, because the cloud entity is deliberately
+    absent from ``availability:`` (it may appear only as an actuation target and as
+    diagnostic text in a notification message).
     """
-    matches = [
-        entity_id
-        for entity_id in re.findall(r"states\('([^']+)'\)", blk["availability"])
-        if entity_id.startswith("switch.")
-    ]
-    assert len(matches) == 1, f"expected exactly one cloud entity, got {matches}"
-    return matches[0]
+    entity_id = blk["turn_on"][1]["target"]["entity_id"]
+    assert entity_id.startswith("switch."), entity_id
+    return entity_id
 
 
 def wait_of(blk: dict[str, Any], direction: str) -> str:
@@ -182,8 +218,8 @@ def _negate(rendered: str) -> str:
 def eval_ha_template(text: str, states: dict[str, str]) -> str:
     """Render an emitted HA-runtime template with stubbed HA globals.
 
-    Whitespace is collapsed rather than merely stripped, because ``state:`` is a
-    ``>`` folded scalar whose more-indented body lines keep their newlines.
+    Whitespace is collapsed rather than merely stripped, because ``state:`` is a ``>``
+    folded scalar whose more-indented body lines keep their newlines.
     """
 
     def _state_of(entity_id: str) -> str:
@@ -197,18 +233,18 @@ def eval_ha_template(text: str, states: dict[str, str]) -> str:
     return " ".join(env.from_string(text).render().split())
 
 
-def leg_states(blk: dict[str, Any], slug: str, mirror: str, cloud: str) -> dict[str, str]:
-    """Build a four-key ``states`` dict for one row of the A1 table.
+def trusted_states(slug: str, row: Row) -> dict[str, str]:
+    """Build the ``states`` dict for one row.
 
-    The two health sensors are seeded because the *pre-edit* ``state:`` reads them
-    before the race tail; a two-key dict would raise ``KeyError`` on every row and
-    mask the failure under test.
+    The cloud entity is **deliberately absent**. Every template under test must consult
+    only the mirror and the two health sensors, so if a future edit reintroduces the cloud
+    leg into ``state:``, ``availability:``, a wait or a notification condition, the raising
+    accessor turns it into a loud ``KeyError`` rather than a silent pass.
     """
     return {
-        f"input_boolean.{slug}_state": mirror,
-        cloud_entity_of(blk): cloud,
-        HEALTH_SENSORS[0]: "on",
-        HEALTH_SENSORS[1]: "on",
+        f"input_boolean.{slug}_state": row.mirror,
+        LINK_SENSOR: row.link,
+        HUB_SENSOR: row.hub,
     }
 
 
@@ -236,7 +272,7 @@ def blocks(parsed: dict[str, Any]) -> dict[str, dict[str, Any]]:
 
 
 # ============================================================================
-# A5: render and parse
+# Render, parse, inventory
 # ============================================================================
 
 
@@ -247,12 +283,13 @@ def test_config_jinja_renders_and_parses(parsed: dict[str, Any]) -> None:
     assert "input_boolean" in parsed
 
 
-def test_facade_block_inventory(parsed: dict[str, Any], blocks: dict[str, dict[str, Any]]) -> None:
-    """Every mapped Legrand device yields exactly one cloud-backed facade block.
+def test_facade_block_inventory(
+    parsed: dict[str, Any], blocks: dict[str, dict[str, Any]]
+) -> None:
+    """Every mapped Legrand device yields exactly one cloud-actuating facade block.
 
-    This is what keeps A1-A4 non-vacuous: it pins the set the other tests quantify
-    over, and asserts cloud-backedness with a predicate that holds both before and
-    after the QS-305 edit. Do not prune it.
+    This is what keeps every other assertion non-vacuous: it pins the set they quantify
+    over. Do not prune it.
     """
     expected_slugs = {
         key.removesuffix("_command")
@@ -263,46 +300,100 @@ def test_facade_block_inventory(parsed: dict[str, Any], blocks: dict[str, dict[s
     assert set(blocks) == expected_slugs
 
     for slug, blk in blocks.items():
-        assert "switch." in blk["availability"], f"{slug} is not cloud-backed"
         assert cloud_entity_of(blk).startswith("switch."), slug
 
 
 # ============================================================================
-# A1: fail-safe reporting
+# Reporting: state and availability (Part 1 section 1.5)
 # ============================================================================
 
 
-def test_facade_state_never_reads_last_changed(blocks: dict[str, dict[str, Any]]) -> None:
-    """The facade ``state:`` elects no winner and trusts no health sensor.
+@pytest.mark.parametrize("row_name", list(ROWS))
+def test_facade_reports_only_what_the_mirror_can_prove(
+    blocks: dict[str, dict[str, Any]], row_name: str
+) -> None:
+    """``state:`` is the mirror when trusted, and nothing at all when it is not.
 
-    ``last_changed`` was the wrong arbiter (a stale leg keeps an old timestamp), and
-    gating mirror validity on ``hk_ok`` let a healthy-looking link vouch for a frozen
-    mirror. The health-sensor entity ids are asserted absent *positively*, so a
-    re-inlined health test cannot survive as a mere name change.
+    Never report ``off`` when the mirror cannot be trusted. The Netatmo leg is not a
+    fallback: a backup that lies is worse than no backup, because it sits at ``off`` and
+    reports it with full confidence, turning every HomeKit outage into exactly the false
+    ``off`` this work exists to eliminate. Going dark honestly is better.
+    """
+    row = ROWS[row_name]
+    for slug, blk in blocks.items():
+        states = trusted_states(slug, row)
+        assert eval_ha_template(blk["state"], states) == row.state, f"{slug} / {row_name}"
+        assert (
+            eval_ha_template(blk["availability"], states) == row.available
+        ), f"{slug} / {row_name} availability"
+
+
+def test_facade_never_reports_confident_off_while_untrusted(
+    blocks: dict[str, dict[str, Any]],
+) -> None:
+    """The incident class, asserted directly rather than only via the row table.
+
+    An entity confidently reporting ``off`` while a boiler ran is the entire incident.
+    """
+    for row_name, row in ROWS.items():
+        if row.available == "True":
+            continue
+        for slug, blk in blocks.items():
+            reported = eval_ha_template(blk["state"], trusted_states(slug, row))
+            assert reported == "unknown", f"{slug} / {row_name} leaked {reported!r}"
+
+
+def test_cloud_leg_cannot_move_the_facade(blocks: dict[str, dict[str, Any]]) -> None:
+    """The cloud leg has no effect whatsoever on what the facade reports.
+
+    Seeds the cloud entity at ``on`` and at ``off`` against a mirror reading the opposite
+    and asserts the reported state and availability are identical. This is the regression
+    guard for "the Netatmo leg is not a fallback for state".
     """
     for slug, blk in blocks.items():
-        state = blk["state"]
-        assert "last_changed" not in state, slug
-        assert "hk_ok" not in state, slug
-        for sensor in HEALTH_SENSORS:
-            assert sensor not in state, f"{slug} still reads {sensor}"
+        cloud = cloud_entity_of(blk)
+        for mirror in ("on", "off"):
+            row = Row(mirror, "on", "on", "", "", "probe")
+            base = trusted_states(slug, row)
+            results = set()
+            avail = set()
+            for cloud_value in ("on", "off", "unavailable"):
+                probe = dict(base) | {cloud: cloud_value}
+                results.add(eval_ha_template(blk["state"], probe))
+                avail.add(eval_ha_template(blk["availability"], probe))
+            assert results == {"True" if mirror == "on" else "False"}, f"{slug}/{mirror}"
+            assert avail == {"True"}, f"{slug}/{mirror}"
 
 
-@pytest.mark.parametrize("row", list(STATE_ROWS))
-def test_facade_state_is_fail_safe(blocks: dict[str, dict[str, Any]], row: str) -> None:
-    """The facade reports ``off`` only when no valid leg says ``on``.
-
-    False-``off`` is the incident's failure mode and is narrowed to "all valid legs
-    stuck at ``off``"; false-``on`` is the accepted cost and is what D3 reports on.
-    """
-    mirror, cloud, expected = STATE_ROWS[row]
+def test_state_and_availability_never_read_last_changed(
+    blocks: dict[str, dict[str, Any]],
+) -> None:
+    """No ``last_changed`` anywhere: a stale leg keeps an old timestamp."""
     for slug, blk in blocks.items():
-        states = leg_states(blk, slug, mirror, cloud)
-        assert eval_ha_template(blk["state"], states) == expected, f"{slug} / {row}"
+        assert "last_changed" not in blk["state"], slug
+        assert "last_changed" not in blk["availability"], slug
+
+
+def test_cloud_entity_confined_to_actuation_and_message(
+    blocks: dict[str, dict[str, Any]],
+) -> None:
+    """The cloud entity id appears only where Part 1 section 1.6 permits it.
+
+    Allowed: the target of the actuation write, and the notification message as diagnostic
+    context. Forbidden: ``state:``, ``availability:``, either wait, either notification
+    condition.
+    """
+    for slug, blk in blocks.items():
+        cloud = cloud_entity_of(blk)
+        assert cloud not in blk["state"], f"{slug}: cloud leaked into state"
+        assert cloud not in blk["availability"], f"{slug}: cloud leaked into availability"
+        for direction in DIRECTIONS:
+            assert cloud not in wait_of(blk, direction), f"{slug}/{direction} wait"
+            assert cloud not in complain_of(blk, direction), f"{slug}/{direction} condition"
 
 
 # ============================================================================
-# A2: unconditional actuation
+# Actuation: unconditional, both channels (Part 1 sections 1.3, 1.6)
 # ============================================================================
 
 
@@ -310,96 +401,85 @@ def test_facade_state_is_fail_safe(blocks: dict[str, dict[str, Any]], row: str) 
 def test_both_channels_driven_unconditionally(
     blocks: dict[str, dict[str, Any]], direction: str
 ) -> None:
-    """Both the HomeKit command boolean and the Netatmo cloud entity are always driven.
+    """Both channels are driven every time, and nothing can suppress either write.
 
-    This is the QS-305 fix. The old script *predicted* whether the HomeKit leg had
-    worked and drove the cloud leg only if it concluded otherwise; any leg can lie, so
-    a wrong prediction meant the one channel that worked was never driven. There is no
-    longer a decision to get wrong: no ``variables:``, no ``choose:`` in the actuation
-    head, and therefore no predicate that can suppress a command.
-
-    The local boolean is written *first* so it still happens if the cloud call fails.
-    ``continue_on_error`` on the cloud step keeps a ``HomeAssistantError`` from aborting
-    the script before the diagnostic wait can report the failure.
+    We cannot know in advance which channel will work, and *deciding* is exactly what
+    caused the incident. Both steps carry ``continue_on_error`` so a failure of one still
+    drives the other -- notably, an exception on the local boolean must not abort before
+    the cloud, which is the verified-working actuator.
     """
     for slug, blk in blocks.items():
         steps = blk[direction]
         assert len(steps) == 4, f"{slug} / {direction}: expected actuation head + diagnostic"
 
-        assert steps[0].get("action") == f"input_boolean.{direction}", f"{slug} / {direction}"
+        assert steps[0].get("action") == f"input_boolean.{direction}", f"{slug}/{direction}"
         assert steps[0]["target"]["entity_id"] == f"input_boolean.{slug}_command"
 
-        assert steps[1].get("action") == f"switch.{direction}", f"{slug} / {direction}"
+        assert steps[1].get("action") == f"switch.{direction}", f"{slug}/{direction}"
         assert steps[1]["target"]["entity_id"] == cloud_entity_of(blk)
-        assert steps[1].get("continue_on_error") is True, f"{slug} / {direction}"
 
-        # `continue_on_timeout` is load-bearing: without it a timeout errors the script
-        # and the diagnostic `choose` never runs.
-        assert steps[2]["timeout"] == "00:00:10", f"{slug} / {direction}"
-        assert steps[2]["continue_on_timeout"] is True, f"{slug} / {direction}"
+        for index in (0, 1):
+            assert steps[index].get("continue_on_error") is True, f"{slug}/{direction}/{index}"
+            # HA honours `enabled: false` on a script action, which would silently
+            # disable an actuation write while every other assertion still passed.
+            assert "enabled" not in steps[index], f"{slug}/{direction}: step {index} disabled"
+
+        assert steps[2]["timeout"] == "00:00:10", f"{slug}/{direction}"
+        assert steps[2]["continue_on_timeout"] is True, f"{slug}/{direction}"
 
         for index, step in enumerate(steps):
-            assert "variables" not in step, f"{slug} / {direction}: step {index} is conditional"
+            assert "variables" not in step, f"{slug}/{direction}: step {index} is conditional"
             assert ("choose" in step) == (index == 3), (
-                f"{slug} / {direction}: step {index} must not branch"
+                f"{slug}/{direction}: step {index} must not branch"
             )
 
 
 # ============================================================================
-# A3: the diagnostic predicates agree with reporting
+# Diagnostics: positive confirmation on the mirror (Part 1 sections 1.3, 1.4)
 # ============================================================================
 
 
-@pytest.mark.parametrize("row", list(STATE_ROWS))
-def test_diagnostic_predicates_agree_with_state(
-    blocks: dict[str, dict[str, Any]], row: str
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_wait_positively_confirms_the_target_value(
+    blocks: dict[str, dict[str, Any]], direction: str
 ) -> None:
-    """The wait and complain predicates are derived from what ``state:`` reports.
+    """Each wait confirms the target value itself, never the absence of its opposite.
 
-    Letting ``state:``, ``wait_template:`` and the fallback condition disagree was the
-    QS-305 incident's first defect. With ``S`` the reported state, this pins
-    ``wait(turn_off) = not S``, ``wait(turn_on) = S`` and ``complain = not wait`` in both
-    directions, so the three predicates cannot drift apart again.
+    ``not is_state(mirror,'on')`` is satisfied by an ``unavailable`` or ``unknown`` mirror,
+    which would let us silently conclude a turn-off succeeded. Confirm the target.
     """
-    mirror, cloud, expected = STATE_ROWS[row]
+    target = TARGET_OF[direction]
     for slug, blk in blocks.items():
-        states = leg_states(blk, slug, mirror, cloud)
-        waits = {d: eval_ha_template(wait_of(blk, d), states) for d in DIRECTIONS}
-        complains = {d: eval_ha_template(complain_of(blk, d), states) for d in DIRECTIONS}
+        wait = wait_of(blk, direction)
+        assert f"'{target}'" in wait, f"{slug}/{direction} does not mention {target!r}"
+        assert "not " not in wait, f"{slug}/{direction} is expressed as a negation: {wait}"
 
-        if row == "R_none_valid":
-            # `state:` reports `unknown`, which is not a boolean, so the identities are
-            # pinned as literals instead. Both legs invalid reads as "not on".
-            assert expected == "unknown", row
-            assert waits["turn_off"] == "True", slug
-            assert waits["turn_on"] == "False", slug
-            assert complains["turn_off"] == "False", slug
-            assert complains["turn_on"] == "True", slug
-        else:
-            assert waits["turn_off"] == _negate(expected), f"{slug} / {row}"
-            assert waits["turn_on"] == expected, f"{slug} / {row}"
+        # An invalid mirror must NOT satisfy either direction's wait.
+        for mirror in ("unknown", "unavailable"):
+            states = trusted_states(slug, Row(mirror, "on", "on", "", "", "probe"))
+            assert eval_ha_template(wait, states) == "False", f"{slug}/{direction}/{mirror}"
 
+
+@pytest.mark.parametrize("row_name", list(ROWS))
+def test_wait_and_complain_track_the_mirror_only(
+    blocks: dict[str, dict[str, Any]], row_name: str
+) -> None:
+    """The wait is satisfied exactly when the mirror reads the target value.
+
+    Deliberately **not** the old ``wait == not state`` identity. ``state:`` answers "is the
+    load on?" and consults ``hk_ok``; the wait answers "did the mirror confirm the target?"
+    and does not. The divergence is intentional -- do not "fix" it back.
+    """
+    row = ROWS[row_name]
+    for slug, blk in blocks.items():
+        states = trusted_states(slug, row)
         for direction in DIRECTIONS:
-            assert complains[direction] == _negate(waits[direction]), f"{slug} / {row} / {direction}"
-
-
-def test_diagnostic_reports_the_incident_state(blocks: dict[str, dict[str, Any]]) -> None:
-    """In the observed incident state, a ``turn_off`` complains instead of going silent.
-
-    ``R_incident`` (mirror ``on``, cloud ``off``) is what the boiler actually reported
-    while it ran for ~7 hours. Pre-fix the wait was satisfied by the cloud leg alone and
-    nothing was raised; now the wait fails and the notification fires.
-    """
-    mirror, cloud, _ = STATE_ROWS["R_incident"]
-    for slug, blk in blocks.items():
-        states = leg_states(blk, slug, mirror, cloud)
-        assert eval_ha_template(wait_of(blk, "turn_off"), states) == "False", slug
-        assert eval_ha_template(complain_of(blk, "turn_off"), states) == "True", slug
-
-
-# ============================================================================
-# A4: notifications
-# ============================================================================
+            expected = "True" if row.mirror == TARGET_OF[direction] else "False"
+            wait = eval_ha_template(wait_of(blk, direction), states)
+            assert wait == expected, f"{slug}/{row_name}/{direction}"
+            # We complain exactly when the wait was not satisfied.
+            complain = eval_ha_template(complain_of(blk, direction), states)
+            assert complain == _negate(wait), f"{slug}/{row_name}/{direction} condition"
 
 
 def test_notifications_have_per_direction_id(
@@ -408,13 +488,13 @@ def test_notifications_have_per_direction_id(
     """Every facade notification carries a stable, per-direction ``notification_id``.
 
     Without an id HA generates a fresh one per call, so repeated failures pile up
-    duplicates that cannot be replaced. Per-direction ids also stop a ``turn_off``
-    result from erasing a ``turn_on`` failure.
-
-    Direction attribution is asserted through ``notification_of``, because a flat walk
-    cannot tell direction: ten *swapped* ids would pass a whole-render check alone.
+    duplicates that cannot be replaced. Direction attribution is asserted through
+    ``notification_of``, because a flat walk cannot tell direction: ten *swapped* ids
+    would otherwise pass.
     """
-    stale_phrases = ("falling back", "Mirror did not confirm", "HK turn")
+    # "Mirror did not confirm" is absent from this list on purpose: under the mirror-only
+    # design the message legitimately says the mirror did not confirm.
+    stale_phrases = ("falling back", "HK turn")
     suffixes = {"turn_on": "_facade_on_unconfirmed", "turn_off": "_facade_off_unconfirmed"}
     valid_ids = {f"{slug}{suffix}" for slug in blocks for suffix in suffixes.values()}
 
@@ -430,17 +510,18 @@ def test_notifications_have_per_direction_id(
     for slug, blk in blocks.items():
         for direction, suffix in suffixes.items():
             data = notification_of(blk, direction)
-            assert data["notification_id"] == f"{slug}{suffix}", f"{slug} / {direction}"
-            # The message carries both leg states, the only cheap evidence that
-            # distinguishes a truthful mirror from one frozen at its old value.
-            assert f"input_boolean.{slug}_state" in data["message"], f"{slug} / {direction}"
-            assert cloud_entity_of(blk) in data["message"], f"{slug} / {direction}"
+            assert data["notification_id"] == f"{slug}{suffix}", f"{slug}/{direction}"
+            # Both leg states are reported: the cheapest evidence that distinguishes a
+            # truthful mirror from one frozen at its old value.
+            assert f"input_boolean.{slug}_state" in data["message"], f"{slug}/{direction}"
+            assert cloud_entity_of(blk) in data["message"], f"{slug}/{direction}"
 
 
 def test_state_stub_raises_on_unknown_entity() -> None:
     """The layer-3 accessor raises on an unstubbed entity id.
 
-    A typo'd entity id must be a loud red, never a silent falsy read.
+    This is what makes ``trusted_states``' omission of the cloud entity load-bearing: a
+    template that reads it fails loudly instead of silently passing.
     """
     with pytest.raises(KeyError, match="unstubbed entity"):
         eval_ha_template("{{ states('sensor.never_stubbed') }}", {})


### PR DESCRIPTION
## Summary

Fixes the QS-305 incident. **Actuation drives both channels unconditionally; trust is mirror-only; an untrusted mirror reports `unknown` and stays available.** The governing rule:

> **Never trust a value you just wrote. Never report a value you can't trust.**

Implements fix plan #01 Part 1 as amended by **fix plan #02 Part A**. Both records are appended to `docs/stories/QS-305.story.md`.

> **⚠️ This body has been rewritten twice.** Two earlier designs were replaced, and each replacement was driven by a reviewer finding a way the diagnostic could not fire. That history is preserved in the story, not here.

## The three entities

| Entity | Who writes it | What it actually tells you |
| --- | --- | --- |
| `input_boolean.<slug>_command` | **we do** | Nothing. It is our outbox. |
| `input_boolean.<slug>_state` (mirror) | **Apple Home only — never HA** | The truth. Follows a real change in 2-3 s. The only honest witness. |
| `switch.<cloud_entity>` (Netatmo) | **we do**, and Netatmo does | Writing it physically switches the device. *Reading* it tells you only what Netatmo last commanded. **Good arm, blind eye.** |

## What each round fixed

**Round 1** — the shipped design *predicted* whether actuation succeeded and drove the cloud only if it concluded otherwise. Replaced by unconditional dual-channel actuation.

**Round 2** — the round-1 wait read `is_state(mirror,'on') or is_state(cloud,'on')`. Steps run blocking and the Netatmo switch writes state optimistically, so **our own cloud write satisfied the wait before it was evaluated**: vacuously true, notification unreachable. Reporting became mirror-only.

**Round 3 (this round)** — round 2 made the facade `unavailable` when untrusted. That was **wrong and dangerous**:

`helpers/service.py:763`, inside the resolver used by `entity_service_call`:

```python
entity_candidates = [e for e in entity_candidates if e.available]
```

then one WARNING, no exception. `switch.turn_on`/`turn_off`/`toggle` are registered as **entity services** (`components/switch/__init__.py:67-69`), so they pass through that filter. **An `unavailable` facade silently swallows every actuation quiet-solar issues** — both channels undriven, and since the action script never runs, no diagnostic either. It would have fired **on every HA restart**, because both health sensors force themselves `off` for 120 s after start, well past the ~70 s QS needs to give up on a command.

The pattern across all three rounds is the same: *a mechanism that quietly prevents the failure from being reported.* Note the reason is **not** QS-side — `STATE_UNKNOWN` and `STATE_UNAVAILABLE` are indistinguishable to quiet-solar (`ha_model/device.py:52`, `bistate_duration.py:550`). The difference is entirely in HA core.

## Changes in this round

| | Change |
| --- | --- |
| **A1** | Untrusted → `unknown`, entity **stays available**. The `availability:` key is removed outright, with a comment recording why it must not come back. |
| **A1.1** | The untrusted branch emits `{{ none }}`, **not** the string `unknown`. `cv.boolean` is applied without `none_on_unknown_unavailable`, so a string fails validation and logs an ERROR on *every* evaluation. Verified empirically: `{{ none }}` → `None`, `check_result_for_none` **True**; ` unknown ` → `'unknown'`, **False**. |
| **B1** | The cloud write moved into its own `parallel:` branch. pyatmo raises plain `Exception` subclasses (`ApiError`, `ApiThrottlingError`, `ApiTooManyRequestError`), which `continue_on_error` does **not** swallow — so a 429 aborted the script at the cloud step. `_async_step_parallel` gathers with `return_exceptions=True` and re-raises only after every branch completes, so the wait and notification still run. |
| **B2** | **Accepted and documented** per your decision (option 3) — see below. |
| **C1** | The HK-only facade variant **deleted**. Unreachable dead code still on the superseded design; mutating it to report a confident `off` left all 26 tests green. Deleting it also makes a missing `cloud_entity` fail the render loudly instead of silently degrading to one channel. |
| **C2/C5/C7** | Message templates are now *evaluated*, not substring-checked; the success path dismisses the notification; `cloud=` dropped from the message. |
| **Part D** | `%23` doc links, MD001/MD028, dead test imports, header comment no longer hardcodes an external path/line range, and **`| tojson` on `name:` and `title:`** — a name containing `"`, `:` or a leading `{`/`[` would break the render, and a malformed render fails **all** of HA's startup. |

**B1's rejected alternative:** delegating the cloud write to a `script:` entity (fire-and-forget). Blocked here — the config already has `script: !include scripts.yaml`, so inline script entities would need `scripts.yaml` (outside the one-file `config/` grant) or a restructure of that include, which would change non-facade rendered lines.

## B2 — accepted, with a mandatory deployment step

`input_boolean.<slug>_state` has no `initial:`, and `input_boolean` sets `_attr_is_on = state is not None and state.state == STATE_ON` — **`off` when there is no restore data**. So a mirror Apple Home has never written reads `off`, is fully trusted, and the facade reports a **confident `off`**; `turn_off`'s wait is then satisfied instantly with zero observation. The trust predicate cannot distinguish *"Apple has never written me"* from *"the device is off"*.

**Accepted (option 3).** The `last_changed` carve-out was **rejected on the merits**, not just deferred: a restored mirror also carries `last_changed` = HA start time, so it cannot distinguish "never written" from "restored and still correct" — it looks like a fix without being one.

> **⚠️ Deployment step.** When adding a device to `legrand_switches_to_map`, on a fresh install, after restoring a backup without `.storage/core.restore_state`, or after `input_boolean.reload` — **manually set the mirror boolean to match reality before the facade is used.** All are operator-initiated; none happens spontaneously.

**Requested follow-up (Issue D): a proper mirror resync from real HomeKit state.** One constraint to design around: **HA cannot read the Legrand accessory directly** — HA is the HomeKit *bridge* publishing these booleans, while the gateway is an accessory Apple Home controls. A resync must be Apple-driven (the existing `legrand_pumpkin`/`homekit_hub_alive` ticker is the precedent: HA toggles a boolean, an Apple automation reacts), unless `homekit_controller` is added so HA talks to the gateway as a controller — which would also supply a genuinely independent second leg.

## Verification

- **9/9 mutations caught**, including the two Part F survivors. Re-adding plan #01's `availability:` template fails **both** `test_facade_is_never_unavailable` and the new end-to-end regression test — so §A1 is closed by demonstration, not by argument. C1's confident-`off` mutant is *structurally* eliminated with the branch deleted.
- **Two runtime tests, not just structural ones.** One drives the real rendered sequence through HA's `Script` with a raising cloud service and asserts the notification still fires (B1). The other sets up the real facade via the `template` integration with the link down, confirms it publishes `unknown`, calls `switch.turn_on` on it, and asserts the local actuation executed (A1).
- **Render diff at `n=0`:** 0 changed lines outside the five facade regions; non-facade remainder byte-identical. Cloud entity id appears **only** as an actuation target. No `availability` key, no literal state string, no `last_changed`, both waits positively confirming, cloud write isolated in all 5 blocks.
- **813 tests pass** across the five YAML-consuming files.

**Correcting the plan's test-count note:** the plan says the real figure is 853 and that my earlier "805" was wrong. Actual per-file counts are 34 + 245 + 480 + 35 + 19; with my file previously at 26 tests that summed to exactly **805**, so the original figure was right. It is **813** now that the suite has grown to 34. The plan's breakdown assigned 20 and 82 to two files that actually hold 480 and 19.

## Residuals

1. **A mirror freeze between commands is undetectable** — three documented, silent, non-self-healing ways exist for HomeKit characteristic events to stop arriving, and Apple's Home app has no automation execution log. **No evidence any occurred on 07-27.**
2. **`hk_ok` may not cover per-accessory subscription loss** — the cumulus accessory lives on the Legrand gateway, so its subscription state is not observable from HA at all.
3. **HomeKit actuation failed in the incident and this does not fix it** — we work around it by always driving the cloud.
4. **Manual verification of the mirror is self-invalidating** — opening a HomeKit app back-syncs the value over iCloud ([homebridge#2622](https://github.com/homebridge/homebridge/issues/2622)). "The Home app shows the right state" is not evidence.
5. **QS now sees `unknown` where it previously saw a value**, whenever HomeKit is down. Behaviourally identical to `unavailable` for QS, but — critically — actuation still reaches the entity.
6. **A no-op `input_boolean.turn_*` produces no `state_changed`**, so the Apple automation never re-fires on relaunch. The real fix is the Apple automation's trigger.
7. **`mode: single` now has a real 10 s window.** A second same-direction call while the first is in its wait is discarded **before either actuation write executes**. Previously the wait was vacuously true and runs finished in milliseconds, so this window did not exist. Not fixable in-template. QS's own >50 s relaunch cadence does not hit it; the exposure is a double tap in the UI or a user override racing a solver command.
8. **Mirror staleness across HA downtime is trusted with no age check.** Switch the device while HA is down and never switch it again: the facade reports the pre-restart value with full confidence, indefinitely. Overlaps B2; Issue D would address both.
9. **The mirror is bridged to HomeKit as a writable switch.** A hand tap in Apple Home, or the mirror being swept into a scene, writes the facade's only witness and only confirmation source.

## Update — periodic Apple-side mirror sync (user, 2026-07-30)

The user implemented an **Apple Shortcuts script that periodically syncs each device's real state into its mirror boolean**. This is deployment-side, outside the repo, and it is a **strict improvement over anything achievable in-template**: it converts the mirror from *event-driven* to *polled*, weakening the single-leg design's worst failure modes at the source.

| Residual | New status |
| --- | --- |
| **B2** (never-written mirror trusted) | **Mitigated, bounded by one sync period.** The manual "set the mirror" step reduces to "wait one sync period". |
| **1** (mirror freeze undetectable) | **Substantially mitigated** — every documented freeze mode stops *change events*; a periodic write does not depend on them, so a frozen mirror self-heals within one period. |
| **8** (staleness across HA downtime) | **Mitigated** — something now re-publishes the mirror after a restart. |
| **9** (mirror writable from HomeKit) | **Mitigated** — a stray tap or scene sweep is corrected within one period. |

**What it does not close, stated so it is not assumed:** the template cannot verify the sync exists, so none of the above is enforced by a test — these are mitigated by an operational practice, not fixed in code. The sync also inherits the same blind spot as the automation it supplements: Apple's Home app has no execution log, so a Shortcuts automation that silently stops is undetectable from the Apple side, and behaviour would degrade silently to the pre-sync design. And the exposure window is now **one sync period**, not zero.

**New opportunity — `last_reported` becomes a real freshness signal.** HA core mutates the existing state with an updated `last_reported` when the value is unchanged (`core.py:1814`, `:1888-1892`), even though `last_changed` does not move. So *if* the sync writes unconditionally every tick, `states.input_boolean.<slug>_state.last_reported` answers "has this mirror been refreshed recently?" — exactly the positive freshness evidence B2's option 1 wanted, with **no extra helpers**, and without breaching §1.6's `last_changed` ban (which targets its use as a race arbiter). That would close B2 and residual 8 properly rather than by convention. **Not implemented here**: it depends on two unconfirmed facts about the shortcut and is a spec change beyond fix plan #02. **Issue D is re-scoped** to confirm those facts, add the freshness conjunct, and add a sync-liveness signal.

## Deferred / not actioned

Deferred per the plan: the superseded-command false notification (`turn_on`/`turn_off` are separate `Script` objects, so `mode: single` does not make them mutually exclusive) and inventory validation for a renamed `cloud_entity`.

Not actioned (invalid): ruff `E501`/`F401` and mypy `warn_return_any` on the test file — both tools are scoped to `custom_components/quiet_solar`, so `tests/` is unlinted, locally and in CI; CodeRabbit's "define config keys in `const.py`" (`template`/`switch`/`unique_id` are HA YAML schema keys); and three stale CodeRabbit comments from review `4812287720`, which target the superseded design.

## Deployment — manual, user-owned, post-merge. Zero effect until then.

No in-repo render target; `config/configuration.yaml` is not the render output. **No release needed** — this file is not part of the HACS component. **#304 is still required** for the QS-side deadlock.

1. **Run HA's config check on the edited render before reloading.** A malformed block fails the reload of the **entire `template:` section** — all five facades plus the health sensors.
2. **Take your own copy of the live rendered config first — that is the revert artifact.**
3. **Wait one sync period** before relying on a newly added facade, so the Apple-side periodic sync has written its mirror (B2). No manual mirror write is needed while that sync is running.
4. **Dismiss the pre-existing notifications by title** (`… - HK turn_on timed out` / `… - HK turn_off timed out`). The pre-edit calls set no `notification_id`, so the new ids can never replace them.
5. Consider routing the diagnostic to a `notify.*` mobile channel; a `persistent_notification` is only a signal if it is seen.
6. Confirm one real `turn_off`: both channels driven, load actually stopping, no notification. Exercising the diagnostic requires an **induced** failure — e.g. hold the mirror at its pre-command value.

## Doc maintenance

`python scripts/qs/check_doc_drift.py` → **exit 0**. No `docs/agents/` file has a `covers:` entry pointing at `config/configuration.jinja`, and the checker only tracks `covers:` paths under `custom_components/quiet_solar/`, so a deployment artifact cannot be drift-tracked. Only pre-existing unrelated `tests/` warnings appear.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Legrand façade switches now report state only from the HomeKit mirror when it is trusted and valid (`on/off`); otherwise they show an empty/non-state instead of misleading values.
  - Turn on/off now actuate both local and cloud controls in parallel and confirm success via mirror state within a short timeout.

- **Bug Fixes**
  - If mirror confirmation fails, a persistent notification is created per device/action and dismissed on success; cloud-side errors no longer block diagnostics/notifications.

- **Documentation**
  - Updated QS-305 story and review-fix plans, including corrected citation notes and clarified untrusted mirror/unknown behavior and mirror resync guidance.

- **Tests**
  - Expanded automated validation to cover facade state, template safety, actuation structure, waits/complaints, and notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
