### PR TITLE
QS-306: Reduce quiet_solar INFO log volume

### DIFF
--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from enum import StrEnum
-from typing import Any, TypeGuard
+from typing import Any, TypeIs
 
 import pytz
 from haversine import Unit, haversine
@@ -589,8 +589,12 @@ class QSChargerStatus:
         return possible_num_phases, consign_amp
 
 
-def _is_number(x: object) -> TypeGuard[float]:
-    """Return True for a real number. `bool` is excluded: it passes isinstance(int)."""
+def _is_number(x: object) -> TypeIs[int | float]:
+    """Return True for a real number. `bool` is excluded: it passes isinstance(int).
+
+    `TypeIs` rather than `TypeGuard[float]`: an `int` input stays an `int` at runtime,
+    and `_element_unchanged` relies on this narrowing for its arithmetic.
+    """
     return isinstance(x, int | float) and not isinstance(x, bool)
 
 
@@ -608,9 +612,15 @@ def _element_unchanged(prev: object, current: object, deadband: float) -> bool:
         # sensor would report "changed" every cycle and re-inflate the log to the
         # full cycle rate — silently recreating the volume this throttle removes.
         return True
-    if (prev > 0) != (current > 0):
+    if (prev > 0) != (current > 0) and max(abs(prev), abs(current)) >= deadband:
         # A sign flip is the operationally meaningful boundary (exporting vs
-        # importing), so it beats the deadband however small the absolute step.
+        # importing), so it beats the deadband — but ONLY above a magnitude floor.
+        # An unbounded flip term makes near-zero dither (+20W / -20W on alternating
+        # cycles, the steady state of a well-regulated home) log every cycle, which
+        # is the same full-cycle-rate re-inflation the NaN guard above prevents.
+        # A real export/import transition necessarily clears the floor on one side.
+        # The floor also makes the `> 0` test's asymmetry about zero unreachable for
+        # small values, so 0 -> +50 and 0 -> -50 behave identically.
         return False
     return abs(current - prev) < deadband
 
@@ -628,7 +638,14 @@ def _is_unchanged(prev: object, current: object, deadband: float | None) -> bool
 
 
 class LogOnChangeMixin:
-    """Emit INFO only when a reported value changes, or after 900 s (QS-306)."""
+    """Emit INFO only when a reported value changes, or after 900 s (QS-306).
+
+    NOTE: this deliberately closes over THIS module's `_LOGGER`, so every host emits
+    on the `ha_model.charger` logger. Both current hosts live here, and the tests pin
+    that logger name on purpose (a move would change the operator's `logger:` config).
+    A future non-charger host — the `home_model/load.py` sites are the candidates —
+    must take the logger as a class attribute rather than inherit this one.
+    """
 
     # Annotation WITH an immutable default. Never give this a `{}` default: a mutable
     # class attribute is shared across instances, and the per-charger sites use keys
@@ -710,6 +727,11 @@ class QSChargerGroup(LogOnChangeMixin):
         actionable_chargers = []
         for charger in self._chargers:
             if charger.qs_enable_device is False:
+                # QS-306: evict rather than leave a stale entry, so the first status
+                # line after a re-enable inside the 900 s window is not suppressed —
+                # the log needs a marker that the charger is back under management.
+                if self._log_on_change_state is not None:
+                    self._log_on_change_state.pop(f"ensure_correct_state:{charger.name}", None)
                 continue
 
             res, handled_static, vcst = await charger.ensure_correct_state(time, probe_only=probe_only)
@@ -5019,12 +5041,23 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         # includes the car name as defence in depth — `detach_car()` clears the memo,
         # but a future path could swap a car without routing through it. The literal
         # `%` must be `%%` or `record.getMessage()` raises ValueError.
+        # The memo covers everything the message PRINTS, so no printed field can go
+        # stale for up to 900 s — including `power_consign`, which `LoadCommand.__eq__`
+        # compares but the command NAME alone hides. The continuous values are
+        # quantised to whole units: these are SoC percentages and Wh figures where
+        # sub-unit jitter carries no operator value, and memoizing them raw would make
+        # the site log every cycle.
         self.log_info_on_change(
             f"update_value_callback_soc:{self.car.name}:{is_target_percent}",
             (
                 do_continue_constraint,
                 is_car_charged,
-                None if self.current_command is None else self.current_command.command,
+                None
+                if self.current_command is None
+                else (self.current_command.command, self.current_command.power_consign),
+                None if result is None else round(result),
+                None if sensor_result is None else round(sensor_result),
+                None if result_calculus is None else round(result_calculus),
             ),
             time,
             "update_value_callback (is %%:%s):%s %s  %s/%s (%s/%s) is_car_charged %s cmd %s",

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from enum import StrEnum
-from typing import Any
+from typing import Any, TypeGuard
 
 import pytz
 from haversine import Unit, haversine
@@ -219,6 +219,13 @@ TIME_OK_SHOULD_BUDGET_RESET_S = min(
 
 TIME_OK_BETWEEN_CHANGING_CHARGER_PHASES = 60 * 30
 CHARGER_START_STOP_RETRY_S = 90
+
+
+# QS-306 log-tuning values. Module-private: they are not operator configuration,
+# so they stay here rather than in const.py, and they are deliberately NOT
+# sourced from SOLVER_STEP_S despite the numeric coincidence.
+_RELOG_UNCHANGED_AFTER_S = 900  # max gap between two emissions for one key
+_POWER_LOG_DEADBAND_W = 100.0  # ignore sub-100W jitter on the available-power line
 
 
 class QSChargerStates(StrEnum):
@@ -581,7 +588,62 @@ class QSChargerStatus:
         return possible_num_phases, consign_amp
 
 
-class QSChargerGroup:
+def _is_number(x: object) -> TypeGuard[float]:
+    """Return True for a real number. `bool` is excluded: it passes isinstance(int)."""
+    return isinstance(x, int | float) and not isinstance(x, bool)
+
+
+def _is_unchanged(prev: object, current: object, deadband: float | None) -> bool:
+    """Return True when `current` is indistinguishable from `prev`."""
+    if deadband is None:
+        return bool(prev == current)
+    # Only the available-power site passes a deadband, always a fixed-arity numeric
+    # tuple. Anything else (including a test double) counts as changed: log rather
+    # than crash.
+    if not isinstance(prev, tuple) or not isinstance(current, tuple) or len(prev) != len(current):
+        return False
+    return all(_is_number(p) and _is_number(c) and abs(c - p) < deadband for p, c in zip(prev, current))
+
+
+class LogOnChangeMixin:
+    """Emit INFO only when a reported value changes, or after 900 s (QS-306)."""
+
+    # Annotation WITH an immutable default. Never give this a `{}` default: a mutable
+    # class attribute is shared across instances, and the per-charger sites use keys
+    # that are not instance-qualified, so every charger would silence the others.
+    _log_on_change_state: dict[str, tuple[object, datetime]] | None = None
+
+    def log_info_on_change(
+        self,
+        key: str,
+        value: object,
+        time: datetime,
+        msg: str,
+        *args: object,
+        deadband: float | None = None,
+    ) -> None:
+        """Log `msg` at INFO if `value` changed for `key`, or if 900 s elapsed.
+
+        `time` must be timezone-aware UTC — the same value the caller already
+        receives. `|elapsed|` is used so a backwards clock jump cannot silence a
+        key. The timer is re-stamped on every emission, so the constant bounds the
+        gap between emissions rather than imposing a fixed cadence.
+        """
+        state = self._log_on_change_state
+        if state is None:
+            state = self._log_on_change_state = {}
+        prev = state.get(key)
+        if prev is not None:
+            prev_value, prev_time = prev
+            if abs((time - prev_time).total_seconds()) < _RELOG_UNCHANGED_AFTER_S and _is_unchanged(
+                prev_value, value, deadband
+            ):
+                return
+        state[key] = (value, time)
+        _LOGGER.info(msg, *args)
+
+
+class QSChargerGroup(LogOnChangeMixin):
     def __init__(self, dynamic_group: QSDynamicGroup):
         self.dynamic_group: QSDynamicGroup = dynamic_group
         self._chargers: list[QSChargerGeneric] = []
@@ -624,9 +686,25 @@ class QSChargerGroup:
 
             res, handled_static, vcst = await charger.ensure_correct_state(time, probe_only=probe_only)
 
-            _LOGGER.info(
-                f"ensure_correct_state dyn group: {charger.name}  correct_state: {res} handled_static: {handled_static}"
-            )
+            if probe_only:
+                # Defensive: no production caller probes at the group level, but a
+                # probe performs no action, so it must not claim an INFO line.
+                _LOGGER.debug(
+                    "ensure_correct_state dyn group: %s  correct_state: %s handled_static: %s",
+                    charger.name,
+                    res,
+                    handled_static,
+                )
+            else:
+                self.log_info_on_change(
+                    f"ensure_correct_state:{charger.name}",
+                    (res, handled_static),
+                    time,
+                    "ensure_correct_state dyn group: %s  correct_state: %s handled_static: %s",
+                    charger.name,
+                    res,
+                    handled_static,
+                )
 
             if handled_static:
                 continue
@@ -686,12 +764,12 @@ class QSChargerGroup:
 
         # here we check all the chargers and they all need to be in a good state
         # could be plugged, unplugged whatever but in a good state
-        _LOGGER.info("dyn_handle: START")
+        _LOGGER.debug("dyn_handle: START")
 
         actionable_chargers, verified_correct_state_time = await self.ensure_correct_state(time)
 
         if len(actionable_chargers) == 0:
-            _LOGGER.info("dyn_handle: no actionable chargers, do nothing")
+            _LOGGER.debug("dyn_handle: no actionable chargers, do nothing")
         else:
             if self.remaining_budget_to_apply:
                 # in case we would have had increases that could go above the limits because done before the decrease
@@ -754,8 +832,15 @@ class QSChargerGroup:
                     # battery_asked_charge > 0 : the battery needs to charge
                     # battery_asked_charge < 0 : the battery needs to discharge: it means if a charger is "post battery" we don't charge the car ?
 
-                _LOGGER.info(
-                    f"dyn_handle: full_available_home_power {full_available_home_power}W, grid_available_home_power {grid_available_home_power}W battery_asked_charge {battery_asked_charge}W"
+                self.log_info_on_change(
+                    "dyn_handle_available_power",
+                    (full_available_home_power, grid_available_home_power, battery_asked_charge),
+                    time,
+                    "dyn_handle: full_available_home_power %sW, grid_available_home_power %sW battery_asked_charge %sW",
+                    full_available_home_power,
+                    grid_available_home_power,
+                    battery_asked_charge,
+                    deadband=_POWER_LOG_DEADBAND_W,
                 )
 
                 dampened_chargers = {}
@@ -846,7 +931,7 @@ class QSChargerGroup:
                     )
                     dampened_chargers[charger] = a_charging_cs
                 else:
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "dyn_handle: can't dampen simple case %s %s %s", num_true_charging_cs, charging, reason
                     )
 
@@ -935,7 +1020,7 @@ class QSChargerGroup:
                         # Keep current amp as budget so apply_budget_strategy won't crash
                         cs.budgeted_amp = cs.current_real_max_charging_amp or 0
                         cs.budgeted_num_phases = cs.current_active_phase_number or (3 if cs.charger.physical_3p else 1)
-                        _LOGGER.info(
+                        _LOGGER.debug(
                             "dyn_handle: skipping %s for budgeting, amp change cooldown (%ss since last change)",
                             cs.name,
                             (time - cs.charger._last_amp_change_time).total_seconds(),
@@ -944,7 +1029,7 @@ class QSChargerGroup:
                         budget_chargers.append(cs)
 
                 if len(budget_chargers) == 0:
-                    _LOGGER.info("dyn_handle: all chargers in cooldown, skipping budgeting")
+                    _LOGGER.debug("dyn_handle: all chargers in cooldown, skipping budgeting")
                     success = False
                     should_do_reset_allocation = False
                     done_reset_budget = False
@@ -2015,7 +2100,7 @@ class QSChargerGroup:
             await cs.charger._ensure_correct_state(time)
 
 
-class QSChargerGeneric(HADeviceMixin, AbstractLoad):
+class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
     conf_type_name = CONF_TYPE_NAME_QSChargerGeneric
 
     def __init__(self, **kwargs):
@@ -2498,8 +2583,15 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
 
         score = self.get_normalized_score(ct, time)
 
-        _LOGGER.info(
-            f"get_stable_dynamic_charge_status: {self.name} for {self.car.name} score:{score} possible_amps:{cs.possible_amps} possible_num_phases:{cs.possible_num_phases} current_amps:{cs.get_current_charging_amps()} command:{cs.command}"
+        _LOGGER.debug(
+            "get_stable_dynamic_charge_status: %s for %s score:%s possible_amps:%s possible_num_phases:%s current_amps:%s command:%s",
+            self.name,
+            self.car.name,
+            score,
+            cs.possible_amps,
+            cs.possible_num_phases,
+            cs.get_current_charging_amps(),
+            cs.command,
         )
 
         native_score_span_duration, native_score_span_battery, native_score_span = (
@@ -3013,8 +3105,16 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
                 )
                 best_car = self._boot_car
             else:
-                _LOGGER.info(
-                    f"get_best_car: {best_car.name} with score {assigned_chargers_score.get(self)} for charger {self.name}"
+                # Keyed on the car name only: the score is a per-cycle float, so
+                # keying on it would preserve every line.
+                self.log_info_on_change(
+                    "get_best_car",
+                    best_car.name,
+                    time,
+                    "get_best_car: %s with score %s for charger %s",
+                    best_car.name,
+                    assigned_chargers_score.get(self),
+                    self.name,
                 )
 
         if best_car.charger is not None and best_car.charger != self:
@@ -3749,8 +3849,9 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
 
                     if do_remove_all_person_constraints:
                         # we should remove ALL previous person based constraints from this car
-                        _LOGGER.info(
-                            f"check_load_activity_and_constraints: plugged car {self.car.name} do_remove_all_person_constraints"
+                        _LOGGER.debug(
+                            "check_load_activity_and_constraints: plugged car %s do_remove_all_person_constraints",
+                            self.car.name,
                         )
 
                         if self.clean_constraints_for_load_param_and_if_same_key_same_value_info(
@@ -4866,8 +4967,27 @@ class QSChargerGeneric(HADeviceMixin, AbstractLoad):
             # await self._dynamic_compute_and_launch_new_charge_state(time)
             await self.charger_group.dyn_handle(time)
 
-        _LOGGER.info(
-            f"update_value_callback (is %:{is_target_percent}):{self.name} {self.car.name}  {do_continue_constraint}/{result} ({sensor_result}/{result_calculus}) is_car_charged {is_car_charged} cmd {self.current_command}"
+        # The key includes `is_target_percent`: the percent and energy callbacks are two
+        # delegating entry points, and one shared key would let them thrash. The literal
+        # `%` must be `%%` or `record.getMessage()` raises ValueError.
+        self.log_info_on_change(
+            f"update_value_callback_soc:{is_target_percent}",
+            (
+                do_continue_constraint,
+                is_car_charged,
+                None if self.current_command is None else self.current_command.command,
+            ),
+            time,
+            "update_value_callback (is %%:%s):%s %s %s/%s (%s/%s) is_car_charged %s cmd %s",
+            is_target_percent,
+            self.name,
+            self.car.name,
+            do_continue_constraint,
+            result,
+            sensor_result,
+            result_calculus,
+            is_car_charged,
+            self.current_command,
         )
 
         return (result, do_continue_constraint)

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -1,6 +1,7 @@
 import bisect
 import copy
 import logging
+import math
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from datetime import time as dt_time
@@ -593,6 +594,27 @@ def _is_number(x: object) -> TypeGuard[float]:
     return isinstance(x, int | float) and not isinstance(x, bool)
 
 
+def _element_unchanged(prev: object, current: object, deadband: float) -> bool:
+    """Return True when one deadband-compared element is indistinguishable."""
+    if not _is_number(prev) or not _is_number(current):
+        # Fail open: anything non-numeric (including a test double) counts as
+        # changed, so we log rather than crash.
+        return False
+    if prev == current:
+        # Covers a stuck-at-inf sensor, where `inf - inf` would be NaN below.
+        return True
+    if math.isnan(prev) and math.isnan(current):
+        # `abs(NaN - NaN) < deadband` is False, so without this a persistently-NaN
+        # sensor would report "changed" every cycle and re-inflate the log to the
+        # full cycle rate — silently recreating the volume this throttle removes.
+        return True
+    if (prev > 0) != (current > 0):
+        # A sign flip is the operationally meaningful boundary (exporting vs
+        # importing), so it beats the deadband however small the absolute step.
+        return False
+    return abs(current - prev) < deadband
+
+
 def _is_unchanged(prev: object, current: object, deadband: float | None) -> bool:
     """Return True when `current` is indistinguishable from `prev`."""
     if deadband is None:
@@ -602,7 +624,7 @@ def _is_unchanged(prev: object, current: object, deadband: float | None) -> bool
     # than crash.
     if not isinstance(prev, tuple) or not isinstance(current, tuple) or len(prev) != len(current):
         return False
-    return all(_is_number(p) and _is_number(c) and abs(c - p) < deadband for p, c in zip(prev, current))
+    return all(_element_unchanged(p, c, deadband) for p, c in zip(prev, current, strict=True))
 
 
 class LogOnChangeMixin:
@@ -635,8 +657,14 @@ class LogOnChangeMixin:
         prev = state.get(key)
         if prev is not None:
             prev_value, prev_time = prev
-            if abs((time - prev_time).total_seconds()) < _RELOG_UNCHANGED_AFTER_S and _is_unchanged(
-                prev_value, value, deadband
+            # Mixing naive and aware datetimes under one key would raise TypeError on
+            # the subtraction. A logging helper must never be load-bearing, so bail to
+            # logging instead of propagating out of the caller's control cycle.
+            comparable = (prev_time.tzinfo is None) == (time.tzinfo is None)
+            if (
+                comparable
+                and abs((time - prev_time).total_seconds()) < _RELOG_UNCHANGED_AFTER_S
+                and _is_unchanged(prev_value, value, deadband)
             ):
                 return
         state[key] = (value, time)
@@ -3257,6 +3285,20 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         self._boot_constraints = self._constraints
         self._constraints = []
 
+    def _has_state_to_reset(self, keep_commands: bool) -> bool:
+        """Extend the base predicate with the user-initiated flags this class clears.
+
+        QS-306: the override below destroys `do_force_next_charge` /
+        `do_next_charge_time`, which are user-initiated actions — exactly the class
+        of line the log-volume work set out to PRESERVE at INFO. `getattr` for the
+        same `__init__`-ordering reason the base documents: `car` does not exist yet
+        when `AbstractDevice.__init__` first calls the reset.
+        """
+        car = getattr(self, "car", None)
+        return super()._has_state_to_reset(keep_commands) or (
+            car is not None and (bool(car.do_force_next_charge) or car.do_next_charge_time is not None)
+        )
+
     def constraint_reset_and_reset_commands_if_needed(self, keep_commands=True):
         super().constraint_reset_and_reset_commands_if_needed(keep_commands=keep_commands)
         # reset the next charge force state
@@ -4014,6 +4056,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         self.car = None
         self._power_steps = []
         self.car_attach_time = None
+        # QS-306: the log-on-change memos describe the car that just left. Keeping
+        # them would suppress the first line of the NEXT charge session whenever the
+        # new car reports the same value inside the 900 s window — and the last
+        # emitted record would name the wrong car.
+        self._log_on_change_state = None
 
     # update in place the power steps
     def update_power_steps(self):
@@ -4968,17 +5015,19 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             await self.charger_group.dyn_handle(time)
 
         # The key includes `is_target_percent`: the percent and energy callbacks are two
-        # delegating entry points, and one shared key would let them thrash. The literal
+        # delegating entry points, and one shared key would let them thrash. It also
+        # includes the car name as defence in depth — `detach_car()` clears the memo,
+        # but a future path could swap a car without routing through it. The literal
         # `%` must be `%%` or `record.getMessage()` raises ValueError.
         self.log_info_on_change(
-            f"update_value_callback_soc:{is_target_percent}",
+            f"update_value_callback_soc:{self.car.name}:{is_target_percent}",
             (
                 do_continue_constraint,
                 is_car_charged,
                 None if self.current_command is None else self.current_command.command,
             ),
             time,
-            "update_value_callback (is %%:%s):%s %s %s/%s (%s/%s) is_car_charged %s cmd %s",
+            "update_value_callback (is %%:%s):%s %s  %s/%s (%s/%s) is_car_charged %s cmd %s",
             is_target_percent,
             self.name,
             self.car.name,

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -322,18 +322,33 @@ class AbstractDevice:
         if self.father_device is not None:
             return self.father_device.update_available_amps_for_group(idx, amps, add)
 
-    def constraint_reset_and_reset_commands_if_needed(self, keep_commands=True):
-        # QS-306: log INFO only when there was actually something to reset. The three
-        # `getattr` defaults are all required: `AbstractDevice.__init__` calls this
-        # method (load.py:155) BEFORE `_constraints` / `current_command` exist, and
-        # `AbstractLoad` assigns `_last_completed_constraint` only after its own
-        # `super().__init__()` returns. `AbstractLoad`'s override calls `super()`
-        # first, so this predicate still observes the pre-clear values.
+    def _has_state_to_reset(self, keep_commands: bool) -> bool:
+        """Return True when this reset will actually destroy something.
+
+        QS-306: the reset logs INFO only when it did work. Subclasses that clear
+        EXTRA state in their override must extend this predicate, otherwise their
+        work is destroyed while the base reports "nothing to reset" at DEBUG.
+
+        Every `getattr` default is required: `AbstractDevice.__init__` calls
+        `constraint_reset_and_reset_commands_if_needed` (see the call in
+        `__init__`) BEFORE `_constraints` / `current_command` exist, and
+        `AbstractLoad` assigns `_last_completed_constraint` only after its own
+        `super().__init__()` returns. Overrides must follow the same rule.
+        """
         had_constraints = bool(getattr(self, "_constraints", None)) or (
             getattr(self, "_last_completed_constraint", None) is not None
         )
-        had_commands = not keep_commands and getattr(self, "current_command", None) is not None
-        if had_constraints or had_commands:
+        # `keep_commands=False` also drops `running_command` — an in-flight command
+        # awaiting verification — so both are loggable work.
+        had_commands = not keep_commands and (
+            getattr(self, "current_command", None) is not None or getattr(self, "running_command", None) is not None
+        )
+        return had_constraints or had_commands
+
+    def constraint_reset_and_reset_commands_if_needed(self, keep_commands=True):
+        # `AbstractLoad`'s override calls `super()` first, so the predicate still
+        # observes the pre-clear values.
+        if self._has_state_to_reset(keep_commands):
             _LOGGER.info("Constraint Reset device %s", self.name)
         else:
             _LOGGER.debug("Constraint Reset device %s, nothing to reset", self.name)

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -323,7 +323,20 @@ class AbstractDevice:
             return self.father_device.update_available_amps_for_group(idx, amps, add)
 
     def constraint_reset_and_reset_commands_if_needed(self, keep_commands=True):
-        _LOGGER.info("Constraint Reset device %s", self.name)
+        # QS-306: log INFO only when there was actually something to reset. The three
+        # `getattr` defaults are all required: `AbstractDevice.__init__` calls this
+        # method (load.py:155) BEFORE `_constraints` / `current_command` exist, and
+        # `AbstractLoad` assigns `_last_completed_constraint` only after its own
+        # `super().__init__()` returns. `AbstractLoad`'s override calls `super()`
+        # first, so this predicate still observes the pre-clear values.
+        had_constraints = bool(getattr(self, "_constraints", None)) or (
+            getattr(self, "_last_completed_constraint", None) is not None
+        )
+        had_commands = not keep_commands and getattr(self, "current_command", None) is not None
+        if had_constraints or had_commands:
+            _LOGGER.info("Constraint Reset device %s", self.name)
+        else:
+            _LOGGER.debug("Constraint Reset device %s, nothing to reset", self.name)
         self._constraints: list[LoadConstraint | None] = []
         if keep_commands is False:
             self.current_command: LoadCommand | None = None
@@ -1215,7 +1228,7 @@ class AbstractLoad(AbstractDevice):
 
         if found_one_bad is False and for_full_reset is False:
             # no need to reset, we have all the constraints we need
-            _LOGGER.info(
+            _LOGGER.debug(
                 "clean_constraints_for_load_param: No bad constraint found for %s, no reset needed", load_param
             )
             return False

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -339,9 +339,12 @@ class AbstractDevice:
             getattr(self, "_last_completed_constraint", None) is not None
         )
         # `keep_commands=False` also drops `running_command` — an in-flight command
-        # awaiting verification — so both are loggable work.
+        # awaiting verification — and `_stacked_command`, one queued behind it. All
+        # three are loggable work.
         had_commands = not keep_commands and (
-            getattr(self, "current_command", None) is not None or getattr(self, "running_command", None) is not None
+            getattr(self, "current_command", None) is not None
+            or getattr(self, "running_command", None) is not None
+            or getattr(self, "_stacked_command", None) is not None
         )
         return had_constraints or had_commands
 

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -20,17 +20,24 @@ conflict. Phase switching (1P↔3P), staged transitions, and dampening
 (real-power measurement) all live here. A bug in the solver makes a
 bad plan; a bug here trips a breaker.
 
-**Log levels (QS-306).** Per-cycle status lines from this file are now
-DEBUG, or emitted at INFO only when the reported value changes (or after
-900 s). Behavior is unchanged: only log levels and log frequency moved.
+**Log levels (QS-306).** The QS-306-touched per-cycle status lines in this
+file are now DEBUG, or emitted at INFO only on change (or after 900 s);
+**other INFO sites in this file are unchanged** — notably the start/stop
+keepers and the `budgeting_algorithm_minimize_diffs` lines, which were
+deliberately left out of scope. Behavior is unchanged: only log levels and
+log frequency moved.
+
 The available-power line compares against a 100 W deadband, with three
-deliberate exceptions: a sign flip (export ↔ import) always logs, and a
-stuck-at-`NaN` or stuck-at-`inf` sensor counts as *unchanged* so a broken
-sensor cannot re-inflate the log to the full cycle rate. `detach_car()`
-clears the memos, so each charge session gets a fresh first line.
-`QSChargerGeneric` extends `_has_state_to_reset()` (see
-[load-base.md](load-base.md)) because its reset override destroys the
-user-initiated `do_force_next_charge` / `do_next_charge_time` flags.
+deliberate exceptions: a sign flip (export ↔ import) logs **when either side
+is at least the deadband** — the floor matters, because an unbounded flip term
+makes near-zero dither log every cycle — and a stuck-at-`NaN` or
+stuck-at-`inf` sensor counts as *unchanged*, so a broken sensor cannot
+re-inflate the log to the full cycle rate. `detach_car()` clears the memos, so
+each charge session gets a fresh first line, and a disabled charger's key is
+evicted so a re-enable is always announced. `QSChargerGeneric` extends
+`_has_state_to_reset()` (see [load-base.md](load-base.md)) because its reset
+override destroys the user-initiated `do_force_next_charge` /
+`do_next_charge_time` flags.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -23,6 +23,14 @@ bad plan; a bug here trips a breaker.
 **Log levels (QS-306).** Per-cycle status lines from this file are now
 DEBUG, or emitted at INFO only when the reported value changes (or after
 900 s). Behavior is unchanged: only log levels and log frequency moved.
+The available-power line compares against a 100 W deadband, with three
+deliberate exceptions: a sign flip (export ↔ import) always logs, and a
+stuck-at-`NaN` or stuck-at-`inf` sensor counts as *unchanged* so a broken
+sensor cannot re-inflate the log to the full cycle rate. `detach_car()`
+clears the memos, so each charge session gets a fresh first line.
+`QSChargerGeneric` extends `_has_state_to_reset()` (see
+[load-base.md](load-base.md)) because its reset override destroys the
+user-initiated `do_force_next_charge` / `do_next_charge_time` flags.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -4,7 +4,7 @@ slug: charger-budgeting
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/charger.py
-last_verified: 2026-06-13
+last_verified: 2026-07-30
 ---
 
 # Charger Dynamic Budgeting — the tactical layer
@@ -19,6 +19,10 @@ same circuit, and **can override the solver** when amp budgets
 conflict. Phase switching (1P↔3P), staged transitions, and dampening
 (real-power measurement) all live here. A bug in the solver makes a
 bad plan; a bug here trips a breaker.
+
+**Log levels (QS-306).** Per-cycle status lines from this file are now
+DEBUG, or emitted at INFO only when the reported value changes (or after
+900 s). Behavior is unchanged: only log levels and log frequency moved.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/external-control-detection.md
+++ b/docs/agents/concepts/external-control-detection.md
@@ -21,7 +21,9 @@ human. The detection logic lives in `home_model/load.py`
 `HADeviceMixin.update_states()` in `ha_model/device.py`.
 
 **Log levels (QS-306).** No-op announcements in `home_model/load.py` are now
-DEBUG. Detection behavior is unchanged.
+DEBUG. Detection behavior is unchanged. The constraint-reset line logs INFO
+via the `_has_state_to_reset()` hook described in
+[load-base.md](load-base.md).
 
 ## When you need this concept
 

--- a/docs/agents/concepts/external-control-detection.md
+++ b/docs/agents/concepts/external-control-detection.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
   - custom_components/quiet_solar/ha_model/device.py
-last_verified: 2026-06-05
+last_verified: 2026-07-30
 ---
 
 # External control detection
@@ -19,6 +19,9 @@ quiet-solar **detects this** and steps back rather than fighting the
 human. The detection logic lives in `home_model/load.py`
 (`external_user_initiated_state`) and is set during
 `HADeviceMixin.update_states()` in `ha_model/device.py`.
+
+**Log levels (QS-306).** No-op announcements in `home_model/load.py` are now
+DEBUG. Detection behavior is unchanged.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/external-control-detection.md
+++ b/docs/agents/concepts/external-control-detection.md
@@ -23,7 +23,8 @@ human. The detection logic lives in `home_model/load.py`
 **Log levels (QS-306).** No-op announcements in `home_model/load.py` are now
 DEBUG. Detection behavior is unchanged. The constraint-reset line logs INFO
 via the `_has_state_to_reset()` hook described in
-[load-base.md](load-base.md).
+[load-base.md](load-base.md), which counts a dropped in-flight or queued
+command as work worth reporting.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -25,6 +25,15 @@ strict zero-HA-import boundary.**
 now logs INFO only when there was something to reset, and the
 "no bad constraint found" line is DEBUG. No behavior change.
 
+The "was there anything to reset?" test lives in the overridable
+`_has_state_to_reset(keep_commands)` hook. **Any subclass whose reset
+override clears extra state must extend it**, or that work is destroyed
+while the base reports "nothing to reset" at DEBUG. The base term covers
+`_constraints`, `_last_completed_constraint`, and — when
+`keep_commands=False` — `current_command` or an in-flight
+`running_command`. Every access uses `getattr` with a default: the hook
+runs during `AbstractDevice.__init__`, before those attributes exist.
+
 ## When you need this concept
 
 - Adding a new device type — you'll extend `AbstractLoad` (or, rarely,

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -30,9 +30,15 @@ The "was there anything to reset?" test lives in the overridable
 override clears extra state must extend it**, or that work is destroyed
 while the base reports "nothing to reset" at DEBUG. The base term covers
 `_constraints`, `_last_completed_constraint`, and — when
-`keep_commands=False` — `current_command` or an in-flight
-`running_command`. Every access uses `getattr` with a default: the hook
-runs during `AbstractDevice.__init__`, before those attributes exist.
+`keep_commands=False` — `current_command`, an in-flight `running_command`, or
+a queued `_stacked_command`. Every access uses `getattr` with a default: the
+hook runs during `AbstractDevice.__init__`, before those attributes exist.
+
+`QSChargerGeneric` is the worked example: its override clears the
+user-initiated `do_force_next_charge` / `do_next_charge_time`, so it ORs them
+into the hook. Without that, a user pressing "force next charge" on a charger
+holding no constraints would have the flag destroyed while the log said
+"nothing to reset".
 
 ## When you need this concept
 

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -4,7 +4,7 @@ slug: load-base
 kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
-last_verified: 2026-06-05
+last_verified: 2026-07-30
 ---
 
 # AbstractDevice & AbstractLoad
@@ -20,6 +20,10 @@ constraint-management surface (`get_for_solver_constraints()` is the
 solver's entry point), plus green-only mode, user override state, and
 external-control detection. **Both live in `home_model/load.py` —
 strict zero-HA-import boundary.**
+
+**Log levels (QS-306).** `constraint_reset_and_reset_commands_if_needed()`
+now logs INFO only when there was something to reset, and the
+"no bad constraint found" line is DEBUG. No behavior change.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/piloted-device-and-heat-pump.md
+++ b/docs/agents/concepts/piloted-device-and-heat-pump.md
@@ -23,8 +23,10 @@ when the heat pump alone can't meet the climate setpoint.
 translates climate setpoints into the heat pump's command vocabulary.
 
 **Log levels (QS-306).** The shared `home_model/load.py` reset path logs
-INFO only when it actually resets something. Piloting behavior is
-unchanged.
+INFO only when it actually resets something, via the overridable
+`_has_state_to_reset()` hook ([load-base.md](load-base.md)). A
+`PilotedDevice` subclass that clears extra state in its reset override
+should extend that hook. Piloting behavior is unchanged.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/piloted-device-and-heat-pump.md
+++ b/docs/agents/concepts/piloted-device-and-heat-pump.md
@@ -24,9 +24,10 @@ translates climate setpoints into the heat pump's command vocabulary.
 
 **Log levels (QS-306).** The shared `home_model/load.py` reset path logs
 INFO only when it actually resets something, via the overridable
-`_has_state_to_reset()` hook ([load-base.md](load-base.md)). A
-`PilotedDevice` subclass that clears extra state in its reset override
-should extend that hook. Piloting behavior is unchanged.
+`_has_state_to_reset()` hook ([load-base.md](load-base.md)) — which covers a
+dropped `current_command`, `running_command` or `_stacked_command`. A
+`PilotedDevice` subclass that clears extra state in its reset override **must**
+extend that hook. Piloting behavior is unchanged.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/piloted-device-and-heat-pump.md
+++ b/docs/agents/concepts/piloted-device-and-heat-pump.md
@@ -6,7 +6,7 @@ covers:
   - custom_components/quiet_solar/home_model/load.py
   - custom_components/quiet_solar/ha_model/heat_pump.py
   - custom_components/quiet_solar/ha_model/climate_controller.py
-last_verified: 2026-05-21
+last_verified: 2026-07-30
 ---
 
 # PilotedDevice and heat pump
@@ -21,6 +21,10 @@ canonical user: it pilots an auxiliary electric heater that kicks in
 when the heat pump alone can't meet the climate setpoint.
 `climate_controller.py` is the thin HA-facing controller that
 translates climate setpoints into the heat pump's command vocabulary.
+
+**Log levels (QS-306).** The shared `home_model/load.py` reset path logs
+INFO only when it actually resets something. Piloting behavior is
+unchanged.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/user-override.md
+++ b/docs/agents/concepts/user-override.md
@@ -25,7 +25,8 @@ is driving the device themselves".
 constraint-reset lines in `home_model/load.py` moved to DEBUG. A reset that
 destroys a user-initiated flag still logs INFO — that is what the
 `_has_state_to_reset()` hook ([load-base.md](load-base.md)) exists to
-guarantee for subclasses such as `QSChargerGeneric`.
+guarantee for subclasses such as `QSChargerGeneric`, whose override ORs in
+`do_force_next_charge` / `do_next_charge_time`.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/user-override.md
+++ b/docs/agents/concepts/user-override.md
@@ -4,7 +4,7 @@ slug: user-override
 kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
-last_verified: 2026-06-05
+last_verified: 2026-07-30
 ---
 
 # User override
@@ -20,6 +20,9 @@ override is **distinct** from external control detection
 ([external-control-detection.md](external-control-detection.md)):
 override = "user told *us* to do this differently"; external = "user
 is driving the device themselves".
+
+**Log levels (QS-306).** Override handling is unchanged; only the no-op
+constraint-reset lines in `home_model/load.py` moved to DEBUG.
 
 ## When you need this concept
 

--- a/docs/agents/concepts/user-override.md
+++ b/docs/agents/concepts/user-override.md
@@ -22,7 +22,10 @@ override = "user told *us* to do this differently"; external = "user
 is driving the device themselves".
 
 **Log levels (QS-306).** Override handling is unchanged; only the no-op
-constraint-reset lines in `home_model/load.py` moved to DEBUG.
+constraint-reset lines in `home_model/load.py` moved to DEBUG. A reset that
+destroys a user-initiated flag still logs INFO — that is what the
+`_has_state_to_reset()` hook ([load-base.md](load-base.md)) exists to
+guarantee for subclasses such as `QSChargerGeneric`.
 
 ## When you need this concept
 

--- a/docs/stories/QS-306.story.md
+++ b/docs/stories/QS-306.story.md
@@ -222,7 +222,7 @@ fixed cadence.
 The timer uses the **`time` parameter already passed to every rule-1
 method** — never `datetime.now()`. Verified signatures:
 
-```
+```text
 QSChargerGroup.ensure_correct_state(self, time: datetime, probe_only=False)   # S9  async
 QSChargerGroup.dyn_handle(self, time: datetime)                               # S10, S13 async
 QSChargerGeneric.get_best_car(self, time: datetime)                           # S11 SYNC
@@ -259,37 +259,78 @@ inter-emission interval is more machinery than this issue warrants.
 
 ### The helper
 
+As shipped (updated after review fix plans #01 and #02 — the original draft had
+a single `_is_unchanged` with no NaN/inf guard, no sign-flip term, no
+`strict=True`, and `TypeGuard[float]`):
+
 ```python
-# in the constants block (178-221)
+# in the constants block
 _RELOG_UNCHANGED_AFTER_S = 900   # max gap between emissions for one key
 _POWER_LOG_DEADBAND_W = 100.0    # ignore sub-100W jitter on available-power lines
 
 
 # immediately before `class QSChargerGroup`
-def _is_number(x: object) -> TypeGuard[float]:
-    """Return True for a real number. `bool` is excluded: it passes isinstance(int)."""
+def _is_number(x: object) -> TypeIs[int | float]:
+    """Return True for a real number. `bool` is excluded: it passes isinstance(int).
+
+    `TypeIs` rather than `TypeGuard[float]`: an `int` input stays an `int` at runtime,
+    and `_element_unchanged` relies on this narrowing for its arithmetic.
+    """
     return isinstance(x, int | float) and not isinstance(x, bool)
+
+
+def _element_unchanged(prev: object, current: object, deadband: float) -> bool:
+    """Return True when one deadband-compared element is indistinguishable."""
+    if not _is_number(prev) or not _is_number(current):
+        # Fail open: anything non-numeric (including a test double) counts as
+        # changed, so we log rather than crash.
+        return False
+    if prev == current:
+        # Covers a stuck-at-inf sensor, where `inf - inf` would be NaN below.
+        return True
+    if math.isnan(prev) and math.isnan(current):
+        # `abs(NaN - NaN) < deadband` is False, so without this a persistently-NaN
+        # sensor would report "changed" every cycle and re-inflate the log to the
+        # full cycle rate — silently recreating the volume this throttle removes.
+        return True
+    if (prev > 0) != (current > 0) and max(abs(prev), abs(current)) >= deadband:
+        # A sign flip is the operationally meaningful boundary (exporting vs
+        # importing), so it beats the deadband — but ONLY above a magnitude floor.
+        # An unbounded flip term makes near-zero dither (+20W / -20W on alternating
+        # cycles, the steady state of a well-regulated home) log every cycle, which
+        # is the same full-cycle-rate re-inflation the NaN guard above prevents.
+        # A real export/import transition necessarily clears the floor on one side.
+        # The floor also makes the `> 0` test's asymmetry about zero unreachable for
+        # small values, so 0 -> +50 and 0 -> -50 behave identically.
+        return False
+    return abs(current - prev) < deadband
 
 
 def _is_unchanged(prev: object, current: object, deadband: float | None) -> bool:
     """Return True when `current` is indistinguishable from `prev`."""
     if deadband is None:
         return bool(prev == current)
-    # Only S10 passes a deadband, always a fixed-arity numeric tuple. Anything
-    # else (including a test double) counts as changed: log rather than crash.
+    # Only the available-power site passes a deadband, always a fixed-arity numeric
+    # tuple. Anything else (including a test double) counts as changed: log rather
+    # than crash.
     if not isinstance(prev, tuple) or not isinstance(current, tuple) or len(prev) != len(current):
         return False
-    return all(
-        _is_number(p) and _is_number(c) and abs(c - p) < deadband for p, c in zip(prev, current)
-    )
+    return all(_element_unchanged(p, c, deadband) for p, c in zip(prev, current, strict=True))
 
 
 class LogOnChangeMixin:
-    """Emit INFO only when a reported value changes, or after 900 s."""
+    """Emit INFO only when a reported value changes, or after 900 s (QS-306).
 
-    # Annotation WITH an immutable default. Never give this a `{}` default:
-    # a mutable class attribute is shared across instances, and S11/S12 keys
-    # are not instance-qualified, so every charger would silence the others.
+    NOTE: this deliberately closes over THIS module's `_LOGGER`, so every host emits
+    on the `ha_model.charger` logger. Both current hosts live here, and the tests pin
+    that logger name on purpose (a move would change the operator's `logger:` config).
+    A future non-charger host — the `home_model/load.py` sites are the candidates —
+    must take the logger as a class attribute rather than inherit this one.
+    """
+
+    # Annotation WITH an immutable default. Never give this a `{}` default: a mutable
+    # class attribute is shared across instances, and the per-charger sites use keys
+    # that are not instance-qualified, so every charger would silence the others.
     _log_on_change_state: dict[str, tuple[object, datetime]] | None = None
 
     def log_info_on_change(
@@ -301,23 +342,36 @@ class LogOnChangeMixin:
         *args: object,
         deadband: float | None = None,
     ) -> None:
-        """Log `msg` at INFO if `value` changed, or if 900 s elapsed."""
+        """Log `msg` at INFO if `value` changed for `key`, or if 900 s elapsed.
+
+        `time` must be timezone-aware UTC — the same value the caller already
+        receives. `|elapsed|` is used so a backwards clock jump cannot silence a
+        key. The timer is re-stamped on every emission, so the constant bounds the
+        gap between emissions rather than imposing a fixed cadence.
+        """
         state = self._log_on_change_state
         if state is None:
             state = self._log_on_change_state = {}
         prev = state.get(key)
         if prev is not None:
             prev_value, prev_time = prev
-            if abs((time - prev_time).total_seconds()) < _RELOG_UNCHANGED_AFTER_S and _is_unchanged(
-                prev_value, value, deadband
+            # Mixing naive and aware datetimes under one key would raise TypeError on
+            # the subtraction. A logging helper must never be load-bearing, so bail to
+            # logging instead of propagating out of the caller's control cycle.
+            comparable = (prev_time.tzinfo is None) == (time.tzinfo is None)
+            if (
+                comparable
+                and abs((time - prev_time).total_seconds()) < _RELOG_UNCHANGED_AFTER_S
+                and _is_unchanged(prev_value, value, deadband)
             ):
                 return
         state[key] = (value, time)
         _LOGGER.info(msg, *args)
 ```
 
-`TypeGuard` must be added to the existing `from typing import Any` at
-`charger.py:8`.
+`TypeIs` must be added to the existing `from typing import Any` at
+`charger.py:8`. (`TypeGuard[float]` was the original choice; it lies about `int`
+inputs, which stay `int` at runtime — review fix plan #02 NH-F.)
 
 Six deliberate properties:
 
@@ -387,27 +441,45 @@ claimed as "recoverable".
 (`home_model/load.py:326`).
 
 Story v1's guard crashed on every device construction and tested caller
-intent rather than work performed. Corrected:
+intent rather than work performed. As shipped (the inline predicate became an
+**overridable hook** in review fix plan #02 — see below):
 
 ```python
-had_constraints = bool(getattr(self, "_constraints", None)) or (
-    getattr(self, "_last_completed_constraint", None) is not None
-)
-had_commands = not keep_commands and getattr(self, "current_command", None) is not None
-if had_constraints or had_commands:
-    _LOGGER.info("Constraint Reset device %s", self.name)
-else:
-    _LOGGER.debug("Constraint Reset device %s, nothing to reset", self.name)
+def _has_state_to_reset(self, keep_commands: bool) -> bool:
+    had_constraints = bool(getattr(self, "_constraints", None)) or (
+        getattr(self, "_last_completed_constraint", None) is not None
+    )
+    had_commands = not keep_commands and (
+        getattr(self, "current_command", None) is not None
+        or getattr(self, "running_command", None) is not None
+        or getattr(self, "_stacked_command", None) is not None
+    )
+    return had_constraints or had_commands
+
+
+def constraint_reset_and_reset_commands_if_needed(self, keep_commands=True):
+    if self._has_state_to_reset(keep_commands):
+        _LOGGER.info("Constraint Reset device %s", self.name)
+    else:
+        _LOGGER.debug("Constraint Reset device %s, nothing to reset", self.name)
+    ...
 ```
 
-All three `getattr` defaults are required (F15). Comment them with *why*,
+Every `getattr` default is required (F15). Comment them with *why*,
 naming `load.py:155`. `_last_completed_constraint` is included because
 `AbstractLoad`'s override clears it plus five `current_constraint_*` /
 `next_or_current_constraint_*` fields — and calls `super()` first, so the
-predicate sees the pre-clear value. `QSChargerGeneric`'s override
-(`charger.py:3160-3165`) clears `car.do_force_next_charge` /
-`do_next_charge_time`; that is deliberately **not** loggable work — they
-are per-cycle scheduling hints.
+predicate sees the pre-clear value.
+
+**The predicate is a hook because a fixed base predicate is blind to what
+subclasses clear.** `QSChargerGeneric`'s override clears
+`car.do_force_next_charge` / `do_next_charge_time`. Story v4 called those "not
+loggable work — per-cycle scheduling hints"; **that was wrong**, and review fix
+plan #02 SF2 reversed it: they are set by a *user* pressing "force next charge",
+so destroying them silently at DEBUG loses exactly the class of record this story
+set out to preserve. `QSChargerGeneric` therefore overrides
+`_has_state_to_reset` to OR them in. Any future subclass that clears extra state
+in its reset override must do the same.
 
 `not keep_commands` rather than `is False` is defensive only: all literal
 callers pass `True` or `False`, and three sites forward the parameter
@@ -798,6 +870,33 @@ change.
 - B3 has 13 cases rather than the issue's "three branches" — the helper
   gained a deadband (needed for row 11) and a timer (user-confirmed).
 - B6 adds `--quick tests/qs` beyond the issue's B1–B5.
+
+### Log-policy deviations added during review
+
+These change *when* a line is emitted, beyond anything the issue or story v4
+specified. All three were accepted at triage; recorded here so a later audit does
+not read them as scope creep.
+
+- **Sign-flip term on the deadband** (fix plan #01 NH4, amended by #02 MF1). A
+  sign change on an available-power element beats the deadband, because
+  export↔import is the operationally meaningful boundary and a symmetric ±100 W
+  band hides it. **Bounded by a magnitude floor**
+  (`max(abs(prev), abs(current)) >= deadband`): fix plan #01 specified the term
+  *without* a floor, which made near-zero dither (+20 W / −20 W on alternating
+  cycles — the steady state of a well-regulated home) log every ~7 s and silently
+  re-inflated the highest-volume site in the change set. Pinned by a 10-cycle
+  oscillation test asserting an INFO count of exactly 1.
+- **`running_command` / `_stacked_command` in the reset predicate** (fix plan #01
+  NH5, extended by #02 NH-A). `keep_commands=False` destroys both, so a reset that
+  drops an in-flight or queued command now logs INFO instead of reporting "nothing
+  to reset".
+- **The S12 memo covers every printed value, quantised** (fix plan #02 SF-G). This
+  **reverses story v4's explicit decision to drop `round(result)` from the S12
+  memo**: v4 dropped it because `result` can be `None` (which `round()` would
+  raise on), and relied on the 900 s re-log for progress visibility. That left the
+  printed charge-progress numbers and `power_consign` able to go stale for a full
+  900 s. They are now memoized `None`-safely and rounded to whole units — raw
+  values would make the site log every cycle, the same trap MF1 fell into.
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-306.story.md
+++ b/docs/stories/QS-306.story.md
@@ -1,0 +1,862 @@
+# QS-306: Reduce quiet_solar INFO log volume
+
+- **Issue**: [#306](https://github.com/tmenguy/quiet-solar/issues/306)
+- **Branch**: `QS_306`
+- **Next phase**: `implement-task`
+- **Story version**: v4 (after adversarial review rounds 1–3)
+
+## Problem
+
+`quiet_solar` emits ~1.4M INFO lines in 3 days (94% of a 311 MB
+`home-assistant-3.log`). ~78% carry no information: they repeat
+identically every load-management cycle (~7s) or announce a no-op
+("nothing found", "no reset needed", "START", "do nothing",
+"correct_state: True").
+
+## Goal
+
+Apply the issue's three-rule policy to **13 enumerated call sites**:
+
+1. **Log transitions, not states** — re-emit only when the reported value
+   changes, or after 900 s.
+2. **Never log a no-op at INFO** — demote to DEBUG.
+3. **INFO stays for real actions and decisions** — untouched.
+
+Non-goal: a blanket demote, a logging framework, a configurable
+verbosity system.
+
+Recovery: operators who need a demoted line set
+`custom_components.quiet_solar.ha_model.charger: debug` **and**
+`custom_components.quiet_solar.home_model.load: debug` under `logger:`
+in `configuration.yaml` (both loggers are touched). Revert path:
+re-promote a single call — a one-token change.
+
+## Site identification convention
+
+**Line numbers are advisory, correct as of this writing.** Task 1 inserts
+code into `charger.py` and task 6 edits `home_model/load.py`, shifting
+every later line number in both files. The **authoritative key for every
+site is `function name` + `exact message text`**; tests assert on message
+text, never on line numbers.
+
+Existing test files contain many comments citing `charger.py` line
+numbers (`tests/test_charger_coverage_deep.py:3096`, `:4989`, `:6025`,
+and others). No gate enforces them; they are **deliberately left stale**.
+
+## Verified findings
+
+All verified against source in this worktree. Several correct the issue
+body; F9–F13 correct earlier versions of this story.
+
+- **F1 — The 220k-line site's per-cycle callers are in a third file, and
+  all six pass `keep_commands=True`.** `Constraint Reset device %s` is at
+  `load.py:326`, unconditional at the top of
+  `AbstractDevice.constraint_reset_and_reset_commands_if_needed`. The
+  per-cycle callers for the 7 Clims are in **`ha_model/bistate_duration.py`**
+  (729, 738, 894, 925, 1058, 1062); all six pass `keep_commands=True`,
+  so the command half of the guard is dead on that path. **Both the
+  empty and non-empty `_constraints` cases occur and the frequency is
+  unmeasured** — earlier versions of this story inferred that empty
+  dominates from the `if len(self._constraints) > 0:` at 1056/1060, which
+  is wrong twice over: that guard's body is only
+  `do_force_next_solve = True` (the reset call sits at the same indent,
+  unconditional), and a call *inside* such a guard would reach the callee
+  only when non-empty. See R1. We do **not** touch `bistate_duration.py`.
+
+- **F2 — `charger.py:4831` is `_LOGGER.error`, not `.info`.** The issue
+  lists `4832` among the `update_value_callback` sites. Out of scope. The
+  eight are 7 × `info` + 1 × `error`.
+
+- **F3 — The issue's line hints point at the message, not the call.**
+  `4675/4755/4789/4796/4832/4870` are message lines; the `_LOGGER.info(`
+  call is one above. The per-cycle summary is the call at **4869**.
+
+- **F4 — `check_doc_drift.py` flags five docs, not one**:
+  `charger-budgeting.md`, `external-control-detection.md`,
+  `load-base.md`, `piloted-device-and-heat-pump.md`, `user-override.md`.
+  `last_verified` is present in all five (7, 8, 7, 9, 7).
+
+- **F5 — There is no `Doc-OK` mechanism in the checker.**
+  `check_doc_drift.py` computes staleness from `covers:` frontmatter plus
+  co-modification and exits 1 on any stale doc. `Doc-OK` is a
+  **story-file convention** from `project-rules.md`; it records a
+  judgment but **does not silence the checker**. The issue and story v1
+  were wrong that a `Doc-OK` line alone unblocks `finish-task`. The five
+  docs must be **co-modified**; bumping `last_verified` works only
+  *because it is an edit* — the field is inert to the checker.
+  Editing `docs/agents/**` does **not** trigger harness sync (that
+  applies only to `.claude|.cursor|.opencode/agents/*.md`, none touched).
+
+- **F6 — `dyn_handle` has 13 `dyn_handle:`-prefixed INFO sites**, not 14:
+  11 inside `dyn_handle` (689, 694, 698, 741, 757, 832, 849, 893, 910,
+  938, 947) and 2 in `budgeting_algorithm_minimize_diffs` (1539, 1586).
+  **6 in scope** (S1–S4, S10, S13), 7 out. **741, 832 and 910 fire per
+  cycle on realistic inputs** — which is why every criterion counts by
+  message text, never per logger.
+
+- **F7 — `QSChargerGroup` lifetime confirmed.** Created lazily at
+  `charger.py:2139`, cached as `father_device.charger_group`; the slot is
+  declared once at `dynamic_group.py:34` and never reassigned. Memo state
+  persists across `dyn_handle` calls. It does not survive an HA config
+  reload — acceptable; a reload should re-announce current state once.
+  `QSChargerGroup` has **no subclasses**.
+
+- **F8 — `LoadCommand` equality is value-based.** `commands.py:28-34` is
+  a `@dataclass` with `__eq__` over `command` **and** `power_consign`.
+  Story v1 claimed the opposite and used `str(...)`; both were wrong.
+  `power_consign` is a per-cycle budgeted float, so neither `==` nor
+  `str()` is stable — S12 keys on `.command` (a `str`, `commands.py:30`).
+
+- **F9 — `charger.py` has no `from __future__ import annotations` and no
+  module docstring.** Line 1 is `import bisect`; `_LOGGER` at 175;
+  `datetime` imported at line 5; `from typing import Any` at line 8.
+  Story v2 claimed otherwise. The mixin must use **no forward
+  references**. Do **not** add the future import: line 17 already uses
+  PEP 758 `except ImportError, ModuleNotFoundError:`, so the file is
+  3.14-only by design. The file currently has **zero module-level
+  functions**; constants are clustered at 178-221.
+
+- **F10 — mypy cannot police the numeric comparison.**
+  `pyproject.toml:64` disables the `operator` error code, and narrowing
+  `object` via `isinstance(x, tuple)` yields `tuple[Any, ...]`, laundering
+  elements to `Any`. Confirmed clean-as-written otherwise: `state =
+  self._log_on_change_state = {}` type-checks because mypy resolves the
+  last lvalue first, and no `cast` is needed. Using a `TypeGuard` for
+  `_is_number` makes the arithmetic properly narrowed regardless.
+
+- **F11 — no existing test asserts any of the 13 messages at INFO.**
+  The suite has **ten** INFO-level `caplog` calls:
+  `tests/test_ha_bistate_duration.py:817`, `:864`,
+  `tests/test_solar_forecast_resilience.py:591`, `:619`, and six in
+  `tests/test_qs256_override_lifecycle.py` (281, 350, 581, 735, 799, 844)
+  with record assertions at `:297` and `:371`. **`:281` pins
+  `custom_components.quiet_solar.home_model.load` at INFO**, so that file
+  must be re-run after task 6. Grep of all 13 message texts across
+  `tests/` returns only variable names, docstrings and comments.
+
+- **F12 — `battery_asked_charge` can never be `None`.**
+  `charger.py:745` sets `0.0`; 750 overwrites only
+  `if self.home.battery is not None:`; `battery.py:275` is
+  `-> float` and every return path returns a float. Story v3 claimed it
+  is "persistently `None` on a battery-less home" — **wrong**; a
+  battery-less home yields `0.0`. The real hazard is **test-only**: a
+  driver that leaves `home.battery` a bare `MagicMock`
+  (as `tests/ha_tests/test_charger.py:2784-2786` does) puts a non-numeric
+  into S10's tuple, `_is_unchanged` returns `False` every cycle, and B2's
+  "exactly once" fails. Hence the numeric guard, and the task-9 note.
+  `full_available_home_power` / `grid_available_home_power` are guaranteed
+  numeric by the guard at 740-743.
+
+- **F13 — `QSChargerGroup.ensure_correct_state` has one production
+  caller, which never passes `probe_only`.** The only group-level call is
+  `charger.py:691` (`await self.ensure_correct_state(time)`) inside
+  `dyn_handle`. The `probe_only=True` call sites (2332, 5053) are on
+  `QSChargerGeneric`, a different method on a different class. Story v3's
+  claim that it "is called in probe mode too" was false; S9's early-out
+  is retained as **defensive**, not as a fix for an observed path.
+
+- **F14 — subclass initialization is safe.** `QSChargerOCPP.__init__`
+  (5369) and `QSChargerWallbox.__init__` (5729) both call
+  `super().__init__(**kwargs)` (5422, 5758). `AbstractDevice.__init__`
+  calls bare `super().__init__()`; `HADeviceMixin.__init__` forwards
+  `**kwargs` (`device.py:290`). Mixin-first MRO is safe.
+
+- **F15 — S8's `getattr` defaults are all required.** `AbstractDevice.__init__`
+  calls the method at `load.py:155`; `_constraints` is created at 327,
+  `current_command` at 329/165, and `AbstractLoad` assigns
+  `_last_completed_constraint` at `load.py:877` — *after* its
+  `super().__init__(**kwargs)` at 875. So all three are absent on the
+  first call. Critically, `AbstractLoad`'s override (`load.py:893-901`)
+  calls `super()` **first**, so the base predicate still observes the
+  pre-clear values — the `_last_completed_constraint` term is live, not
+  inert.
+
+## Design
+
+### Where the helper lives
+
+**Inside `ha_model/charger.py`.** Story v1 put it in a new
+`home_model/log_throttling.py` justified by future reuse in files the same
+plan scoped out — circular. Both consumers live in `charger.py`, so the
+mixin uses that module's `_LOGGER` directly, which deletes the
+class-attribute logger indirection and its failure modes.
+
+No rule-1 site lives in `load.py`, so there is no `home_model → ha_model`
+edge and the two-layer boundary is untouched.
+
+Cost: testmon re-selects every test touching `charger.py` when the mixin
+changes. A later extraction would change the logger name that **B2**
+asserts on — record that coupling before moving it.
+
+Placement: the two constants join the existing constants block
+(178-221), following the file's convention; `LogOnChangeMixin`,
+`_is_unchanged` and `_is_number` go immediately before
+`class QSChargerGroup` (currently line **584**), separated by two blank
+lines. These are the file's first module-level functions. No name
+collisions repo-wide.
+
+### Why re-log after 900 s
+
+Pure on-change is a **diagnostic regression**. A charger that goes bad at
+02:00 and stays bad logs exactly one line, at 02:00. HA rotates its log
+on restart; an operator reading at 11:00 sees *nothing*.
+
+So: emit on change, **and** re-emit if ≥900 s since this key last
+emitted. ~12,300 cycles/day per key → ~96 emissions/day. Still a >99%
+cut. (User-confirmed. What the deviation buys in machinery: the `time`
+parameter, the timezone contract, one constant, one B2 step and two B3
+cases. The zero-machinery alternative — operators enable DEBUG for the
+in-between cycles — was rejected because it requires knowing there is
+something to look for.)
+
+**Canonical emission predicate.** Emit iff:
+
+> no prior state for this key **OR** the value changed (per the deadband,
+> if given) **OR** `|elapsed| ≥ 900 s` since this key last **emitted**.
+
+Silent iff prior state exists **AND** `|elapsed| < 900 s` **AND** the
+value is unchanged. The timer resets on *every* emission, including a
+change, so the constant bounds the gap between emissions — it is not a
+fixed cadence.
+
+The timer uses the **`time` parameter already passed to every rule-1
+method** — never `datetime.now()`. Verified signatures:
+
+```
+QSChargerGroup.ensure_correct_state(self, time: datetime, probe_only=False)   # S9  async
+QSChargerGroup.dyn_handle(self, time: datetime)                               # S10, S13 async
+QSChargerGeneric.get_best_car(self, time: datetime)                           # S11 SYNC
+QSChargerGeneric.constraint_update_value_callback_soc(self, ct, time, is_target_percent=True)  # S12 async
+```
+
+**Time contract:** all `time` values are timezone-aware UTC. Mixing aware
+and naive under one key raises `TypeError`, so drivers must pass aware
+datetimes. `|elapsed|` is used so a backwards clock jump cannot silence a
+key: a small backward jump stays inside the window, a jump ≥900 s emits.
+
+`900` must **not** be sourced from `SOLVER_STEP_S` despite the numeric
+coincidence. Both constants are module-private log-tuning values, not
+operator configuration, so they stay in `charger.py` rather than
+`const.py` (whose rule is about *configuration keys*). `CHARGER_ADAPTATION_WINDOW_S`
+does live in `const.py`, but it is referenced across modules; these two
+are not.
+
+### Deadband, not bucketing
+
+Story v1 rounded to 100 W buckets. **Bucketing does not bound volume**:
+power jittering 1049/1051/1049 W crosses a boundary every cycle. The
+comparison is a **deadband against the last *emitted* value**, which
+falls out naturally because state is stamped only on emit.
+
+Only S10 uses it — the sole site whose reported value *is* a float.
+S12 drops its float term entirely; the 900 s re-log gives periodic SOC
+visibility instead.
+
+Residual limit: a deadband bounds *drift* but not *oscillation*. Power
+alternating 1000/1150/1000 W trips the threshold every cycle. Accepted —
+100 W is well above observed sensor jitter, and hysteresis plus a minimum
+inter-emission interval is more machinery than this issue warrants.
+
+### The helper
+
+```python
+# in the constants block (178-221)
+_RELOG_UNCHANGED_AFTER_S = 900   # max gap between emissions for one key
+_POWER_LOG_DEADBAND_W = 100.0    # ignore sub-100W jitter on available-power lines
+
+
+# immediately before `class QSChargerGroup`
+def _is_number(x: object) -> TypeGuard[float]:
+    """Return True for a real number. `bool` is excluded: it passes isinstance(int)."""
+    return isinstance(x, int | float) and not isinstance(x, bool)
+
+
+def _is_unchanged(prev: object, current: object, deadband: float | None) -> bool:
+    """Return True when `current` is indistinguishable from `prev`."""
+    if deadband is None:
+        return bool(prev == current)
+    # Only S10 passes a deadband, always a fixed-arity numeric tuple. Anything
+    # else (including a test double) counts as changed: log rather than crash.
+    if not isinstance(prev, tuple) or not isinstance(current, tuple) or len(prev) != len(current):
+        return False
+    return all(
+        _is_number(p) and _is_number(c) and abs(c - p) < deadband for p, c in zip(prev, current)
+    )
+
+
+class LogOnChangeMixin:
+    """Emit INFO only when a reported value changes, or after 900 s."""
+
+    # Annotation WITH an immutable default. Never give this a `{}` default:
+    # a mutable class attribute is shared across instances, and S11/S12 keys
+    # are not instance-qualified, so every charger would silence the others.
+    _log_on_change_state: dict[str, tuple[object, datetime]] | None = None
+
+    def log_info_on_change(
+        self,
+        key: str,
+        value: object,
+        time: datetime,
+        msg: str,
+        *args: object,
+        deadband: float | None = None,
+    ) -> None:
+        """Log `msg` at INFO if `value` changed, or if 900 s elapsed."""
+        state = self._log_on_change_state
+        if state is None:
+            state = self._log_on_change_state = {}
+        prev = state.get(key)
+        if prev is not None:
+            prev_value, prev_time = prev
+            if abs((time - prev_time).total_seconds()) < _RELOG_UNCHANGED_AFTER_S and _is_unchanged(
+                prev_value, value, deadband
+            ):
+                return
+        state[key] = (value, time)
+        _LOGGER.info(msg, *args)
+```
+
+`TypeGuard` must be added to the existing `from typing import Any` at
+`charger.py:8`.
+
+Six deliberate properties:
+
+- **Lazy init behind an immutable class default** — the one shape that is
+  mypy-clean, cannot share state between instances, and cannot raise
+  `AttributeError` in a subclass that skips `super().__init__()`. Costs
+  one 2-arc branch (both arcs covered by B3 cases 1 and 2) and needs
+  **no `__init__` edits**.
+- **`value` is separate from `msg`/`*args`** — the volatile float stays in
+  the message. Accepted deviation from the issue's
+  `_log_on_change(key, msg, *args)`; without it the detector is either
+  the volatile args or nothing.
+- **No sentinel.** `state.get(key, _UNSET) == value` could raise:
+  `LoadCommand.__eq__` accesses `other.command` after only a `None`
+  check, so a reflected comparison hits `_UNSET.command`.
+- **No `None`-specific handling in `_is_unchanged`.** Per F12 the S10
+  values are always numeric, so a `None` element is unreachable in
+  production; a `None` (or any non-number) simply counts as changed,
+  which logs rather than crashes.
+- **The mixin defines no `__init__`**, so it composes at any base
+  position (F14): `class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad)`,
+  `class QSChargerGroup(LogOnChangeMixin)`.
+- **Returns `None`; mutates only `_log_on_change_state`.** State growth is
+  bounded by distinct keys: one per charger for S9, three constants for
+  S10/S11/S12. No pruning needed.
+
+## The 13 call sites
+
+### Rule 2 — demote to DEBUG (8 sites)
+
+| ID | Function (class) | Message | Conversion | Branch precondition |
+| -- | ---------------- | ------- | ---------- | ------------------- |
+| S1 | `dyn_handle` (`QSChargerGroup`) | `dyn_handle: START` | none, argless | unconditional |
+| S2 | `dyn_handle` | `dyn_handle: skipping %s for budgeting, amp change cooldown (%ss since last change)` | none, already lazy | ≥1 charger with `_last_amp_change_time` inside `CHARGER_ADAPTATION_WINDOW_S` |
+| S3 | `dyn_handle` | `dyn_handle: all chargers in cooldown, skipping budgeting` | none, argless | **every** actionable charger in cooldown |
+| S4 | `dyn_handle` | `dyn_handle: can't dampen simple case %s %s %s` | none, already lazy | not exactly one truly-charging charger |
+| S5 | `get_stable_dynamic_charge_status` (`QSChargerGeneric`) | `get_stable_dynamic_charge_status: %s for %s score:%s possible_amps:%s ...` | **f-string → lazy** | plugged car, enabled, available |
+| S6 | `check_load_activity_and_constraints` (`QSChargerGeneric`) | `check_load_activity_and_constraints: plugged car %s do_remove_all_person_constraints` | **f-string → lazy** | plugged car **and** person constraints present |
+| S7 | `clean_constraints_for_load_param_and_if_same_key_same_value_info` (`AbstractLoad`, `home_model/load.py`) | `clean_constraints_for_load_param: No bad constraint found for %s, no reset needed` | none, already lazy | `found_one_bad is False and for_full_reset is False` |
+| S13 | `dyn_handle` | `dyn_handle: no actionable chargers, do nothing` | none, argless | `len(actionable_chargers) == 0` |
+
+Advisory lines: S1 689, S2 938, S3 947, S4 849, S5 2501, S6 3752,
+S7 `load.py:1218`, S13 694.
+
+S2/S3 are the two messages the issue collapsed into one 147,396-line row.
+**S13 is not in the issue's table** — added on review as a
+**user-confirmed one-off**: its text is literally "do nothing" and it
+fires every ~7s whenever nothing is plugged in. (Story v3 generalized
+this into an "inclusion rule"; that rule was self-contradictory — it
+admitted the deferred idle-charger lines it claimed to exclude — and is
+withdrawn. There is a list, not a criterion.)
+
+**S13's branch is mutually exclusive with S9/S10's** (`== 0` vs `> 0`),
+so they need separate drivers.
+
+Note on S5/S6: neither is strictly a no-op (an accepted deviation). S5 is
+a per-cycle state dump; S6 immediately precedes
+`clean_constraints_for_load_param_and_if_same_key_same_value_info`
+(`charger.py:3756`), whose outcome is logged by S7 — at DEBUG after this
+change. So S5/S6 are **information loss at INFO**, mitigated only by the
+DEBUG level, not by a surviving INFO line. Recorded honestly rather than
+claimed as "recoverable".
+
+### Rule 2 — guard so the no-op path is silent (1 site)
+
+**S8** — `AbstractDevice.constraint_reset_and_reset_commands_if_needed`
+(`home_model/load.py:326`).
+
+Story v1's guard crashed on every device construction and tested caller
+intent rather than work performed. Corrected:
+
+```python
+had_constraints = bool(getattr(self, "_constraints", None)) or (
+    getattr(self, "_last_completed_constraint", None) is not None
+)
+had_commands = not keep_commands and getattr(self, "current_command", None) is not None
+if had_constraints or had_commands:
+    _LOGGER.info("Constraint Reset device %s", self.name)
+else:
+    _LOGGER.debug("Constraint Reset device %s, nothing to reset", self.name)
+```
+
+All three `getattr` defaults are required (F15). Comment them with *why*,
+naming `load.py:155`. `_last_completed_constraint` is included because
+`AbstractLoad`'s override clears it plus five `current_constraint_*` /
+`next_or_current_constraint_*` fields — and calls `super()` first, so the
+predicate sees the pre-clear value. `QSChargerGeneric`'s override
+(`charger.py:3160-3165`) clears `car.do_force_next_charge` /
+`do_next_charge_time`; that is deliberately **not** loggable work — they
+are per-cycle scheduling hints.
+
+`not keep_commands` rather than `is False` is defensive only: all literal
+callers pass `True` or `False`, and three sites forward the parameter
+unchanged (`load.py:345`, and the two `super()` calls at `load.py:894`
+and `charger.py:3161`).
+
+A cleaner fix — initializing the attributes before `load.py:155` — is
+deliberately out of scope: it changes construction order in the base
+class of every device type.
+
+### Rule 1 — log on change via the helper (4 sites)
+
+| ID | Function (class) | Message (current → lazy) | `key` | `value` | deadband |
+| -- | ---------------- | ------------------------ | ----- | ------- | -------- |
+| S9 | `ensure_correct_state` (`QSChargerGroup`) | `ensure_correct_state dyn group: %s  correct_state: %s handled_static: %s` | `f"ensure_correct_state:{charger.name}"` — **per charger** | `(res, handled_static)` | — |
+| S10 | `dyn_handle` (`QSChargerGroup`) | `dyn_handle: full_available_home_power %sW, grid_available_home_power %sW battery_asked_charge %sW` | `"dyn_handle_available_power"` | `(full_available_home_power, grid_available_home_power, battery_asked_charge)` raw | `_POWER_LOG_DEADBAND_W` |
+| S11 | `get_best_car` (`QSChargerGeneric`) | `get_best_car: %s with score %s for charger %s` | `"get_best_car"` | `best_car.name` — **never the score** | — |
+| S12 | `constraint_update_value_callback_soc` (`QSChargerGeneric`) | `update_value_callback (is %%:%s):%s %s %s/%s (%s/%s) is_car_charged %s cmd %s` | `f"update_value_callback_soc:{is_target_percent}"` | `(do_continue_constraint, is_car_charged, None if self.current_command is None else self.current_command.command)` | — |
+
+Advisory lines: S9 627, S10 757, S11 3016, S12 4869. All four are
+f-strings today. Verified in scope: `res`/`handled_static` at 625;
+S10's three names as listed; `best_car` and
+`assigned_chargers_score.get(self)` at 3016; `do_continue_constraint`
+(4860/4862), `is_car_charged` (4851, a local bool shadowing the method)
+and `self.current_command.command` at 4869.
+
+**S12 contains a literal `%` that must be escaped as `%%`.** The current
+message is `f"update_value_callback (is %:{is_target_percent}):..."`. A
+naive conversion to `"... (is %:%s) ..."` makes `record.getMessage()`
+raise `ValueError: unsupported format character ':'`. The neighbouring
+lazy call at `charger.py:4681` already uses `(is %%:%s)`. B1/B2/B5 must
+match on a fragment that excludes the `%%`.
+
+Corrections carried from review:
+
+- **S11 keys on `best_car.name` only** — the score is a per-cycle float
+  and keying on it would preserve all 71k lines.
+- **S12's key includes `is_target_percent`** — `charger.py:4654-4662` are
+  two delegating callbacks (`..._percent_soc` / `..._energy_soc`)
+  discriminated by that flag; one key would let them thrash.
+- **S12 drops `round(result)`** — `result = None` at 4692 falls through to
+  4869, so `round()` would raise `TypeError`.
+- **S9 skips the helper when `probe_only is True`** (DEBUG instead) —
+  defensive per F13, not a fix for an observed path.
+
+**S11's branch precondition:** `best_car` non-`None` at 2985 **and** the
+`else` at 3005-3014 (`_boot_car` is `None` or has the same name). A
+driver with no scored car lands on 2997 instead.
+
+**S9 uses the issue's primary "on change" option**, not its
+`correct_state is False` alternative: a bare `if not res:` guard logs
+every cycle for the duration of a fault. The issue offers both.
+
+### Explicitly out of scope
+
+- `home_model/constraints.py` (62k), `ha_model/battery.py` (44k),
+  `ha_model/home.py` (22k), `home_model/solver.py` (17k). None appear in
+  the issue's call-site table. B4 protects one solver line.
+- `ha_model/bistate_duration.py` — see F1.
+- The 7 other `dyn_handle`-prefixed INFO sites — see F6.
+- `charger.py:4831` `_LOGGER.error` — see F2.
+- The other **6** `update_value_callback` INFO sites (4674, 4681, 4691,
+  4754, 4788, 4795) — branch-guarded, not per-cycle.
+- The other three `get_best_car:` INFO sites — 2993 ("Best Car from boot
+  data"), 2997 ("Default car used"), 3011 ("Use Best Car from boot
+  data"). **2997 is per-cycle when no real car scores**, so the issue's
+  71,023 for row 6 may include it; if so, S11 discharges only part of
+  that row.
+- `get_stable_dynamic_charge_status`' other INFO sites — 2320 ("not
+  enabled in qs"), 2324 ("no car or no plugged"), 2328 ("unavailable"),
+  2337. These are per-cycle-per-idle-charger rule-2 no-ops in the same
+  function S5 edits, but each needs a **distinct fixture** (disabled /
+  unplugged / unavailable charger states, versus S5's plugged-and-active
+  precondition), so folding them in means four more drivers, not four
+  more tokens. Deferred with the modules above. **The issue's 127,417 for
+  row 5 describes `score:N possible_amps:[...]`, i.e. site 2501 only**, so
+  row 5 is fully discharged by S5 and no counted volume is deferred.
+
+## Measured volume
+
+Per-site counts from the issue's analysis (2026-07-25 → 07-27,
+1,398,706 `quiet_solar` lines). One cycle ≈ 7 s → ~12,300 cycles/day
+**per key**; sites that fire per charger or per device multiply that.
+
+| Site | Lines today | After |
+| ---- | ----------- | ----- |
+| S8 `Constraint Reset device` | 219,949 | **unquantified** — see R1 |
+| S2+S3 cooldown (two messages) | 147,396 | 0 at INFO |
+| S7 `No bad constraint found` | 143,866 | 0 at INFO |
+| S9 `ensure_correct_state dyn group` | 143,669 | ~96/day per charger |
+| S5 `get_stable_dynamic_charge_status` | 127,417 | 0 at INFO |
+| S11 `get_best_car` | 71,023 | ~96/day (possibly partial — see 2997 above) |
+| S6 `do_remove_all_person_constraints` | 70,562 | 0 at INFO |
+| S1 `dyn_handle: START` | 49,818 | 0 at INFO |
+| S4 `can't dampen simple case` | 40,200 | 0 at INFO |
+| S12 `update_value_callback` | 35,926 | ~96/day per mode |
+| S10 `full_available_home_power` | 34,610 | ~96/day |
+| S13 `no actionable chargers` | ≤49,818, ≈15,000 | 0 at INFO |
+| **Total (S1–S12)** | **1,084,436 = 77.5%** | |
+
+S13's bound is derived, not measured: S1 is unconditional in `dyn_handle`
+so 49,818 is the total call count, and S10 (reached only when budgeting
+runs) is 34,610 — leaving ≈15,000 calls that took the "do nothing"
+branch, ~1% more of the log.
+
+**How the analysis shape was obtained** (not row-level reproduction — the
+per-site rows come from the issue body and are not fully re-derivable
+from these commands, because each charger and car produces its own
+message variant that must be summed):
+
+```bash
+grep ' INFO ' home-assistant.log \
+  | grep -oE 'custom_components\.quiet_solar\.[a-z_.]+' | sort | uniq -c | sort -rn
+grep ' INFO ' home-assistant.log \
+  | grep -oE 'quiet_solar\.[a-z_.]+.*' | cut -c1-80 | sort | uniq -c | sort -rn | head -30
+```
+
+`grep -oE` rather than `-oP`: the dev platform is darwin (BSD grep, no
+PCRE). Both commands filter on level, which earlier versions omitted.
+
+## Acceptance criteria
+
+- **B1 (rule-2 demotions).** For each of S1–S7 and S13, driving the
+  enclosing method with its precondition satisfied yields the message
+  text **zero times at INFO** and **`n` times at DEBUG**, where `n` is
+  the number of entities satisfying the precondition (`1` for the
+  single-charger fixtures; S2 fires per charger in cooldown, so its
+  driver uses exactly one actionable charger). Both directions are
+  required — an INFO-absence assertion alone passes if the call were
+  deleted or the branch never reached.
+  Requires `caplog.set_level(logging.DEBUG, logger="custom_components.quiet_solar.ha_model.charger")`
+  (and `...home_model.load` for S7): `caplog`'s handler is level 0 but the
+  root logger stays at WARNING, so DEBUG records are otherwise dropped
+  before capture. Propagation is on by default; no handler wiring needed.
+  Assert on `record.levelno`.
+- **B1b (S8 guard).** INFO iff work was performed: (a) non-empty
+  `_constraints` → INFO; (b) empty `_constraints` with
+  `_last_completed_constraint` set → INFO; (c) empty, `keep_commands`
+  falsy, `current_command` set → INFO; (d) empty, `keep_commands=True`,
+  nothing else → DEBUG. Plus: constructing a fresh `MinimalTestLoad`
+  raises nothing and logs case (d).
+- **B2 (rule-1 memos).** For each of S9–S12, over **10 consecutive
+  invocations** with unchanged inputs and `time` advancing ~7 s per call,
+  the site's message text appears **exactly once** at INFO on logger
+  `custom_components.quiet_solar.ha_model.charger`. Then an 11th
+  invocation with `time` advanced ≥900 s emits it once more. Then one
+  invocation **less than 900 s later** with a changed `value` emits it
+  once more (this pins "a change is not deferred to the next tick").
+  - **S9**: exactly one record **per charger** (per-charger key), and
+    **zero INFO records** when `probe_only=True`.
+  - **S10 (deadband)**: a run where `full_available_home_power` walks
+    1000/1049/1051/1049… — every step <100 W — emits **exactly one**
+    record across 10 invocations; a single ≥100 W step then emits one
+    more. Without this, an implementation that ignores the `deadband`
+    kwarg passes every other criterion.
+  - **S12**: percent and energy modes each get their own record.
+  - **S11**: the changed-value step needs a second car outranking the
+    first in `assigned_chargers_score`.
+  - `time` is passed explicitly as timezone-aware UTC. **No `freezegun`**
+    — the helper never reads the wall clock, so freezing it is inert.
+- **B3 (helper unit tests).** A `pytest.mark.parametrize` table:
+  1. lazy init: first call on a fresh instance → logs (state was `None`).
+  2. second call on the same instance → the initialized-state arc.
+  3. no deadband, equal value, inside window → silent.
+  4. no deadband, changed value, **inside** window → logs.
+  5. unchanged, `|elapsed| ≥ 900` → logs.
+  6. small backward clock jump (−5 s) → silent.
+  7. large backward jump (−1000 s) → logs.
+  8. `deadband` kwarg threaded through: sub-threshold tuple change →
+     silent.
+  9. deadband, one element ≥ threshold → logs.
+  10. deadband, non-tuple or length-mismatch operand → logs.
+  11. deadband, non-numeric element (`bool`, `MagicMock`, `None`) → logs.
+  12. two instances keep independent state — `a` logging does not silence
+      `b` (guards the shared-class-attribute trap).
+  13. returns `None`, and a **deep copy** of `vars(obj)` before the call
+      differs after it only by the addition of `_log_on_change_state`
+      (compare key *sets* symmetrically: before the first call the
+      attribute is absent from the instance `__dict__` entirely).
+- **B4 (keepers still at INFO).** Static source assertions over each
+  module's text, using a DOTALL-tolerant regex such as
+  `_LOGGER\.info\(\s*[^)]*STOP CHARGE LAUNCHED`, asserting **exactly one**
+  match each (so a duplicate elsewhere cannot satisfy it). Regex rather
+  than `inspect.getsource` of an enclosing function: ruff may split a
+  call across lines, and it keeps the check independent of function
+  naming.
+  - `charger.py` `stop_charge` (3952) — `STOP CHARGE LAUNCHED` (3958)
+  - `charger.py` `start_charge` (3964) — `START CHARGE LAUNCHED` (3968)
+  - `load.py` `launch_command` — `launch_command: %s for this load %s), ctxt: %s` (663) — the unbalanced `)` is pre-existing; do **not** "fix" it
+  - `load.py` `_ack_command` (552) — `ack command %s for load %s` (555)
+  - `constraints.py` — `%s update callback asked for stop` (636), inside
+    the `_update_value_callback is not None` branch. This is a
+    stop-request, the closest available proxy for the issue's
+    "constraint completion" category; if a literal constraint-met INFO
+    line exists it is the better anchor.
+  - `solver.py` `_constraints_delta` — `_constraints_delta: trying to
+    consume more: %sWh from %s to %s for loads %s` (861, twin `reclaim`
+    at 869) — **solver run**
+  For `load.py:555/663` and `charger.py:3958/3968` a runtime `caplog`
+  assertion is also cheap (those files are edited by this change set, and
+  `MinimalTestLoad` already drives `load.py`); only `constraints.py` and
+  `solver.py` are in untouched modules where a scenario build would be
+  disproportionate.
+- **B5 (lazy logging).** Two clauses:
+  - For the **six converted sites** (S5, S6, S9–S12): `record.args` is
+    non-empty and `record.msg` contains a `%` placeholder. S2, S4 and S7
+    are already lazy; S1, S3 and S13 are argless literals and are
+    excluded — an earlier version asserted non-empty `args` for *every*
+    touched site, which those three can never satisfy.
+  - For **all** touched sites: `record.msg` equals the expected literal
+    (a surviving f-string would have been interpolated, so exact-literal
+    match is the detector for the argless sites) and
+    `record.msg.rstrip()` does not end with `.` — per
+    `project-context.md` "No periods at end of log messages". None of the
+    13 current messages ends with a period, so this clause needs no
+    message edits.
+  No gate can catch this: `pyproject.toml:27` ignores `G004` with 384
+  existing occurrences, and `per-file-ignores` cannot scope below file
+  granularity.
+- **B6 (process gate).** `python scripts/qs/quality_gate.py --impacted`
+  passes, plus `--quick tests/qs`. F5 verified that
+  `tests/qs/test_check_doc_drift.py` uses synthetic repos in `tmp_path`,
+  but that establishes only one file; the rules' tiebreak is "prefer the
+  more restrictive option" and the run costs seconds against a CI red.
+
+**B7 (from story v2) was removed.** It asserted "≤5 INFO records from the
+charger logger over 10 cycles". All five round-2 reviewers rejected it as
+simultaneously **unsatisfiable** (out-of-scope sites 741/832/910 fire per
+cycle inside the driven loop) and **vacuous** (a no-actionable-charger
+fixture takes the S13 path, never reaches S9/S10, and passes at 0 ≤ 5). A
+logger-wide cap also pressures an implementer to demote out-of-scope
+lines. Its intent is carried by B1's two-sided per-message assertions and
+B2's exactly-once counts, which are per-site and cannot pass vacuously.
+
+## Risks
+
+- **R1 — S8's saving is unquantified, and it is 20% of the headline.**
+  F1 establishes that all six Clim callers pass `keep_commands=True` and
+  that both empty and non-empty `_constraints` cases occur, with
+  frequency unmeasured. If `_constraints` is usually non-empty for the
+  Clims, S8 saves ~0 and the headline falls from ~78% to ~62%. B1b
+  asserts the guard's behavior; the 219,949 figure is not claimed.
+- **R2 — memo state in the hottest file.** State lives only in the mixin,
+  is never read by control flow (B3), the mixin has no `__init__`, and the
+  immutable class default cannot be shared between instances.
+- **R3 — existing tests.** F11: no existing test asserts any of the 13
+  messages at INFO, but `tests/test_qs256_override_lifecycle.py` pins the
+  `home_model.load` logger at INFO and must be re-run after task 6.
+- **R4 — `__slots__` and `__dict__` observers.** `__slots__` /
+  `__setattr__` / `frozen=True` verified absent on `QSChargerGroup`,
+  `QSChargerGeneric`, `HADeviceMixin`, `AbstractLoad`, `AbstractDevice`.
+  Separately, the lazy attribute means `vars(charger)` gains a key after
+  the first emission — task 0 confirms nothing serializes or snapshots a
+  charger's `__dict__` (diagnostics payloads, dashboard state dumps,
+  syrupy snapshots).
+- **R5 — deadband bounds drift, not oscillation.** Accepted; see design.
+
+## Task breakdown
+
+**One commit, after task 10.** No intermediate commits: tasks 1 and 4–8
+add lines whose covering tests land in task 9, so `--impacted`'s
+changed-line 100% check can only pass on the complete change set. "Green"
+between tasks means `--quick` passes, not that the coverage gate would.
+
+Inner loop per task (all `--quick`, the sanctioned TDD form):
+task 1 → `tests/test_charger_coverage_deep.py`; tasks 2–5, 7, 8 →
+`tests/test_qs306_log_volume.py tests/test_charger_coverage_deep.py`;
+task 6 → add `tests/test_qs256_override_lifecycle.py tests/test_coverage_load.py`.
+Where a task changes a log level, fix any assertion it breaks **in that
+same task**.
+
+0. **Audit (read-only).** Re-confirm F11. Confirm nothing serializes or
+   snapshots a charger's `__dict__`/`vars()` (R4).
+1. Add the two constants to the constants block (178-221); add
+   `_is_number`, `_is_unchanged`, `LogOnChangeMixin` immediately before
+   `class QSChargerGroup` (584); add `TypeGuard` to the `typing` import
+   at line 8. Docstrings and full type hints; **no forward references**
+   (F9); do not add a future import or module docstring.
+2. Add B3's parametrized unit tests in `tests/test_qs306_log_volume.py`
+   (the same file task 9 extends). The tests define a minimal local host
+   class, so task 2 does **not** depend on task 3.
+3. `class QSChargerGroup(LogOnChangeMixin)` and
+   `class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad)`.
+   **No `__init__` edits.**
+4. Apply S1–S4 and S13 (DEBUG demotions in `dyn_handle`).
+5. Apply S5, S6 (DEBUG + lazy conversion).
+6. Apply S7 (DEBUG) and S8 (corrected guard) in `home_model/load.py`.
+7. Apply S9 (with the `probe_only` early-out) and S10 (with deadband).
+8. Apply S11, S12 (S12 with the `%%` escape).
+9. Site tests in `tests/test_qs306_log_volume.py` — B1, B1b, B2, B4, B5.
+   Placed in `tests/` as a cross-cutting test (`FakeHass` is in
+   `tests/conftest.py`); **move to `tests/ha_tests/` if any driver needs
+   `MOCK_CHARGER_CONFIG`**, which is HA-tests-local.
+   **Harness.** The two factories named in earlier versions do not work:
+   `create_test_charger_double` returns `TestChargerDouble`
+   (`tests/factories.py:763`), a standalone class with four methods and no
+   `QSChargerGeneric.__init__`; and `create_charger_group`
+   (`tests/factories.py:542`) builds a group whose children fail
+   `QSChargerGroup.__init__`'s `isinstance(device, QSChargerGeneric)`
+   filter and stubs a `spec=`'d `QSDynamicGroup` lacking the
+   instance-only `accurate_power_sensor`. The working helpers are
+   module-level in `tests/test_charger_coverage_deep.py` — `_make_hass`
+   (83), `_make_home` (98), `_make_charger_group` (173), `_create_charger`
+   (197), `_init_charger_states` (231), `_plug_car` (243), `_make_battery`
+   (248), `_make_real_car` (140). **Promote them to
+   `tests/utils/charger_harness.py` with public names** (`tests/utils/` is
+   the sanctioned shared-utility location) and import from there; leave
+   `test_charger_coverage_deep.py` untouched. Do **not** copy them
+   inline, and do not re-point existing tests.
+   Per-site drivers:
+   - **S1–S4, S10, S13** — drive `dyn_handle` with
+     `group.ensure_correct_state` stubbed as `AsyncMock` (pattern at
+     `:6034-6096`). S13 needs a **separate** fixture with no actionable
+     charger; S3's fixture uses exactly one actionable charger.
+   - **S9** — a **separate** driver that awaits the **real**
+     `group.ensure_correct_state(time)`, with each child's
+     `charger.ensure_correct_state` stubbed as
+     `AsyncMock(return_value=(True, False, time))` (real signature at
+     `charger.py:4410`, a 3-tuple). Two chargers, for the per-charger-key
+     assertion. Note the real path also calls
+     `charger.get_stable_dynamic_charge_status(time)` at 650, so S5 and
+     the 2320-2337 records appear in the same run — harmless, because
+     every assertion counts by message text.
+   - **S11, S12** — the real-charger pattern at `:6700-6739`. The `ct`
+     mock is `MagicMock(spec=LoadConstraint)` and must set six
+     attributes: `last_value_update`, `first_value_update`,
+     `last_value_change_update`, `current_value`, `target_value`,
+     `is_constraint_met` (or use `create_charge_percent_constraint`,
+     `tests/factories.py:209`). Patch `_do_update_charger_state` and
+     `charger_group.dyn_handle` with `AsyncMock`, not `MagicMock`. Use
+     `return_value=` for `_compute_added_charge_update` — the pattern's
+     `side_effect=[6.0, 10.0, 8.0]` raises `StopIteration` on invocation 2
+     of 10.
+   - **S10 specifically** — keep `_make_home`'s default `battery=None`
+     or use `_make_battery(0.0)`; a bare `MagicMock` battery puts a
+     non-numeric into the tuple and S10 re-logs every cycle (F12). Stub
+     the power-values getters to return **non-empty, constant**
+     `(datetime, value, dict)` triples — e.g.
+     `[(t0 - timedelta(seconds=30), 1000.0, {}), (t0, 1000.0, {})]` —
+     because they feed `get_average_time_series(..., last_timing=time)`
+     and `time` advances 7 s per call, so a varying series drifts the
+     weighted mean and defeats the deadband. Non-empty also keeps
+     `charger.py:741` silent.
+   - **S5, S6** — `_create_charger` + `_plug_car`; S6 additionally needs
+     person constraints present.
+   - **S8** — `MinimalTestLoad` (`tests/factories.py:102`).
+10. **Co-modify the five docs** from F4 — bump `last_verified`, add one
+    line noting log levels changed with no behavior change (American
+    English). Per F5 the co-modification is what clears the checker. Then
+    run `python scripts/qs/check_doc_drift.py` and confirm exit 0 against
+    the **final** change set, since the flagged set depends on which
+    sources actually ended up modified.
+11. Run `python scripts/qs/quality_gate.py --impacted`, then
+    `python scripts/qs/quality_gate.py --quick tests/qs`.
+
+## Resolved decisions
+
+- **Q1 (helper shape)**: mixin in `charger.py` using that module's
+  `_LOGGER`; state lazily initialized behind an immutable class default.
+- **Q2 (reproducibility)**: **neither** script nor fixture. The
+  reproduction commands and per-site counts are in "Measured volume". The
+  issue offers script **or** fixture; a `scripts/qs/` module would need
+  its own tests to clear the changed-line gate, and committing a slice of
+  a real user log carries a data-hygiene obligation (entity IDs, device
+  names).
+- **Q3 (docs)**: co-modify all five, bump `last_verified`, one line each,
+  no prose redesign.
+
+**Doc co-modification rationale** (the gate is cleared by the edit in
+task 10, not by this note — F5): `charger-budgeting.md`,
+`external-control-detection.md`, `load-base.md`,
+`piloted-device-and-heat-pump.md`, `user-override.md` — log-level and
+log-throttling changes only; no budgeting, override, or load behavior
+change.
+
+## Accepted deviations from the issue
+
+- Extra `value` parameter on the helper — else the change detector is
+  either the volatile args or nothing.
+- Extra `time` parameter and the 900 s re-log — user-confirmed; pure
+  on-change is a diagnostic regression.
+- Deadband on S10 — bucketing does not bound volume.
+- **S5/S6 are not no-ops**; demoting them is information loss at INFO,
+  recorded above rather than justified away.
+- S13 added as a user-confirmed one-off.
+- Five doc co-modifications where the issue expected one `Doc-OK` line
+  (forced by F5).
+- B3 has 13 cases rather than the issue's "three branches" — the helper
+  gained a deadband (needed for row 11) and a timer (user-confirmed).
+- B6 adds `--quick tests/qs` beyond the issue's B1–B5.
+
+## Adversarial Review Notes
+
+**Round 3 — 5 reviewers.** No design defects. Findings were documentation
+accuracy and test-driver specificity. Resolved in v4: B5 unsatisfiable
+for the three argless sites (4 of 5 reviewers) → split into two clauses;
+`_do_start_charge` does not exist → `stop_charge` / `start_charge`, and
+B4 moved to module-source regex; task 9's S9 driver stubbed the method S9
+lives in (3 of 5) → separate driver; S12's literal `%` → `%%` escape
+documented; rule-1 table gained a Message column; `battery_asked_charge`
+is never `None` (F12) → `None`-handling removed from `_is_unchanged`, the
+numeric guard rejustified as a test-only hazard; `probe_only` premise
+false (F13) → early-out relabeled defensive; F1's inference wrong in both
+directions → R1 restored as a live risk on 20% of the headline and the
+volume table hedged; F10/F11 citations corrected (F11 undercounted: ten
+INFO calls, one pinning the `load` logger); `_is_number` → `TypeGuard`;
+`caplog.set_level` named; B3 gained "changed inside window" and dropped
+two dead branches; deadband gained a falsifiable B2 sub-bullet; B1's
+DEBUG count made charger-count-aware; harness promoted to
+`tests/utils/charger_harness.py`; three driver landmines documented
+(sixth `ct` attribute, `side_effect` exhaustion, constant power series);
+single-commit policy stated; per-task inner-loop targets named; task 10
+runs the drift checker; `--quick tests/qs` adopted; repro commands made
+portable and level-filtered; S13's bound derived; the self-contradictory
+"inclusion rule" withdrawn; row 5's per-message question settled.
+
+Rejected in round 3: fold the `get_stable_dynamic_charge_status`
+idle-charger lines into S5 (each needs a distinct fixture — four drivers,
+not four tokens); delete the deadband's defensive tuple guard (it is the
+guard that converts a test double from a crash into a log).
+
+**Rounds 1–2 — 4 and 5 reviewers.** Round 1: 8 criticals, 7 redesigns —
+S8 crash + intent-vs-work predicate, `round(None)` TypeError, `_UNSET`
+reflected `__eq__`, annotation-only logger attribute, mypy-unclean
+helper, B4 missing solver run, B1/task-9 scope mismatch, bucketing, pure
+on-change, S12 shared key, `str(current_command)`, circular module
+justification, `charger.py:694`, line-number anchoring. Round 2: 12
+criticals — B7 unsatisfiable+vacuous (all 5 reviewers; B7 later deleted
+rather than repaired), both named test factories unusable, B1 vacuous,
+annotation-only state / shared-`{}` trap, `None`-as-changed regression,
+B3 under-coverage, incoherent `vars()` check, B4 undrivable, task 1's
+false future-import premise. Rejected across both: initialize
+`_constraints` before `load.py:155` (blast radius); the bare
+`if not res:` guard for S9 (spams during a fault); prose in
+`charger-budgeting.md`; extract the mixin (changes the logger name B2
+asserts on).
+
+**Open**: none.
+
+**Shipped state.** v4 was finalized **without a fourth review round**, on
+explicit user confirmation, with **0 open critical findings**. Every v3→v4
+change traces to a specific round-3 finding with a source line reference,
+and round 3 returned no design defects — but v4's own text is unreviewed.
+The residual risk is concentrated in task 9's drivers, where `--quick`
+gives immediate feedback during implementation. **R1 ships open and
+unquantified** (S8 = 20% of the claimed saving); it is a measurement gap,
+not a correctness gap.
+
+**Deferred to a follow-up issue**: `get_stable_dynamic_charge_status`
+idle-charger lines (2320/2324/2328/2337), the other `get_best_car:` sites
+(2993/2997/3011, where 2997 may hold part of row 6's 71,023), and
+`constraints.py` / `battery.py` / `home.py` / `solver.py` (~145k lines).

--- a/docs/stories/QS-306.story_review_fix_#01.md
+++ b/docs/stories/QS-306.story_review_fix_#01.md
@@ -1,0 +1,272 @@
+# QS-306 — Review fix plan #01
+
+## Summary
+- Source PR: #312
+- Source story: `docs/stories/QS-306.story.md`
+- Findings to fix: 12 (4 should-fix, 8 nice-to-have)
+- Findings dismissed as invalid: 3 (see "Not fixing" at the bottom)
+- Next implement phase: `/implement-task`
+
+Reviewers: `qs-review-blind-hunter`, `qs-review-edge-case-hunter`,
+`qs-review-acceptance-auditor`. **CodeRabbit abstained** — the account hit its
+PR review limit before the run, then marked head `8bbe8e58` as "already
+reviewed" and returned nothing. Pushing the commit that applies this plan
+resets CodeRabbit's incremental-review state, so the follow-up `/review-task`
+round should get a real fourth opinion. If it still comes back empty, run
+`@coderabbitai full review` on the PR.
+
+No must-fix findings: no reviewer found a correctness bug, and all 18
+acceptance criteria trace to asserting tests with CI green. Everything below
+is an observability regression, a robustness gap in the new helper, or test
+rigour.
+
+## Findings to fix
+
+### [should-fix] SF1 — Memo state is not car-qualified and survives a car swap
+- File: `custom_components/quiet_solar/ha_model/charger.py:4973` and `custom_components/quiet_solar/ha_model/charger.py:3110`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (same root cause, merged)
+- Description: The S12 memo key `f"update_value_callback_soc:{is_target_percent}"`
+  omits `self.car.name` even though the message *prints* it, and the S11 key is
+  the bare literal `"get_best_car"`. Neither is invalidated when the car
+  changes: `detach_car()` (`charger.py:4009-4016`) clears `self.car`,
+  `_power_steps` and `car_attach_time` but not `_log_on_change_state`.
+  Reproduces when car A is unplugged and car B plugged into the same charger
+  inside the 900 s window and both yield the same memoized tuple
+  (`(True, False, "auto_green_only")` is the normal mid-charge value): the line
+  is suppressed and the last emitted INFO record names the **wrong car**. The
+  same shape hides a new charge session on unplug/replug of the *same* car —
+  `get_best_car` emits nothing, so the log has no session marker.
+  S9/S10 both key on everything they print; S11's *score* omission is
+  deliberate and documented, but the *car* omission is not.
+- Proposed fix: Clear the memo in `detach_car()` — add
+  `self._log_on_change_state = None` alongside the existing resets. That is one
+  line, covers both sites, and keeps the keys readable. Additionally qualify
+  the S12 key by car name
+  (`f"update_value_callback_soc:{self.car.name}:{is_target_percent}"`) as
+  defence in depth for any future path that swaps a car without routing through
+  `detach_car()`. Add a test: attach car A, log, `detach_car()`, attach car B
+  with an identical value tuple inside the window, assert a second INFO record
+  is emitted and that it names car B.
+
+### [should-fix] SF2 — S8 predicate is blind to what subclass overrides clear
+- File: `custom_components/quiet_solar/home_model/load.py:332`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter (verified by the orchestrator against `charger.py:3260-3266`)
+- Description: `QSChargerGeneric.constraint_reset_and_reset_commands_if_needed`
+  calls `super()` **first** and then wipes `self.car.do_force_next_charge = False`
+  and `self.car.do_next_charge_time = None`. When `_constraints == []` and
+  `_last_completed_constraint is None`, the base predicate concludes "nothing to
+  reset" and emits DEBUG *while a user-initiated flag is being destroyed*.
+  Reproduces when a car is plugged onto a charger holding no constraints (first
+  cycle after plug, or right after a full reset cleared
+  `_last_completed_constraint` at `load.py:914`), the user presses "force next
+  charge", and `check_load_activity_and_constraints` reaches the
+  `force_charge is True` branch at `charger.py:3507`. Same shape at
+  `charger.py:3604` for the charge-time path. Losing the INFO record of a
+  user-initiated action is exactly the class of line QS-306 set out to
+  *preserve*.
+- Proposed fix: Make the predicate extendable rather than fixed in the base.
+  Extract the "did we have anything to reset?" term into a small overridable
+  hook — e.g. `_has_state_to_reset(self, keep_commands: bool) -> bool` on
+  `AbstractDevice` returning the current `had_constraints or had_commands`
+  expression — and have `QSChargerGeneric` override it to OR in
+  `self.car is not None and (self.car.do_force_next_charge or self.car.do_next_charge_time is not None)`.
+  The base method then logs INFO iff the hook is true. Keep the three `getattr`
+  defaults and their existing comment: the `AbstractDevice.__init__` ordering
+  constraint documented at `load.py:155` still applies, and the charger override
+  must use `getattr(self, "car", None)` for the same reason. Add tests for both
+  halves: force-charge flag set + no constraints → INFO; nothing set at all →
+  DEBUG.
+
+### [should-fix] SF3 — B2's logger-name clause is never asserted
+- File: `tests/test_qs306_log_volume.py:58`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC B2 requires the message to appear "exactly once at INFO **on
+  logger `custom_components.quiet_solar.ha_model.charger`**", and the story's
+  Design section calls this out as a deliberate coupling worth pinning ("A later
+  extraction would change the logger name that B2 asserts on — record that
+  coupling before moving it"). The `_messages` helper filters on `r.levelno` and
+  a message fragment only, never on `r.name`, so the extraction guard the story
+  asked for does not exist. Low risk today because the fragments happen to be
+  unique.
+- Proposed fix: Add an optional `logger_name: str | None = None` parameter to
+  `_messages` and include `and (logger_name is None or r.name == logger_name)`
+  in the comprehension. Define module constants `CHARGER_LOGGER =
+  "custom_components.quiet_solar.ha_model.charger"` and `LOAD_LOGGER =
+  "custom_components.quiet_solar.home_model.load"`, and pass the right one at
+  every B2 call site (and the B1/B1b `load.py` sites, which have the same
+  coupling). Do not make the parameter mandatory — the B3 helper unit tests log
+  from the test module itself.
+
+### [should-fix] SF4 — Non-assertion on the ack-command count
+- File: `tests/test_qs306_log_volume.py:738`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `assert len(acks) >= 1` passes on any duplication regression,
+  while the sibling assertion one line down is `assert len(launches) == 1`. The
+  test cannot fail in the direction it exists to guard.
+- Proposed fix: Pin the exact count. Determine the true value by running the
+  test and asserting `== N`; if the count is genuinely non-deterministic across
+  the fixture's cycles, assert an exact upper *and* lower bound rather than an
+  open-ended `>=`.
+
+### [nice-to-have] NH1 — NaN/inf silently re-inflates the log to full cycle rate
+- File: `custom_components/quiet_solar/ha_model/charger.py:597`
+- Severity: nice-to-have (robustness — highest-value item in this bucket)
+- Source: qs-review-edge-case-hunter
+- Description: `abs(c - p) < deadband` is `False` when either side is `NaN`, so a
+  persistently-`NaN` element makes *every* cycle compare as "changed" and the
+  available-power site logs at INFO at full cycle rate — silently recreating the
+  exact volume this PR removes. Reproduces when a power sensor feeds `NaN`
+  through `get_average_time_series` / `get_median_sensor` into
+  `_extracts_power_value_from_data` (`charger.py:753-761`), which has no `NaN`
+  filter.
+- Proposed fix: In `_is_unchanged`, treat two `NaN`s in the same position as
+  unchanged: for each pair, `unchanged = (math.isnan(p) and math.isnan(c)) or
+  abs(c - p) < deadband`. Keep the fail-open direction for genuinely unknown
+  types — that call is correct — this narrows it only for `NaN`. Note `inf - inf`
+  is `NaN`, so the same guard also stops a stuck-at-`inf` sensor. Add
+  parametrized `_B3_CASES` entries for NaN→NaN (no log) and NaN→finite (log).
+
+### [nice-to-have] NH2 — Naive/aware datetime `TypeError` can abort `dyn_handle`
+- File: `custom_components/quiet_solar/ha_model/charger.py:616`
+- Severity: nice-to-have (robustness)
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (merged)
+- Description: The "`time` must be timezone-aware UTC" contract is documented in
+  the docstring but unenforced. `(time - prev_time)` raises
+  `TypeError: can't subtract offset-naive and offset-aware datetimes` if a naive
+  value ever reaches a key already holding an aware stamp — and the exception
+  propagates out of a *logging* helper, killing the whole `dyn_handle` budgeting
+  cycle. All four current call sites are aware-only, so this is latent, not live;
+  but a logging helper must never be load-bearing.
+- Proposed fix: Guard the subtraction — if
+  `(prev_time.tzinfo is None) != (time.tzinfo is None)`, skip the elapsed-time
+  comparison and fall through to emitting (bail-to-log, consistent with the
+  existing fail-open philosophy), re-stamping the key with the new value. Add a
+  unit test driving the mixin directly with a naive `datetime` after an aware
+  one and asserting it logs instead of raising.
+
+### [nice-to-have] NH3 — `zip()` without `strict=`
+- File: `custom_components/quiet_solar/ha_model/charger.py:601`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Ruff `B905` territory. Lengths are already verified equal one line
+  above, so the strictness is free.
+- Proposed fix: `zip(prev, current, strict=True)`.
+
+### [nice-to-have] NH4 — Deadband has no zero-crossing case
+- File: `custom_components/quiet_solar/ha_model/charger.py:835`
+- Severity: nice-to-have (log-policy change)
+- Source: qs-review-edge-case-hunter
+- Description: The 100 W deadband is symmetric around the last emitted value and
+  has no special case for the sign flip, which is the operationally meaningful
+  boundary (exporting vs. importing). When `grid_available_home_power`
+  oscillates inside ±50 W under cloud-edge / near-balance conditions, the home
+  flips between export and import repeatedly and the line stays silent for the
+  full 900 s. Values are correct; only the observability of the sign flip is lost.
+- Proposed fix: Treat a sign change on `grid_available_home_power` as a change
+  regardless of deadband. Implement it inside `_is_unchanged` as an additional
+  per-element term — `(p > 0) != (c > 0)` forces "changed" — so it applies
+  uniformly to every deadband element rather than special-casing one tuple
+  position. **Note this is a deliberate log-policy change beyond the original
+  story**, accepted at triage; call it out in the PR description so the next
+  reviewer does not read it as scope creep. Add a `_B3_CASES` entry for a
+  sub-deadband sign flip.
+
+### [nice-to-have] NH5 — `had_commands` only inspects `current_command`
+- File: `custom_components/quiet_solar/home_model/load.py:335`
+- Severity: nice-to-have (log-policy change)
+- Source: qs-review-edge-case-hunter
+- Description: `keep_commands=False` also clears `running_command`,
+  `_stacked_command`, `prev_command`, `running_command_first_launch`,
+  `running_command_last_launch` and the two relaunch counters
+  (`load.py:340-353`), but the predicate only inspects `current_command`.
+  Reproduces when `check_commands` gives up on an unverifiable command and calls
+  `_ack_command(time, None)` (`load.py:734`), setting `current_command = None`;
+  the next cycle `launch_command` sets `running_command` (`load.py:672`); a
+  `keep_commands=False` reset then drops that in-flight command while logging
+  DEBUG "nothing to reset". Mitigated in practice because `reset()` emits its own
+  INFO at `load.py:357` — but `async_load_constraints_from_storage`
+  (`load.py:1135`) has no such companion line.
+- Proposed fix: Widen `had_commands` to
+  `not keep_commands and (getattr(self, "current_command", None) is not None or
+  getattr(self, "running_command", None) is not None)`. Keep the `getattr`
+  defaults for the `__init__`-ordering reason already documented. Fold this into
+  the SF2 `_has_state_to_reset` hook so there is a single predicate. Add a test
+  for `running_command` set + `current_command` None + `keep_commands=False` →
+  INFO.
+
+### [nice-to-have] NH6 — Log format double-space drift
+- File: `custom_components/quiet_solar/ha_model/charger.py:4977`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The original f-string had two spaces
+  (`{self.car.name}  {do_continue_constraint}`); the lazy version has one.
+  Cosmetic, but it breaks grep-compatibility with historical logs.
+- Proposed fix: Restore the double space in the format string. If
+  `_B5_SITES` pins this literal, update the expected literal in lockstep.
+
+### [nice-to-have] NH7 — Vacuous assertion
+- File: `tests/test_qs306_log_volume.py:598`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `assert car_a.name == "CarA"` re-asserts a value the factory set
+  two lines of setup earlier; it says nothing about the code under test.
+- Proposed fix: Delete it, or replace it with an assertion on the *emitted log
+  record* naming CarA — which is what the test actually cares about and which
+  dovetails with the SF1 test.
+
+### [nice-to-have] NH8 — Module-scope shared mock
+- File: `tests/test_qs306_log_volume.py:67`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `_SHARED_MOCK = MagicMock()` at module scope is shared mutable
+  state across parametrized runs (used by the
+  `deadband_mock_element_logs` case at line 97), so call history leaks between
+  cases.
+- Proposed fix: Build the mock inside a fixture or a factory lambda per case so
+  each parametrized run gets a fresh object. The `_B3_CASES` table holds values
+  directly, so this likely means storing a zero-arg callable for that entry (or
+  a sentinel the test body resolves) rather than the instance.
+
+## Not fixing (invalid)
+
+- **Missing `tests/utils/__init__.py`** (blind-hunter, assumed without repo
+  context) — the file already exists and predates this PR.
+- **"Harness helpers copied, not promoted"** (blind-hunter) — the story's Task 9
+  explicitly specifies leaving `tests/test_charger_coverage_deep.py` untouched,
+  and the acceptance-auditor confirmed the PR matches. Independently verified
+  that per-file `make_hass`/`make_home`/`create_charger` definitions are a
+  pre-existing repo-wide pattern across 9 test modules; consolidating them is a
+  separate refactor, not this PR's job.
+- **"Memo state is never pruned"** (blind-hunter) — the edge-case-hunter verified
+  the key sets are bounded (per-charger name, one bool suffix, two fixed keys).
+  SF1's `detach_car()` clear also happens to bound it further.
+
+## How to apply
+
+Run `/implement-task` against this fix plan.
+
+Suggested ordering — SF2 and NH5 both touch the same predicate, and SF1 and NH7
+both touch the car-identity tests, so do them together:
+
+1. **SF2 + NH5** — the `_has_state_to_reset` hook in `load.py` plus the
+   `QSChargerGeneric` override.
+2. **SF1 + NH7** — clear the memo in `detach_car()`, qualify the S12 key, add the
+   car-swap test, drop the vacuous assertion.
+3. **NH1 + NH2 + NH3 + NH4** — all inside `_is_unchanged` / `log_info_on_change`;
+   extend `_B3_CASES` in one pass.
+4. **SF3 + SF4 + NH8** — test-rigour pass over `tests/test_qs306_log_volume.py`.
+5. **NH6** — one-line format restore, plus the `_B5_SITES` literal if pinned.
+
+Note that NH4 and NH5 deliberately change log policy beyond the original story;
+mention both in the PR description.
+
+Gate before commit: `python scripts/qs/quality_gate.py --impacted`. This change
+set is product code under `custom_components/`, so no `--quick tests/qs`
+supplement is needed unless you also touch agent/command/workflow files.
+
+When done, return and run `/review-task` again to re-verify — that round should
+also recover the CodeRabbit opinion this one lost.

--- a/docs/stories/QS-306.story_review_fix_#02.md
+++ b/docs/stories/QS-306.story_review_fix_#02.md
@@ -1,0 +1,345 @@
+# QS-306 — Review fix plan #02
+
+## Summary
+- Source PR: #312
+- Source story: `docs/stories/QS-306.story.md`
+- Previous fix plan: `docs/stories/QS-306.story_review_fix_#01.md` (all 12 findings verified applied)
+- Findings to fix: 16 (1 must-fix, 5 should-fix, 10 nice-to-have)
+- Findings dismissed as stale/invalid: 4 (see "Not fixing")
+- Next implement phase: `/implement-task`
+
+Round-2 reviewers: `qs-review-blind-hunter`, `qs-review-edge-case-hunter`,
+`qs-review-acceptance-auditor`, `qs-review-coderabbit`.
+
+Round 1's fixes verified good: the acceptance-auditor confirmed all 12 findings
+landed **with tests** (62 tests pass, all 6 CI checks green, `check_doc_drift.py`
+exit 0), and the edge-case-hunter re-walked the NaN/inf guard, the naive-datetime
+guard, the `detach_car()` memo clear and the `_has_state_to_reset` hook and found
+them sound. MF1 below is the one regression the round introduced — and it came
+from **this orchestrator's instruction in fix plan #01**, not from an
+implementation error. See MF1.
+
+## Findings to fix
+
+### [must-fix] MF1 — The NH4 sign-flip term re-inflates the highest-volume line
+- File: `custom_components/quiet_solar/ha_model/charger.py:611` (`_element_unchanged`)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter + qs-review-acceptance-auditor (both should-fix)
+  and qs-review-blind-hunter (the zero-asymmetry facet) — **three independent
+  reviewers converged on this**; elevated to must-fix by the orchestrator because it
+  silently defeats the PR's primary acceptance goal and no test bounds it.
+- Description: `(prev > 0) != (current > 0)` forces "changed" for an arbitrarily
+  small step, with no magnitude floor. When `grid_available_home_power` alternates
+  around zero inside the deadband — `+20.0`, then `-20.0`, then `+20.0` on
+  consecutive `dyn_handle` cycles — |Δ| = 40 W < 100 W, but every cycle flips sign,
+  so `dyn_handle_available_power` emits INFO **every ~7 s indefinitely**. This is
+  precisely the full-cycle-rate re-inflation that the NaN guard three lines above
+  was written to prevent, on the single highest-volume site in the change set.
+
+  It cannot be vetoed by another tuple element: `full_available_home_power` falls
+  back to `grid_available_home_power` when `available_power` is empty
+  (`charger.py:841-844`), so both flip together. Near-zero grid power is not
+  exotic — it is the steady state of a well-regulated self-consumption home.
+
+  Second defect, same line: zero sits on the negative side of the test.
+  `(0.0 > 0)` and `(-50.0 > 0)` are both `False`, so `0.0 → -50` (battery idle →
+  starts discharging, the "post battery" case called out at `charger.py:857-859`)
+  is **not** detected, while the mirror `0.0 → +50` logs immediately.
+
+  **Provenance.** Fix plan #01 instructed: *"Implement it inside `_is_unchanged` as
+  an additional per-element term — `(p > 0) != (c > 0)` forces 'changed' — so it
+  applies uniformly to every deadband element rather than special-casing one tuple
+  position."* Uniform application is the direct cause. The implementer followed the
+  plan correctly; the plan was wrong.
+- Proposed fix: Keep the export↔import signal but bound it — add a magnitude floor
+  so a flip only counts when at least one side is outside the deadband:
+
+  ```python
+  if (prev > 0) != (current > 0) and max(abs(prev), abs(current)) >= deadband:
+      return False
+  ```
+
+  This preserves a real export→import transition (which necessarily crosses the
+  deadband on one side) while collapsing near-zero dither, and it makes the
+  zero-asymmetry moot for small values. Keep the ordering: the `prev == current`
+  and NaN checks must stay **above** this term.
+
+  Rejected alternative: reverting NH4 entirely. It is simpler, but the operator
+  loses export↔import visibility inside the deadband, and the triage decision was
+  explicit that observability of state transitions matters (see SF-G).
+- Required test: the volume consequence must be pinned, not just the single-step
+  behaviour. Add a B2/S10 driver where `grid_available_home_power` alternates
+  `+20 / -20` across 10 cycles and assert the resulting INFO count is **1**
+  (not "≥1"). Add a companion case where the oscillation is `+150 / -150` and
+  assert the flip is still honoured. Extend `_B3_CASES` with a sub-deadband flip
+  (silent) and a supra-deadband flip (logs), replacing the existing
+  `deadband_sub_threshold_sign_flip_logs` case, whose expectation inverts under
+  this fix.
+
+### [should-fix] SF-B — Undisclosed log-policy deviations in the PR description
+- File: PR #312 body (no source file)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: Fix plan #01 required this twice, explicitly: *"**Note this is a
+  deliberate log-policy change beyond the original story**, accepted at triage; call
+  it out in the PR description so the next reviewer does not read it as scope
+  creep"* and *"Note that NH4 and NH5 deliberately change log policy beyond the
+  original story; mention both in the PR description."* Neither the sign-flip term
+  (NH4) nor the `running_command` widening (NH5) appears in the PR body. Code and
+  tests landed; only the disclosure step was skipped. Separately the body still
+  claims "46 new tests in tests/test_qs306_log_volume.py" — the file now collects
+  **62**.
+- Proposed fix: Add a short "Log-policy deviations beyond the story" section to the
+  PR body covering (a) the sign-flip term as amended by MF1, and (b) `running_command`
+  and `_stacked_command` (NH5 + NH-A) in the reset predicate. Correct the test count.
+  Use `gh pr edit 312 --body-file <file>`.
+
+### [should-fix] SF-C — `QS-306.story.md` no longer matches the implementation
+- File: `docs/stories/QS-306.story.md` (Design section ~lines 274-284 and ~392-401;
+  "Accepted deviations from the issue")
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The story's Design section still shows the superseded `_is_unchanged`
+  — no `_element_unchanged` split, no NaN/inf guard, no sign-flip term, no
+  `strict=True` — and the S8 block still shows the inline predicate rather than the
+  `_has_state_to_reset` hook. "Accepted deviations from the issue" lists neither NH4
+  nor NH5. The story is the artefact the *next* review round audits against, so
+  leaving it stale guarantees a false finding next time.
+- Proposed fix: Update both code blocks to the shipped implementation (post-MF1) and
+  add NH4 + NH5 to "Accepted deviations", each with a one-line rationale and a
+  pointer to the fix plan that introduced it.
+
+### [should-fix] SF-D — `charger-budgeting.md` overstates the change's scope
+- File: `docs/agents/concepts/charger-budgeting.md:25`
+- Severity: should-fix
+- Source: qs-review-coderabbit (thread still anchored to current head, unresolved)
+- Description: The note reads "Per-cycle status lines from this file are now DEBUG,
+  or emitted at INFO only when the reported value changes". The story deliberately
+  left other per-cycle INFO sites in this file out of scope (B4's keepers, and the
+  untouched `budgeting_algorithm_minimize_diffs` f-strings at `charger.py:1508`,
+  `:1574`, `:1595`), so the sentence claims more than the PR did.
+- Proposed fix: Narrow to "The QS-306-touched per-cycle status lines in this file
+  are now DEBUG, or emitted at INFO only on change (or after 900 s); other INFO
+  sites in this file are unchanged." Do **not** bump `last_verified` again — it is
+  already `2026-07-30` from this PR, and the drift checker is satisfied.
+
+### [should-fix] SF-E — Fenced block missing a language identifier (MD040)
+- File: `docs/stories/QS-306.story.md:225`
+- Severity: should-fix
+- Source: qs-review-coderabbit (markdownlint-cli2)
+- Description: The fenced block has no language identifier, tripping markdownlint
+  MD040. Contents are signature/reference text, not executable Python.
+- Proposed fix: Tag the fence as `text`. While in the file, scan for any other
+  untagged fences introduced by this PR and fix them in the same pass.
+
+### [should-fix] SF-G — The SOC line's own numbers are invisible for up to 900 s
+- File: `custom_components/quiet_solar/ha_model/charger.py:5022-5040`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (two facets, merged)
+- Description: **Explicitly accepted at triage — "it can't be invisible".** The memo
+  tuple is `(do_continue_constraint, is_car_charged, current_command.command)` but
+  the message prints `result`, `sensor_result`, `result_calculus` and the whole
+  `current_command`. Two consequences:
+
+  1. The charge-progress numbers are omitted from the memo entirely, so with the two
+     flags constant an operator sees a progress line only every 900 s.
+  2. The memo stores `current_command.command` — the **name only** — while
+     `LoadCommand.__eq__` (`home_model/commands.py:32-34`) also compares
+     `power_consign`. A consign change under the same command name (e.g.
+     `auto_consign` 3000 W → 7000 W) is invisible in the memo, so the `cmd …` field
+     of the emitted line goes stale for up to 900 s.
+- Proposed fix: Include the printed values in the memo, but **quantise the
+  continuous ones** so this does not degenerate into logging every cycle — that is
+  the trap MF1 fell into. Concretely:
+
+  ```python
+  (
+      do_continue_constraint,
+      is_car_charged,
+      None if self.current_command is None else (self.current_command.command, self.current_command.power_consign),
+      None if result is None else round(result),
+      None if sensor_result is None else round(sensor_result),
+      None if result_calculus is None else round(result_calculus),
+  )
+  ```
+
+  Rounding to whole units is deliberate: these are SoC percentages / energy figures
+  where sub-unit jitter carries no operator value. Note the original story
+  explicitly dropped `round(result)` from the S12 memo (see B2/S12); this reverses
+  that decision, so **record it in the story's "Accepted deviations" alongside
+  SF-C**, and mention it in the PR body per SF-B.
+- Required test: a driver where only `result` moves by a fraction of a unit across
+  10 cycles asserts 1 INFO; a driver where `result` moves by a whole unit asserts a
+  second INFO; a driver where `power_consign` changes under a constant command name
+  asserts a second INFO.
+
+### [nice-to-have] NH-A — `_stacked_command` missing from the reset predicate
+- File: `custom_components/quiet_solar/home_model/load.py:343`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `keep_commands=False` destroys `_stacked_command` (`load.py:362`) but
+  the predicate does not mention it, even though round-1 NH5 added its sibling
+  `running_command` on exactly the "a pending command is loggable work" reasoning.
+  Reproduces via `force_relaunch_command` (`load.py:766-767`): `if
+  self.qs_enable_device is False: self.running_command = None` returns with
+  `_stacked_command` still set; if `current_command` is also `None`, the next
+  `constraint_reset_and_reset_commands_if_needed(keep_commands=False)` silently drops
+  the queued command and reports "nothing to reset" at DEBUG.
+- Proposed fix: Add `or getattr(self, "_stacked_command", None) is not None` to the
+  `had_commands` term. Keep the `getattr` default for the documented
+  `__init__`-ordering reason. Add a test mirroring the existing
+  `f_running_command_dropped` case.
+
+### [nice-to-have] NH-B — Group memo goes stale for a disabled charger
+- File: `custom_components/quiet_solar/ha_model/charger.py:712-727`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter (blind-hunter raised the same key-eviction
+  concern from the diff alone)
+- Description: The `charger.qs_enable_device is False` `continue` sits *before* the
+  memo write, so a disabled charger's entry goes stale instead of being invalidated.
+  If the charger is re-enabled inside 900 s with the same `(res, handled_static)`
+  pair, the first status line after re-enable is suppressed and the log carries no
+  marker that the charger came back under management. `detach_car()` gives the
+  charger-level memo this cleanup; the group object has no equivalent.
+- Proposed fix: In the disabled branch, pop the charger's key before `continue`:
+  `self._log_on_change_state and self._log_on_change_state.pop(f"ensure_correct_state:{charger.name}", None)`.
+  Add a test: log, disable, re-enable inside the window with an unchanged pair,
+  assert a second INFO.
+
+### [nice-to-have] NH-C — Harness hardcodes `/tmp/test` as the config dir
+- File: `tests/utils/charger_harness.py:49`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter + qs-review-coderabbit (CWE-377)
+- Description: A fixed shared path is collision-prone across parallel test runs.
+- Proposed fix: Accept an optional `config_dir` parameter on the factory, defaulting
+  to the current value so existing callers are unaffected, and pass pytest's
+  `tmp_path` from `tests/test_qs306_log_volume.py`.
+
+### [nice-to-have] NH-D — `async_add_executor_job` mock drops kwargs
+- File: `tests/utils/charger_harness.py:52`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: `side_effect=lambda f, *a: f(*a)` raises `TypeError` if any production
+  path calls it with keyword arguments.
+- Proposed fix: `side_effect=lambda f, *a, **kw: f(*a, **kw)`.
+
+### [nice-to-have] NH-E — B4's source-text regex is brittle
+- File: `tests/test_qs306_log_volume.py:862`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter + qs-review-coderabbit
+- Description: `re.compile(r"_LOGGER\.info\(\s*[^)]*" + re.escape(anchor), re.DOTALL)`
+  has two problems: `re.DOTALL` is a no-op because `[^)]` already matches newlines,
+  and `[^)]*` stops at the first `)`, so a keeper wrapped in an inner call — e.g.
+  `_LOGGER.info("… %s", f(x), anchor…)` — would not match. A purely cosmetic ruff
+  reformat could fail the test while behaviour is intact.
+- Proposed fix: Drop the `re.DOTALL` flag, and either bound the scan to a window
+  after each `_LOGGER.info(` occurrence or assert on the count of the anchor literal
+  itself. The sibling runtime caplog assertions (`:867`, `:883`) already cover the
+  behavioural intent, so this test only needs to be non-brittle, not clever.
+
+### [nice-to-have] NH-F — `TypeGuard[float]` is dishonest for `int` inputs
+- File: `custom_components/quiet_solar/ha_model/charger.py:592`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `_is_number` narrows `int` inputs to `float`, which is not what
+  happens at runtime.
+- Proposed fix: Use `TypeIs[int | float]` (`typing_extensions` / 3.13+) if available
+  in the project's supported Python range, else `TypeGuard[int | float]`. Verify
+  MyPy still passes — `_element_unchanged` relies on this narrowing for its
+  arithmetic.
+
+### [nice-to-have] NH-G — `LogOnChangeMixin` hardcodes charger's module logger
+- File: `custom_components/quiet_solar/ha_model/charger.py:630`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter (raised as should-fix; downgraded — no non-charger
+  host exists today, and SF3's `logger_name` test pinning would catch a bad move)
+- Description: The mixin closes over `charger.py`'s module-level `_LOGGER`, so a
+  future non-charger host — the `load.py` sites are the obvious candidates — would
+  emit records attributed to the charger logger.
+- Proposed fix: `logging.getLogger(type(self).__module__).info(msg, *args)`, or take
+  the logger as a constructor/class attribute. If deferring, add a one-line comment
+  on the mixin recording the constraint, since the round-1 SF3 work made logger
+  identity load-bearing in tests.
+
+### [nice-to-have] NH-H — Harness docstring claims a promotion that did not happen
+- File: `tests/utils/charger_harness.py:1`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The docstring says "Promoted from the module-level helpers in
+  `tests/test_charger_coverage_deep.py`", but that file is untouched — the helpers
+  were **copied**, by explicit story decision (Task 9). The wording invites a future
+  reader to assume a single source of truth that does not exist.
+- Proposed fix: Reword to "Copied from … which intentionally retains its own copies
+  (QS-306 Task 9); consolidating the ~9 test modules that define these helpers is
+  out of scope." No code change.
+
+### [nice-to-have] NH-I — Test mixes `group.home` and the returned `home` handle
+- File: `tests/test_qs306_log_volume.py:292-306`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: Line 304 reaches through `group.home` while the sibling test at
+  312-320 uses the returned `home`. Both work only because they are the same object.
+- Proposed fix: Use the returned handle consistently.
+
+### [nice-to-have] NH-J — Zero-side asymmetry of the sign test
+- File: `custom_components/quiet_solar/ha_model/charger.py:611`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter + qs-review-blind-hunter
+- Description: Folded into **MF1** — the magnitude floor makes the asymmetry
+  unreachable for sub-deadband values. Listed separately so it is consciously
+  re-checked after MF1 lands rather than assumed fixed.
+- Proposed fix: After implementing MF1, confirm `0.0 → -150` and `0.0 → +150` behave
+  symmetrically and add a `_B3_CASES` pair asserting it.
+
+## Not fixing (stale / invalid)
+
+- **"`None` power values re-log every cycle"** (blind-hunter, hedged as "assumed
+  without repo context") — verified invalid. `full_available_home_power` and
+  `grid_available_home_power` are explicitly None-checked and coerced to `0.0` at
+  `charger.py:845-848`, three lines above the log call, and
+  `get_current_battery_asked_change_for_outside_production_system()` is typed
+  `-> float` with every return path returning a float (`ha_model/battery.py:275-294`).
+- **CodeRabbit `load.py:339` "include pending commands in the predicate"** — already
+  implemented by round-1 NH5; `running_command` is in the predicate at `load.py:343`.
+  GitHub itself marks the thread outdated. CodeRabbit reviewed `08309efc`, the commit
+  *before* the fixes.
+- **CodeRabbit "tighten the `acks` assertion"** — already fixed by round-1 SF4; the
+  assertion is `== 2` at `tests/test_qs306_log_volume.py:901`.
+- **"`zip(..., strict=True)` is dead defensiveness"** (blind-hunter) — the explicit
+  `len(prev) != len(current)` check does make it unreachable, but it is free, it was
+  requested by fix plan #01 NH3, and removing it would only churn the diff.
+
+## Note on CodeRabbit coverage
+
+CodeRabbit has **never reviewed the logic changes on this PR.** It produced a real
+review of `08309efc` (3 actionable + 5 nitpicks, all triaged above), but both the
+auto-incremental run and a manual `@coderabbitai review` against `ecdf88a3` were
+rejected by the account's PR review limit, and it will not re-review a commit it has
+marked as seen. Pushing the commit that applies this plan creates a new head and
+should let the next window pick it up. If round 3 still comes back empty, wait out
+the limit and use `@coderabbitai full review`.
+
+## How to apply
+
+Run `/implement-task` against this fix plan.
+
+Suggested ordering — MF1 and SF-G are the two memo-semantics changes and share the
+"quantise before memoizing" lesson; do them first while that context is loaded:
+
+1. **MF1 (+ NH-J)** — magnitude floor in `_element_unchanged`, replace the inverted
+   `_B3_CASES` entry, add the 10-cycle oscillation volume test, re-check zero symmetry.
+2. **SF-G** — widen the SOC memo with rounded values and `power_consign`; three new
+   drivers.
+3. **NH-A + NH-B** — the two remaining memo/predicate staleness gaps.
+4. **NH-C + NH-D + NH-E + NH-H + NH-I** — test-harness pass.
+5. **NH-F + NH-G** — typing and logger-identity polish; both must keep MyPy green.
+6. **SF-C + SF-E** — story updates, including the NH4/NH5/SF-G deviation entries.
+7. **SF-D** — narrow the `charger-budgeting.md` claim.
+8. **SF-B** — last, so the PR body describes the final state: deviations section
+   plus the corrected test count.
+
+Gate before commit: `python scripts/qs/quality_gate.py --impacted`. This change set
+is product code under `custom_components/`, so no `--quick tests/qs` supplement is
+needed unless you also touch agent/command/workflow files.
+
+When done, return and run `/review-task` again to re-verify.

--- a/tests/test_qs306_log_volume.py
+++ b/tests/test_qs306_log_volume.py
@@ -29,7 +29,12 @@ from custom_components.quiet_solar.ha_model.charger import (
     LogOnChangeMixin,
     QSChargerStatus,
 )
-from custom_components.quiet_solar.home_model.commands import CMD_AUTO_GREEN_ONLY, CMD_ON, copy_command
+from custom_components.quiet_solar.home_model.commands import (
+    CMD_AUTO_FROM_CONSIGN,
+    CMD_AUTO_GREEN_ONLY,
+    CMD_ON,
+    copy_command,
+)
 from custom_components.quiet_solar.home_model.constraints import (
     LoadConstraint,
     MultiStepsPowerLoadConstraintChargePercent,
@@ -949,6 +954,51 @@ async def test_sfg_consign_change_under_the_same_command_name_is_logged(
     records = _messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)
     assert len(records) == 2
     assert "7000" in records[1].getMessage()
+
+
+async def test_sfg_soc_volume_scales_with_amp_changes_not_cycles(caplog: pytest.LogCaptureFixture) -> None:
+    """SF-G's COST, pinned: S12 volume is proportional to amp changes, not cycles.
+
+    The story deliberately kept `power_consign` OUT of this memo (F8 calls it "a
+    per-cycle budgeted float"), and review fix plan #02 SF-G put it back. That is the
+    same shape as the MF1 defect — a volatile value entering a memo — so the saving
+    needs an explicit assertion, not an argument. `power_consign` is safe because it
+    comes from the DISCRETE power-step table, so a hold is silent and only the step
+    logs.
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    charger, constraint = _make_soc_callback_charger()
+
+    # Three discrete power steps, each held for four ~7 s cycles.
+    consigns = [1380.0] * 4 + [1610.0] * 4 + [1840.0] * 4
+    for cycle, consign in enumerate(consigns):
+        charger.current_command = copy_command(CMD_AUTO_FROM_CONSIGN, power_consign=consign)
+        await charger.constraint_update_value_callback_percent_soc(constraint, T0 + timedelta(seconds=7 * cycle))
+
+    records = _messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)
+    assert len(records) == len(set(consigns)) == 3, "one line per amp change, not one per cycle"
+
+
+async def test_sfg_soc_volume_ceiling_is_one_line_per_consign_change(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The documented CEILING of SF-G, so the cost is explicit rather than implied.
+
+    If the consign genuinely changed on every cycle, every cycle would log. In
+    production that is bounded by the 45 s amp-change cooldown (the S2 site), not by
+    this memo — so the worst realistic case is ~1 line per 45 s, still far below the
+    ~7 s cycle rate. If a future change adds smoothing, this test should fail and
+    force a conscious decision.
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    charger, constraint = _make_soc_callback_charger()
+
+    for cycle in range(10):
+        consign = 1380.0 if cycle % 2 == 0 else 1610.0
+        charger.current_command = copy_command(CMD_AUTO_FROM_CONSIGN, power_consign=consign)
+        await charger.constraint_update_value_callback_percent_soc(constraint, T0 + timedelta(seconds=7 * cycle))
+
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 10
 
 
 async def test_s12_literal_percent_is_escaped(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_qs306_log_volume.py
+++ b/tests/test_qs306_log_volume.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import math
 import re
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -55,75 +56,121 @@ class _Host(LogOnChangeMixin):
     """Minimal mixin host: the mixin defines no `__init__`, so this suffices."""
 
 
-def _messages(caplog: pytest.LogCaptureFixture, fragment: str, level: int) -> list[logging.LogRecord]:
-    """Return the captured records at `level` whose message contains `fragment`."""
-    return [r for r in caplog.records if r.levelno == level and fragment in r.getMessage()]
+def _messages(
+    caplog: pytest.LogCaptureFixture,
+    fragment: str,
+    level: int,
+    logger_name: str | None = None,
+) -> list[logging.LogRecord]:
+    """Return the captured records at `level` whose message contains `fragment`.
+
+    `logger_name` pins the emitting logger. B2 requires it, and the story records
+    the coupling deliberately: extracting the mixin out of `charger.py` would
+    change the logger name, and this assertion is the guard that notices. Every
+    call site in this module passes it; it stays optional so a future caller that
+    genuinely does not care is not forced to lie.
+    """
+    return [
+        r
+        for r in caplog.records
+        if r.levelno == level and fragment in r.getMessage() and (logger_name is None or r.name == logger_name)
+    ]
 
 
 # =============================================================================
 # B3 — helper unit tests
 # =============================================================================
 
-_SHARED_MOCK = MagicMock()
 
-# (label, first_value, second_value, delta_seconds, deadband, second_call_logs)
+def _same_mock_twice() -> tuple[object, object]:
+    """One FRESH `MagicMock` in both positions — equal by identity, not a number.
+
+    A module-scope mock would be shared mutable state across parametrized runs, so
+    call history would leak between cases.
+    """
+    mock = MagicMock()
+    return (mock,), (mock,)
+
+
+_DB = _POWER_LOG_DEADBAND_W
+
+# (label, values_factory, delta_seconds, deadband, second_call_logs)
+# `values_factory` returns `(first_value, second_value)`. It is a factory rather
+# than a pair of literals so any case needing a fresh mutable object gets one per
+# parametrized run.
 _B3_CASES = [
-    ("no_deadband_equal_inside_window", 1, 1, 7, None, False),
-    ("no_deadband_changed_inside_window", 1, 2, 7, None, True),
-    ("no_deadband_unchanged_after_window", 1, 1, _RELOG_UNCHANGED_AFTER_S, None, True),
-    ("small_backward_jump_stays_silent", 1, 1, -5, None, False),
-    ("large_backward_jump_relogs", 1, 1, -1000, None, True),
-    (
-        "deadband_sub_threshold_silent",
-        (1000.0, 500.0, 0.0),
-        (1049.0, 500.0, 0.0),
-        7,
-        _POWER_LOG_DEADBAND_W,
-        False,
-    ),
-    (
-        "deadband_one_element_over_threshold_logs",
-        (1000.0, 500.0, 0.0),
-        (1000.0, 650.0, 0.0),
-        7,
-        _POWER_LOG_DEADBAND_W,
-        True,
-    ),
-    ("deadband_non_tuple_current_logs", (1000.0,), 1000.0, 7, _POWER_LOG_DEADBAND_W, True),
-    ("deadband_non_tuple_prev_logs", 1000.0, (1000.0,), 7, _POWER_LOG_DEADBAND_W, True),
-    ("deadband_length_mismatch_logs", (1000.0,), (1000.0, 2.0), 7, _POWER_LOG_DEADBAND_W, True),
-    ("deadband_bool_element_logs", (True,), (True,), 7, _POWER_LOG_DEADBAND_W, True),
-    ("deadband_none_element_logs", (None,), (None,), 7, _POWER_LOG_DEADBAND_W, True),
-    ("deadband_mock_element_logs", (_SHARED_MOCK,), (_SHARED_MOCK,), 7, _POWER_LOG_DEADBAND_W, True),
+    ("no_deadband_equal_inside_window", lambda: (1, 1), 7, None, False),
+    ("no_deadband_changed_inside_window", lambda: (1, 2), 7, None, True),
+    ("no_deadband_unchanged_after_window", lambda: (1, 1), _RELOG_UNCHANGED_AFTER_S, None, True),
+    ("small_backward_jump_stays_silent", lambda: (1, 1), -5, None, False),
+    ("large_backward_jump_relogs", lambda: (1, 1), -1000, None, True),
+    ("deadband_sub_threshold_silent", lambda: ((1000.0, 500.0, 0.0), (1049.0, 500.0, 0.0)), 7, _DB, False),
+    ("deadband_one_element_over_threshold_logs", lambda: ((1000.0, 500.0, 0.0), (1000.0, 650.0, 0.0)), 7, _DB, True),
+    ("deadband_non_tuple_current_logs", lambda: ((1000.0,), 1000.0), 7, _DB, True),
+    ("deadband_non_tuple_prev_logs", lambda: (1000.0, (1000.0,)), 7, _DB, True),
+    ("deadband_length_mismatch_logs", lambda: ((1000.0,), (1000.0, 2.0)), 7, _DB, True),
+    ("deadband_bool_element_logs", lambda: ((True,), (True,)), 7, _DB, True),
+    ("deadband_none_element_logs", lambda: ((None,), (None,)), 7, _DB, True),
+    ("deadband_mock_element_logs", _same_mock_twice, 7, _DB, True),
+    # NH1: a persistently-NaN sensor must NOT re-inflate the log to full cycle rate.
+    ("deadband_nan_to_nan_silent", lambda: ((math.nan, 500.0, 0.0), (math.nan, 500.0, 0.0)), 7, _DB, False),
+    ("deadband_nan_to_finite_logs", lambda: ((math.nan, 500.0, 0.0), (1000.0, 500.0, 0.0)), 7, _DB, True),
+    ("deadband_finite_to_nan_logs", lambda: ((1000.0, 500.0, 0.0), (math.nan, 500.0, 0.0)), 7, _DB, True),
+    # A stuck-at-inf sensor is the same failure mode (`inf - inf` is NaN).
+    ("deadband_inf_to_inf_silent", lambda: ((math.inf, 500.0, 0.0), (math.inf, 500.0, 0.0)), 7, _DB, False),
+    ("deadband_inf_to_finite_logs", lambda: ((math.inf, 500.0, 0.0), (1000.0, 500.0, 0.0)), 7, _DB, True),
+    # NH4: a sign flip is the operationally meaningful boundary (export vs import),
+    # so it beats the deadband even when the absolute step is tiny.
+    ("deadband_sub_threshold_sign_flip_logs", lambda: ((20.0, 500.0, 0.0), (-20.0, 500.0, 0.0)), 7, _DB, True),
+    ("deadband_sub_threshold_same_sign_silent", lambda: ((20.0, 500.0, 0.0), (40.0, 500.0, 0.0)), 7, _DB, False),
 ]
 
 
 @pytest.mark.parametrize(
-    ("first_value", "second_value", "delta_seconds", "deadband", "second_call_logs"),
+    ("values_factory", "delta_seconds", "deadband", "second_call_logs"),
     [pytest.param(*case[1:], id=case[0]) for case in _B3_CASES],
 )
 def test_log_info_on_change_emission_predicate(
     caplog: pytest.LogCaptureFixture,
-    first_value: object,
-    second_value: object,
+    values_factory,
     delta_seconds: int,
     deadband: float | None,
     second_call_logs: bool,
 ) -> None:
-    """B3 cases 1-11: the first call always logs; the second follows the predicate."""
+    """B3 cases 1-11 plus the NaN/inf and sign-flip cases."""
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     host = _Host()
+    first_value, second_value = values_factory()
 
     # Case 1: lazy init — `_log_on_change_state` is `None`, so the first call logs.
     host.log_info_on_change("k", first_value, T0, "probe %s", "one", deadband=deadband)
-    assert len(_messages(caplog, "probe", logging.INFO)) == 1
+    assert len(_messages(caplog, "probe", logging.INFO, CHARGER_LOGGER)) == 1
 
     # Case 2: the state is now initialized — the second call takes the other arc.
     host.log_info_on_change(
         "k", second_value, T0 + timedelta(seconds=delta_seconds), "probe %s", "two", deadband=deadband
     )
     expected = 2 if second_call_logs else 1
-    assert len(_messages(caplog, "probe", logging.INFO)) == expected
+    assert len(_messages(caplog, "probe", logging.INFO, CHARGER_LOGGER)) == expected
+
+
+def test_log_info_on_change_survives_a_naive_datetime(caplog: pytest.LogCaptureFixture) -> None:
+    """NH2: a logging helper must never be load-bearing.
+
+    Mixing naive and aware datetimes under one key raises `TypeError` on the
+    subtraction; that exception would propagate out of `dyn_handle` and kill the
+    whole budgeting cycle. Bail to logging instead.
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    host = _Host()
+
+    host.log_info_on_change("k", 1, T0, "naive %s", "aware")
+    host.log_info_on_change("k", 1, T0.replace(tzinfo=None), "naive %s", "naive")
+
+    assert len(_messages(caplog, "naive", logging.INFO, CHARGER_LOGGER)) == 2
+    # The key is re-stamped with the naive value, so the reverse direction is safe too.
+    host.log_info_on_change("k", 1, T0, "naive %s", "aware again")
+    assert len(_messages(caplog, "naive", logging.INFO, CHARGER_LOGGER)) == 3
 
 
 def test_log_info_on_change_keeps_state_per_instance(caplog: pytest.LogCaptureFixture) -> None:
@@ -135,7 +182,7 @@ def test_log_info_on_change_keeps_state_per_instance(caplog: pytest.LogCaptureFi
     first.log_info_on_change("shared_key", "value", T0, "per instance %s", "a")
     second.log_info_on_change("shared_key", "value", T0, "per instance %s", "b")
 
-    assert len(_messages(caplog, "per instance", logging.INFO)) == 2
+    assert len(_messages(caplog, "per instance", logging.INFO, CHARGER_LOGGER)) == 2
     assert LogOnChangeMixin._log_on_change_state is None
 
 
@@ -165,7 +212,7 @@ def test_log_info_on_change_resets_the_timer_on_every_emission(caplog: pytest.Lo
     host.log_info_on_change("k", 2, changed_at, "timer %s", 2)
     host.log_info_on_change("k", 2, changed_at + timedelta(seconds=7), "timer %s", 3)
 
-    assert len(_messages(caplog, "timer", logging.INFO)) == 2
+    assert len(_messages(caplog, "timer", logging.INFO, CHARGER_LOGGER)) == 2
 
 
 def test_log_info_on_change_keys_are_independent(caplog: pytest.LogCaptureFixture) -> None:
@@ -177,7 +224,7 @@ def test_log_info_on_change_keys_are_independent(caplog: pytest.LogCaptureFixtur
     host.log_info_on_change("b", 1, T0, "keyed %s", "b")
     host.log_info_on_change("a", 1, T0 + timedelta(seconds=7), "keyed %s", "a")
 
-    assert len(_messages(caplog, "keyed", logging.INFO)) == 2
+    assert len(_messages(caplog, "keyed", logging.INFO, CHARGER_LOGGER)) == 2
 
 
 # =============================================================================
@@ -247,8 +294,8 @@ async def test_s1_dyn_handle_start_is_debug(caplog: pytest.LogCaptureFixture) ->
 
     await group.dyn_handle(T0)
 
-    assert _messages(caplog, "dyn_handle: START", logging.INFO) == []
-    assert len(_messages(caplog, "dyn_handle: START", logging.DEBUG)) == 1
+    assert _messages(caplog, "dyn_handle: START", logging.INFO, CHARGER_LOGGER) == []
+    assert len(_messages(caplog, "dyn_handle: START", logging.DEBUG, CHARGER_LOGGER)) == 1
 
 
 async def test_s4_cannot_dampen_simple_case_is_debug(caplog: pytest.LogCaptureFixture) -> None:
@@ -258,8 +305,8 @@ async def test_s4_cannot_dampen_simple_case_is_debug(caplog: pytest.LogCaptureFi
 
     await group.dyn_handle(T0)
 
-    assert _messages(caplog, "can't dampen simple case", logging.INFO) == []
-    assert len(_messages(caplog, "can't dampen simple case", logging.DEBUG)) == 1
+    assert _messages(caplog, "can't dampen simple case", logging.INFO, CHARGER_LOGGER) == []
+    assert len(_messages(caplog, "can't dampen simple case", logging.DEBUG, CHARGER_LOGGER)) == 1
 
 
 async def test_s2_and_s3_cooldown_are_debug(caplog: pytest.LogCaptureFixture) -> None:
@@ -269,10 +316,10 @@ async def test_s2_and_s3_cooldown_are_debug(caplog: pytest.LogCaptureFixture) ->
 
     await group.dyn_handle(T0)
 
-    assert _messages(caplog, "amp change cooldown", logging.INFO) == []
-    assert len(_messages(caplog, "amp change cooldown", logging.DEBUG)) == 1
-    assert _messages(caplog, "all chargers in cooldown", logging.INFO) == []
-    assert len(_messages(caplog, "all chargers in cooldown", logging.DEBUG)) == 1
+    assert _messages(caplog, "amp change cooldown", logging.INFO, CHARGER_LOGGER) == []
+    assert len(_messages(caplog, "amp change cooldown", logging.DEBUG, CHARGER_LOGGER)) == 1
+    assert _messages(caplog, "all chargers in cooldown", logging.INFO, CHARGER_LOGGER) == []
+    assert len(_messages(caplog, "all chargers in cooldown", logging.DEBUG, CHARGER_LOGGER)) == 1
     group.budgeting_algorithm_minimize_diffs.assert_not_awaited()
 
 
@@ -284,9 +331,9 @@ async def test_s13_no_actionable_chargers_is_debug(caplog: pytest.LogCaptureFixt
 
     await group.dyn_handle(T0)
 
-    assert _messages(caplog, "no actionable chargers, do nothing", logging.INFO) == []
-    assert len(_messages(caplog, "no actionable chargers, do nothing", logging.DEBUG)) == 1
-    assert _messages(caplog, "battery_asked_charge", logging.INFO) == []
+    assert _messages(caplog, "no actionable chargers, do nothing", logging.INFO, CHARGER_LOGGER) == []
+    assert len(_messages(caplog, "no actionable chargers, do nothing", logging.DEBUG, CHARGER_LOGGER)) == 1
+    assert _messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER) == []
 
 
 async def test_s10_available_power_logged_once_per_window(caplog: pytest.LogCaptureFixture) -> None:
@@ -296,14 +343,14 @@ async def test_s10_available_power_logged_once_per_window(caplog: pytest.LogCapt
 
     for cycle in range(10):
         await group.dyn_handle(T0 + timedelta(seconds=7 * cycle))
-    assert len(_messages(caplog, "battery_asked_charge", logging.INFO)) == 1
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 1
 
     await group.dyn_handle(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 63))
-    assert len(_messages(caplog, "battery_asked_charge", logging.INFO)) == 2
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 2
 
     group.home.get_available_power_values = MagicMock(side_effect=lambda _w, t: _power_series(5000.0, t))
     await group.dyn_handle(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 70))
-    assert len(_messages(caplog, "battery_asked_charge", logging.INFO)) == 3
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 3
 
 
 async def test_s10_deadband_absorbs_sub_threshold_jitter(caplog: pytest.LogCaptureFixture) -> None:
@@ -315,11 +362,11 @@ async def test_s10_deadband_absorbs_sub_threshold_jitter(caplog: pytest.LogCaptu
     for cycle, watts in enumerate(jitter):
         home.get_available_power_values = MagicMock(side_effect=lambda _w, t, v=watts: _power_series(v, t))
         await group.dyn_handle(T0 + timedelta(seconds=7 * cycle))
-    assert len(_messages(caplog, "battery_asked_charge", logging.INFO)) == 1
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 1
 
     home.get_available_power_values = MagicMock(side_effect=lambda _w, t: _power_series(1051.0 + 100.0, t))
     await group.dyn_handle(T0 + timedelta(seconds=7 * len(jitter)))
-    assert len(_messages(caplog, "battery_asked_charge", logging.INFO)) == 2
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 2
 
 
 # =============================================================================
@@ -361,8 +408,8 @@ def test_s5_stable_status_dump_is_debug(caplog: pytest.LogCaptureFixture) -> Non
 
     assert charger.get_stable_dynamic_charge_status(T0) is not None
 
-    assert _messages(caplog, "possible_amps:", logging.INFO) == []
-    assert len(_messages(caplog, "possible_amps:", logging.DEBUG)) == 1
+    assert _messages(caplog, "possible_amps:", logging.INFO, CHARGER_LOGGER) == []
+    assert len(_messages(caplog, "possible_amps:", logging.DEBUG, CHARGER_LOGGER)) == 1
 
 
 async def _drive_remove_all_person_constraints() -> None:
@@ -421,8 +468,8 @@ async def test_s6_remove_all_person_constraints_is_debug(caplog: pytest.LogCaptu
 
     await _drive_remove_all_person_constraints()
 
-    assert _messages(caplog, "do_remove_all_person_constraints", logging.INFO) == []
-    assert len(_messages(caplog, "do_remove_all_person_constraints", logging.DEBUG)) == 1
+    assert _messages(caplog, "do_remove_all_person_constraints", logging.INFO, CHARGER_LOGGER) == []
+    assert len(_messages(caplog, "do_remove_all_person_constraints", logging.DEBUG, CHARGER_LOGGER)) == 1
 
 
 # =============================================================================
@@ -445,8 +492,8 @@ def test_s7_no_bad_constraint_found_is_debug(caplog: pytest.LogCaptureFixture) -
         is False
     )
 
-    assert _messages(caplog, "No bad constraint found", logging.INFO) == []
-    assert len(_messages(caplog, "No bad constraint found", logging.DEBUG)) == 1
+    assert _messages(caplog, "No bad constraint found", logging.INFO, LOAD_LOGGER) == []
+    assert len(_messages(caplog, "No bad constraint found", logging.DEBUG, LOAD_LOGGER)) == 1
 
 
 def test_b1b_fresh_load_construction_logs_the_no_op_at_debug(caplog: pytest.LogCaptureFixture) -> None:
@@ -456,9 +503,9 @@ def test_b1b_fresh_load_construction_logs_the_no_op_at_debug(caplog: pytest.LogC
     load = MinimalTestLoad(name="FreshLoad")
 
     assert load.name == "FreshLoad"
-    assert _messages(caplog, _S8_FRAGMENT, logging.INFO) == []
-    assert len(_messages(caplog, _S8_FRAGMENT, logging.DEBUG)) == 1
-    assert "nothing to reset" in _messages(caplog, _S8_FRAGMENT, logging.DEBUG)[0].getMessage()
+    assert _messages(caplog, _S8_FRAGMENT, logging.INFO, LOAD_LOGGER) == []
+    assert len(_messages(caplog, _S8_FRAGMENT, logging.DEBUG, LOAD_LOGGER)) == 1
+    assert "nothing to reset" in _messages(caplog, _S8_FRAGMENT, logging.DEBUG, LOAD_LOGGER)[0].getMessage()
 
 
 @pytest.mark.parametrize(
@@ -469,6 +516,9 @@ def test_b1b_fresh_load_construction_logs_the_no_op_at_debug(caplog: pytest.LogC
         pytest.param("command", False, logging.INFO, id="c_command_dropped"),
         pytest.param("nothing", True, logging.DEBUG, id="d_nothing_to_reset"),
         pytest.param("command", True, logging.DEBUG, id="e_command_kept"),
+        # NH5: `keep_commands=False` also drops an in-flight `running_command`.
+        pytest.param("running_command", False, logging.INFO, id="f_running_command_dropped"),
+        pytest.param("running_command", True, logging.DEBUG, id="g_running_command_kept"),
     ],
 )
 def test_b1b_s8_logs_info_only_when_work_is_performed(
@@ -480,6 +530,7 @@ def test_b1b_s8_logs_info_only_when_work_is_performed(
     load._constraints = []
     load._last_completed_constraint = None
     load.current_command = None
+    load.running_command = None
 
     if case == "constraints":
         load._constraints = [create_constraint(load=load, time=T0)]
@@ -487,13 +538,72 @@ def test_b1b_s8_logs_info_only_when_work_is_performed(
         load._last_completed_constraint = create_constraint(load=load, time=T0)
     elif case == "command":
         load.current_command = copy_command(CMD_ON, power_consign=1000.0)
+    elif case == "running_command":
+        load.running_command = copy_command(CMD_ON, power_consign=1000.0)
 
     caplog.clear()
     load.constraint_reset_and_reset_commands_if_needed(keep_commands=keep_commands)
 
     other_level = logging.DEBUG if expected_level == logging.INFO else logging.INFO
-    assert len(_messages(caplog, _S8_FRAGMENT, expected_level)) == 1
-    assert _messages(caplog, _S8_FRAGMENT, other_level) == []
+    assert len(_messages(caplog, _S8_FRAGMENT, expected_level, LOAD_LOGGER)) == 1
+    assert _messages(caplog, _S8_FRAGMENT, other_level, LOAD_LOGGER) == []
+
+
+@pytest.mark.parametrize(
+    ("force_next_charge", "next_charge_time", "expected_level"),
+    [
+        pytest.param(True, None, logging.INFO, id="force_next_charge_flag"),
+        pytest.param(False, T0 + timedelta(hours=3), logging.INFO, id="next_charge_time"),
+        pytest.param(False, None, logging.DEBUG, id="nothing_set"),
+    ],
+)
+def test_sf2_charger_reset_logs_info_when_it_clears_a_user_flag(
+    caplog: pytest.LogCaptureFixture,
+    force_next_charge: bool,
+    next_charge_time: datetime | None,
+    expected_level: int,
+) -> None:
+    """SF2: `QSChargerGeneric`'s override destroys user-initiated flags.
+
+    The base predicate must see them, else a user-initiated action is wiped while
+    the reset reports "nothing to reset" at DEBUG.
+    """
+    caplog.set_level(logging.DEBUG, logger=LOAD_LOGGER)
+    hass = make_hass()
+    home = make_home()
+    charger = create_charger(hass, home, name="Sf2Ch")
+    car = make_real_car(hass, home, name="Sf2Car")
+    init_charger_states(charger)
+    plug_car(charger, car, T0 - timedelta(hours=1))
+
+    charger._constraints = []
+    charger._last_completed_constraint = None
+    charger.current_command = None
+    charger.running_command = None
+    car.do_force_next_charge = force_next_charge
+    car.do_next_charge_time = next_charge_time
+
+    caplog.clear()
+    charger.constraint_reset_and_reset_commands_if_needed(keep_commands=True)
+
+    other_level = logging.DEBUG if expected_level == logging.INFO else logging.INFO
+    assert len(_messages(caplog, _S8_FRAGMENT, expected_level, LOAD_LOGGER)) == 1
+    assert _messages(caplog, _S8_FRAGMENT, other_level, LOAD_LOGGER) == []
+    # The override still clears the flags either way.
+    assert car.do_force_next_charge is False
+    assert car.do_next_charge_time is None
+
+
+def test_sf2_base_hook_survives_a_carless_charger(caplog: pytest.LogCaptureFixture) -> None:
+    """SF2: the charger override must use `getattr` — `car` is absent during __init__."""
+    caplog.set_level(logging.DEBUG, logger=LOAD_LOGGER)
+    hass = make_hass()
+    home = make_home()
+
+    charger = create_charger(hass, home, name="Sf2NoCar")
+
+    assert charger.car is None
+    assert charger._has_state_to_reset(keep_commands=True) is False
 
 
 # =============================================================================
@@ -523,19 +633,19 @@ async def test_s9_correct_state_logged_once_per_charger_per_window(caplog: pytes
 
     for cycle in range(10):
         await group.ensure_correct_state(T0 + timedelta(seconds=7 * cycle))
-    records = _messages(caplog, "ensure_correct_state dyn group", logging.INFO)
+    records = _messages(caplog, "ensure_correct_state dyn group", logging.INFO, CHARGER_LOGGER)
     assert len(records) == 2
     for charger in chargers:
         assert len([r for r in records if charger.name in r.getMessage()]) == 1
 
     await group.ensure_correct_state(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 63))
-    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.INFO)) == 4
+    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.INFO, CHARGER_LOGGER)) == 4
 
     # A change is not deferred to the next tick, even well inside the window.
     for charger in chargers:
         charger.ensure_correct_state = AsyncMock(return_value=(True, True, T0))
     await group.ensure_correct_state(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 70))
-    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.INFO)) == 6
+    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.INFO, CHARGER_LOGGER)) == 6
 
 
 async def test_s9_probe_only_never_logs_at_info(caplog: pytest.LogCaptureFixture) -> None:
@@ -546,8 +656,8 @@ async def test_s9_probe_only_never_logs_at_info(caplog: pytest.LogCaptureFixture
     for cycle in range(3):
         await group.ensure_correct_state(T0 + timedelta(seconds=7 * cycle), probe_only=True)
 
-    assert _messages(caplog, "ensure_correct_state dyn group", logging.INFO) == []
-    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.DEBUG)) == 6
+    assert _messages(caplog, "ensure_correct_state dyn group", logging.INFO, CHARGER_LOGGER) == []
+    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.DEBUG, CHARGER_LOGGER)) == 6
 
 
 # =============================================================================
@@ -587,15 +697,65 @@ async def test_s11_best_car_logged_once_per_window(caplog: pytest.LogCaptureFixt
 
     for cycle in range(10):
         assert charger.get_best_car(T0 + timedelta(seconds=7 * cycle)).name == "CarA"
-    assert len(_messages(caplog, "with score", logging.INFO)) == 1
+    assert len(_messages(caplog, "with score", logging.INFO, CHARGER_LOGGER)) == 1
 
     assert charger.get_best_car(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 63)).name == "CarA"
-    assert len(_messages(caplog, "with score", logging.INFO)) == 2
+    assert len(_messages(caplog, "with score", logging.INFO, CHARGER_LOGGER)) == 2
 
     scores["CarB"] = 100.0
     assert charger.get_best_car(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 70)).name == car_b.name
-    assert len(_messages(caplog, "with score", logging.INFO)) == 3
-    assert car_a.name == "CarA"
+    records = _messages(caplog, "with score", logging.INFO, CHARGER_LOGGER)
+    assert len(records) == 3
+    # NH7: the records must name the car that actually won each time.
+    assert [car_a.name, car_a.name, car_b.name] == [r.args[0] for r in records]
+
+
+async def test_sf1_car_swap_is_not_silenced_by_the_memo(caplog: pytest.LogCaptureFixture) -> None:
+    """SF1: `detach_car()` must invalidate the memo, else a swap names the wrong car.
+
+    Car A unplugged and car B plugged into the same charger inside the 900 s window
+    yields the same memoized tuple, so without the clear the line is suppressed and
+    the last INFO record names the WRONG car.
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    charger, constraint = _make_soc_callback_charger()
+    car_a = charger.car
+    hass, home = charger.hass, charger.home
+
+    await charger.constraint_update_value_callback_percent_soc(constraint, T0)
+    first = _messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)
+    assert len(first) == 1
+    assert car_a.name in first[0].getMessage()
+
+    charger.detach_car()
+    car_b = make_real_car(hass, home, name="SwapCar")
+    plug_car(charger, car_b, T0)
+    car_b.get_car_charge_percent_raw_sensor = MagicMock(return_value=52.0)
+    car_b.is_car_charge_growing = MagicMock(return_value=True)
+    car_b.setup_car_charge_target_if_needed = AsyncMock()
+
+    # Well inside the window, and the reported tuple is identical to car A's.
+    await charger.constraint_update_value_callback_percent_soc(constraint, T0 + timedelta(seconds=7))
+
+    records = _messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)
+    assert len(records) == 2
+    assert car_b.name in records[1].getMessage()
+
+
+def test_sf1_detach_car_clears_the_memo() -> None:
+    """SF1: the clear is unconditional — it also marks a new session on replug."""
+    hass = make_hass()
+    home = make_home()
+    charger = create_charger(hass, home, name="DetachCh")
+    car = make_real_car(hass, home, name="DetachCar")
+    init_charger_states(charger)
+    plug_car(charger, car, T0)
+    charger.log_info_on_change("get_best_car", car.name, T0, "seed %s", car.name)
+    assert charger._log_on_change_state
+
+    charger.detach_car()
+
+    assert charger._log_on_change_state is None
 
 
 # =============================================================================
@@ -645,22 +805,22 @@ async def test_s12_soc_callback_logged_once_per_mode_per_window(caplog: pytest.L
 
     for cycle in range(10):
         await charger.constraint_update_value_callback_percent_soc(constraint, T0 + timedelta(seconds=7 * cycle))
-    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO)) == 1
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 1
 
     # The energy mode is a different key: one key would let the two callbacks thrash.
     await charger.constraint_update_value_callback_energy_soc(constraint, T0 + timedelta(seconds=70))
-    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO)) == 2
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 2
 
     await charger.constraint_update_value_callback_percent_soc(
         constraint, T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 63)
     )
-    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO)) == 3
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 3
 
     constraint.is_constraint_met = MagicMock(return_value=True)
     await charger.constraint_update_value_callback_percent_soc(
         constraint, T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 70)
     )
-    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO)) == 4
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 4
 
 
 async def test_s12_literal_percent_is_escaped(caplog: pytest.LogCaptureFixture) -> None:
@@ -670,7 +830,7 @@ async def test_s12_literal_percent_is_escaped(caplog: pytest.LogCaptureFixture) 
 
     await charger.constraint_update_value_callback_percent_soc(constraint, T0)
 
-    record = _messages(caplog, _S12_FRAGMENT, logging.INFO)[0]
+    record = _messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)[0]
     assert "(is %:True)" in record.getMessage()
     assert "%%" in record.msg
 
@@ -716,8 +876,8 @@ async def test_b4_charger_start_stop_charge_still_log_at_info(caplog: pytest.Log
     await charger.stop_charge(T0)
     await charger.start_charge(T0)
 
-    assert len(_messages(caplog, "STOP CHARGE LAUNCHED", logging.INFO)) == 1
-    assert len(_messages(caplog, "START CHARGE LAUNCHED", logging.INFO)) == 1
+    assert len(_messages(caplog, "STOP CHARGE LAUNCHED", logging.INFO, CHARGER_LOGGER)) == 1
+    assert len(_messages(caplog, "START CHARGE LAUNCHED", logging.INFO, CHARGER_LOGGER)) == 1
 
 
 async def test_b4_load_command_lines_still_log_at_info(caplog: pytest.LogCaptureFixture) -> None:
@@ -735,7 +895,10 @@ async def test_b4_load_command_lines_still_log_at_info(caplog: pytest.LogCapture
         for r in caplog.records
         if r.msg == "launch_command: %s for this load %s), ctxt: %s" and r.levelno == logging.INFO
     ]
-    assert len(acks) >= 1
+    # Exact counts: `>=` would pass on a duplication regression, which is the
+    # direction this assertion exists to guard. `launch_command` acks its own
+    # command once the probe confirms it, so the explicit call plus that ack is 2.
+    assert len(acks) == 2
     assert len(launches) == 1
 
 
@@ -778,7 +941,7 @@ _B5_SITES = {
     "S11": ("with score", "get_best_car: %s with score %s for charger %s"),
     "S12": (
         "is_car_charged",
-        "update_value_callback (is %%:%s):%s %s %s/%s (%s/%s) is_car_charged %s cmd %s",
+        "update_value_callback (is %%:%s):%s %s  %s/%s (%s/%s) is_car_charged %s cmd %s",
     ),
     "S13": ("no actionable chargers, do nothing", "dyn_handle: no actionable chargers, do nothing"),
 }

--- a/tests/test_qs306_log_volume.py
+++ b/tests/test_qs306_log_volume.py
@@ -1,0 +1,848 @@
+"""QS-306: INFO log volume reduction.
+
+Covers the `LogOnChangeMixin` helper (B3) and the 13 call sites the story
+enumerates (B1, B1b, B2, B4, B5).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytz
+
+import custom_components.quiet_solar as quiet_solar
+from custom_components.quiet_solar.const import (
+    CONSTRAINT_TYPE_MANDATORY_END_TIME,
+    USER_ORIGINATED_CAR_NAME,
+)
+from custom_components.quiet_solar.ha_model.charger import (
+    _POWER_LOG_DEADBAND_W,
+    _RELOG_UNCHANGED_AFTER_S,
+    CHARGER_ADAPTATION_WINDOW_S,
+    LogOnChangeMixin,
+    QSChargerStatus,
+)
+from custom_components.quiet_solar.home_model.commands import CMD_AUTO_GREEN_ONLY, CMD_ON, copy_command
+from custom_components.quiet_solar.home_model.constraints import (
+    LoadConstraint,
+    MultiStepsPowerLoadConstraintChargePercent,
+)
+from tests.factories import MinimalTestLoad, create_constraint
+from tests.utils.charger_harness import (
+    create_charger,
+    init_charger_states,
+    make_battery,
+    make_charger_group,
+    make_hass,
+    make_home,
+    make_real_car,
+    plug_car,
+)
+
+CHARGER_LOGGER = "custom_components.quiet_solar.ha_model.charger"
+LOAD_LOGGER = "custom_components.quiet_solar.home_model.load"
+
+T0 = datetime(2026, 7, 29, 8, 0, 0, tzinfo=pytz.UTC)
+
+
+class _Host(LogOnChangeMixin):
+    """Minimal mixin host: the mixin defines no `__init__`, so this suffices."""
+
+
+def _messages(caplog: pytest.LogCaptureFixture, fragment: str, level: int) -> list[logging.LogRecord]:
+    """Return the captured records at `level` whose message contains `fragment`."""
+    return [r for r in caplog.records if r.levelno == level and fragment in r.getMessage()]
+
+
+# =============================================================================
+# B3 — helper unit tests
+# =============================================================================
+
+_SHARED_MOCK = MagicMock()
+
+# (label, first_value, second_value, delta_seconds, deadband, second_call_logs)
+_B3_CASES = [
+    ("no_deadband_equal_inside_window", 1, 1, 7, None, False),
+    ("no_deadband_changed_inside_window", 1, 2, 7, None, True),
+    ("no_deadband_unchanged_after_window", 1, 1, _RELOG_UNCHANGED_AFTER_S, None, True),
+    ("small_backward_jump_stays_silent", 1, 1, -5, None, False),
+    ("large_backward_jump_relogs", 1, 1, -1000, None, True),
+    (
+        "deadband_sub_threshold_silent",
+        (1000.0, 500.0, 0.0),
+        (1049.0, 500.0, 0.0),
+        7,
+        _POWER_LOG_DEADBAND_W,
+        False,
+    ),
+    (
+        "deadband_one_element_over_threshold_logs",
+        (1000.0, 500.0, 0.0),
+        (1000.0, 650.0, 0.0),
+        7,
+        _POWER_LOG_DEADBAND_W,
+        True,
+    ),
+    ("deadband_non_tuple_current_logs", (1000.0,), 1000.0, 7, _POWER_LOG_DEADBAND_W, True),
+    ("deadband_non_tuple_prev_logs", 1000.0, (1000.0,), 7, _POWER_LOG_DEADBAND_W, True),
+    ("deadband_length_mismatch_logs", (1000.0,), (1000.0, 2.0), 7, _POWER_LOG_DEADBAND_W, True),
+    ("deadband_bool_element_logs", (True,), (True,), 7, _POWER_LOG_DEADBAND_W, True),
+    ("deadband_none_element_logs", (None,), (None,), 7, _POWER_LOG_DEADBAND_W, True),
+    ("deadband_mock_element_logs", (_SHARED_MOCK,), (_SHARED_MOCK,), 7, _POWER_LOG_DEADBAND_W, True),
+]
+
+
+@pytest.mark.parametrize(
+    ("first_value", "second_value", "delta_seconds", "deadband", "second_call_logs"),
+    [pytest.param(*case[1:], id=case[0]) for case in _B3_CASES],
+)
+def test_log_info_on_change_emission_predicate(
+    caplog: pytest.LogCaptureFixture,
+    first_value: object,
+    second_value: object,
+    delta_seconds: int,
+    deadband: float | None,
+    second_call_logs: bool,
+) -> None:
+    """B3 cases 1-11: the first call always logs; the second follows the predicate."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    host = _Host()
+
+    # Case 1: lazy init — `_log_on_change_state` is `None`, so the first call logs.
+    host.log_info_on_change("k", first_value, T0, "probe %s", "one", deadband=deadband)
+    assert len(_messages(caplog, "probe", logging.INFO)) == 1
+
+    # Case 2: the state is now initialized — the second call takes the other arc.
+    host.log_info_on_change(
+        "k", second_value, T0 + timedelta(seconds=delta_seconds), "probe %s", "two", deadband=deadband
+    )
+    expected = 2 if second_call_logs else 1
+    assert len(_messages(caplog, "probe", logging.INFO)) == expected
+
+
+def test_log_info_on_change_keeps_state_per_instance(caplog: pytest.LogCaptureFixture) -> None:
+    """B3 case 12: an immutable class default cannot leak state between instances."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    first = _Host()
+    second = _Host()
+
+    first.log_info_on_change("shared_key", "value", T0, "per instance %s", "a")
+    second.log_info_on_change("shared_key", "value", T0, "per instance %s", "b")
+
+    assert len(_messages(caplog, "per instance", logging.INFO)) == 2
+    assert LogOnChangeMixin._log_on_change_state is None
+
+
+def test_log_info_on_change_only_mutates_its_own_state(caplog: pytest.LogCaptureFixture) -> None:
+    """B3 case 13: returns `None` and adds exactly one attribute to the instance."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    host = _Host()
+    before = copy.deepcopy(vars(host))
+    assert "_log_on_change_state" not in before
+
+    assert host.log_info_on_change("k", "v", T0, "only state %s", "x") is None
+
+    after = vars(host)
+    assert set(after) - set(before) == {"_log_on_change_state"}
+    assert set(before) - set(after) == set()
+    assert host._log_on_change_state == {"k": ("v", T0)}
+
+
+def test_log_info_on_change_resets_the_timer_on_every_emission(caplog: pytest.LogCaptureFixture) -> None:
+    """The 900 s constant bounds the gap between emissions, not a fixed cadence."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    host = _Host()
+
+    host.log_info_on_change("k", 1, T0, "timer %s", 1)
+    # A change re-stamps the timer, so 899 s after the change is still inside the window.
+    changed_at = T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S - 1)
+    host.log_info_on_change("k", 2, changed_at, "timer %s", 2)
+    host.log_info_on_change("k", 2, changed_at + timedelta(seconds=7), "timer %s", 3)
+
+    assert len(_messages(caplog, "timer", logging.INFO)) == 2
+
+
+def test_log_info_on_change_keys_are_independent(caplog: pytest.LogCaptureFixture) -> None:
+    """Two keys on one instance memo independently."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    host = _Host()
+
+    host.log_info_on_change("a", 1, T0, "keyed %s", "a")
+    host.log_info_on_change("b", 1, T0, "keyed %s", "b")
+    host.log_info_on_change("a", 1, T0 + timedelta(seconds=7), "keyed %s", "a")
+
+    assert len(_messages(caplog, "keyed", logging.INFO)) == 2
+
+
+# =============================================================================
+# dyn_handle drivers — S1, S2, S3, S4, S13 (B1) and S10 (B2)
+# =============================================================================
+
+
+def _power_series(value: float, time: datetime) -> list[tuple[datetime, float, dict]]:
+    """A non-empty, CONSTANT series: a varying one drifts the weighted mean."""
+    return [(time - timedelta(seconds=30), value, {}), (time, value, {})]
+
+
+def _make_dyn_handle_group(
+    num_chargers: int = 2,
+    cooldown_seconds: float | None = None,
+    battery=None,
+    available_power_w: float | None = None,
+    grid_power_w: float = 500.0,
+):
+    """Build a group whose `dyn_handle` reaches the budgeting branch.
+
+    `ensure_correct_state` is stubbed (the S9 driver below uses the real one).
+    """
+    hass = make_hass()
+    home = make_home(battery=battery)
+    past = T0 - timedelta(seconds=CHARGER_ADAPTATION_WINDOW_S + 100)
+
+    chargers = []
+    statuses = []
+    for index in range(num_chargers):
+        charger = create_charger(hass, home, name=f"Ch{index}")
+        car = make_real_car(hass, home, name=f"Car{index}")
+        init_charger_states(charger, charge_state=True, amperage=10, num_phases=1)
+        plug_car(charger, car, past)
+        charger.is_charging_power_zero = MagicMock(return_value=False)
+        charger.qs_enable_device = True
+        charger.update_car_dampening_value = MagicMock()
+        if cooldown_seconds is not None:
+            charger._last_amp_change_time = T0 - timedelta(seconds=cooldown_seconds)
+        chargers.append(charger)
+
+        status = QSChargerStatus(charger)
+        status.current_real_max_charging_amp = 10
+        status.current_active_phase_number = 1
+        status.accurate_current_power = 2300.0
+        statuses.append(status)
+
+    group = make_charger_group(home, chargers)
+    group.ensure_correct_state = AsyncMock(return_value=(statuses, past))
+    group.dynamic_group.get_median_sensor = MagicMock(return_value=4600.0)
+    group.apply_budgets = AsyncMock()
+    group.apply_budget_strategy = AsyncMock()
+    group.budgeting_algorithm_minimize_diffs = AsyncMock(return_value=(True, False, False))
+    group.remaining_budget_to_apply = []
+
+    if available_power_w is not None:
+        home.get_available_power_values = MagicMock(side_effect=lambda _w, t: _power_series(available_power_w, t))
+        home.get_grid_consumption_power_values = MagicMock(side_effect=lambda _w, t: _power_series(grid_power_w, t))
+
+    return group, chargers, home
+
+
+async def test_s1_dyn_handle_start_is_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """B1/S1: `dyn_handle: START` is unconditional — it must never be INFO."""
+    caplog.set_level(logging.DEBUG, logger=CHARGER_LOGGER)
+    group, _, _ = _make_dyn_handle_group()
+
+    await group.dyn_handle(T0)
+
+    assert _messages(caplog, "dyn_handle: START", logging.INFO) == []
+    assert len(_messages(caplog, "dyn_handle: START", logging.DEBUG)) == 1
+
+
+async def test_s4_cannot_dampen_simple_case_is_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """B1/S4: two truly-charging chargers means the simple case does not apply."""
+    caplog.set_level(logging.DEBUG, logger=CHARGER_LOGGER)
+    group, _, _ = _make_dyn_handle_group(num_chargers=2)
+
+    await group.dyn_handle(T0)
+
+    assert _messages(caplog, "can't dampen simple case", logging.INFO) == []
+    assert len(_messages(caplog, "can't dampen simple case", logging.DEBUG)) == 1
+
+
+async def test_s2_and_s3_cooldown_are_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """B1/S2+S3: one actionable charger in cooldown means one skip plus one all-in-cooldown."""
+    caplog.set_level(logging.DEBUG, logger=CHARGER_LOGGER)
+    group, _, _ = _make_dyn_handle_group(num_chargers=1, cooldown_seconds=10)
+
+    await group.dyn_handle(T0)
+
+    assert _messages(caplog, "amp change cooldown", logging.INFO) == []
+    assert len(_messages(caplog, "amp change cooldown", logging.DEBUG)) == 1
+    assert _messages(caplog, "all chargers in cooldown", logging.INFO) == []
+    assert len(_messages(caplog, "all chargers in cooldown", logging.DEBUG)) == 1
+    group.budgeting_algorithm_minimize_diffs.assert_not_awaited()
+
+
+async def test_s13_no_actionable_chargers_is_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """B1/S13: the `do nothing` branch is mutually exclusive with S9/S10's."""
+    caplog.set_level(logging.DEBUG, logger=CHARGER_LOGGER)
+    group, _, _ = _make_dyn_handle_group(num_chargers=1)
+    group.ensure_correct_state = AsyncMock(return_value=([], None))
+
+    await group.dyn_handle(T0)
+
+    assert _messages(caplog, "no actionable chargers, do nothing", logging.INFO) == []
+    assert len(_messages(caplog, "no actionable chargers, do nothing", logging.DEBUG)) == 1
+    assert _messages(caplog, "battery_asked_charge", logging.INFO) == []
+
+
+async def test_s10_available_power_logged_once_per_window(caplog: pytest.LogCaptureFixture) -> None:
+    """B2/S10: unchanged power over 10 cycles emits once; +900 s and a change re-emit."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    group, _, _ = _make_dyn_handle_group(num_chargers=2, battery=make_battery(0.0), available_power_w=1000.0)
+
+    for cycle in range(10):
+        await group.dyn_handle(T0 + timedelta(seconds=7 * cycle))
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO)) == 1
+
+    await group.dyn_handle(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 63))
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO)) == 2
+
+    group.home.get_available_power_values = MagicMock(side_effect=lambda _w, t: _power_series(5000.0, t))
+    await group.dyn_handle(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 70))
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO)) == 3
+
+
+async def test_s10_deadband_absorbs_sub_threshold_jitter(caplog: pytest.LogCaptureFixture) -> None:
+    """B2/S10: a walk whose every step is <100 W emits once; a >=100 W step emits again."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    group, _, home = _make_dyn_handle_group(num_chargers=2, battery=make_battery(0.0), available_power_w=1000.0)
+
+    jitter = [1000.0, 1049.0, 1051.0, 1049.0, 1055.0, 1049.0, 1051.0, 1060.0, 1049.0, 1051.0]
+    for cycle, watts in enumerate(jitter):
+        home.get_available_power_values = MagicMock(side_effect=lambda _w, t, v=watts: _power_series(v, t))
+        await group.dyn_handle(T0 + timedelta(seconds=7 * cycle))
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO)) == 1
+
+    home.get_available_power_values = MagicMock(side_effect=lambda _w, t: _power_series(1051.0 + 100.0, t))
+    await group.dyn_handle(T0 + timedelta(seconds=7 * len(jitter)))
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO)) == 2
+
+
+# =============================================================================
+# S5, S6 — charger-side rule-2 demotions (B1)
+# =============================================================================
+
+
+def _make_stable_status_charger():
+    """A plugged, enabled, available charger — S5's branch precondition."""
+    hass = make_hass()
+    home = make_home()
+    charger = create_charger(hass, home)
+    car = make_real_car(hass, home)
+    past = T0 - timedelta(hours=2)
+
+    init_charger_states(charger, charge_state=True, amperage=10, num_phases=1)
+    plug_car(charger, car, past)
+
+    charger.qs_enable_device = True
+    charger.current_command = copy_command(CMD_AUTO_GREEN_ONLY)
+    charger.is_not_plugged = MagicMock(return_value=False)
+    charger.is_charger_unavailable = MagicMock(return_value=False)
+    charger._probe_and_enforce_stopped_charge_command_state = MagicMock(return_value=False)
+    charger.get_median_sensor = MagicMock(return_value=1000.0)
+    charger.get_current_active_constraint = MagicMock(return_value=None)
+    charger.can_do_3_to_1_phase_switch = MagicMock(return_value=False)
+    charger._expected_charge_state.last_change_asked = past
+    charger._expected_charge_state.last_time_set = past
+    charger._expected_num_active_phases.last_change_asked = past
+    charger._expected_num_active_phases.last_time_set = past
+
+    return hass, home, charger, car
+
+
+def test_s5_stable_status_dump_is_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """B1/S5: the per-cycle state dump moves to DEBUG."""
+    caplog.set_level(logging.DEBUG, logger=CHARGER_LOGGER)
+    *_, charger, _ = _make_stable_status_charger()
+
+    assert charger.get_stable_dynamic_charge_status(T0) is not None
+
+    assert _messages(caplog, "possible_amps:", logging.INFO) == []
+    assert len(_messages(caplog, "possible_amps:", logging.DEBUG)) == 1
+
+
+async def _drive_remove_all_person_constraints() -> None:
+    """Reach S6: a plugged car charged past a person's minimum target."""
+    hass = make_hass()
+    home = make_home()
+    charger = create_charger(hass, home)
+    car = make_real_car(hass, home)
+    init_charger_states(charger)
+    charger.is_charger_unavailable = MagicMock(return_value=False)
+    charger.probe_for_possible_needed_reboot = MagicMock(return_value=False)
+    charger.is_not_plugged = MagicMock(return_value=False)
+    charger.is_plugged = MagicMock(return_value=True)
+    charger.set_charging_num_phases = AsyncMock(return_value=False)
+    charger.set_max_charging_current = AsyncMock(return_value=True)
+    charger.reboot = AsyncMock()
+    plug_car(charger, car, T0)
+    charger.get_best_car = MagicMock(return_value=car)
+    car.get_car_charge_percent = lambda time=None, *a, **kw: 80.0
+    charger.is_car_stopped_asking_current = MagicMock(return_value=True)
+
+    person = MagicMock()
+    person.name = "Dave"
+    person.notify_of_forecast_if_needed = AsyncMock()
+
+    next_usage_time = T0 + timedelta(hours=10)
+    person_min_target_charge = 50.0
+    old_person_ct = MultiStepsPowerLoadConstraintChargePercent(
+        total_capacity_wh=60000,
+        type=CONSTRAINT_TYPE_MANDATORY_END_TIME,
+        time=T0 - timedelta(hours=1),
+        load=charger,
+        load_param=car.name,
+        from_user=False,
+        end_of_constraint=next_usage_time,
+        initial_value=30.0,
+        target_value=person_min_target_charge,
+        power_steps=charger._power_steps,
+        support_auto=True,
+    )
+    old_person_ct.load_info = {"person": "Dave"}
+    charger.push_live_constraint(T0 - timedelta(hours=1), old_person_ct)
+
+    car.get_best_person_next_need = AsyncMock(return_value=(False, next_usage_time, person_min_target_charge, person))
+    car.get_next_scheduled_event = AsyncMock(return_value=(None, None))
+    car.do_next_charge_time = None
+    car.do_force_next_charge = False
+    charger._auto_constraints_cleaned_at_user_reset = []
+
+    await charger.check_load_activity_and_constraints(T0)
+
+
+async def test_s6_remove_all_person_constraints_is_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """B1/S6: the announcement of the person-constraint cleanup moves to DEBUG."""
+    caplog.set_level(logging.DEBUG, logger=CHARGER_LOGGER)
+
+    await _drive_remove_all_person_constraints()
+
+    assert _messages(caplog, "do_remove_all_person_constraints", logging.INFO) == []
+    assert len(_messages(caplog, "do_remove_all_person_constraints", logging.DEBUG)) == 1
+
+
+# =============================================================================
+# S7, S8 — home_model/load.py (B1 and B1b)
+# =============================================================================
+
+_S8_FRAGMENT = "Constraint Reset device"
+
+
+def test_s7_no_bad_constraint_found_is_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """B1/S7: `no reset needed` is a no-op announcement."""
+    caplog.set_level(logging.DEBUG, logger=LOAD_LOGGER)
+    load = MinimalTestLoad(name="S7Load")
+    caplog.clear()
+
+    assert (
+        load.clean_constraints_for_load_param_and_if_same_key_same_value_info(
+            T0, load_param="CarA", load_info=None, for_full_reset=False
+        )
+        is False
+    )
+
+    assert _messages(caplog, "No bad constraint found", logging.INFO) == []
+    assert len(_messages(caplog, "No bad constraint found", logging.DEBUG)) == 1
+
+
+def test_b1b_fresh_load_construction_logs_the_no_op_at_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """B1b: constructing a load raises nothing and takes case (d) — nothing to reset."""
+    caplog.set_level(logging.DEBUG, logger=LOAD_LOGGER)
+
+    load = MinimalTestLoad(name="FreshLoad")
+
+    assert load.name == "FreshLoad"
+    assert _messages(caplog, _S8_FRAGMENT, logging.INFO) == []
+    assert len(_messages(caplog, _S8_FRAGMENT, logging.DEBUG)) == 1
+    assert "nothing to reset" in _messages(caplog, _S8_FRAGMENT, logging.DEBUG)[0].getMessage()
+
+
+@pytest.mark.parametrize(
+    ("case", "keep_commands", "expected_level"),
+    [
+        pytest.param("constraints", True, logging.INFO, id="a_non_empty_constraints"),
+        pytest.param("last_completed", True, logging.INFO, id="b_last_completed_constraint"),
+        pytest.param("command", False, logging.INFO, id="c_command_dropped"),
+        pytest.param("nothing", True, logging.DEBUG, id="d_nothing_to_reset"),
+        pytest.param("command", True, logging.DEBUG, id="e_command_kept"),
+    ],
+)
+def test_b1b_s8_logs_info_only_when_work_is_performed(
+    caplog: pytest.LogCaptureFixture, case: str, keep_commands: bool, expected_level: int
+) -> None:
+    """B1b: INFO iff the reset actually had something to reset."""
+    caplog.set_level(logging.DEBUG, logger=LOAD_LOGGER)
+    load = MinimalTestLoad(name=f"S8Load{case}")
+    load._constraints = []
+    load._last_completed_constraint = None
+    load.current_command = None
+
+    if case == "constraints":
+        load._constraints = [create_constraint(load=load, time=T0)]
+    elif case == "last_completed":
+        load._last_completed_constraint = create_constraint(load=load, time=T0)
+    elif case == "command":
+        load.current_command = copy_command(CMD_ON, power_consign=1000.0)
+
+    caplog.clear()
+    load.constraint_reset_and_reset_commands_if_needed(keep_commands=keep_commands)
+
+    other_level = logging.DEBUG if expected_level == logging.INFO else logging.INFO
+    assert len(_messages(caplog, _S8_FRAGMENT, expected_level)) == 1
+    assert _messages(caplog, _S8_FRAGMENT, other_level) == []
+
+
+# =============================================================================
+# S9 — ensure_correct_state, per-charger key (B2)
+# =============================================================================
+
+
+def _make_ensure_correct_state_group(num_chargers: int = 2):
+    """Drive the REAL `QSChargerGroup.ensure_correct_state`; stub the children only."""
+    hass = make_hass()
+    home = make_home()
+    chargers = []
+    for index in range(num_chargers):
+        charger = create_charger(hass, home, name=f"EcsCh{index}")
+        charger.qs_enable_device = True
+        charger.ensure_correct_state = AsyncMock(return_value=(True, False, T0))
+        charger.get_stable_dynamic_charge_status = MagicMock(return_value=None)
+        chargers.append(charger)
+
+    return make_charger_group(home, chargers), chargers
+
+
+async def test_s9_correct_state_logged_once_per_charger_per_window(caplog: pytest.LogCaptureFixture) -> None:
+    """B2/S9: one record PER CHARGER over 10 cycles; +900 s and a change re-emit."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    group, chargers = _make_ensure_correct_state_group(num_chargers=2)
+
+    for cycle in range(10):
+        await group.ensure_correct_state(T0 + timedelta(seconds=7 * cycle))
+    records = _messages(caplog, "ensure_correct_state dyn group", logging.INFO)
+    assert len(records) == 2
+    for charger in chargers:
+        assert len([r for r in records if charger.name in r.getMessage()]) == 1
+
+    await group.ensure_correct_state(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 63))
+    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.INFO)) == 4
+
+    # A change is not deferred to the next tick, even well inside the window.
+    for charger in chargers:
+        charger.ensure_correct_state = AsyncMock(return_value=(True, True, T0))
+    await group.ensure_correct_state(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 70))
+    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.INFO)) == 6
+
+
+async def test_s9_probe_only_never_logs_at_info(caplog: pytest.LogCaptureFixture) -> None:
+    """B2/S9: the defensive `probe_only` early-out reports at DEBUG only."""
+    caplog.set_level(logging.DEBUG, logger=CHARGER_LOGGER)
+    group, chargers = _make_ensure_correct_state_group(num_chargers=2)
+
+    for cycle in range(3):
+        await group.ensure_correct_state(T0 + timedelta(seconds=7 * cycle), probe_only=True)
+
+    assert _messages(caplog, "ensure_correct_state dyn group", logging.INFO) == []
+    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.DEBUG)) == 6
+
+
+# =============================================================================
+# S11 — get_best_car (B2)
+# =============================================================================
+
+
+def _make_best_car_charger():
+    """A charger whose `get_best_car` lands on the computed-best-car branch."""
+    hass = make_hass()
+    home = make_home()
+    charger = create_charger(hass, home, name="BestCh")
+    car_a = make_real_car(hass, home, name="CarA")
+    car_b = make_real_car(hass, home, name="CarB")
+    init_charger_states(charger, charge_state=True, amperage=10)
+    plug_car(charger, car_a, T0 - timedelta(hours=1))
+    charger.clear_user_originated(USER_ORIGINATED_CAR_NAME)
+    charger._boot_car = None
+    charger.is_plugged = MagicMock(return_value=True)
+    return hass, home, charger, car_a, car_b
+
+
+async def test_s11_best_car_logged_once_per_window(caplog: pytest.LogCaptureFixture) -> None:
+    """B2/S11: the key is the car name only — a per-cycle score must not re-emit."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    _, _, charger, car_a, car_b = _make_best_car_charger()
+
+    scores = {"CarA": 10.0, "CarB": 5.0}
+    drift = {"n": 0}
+
+    def _score(car, time, cache):
+        # The score drifts every cycle: keying on it would preserve all 71k lines.
+        drift["n"] += 1
+        return scores[car.name] + drift["n"] * 0.001
+
+    charger.get_car_score = MagicMock(side_effect=_score)
+
+    for cycle in range(10):
+        assert charger.get_best_car(T0 + timedelta(seconds=7 * cycle)).name == "CarA"
+    assert len(_messages(caplog, "with score", logging.INFO)) == 1
+
+    assert charger.get_best_car(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 63)).name == "CarA"
+    assert len(_messages(caplog, "with score", logging.INFO)) == 2
+
+    scores["CarB"] = 100.0
+    assert charger.get_best_car(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 70)).name == car_b.name
+    assert len(_messages(caplog, "with score", logging.INFO)) == 3
+    assert car_a.name == "CarA"
+
+
+# =============================================================================
+# S12 — constraint_update_value_callback_soc (B2)
+# =============================================================================
+
+_S12_FRAGMENT = "is_car_charged"
+
+
+def _make_soc_callback_charger():
+    """The real-charger SOC-callback driver: constant inputs across invocations."""
+    hass = make_hass()
+    home = make_home()
+    charger = create_charger(hass, home, name="SocCh")
+    car = make_real_car(hass, home, name="SocCar")
+    init_charger_states(charger, charge_state=True, amperage=10, num_phases=1)
+    plug_car(charger, car, T0 - timedelta(hours=2))
+
+    charger.current_command = copy_command(CMD_AUTO_GREEN_ONLY)
+    charger.is_not_plugged = MagicMock(return_value=False)
+    # `return_value`, never `side_effect`: a finite list raises StopIteration on cycle 2.
+    charger._compute_added_charge_update = MagicMock(return_value=6.0)
+    charger._do_update_charger_state = AsyncMock()
+    charger.charger_group.dyn_handle = AsyncMock()
+
+    car.car_charge_percent_sensor = "sensor.car_soc"
+    car.get_car_charge_percent_raw_sensor = MagicMock(return_value=52.0)
+    car.is_car_charge_growing = MagicMock(return_value=True)
+    car.setup_car_charge_target_if_needed = AsyncMock()
+
+    probe_charge_window = 30 * 60
+    constraint = MagicMock(spec=LoadConstraint)
+    constraint.first_value_update = T0 - timedelta(seconds=probe_charge_window + 100)
+    constraint.last_value_update = T0
+    constraint.last_value_change_update = T0 - timedelta(seconds=60)
+    constraint.current_value = 50.0
+    constraint.target_value = 80.0
+    constraint.is_constraint_met = MagicMock(return_value=False)
+
+    return charger, constraint
+
+
+async def test_s12_soc_callback_logged_once_per_mode_per_window(caplog: pytest.LogCaptureFixture) -> None:
+    """B2/S12: percent and energy modes memo separately; +900 s and a change re-emit."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    charger, constraint = _make_soc_callback_charger()
+
+    for cycle in range(10):
+        await charger.constraint_update_value_callback_percent_soc(constraint, T0 + timedelta(seconds=7 * cycle))
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO)) == 1
+
+    # The energy mode is a different key: one key would let the two callbacks thrash.
+    await charger.constraint_update_value_callback_energy_soc(constraint, T0 + timedelta(seconds=70))
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO)) == 2
+
+    await charger.constraint_update_value_callback_percent_soc(
+        constraint, T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 63)
+    )
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO)) == 3
+
+    constraint.is_constraint_met = MagicMock(return_value=True)
+    await charger.constraint_update_value_callback_percent_soc(
+        constraint, T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 70)
+    )
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO)) == 4
+
+
+async def test_s12_literal_percent_is_escaped(caplog: pytest.LogCaptureFixture) -> None:
+    """The literal `%` must be `%%`, else `record.getMessage()` raises ValueError."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    charger, constraint = _make_soc_callback_charger()
+
+    await charger.constraint_update_value_callback_percent_soc(constraint, T0)
+
+    record = _messages(caplog, _S12_FRAGMENT, logging.INFO)[0]
+    assert "(is %:True)" in record.getMessage()
+    assert "%%" in record.msg
+
+
+# =============================================================================
+# B4 — the keepers are still at INFO
+# =============================================================================
+
+# Regex rather than `inspect.getsource` of an enclosing function: ruff may split a
+# call across lines, and this keeps the check independent of function naming.
+_B4_SOURCE_ANCHORS = [
+    pytest.param("ha_model/charger.py", "STOP CHARGE LAUNCHED", id="charger_stop_charge"),
+    pytest.param("ha_model/charger.py", "START CHARGE LAUNCHED", id="charger_start_charge"),
+    pytest.param("home_model/load.py", "ack command %s for load %s", id="load_ack_command"),
+    pytest.param("home_model/load.py", "launch_command: %s for this load %s), ctxt: %s", id="load_launch_command"),
+    pytest.param("home_model/constraints.py", "%s update callback asked for stop", id="constraints_asked_for_stop"),
+    pytest.param(
+        "home_model/solver.py",
+        "_constraints_delta: trying to consume more: %sWh from %s to %s for loads %s",
+        id="solver_constraints_delta",
+    ),
+]
+
+
+@pytest.mark.parametrize(("module_path", "anchor"), _B4_SOURCE_ANCHORS)
+def test_b4_keeper_lines_are_still_logged_at_info(module_path: str, anchor: str) -> None:
+    """B4: each keeper is matched by exactly one `_LOGGER.info(` call."""
+    source = (Path(quiet_solar.__file__).parent / module_path).read_text(encoding="utf-8")
+    pattern = re.compile(r"_LOGGER\.info\(\s*[^)]*" + re.escape(anchor), re.DOTALL)
+
+    assert len(pattern.findall(source)) == 1, f"expected exactly one INFO call for {anchor!r}"
+
+
+async def test_b4_charger_start_stop_charge_still_log_at_info(caplog: pytest.LogCaptureFixture) -> None:
+    """B4 runtime: the real action lines survive in the file this change set edits."""
+    caplog.set_level(logging.DEBUG, logger=CHARGER_LOGGER)
+    *_, charger, _ = _make_stable_status_charger()
+    charger.low_level_stop_charge = AsyncMock()
+    charger.low_level_start_charge = AsyncMock()
+    charger.is_charge_enabled = MagicMock(return_value=True)
+    charger.is_charge_disabled = MagicMock(return_value=True)
+
+    await charger.stop_charge(T0)
+    await charger.start_charge(T0)
+
+    assert len(_messages(caplog, "STOP CHARGE LAUNCHED", logging.INFO)) == 1
+    assert len(_messages(caplog, "START CHARGE LAUNCHED", logging.INFO)) == 1
+
+
+async def test_b4_load_command_lines_still_log_at_info(caplog: pytest.LogCaptureFixture) -> None:
+    """B4 runtime: `launch_command` and `_ack_command` stay at INFO in `load.py`."""
+    caplog.set_level(logging.DEBUG, logger=LOAD_LOGGER)
+    load = MinimalTestLoad(name="B4Load")
+    caplog.clear()
+
+    load._ack_command(T0, copy_command(CMD_ON, power_consign=1000.0))
+    await load.launch_command(T0, copy_command(CMD_ON, power_consign=2000.0), ctxt="B4")
+
+    acks = [r for r in caplog.records if r.msg == "ack command %s for load %s" and r.levelno == logging.INFO]
+    launches = [
+        r
+        for r in caplog.records
+        if r.msg == "launch_command: %s for this load %s), ctxt: %s" and r.levelno == logging.INFO
+    ]
+    assert len(acks) >= 1
+    assert len(launches) == 1
+
+
+# =============================================================================
+# B5 — every touched site logs lazily, with the expected literal
+# =============================================================================
+
+# site id -> (fragment used to find the record, expected `record.msg` literal)
+_B5_SITES = {
+    "S1": ("dyn_handle: START", "dyn_handle: START"),
+    "S2": (
+        "amp change cooldown",
+        "dyn_handle: skipping %s for budgeting, amp change cooldown (%ss since last change)",
+    ),
+    "S3": ("all chargers in cooldown", "dyn_handle: all chargers in cooldown, skipping budgeting"),
+    "S4": ("can't dampen simple case", "dyn_handle: can't dampen simple case %s %s %s"),
+    "S5": (
+        "possible_amps:",
+        "get_stable_dynamic_charge_status: %s for %s score:%s possible_amps:%s "
+        "possible_num_phases:%s current_amps:%s command:%s",
+    ),
+    "S6": (
+        "do_remove_all_person_constraints",
+        "check_load_activity_and_constraints: plugged car %s do_remove_all_person_constraints",
+    ),
+    "S7": (
+        "No bad constraint found",
+        "clean_constraints_for_load_param: No bad constraint found for %s, no reset needed",
+    ),
+    "S8": ("Constraint Reset device", "Constraint Reset device %s"),
+    "S8d": ("nothing to reset", "Constraint Reset device %s, nothing to reset"),
+    "S9": (
+        "ensure_correct_state dyn group",
+        "ensure_correct_state dyn group: %s  correct_state: %s handled_static: %s",
+    ),
+    "S10": (
+        "battery_asked_charge",
+        "dyn_handle: full_available_home_power %sW, grid_available_home_power %sW battery_asked_charge %sW",
+    ),
+    "S11": ("with score", "get_best_car: %s with score %s for charger %s"),
+    "S12": (
+        "is_car_charged",
+        "update_value_callback (is %%:%s):%s %s %s/%s (%s/%s) is_car_charged %s cmd %s",
+    ),
+    "S13": ("no actionable chargers, do nothing", "dyn_handle: no actionable chargers, do nothing"),
+}
+
+# S1, S3 and S13 are argless literals; every other touched site interpolates.
+_B5_ARGLESS_SITES = {"S1", "S3", "S13"}
+
+
+async def _drive_every_touched_site() -> None:
+    """Drive all 13 sites once, in the branch each one needs."""
+    group, _, _ = _make_dyn_handle_group(num_chargers=2, battery=make_battery(0.0), available_power_w=1000.0)
+    await group.dyn_handle(T0)  # S1, S4, S10
+
+    cooldown_group, _, _ = _make_dyn_handle_group(num_chargers=1, cooldown_seconds=10)
+    await cooldown_group.dyn_handle(T0)  # S2, S3
+
+    idle_group, _, _ = _make_dyn_handle_group(num_chargers=1)
+    idle_group.ensure_correct_state = AsyncMock(return_value=([], None))
+    await idle_group.dyn_handle(T0)  # S13
+
+    *_, stable_charger, _ = _make_stable_status_charger()
+    stable_charger.get_stable_dynamic_charge_status(T0)  # S5
+
+    await _drive_remove_all_person_constraints()  # S6
+
+    ecs_group, _ = _make_ensure_correct_state_group(num_chargers=1)
+    await ecs_group.ensure_correct_state(T0)  # S9
+
+    _, _, best_charger, _, _ = _make_best_car_charger()
+    best_charger.get_car_score = MagicMock(return_value=10.0)
+    best_charger.get_best_car(T0)  # S11
+
+    soc_charger, constraint = _make_soc_callback_charger()
+    await soc_charger.constraint_update_value_callback_percent_soc(constraint, T0)  # S12
+
+    load = MinimalTestLoad(name="B5Load")  # S8d (nothing to reset)
+    load.clean_constraints_for_load_param_and_if_same_key_same_value_info(
+        T0, load_param="CarA", load_info=None, for_full_reset=False
+    )  # S7
+    load._constraints = [create_constraint(load=load, time=T0)]
+    load.constraint_reset_and_reset_commands_if_needed(keep_commands=True)  # S8
+
+
+async def test_b5_every_touched_site_logs_lazily(caplog: pytest.LogCaptureFixture) -> None:
+    """B5: no surviving f-string, no trailing period, and `%s` args where expected.
+
+    No gate can catch this: `pyproject.toml` ignores `G004` with 384 existing
+    occurrences, and `per-file-ignores` cannot scope below file granularity.
+    """
+    caplog.set_level(logging.DEBUG, logger=CHARGER_LOGGER)
+    caplog.set_level(logging.DEBUG, logger=LOAD_LOGGER)
+
+    await _drive_every_touched_site()
+
+    for site, (fragment, expected_msg) in _B5_SITES.items():
+        matching = [r for r in caplog.records if fragment in r.getMessage() and r.msg == expected_msg]
+        assert matching, f"{site}: no record whose msg is exactly {expected_msg!r}"
+        record = matching[0]
+        # An f-string would have been interpolated, so an exact-literal match is the
+        # detector even for the argless sites.
+        assert record.msg == expected_msg
+        assert not record.msg.rstrip().endswith("."), f"{site}: log messages take no trailing period"
+        if site in _B5_ARGLESS_SITES:
+            assert not record.args
+        else:
+            assert record.args, f"{site}: converted site must interpolate lazily"
+            assert "%" in record.msg

--- a/tests/test_qs306_log_volume.py
+++ b/tests/test_qs306_log_volume.py
@@ -119,10 +119,23 @@ _B3_CASES = [
     # A stuck-at-inf sensor is the same failure mode (`inf - inf` is NaN).
     ("deadband_inf_to_inf_silent", lambda: ((math.inf, 500.0, 0.0), (math.inf, 500.0, 0.0)), 7, _DB, False),
     ("deadband_inf_to_finite_logs", lambda: ((math.inf, 500.0, 0.0), (1000.0, 500.0, 0.0)), 7, _DB, True),
-    # NH4: a sign flip is the operationally meaningful boundary (export vs import),
-    # so it beats the deadband even when the absolute step is tiny.
-    ("deadband_sub_threshold_sign_flip_logs", lambda: ((20.0, 500.0, 0.0), (-20.0, 500.0, 0.0)), 7, _DB, True),
+    # NH4/MF1: a sign flip is the operationally meaningful boundary (export vs
+    # import) and beats the deadband — but ONLY above a magnitude floor. An unbounded
+    # flip term makes near-zero dither log every cycle, which is the same
+    # full-cycle-rate re-inflation the NaN guard above exists to prevent.
+    ("deadband_sub_threshold_sign_flip_silent", lambda: ((20.0, 500.0, 0.0), (-20.0, 500.0, 0.0)), 7, _DB, False),
+    ("deadband_supra_threshold_sign_flip_logs", lambda: ((150.0, 500.0, 0.0), (-150.0, 500.0, 0.0)), 7, _DB, True),
+    # One side outside the floor is enough: a real export -> import transition
+    # necessarily crosses the deadband on one side.
+    ("deadband_sign_flip_one_side_over_floor_logs", lambda: ((10.0, 500.0, 0.0), (-120.0, 500.0, 0.0)), 7, _DB, True),
     ("deadband_sub_threshold_same_sign_silent", lambda: ((20.0, 500.0, 0.0), (40.0, 500.0, 0.0)), 7, _DB, False),
+    # NH-J: zero sits on the negative side of `> 0`, so the sign test alone is
+    # asymmetric about zero. The magnitude floor must make both directions behave
+    # identically — small moves silent, large moves logged.
+    ("deadband_zero_to_small_negative_silent", lambda: ((0.0, 500.0, 0.0), (-50.0, 500.0, 0.0)), 7, _DB, False),
+    ("deadband_zero_to_small_positive_silent", lambda: ((0.0, 500.0, 0.0), (50.0, 500.0, 0.0)), 7, _DB, False),
+    ("deadband_zero_to_large_negative_logs", lambda: ((0.0, 500.0, 0.0), (-150.0, 500.0, 0.0)), 7, _DB, True),
+    ("deadband_zero_to_large_positive_logs", lambda: ((0.0, 500.0, 0.0), (150.0, 500.0, 0.0)), 7, _DB, True),
 ]
 
 
@@ -339,7 +352,7 @@ async def test_s13_no_actionable_chargers_is_debug(caplog: pytest.LogCaptureFixt
 async def test_s10_available_power_logged_once_per_window(caplog: pytest.LogCaptureFixture) -> None:
     """B2/S10: unchanged power over 10 cycles emits once; +900 s and a change re-emit."""
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
-    group, _, _ = _make_dyn_handle_group(num_chargers=2, battery=make_battery(0.0), available_power_w=1000.0)
+    group, _, home = _make_dyn_handle_group(num_chargers=2, battery=make_battery(0.0), available_power_w=1000.0)
 
     for cycle in range(10):
         await group.dyn_handle(T0 + timedelta(seconds=7 * cycle))
@@ -348,7 +361,7 @@ async def test_s10_available_power_logged_once_per_window(caplog: pytest.LogCapt
     await group.dyn_handle(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 63))
     assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 2
 
-    group.home.get_available_power_values = MagicMock(side_effect=lambda _w, t: _power_series(5000.0, t))
+    home.get_available_power_values = MagicMock(side_effect=lambda _w, t: _power_series(5000.0, t))
     await group.dyn_handle(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 70))
     assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 3
 
@@ -367,6 +380,44 @@ async def test_s10_deadband_absorbs_sub_threshold_jitter(caplog: pytest.LogCaptu
     home.get_available_power_values = MagicMock(side_effect=lambda _w, t: _power_series(1051.0 + 100.0, t))
     await group.dyn_handle(T0 + timedelta(seconds=7 * len(jitter)))
     assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 2
+
+
+async def _run_oscillating_power_cycles(group, home, watts: float, cycles: int = 10) -> None:
+    """Drive `dyn_handle` with the power series alternating +watts / -watts."""
+    for cycle in range(cycles):
+        value = watts if cycle % 2 == 0 else -watts
+        home.get_available_power_values = MagicMock(side_effect=lambda _w, t, v=value: _power_series(v, t))
+        home.get_grid_consumption_power_values = MagicMock(side_effect=lambda _w, t, v=value: _power_series(v, t))
+        await group.dyn_handle(T0 + timedelta(seconds=7 * cycle))
+
+
+async def test_mf1_near_zero_sign_dither_does_not_re_inflate_the_log(caplog: pytest.LogCaptureFixture) -> None:
+    """MF1: an UNBOUNDED sign-flip term logs every ~7 s forever near zero.
+
+    Near-zero grid power is the steady state of a well-regulated self-consumption
+    home, so this is the common case, not an exotic one. |delta| is 40 W here, well
+    inside the 100 W deadband, yet every cycle flips sign. Without a magnitude floor
+    this is exactly the full-cycle-rate volume the PR exists to remove — on its
+    highest-volume site.
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    group, _, home = _make_dyn_handle_group(num_chargers=2, battery=make_battery(0.0), available_power_w=1000.0)
+
+    await _run_oscillating_power_cycles(group, home, watts=20.0)
+
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 1
+
+
+async def test_mf1_real_export_import_transition_is_still_logged(caplog: pytest.LogCaptureFixture) -> None:
+    """MF1: the floor must not cost us a genuine export <-> import transition."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    group, _, home = _make_dyn_handle_group(num_chargers=2, battery=make_battery(0.0), available_power_w=1000.0)
+
+    await _run_oscillating_power_cycles(group, home, watts=150.0)
+
+    # Every cycle crosses zero with both sides outside the deadband, so every cycle
+    # is a real transition and every cycle is reported.
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 10
 
 
 # =============================================================================
@@ -519,6 +570,9 @@ def test_b1b_fresh_load_construction_logs_the_no_op_at_debug(caplog: pytest.LogC
         # NH5: `keep_commands=False` also drops an in-flight `running_command`.
         pytest.param("running_command", False, logging.INFO, id="f_running_command_dropped"),
         pytest.param("running_command", True, logging.DEBUG, id="g_running_command_kept"),
+        # NH-A: ... and a queued `_stacked_command`, on the same reasoning.
+        pytest.param("stacked_command", False, logging.INFO, id="h_stacked_command_dropped"),
+        pytest.param("stacked_command", True, logging.DEBUG, id="i_stacked_command_kept"),
     ],
 )
 def test_b1b_s8_logs_info_only_when_work_is_performed(
@@ -531,6 +585,7 @@ def test_b1b_s8_logs_info_only_when_work_is_performed(
     load._last_completed_constraint = None
     load.current_command = None
     load.running_command = None
+    load._stacked_command = None
 
     if case == "constraints":
         load._constraints = [create_constraint(load=load, time=T0)]
@@ -540,6 +595,8 @@ def test_b1b_s8_logs_info_only_when_work_is_performed(
         load.current_command = copy_command(CMD_ON, power_consign=1000.0)
     elif case == "running_command":
         load.running_command = copy_command(CMD_ON, power_consign=1000.0)
+    elif case == "stacked_command":
+        load._stacked_command = copy_command(CMD_ON, power_consign=1000.0)
 
     caplog.clear()
     load.constraint_reset_and_reset_commands_if_needed(keep_commands=keep_commands)
@@ -658,6 +715,33 @@ async def test_s9_probe_only_never_logs_at_info(caplog: pytest.LogCaptureFixture
 
     assert _messages(caplog, "ensure_correct_state dyn group", logging.INFO, CHARGER_LOGGER) == []
     assert len(_messages(caplog, "ensure_correct_state dyn group", logging.DEBUG, CHARGER_LOGGER)) == 6
+
+
+async def test_nhb_re_enabling_a_charger_inside_the_window_emits_a_marker(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """NH-B: the `qs_enable_device is False` early-out must EVICT the memo key.
+
+    Otherwise the entry goes stale, and a charger re-enabled inside 900 s with the
+    same `(res, handled_static)` pair produces no line — the log carries no marker
+    that it came back under management. `detach_car()` gives the charger-level memo
+    this cleanup; the group needs its own.
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    group, chargers = _make_ensure_correct_state_group(num_chargers=1)
+    charger = chargers[0]
+
+    await group.ensure_correct_state(T0)
+    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.INFO, CHARGER_LOGGER)) == 1
+
+    charger.qs_enable_device = False
+    await group.ensure_correct_state(T0 + timedelta(seconds=7))
+    # The disabled charger reports nothing at all, by design.
+    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.INFO, CHARGER_LOGGER)) == 1
+
+    charger.qs_enable_device = True
+    await group.ensure_correct_state(T0 + timedelta(seconds=14))
+    assert len(_messages(caplog, "ensure_correct_state dyn group", logging.INFO, CHARGER_LOGGER)) == 2
 
 
 # =============================================================================
@@ -823,6 +907,50 @@ async def test_s12_soc_callback_logged_once_per_mode_per_window(caplog: pytest.L
     assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 4
 
 
+async def test_sfg_soc_progress_numbers_are_memoized_but_quantised(caplog: pytest.LogCaptureFixture) -> None:
+    """SF-G: the printed charge-progress numbers must be in the memo — "it can't be
+    invisible" — but QUANTISED, or the site degenerates into logging every cycle
+    (the trap MF1 fell into).
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    charger, constraint = _make_soc_callback_charger()
+
+    # Sub-unit drift: every reading rounds to 52, so the operator learns nothing new.
+    for cycle, soc in enumerate([52.0, 52.1, 52.4, 52.2, 51.8, 52.3, 51.6, 52.4, 52.0, 51.9]):
+        charger.car.get_car_charge_percent_raw_sensor = MagicMock(return_value=soc)
+        await charger.constraint_update_value_callback_percent_soc(constraint, T0 + timedelta(seconds=7 * cycle))
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 1
+
+    # A whole unit of real progress is worth a line, well inside the 900 s window.
+    charger.car.get_car_charge_percent_raw_sensor = MagicMock(return_value=53.0)
+    await charger.constraint_update_value_callback_percent_soc(constraint, T0 + timedelta(seconds=77))
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 2
+
+
+async def test_sfg_consign_change_under_the_same_command_name_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """SF-G: the memo stored only `command.command`, so a consign change was invisible.
+
+    `LoadCommand.__eq__` compares `power_consign` too, and the message prints the whole
+    command — so `auto_green` at 3000 W and at 7000 W must not share a memo entry.
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    charger, constraint = _make_soc_callback_charger()
+
+    charger.current_command = copy_command(CMD_AUTO_GREEN_ONLY, power_consign=3000.0)
+    await charger.constraint_update_value_callback_percent_soc(constraint, T0)
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 1
+
+    charger.current_command = copy_command(CMD_AUTO_GREEN_ONLY, power_consign=7000.0)
+    assert charger.current_command.command == CMD_AUTO_GREEN_ONLY.command
+    await charger.constraint_update_value_callback_percent_soc(constraint, T0 + timedelta(seconds=7))
+
+    records = _messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)
+    assert len(records) == 2
+    assert "7000" in records[1].getMessage()
+
+
 async def test_s12_literal_percent_is_escaped(caplog: pytest.LogCaptureFixture) -> None:
     """The literal `%` must be `%%`, else `record.getMessage()` raises ValueError."""
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
@@ -833,6 +961,24 @@ async def test_s12_literal_percent_is_escaped(caplog: pytest.LogCaptureFixture) 
     record = _messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)[0]
     assert "(is %:True)" in record.getMessage()
     assert "%%" in record.msg
+
+
+# =============================================================================
+# Harness contract (NH-C, NH-D)
+# =============================================================================
+
+
+def test_harness_hass_config_dir_is_caller_controlled_and_unique(tmp_path: Path) -> None:
+    """NH-C: a fixed shared config dir is collision-prone under parallel runs."""
+    assert make_hass(config_dir=str(tmp_path)).config.config_dir == str(tmp_path)
+    assert make_hass().config.config_dir != make_hass().config.config_dir
+
+
+async def test_harness_executor_job_forwards_keyword_arguments() -> None:
+    """NH-D: dropping kwargs would raise TypeError instead of running the job."""
+    hass = make_hass()
+
+    assert await hass.async_add_executor_job(lambda a, b=0: a + b, 1, b=2) == 3
 
 
 # =============================================================================
@@ -857,11 +1003,25 @@ _B4_SOURCE_ANCHORS = [
 
 @pytest.mark.parametrize(("module_path", "anchor"), _B4_SOURCE_ANCHORS)
 def test_b4_keeper_lines_are_still_logged_at_info(module_path: str, anchor: str) -> None:
-    """B4: each keeper is matched by exactly one `_LOGGER.info(` call."""
-    source = (Path(quiet_solar.__file__).parent / module_path).read_text(encoding="utf-8")
-    pattern = re.compile(r"_LOGGER\.info\(\s*[^)]*" + re.escape(anchor), re.DOTALL)
+    r"""B4: each keeper appears exactly once, inside an INFO call.
 
-    assert len(pattern.findall(source)) == 1, f"expected exactly one INFO call for {anchor!r}"
+    Deliberately NOT a single clever regex. The previous form
+    (`_LOGGER\.info\(\s*[^)]*` + anchor) had `[^)]*` stop at the first `)`, so a
+    keeper wrapped in an inner call would silently stop matching, and a cosmetic ruff
+    reformat could fail the test while behavior was intact. Instead: assert the anchor
+    is unique in the module, then check the nearest preceding logger call is `.info`.
+    The sibling runtime `caplog` assertions below carry the behavioral weight.
+    """
+    source = (Path(quiet_solar.__file__).parent / module_path).read_text(encoding="utf-8")
+
+    occurrences = [m.start() for m in re.finditer(re.escape(anchor), source)]
+    assert len(occurrences) == 1, f"expected exactly one occurrence of {anchor!r}"
+
+    preceding_calls = list(re.finditer(r"_LOGGER\.(\w+)\(", source[: occurrences[0]]))
+    assert preceding_calls, f"no logger call precedes {anchor!r}"
+    assert preceding_calls[-1].group(1) == "info", (
+        f"{anchor!r} is emitted by _LOGGER.{preceding_calls[-1].group(1)}, expected info"
+    )
 
 
 async def test_b4_charger_start_stop_charge_still_log_at_info(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/utils/charger_harness.py
+++ b/tests/utils/charger_harness.py
@@ -1,15 +1,19 @@
 """Shared charger-test harness: real `QSChargerGeneric` / `QSCar` / `QSChargerGroup`.
 
-Promoted from the module-level helpers in `tests/test_charger_coverage_deep.py`
-(QS-306) so more than one test module can drive a real charger. Only Home
-Assistant I/O (sensor state reads, service calls, the dynamic group) is mocked;
-the charger, car and charger group are real objects.
+Copied from the module-level helpers in `tests/test_charger_coverage_deep.py`, which
+intentionally retains its own copies (QS-306 Task 9) — this is NOT a single source of
+truth. Roughly nine test modules define their own `make_hass` / `make_home` /
+`create_charger`; consolidating them is out of scope here.
+
+Only Home Assistant I/O (sensor state reads, service calls, the dynamic group) is
+mocked; the charger, car and charger group are real objects.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytz
 
@@ -38,18 +42,27 @@ from custom_components.quiet_solar.ha_model.charger import (
 )
 
 
-def make_hass() -> MagicMock:
-    """Minimal hass mock: only for HA-level I/O (states, services, bus)."""
+def make_hass(config_dir: str | None = None) -> MagicMock:
+    """Minimal hass mock: only for HA-level I/O (states, services, bus).
+
+    `config_dir` defaults to a UNIQUE path per call rather than a fixed shared one,
+    which would be collision-prone under parallel test runs (xdist). Pass pytest's
+    `tmp_path` when a test needs a directory that actually exists. Nothing in
+    `custom_components/quiet_solar/` reads `config_dir` today, so this is hygiene
+    against a future reader copying a shared path.
+    """
     hass = MagicMock()
     hass.states = MagicMock()
     hass.states.get = MagicMock(return_value=None)
     hass.services = MagicMock()
     hass.services.async_call = AsyncMock()
     hass.config = MagicMock()
-    hass.config.config_dir = "/tmp/test"
+    hass.config.config_dir = config_dir if config_dir is not None else f"/tmp/qs-test-{uuid4().hex}"
     hass.bus = MagicMock()
     hass.bus.async_listen = MagicMock(return_value=lambda: None)
-    hass.async_add_executor_job = AsyncMock(side_effect=lambda f, *a: f(*a))
+    # `**kw` matters: `async_add_executor_job` is routinely called with keyword
+    # arguments, and dropping them would raise TypeError instead of running the job.
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda f, *a, **kw: f(*a, **kw))
     return hass
 
 

--- a/tests/utils/charger_harness.py
+++ b/tests/utils/charger_harness.py
@@ -1,0 +1,210 @@
+"""Shared charger-test harness: real `QSChargerGeneric` / `QSCar` / `QSChargerGroup`.
+
+Promoted from the module-level helpers in `tests/test_charger_coverage_deep.py`
+(QS-306) so more than one test module can drive a real charger. Only Home
+Assistant I/O (sensor state reads, service calls, the dynamic group) is mocked;
+the charger, car and charger group are real objects.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytz
+
+from custom_components.quiet_solar.const import (
+    CONF_CAR_BATTERY_CAPACITY,
+    CONF_CAR_CHARGE_PERCENT_SENSOR,
+    CONF_CAR_CHARGER_MAX_CHARGE,
+    CONF_CAR_CHARGER_MIN_CHARGE,
+    CONF_CAR_IS_INVITED,
+    CONF_CHARGER_MAX_CHARGE,
+    CONF_CHARGER_MAX_CHARGING_CURRENT_NUMBER,
+    CONF_CHARGER_MIN_CHARGE,
+    CONF_CHARGER_PLUGGED,
+    CONF_CHARGER_STATUS_SENSOR,
+    CONF_DEFAULT_CAR_CHARGE,
+    CONF_DEVICE_EFFICIENCY,
+    CONF_IS_3P,
+    CONF_MINIMUM_OK_CAR_CHARGE,
+    CONF_MONO_PHASE,
+)
+from custom_components.quiet_solar.ha_model.car import QSCar
+from custom_components.quiet_solar.ha_model.charger import (
+    QSChargerGeneric,
+    QSChargerGroup,
+    QSStateCmd,
+)
+
+
+def make_hass() -> MagicMock:
+    """Minimal hass mock: only for HA-level I/O (states, services, bus)."""
+    hass = MagicMock()
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=None)
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.config = MagicMock()
+    hass.config.config_dir = "/tmp/test"
+    hass.bus = MagicMock()
+    hass.bus.async_listen = MagicMock(return_value=lambda: None)
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda f, *a: f(*a))
+    return hass
+
+
+def make_home(battery=None, voltage=230.0, home_load_power=500.0, max_production_power=3000.0):
+    """Create a mock home.  Home has no simple real constructor so we mock it."""
+    home = MagicMock()
+    home.name = "TestHome"
+    home.voltage = voltage
+    home.is_3p = True
+    home._cars = []
+    home._chargers = []
+    home._loads = []
+    home._persons = []
+    home.available_amps_for_group = [[32.0, 32.0, 32.0]]
+    home.battery = battery
+    home.get_car_by_name = lambda n: next((c for c in home._cars if c.name == n), None)
+    home.get_available_power_values = MagicMock(return_value=None)
+    home.get_grid_consumption_power_values = MagicMock(return_value=None)
+    home.get_best_tariff = MagicMock(return_value=0.15)
+    home.get_tariff = MagicMock(return_value=0.20)
+    home.battery_can_discharge = MagicMock(return_value=True)
+    home.is_off_grid = MagicMock(return_value=False)
+    home.dashboard_sections = None
+    home.compute_and_set_best_persons_cars_allocations = AsyncMock()
+    home.get_preferred_person_for_car = MagicMock(return_value=None)
+    home._last_persons_car_allocation = {}
+    home.force_next_person_allocation_compute_and_set = MagicMock()
+
+    # Provide realistic power values for budget capping in
+    # budgeting_algorithm_minimize_diffs when battery discharge is involved.
+    _now = datetime.now(pytz.UTC)
+    home.get_device_power_values = MagicMock(
+        return_value=[
+            (_now - timedelta(seconds=30), home_load_power, {}),
+            (_now - timedelta(seconds=15), home_load_power, {}),
+            (_now, home_load_power, {}),
+        ]
+    )
+    home.get_home_max_available_production_power = MagicMock(return_value=max_production_power)
+    home.get_current_maximum_production_output_power = MagicMock(return_value=max_production_power)
+    home.solar_plant = None
+
+    return home
+
+
+def make_real_car(
+    hass,
+    home,
+    name="TestCar",
+    battery_capacity=60000,
+    min_charge=6,
+    max_charge=32,
+    default_charge=80.0,
+    minimum_ok_charge=20.0,
+    is_invited=False,
+    has_soc_sensor=True,
+) -> QSCar:
+    """Create a REAL QSCar with minimal HA mocking."""
+    kwargs = {
+        "name": name,
+        "hass": hass,
+        "home": home,
+        "config_entry": None,
+        CONF_CAR_BATTERY_CAPACITY: battery_capacity,
+        CONF_CAR_CHARGER_MIN_CHARGE: min_charge,
+        CONF_CAR_CHARGER_MAX_CHARGE: max_charge,
+        CONF_DEFAULT_CAR_CHARGE: default_charge,
+        CONF_MINIMUM_OK_CAR_CHARGE: minimum_ok_charge,
+        CONF_CAR_IS_INVITED: is_invited,
+        CONF_DEVICE_EFFICIENCY: 90.0,
+    }
+    if has_soc_sensor:
+        kwargs[CONF_CAR_CHARGE_PERCENT_SENSOR] = f"sensor.{name.lower().replace(' ', '_')}_soc"
+    car = QSCar(**kwargs)
+    home._cars.append(car)
+    return car
+
+
+def make_charger_group(home, chargers, max_amps=None) -> QSChargerGroup:
+    """Build QSChargerGroup around a mock dynamic-group (the group has no easy real ctor)."""
+    from custom_components.quiet_solar.ha_model.dynamic_group import QSDynamicGroup
+
+    if max_amps is None:
+        max_amps = [32.0, 32.0, 32.0]
+
+    dg = MagicMock(spec=QSDynamicGroup)
+    dg.name = "TestGroup"
+    dg.home = home
+    dg._childrens = chargers
+    dg.available_amps_for_group = [max_amps]
+    dg.dyn_group_max_phase_current = max(max_amps)
+    dg.is_current_acceptable = MagicMock(return_value=True)
+    dg.is_current_acceptable_and_diff = MagicMock(return_value=(True, [0.0, 0.0, 0.0]))
+    dg.get_median_sensor = MagicMock(return_value=None)
+    dg.accurate_power_sensor = "sensor.group_power"
+    dg.secondary_power_sensor = None
+
+    group = QSChargerGroup(dg)
+    group.charger_consumption_W = 70
+    return group
+
+
+def create_charger(
+    hass, home, name="TestCharger", is_3p=False, min_charge=6, max_charge=32, **extra
+) -> QSChargerGeneric:
+    """Create a REAL QSChargerGeneric."""
+    config_entry = MagicMock()
+    config_entry.entry_id = f"test_entry_{name}"
+    config_entry.data = {}
+
+    config = {
+        "name": name,
+        "hass": hass,
+        "home": home,
+        "config_entry": config_entry,
+        CONF_CHARGER_MIN_CHARGE: min_charge,
+        CONF_CHARGER_MAX_CHARGE: max_charge,
+        CONF_IS_3P: is_3p,
+        CONF_MONO_PHASE: 1,
+        CONF_CHARGER_STATUS_SENSOR: f"sensor.{name}_status",
+        CONF_CHARGER_PLUGGED: f"sensor.{name}_plugged",
+        CONF_CHARGER_MAX_CHARGING_CURRENT_NUMBER: f"number.{name}_max_current",
+    }
+    config.update(extra)
+
+    with patch("custom_components.quiet_solar.ha_model.charger.entity_registry"):
+        charger = QSChargerGeneric(**config)
+
+    home._chargers.append(charger)
+
+    if hasattr(charger, "father_device") and charger.father_device is not None:
+        group = make_charger_group(home, [charger])
+        charger.father_device.charger_group = group
+    return charger
+
+
+def init_charger_states(charger, charge_state=True, amperage=None, num_phases=1) -> None:
+    """Set up inner state objects (the charger resets them to None on reset)."""
+    if amperage is None:
+        amperage = charger.min_charge
+    charger._inner_expected_charge_state = QSStateCmd()
+    charger._inner_expected_charge_state.value = charge_state
+    charger._inner_amperage = QSStateCmd()
+    charger._inner_amperage.value = amperage
+    charger._inner_num_active_phases = QSStateCmd()
+    charger._inner_num_active_phases.value = num_phases
+
+
+def plug_car(charger, car, time) -> None:
+    """Attach a real car to a real charger (calls update_power_steps)."""
+    charger.attach_car(car, time)
+
+
+def make_battery(asked_charge=0.0) -> MagicMock:
+    """Mock battery reporting a fixed asked-charge value."""
+    battery = MagicMock()
+    battery.get_current_battery_asked_change_for_outside_production_system = MagicMock(return_value=asked_charge)
+    return battery


### PR DESCRIPTION
## Summary
- Demote 8 no-op / per-cycle-dump INFO sites to DEBUG (S1-S7, S13) and guard the constraint-reset line so it only logs INFO when there was something to reset (S8).
- Add `LogOnChangeMixin` to `ha_model/charger.py` and route 4 sites through it (S9-S12): emit on change, or after 900s so a persistent fault stays visible; 100W deadband on the available-power line; per-charger / per-car / per-mode keys.
- **77 tests** in `tests/test_qs306_log_volume.py` (B1, B1b, B2, B3, B4, B5); charger test harness copied to `tests/utils/charger_harness.py`.

Fixes #306

## Log-policy deviations beyond the story

Three changes alter *when* a line is emitted, beyond anything the issue or the story specified. All were accepted at review triage; flagged here so they are not read as scope creep. Each is also recorded in the story's "Accepted deviations" section.

**1. Sign flip beats the deadband — above a magnitude floor.** A symmetric ±100 W band hides the export↔import transition, which is the operationally meaningful boundary. So a sign change on an available-power element forces "changed" — but only when `max(abs(prev), abs(current)) >= deadband`.

The floor is not cosmetic. Fix plan #01 specified this term *without* one, and fix plan #02 MF1 caught the consequence: with `grid_available_home_power` dithering `+20 / -20 / +20` on consecutive cycles, |Δ| = 40 W sits inside the deadband but every cycle flips sign, so the site logged **every ~7 s indefinitely** — silently re-inflating the single highest-volume line in the change set. Near-zero grid power is the steady state of a well-regulated self-consumption home, so this was the common case. Now bounded and pinned by a 10-cycle oscillation test asserting an INFO count of exactly **1**, with a companion at ±150 W asserting a genuine transition is still reported.

**2. `running_command` and `_stacked_command` count as work to reset.** `keep_commands=False` destroys both, so a reset that drops an in-flight or queued command logs INFO rather than reporting "nothing to reset" at DEBUG.

**3. The SOC line's memo covers every printed value, quantised.** This **reverses the story's explicit decision** to drop `round(result)` from the S12 memo. The story dropped it because `result` can be `None`; the cost was that the printed charge-progress numbers — and `power_consign`, which `LoadCommand.__eq__` compares but the command *name* alone hides — could go stale for a full 900 s. They are now memoized `None`-safely and rounded to whole units. Rounding is load-bearing: memoizing the raw floats would make the site log every cycle, the same trap deviation 1 fell into.

## Known limitation

**The saving attributed to S8 (`Constraint Reset device`, 219,949 lines ≈ 20% of the total) is unquantified.** Unlike every other site, S8 is guarded rather than demoted, so its saving depends on how often the reset is called with nothing to reset — which was never measured. The hot path is 7 Clim devices via six `bistate_duration.py` call sites, all passing `keep_commands=True`, which makes the outcome hinge entirely on whether `_constraints` is empty. If usually empty the headline holds near 78%; if usually non-empty, S8 saves ~0 and the honest figure is ~62%.

This is a measurement gap, not a correctness gap — the guard's behavior is fully pinned by B1b. It is now cheaply measurable in production, because the two branches emit distinguishable text:

```bash
grep -c "Constraint Reset device .*nothing to reset" home-assistant.log   # suppressed
grep -c "Constraint Reset device" home-assistant.log                     # total
```

The ratio is the realized saving.

## Deferred

**The mixin hardcodes `charger.py`'s module logger** (fix plan #02 NH-G, nice-to-have). Resolving it from `type(self).__module__` would attribute a test double's records to the test module, un-pinning the logger-identity guard added in fix plan #01 SF3 — which would weaken the tests to fix a problem no current host has, since both hosts live in `charger.py`. A comment on the mixin records the constraint for the first non-charger host.

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified (`--impacted`: 84 changed lines, 0 missing)
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [x] CRITICAL (solver, constraints, charger budgeting)
- [x] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repetitive informational logs while preserving messages for meaningful changes, actions, and periodic updates.
  * Improved change detection for special numeric values, sign changes, timestamps, and command updates.
  * Reset stale logging state when chargers are re-enabled or cars are detached.
  * Reset notifications now reflect pending commands and user-requested charging states.

* **Documentation**
  * Updated charger, load, override, piloting, and external-control documentation.

* **Tests**
  * Added comprehensive coverage for throttling, reset behavior, edge cases, and log severity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->