### PR TITLE
QS-307: an override on an unresponsive load can never expire

### DIFF
--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -199,8 +199,8 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         # review fix QS-256#03: a future-dated reset-ask timestamp keeps the
         # post-override cooldown permanently active (negative age is always
         # below the cooldown window) — same future-dated drop as the override
-        # timestamp, with the same skew tolerance (QS-307: shared constant,
-        # so retuning it cannot desync this site from the runtime comparisons)
+        # timestamp, with the same `CLOCK_SKEW_TOLERANCE_S` band. Restore boundary
+        # only — the runtime comparisons use plain subtraction (QS-307).
         if self.asked_for_reset_user_initiated_state_time is not None:
             ask_age_s = (datetime.now(pytz.UTC) - self.asked_for_reset_user_initiated_state_time).total_seconds()
             # QS-307: a load that cannot hold an override has no lifecycle to drain a

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -693,18 +693,19 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         do_push_constraint_after = None
 
         # we want to check that the load hasn't been changed externally from the system:
-        # QS-307: the gate is `is_load_command_set(time)` no more. Only DETECTION may
-        # be gated on command state (see the `elif` below): while a command is landing,
-        # observed state != wanted state is expected, and reading that as a user action
-        # would be a false positive. The state-FREE branches of the override lifecycle
-        # — expiry, the reset-ask follow-up, the post-override cooldown — are pure
-        # clock/flag arithmetic and must run whatever the command slot holds. Since
-        # QS-304 made the relaunch backoff saturate and retry forever, the old gate
-        # could stay shut indefinitely and an override on a load that stopped obeying
-        # was pinned FOREVER. `qs_enable_device` is kept explicitly because
-        # `is_load_command_set` returned False for a disabled load: QS was told to
-        # leave that load alone, so it must not start expiring overrides on it.
-        if self.qs_enable_device is not False and self.support_user_override():
+        # QS-307 — the split gate: override DETECTION is gated on command state, the
+        # override LIFECYCLE is not. The lifecycle branches read no entity state, so
+        # nothing about an unresponsive device may be allowed to freeze them. See
+        # `docs/agents/concepts/bistate-duration-devices.md`, "the split gate", for
+        # the reasoning and the failure it fixes.
+        #
+        # `qs_enable_device is not False` is defence in depth: every production caller
+        # arrives via `do_run_check_load_activity_and_constraints`, which already
+        # short-circuits on a disabled load, so only a direct call reaches here with
+        # one. `None`/unset is deliberately treated as enabled, like every other
+        # `is not False` guard on the load. `support_user_override()` deliberately does
+        # NOT belong here (review fix #03) — it guards detection, below.
+        if self.qs_enable_device is not False:
             # we need to know if the state we have is compatible with the current command
             # well more if it has been set ON or any other stuff externally so that we don't want to reset it to OFF
             # because the user wanted to force the state of the load
@@ -725,12 +726,37 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                     tzinfo=pytz.UTC
                 )
 
-            if self.external_user_initiated_state_time is not None and (
-                time - self.external_user_initiated_state_time
-            ).total_seconds() > (3600.0 * self.override_duration):
+            # QS-307 review fix #08: route the age comparison through
+            # `_seconds_since`, which returns None for an anchor in the FUTURE (a
+            # backwards clock step, e.g. HA booting without an RTC and NTP correcting
+            # afterwards) and means "treat as fully elapsed". A raw subtraction would
+            # freeze the expiry for the whole duration of the jump.
+            override_expired = False
+            if self.external_user_initiated_state_time is not None:
+                override_age_s = self._seconds_since(time, self.external_user_initiated_state_time)
+                override_expired = override_age_s is None or override_age_s > (3600.0 * self.override_duration)
+
+            if override_expired:
                 _LOGGER.info(
                     f"External state time is long, reset from {self.external_user_initiated_state} for load {self.name} "
                 )
+                # QS-307 review fix #02: an override-aligned command still in flight at
+                # expiry was unconstructible before the hoist — the old
+                # `is_load_command_set` gate guaranteed an empty slot here — but it is
+                # reachable now. Once the override state is nulled just below,
+                # `force_relaunch_command`'s suppression drop stops applying, so QS
+                # would keep re-issuing the ENDED override's own service call at the
+                # 50→300 s cadence for up to a full ladder while the post-expiry intent
+                # merely stacks behind it. This branch is the one place that knows the
+                # override just ended, so it owns the drop. `_drop_running_command` and
+                # not `abandon_running_command`: no successor is launched in this call,
+                # so the rung and the clock must go with the slot — the same reasoning
+                # as the override-suppression drop in `force_relaunch_command`.
+                if (
+                    self.running_command is not None
+                    and self.expected_state_from_command(self.running_command) == self.external_user_initiated_state
+                ):
+                    self._drop_running_command("the user override this command was serving expired")
                 # we need to reset the external user initiated state
                 self.reset_override_state_and_set_reset_ask_time(time)
                 do_force_next_solve = True
@@ -748,7 +774,6 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                 self.constraint_reset_and_reset_commands_if_needed(
                     keep_commands=True
                 )  # remove any constraint if any we will add it back if needed below
-
             else:
                 # QS-307: the post-override cooldown EXPIRY is clock arithmetic too, so
                 # it is drained here rather than inside the detection branch below. On a
@@ -765,13 +790,23 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                         self.asked_for_reset_user_initiated_state_time = (
                             self.asked_for_reset_user_initiated_state_time.replace(tzinfo=pytz.UTC)
                         )
-                    if (time - self.asked_for_reset_user_initiated_state_time).total_seconds() >= min(
+                    # QS-307 review fix #08: clock-step-safe, like the expiry above —
+                    # this drain is now the ONLY release of the cooldown, so a rewound
+                    # clock freezing it would pin `is_user_overridden()` True
+                    ask_age_s = self._seconds_since(time, self.asked_for_reset_user_initiated_state_time)
+                    if ask_age_s is None or ask_age_s >= min(
                         float(USER_OVERRIDE_STATE_BACK_DURATION_S), (3600.0 * self.override_duration) / 2.0
                     ):
                         # long enough ask to check the fact that the override should be finished
                         self.asked_for_reset_user_initiated_state_time = None
 
-                if self.is_load_command_set(time):
+                # QS-307 review fix #03: `support_user_override()` guards DETECTION,
+                # never the lifecycle above. Gating the lifecycle on it was a second
+                # "an override can never expire" path, and a worse one — unlike the
+                # disabled-load arm it is not self-healing, so a load reconfigured to
+                # boost-only kept a restored override or reset-ask forever, across
+                # restarts, and stayed out of controlled consumption.
+                if self.support_user_override() and self.is_load_command_set(time):
                     for i, ct in enumerate(self._constraints):
                         if (
                             ct.load_param is not None

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -693,7 +693,18 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         do_push_constraint_after = None
 
         # we want to check that the load hasn't been changed externally from the system:
-        if self.is_load_command_set(time) and self.support_user_override():
+        # QS-307: the gate is `is_load_command_set(time)` no more. Only DETECTION may
+        # be gated on command state (see the `elif` below): while a command is landing,
+        # observed state != wanted state is expected, and reading that as a user action
+        # would be a false positive. The state-FREE branches of the override lifecycle
+        # — expiry, the reset-ask follow-up, the post-override cooldown — are pure
+        # clock/flag arithmetic and must run whatever the command slot holds. Since
+        # QS-304 made the relaunch backoff saturate and retry forever, the old gate
+        # could stay shut indefinitely and an override on a load that stopped obeying
+        # was pinned FOREVER. `qs_enable_device` is kept explicitly because
+        # `is_load_command_set` returned False for a disabled load: QS was told to
+        # leave that load alone, so it must not start expiring overrides on it.
+        if self.qs_enable_device is not False and self.support_user_override():
             # we need to know if the state we have is compatible with the current command
             # well more if it has been set ON or any other stuff externally so that we don't want to reset it to OFF
             # because the user wanted to force the state of the load
@@ -729,17 +740,38 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                 self.constraint_reset_and_reset_commands_if_needed(
                     keep_commands=True
                 )  # remove any constraint if any we will add it back if needed below
-            else:
-                if self.asked_for_reset_user_initiated_state_time_first_cmd_reset_done is not None:
-                    # do nothing below, just ask for a proper constraint evaluation to kill the current override:
-                    has_a_running_override = False
-                    do_force_next_solve = True
-                    self.asked_for_reset_user_initiated_state_time_first_cmd_reset_done = None
-                    self.constraint_reset_and_reset_commands_if_needed(
-                        keep_commands=True
-                    )  # remove any constraint if any we will add it back if needed below
+            elif self.asked_for_reset_user_initiated_state_time_first_cmd_reset_done is not None:
+                # do nothing below, just ask for a proper constraint evaluation to kill the current override:
+                has_a_running_override = False
+                do_force_next_solve = True
+                self.asked_for_reset_user_initiated_state_time_first_cmd_reset_done = None
+                self.constraint_reset_and_reset_commands_if_needed(
+                    keep_commands=True
+                )  # remove any constraint if any we will add it back if needed below
 
-                else:
+            else:
+                # QS-307: the post-override cooldown EXPIRY is clock arithmetic too, so
+                # it is drained here rather than inside the detection branch below. On a
+                # load QS can no longer talk to, leaving it behind pinned the load in
+                # ASKED FOR RESET forever — `is_user_overridden()` stayed True and the
+                # load never came back into controlled consumption, i.e. the same bug
+                # one step later. Position is unchanged: this ran in the same
+                # not-expired / no-reset-ask-pending branch before, so for a healthy
+                # load it still lands on exactly the same cycle.
+                if self.asked_for_reset_user_initiated_state_time is not None:
+                    # review fix QS-256#02: coerce a legacy tz-naive
+                    # reset-ask timestamp before the subtraction
+                    if self.asked_for_reset_user_initiated_state_time.tzinfo is None:
+                        self.asked_for_reset_user_initiated_state_time = (
+                            self.asked_for_reset_user_initiated_state_time.replace(tzinfo=pytz.UTC)
+                        )
+                    if (time - self.asked_for_reset_user_initiated_state_time).total_seconds() >= min(
+                        float(USER_OVERRIDE_STATE_BACK_DURATION_S), (3600.0 * self.override_duration) / 2.0
+                    ):
+                        # long enough ask to check the fact that the override should be finished
+                        self.asked_for_reset_user_initiated_state_time = None
+
+                if self.is_load_command_set(time):
                     for i, ct in enumerate(self._constraints):
                         if (
                             ct.load_param is not None
@@ -849,21 +881,12 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                             is_command_overridden_state_changed = False
 
                     if self.asked_for_reset_user_initiated_state_time is not None:
-                        # review fix QS-256#02: coerce a legacy tz-naive
-                        # reset-ask timestamp before the subtraction
-                        if self.asked_for_reset_user_initiated_state_time.tzinfo is None:
-                            self.asked_for_reset_user_initiated_state_time = (
-                                self.asked_for_reset_user_initiated_state_time.replace(tzinfo=pytz.UTC)
-                            )
-                        if (time - self.asked_for_reset_user_initiated_state_time).total_seconds() < min(
-                            float(USER_OVERRIDE_STATE_BACK_DURATION_S), (3600.0 * self.override_duration) / 2.0
-                        ):
-                            # small time window after asking for reset, do not consider the command overridden
-                            # too soon to launch an override again
-                            is_command_overridden_state_changed = False
-                        else:
-                            # long enough ask to check the fact that the override should be finished
-                            self.asked_for_reset_user_initiated_state_time = None
+                        # small time window after asking for reset, do not consider the command overridden
+                        # too soon to launch an override again.
+                        # QS-307: the window's EXPIRY moved above the detection gate
+                        # (pure clock arithmetic, and the tz coercion with it), so
+                        # reaching here means the window is still open.
+                        is_command_overridden_state_changed = False
 
                     if is_command_overridden_state_changed:
                         # "back to normal" — user overrides back to base mode state

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -22,7 +22,7 @@ from ..home_model.constraints import (
     TimeBasedHoldOffConstraint,
     TimeBasedSimplePowerLoadConstraint,
 )
-from ..home_model.load import AbstractLoad
+from ..home_model.load import CLOCK_SKEW_TOLERANCE_S, AbstractLoad
 
 if TYPE_CHECKING:
     from .bistate_transport import BistateTransport
@@ -199,10 +199,11 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         # review fix QS-256#03: a future-dated reset-ask timestamp keeps the
         # post-override cooldown permanently active (negative age is always
         # below the cooldown window) — same future-dated drop as the override
-        # timestamp, with the same 60s skew tolerance
+        # timestamp, with the same skew tolerance (QS-307: shared constant,
+        # so retuning it cannot desync this site from the runtime comparisons)
         if self.asked_for_reset_user_initiated_state_time is not None:
             ask_age_s = (datetime.now(pytz.UTC) - self.asked_for_reset_user_initiated_state_time).total_seconds()
-            if ask_age_s < -60.0:
+            if ask_age_s < -CLOCK_SKEW_TOLERANCE_S:
                 _LOGGER.info(
                     "use_saved_extra_device_info: dropping future-dated stored reset-ask time for load %s (age %ss)",
                     self.name,
@@ -221,7 +222,7 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
             # review fix QS-256#02: a clearly future-dated timestamp (clock
             # skew, NTP correction) is poison too — drop rather than keep,
             # with a small tolerance for benign skew
-            if age_s > 3600.0 * self.override_duration or age_s < -60.0:
+            if age_s > 3600.0 * self.override_duration or age_s < -CLOCK_SKEW_TOLERANCE_S:
                 _LOGGER.info(
                     "use_saved_extra_device_info: dropping expired or future-dated "
                     "stored user override %s for load %s (age %ss)",
@@ -771,10 +772,12 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                 # timer, and `get_override_state()` reports ASKED FOR RESET while it is
                 # set, so leaving the drain behind the detection gate meant an
                 # unresponsive load expired its override and stayed out of controlled
-                # consumption anyway. Position relative to `main` is unchanged — same
-                # not-expired / no-reset-ask-pending arm — so a healthy load still
-                # drains on exactly the same cycle. Only the *suppression* half stays
-                # inside detection, below.
+                # consumption anyway. It sits in the same not-expired /
+                # no-reset-ask-pending arm it did before, so a load with a HEALTHY
+                # command slot drains on the same cycle as on `main` — but for a load
+                # whose slot is not healthy it now drains where `main` never drained
+                # at all, which is the whole point (AC15). Only the *suppression* half
+                # stays inside detection, below.
                 if self.asked_for_reset_user_initiated_state_time is not None:
                     # review fix QS-256#02: coerce a legacy tz-naive
                     # reset-ask timestamp before the subtraction

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -203,9 +203,12 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         # so retuning it cannot desync this site from the runtime comparisons)
         if self.asked_for_reset_user_initiated_state_time is not None:
             ask_age_s = (datetime.now(pytz.UTC) - self.asked_for_reset_user_initiated_state_time).total_seconds()
-            if ask_age_s < -CLOCK_SKEW_TOLERANCE_S:
+            # QS-307: a load that cannot hold an override has no lifecycle to drain a
+            # restored reset-ask, so drop it here — a reconfigure reloads the entry.
+            if ask_age_s < -CLOCK_SKEW_TOLERANCE_S or not self.support_user_override():
                 _LOGGER.info(
-                    "use_saved_extra_device_info: dropping future-dated stored reset-ask time for load %s (age %ss)",
+                    "use_saved_extra_device_info: dropping future-dated or unsupported stored "
+                    "reset-ask time for load %s (age %ss)",
                     self.name,
                     int(ask_age_s),
                 )
@@ -222,9 +225,14 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
             # review fix QS-256#02: a clearly future-dated timestamp (clock
             # skew, NTP correction) is poison too — drop rather than keep,
             # with a small tolerance for benign skew
-            if age_s > 3600.0 * self.override_duration or age_s < -CLOCK_SKEW_TOLERANCE_S:
+            # QS-307: same reason as the reset-ask above — nothing could expire it.
+            if (
+                age_s > 3600.0 * self.override_duration
+                or age_s < -CLOCK_SKEW_TOLERANCE_S
+                or not self.support_user_override()
+            ):
                 _LOGGER.info(
-                    "use_saved_extra_device_info: dropping expired or future-dated "
+                    "use_saved_extra_device_info: dropping expired, future-dated or unsupported "
                     "stored user override %s for load %s (age %ss)",
                     self.external_user_initiated_state,
                     self.name,
@@ -694,14 +702,10 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         do_push_constraint_after = None
 
         # we want to check that the load hasn't been changed externally from the system:
-        # THE SPLIT GATE (QS-307). Invariant: override DETECTION is gated on command
-        # state, the override LIFECYCLE is not — the lifecycle branches read no entity
-        # state, so an unresponsive device must not be able to freeze them. The
-        # `qs_enable_device` guard is defence in depth (callers already short-circuit)
-        # and treats `None`/unset as enabled. Rationale, failure modes and the four
-        # load-bearing properties of this shape:
-        # `docs/agents/concepts/bistate-duration-devices.md`, "the split gate".
-        if self.qs_enable_device is not False:
+        # QS-307: only override DETECTION is gated on `is_load_command_set` (below);
+        # the lifecycle branches read no entity state, so an unresponsive device must
+        # not freeze them. See `docs/agents/concepts/bistate-duration-devices.md`.
+        if self.qs_enable_device is not False and self.support_user_override():
             # we need to know if the state we have is compatible with the current command
             # well more if it has been set ON or any other stuff externally so that we don't want to reset it to OFF
             # because the user wanted to force the state of the load
@@ -722,28 +726,18 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                     tzinfo=pytz.UTC
                 )
 
-            # Clock-step-safe, and skew-tolerant: a future-dated anchor beyond the
-            # tolerance band is treated as fully elapsed (a real backwards jump must
-            # not freeze the expiry), but a few seconds of future-dating is benign and
-            # must NOT cancel a brand-new override. See
-            # `AbstractDevice._seconds_since_skew_tolerant`.
-            override_expired = False
-            if self.external_user_initiated_state_time is not None:
-                override_age_s = self._seconds_since_skew_tolerant(time, self.external_user_initiated_state_time)
-                override_expired = override_age_s is None or override_age_s > (3600.0 * self.override_duration)
-
-            if override_expired:
+            # Plain subtraction on purpose: a future-dated anchor is negative, so the
+            # override just lasts longer. Reading it as "fully elapsed" would destroy a
+            # live user override — strictly worse than expiring late (QS-307).
+            if self.external_user_initiated_state_time is not None and (
+                time - self.external_user_initiated_state_time
+            ).total_seconds() > (3600.0 * self.override_duration):
                 _LOGGER.info(
                     f"External state time is long, reset from {self.external_user_initiated_state} for load {self.name} "
                 )
-                # Expiry owns dropping the override's OWN in-flight service call: it is
-                # the one place that knows the override just ended, and nulling the
-                # override state below disables `force_relaunch_command`'s suppression
-                # drop, so an aligned command would otherwise keep being relaunched
-                # after the override was over. Only an ALIGNED command — anything else
-                # is a genuine solver intent that `keep_commands=True` must preserve.
-                # `_drop_running_command`, not `abandon_running_command`: no successor
-                # is launched here, so the rung and the clock go with the slot.
+                # Nulling the override state below disables the suppression drop, so
+                # the override's OWN command must go with it. ALIGNED only — anything
+                # else is a solver intent `keep_commands=True` must preserve.
                 if (
                     self.running_command is not None
                     and self.expected_state_from_command(self.running_command) == self.external_user_initiated_state
@@ -767,17 +761,9 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                     keep_commands=True
                 )  # remove any constraint if any we will add it back if needed below
             else:
-                # The post-override cooldown drain: the third state-free branch, and
-                # the one that finishes the lifecycle. Expiry only hands off to this
-                # timer, and `get_override_state()` reports ASKED FOR RESET while it is
-                # set, so leaving the drain behind the detection gate meant an
-                # unresponsive load expired its override and stayed out of controlled
-                # consumption anyway. It sits in the same not-expired /
-                # no-reset-ask-pending arm it did before, so a load with a HEALTHY
-                # command slot drains on the same cycle as on `main` — but for a load
-                # whose slot is not healthy it now drains where `main` never drained
-                # at all, which is the whole point (AC15). Only the *suppression* half
-                # stays inside detection, below.
+                # The cooldown drain: expiry only hands off to this timer, and
+                # `get_override_state()` reports ASKED FOR RESET while it is set. Only
+                # the *suppression* half stays inside detection, below.
                 if self.asked_for_reset_user_initiated_state_time is not None:
                     # review fix QS-256#02: coerce a legacy tz-naive
                     # reset-ask timestamp before the subtraction
@@ -785,20 +771,13 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                         self.asked_for_reset_user_initiated_state_time = (
                             self.asked_for_reset_user_initiated_state_time.replace(tzinfo=pytz.UTC)
                         )
-                    # Shares the expiry's skew-tolerant helper: this is the ONLY release
-                    # of the cooldown, so a frozen comparison pins `is_user_overridden()`
-                    ask_age_s = self._seconds_since_skew_tolerant(time, self.asked_for_reset_user_initiated_state_time)
-                    if ask_age_s is None or ask_age_s >= min(
+                    if (time - self.asked_for_reset_user_initiated_state_time).total_seconds() >= min(
                         float(USER_OVERRIDE_STATE_BACK_DURATION_S), (3600.0 * self.override_duration) / 2.0
                     ):
                         # long enough ask to check the fact that the override should be finished
                         self.asked_for_reset_user_initiated_state_time = None
 
-                # `support_user_override()` guards DETECTION, never the lifecycle above:
-                # on the outer gate it was a second, non-self-healing "an override can
-                # never expire" path (a load flipped to boost-only kept a restored
-                # override forever, across restarts).
-                if self.support_user_override() and self.is_load_command_set(time):
+                if self.is_load_command_set(time):
                     for i, ct in enumerate(self._constraints):
                         if (
                             ct.load_param is not None

--- a/custom_components/quiet_solar/ha_model/bistate_duration.py
+++ b/custom_components/quiet_solar/ha_model/bistate_duration.py
@@ -693,18 +693,13 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
         do_push_constraint_after = None
 
         # we want to check that the load hasn't been changed externally from the system:
-        # QS-307 — the split gate: override DETECTION is gated on command state, the
-        # override LIFECYCLE is not. The lifecycle branches read no entity state, so
-        # nothing about an unresponsive device may be allowed to freeze them. See
-        # `docs/agents/concepts/bistate-duration-devices.md`, "the split gate", for
-        # the reasoning and the failure it fixes.
-        #
-        # `qs_enable_device is not False` is defence in depth: every production caller
-        # arrives via `do_run_check_load_activity_and_constraints`, which already
-        # short-circuits on a disabled load, so only a direct call reaches here with
-        # one. `None`/unset is deliberately treated as enabled, like every other
-        # `is not False` guard on the load. `support_user_override()` deliberately does
-        # NOT belong here (review fix #03) — it guards detection, below.
+        # THE SPLIT GATE (QS-307). Invariant: override DETECTION is gated on command
+        # state, the override LIFECYCLE is not — the lifecycle branches read no entity
+        # state, so an unresponsive device must not be able to freeze them. The
+        # `qs_enable_device` guard is defence in depth (callers already short-circuit)
+        # and treats `None`/unset as enabled. Rationale, failure modes and the four
+        # load-bearing properties of this shape:
+        # `docs/agents/concepts/bistate-duration-devices.md`, "the split gate".
         if self.qs_enable_device is not False:
             # we need to know if the state we have is compatible with the current command
             # well more if it has been set ON or any other stuff externally so that we don't want to reset it to OFF
@@ -726,32 +721,28 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                     tzinfo=pytz.UTC
                 )
 
-            # QS-307 review fix #08: route the age comparison through
-            # `_seconds_since`, which returns None for an anchor in the FUTURE (a
-            # backwards clock step, e.g. HA booting without an RTC and NTP correcting
-            # afterwards) and means "treat as fully elapsed". A raw subtraction would
-            # freeze the expiry for the whole duration of the jump.
+            # Clock-step-safe, and skew-tolerant: a future-dated anchor beyond the
+            # tolerance band is treated as fully elapsed (a real backwards jump must
+            # not freeze the expiry), but a few seconds of future-dating is benign and
+            # must NOT cancel a brand-new override. See
+            # `AbstractDevice._seconds_since_skew_tolerant`.
             override_expired = False
             if self.external_user_initiated_state_time is not None:
-                override_age_s = self._seconds_since(time, self.external_user_initiated_state_time)
+                override_age_s = self._seconds_since_skew_tolerant(time, self.external_user_initiated_state_time)
                 override_expired = override_age_s is None or override_age_s > (3600.0 * self.override_duration)
 
             if override_expired:
                 _LOGGER.info(
                     f"External state time is long, reset from {self.external_user_initiated_state} for load {self.name} "
                 )
-                # QS-307 review fix #02: an override-aligned command still in flight at
-                # expiry was unconstructible before the hoist — the old
-                # `is_load_command_set` gate guaranteed an empty slot here — but it is
-                # reachable now. Once the override state is nulled just below,
-                # `force_relaunch_command`'s suppression drop stops applying, so QS
-                # would keep re-issuing the ENDED override's own service call at the
-                # 50→300 s cadence for up to a full ladder while the post-expiry intent
-                # merely stacks behind it. This branch is the one place that knows the
-                # override just ended, so it owns the drop. `_drop_running_command` and
-                # not `abandon_running_command`: no successor is launched in this call,
-                # so the rung and the clock must go with the slot — the same reasoning
-                # as the override-suppression drop in `force_relaunch_command`.
+                # Expiry owns dropping the override's OWN in-flight service call: it is
+                # the one place that knows the override just ended, and nulling the
+                # override state below disables `force_relaunch_command`'s suppression
+                # drop, so an aligned command would otherwise keep being relaunched
+                # after the override was over. Only an ALIGNED command — anything else
+                # is a genuine solver intent that `keep_commands=True` must preserve.
+                # `_drop_running_command`, not `abandon_running_command`: no successor
+                # is launched here, so the rung and the clock go with the slot.
                 if (
                     self.running_command is not None
                     and self.expected_state_from_command(self.running_command) == self.external_user_initiated_state
@@ -775,14 +766,15 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                     keep_commands=True
                 )  # remove any constraint if any we will add it back if needed below
             else:
-                # QS-307: the post-override cooldown EXPIRY is clock arithmetic too, so
-                # it is drained here rather than inside the detection branch below. On a
-                # load QS can no longer talk to, leaving it behind pinned the load in
-                # ASKED FOR RESET forever — `is_user_overridden()` stayed True and the
-                # load never came back into controlled consumption, i.e. the same bug
-                # one step later. Position is unchanged: this ran in the same
-                # not-expired / no-reset-ask-pending branch before, so for a healthy
-                # load it still lands on exactly the same cycle.
+                # The post-override cooldown drain: the third state-free branch, and
+                # the one that finishes the lifecycle. Expiry only hands off to this
+                # timer, and `get_override_state()` reports ASKED FOR RESET while it is
+                # set, so leaving the drain behind the detection gate meant an
+                # unresponsive load expired its override and stayed out of controlled
+                # consumption anyway. Position relative to `main` is unchanged — same
+                # not-expired / no-reset-ask-pending arm — so a healthy load still
+                # drains on exactly the same cycle. Only the *suppression* half stays
+                # inside detection, below.
                 if self.asked_for_reset_user_initiated_state_time is not None:
                     # review fix QS-256#02: coerce a legacy tz-naive
                     # reset-ask timestamp before the subtraction
@@ -790,22 +782,19 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                         self.asked_for_reset_user_initiated_state_time = (
                             self.asked_for_reset_user_initiated_state_time.replace(tzinfo=pytz.UTC)
                         )
-                    # QS-307 review fix #08: clock-step-safe, like the expiry above —
-                    # this drain is now the ONLY release of the cooldown, so a rewound
-                    # clock freezing it would pin `is_user_overridden()` True
-                    ask_age_s = self._seconds_since(time, self.asked_for_reset_user_initiated_state_time)
+                    # Shares the expiry's skew-tolerant helper: this is the ONLY release
+                    # of the cooldown, so a frozen comparison pins `is_user_overridden()`
+                    ask_age_s = self._seconds_since_skew_tolerant(time, self.asked_for_reset_user_initiated_state_time)
                     if ask_age_s is None or ask_age_s >= min(
                         float(USER_OVERRIDE_STATE_BACK_DURATION_S), (3600.0 * self.override_duration) / 2.0
                     ):
                         # long enough ask to check the fact that the override should be finished
                         self.asked_for_reset_user_initiated_state_time = None
 
-                # QS-307 review fix #03: `support_user_override()` guards DETECTION,
-                # never the lifecycle above. Gating the lifecycle on it was a second
-                # "an override can never expire" path, and a worse one — unlike the
-                # disabled-load arm it is not self-healing, so a load reconfigured to
-                # boost-only kept a restored override or reset-ask forever, across
-                # restarts, and stayed out of controlled consumption.
+                # `support_user_override()` guards DETECTION, never the lifecycle above:
+                # on the outer gate it was a second, non-self-healing "an override can
+                # never expire" path (a load flipped to boost-only kept a restored
+                # override forever, across restarts).
                 if self.support_user_override() and self.is_load_command_set(time):
                     for i, ct in enumerate(self._constraints):
                         if (
@@ -918,9 +907,8 @@ class QSBiStateDuration(HADeviceMixin, AbstractLoad):
                     if self.asked_for_reset_user_initiated_state_time is not None:
                         # small time window after asking for reset, do not consider the command overridden
                         # too soon to launch an override again.
-                        # QS-307: the window's EXPIRY moved above the detection gate
-                        # (pure clock arithmetic, and the tz coercion with it), so
-                        # reaching here means the window is still open.
+                        # The window's EXPIRY lives above the detection gate (QS-307),
+                        # so reaching here means the window is still open.
                         is_command_overridden_state_changed = False
 
                     if is_command_overridden_state_changed:

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -202,17 +202,9 @@ class AbstractDevice:
         # can clear them — that wipe destroys the command the clock describes.
         self.unresponsive_since: datetime | None = None
         self._last_supersede_time: datetime | None = None
-        # QS-307: the EPISODE latch. `unresponsive_since` is per-command by
-        # construction (every slot-emptying path releases it, so it can drive
-        # supersede-vs-stack), which makes it unfit to be the once-only notification
-        # guard on its own: a device that alternates unreachable with
-        # answering-but-disobeying releases and re-crosses the threshold every
-        # ~18 min forever. This latch is per EPISODE and gates the shout, never the
-        # clock. Set only when an ANNOUNCED episode's clock is released with the
-        # device unreachable; cleared only by a real ack. Everything else — a drop we
-        # chose, a command wipe — leaves it alone, because it is evidence of nothing.
-        # In-memory only, like `unresponsive_since`: see `notification-routing.md` for
-        # the restart semantics that follow from that.
+        # QS-307: the per-EPISODE latch, as against `unresponsive_since`'s
+        # per-command clock. Gates the shout, never the clock. See
+        # `_clear_unresponsive` and `docs/agents/concepts/load-base.md`.
         self._unresponsive_needs_ack: bool = False
 
         self.constraint_reset_and_reset_commands_if_needed(keep_commands=False)
@@ -676,11 +668,8 @@ class AbstractDevice:
             # `_ack_command(time, None)` is NOT one — it is the give-up on an
             # unavailable probe, i.e. the device failing harder — and
             # `_ack_command(None, None)` is just `__init__` priming the fields.
-            # QS-307 (from #308): the give-up still releases the clock, but from its
-            # OWN call site in `check_commands`, with `earned_recovery=False` and a
-            # reason that says so. Keeping the release out of here is what keeps the
-            # two meanings distinguishable — and this call, the only real ack in the
-            # class, is what clears the episode latch so the load may shout again.
+            # The give-up releases the clock from its own call site instead, so
+            # "acked" and "gave up" stay distinguishable (QS-307).
             self._clear_unresponsive("control returned, the command was acked", contact=ContactEvidence.CONFIRMED)
 
         if command is not None and time is not None and self.prev_command is not None:
@@ -903,37 +892,6 @@ class AbstractDevice:
 
         return elapsed
 
-    @classmethod
-    def _seconds_since_skew_tolerant(cls, time: datetime, anchor: datetime | None) -> float | None:
-        """`_seconds_since`, but a *slightly* future anchor means "just armed".
-
-        QS-307: `_seconds_since` collapses EVERY negative delta to `None` ("treat as
-        fully elapsed"). That is right for a real backwards clock step, and wrong —
-        actively harmful — for a window whose anchor is a user action: a few seconds
-        of future-dating would then read as "fully elapsed" and cancel a brand-new
-        8-hour user override on the spot, i.e. QS fighting the user.
-
-        A few seconds of future-dating is routine, with no clock anomaly at all:
-        `user_set_bistate_mode`, `user_set_default_on_duration` and
-        `async_reset_override_state` each take their own unlocked
-        `datetime.now(pytz.UTC)`, while an `async_update_loads` cycle already in
-        flight is still carrying an earlier `event_time`. So a user-stamped anchor
-        can legitimately sit ahead of the cycle time that evaluates it.
-
-        Hence the band, the same ±`CLOCK_SKEW_TOLERANCE_S` the bistate restore path
-        already grants these timestamps: future by AT MOST the tolerance ⇒ zero
-        elapsed (not expired); beyond it ⇒ `None`, keeping `_seconds_since`'s
-        fully-elapsed meaning for the genuine large-jump case.
-        """
-        elapsed = cls._seconds_since(time, anchor)
-        if elapsed is not None or anchor is None:
-            return elapsed
-
-        if (anchor - time).total_seconds() <= CLOCK_SKEW_TOLERANCE_S:
-            return 0.0
-
-        return None
-
     def _is_supersede_throttled(self, time: datetime) -> bool:
         """Return True while the supersede window is still closed."""
         elapsed = self._seconds_since(time, self._last_supersede_time)
@@ -963,11 +921,8 @@ class AbstractDevice:
         """
         self.abandon_running_command(reason=reason)
         self.running_command_num_relaunch = 0
-        # `UNKNOWN` (QS-307): a drop is OUR decision — the user took control,
-        # the load was disabled, the command became redundant — and says nothing about
-        # whether the device is answering. Ending the episode here let a latched
-        # flapping load shout again on its next ladder climb, once per override
-        # expiry, for a device that never answered.
+        # `UNKNOWN`: a drop is OUR decision, so it says nothing about the device and
+        # must not end a lost-control episode (QS-307).
         self._clear_unresponsive(reason, contact=ContactEvidence.UNKNOWN)
 
     async def launch_command(self, time: datetime, command: LoadCommand, ctxt="NO CTXT"):
@@ -1086,6 +1041,16 @@ class AbstractDevice:
                 is_command_set = None
             self._anchor_causality_guard_if_executed(is_command_set, time)
 
+        if self.running_command is None:
+            # QS-307: same guard, same reason as in `force_relaunch_command`.
+            _LOGGER.info(
+                "launch_command: command %s for load %s was dropped while its service call was in flight, ctxt: %s",
+                command.command,
+                self.name,
+                ctxt,
+            )
+            return
+
         if is_command_set is None:
             # hum we may have an impossibility to launch this command
             _LOGGER.info(
@@ -1128,19 +1093,9 @@ class AbstractDevice:
                 if self.running_command_num_relaunch_after_invalid >= NUM_MAX_INVALID_PROBES_COMMANDS:
                     # will kill completely the command ....
                     self._ack_command(time, None)
-                    # QS-307 (from #308): the give-up destroys the clock's subject —
-                    # `current_command` and the slot both go — so the clock goes with
-                    # it. Leaving it made the clock ownerless (`_ack_command` clears
-                    # only on a real ack, and `_escalate_or_recover`'s re-arm is gated
-                    # on the `current_command` this path just nulled), and the next
-                    # command inherited supersede semantics with zero evidence.
-                    # `UNREACHABLE`: the device cannot be reached, so this is not news.
-                    # When it releases a live clock it latches the episode, so the
-                    # ladder that follows cannot shout again until the device actually
-                    # answers. When there was no clock — the usual case, since this
-                    # fires ~70 s in and the escalation threshold is ~1050 s away —
-                    # it latches nothing, or the load's first genuine push would be
-                    # swallowed for good.
+                    # QS-307 (from #308): this destroys the clock's subject, so the
+                    # clock goes with it or the next command inherits it. `UNREACHABLE`
+                    # because the device cannot be reached — see `_clear_unresponsive`.
                     self._clear_unresponsive("the probe went unavailable", contact=ContactEvidence.UNREACHABLE)
 
             if is_command_set is True:
@@ -1180,9 +1135,11 @@ class AbstractDevice:
         mode select, the on-duration number, the reset-override button) run outside
         the lock. So the slot CAN be emptied across an await. What makes that safe is
         the post-await re-check in `force_relaunch_command`: it holds the command it
-        launched in a local, and bails out if the slot no longer holds it rather than
-        writing counters for, acking, or dereferencing a command that is gone. The
-        clock is still only cleared alongside the command state it describes.
+        launched in a local, and bails out if the slot is EMPTY rather than writing
+        counters for, acking, or dereferencing a command that is gone. Emptied, not
+        replaced: every `launch_command` site runs inside `home.update_loads`, and the
+        unlocked user-action callers only ever drop. The clock is still only cleared
+        alongside the command state it describes.
         """
         try:
             _wait_time, command_acked_or_good = await self.check_commands(time)
@@ -1265,17 +1222,9 @@ class AbstractDevice:
             # to be a floor. `unresponsive_since is None` is the per-COMMAND guard.
             self.unresponsive_since = time
             if self._unresponsive_needs_ack:
-                # QS-307: same episode, and the device has not answered since.
-                # Re-arming the clock is still required — it is what drives
-                # supersede-vs-stack, and suppressing it here would starve a newer
-                # intent behind a command we already know is going nowhere — but
-                # there is nothing new to tell anyone. Without this, releasing the
-                # clock at the give-up turned an intermittently unreachable device
-                # into 5 alerts per 105 min where `main` produced 1.
-                #
-                # Still logged, at INFO: `main` always emitted something here, and a
-                # silent re-arm makes a load hitting the ladder wall again invisible
-                # in user logs — which is exactly what diagnosing #319 needs.
+                # QS-307: same episode, no contact since. The clock still has to be
+                # re-armed (it drives supersede-vs-stack) but there is nothing new to
+                # tell anyone. Logged so the ladder wall stays visible in user logs.
                 _LOGGER.info(
                     "Lost-control clock re-armed for load %s: command %s still unconfirmed after %s relaunches, "
                     "incident already announced, not re-notifying",
@@ -1316,26 +1265,10 @@ class AbstractDevice:
             # legitimate supersede.
             self._last_supersede_time = None
 
-            # The gate below is LOAD-BEARING for `_unresponsive_needs_ack` (QS-307 —
-            # an earlier revision of this comment called it redundant, which was wrong
-            # once the episode latch existed). Reaching here with `current_command is
-            # None` means the slot was emptied by a path that nulled the confirmed
-            # command too, and the only such path is the invalid-probe give-up — which
-            # runs in THIS cycle, immediately before us, and may have just latched the
-            # episode. The release below is `CONFIRMED`, which clears the latch
-            # unconditionally, so without the gate it would undo that one statement
-            # later and restore the push storm the latch exists to damp.
-            #
-            # `CONFIRMED` is the honest value here: `current_command is not
-            # None` means a command of record was confirmed by the device, and the slot
-            # emptied without a give-up.
-            #
-            # For `unresponsive_since` itself the gate is belt-and-braces: every
-            # slot-emptying path releases the clock at its own call site (a real
-            # ack, `_drop_running_command`, a `keep_commands=False` wipe, the
-            # give-up), so there is never a live clock left for us to find. The
-            # branch is the re-arm for the ordinary case — nothing in flight means
-            # nothing can clear the clock later.
+            # Gated because the release below is `CONFIRMED`, which clears the
+            # episode latch. Only the give-up sets that latch, and the give-up nulls
+            # `current_command` — so this branch runs exactly when nothing has latched
+            # in this cycle (QS-307).
             if self.current_command is not None:
                 self._clear_unresponsive(
                     "the command slot emptied with no successor", contact=ContactEvidence.CONFIRMED
@@ -1377,43 +1310,36 @@ class AbstractDevice:
                 self._drop_running_command("suppressed by user override")
                 return
 
-            # QS-307: hold the command locally across the await. The slot can be
-            # emptied underneath us (see the re-check below), and both the error
-            # handler and the logging after it used to dereference
-            # `self.running_command` unguarded.
+            # Held locally: the slot can empty across the await (see the re-check).
             launched_command = self.running_command
             _LOGGER.info(
-                f"force launch command {launched_command.command} for this load {self.name} (#{self.running_command_num_relaunch})"
+                "force launch command %s for this load %s (#%s)",
+                launched_command.command,
+                self.name,
+                self.running_command_num_relaunch,
             )
             self.running_command_num_relaunch += 1
             try:
                 is_command_set = await self.execute_command(time, launched_command)
             except Exception as err:
                 _LOGGER.error(
-                    f"Error while executing command {launched_command.command} for load {self.name} : {err}",
+                    "Error while executing command %s for load %s : %s",
+                    launched_command.command,
+                    self.name,
+                    err,
                     exc_info=True,
                     stack_info=True,
                 )
                 is_command_set = None
 
-            # Anchored before the re-check on purpose: a service call really did land,
-            # so the causality guard must know about it even if the slot is now empty —
-            # otherwise the resulting state change reads as a user override.
+            # Before the re-check: a service call really landed, so the causality
+            # guard must know even if the slot is now empty.
             self._anchor_causality_guard_if_executed(is_command_set, time)
 
             if self.running_command is None:
-                # QS-307: the slot emptied ACROSS the await. Three callers of
-                # `check_load_activity_and_constraints` run outside
-                # `_update_loads_lock` (the bistate mode select, the on-duration
-                # number, the reset-override button), and its override-expiry branch
-                # drops an override-aligned command — so a user action landing while
-                # this service call is in flight legitimately removes the command we
-                # launched. Everything below describes THAT command: writing its
-                # launch stamp would outlive it, `_ack_command(time,
-                # self.running_command)` would ack `None` and silently null
-                # `current_command` (dropping the load out of controlled-consumption
-                # accounting), and the log line would raise on a `None` deref. Nothing
-                # left to do, so stop here.
+                # QS-307: the slot emptied across the await — a user action can reach
+                # the override expiry outside `_update_loads_lock`. Everything below
+                # describes the command that is now gone, so stop.
                 _LOGGER.info(
                     "force_relaunch_command: command %s for load %s was dropped while its service call was in flight",
                     launched_command.command,
@@ -1810,12 +1736,13 @@ class AbstractLoad(AbstractDevice):
         be dismissed. That is exactly why the guard has to be tight: pushes
         accumulate on the phone and cannot be collapsed afterwards.
 
-        QS-307 (from #308): once per EPISODE — not once per lifetime, and not
-        once per ladder climb. The clock is released on every slot-emptying
-        path now, so a load that loses control, *answers again*, and loses it
-        again pushes twice; a load that merely flaps in and out of reach
-        without ever answering pushes once. `_unresponsive_needs_ack` is what
-        tells those two apart.
+        QS-307 (from #308): the clock is released on every slot-emptying path
+        now, and `_unresponsive_needs_ack` stops that release re-announcing an
+        incident already announced — a device flapping in and out of reach
+        pushes once, not once per ~18 min. It does NOT deduplicate alerts for a
+        device that stays reachable and simply never obeys; that re-crosses the
+        threshold about every 18.5 min and pushes each time, here and on `main`
+        alike. Pre-existing, tracked in #319.
         """
         await self.on_device_state_change(
             time,

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -177,6 +177,15 @@ class AbstractDevice:
         # can clear them — that wipe destroys the command the clock describes.
         self.unresponsive_since: datetime | None = None
         self._last_supersede_time: datetime | None = None
+        # QS-307 review fix #01: the EPISODE latch. `unresponsive_since` is
+        # per-command by construction (every slot-emptying path releases it, so it
+        # can drive supersede-vs-stack), which makes it unfit to be the once-only
+        # notification guard on its own: a device that alternates unreachable with
+        # answering-but-disobeying releases and re-crosses the threshold every
+        # ~18 min forever. This latch is per EPISODE — set when the clock is
+        # released with NO evidence the device answered, cleared only by evidence
+        # that it did — and it gates the shout, never the clock.
+        self._unresponsive_needs_ack: bool = False
 
         self.constraint_reset_and_reset_commands_if_needed(keep_commands=False)
         self.last_check_update: datetime | None = None
@@ -638,8 +647,10 @@ class AbstractDevice:
             # unavailable probe, i.e. the device failing harder — and
             # `_ack_command(None, None)` is just `__init__` priming the fields.
             # QS-307 (from #308): the give-up still releases the clock, but from its
-            # OWN call site in `check_commands`, with a reason that says so. Keeping
-            # the release out of here is what keeps the two meanings distinguishable.
+            # OWN call site in `check_commands`, with `earned_recovery=False` and a
+            # reason that says so. Keeping the release out of here is what keeps the
+            # two meanings distinguishable — and this call, the only real ack in the
+            # class, is what clears the episode latch so the load may shout again.
             self._clear_unresponsive("control returned, the command was acked")
 
         if command is not None and time is not None and self.prev_command is not None:
@@ -708,8 +719,9 @@ class AbstractDevice:
 
         QS-307 (from #308): every slot-emptying path now releases the clock,
         including the invalid-probe give-up, which used to keep it and hand it to
-        the next command. So a command in flight with the clock set really has an
-        unresolved episode behind it.
+        the next command. So this really is per-command. "Are we still in an
+        unresolved lost-control EPISODE" is a different question, answered by
+        `_unresponsive_needs_ack` — do not conflate the two again.
         """
         return self.unresponsive_since is not None and self.running_command is not None
 
@@ -724,11 +736,11 @@ class AbstractDevice:
             COMMAND_RELAUNCH_BASE_DELAY_S * min(self.running_command_num_relaunch + 1, NUM_MAX_COMMAND_RELAUNCH)
         )
 
-    def _clear_unresponsive(self, reason: str) -> None:
-        """Re-arm the lost-control detection, logging the exit exactly once.
+    def _clear_unresponsive(self, reason: str, earned_recovery: bool = True) -> None:
+        """Release the per-command lost-control clock, logging the exit exactly once.
 
         The single writer, so the "one line out" guarantee cannot drift between
-        its callers. Re-arming matters more than the log line: the entry guard is
+        its callers. Releasing matters more than the log line: the entry guard is
         `unresponsive_since is None`, so a load that loses control, recovers and
         loses it again must be able to shout twice.
 
@@ -736,6 +748,17 @@ class AbstractDevice:
         several callers are not recoveries at all — a user override drop means
         control was taken *away* from QS, and a `keep_commands=False` reset simply
         destroys the clock's subject.
+
+        QS-307 review fix #01 — `earned_recovery` says whether the release came
+        with evidence that QS is back in contact with the device. It is `True` for
+        every caller but one: a real ack, a deliberate drop, and a command wipe all
+        happen because *we* changed our mind or the device answered. The
+        invalid-probe give-up is the exception — the device is unreachable, so
+        releasing its clock is bookkeeping, not news — and it passes `False`, which
+        latches `_unresponsive_needs_ack` and suppresses the NEXT shout (never the
+        next clock) until contact is genuinely re-established. The two cases also
+        log distinguishable lines, so "the clock was released" no longer implies
+        "the device came back".
         """
         # The supersede anchor is cleared unconditionally: it is meaningless
         # without a lost-control episode to throttle, and leaving it behind let a
@@ -743,11 +766,19 @@ class AbstractDevice:
         # supersede throttled for up to `SUPERSEDE_MIN_INTERVAL_S`.
         self._last_supersede_time = None
 
+        if earned_recovery:
+            self._unresponsive_needs_ack = False
+        else:
+            self._unresponsive_needs_ack = True
+
         if self.unresponsive_since is None:
             return
 
         self.unresponsive_since = None
-        _LOGGER.info("Lost-control state cleared for load %s: %s", self.name, reason)
+        if earned_recovery:
+            _LOGGER.info("Lost-control state cleared for load %s: %s", self.name, reason)
+        else:
+            _LOGGER.info("Lost-control clock released without contact for load %s: %s", self.name, reason)
 
     def abandon_running_command(self, reason: str) -> None:
         """Drop the stale in-flight command without faking an ack.
@@ -1029,7 +1060,10 @@ class AbstractDevice:
                     # only on a real ack, and `_escalate_or_recover`'s re-arm is gated
                     # on the `current_command` this path just nulled), and the next
                     # command inherited supersede semantics with zero evidence.
-                    self._clear_unresponsive("the probe went unavailable")
+                    # `earned_recovery=False`: the device is UNREACHABLE, so this is
+                    # not news. It latches the episode so the ladder that follows
+                    # cannot shout again until the device actually answers.
+                    self._clear_unresponsive("the probe went unavailable", earned_recovery=False)
 
             if is_command_set is True:
                 self._ack_command(time, self.running_command)
@@ -1142,18 +1176,29 @@ class AbstractDevice:
             and self.unresponsive_since is None
         ):
             # `>=` and not `==`: the counter is resettable, so the threshold has
-            # to be a floor. `unresponsive_since is None` is the once-only guard.
+            # to be a floor. `unresponsive_since is None` is the per-COMMAND guard.
             self.unresponsive_since = time
-            _LOGGER.error(
-                # "in this episode": `abandon_running_command` preserves the rung
-                # across a supersede on purpose, so the count can include
-                # relaunches of this command's predecessors.
-                "Lost control of load %s: command %s not confirmed after %s relaunches in this episode",
-                self.name,
-                self.running_command,
-                self.running_command_num_relaunch,
-            )
-            unresponsive_command = self.running_command
+            if self._unresponsive_needs_ack:
+                # QS-307 review fix #01: same episode, and the device has not
+                # answered since. Re-arming the clock is still required — it is what
+                # drives supersede-vs-stack, and suppressing it here would starve a
+                # newer intent behind a command we already know is going nowhere —
+                # but there is nothing new to tell anyone. Without this, a device
+                # flapping between unreachable and answering-but-disobeying pushed
+                # once per ladder climb (~18 min) forever, on a fire-and-forget
+                # channel with no notification id to collapse them.
+                unresponsive_command = None
+            else:
+                _LOGGER.error(
+                    # "in this episode": `abandon_running_command` preserves the rung
+                    # across a supersede on purpose, so the count can include
+                    # relaunches of this command's predecessors.
+                    "Lost control of load %s: command %s not confirmed after %s relaunches in this episode",
+                    self.name,
+                    self.running_command,
+                    self.running_command_num_relaunch,
+                )
+                unresponsive_command = self.running_command
         else:
             unresponsive_command = None
 
@@ -1169,18 +1214,30 @@ class AbstractDevice:
             # equal-command early-return and the override-suppression drop
             # leave no successor at all.
             self.running_command_num_relaunch = 0
-            # Cleared OUTSIDE the gate below, and kept that way: several paths reach
-            # here with `current_command` already nulled, and a stale anchor would
-            # throttle the next command's first legitimate supersede.
+            # `_last_supersede_time` (this line) is cleared OUTSIDE the gate below,
+            # and kept that way: paths reach here with `current_command` already
+            # nulled, and a stale anchor would throttle the next command's first
+            # legitimate supersede.
             self._last_supersede_time = None
 
+            # The gate below governs `unresponsive_since` and
+            # `_unresponsive_needs_ack`, and it is LOAD-BEARING (QS-307 review fix
+            # #01 — an earlier revision of this comment called it redundant, which
+            # was wrong once the episode latch existed). Reaching here with
+            # `current_command is None` means the slot was emptied by a path that
+            # nulled the confirmed command too, and the only such path is the
+            # invalid-probe give-up — which runs in THIS cycle, immediately before
+            # us, and has just latched `_unresponsive_needs_ack` on purpose. An
+            # unconditional `earned_recovery=True` release here would clear that
+            # latch one statement later and restore the push storm it exists to damp.
+            #
+            # For `unresponsive_since` itself the gate is belt-and-braces: every
+            # slot-emptying path releases the clock at its own call site (a real
+            # ack, `_drop_running_command`, a `keep_commands=False` wipe, the
+            # give-up), so there is never a live clock left for us to find. The
+            # branch is the re-arm for the ordinary case — nothing in flight means
+            # nothing can clear the clock later.
             if self.current_command is not None:
-                # Nothing in flight, so nothing can clear the clock later — re-arm
-                # now. QS-307 (from #308) made the `current_command` gate redundant:
-                # the invalid-probe give-up it existed to preserve now releases the
-                # clock at its own call site, right where it nulls `current_command`.
-                # Kept anyway — it is harmless, both arms stay exercised, and the
-                # release belongs next to the state destruction that motivates it.
                 self._clear_unresponsive("the command slot emptied with no successor")
 
         if unresponsive_command is not None:
@@ -1619,11 +1676,15 @@ class AbstractLoad(AbstractDevice):
 
         QS-304: entry only. There is no recovery push — the channel is a
         fire-and-forget mobile push with no notification id, so nothing could
-        be dismissed.
+        be dismissed. That is exactly why the guard has to be tight: pushes
+        accumulate on the phone and cannot be collapsed afterwards.
 
-        QS-307 (from #308): once per EPISODE, not once per lifetime. The clock
-        is released on every slot-emptying path now, so a load that loses
-        control, recovers, and loses it again pushes twice.
+        QS-307 (from #308): once per EPISODE — not once per lifetime, and not
+        once per ladder climb. The clock is released on every slot-emptying
+        path now, so a load that loses control, *answers again*, and loses it
+        again pushes twice; a load that merely flaps in and out of reach
+        without ever answering pushes once. `_unresponsive_needs_ack` is what
+        tells those two apart.
         """
         await self.on_device_state_change(
             time,

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -637,6 +637,9 @@ class AbstractDevice:
             # `_ack_command(time, None)` is NOT one — it is the give-up on an
             # unavailable probe, i.e. the device failing harder — and
             # `_ack_command(None, None)` is just `__init__` priming the fields.
+            # QS-307 (from #308): the give-up still releases the clock, but from its
+            # OWN call site in `check_commands`, with a reason that says so. Keeping
+            # the release out of here is what keeps the two meanings distinguishable.
             self._clear_unresponsive("control returned, the command was acked")
 
         if command is not None and time is not None and self.prev_command is not None:
@@ -701,8 +704,12 @@ class AbstractDevice:
         The in-flight conjunct is load-bearing: several paths empty the slot with no
         successor, and a clock-only property would stay True forever with no retry
         able to clear it. Note this is NOT "the in-flight command failed N times" —
-        the invalid-probe give-up keeps the clock while nulling `current_command`, so
-        the next command inherits it. See the story.
+        the clock is per EPISODE, not per command, and survives a supersede.
+
+        QS-307 (from #308): every slot-emptying path now releases the clock,
+        including the invalid-probe give-up, which used to keep it and hand it to
+        the next command. So a command in flight with the clock set really has an
+        unresolved episode behind it.
         """
         return self.unresponsive_since is not None and self.running_command is not None
 
@@ -1016,6 +1023,13 @@ class AbstractDevice:
                 if self.running_command_num_relaunch_after_invalid >= NUM_MAX_INVALID_PROBES_COMMANDS:
                     # will kill completely the command ....
                     self._ack_command(time, None)
+                    # QS-307 (from #308): the give-up destroys the clock's subject —
+                    # `current_command` and the slot both go — so the clock goes with
+                    # it. Leaving it made the clock ownerless (`_ack_command` clears
+                    # only on a real ack, and `_escalate_or_recover`'s re-arm is gated
+                    # on the `current_command` this path just nulled), and the next
+                    # command inherited supersede semantics with zero evidence.
+                    self._clear_unresponsive("the probe went unavailable")
 
             if is_command_set is True:
                 self._ack_command(time, self.running_command)
@@ -1155,19 +1169,18 @@ class AbstractDevice:
             # equal-command early-return and the override-suppression drop
             # leave no successor at all.
             self.running_command_num_relaunch = 0
-            # Cleared OUTSIDE the gate below: the invalid-probe give-up reaches here
-            # via `_ack_command(time, None)`, which never calls
-            # `_clear_unresponsive`, so a stale anchor would throttle the next
-            # command's first legitimate supersede. That give-up keeps the clock on
-            # purpose.
+            # Cleared OUTSIDE the gate below, and kept that way: several paths reach
+            # here with `current_command` already nulled, and a stale anchor would
+            # throttle the next command's first legitimate supersede.
             self._last_supersede_time = None
 
             if self.current_command is not None:
                 # Nothing in flight, so nothing can clear the clock later — re-arm
-                # now. The `current_command` gate exists solely to preserve the
-                # invalid-probe give-up shape: that path nulls `current_command` on
-                # purpose, and an unavailable probe means the device is failing
-                # harder, not recovering.
+                # now. QS-307 (from #308) made the `current_command` gate redundant:
+                # the invalid-probe give-up it existed to preserve now releases the
+                # clock at its own call site, right where it nulls `current_command`.
+                # Kept anyway — it is harmless, both arms stay exercised, and the
+                # release belongs next to the state destruction that motivates it.
                 self._clear_unresponsive("the command slot emptied with no successor")
 
         if unresponsive_command is not None:
@@ -1606,8 +1619,11 @@ class AbstractLoad(AbstractDevice):
 
         QS-304: entry only. There is no recovery push — the channel is a
         fire-and-forget mobile push with no notification id, so nothing could
-        be dismissed, and the `qs_load_uncontrollable` binary sensor is the
-        live state that clears itself.
+        be dismissed.
+
+        QS-307 (from #308): once per EPISODE, not once per lifetime. The clock
+        is released on every slot-emptying path now, so a load that loses
+        control, recovers, and loses it again pushes twice.
         """
         await self.on_device_state_change(
             time,

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -4,6 +4,7 @@ import random
 from bisect import bisect_left
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import pytz
@@ -70,16 +71,28 @@ NUM_MAX_COMMAND_RELAUNCH = 6
 # relaunch delay a newer intent.
 SUPERSEDE_MIN_INTERVAL_S = COMMAND_RELAUNCH_BASE_DELAY_S * NUM_MAX_COMMAND_RELAUNCH
 
-# QS-307: what releasing the lost-control clock tells us about the device, which is
-# what decides whether a lost-control EPISODE has ended. See
-# `AbstractDevice._clear_unresponsive`.
-CONTACT_CONFIRMED = "confirmed"  # the device answered: the episode is over
-CONTACT_NONE = "none"  # the device is unreachable: the episode continues
-CONTACT_UNKNOWN = "unknown"  # we abandoned the command: says nothing either way
 
-# QS-307: benign clock-skew tolerance for a FUTURE-dated anchor, mirroring the ±60 s
-# `QSBiStateDuration.use_saved_extra_device_info` already grants the very same
-# override timestamps at the restore boundary.
+class ContactEvidence(StrEnum):
+    """What releasing the lost-control clock says about the device (QS-307).
+
+    That question — not the release itself — is what decides whether a lost-control
+    EPISODE has ended, and therefore whether the next threshold crossing is worth
+    announcing. An `enum` rather than bare strings so a typo is an `AttributeError`
+    at the call site instead of a value that silently matches no branch;
+    `_clear_unresponsive` takes it as a REQUIRED argument for the same reason, since
+    defaulting to the episode-ending value would let a future caller end an incident
+    by omission.
+    """
+
+    CONFIRMED = "confirmed"  # the device answered: the episode is over
+    UNREACHABLE = "unreachable"  # we could not reach it: the episode continues
+    UNKNOWN = "unknown"  # we abandoned the command: says nothing either way
+
+
+# QS-307: benign clock-skew tolerance for a FUTURE-dated anchor. Single source of
+# truth — `QSBiStateDuration.use_saved_extra_device_info` grants the very same
+# override timestamps the very same band at the restore boundary, and used to
+# hard-code it.
 CLOCK_SKEW_TOLERANCE_S = 60.0
 
 _LOGGER = logging.getLogger(__name__)
@@ -429,9 +442,9 @@ class AbstractDevice:
             # relaunches — flashing PROBLEM right after the user's own
             # remediation. Routed through `_clear_unresponsive` to keep the
             # single-writer / one-line-out guarantee.
-            # `CONTACT_UNKNOWN`: a wipe is OUR decision, not the device answering, so
+            # `UNKNOWN`: a wipe is OUR decision, not the device answering, so
             # it must not end a lost-control episode (QS-307).
-            self._clear_unresponsive("the command state was reset", contact=CONTACT_UNKNOWN)
+            self._clear_unresponsive("the command state was reset", contact=ContactEvidence.UNKNOWN)
 
     # for class overcharging reset
     def reset(self, keep_commands=False):
@@ -668,7 +681,7 @@ class AbstractDevice:
             # reason that says so. Keeping the release out of here is what keeps the
             # two meanings distinguishable — and this call, the only real ack in the
             # class, is what clears the episode latch so the load may shout again.
-            self._clear_unresponsive("control returned, the command was acked")
+            self._clear_unresponsive("control returned, the command was acked", contact=ContactEvidence.CONFIRMED)
 
         if command is not None and time is not None and self.prev_command is not None:
             do_count = False
@@ -752,7 +765,7 @@ class AbstractDevice:
             COMMAND_RELAUNCH_BASE_DELAY_S * min(self.running_command_num_relaunch + 1, NUM_MAX_COMMAND_RELAUNCH)
         )
 
-    def _clear_unresponsive(self, reason: str, contact: str = CONTACT_CONFIRMED) -> None:
+    def _clear_unresponsive(self, reason: str, contact: ContactEvidence) -> None:
         """Release the per-command lost-control clock, logging the exit exactly once.
 
         The single writer, so the "one line out" guarantee cannot drift between
@@ -771,14 +784,14 @@ class AbstractDevice:
         way, and forcing it into "recovered" re-opened the push storm the latch
         exists to damp:
 
-        - `CONTACT_CONFIRMED` — the device answered. Ends the episode, and does so
+        - `CONFIRMED` — the device answered. Ends the episode, and does so
           **unconditionally**: an ack is contact whether or not a clock was live.
-        - `CONTACT_NONE` — the device is unreachable (the invalid-probe give-up).
+        - `UNREACHABLE` — we could not reach it (the invalid-probe give-up).
           Latches the episode, but only if a clock was actually live: latching a
           release that released nothing swallowed the load's FIRST genuine push
           forever, since the give-up fires ~70 s in and the escalation threshold is
           ~1050 s away.
-        - `CONTACT_UNKNOWN` — *we* abandoned the command (a deliberate drop, a
+        - `UNKNOWN` — *we* abandoned the command (a deliberate drop, a
           `keep_commands=False` wipe). Says nothing about the device, so it leaves
           the latch exactly as it was.
         """
@@ -788,7 +801,7 @@ class AbstractDevice:
         # supersede throttled for up to `SUPERSEDE_MIN_INTERVAL_S`.
         self._last_supersede_time = None
 
-        if contact == CONTACT_CONFIRMED:
+        if contact is ContactEvidence.CONFIRMED:
             # Above the early return on purpose: the device answered, so the episode
             # is over regardless of whether there was a clock left to release.
             self._unresponsive_needs_ack = False
@@ -797,7 +810,7 @@ class AbstractDevice:
             return
 
         self.unresponsive_since = None
-        if contact == CONTACT_NONE:
+        if contact is ContactEvidence.UNREACHABLE:
             # Below the early return on purpose (see the docstring): the latch may
             # only suppress a NEXT shout when there was a shout to follow.
             self._unresponsive_needs_ack = True
@@ -908,7 +921,7 @@ class AbstractDevice:
         can legitimately sit ahead of the cycle time that evaluates it.
 
         Hence the band, the same ±`CLOCK_SKEW_TOLERANCE_S` the bistate restore path
-        already grants these timestamps: future by less than the tolerance ⇒ zero
+        already grants these timestamps: future by AT MOST the tolerance ⇒ zero
         elapsed (not expired); beyond it ⇒ `None`, keeping `_seconds_since`'s
         fully-elapsed meaning for the genuine large-jump case.
         """
@@ -950,12 +963,12 @@ class AbstractDevice:
         """
         self.abandon_running_command(reason=reason)
         self.running_command_num_relaunch = 0
-        # `CONTACT_UNKNOWN` (QS-307): a drop is OUR decision — the user took control,
+        # `UNKNOWN` (QS-307): a drop is OUR decision — the user took control,
         # the load was disabled, the command became redundant — and says nothing about
         # whether the device is answering. Ending the episode here let a latched
         # flapping load shout again on its next ladder climb, once per override
         # expiry, for a device that never answered.
-        self._clear_unresponsive(reason, contact=CONTACT_UNKNOWN)
+        self._clear_unresponsive(reason, contact=ContactEvidence.UNKNOWN)
 
     async def launch_command(self, time: datetime, command: LoadCommand, ctxt="NO CTXT"):
         if self.qs_enable_device is False:
@@ -1121,14 +1134,14 @@ class AbstractDevice:
                     # only on a real ack, and `_escalate_or_recover`'s re-arm is gated
                     # on the `current_command` this path just nulled), and the next
                     # command inherited supersede semantics with zero evidence.
-                    # `CONTACT_NONE`: the device is UNREACHABLE, so this is not news.
+                    # `UNREACHABLE`: the device cannot be reached, so this is not news.
                     # When it releases a live clock it latches the episode, so the
                     # ladder that follows cannot shout again until the device actually
                     # answers. When there was no clock — the usual case, since this
                     # fires ~70 s in and the escalation threshold is ~1050 s away —
                     # it latches nothing, or the load's first genuine push would be
                     # swallowed for good.
-                    self._clear_unresponsive("the probe went unavailable", contact=CONTACT_NONE)
+                    self._clear_unresponsive("the probe went unavailable", contact=ContactEvidence.UNREACHABLE)
 
             if is_command_set is True:
                 self._ack_command(time, self.running_command)
@@ -1158,10 +1171,18 @@ class AbstractDevice:
         replace it.
 
         NOT protected by a lock: `_update_loads_lock` guards only
-        `async_update_loads`, while `button.py` calls into this chain unlocked. The
-        invariant relied on is narrower — each command-slot mutation happens between
-        `await`s, and the clock is only cleared alongside the command state it
-        describes.
+        `async_update_loads`, while `button.py` calls into this chain unlocked.
+
+        QS-307 corrected the invariant this used to claim. "Each command-slot
+        mutation happens between `await`s" is **no longer true**: the override-expiry
+        branch of `QSBiStateDuration.check_load_activity_and_constraints` drops an
+        override-aligned command, and three of that method's callers (the bistate
+        mode select, the on-duration number, the reset-override button) run outside
+        the lock. So the slot CAN be emptied across an await. What makes that safe is
+        the post-await re-check in `force_relaunch_command`: it holds the command it
+        launched in a local, and bails out if the slot no longer holds it rather than
+        writing counters for, acking, or dereferencing a command that is gone. The
+        clock is still only cleared alongside the command state it describes.
         """
         try:
             _wait_time, command_acked_or_good = await self.check_commands(time)
@@ -1244,14 +1265,24 @@ class AbstractDevice:
             # to be a floor. `unresponsive_since is None` is the per-COMMAND guard.
             self.unresponsive_since = time
             if self._unresponsive_needs_ack:
-                # QS-307 review fix #01: same episode, and the device has not
-                # answered since. Re-arming the clock is still required — it is what
-                # drives supersede-vs-stack, and suppressing it here would starve a
-                # newer intent behind a command we already know is going nowhere —
-                # but there is nothing new to tell anyone. Without this, a device
-                # flapping between unreachable and answering-but-disobeying pushed
-                # once per ladder climb (~18 min) forever, on a fire-and-forget
-                # channel with no notification id to collapse them.
+                # QS-307: same episode, and the device has not answered since.
+                # Re-arming the clock is still required — it is what drives
+                # supersede-vs-stack, and suppressing it here would starve a newer
+                # intent behind a command we already know is going nowhere — but
+                # there is nothing new to tell anyone. Without this, releasing the
+                # clock at the give-up turned an intermittently unreachable device
+                # into 5 alerts per 105 min where `main` produced 1.
+                #
+                # Still logged, at INFO: `main` always emitted something here, and a
+                # silent re-arm makes a load hitting the ladder wall again invisible
+                # in user logs — which is exactly what diagnosing #319 needs.
+                _LOGGER.info(
+                    "Lost-control clock re-armed for load %s: command %s still unconfirmed after %s relaunches, "
+                    "incident already announced, not re-notifying",
+                    self.name,
+                    self.running_command,
+                    self.running_command_num_relaunch,
+                )
                 unresponsive_command = None
             else:
                 _LOGGER.error(
@@ -1291,11 +1322,11 @@ class AbstractDevice:
             # None` means the slot was emptied by a path that nulled the confirmed
             # command too, and the only such path is the invalid-probe give-up — which
             # runs in THIS cycle, immediately before us, and may have just latched the
-            # episode. The release below is `CONTACT_CONFIRMED`, which clears the latch
+            # episode. The release below is `CONFIRMED`, which clears the latch
             # unconditionally, so without the gate it would undo that one statement
             # later and restore the push storm the latch exists to damp.
             #
-            # `CONTACT_CONFIRMED` is the honest value here: `current_command is not
+            # `CONFIRMED` is the honest value here: `current_command is not
             # None` means a command of record was confirmed by the device, and the slot
             # emptied without a give-up.
             #
@@ -1306,7 +1337,9 @@ class AbstractDevice:
             # branch is the re-arm for the ordinary case — nothing in flight means
             # nothing can clear the clock later.
             if self.current_command is not None:
-                self._clear_unresponsive("the command slot emptied with no successor")
+                self._clear_unresponsive(
+                    "the command slot emptied with no successor", contact=ContactEvidence.CONFIRMED
+                )
 
         if unresponsive_command is not None:
             # The push goes LAST: it is the only part that can realistically raise
@@ -1344,20 +1377,50 @@ class AbstractDevice:
                 self._drop_running_command("suppressed by user override")
                 return
 
+            # QS-307: hold the command locally across the await. The slot can be
+            # emptied underneath us (see the re-check below), and both the error
+            # handler and the logging after it used to dereference
+            # `self.running_command` unguarded.
+            launched_command = self.running_command
             _LOGGER.info(
-                f"force launch command {self.running_command.command} for this load {self.name} (#{self.running_command_num_relaunch})"
+                f"force launch command {launched_command.command} for this load {self.name} (#{self.running_command_num_relaunch})"
             )
             self.running_command_num_relaunch += 1
             try:
-                is_command_set = await self.execute_command(time, self.running_command)
+                is_command_set = await self.execute_command(time, launched_command)
             except Exception as err:
                 _LOGGER.error(
-                    f"Error while executing command {self.running_command.command} for load {self.name} : {err}",
+                    f"Error while executing command {launched_command.command} for load {self.name} : {err}",
                     exc_info=True,
                     stack_info=True,
                 )
                 is_command_set = None
+
+            # Anchored before the re-check on purpose: a service call really did land,
+            # so the causality guard must know about it even if the slot is now empty —
+            # otherwise the resulting state change reads as a user override.
             self._anchor_causality_guard_if_executed(is_command_set, time)
+
+            if self.running_command is None:
+                # QS-307: the slot emptied ACROSS the await. Three callers of
+                # `check_load_activity_and_constraints` run outside
+                # `_update_loads_lock` (the bistate mode select, the on-duration
+                # number, the reset-override button), and its override-expiry branch
+                # drops an override-aligned command — so a user action landing while
+                # this service call is in flight legitimately removes the command we
+                # launched. Everything below describes THAT command: writing its
+                # launch stamp would outlive it, `_ack_command(time,
+                # self.running_command)` would ack `None` and silently null
+                # `current_command` (dropping the load out of controlled-consumption
+                # accounting), and the log line would raise on a `None` deref. Nothing
+                # left to do, so stop here.
+                _LOGGER.info(
+                    "force_relaunch_command: command %s for load %s was dropped while its service call was in flight",
+                    launched_command.command,
+                    self.name,
+                )
+                return
+
             self.running_command_last_launch = time
             if is_command_set is None:
                 _LOGGER.info(

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -89,10 +89,10 @@ class ContactEvidence(StrEnum):
     UNKNOWN = "unknown"  # we abandoned the command: says nothing either way
 
 
-# QS-307: benign clock-skew tolerance for a FUTURE-dated anchor. Single source of
-# truth — `QSBiStateDuration.use_saved_extra_device_info` grants the very same
-# override timestamps the very same band at the restore boundary, and used to
-# hard-code it.
+# Tolerance for a clearly FUTURE-dated stored timestamp at the RESTORE boundary, and
+# nowhere else: `QSBiStateDuration.use_saved_extra_device_info` is the only consumer.
+# The runtime override comparisons use plain subtraction on purpose (QS-307), so
+# retuning this does not widen any live window.
 CLOCK_SKEW_TOLERANCE_S = 60.0
 
 _LOGGER = logging.getLogger(__name__)
@@ -735,11 +735,17 @@ class AbstractDevice:
         successor, and a clock-only property would stay True forever with no retry
         able to clear it.
 
-        QS-307 (from #308): every slot-emptying path releases the clock, including
-        the invalid-probe give-up, which used to keep it and hand it to the next
-        command. So `unresponsive_since` is per-COMMAND. "Are we still in an
+        QS-307 (from #308): every path that empties the slot **with no successor**
+        releases the clock, including the invalid-probe give-up, which used to keep it
+        and hand it to an unrelated next command. A *supersede* is the deliberate
+        exception: `abandon_running_command` preserves the clock and
+        `launch_command` hands it to the successor on purpose, so the load keeps
+        superseding instead of stacking and holds QS-304's saturated 300 s cadence.
+        Do NOT "restore the invariant" by releasing it there.
+
+        So `unresponsive_since` tracks the command in flight. "Are we still in an
         unresolved lost-control EPISODE" is a different question, answered by
-        `_unresponsive_needs_ack` — do not conflate the two again.
+        `_unresponsive_needs_ack` — do not conflate the two.
         """
         return self.unresponsive_since is not None and self.running_command is not None
 
@@ -1042,9 +1048,11 @@ class AbstractDevice:
             self._anchor_causality_guard_if_executed(is_command_set, time)
 
         if self.running_command is None:
-            # QS-307: same guard, same reason as in `force_relaunch_command`.
+            # QS-307: same guard, same reason as in `force_relaunch_command`. Placed
+            # here, at 8 spaces, so it covers BOTH awaits above — the probe and the
+            # conditional execute. Do not move it inside the `else:`.
             _LOGGER.info(
-                "launch_command: command %s for load %s was dropped while its service call was in flight, ctxt: %s",
+                "launch_command: command %s for load %s was dropped while a call to the device was in flight, ctxt: %s",
                 command.command,
                 self.name,
                 ctxt,
@@ -1133,13 +1141,18 @@ class AbstractDevice:
         branch of `QSBiStateDuration.check_load_activity_and_constraints` drops an
         override-aligned command, and three of that method's callers (the bistate
         mode select, the on-duration number, the reset-override button) run outside
-        the lock. So the slot CAN be emptied across an await. What makes that safe is
-        the post-await re-check in `force_relaunch_command`: it holds the command it
-        launched in a local, and bails out if the slot is EMPTY rather than writing
-        counters for, acking, or dereferencing a command that is gone. Emptied, not
-        replaced: every `launch_command` site runs inside `home.update_loads`, and the
-        unlocked user-action callers only ever drop. The clock is still only cleared
-        alongside the command state it describes.
+        the lock. So the slot CAN be emptied across an await. `launch_command` and
+        `force_relaunch_command` both hold the command they launched in a local and
+        bail out if the slot is EMPTY, rather than writing counters for, acking, or
+        dereferencing a command that is gone.
+
+        Scope of those guards, precisely: they cover the slot being **emptied**, not
+        **replaced**. A replaced slot passes an `is None` test, so a button press that
+        supersedes the in-flight command mid-await can still stamp its launch time or
+        ack it off the previous command's result. That is pre-existing — it behaves
+        identically on `main` — and is tracked in #320, deliberately not fixed here.
+
+        The clock is still only cleared alongside the command state it describes.
         """
         try:
             _wait_time, command_acked_or_good = await self.check_commands(time)
@@ -1266,9 +1279,10 @@ class AbstractDevice:
             self._last_supersede_time = None
 
             # Gated because the release below is `CONFIRMED`, which clears the
-            # episode latch. Only the give-up sets that latch, and the give-up nulls
-            # `current_command` — so this branch runs exactly when nothing has latched
-            # in this cycle (QS-307).
+            # episode latch. Only the give-up sets that latch, and it nulls
+            # `current_command`, so reaching here means either nothing latched this
+            # cycle or something legitimately ended the episode afterwards — e.g. a
+            # promoted stacked command that acked (QS-307).
             if self.current_command is not None:
                 self._clear_unresponsive(
                     "the command slot emptied with no successor", contact=ContactEvidence.CONFIRMED

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -70,6 +70,18 @@ NUM_MAX_COMMAND_RELAUNCH = 6
 # relaunch delay a newer intent.
 SUPERSEDE_MIN_INTERVAL_S = COMMAND_RELAUNCH_BASE_DELAY_S * NUM_MAX_COMMAND_RELAUNCH
 
+# QS-307: what releasing the lost-control clock tells us about the device, which is
+# what decides whether a lost-control EPISODE has ended. See
+# `AbstractDevice._clear_unresponsive`.
+CONTACT_CONFIRMED = "confirmed"  # the device answered: the episode is over
+CONTACT_NONE = "none"  # the device is unreachable: the episode continues
+CONTACT_UNKNOWN = "unknown"  # we abandoned the command: says nothing either way
+
+# QS-307: benign clock-skew tolerance for a FUTURE-dated anchor, mirroring the ±60 s
+# `QSBiStateDuration.use_saved_extra_device_info` already grants the very same
+# override timestamps at the restore boundary.
+CLOCK_SKEW_TOLERANCE_S = 60.0
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -177,14 +189,17 @@ class AbstractDevice:
         # can clear them — that wipe destroys the command the clock describes.
         self.unresponsive_since: datetime | None = None
         self._last_supersede_time: datetime | None = None
-        # QS-307 review fix #01: the EPISODE latch. `unresponsive_since` is
-        # per-command by construction (every slot-emptying path releases it, so it
-        # can drive supersede-vs-stack), which makes it unfit to be the once-only
-        # notification guard on its own: a device that alternates unreachable with
+        # QS-307: the EPISODE latch. `unresponsive_since` is per-command by
+        # construction (every slot-emptying path releases it, so it can drive
+        # supersede-vs-stack), which makes it unfit to be the once-only notification
+        # guard on its own: a device that alternates unreachable with
         # answering-but-disobeying releases and re-crosses the threshold every
-        # ~18 min forever. This latch is per EPISODE — set when the clock is
-        # released with NO evidence the device answered, cleared only by evidence
-        # that it did — and it gates the shout, never the clock.
+        # ~18 min forever. This latch is per EPISODE and gates the shout, never the
+        # clock. Set only when an ANNOUNCED episode's clock is released with the
+        # device unreachable; cleared only by a real ack. Everything else — a drop we
+        # chose, a command wipe — leaves it alone, because it is evidence of nothing.
+        # In-memory only, like `unresponsive_since`: see `notification-routing.md` for
+        # the restart semantics that follow from that.
         self._unresponsive_needs_ack: bool = False
 
         self.constraint_reset_and_reset_commands_if_needed(keep_commands=False)
@@ -414,7 +429,9 @@ class AbstractDevice:
             # relaunches — flashing PROBLEM right after the user's own
             # remediation. Routed through `_clear_unresponsive` to keep the
             # single-writer / one-line-out guarantee.
-            self._clear_unresponsive("the command state was reset")
+            # `CONTACT_UNKNOWN`: a wipe is OUR decision, not the device answering, so
+            # it must not end a lost-control episode (QS-307).
+            self._clear_unresponsive("the command state was reset", contact=CONTACT_UNKNOWN)
 
     # for class overcharging reset
     def reset(self, keep_commands=False):
@@ -714,12 +731,11 @@ class AbstractDevice:
 
         The in-flight conjunct is load-bearing: several paths empty the slot with no
         successor, and a clock-only property would stay True forever with no retry
-        able to clear it. Note this is NOT "the in-flight command failed N times" —
-        the clock is per EPISODE, not per command, and survives a supersede.
+        able to clear it.
 
-        QS-307 (from #308): every slot-emptying path now releases the clock,
-        including the invalid-probe give-up, which used to keep it and hand it to
-        the next command. So this really is per-command. "Are we still in an
+        QS-307 (from #308): every slot-emptying path releases the clock, including
+        the invalid-probe give-up, which used to keep it and hand it to the next
+        command. So `unresponsive_since` is per-COMMAND. "Are we still in an
         unresolved lost-control EPISODE" is a different question, answered by
         `_unresponsive_needs_ack` — do not conflate the two again.
         """
@@ -736,7 +752,7 @@ class AbstractDevice:
             COMMAND_RELAUNCH_BASE_DELAY_S * min(self.running_command_num_relaunch + 1, NUM_MAX_COMMAND_RELAUNCH)
         )
 
-    def _clear_unresponsive(self, reason: str, earned_recovery: bool = True) -> None:
+    def _clear_unresponsive(self, reason: str, contact: str = CONTACT_CONFIRMED) -> None:
         """Release the per-command lost-control clock, logging the exit exactly once.
 
         The single writer, so the "one line out" guarantee cannot drift between
@@ -749,16 +765,22 @@ class AbstractDevice:
         control was taken *away* from QS, and a `keep_commands=False` reset simply
         destroys the clock's subject.
 
-        QS-307 review fix #01 — `earned_recovery` says whether the release came
-        with evidence that QS is back in contact with the device. It is `True` for
-        every caller but one: a real ack, a deliberate drop, and a command wipe all
-        happen because *we* changed our mind or the device answered. The
-        invalid-probe give-up is the exception — the device is unreachable, so
-        releasing its clock is bookkeeping, not news — and it passes `False`, which
-        latches `_unresponsive_needs_ack` and suppresses the NEXT shout (never the
-        next clock) until contact is genuinely re-established. The two cases also
-        log distinguishable lines, so "the clock was released" no longer implies
-        "the device came back".
+        `contact` says what the release tells us about the device, and drives
+        `_unresponsive_needs_ack` (the per-EPISODE latch). Three values, because two
+        were not enough — a drop we chose ourselves is evidence of nothing either
+        way, and forcing it into "recovered" re-opened the push storm the latch
+        exists to damp:
+
+        - `CONTACT_CONFIRMED` — the device answered. Ends the episode, and does so
+          **unconditionally**: an ack is contact whether or not a clock was live.
+        - `CONTACT_NONE` — the device is unreachable (the invalid-probe give-up).
+          Latches the episode, but only if a clock was actually live: latching a
+          release that released nothing swallowed the load's FIRST genuine push
+          forever, since the give-up fires ~70 s in and the escalation threshold is
+          ~1050 s away.
+        - `CONTACT_UNKNOWN` — *we* abandoned the command (a deliberate drop, a
+          `keep_commands=False` wipe). Says nothing about the device, so it leaves
+          the latch exactly as it was.
         """
         # The supersede anchor is cleared unconditionally: it is meaningless
         # without a lost-control episode to throttle, and leaving it behind let a
@@ -766,19 +788,22 @@ class AbstractDevice:
         # supersede throttled for up to `SUPERSEDE_MIN_INTERVAL_S`.
         self._last_supersede_time = None
 
-        if earned_recovery:
+        if contact == CONTACT_CONFIRMED:
+            # Above the early return on purpose: the device answered, so the episode
+            # is over regardless of whether there was a clock left to release.
             self._unresponsive_needs_ack = False
-        else:
-            self._unresponsive_needs_ack = True
 
         if self.unresponsive_since is None:
             return
 
         self.unresponsive_since = None
-        if earned_recovery:
-            _LOGGER.info("Lost-control state cleared for load %s: %s", self.name, reason)
-        else:
+        if contact == CONTACT_NONE:
+            # Below the early return on purpose (see the docstring): the latch may
+            # only suppress a NEXT shout when there was a shout to follow.
+            self._unresponsive_needs_ack = True
             _LOGGER.info("Lost-control clock released without contact for load %s: %s", self.name, reason)
+        else:
+            _LOGGER.info("Lost-control state cleared for load %s: %s", self.name, reason)
 
     def abandon_running_command(self, reason: str) -> None:
         """Drop the stale in-flight command without faking an ack.
@@ -865,6 +890,37 @@ class AbstractDevice:
 
         return elapsed
 
+    @classmethod
+    def _seconds_since_skew_tolerant(cls, time: datetime, anchor: datetime | None) -> float | None:
+        """`_seconds_since`, but a *slightly* future anchor means "just armed".
+
+        QS-307: `_seconds_since` collapses EVERY negative delta to `None` ("treat as
+        fully elapsed"). That is right for a real backwards clock step, and wrong —
+        actively harmful — for a window whose anchor is a user action: a few seconds
+        of future-dating would then read as "fully elapsed" and cancel a brand-new
+        8-hour user override on the spot, i.e. QS fighting the user.
+
+        A few seconds of future-dating is routine, with no clock anomaly at all:
+        `user_set_bistate_mode`, `user_set_default_on_duration` and
+        `async_reset_override_state` each take their own unlocked
+        `datetime.now(pytz.UTC)`, while an `async_update_loads` cycle already in
+        flight is still carrying an earlier `event_time`. So a user-stamped anchor
+        can legitimately sit ahead of the cycle time that evaluates it.
+
+        Hence the band, the same ±`CLOCK_SKEW_TOLERANCE_S` the bistate restore path
+        already grants these timestamps: future by less than the tolerance ⇒ zero
+        elapsed (not expired); beyond it ⇒ `None`, keeping `_seconds_since`'s
+        fully-elapsed meaning for the genuine large-jump case.
+        """
+        elapsed = cls._seconds_since(time, anchor)
+        if elapsed is not None or anchor is None:
+            return elapsed
+
+        if (anchor - time).total_seconds() <= CLOCK_SKEW_TOLERANCE_S:
+            return 0.0
+
+        return None
+
     def _is_supersede_throttled(self, time: datetime) -> bool:
         """Return True while the supersede window is still closed."""
         elapsed = self._seconds_since(time, self._last_supersede_time)
@@ -894,7 +950,12 @@ class AbstractDevice:
         """
         self.abandon_running_command(reason=reason)
         self.running_command_num_relaunch = 0
-        self._clear_unresponsive(reason)
+        # `CONTACT_UNKNOWN` (QS-307): a drop is OUR decision — the user took control,
+        # the load was disabled, the command became redundant — and says nothing about
+        # whether the device is answering. Ending the episode here let a latched
+        # flapping load shout again on its next ladder climb, once per override
+        # expiry, for a device that never answered.
+        self._clear_unresponsive(reason, contact=CONTACT_UNKNOWN)
 
     async def launch_command(self, time: datetime, command: LoadCommand, ctxt="NO CTXT"):
         if self.qs_enable_device is False:
@@ -1060,10 +1121,14 @@ class AbstractDevice:
                     # only on a real ack, and `_escalate_or_recover`'s re-arm is gated
                     # on the `current_command` this path just nulled), and the next
                     # command inherited supersede semantics with zero evidence.
-                    # `earned_recovery=False`: the device is UNREACHABLE, so this is
-                    # not news. It latches the episode so the ladder that follows
-                    # cannot shout again until the device actually answers.
-                    self._clear_unresponsive("the probe went unavailable", earned_recovery=False)
+                    # `CONTACT_NONE`: the device is UNREACHABLE, so this is not news.
+                    # When it releases a live clock it latches the episode, so the
+                    # ladder that follows cannot shout again until the device actually
+                    # answers. When there was no clock — the usual case, since this
+                    # fires ~70 s in and the escalation threshold is ~1050 s away —
+                    # it latches nothing, or the load's first genuine push would be
+                    # swallowed for good.
+                    self._clear_unresponsive("the probe went unavailable", contact=CONTACT_NONE)
 
             if is_command_set is True:
                 self._ack_command(time, self.running_command)
@@ -1220,16 +1285,19 @@ class AbstractDevice:
             # legitimate supersede.
             self._last_supersede_time = None
 
-            # The gate below governs `unresponsive_since` and
-            # `_unresponsive_needs_ack`, and it is LOAD-BEARING (QS-307 review fix
-            # #01 — an earlier revision of this comment called it redundant, which
-            # was wrong once the episode latch existed). Reaching here with
-            # `current_command is None` means the slot was emptied by a path that
-            # nulled the confirmed command too, and the only such path is the
-            # invalid-probe give-up — which runs in THIS cycle, immediately before
-            # us, and has just latched `_unresponsive_needs_ack` on purpose. An
-            # unconditional `earned_recovery=True` release here would clear that
-            # latch one statement later and restore the push storm it exists to damp.
+            # The gate below is LOAD-BEARING for `_unresponsive_needs_ack` (QS-307 —
+            # an earlier revision of this comment called it redundant, which was wrong
+            # once the episode latch existed). Reaching here with `current_command is
+            # None` means the slot was emptied by a path that nulled the confirmed
+            # command too, and the only such path is the invalid-probe give-up — which
+            # runs in THIS cycle, immediately before us, and may have just latched the
+            # episode. The release below is `CONTACT_CONFIRMED`, which clears the latch
+            # unconditionally, so without the gate it would undo that one statement
+            # later and restore the push storm the latch exists to damp.
+            #
+            # `CONTACT_CONFIRMED` is the honest value here: `current_command is not
+            # None` means a command of record was confirmed by the device, and the slot
+            # emptied without a give-up.
             #
             # For `unresponsive_since` itself the gate is belt-and-braces: every
             # slot-emptying path releases the clock at its own call site (a real

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -107,13 +107,13 @@ of the on/off behaviour unchanged.
 command state; only **detection** is:
 
 ```text
-if qs_enable_device is not False:
+if qs_enable_device is not False and support_user_override():
     if <override aged past override_duration>:      # unconditional
         <drop an override-ALIGNED running_command>
     elif <reset-ask follow-up flag set>:            # unconditional
     else:
         <post-override cooldown drain>              # unconditional
-        if support_user_override() and is_load_command_set(time):
+        if is_load_command_set(time):
             <detection: reads entity state>
 ```
 
@@ -143,13 +143,17 @@ Four things about this shape are load-bearing:
    to power accounting. The drain must hoist too, or the load expires its
    override and stays out of controlled consumption anyway. Only the
    *suppression* half stays inside detection.
-2. **`support_user_override()` guards detection, never the lifecycle.**
-   Leaving it on the outer gate was the same bug in a worse form: unlike the
-   `qs_enable_device` arm it is not self-healing. Disabling and re-enabling a
-   load runs the lifecycle again; flipping one to boost-only
-   (`CONF_LOAD_IS_BOOST_ONLY`) never does — and since the reset-ask timestamp
-   is persisted and restore only drops *future*-dated ones, such a load stayed
-   `is_user_overridden()` forever, across restarts.
+2. **`support_user_override()` stays on the OUTER gate; only
+   `is_load_command_set` moved inward.** The two answer different questions:
+   "am I waiting on a command" (unrelated to clock arithmetic, so splitting it
+   out is the actual fix) versus "can this load have an override at all" (a load
+   that cannot needs no lifecycle, ever). QS-307 briefly moved this one down too,
+   which ran the whole override lifecycle every cycle for chargers and boost-only
+   loads, and reverted it. The case that motivated the move — a load
+   reconfigured to boost-only holding a live override nothing could clear — is
+   handled at the restore boundary instead: `use_saved_extra_device_info` already
+   drops stale and future-dated overrides, and now also drops them when
+   `support_user_override()` is false. A reconfigure reloads the entry.
 3. **Expiry drops an override-*aligned* in-flight command.** Reachable only
    after the hoist (the old gate guaranteed an empty slot here). Nulling the
    override state also disables `force_relaunch_command`'s suppression drop,
@@ -158,25 +162,14 @@ Four things about this shape are load-bearing:
    it. Alignment is `expected_state_from_command(running_command) ==
    external_user_initiated_state`; anything else is a genuine solver intent
    and must survive `keep_commands=True`.
-4. **Every clock comparison goes through
-   `AbstractDevice._seconds_since_skew_tolerant`,** which needs a *band*, not
-   just a sign test. Both failure directions are live here:
-   - a raw subtraction freezes whatever it gates for the duration of a
-     backwards clock step, and the drain is the *only* release of the
-     cooldown — hence `_seconds_since`'s "a future anchor means fully
-     elapsed";
-   - but reading **any** future-dating as "fully elapsed" cancels a
-     brand-new 8-hour override on the spot, which is QS fighting the user.
-     And a few seconds of future-dating is routine with no clock anomaly at
-     all: the user-action call sites (`user_set_bistate_mode`,
-     `user_set_default_on_duration`, `async_reset_override_state`) each take
-     their own unlocked `datetime.now()`, while a cycle already in flight
-     carries an earlier `event_time` (see
-     [#317](https://github.com/tmenguy/quiet-solar/issues/317)).
-
-   So: future by at most `CLOCK_SKEW_TOLERANCE_S` ⇒ zero elapsed; beyond
-   it ⇒ fully elapsed. Same ±60 s the restore path already grants these
-   timestamps.
+4. **The clock comparisons use plain subtraction, on purpose.** A future-dated
+   anchor gives a negative age, which is never past the threshold, so the
+   override simply lasts a little longer. Do **not** "fix" this by routing
+   through a clock-safe helper: `_seconds_since`'s "a future anchor means fully
+   elapsed" is right for the retry ladder it was written for, and on an override
+   it means *destroy what the user just set* — state nulled, aligned command
+   dropped, constraint wiped. QS-307 tried it, and a ±60 s tolerance band on top
+   of it, and reverted both. Expiring late is the benign direction.
 
 The `qs_enable_device` guard is deliberate, not incidental:
 `is_load_command_set` returned False for a disabled load, so dropping the

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -148,12 +148,18 @@ Four things about this shape are load-bearing:
    "am I waiting on a command" (unrelated to clock arithmetic, so splitting it
    out is the actual fix) versus "can this load have an override at all" (a load
    that cannot needs no lifecycle, ever). QS-307 briefly moved this one down too,
-   which ran the whole override lifecycle every cycle for chargers and boost-only
-   loads, and reverted it. The case that motivated the move — a load
-   reconfigured to boost-only holding a live override nothing could clear — is
-   handled at the restore boundary instead: `use_saved_extra_device_info` already
-   drops stale and future-dated overrides, and now also drops them when
-   `support_user_override()` is false. A reconfigure reloads the entry.
+   which ran the whole override lifecycle every cycle for boost-only
+   `QSBiStateDuration` loads, and reverted it. (Chargers are unaffected either
+   way: `QSChargerGeneric` is not a `QSBiStateDuration`, overrides
+   `check_load_activity_and_constraints` outright, and its
+   `support_user_override()` returns `True`.) The case that motivated the move —
+   a load reconfigured to boost-only holding a live override nothing could
+   clear — is handled at the restore boundary instead:
+   `use_saved_extra_device_info` already drops stale and future-dated overrides,
+   and now also drops the override *state* when `support_user_override()` is
+   false. A reconfigure reloads the entry. Note this covers the stored override
+   fields, not a persisted override *constraint*, which self-heals at its
+   `end_of_constraint` exactly as on `main`.
 3. **Expiry drops an override-*aligned* in-flight command.** Reachable only
    after the hoist (the old gate guaranteed an empty slot here). Nulling the
    override state also disables `force_relaunch_command`'s suppression drop,

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -158,10 +158,25 @@ Four things about this shape are load-bearing:
    it. Alignment is `expected_state_from_command(running_command) ==
    external_user_initiated_state`; anything else is a genuine solver intent
    and must survive `keep_commands=True`.
-4. **Every clock comparison goes through `AbstractDevice._seconds_since`,**
-   which treats a future-dated anchor as fully elapsed. A raw subtraction
-   freezes whatever it gates for the duration of a backwards clock step, and
-   the drain is the *only* release of the cooldown.
+4. **Every clock comparison goes through
+   `AbstractDevice._seconds_since_skew_tolerant`,** which needs a *band*, not
+   just a sign test. Both failure directions are live here:
+   - a raw subtraction freezes whatever it gates for the duration of a
+     backwards clock step, and the drain is the *only* release of the
+     cooldown — hence `_seconds_since`'s "a future anchor means fully
+     elapsed";
+   - but reading **any** future-dating as "fully elapsed" cancels a
+     brand-new 8-hour override on the spot, which is QS fighting the user.
+     And a few seconds of future-dating is routine with no clock anomaly at
+     all: the user-action call sites (`user_set_bistate_mode`,
+     `user_set_default_on_duration`, `async_reset_override_state`) each take
+     their own unlocked `datetime.now()`, while a cycle already in flight
+     carries an earlier `event_time` (see
+     [#317](https://github.com/tmenguy/quiet-solar/issues/317)).
+
+   So: future by less than `CLOCK_SKEW_TOLERANCE_S` ⇒ zero elapsed; beyond
+   it ⇒ fully elapsed. Same ±60 s the restore path already grants these
+   timestamps.
 
 The `qs_enable_device` guard is deliberate, not incidental:
 `is_load_command_set` returned False for a disabled load, so dropping the

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -10,7 +10,7 @@ covers:
   - custom_components/quiet_solar/ha_model/radiator.py
   - custom_components/quiet_solar/ha_model/bistate_transport.py
   - custom_components/quiet_solar/ha_model/water_boiler.py
-last_verified: 2026-06-05
+last_verified: 2026-07-31
 ---
 
 # Bistate-duration devices (pool, on/off duration, water boiler, climate, radiator)
@@ -102,6 +102,50 @@ the solver picks the cheapest contiguous (or split) windows.
 `QSOnOffDuration`: warmer water → longer filter duration. The
 extension overrides the duration calculation but inherits the rest
 of the on/off behaviour unchanged.
+
+**The split gate (QS-307).** `check_load_activity_and_constraints`'
+user-override block is guarded by `qs_enable_device is not False and
+support_user_override()`. Inside it, only **detection** is gated on
+`is_load_command_set(time)`:
+
+```text
+if qs_enable_device is not False and support_user_override():
+    if <override aged past override_duration>:   # unconditional
+    elif <reset-ask follow-up flag set>:         # unconditional
+    else:
+        <post-override cooldown expiry>          # unconditional
+        if is_load_command_set(time):
+            <detection: reads entity state>
+```
+
+The three unconditional branches never read entity state — they are pure
+clock/flag arithmetic — so nothing about an in-flight command makes them
+unsafe. Detection is different: while a command is landing, observed state
+≠ wanted state is expected, and classifying that as a user action would be
+a false positive, so `is_load_command_set` (which requires
+`running_command is None and current_command is not None`) still guards it.
+
+Gating the *whole* block was the bug: since QS-304 made the relaunch backoff
+saturate and retry forever, the gate could stay shut indefinitely, so an
+override on a load that stopped obeying never expired — the load was
+permanently excluded from controlled consumption and from the solver, and
+that flowed into the persisted forecast. Both death modes are covered: a
+*visible but disobeying* entity keeps `running_command` set forever, while an
+*unavailable* one reaches the invalid-probe give-up, which nulls
+`current_command` — `is_load_command_set` is False on either arm.
+
+The `qs_enable_device` guard is deliberate, not incidental:
+`is_load_command_set` returned False for a disabled load, so dropping the
+gate without it would newly expire overrides on loads QS was told to leave
+alone.
+
+**Non-goal, do not "fix":** QS-307 changed **no** detection behaviour. Fresh
+detection on an unresponsive load is not merely gated, it is unsafe — for a
+dead device the state mismatch is permanent, so "matches neither expectation"
+stops meaning "a user acted" and a dead multi-mode load sitting in some
+leftover mode would be classified as a user override with nobody involved.
+On a 2-state switch it is unconstructible anyway (the state can only ever be
+one of the two expectations).
 
 **Override semantics (QS-256):**
 

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -103,18 +103,17 @@ the solver picks the cheapest contiguous (or split) windows.
 extension overrides the duration calculation but inherits the rest
 of the on/off behaviour unchanged.
 
-**The split gate (QS-307).** `check_load_activity_and_constraints`'
-user-override block is guarded by `qs_enable_device is not False and
-support_user_override()`. Inside it, only **detection** is gated on
-`is_load_command_set(time)`:
+**The split gate (QS-307).** The override **lifecycle** is not gated on
+command state; only **detection** is:
 
 ```text
-if qs_enable_device is not False and support_user_override():
-    if <override aged past override_duration>:   # unconditional
-    elif <reset-ask follow-up flag set>:         # unconditional
+if qs_enable_device is not False:
+    if <override aged past override_duration>:      # unconditional
+        <drop an override-ALIGNED running_command>
+    elif <reset-ask follow-up flag set>:            # unconditional
     else:
-        <post-override cooldown expiry>          # unconditional
-        if is_load_command_set(time):
+        <post-override cooldown drain>              # unconditional
+        if support_user_override() and is_load_command_set(time):
             <detection: reads entity state>
 ```
 
@@ -134,10 +133,43 @@ that flowed into the persisted forecast. Both death modes are covered: a
 *unavailable* one reaches the invalid-probe give-up, which nulls
 `current_command` — `is_load_command_set` is False on either arm.
 
+Four things about this shape are load-bearing:
+
+1. **The lifecycle is THREE branches, not two.** Expiry does not finish the
+   job: it hands off to `asked_for_reset_user_initiated_state_time` (the
+   180 s "too soon to re-override" window), and while that is set
+   `get_override_state()` returns `ASKED FOR RESET`, so
+   `is_user_overridden()` is still `True` and the load is still worth `0.0`
+   to power accounting. The drain must hoist too, or the load expires its
+   override and stays out of controlled consumption anyway. Only the
+   *suppression* half stays inside detection.
+2. **`support_user_override()` guards detection, never the lifecycle.**
+   Leaving it on the outer gate was the same bug in a worse form: unlike the
+   `qs_enable_device` arm it is not self-healing. Disabling and re-enabling a
+   load runs the lifecycle again; flipping one to boost-only
+   (`CONF_LOAD_IS_BOOST_ONLY`) never does — and since the reset-ask timestamp
+   is persisted and restore only drops *future*-dated ones, such a load stayed
+   `is_user_overridden()` forever, across restarts.
+3. **Expiry drops an override-*aligned* in-flight command.** Reachable only
+   after the hoist (the old gate guaranteed an empty slot here). Nulling the
+   override state also disables `force_relaunch_command`'s suppression drop,
+   so the **ended** override's own service call would keep being relaunched
+   for up to a full ladder while the real post-expiry intent stacked behind
+   it. Alignment is `expected_state_from_command(running_command) ==
+   external_user_initiated_state`; anything else is a genuine solver intent
+   and must survive `keep_commands=True`.
+4. **Every clock comparison goes through `AbstractDevice._seconds_since`,**
+   which treats a future-dated anchor as fully elapsed. A raw subtraction
+   freezes whatever it gates for the duration of a backwards clock step, and
+   the drain is the *only* release of the cooldown.
+
 The `qs_enable_device` guard is deliberate, not incidental:
 `is_load_command_set` returned False for a disabled load, so dropping the
 gate without it would newly expire overrides on loads QS was told to leave
-alone.
+alone. It is defence in depth — production callers arrive via
+`do_run_check_load_activity_and_constraints`, which already short-circuits on
+a disabled load — and `None`/unset is deliberately treated as **enabled**,
+like every other `is not False` guard on the load.
 
 **Non-goal, do not "fix":** QS-307 changed **no** detection behaviour. Fresh
 detection on an unresponsive load is not merely gated, it is unsafe — for a

--- a/docs/agents/concepts/bistate-duration-devices.md
+++ b/docs/agents/concepts/bistate-duration-devices.md
@@ -174,7 +174,7 @@ Four things about this shape are load-bearing:
      carries an earlier `event_time` (see
      [#317](https://github.com/tmenguy/quiet-solar/issues/317)).
 
-   So: future by less than `CLOCK_SKEW_TOLERANCE_S` ⇒ zero elapsed; beyond
+   So: future by at most `CLOCK_SKEW_TOLERANCE_S` ⇒ zero elapsed; beyond
    it ⇒ fully elapsed. Same ±60 s the restore path already grants these
    timestamps.
 

--- a/docs/agents/concepts/external-control-detection.md
+++ b/docs/agents/concepts/external-control-detection.md
@@ -57,11 +57,11 @@ When external control is detected:
 This is the structural defence behind "embrace uncertainty" —
 quiet-solar doesn't assume it has exclusive control of the device.
 
-**Detection rules (QS-256).** Detection itself is reached only when
-`support_user_override() and is_load_command_set(time)` — QS-307 moved
-**both** of those conjuncts inward so they guard detection *only* and
-no longer freeze the override lifecycle around it (see the "split gate"
-section of
+**Detection rules (QS-256).** Detection sits behind
+`support_user_override()` (the outer gate — can this load have an override
+at all) and `is_load_command_set(time)`, which QS-307 moved inward so it
+guards detection *only* and no longer freezes the override lifecycle
+around it (see the "split gate" section of
 [bistate-duration-devices.md](bistate-duration-devices.md)). Detection
 behaviour is unchanged by that story: while a command is landing,
 observed state ≠ wanted state is expected, so classifying it as a user

--- a/docs/agents/concepts/external-control-detection.md
+++ b/docs/agents/concepts/external-control-detection.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
   - custom_components/quiet_solar/ha_model/device.py
-last_verified: 2026-07-30
+last_verified: 2026-07-31
 ---
 
 # External control detection
@@ -57,8 +57,17 @@ When external control is detected:
 This is the structural defence behind "embrace uncertainty" —
 quiet-solar doesn't assume it has exclusive control of the device.
 
-**Detection rules (QS-256).** Three guards keep false positives out
-of the bistate detection in
+**Detection rules (QS-256).** Detection itself is reached only when
+`support_user_override() and is_load_command_set(time)` — QS-307 moved
+**both** of those conjuncts inward so they guard detection *only* and
+no longer freeze the override lifecycle around it (see the "split gate"
+section of
+[bistate-duration-devices.md](bistate-duration-devices.md)). Detection
+behaviour is unchanged by that story: while a command is landing,
+observed state ≠ wanted state is expected, so classifying it as a user
+action would be a false positive.
+
+Three guards then keep false positives out of the bistate detection in
 `QSBiStateDuration.check_load_activity_and_constraints`:
 
 1. **Causality** — a mismatch counts only if the entity state's
@@ -71,7 +80,12 @@ of the bistate detection in
    freshness → no override is classified.
 2. **Cooldown** — after an override resets, no new override is
    classified for `USER_OVERRIDE_STATE_BACK_DURATION_S` (180s),
-   bounded by half the override window.
+   bounded by half the override window. QS-307 split this in two: the
+   *suppression* stays here (an open window forces
+   `is_command_overridden_state_changed = False`), while the window's
+   **expiry** moved out to the lifecycle above, because a timer draining
+   is not a detection decision and must not need a healthy command slot
+   to happen.
 3. **Constraint-driven end** — an override to the idle state pushes a
    `TimeBasedHoldOffConstraint` so the solver natively sees the
    pinned-off window and the override ends through the constraint-ack

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -93,11 +93,14 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   `unresponsive_since`-only property would stay `True` forever with no
   retry left to clear it. If we are not waiting on anything, we are not
   uncontrollable. QS-307 (from #308) closed the last path that emptied
-  the slot while keeping the clock, so a set clock now always describes
-  a live, unresolved episode.
-- **Two clocks, not one (QS-307).** `unresponsive_since` is per **command**
-  — every slot-emptying path releases it, which is what lets it drive
-  supersede-vs-stack honestly. `_unresponsive_needs_ack` is per **episode**
+  the slot **with no successor** while keeping the clock.
+- **Two clocks, not one (QS-307).** `unresponsive_since` tracks the command
+  in flight — every path that empties the slot **with no successor** releases
+  it, which is what lets it drive supersede-vs-stack honestly. A *supersede*
+  is the deliberate exception: `abandon_running_command` preserves the clock
+  and hands it to the successor, so the load keeps superseding instead of
+  stacking and holds QS-304's saturated 300 s cadence. Releasing it there to
+  "restore the invariant" would silently undo that. `_unresponsive_needs_ack` is per **episode**
   — "we are still in an unresolved lost-control episode" — and it gates the
   ERROR log and the push, never the clock. Conflating them is what produced
   a notification every ~18 min for a device flapping between unreachable and

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -95,12 +95,26 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   uncontrollable. QS-307 (from #308) closed the last path that emptied
   the slot while keeping the clock, so a set clock now always describes
   a live, unresolved episode.
+- **Two clocks, not one (QS-307).** `unresponsive_since` is per **command**
+  — every slot-emptying path releases it, which is what lets it drive
+  supersede-vs-stack honestly. `_unresponsive_needs_ack` is per **episode**
+  — "we are still in an unresolved lost-control episode" — and it gates the
+  ERROR log and the push, never the clock. Conflating them is what produced
+  a notification every ~18 min for a device flapping between unreachable and
+  answering-but-disobeying: `running_command_num_relaunch_after_invalid` is
+  cumulative over a command's life, so the give-up can fire long after the
+  threshold was crossed by ordinary relaunches, and each release re-opened
+  the guard. `_clear_unresponsive(reason, earned_recovery=False)` — the
+  give-up, and only the give-up — latches the episode; every other caller
+  clears it, because a real ack, a deliberate drop and a command wipe all
+  carry evidence that QS is back in contact.
 - **Five clearers, one writer.** `_clear_unresponsive` is the only writer;
   it is reached by an ack, by the empty-slot re-arm, by
   `_drop_running_command` (**unconditionally** — an emptied slot has no
   owner for the clock whether or not a confirmed command ever existed), by
   the `NUM_MAX_INVALID_PROBES_COMMANDS` give-up in `check_commands`
-  (QS-307), and by a `keep_commands=False` wipe. It also clears the
+  (QS-307, the one `earned_recovery=False` caller), and by a
+  `keep_commands=False` wipe. It also clears the
   supersede anchor
   *ahead of* its own early return, so the two fields cannot
   desynchronise.
@@ -155,6 +169,17 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
 - **A disabled load never shouts.** The escalation branch is gated on
   `qs_enable_device`; the housekeeping half still runs. QS was
   explicitly told to leave the load alone, so it must not push.
+- **`_escalate_or_recover`'s `current_command is not None` gate is
+  load-bearing (QS-307).** Not for `unresponsive_since` — every
+  slot-emptying path releases the clock at its own call site, so there is
+  never a live one left here — but for `_unresponsive_needs_ack`. Reaching
+  the housekeeping arm with `current_command is None` means the give-up ran
+  earlier in **this same cycle** and nulled it; an unconditional
+  `earned_recovery=True` release here would clear the episode latch one
+  statement later and restore the push storm it exists to damp. Note
+  `_last_supersede_time` is cleared *outside* that gate, on purpose — the
+  two fields answer different questions, so read the comment for which
+  sentence governs which.
 - **No shape keeps the clock with an empty slot (QS-307, from #308).** The
   last one that did was the `NUM_MAX_INVALID_PROBES_COMMANDS` give-up: it
   goes through `_ack_command(time, None)`, which nulls `current_command` on
@@ -169,17 +194,17 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   unavailable")` right after the give-up, next to the state destruction that
   motivates it. `_ack_command` itself is unchanged — the release lives at the
   caller so "acked" and "gave up" stay distinguishable in the log.
-  Re-escalation cannot storm: `_escalate_or_recover` resets the rung on every
-  emptied slot, and one give-up window
+  Two things stop re-escalation storming, and **both** are needed. The rung
+  reset (`_escalate_or_recover` zeroes `running_command_num_relaunch` on
+  every emptied slot, and one give-up window
   (`NUM_MAX_INVALID_PROBES_COMMANDS` × cycle ≈ 70 s) is far too short to
-  climb back to `NUM_MAX_COMMAND_RELAUNCH`. The supersede **anchor** was
+  climb back to `NUM_MAX_COMMAND_RELAUNCH`) covers a rung earned *inside* a
+  give-up window. The **episode latch** covers a rung earned *before* one,
+  which is the case the rung argument alone misses — see "Two clocks, not
+  one" above. The supersede **anchor** was
   already released on that path (in `_escalate_or_recover`'s housekeeping
   arm, outside the `current_command` gate) so a fresh command's first
   legitimate supersede is not throttled.
-  *Accepted residual:* an **intermittently** available device — visible-stuck
-  long enough to escalate, then unavailable for a give-up window, repeating
-  — can now push about once per such cycle (~19 min) where the old
-  once-ever guard capped it at one. Each push describes a real new episode.
 - **"One service call per 300 s" is per command *identity*, not per
   load.** The relaunch ladder and the supersede throttle are measured on
   two independent anchors, so a relaunch immediately followed by a

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -89,20 +89,19 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   escalation; nothing exposes it to Home Assistant. That is why a clock
   that outlives its command is a nuisance rather than a user-visible bug.
 - **`is_uncontrollable` needs `running_command is not None`.** That
-  conjunct is load-bearing, not defensive. The remaining path that
-  empties the slot while keeping the clock is the
-  `NUM_MAX_INVALID_PROBES_COMMANDS` give-up, which nulls
-  `current_command` on purpose (preserving it would bill phantom
-  consumption into the persisted forecast) and so cannot re-arm. Without
-  the conjunct an `unresponsive_since`-only property would stay `True`
-  forever with no retry left to clear it. If we are not waiting on
-  anything, we are not uncontrollable. That give-up also makes the *next*
-  command inherit the clock — see #308.
-- **Four clearers, one writer.** `_clear_unresponsive` is the only writer;
+  conjunct is load-bearing, not defensive. Without it an
+  `unresponsive_since`-only property would stay `True` forever with no
+  retry left to clear it. If we are not waiting on anything, we are not
+  uncontrollable. QS-307 (from #308) closed the last path that emptied
+  the slot while keeping the clock, so a set clock now always describes
+  a live, unresolved episode.
+- **Five clearers, one writer.** `_clear_unresponsive` is the only writer;
   it is reached by an ack, by the empty-slot re-arm, by
   `_drop_running_command` (**unconditionally** — an emptied slot has no
-  owner for the clock whether or not a confirmed command ever existed), and
-  by a `keep_commands=False` wipe. It also clears the supersede anchor
+  owner for the clock whether or not a confirmed command ever existed), by
+  the `NUM_MAX_INVALID_PROBES_COMMANDS` give-up in `check_commands`
+  (QS-307), and by a `keep_commands=False` wipe. It also clears the
+  supersede anchor
   *ahead of* its own early return, so the two fields cannot
   desynchronise.
 - **Both clock comparisons go through `_seconds_since`.** It returns
@@ -156,17 +155,31 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
 - **A disabled load never shouts.** The escalation branch is gated on
   `qs_enable_device`; the housekeeping half still runs. QS was
   explicitly told to leave the load alone, so it must not push.
-- **One shape keeps the clock with an empty slot**: the
-  `NUM_MAX_INVALID_PROBES_COMMANDS` give-up goes through
-  `_ack_command(time, None)`, which nulls `current_command` on purpose
-  (preserving it would bill phantom consumption into the persisted
-  forecast) and so cannot re-arm. The *next* command therefore inherits
-  the clock. Consequence is limited to supersede-vs-stack choice — there
-  is no entity exposing `is_uncontrollable` — and the once-only guard
-  means no repeat notification. The supersede **anchor** is released on
-  that path (in `_escalate_or_recover`'s housekeeping arm, outside the
-  `current_command` gate) so a fresh command's first legitimate supersede
-  is not throttled.
+- **No shape keeps the clock with an empty slot (QS-307, from #308).** The
+  last one that did was the `NUM_MAX_INVALID_PROBES_COMMANDS` give-up: it
+  goes through `_ack_command(time, None)`, which nulls `current_command` on
+  purpose (preserving it would bill phantom consumption into the persisted
+  forecast) — and that is exactly what put it out of reach of
+  `_escalate_or_recover`'s `current_command is not None` re-arm. The clock
+  survived describing a command that no longer existed, and the *next*
+  command inherited it: `is_uncontrollable` on its first cycle, so it
+  **superseded** where it should have stacked, and the once-only guard then
+  silenced every genuinely new episode for the rest of the load's life.
+  `check_commands` now calls `_clear_unresponsive("the probe went
+  unavailable")` right after the give-up, next to the state destruction that
+  motivates it. `_ack_command` itself is unchanged — the release lives at the
+  caller so "acked" and "gave up" stay distinguishable in the log.
+  Re-escalation cannot storm: `_escalate_or_recover` resets the rung on every
+  emptied slot, and one give-up window
+  (`NUM_MAX_INVALID_PROBES_COMMANDS` × cycle ≈ 70 s) is far too short to
+  climb back to `NUM_MAX_COMMAND_RELAUNCH`. The supersede **anchor** was
+  already released on that path (in `_escalate_or_recover`'s housekeeping
+  arm, outside the `current_command` gate) so a fresh command's first
+  legitimate supersede is not throttled.
+  *Accepted residual:* an **intermittently** available device — visible-stuck
+  long enough to escalate, then unavailable for a give-up window, repeating
+  — can now push about once per such cycle (~19 min) where the old
+  once-ever guard capped it at one. Each push describes a real new episode.
 - **"One service call per 300 s" is per command *identity*, not per
   load.** The relaunch ladder and the supersede throttle are measured on
   two independent anchors, so a relaunch immediately followed by a
@@ -270,11 +283,13 @@ Switching-cost protection (`AbstractDevice`):
 - Keying "we have lost control" on `running_command_num_relaunch`.
   `abandon_running_command` no longer zeroes it, but `_ack_command`
   still does — read `is_uncontrollable` instead (QS-304).
-- Adding a give-up that empties `running_command` without either
-  clearing `unresponsive_since` (sensor pinned on, recovery edge
-  unreachable) or deliberately keeping it (a probe that went
-  *unavailable* is the device failing harder, not recovering — that is
-  why the empty-slot clear is guarded on `current_command is not None`).
+- Adding a give-up that empties `running_command` without clearing
+  `unresponsive_since`. The clock describes an in-flight command; with the
+  slot empty it is ownerless, and the next command inherits supersede
+  semantics with zero evidence of its own. "The device is failing harder,
+  so keep the clock" sounds right and is wrong (QS-307, from #308) — keep
+  the *reason string* honest instead; `_clear_unresponsive` is reason-led
+  precisely so a release does not have to claim a recovery.
 - Calling `abandon_running_command` on a path that does not go on to
   launch a successor. It preserves the rung by design; use
   `_drop_running_command` instead, or the next command inherits a spent

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -200,9 +200,10 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   never a live one left here — but for `_unresponsive_needs_ack`. Reaching
   the housekeeping arm with `current_command is None` means the give-up ran
   earlier in **this same cycle** and may have just latched the episode; the
-  release here is `CONFIRMED`, which clears the latch
-  *unconditionally*, so without the gate it would undo that one statement
-  later and re-announce an already-announced incident. Note
+  release here is `CONFIRMED`, which clears the latch *unconditionally*, so
+  without the gate it would undo that one statement later. The invariant to
+  keep in mind: only the give-up sets the latch, and the give-up nulls
+  `current_command`. Note
   `_last_supersede_time` is cleared *outside* that gate, on purpose — the
   two fields answer different questions, so read the comment for which
   sentence governs which.
@@ -216,9 +217,9 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   command inherited it: `is_uncontrollable` on its first cycle, so it
   **superseded** where it should have stacked, and the once-only guard then
   silenced every genuinely new episode for the rest of the load's life.
-  `check_commands` now calls `_clear_unresponsive("the probe went
-  unavailable")` right after the give-up, next to the state destruction that
-  motivates it. `_ack_command` itself is unchanged — the release lives at the
+  `check_commands` now calls `_clear_unresponsive("the probe went unavailable",
+  contact=ContactEvidence.UNREACHABLE)` right after the give-up, next to the
+  state destruction that motivates it. `_ack_command` itself is unchanged — the release lives at the
   caller so "acked" and "gave up" stay distinguishable in the log.
   Two things stop *this release* re-announcing, and **both** are needed. The
   rung reset (`_escalate_or_recover` zeroes `running_command_num_relaunch` on

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -104,17 +104,34 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   answering-but-disobeying: `running_command_num_relaunch_after_invalid` is
   cumulative over a command's life, so the give-up can fire long after the
   threshold was crossed by ordinary relaunches, and each release re-opened
-  the guard. `_clear_unresponsive(reason, earned_recovery=False)` — the
-  give-up, and only the give-up — latches the episode; every other caller
-  clears it, because a real ack, a deliberate drop and a command wipe all
-  carry evidence that QS is back in contact.
-- **Five clearers, one writer.** `_clear_unresponsive` is the only writer;
+  the guard.
+- **`_clear_unresponsive(reason, contact=...)` — three values, because two
+  were not enough.** The parameter says what the release tells us about the
+  device, and only that decides whether an **episode** ended:
+  - `CONTACT_CONFIRMED` (the default; the real ack in `_ack_command`, and the
+    empty-slot re-arm) **clears** the latch, and does so *unconditionally* —
+    an ack is contact whether or not there was a clock left to release.
+  - `CONTACT_NONE` (the invalid-probe give-up, the only such caller)
+    **latches** it — but only when it actually released a live clock. Latching
+    a release that released nothing swallowed the load's first genuine push
+    forever, and that is the *ordinary* ordering: the give-up fires ~70 s in,
+    the escalation threshold is ~1050 s away.
+  - `CONTACT_UNKNOWN` (`_drop_running_command`, the `keep_commands=False`
+    wipe) **leaves it alone**. These are QS changing its mind — the user took
+    control, the load was disabled, an override expired — and say nothing
+    about whether the device answers. Calling them recoveries let a latched
+    flapping load shout again on its next ladder climb, once per drop.
+
+  So: an episode ends only on a real ack (or the confirmed-command re-arm).
+  Nothing else, and in particular not a drop we chose ourselves.
+- **Five releasers, one writer.** `_clear_unresponsive` is the only writer;
   it is reached by an ack, by the empty-slot re-arm, by
   `_drop_running_command` (**unconditionally** — an emptied slot has no
   owner for the clock whether or not a confirmed command ever existed), by
   the `NUM_MAX_INVALID_PROBES_COMMANDS` give-up in `check_commands`
-  (QS-307, the one `earned_recovery=False` caller), and by a
-  `keep_commands=False` wipe. It also clears the
+  (QS-307, the one `CONTACT_NONE` caller), and by a
+  `keep_commands=False` wipe. All five release the *clock*; which of them end
+  an *episode* is the `contact` question above. It also clears the
   supersede anchor
   *ahead of* its own early return, so the two fields cannot
   desynchronise.
@@ -174,9 +191,10 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   slot-emptying path releases the clock at its own call site, so there is
   never a live one left here — but for `_unresponsive_needs_ack`. Reaching
   the housekeeping arm with `current_command is None` means the give-up ran
-  earlier in **this same cycle** and nulled it; an unconditional
-  `earned_recovery=True` release here would clear the episode latch one
-  statement later and restore the push storm it exists to damp. Note
+  earlier in **this same cycle** and may have just latched the episode; the
+  release here is `CONTACT_CONFIRMED`, which clears the latch
+  *unconditionally*, so without the gate it would undo that one statement
+  later and restore the push storm the latch exists to damp. Note
   `_last_supersede_time` is cleared *outside* that gate, on purpose — the
   two fields answer different questions, so read the comment for which
   sentence governs which.

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -105,31 +105,39 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   cumulative over a command's life, so the give-up can fire long after the
   threshold was crossed by ordinary relaunches, and each release re-opened
   the guard.
-- **`_clear_unresponsive(reason, contact=...)` — three values, because two
-  were not enough.** The parameter says what the release tells us about the
-  device, and only that decides whether an **episode** ended:
-  - `CONTACT_CONFIRMED` (the default; the real ack in `_ack_command`, and the
-    empty-slot re-arm) **clears** the latch, and does so *unconditionally* —
-    an ack is contact whether or not there was a clock left to release.
-  - `CONTACT_NONE` (the invalid-probe give-up, the only such caller)
+- **`_clear_unresponsive(reason, contact=ContactEvidence...)`.** The argument
+  says what the release tells us about the device, and only that decides
+  whether an **episode** ended. It is **required** and an `enum`, so a
+  forgotten kwarg is a `TypeError` and a typo an `AttributeError` — defaulting
+  to the episode-ending value would let a future caller end an incident by
+  omission.
+  - `CONFIRMED` (the real ack in `_ack_command`, and the empty-slot re-arm)
+    **clears** the latch, *unconditionally* — an ack is contact whether or not
+    there was a clock left to release.
+  - `UNREACHABLE` (the invalid-probe give-up, the only such caller)
     **latches** it — but only when it actually released a live clock. Latching
     a release that released nothing swallowed the load's first genuine push
     forever, and that is the *ordinary* ordering: the give-up fires ~70 s in,
     the escalation threshold is ~1050 s away.
-  - `CONTACT_UNKNOWN` (`_drop_running_command`, the `keep_commands=False`
-    wipe) **leaves it alone**. These are QS changing its mind — the user took
+  - `UNKNOWN` (`_drop_running_command`, the `keep_commands=False` wipe)
+    **leaves it alone**. These are QS changing its mind — the user took
     control, the load was disabled, an override expired — and say nothing
-    about whether the device answers. Calling them recoveries let a latched
-    flapping load shout again on its next ladder climb, once per drop.
+    about whether the device answers.
 
-  So: an episode ends only on a real ack (or the confirmed-command re-arm).
-  Nothing else, and in particular not a drop we chose ourselves.
+  **What the third value is for, precisely.** Measured against the parity
+  oracle, a two-valued signal is enough for the flapping scenario on its own.
+  `UNKNOWN` exists because QS-307 *added* a drop the codebase did not have —
+  the override-expiry drop in `check_load_activity_and_constraints` — and
+  without it that new drop would re-announce an already-announced incident.
+  That it also quiets the two pre-existing drop paths (where `main` does
+  re-announce) is a bonus, not the justification. Do not read it as a general
+  alert-deduplication guarantee: see the storm caveat below.
 - **Five releasers, one writer.** `_clear_unresponsive` is the only writer;
   it is reached by an ack, by the empty-slot re-arm, by
   `_drop_running_command` (**unconditionally** — an emptied slot has no
   owner for the clock whether or not a confirmed command ever existed), by
   the `NUM_MAX_INVALID_PROBES_COMMANDS` give-up in `check_commands`
-  (QS-307, the one `CONTACT_NONE` caller), and by a
+  (QS-307, the one `UNREACHABLE` caller), and by a
   `keep_commands=False` wipe. All five release the *clock*; which of them end
   an *episode* is the `contact` question above. It also clears the
   supersede anchor
@@ -192,9 +200,9 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   never a live one left here — but for `_unresponsive_needs_ack`. Reaching
   the housekeeping arm with `current_command is None` means the give-up ran
   earlier in **this same cycle** and may have just latched the episode; the
-  release here is `CONTACT_CONFIRMED`, which clears the latch
+  release here is `CONFIRMED`, which clears the latch
   *unconditionally*, so without the gate it would undo that one statement
-  later and restore the push storm the latch exists to damp. Note
+  later and re-announce an already-announced incident. Note
   `_last_supersede_time` is cleared *outside* that gate, on purpose — the
   two fields answer different questions, so read the comment for which
   sentence governs which.
@@ -212,17 +220,26 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   unavailable")` right after the give-up, next to the state destruction that
   motivates it. `_ack_command` itself is unchanged — the release lives at the
   caller so "acked" and "gave up" stay distinguishable in the log.
-  Two things stop re-escalation storming, and **both** are needed. The rung
-  reset (`_escalate_or_recover` zeroes `running_command_num_relaunch` on
+  Two things stop *this release* re-announcing, and **both** are needed. The
+  rung reset (`_escalate_or_recover` zeroes `running_command_num_relaunch` on
   every emptied slot, and one give-up window
   (`NUM_MAX_INVALID_PROBES_COMMANDS` × cycle ≈ 70 s) is far too short to
   climb back to `NUM_MAX_COMMAND_RELAUNCH`) covers a rung earned *inside* a
   give-up window. The **episode latch** covers a rung earned *before* one,
   which is the case the rung argument alone misses — see "Two clocks, not
-  one" above. The supersede **anchor** was
+  one" above. Together they hold the measured parity with `main`: an
+  intermittently unreachable device produces **1 alert per 105 min** on both,
+  where the release without the latch produced 5. The supersede **anchor** was
   already released on that path (in `_escalate_or_recover`'s housekeeping
   arm, outside the `current_command` gate) so a fresh command's first
   legitimate supersede is not throttled.
+
+  **Scope caveat — this is not general alert deduplication.** A device that
+  stays *reachable* and simply never obeys re-crosses the threshold about every
+  18.5 minutes and alerts every time, on this code and on `main` alike. That is
+  pre-existing and deliberately untouched here; it is tracked in
+  [#319](https://github.com/tmenguy/quiet-solar/issues/319), where the
+  notification policy it needs can be designed properly.
 - **"One service call per 300 s" is per command *identity*, not per
   load.** The relaunch ladder and the supersede throttle are measured on
   two independent anchors, so a relaunch immediately followed by a

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -68,6 +68,19 @@ alarm at 3am is supposed to wake you).
   load that loses control, *answers again*, then loses it again pushes twice,
   while one that merely flaps without ever answering pushes once. See
   [load-base.md](load-base.md), "Two clocks, not one".
+
+  **"Once per episode" is scoped to the process lifetime.**
+  `_unresponsive_needs_ack` is deliberately **not** persisted, so an HA
+  restart or a config-entry reload resets it and a permanently flapping
+  device pushes once more per restart. That is consistent with
+  `unresponsive_since`, which is not persisted either, and for the same
+  reason: both describe an in-flight command, and a reload wipes the command
+  slot, so the episode's *subject* is gone. Persisting the latch would also
+  reintroduce the failure mode QS-307 had to fix once already — a latch
+  carried into a process where no episode has been announced silences the
+  first genuine push. If a flapping device pushing once per restart ever
+  becomes a real complaint, throttle at the notification channel rather than
+  by persisting this flag.
   It is `AbstractLoad`-only:
   the base `AbstractDevice._notify_unresponsive` is a documented no-op,
   so an uncontrollable **battery** gets the ERROR log but no push.

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -59,9 +59,16 @@ alarm at 3am is supposed to wake you).
   `AbstractLoad._notify_unresponsive` (QS-304), fired **once per episode**
   from `check_and_relaunch_command` when a load crosses the lost-control
   threshold (~1050 s of unacked relaunches). Once per *episode*, not once
-  per lifetime: QS-307 (from #308) made every slot-emptying path release
-  `unresponsive_since`, which is the once-only guard, so a load that loses
-  control, recovers and loses it again pushes twice. It is `AbstractLoad`-only:
+  per lifetime and not once per ladder climb. QS-307 (from #308) made every
+  slot-emptying path release `unresponsive_since`, so that field could no
+  longer be the guard on its own — a device flapping between unreachable and
+  answering-but-disobeying would have pushed every ~18 min forever, on a
+  channel with no notification id to collapse them. `_unresponsive_needs_ack`
+  is the actual guard: an **episode** ends only when QS gets a real ack, so a
+  load that loses control, *answers again*, then loses it again pushes twice,
+  while one that merely flaps without ever answering pushes once. See
+  [load-base.md](load-base.md), "Two clocks, not one".
+  It is `AbstractLoad`-only:
   the base `AbstractDevice._notify_unresponsive` is a documented no-op,
   so an uncontrollable **battery** gets the ERROR log but no push.
   Accepted product consequence.

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -56,35 +56,36 @@ alarm at 3am is supposed to wake you).
 - Per-person preferences (quiet hours, channel, opt-in flags) live
   on `QSPerson`.
 - `DEVICE_STATUS_CHANGE_ERROR` producers — the newest is
-  `AbstractLoad._notify_unresponsive` (QS-304), fired **once per episode**
-  from `check_and_relaunch_command` when a load crosses the lost-control
-  threshold (~1050 s of unacked relaunches). Once per *episode*, not once
-  per lifetime and not once per ladder climb. QS-307 (from #308) made every
-  slot-emptying path release `unresponsive_since`, so that field could no
-  longer be the guard on its own — a device flapping between unreachable and
-  answering-but-disobeying would have pushed every ~18 min forever, on a
-  channel with no notification id to collapse them. `_unresponsive_needs_ack`
-  is the actual guard: an **episode** ends only when QS gets a real ack, so a
-  load that loses control, *answers again*, then loses it again pushes twice,
-  while one that merely flaps without ever answering pushes once. See
-  [load-base.md](load-base.md), "Two clocks, not one".
-
-  **"Once per episode" is scoped to the process lifetime.**
-  `_unresponsive_needs_ack` is deliberately **not** persisted, so an HA
-  restart or a config-entry reload resets it and a permanently flapping
-  device pushes once more per restart. That is consistent with
-  `unresponsive_since`, which is not persisted either, and for the same
-  reason: both describe an in-flight command, and a reload wipes the command
-  slot, so the episode's *subject* is gone. Persisting the latch would also
-  reintroduce the failure mode QS-307 had to fix once already — a latch
-  carried into a process where no episode has been announced silences the
-  first genuine push. If a flapping device pushing once per restart ever
-  becomes a real complaint, throttle at the notification channel rather than
-  by persisting this flag.
-  It is `AbstractLoad`-only:
+  `AbstractLoad._notify_unresponsive` (QS-304), fired from
+  `check_and_relaunch_command` when a load crosses the lost-control threshold
+  (~1050 s of unacked relaunches). It is `AbstractLoad`-only:
   the base `AbstractDevice._notify_unresponsive` is a documented no-op,
   so an uncontrollable **battery** gets the ERROR log but no push.
   Accepted product consequence.
+
+  **How often it fires — stated exactly, because it is easy to overclaim.**
+  When QS gives up probing a device it cannot reach, the lost-control clock is
+  released so the next command is not mis-scored (QS-307, from #308).
+  `_unresponsive_needs_ack` stops that release from **re-announcing an incident
+  that was already announced** — without it, a device dropping off the network
+  intermittently alerted 5× where `main` alerted once over the same 105
+  minutes. That is the flag's entire job.
+
+  It does **not** deduplicate alerts for a device that stays *reachable* and
+  simply never obeys. That case re-crosses the threshold about every 18.5
+  minutes and alerts each time, here and on `main` alike — pre-existing,
+  measured identical, and tracked in
+  [#319](https://github.com/tmenguy/quiet-solar/issues/319), which is where a
+  general notification policy belongs.
+
+  Nor does it survive a restart: `_unresponsive_needs_ack` is deliberately
+  **not** persisted, matching `unresponsive_since`, because both describe an
+  in-flight command and a reload wipes the command slot. So a permanently
+  flapping device announces once more per HA restart. Persisting it would
+  reintroduce a failure QS-307 already had to fix — a latch carried into a
+  process where nothing has been announced silences the first genuine
+  alert — so if this ever becomes a real complaint, throttle at the channel
+  instead. Noted in #319.
 
 The push is issued **last** in `_escalate_or_recover`, and a failure in it
 cannot skip the surrounding housekeeping or mask the device exception the

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -56,9 +56,12 @@ alarm at 3am is supposed to wake you).
 - Per-person preferences (quiet hours, channel, opt-in flags) live
   on `QSPerson`.
 - `DEVICE_STATUS_CHANGE_ERROR` producers — the newest is
-  `AbstractLoad._notify_unresponsive` (QS-304), fired **once** from
-  `check_and_relaunch_command` when a load crosses the lost-control
-  threshold (~1050 s of unacked relaunches). It is `AbstractLoad`-only:
+  `AbstractLoad._notify_unresponsive` (QS-304), fired **once per episode**
+  from `check_and_relaunch_command` when a load crosses the lost-control
+  threshold (~1050 s of unacked relaunches). Once per *episode*, not once
+  per lifetime: QS-307 (from #308) made every slot-emptying path release
+  `unresponsive_since`, which is the once-only guard, so a load that loses
+  control, recovers and loses it again pushes twice. It is `AbstractLoad`-only:
   the base `AbstractDevice._notify_unresponsive` is a documented no-op,
   so an uncontrollable **battery** gets the ERROR log but no push.
   Accepted product consequence.

--- a/docs/agents/concepts/user-override.md
+++ b/docs/agents/concepts/user-override.md
@@ -4,7 +4,7 @@ slug: user-override
 kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
-last_verified: 2026-07-30
+last_verified: 2026-07-31
 ---
 
 # User override
@@ -95,6 +95,22 @@ an externally-detected override are constraint-driven:
   smaller than the configured value, a still-valid override can be
   dropped on restart — accepted conservative direction (drop early
   rather than keep poison).
+
+**An override ALWAYS expires, even on a dead load (QS-307).** The
+override lifecycle's clock-driven branches — expiry, the reset-ask
+follow-up, the post-override cooldown — run regardless of what the
+command slot holds. They read no entity state, so an unresponsive
+device cannot freeze them. Only *detection* is gated on
+`is_load_command_set()`; see the "split gate" section of
+[bistate-duration-devices.md](bistate-duration-devices.md).
+
+Before QS-307 the whole block sat behind that gate, and QS-304's
+saturating retry ladder meant the gate could stay shut forever: an
+override on a load that stopped obeying was pinned permanently, so
+`is_user_overridden()` stayed True and the load never returned to
+controlled consumption or to the solver. When debugging a stuck
+override, check the clock branches first — they are the self-heal, and
+they are deliberately independent of command state.
 
 ## Key types / structures
 

--- a/docs/agents/concepts/user-override.md
+++ b/docs/agents/concepts/user-override.md
@@ -80,6 +80,18 @@ an externally-detected override are constraint-driven:
   phantom-acked: `launch_command` drops it at the drop point and
   `force_relaunch_command` drops a stale suppressed `running_command`
   (both via `is_command_suppressed_by_override`).
+- **And the mirror image (QS-307): when the override ENDS, its own
+  command is dropped.** Nulling `external_user_initiated_state` also
+  disables the suppression drop above, so an override-aligned command
+  still in flight would keep being relaunched after the override was
+  over. Expiry is the one place that knows the override just ended, so
+  it owns that drop — for the *aligned* command only; anything else is
+  a genuine solver intent. Note this is the first command-slot mutation
+  inside `check_load_activity_and_constraints`, and three of that
+  method's callers run outside `_update_loads_lock`, so
+  `force_relaunch_command` re-checks the slot after its `await` rather
+  than assuming it still owns the command it launched. See
+  [load-base.md](load-base.md).
 - A state mismatch only classifies as a NEW override when the entity
   state is newer than `last_command_execution_time` (causality guard)
   and the 180s post-override cooldown has elapsed.

--- a/docs/agents/concepts/user-override.md
+++ b/docs/agents/concepts/user-override.md
@@ -88,10 +88,10 @@ an externally-detected override are constraint-driven:
   it owns that drop — for the *aligned* command only; anything else is
   a genuine solver intent. Note this is the first command-slot mutation
   inside `check_load_activity_and_constraints`, and three of that
-  method's callers run outside `_update_loads_lock`, so
-  `force_relaunch_command` re-checks the slot after its `await` rather
-  than assuming it still owns the command it launched. See
-  [load-base.md](load-base.md).
+  method's callers run outside `_update_loads_lock`, so both
+  `launch_command` and `force_relaunch_command` re-check the slot after
+  their `await` rather than assuming they still own the command they
+  launched. See [load-base.md](load-base.md).
 - A state mismatch only classifies as a NEW override when the entity
   state is newer than `last_command_execution_time` (causality guard)
   and the 180s post-override cooldown has elapsed.
@@ -111,12 +111,14 @@ an externally-detected override are constraint-driven:
 **An override ALWAYS expires, even on a dead load (QS-307).** The
 override lifecycle's clock-driven branches — expiry, the reset-ask
 follow-up, the post-override cooldown drain — run regardless of what
-the command slot holds, and regardless of whether the load even
-*supports* overrides any more. They read no entity state, so an
-unresponsive device cannot freeze them. Only *detection* is gated, on
-`support_user_override() and is_load_command_set()`; see the "split
-gate" section of
-[bistate-duration-devices.md](bistate-duration-devices.md).
+the command slot holds. They read no entity state, so an unresponsive
+device cannot freeze them. Only *detection* is gated on
+`is_load_command_set()`; see the "split gate" section of
+[bistate-duration-devices.md](bistate-duration-devices.md). (A load that
+cannot have an override at all is still gated out entirely, by
+`support_user_override()` on the outer gate — and a stored override on
+such a load is dropped at restore rather than left for a lifecycle that
+will never run.)
 
 Before QS-307 the whole block sat behind that gate, and QS-304's
 saturating retry ladder meant the gate could stay shut forever: an

--- a/docs/agents/concepts/user-override.md
+++ b/docs/agents/concepts/user-override.md
@@ -98,19 +98,31 @@ an externally-detected override are constraint-driven:
 
 **An override ALWAYS expires, even on a dead load (QS-307).** The
 override lifecycle's clock-driven branches — expiry, the reset-ask
-follow-up, the post-override cooldown — run regardless of what the
-command slot holds. They read no entity state, so an unresponsive
-device cannot freeze them. Only *detection* is gated on
-`is_load_command_set()`; see the "split gate" section of
+follow-up, the post-override cooldown drain — run regardless of what
+the command slot holds, and regardless of whether the load even
+*supports* overrides any more. They read no entity state, so an
+unresponsive device cannot freeze them. Only *detection* is gated, on
+`support_user_override() and is_load_command_set()`; see the "split
+gate" section of
 [bistate-duration-devices.md](bistate-duration-devices.md).
 
 Before QS-307 the whole block sat behind that gate, and QS-304's
 saturating retry ladder meant the gate could stay shut forever: an
 override on a load that stopped obeying was pinned permanently, so
 `is_user_overridden()` stayed True and the load never returned to
-controlled consumption or to the solver. When debugging a stuck
-override, check the clock branches first — they are the self-heal, and
-they are deliberately independent of command state.
+controlled consumption or to the solver.
+
+**The lifecycle does not end at expiry.**
+`reset_override_state_and_set_reset_ask_time` nulls the override state
+but arms `asked_for_reset_user_initiated_state_time`, and
+`get_override_state()` reports `ASKED FOR RESET` while that is set — so
+`is_user_overridden()` is still `True` and
+`get_device_power_latest_possible_valid_value(ignore_auto_and_user_overridden_load=True)`
+still returns `0.0`. Any change that lets the override expire but not
+the cooldown has not fixed anything; it has moved the bug one step
+later. When debugging a stuck override, walk all three clock branches —
+they are the self-heal, and they are deliberately independent of
+command state.
 
 ## Key types / structures
 

--- a/docs/stories/QS-307.story.md
+++ b/docs/stories/QS-307.story.md
@@ -247,10 +247,12 @@ no longer the whole truth:
 Neither changes anything for a load with an empty slot, which is the only state `main`
 could reach these branches in at all.
 
-All three clock comparisons go through `AbstractDevice._seconds_since` (review
-fix #01/08), which treats a future-dated anchor as **fully elapsed**. A raw
-subtraction would freeze whatever it gates for the whole duration of a backwards
-clock step, and the cooldown drain is now the *only* release of that timer.
+The two override clock comparisons go through
+`AbstractDevice._seconds_since_skew_tolerant`, **not** the raw `_seconds_since` —
+D7 reversed exactly the "any future-dated anchor is fully elapsed" reading that this
+paragraph used to state, because it destroyed brand-new overrides. A raw subtraction
+would freeze whatever it gates for the whole duration of a backwards clock step, and
+the cooldown drain is the *only* release of that timer, so both directions matter.
 
 ### D3 — why not open detection too
 
@@ -299,10 +301,11 @@ This was #308's explicitly "Rejected 1" option, rejected solely because it dropp
 `qs_load_uncontrollable` duty cycle to ~0%. That objection died with the sensor
 (cut in `11d25d98`). Do not re-litigate it.
 
-**Naming caveat — resolved, not accepted (review fix #01/10).** The clear no longer
-reuses `REGAINED_CONTROL_LOG`. `_clear_unresponsive` takes `earned_recovery: bool =
-True` (see D6) and emits a distinct line, `"Lost-control clock released without
-contact for load ..."`, when it is `False`. A release stops implying a recovery.
+**Naming caveat — resolved, not accepted.** The clear no longer reuses
+`REGAINED_CONTROL_LOG`. `_clear_unresponsive` takes a required
+`contact: ContactEvidence` (see D6) and emits a distinct line, `"Lost-control clock
+released without contact for load ..."`, for `ContactEvidence.UNREACHABLE`. A release
+stops implying a recovery.
 
 ### D5 — the re-arm cannot become a push storm
 
@@ -325,14 +328,36 @@ Pinned by AC9 as a constants assertion so a future constant change fails loudly.
 
 ### D6 — the episode latch (review fix #01, must-fix)
 
-**The bug D5 missed.** For a load that both answers-but-disobeys *and* drops out
+> **Scope, measured (review fix #03).** Two alert-storm scenarios, run identically on
+> each revision:
+>
+> | Scenario | `main` | Part B without the latch | With the latch |
+> | --- | --- | --- | --- |
+> | Device **drops off the network** intermittently | 1 alert / 105 min | **5** | 1 alert / 105 min |
+> | Device **reachable but ignores commands** | **5 alerts / 105 min** | 5 | **5 alerts / 105 min** |
+>
+> Row 2 is identical on `main`: **pre-existing, not this PR's bug**, filed as
+> [#319](https://github.com/tmenguy/quiet-solar/issues/319) and deliberately out of
+> scope. Row 1 is a genuine regression this PR creates, because Part B releases the
+> lost-control clock at the give-up and that re-arms the once-only guard.
+>
+> So the latch's job is exactly one sentence: **the give-up must not re-announce an
+> incident that was already announced.** It is not general alert deduplication, and
+> nothing in this story should be read as claiming otherwise. `AC13` is the parity
+> oracle that pins row 1 at 1 alert / 105 min; any future simplification of the
+> contact signal must be checked against it rather than against reasoning.
+
+**The bug the latch fixes.** For a load that both answers-but-disobeys *and* drops out
 intermittently: fewer than 10 `None` probes land during the ~1050 s ladder climb, the
 threshold is crossed and push #1 fires; the 10th cumulative `None` then triggers the
 give-up, which releases the clock and zeroes the rung; the slot is empty so a command
 is relaunched immediately; ~1050 s later push #2 fires. Steady state: one *"Quiet
-Solar lost control of X"* push every ~18–20 min, indefinitely, for a device whose
-situation never changed — on a fire-and-forget channel with no notification id, so
-they accumulate on the phone and cannot be collapsed or dismissed.
+Solar lost control of X"* push every ~18–20 min for a device whose situation never
+changed — on a fire-and-forget channel with no notification id, so they accumulate on
+the phone and cannot be collapsed or dismissed. D5's constants argument does not cover
+it: it only proves a single give-up window is too short to climb the ladder, and
+`running_command_num_relaunch_after_invalid` is cumulative over a command's life, so a
+give-up can fire long after the threshold was crossed by ordinary relaunches.
 
 **Reverting the clock release is not an option** — that release is #308's fix, and
 AC9/AC12 depend on it. The defect is not that the clock is released; it is that
@@ -368,9 +393,13 @@ Two failures made those two refinements necessary, both found in round 4:
   AC21 pins it.
 - **Three callers cleared the latch without any device contact.** A drop is QS
   changing its mind — the user took control, the load was disabled, an override
-  expired (D1d, new in round 3) — so treating it as a recovery let a latched flapping
-  load shout again on its next ladder climb, once per drop. AC22 pins the missing
-  "and *only* a real ack".
+  expired — so treating it as a recovery let a latched load re-announce on its next
+  ladder climb, once per drop. Re-measured in round 4 (review fix #03): a two-valued
+  signal is enough for the parity oracle on its own, so `ContactEvidence.UNKNOWN`
+  earns its keep for a narrower reason — **D1d's expiry-time drop is new in this
+  PR**, `main` has no drop in that branch at all, and without `UNKNOWN` that new drop
+  would re-announce. That it also quiets the two pre-existing drop paths (where `main`
+  does re-announce) is a bonus, not the justification. AC22 pins the contract.
 
 `_unresponsive_needs_ack` is **not persisted**, matching `unresponsive_since`: both
 describe an in-flight command, and a reload wipes the command slot, so the episode's
@@ -408,9 +437,19 @@ in fact stronger, since the clear no longer depends on the early return either.
 than decorative: a second episode requires a real ack in between. The AC10 timeline is
 amended to include one (see AC10).
 
-**Residual, now bounded:** a flapping device pushes **once** and then stays quiet until
-it actually answers a command. The cost is that a genuinely new episode on a device
-that never acks in between is silent — correct, because it is not a new episode.
+**Residual, now bounded:** a device dropping off the network intermittently alerts
+**once** and then stays quiet until it actually answers a command — parity with
+`main`, pinned by AC13. The cost is that a genuinely new episode on a device that
+never acks in between is silent, which is correct: it is not a new episode.
+
+**Residual NOT addressed here, and not this story's (#319).** A device that stays
+*reachable* and simply never obeys re-crosses the threshold about every 18.5 minutes
+and alerts every time. Measured identical on `main` (5 alerts / 105 min on both), so
+it is pre-existing rather than a regression, and fixing it needs a notification-policy
+design this story should not improvise. Tracked as
+[#319](https://github.com/tmenguy/quiet-solar/issues/319) and referenced from #307's
+closing comment. The unpersisted-latch question (a flapping device announcing once per
+HA restart) is noted there too, since the right answer depends on that policy.
 
 ### D7 — the clock-skew tolerance band (review fix #02, must-fix)
 
@@ -432,13 +471,22 @@ concurrently-running `async_update_loads` cycle is still carrying an earlier
 the cycle time that evaluates it, and that cycle expired it immediately.
 
 **Fix:** `AbstractDevice._seconds_since_skew_tolerant`, shared by the expiry and the
-cooldown drain rather than open-coded twice. Future by less than
+cooldown drain rather than open-coded twice. Future by **at most**
 `CLOCK_SKEW_TOLERANCE_S` ⇒ **zero elapsed** (just armed, not expired); beyond it ⇒
 `None`, preserving `_seconds_since`'s fully-elapsed meaning for the genuine
 large-backwards-jump case that AC20 pins. The band is the same ±60 s that
 `use_saved_extra_device_info` already grants these very timestamps at the restore
-boundary ("a small tolerance for benign skew"), so this is a precedent applied
-consistently rather than a new tunable. AC23/AC24 pin both directions.
+boundary ("a small tolerance for benign skew") — and since review fix #03 that really
+is **one** constant: both restore sites import `CLOCK_SKEW_TOLERANCE_S` instead of
+hard-coding `-60.0`, so retuning it cannot desync them. AC23/AC24 pin both directions.
+
+**Residual (accepted, recorded rather than fixed).** The band does not close the race
+in general — it only absorbs skew smaller than itself. The skew it must absorb is
+bounded by how long one `update_loads` pass takes to reach this load, and nothing caps
+that: `_update_loads_lock` only skips re-entrant *starts*. A pass that stalls for more
+than `CLOCK_SKEW_TOLERANCE_S` before reaching a load reproduces the original harm in
+full. The real fix is threading the cycle's `event_time` through the service handlers,
+which is out of scope here and tracked below.
 
 **Deliberately out of scope:** making those unlocked `datetime.now(pytz.UTC)` call
 sites take the cycle's `event_time`. That is the deeper fix for the concurrency route
@@ -544,12 +592,14 @@ closing comment on `#307`.
 - **AC12 — the next command starts clean.** The command launched after a give-up has
   `is_uncontrollable is False` on its first cycle and therefore **stacks** rather
   than supersedes (`load.py:881`).
-- **AC13 — a flapping device shouts once** (review fix #01, must-fix; D6). Repeat
-  [unavailable for one give-up window → visible-stuck for a full `LADDER_WALL_S`]
-  three times after a legitimate first escalation ⇒ still **one** push and **no**
-  further `LOST_CONTROL_LOG`, while `unresponsive_since` is still re-armed each climb
-  (`is_uncontrollable is True`) so supersede semantics survive. Then a real ack ⇒ a
-  subsequent episode escalates again.
+- **AC13 — the parity oracle: 1 alert / 105 min, matching `main`** (D6, must-fix).
+  Repeat [unavailable for one give-up window → visible-stuck for a full
+  `LADDER_WALL_S`] across the **105 simulated minutes** the storm measurement used —
+  at least five cycles — after a legitimate first escalation ⇒ still **one** push and
+  **no** further `LOST_CONTROL_LOG`, while `unresponsive_since` is still re-armed each
+  climb (`is_uncontrollable is True`) so supersede semantics survive. Then a real ack
+  ⇒ a subsequent episode escalates again. This is the flag's entire justification and
+  the oracle any future simplification must be checked against.
 - **AC14 — the housekeeping gate is load-bearing** (D6). Covered by AC13: dropping
   `_escalate_or_recover`'s `current_command is not None` gate would clear the latch in
   the same cycle the give-up sets it, and AC13 goes red.
@@ -562,10 +612,12 @@ closing comment on `#307`.
   `False`), then visible-but-disobeying for two full ladders ⇒ **exactly one**
   `LOST_CONTROL_LOG` and one push. Also assert `_unresponsive_needs_ack is False` at
   the end of AC11, where this bug was already being driven but never observed.
-- **AC22 — only a real ack clears the latch** (D6, should-fix). A latched load whose
-  in-flight command is **dropped** (override suppression, i.e. the same
-  `_drop_running_command` the expiry-time drop uses) does **not** shout on its next
-  full ladder climb. The "and *only* a real ack" half that AC13 was missing.
+- **AC22 — a drop we chose does not re-announce an incident** (D6, should-fix).
+  A latched load whose in-flight command is **dropped** — exercised through the
+  override-suppression drop, the same `_drop_running_command` D1d's expiry-time drop
+  goes through — does not announce again on its next full ladder climb. Pins
+  `_drop_running_command`'s contact contract, **not** a general "only a real ack ever
+  clears the latch" guarantee: see D6's scope box and #319.
 - **AC23 — benign skew does not destroy a fresh override** (D7, must-fix). An override
   armed at `T`, evaluated at `T − 5 s` ⇒ state, timestamp, in-flight command,
   `get_override_state()` and the USER_OVERRIDE constraint all intact. Symmetric case
@@ -575,6 +627,18 @@ closing comment on `#307`.
   guarantee is preserved. Pinned as a unit test on
   `_seconds_since_skew_tolerant` (jitter / band edge / beyond / no anchor) plus the two
   AC20 end-to-end tests.
+
+#### Added by review fix #03
+
+- **AC25 — the expiry drop must not strand a command slot across an `await`**
+  (must-fix). D1d is the first command-slot mutation inside
+  `check_load_activity_and_constraints`, and three of that method's callers run
+  outside `_update_loads_lock`, so the slot really can empty mid-service-call. Drive
+  `force_relaunch_command` with a transport that runs the expiry while it is awaited,
+  for **both** post-await branches (`execute_command` returning `True` → the ack path,
+  and `None` → the "impossible to force" log): no exception escapes, `current_command`
+  is preserved, `is_load_command_set` still reports the load inside power accounting,
+  and no counter outlives the command it describes.
 
 ## Task breakdown
 
@@ -688,10 +752,8 @@ decision.
 
 ## Files touched
 
-| File | Part | Change |
-| --- | --- | --- |
-Updated at implement time (review fix #02/08 — the first two rows had gone stale
-against D1a/D1b/D1d and the two later fix plans).
+Updated at implement time (review fixes #02/08 and #03 — the original rows had gone
+stale against D1a/D1b/D1d and the three later fix plans).
 
 | File | Part | Change |
 | --- | --- | --- |
@@ -804,5 +866,35 @@ the closing comment, along with the deferred multi-mode detection issue.
 `str`, and `running_command is not None` is already required), and an unreachable
 conjunct would need a `# pragma` or a contrived test to keep coverage at 100% — worse
 than the clarity it buys. Also declined: persisting `_unresponsive_needs_ack` (see D6).
+
+### Round 5 (code review of `ea16763a`) — `QS-307.story_review_fix_#03.md`, applied here
+
+8 findings: **1 must-fix**, 7 corrections. The round opened by **measuring** the two
+alert-storm scenarios on `main`, on the pre-latch branch and on the branch (see D6's
+scope box), which re-scoped everything: the larger of the two storms is pre-existing,
+not a regression, and belongs to #319. This plan therefore fixed only what this PR
+itself introduced and deleted every claim that overstated the rest.
+
+The must-fix was the last correctness defect the PR still owned, and it was a
+consequence of D1d: the expiry-time drop is the **first command-slot mutation inside
+`check_load_activity_and_constraints`**, and three of that method's callers run
+outside `_update_loads_lock`. So "each command-slot mutation happens between `await`s"
+— an invariant the retry lifecycle states in-code and relies on — stopped being true,
+and `force_relaunch_command` dereferences the slot after its `await`: either
+`_ack_command(time, None)`, silently dropping the load out of controlled-consumption
+accounting, or a `None` deref that aborts the cycle. Fixed with a post-await re-check
+rather than a wider lock; AC25 pins both branches.
+
+Also this round: the contact signal was re-measured against the parity oracle and kept
+at three values for a narrower, honest reason (D6); it became a required `StrEnum`
+argument, since defaulting to the episode-ending value invited a future caller to end
+an incident by omission; `CLOCK_SKEW_TOLERANCE_S` became a genuine single source of
+truth (both restore sites had hard-coded `-60.0` while D7 claimed they shared it); and
+AC8's "no further override-aligned service call" assertion, which the auditor showed
+was vacuous, now drives a full relaunch ladder before re-reading the counter.
+
+**Deliberately dropped, per the plan:** the #319 storm itself; restoring the 6-hour
+push-storm horizon; persisting the latch; a speculative stranded-`_stacked_command`
+guard (the post-await re-check covers the reachable case); and three cosmetics.
 
 **Open criticals: 0.**

--- a/docs/stories/QS-307.story.md
+++ b/docs/stories/QS-307.story.md
@@ -196,8 +196,11 @@ Review fix #01/03 moved this conjunct down beside `is_load_command_set`, on the
 argument that it was a second "an override can never expire" path: a load reconfigured
 to boost-only kept a live override forever, because the only code that could clear it
 sat behind the gate. The bug was real; the fix was not proportionate. It made the whole
-override lifecycle run every cycle for every load that cannot have an override —
-chargers included — to serve one reconfiguration case.
+override lifecycle run every cycle for boost-only `QSBiStateDuration` loads, to serve
+one reconfiguration case. (An earlier draft said "chargers included" — wrong on both
+counts: `QSChargerGeneric` is not a `QSBiStateDuration` and overrides
+`check_load_activity_and_constraints` outright, so it never reaches this gate wherever
+the conjunct sits, and its `support_user_override()` returns `True` anyway.)
 
 **Reverted.** The two conjuncts answer different questions. `is_load_command_set` means
 "am I waiting on a command", which has nothing to do with clock arithmetic — splitting
@@ -205,9 +208,11 @@ chargers included — to serve one reconfiguration case.
 load have an override at all", and a load that cannot needs no lifecycle, ever.
 
 The boost-only case is handled where it belongs: `use_saved_extra_device_info` already
-drops stale and future-dated overrides, so it also drops them when
+drops stale and future-dated overrides, **and this PR adds** a drop when
 `support_user_override()` is false. A reconfigure reloads the config entry, which runs
-that path. AC17/AC18 pin both halves.
+that path. AC17/AC18 pin both halves. Scope: this drops the stored override *fields*,
+not a persisted override *constraint*, which self-heals at its `end_of_constraint`
+exactly as on `main`.
 
 #### D1d — expiry drops an override-aligned in-flight command (review fix #01/02)
 
@@ -398,7 +403,7 @@ Two failures made those two refinements necessary, both found in round 4:
 - **Three callers cleared the latch without any device contact.** A drop is QS
   changing its mind — the user took control, the load was disabled, an override
   expired — so treating it as a recovery let a latched load re-announce on its next
-  ladder climb, once per drop. Re-measured in round 4 (review fix #03): a two-valued
+  ladder climb, once per drop. Re-measured in round 5 (review fix #03): a two-valued
   signal is enough for the parity oracle on its own, so `ContactEvidence.UNKNOWN`
   earns its keep for a narrower reason — **D1d's expiry-time drop is new in this
   PR**, `main` has no drop in that branch at all, and without `UNKNOWN` that new drop
@@ -468,7 +473,7 @@ fully elapsed*, is correct for the retry ladder it was written for, where it mea
 "do not freeze the retry". On an override it means **destroy what the user just set**:
 the override state nulled, its aligned command dropped, its constraint wiped, and the
 load parked in `ASKED FOR RESET`. Review fix #02 added a ±60 s band, which narrowed the
-window without closing it — round 4 reproduced the same destruction at 90 s.
+window without closing it — round 6 reproduced the same destruction at 90 s.
 
 `main` uses plain subtraction. A future-dated anchor yields a negative age, never
 greater than the threshold, so the override simply is not expired on that cycle and
@@ -691,8 +696,10 @@ TDD: tests red first, then the change. Two commits in one PR.
    `:1166-1170` — the latter's *sole stated justification* disappears); and
    `_ack_command`'s (`:636-639`, add a pointer to the new caller-side clear).
    **Decision, do not defer:** the `current_command is not None` gate at `:1165`
-   is **kept** — redundant but harmless, and both branches stay covered. Comment
-   only.
+   is **kept**. (It read "redundant but harmless" as planned; D6 and
+   `load-base.md` later established it is **load-bearing** — it stops the
+   `CONFIRMED` release clearing the episode latch the give-up just set, AC14.)
+   Comment only.
 10. **T10 — dead-sensor sweep** (verified exhaustive, three sites): `load.py:1609`
     (`_notify_unresponsive`'s docstring cites the `qs_load_uncontrollable` binary
     sensor, cut in `11d25d98`), `tests/test_bug_304_command_deadlock.py:160`
@@ -744,7 +751,7 @@ stale against D1a/D1b/D1d and the three later fix plans).
 
 | File | Part | Change |
 | --- | --- | --- |
-| `custom_components/quiet_solar/ha_model/bistate_duration.py` | A | restructure the lifecycle chain per D1; the detection body is **not moved and not re-indented** (D1b). The only edit inside it is the cooldown block, whose expiry half moves out (D1a). Plus the expiry-time drop (D1d) and the skew-tolerant comparisons (D7) |
+| `custom_components/quiet_solar/ha_model/bistate_duration.py` | A | restructure the lifecycle chain per D1; the detection body is **not moved and not re-indented** (D1b). The only edit inside it is the cooldown block, whose expiry half moves out (D1a). Plus the expiry-time drop (D1d) and the `not support_user_override()` drops in `use_saved_extra_device_info` (D1c, the mechanism behind AC18) |
 | `custom_components/quiet_solar/home_model/load.py` | B | the give-up's clock release in `check_commands`; the `_unresponsive_needs_ack` episode latch and the three-valued `ContactEvidence` signal (D6); post-await slot re-checks in `launch_command` and `force_relaunch_command`; comments |
 | `tests/test_qs307_override_expiry_unfreeze.py` | A | new — AC1/AC1b, AC2–AC6, AC8, AC15–AC19, AC25, AC26 |
 | `tests/ha_tests/test_bug_304_uncontrollable_load.py` | A + B | AC7 rows; 1 dead docstring ref |
@@ -832,7 +839,7 @@ reviewers:
    literally in round 3, it read a few seconds of benign skew as "fully elapsed" and
    destroyed a brand-new user override. Reachable with **no clock anomaly at all**, via
    unlocked `datetime.now()` at the user-action call sites racing a cycle's
-   `event_time`. Reversed in round 5 — see D7; AC26 pins `main`'s behaviour.
+   `event_time`. Reversed in round 6 — see D7; AC26 pins `main`'s behaviour.
 
 Round 4 also confirmed a documented invariant had drifted from the code (three
 `_clear_unresponsive` callers cleared the episode latch without any device contact),

--- a/docs/stories/QS-307.story.md
+++ b/docs/stories/QS-307.story.md
@@ -25,16 +25,25 @@ Gating **detection** that way is correct: while a command is landing, observed
 state ≠ wanted state is expected, and classifying that as a user action would be
 a false positive.
 
-But the same gate also suppresses two branches that **never read entity state**:
+But the same gate also suppresses three branches that **never read entity state**:
 
 | Line | Branch | Reads entity state? |
 | --- | --- | --- |
 | `:717` | override **expiry** — `(time - external_user_initiated_state_time) > override_duration` | **no** — pure clock arithmetic |
 | `:733` | **reset-ask follow-up** — `asked_for_..._first_cmd_reset_done` | **no** — pure flag check |
+| `:851` | post-override **cooldown drain** — `asked_for_reset_user_initiated_state_time` vs `USER_OVERRIDE_STATE_BACK_DURATION_S` | **no** — pure clock arithmetic |
 | `:742+` | detection — state vs `expected_state` / `expected_state_running` | yes |
 
+> **Amended at implement time (review fix #01/04).** The `:851` row was **not** in
+> the plan as reviewed — it was found during implementation and is now designed in
+> below (D1a). Without it AC8 cannot hold: expiry hands off to
+> `asked_for_reset_user_initiated_state_time`, `get_override_state()`
+> (`load.py:1424`) returns `OVERRIDE_STATE_ASKED_FOR_RESET` while that is set, and
+> the only drain lived *inside* the detection branch. The load would expire its
+> override and still never return to controlled consumption.
+
 There is no reason for a clock comparison to be gated on command state. And because
-#304 made the relaunch backoff saturate and retry forever, the gate can stay shut
+`#304` made the relaunch backoff saturate and retry forever, the gate can stay shut
 indefinitely — so the expiry never fires.
 
 ### The user-visible bug
@@ -57,8 +66,9 @@ behind the gate.
 
 ## Goal
 
-Run the two state-free branches of the override lifecycle unconditionally, so an
-override always expires on time regardless of command state or how the device died.
+Run the state-free branches of the override lifecycle unconditionally, so an
+override always expires **and finishes expiring** on time, regardless of command
+state or how the device died.
 
 **Non-goals:** changing detection in any way; changing the retry ladder or #304's
 escalation threshold; touching `is_load_command_set` or any power-accounting call
@@ -96,7 +106,12 @@ from #307's closing comment.
 
 ## Part A — design
 
-### D1 — hoist the two state-free branches out of the gate
+### D1 — hoist the three state-free branches out of the gate
+
+> **Amended (review fix #01/04).** As reviewed, this section hoisted **two**
+> branches and specified a flat `elif self.is_load_command_set(time):`. Both changed
+> at implement time; the third branch is D1a and the shape is D1b. Review fix #01/03
+> then moved `support_user_override()` inward too — D1c.
 
 Current shape (`bistate_duration.py:696-1025`):
 
@@ -109,36 +124,104 @@ if self.is_load_command_set(time) and self.support_user_override():   # :696
         if <reset-ask pending>:                                       # :733
             ...
         else:                                                         # :742
-            <detection: reads entity state>
+            <detection: reads entity state, and drains the cooldown at :851>
 ```
 
 Target shape:
 
 ```python
-if self.qs_enable_device is not False and self.support_user_override():
+if self.qs_enable_device is not False:
     <tz coercion>                                                     # unchanged
     if <expired>:                                                     # now unconditional
+        <drop an override-ALIGNED running_command>                    # D1d
         ...
     elif <reset-ask pending>:                                         # now unconditional
         ...
-    elif self.is_load_command_set(time):                              # detection UNCHANGED
-        <detection: reads entity state>
+    else:
+        <post-override cooldown drain>                                # D1a, now unconditional
+        if self.support_user_override() and self.is_load_command_set(time):
+            <detection: reads entity state>                           # UNCHANGED
 ```
 
-Three properties of this shape:
+Properties of this shape:
 
 - **`is_load_command_set` is untouched** — body and all four call sites
   (`bistate_duration.py:696`, `device.py:671`, `device.py:871`,
   `dynamic_group.py:204`; the last three are power accounting, reaching the
   persisted forecast indirectly via `home.py:1739`). It simply moves inward to guard
-  detection only.
+  detection only. AC7 pins the body, including indifference to `unresponsive_since`.
 - **The `qs_enable_device` guard is deliberate.** `is_load_command_set` returns
   `False` for a disabled load, so without this guard the hoist would newly run expiry
   on disabled loads. Preserving today's behaviour is the conservative choice; AC4
-  pins it.
+  pins it. It is **defence in depth**: every production caller arrives via
+  `do_run_check_load_activity_and_constraints`, which already short-circuits on a
+  disabled load (`load.py:1568`), so only a direct call reaches it. `None`/unset is
+  deliberately treated as **enabled**, consistent with every other `is not False`
+  guard on the load (review fix #01/09).
 - **`do_push_constraint_after` (`:1012-1025`) is unaffected** — it is set only inside
   the detection branch, which stays gated, so the `bistate_mode_off` interaction at
   `:1027` is unchanged. Verified.
+
+#### D1a — the third state-free branch: the post-override cooldown drain
+
+Found at implement time, and **mandatory** for AC8 rather than optional. Expiry does
+not end the lifecycle; it hands off to `asked_for_reset_user_initiated_state_time`
+(the 180 s "too soon to re-override" window). While that is set,
+`get_override_state()` returns `OVERRIDE_STATE_ASKED_FOR_RESET`, so
+`is_user_overridden()` is still `True` and
+`get_device_power_latest_possible_valid_value(ignore_auto_and_user_overridden_load=True)`
+still returns `0.0`. The only drain lived at `:851`, *inside* the detection branch —
+so on an unresponsive load the override expired and the load stayed out of controlled
+consumption **forever anyway**. Same bug, one step later.
+
+The drain is pure clock arithmetic, so it hoists on exactly the same argument as the
+other two. Its **position is unchanged**: it ran in the same not-expired /
+no-reset-ask-pending arm before, so for a healthy load it still lands on exactly the
+same cycle. What stays behind at `:851` is only the *suppression* half —
+`is_command_overridden_state_changed = False` while the window is open — which is
+detection logic and belongs there. Pinned directly by AC15/AC16 rather than
+transitively through AC8.
+
+#### D1b — `else:` + nested `if`, not a flat `elif`
+
+The reviewed shape (`elif self.is_load_command_set(time):`) would dedent the whole
+~280-line detection body by four spaces. The implemented shape nests it under
+`else:` instead, which keeps every line of that body at its original indentation —
+the diff shows the branch structure changing and **nothing** moving inside. D1a needs
+a statement before the detection gate anyway, so the nesting is not merely cosmetic.
+
+#### D1c — `support_user_override()` guards detection too (review fix #01/03)
+
+Leaving it on the outer gate reintroduced this story's own bug class, in a form
+**worse** than the original: unlike the `qs_enable_device` arm it is not
+self-healing. Disabling and re-enabling a load runs the lifecycle again; flipping a
+load to boost-only (`CONF_LOAD_IS_BOOST_ONLY`) never does. Since
+`asked_for_reset_user_initiated_state_time` is persisted and
+`use_saved_extra_device_info` only drops it when *future*-dated, a load reconfigured
+to boost-only kept `is_user_overridden() is True` **forever, across restarts**. Same
+"gate detection, not lifecycle" principle, applied consistently. AC17–AC19 pin it.
+
+#### D1d — expiry drops an override-aligned in-flight command (review fix #01/02)
+
+A regression the hoist introduced, not a pre-existing bug: on `main` the
+`is_load_command_set` gate guaranteed `running_command is None` at expiry, so this
+state was unconstructible. Now it is reachable, and
+`constraint_reset_and_reset_commands_if_needed(keep_commands=True)` deliberately
+leaves the slot alone. Once `reset_override_state_and_set_reset_ask_time` nulls the
+override state, `force_relaunch_command`'s suppression drop stops applying — so QS
+kept issuing the **ended** override's own service call at the 50→300 s cadence for up
+to a full ladder, while the post-expiry intent merely stacked behind it
+(`check_commands` promotes the stack only when the slot empties, and
+`_relaunch_stale_command`'s "retry newest stacked intent" needs `is_uncontrollable`,
+still `None` below rung 6).
+
+Expiry is the one place that *knows* the override just ended, so it owns the drop.
+Only an **aligned** command is dropped — `expected_state_from_command(running_command)
+== external_user_initiated_state` — because anything else is a genuine solver intent
+that got through the degraded-override nuance and must survive `keep_commands=True`.
+`_drop_running_command`, not `abandon_running_command`: no successor is launched in
+this call, so the rung and the clock go with the slot, exactly as for the
+override-suppression drop. AC1/AC1b and AC8 pin both directions.
 
 ### D2 — the behaviour change, stated honestly
 
@@ -146,11 +229,18 @@ For a **healthy** load with an in-flight command, expiry can now fire up to one 
 earlier than before — during the command flight rather than just after it. This is a
 real change, not a no-op.
 
-It is safe because neither hoisted branch reads entity state: expiry is a comparison
-against `external_user_initiated_state_time`, and the reset-ask branch is a flag
-check. Both call
-`constraint_reset_and_reset_commands_if_needed(keep_commands=True)`, which preserves
-commands. The outcome is identical; only the cycle it lands on changes. AC3 pins it.
+It is safe because no hoisted branch reads entity state: expiry and the cooldown drain
+are comparisons against stored timestamps, and the reset-ask branch is a flag check.
+All call `constraint_reset_and_reset_commands_if_needed(keep_commands=True)`, which
+preserves commands (D1d then removes exactly one command, the ended override's own).
+The outcome is identical; only the cycle it lands on changes. AC3 pins it in **both**
+directions — the not-yet-aged override survives, and the aged one resets on the same
+cycle as on `main`.
+
+All three clock comparisons go through `AbstractDevice._seconds_since` (review
+fix #01/08), which treats a future-dated anchor as **fully elapsed**. A raw
+subtraction would freeze whatever it gates for the whole duration of a backwards
+clock step, and the cooldown drain is now the *only* release of that timer.
 
 ### D3 — why not open detection too
 
@@ -199,9 +289,10 @@ This was #308's explicitly "Rejected 1" option, rejected solely because it dropp
 `qs_load_uncontrollable` duty cycle to ~0%. That objection died with the sensor
 (cut in `11d25d98`). Do not re-litigate it.
 
-**Naming caveat (accepted):** the clear reuses `REGAINED_CONTROL_LOG`, so the log says
-the clock was released when the device went *unreachable* — not a recovery. Accepted:
-the message is reason-led by design and the reason string disambiguates.
+**Naming caveat — resolved, not accepted (review fix #01/10).** The clear no longer
+reuses `REGAINED_CONTROL_LOG`. `_clear_unresponsive` takes `earned_recovery: bool =
+True` (see D6) and emits a distinct line, `"Lost-control clock released without
+contact for load ..."`, when it is `False`. A release stops implying a recovery.
 
 ### D5 — the re-arm cannot become a push storm
 
@@ -215,12 +306,69 @@ peaks at 1 and never reaches 6.
 **Stated invariant:** `relaunches per give-up window < NUM_MAX_COMMAND_RELAUNCH`.
 Pinned by AC9 as a constants assertion so a future constant change fails loudly.
 
-**Known residual (accepted):** an *intermittently* available device — visible-stuck
-for ≥ `LADDER_WALL_S`, then unavailable for ≥ one give-up window, repeating — can now
-escalate once per cycle of that pattern (~1 push per 19 min) where today the
-once-only guard capped it at one, ever. Judged acceptable: it requires a specific
-flapping pattern, and each push describes a genuine new episode. AC10 documents the
-bound rather than enforcing one.
+> **This argument is necessary but NOT sufficient — the residual below was a real
+> bug, and D6 fixes it (review fix #01, must-fix).** D5 only proves *a single give-up
+> window is too short to climb the ladder*. It says nothing about a rung earned
+> **before** one, and `running_command_num_relaunch_after_invalid` is cumulative over
+> a command's life (`force_relaunch_command` never resets it), so a give-up can fire
+> long after the threshold was crossed by ordinary relaunches.
+
+### D6 — the episode latch (review fix #01, must-fix)
+
+**The bug D5 missed.** For a load that both answers-but-disobeys *and* drops out
+intermittently: fewer than 10 `None` probes land during the ~1050 s ladder climb, the
+threshold is crossed and push #1 fires; the 10th cumulative `None` then triggers the
+give-up, which releases the clock and zeroes the rung; the slot is empty so a command
+is relaunched immediately; ~1050 s later push #2 fires. Steady state: one *"Quiet
+Solar lost control of X"* push every ~18–20 min, indefinitely, for a device whose
+situation never changed — on a fire-and-forget channel with no notification id, so
+they accumulate on the phone and cannot be collapsed or dismissed.
+
+**Reverting the clock release is not an option** — that release is #308's fix, and
+AC9/AC12 depend on it. The defect is not that the clock is released; it is that
+`unresponsive_since` was carrying two different jobs:
+
+| Field | Scope | Job |
+| --- | --- | --- |
+| `unresponsive_since` | per **command** | drives `is_uncontrollable`, i.e. supersede-vs-stack and which intent gets retried. Must be released whenever the slot empties. |
+| `_unresponsive_needs_ack` | per **episode** | "we are still in an unresolved lost-control episode". Gates the shout. |
+
+`_clear_unresponsive(reason, earned_recovery=True)` — the give-up is the **only**
+caller passing `False`, because it is the only one where the release carries no
+evidence QS is back in contact (the device is unreachable; a real ack, a deliberate
+drop and a command wipe all do carry it). `earned_recovery=False` latches
+`_unresponsive_needs_ack`; every `True` caller clears it.
+
+**Deviation from the fix plan's Option A, deliberately.** Option A proposed adding
+`and not self._unresponsive_needs_ack` to the escalation *conjunction*, which also
+suppresses `unresponsive_since`. That would leave `is_uncontrollable` permanently
+`False` for a flapping device, disabling #304's supersede path and starving newer
+intents behind a command already known to be going nowhere — a #304 regression. So the
+latch gates **only the ERROR log and the push**; the clock is still re-armed:
+
+```python
+self.unresponsive_since = time
+if self._unresponsive_needs_ack:
+    unresponsive_command = None          # same episode, no contact since: no news
+else:
+    _LOGGER.error("Lost control of load %s: ...")
+    unresponsive_command = self.running_command
+```
+
+**`_escalate_or_recover`'s `current_command is not None` gate is now load-bearing**
+(it was described as redundant-but-kept in the first implementation, which
+review fix #01/05 flagged as contradicting `load-base.md`). The give-up runs
+earlier in the same cycle and nulls `current_command`; an unconditional
+`earned_recovery=True` release in the housekeeping arm would clear the latch one
+statement later and restore the storm.
+
+**Consequence for AC10.** "Recover" in AC10's own wording becomes load-bearing rather
+than decorative: a second episode requires a real ack in between. The AC10 timeline is
+amended to include one (see AC10).
+
+**Residual, now bounded:** a flapping device pushes **once** and then stays quiet until
+it actually answers a command. The cost is that a genuinely new episode on a device
+that never acks in between is silent — correct, because it is not a new episode.
 
 ## Acceptance criteria
 
@@ -228,17 +376,30 @@ bound rather than enforcing one.
 
 - **AC1 — expiry fires while a command is in flight.** Override aged past
   `override_duration`, `running_command` set, `current_command` set: the override is
-  reset via `reset_override_state_and_set_reset_ask_time`. Fails on `main`.
+  reset via `reset_override_state_and_set_reset_ask_time`. Fails on `main`. Amended
+  (review fix #01/02): when that in-flight command is the override's **own** service
+  call (`expected_state_from_command(running_command) ==
+  external_user_initiated_state`), assert it is **dropped** — `running_command is
+  None` — while `current_command` survives.
+- **AC1b — expiry does not over-reach** (review fix #01/02). Same setup with a
+  **non**-aligned in-flight command ⇒ it survives expiry, because
+  `keep_commands=True` still governs everything the override was not driving.
 - **AC2 — expiry fires after the invalid-probe give-up** (the *unavailable* death
   mode): `current_command is None` and `running_command is None`, override aged out
   ⇒ reset. This is the case the discarded predicate design could **not** fix; it is
   the reason Option 1 was chosen and must be pinned.
-- **AC3 — healthy-load parity.** For a load with no in-flight command, expiry and
-  reset-ask behave exactly as on `main` (same cycle, same effects). Table-driven over
-  `running_command ∈ {None, CMD_ON}` × `current_command ∈ {None, CMD_ON}` with an
-  override that is **not** yet aged out ⇒ no reset in any combination.
-- **AC4 — disabled loads unchanged.** `qs_enable_device is False` ⇒ neither hoisted
-  branch runs, even with an aged override. Pins D1's explicit guard.
+- **AC3 — healthy-load parity, both directions** (amended, review fix #01/07).
+  Parametrized over `running_command ∈ {None, CMD_ON}` × `current_command ∈ {None,
+  CMD_ON}`:
+  - **negative** — an override that is **not** yet aged out ⇒ no reset in any
+    combination;
+  - **positive** — an **aged** override resets on exactly the cycle it would on
+    `main`: still alive at exactly `override_duration` (the comparison is `>`, not
+    `>=`), reset on the next cycle, in all four combinations. Previously delegated to
+    `tests/test_qs256_override_lifecycle.py:517`/`:665`; now pinned here, since AC3
+    is billed as the safety net for D2.
+- **AC4 — disabled loads unchanged.** `qs_enable_device is False` ⇒ no hoisted branch
+  runs, even with an aged override. Pins D1's explicit guard.
 - **AC5 — reset-ask follow-up runs unconditionally.** With
   `asked_for_reset_user_initiated_state_time_first_cmd_reset_done` set and a command
   in flight, assert the `:733` branch's effects: the flag is cleared and
@@ -247,7 +408,8 @@ bound rather than enforcing one.
 - **AC6 — detection is unchanged.** The gate still shuts detection for every state
   where `is_load_command_set(time)` is `False`: with a command in flight and an
   entity state matching neither expectation, **no** override is created. This is the
-  regression pin for the non-goal.
+  regression pin for the non-goal. Complemented by the positive case — detection
+  still classifies the user once the command has landed.
 - **AC7 — `is_load_command_set` body unchanged.** Extend the existing
   `test_is_load_command_set_truth_table_is_unmodified`
   (`tests/ha_tests/test_bug_304_uncontrollable_load.py:91`) — widen its 4-tuples to
@@ -255,22 +417,64 @@ bound rather than enforcing one.
   it.
 - **AC8 — the end-to-end bug.** Worked example from Problem: override at T, device
   stops responding at T+1 h, assert the override is gone at T+8 h and the load is
-  back in controlled consumption. Asserted for **both** death modes (visible-stuck
-  and unavailable).
+  back in controlled consumption, for **both** death modes (visible-stuck and
+  unavailable). Amended (review fix #01/06): "back in controlled consumption" is
+  asserted on the **observable the Problem section blames**, not by proxy —
+  `get_device_power_latest_possible_valid_value(ignore_auto_and_user_overridden_load=True)`
+  returns `0.0` while the override stands and the load's real `power_use` afterwards.
+  Also assert no further override-aligned service call after expiry (D1d).
+
+#### Part A — added by review fix #01
+
+- **AC15 — the cooldown drain runs with a command in flight** (D1a). Pin the third
+  hoisted branch directly: `asked_for_reset_user_initiated_state_time` set,
+  `is_load_command_set(time)` `False`, past the window ⇒ drained,
+  `get_override_state()` is `NO_OVERRIDE`, `is_user_overridden()` is `False`.
+- **AC16 — the cooldown window is still honoured.** Same setup *inside* the window ⇒
+  untouched. Hoisting must not shorten the "too soon to re-override" guard.
+- **AC17 — a boost-only load still expires its override** (D1c). Aged override, then
+  `load_is_auto_to_be_boosted = True` ⇒ expiry and drain still run;
+  `is_user_overridden()` ends `False`.
+- **AC18 — and drains a reset-ask restored from storage** (D1c). `use_saved_extra_device_info`
+  with a **past**-dated `STORAGE_KEY_ASKED_FOR_RESET_TIME` on a boost-only load
+  (restore deliberately keeps those) ⇒ the drain clears it. This is the
+  across-restarts half of the bug.
+- **AC19 — detection stays off for a boost-only load.** `support_user_override()`
+  still does its real job in its new position: no override is created even with
+  `is_load_command_set(time)` `True`.
+- **AC20 — a rewound clock freezes nothing** (review fix #01/08). A future-dated
+  `asked_for_reset_user_initiated_state_time` (NTP correcting backwards *after*
+  restore, so the future-dated drop at restore could not help) is treated as fully
+  elapsed and drained; same for `external_user_initiated_state_time` and expiry.
 
 ### Part B
 
 - **AC9 — the give-up releases the clock.** After the invalid-probe give-up:
-  `unresponsive_since is None` and exactly one `REGAINED_CONTROL_LOG` line. Plus the
-  D5 constants assertion.
-- **AC10 — a second episode can escalate.** Lose control → unavailable → recover →
-  lose control again ⇒ a **second** push and log. Impossible today.
+  `unresponsive_since is None`, `_unresponsive_needs_ack is True`, and exactly one
+  release line. Amended (review fix #01/10): the line is the distinct
+  `"Lost-control clock released without contact"` message, and **zero**
+  `REGAINED_CONTROL_LOG` lines — the give-up no longer claims a recovery. Plus the D5
+  constants assertion.
+- **AC10 — a second episode can escalate.** Lose control → unavailable → **recover
+  with a real ack** → lose control again ⇒ a **second** push and log. Impossible
+  today. Amended (review fix #01): the ack is required, not incidental — see D6.
+  Without it this is the same episode, and AC13 pins that it stays quiet.
 - **AC11 — no storm.** Permanently unavailable from the start: **zero** pushes, zero
-  `REGAINED_CONTROL_LOG` lines. Drive 3–4 give-up windows (~5 min simulated), not
-  6 h — D5 makes longer horizons redundant.
+  release lines. Drive 3–4 give-up windows (~5 min simulated), not 6 h — D5 makes
+  longer horizons redundant. The pre-existing 6 h push-storm test is trimmed to the
+  same horizon (review fix #01/13).
 - **AC12 — the next command starts clean.** The command launched after a give-up has
   `is_uncontrollable is False` on its first cycle and therefore **stacks** rather
   than supersedes (`load.py:881`).
+- **AC13 — a flapping device shouts once** (review fix #01, must-fix; D6). Repeat
+  [unavailable for one give-up window → visible-stuck for a full `LADDER_WALL_S`]
+  three times after a legitimate first escalation ⇒ still **one** push and **no**
+  further `LOST_CONTROL_LOG`, while `unresponsive_since` is still re-armed each climb
+  (`is_uncontrollable is True`) so supersede semantics survive. Then a real ack ⇒ a
+  subsequent episode escalates again.
+- **AC14 — the housekeeping gate is load-bearing** (D6). Covered by AC13: dropping
+  `_escalate_or_recover`'s `current_command is not None` gate would clear the latch in
+  the same cycle the give-up sets it, and AC13 goes red.
 
 ## Task breakdown
 
@@ -287,9 +491,12 @@ TDD: tests red first, then the change. Two commits in one PR.
    `NUM_MAX_INVALID_PROBES_COMMANDS + 2` cycles. Note `qs304_helpers.drive` only
    calls `check_and_relaunch_command`; `check_load_activity_and_constraints` must be
    called explicitly (`home.py:2915` vs `:2919` are separate entry points).
-2. **T2 — the hoist.** Restructure `bistate_duration.py:696-742` per D1. No other
-   edit in that file; the detection body is moved, not modified (keep the diff a pure
-   re-indent where possible so review can see nothing changed inside).
+2. **T2 — the hoist.** Restructure `bistate_duration.py:696-742` per D1. The
+   detection body is **not** modified. As implemented (D1b) it is not even moved: the
+   `else:` + nested-`if` shape keeps every line at its original indentation, so the
+   diff shows the branch structure changing and nothing inside it. The only edit
+   *within* the old detection body is the cooldown block at `:851`, whose expiry half
+   moves out (D1a) and whose suppression half stays.
 3. **T3 — AC7.** Extend
    `tests/ha_tests/test_bug_304_uncontrollable_load.py:91-116` (4-tuples →
    5-tuples with `unresponsive_since`).

--- a/docs/stories/QS-307.story.md
+++ b/docs/stories/QS-307.story.md
@@ -130,7 +130,7 @@ if self.is_load_command_set(time) and self.support_user_override():   # :696
 Target shape:
 
 ```python
-if self.qs_enable_device is not False:
+if self.qs_enable_device is not False and self.support_user_override():
     <tz coercion>                                                     # unchanged
     if <expired>:                                                     # now unconditional
         <drop an override-ALIGNED running_command>                    # D1d
@@ -139,7 +139,7 @@ if self.qs_enable_device is not False:
         ...
     else:
         <post-override cooldown drain>                                # D1a, now unconditional
-        if self.support_user_override() and self.is_load_command_set(time):
+        if self.is_load_command_set(time):
             <detection: reads entity state>                           # UNCHANGED
 ```
 
@@ -190,16 +190,24 @@ The reviewed shape (`elif self.is_load_command_set(time):`) would dedent the who
 the diff shows the branch structure changing and **nothing** moving inside. D1a needs
 a statement before the detection gate anyway, so the nesting is not merely cosmetic.
 
-#### D1c — `support_user_override()` guards detection too (review fix #01/03)
+#### D1c — `support_user_override()` stays on the OUTER gate (reversed in review fix #04)
 
-Leaving it on the outer gate reintroduced this story's own bug class, in a form
-**worse** than the original: unlike the `qs_enable_device` arm it is not
-self-healing. Disabling and re-enabling a load runs the lifecycle again; flipping a
-load to boost-only (`CONF_LOAD_IS_BOOST_ONLY`) never does. Since
-`asked_for_reset_user_initiated_state_time` is persisted and
-`use_saved_extra_device_info` only drops it when *future*-dated, a load reconfigured
-to boost-only kept `is_user_overridden() is True` **forever, across restarts**. Same
-"gate detection, not lifecycle" principle, applied consistently. AC17–AC19 pin it.
+Review fix #01/03 moved this conjunct down beside `is_load_command_set`, on the
+argument that it was a second "an override can never expire" path: a load reconfigured
+to boost-only kept a live override forever, because the only code that could clear it
+sat behind the gate. The bug was real; the fix was not proportionate. It made the whole
+override lifecycle run every cycle for every load that cannot have an override —
+chargers included — to serve one reconfiguration case.
+
+**Reverted.** The two conjuncts answer different questions. `is_load_command_set` means
+"am I waiting on a command", which has nothing to do with clock arithmetic — splitting
+*that* out is the actual #307 fix and stays. `support_user_override()` means "can this
+load have an override at all", and a load that cannot needs no lifecycle, ever.
+
+The boost-only case is handled where it belongs: `use_saved_extra_device_info` already
+drops stale and future-dated overrides, so it also drops them when
+`support_user_override()` is false. A reconfigure reloads the config entry, which runs
+that path. AC17/AC18 pin both halves.
 
 #### D1d — expiry drops an override-aligned in-flight command (review fix #01/02)
 
@@ -247,12 +255,8 @@ no longer the whole truth:
 Neither changes anything for a load with an empty slot, which is the only state `main`
 could reach these branches in at all.
 
-The two override clock comparisons go through
-`AbstractDevice._seconds_since_skew_tolerant`, **not** the raw `_seconds_since` —
-D7 reversed exactly the "any future-dated anchor is fully elapsed" reading that this
-paragraph used to state, because it destroyed brand-new overrides. A raw subtraction
-would freeze whatever it gates for the whole duration of a backwards clock step, and
-the cooldown drain is the *only* release of that timer, so both directions matter.
+Both override clock comparisons use `main`'s plain subtraction — see D7 for why the
+"clock-safe" alternative was reversed.
 
 ### D3 — why not open detection too
 
@@ -376,9 +380,9 @@ None` early return latched releases that released nothing:
 
 | `contact` | Callers | Effect on the latch |
 | --- | --- | --- |
-| `CONTACT_CONFIRMED` (default) | the real ack in `_ack_command`; the empty-slot re-arm | **clears** it, unconditionally — an ack is contact whether or not a clock was live |
-| `CONTACT_NONE` | the invalid-probe give-up, and only it | **latches** it, but *only when a live clock was released* |
-| `CONTACT_UNKNOWN` | `_drop_running_command`, the `keep_commands=False` wipe | **leaves it unchanged** — QS changed its mind; that is evidence of nothing |
+| `ContactEvidence.CONFIRMED` | the real ack in `_ack_command`; the empty-slot re-arm | **clears** it, unconditionally — an ack is contact whether or not a clock was live |
+| `ContactEvidence.UNREACHABLE` | the invalid-probe give-up, and only it | **latches** it, but *only when a live clock was released* |
+| `ContactEvidence.UNKNOWN` | `_drop_running_command`, the `keep_commands=False` wipe | **leaves it unchanged** — QS changed its mind; that is evidence of nothing |
 
 Two failures made those two refinements necessary, both found in round 4:
 
@@ -428,7 +432,7 @@ else:
 (it was described as redundant-but-kept in the first implementation, which
 review fix #01/05 flagged as contradicting `load-base.md`). The give-up runs
 earlier in the same cycle and may have just latched the episode; the release in the
-housekeeping arm is `CONTACT_CONFIRMED`, which clears the latch *unconditionally*, so
+housekeeping arm is `ContactEvidence.CONFIRMED`, which clears the latch *unconditionally*, so
 without the gate it would undo that one statement later and restore the storm. The
 argument survives the three-valued signal (re-checked per review fix #02/03) — it is
 in fact stronger, since the clear no longer depends on the early return either.
@@ -451,47 +455,35 @@ design this story should not improvise. Tracked as
 closing comment. The unpersisted-latch question (a flapping device announcing once per
 HA restart) is noted there too, since the right answer depends on that policy.
 
-### D7 — the clock-skew tolerance band (review fix #02, must-fix)
+### D7 — REVERSED: the override clocks use `main`'s plain subtraction
 
-Adopting `_seconds_since` for the override clocks (review fix #01/08) fixed a frozen
-comparison and introduced a worse one in the other direction. `_seconds_since` returns
-`None` for **any** negative delta, and the callers read `None` as "fully elapsed" — so
-an arbitrarily small future-dating of `external_user_initiated_state_time` cancelled a
-brand-new 8-hour user override on the spot: state and timestamp nulled, the override's
-in-flight command dropped (D1d), the USER_OVERRIDE constraint wiped,
-`do_force_next_solve` set, and the load parked in `ASKED FOR RESET` for 180 s. QS
-actively fighting the user — the harm class this story exists to remove, arriving from
-the other side.
+**This section used to specify a clock-skew tolerance band. It is deleted, and the
+code is back to `main`'s arithmetic.** Recorded as a reversal rather than a
+relaxation, because the ACs removed with it (AC20, AC23, AC24) pinned behaviour that
+*was* the defect.
 
-**And it needs no clock anomaly at all.** `user_set_bistate_mode`,
-`user_set_default_on_duration` (`bistate_duration.py`) and `async_reset_override_state`
-(`load.py`) each take their **own** unlocked `datetime.now(pytz.UTC)`, while a
-concurrently-running `async_update_loads` cycle is still carrying an earlier
-`event_time` (`data_handler.py`). A user-stamped anchor can therefore sit *ahead* of
-the cycle time that evaluates it, and that cycle expired it immediately.
+Origin: review fix #01 carried a **nice-to-have** — "route the age comparisons through
+`AbstractDevice._seconds_since`". That helper's rule, *a future-dated anchor means
+fully elapsed*, is correct for the retry ladder it was written for, where it means
+"do not freeze the retry". On an override it means **destroy what the user just set**:
+the override state nulled, its aligned command dropped, its constraint wiped, and the
+load parked in `ASKED FOR RESET`. Review fix #02 added a ±60 s band, which narrowed the
+window without closing it — round 4 reproduced the same destruction at 90 s.
 
-**Fix:** `AbstractDevice._seconds_since_skew_tolerant`, shared by the expiry and the
-cooldown drain rather than open-coded twice. Future by **at most**
-`CLOCK_SKEW_TOLERANCE_S` ⇒ **zero elapsed** (just armed, not expired); beyond it ⇒
-`None`, preserving `_seconds_since`'s fully-elapsed meaning for the genuine
-large-backwards-jump case that AC20 pins. The band is the same ±60 s that
-`use_saved_extra_device_info` already grants these very timestamps at the restore
-boundary ("a small tolerance for benign skew") — and since review fix #03 that really
-is **one** constant: both restore sites import `CLOCK_SKEW_TOLERANCE_S` instead of
-hard-coding `-60.0`, so retuning it cannot desync them. AC23/AC24 pin both directions.
+`main` uses plain subtraction. A future-dated anchor yields a negative age, never
+greater than the threshold, so the override simply is not expired on that cycle and
+lasts slightly longer. Benign, and the correct direction for a user's setting. **There
+was never a bug here** — the whole chain was invented by a nice-to-have.
 
-**Residual (accepted, recorded rather than fixed).** The band does not close the race
-in general — it only absorbs skew smaller than itself. The skew it must absorb is
-bounded by how long one `update_loads` pass takes to reach this load, and nothing caps
-that: `_update_loads_lock` only skips re-entrant *starts*. A pass that stalls for more
-than `CLOCK_SKEW_TOLERANCE_S` before reaching a load reproduces the original harm in
-full. The real fix is threading the cycle's `event_time` through the service handlers,
-which is out of scope here and tracked below.
+`_seconds_since_skew_tolerant` is deleted. `CLOCK_SKEW_TOLERANCE_S` stays, used only by
+`use_saved_extra_device_info`, where a ±60 s tolerance already existed on `main` as a
+literal `-60.0`. **AC26** replaces AC20/AC23/AC24: a 90 s-ahead anchor keeps the
+override and keeps the cooldown.
 
-**Deliberately out of scope:** making those unlocked `datetime.now(pytz.UTC)` call
-sites take the cycle's `event_time`. That is the deeper fix for the concurrency route
-and has a much wider blast radius — tracked as a follow-up issue, referenced from the
-closing comment on `#307`.
+Consequence for the deferred follow-up: with `main`'s arithmetic restored, the unlocked
+`datetime.now(pytz.UTC)` race is benign for these anchors, so
+[#317](https://github.com/tmenguy/quiet-solar/issues/317)'s premise no longer holds —
+noted on the issue.
 
 ## Acceptance criteria
 
@@ -558,20 +550,19 @@ closing comment on `#307`.
   `get_override_state()` is `NO_OVERRIDE`, `is_user_overridden()` is `False`.
 - **AC16 — the cooldown window is still honoured.** Same setup *inside* the window ⇒
   untouched. Hoisting must not shorten the "too soon to re-override" guard.
-- **AC17 — a boost-only load still expires its override** (D1c). Aged override, then
-  `load_is_auto_to_be_boosted = True` ⇒ expiry and drain still run;
-  `is_user_overridden()` ends `False`.
-- **AC18 — and drains a reset-ask restored from storage** (D1c). `use_saved_extra_device_info`
-  with a **past**-dated `STORAGE_KEY_ASKED_FOR_RESET_TIME` on a boost-only load
-  (restore deliberately keeps those) ⇒ the drain clears it. This is the
-  across-restarts half of the bug.
+- **AC17 — a boost-only load runs NO override lifecycle** (D1c, reworked in review
+  fix #04). Aged override + pending reset-ask + pending follow-up flag, then
+  `load_is_auto_to_be_boosted = True` ⇒ **every field untouched**. `main`'s behaviour:
+  `support_user_override()` answers "can this load have an override at all", which is
+  not a command-state question, so it belongs on the outer gate.
+- **AC18 — and a stored override is dropped at RESTORE instead** (D1c, reworked).
+  `use_saved_extra_device_info` on a boost-only load drops the override and the
+  reset-ask even when neither is stale or future-dated — nothing downstream could ever
+  clear them. Plus the converse: a load that *does* support overrides still restores
+  them.
 - **AC19 — detection stays off for a boost-only load.** `support_user_override()`
   still does its real job in its new position: no override is created even with
   `is_load_command_set(time)` `True`.
-- **AC20 — a rewound clock freezes nothing** (review fix #01/08). A future-dated
-  `asked_for_reset_user_initiated_state_time` (NTP correcting backwards *after*
-  restore, so the future-dated drop at restore could not help) is treated as fully
-  elapsed and drained; same for `external_user_initiated_state_time` and expiry.
 
 ### Part B
 
@@ -618,15 +609,11 @@ closing comment on `#307`.
   goes through — does not announce again on its next full ladder climb. Pins
   `_drop_running_command`'s contact contract, **not** a general "only a real ack ever
   clears the latch" guarantee: see D6's scope box and #319.
-- **AC23 — benign skew does not destroy a fresh override** (D7, must-fix). An override
-  armed at `T`, evaluated at `T − 5 s` ⇒ state, timestamp, in-flight command,
-  `get_override_state()` and the USER_OVERRIDE constraint all intact. Symmetric case
-  for the cooldown drain: not drained early.
-- **AC24 — the band's far edge still expires** (D7). Future-dated beyond
-  `CLOCK_SKEW_TOLERANCE_S` ⇒ treated as fully elapsed, so AC20's large-backwards-jump
-  guarantee is preserved. Pinned as a unit test on
-  `_seconds_since_skew_tolerant` (jitter / band edge / beyond / no anchor) plus the two
-  AC20 end-to-end tests.
+- **AC26 — a confused clock KEEPS the override** (D7, reversed). An anchor dated 90 s
+  ahead of the cycle time — beyond the band review fix #02 added, so the band's absence
+  is pinned too — leaves the override state, its timestamp, its aligned in-flight
+  command and its constraint intact, and leaves the cooldown undrained. `main`'s
+  behaviour. Replaces the deleted AC20/AC23/AC24, which pinned the destruction.
 
 #### Added by review fix #03
 
@@ -758,11 +745,11 @@ stale against D1a/D1b/D1d and the three later fix plans).
 | File | Part | Change |
 | --- | --- | --- |
 | `custom_components/quiet_solar/ha_model/bistate_duration.py` | A | restructure the lifecycle chain per D1; the detection body is **not moved and not re-indented** (D1b). The only edit inside it is the cooldown block, whose expiry half moves out (D1a). Plus the expiry-time drop (D1d) and the skew-tolerant comparisons (D7) |
-| `custom_components/quiet_solar/home_model/load.py` | B | the give-up's clock release in `check_commands`; the `_unresponsive_needs_ack` episode latch and the three-valued `contact` signal (D6); `_seconds_since_skew_tolerant` (D7); comments |
-| `tests/test_qs307_override_expiry_unfreeze.py` | A | new — AC1/AC1b, AC2–AC6, AC8, AC15–AC20, AC23 |
+| `custom_components/quiet_solar/home_model/load.py` | B | the give-up's clock release in `check_commands`; the `_unresponsive_needs_ack` episode latch and the three-valued `ContactEvidence` signal (D6); post-await slot re-checks in `launch_command` and `force_relaunch_command`; comments |
+| `tests/test_qs307_override_expiry_unfreeze.py` | A | new — AC1/AC1b, AC2–AC6, AC8, AC15–AC19, AC25, AC26 |
 | `tests/ha_tests/test_bug_304_uncontrollable_load.py` | A + B | AC7 rows; 1 dead docstring ref |
 | `tests/test_ha_bistate_duration.py`, `tests/test_coverage_bistate_duration.py`, `tests/test_ha_pool_real.py` | A | audit only; churn was **0**, verified |
-| `tests/test_bug_304_command_deadlock.py` | B | AC9–AC14, AC21, AC22, AC24; 1 test inverted+renamed; docstrings |
+| `tests/test_bug_304_command_deadlock.py` | B | AC9–AC14, AC21, AC22; 1 test inverted+renamed; docstrings |
 | `docs/agents/concepts/{bistate-duration-devices,user-override,external-control-detection}.md` | A | updates |
 | `docs/agents/concepts/{load-base,notification-routing}.md` | B | updates |
 
@@ -845,7 +832,7 @@ reviewers:
    literally in round 3, it read a few seconds of benign skew as "fully elapsed" and
    destroyed a brand-new user override. Reachable with **no clock anomaly at all**, via
    unlocked `datetime.now()` at the user-action call sites racing a cycle's
-   `event_time`. Fixed by D7's tolerance band; AC23/AC24 pin it.
+   `event_time`. Reversed in round 5 — see D7; AC26 pins `main`'s behaviour.
 
 Round 4 also confirmed a documented invariant had drifted from the code (three
 `_clear_unresponsive` callers cleared the episode latch without any device contact),
@@ -896,5 +883,30 @@ was vacuous, now drives a full relaunch ladder before re-reading the counter.
 **Deliberately dropped, per the plan:** the #319 storm itself; restoring the 6-hour
 push-storm horizon; persisting the latch; a speculative stranded-`_stacked_command`
 guard (the post-await re-check covers the reachable case); and three cosmetics.
+
+### Round 6 (code review of `e760f00e`) — `QS-307.story_review_fix_#04.md`, applied here
+
+The closing round, and the one that named the pattern: **every mechanism this story
+added during review spawned a defect; every deletion and text correction spawned
+none.** Three of its six items are therefore reverts.
+
+- **D7 deleted.** The clock-skew helper and its tolerance band came from a round-3
+  *nice-to-have*, not from a bug, and turned benign behaviour destructive. `main`'s
+  plain subtraction restored; AC20/AC23/AC24 removed as pinning the defect, AC26 added.
+- **D1c reverted.** `support_user_override()` back on the outer gate; the boost-only
+  case moved to the restore boundary where it costs nothing per cycle. AC17/AC18
+  reworked.
+- **The post-await guard copied to its second call site.** Round 5 fixed
+  `force_relaunch_command` and claimed the invariant break closed; `launch_command`
+  acks after its own await too. Literal copy, no redesign. AC25 extended.
+
+Plus text-only corrections (claims the code contradicted), lazy logging on the two
+lines this PR modified, and a commentary cull: added production comment lines went from
+45% of the diff to 28%, most of it disappearing for free with the two reverts.
+
+Verification protocol re-run and green: flapping device 1 alert / 105 min (matching
+`main`); the #319 scenario still 5 alerts / 105 min on both `main` and this branch —
+**neither fixed nor worsened**; a 90 s-ahead anchor keeps the override; a boost-only
+load runs no lifecycle and drops a stored override at restore.
 
 **Open criticals: 0.**

--- a/docs/stories/QS-307.story.md
+++ b/docs/stories/QS-307.story.md
@@ -232,10 +232,20 @@ real change, not a no-op.
 It is safe because no hoisted branch reads entity state: expiry and the cooldown drain
 are comparisons against stored timestamps, and the reset-ask branch is a flag check.
 All call `constraint_reset_and_reset_commands_if_needed(keep_commands=True)`, which
-preserves commands (D1d then removes exactly one command, the ended override's own).
-The outcome is identical; only the cycle it lands on changes. AC3 pins it in **both**
-directions — the not-yet-aged override survives, and the aged one resets on the same
-cycle as on `main`.
+preserves commands. AC3 pins the timing in **both** directions — the not-yet-aged
+override survives, and the aged one resets on the same cycle as on `main`.
+
+**Two honest caveats (amended, review fix #02/08).** "Same outcome, different cycle" is
+no longer the whole truth:
+
+- for an override with an **aligned** command in flight, D1d now *abandons* that
+  command where `main` would have acked or relaunched it one cycle later. That is the
+  intended fix, not a side effect, and AC1/AC1b pin both the drop and its limits;
+- the cooldown drain (D1a) is genuinely new behaviour for a load whose command slot is
+  unhealthy — on `main` it simply never ran there.
+
+Neither changes anything for a load with an empty slot, which is the only state `main`
+could reach these branches in at all.
 
 All three clock comparisons go through `AbstractDevice._seconds_since` (review
 fix #01/08), which treats a future-dated anchor as **fully elapsed**. A raw
@@ -333,11 +343,41 @@ AC9/AC12 depend on it. The defect is not that the clock is released; it is that
 | `unresponsive_since` | per **command** | drives `is_uncontrollable`, i.e. supersede-vs-stack and which intent gets retried. Must be released whenever the slot empties. |
 | `_unresponsive_needs_ack` | per **episode** | "we are still in an unresolved lost-control episode". Gates the shout. |
 
-`_clear_unresponsive(reason, earned_recovery=True)` — the give-up is the **only**
-caller passing `False`, because it is the only one where the release carries no
-evidence QS is back in contact (the device is unreachable; a real ack, a deliberate
-drop and a command wipe all do carry it). `earned_recovery=False` latches
-`_unresponsive_needs_ack`; every `True` caller clears it.
+`_clear_unresponsive(reason, contact=...)` carries that distinction. **Amended
+(review fix #02/01 and #02/03): the signal is three-valued and the latch write is
+conditional.** A boolean could not express what `_drop_running_command` needs —
+"leave the latch alone" — and writing the latch above the `unresponsive_since is
+None` early return latched releases that released nothing:
+
+| `contact` | Callers | Effect on the latch |
+| --- | --- | --- |
+| `CONTACT_CONFIRMED` (default) | the real ack in `_ack_command`; the empty-slot re-arm | **clears** it, unconditionally — an ack is contact whether or not a clock was live |
+| `CONTACT_NONE` | the invalid-probe give-up, and only it | **latches** it, but *only when a live clock was released* |
+| `CONTACT_UNKNOWN` | `_drop_running_command`, the `keep_commands=False` wipe | **leaves it unchanged** — QS changed its mind; that is evidence of nothing |
+
+Two failures made those two refinements necessary, both found in round 4:
+
+- **The latch fired when no episode existed** (must-fix). The give-up fires after
+  `NUM_MAX_INVALID_PROBES_COMMANDS × CYCLE_S` ≈ 70 s, an order of magnitude before
+  the ~1050 s escalation threshold — so the *ordinary* timeline latched with
+  `unresponsive_since` still `None` and no push ever sent, and then suppressed the
+  load's **first genuine** episode permanently. Trigger is mundane: an entity
+  unavailable for ~70 s (HA restart, integration reload, Zigbee coordinator restart),
+  then back but ignoring commands forever. Fixed by writing the latch **below** the
+  early return: it may only suppress a next shout when there was a shout to follow.
+  AC21 pins it.
+- **Three callers cleared the latch without any device contact.** A drop is QS
+  changing its mind — the user took control, the load was disabled, an override
+  expired (D1d, new in round 3) — so treating it as a recovery let a latched flapping
+  load shout again on its next ladder climb, once per drop. AC22 pins the missing
+  "and *only* a real ack".
+
+`_unresponsive_needs_ack` is **not persisted**, matching `unresponsive_since`: both
+describe an in-flight command, and a reload wipes the command slot, so the episode's
+subject is gone. Consequence — "once per episode" is scoped to the process lifetime,
+and a permanently flapping device pushes once more per restart. Recorded in
+`notification-routing.md` rather than fixed by persisting, because a latch carried
+into a process where nothing has been announced is exactly the must-fix above.
 
 **Deviation from the fix plan's Option A, deliberately.** Option A proposed adding
 `and not self._unresponsive_needs_ack` to the escalation *conjunction*, which also
@@ -358,9 +398,11 @@ else:
 **`_escalate_or_recover`'s `current_command is not None` gate is now load-bearing**
 (it was described as redundant-but-kept in the first implementation, which
 review fix #01/05 flagged as contradicting `load-base.md`). The give-up runs
-earlier in the same cycle and nulls `current_command`; an unconditional
-`earned_recovery=True` release in the housekeeping arm would clear the latch one
-statement later and restore the storm.
+earlier in the same cycle and may have just latched the episode; the release in the
+housekeeping arm is `CONTACT_CONFIRMED`, which clears the latch *unconditionally*, so
+without the gate it would undo that one statement later and restore the storm. The
+argument survives the three-valued signal (re-checked per review fix #02/03) — it is
+in fact stronger, since the clear no longer depends on the early return either.
 
 **Consequence for AC10.** "Recover" in AC10's own wording becomes load-bearing rather
 than decorative: a second episode requires a real ack in between. The AC10 timeline is
@@ -369,6 +411,39 @@ amended to include one (see AC10).
 **Residual, now bounded:** a flapping device pushes **once** and then stays quiet until
 it actually answers a command. The cost is that a genuinely new episode on a device
 that never acks in between is silent — correct, because it is not a new episode.
+
+### D7 — the clock-skew tolerance band (review fix #02, must-fix)
+
+Adopting `_seconds_since` for the override clocks (review fix #01/08) fixed a frozen
+comparison and introduced a worse one in the other direction. `_seconds_since` returns
+`None` for **any** negative delta, and the callers read `None` as "fully elapsed" — so
+an arbitrarily small future-dating of `external_user_initiated_state_time` cancelled a
+brand-new 8-hour user override on the spot: state and timestamp nulled, the override's
+in-flight command dropped (D1d), the USER_OVERRIDE constraint wiped,
+`do_force_next_solve` set, and the load parked in `ASKED FOR RESET` for 180 s. QS
+actively fighting the user — the harm class this story exists to remove, arriving from
+the other side.
+
+**And it needs no clock anomaly at all.** `user_set_bistate_mode`,
+`user_set_default_on_duration` (`bistate_duration.py`) and `async_reset_override_state`
+(`load.py`) each take their **own** unlocked `datetime.now(pytz.UTC)`, while a
+concurrently-running `async_update_loads` cycle is still carrying an earlier
+`event_time` (`data_handler.py`). A user-stamped anchor can therefore sit *ahead* of
+the cycle time that evaluates it, and that cycle expired it immediately.
+
+**Fix:** `AbstractDevice._seconds_since_skew_tolerant`, shared by the expiry and the
+cooldown drain rather than open-coded twice. Future by less than
+`CLOCK_SKEW_TOLERANCE_S` ⇒ **zero elapsed** (just armed, not expired); beyond it ⇒
+`None`, preserving `_seconds_since`'s fully-elapsed meaning for the genuine
+large-backwards-jump case that AC20 pins. The band is the same ±60 s that
+`use_saved_extra_device_info` already grants these very timestamps at the restore
+boundary ("a small tolerance for benign skew"), so this is a precedent applied
+consistently rather than a new tunable. AC23/AC24 pin both directions.
+
+**Deliberately out of scope:** making those unlocked `datetime.now(pytz.UTC)` call
+sites take the cycle's `event_time`. That is the deeper fix for the concurrency route
+and has a much wider blast radius — tracked as a follow-up issue, referenced from the
+closing comment on `#307`.
 
 ## Acceptance criteria
 
@@ -399,7 +474,10 @@ that never acks in between is silent — correct, because it is not a new episod
     `tests/test_qs256_override_lifecycle.py:517`/`:665`; now pinned here, since AC3
     is billed as the safety net for D2.
 - **AC4 — disabled loads unchanged.** `qs_enable_device is False` ⇒ no hoisted branch
-  runs, even with an aged override. Pins D1's explicit guard.
+  runs, even with an aged override. Pins D1's explicit guard. Amended (review fix
+  #02/05): all **three** branches are armed in the test — an aged override, a pending
+  reset-ask follow-up flag, **and** a long-past cooldown timer. The wording was
+  widened to "no branch" when D1a landed without its test being widened with it.
 - **AC5 — reset-ask follow-up runs unconditionally.** With
   `asked_for_reset_user_initiated_state_time_first_cmd_reset_done` set and a command
   in flight, assert the `:733` branch's effects: the flag is cleared and
@@ -475,6 +553,28 @@ that never acks in between is silent — correct, because it is not a new episod
 - **AC14 — the housekeeping gate is load-bearing** (D6). Covered by AC13: dropping
   `_escalate_or_recover`'s `current_command is not None` gate would clear the latch in
   the same cycle the give-up sets it, and AC13 goes red.
+
+#### Part B — added by review fix #02
+
+- **AC21 — a give-up before any episode does not swallow the first push** (D6,
+  must-fix). Unavailable from the first cycle for one give-up window (so the give-up
+  fires with `unresponsive_since` still `None`, no push, and the latch must stay
+  `False`), then visible-but-disobeying for two full ladders ⇒ **exactly one**
+  `LOST_CONTROL_LOG` and one push. Also assert `_unresponsive_needs_ack is False` at
+  the end of AC11, where this bug was already being driven but never observed.
+- **AC22 — only a real ack clears the latch** (D6, should-fix). A latched load whose
+  in-flight command is **dropped** (override suppression, i.e. the same
+  `_drop_running_command` the expiry-time drop uses) does **not** shout on its next
+  full ladder climb. The "and *only* a real ack" half that AC13 was missing.
+- **AC23 — benign skew does not destroy a fresh override** (D7, must-fix). An override
+  armed at `T`, evaluated at `T − 5 s` ⇒ state, timestamp, in-flight command,
+  `get_override_state()` and the USER_OVERRIDE constraint all intact. Symmetric case
+  for the cooldown drain: not drained early.
+- **AC24 — the band's far edge still expires** (D7). Future-dated beyond
+  `CLOCK_SKEW_TOLERANCE_S` ⇒ treated as fully elapsed, so AC20's large-backwards-jump
+  guarantee is preserved. Pinned as a unit test on
+  `_seconds_since_skew_tolerant` (jitter / band edge / beyond / no anchor) plus the two
+  AC20 end-to-end tests.
 
 ## Task breakdown
 
@@ -565,15 +665,20 @@ Run the checker **per commit**; the path sets differ.
 | 1 | `ha_model/bistate_duration.py` | `bistate-duration-devices.md` | **Update** (T5) |
 | 2 | `home_model/load.py` | `external-control-detection.md`, `load-base.md`, `user-override.md`, `piloted-device-and-heat-pump.md` | `load-base.md` **update** (T11); `user-override.md` **update** (T5, lands in commit 1 — bump `last_verified` again in commit 2 if the checker re-flags it); the other two see below |
 
-- `external-control-detection.md` — **`Doc-OK`**: it documents the detection guards,
-  and this story changes **no** detection behaviour (AC6 pins that). Part B touches
-  the command lifecycle, not detection.
+- `external-control-detection.md` — **updated**, not `Doc-OK` (amended, review fix
+  #02/09). It was `Doc-OK` while detection was untouched, but D1c moved
+  `support_user_override()` into the detection gate and D1a split the cooldown rule
+  the doc describes (suppression stays, expiry leaves), so both are now recorded
+  there. Detection *behaviour* is still unchanged — AC6 pins that.
 - `piloted-device-and-heat-pump.md` — **`Doc-OK`**: `PilotedDevice`
   (`load.py:1241`) extends `AbstractDevice`, **not** `AbstractLoad`, so it has no
   override surface and never reaches `bistate_duration.py`. It does inherit
   `check_commands`, so Part B's line is reachable for it — the effect is purely to
   clear a clock that would otherwise be inherited, which is the intended fix for all
-  devices alike.
+  devices alike. It also inherits `_escalate_or_recover`, but its
+  `_notify_unresponsive` is the documented `AbstractDevice` no-op, so the episode
+  latch changes nothing observable for it either. Re-verified in round 4: the doc
+  mentions none of `unresponsive`, `lost control` or `override`.
 
 `notification-routing.md` is **not** flagged by the checker (its `covers:` lists only
 `ha_model/home.py` and `ha_model/person.py`) yet it documents `_notify_unresponsive`,
@@ -585,13 +690,18 @@ decision.
 
 | File | Part | Change |
 | --- | --- | --- |
-| `custom_components/quiet_solar/ha_model/bistate_duration.py` | A | restructure `:696-742`; detection body re-indented, not modified |
-| `custom_components/quiet_solar/home_model/load.py` | B | +1 line in `check_commands`; 4 comments; −1 dead docstring clause |
-| `tests/test_qs307_override_expiry_unfreeze.py` | A | new — AC1–AC6, AC8 |
+Updated at implement time (review fix #02/08 — the first two rows had gone stale
+against D1a/D1b/D1d and the two later fix plans).
+
+| File | Part | Change |
+| --- | --- | --- |
+| `custom_components/quiet_solar/ha_model/bistate_duration.py` | A | restructure the lifecycle chain per D1; the detection body is **not moved and not re-indented** (D1b). The only edit inside it is the cooldown block, whose expiry half moves out (D1a). Plus the expiry-time drop (D1d) and the skew-tolerant comparisons (D7) |
+| `custom_components/quiet_solar/home_model/load.py` | B | the give-up's clock release in `check_commands`; the `_unresponsive_needs_ack` episode latch and the three-valued `contact` signal (D6); `_seconds_since_skew_tolerant` (D7); comments |
+| `tests/test_qs307_override_expiry_unfreeze.py` | A | new — AC1/AC1b, AC2–AC6, AC8, AC15–AC20, AC23 |
 | `tests/ha_tests/test_bug_304_uncontrollable_load.py` | A + B | AC7 rows; 1 dead docstring ref |
-| `tests/test_ha_bistate_duration.py`, `tests/test_coverage_bistate_duration.py`, `tests/test_ha_pool_real.py` | A | audit only; churn expected ≈ 0 |
-| `tests/test_bug_304_command_deadlock.py` | B | AC9–AC12; 1 test inverted+renamed; 2 docstrings |
-| `docs/agents/concepts/{bistate-duration-devices,user-override}.md` | A | updates |
+| `tests/test_ha_bistate_duration.py`, `tests/test_coverage_bistate_duration.py`, `tests/test_ha_pool_real.py` | A | audit only; churn was **0**, verified |
+| `tests/test_bug_304_command_deadlock.py` | B | AC9–AC14, AC21, AC22, AC24; 1 test inverted+renamed; docstrings |
+| `docs/agents/concepts/{bistate-duration-devices,user-override,external-control-detection}.md` | A | updates |
 | `docs/agents/concepts/{load-base,notification-routing}.md` | B | updates |
 
 ## Residual risks for the implement phase
@@ -641,5 +751,58 @@ documented in D5.
 
 **Deliberately rejected:** splitting Part B into its own PR (#308 handed it here);
 widening `notification-routing.md`'s `covers:`; a shared test-helper module.
+
+### Round 3 (code review of PR #316) — `QS-307.story_review_fix_#01.md`, applied in `e79f889d`
+
+15 findings: **1 must-fix**, 6 should-fix, 8 nice-to-have. The must-fix was a **real
+regression introduced by this PR**: the give-up's clock release re-opened the
+escalation guard, so a device flapping between unreachable and
+answering-but-disobeying pushed "lost control" every ~18 min forever. D5's constants
+argument only ever covered a rung earned *inside* a give-up window, and
+`running_command_num_relaunch_after_invalid` is cumulative — so a give-up can fire long
+after the threshold was crossed by ordinary relaunches. Fixed by D6.
+
+Also found: two further "an override can never expire" paths of the same shape as the
+original bug — `support_user_override()` on the outer gate (D1c) and the *ended*
+override's own command still being relaunched (D1d). D5's former "accepted residual"
+push storm was **deleted and replaced by a fix**, not re-accepted.
+
+### Round 4 (code review of `e79f889d`) — `QS-307.story_review_fix_#02.md`, applied here
+
+14 findings: **2 must-fix**, 4 should-fix, 8 nice-to-have. Both must-fixes were
+regressions introduced by round 3's own fixes, each found independently by two
+reviewers:
+
+1. **The episode latch fired when no episode existed** — the latch write sat above
+   `_clear_unresponsive`'s early return, and the give-up normally fires ~70 s in,
+   ~1050 s before the escalation threshold. So the ordinary timeline latched nothing
+   worth latching and swallowed the load's **first genuine** push permanently. Fixed in
+   D6; AC21 pins it. The PR's own AC11 test was already driving this exact sequence
+   without ever observing the latch.
+2. **`_seconds_since` has zero tolerance for a future-dated anchor** — adopted
+   literally in round 3, it read a few seconds of benign skew as "fully elapsed" and
+   destroyed a brand-new user override. Reachable with **no clock anomaly at all**, via
+   unlocked `datetime.now()` at the user-action call sites racing a cycle's
+   `event_time`. Fixed by D7's tolerance band; AC23/AC24 pin it.
+
+Round 4 also confirmed a documented invariant had drifted from the code (three
+`_clear_unresponsive` callers cleared the episode latch without any device contact),
+resolved by making the signal three-valued.
+
+**Deliberately not done, with follow-up issues instead:** routing the unlocked
+`datetime.now(pytz.UTC)` call sites through the cycle's `event_time` — the deeper fix
+for D7's concurrency route, much wider blast radius — opened as
+[#317](https://github.com/tmenguy/quiet-solar/issues/317); and dropping the `#` from
+generated fix-plan filenames — `scripts/qs/utils.next_review_fix_path` owns the name, so
+renaming here would desync from the tool — opened as
+[#318](https://github.com/tmenguy/quiet-solar/issues/318). Both to be referenced from
+the closing comment, along with the deferred multi-mode detection issue.
+
+**Declined, with reasoning recorded:** the defensive
+`external_user_initiated_state is not None` conjunct on D1d's alignment check. The
+`None == None` false-drop it guards against is unreachable (`_state_on`/`_state_off` are
+`str`, and `running_command is not None` is already required), and an unreachable
+conjunct would need a `# pragma` or a contrived test to keep coverage at 100% — worse
+than the clarity it buys. Also declined: persisting `_unresponsive_needs_ack` (see D6).
 
 **Open criticals: 0.**

--- a/docs/stories/QS-307.story.md
+++ b/docs/stories/QS-307.story.md
@@ -1,0 +1,438 @@
+# QS-307 — An override on an unresponsive load can never expire
+
+- **Issue:** [#307](https://github.com/tmenguy/quiet-solar/issues/307)
+- **Branch:** `QS_307`
+- **Depends on:** #304 (merged as [#309](https://github.com/tmenguy/quiet-solar/pull/309))
+- **Absorbs:** [#308](https://github.com/tmenguy/quiet-solar/issues/308), to be **closed**
+  against this story — see **Part B**.
+
+> **This story does not deliver the issue's headline.** #307 asks for user-override
+> *detection* to resume on a stuck load. Two adversarial review rounds established
+> that detection is either impossible (2-state switches) or not worth its cost
+> (multi-mode). What #307 actually exposed is a **worse** bug hiding behind the same
+> gate: an override on an unresponsive load can never expire. That is what this story
+> fixes. See "Scope decision" — **#307 closes without its literal ask, and multi-mode
+> detection is deferred to a new issue.**
+
+## Problem
+
+`QSBiStateDuration.check_load_activity_and_constraints` gates its **entire**
+user-override block (`ha_model/bistate_duration.py:696-1025`) on
+`is_load_command_set(time)` (`home_model/load.py:988`), which requires
+`running_command is None`. Any in-flight command suppresses the whole block.
+
+Gating **detection** that way is correct: while a command is landing, observed
+state ≠ wanted state is expected, and classifying that as a user action would be
+a false positive.
+
+But the same gate also suppresses two branches that **never read entity state**:
+
+| Line | Branch | Reads entity state? |
+| --- | --- | --- |
+| `:717` | override **expiry** — `(time - external_user_initiated_state_time) > override_duration` | **no** — pure clock arithmetic |
+| `:733` | **reset-ask follow-up** — `asked_for_..._first_cmd_reset_done` | **no** — pure flag check |
+| `:742+` | detection — state vs `expected_state` / `expected_state_running` | yes |
+
+There is no reason for a clock comparison to be gated on command state. And because
+#304 made the relaunch backoff saturate and retry forever, the gate can stay shut
+indefinitely — so the expiry never fires.
+
+### The user-visible bug
+
+18:00 you override the pool pump ON with an 8 h window (should end 02:00). 19:00 the
+switch stops responding to Quiet Solar. The override is now pinned **forever**: the
+pump is permanently excluded from controlled consumption and from the solver, and
+that flows into the **persisted** consumption forecast. It never self-heals, even
+after the device recovers, because `reset_override_state_and_set_reset_ask_time` is
+behind the gate.
+
+**Both failure modes must be covered**, and they behave differently:
+
+- **visible but disobeying** — the entity still reports `on`/`off`, it just ignores
+  commands. This is the #304 pool-pump incident (`probe_result=False`).
+- **unavailable** — the entity drops off the network. The invalid-probe give-up
+  (`NUM_MAX_INVALID_PROBES_COMMANDS`, ~70 s) then nulls `current_command` via
+  `_ack_command(time, None)`, so `is_load_command_set` is `False` on the
+  `current_command is None` arm and the ladder never climbs.
+
+## Goal
+
+Run the two state-free branches of the override lifecycle unconditionally, so an
+override always expires on time regardless of command state or how the device died.
+
+**Non-goals:** changing detection in any way; changing the retry ladder or #304's
+escalation threshold; touching `is_load_command_set` or any power-accounting call
+site.
+
+## Scope decision — what is NOT being done, and why
+
+Recorded so it is not silently re-litigated. Both were live designs in v2–v4 of this
+story and were dropped after review.
+
+1. **A new `is_override_detection_allowed()` predicate that opens the whole block
+   for an uncontrollable load.** Dropped. It only helps the visible-but-disobeying
+   mode (the unavailable mode never reaches the escalation threshold), it costs a
+   ~18-minute latency, it couples this story to #304's internals, and it drags in
+   items 2 and 3.
+2. **Fresh detection on a 2-state switch** (the issue's literal scenario). Impossible
+   by construction: with no override active, `:794-799` compares the state against
+   *both* `expected_from(current_command)` and `expected_from(running_command)`, and a
+   2-state entity can only ever be one of those two. "Fixing" it means treating *"you
+   turned it off while we were trying to turn it off"* as fighting the user.
+3. **Fresh detection on a multi-mode load** (HVAC set to `cool` while stuck). Real,
+   but deferred to a **new issue**, because it needs a false-positive guard this
+   story cannot cheaply carry: for an unresponsive load the state mismatch is
+   permanent, so "matches neither expectation" stops meaning "a user acted" — a dead
+   HVAC sitting in `dry` would be classified as a user override with nobody involved,
+   and per the power-accounting chain that lands in the persisted forecast. Every
+   anchor design tried in review either contradicted itself or failed on the
+   device-reboot case. Additionally, review found the window is **self-terminating**:
+   `_drop_running_command` (`load.py:835-859`) calls `_clear_unresponsive`
+   unconditionally, so ~one relaunch rung (≤300 s) after such an override is
+   classified, the clock clears and the gate shuts again.
+
+**Action required at finalize:** open the follow-up issue for item 3 and reference it
+from #307's closing comment.
+
+## Part A — design
+
+### D1 — hoist the two state-free branches out of the gate
+
+Current shape (`bistate_duration.py:696-1025`):
+
+```python
+if self.is_load_command_set(time) and self.support_user_override():   # :696
+    <tz coercion of external_user_initiated_state_time>               # :707-713
+    if <expired>:                                                     # :717
+        ...
+    else:
+        if <reset-ask pending>:                                       # :733
+            ...
+        else:                                                         # :742
+            <detection: reads entity state>
+```
+
+Target shape:
+
+```python
+if self.qs_enable_device is not False and self.support_user_override():
+    <tz coercion>                                                     # unchanged
+    if <expired>:                                                     # now unconditional
+        ...
+    elif <reset-ask pending>:                                         # now unconditional
+        ...
+    elif self.is_load_command_set(time):                              # detection UNCHANGED
+        <detection: reads entity state>
+```
+
+Three properties of this shape:
+
+- **`is_load_command_set` is untouched** — body and all four call sites
+  (`bistate_duration.py:696`, `device.py:671`, `device.py:871`,
+  `dynamic_group.py:204`; the last three are power accounting, reaching the
+  persisted forecast indirectly via `home.py:1739`). It simply moves inward to guard
+  detection only.
+- **The `qs_enable_device` guard is deliberate.** `is_load_command_set` returns
+  `False` for a disabled load, so without this guard the hoist would newly run expiry
+  on disabled loads. Preserving today's behaviour is the conservative choice; AC4
+  pins it.
+- **`do_push_constraint_after` (`:1012-1025`) is unaffected** — it is set only inside
+  the detection branch, which stays gated, so the `bistate_mode_off` interaction at
+  `:1027` is unchanged. Verified.
+
+### D2 — the behaviour change, stated honestly
+
+For a **healthy** load with an in-flight command, expiry can now fire up to one cycle
+earlier than before — during the command flight rather than just after it. This is a
+real change, not a no-op.
+
+It is safe because neither hoisted branch reads entity state: expiry is a comparison
+against `external_user_initiated_state_time`, and the reset-ask branch is a flag
+check. Both call
+`constraint_reset_and_reset_commands_if_needed(keep_commands=True)`, which preserves
+commands. The outcome is identical; only the cycle it lands on changes. AC3 pins it.
+
+### D3 — why not open detection too
+
+See "Scope decision" items 2 and 3. Briefly: the issue's own required safeguard is
+*"parity for healthy loads"*, and opening detection for unresponsive loads makes them
+behave **differently** from healthy ones (permanent mismatch ⇒ near-certain
+classification), which is the opposite of parity.
+
+## Part B — the ownerless lost-control clock (from #308)
+
+Unchanged from the #308 handoff, and **independent of Part A** — Part A no longer
+reads `is_uncontrollable` at all, so the two parts now share only a file.
+
+### D4 — the invalid-probe give-up releases the clock
+
+At the give-up, `_ack_command(time, None)` nulls `current_command` and empties the
+slot, but `unresponsive_since` survives (`_ack_command` clears only when
+`command is not None`, `load.py:635-640`; the `_escalate_or_recover` re-arm is gated
+on `current_command is not None`, `:1165-1171`). The clock then describes a command
+that no longer exists and is inherited by the next command, which becomes
+`is_uncontrollable` with **zero relaunches of its own**.
+
+That matters because `is_uncontrollable` is load-bearing in two places:
+`load.py:881` (stack vs **supersede**) and `load.py:1104` (retry the newest *stacked*
+intent). So a load carries supersede semantics on brand-new commands until its next
+successful ack.
+
+**Fix** — `check_commands`, probe-`None` branch (`load.py:1016-1018` on `main`):
+
+```python
+                if self.running_command_num_relaunch_after_invalid >= NUM_MAX_INVALID_PROBES_COMMANDS:
+                    # will kill completely the command ....
+                    self._ack_command(time, None)
+                    # QS-307 (from #308): the give-up destroys the clock's subject —
+                    # `current_command` and the slot both go — so the clock goes with
+                    # it. Leaving it made the clock ownerless and the next command
+                    # inherited supersede semantics with zero evidence.
+                    self._clear_unresponsive("the probe went unavailable")
+```
+
+`_ack_command(time, None)` is **unchanged** — preserving `current_command` there
+would bill phantom consumption into the persisted forecast (#308's "Rejected 2",
+QS-304 AC7's forbidden zone). `_clear_unresponsive` takes only `reason` on `main`.
+
+This was #308's explicitly "Rejected 1" option, rejected solely because it dropped the
+`qs_load_uncontrollable` duty cycle to ~0%. That objection died with the sensor
+(cut in `11d25d98`). Do not re-litigate it.
+
+**Naming caveat (accepted):** the clear reuses `REGAINED_CONTROL_LOG`, so the log says
+the clock was released when the device went *unreachable* — not a recovery. Accepted:
+the message is reason-led by design and the reason string disambiguates.
+
+### D5 — the re-arm cannot become a push storm
+
+Re-escalation needs `running_command_num_relaunch >= NUM_MAX_COMMAND_RELAUNCH` (6).
+Derived from named constants: give-up window = `NUM_MAX_INVALID_PROBES_COMMANDS` (10,
+`load.py:52`) × `CYCLE_S` (7) = 70 s; rung-0 relaunch fires at
+`COMMAND_RELAUNCH_BASE_DELAY_S` = 50 s, so at most **one** relaunch per window; and
+`_escalate_or_recover` resets the rung to 0 on an empty slot every window. The rung
+peaks at 1 and never reaches 6.
+
+**Stated invariant:** `relaunches per give-up window < NUM_MAX_COMMAND_RELAUNCH`.
+Pinned by AC9 as a constants assertion so a future constant change fails loudly.
+
+**Known residual (accepted):** an *intermittently* available device — visible-stuck
+for ≥ `LADDER_WALL_S`, then unavailable for ≥ one give-up window, repeating — can now
+escalate once per cycle of that pattern (~1 push per 19 min) where today the
+once-only guard capped it at one, ever. Judged acceptable: it requires a specific
+flapping pattern, and each push describes a genuine new episode. AC10 documents the
+bound rather than enforcing one.
+
+## Acceptance criteria
+
+### Part A
+
+- **AC1 — expiry fires while a command is in flight.** Override aged past
+  `override_duration`, `running_command` set, `current_command` set: the override is
+  reset via `reset_override_state_and_set_reset_ask_time`. Fails on `main`.
+- **AC2 — expiry fires after the invalid-probe give-up** (the *unavailable* death
+  mode): `current_command is None` and `running_command is None`, override aged out
+  ⇒ reset. This is the case the discarded predicate design could **not** fix; it is
+  the reason Option 1 was chosen and must be pinned.
+- **AC3 — healthy-load parity.** For a load with no in-flight command, expiry and
+  reset-ask behave exactly as on `main` (same cycle, same effects). Table-driven over
+  `running_command ∈ {None, CMD_ON}` × `current_command ∈ {None, CMD_ON}` with an
+  override that is **not** yet aged out ⇒ no reset in any combination.
+- **AC4 — disabled loads unchanged.** `qs_enable_device is False` ⇒ neither hoisted
+  branch runs, even with an aged override. Pins D1's explicit guard.
+- **AC5 — reset-ask follow-up runs unconditionally.** With
+  `asked_for_reset_user_initiated_state_time_first_cmd_reset_done` set and a command
+  in flight, assert the `:733` branch's effects: the flag is cleared and
+  `constraint_reset_and_reset_commands_if_needed(keep_commands=True)` ran (assert via
+  the resulting constraint list and that commands survived).
+- **AC6 — detection is unchanged.** The gate still shuts detection for every state
+  where `is_load_command_set(time)` is `False`: with a command in flight and an
+  entity state matching neither expectation, **no** override is created. This is the
+  regression pin for the non-goal.
+- **AC7 — `is_load_command_set` body unchanged.** Extend the existing
+  `test_is_load_command_set_truth_table_is_unmodified`
+  (`tests/ha_tests/test_bug_304_uncontrollable_load.py:91`) — widen its 4-tuples to
+  include an `unresponsive_since` column and assert the predicate is indifferent to
+  it.
+- **AC8 — the end-to-end bug.** Worked example from Problem: override at T, device
+  stops responding at T+1 h, assert the override is gone at T+8 h and the load is
+  back in controlled consumption. Asserted for **both** death modes (visible-stuck
+  and unavailable).
+
+### Part B
+
+- **AC9 — the give-up releases the clock.** After the invalid-probe give-up:
+  `unresponsive_since is None` and exactly one `REGAINED_CONTROL_LOG` line. Plus the
+  D5 constants assertion.
+- **AC10 — a second episode can escalate.** Lose control → unavailable → recover →
+  lose control again ⇒ a **second** push and log. Impossible today.
+- **AC11 — no storm.** Permanently unavailable from the start: **zero** pushes, zero
+  `REGAINED_CONTROL_LOG` lines. Drive 3–4 give-up windows (~5 min simulated), not
+  6 h — D5 makes longer horizons redundant.
+- **AC12 — the next command starts clean.** The command launched after a give-up has
+  `is_uncontrollable is False` on its first cycle and therefore **stacks** rather
+  than supersedes (`load.py:881`).
+
+## Task breakdown
+
+TDD: tests red first, then the change. Two commits in one PR.
+
+### Part A (commit 1)
+
+1. **T1 — red tests.** New `tests/test_qs307_override_expiry_unfreeze.py` for
+   AC1–AC6, AC8. Harness: model on `tests/test_qs256_override_lifecycle.py:64-117`
+   (`_ReplayPump(QSBiStateDuration)` + `_make_pump()`, `FakeHass`,
+   `config_entry=None`) — it already sets entity state with explicit `last_changed`,
+   which `FakeHass` requires (`tests/conftest.py:58-66`). For AC2, reach the
+   give-up by driving `probe_result = None` for
+   `NUM_MAX_INVALID_PROBES_COMMANDS + 2` cycles. Note `qs304_helpers.drive` only
+   calls `check_and_relaunch_command`; `check_load_activity_and_constraints` must be
+   called explicitly (`home.py:2915` vs `:2919` are separate entry points).
+2. **T2 — the hoist.** Restructure `bistate_duration.py:696-742` per D1. No other
+   edit in that file; the detection body is moved, not modified (keep the diff a pure
+   re-indent where possible so review can see nothing changed inside).
+3. **T3 — AC7.** Extend
+   `tests/ha_tests/test_bug_304_uncontrollable_load.py:91-116` (4-tuples →
+   5-tuples with `unresponsive_since`).
+4. **T4 — audit the existing gate mocks (audit, not bulk-rename).** 55 sites mock
+   `is_load_command_set`: `tests/test_ha_bistate_duration.py` 30,
+   `tests/test_coverage_bistate_duration.py` 24, `tests/test_ha_pool_real.py` 1.
+   The gate still exists and still guards detection, so **most need no change**.
+   Only sites that mock it `False` **and** carry a non-`None`
+   `external_user_initiated_state_time` (or a pending reset-ask flag) can change
+   behaviour. Pre-check found the `False`-mocked sites leave that timestamp at its
+   `None` default, so the expected churn is near zero — **verify, don't assume**.
+   Do not touch `tests/test_bug_78_daily_metrics.py`,
+   `tests/test_home_consumption.py`, `tests/test_coverage_device.py:243` (comment
+   only) — power accounting.
+5. **T5 — docs.** `docs/agents/concepts/bistate-duration-devices.md` is the only doc
+   the checker flags for `bistate_duration.py`: describe the split gate (state-free
+   lifecycle branches unconditional, detection gated) and the non-goal. Also update
+   `docs/agents/concepts/user-override.md` — it is flagged by Part B's `load.py`
+   change and is the natural home for "an override always expires, even on a dead
+   load". Bump `last_verified`.
+6. **T6 — gate.** `python scripts/qs/quality_gate.py --impacted`, plus `--quick` on
+   the touched test files and `--quick tests/qs`.
+
+### Part B (commit 2)
+
+7. **T7 — red tests** in `tests/test_bug_304_command_deadlock.py` for AC9–AC12, and
+   invert + **rename** `test_unavailable_probe_give_up_is_not_a_recovery` (`:393`) —
+   its premise becomes wrong; `..._is_not_a_recovery` no longer describes what it
+   pins. Also correct the docstring of
+   `test_unreachable_entity_does_not_produce_a_push_storm` (`:364`): it credits the
+   once-only guard and says the clock "is deliberately kept"; after T8 the reason is
+   the rung reset (D5). Its assertions are unchanged, but adding a log-count
+   assertion requires adding the `caplog` fixture. Verified unaffected, do not touch:
+   `test_relaunch_counters_never_outlive_the_command_they_describe` (`:264`),
+   `test_pool_house_incident_regression` (`:923`).
+8. **T8 — the one-line fix**, per D4.
+9. **T9 — the four in-code comments T8 falsifies**, all in `load.py` (**re-anchor by
+   symbol; commit 1 does not touch `load.py`, so `main` line numbers hold**):
+   `is_uncontrollable`'s docstring (`:703-705`, "the give-up keeps the clock … the
+   next command inherits it"); `_escalate_or_recover`'s two comments (`:1158-1162`,
+   `:1166-1170` — the latter's *sole stated justification* disappears); and
+   `_ack_command`'s (`:636-639`, add a pointer to the new caller-side clear).
+   **Decision, do not defer:** the `current_command is not None` gate at `:1165`
+   is **kept** — redundant but harmless, and both branches stay covered. Comment
+   only.
+10. **T10 — dead-sensor sweep** (verified exhaustive, three sites): `load.py:1609`
+    (`_notify_unresponsive`'s docstring cites the `qs_load_uncontrollable` binary
+    sensor, cut in `11d25d98`), `tests/test_bug_304_command_deadlock.py:160`
+    (inside `test_reset_button_does_not_flash_problem_on_a_healthy_load`, a *third*
+    test), `tests/ha_tests/test_bug_304_uncontrollable_load.py:4`.
+11. **T11 — docs.** `load-base.md` Part B inversions: `:94-100` (the give-up "keeps
+    the clock … see #308"), `:159-169` ("**One shape keeps the clock with an empty
+    slot**" — after T8 there is none), the **Common mistakes** entry at `:273-277`
+    which instructs agents to keep it, and "**Four clearers, one writer**" (`:101`)
+    → **five**. `notification-routing.md:59`: the push is fired "**once**" → once
+    **per episode** (AC10); wording only, **not** a `covers:` widening. Bump
+    `last_verified`.
+12. **T12 — gate.** As T6.
+
+## Doc maintenance
+
+Run the checker **per commit**; the path sets differ.
+
+| Commit | Paths | Checker flags | Disposition |
+| --- | --- | --- | --- |
+| 1 | `ha_model/bistate_duration.py` | `bistate-duration-devices.md` | **Update** (T5) |
+| 2 | `home_model/load.py` | `external-control-detection.md`, `load-base.md`, `user-override.md`, `piloted-device-and-heat-pump.md` | `load-base.md` **update** (T11); `user-override.md` **update** (T5, lands in commit 1 — bump `last_verified` again in commit 2 if the checker re-flags it); the other two see below |
+
+- `external-control-detection.md` — **`Doc-OK`**: it documents the detection guards,
+  and this story changes **no** detection behaviour (AC6 pins that). Part B touches
+  the command lifecycle, not detection.
+- `piloted-device-and-heat-pump.md` — **`Doc-OK`**: `PilotedDevice`
+  (`load.py:1241`) extends `AbstractDevice`, **not** `AbstractLoad`, so it has no
+  override surface and never reaches `bistate_duration.py`. It does inherit
+  `check_commands`, so Part B's line is reachable for it — the effect is purely to
+  clear a clock that would otherwise be inherited, which is the intended fix for all
+  devices alike.
+
+`notification-routing.md` is **not** flagged by the checker (its `covers:` lists only
+`ha_model/home.py` and `ha_model/person.py`) yet it documents `_notify_unresponsive`,
+a `load.py` symbol. T11 fixes the wording; the `covers:` widening is deliberately
+**not** done here — it would tax every future `load.py` change and deserves its own
+decision.
+
+## Files touched
+
+| File | Part | Change |
+| --- | --- | --- |
+| `custom_components/quiet_solar/ha_model/bistate_duration.py` | A | restructure `:696-742`; detection body re-indented, not modified |
+| `custom_components/quiet_solar/home_model/load.py` | B | +1 line in `check_commands`; 4 comments; −1 dead docstring clause |
+| `tests/test_qs307_override_expiry_unfreeze.py` | A | new — AC1–AC6, AC8 |
+| `tests/ha_tests/test_bug_304_uncontrollable_load.py` | A + B | AC7 rows; 1 dead docstring ref |
+| `tests/test_ha_bistate_duration.py`, `tests/test_coverage_bistate_duration.py`, `tests/test_ha_pool_real.py` | A | audit only; churn expected ≈ 0 |
+| `tests/test_bug_304_command_deadlock.py` | B | AC9–AC12; 1 test inverted+renamed; 2 docstrings |
+| `docs/agents/concepts/{bistate-duration-devices,user-override}.md` | A | updates |
+| `docs/agents/concepts/{load-base,notification-routing}.md` | B | updates |
+
+## Residual risks for the implement phase
+
+The Option 1 design was **proposed by the round-2 reviewers**, but this concrete plan
+for it has not itself been through a review round. Three things to watch:
+
+1. **The hoist is a re-indent of a large block.** Keep T2's diff mechanical so a
+   reviewer can confirm nothing inside the detection body changed.
+2. **T4's "churn ≈ 0" is a pre-check, not a proof.** If more sites move than
+   expected, that is a signal the hoist changed more than intended — stop and
+   re-examine rather than mass-editing tests.
+3. **AC3 is the safety net** for D2's admitted healthy-load behaviour change. If it
+   cannot be made to pass, the hoist is not as inert as claimed.
+
+## Adversarial Review Notes
+
+### Round 1 (4 reviewers) and Round 2 (4 reviewers + delta-auditor), 2026-07-31
+
+Both rounds reviewed a **different design** — a new `is_override_detection_allowed()`
+predicate plus a `_state_at_lost_control` anchor — which was **discarded** in favour
+of the present hoist. Round 2's delta-auditor confirmed 21/24 round-1 findings fully
+resolved, 3 partial, **zero regressions**, and concrete-planner re-verified every
+round-1 line-number correction as correct.
+
+**Why the design was discarded.** Round 2 produced one critical found independently
+by **all five** reviewers: the anchor added to stop a dead-but-drifting device being
+misread as a user action made the story's own latency-acceptance criterion
+unsatisfiable — the two could not both ship. Attempts to rescue it (launch-time
+anchor) failed on the device-reboot case. Concrete-planner additionally proved that
+re-override on a 2-state switch is **unconstructible** (the suppression drop in
+`force_relaunch_command` requires the entity to already be off the override state),
+and that the uncontrollable+override window is **self-terminating** within one
+relaunch rung. Plan-critic then showed the rejection of the cheap alternative was
+unsound: it had been rejected with a *detection* argument, while expiry reads no
+entity state. Scope-guardian independently reached the same place from the scope
+side. Option 1 is that alternative.
+
+**Findings carried into this plan:** the `qs_enable_device` guard (parity for
+disabled loads); the two death modes as separate ACs; audit-don't-bulk-rename for the
+55 mocks; AC7 extending the existing truth-table pin rather than "verified by diff
+review"; the `_ReplayPump` harness as the template; per-commit doc-drift path sets;
+the corrected `piloted-device-and-heat-pump.md` Doc-OK reason (`PilotedDevice` is not
+an `AbstractLoad`); T9's keep-the-gate decision taken in the plan rather than
+deferred; AC11's horizon cut from 6 h to ~5 min; the flapping-device push residual
+documented in D5.
+
+**Deliberately rejected:** splitting Part B into its own PR (#308 handed it here);
+widening `notification-routing.md`'s `covers:`; a shared test-helper module.
+
+**Open criticals: 0.**

--- a/docs/stories/QS-307.story_review_fix_#01.md
+++ b/docs/stories/QS-307.story_review_fix_#01.md
@@ -1,0 +1,386 @@
+# QS-307 — Review fix plan #01
+
+## Summary
+- Source PR: #316
+- Source story: `docs/stories/QS-307.story.md`
+- Findings to fix: 15 (1 must-fix, 6 should-fix, 8 nice-to-have)
+- Next implement phase: `/implement-task`
+
+Reviewers: `qs-review-blind-hunter`, `qs-review-edge-case-hunter`,
+`qs-review-acceptance-auditor`, `qs-review-coderabbit`.
+
+Three blind-hunter findings were triaged **invalid** and are not below:
+`last_verified` not bumped (all four touched concept docs already read
+`2026-07-31`, on `main` too); missing test imports causing `NameError`
+(all 51 tests in both files pass); and "the hoisted cooldown clear
+changes healthy-load behaviour" (raised without repo access — the
+acceptance-auditor read the region and confirmed straight-line code, no
+early exits, so the clear lands on exactly the same cycle).
+
+## Findings to fix
+
+### [must-fix] A give-up wipes an escalation rung earned outside its window → unbounded push storm
+
+- File: `custom_components/quiet_solar/home_model/load.py:1032`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: the new
+  `self._clear_unresponsive("the probe went unavailable")` at the
+  invalid-probe give-up re-arms the once-only escalation guard
+  (`unresponsive_since is None` at `load.py:1142`). For a load that
+  *both* answers-but-disobeys *and* drops out for isolated single
+  cycles, `running_command_num_relaunch_after_invalid` is cumulative
+  over the command's life (`force_relaunch_command` never resets it),
+  so a give-up can fire *after* a rung was already earned outside any
+  give-up window. Sequence: fewer than
+  `NUM_MAX_INVALID_PROBES_COMMANDS` (10) `None` probes land inside the
+  ~1050 s ladder climb → `unresponsive_since` is set and push #1 fires;
+  the 10th cumulative `None` then triggers the give-up → clock released
+  and rung zeroed; `update_loads` relaunches immediately (the slot is
+  empty after `_ack_command(time, None)`); ~1050 s later push #2 fires.
+  Steady state: one "Quiet Solar lost control of X" push every ~18–20
+  min, indefinitely, for a device whose situation never changed. Worse,
+  `_notify_unresponsive` (`load.py:1617`) is fire-and-forget with no
+  notification id, so the pushes accumulate on the phone and cannot be
+  collapsed or dismissed. D5 / AC11
+  (`test_a_give_up_window_cannot_climb_the_escalation_ladder`) only
+  prove that *a single give-up window is too short to climb the
+  ladder* — they say nothing about a rung earned before one.
+- **Constraint — do not simply revert the clock release.** AC9/AC10
+  deliberately re-arm the guard so a genuine second episode can shout
+  twice, and that is #308's fix. The repair must damp the flapping case
+  while keeping AC9/AC10 green.
+- Proposed fix (Option A, preferred): make the *reason* for re-arming
+  load-bearing. Add `AbstractLoad._unresponsive_needs_ack: bool`
+  (default `False`). Give `_clear_unresponsive` a keyword
+  `earned_recovery: bool = True`; the give-up call site passes
+  `earned_recovery=False`, which sets `_unresponsive_needs_ack = True`.
+  Add `and not self._unresponsive_needs_ack` to the `_escalate_or_recover`
+  escalation conjunction (`load.py:1136-1141`), and clear the flag in
+  `_ack_command` on a *real* ack (`command is not None`) — i.e. the next
+  episode may escalate only once QS has evidence the device answered at
+  least once in between. This preserves #308's intent (the clock is
+  still released, supersede semantics are still not inherited) while
+  making "second episode" mean "second episode after contact was
+  re-established".
+- **Then re-verify AC9/AC10 and amend the story if needed.** Inspect
+  `tests/test_bug_304_command_deadlock.py:410` (AC9, expects exactly 1
+  `REGAINED_CONTROL_LOG`) and `:456` (AC10, expects 2 pushes / 2
+  `LOST_CONTROL_LOG`). If AC10's second episode has no intervening
+  successful ack, Option A will turn it red. In that case either drive
+  an ack into AC10's timeline (correct, if the scenario is meant to be
+  a genuinely distinct episode) or fall back to Option B — a minimum
+  spacing `UNRESPONSIVE_EPISODE_MIN_SPACING_S` between episodes,
+  compared through `_seconds_since` — and amend the story's D5 to
+  record the new discriminator either way. Do not silently weaken
+  AC10's assertion to make Option A fit.
+- Test: new AC — a load whose probe alternates `False` / `None` across
+  many cycles emits **one** `LOST_CONTROL_LOG`, not one per ~18 min.
+  Drive at least 3 give-up windows and assert the log count stays 1
+  while no ack occurs; then ack once and assert a subsequent episode
+  *can* escalate again (that second half is the AC9/AC10 guarantee,
+  pinned explicitly).
+
+### [should-fix] An override-aligned command in flight survives expiry and keeps being executed
+
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:728`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: the expiry branch calls
+  `constraint_reset_and_reset_commands_if_needed(keep_commands=True)`,
+  which deliberately leaves `running_command` alone. Once
+  `reset_override_state_and_set_reset_ask_time(time)` has nulled
+  `external_user_initiated_state`, the `force_relaunch_command`
+  override-suppression drop no longer applies — so QS keeps issuing the
+  *override's* service call after the override has ended, while the
+  post-expiry intent is merely stacked behind it (`check_commands` only
+  promotes the stack when the slot empties, and `_relaunch_stale_command`'s
+  "retry newest stacked intent" path needs `is_uncontrollable`, i.e. the
+  clock, which is still `None` at rung < 6). ON keeps being re-executed
+  at the 50→300 s cadence for up to ~1050 s. On `main` this state was
+  unconstructible: the old `is_load_command_set(time)` gate guaranteed
+  `running_command is None` at expiry time — so this is a regression
+  introduced by the hoist, not a pre-existing bug.
+- Proposed fix: in the expiry branch, when the in-flight command is
+  override-aligned, drop it —
+  `self._drop_running_command(...)` / `abandon_running_command(...)` with
+  a QS-307 reason string — before/alongside the
+  `constraint_reset_and_reset_commands_if_needed(keep_commands=True)`
+  call. The expiry branch is the one place that *knows* the override
+  just ended, so it is the natural owner. Preserve the rung semantics
+  documented at `abandon_running_command` (do not restart the backoff).
+- Test: extend/duplicate
+  `test_ac8_override_expires_on_a_visible_but_disobeying_load`
+  (`tests/test_qs307_override_expiry_unfreeze.py:429`) to assert on
+  `running_command` after `_assert_override_self_heals` — the override's
+  command must not still be in flight, and no further override-aligned
+  service call is issued after expiry.
+
+### [should-fix] `support_user_override()` is a second "an override can never expire" path
+
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:707`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: the new outer gate is
+  `if self.qs_enable_device is not False and self.support_user_override():`.
+  The `support_user_override()` conjunct reintroduces exactly the class
+  of bug this PR fixes, and unlike the `qs_enable_device` arm it is
+  **not self-healing**: disabling then re-enabling a load runs the
+  branch again and expires, but flipping a load to boost-only never
+  does. `asked_for_reset_user_initiated_state_time` is persisted and
+  `use_saved_extra_device_info` only drops it when *future-dated*; the
+  only other clearers are the hoisted drain (behind this gate) and the
+  reset button. So: a bistate load with a live override or pending
+  reset-ask is reconfigured to boost-only (`CONF_LOAD_IS_BOOST_ONLY`)
+  → entry reloads → the timestamp is restored →
+  `support_user_override()` is now `False` → `get_override_state()`
+  returns `ASKED FOR RESET` and `is_user_overridden()` returns `True`
+  **forever, across restarts**. That is precisely the harm the PR
+  cites: `get_device_power_latest_possible_valid_value(
+  ignore_auto_and_user_overridden_load=True)` returns `0.0`, the load
+  leaves controlled consumption and lands in the persisted forecast
+  (`home.py:1723` also drops its piloted devices).
+- Proposed fix: the state-free lifecycle branches must not be gated on
+  `support_user_override()`. Either (a) restructure so the outer gate is
+  `qs_enable_device is not False` only, with `support_user_override()`
+  moved down to guard detection alongside `is_load_command_set(time)`;
+  or (b) keep the gate but add an unconditional teardown that clears
+  `external_user_initiated_state{,_time}` and
+  `asked_for_reset_user_initiated_state_time` when
+  `support_user_override()` is `False`. (a) is preferred — it is the
+  same "gate detection, not lifecycle" principle the PR is built on,
+  applied consistently.
+- Test: new AC — arm an override/reset-ask, flip the load to
+  boost-only, run the cycle, assert `is_user_overridden()` is `False`
+  and `get_override_state()` is `NO_OVERRIDE`. Also assert the
+  restore path (`use_saved_extra_device_info` with a past-dated
+  timestamp) does not resurrect it.
+
+### [should-fix] A third state-free branch was hoisted that the story never designed or pinned
+
+- Files: `docs/stories/QS-307.story.md` (D1, D2),
+  `custom_components/quiet_solar/ha_model/bistate_duration.py:761-772`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-acceptance-auditor (deduped)
+- Description: D1's target shape lists **two** hoisted state-free
+  branches (expiry, reset-ask follow-up) and T2 says "No other edit in
+  that file; the detection body is moved, not modified." The
+  implementation hoists a **third** — the post-override cooldown drain
+  — and *deletes* that logic from inside the detection body (`:883-890`
+  now unconditionally sets `is_command_overridden_state_changed =
+  False`). It also uses `else:` + nested `if is_load_command_set(time):`
+  rather than D1's `elif self.is_load_command_set(time):`. The change is
+  correct and arguably mandatory (`get_override_state()` at
+  `load.py:1424` returns `OVERRIDE_STATE_ASKED_FOR_RESET` while that
+  timestamp is set, so without it AC8 cannot hold) and was verified
+  behaviour-preserving for healthy loads — but it is an implement-phase
+  design decision with **no AC of its own**, covered only transitively
+  by AC8. The PR body discloses it; the story does not.
+- Proposed fix: amend the story's D1/D2 to name three hoisted branches
+  and the `else:` + nested-`if` shape (with the "keeps the ~280-line
+  detection body at its original indentation" rationale), and add a
+  dedicated AC.
+- Test: new AC — the post-override cooldown drains with a command in
+  flight (`is_load_command_set(time)` False), i.e. directly pin the
+  third branch instead of reaching it through AC8's 8-hour end-to-end
+  scenario.
+
+### [should-fix] Comment and `load-base.md` contradict each other on the emptied-slot invariant
+
+- File: `custom_components/quiet_solar/home_model/load.py:1169-1183`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: the retained comment says "several paths reach here with
+  `current_command` already nulled", while `docs/agents/concepts/load-base.md`
+  now asserts "**No** shape keeps the clock with an empty slot". Both
+  cannot be true as written: if such a path exists and does not clear
+  the clock, the absolute doc claim is false and the kept
+  `current_command is not None` gate (plan T9) is *not* redundant.
+- Proposed fix: establish which holds. Enumerate the paths that reach
+  the `running_command is None` block with `current_command` already
+  `None`; if all of them provably have no clock to clear, reword the
+  comment to say so explicitly (the gate is then genuinely redundant
+  and kept for locality). If any can carry a live
+  `unresponsive_since`, the doc's absolute claim must be softened and
+  the gate documented as load-bearing. Note the comment quoted is
+  about `_last_supersede_time`, so make clear which field each
+  sentence governs.
+- Test: if a path is found that keeps the clock with an empty slot, pin
+  it with a test; otherwise this is a comment/doc-only change.
+
+### [should-fix] AC8's "back in controlled consumption" is asserted only by proxy
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py:411-427`
+  (`_assert_override_self_heals`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: the helper asserts
+  `get_override_state() == OVERRIDE_STATE_NO_OVERRIDE`,
+  `is_user_overridden() is False` and `_constraints != []`. Nothing
+  asserts the power-accounting / solver observable that the story's
+  Problem section actually blames ("permanently excluded from
+  controlled consumption … flows into the persisted forecast").
+- Proposed fix: add the missing observable to
+  `_assert_override_self_heals` —
+  `get_device_power_latest_possible_valid_value(
+  ignore_auto_and_user_overridden_load=True)` returns the load's real
+  power (not `0.0`) once the override is gone, so the load is back in
+  controlled consumption. Amend the story's AC8 to name that observable
+  rather than the consequence.
+
+### [should-fix] AC3's parity claim is half-delegated
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py:260`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: the new table-driven test pins only the **negative**
+  half (a not-yet-aged override survives all four
+  `running_command × current_command` combinations). The positive parity
+  claim — a healthy *aged* override still resets on exactly the same
+  cycle as on `main` — rests entirely on pre-existing
+  `tests/test_qs256_override_lifecycle.py:517` / `:665`. Those pass, so
+  the risk is low, but AC3 is billed as "the safety net for D2" and its
+  operational definition is narrower than its headline.
+- Proposed fix: extend the table with the aged-override arm (assert the
+  reset fires on the expected cycle for each command-state
+  combination), or amend AC3 to state explicitly that the positive half
+  is delegated and name the two QS-256 tests it relies on.
+
+### [nice-to-have] A backwards clock step freezes the cooldown drain
+
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:768`
+  (and the unchanged expiry comparison at `:730`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: the hoisted drain is now the *only* place the
+  post-override cooldown is released, and it uses a raw
+  `(time - anchor).total_seconds() >= …`. `load.py:811` introduced
+  `_seconds_since` for exactly this hazard ("`None` means treat as
+  fully elapsed … an unguarded comparison freezes whatever it gates for
+  the whole duration of the jump"). If HA boots without an RTC and NTP
+  corrects the clock backwards *after* restore (so
+  `use_saved_extra_device_info`'s future-dated drop cannot help),
+  elapsed is negative, the drain never fires, `is_user_overridden()`
+  stays `True` and detection stays suppressed by the unconditional
+  `is_command_overridden_state_changed = False`.
+- Proposed fix: route both comparisons through a shared
+  clock-step-safe helper (reuse `AbstractLoad._seconds_since`, which is
+  already a `@staticmethod`), treating `None` as fully elapsed.
+
+### [nice-to-have] `qs_enable_device is not False` — unreachable in production, and reads as a widening
+
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:696,707`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter + qs-review-blind-hunter (deduped)
+- Description: two angles on one line. (a) every production caller goes
+  through `do_run_check_load_activity_and_constraints`, which already
+  returns early on `qs_enable_device is False` (`load.py:1568`) — so
+  AC4 is pinned on a branch only a direct test call can reach. (b) the
+  double negative opens the block when the flag is `None`/unset, which
+  is a silent widening if "unknown" ought to mean disabled.
+- Proposed fix: keep the guard as defence-in-depth but say so in the
+  comment (one line: "unreachable via
+  `do_run_check_load_activity_and_constraints`, which already
+  short-circuits; kept so a direct call cannot expire overrides on a
+  disabled load") and state that `None` is deliberately treated as
+  enabled.
+
+### [nice-to-have] `REGAINED_CONTROL_LOG` reused for "the probe went unavailable"
+
+- File: `custom_components/quiet_solar/home_model/load.py:1032`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: the give-up is not a recovery, so emitting the
+  regained-control constant makes the log claim something that did not
+  happen. `_clear_unresponsive`'s docstring already acknowledges this
+  ("several callers are not recoveries at all") and mitigates it with a
+  reason-led message.
+- Proposed fix: prefer a distinct constant for the non-recovery exits
+  over the accepted-caveat route. If must-fix #1 lands as Option A, the
+  `earned_recovery=False` flag already distinguishes them — key the log
+  constant off it. Keep AC9's "exactly one release line" assertion
+  meaningful (update the constant it greps for if it changes).
+
+### [nice-to-have] Trim the 11-line historical narrative comment
+
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:694-706`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: an 11-line narrative with shouted emphasis ("pinned
+  FOREVER", "state-FREE") duplicating what
+  `docs/agents/concepts/bistate-duration-devices.md` and
+  `user-override.md` now say.
+- Proposed fix: cut to 2–3 lines stating the invariant (detection is
+  gated, lifecycle is not) plus a pointer to the concept doc; drop the
+  caps.
+
+### [nice-to-have] AC3 nested loops → `pytest.mark.parametrize`
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py:260`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: nested `for running / for current` loops with a
+  `context` tuple to recover attribution on failure; `parametrize`
+  gives per-case names and attribution for free.
+- Proposed fix: parametrize the 2×2. Fold in should-fix AC3's extra
+  aged-override arm while you are there.
+
+### [nice-to-have] Push-storm test drives 6 simulated hours under log capture
+
+- File: `tests/test_bug_304_command_deadlock.py:~380`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: the test drives 6 simulated hours inside
+  `caplog.at_level(logging.INFO)`, while its AC11 sibling was
+  deliberately trimmed to ~4 give-up windows per D5 — a large log
+  capture for no added coverage.
+- Proposed fix: trim to the minimum number of windows that still
+  demonstrates the property, consistent with D5. Note must-fix #1's new
+  test also needs ≥3 windows — size both together.
+
+### [nice-to-have] Stray blank line in the lifecycle chain
+
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:~750`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: stray blank line between the new `elif` block and the
+  `else:` of the same chain.
+- Proposed fix: remove it.
+
+### [nice-to-have] Story line 37 parses as a Markdown heading (MD018)
+
+- File: `docs/stories/QS-307.story.md:37`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit (markdownlint-cli2 0.23.1, MD018
+  `no-missing-space-atx`)
+- Description: the line begins `#304 made the relaunch backoff
+  saturate…`, which ATX-parses as a heading. Verified: the repo has no
+  markdownlint config and no CI hook, so this is cosmetic and
+  CodeRabbit-local only.
+- Proposed fix: reflow so the line does not start with `#`, or write
+  `` `#304` ``.
+
+## How to apply
+
+Run `/implement-task` against this fix plan (or open a fresh
+`claude --agent qs-implement-task` session). Suggested order — the
+must-fix and should-fix #2/#3 all touch the same two hot regions:
+
+1. must-fix #1 (`load.py` escalation discriminator) + its AC, then
+   re-run AC9/AC10 and amend D5.
+2. should-fix #2 and #3 (`bistate_duration.py` expiry branch and outer
+   gate) + their ACs.
+3. should-fix #4/#6/#7 (story amendments + assertion strengthening).
+4. should-fix #5 (resolve the comment/doc contradiction).
+5. The nice-to-haves, folding #10 into #1 and #12 into #7.
+
+Story amendments are expected for D1/D2 (three hoisted branches), D5
+(the new escalation discriminator), AC3 and AC8. Update
+`docs/agents/concepts/` alongside — at minimum `load-base.md`
+(finding #5, and the escalation guard if must-fix #1 changes it),
+`user-override.md` and `bistate-duration-devices.md` (findings #3
+and #4), `notification-routing.md` (must-fix #1 changes when a push
+fires). Re-run
+`python scripts/qs/quality_gate.py --impacted` before commit.
+
+When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-307.story_review_fix_#02.md
+++ b/docs/stories/QS-307.story_review_fix_#02.md
@@ -1,0 +1,411 @@
+# QS-307 — Review fix plan #02
+
+## Summary
+- Source PR: #316
+- Source story: `docs/stories/QS-307.story.md`
+- Previous fix plan: `docs/stories/QS-307.story_review_fix_#01.md` (applied in `e79f889d`)
+- Findings to fix: 14 (2 must-fix, 4 should-fix, 8 nice-to-have)
+- Next implement phase: `/implement-task`
+
+Reviewers: `qs-review-blind-hunter`, `qs-review-edge-case-hunter`,
+`qs-review-acceptance-auditor`, `qs-review-coderabbit`.
+
+**What round 2 confirmed resolved** — keep these green:
+`bistate_duration.py:755-759` drops only the override-*aligned* command
+at expiry (AC1/AC1b); `support_user_override()` moved down to the
+detection gate at `:809`, so all three lifecycle branches run for a
+boost-only load (AC17–AC19); the cooldown drain is clock-step-safe
+(AC20); the round-1 push storm is damped for its reported timeline
+(AC13). All 20 ACs trace to an implementation site and a test, and the
+auditor's verdict on the story amendments is that they are **honest** —
+dominated by strengthening, with D5's former "accepted residual" push
+storm deleted and *replaced* by a fix. CI is fully green.
+
+**Triaged invalid, not below:** blind-hunter's "`expected_state_from_command(...)
+== external_user_initiated_state` can be `None == None` and drop a
+legitimate solver command". `_state_on`/`_state_off` are typed `str` and
+default to `"on"`/`"off"`, and the conjunct already guards
+`running_command is not None`, so the expression cannot be `None` on the
+left. Unreachable; edge-case-hunter reached the same conclusion
+independently. CodeRabbit's round-1 MD018 nit is already fixed (verified:
+no line in either story file starts with `#` + digit). CodeRabbit
+produced **no** round-2 coverage — it is rate-limited and its only
+review is pinned to the pre-fix-plan commit `69ff28e1`, so commit
+`e79f889d` is unreviewed by it. Re-running it is worthwhile if the limit
+clears, but nothing blocks on it.
+
+## Findings to fix
+
+### [must-fix] The episode latch is set when no episode exists — the first genuine push is swallowed forever
+
+- File: `custom_components/quiet_solar/home_model/load.py:769-772`
+- Severity: must-fix
+- Source: qs-review-blind-hunter **and** qs-review-edge-case-hunter
+  (found independently), reproduced by the orchestrator
+- Description: in `_clear_unresponsive`, the latch write
+  ```python
+  if earned_recovery:
+      self._unresponsive_needs_ack = False
+  else:
+      self._unresponsive_needs_ack = True
+  ```
+  sits **above** the `if self.unresponsive_since is None: return` early
+  return. So a give-up that releases *nothing* still latches the
+  episode. This is not a corner case — it is the ordinary ordering: the
+  invalid-probe give-up fires after
+  `NUM_MAX_INVALID_PROBES_COMMANDS × CYCLE_S` ≈ **70 s** of `None`
+  probes, an order of magnitude before the ~1050 s
+  (`NUM_MAX_COMMAND_RELAUNCH`) escalation threshold. So the normal
+  timeline latches with `unresponsive_since` still `None` and no push
+  ever sent. `_escalate_or_recover` (`load.py:1181`) then takes the
+  `unresponsive_command = None` arm and suppresses **both** the ERROR
+  log and the push for the load's **first genuine** lost-control
+  episode — permanently, because the clearers (a real ack,
+  `_drop_running_command`, a `keep_commands=False` wipe) never happen
+  for a device that answers-but-disobeys.
+  Trigger is mundane: an entity `unavailable` for ~70 s (HA restart,
+  integration reload, Zigbee coordinator restart), then back but
+  ignoring commands forever. The PR's own new test
+  `test_a_device_unavailable_from_the_start_never_escalates`
+  (`tests/test_bug_304_command_deadlock.py:588`) drives exactly this and
+  leaves the latch `True` with zero pushes — it just never asserts on
+  the latch.
+- Orchestrator reproduction (throwaway, discarded): phase 1 — probe
+  `None` from cycle 1 → `unresponsive_since is None`, 0 pushes, 0
+  `LOST_CONTROL_LOG`, `_unresponsive_needs_ack is True`. Phase 2 — probe
+  flips to `False`, ladder climbs to rung 11 (threshold 6),
+  `unresponsive_since` armed → still **0 pushes, 0 `LOST_CONTROL_LOG`**.
+- Proposed fix: latch only when an episode is actually being released —
+  move the `_unresponsive_needs_ack` write **below** the
+  `if self.unresponsive_since is None: return` early return (keeping the
+  `_last_supersede_time = None` write above it, where it belongs). The
+  invariant becomes "the latch suppresses the next shout only when there
+  was a shout to follow", which is what D6 intends. Edge-case-hunter
+  verified every existing assertion stays green under this change: AC10
+  and AC13 and
+  `test_unavailable_probe_give_up_releases_the_ownerless_clock:444` all
+  escalate *before* their give-up, so their clock is live at that point.
+- Test: new AC — a load whose entity is unavailable for ~70 s (give-up
+  fires, no episode announced), then visible-but-disobeying for two full
+  ladders, emits **exactly 1** `LOST_CONTROL_LOG` and **1** push.
+  Additionally assert `_unresponsive_needs_ack is False` at the end of
+  `test_a_device_unavailable_from_the_start_never_escalates`, so the
+  latch state that made this bug invisible is pinned going forward.
+
+### [must-fix] Expiry has zero tolerance for a future-dated anchor — a fresh user override is destroyed
+
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:734-737`
+- Severity: must-fix (escalated from the reviewer's should-fix by the
+  orchestrator, see reachability below)
+- Source: qs-review-edge-case-hunter
+- Description: a regression introduced by **review fix #08 of plan
+  #01** — `_seconds_since` was adopted literally, and it returns `None`
+  for *any* negative delta, which
+  ```python
+  override_expired = override_age_s is None or override_age_s > (3600.0 * self.override_duration)
+  ```
+  treats as "fully elapsed". So an arbitrarily small future-dating of
+  `external_user_initiated_state_time` cancels a brand-new
+  8-hour user override on the spot: `external_user_initiated_state` and
+  its timestamp are nulled, the override's in-flight command is dropped
+  (via the new review-fix-#02 drop), the USER_OVERRIDE constraint is
+  wiped, `do_force_next_solve` is set, and the load sits in
+  `ASKED FOR RESET` for the next 180 s. QS actively fighting the user —
+  the exact harm class this story exists to remove, arriving from the
+  other direction.
+- Why the orchestrator escalated this to must-fix — **route (b) needs no
+  clock anomaly at all.** Verified: `user_set_bistate_mode` and
+  `user_set_default_on_duration`
+  (`bistate_duration.py:439,450`) and `async_reset_override_state`
+  (`load.py:2288`) each take their **own** unlocked
+  `datetime.now(pytz.UTC)`, while a concurrently-running
+  `async_update_loads` cycle is still carrying an earlier `event_time`
+  (`data_handler.py:110`). An override anchored by a user action can
+  therefore be *ahead* of the cycle time that then evaluates it, and
+  that cycle expires it immediately. Route (a) is the plain backwards
+  clock step (NTP correcting after an RTC-less boot), which
+  edge-case-hunter verified end-to-end with the `_StuckPump` harness:
+  `external_user_initiated_state` → `None`, `get_override_state()` →
+  `ASKED FOR RESET`, `running_command` → `None`, override constraints →
+  `[]`.
+- Proposed fix (signed off by the user): a **tolerance band**, mirroring
+  the precedent the codebase already sets for this very field. Verified
+  at `bistate_duration.py:224`, the restore path grants ±60 s
+  deliberately (`age_s > 3600.0 * self.override_duration or age_s < -60.0`,
+  commented "a small tolerance for benign skew"). Apply the same shape
+  here: **future by < 60 s ⇒ treat as zero elapsed (not expired);
+  beyond that ⇒ treat as fully elapsed (expired).** Factor the band so
+  the expiry and the cooldown drain share it rather than open-coding it
+  twice, and keep `_seconds_since`'s "fully elapsed" meaning intact for
+  the large-jump case that AC20 pins.
+- Explicitly **out of scope**: making the unlocked `datetime.now(pytz.UTC)`
+  call sites take the cycle's `event_time`. That is the deeper fix for
+  route (b) but has a much wider blast radius; if it is worth doing it
+  deserves its own issue. Note that in the closing comment if you open
+  one.
+- Test: new ACs — (a) an override armed at `T`, evaluated at `T - 5 s`,
+  survives (state, timestamp, in-flight command and constraint all
+  intact, `get_override_state()` unchanged); (b) an override whose
+  anchor is future-dated **beyond** the band still expires, so AC20's
+  large-backwards-jump guarantee is preserved. Add the symmetric pair
+  for the cooldown drain.
+
+### [should-fix] The latch is cleared by three callers that are not device contact
+
+- Files: `custom_components/quiet_solar/home_model/load.py:417, 897, 1241`
+  (+ `:167-168` comment), `docs/stories/QS-307.story.md` (D6),
+  `docs/agents/concepts/load-base.md`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-acceptance-auditor +
+  qs-review-edge-case-hunter (three reviewers, one root cause — deduped)
+- Description: `_clear_unresponsive` has four `earned_recovery=True`
+  call sites and only **one** is evidence the device answered:
+  `:654` (a real ack). The others are `:417` (a `keep_commands=False`
+  wipe), `:897` (`_drop_running_command` — now reached by the new
+  expiry-time drop) and `:1241` (housekeeping re-arm). Verified by
+  grep. Meanwhile D6's table calls the latch per-**episode** and
+  justifies the `True` callers as carrying "evidence QS is back in
+  contact"; the in-code comment at `load.py:167-168` is stronger still
+  ("cleared only by evidence that it did"); and `load-base.md` says "an
+  **episode** ends only when QS gets a real ack". Code and documented
+  invariant disagree. Concretely: a flapping device latches via the
+  give-up, then an override on the same load expires → the new drop
+  clears the latch → the next ladder climb shouts again for a device
+  that never answered. Bounded (one extra push per override expiry), but
+  it re-opens the storm D6 exists to damp, and AC13 pins "a real ack ⇒
+  escalates again" without pinning "and *only* a real ack".
+- Proposed fix (shape signed off by the user): `earned_recovery: bool`
+  cannot express the third state `_drop_running_command` needs — "leave
+  the latch alone". Replace it with a three-valued signal, e.g.
+  `contact_evidence: Literal["acked", "none", "unchanged"]` (or a
+  separate `clear_needs_ack: bool | None`), and map the call sites:
+  `:654` → clears the latch; `:1066` (give-up) → sets it; `:897` and
+  `:417` → leave it unchanged; `:1241` → keep today's behaviour, but
+  note the comment at `:1231` already argues the gate above it is
+  load-bearing precisely because of the latch (AC14), so re-check that
+  argument still holds under the new signal.
+- **Then reword the documentation to match whatever lands** — D6, the
+  `load.py:167-168` comment and `load-base.md`'s "an episode ends only
+  when QS gets a real ack" must describe the code, not an idealised
+  version of it.
+- Test: new AC — a latched flapping load whose override expires does
+  **not** shout on the next ladder climb (i.e. only a real ack clears
+  the latch). This is the "and only a real ack" half AC13 is missing.
+
+### [should-fix] `is_uncontrollable` docstring contradicts itself and `load-base.md`
+
+- File: `custom_components/quiet_solar/home_model/load.py:715-725`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: the docstring says "the clock is per EPISODE, not per
+  command, and survives a supersede" and then, two sentences later,
+  "So this really is per-command." The first sentence is leftover
+  pre-#308 text — #308/QS-307 made every slot-emptying path release the
+  clock — and it also contradicts
+  `docs/agents/concepts/load-base.md` ("`unresponsive_since` is per
+  **command**").
+- Proposed fix: delete the stale sentence and keep the corrected
+  framing: `unresponsive_since` is per-command; "are we still in an
+  unresolved lost-control episode" is `_unresponsive_needs_ack`. The
+  existing "do not conflate the two again" line is good — leave it.
+  Cross-check `load-base.md` agrees after the edit, and fold in whatever
+  wording should-fix #3 forces.
+
+### [should-fix] AC4 was reworded to cover three branches; its test still pins two
+
+- Files: `docs/stories/QS-307.story.md` (AC4),
+  `tests/test_qs307_override_expiry_unfreeze.py:359`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC4 was amended from "neither hoisted branch" to "**no**
+  hoisted branch" when the third branch (the D1a cooldown drain) was
+  added, but `test_ac4_a_disabled_load_runs_no_lifecycle_branch` was not
+  extended. It arms an aged override and
+  `asked_for_reset_user_initiated_state_time_first_cmd_reset_done`,
+  pinning that expiry and the reset-ask follow-up stay put on a disabled
+  load — but it never arms `asked_for_reset_user_initiated_state_time`,
+  so the branch added *by this very round* is unpinned for
+  `qs_enable_device is False`.
+- Proposed fix: arm `asked_for_reset_user_initiated_state_time` in that
+  test and assert it is **not** drained on a disabled load. One
+  assignment, one assertion.
+
+### [should-fix] AC11 asserts against the log constant the code no longer uses on that path
+
+- File: `tests/test_bug_304_command_deadlock.py:588`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: `test_a_device_unavailable_from_the_start_never_escalates`
+  asserts `count_log(caplog, REGAINED_CONTROL_LOG) == 0` but **not**
+  `count_log(caplog, RELEASED_WITHOUT_CONTACT_LOG) == 0`, even though
+  the give-up fires four times in that test and `load.py:1066` now
+  passes `earned_recovery=False` — i.e. the line that could actually
+  appear is the one not asserted. The property does hold today (the
+  clock is never set, so `_clear_unresponsive` returns before logging),
+  but the assertion is aimed at the wrong constant. Its sibling at
+  `:368` got both counters.
+- Proposed fix: add the `RELEASED_WITHOUT_CONTACT_LOG == 0` assertion.
+  Note this test is also touched by must-fix #1 (add the
+  `_unresponsive_needs_ack is False` assertion) — do both in one pass.
+
+### [nice-to-have] The latch is not persisted, so a flapping device shouts once per restart
+
+- Files: `custom_components/quiet_solar/home_model/load.py:188`
+  (`get_to_save_extra_device_info` / `use_saved_extra_device_info`),
+  `docs/agents/concepts/notification-routing.md`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `_unresponsive_needs_ack` is neither saved nor restored,
+  so it resets to `False` on every HA restart or config-entry reload
+  while the device's situation is unchanged — a permanently flapping
+  device shouts once per restart. `notification-routing.md` and
+  `_notify_unresponsive`'s docstring say "once per episode, not once per
+  lifetime" without carving this out.
+- Proposed fix: either persist it alongside `unresponsive_since` (check
+  what that field does today and stay consistent), or state the
+  restart-resets-the-episode semantics explicitly in
+  `notification-routing.md`. Persisting is the smaller surprise; a
+  restart is not contact with the device. If you choose not to persist,
+  say why in the doc.
+
+### [nice-to-have] Story "Files touched" and D2 over-claim after the amendments
+
+- File: `docs/stories/QS-307.story.md:588` (and the D2 paragraph)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: the "Files touched" table still reads "detection body
+  re-indented, not modified", which D1b explicitly reverses ("not even
+  moved") and D1a/T2 contradict ("the only edit *within* the old
+  detection body is the cooldown block"). Separately D2 still says "The
+  outcome is identical; only the cycle it lands on changes", while its
+  own parenthetical concedes D1d removes a command — for a healthy load
+  with an aligned command in flight the outcome is now *not* identical
+  to `main` (the command is abandoned rather than acking one cycle
+  later). AC1 covers the behaviour correctly; only the prose is wrong.
+- Proposed fix: reconcile both sentences with D1a/D1b/D1d.
+
+### [nice-to-have] Doc-maintenance table still calls `external-control-detection.md` untouched
+
+- File: `docs/stories/QS-307.story.md` (doc-maintenance table)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: the story declares `external-control-detection.md`
+  **`Doc-OK` / deliberately not touched**, but the PR now updates it
+  (split-gate paragraph + the cooldown suppression/expiry split). The
+  update is correct; the table is stale.
+- Proposed fix: move it from `Doc-OK` to updated, with a one-line note
+  on what changed. Also re-check the PR body's Doc-maintenance section,
+  which carries the same claim.
+
+### [nice-to-have] No round-3 entry in Adversarial Review Notes
+
+- File: `docs/stories/QS-307.story.md` (Adversarial Review Notes)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: the section has no round-3 entry and still ends "**Open
+  criticals: 0**", without recording that a must-fix was found and
+  fixed in round 3. Bookkeeping — the `_review_fix_#01.md` file carries
+  the record and every D-section cites "review fix #01".
+- Proposed fix: add the round-3 entry, and a round-4 entry for this
+  plan (2 must-fix: the latch ordering and the expiry tolerance band).
+
+### [nice-to-have] Collapse the latch branch and the two log arms
+
+- File: `custom_components/quiet_solar/home_model/load.py:769-781`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `if earned_recovery: ... = False else: ... = True` is
+  just `self._unresponsive_needs_ack = not earned_recovery`, and the two
+  `_LOGGER.info` arms could share one call with a selected message.
+- Proposed fix: simplify. Note must-fix #1 moves this code and
+  should-fix #3 changes the parameter to a three-valued signal — do
+  this **last**, and re-derive the simplification against whatever
+  shape lands rather than applying it literally.
+
+### [nice-to-have] Trim the process-artefact comments in the hot function
+
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:696-706, 733-746`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: ~35 lines of narrative comments referencing "review fix
+  #02 / #03 / #08" inside `check_load_activity_and_constraints`. Those
+  numbers are meaningless once the story is archived, and the reasoning
+  is already in the concept docs.
+- Proposed fix: keep the invariant statements, drop the process
+  numbering and the historical narrative, and point at
+  `docs/agents/concepts/bistate-duration-devices.md` /
+  `user-override.md`. This was also raised in round 1 (plan #01's
+  "trim the 11-line narrative") and has since grown — so trim with
+  intent rather than deferring again.
+
+### [nice-to-have] `#` in the committed fix-plan filenames
+
+- Files: `docs/stories/QS-307.story_review_fix_#01.md`,
+  `docs/stories/QS-307.story_review_fix_#02.md`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: a `#` in a committed filename breaks plain
+  markdown/URL links (it is a fragment delimiter) and needs quoting in
+  every shell invocation.
+- Proposed fix: **do not rename anything in this PR** — the name is
+  generated by `scripts/qs/utils.next_review_fix_path`, so a rename here
+  would desync from the tool. Open a follow-up issue against the
+  pipeline to drop the `#` from generated fix-plan paths, and reference
+  it from the story's closing comment.
+
+### [nice-to-have] Defensive conjunct on the expiry-time drop
+
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:755-759`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter (downgraded from should-fix by the
+  orchestrator — the reported failure mode is unreachable)
+- Description: the alignment conjunct compares
+  `expected_state_from_command(self.running_command) ==
+  self.external_user_initiated_state`. The reviewer's claimed
+  `None == None` false-drop cannot occur (`_state_on`/`_state_off` are
+  `str` defaulting to `"on"`/`"off"`, and `running_command is not None`
+  is already guarded), so this is clarity only.
+- Proposed fix: optionally add `self.external_user_initiated_state is not None`
+  to the conjunct to make the intent local and future-proof, with a
+  one-line comment that it is defensive rather than fixing a live bug.
+  Skip it if you prefer not to add unreachable branches — coverage is at
+  100%, so an unreachable conjunct may need a `# pragma` or a test, which
+  would be worse than leaving it out. Your call; record the decision.
+
+## How to apply
+
+Run `/implement-task` against this fix plan (or open a fresh
+`claude --agent qs-implement-task` session). Suggested order — the two
+must-fixes and should-fix #3 all touch `_clear_unresponsive` and its
+callers, so sequence them deliberately:
+
+1. **must-fix #1** — move the latch write below the early return; add
+   its AC and the `_unresponsive_needs_ack` assertion. Smallest change,
+   biggest correctness win; land it first and independently.
+2. **must-fix #2** — the shared tolerance band for expiry + cooldown
+   drain, with the two new ACs.
+3. **should-fix #3** — the three-valued contact signal, then reword D6,
+   `load.py:167-168` and `load-base.md` to match. Re-check AC14's
+   load-bearing-gate argument survives.
+4. **should-fix #4/#5/#6** — docstring contradiction, AC4's third
+   branch, AC11's log constant.
+5. The nice-to-haves, doing the `not earned_recovery` simplification
+   **last** (it depends on the shape from steps 1 and 3).
+
+Story amendments expected: D6 (latch semantics), a new D-section or
+amendment for the tolerance band, AC4's test, plus the Adversarial
+Review Notes and doc-maintenance-table corrections. Update
+`docs/agents/concepts/load-base.md` (episode vs per-command, the latch
+clearers) and `notification-routing.md` (restart semantics, if you take
+the doc route on the persistence nice-to-have). Two follow-up issues to
+open and reference from #307's closing comment: the unlocked
+`datetime.now(pytz.UTC)` cycle-time race, and the `#` in generated
+fix-plan filenames.
+
+Re-run `python scripts/qs/quality_gate.py --impacted` before commit. The
+change set touches `tests/qs`-pinned docs, so also run
+`python scripts/qs/quality_gate.py --quick tests/qs`.
+
+When done, return and run `/review-task` again to re-verify. If
+CodeRabbit's rate limit has cleared by then it will finally cover the
+fix-plan commits, which it has not yet done.

--- a/docs/stories/QS-307.story_review_fix_#03.md
+++ b/docs/stories/QS-307.story_review_fix_#03.md
@@ -1,0 +1,291 @@
+# QS-307 — Review fix plan #03 (final, minimal)
+
+## Summary
+- Source PR: #316
+- Source story: `docs/stories/QS-307.story.md`
+- Previous fix plans: `_review_fix_#01.md` (`e79f889d`), `_review_fix_#02.md` (`ea16763a`)
+- Findings to fix: 8 (1 must-fix, 7 minimal corrections)
+- Next implement phase: `/implement-task`
+
+**This plan is deliberately smaller than its predecessors.** Round 3
+established, by measurement, that the biggest remaining finding is **not
+a regression from this PR**. It has been filed as **#319** and is out of
+scope here. This plan fixes only what PR #316 itself introduced, with the
+simplest change that works, and removes every claim in the PR and its
+docs that overstates what was solved.
+
+### The measurement that scoped this plan
+
+Two alert-storm scenarios, run identically on each revision:
+
+| Scenario | `main` (`8ea823dc`) | Pre-flag (`69ff28e1`) | Today (`ea16763a`) |
+| --- | --- | --- | --- |
+| Device **drops off the network** intermittently | 1 alert / 105 min | **5** | 1 alert / 105 min |
+| Device **reachable but ignores commands** | **5 alerts / 105 min** | 5 | **5 alerts / 105 min** |
+
+Conclusions, both load-bearing for this plan:
+
+1. **Row 2 is pre-existing.** Identical on `main` and on the branch. Not
+   this PR's bug → **#319**. Do not fix it here.
+2. **Row 1 is a real regression this PR created** (Part B releases the
+   lost-control clock at the invalid-probe give-up, which re-arms the
+   once-only guard). The `_unresponsive_needs_ack` flag is what returns
+   it to parity with `main`. **It must stay.** Deleting it ships a 5×
+   alert regression.
+
+So the flag's job shrinks to exactly one sentence: *the give-up must not
+re-arm the alert.* Everything added to it beyond that job was chasing
+#319 and should be simplified away or, where it is load-bearing, left
+alone but described accurately.
+
+## Findings to fix
+
+### [must-fix] The expiry-time command drop can mutate the command slot across an `await`
+
+- File: `custom_components/quiet_solar/ha_model/bistate_duration.py:750`
+- Severity: must-fix (the only correctness defect this PR still owns)
+- Source: qs-review-edge-case-hunter
+- Description: the D1d drop added in fix plan #01 is the **first
+  command-slot mutation ever performed inside
+  `check_load_activity_and_constraints`**, and three of that method's
+  four callers run *outside* `_update_loads_lock`
+  (`bistate_duration.py:440` `user_set_default_on_duration`, `:451`
+  `user_set_bistate_mode`, `load.py:2358` `async_reset_override_state`).
+  The invariant the retry lifecycle relies on — stated in-code at
+  `load.py:1160-1164`, "each command-slot mutation happens between
+  `await`s" — is therefore no longer true.
+  Verified by the orchestrator: in `force_relaunch_command` the
+  `try/except` wraps **only** `await self.execute_command(...)`. The
+  code after that await dereferences `self.running_command` unguarded
+  (`load.py:1362`, and `self._ack_command(time, self.running_command)`
+  at `:1367`). If the user touches that load's mode select, on-duration
+  number or reset-override button while the service call is in flight,
+  the expiry can null `running_command` underneath it, giving either an
+  `AttributeError` (caught per-load upstream, so it degrades to a logged
+  error and an aborted cycle) or `_ack_command(time, None)`, which nulls
+  `current_command` and silently drops the load out of the
+  controlled-consumption accounting — the exact harm class this story
+  exists to remove.
+- Proposed fix — **simplest that works**: re-check the slot after the
+  await instead of restructuring the locking. In
+  `force_relaunch_command`, immediately after the
+  `try/except` around `execute_command`, bail out if
+  `self.running_command is None` (the command we launched is gone;
+  another task legitimately dropped it, and there is nothing left to
+  ack or log about). Do **not** attempt to introduce a lock around
+  `check_load_activity_and_constraints` — that is a much wider change
+  and this story should not carry it.
+- Also update the now-false invariant comment at `load.py:1160-1164` to
+  say the slot can be emptied across an await and that the post-await
+  re-check is what makes it safe.
+- Test: pin the race deterministically — drive `force_relaunch_command`
+  with an `execute_command` double that nulls `running_command` (via the
+  expiry path) while it is awaited, and assert no exception escapes,
+  `current_command` is preserved, and the load stays inside
+  `is_load_command_set` accounting.
+
+### [required] Remove the claims that this PR solved the general alert storm
+
+- Files: `docs/agents/concepts/notification-routing.md`,
+  `docs/agents/concepts/load-base.md`,
+  `docs/stories/QS-307.story.md` (D6, AC22)
+- Source: qs-review-edge-case-hunter (the docs assert more than the code
+  does), confirmed by the orchestrator's measurement
+- Description: the PR ships two sentences that are false — on this
+  branch *and* on `main`:
+  - `notification-routing.md`: fires "once per **episode**, not once per
+    lifetime **and not once per ladder climb**";
+  - `load-base.md`: "an episode ends only on a real ack".
+  Measured row 2 above: a reachable-but-disobeying device alerts about
+  every 18.5 minutes, because the flag is only ever *set* by the
+  invalid-probe give-up. Shipping a doc that promises a guarantee the
+  code does not provide is worse than shipping the gap.
+- Proposed fix: state exactly what the flag does and nothing more —
+  *"when QS gives up probing a device it cannot reach, the lost-control
+  clock is released so the next command is not mis-scored; the flag
+  stops that release from re-announcing an incident that was already
+  announced. It does not deduplicate alerts for a device that stays
+  reachable and simply never obeys — see #319."* Link #319 from both
+  docs.
+- Re-scope **D6** to that one job, and re-word **AC22** so it pins what
+  the flag actually guarantees rather than "only a real ack clears the
+  latch" (which reads as a general guarantee). Keep AC22's test — the
+  behaviour it exercises is real; only the claim around it is too broad.
+- Add a **residual** note in the story: #319 is pre-existing, measured
+  identical on `main`, and deliberately out of scope. Reference it from
+  #307's closing comment at finish-task.
+
+### [required] Simplify the contact signal to the smallest thing that holds parity
+
+- File: `custom_components/quiet_solar/home_model/load.py:76-78, 755, 791-806`
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter
+- Description: two problems in one place. (a) The three-valued
+  `CONTACT_CONFIRMED` / `CONTACT_NONE` / `CONTACT_UNKNOWN` signal was
+  introduced in fix plan #02 to let `_drop_running_command` "leave the
+  flag alone" — a requirement that came from trying to cover #319. With
+  #319 out of scope, that third value may no longer earn its keep.
+  (b) Whatever survives, the signature is dangerous as written:
+  `contact: str = CONTACT_CONFIRMED` defaults to the value that
+  *clears* the flag, so any future call site that forgets the kwarg
+  silently ends an incident, and the bare `str` type means a typo
+  matches no branch and degrades silently with no mypy error.
+- Proposed fix, in this order:
+  1. Try collapsing to the simplest signal that still holds **row 1 at 1
+     alert / 105 min**. Use the regression test below as the oracle, not
+     reasoning. If a two-valued form suffices, use it.
+  2. Whatever the arity, make the argument **required** (no default) and
+     typed so mypy checks it — `Literal[...]` over the constants, or a
+     small `enum`. Never default to the flag-clearing value.
+- Test: add the row-1 scenario as a permanent regression test — a
+  device flapping between unreachable and disobeying emits **exactly 1**
+  alert over ~105 simulated minutes, matching `main`. This is the test
+  that makes the flag's existence self-documenting, and it is what any
+  future simplification must be checked against.
+
+### [required] Correct the stale prose, the API references and the PR description
+
+- Files: `docs/stories/QS-307.story.md` (D2 lines 250-253, D4 line 303,
+  "Files touched" table lines 691-697), `custom_components/quiet_solar/home_model/load.py:667`,
+  `:1290`, `:911`, `custom_components/quiet_solar/ha_model/bistate_duration.py:772-776`,
+  and the **PR #316 description**
+- Source: qs-review-acceptance-auditor + qs-review-blind-hunter +
+  qs-review-edge-case-hunter (all three)
+- Description: a batch of statements that no longer match the code.
+  Individually trivial, collectively the thing that has made this PR
+  hard to review:
+  - story **D4:303** and the `load.py:667` comment still reference
+    `earned_recovery: bool`, a parameter that no longer exists;
+  - story **D2:250-253** still says the clock comparisons treat a
+    future-dated anchor as "fully elapsed" — D7 reversed exactly that
+    for the two comparisons in question;
+  - the **"Files touched" table** has an orphan header + separator, so
+    the note after it renders inside a broken table;
+  - `load.py:1290` says the invalid-probe give-up is "the only" path
+    nulling `current_command`; the `keep_commands=False` wipe does too
+    (the conclusion still holds — only the word "only" is wrong);
+  - `load.py:911` docstring and `bistate-duration-devices.md` say
+    "future by **less than** the tolerance", the code is `<=`;
+  - `bistate_duration.py:772-776` claims the cooldown drain lands "on
+    exactly the same cycle" as `main`, which is false precisely at the
+    boundary the hoist targets — AC15 deliberately pins the new
+    behaviour;
+  - the **PR description** still lists `external-control-detection.md`
+    as "Doc-OK: deliberately not touched" (the PR updates it), still
+    calls `_escalate_or_recover`'s `current_command is not None` gate
+    "now-redundant" (D6/AC14 and `load.py:1288` reverse it:
+    "LOAD-BEARING"), and still describes the test inventory as AC1–AC12
+    when there are 24 ACs.
+- Proposed fix: correct each to match the code. The PR description
+  matters most — it is what a merger reads first, and it currently
+  contradicts the branch. Rewrite it to describe what actually ships,
+  including a short "what this PR does **not** fix" pointing at #319.
+
+### [required] Use one source of truth for the clock-skew tolerance
+
+- Files: `custom_components/quiet_solar/home_model/load.py:83`,
+  `custom_components/quiet_solar/ha_model/bistate_duration.py:205, 224`
+- Source: all three code reviewers
+- Description: verified — `CLOCK_SKEW_TOLERANCE_S = 60.0` was added in
+  fix plan #02 and the story's D7 justifies it as "the same ±60 s the
+  restore path already grants these very timestamps", but that restore
+  path still hard-codes `-60.0` at both sites. Two independent values
+  that the story claims are one; retuning the constant would silently
+  desync them.
+- Proposed fix: import `CLOCK_SKEW_TOLERANCE_S` at both sites. One-line
+  change each; no behaviour change today (they agree at the boundary).
+
+### [required] Record the tolerance band's residual honestly
+
+- File: `docs/stories/QS-307.story.md` (D7)
+- Source: qs-review-edge-case-hunter
+- Description: D7 presents the ±60 s band as closing the
+  unlocked-`datetime.now()` race. It does not close it in general — the
+  skew the band must absorb is bounded by the duration of one
+  `update_loads` pass, and nothing caps that (`_update_loads_lock` only
+  skips re-entrant *starts*). A pass that stalls >60 s before reaching a
+  load reproduces the original harm in full.
+- Proposed fix: one sentence in D7 recording the residual, next to the
+  already-deferred cycle-time follow-up. No code change — the deeper fix
+  (threading the cycle's `event_time` through the service handlers) is
+  correctly out of scope for this story.
+
+### [required] Make AC8's post-expiry assertion real, or drop it
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py:720-741`
+  (`_assert_override_self_heals`)
+- Source: qs-review-acceptance-auditor (reproduced)
+- Description: the clause "assert no further override-aligned service
+  call after expiry" is pinned **vacuously**. The transport-call count is
+  snapshotted after expiry and re-asserted after a single
+  `check_load_activity_and_constraints` call, with no relaunch cycle in
+  between — so nothing *could* re-issue the call. The auditor
+  re-introduced the regression it is meant to catch and the assertion
+  still passed (`before=7 after=7`).
+- Proposed fix — pick the cheaper of: (a) drive the relaunch ladder
+  across the post-expiry window and assert no new call whose expected
+  state equals the ended override state; or (b) delete the vacuous
+  assertion and note that AC1's `running_command is None` is what
+  actually pins D1b/D1d. **(b) is acceptable** — AC1 already provides
+  the guarantee, and a test that cannot fail is worse than no test.
+
+### [required] Add the missing observability line on a suppressed re-arm
+
+- File: `custom_components/quiet_solar/home_model/load.py:1244`
+- Source: qs-review-blind-hunter
+- Description: when the flag suppresses the announcement, the re-arm is
+  now **completely silent** — `unresponsive_since = time` with no log at
+  all, where `main` always emitted an ERROR. Hitting the ladder wall
+  again becomes invisible in the field, which will make #319 harder to
+  diagnose from user logs.
+- Proposed fix: one `INFO`/`DEBUG` line — "lost-control clock re-armed
+  for load X; incident already announced, not re-notifying". One line,
+  no behaviour change.
+
+## Explicitly dropped
+
+Reviewed and deliberately **not** actioned, so the next round does not
+re-raise them:
+
+- **The #319 alert storm itself** — pre-existing, measured identical on
+  `main`, filed separately. Any fix belongs there, with a design phase
+  for QS's notification policy.
+- **A stranded `_stacked_command` behind the expiry drop**
+  (blind-hunter) — investigate only if the must-fix's post-await
+  re-check does not already cover it; do not add machinery
+  speculatively.
+- **Persisting the suppression flag across HA restarts**
+  (edge-case-hunter) — the correct behaviour depends on the policy
+  chosen in #319; noted there.
+- **Restoring the 6-hour push-storm test horizon** (blind-hunter) —
+  the long-horizon coverage argument is real, but #319 now owns the
+  unbounded-storm question and carries the reproduction.
+- **`CONTACT_UNKNOWN`'s recovery-flavoured log wording**, **AC4's
+  unset/`None` arm**, and the **`qs_load_uncontrollable` docstring
+  mention** — cosmetic; skipped under the minimal-fix instruction.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. Suggested order:
+
+1. The **must-fix** post-await re-check + its test + the corrected
+   invariant comment.
+2. The **row-1 regression test** (1 alert / 105 min), then attempt the
+   contact-signal simplification against it, then make the argument
+   required and typed.
+3. The doc/claim corrections: notification docs + D6/AC22 re-scope +
+   #319 references; then the stale-prose batch and the **PR
+   description**.
+4. The one-line items: shared `CLOCK_SKEW_TOLERANCE_S`, D7 residual,
+   suppressed re-arm log, AC8 de-vacuuming.
+
+Re-run `python scripts/qs/quality_gate.py --impacted`, plus
+`python scripts/qs/quality_gate.py --quick tests/qs` (this change set
+touches `tests/qs`-pinned docs).
+
+Reference #319 from #307's closing comment at finish-task.
+
+When done, return and run `/review-task`. **Scope the next round
+accordingly**: the reviewers should be told #319 is out of scope, so a
+finding is only actionable if it is a regression against `main` or an
+inaccurate claim in what ships. If CodeRabbit's rate limit has cleared it
+will finally cover the fix-plan commits, which it still has not.

--- a/docs/stories/QS-307.story_review_fix_#04.md
+++ b/docs/stories/QS-307.story_review_fix_#04.md
@@ -1,0 +1,270 @@
+# QS-307 — Review fix plan #04 (closing plan)
+
+## Summary
+- Source PR: #316
+- Previous plans: `#01` (`e79f889d`), `#02` (`ea16763a`), `#03` (`e760f00e`)
+- Items: **6** — three reverts, one copy, text, and a comment cull
+- Next implement phase: `/implement-task`
+
+## The rule this plan is built on
+
+| Plan | Asked for | Result |
+| --- | --- | --- |
+| #01 | adopt a "clock-safe" helper (*a nice-to-have I invented*) | made benign behaviour **destructive** → round-2 must-fix |
+| #01 | add a suppression flag | two must-fixes inside the new flag (rounds 2, 3) |
+| #01 | drop the command at expiry | concurrency must-fix (round 3); 2nd call site missed (round 4) |
+| #02 | add a tolerance band to patch the helper | still destructive past 60 s → round-4 regression |
+| #02 | move `support_user_override()` off the outer gate | override lifecycle now runs for loads that can't have overrides |
+| #03 | add a post-await guard | guarded 1 of 2 call sites |
+
+**Every mechanism added spawned a defect. Every deletion and text
+correction spawned none.** This plan adds no mechanism.
+
+> **Stop rule for the implementer:** if an item appears to need a new
+> helper, constant, parameter or state flag — **stop and report back**.
+> Do not improvise. Improvisation inside a review loop produced rounds
+> 2, 3 and 4.
+
+## Item 1 — DELETE the clock-skew machinery; restore `main`'s arithmetic
+
+**Revert.**
+
+Round 4 reproduced: an override anchor dated >60 s ahead of the cycle
+time wipes a live 8-hour override (state nulled, aligned command
+dropped, constraints reset); the same overshoot on the reset-ask anchor
+drains the cooldown instantly *and* lets detection re-classify the
+user's manual action — QS re-arming the override the user just
+cancelled.
+
+`main` uses plain subtraction. A future-dated anchor gives a negative
+number, never greater than the threshold, so `main` simply does not
+expire that cycle — the override lasts slightly longer. Benign.
+
+The destructive rule came from plan #01's *nice-to-have*
+("route through `_seconds_since`"). That helper's "future anchor ⇒ fully
+elapsed" is correct for the retry ladder it was written for, where it
+means *don't freeze the retry*. On an override it means *destroy what
+the user set*. There was never a bug here.
+
+Do:
+1. Revert both comparisons to `main`'s plain subtraction — reference
+   `git show 8ea823dc:custom_components/quiet_solar/ha_model/bistate_duration.py`.
+   Keep the hoisted-branch structure and the QS-256#02 tz-coercion lines.
+2. Delete `_seconds_since_skew_tolerant` (`home_model/load.py:907-932`).
+   Verified: exactly two callers, both at
+   `ha_model/bistate_duration.py:732` and `:790`.
+3. **Keep** `CLOCK_SKEW_TOLERANCE_S` and its uses at
+   `bistate_duration.py:206,225` — that is the restore path, where a
+   ±60 s tolerance already existed on `main` as a literal `-60.0`.
+4. Delete `tests/test_bug_304_command_deadlock.py:462-469` and the
+   AC20/AC23/AC24 tests.
+5. Remove **AC20, AC23, AC24** and D7 from the story.
+
+Record this as a **reversal**, naming plan #01's nice-to-have as the
+origin — not a relaxation. Removing ACs otherwise looks like lowering
+the bar; here they pinned behaviour that *was* the defect.
+
+Comment on **#317** to say its premise is gone: with `main`'s arithmetic
+restored, the unlocked-`datetime.now()` race is benign for these anchors.
+
+Side effect — these findings cease to exist, do not fix them: duplicated
+60 s constant, "less than" vs `<=` mismatch, tz-naive `TypeError` in the
+helper's fallback.
+
+## Item 2 — COPY the existing post-await guard to the second call site
+
+**Literal copy of tested code.**
+
+`launch_command` (`home_model/load.py:1096`) runs
+`_ack_command(time, self.running_command)` after
+`await self.execute_command(...)`. If the slot emptied across that await
+— which the expiry-time drop **this PR added** can cause, from three
+callers outside `_update_loads_lock` — it acks `None`, nulling
+`current_command` and dropping the load out of controlled-consumption
+accounting. Reproduced on this branch with the existing `_RacingPump`.
+
+Round 3 fixed this exact shape in `force_relaunch_command`
+(`load.py:1384-1422`); only one of two reachable await points was
+guarded, while the PR body and `load.py:1176-1185` claim it "is fixed".
+
+Do: apply the **same** pattern — hold the launched command in a local,
+bail after the await if `self.running_command is None`, before the ack.
+Copy it; do not redesign, do not widen the condition, do not touch
+`force_relaunch_command`. Extend AC25 to the second site with the
+existing harness.
+
+Leave `check_commands`' `_ack_command` (`load.py:1147`) alone — same
+shape, not realistically reachable (bistate `probe_if_command_set` never
+yields). No speculative guard.
+
+## Item 3 — RESTORE `support_user_override()` to the outer gate
+
+**Revert.** Raised by the user; I would have shipped this.
+
+`main`:
+
+```python
+if self.is_load_command_set(time) and self.support_user_override():
+    # entire override block
+```
+
+Both conditions gated everything, so a boost-only load
+(`load_is_auto_to_be_boosted`) or a charger never executed a line of it.
+Plan #02 moved `support_user_override()` down to the detection gate, so
+the override lifecycle now runs every cycle for loads that cannot have
+overrides.
+
+Splitting `is_load_command_set` is the real #307 fix and stays — that
+condition means "am I waiting on a command", unrelated to clock
+arithmetic. `support_user_override()` answers a different question,
+"can this load have an override at all", and belongs on the outer gate.
+I conflated them to fix one narrow case: a load reconfigured to
+boost-only while holding a live override kept it forever, because the
+only code that could clear it sat behind the gate. Real, but it does not
+justify restructuring the hot path for every load.
+
+Do:
+1. Outer gate back to
+   `if self.qs_enable_device is not False and self.support_user_override():`,
+   detection keeps its inner `if self.is_load_command_set(time):`. Keep
+   the explicit `qs_enable_device` guard — needed because
+   `is_load_command_set` used to imply it.
+2. Handle the boost-only case where it belongs: extend the existing drop
+   condition in `use_saved_extra_device_info`
+   (`bistate_duration.py:206-235`, which already nulls these four fields
+   for stale/future-dated state) to also drop when
+   `support_user_override()` is false. A reconfigure reloads the entry,
+   which runs this path.
+3. Rework **AC17/AC18** — they currently assert the lifecycle runs for
+   boost-only loads, the behaviour being reverted. AC19 (detection stays
+   off) is unaffected.
+
+## Item 4 — Text only: delete claims the code contradicts
+
+No code changes. Text corrections have caused zero regressions in four
+rounds.
+
+Code:
+1. `load.py:1813` — delete "and not once per ladder climb" from
+   `_notify_unresponsive`'s docstring. Measured false (5 alerts/105 min,
+   on this branch *and* `main`). Plan #03 ordered this removed; it landed
+   in the two concept docs but not here. Add the same #319 caveat.
+2. `load.py:680` — drop `earned_recovery=False`; say
+   `contact=ContactEvidence.UNREACHABLE`.
+3. `load.py:1323` — drop "only" from "the only such path is the
+   invalid-probe give-up"; the `keep_commands=False` wipe nulls
+   `current_command` too.
+4. `load.py:1181-1185` — says the guard bails "if the slot no longer
+   **holds it**"; it bails only when the slot is **empty**. Round 4
+   established the replaced-slot case is unreachable (every
+   `launch_command` site is inside `home.update_loads`; unlocked
+   user-action callers only drop, never launch). **Narrow the wording**;
+   do not widen the guard.
+5. `load.py:1329-1342` — the comment credits the
+   `current_command is not None` gate; what protects the flag is that
+   only the give-up sets it, and that nulls `current_command`. State the
+   invariant instead.
+
+Docs/story/PR:
+6. `docs/agents/concepts/load-base.md` — the example
+   `_clear_unresponsive("the probe went unavailable")` omits the required
+   `contact` argument and would `TypeError`.
+7. Story D6 table — `CONTACT_*` → `ContactEvidence.CONFIRMED/.UNREACHABLE/.UNKNOWN`;
+   delete the "(default)" annotation, the argument is required. Same near `:432`.
+8. Rename `test_only_a_real_ack_clears_the_episode_latch` (and fix its
+   docstring plus `_recover_with_a_real_ack`'s) — the claim is untrue;
+   the empty-slot re-arm clears without an ack. Suggest
+   `test_a_drop_we_chose_does_not_re_announce_the_episode`.
+9. Story "Files touched" — add AC25 and this round's changes; fix D6's
+   round-number drift.
+10. **PR #316 description** — AC7 lives in
+    `tests/ha_tests/test_bug_304_uncontrollable_load.py`. Refresh the AC
+    inventory after items 1–3, and drop the claim that the mid-await
+    invariant break "is fixed" unless item 2 has landed.
+
+## Item 5 — Lazy logging on the two lines this PR touched
+
+From CodeRabbit (the one finding of theirs that survived triage).
+
+`load.py:1386` and `:1393` use f-strings in log calls, violating a
+documented project rule
+(`docs/workflow/project-rules.md:151`, `project-context.md:129,236`).
+Ruff does not enforce it (no `G004` in `select`), which is why CI is
+green. Repo-wide the convention holds at 238 lazy vs 15 f-string.
+
+These f-strings pre-date the PR, so they are not a regression — but this
+PR **modified both lines** (to reference the new `launched_command`
+local) and left them non-compliant.
+
+Do: convert those **two** call sites to lazy `%s`. **Not** a repo-wide
+f-string cleanup — the other 13 sites are untouched by this PR and
+belong in their own change.
+
+## Item 6 — Cut the commentary
+
+Measured on this PR's additions to production code:
+
+| | |
+| --- | --- |
+| Added lines | 331 |
+| `#` comment lines | **149 (45%)** |
+| Comment lines naming a story/issue/"review fix #NN" | 14 |
+| Longest added comment blocks | 24, 13, 12, 11, 11 lines |
+
+Nearly half of what this PR adds is commentary, much of it narrating
+review history, with a 24-line block in the hot path.
+
+Rules, not a target number:
+- No `review fix #NN`, round numbers or story artefacts in code
+  comments — that belongs in git history and `docs/`.
+- Nothing over ~4 lines in `check_load_activity_and_constraints` or
+  `force_relaunch_command`; if more is needed, one line pointing at the
+  concept doc.
+- Keep only comments stating a non-obvious invariant a reader cannot
+  derive from the code.
+
+**Run this item LAST.** Items 1 and 3 are reverts that delete the code
+much of this commentary explains, so a large share disappears for free.
+Re-measure after them, then trim what survives.
+
+## Explicitly dropped — do not action
+
+- **#319** (repeating alerts, reachable-but-disobeying load) —
+  pre-existing, measured identical on `main`, filed separately.
+- **CodeRabbit's MD018 finding** — verified already fixed in `e79f889d`;
+  the comment is pinned to the outdated commit `32aff99a`. Stale.
+- **`ContactEvidence` `StrEnum` → plain `Enum`** — a code change with no
+  defect behind it; exactly the "harmless improvement" class that cost
+  three rounds.
+- **A guard at `check_commands`' `_ack_command`** — not reachable.
+- **Persisting the suppression flag across restarts** — belongs to #319.
+- **Restoring the 6-hour storm horizon** — #319 owns it.
+- Repo-wide f-string logging cleanup; test-header AC numbering; other
+  cosmetics.
+
+## Verification protocol
+
+All four must hold before pushing:
+
+1. **Flapping device: exactly 1 alert / 105 simulated min**, matching
+   `main` (`test_a_flapping_device_shouts_once_until_it_answers_again`).
+2. **#319 scenario: still 5 alerts / 105 min** — unchanged from `main`.
+   This PR must neither fix nor worsen it.
+3. **Override survives a confused clock**: anchor 90 s ahead of cycle
+   time ⇒ override **kept** (state, timestamp, aligned command,
+   constraints intact). `main`'s behaviour; replaces deleted AC23/AC24.
+4. **A boost-only load runs no override lifecycle** (item 3), and a
+   stored override is dropped at restore instead.
+
+Plus `python scripts/qs/quality_gate.py --impacted` and
+`python scripts/qs/quality_gate.py --quick tests/qs`.
+
+## How to apply
+
+`/implement-task`, in order: 1 (revert), 3 (revert), 2 (copy), 4 (text),
+5 (logging), 6 (comment cull, last). Re-run the verification protocol
+after items 1 and 3, and again after 2.
+
+Then `/review-task`. Scoping rule: a finding is actionable only if it is
+a **regression against `main`** or an **inaccurate claim in what ships**.
+#319 is out of scope.

--- a/docs/stories/QS-307.story_review_fix_#05.md
+++ b/docs/stories/QS-307.story_review_fix_#05.md
@@ -103,20 +103,12 @@ That is a code change to fix a long-standing defect, bundled into a PR that
 has already been through five review rounds — exactly the pattern that caused
 rounds 2, 3 and 4.
 
-Fix: open a new issue, in the shape of #319, and reference it from item 1's
-docstring. Content:
+**Filed as #320** (already created — do not re-file). It carries the full
+mechanism, the two button trigger paths, the candidate `is not launched_command`
+fix for both guards, and a note that the `_RacingPump` harness added in #316 is
+the natural place to pin it.
 
-- **Title:** phantom ack when a button press replaces the command slot mid-await
-- Trigger: a load with `unresponsive_since` set and a command in flight, inside
-  `force_relaunch_command`'s `await self.execute_command(...)`, while the user
-  presses "mark current constraint done" or "clean and reset".
-- Mechanism: `abandon_running_command` empties the slot, `launch_command` sets
-  `running_command = CMD_IDLE`; the guard sees a non-`None` slot, so
-  `running_command_last_launch` is stamped and `_ack_command(time, CMD_IDLE)`
-  can run off the previous command's `is_command_set`.
-- Candidate fix: `is not launched_command` in both guards
-  (`load.py:1044`, `:1338`), which subsumes the `is None` case at no cost.
-- State that it reproduces on `main` and predates #316.
+Fix here: reference **#320** from item 1's docstring rewrite. Nothing else.
 
 ### 5. `docs/agents/concepts/bistate-duration-devices.md:151` and story `:200` — chargers were never affected
 

--- a/docs/stories/QS-307.story_review_fix_#05.md
+++ b/docs/stories/QS-307.story_review_fix_#05.md
@@ -1,0 +1,235 @@
+# QS-307 — Review fix plan #05 (text only)
+
+## Summary
+- Source PR: #316
+- Previous plans: `#01`–`#04` (`e79f889d`, `ea16763a`, `e760f00e`, `e632e497`)
+- Items: **12, all text**
+- Next implement phase: `/implement-task`
+
+## Scope: zero code changes
+
+Round 5 found **no code defects and no regression against `main`**. All four
+reviewers converged on the same thing: the reverts in plan #04 landed
+correctly, and the prose describing them did not.
+
+**This plan changes no executable code.** No logic, no signatures, no
+constants, no tests other than one docstring and one attribution string.
+Across five rounds, text corrections are the only category that has never
+introduced a defect — so this plan is deliberately confined to that category.
+
+> **Stop rule:** if an item looks like it needs a code change, **stop and
+> report back**. It has been mis-scoped. The one borderline case (item 4) is
+> called out explicitly below with the reason it stays text.
+
+Round-5 verification, for the record — re-run these unchanged at the end:
+
+| Check | Expected |
+| --- | --- |
+| Flapping device | 1 alert / 105 min (= `main`) |
+| #319 scenario | 5 alerts / 105 min (unchanged from `main`) |
+| Anchor 90 s ahead | override **kept** |
+| Boost-only load, 48 h past expiry | no lifecycle runs |
+
+## A. Claims contradicted by the shipped code
+
+### 1. `home_model/load.py:1139` — asserts away a bug that is real
+
+`check_and_relaunch_command`'s docstring says:
+
+> "Emptied, not replaced: every `launch_command` site runs inside
+> `home.update_loads`, and the unlocked user-action callers only ever drop."
+
+Both halves are false. Two unlocked button paths call `launch_command`
+directly — `button.py:190` → `mark_current_constraint_has_done`
+(`load.py:2324`) and `button.py:213` → `user_clean_and_reset`
+(`load.py:2343`) — and on an uncontrollable load `launch_command` takes the
+supersede branch and **replaces** the slot (`load.py:1003-1007`). The
+post-await guard only tests `is None`, so a replaced slot passes it and can
+stamp `running_command_last_launch` and ack the *new* command off the *old*
+command's result.
+
+**This behaves identically on `main`** — it is not a regression and **must not
+be fixed here** (see item 4). But the docstring makes the emptied-only guard
+read as complete, which is precisely the claim/code mismatch this round exists
+to remove.
+
+Fix: state what the guard actually covers — the slot being **emptied** across
+the await — and say plainly that a *replaced* slot is not covered, is
+pre-existing, and is tracked in the follow-up issue from item 4. Do not
+weaken the two lines below it that correctly note `button.py` calls in
+unlocked.
+
+### 2. `home_model/load.py:738` and `docs/agents/concepts/load-base.md:96` — an invariant that is deliberately violated
+
+Both say the clock is per-command because *"every slot-emptying path releases
+it"*. `abandon_running_command` (`load.py:810-823`) explicitly **preserves**
+`unresponsive_since`, and `launch_command` calls it on the supersede path
+(`load.py:1005`), so a successor command legitimately inherits the clock.
+
+That inheritance is **intentional** — it keeps `is_uncontrollable` true so the
+load keeps superseding instead of stacking, and holds the saturated 300 s
+cadence from QS-304.
+
+This is the highest-risk item in the plan: a maintainer "restoring the
+invariant" by releasing the clock in `abandon_running_command` would silently
+break QS-304's supersede-vs-stack behaviour. Fix both places to say the clock
+is released by every path that empties the slot **without a successor**, and
+that a supersede deliberately hands it to the successor, with the reason.
+
+### 3. `ha_model/bistate_duration.py:202-203` and `home_model/load.py:92-95` — a sharing relationship that no longer exists
+
+`bistate_duration.py` says the shared constant means *"retuning it cannot
+desync this site from the runtime comparisons"*, and `load.py` describes
+`CLOCK_SKEW_TOLERANCE_S` as one of two consumers. Plan #04 reverted the
+runtime comparisons to plain subtraction, so the restore boundary
+(`bistate_duration.py:208,231`) is now the constant's **only** consumer, and it
+is referenced from a different module than the one defining it.
+
+Concretely misleading: someone setting `CLOCK_SKEW_TOLERANCE_S = 600.0`
+expecting a 10-minute runtime band would change only the two restore-boundary
+drops; a live override with a 90 s-future anchor would behave identically.
+
+Fix both comments to say the constant governs the restore boundary only. The
+story already states this correctly at line 478 — match it.
+
+### 4. Do **not** widen the post-await guard — file the bug instead
+
+The replaced-slot phantom ack described in item 1 is real and reproducible,
+but it is **pre-existing on `main`** and therefore out of scope by this
+round's rule.
+
+Two rounds ago I proposed changing `is None` to `is not launched_command`.
+That is a code change to fix a long-standing defect, bundled into a PR that
+has already been through five review rounds — exactly the pattern that caused
+rounds 2, 3 and 4.
+
+Fix: open a new issue, in the shape of #319, and reference it from item 1's
+docstring. Content:
+
+- **Title:** phantom ack when a button press replaces the command slot mid-await
+- Trigger: a load with `unresponsive_since` set and a command in flight, inside
+  `force_relaunch_command`'s `await self.execute_command(...)`, while the user
+  presses "mark current constraint done" or "clean and reset".
+- Mechanism: `abandon_running_command` empties the slot, `launch_command` sets
+  `running_command = CMD_IDLE`; the guard sees a non-`None` slot, so
+  `running_command_last_launch` is stamped and `_ack_command(time, CMD_IDLE)`
+  can run off the previous command's `is_command_set`.
+- Candidate fix: `is not launched_command` in both guards
+  (`load.py:1044`, `:1338`), which subsumes the `is None` case at no cost.
+- State that it reproduces on `main` and predates #316.
+
+### 5. `docs/agents/concepts/bistate-duration-devices.md:151` and story `:200` — chargers were never affected
+
+Both justify plan #04's gate revert by saying the previous shape *"ran the
+whole override lifecycle every cycle for chargers and boost-only loads"* /
+*"for every load that cannot have an override — chargers included"*.
+
+Chargers are `QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad)`
+(`charger.py:2153`) — **not** `QSBiStateDuration` — and override
+`check_load_activity_and_constraints` (`charger.py:3331`), so they never reach
+that gate wherever the conjunct sits. They also *can* hold overrides:
+`QSChargerGeneric.support_user_override()` returns `True` (`charger.py:2251`).
+
+The revert remains correct; only the stated blast radius was wrong. Fix both
+to say **boost-only `QSBiStateDuration` loads**. (Origin: this overstatement
+came from the review discussion, not from a reviewer.)
+
+### 6. `home_model/load.py:1268` — `_escalate_or_recover` comment is over-tight
+
+*"this branch runs exactly when nothing has latched in this cycle"* is
+stronger than reality: in one cycle `check_commands` can hit the give-up
+(latching, nulling `current_command`) and then promote `_stacked_command`,
+whose `launch_command` acks it, clearing the latch via `CONFIRMED`. The
+conclusion still holds — the ack legitimately ended the episode — but the
+stated invariant does not. Soften to describe the outcome, not an absolute.
+
+### 7. `launch_command`'s new guard log message is imprecise
+
+The guard at `load.py:1044` logs *"dropped while its **service call** was in
+flight"*, but it sits after **two** await points — `probe_if_command_set`
+(`load.py:1015`) and, conditionally, `execute_command` (`:1033`). The 8-space
+placement is correct and deliberate (it covers both; placing it inside the
+`else:` would miss the probe await) — only the wording is wrong. Say "while a
+call to the device was in flight". Add one short line noting it covers both
+awaits, so nobody "fixes" the indentation later.
+
+## B. Story and docs left stale by the reverts
+
+### 8. Story `:747` "Files touched" — describes deleted work, omits shipped work
+
+The `bistate_duration.py` row still ends *"and the skew-tolerant comparisons
+(D7)"*, which plan #04 deleted, and omits what shipped in their place: the
+`not self.support_user_override()` drop in `use_saved_extra_device_info`
+(`bistate_duration.py:208`, `:232`) — the entire mechanism behind AC18.
+
+### 9. Story `:694` T9 — contradicts D6 and `load-base.md`
+
+Still says the `current_command is not None` gate is *"kept — redundant but
+harmless"*. D6 and `load-base.md` both state it is load-bearing: it stops the
+`CONFIRMED` release clearing the latch the give-up just set (AC14).
+
+### 10. Story D1c `:207-209` — implies no code change was needed
+
+*"`use_saved_extra_device_info` **already** drops stale and future-dated
+overrides, so it also drops them when `support_user_override()` is false"*
+reads as a property that fell out for free; it is a condition this PR added.
+`bistate-duration-devices.md` has the right phrasing — *"already drops stale
+and future-dated overrides, **and now also drops** them when
+`support_user_override()` is false"*. Adopt it.
+
+### 11. Story round-number attribution drift
+
+Under the story's own scheme (fix #NN ↔ round NN+2, per the headers at
+`:804/:819/:857/:887`):
+
+- `:401` "Re-measured in **round 4** (review fix #03)" → round 5.
+- `:471` "**round 4** reproduced the same destruction at 90 s" →
+  round 6. Self-contradicting: it follows "Review fix #02 added a ±60 s band",
+  and round 4 *produced* #02, so it cannot have reproduced against it.
+- `:835` "Reversed in **round 5** — see D7" → round 6 (the reversal is #04).
+- `tests/test_qs307_override_expiry_unfreeze.py:609` attributes the
+  `support_user_override()` work to "review fix #03"; it came from #01.
+
+Also note for the record: plan #04's own summary table misattributes D1c to
+plan #02; the story is right and the plan is wrong. No edit needed to the
+committed plan — just do not propagate it.
+
+*(Test-header AC numbering stays out of scope, per plan #04's dropped list.
+This is attribution, not numbering.)*
+
+### 12. `check_and_relaunch_command` docstring enumeration is one round out of date
+
+It credits only *"the post-await re-check in `force_relaunch_command`"*. Plan
+#04 added the same guard to `launch_command`, and `user-override.md` already
+says both re-check. Fold this into item 1's rewrite.
+
+## Explicitly dropped — do not action
+
+- **#319** — pre-existing, out of scope. Analysis and a suggested two-part fix
+  (a stable notification `tag` for the pile-up; latch-at-announce for the
+  frequency) were posted to the issue this round.
+- **Widening the post-await guard** — item 4: file it, do not fix it here.
+- **`ContactEvidence` `StrEnum` → plain `Enum`** — a code change with no defect
+  behind it. Raised in rounds 4 and 5; declined both times for the same reason.
+- **The persisted override *constraint* not being dropped at restore for a
+  boost-only load** — real, bounded, self-heals at `end_of_constraint`, and
+  behaves identically on `main`. Out of scope. If any doc sentence claims the
+  restore drop is *total* coverage, narrow that sentence under item 5 rather
+  than changing behaviour.
+- Repo-wide f-string logging cleanup; test-header AC numbering; other cosmetics.
+
+## How to apply
+
+`/implement-task`. Items are independent; suggested order is A then B, with
+item 4 (filing the issue) done before item 1 so the docstring can reference it.
+
+Because nothing executable changes, the risk is confined to typos in comments
+and docstrings. Still re-run
+`python scripts/qs/quality_gate.py --impacted` and
+`python scripts/qs/quality_gate.py --quick tests/qs`, plus the four
+verification checks in the table above — if any of them moves, something
+outside this plan's scope was touched and it should be reverted.
+
+Then `/review-task`. Same scoping rule: actionable only if a **regression
+against `main`** or an **inaccurate claim in what ships**. #319 and the new
+phantom-ack issue are both out of scope.

--- a/tests/ha_tests/test_bug_304_uncontrollable_load.py
+++ b/tests/ha_tests/test_bug_304_uncontrollable_load.py
@@ -1,9 +1,9 @@
 """QS-304: HA-layer behaviour when QS loses control of a load.
 
 Covers the parts of the story that only exist above the domain boundary: the
-`qs_load_uncontrollable` binary sensor, the mobile push, the absence of
-collateral damage on power accounting, the off-grid contract, and the fact that
-QS never touches the user's `qs_enable_device` switch.
+mobile push, the absence of collateral damage on power accounting, the off-grid
+contract, and the fact that QS never touches the user's `qs_enable_device`
+switch.
 """
 
 from __future__ import annotations
@@ -95,25 +95,40 @@ def test_is_load_command_set_truth_table_is_unmodified():
     body>"`, which broke on any reformat or comment while letting a real semantic
     change through if it happened to reformat identically. The behavioural truth
     table over the three inputs it actually reads is both stricter and stable.
+
+    QS-307 widened the table with an `unresponsive_since` column. That story moved
+    this predicate INWARD in `check_load_activity_and_constraints` — from the whole
+    user-override block down to detection only — and the tempting shortcut was to
+    make it lost-control-aware instead. It must stay indifferent: it is read by
+    three power-accounting call sites that reach the persisted consumption
+    forecast, so widening it there would move billed energy.
     """
     load = NeverAcksLoad(name="accounting_probe")
     time = T0
 
-    # (enabled, running_command, current_command, expected)
+    # (enabled, running_command, current_command, unresponsive_since, expected)
     cases = [
-        (True, None, None, False),
-        (True, None, CMD_ON, True),
-        (True, CMD_IDLE, None, False),
-        (True, CMD_IDLE, CMD_ON, False),
-        (False, None, CMD_ON, False),
-        (False, CMD_IDLE, CMD_ON, False),
+        (True, None, None, None, False),
+        (True, None, None, T0, False),
+        (True, None, CMD_ON, None, True),
+        (True, None, CMD_ON, T0, True),
+        (True, CMD_IDLE, None, None, False),
+        (True, CMD_IDLE, None, T0, False),
+        (True, CMD_IDLE, CMD_ON, None, False),
+        (True, CMD_IDLE, CMD_ON, T0, False),
+        (False, None, CMD_ON, None, False),
+        (False, None, CMD_ON, T0, False),
+        (False, CMD_IDLE, CMD_ON, None, False),
+        (False, CMD_IDLE, CMD_ON, T0, False),
     ]
 
-    for enabled, running, current, expected in cases:
+    for enabled, running, current, unresponsive_since, expected in cases:
         load._enabled = enabled
         load.running_command = None if running is None else copy_command(running)
         load.current_command = None if current is None else copy_command(current)
-        assert load.is_load_command_set(time) is expected, (enabled, running, current)
+        load.unresponsive_since = unresponsive_since
+        context = (enabled, running, current, unresponsive_since)
+        assert load.is_load_command_set(time) is expected, context
 
 
 def _accounting_snapshot(home: QSHome, load, time: datetime) -> dict:

--- a/tests/test_bug_304_command_deadlock.py
+++ b/tests/test_bug_304_command_deadlock.py
@@ -50,6 +50,9 @@ T0 = datetime(2026, 7, 27, 12, 12, 19, tzinfo=pytz.UTC)
 
 LOST_CONTROL_LOG = "Lost control of load"
 REGAINED_CONTROL_LOG = "Lost-control state cleared for load"
+# QS-307 review fix #01: the give-up releases the clock without being a recovery,
+# and says so in its own words rather than borrowing the recovery line's.
+RELEASED_WITHOUT_CONTACT_LOG = "Lost-control clock released without contact for load"
 
 
 async def drive_until_uncontrollable(load, start: datetime = T0) -> datetime:
@@ -368,16 +371,16 @@ async def test_unreachable_entity_does_not_produce_a_push_storm(caplog: pytest.L
     When a load's probe returns `None` forever, the
     `NUM_MAX_INVALID_PROBES_COMMANDS` give-up empties the command slot every ~70 s.
     QS-307 (from #308) releases the lost-control clock on that path, so the
-    once-only guard is no longer what holds the line here — the **rung reset** is.
-    `_escalate_or_recover` zeroes `running_command_num_relaunch` on every emptied
-    slot, and one give-up window is far too short to climb back to
-    `NUM_MAX_COMMAND_RELAUNCH` (see
-    `test_a_give_up_window_cannot_climb_the_escalation_ladder`), so re-escalation
-    is unreachable for a device that never comes back.
+    per-command guard is no longer what holds the line here. Two things do: the
+    **rung reset** (`_escalate_or_recover` zeroes
+    `running_command_num_relaunch` on every emptied slot, and one give-up window
+    is far too short to climb back to `NUM_MAX_COMMAND_RELAUNCH` — see
+    `test_a_give_up_window_cannot_climb_the_escalation_ladder`) and the **episode
+    latch** (review fix #01), which is what covers the case where a rung was
+    already earned *before* a give-up.
 
-    The clock is released exactly once too: the first give-up clears the episode
-    opened by the initial escalation, and every later window finds it already
-    `None` and stays silent.
+    Review fix #01 also trimmed the horizon: six simulated hours under log
+    capture bought nothing over the give-up windows D5 actually reasons about.
     """
     load = NeverAcksLoad(name="broken_entity")
     load._ack_command(T0 - timedelta(seconds=60), copy_command(CMD_ON))
@@ -387,10 +390,11 @@ async def test_unreachable_entity_does_not_produce_a_push_storm(caplog: pytest.L
         time = await drive(load, T0 + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
         assert len(load.state_change_notifications) == 1
 
-        # Six hours of a permanently unavailable entity, while QS keeps commanding it.
+        # Four give-up windows of a permanently unavailable entity, while QS keeps
+        # commanding it — the same horizon as the AC11 sibling below.
         load.probe_result = None
         total = 0
-        end = time + timedelta(seconds=6 * 3600)
+        end = time + timedelta(seconds=4 * NUM_MAX_INVALID_PROBES_COMMANDS * CYCLE_S)
         while time <= end:
             if load.running_command is None:
                 await load.launch_command(time, CMD_IDLE if total % 2 else CMD_ON)
@@ -399,7 +403,9 @@ async def test_unreachable_entity_does_not_produce_a_push_storm(caplog: pytest.L
             time = time + timedelta(seconds=CYCLE_S)
 
     assert len(load.state_change_notifications) == 1
-    assert count_log(caplog, REGAINED_CONTROL_LOG) == 1
+    # The give-up is not a recovery, and no longer claims to be one.
+    assert count_log(caplog, REGAINED_CONTROL_LOG) == 0
+    assert count_log(caplog, RELEASED_WITHOUT_CONTACT_LOG) == 1
 
 
 # =============================================================================
@@ -419,8 +425,9 @@ async def test_unavailable_probe_give_up_releases_the_ownerless_clock(caplog: py
     then inherited by the next command, which became `is_uncontrollable` with zero
     relaunches of its own.
 
-    This is NOT a recovery — the device is failing harder — which is why the log
-    line is reason-led rather than claiming control returned.
+    This is NOT a recovery — the device is failing harder — so it gets its own log
+    line (review fix #01) instead of borrowing the recovery one, and it latches
+    `_unresponsive_needs_ack` so the next ladder climb cannot shout.
     """
     load = NeverAcksLoad(name="pool_house")
     time = await drive_until_uncontrollable(load)
@@ -434,7 +441,9 @@ async def test_unavailable_probe_give_up_releases_the_ownerless_clock(caplog: py
     assert load.running_command is None
     assert load.unresponsive_since is None
     assert load.is_uncontrollable is False
-    assert count_log(caplog, REGAINED_CONTROL_LOG) == 1
+    assert load._unresponsive_needs_ack is True
+    assert count_log(caplog, RELEASED_WITHOUT_CONTACT_LOG) == 1
+    assert count_log(caplog, REGAINED_CONTROL_LOG) == 0
 
 
 def test_a_give_up_window_cannot_climb_the_escalation_ladder():
@@ -453,12 +462,35 @@ def test_a_give_up_window_cannot_climb_the_escalation_ladder():
     assert max_relaunches_per_window < NUM_MAX_COMMAND_RELAUNCH
 
 
+async def _recover_with_a_real_ack(load: NeverAcksLoad, time: datetime) -> datetime:
+    """Let the device answer once — the only thing that ends an episode."""
+    load.probe_result = True
+    if load.running_command is None:
+        # the give-up emptied the slot, so there is nothing to probe: dispatch a
+        # command and let the now-truthful probe ack it on the spot
+        await load.launch_command(time, CMD_ON)
+        time = time + timedelta(seconds=CYCLE_S)
+    else:
+        time = await drive(load, time, 2 * CYCLE_S)
+
+    assert load.current_command is not None
+    assert load._unresponsive_needs_ack is False
+    return time
+
+
 async def test_a_second_lost_control_episode_can_escalate_again(caplog: pytest.LogCaptureFixture):
-    """AC10: lose control, go unavailable, come back, lose control again → 2 pushes.
+    """AC10: lose control, go unavailable, RECOVER, lose control again → 2 pushes.
 
     Impossible before the clock release: `unresponsive_since` survived the give-up
-    forever, and it is the once-only guard, so the load could shout about its first
-    episode and then never again — however many genuinely new episodes followed.
+    forever, and it was the only escalation guard, so the load could shout about its
+    first episode and then never again — however many genuinely new episodes
+    followed.
+
+    Review fix #01 made the "recover" step in AC10's own wording load-bearing
+    rather than decorative: a second episode needs evidence that QS got back in
+    contact, which is a real ack. Without one this is the same episode still
+    running, and `test_a_flapping_device_shouts_once_until_it_answers_again` pins
+    that it stays quiet.
     """
     load = NeverAcksLoad(name="pool_house")
     time = await drive_until_uncontrollable(load)
@@ -470,17 +502,87 @@ async def test_a_second_lost_control_episode_can_escalate_again(caplog: pytest.L
         time = await drive(load, time, CYCLE_S * (NUM_MAX_INVALID_PROBES_COMMANDS + 2))
         assert load.unresponsive_since is None
 
-        # the entity comes back — reachable, answering, and still not obeying
+        # the entity comes back and confirms a command: episode 1 is over
+        time = await _recover_with_a_real_ack(load, time)
+
+        # ...and then genuinely loses control again: a NEW episode
         load.probe_result = False
-        await load.launch_command(time, CMD_ON)
+        await load.launch_command(time, CMD_OFF)
         time = await drive(load, time + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
 
     assert load.is_uncontrollable is True
     assert len(load.state_change_notifications) == 2
     # `caplog` spans the whole test, so both episodes' ERROR lines are here; only
-    # the INFO release needed `at_level`.
+    # the INFO releases needed `at_level`.
     assert count_log(caplog, LOST_CONTROL_LOG) == 2
-    assert count_log(caplog, REGAINED_CONTROL_LOG) == 1
+    assert count_log(caplog, RELEASED_WITHOUT_CONTACT_LOG) == 1
+
+
+async def _flap_once(load: NeverAcksLoad, time: datetime) -> datetime:
+    """Drop off the network for one give-up window, then answer-but-disobey.
+
+    The exact pattern D5 used to write off as an accepted residual: each cycle of
+    it re-earns a full ladder rung, so each one used to produce a push.
+    """
+    load.probe_result = None
+    time = await drive(load, time, CYCLE_S * (NUM_MAX_INVALID_PROBES_COMMANDS + 2))
+    assert load.running_command is None  # the give-up emptied the slot
+
+    load.probe_result = False
+    await load.launch_command(time, CMD_ON)
+    return await drive(load, time + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+
+
+async def test_a_flapping_device_shouts_once_until_it_answers_again(caplog: pytest.LogCaptureFixture):
+    """Review fix #01 (must-fix): flapping must not become a push every ~18 min.
+
+    `running_command_num_relaunch_after_invalid` is cumulative over a command's
+    life, so a give-up can fire *after* a rung was already earned outside any
+    give-up window. D5 and
+    `test_a_give_up_window_cannot_climb_the_escalation_ladder` only prove a single
+    give-up window is too short to climb the ladder — they say nothing about a rung
+    earned before one. So the clock release re-opened the escalation guard once per
+    [unavailable window + ladder climb] cycle, indefinitely, for a device whose
+    situation never changed — on a fire-and-forget channel whose pushes accumulate
+    on the phone and cannot be collapsed.
+
+    The fix must NOT be to stop releasing the clock (that is #308's fix, and AC9 /
+    AC10 depend on it). It is to stop treating "the clock was released" as "a new
+    episode began": `_unresponsive_needs_ack` requires evidence of contact first.
+    """
+    load = NeverAcksLoad(name="pool_house")
+    load._ack_command(T0 - timedelta(seconds=60), copy_command(CMD_ON))
+    await load.launch_command(T0, CMD_IDLE)
+
+    # Episode 1 escalates, legitimately.
+    time = await drive(load, T0 + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+    assert len(load.state_change_notifications) == 1
+
+    with caplog.at_level(logging.INFO):
+        # `caplog` spans the whole test and the ERROR above is already in it, so
+        # baseline rather than assume.
+        lost_control_before = count_log(caplog, LOST_CONTROL_LOG)
+        assert lost_control_before == 1
+
+        for _ in range(3):
+            time = await _flap_once(load, time)
+
+    # Three more full ladder climbs, each preceded by a give-up, and QS stays quiet:
+    # nothing about the device's situation changed and it never answered.
+    assert len(load.state_change_notifications) == 1
+    assert count_log(caplog, LOST_CONTROL_LOG) == lost_control_before
+    # The clock still gets re-armed every climb — it is what drives
+    # supersede-vs-stack, and suppressing it would starve newer intents.
+    assert load.unresponsive_since is not None
+    assert load.is_uncontrollable is True
+
+    # ...and once the device really answers, a later failure is a NEW episode.
+    time = await _recover_with_a_real_ack(load, time)
+    load.probe_result = False
+    await load.launch_command(time, CMD_OFF)
+    await drive(load, time + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+
+    assert len(load.state_change_notifications) == 2
 
 
 async def test_a_device_unavailable_from_the_start_never_escalates(caplog: pytest.LogCaptureFixture):

--- a/tests/test_bug_304_command_deadlock.py
+++ b/tests/test_bug_304_command_deadlock.py
@@ -9,6 +9,7 @@ Home Assistant.
 from __future__ import annotations
 
 import logging
+import math
 import re
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -156,8 +157,8 @@ async def test_reset_button_does_not_flash_problem_on_a_healthy_load():
     Review fix #01/4: `user_clean_and_reset` → `reset()` →
     `constraint_reset_and_reset_commands_if_needed(keep_commands=False)`, and a
     bistate load's `execute_command` returns falsy on a perfectly normal service
-    call, so the follow-up command sits in flight for one cycle — long enough for
-    `qs_load_uncontrollable` to flash right after the user pressed reset.
+    call, so the follow-up command sits in flight for one cycle — long enough to
+    re-declare lost control right after the user pressed reset.
     """
     load = await _uncontrollable_load()
     assert load.is_uncontrollable is True
@@ -361,37 +362,66 @@ async def test_relaunch_counters_never_outlive_the_command_they_describe():
     assert earned_rung_cycles > 10
 
 
-async def test_unreachable_entity_does_not_produce_a_push_storm():
+async def test_unreachable_entity_does_not_produce_a_push_storm(caplog: pytest.LogCaptureFixture):
     """A permanently unreachable entity must be reported once, not per cycle.
 
     When a load's probe returns `None` forever, the
-    `NUM_MAX_INVALID_PROBES_COMMANDS` give-up empties the command slot every ~70 s
-    while `unresponsive_since` is deliberately kept. The once-only escalation guard
-    is what stops that turning into a notification per cycle.
+    `NUM_MAX_INVALID_PROBES_COMMANDS` give-up empties the command slot every ~70 s.
+    QS-307 (from #308) releases the lost-control clock on that path, so the
+    once-only guard is no longer what holds the line here — the **rung reset** is.
+    `_escalate_or_recover` zeroes `running_command_num_relaunch` on every emptied
+    slot, and one give-up window is far too short to climb back to
+    `NUM_MAX_COMMAND_RELAUNCH` (see
+    `test_a_give_up_window_cannot_climb_the_escalation_ladder`), so re-escalation
+    is unreachable for a device that never comes back.
+
+    The clock is released exactly once too: the first give-up clears the episode
+    opened by the initial escalation, and every later window finds it already
+    `None` and stays silent.
     """
     load = NeverAcksLoad(name="broken_entity")
     load._ack_command(T0 - timedelta(seconds=60), copy_command(CMD_ON))
     await load.launch_command(T0, CMD_IDLE)
 
-    time = await drive(load, T0 + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+    with caplog.at_level(logging.INFO):
+        time = await drive(load, T0 + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+        assert len(load.state_change_notifications) == 1
+
+        # Six hours of a permanently unavailable entity, while QS keeps commanding it.
+        load.probe_result = None
+        total = 0
+        end = time + timedelta(seconds=6 * 3600)
+        while time <= end:
+            if load.running_command is None:
+                await load.launch_command(time, CMD_IDLE if total % 2 else CMD_ON)
+            await load.check_and_relaunch_command(time)
+            total += 1
+            time = time + timedelta(seconds=CYCLE_S)
+
     assert len(load.state_change_notifications) == 1
-
-    # Six hours of a permanently unavailable entity, while QS keeps commanding it.
-    load.probe_result = None
-    total = 0
-    end = time + timedelta(seconds=6 * 3600)
-    while time <= end:
-        if load.running_command is None:
-            await load.launch_command(time, CMD_IDLE if total % 2 else CMD_ON)
-        await load.check_and_relaunch_command(time)
-        total += 1
-        time = time + timedelta(seconds=CYCLE_S)
-
-    assert len(load.state_change_notifications) == 1
+    assert count_log(caplog, REGAINED_CONTROL_LOG) == 1
 
 
-async def test_unavailable_probe_give_up_is_not_a_recovery(caplog: pytest.LogCaptureFixture):
-    """`_ack_command(time, None)` empties the slot, but the device is failing harder."""
+# =============================================================================
+# QS-307 Part B (from #308) — the give-up must not leave an ownerless clock
+# =============================================================================
+
+
+async def test_unavailable_probe_give_up_releases_the_ownerless_clock(caplog: pytest.LogCaptureFixture):
+    """AC9: the give-up destroys the clock's subject, so the clock goes with it.
+
+    `_ack_command(time, None)` nulls `current_command` AND empties the slot — that
+    is deliberate, because preserving `current_command` would bill phantom
+    consumption into the persisted forecast. But it left `unresponsive_since`
+    behind describing a command that no longer exists: `_ack_command` only clears
+    on a real ack, and `_escalate_or_recover`'s re-arm is gated on
+    `current_command is not None`, which this path has just nulled. The clock was
+    then inherited by the next command, which became `is_uncontrollable` with zero
+    relaunches of its own.
+
+    This is NOT a recovery — the device is failing harder — which is why the log
+    line is reason-led rather than claiming control returned.
+    """
     load = NeverAcksLoad(name="pool_house")
     time = await drive_until_uncontrollable(load)
 
@@ -402,8 +432,117 @@ async def test_unavailable_probe_give_up_is_not_a_recovery(caplog: pytest.LogCap
 
     assert load.current_command is None
     assert load.running_command is None
-    assert load.unresponsive_since is not None
+    assert load.unresponsive_since is None
+    assert load.is_uncontrollable is False
+    assert count_log(caplog, REGAINED_CONTROL_LOG) == 1
+
+
+def test_a_give_up_window_cannot_climb_the_escalation_ladder():
+    """AC9 (D5): re-arming cannot become a push storm, from the constants alone.
+
+    `_escalate_or_recover` resets the rung on every emptied slot, so re-escalation
+    needs `NUM_MAX_COMMAND_RELAUNCH` relaunches *inside a single give-up window*.
+    Asserted against the named constants so a future constant change fails loudly
+    here rather than as a notification flood in production.
+    """
+    give_up_window_s = NUM_MAX_INVALID_PROBES_COMMANDS * CYCLE_S
+    # Generous upper bound: the ladder's FIRST rung is the shortest one, so
+    # dividing the window by it can only over-count.
+    max_relaunches_per_window = math.ceil(give_up_window_s / COMMAND_RELAUNCH_BASE_DELAY_S)
+
+    assert max_relaunches_per_window < NUM_MAX_COMMAND_RELAUNCH
+
+
+async def test_a_second_lost_control_episode_can_escalate_again(caplog: pytest.LogCaptureFixture):
+    """AC10: lose control, go unavailable, come back, lose control again → 2 pushes.
+
+    Impossible before the clock release: `unresponsive_since` survived the give-up
+    forever, and it is the once-only guard, so the load could shout about its first
+    episode and then never again — however many genuinely new episodes followed.
+    """
+    load = NeverAcksLoad(name="pool_house")
+    time = await drive_until_uncontrollable(load)
+    assert len(load.state_change_notifications) == 1
+
+    with caplog.at_level(logging.INFO):
+        # episode 1 ends the ugly way: the entity drops off the network
+        load.probe_result = None
+        time = await drive(load, time, CYCLE_S * (NUM_MAX_INVALID_PROBES_COMMANDS + 2))
+        assert load.unresponsive_since is None
+
+        # the entity comes back — reachable, answering, and still not obeying
+        load.probe_result = False
+        await load.launch_command(time, CMD_ON)
+        time = await drive(load, time + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+
+    assert load.is_uncontrollable is True
+    assert len(load.state_change_notifications) == 2
+    # `caplog` spans the whole test, so both episodes' ERROR lines are here; only
+    # the INFO release needed `at_level`.
+    assert count_log(caplog, LOST_CONTROL_LOG) == 2
+    assert count_log(caplog, REGAINED_CONTROL_LOG) == 1
+
+
+async def test_a_device_unavailable_from_the_start_never_escalates(caplog: pytest.LogCaptureFixture):
+    """AC11: no storm — an entity that is unreachable from the first cycle is silent.
+
+    The give-up empties the slot every ~70 s and the solver keeps issuing new
+    commands, so this is the shape that would flood if the re-arm were unbounded.
+    Four give-up windows is enough: D5 proves the rung peaks at 1, so a longer
+    horizon only repeats the same window.
+    """
+    load = NeverAcksLoad(name="broken_entity")
+    load.probe_result = None
+
+    with caplog.at_level(logging.INFO):
+        await load.launch_command(T0, CMD_IDLE)
+        time = T0 + timedelta(seconds=CYCLE_S)
+        end = T0 + timedelta(seconds=4 * NUM_MAX_INVALID_PROBES_COMMANDS * CYCLE_S)
+        total = 0
+        while time <= end:
+            if load.running_command is None:
+                await load.launch_command(time, CMD_IDLE if total % 2 else CMD_ON)
+            await load.check_and_relaunch_command(time)
+            total += 1
+            time = time + timedelta(seconds=CYCLE_S)
+
+    assert load.running_command_num_relaunch < NUM_MAX_COMMAND_RELAUNCH
+    assert load.unresponsive_since is None
+    assert load.state_change_notifications == []
+    assert count_log(caplog, LOST_CONTROL_LOG) == 0
     assert count_log(caplog, REGAINED_CONTROL_LOG) == 0
+
+
+async def test_the_command_after_a_give_up_starts_clean_and_stacks():
+    """AC12: a brand-new command must not inherit supersede semantics.
+
+    `is_uncontrollable` decides stack-vs-supersede (`load.py`'s
+    `launch_command`) and which intent gets retried. An inherited clock made the
+    very first cycle of an unrelated command behave as if QS had already given up
+    on it — a real service call where the correct answer is "stack, last one wins".
+    """
+    load = NeverAcksLoad(name="pool_house")
+    load._ack_command(T0 - timedelta(seconds=60), copy_command(CMD_ON))
+    time = await drive_until_uncontrollable(load)
+
+    load.probe_result = None
+    time = await drive(load, time, CYCLE_S * (NUM_MAX_INVALID_PROBES_COMMANDS + 2))
+    assert load.running_command is None
+
+    # the entity is reachable again, and the solver dispatches a fresh command
+    load.probe_result = False
+    await load.launch_command(time, CMD_ON)
+    assert load.running_command == CMD_ON
+    assert load.is_uncontrollable is False
+    assert load.running_command_num_relaunch == 0
+
+    # ...so a differing command STACKS behind it instead of superseding it
+    calls_before = len(load.executed_commands)
+    await load.launch_command(time + timedelta(seconds=1), CMD_OFF)
+
+    assert load._stacked_command == CMD_OFF
+    assert load.running_command == CMD_ON
+    assert len(load.executed_commands) == calls_before
 
 
 # =============================================================================

--- a/tests/test_bug_304_command_deadlock.py
+++ b/tests/test_bug_304_command_deadlock.py
@@ -541,11 +541,18 @@ async def test_a_second_lost_control_episode_can_escalate_again(caplog: pytest.L
     assert count_log(caplog, RELEASED_WITHOUT_CONTACT_LOG) == 1
 
 
+# The horizon the QS-307 alert-storm measurement was taken over, on `main` and on
+# the branch alike. One [unavailable window + full ladder] cycle is ~19.6 min, so
+# this is between five and six of them.
+STORM_MEASUREMENT_HORIZON_S = 105 * 60
+
+
 async def _flap_once(load: NeverAcksLoad, time: datetime) -> datetime:
     """Drop off the network for one give-up window, then answer-but-disobey.
 
-    The exact pattern D5 used to write off as an accepted residual: each cycle of
-    it re-earns a full ladder rung, so each one used to produce a push.
+    Scenario 1 of the QS-307 alert-storm measurement, and the pattern D5 originally
+    wrote off as an accepted residual: each cycle of it re-earns a full ladder rung,
+    so each one produced a push once the clock release re-armed the guard.
     """
     load.probe_result = None
     time = await drive(load, time, CYCLE_S * (NUM_MAX_INVALID_PROBES_COMMANDS + 2))
@@ -557,21 +564,26 @@ async def _flap_once(load: NeverAcksLoad, time: datetime) -> datetime:
 
 
 async def test_a_flapping_device_shouts_once_until_it_answers_again(caplog: pytest.LogCaptureFixture):
-    """Review fix #01 (must-fix): flapping must not become a push every ~18 min.
+    """The parity oracle for `_unresponsive_needs_ack`: 1 alert / 105 min, like `main`.
 
-    `running_command_num_relaunch_after_invalid` is cumulative over a command's
-    life, so a give-up can fire *after* a rung was already earned outside any
-    give-up window. D5 and
-    `test_a_give_up_window_cannot_climb_the_escalation_ladder` only prove a single
-    give-up window is too short to climb the ladder — they say nothing about a rung
-    earned before one. So the clock release re-opened the escalation guard once per
-    [unavailable window + ladder climb] cycle, indefinitely, for a device whose
-    situation never changed — on a fire-and-forget channel whose pushes accumulate
-    on the phone and cannot be collapsed.
+    **This test is the flag's entire justification.** Measured over the same 105
+    simulated minutes, a device dropping off the network intermittently produces
+    1 alert on `main`, **5** with Part B's clock release and no flag, and 1 again
+    with the flag. Part B has to release the clock at the invalid-probe give-up —
+    that is #308's fix, and AC9/AC12 depend on it — but the release also re-arms the
+    once-only escalation guard, which is a 5x alert regression against `main`. The
+    flag's whole job is to stop the release from re-announcing an incident that was
+    already announced.
 
-    The fix must NOT be to stop releasing the clock (that is #308's fix, and AC9 /
-    AC10 depend on it). It is to stop treating "the clock was released" as "a new
-    episode began": `_unresponsive_needs_ack` requires evidence of contact first.
+    Any future simplification of the contact signal must be checked against **this**,
+    not against reasoning: `running_command_num_relaunch_after_invalid` is cumulative
+    over a command's life, so a give-up can fire long after a rung was earned outside
+    any give-up window, and `test_a_give_up_window_cannot_climb_the_escalation_ladder`
+    does not cover that.
+
+    What this does NOT cover: a device that stays reachable and simply never obeys.
+    That alerts every ~18.5 min here and on `main` alike — pre-existing, out of
+    scope, tracked as #319.
     """
     load = NeverAcksLoad(name="pool_house")
     load._ack_command(T0 - timedelta(seconds=60), copy_command(CMD_ON))
@@ -587,11 +599,19 @@ async def test_a_flapping_device_shouts_once_until_it_answers_again(caplog: pyte
         lost_control_before = count_log(caplog, LOST_CONTROL_LOG)
         assert lost_control_before == 1
 
-        for _ in range(3):
+        flaps = 0
+        horizon_end = time + timedelta(seconds=STORM_MEASUREMENT_HORIZON_S)
+        while time <= horizon_end:
             time = await _flap_once(load, time)
+            flaps += 1
 
-    # Three more full ladder climbs, each preceded by a give-up, and QS stays quiet:
-    # nothing about the device's situation changed and it never answered.
+        # guard against a vacuous pass: `main` produced 1 alert over this horizon
+        # and the unflagged branch produced 5, so the horizon has to fit ~5 cycles
+        assert flaps >= 5
+
+    # Five-plus full ladder climbs, each preceded by a give-up, and QS stays quiet:
+    # nothing about the device's situation changed and it never answered. ONE alert
+    # over the whole 105 minutes — the same count `main` produces.
     assert len(load.state_change_notifications) == 1
     assert count_log(caplog, LOST_CONTROL_LOG) == lost_control_before
     # The clock still gets re-armed every climb — it is what drives
@@ -637,7 +657,7 @@ async def test_a_device_unavailable_from_the_start_never_escalates(caplog: pytes
     assert count_log(caplog, LOST_CONTROL_LOG) == 0
     assert count_log(caplog, REGAINED_CONTROL_LOG) == 0
     # Review fix #02/06: the give-up fires four times here and passes
-    # `CONTACT_NONE`, so THIS is the line that could actually appear — the sibling
+    # `UNREACHABLE`, so THIS is the line that could actually appear — the sibling
     # above was asserting the constant this path no longer uses.
     assert count_log(caplog, RELEASED_WITHOUT_CONTACT_LOG) == 0
     # Review fix #02/01: the latch state that made the swallowed-first-push bug

--- a/tests/test_bug_304_command_deadlock.py
+++ b/tests/test_bug_304_command_deadlock.py
@@ -26,6 +26,7 @@ from custom_components.quiet_solar.home_model.commands import (
     copy_command,
 )
 from custom_components.quiet_solar.home_model.load import (
+    CLOCK_SKEW_TOLERANCE_S,
     COMMAND_RELAUNCH_BASE_DELAY_S,
     NUM_MAX_COMMAND_RELAUNCH,
     NUM_MAX_INVALID_PROBES_COMMANDS,
@@ -446,6 +447,28 @@ async def test_unavailable_probe_give_up_releases_the_ownerless_clock(caplog: py
     assert count_log(caplog, REGAINED_CONTROL_LOG) == 0
 
 
+def test_the_skew_tolerance_band_separates_jitter_from_a_clock_step():
+    """Review fix #02 (must-fix): a few seconds ahead is jitter, not "fully elapsed".
+
+    `_seconds_since` collapses EVERY negative delta to `None`, which its callers read
+    as "treat as fully elapsed". Right for a real backwards clock step; catastrophic
+    for a window anchored by a user action, where a few seconds of future-dating is
+    routine (each user-action call site takes its own unlocked `datetime.now()` while
+    a cycle already in flight carries an earlier `event_time`).
+    """
+    load = NeverAcksLoad(name="pool_house")
+
+    # the ordinary case is untouched
+    assert load._seconds_since_skew_tolerant(T0, T0 - timedelta(seconds=30)) == 30.0
+    # future, inside the band → "just armed", never "fully elapsed"
+    assert load._seconds_since_skew_tolerant(T0, T0 + timedelta(seconds=5)) == 0.0
+    assert load._seconds_since_skew_tolerant(T0, T0 + timedelta(seconds=CLOCK_SKEW_TOLERANCE_S)) == 0.0
+    # beyond it → `_seconds_since`'s fully-elapsed meaning is preserved
+    assert load._seconds_since_skew_tolerant(T0, T0 + timedelta(seconds=CLOCK_SKEW_TOLERANCE_S + 1)) is None
+    # ...and "no anchor" still means the same thing it does in `_seconds_since`
+    assert load._seconds_since_skew_tolerant(T0, None) is None
+
+
 def test_a_give_up_window_cannot_climb_the_escalation_ladder():
     """AC9 (D5): re-arming cannot become a push storm, from the constants alone.
 
@@ -613,6 +636,103 @@ async def test_a_device_unavailable_from_the_start_never_escalates(caplog: pytes
     assert load.state_change_notifications == []
     assert count_log(caplog, LOST_CONTROL_LOG) == 0
     assert count_log(caplog, REGAINED_CONTROL_LOG) == 0
+    # Review fix #02/06: the give-up fires four times here and passes
+    # `CONTACT_NONE`, so THIS is the line that could actually appear — the sibling
+    # above was asserting the constant this path no longer uses.
+    assert count_log(caplog, RELEASED_WITHOUT_CONTACT_LOG) == 0
+    # Review fix #02/01: the latch state that made the swallowed-first-push bug
+    # invisible. Four give-ups released nothing, so they must have latched nothing.
+    assert load._unresponsive_needs_ack is False
+
+
+async def test_a_give_up_before_any_episode_does_not_swallow_the_first_push(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Review fix #02 (must-fix): the latch may not fire when no episode exists.
+
+    The ORDINARY timeline, not a corner case: the invalid-probe give-up fires after
+    `NUM_MAX_INVALID_PROBES_COMMANDS × CYCLE_S` ≈ 70 s, an order of magnitude before
+    the ~1050 s escalation threshold. So the first give-up normally releases
+    *nothing* — and latching there suppressed the load's **first genuine** push for
+    good, since the latch's only clearer is a real ack and this device never acks.
+
+    Trigger is mundane: an entity unavailable for ~70 s (HA restart, integration
+    reload, Zigbee coordinator restart), then back but ignoring commands forever.
+    """
+    load = NeverAcksLoad(name="pool_house")
+    load._ack_command(T0 - timedelta(seconds=60), copy_command(CMD_ON))
+
+    with caplog.at_level(logging.INFO):
+        # phase 1 — unavailable from the first cycle: the give-up fires, but there is
+        # no episode to announce and therefore none to latch
+        load.probe_result = None
+        await load.launch_command(T0, CMD_IDLE)
+        time = await drive(load, T0 + timedelta(seconds=CYCLE_S), CYCLE_S * (NUM_MAX_INVALID_PROBES_COMMANDS + 2))
+
+        assert load.unresponsive_since is None
+        assert load.state_change_notifications == []
+        assert load._unresponsive_needs_ack is False
+
+        # phase 2 — the entity is back, and simply ignores us from now on
+        load.probe_result = False
+        await load.launch_command(time, CMD_ON)
+        time = await drive(load, time + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+
+        # this is a genuine first episode and it must be announced
+        assert load.is_uncontrollable is True
+        assert len(load.state_change_notifications) == 1
+        assert count_log(caplog, LOST_CONTROL_LOG) == 1
+
+        # ...and exactly once: a second ladder on the same episode stays quiet
+        time = await drive(load, time, 2 * LADDER_WALL_S)
+
+    assert len(load.state_change_notifications) == 1
+    assert count_log(caplog, LOST_CONTROL_LOG) == 1
+
+
+async def test_only_a_real_ack_clears_the_episode_latch(caplog: pytest.LogCaptureFixture):
+    """Review fix #02/03: a drop WE chose is not evidence the device answered.
+
+    `_drop_running_command` is reached by the override-suppression drop, the
+    disabled-load cleanup and — since review fix #01 — the expiry-time drop of an
+    override's own command. All three are QS changing its mind. Treating them as
+    recoveries let a latched flapping load shout again on its next ladder climb,
+    once per drop, for a device that never came back. AC13 pins "a real ack ⇒
+    escalates again"; this is the missing "and *only* a real ack".
+    """
+    load = NeverAcksLoad(name="pool_house")
+    load._ack_command(T0 - timedelta(seconds=60), copy_command(CMD_ON))
+    await load.launch_command(T0, CMD_IDLE)
+
+    # a legitimate first episode, then a give-up that latches it
+    time = await drive(load, T0 + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+    assert len(load.state_change_notifications) == 1
+    load.probe_result = None
+    time = await drive(load, time, CYCLE_S * (NUM_MAX_INVALID_PROBES_COMMANDS + 2))
+    assert load._unresponsive_needs_ack is True
+
+    with caplog.at_level(logging.INFO):
+        # `caplog` spans the whole test, so episode 1's ERROR is already in it.
+        lost_control_before = count_log(caplog, LOST_CONTROL_LOG)
+        assert lost_control_before == 1
+
+        # the user takes control, so the stale command is DROPPED — not acked
+        load.probe_result = False
+        await load.launch_command(time, CMD_ON)
+        load.suppress_override = True
+        time = await drive(load, time + timedelta(seconds=CYCLE_S), 2 * SUPERSEDE_MIN_INTERVAL_S)
+        load.suppress_override = False
+
+        assert load.running_command is None
+        # the episode is untouched: we learned nothing about the device
+        assert load._unresponsive_needs_ack is True
+
+        # so the next full ladder must still stay quiet
+        await load.launch_command(time, CMD_OFF)
+        await drive(load, time + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+
+    assert len(load.state_change_notifications) == 1
+    assert count_log(caplog, LOST_CONTROL_LOG) == lost_control_before
 
 
 async def test_the_command_after_a_give_up_starts_clean_and_stacks():

--- a/tests/test_bug_304_command_deadlock.py
+++ b/tests/test_bug_304_command_deadlock.py
@@ -26,7 +26,6 @@ from custom_components.quiet_solar.home_model.commands import (
     copy_command,
 )
 from custom_components.quiet_solar.home_model.load import (
-    CLOCK_SKEW_TOLERANCE_S,
     COMMAND_RELAUNCH_BASE_DELAY_S,
     NUM_MAX_COMMAND_RELAUNCH,
     NUM_MAX_INVALID_PROBES_COMMANDS,
@@ -447,28 +446,6 @@ async def test_unavailable_probe_give_up_releases_the_ownerless_clock(caplog: py
     assert count_log(caplog, REGAINED_CONTROL_LOG) == 0
 
 
-def test_the_skew_tolerance_band_separates_jitter_from_a_clock_step():
-    """Review fix #02 (must-fix): a few seconds ahead is jitter, not "fully elapsed".
-
-    `_seconds_since` collapses EVERY negative delta to `None`, which its callers read
-    as "treat as fully elapsed". Right for a real backwards clock step; catastrophic
-    for a window anchored by a user action, where a few seconds of future-dating is
-    routine (each user-action call site takes its own unlocked `datetime.now()` while
-    a cycle already in flight carries an earlier `event_time`).
-    """
-    load = NeverAcksLoad(name="pool_house")
-
-    # the ordinary case is untouched
-    assert load._seconds_since_skew_tolerant(T0, T0 - timedelta(seconds=30)) == 30.0
-    # future, inside the band → "just armed", never "fully elapsed"
-    assert load._seconds_since_skew_tolerant(T0, T0 + timedelta(seconds=5)) == 0.0
-    assert load._seconds_since_skew_tolerant(T0, T0 + timedelta(seconds=CLOCK_SKEW_TOLERANCE_S)) == 0.0
-    # beyond it → `_seconds_since`'s fully-elapsed meaning is preserved
-    assert load._seconds_since_skew_tolerant(T0, T0 + timedelta(seconds=CLOCK_SKEW_TOLERANCE_S + 1)) is None
-    # ...and "no anchor" still means the same thing it does in `_seconds_since`
-    assert load._seconds_since_skew_tolerant(T0, None) is None
-
-
 def test_a_give_up_window_cannot_climb_the_escalation_ladder():
     """AC9 (D5): re-arming cannot become a push storm, from the constants alone.
 
@@ -486,7 +463,7 @@ def test_a_give_up_window_cannot_climb_the_escalation_ladder():
 
 
 async def _recover_with_a_real_ack(load: NeverAcksLoad, time: datetime) -> datetime:
-    """Let the device answer once — the only thing that ends an episode."""
+    """Let the device answer once, which ends the episode."""
     load.probe_result = True
     if load.running_command is None:
         # the give-up emptied the slot, so there is nothing to probe: dispatch a
@@ -710,15 +687,18 @@ async def test_a_give_up_before_any_episode_does_not_swallow_the_first_push(
     assert count_log(caplog, LOST_CONTROL_LOG) == 1
 
 
-async def test_only_a_real_ack_clears_the_episode_latch(caplog: pytest.LogCaptureFixture):
-    """Review fix #02/03: a drop WE chose is not evidence the device answered.
+async def test_a_drop_we_chose_does_not_re_announce_the_episode(caplog: pytest.LogCaptureFixture):
+    """AC22: a drop WE chose is not evidence the device answered.
 
     `_drop_running_command` is reached by the override-suppression drop, the
-    disabled-load cleanup and — since review fix #01 — the expiry-time drop of an
-    override's own command. All three are QS changing its mind. Treating them as
-    recoveries let a latched flapping load shout again on its next ladder climb,
-    once per drop, for a device that never came back. AC13 pins "a real ack ⇒
-    escalates again"; this is the missing "and *only* a real ack".
+    disabled-load cleanup and — new in QS-307 — the expiry-time drop of an
+    override's own command. All three are QS changing its mind, so treating them as
+    recoveries let a latched load re-announce on its next ladder climb, once per
+    drop, for a device that never came back.
+
+    Scoped deliberately: this pins `_drop_running_command`'s contact contract, NOT a
+    general "only a real ack ever clears the latch" — the empty-slot re-arm clears it
+    too, and #319 owns the reachable-but-disobeying storm.
     """
     load = NeverAcksLoad(name="pool_house")
     load._ack_command(T0 - timedelta(seconds=60), copy_command(CMD_ON))

--- a/tests/test_qs307_override_expiry_unfreeze.py
+++ b/tests/test_qs307_override_expiry_unfreeze.py
@@ -367,7 +367,7 @@ async def test_ac3_a_live_override_is_never_reset_early(running, current):
 @pytest.mark.parametrize("current", [None, CMD_ON], ids=["no-current", "current-on"])
 @pytest.mark.parametrize("running", [None, CMD_ON], ids=["no-running", "running-on"])
 async def test_ac3_an_aged_override_resets_on_the_same_cycle_as_on_main(running, current):
-    """...and the POSITIVE half, which review fix #07 asked to stop delegating.
+    """...and the POSITIVE half, which review fix #01/07 asked to stop delegating.
 
     The window boundary is `> override_duration`, so the last cycle at exactly
     8 h must NOT reset and the next one must — identically in all four
@@ -606,13 +606,13 @@ async def test_ac6_detection_still_works_once_the_command_has_landed():
 
 
 # =============================================================================
-# AC4b — `support_user_override()` is not a second freeze (review fix #03)
+# AC17-AC19 — `support_user_override()` gates the whole block, as on `main`
 #
-# Unlike the `qs_enable_device` arm, this one is not self-healing: disabling and
-# re-enabling a load runs the lifecycle again, but flipping a load to boost-only
-# never does. With the lifecycle behind it, a load reconfigured to boost-only
-# kept a live override or a pending reset-ask FOREVER, across restarts — exactly
-# the harm this story exists to fix.
+# Review fix #01 moved this conjunct down beside `is_load_command_set` so the
+# lifecycle would tear down an override on a load reconfigured to boost-only.
+# Review fix #04 reverted that: it ran the whole override lifecycle every cycle
+# for every boost-only `QSBiStateDuration` load to serve one reconfiguration
+# case, which is now handled at the restore boundary instead.
 # =============================================================================
 
 
@@ -841,7 +841,7 @@ async def _assert_override_self_heals(pump: _StuckPump) -> None:
 
     assert pump.external_user_initiated_state is None
     assert _override_constraints(pump) == []
-    # review fix #02: the override's own command must not outlive the override
+    # review fix #01/02: the override's own command must not outlive the override
     assert pump.running_command is None
     transport_calls_after_expiry = len(pump.transport_calls)
 

--- a/tests/test_qs307_override_expiry_unfreeze.py
+++ b/tests/test_qs307_override_expiry_unfreeze.py
@@ -108,6 +108,37 @@ class _StuckPump(QSBiStateDuration):
         return "test_select_key"
 
 
+class _RacingPump(_StuckPump):
+    """A pump whose service call is interrupted by a user action mid-flight.
+
+    `check_load_activity_and_constraints` gained a command-slot mutation (the
+    expiry-time drop of an override-aligned command), and three of its four callers
+    run OUTSIDE `_update_loads_lock` — `user_set_default_on_duration`,
+    `user_set_bistate_mode` and `AbstractLoad.async_reset_override_state`. So a user
+    touching the mode select, the on-duration number or the reset button while a
+    service call is in flight really can empty the slot across the await. Setting
+    `race_at` replays that deterministically, from inside the transport.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.race_at: datetime | None = None
+        # what the interrupted service call reports back: `True` reaches the ack
+        # branch, `None` reaches the "impossible to force" log — both dereference
+        # the command slot after the await
+        self.race_result: bool | None = True
+
+    async def execute_command_system(self, time, command, state):
+        """Let a user action land in the middle of the service call."""
+        if self.race_at is None:
+            return await super().execute_command_system(time, command, state)
+
+        self.transport_calls.append((time, command.command, state))
+        race_at, self.race_at = self.race_at, None
+        await self.check_load_activity_and_constraints(race_at)
+        return self.race_result
+
+
 def _next_daily_end(local_hours: dt_time, time_utc_now: datetime | None = None, output_in_utc=True):
     """Deterministic, timezone-independent stand-in for get_next_time_from_hours."""
     assert output_in_utc is True
@@ -120,12 +151,15 @@ def _next_daily_end(local_hours: dt_time, time_utc_now: datetime | None = None, 
     return candidate
 
 
-def _make_pump(override_duration_h: float = OVERRIDE_DURATION_H) -> _StuckPump:
+def _make_pump(
+    override_duration_h: float = OVERRIDE_DURATION_H,
+    pump_class: type[_StuckPump] = _StuckPump,
+) -> _StuckPump:
     """Build a switch-backed bistate pump on FakeHass, with no config entry."""
     hass = FakeHass()
     home = create_minimal_home_model()
     home.is_off_grid = MagicMock(return_value=False)
-    pump = _StuckPump(
+    pump = pump_class(
         hass=hass,
         config_entry=None,
         home=home,
@@ -671,6 +705,57 @@ async def test_detection_stays_off_for_a_boost_only_load():
 
 
 # =============================================================================
+# AC25 — the expiry drop must not strand a command slot across an await
+# =============================================================================
+
+
+@pytest.mark.parametrize("race_result", [True, None], ids=["service-call-lands", "service-call-impossible"])
+async def test_a_user_action_during_a_service_call_cannot_strand_the_command_slot(race_result):
+    """Review fix #03 (must-fix): the expiry drop broke a documented invariant.
+
+    D1d's drop is the first command-slot mutation ever performed inside
+    `check_load_activity_and_constraints`, and three of that method's callers run
+    outside `_update_loads_lock`. So "each command-slot mutation happens between
+    `await`s" (`check_and_relaunch_command`'s docstring) stopped being true, and
+    `force_relaunch_command` dereferences the slot after its `await` — either
+    `_ack_command(time, None)`, which nulls `current_command` and silently drops the
+    load out of controlled-consumption accounting, or a `None` deref that aborts the
+    cycle.
+
+    The fix is a post-await re-check, not a wider lock. Both post-await branches are
+    exercised here: a service call that lands, and one that reports impossible.
+    """
+    pump = _make_pump(pump_class=_RacingPump)
+    _arm_override(pump)
+    _push_override_constraint(pump)
+    pump.race_result = race_result
+    pump.hass.states.set(PUMP_ENTITY, "off", last_changed=T_OVERRIDE)
+    # a confirmed command of record, which must survive whatever happens
+    pump._ack_command(T_OVERRIDE, copy_command(CMD_IDLE))
+    confirmed = pump.current_command
+
+    # the override's own ON command goes in flight and is never confirmed
+    pump.obeys = False
+    await pump.launch_command(T_OVERRIDE + timedelta(hours=1), CMD_ON, ctxt="override hold dispatch")
+    assert pump.running_command == CMD_ON
+
+    # the relaunch's service call is interrupted by the user, and the expiry that
+    # runs on that path drops the override-aligned command underneath it
+    pump.race_at = T_EXPIRED
+    await pump.force_relaunch_command(T_EXPIRED)
+
+    assert pump.running_command is None
+    assert pump.external_user_initiated_state is None
+    # no phantom ack of `None`: the confirmed command of record is intact...
+    assert pump.current_command == confirmed
+    # ...so the load is still inside the power-accounting that feeds the forecast
+    assert pump.is_load_command_set(T_EXPIRED) is True
+    # and the counters do not outlive the command they describe
+    assert pump.running_command_num_relaunch == 0
+    assert pump.running_command_last_launch is None
+
+
+# =============================================================================
 # AC8 — the end-to-end bug, in both death modes
 # =============================================================================
 
@@ -721,10 +806,16 @@ async def _assert_override_self_heals(pump: _StuckPump) -> None:
     assert pump.running_command is None
     transport_calls_after_expiry = len(pump.transport_calls)
 
+    # Review fix #03: drive a FULL relaunch ladder across the post-expiry window
+    # before re-reading the counter. Without it the "no further service call"
+    # assertion below was vacuous — nothing could have re-issued the call in zero
+    # cycles, and the auditor re-introduced the regression with the test still green.
+    await drive(pump, T_EXPIRED + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+
     # the post-override cooldown is clock arithmetic too, so it also drains on
     # a load QS can no longer talk to — otherwise the load stayed pinned in
     # ASKED FOR RESET forever, which is the same bug one step later
-    t_back = T_EXPIRED + timedelta(seconds=USER_OVERRIDE_STATE_BACK_DURATION_S + CYCLE_S)
+    t_back = T_EXPIRED + timedelta(seconds=LADDER_WALL_S + USER_OVERRIDE_STATE_BACK_DURATION_S + CYCLE_S)
     await pump.check_load_activity_and_constraints(t_back)
 
     assert pump.asked_for_reset_user_initiated_state_time is None

--- a/tests/test_qs307_override_expiry_unfreeze.py
+++ b/tests/test_qs307_override_expiry_unfreeze.py
@@ -51,6 +51,8 @@ from custom_components.quiet_solar.const import (
     OVERRIDE_STATE_NO_OVERRIDE,
     OVERRIDE_STATE_PREFIX,
     STORAGE_KEY_ASKED_FOR_RESET_TIME,
+    STORAGE_KEY_EXTERNAL_USER_INITIATED_STATE,
+    STORAGE_KEY_EXTERNAL_USER_INITIATED_STATE_TIME,
 )
 from custom_components.quiet_solar.ha_model.bistate_duration import (
     USER_OVERRIDE_STATE_BACK_DURATION_S,
@@ -508,82 +510,55 @@ async def test_the_post_override_cooldown_is_not_drained_early():
     assert pump.get_override_state() == OVERRIDE_STATE_ASKED_FOR_RESET
 
 
-async def test_a_rewound_clock_does_not_freeze_the_cooldown_drain():
-    """A backwards clock step must not pin the load overridden.
+async def test_a_confused_clock_keeps_the_override_rather_than_destroying_it():
+    """AC26 (review fix #04): `main`'s plain subtraction, restored.
 
-    The drain is the ONLY release of the cooldown, so a future-dated anchor beyond
-    the skew band means "treat as fully elapsed" rather than "negative, therefore
-    below the window, therefore never".
+    Review fix #01 routed this comparison through a "clock-safe" helper whose
+    "future anchor ⇒ fully elapsed" rule is right for the retry ladder it was written
+    for — there it means *do not freeze the retry*. On an override it means *destroy
+    what the user just set*: state nulled, the aligned command dropped, constraints
+    wiped, the load parked in ASKED FOR RESET. Review fix #02's ±60 s band narrowed
+    the window without closing it.
+
+    Plain subtraction gives a negative age, which is never past the threshold, so a
+    confused clock simply makes the override last a little longer. That is the benign
+    direction, and it is what `main` did all along. There was never a bug here.
     """
     pump = _make_pump()
-    # NTP corrects the clock backwards AFTER restore, so the future-dated drop in
-    # `use_saved_extra_device_info` never got a chance to help
-    pump.asked_for_reset_user_initiated_state_time = T_OVERRIDE + timedelta(hours=3)
-
-    await pump.check_load_activity_and_constraints(T_OVERRIDE)
-
-    assert pump.asked_for_reset_user_initiated_state_time is None
-    assert pump.is_user_overridden() is False
-
-
-async def test_a_rewound_clock_does_not_freeze_the_override_expiry():
-    """The same hazard on the expiry comparison, which shares the helper."""
-    pump = _make_pump()
-    _arm_override(pump, time=T_OVERRIDE + timedelta(hours=3))
+    # far beyond the tolerance band review fix #02 added, to pin that the band is gone
+    _arm_override(pump, time=T_OVERRIDE + timedelta(seconds=90))
     _push_override_constraint(pump, time=T_OVERRIDE)
-    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
-
-    await pump.check_load_activity_and_constraints(T_OVERRIDE)
-
-    assert pump.external_user_initiated_state is None
-    assert _override_constraints(pump) == []
-
-
-async def test_a_slightly_future_dated_override_is_not_destroyed():
-    """Review fix #02 (must-fix): benign skew must not cancel a BRAND-NEW override.
-
-    `_seconds_since` reads every negative delta as "fully elapsed", so a few seconds
-    of future-dating expired a fresh 8 h override on the spot — the override state
-    nulled, its command dropped, its constraint wiped, and the load parked in
-    ASKED FOR RESET. QS fighting the user, arriving from the other direction.
-
-    And it needs no clock anomaly at all: `user_set_bistate_mode`,
-    `user_set_default_on_duration` and `async_reset_override_state` each take their
-    own unlocked `datetime.now(pytz.UTC)`, while an `async_update_loads` cycle
-    already in flight is still carrying an earlier `event_time` — so a user-stamped
-    anchor can legitimately sit ahead of the cycle that evaluates it.
-    """
-    pump = _make_pump()
-    _arm_override(pump)
-    _push_override_constraint(pump)
     pump.current_command = copy_command(CMD_IDLE)
     pump.running_command = copy_command(CMD_ON)
     pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
 
-    # the cycle evaluating the override is 5 s BEHIND the user action that armed it
-    await pump.check_load_activity_and_constraints(T_OVERRIDE - timedelta(seconds=5))
+    await pump.check_load_activity_and_constraints(T_OVERRIDE)
 
     assert pump.external_user_initiated_state == "on"
-    assert pump.external_user_initiated_state_time == T_OVERRIDE
+    assert pump.external_user_initiated_state_time == T_OVERRIDE + timedelta(seconds=90)
     assert pump.asked_for_reset_user_initiated_state_time is None
     assert pump.get_override_state() == f"{OVERRIDE_STATE_PREFIX}on"
     assert pump.is_user_overridden() is True
-    # ...and the override's own in-flight command is not dropped either
+    # ...and the override's own in-flight command survives with it
     assert pump.running_command == CMD_ON
     assert len(_override_constraints(pump)) == 1
 
 
-async def test_a_slightly_future_dated_cooldown_is_not_drained_early():
-    """The symmetric half: the same band protects the cooldown timer."""
+async def test_a_confused_clock_keeps_the_cooldown_rather_than_draining_it():
+    """AC26, symmetric half — and the worse of the two.
+
+    Draining the cooldown early also lets detection re-classify the user's manual
+    action on the same cycle, so QS re-arms the override the user just cancelled.
+    """
     pump = _make_pump()
-    pump.asked_for_reset_user_initiated_state_time = T_OVERRIDE
+    pump.asked_for_reset_user_initiated_state_time = T_OVERRIDE + timedelta(seconds=90)
     pump.current_command = copy_command(CMD_IDLE)
     pump.running_command = copy_command(CMD_ON)
     pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
 
-    await pump.check_load_activity_and_constraints(T_OVERRIDE - timedelta(seconds=5))
+    await pump.check_load_activity_and_constraints(T_OVERRIDE)
 
-    assert pump.asked_for_reset_user_initiated_state_time == T_OVERRIDE
+    assert pump.asked_for_reset_user_initiated_state_time == T_OVERRIDE + timedelta(seconds=90)
     assert pump.get_override_state() == OVERRIDE_STATE_ASKED_FOR_RESET
 
 
@@ -641,50 +616,82 @@ async def test_ac6_detection_still_works_once_the_command_has_landed():
 # =============================================================================
 
 
-async def test_a_load_flipped_to_boost_only_still_expires_its_override():
-    """The lifecycle is not gated on `support_user_override()` — detection is."""
+async def test_a_boost_only_load_runs_no_override_lifecycle():
+    """AC17 (reworked, review fix #04): `support_user_override()` gates the block.
+
+    Plan #02 moved this conjunct down to the detection gate so the lifecycle would
+    tear down an override on a load reconfigured to boost-only. That fixed a narrow
+    case by running the whole override lifecycle, every cycle, for every load that
+    cannot have an override — chargers included. Reverted: the conjunct answers "can
+    this load have an override at all", which is not a command-state question, so it
+    belongs on the outer gate exactly as on `main`. The boost-only case is handled at
+    restore instead (see the next test).
+    """
     pump = _make_pump()
     _arm_override(pump)
     _push_override_constraint(pump)
+    pump.asked_for_reset_user_initiated_state_time = T_OVERRIDE
+    pump.asked_for_reset_user_initiated_state_time_first_cmd_reset_done = T_OVERRIDE
     pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
 
-    # the user reconfigures the load as boost-only
     pump.load_is_auto_to_be_boosted = True
     assert pump.support_user_override() is False
 
     await pump.check_load_activity_and_constraints(T_EXPIRED)
-    assert pump.external_user_initiated_state is None
-    assert _override_constraints(pump) == []
 
-    t_back = T_EXPIRED + timedelta(seconds=USER_OVERRIDE_STATE_BACK_DURATION_S + CYCLE_S)
-    await pump.check_load_activity_and_constraints(t_back)
-
-    assert pump.asked_for_reset_user_initiated_state_time is None
-    assert pump.get_override_state() == OVERRIDE_STATE_NO_OVERRIDE
-    assert pump.is_user_overridden() is False
+    # not one lifecycle branch ran: every field is exactly as it was
+    assert pump.external_user_initiated_state == "on"
+    assert pump.external_user_initiated_state_time == T_OVERRIDE
+    assert pump.asked_for_reset_user_initiated_state_time == T_OVERRIDE
+    assert pump.asked_for_reset_user_initiated_state_time_first_cmd_reset_done == T_OVERRIDE
 
 
-async def test_a_boost_only_load_drains_a_reset_ask_restored_from_storage():
-    """...and the persisted half: restore keeps a PAST-dated ask, so it must drain.
+async def test_a_boost_only_load_drops_a_stored_override_at_restore():
+    """AC18 (reworked, review fix #04): the teardown belongs at the restore boundary.
 
-    `use_saved_extra_device_info` only drops a *future*-dated reset-ask, and the
-    reset button was the sole other clearer, so a stored timestamp on a boost-only
-    load survived every restart and kept `is_user_overridden()` True for good.
+    A reconfigure to boost-only reloads the config entry, which runs
+    `use_saved_extra_device_info` — where stale and future-dated overrides are
+    already dropped. Extending that existing condition is enough, and it costs
+    nothing per cycle. Without it a stored override would be orphaned: the only code
+    that could ever clear it is now gated off.
     """
     pump = _make_pump()
     pump.load_is_auto_to_be_boosted = True
 
-    with freeze_time(T_EXPIRED):
-        pump.use_saved_extra_device_info({STORAGE_KEY_ASKED_FOR_RESET_TIME: f"{T_OVERRIDE}"})
+    with freeze_time(T_OVERRIDE + timedelta(minutes=1)):
+        pump.use_saved_extra_device_info(
+            {
+                STORAGE_KEY_EXTERNAL_USER_INITIATED_STATE: "on",
+                STORAGE_KEY_EXTERNAL_USER_INITIATED_STATE_TIME: f"{T_OVERRIDE}",
+                STORAGE_KEY_ASKED_FOR_RESET_TIME: f"{T_OVERRIDE}",
+            }
+        )
 
-    # restore deliberately keeps it — nothing there expires a past-dated ask
-    assert pump.asked_for_reset_user_initiated_state_time == T_OVERRIDE
-    assert pump.get_override_state() == OVERRIDE_STATE_ASKED_FOR_RESET
-
-    await pump.check_load_activity_and_constraints(T_EXPIRED)
-
+    # young enough that neither the staleness nor the future-dating arm would fire
+    assert pump.external_user_initiated_state is None
+    assert pump.external_user_initiated_state_time is None
     assert pump.asked_for_reset_user_initiated_state_time is None
+    assert pump.asked_for_reset_user_initiated_state_time_first_cmd_reset_done is None
+    assert pump.get_override_state() == OVERRIDE_STATE_NO_OVERRIDE
     assert pump.is_user_overridden() is False
+
+
+async def test_a_load_that_supports_overrides_keeps_a_stored_override_at_restore():
+    """...and the guard does not over-reach: a normal load still restores its override."""
+    pump = _make_pump()
+
+    with freeze_time(T_OVERRIDE + timedelta(minutes=1)):
+        pump.use_saved_extra_device_info(
+            {
+                STORAGE_KEY_EXTERNAL_USER_INITIATED_STATE: "on",
+                STORAGE_KEY_EXTERNAL_USER_INITIATED_STATE_TIME: f"{T_OVERRIDE}",
+                STORAGE_KEY_ASKED_FOR_RESET_TIME: f"{T_OVERRIDE}",
+            }
+        )
+
+    assert pump.external_user_initiated_state == "on"
+    assert pump.external_user_initiated_state_time == T_OVERRIDE
+    assert pump.asked_for_reset_user_initiated_state_time == T_OVERRIDE
 
 
 async def test_detection_stays_off_for_a_boost_only_load():
@@ -753,6 +760,38 @@ async def test_a_user_action_during_a_service_call_cannot_strand_the_command_slo
     # and the counters do not outlive the command they describe
     assert pump.running_command_num_relaunch == 0
     assert pump.running_command_last_launch is None
+
+
+@pytest.mark.parametrize("race_result", [True, None], ids=["service-call-lands", "service-call-impossible"])
+async def test_a_user_action_during_the_first_launch_cannot_strand_the_command_slot(race_result):
+    """AC25, second call site (review fix #04): `launch_command` has the same shape.
+
+    Review fix #03 guarded `force_relaunch_command` and claimed the invariant break
+    was closed, but `launch_command` acks after its own `await execute_command(...)`
+    too — and it is the FIRST place a command reaches, so it is at least as exposed.
+    Same guard, copied rather than redesigned.
+
+    Only the ack branch was actually broken here (this site's "impossible" log already
+    used a local, unlike `force_relaunch_command`'s). The impossible case is
+    parametrized anyway so both post-await branches stay pinned at both call sites.
+    """
+    pump = _make_pump(pump_class=_RacingPump)
+    _arm_override(pump)
+    _push_override_constraint(pump)
+    pump.race_result = race_result
+    pump.hass.states.set(PUMP_ENTITY, "off", last_changed=T_OVERRIDE)
+    pump._ack_command(T_OVERRIDE, copy_command(CMD_IDLE))
+    confirmed = pump.current_command
+
+    # the very first dispatch of the override's ON command is interrupted by the user
+    pump.obeys = False
+    pump.race_at = T_EXPIRED
+    await pump.launch_command(T_EXPIRED, CMD_ON, ctxt="override hold dispatch")
+
+    assert pump.running_command is None
+    assert pump.external_user_initiated_state is None
+    assert pump.current_command == confirmed
+    assert pump.is_load_command_set(T_EXPIRED) is True
 
 
 # =============================================================================

--- a/tests/test_qs307_override_expiry_unfreeze.py
+++ b/tests/test_qs307_override_expiry_unfreeze.py
@@ -1,0 +1,465 @@
+"""QS-307 — an override on an unresponsive load must still expire.
+
+`QSBiStateDuration.check_load_activity_and_constraints` used to gate its
+**whole** user-override block on `is_load_command_set(time)`, which requires
+`running_command is None`. Gating *detection* that way is correct — while a
+command is landing, observed state != wanted state is expected. But the same
+gate also suppressed the branches of the override lifecycle that never read
+entity state at all:
+
+- override **expiry** — pure clock arithmetic on
+  `external_user_initiated_state_time`;
+- the **reset-ask follow-up** — a pure flag check;
+- the post-override **cooldown expiry** — pure clock arithmetic on
+  `asked_for_reset_user_initiated_state_time`.
+
+Since QS-304 made the relaunch backoff saturate and retry forever, the gate can
+stay shut indefinitely, so those branches never ran: an override on a load that
+stopped obeying was pinned **forever** and the load never came back into
+controlled consumption.
+
+Both death modes are covered, because they leave different command state behind:
+
+- **visible but disobeying** — the entity still reports `on`/`off`, it just
+  ignores commands, so `running_command` stays in flight forever
+  (`probe_if_command_set` keeps returning `False`);
+- **unavailable** — the entity drops off the network, the invalid-probe give-up
+  (`NUM_MAX_INVALID_PROBES_COMMANDS`) nulls `current_command` through
+  `_ack_command(time, None)`, so `is_load_command_set` is `False` on its
+  `current_command is None` arm instead.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from datetime import time as dt_time
+from unittest.mock import MagicMock
+
+import pytz
+from homeassistant.const import CONF_NAME, STATE_UNAVAILABLE
+
+from custom_components.quiet_solar.const import (
+    CONF_POWER,
+    CONF_SWITCH,
+    CONSTRAINT_ORIGINATOR_KEY,
+    CONSTRAINT_ORIGINATOR_USER_OVERRIDE,
+    CONSTRAINT_TYPE_FILLER_AUTO,
+    CONSTRAINT_TYPE_MANDATORY_END_TIME,
+    OVERRIDE_STATE_NO_OVERRIDE,
+)
+from custom_components.quiet_solar.ha_model.bistate_duration import (
+    USER_OVERRIDE_STATE_BACK_DURATION_S,
+    QSBiStateDuration,
+)
+from custom_components.quiet_solar.home_model.commands import CMD_IDLE, CMD_ON, copy_command
+from custom_components.quiet_solar.home_model.constraints import TimeBasedSimplePowerLoadConstraint
+from custom_components.quiet_solar.home_model.load import NUM_MAX_INVALID_PROBES_COMMANDS
+from tests.conftest import FakeHass
+from tests.factories import create_minimal_home_model
+from tests.qs304_helpers import CYCLE_S, LADDER_WALL_S, drive
+
+PUMP_ENTITY = "switch.pool_pump"
+
+# 18:00 — the worked example in the story: the user forces the pool pump ON with
+# an 8 h window that should end at 02:00.
+T_OVERRIDE = datetime(2026, 7, 31, 18, 0, 0, tzinfo=pytz.UTC)
+OVERRIDE_DURATION_H = 8.0
+
+# Past the window whether the override was armed at `T_OVERRIDE` directly or
+# classified one cycle later by the detection branch.
+T_EXPIRED = T_OVERRIDE + timedelta(hours=OVERRIDE_DURATION_H, seconds=2 * CYCLE_S)
+
+
+class _StuckPump(QSBiStateDuration):
+    """Bistate pump whose transport can be made to stop obeying.
+
+    `obeys = False` reproduces the QS-304 pool-house shape: the service call
+    goes out and returns "dispatched, unconfirmed" (the real
+    `BistateTransport.execute` contract) but the entity never follows, so the
+    command can never be acked.
+    """
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault(CONF_SWITCH, PUMP_ENTITY)
+        super().__init__(**kwargs)
+        self.transport_calls: list[tuple[datetime, str, str | None]] = []
+        self.obeys = True
+
+    async def execute_command_system(self, time, command, state):
+        """Record the service call, and only move the entity when obeying."""
+        self.transport_calls.append((time, command.command, state))
+        if self.obeys:
+            target = state if state is not None else self.expected_state_from_command(command)
+            self.hass.states.set(self.bistate_entity, target, last_changed=time)
+            return True
+        return False
+
+    def get_virtual_current_constraint_translation_key(self):
+        """Provide the translation key the entity layer would supply."""
+        return "test_constraint_key"
+
+    def get_select_translation_key(self):
+        """Provide the translation key the entity layer would supply."""
+        return "test_select_key"
+
+
+def _next_daily_end(local_hours: dt_time, time_utc_now: datetime | None = None, output_in_utc=True):
+    """Deterministic, timezone-independent stand-in for get_next_time_from_hours."""
+    assert output_in_utc is True
+    assert time_utc_now is not None
+    candidate = time_utc_now.replace(
+        hour=local_hours.hour, minute=local_hours.minute, second=local_hours.second, microsecond=0
+    )
+    if candidate < time_utc_now:
+        candidate += timedelta(days=1)
+    return candidate
+
+
+def _make_pump(override_duration_h: float = OVERRIDE_DURATION_H) -> _StuckPump:
+    """Build a switch-backed bistate pump on FakeHass, with no config entry."""
+    hass = FakeHass()
+    home = create_minimal_home_model()
+    home.is_off_grid = MagicMock(return_value=False)
+    pump = _StuckPump(
+        hass=hass,
+        config_entry=None,
+        home=home,
+        **{CONF_NAME: "Piscine", CONF_POWER: 1259.0},
+    )
+    pump.override_duration = override_duration_h
+    pump.bistate_mode = "bistate_mode_default"
+    pump.default_on_duration = 1.0
+    pump.default_on_finish_time = dt_time(hour=6, minute=0, second=0)
+    pump.get_next_time_from_hours = _next_daily_end  # type: ignore[method-assign]
+    pump.externally_initialized_constraints = True
+    return pump
+
+
+def _override_constraints(pump: _StuckPump) -> list:
+    """Return the USER_OVERRIDE-originated constraints currently live."""
+    return [
+        c
+        for c in pump._constraints
+        if c.load_info is not None
+        and c.load_info.get(CONSTRAINT_ORIGINATOR_KEY, "") == CONSTRAINT_ORIGINATOR_USER_OVERRIDE
+    ]
+
+
+def _arm_override(pump: _StuckPump, state: str = "on", time: datetime = T_OVERRIDE) -> None:
+    """Put the pump in the state the detection branch would have left behind."""
+    pump.external_user_initiated_state = state
+    pump.external_user_initiated_state_time = time
+
+
+def _push_override_constraint(pump: _StuckPump, time: datetime = T_OVERRIDE) -> None:
+    """Push the hold-off/power constraint an ON override carries."""
+    ct = TimeBasedSimplePowerLoadConstraint(
+        type=CONSTRAINT_TYPE_MANDATORY_END_TIME,
+        degraded_type=CONSTRAINT_TYPE_FILLER_AUTO,
+        time=time,
+        load=pump,
+        load_param=pump.external_user_initiated_state,
+        load_info={CONSTRAINT_ORIGINATOR_KEY: CONSTRAINT_ORIGINATOR_USER_OVERRIDE},
+        from_user=True,
+        start_of_constraint=time,
+        end_of_constraint=time + timedelta(hours=OVERRIDE_DURATION_H),
+        power=pump.power_use,
+        initial_value=0,
+        target_value=3600.0 * OVERRIDE_DURATION_H,
+    )
+    pump.push_live_constraint(time, ct)
+
+
+# =============================================================================
+# AC1 — expiry fires while a command is in flight
+# =============================================================================
+
+
+async def test_ac1_expiry_fires_while_a_command_is_in_flight():
+    """A clock comparison has no business being gated on command state.
+
+    `running_command` set + `current_command` set is the visible-but-disobeying
+    death mode: `is_load_command_set` is `False` on its `running_command is
+    None` arm, and on `main` that froze the expiry with it.
+    """
+    pump = _make_pump()
+    _arm_override(pump)
+    _push_override_constraint(pump)
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.running_command = copy_command(CMD_ON)
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+    # the precondition: the old gate is shut
+    assert pump.is_load_command_set(T_EXPIRED) is False
+    assert _override_constraints(pump) != []
+
+    await pump.check_load_activity_and_constraints(T_EXPIRED)
+
+    assert pump.external_user_initiated_state is None
+    assert pump.external_user_initiated_state_time is None
+    assert pump.asked_for_reset_user_initiated_state_time == T_EXPIRED
+    assert _override_constraints(pump) == []
+    # `keep_commands=True`: the reset must not touch the command slot
+    assert pump.current_command is not None
+    assert pump.running_command is not None
+
+
+# =============================================================================
+# AC2 — expiry fires after the invalid-probe give-up
+# =============================================================================
+
+
+async def _drive_to_invalid_probe_give_up(pump: _StuckPump, start: datetime) -> datetime:
+    """Spin the cycle until the invalid-probe give-up empties the slot."""
+    time = start
+    for _ in range(NUM_MAX_INVALID_PROBES_COMMANDS + 2):
+        await pump.check_and_relaunch_command(time)
+        time = time + timedelta(seconds=CYCLE_S)
+    return time
+
+
+async def test_ac2_expiry_fires_after_the_invalid_probe_give_up():
+    """The *unavailable* death mode empties the slot, so the ladder never climbs.
+
+    `_ack_command(time, None)` nulls `current_command`, so
+    `is_load_command_set` is `False` on its other arm — no relaunch escalation
+    can ever reopen the gate. This is the case a "detection is allowed once the
+    load is uncontrollable" predicate could not have fixed.
+    """
+    pump = _make_pump()
+    _arm_override(pump)
+    _push_override_constraint(pump)
+
+    t_dead = T_OVERRIDE + timedelta(hours=1)
+    pump.obeys = False
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.running_command = copy_command(CMD_ON)
+    pump.running_command_first_launch = t_dead
+    pump.running_command_last_launch = t_dead
+    pump.hass.states.set(PUMP_ENTITY, STATE_UNAVAILABLE, last_changed=t_dead)
+
+    await _drive_to_invalid_probe_give_up(pump, t_dead)
+
+    assert pump.current_command is None
+    assert pump.running_command is None
+    assert pump.is_load_command_set(T_EXPIRED) is False
+
+    await pump.check_load_activity_and_constraints(T_EXPIRED)
+
+    assert pump.external_user_initiated_state is None
+    assert pump.external_user_initiated_state_time is None
+    assert pump.asked_for_reset_user_initiated_state_time == T_EXPIRED
+    assert _override_constraints(pump) == []
+
+
+# =============================================================================
+# AC3 — healthy-load parity
+# =============================================================================
+
+
+async def test_ac3_a_live_override_is_never_reset_early():
+    """Nothing resets an override that has not aged out, in any command state.
+
+    The safety net for the one admitted behaviour change: expiry can now land
+    one cycle earlier (during the command flight rather than just after it).
+    That is only sound if the branches themselves are inert, so a not-yet-aged
+    override must survive every combination of command state.
+    """
+    for running in (None, CMD_ON):
+        for current in (None, CMD_ON):
+            pump = _make_pump()
+            _arm_override(pump)
+            _push_override_constraint(pump)
+            pump.running_command = None if running is None else copy_command(running)
+            pump.current_command = None if current is None else copy_command(current)
+            pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+            # half-way through the 8 h window: nowhere near expiry
+            await pump.check_load_activity_and_constraints(T_OVERRIDE + timedelta(hours=4))
+
+            context = (running, current)
+            assert pump.external_user_initiated_state == "on", context
+            assert pump.external_user_initiated_state_time == T_OVERRIDE, context
+            assert pump.asked_for_reset_user_initiated_state_time is None, context
+            assert pump.is_user_overridden() is True, context
+            assert len(_override_constraints(pump)) == 1, context
+
+
+# =============================================================================
+# AC4 — disabled loads unchanged
+# =============================================================================
+
+
+async def test_ac4_a_disabled_load_runs_no_lifecycle_branch():
+    """`is_load_command_set` is `False` for a disabled load, and stays decisive.
+
+    The hoist replaces the gate with an explicit `qs_enable_device` guard rather
+    than dropping it: QS was told to leave this load alone, so it must not
+    silently start expiring overrides on it.
+    """
+    pump = _make_pump()
+    _arm_override(pump)
+    pump.asked_for_reset_user_initiated_state_time_first_cmd_reset_done = T_OVERRIDE
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+    pump._enabled = False
+
+    await pump.check_load_activity_and_constraints(T_EXPIRED)
+
+    assert pump.external_user_initiated_state == "on"
+    assert pump.external_user_initiated_state_time == T_OVERRIDE
+    assert pump.asked_for_reset_user_initiated_state_time is None
+    assert pump.asked_for_reset_user_initiated_state_time_first_cmd_reset_done == T_OVERRIDE
+
+
+# =============================================================================
+# AC5 — the reset-ask follow-up runs unconditionally
+# =============================================================================
+
+
+async def test_ac5_reset_ask_follow_up_runs_with_a_command_in_flight():
+    """The follow-up cleanup cycle is a flag check, so it must not be gated."""
+    pump = _make_pump()
+    _arm_override(pump)
+    _push_override_constraint(pump)
+    pump.external_user_initiated_state = None
+    pump.external_user_initiated_state_time = None
+    pump.asked_for_reset_user_initiated_state_time = T_OVERRIDE
+    pump.asked_for_reset_user_initiated_state_time_first_cmd_reset_done = T_OVERRIDE
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.running_command = copy_command(CMD_ON)
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+    t = T_OVERRIDE + timedelta(seconds=CYCLE_S)
+    assert pump.is_load_command_set(t) is False
+    assert _override_constraints(pump) != []
+
+    do_force_next_solve = await pump.check_load_activity_and_constraints(t)
+
+    assert pump.asked_for_reset_user_initiated_state_time_first_cmd_reset_done is None
+    assert do_force_next_solve is True
+    # `constraint_reset_and_reset_commands_if_needed(keep_commands=True)` ran:
+    # the stale override constraint is gone, the commands are untouched.
+    assert _override_constraints(pump) == []
+    assert pump.current_command is not None
+    assert pump.running_command is not None
+
+
+# =============================================================================
+# AC6 — detection is unchanged
+# =============================================================================
+
+
+async def test_ac6_detection_stays_shut_while_a_command_is_in_flight():
+    """The regression pin for the non-goal: no new detection, ever.
+
+    A state matching neither `expected_state` nor `expected_state_running` is
+    exactly what "the user acted" looks like — and it is also what a landing
+    command looks like. `is_load_command_set` still guards that decision.
+    """
+    pump = _make_pump()
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.running_command = copy_command(CMD_IDLE)
+    pump.last_command_execution_time = T_OVERRIDE
+    # "on" matches neither expectation (both commands expect "off"), and the
+    # state is newer than the last execution, so the causality guard allows it
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE + timedelta(seconds=30))
+
+    await pump.check_load_activity_and_constraints(T_OVERRIDE + timedelta(minutes=2))
+
+    assert pump.external_user_initiated_state is None
+    assert pump.external_user_initiated_state_time is None
+    assert _override_constraints(pump) == []
+
+
+async def test_ac6_detection_still_works_once_the_command_has_landed():
+    """...and the gate opening on an acked command still classifies the user."""
+    pump = _make_pump()
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.last_command_execution_time = T_OVERRIDE
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE + timedelta(seconds=30))
+
+    t = T_OVERRIDE + timedelta(minutes=2)
+    assert pump.is_load_command_set(t) is True
+
+    await pump.check_load_activity_and_constraints(t)
+
+    assert pump.external_user_initiated_state == "on"
+    assert pump.external_user_initiated_state_time == t
+
+
+# =============================================================================
+# AC8 — the end-to-end bug, in both death modes
+# =============================================================================
+
+
+async def _detect_user_override_on(pump: _StuckPump) -> None:
+    """Replay the story's 18:00: the user flips the pump ON by hand."""
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.last_command_execution_time = T_OVERRIDE - timedelta(hours=1)
+    pump.hass.states.set(PUMP_ENTITY, "off", last_changed=T_OVERRIDE - timedelta(hours=1))
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+    await pump.check_load_activity_and_constraints(T_OVERRIDE + timedelta(seconds=CYCLE_S))
+
+    assert pump.external_user_initiated_state == "on"
+    assert pump.is_user_overridden() is True
+    assert len(_override_constraints(pump)) == 1
+
+
+async def _assert_override_self_heals(pump: _StuckPump) -> None:
+    """The override expires on time, then the cooldown releases the load."""
+    await pump.check_load_activity_and_constraints(T_EXPIRED)
+
+    assert pump.external_user_initiated_state is None
+    assert _override_constraints(pump) == []
+
+    # the post-override cooldown is clock arithmetic too, so it also drains on
+    # a load QS can no longer talk to — otherwise the load stayed pinned in
+    # ASKED FOR RESET forever, which is the same bug one step later
+    t_back = T_EXPIRED + timedelta(seconds=USER_OVERRIDE_STATE_BACK_DURATION_S + CYCLE_S)
+    await pump.check_load_activity_and_constraints(t_back)
+
+    assert pump.asked_for_reset_user_initiated_state_time is None
+    assert pump.get_override_state() == OVERRIDE_STATE_NO_OVERRIDE
+    assert pump.is_user_overridden() is False
+    # ...and the load is back in the solver with its ordinary daily constraint
+    assert pump._constraints != []
+
+
+async def test_ac8_override_expires_on_a_visible_but_disobeying_load():
+    """The #304 pool-house shape: reachable, answering, and ignoring us."""
+    pump = _make_pump()
+    await _detect_user_override_on(pump)
+
+    # 19:00 — the relay dies: the pump falls back to "off" and stops obeying
+    t_dead = T_OVERRIDE + timedelta(hours=1)
+    pump.obeys = False
+    pump.hass.states.set(PUMP_ENTITY, "off", last_changed=t_dead)
+    await pump.launch_command(t_dead, CMD_ON, ctxt="override hold dispatch")
+    assert pump.running_command is not None
+
+    # QS-304: the ladder saturates and retries forever, so the gate stays shut
+    await drive(pump, t_dead + timedelta(seconds=CYCLE_S), LADDER_WALL_S)
+    assert pump.is_uncontrollable is True
+    assert pump.is_load_command_set(t_dead) is False
+
+    await _assert_override_self_heals(pump)
+
+
+async def test_ac8_override_expires_on_an_unavailable_load():
+    """The other death mode: the entity drops off the network entirely."""
+    pump = _make_pump()
+    await _detect_user_override_on(pump)
+
+    t_dead = T_OVERRIDE + timedelta(hours=1)
+    pump.obeys = False
+    pump.hass.states.set(PUMP_ENTITY, STATE_UNAVAILABLE, last_changed=t_dead)
+    await pump.launch_command(t_dead, CMD_ON, ctxt="override hold dispatch")
+    assert pump.running_command is not None
+
+    await _drive_to_invalid_probe_give_up(pump, t_dead + timedelta(seconds=CYCLE_S))
+    assert pump.current_command is None
+    assert pump.running_command is None
+    assert pump.is_load_command_set(t_dead) is False
+
+    await _assert_override_self_heals(pump)

--- a/tests/test_qs307_override_expiry_unfreeze.py
+++ b/tests/test_qs307_override_expiry_unfreeze.py
@@ -35,7 +35,9 @@ from datetime import datetime, timedelta
 from datetime import time as dt_time
 from unittest.mock import MagicMock
 
+import pytest
 import pytz
+from freezegun import freeze_time
 from homeassistant.const import CONF_NAME, STATE_UNAVAILABLE
 
 from custom_components.quiet_solar.const import (
@@ -45,13 +47,15 @@ from custom_components.quiet_solar.const import (
     CONSTRAINT_ORIGINATOR_USER_OVERRIDE,
     CONSTRAINT_TYPE_FILLER_AUTO,
     CONSTRAINT_TYPE_MANDATORY_END_TIME,
+    OVERRIDE_STATE_ASKED_FOR_RESET,
     OVERRIDE_STATE_NO_OVERRIDE,
+    STORAGE_KEY_ASKED_FOR_RESET_TIME,
 )
 from custom_components.quiet_solar.ha_model.bistate_duration import (
     USER_OVERRIDE_STATE_BACK_DURATION_S,
     QSBiStateDuration,
 )
-from custom_components.quiet_solar.home_model.commands import CMD_IDLE, CMD_ON, copy_command
+from custom_components.quiet_solar.home_model.commands import CMD_IDLE, CMD_ON, LoadCommand, copy_command
 from custom_components.quiet_solar.home_model.constraints import TimeBasedSimplePowerLoadConstraint
 from custom_components.quiet_solar.home_model.load import NUM_MAX_INVALID_PROBES_COMMANDS
 from tests.conftest import FakeHass
@@ -181,6 +185,12 @@ async def test_ac1_expiry_fires_while_a_command_is_in_flight():
     `running_command` set + `current_command` set is the visible-but-disobeying
     death mode: `is_load_command_set` is `False` on its `running_command is
     None` arm, and on `main` that froze the expiry with it.
+
+    Review fix #02: the in-flight command here is the override's OWN service call
+    (it drives the entity to the override state), so expiry must drop it. Left
+    alone it would keep being relaunched for up to a full ladder *after* the
+    override ended, because nulling the override state also disables
+    `force_relaunch_command`'s suppression drop.
     """
     pump = _make_pump()
     _arm_override(pump)
@@ -192,6 +202,7 @@ async def test_ac1_expiry_fires_while_a_command_is_in_flight():
     # the precondition: the old gate is shut
     assert pump.is_load_command_set(T_EXPIRED) is False
     assert _override_constraints(pump) != []
+    assert pump.expected_state_from_command(pump.running_command) == pump.external_user_initiated_state
 
     await pump.check_load_activity_and_constraints(T_EXPIRED)
 
@@ -199,9 +210,35 @@ async def test_ac1_expiry_fires_while_a_command_is_in_flight():
     assert pump.external_user_initiated_state_time is None
     assert pump.asked_for_reset_user_initiated_state_time == T_EXPIRED
     assert _override_constraints(pump) == []
-    # `keep_commands=True`: the reset must not touch the command slot
+    # the override's own command is gone...
+    assert pump.running_command is None
+    # ...but `keep_commands=True` still protects the last CONFIRMED command
     assert pump.current_command is not None
-    assert pump.running_command is not None
+
+
+async def test_ac1_expiry_leaves_a_command_the_override_was_not_serving_alone():
+    """Review fix #02 must not over-reach: only the override's own call is dropped.
+
+    A command whose expected state differs from the override state was never the
+    override's service call — it is a genuine solver intent that got through (the
+    degraded-override nuance lets off/idle commands past). Expiry calls
+    `constraint_reset_and_reset_commands_if_needed(keep_commands=True)`, so it must
+    survive.
+    """
+    pump = _make_pump()
+    _arm_override(pump)
+    _push_override_constraint(pump)
+    pump.current_command = copy_command(CMD_ON)
+    pump.running_command = copy_command(CMD_IDLE)
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+    assert pump.expected_state_from_command(pump.running_command) != pump.external_user_initiated_state
+
+    await pump.check_load_activity_and_constraints(T_EXPIRED)
+
+    assert pump.external_user_initiated_state is None
+    assert pump.running_command == CMD_IDLE
+    assert pump.current_command == CMD_ON
 
 
 # =============================================================================
@@ -257,32 +294,61 @@ async def test_ac2_expiry_fires_after_the_invalid_probe_give_up():
 # =============================================================================
 
 
-async def test_ac3_a_live_override_is_never_reset_early():
+def _armed_pump(running: LoadCommand | None, current: LoadCommand | None) -> _StuckPump:
+    """A pump carrying a live ON override plus the given command-slot state."""
+    pump = _make_pump()
+    _arm_override(pump)
+    _push_override_constraint(pump)
+    pump.running_command = None if running is None else copy_command(running)
+    pump.current_command = None if current is None else copy_command(current)
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+    return pump
+
+
+@pytest.mark.parametrize("current", [None, CMD_ON], ids=["no-current", "current-on"])
+@pytest.mark.parametrize("running", [None, CMD_ON], ids=["no-running", "running-on"])
+async def test_ac3_a_live_override_is_never_reset_early(running, current):
     """Nothing resets an override that has not aged out, in any command state.
 
-    The safety net for the one admitted behaviour change: expiry can now land
-    one cycle earlier (during the command flight rather than just after it).
-    That is only sound if the branches themselves are inert, so a not-yet-aged
-    override must survive every combination of command state.
+    The negative half of the safety net for the one admitted behaviour change:
+    expiry can now land one cycle earlier (during the command flight rather than
+    just after it). That is only sound if the branches themselves are inert, so a
+    not-yet-aged override must survive every combination of command state.
     """
-    for running in (None, CMD_ON):
-        for current in (None, CMD_ON):
-            pump = _make_pump()
-            _arm_override(pump)
-            _push_override_constraint(pump)
-            pump.running_command = None if running is None else copy_command(running)
-            pump.current_command = None if current is None else copy_command(current)
-            pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+    pump = _armed_pump(running, current)
 
-            # half-way through the 8 h window: nowhere near expiry
-            await pump.check_load_activity_and_constraints(T_OVERRIDE + timedelta(hours=4))
+    # half-way through the 8 h window: nowhere near expiry
+    await pump.check_load_activity_and_constraints(T_OVERRIDE + timedelta(hours=4))
 
-            context = (running, current)
-            assert pump.external_user_initiated_state == "on", context
-            assert pump.external_user_initiated_state_time == T_OVERRIDE, context
-            assert pump.asked_for_reset_user_initiated_state_time is None, context
-            assert pump.is_user_overridden() is True, context
-            assert len(_override_constraints(pump)) == 1, context
+    assert pump.external_user_initiated_state == "on"
+    assert pump.external_user_initiated_state_time == T_OVERRIDE
+    assert pump.asked_for_reset_user_initiated_state_time is None
+    assert pump.is_user_overridden() is True
+    assert len(_override_constraints(pump)) == 1
+
+
+@pytest.mark.parametrize("current", [None, CMD_ON], ids=["no-current", "current-on"])
+@pytest.mark.parametrize("running", [None, CMD_ON], ids=["no-running", "running-on"])
+async def test_ac3_an_aged_override_resets_on_the_same_cycle_as_on_main(running, current):
+    """...and the POSITIVE half, which review fix #07 asked to stop delegating.
+
+    The window boundary is `> override_duration`, so the last cycle at exactly
+    8 h must NOT reset and the next one must — identically in all four
+    command-state combinations, which is what "same cycle as on `main`" means.
+    """
+    pump = _armed_pump(running, current)
+
+    # exactly at the window edge: still alive (`>` not `>=`)
+    await pump.check_load_activity_and_constraints(T_OVERRIDE + timedelta(hours=OVERRIDE_DURATION_H))
+    assert pump.external_user_initiated_state == "on"
+    assert pump.asked_for_reset_user_initiated_state_time is None
+
+    # the very next cycle resets, whatever the command slot holds
+    await pump.check_load_activity_and_constraints(T_EXPIRED)
+    assert pump.external_user_initiated_state is None
+    assert pump.external_user_initiated_state_time is None
+    assert pump.asked_for_reset_user_initiated_state_time == T_EXPIRED
+    assert _override_constraints(pump) == []
 
 
 # =============================================================================
@@ -345,6 +411,93 @@ async def test_ac5_reset_ask_follow_up_runs_with_a_command_in_flight():
 
 
 # =============================================================================
+# AC5b — the post-override cooldown, the third hoisted branch
+#
+# Review fix #04: the story's D1 designed two hoisted branches and this one was
+# added during implementation because AC8 is unreachable without it —
+# `get_override_state()` returns ASKED FOR RESET while the timestamp is set, so
+# the load would expire its override and still never come back. It was covered
+# only transitively, through AC8's 8-hour end-to-end replay; these two pin it
+# directly.
+# =============================================================================
+
+
+async def test_the_post_override_cooldown_drains_with_a_command_in_flight():
+    """A cooldown timer is clock arithmetic, so a stuck command must not freeze it.
+
+    This drain used to live *inside* the detection branch, which meant a load that
+    stopped answering stayed `ASKED FOR RESET` forever: `is_user_overridden()`
+    stayed `True`, and the load stayed out of controlled consumption.
+    """
+    pump = _make_pump()
+    pump.asked_for_reset_user_initiated_state_time = T_OVERRIDE
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.running_command = copy_command(CMD_ON)
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+    t = T_OVERRIDE + timedelta(seconds=USER_OVERRIDE_STATE_BACK_DURATION_S + CYCLE_S)
+    assert pump.is_load_command_set(t) is False
+    assert pump.get_override_state() == OVERRIDE_STATE_ASKED_FOR_RESET
+
+    await pump.check_load_activity_and_constraints(t)
+
+    assert pump.asked_for_reset_user_initiated_state_time is None
+    assert pump.get_override_state() == OVERRIDE_STATE_NO_OVERRIDE
+    assert pump.is_user_overridden() is False
+
+
+async def test_the_post_override_cooldown_is_not_drained_early():
+    """...and the window is still honoured: an open cooldown is left alone.
+
+    Hoisting must not shorten the 180 s "too soon to re-override" window, which is
+    what stops a just-ended override immediately re-arming itself.
+    """
+    pump = _make_pump()
+    pump.asked_for_reset_user_initiated_state_time = T_OVERRIDE
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.running_command = copy_command(CMD_ON)
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+    await pump.check_load_activity_and_constraints(
+        T_OVERRIDE + timedelta(seconds=USER_OVERRIDE_STATE_BACK_DURATION_S - CYCLE_S)
+    )
+
+    assert pump.asked_for_reset_user_initiated_state_time == T_OVERRIDE
+    assert pump.get_override_state() == OVERRIDE_STATE_ASKED_FOR_RESET
+
+
+async def test_a_rewound_clock_does_not_freeze_the_cooldown_drain():
+    """Review fix #08: a backwards clock step must not pin the load overridden.
+
+    The drain is now the ONLY release of the cooldown, so it goes through
+    `_seconds_since`, where a future-dated anchor means "treat as fully elapsed"
+    rather than "negative, therefore below the window, therefore never".
+    """
+    pump = _make_pump()
+    # NTP corrects the clock backwards AFTER restore, so the future-dated drop in
+    # `use_saved_extra_device_info` never got a chance to help
+    pump.asked_for_reset_user_initiated_state_time = T_OVERRIDE + timedelta(hours=3)
+
+    await pump.check_load_activity_and_constraints(T_OVERRIDE)
+
+    assert pump.asked_for_reset_user_initiated_state_time is None
+    assert pump.is_user_overridden() is False
+
+
+async def test_a_rewound_clock_does_not_freeze_the_override_expiry():
+    """The same hazard on the expiry comparison, which shares the helper."""
+    pump = _make_pump()
+    _arm_override(pump, time=T_OVERRIDE + timedelta(hours=3))
+    _push_override_constraint(pump, time=T_OVERRIDE)
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+    await pump.check_load_activity_and_constraints(T_OVERRIDE)
+
+    assert pump.external_user_initiated_state is None
+    assert _override_constraints(pump) == []
+
+
+# =============================================================================
 # AC6 — detection is unchanged
 # =============================================================================
 
@@ -388,8 +541,96 @@ async def test_ac6_detection_still_works_once_the_command_has_landed():
 
 
 # =============================================================================
+# AC4b — `support_user_override()` is not a second freeze (review fix #03)
+#
+# Unlike the `qs_enable_device` arm, this one is not self-healing: disabling and
+# re-enabling a load runs the lifecycle again, but flipping a load to boost-only
+# never does. With the lifecycle behind it, a load reconfigured to boost-only
+# kept a live override or a pending reset-ask FOREVER, across restarts — exactly
+# the harm this story exists to fix.
+# =============================================================================
+
+
+async def test_a_load_flipped_to_boost_only_still_expires_its_override():
+    """The lifecycle is not gated on `support_user_override()` — detection is."""
+    pump = _make_pump()
+    _arm_override(pump)
+    _push_override_constraint(pump)
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+    # the user reconfigures the load as boost-only
+    pump.load_is_auto_to_be_boosted = True
+    assert pump.support_user_override() is False
+
+    await pump.check_load_activity_and_constraints(T_EXPIRED)
+    assert pump.external_user_initiated_state is None
+    assert _override_constraints(pump) == []
+
+    t_back = T_EXPIRED + timedelta(seconds=USER_OVERRIDE_STATE_BACK_DURATION_S + CYCLE_S)
+    await pump.check_load_activity_and_constraints(t_back)
+
+    assert pump.asked_for_reset_user_initiated_state_time is None
+    assert pump.get_override_state() == OVERRIDE_STATE_NO_OVERRIDE
+    assert pump.is_user_overridden() is False
+
+
+async def test_a_boost_only_load_drains_a_reset_ask_restored_from_storage():
+    """...and the persisted half: restore keeps a PAST-dated ask, so it must drain.
+
+    `use_saved_extra_device_info` only drops a *future*-dated reset-ask, and the
+    reset button was the sole other clearer, so a stored timestamp on a boost-only
+    load survived every restart and kept `is_user_overridden()` True for good.
+    """
+    pump = _make_pump()
+    pump.load_is_auto_to_be_boosted = True
+
+    with freeze_time(T_EXPIRED):
+        pump.use_saved_extra_device_info({STORAGE_KEY_ASKED_FOR_RESET_TIME: f"{T_OVERRIDE}"})
+
+    # restore deliberately keeps it — nothing there expires a past-dated ask
+    assert pump.asked_for_reset_user_initiated_state_time == T_OVERRIDE
+    assert pump.get_override_state() == OVERRIDE_STATE_ASKED_FOR_RESET
+
+    await pump.check_load_activity_and_constraints(T_EXPIRED)
+
+    assert pump.asked_for_reset_user_initiated_state_time is None
+    assert pump.is_user_overridden() is False
+
+
+async def test_detection_stays_off_for_a_boost_only_load():
+    """The conjunct still does its real job: no override detection when unsupported."""
+    pump = _make_pump()
+    pump.load_is_auto_to_be_boosted = True
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.last_command_execution_time = T_OVERRIDE
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE + timedelta(seconds=30))
+
+    t = T_OVERRIDE + timedelta(minutes=2)
+    assert pump.is_load_command_set(t) is True  # the OTHER detection conjunct is open
+
+    await pump.check_load_activity_and_constraints(t)
+
+    assert pump.external_user_initiated_state is None
+    assert _override_constraints(pump) == []
+
+
+# =============================================================================
 # AC8 — the end-to-end bug, in both death modes
 # =============================================================================
+
+
+def _controlled_consumption(pump: _StuckPump, time: datetime) -> float:
+    """The power the home accounting attributes to this load.
+
+    Review fix #06: this is the observable the story's Problem section actually
+    blames — "permanently excluded from controlled consumption … flows into the
+    persisted forecast". `get_device_power_latest_possible_valid_value` returns
+    `0.0` for a user-overridden load, and that zero is what reaches
+    `home.py`'s consumption accounting and the persisted forecast.
+    """
+    return pump.get_device_power_latest_possible_valid_value(
+        tolerance_seconds=None, time=time, ignore_auto_and_user_overridden_load=True
+    )
 
 
 async def _detect_user_override_on(pump: _StuckPump) -> None:
@@ -398,12 +639,20 @@ async def _detect_user_override_on(pump: _StuckPump) -> None:
     pump.last_command_execution_time = T_OVERRIDE - timedelta(hours=1)
     pump.hass.states.set(PUMP_ENTITY, "off", last_changed=T_OVERRIDE - timedelta(hours=1))
     pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+    # a real, measurable draw for the accounting to attribute (or refuse to)
+    pump._entity_probed_last_valid_state[pump._get_power_measure()] = (
+        T_OVERRIDE,
+        pump.power_use,
+        {},
+    )
 
     await pump.check_load_activity_and_constraints(T_OVERRIDE + timedelta(seconds=CYCLE_S))
 
     assert pump.external_user_initiated_state == "on"
     assert pump.is_user_overridden() is True
     assert len(_override_constraints(pump)) == 1
+    # ...and while the override stands, the load is OUT of controlled consumption
+    assert _controlled_consumption(pump, T_OVERRIDE + timedelta(seconds=CYCLE_S)) == 0.0
 
 
 async def _assert_override_self_heals(pump: _StuckPump) -> None:
@@ -412,6 +661,9 @@ async def _assert_override_self_heals(pump: _StuckPump) -> None:
 
     assert pump.external_user_initiated_state is None
     assert _override_constraints(pump) == []
+    # review fix #02: the override's own command must not outlive the override
+    assert pump.running_command is None
+    transport_calls_after_expiry = len(pump.transport_calls)
 
     # the post-override cooldown is clock arithmetic too, so it also drains on
     # a load QS can no longer talk to — otherwise the load stayed pinned in
@@ -424,6 +676,11 @@ async def _assert_override_self_heals(pump: _StuckPump) -> None:
     assert pump.is_user_overridden() is False
     # ...and the load is back in the solver with its ordinary daily constraint
     assert pump._constraints != []
+    # ...and back in controlled consumption: its real draw is billed again,
+    # instead of the 0.0 an override forces into the persisted forecast
+    assert _controlled_consumption(pump, t_back) == pump.power_use
+    # nothing kept re-issuing the ended override's service call
+    assert len(pump.transport_calls) == transport_calls_after_expiry
 
 
 async def test_ac8_override_expires_on_a_visible_but_disobeying_load():

--- a/tests/test_qs307_override_expiry_unfreeze.py
+++ b/tests/test_qs307_override_expiry_unfreeze.py
@@ -49,6 +49,7 @@ from custom_components.quiet_solar.const import (
     CONSTRAINT_TYPE_MANDATORY_END_TIME,
     OVERRIDE_STATE_ASKED_FOR_RESET,
     OVERRIDE_STATE_NO_OVERRIDE,
+    OVERRIDE_STATE_PREFIX,
     STORAGE_KEY_ASKED_FOR_RESET_TIME,
 )
 from custom_components.quiet_solar.ha_model.bistate_duration import (
@@ -362,10 +363,16 @@ async def test_ac4_a_disabled_load_runs_no_lifecycle_branch():
     The hoist replaces the gate with an explicit `qs_enable_device` guard rather
     than dropping it: QS was told to leave this load alone, so it must not
     silently start expiring overrides on it.
+
+    All **three** lifecycle branches are armed here (review fix #02/05): an aged
+    override, a pending reset-ask follow-up flag, and a drained-past cooldown timer.
+    AC4 was reworded from "neither" to "no hoisted branch" when the third one was
+    added, but its test was not extended with it.
     """
     pump = _make_pump()
     _arm_override(pump)
     pump.asked_for_reset_user_initiated_state_time_first_cmd_reset_done = T_OVERRIDE
+    pump.asked_for_reset_user_initiated_state_time = T_OVERRIDE
     pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
     pump._enabled = False
 
@@ -373,8 +380,9 @@ async def test_ac4_a_disabled_load_runs_no_lifecycle_branch():
 
     assert pump.external_user_initiated_state == "on"
     assert pump.external_user_initiated_state_time == T_OVERRIDE
-    assert pump.asked_for_reset_user_initiated_state_time is None
     assert pump.asked_for_reset_user_initiated_state_time_first_cmd_reset_done == T_OVERRIDE
+    # the cooldown is long past its window, and still must not be drained
+    assert pump.asked_for_reset_user_initiated_state_time == T_OVERRIDE
 
 
 # =============================================================================
@@ -467,11 +475,11 @@ async def test_the_post_override_cooldown_is_not_drained_early():
 
 
 async def test_a_rewound_clock_does_not_freeze_the_cooldown_drain():
-    """Review fix #08: a backwards clock step must not pin the load overridden.
+    """A backwards clock step must not pin the load overridden.
 
-    The drain is now the ONLY release of the cooldown, so it goes through
-    `_seconds_since`, where a future-dated anchor means "treat as fully elapsed"
-    rather than "negative, therefore below the window, therefore never".
+    The drain is the ONLY release of the cooldown, so a future-dated anchor beyond
+    the skew band means "treat as fully elapsed" rather than "negative, therefore
+    below the window, therefore never".
     """
     pump = _make_pump()
     # NTP corrects the clock backwards AFTER restore, so the future-dated drop in
@@ -495,6 +503,54 @@ async def test_a_rewound_clock_does_not_freeze_the_override_expiry():
 
     assert pump.external_user_initiated_state is None
     assert _override_constraints(pump) == []
+
+
+async def test_a_slightly_future_dated_override_is_not_destroyed():
+    """Review fix #02 (must-fix): benign skew must not cancel a BRAND-NEW override.
+
+    `_seconds_since` reads every negative delta as "fully elapsed", so a few seconds
+    of future-dating expired a fresh 8 h override on the spot — the override state
+    nulled, its command dropped, its constraint wiped, and the load parked in
+    ASKED FOR RESET. QS fighting the user, arriving from the other direction.
+
+    And it needs no clock anomaly at all: `user_set_bistate_mode`,
+    `user_set_default_on_duration` and `async_reset_override_state` each take their
+    own unlocked `datetime.now(pytz.UTC)`, while an `async_update_loads` cycle
+    already in flight is still carrying an earlier `event_time` — so a user-stamped
+    anchor can legitimately sit ahead of the cycle that evaluates it.
+    """
+    pump = _make_pump()
+    _arm_override(pump)
+    _push_override_constraint(pump)
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.running_command = copy_command(CMD_ON)
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+    # the cycle evaluating the override is 5 s BEHIND the user action that armed it
+    await pump.check_load_activity_and_constraints(T_OVERRIDE - timedelta(seconds=5))
+
+    assert pump.external_user_initiated_state == "on"
+    assert pump.external_user_initiated_state_time == T_OVERRIDE
+    assert pump.asked_for_reset_user_initiated_state_time is None
+    assert pump.get_override_state() == f"{OVERRIDE_STATE_PREFIX}on"
+    assert pump.is_user_overridden() is True
+    # ...and the override's own in-flight command is not dropped either
+    assert pump.running_command == CMD_ON
+    assert len(_override_constraints(pump)) == 1
+
+
+async def test_a_slightly_future_dated_cooldown_is_not_drained_early():
+    """The symmetric half: the same band protects the cooldown timer."""
+    pump = _make_pump()
+    pump.asked_for_reset_user_initiated_state_time = T_OVERRIDE
+    pump.current_command = copy_command(CMD_IDLE)
+    pump.running_command = copy_command(CMD_ON)
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_OVERRIDE)
+
+    await pump.check_load_activity_and_constraints(T_OVERRIDE - timedelta(seconds=5))
+
+    assert pump.asked_for_reset_user_initiated_state_time == T_OVERRIDE
+    assert pump.get_override_state() == OVERRIDE_STATE_ASKED_FOR_RESET
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #307. Absorbs #308.

## What this PR does

**Part A — an override on an unresponsive load can never expire.** `QSBiStateDuration.check_load_activity_and_constraints` gated its *entire* user-override block on `is_load_command_set(time)`, which requires `running_command is None`. Since QS-304 made the retry ladder saturate and retry forever, that gate could stay shut indefinitely — so an override on a load that stopped obeying was pinned **permanently**, out of controlled consumption and out of the solver, and that flowed into the persisted forecast.

`is_load_command_set` now guards **detection only**. It means "am I waiting on a command", which has nothing to do with clock arithmetic; the three clock/flag branches of the override lifecycle run without it:

```text
if qs_enable_device is not False and support_user_override():
    if <override aged past override_duration>:      # unconditional
        <drop an override-ALIGNED running_command>
    elif <reset-ask follow-up flag set>:            # unconditional
    else:
        <post-override cooldown drain>              # unconditional
        if is_load_command_set(time):
            <detection: reads entity state>
```

`support_user_override()` stays on the outer gate, as on `main` — it answers a different question ("can this load have an override at all"), and a load that cannot needs no lifecycle.

Two of these moving parts were found *during review*: the **cooldown drain** (expiry only hands off to a timer that `get_override_state()` reports as `ASKED FOR RESET`, so without draining it the load never returns to controlled consumption anyway) and the **expiry-time drop** of the override's own in-flight command (nulling the override state disables the suppression drop, so that command would otherwise keep being relaunched after the override ended).

**Part B (absorbs #308) — the invalid-probe give-up left an ownerless lost-control clock.** It nulled `current_command` while keeping `unresponsive_since`, so the clock described a command that no longer existed and was inherited by the next one, which then *superseded* where it should have stacked.

Releasing that clock re-arms the once-only alert guard, which is a real regression — so `_unresponsive_needs_ack` (a per-**episode** latch, distinct from the per-**command** clock) restores parity. Measured over 105 simulated minutes:

| Scenario | `main` | Part B without the latch | This PR |
| --- | --- | --- | --- |
| Device **drops off the network** intermittently | 1 alert | **5** | 1 alert |
| Device **reachable but ignores commands** | 5 alerts | 5 | 5 alerts |

## What this PR does *not* fix

**Row 2 above.** A device that stays reachable and simply never obeys alerts about every 18.5 minutes — identically on `main`, re-verified against `8ea823dc` this round. Pre-existing, not a regression from this branch, and fixing it needs a notification-policy design this PR should not improvise. Tracked as **#319**.

Do not read `_unresponsive_needs_ack` as general alert deduplication. Its one job is: *the give-up must not re-announce an incident that was already announced.*

Follow-up: **#318** (`#` in generated fix-plan filenames). **#317** was opened for a clock-skew race and its premise has since been withdrawn — see below.

## What review removed again

Four review rounds landed on a clear pattern: **every mechanism added during review spawned a defect; every deletion and text correction spawned none.** The last round is three reverts, and the PR is smaller for it.

- A "clock-safe" comparison helper and the ±60 s tolerance band that patched it. Both came from a *nice-to-have*, not a bug. `_seconds_since`'s "a future-dated anchor is fully elapsed" is right for the retry ladder it was written for; on an override it destroys what the user just set. `main`'s plain subtraction is restored — a future anchor makes the override last slightly longer, which is the benign direction. #317's premise went with it.
- Moving `support_user_override()` off the outer gate, which ran the whole override lifecycle every cycle for every load that cannot have an override. The reconfigure case that motivated it is handled at the restore boundary instead, where it costs nothing per cycle.

## Reviewability notes

- **The Part A diff is not a re-indent.** `else:` + a nested `if` keeps the ~280-line detection body at its original indentation; nothing inside it moved. The only edit *within* it is the cooldown block, whose expiry half moved out and whose suppression half stayed.
- **`_escalate_or_recover`'s `current_command is not None` gate is load-bearing**, not redundant: only the give-up sets the episode latch, and the give-up nulls `current_command`, so this branch runs exactly when nothing has latched in this cycle.
- **The expiry drop breaks the "each command-slot mutation happens between `await`s" invariant, and both exposed sites are guarded.** It is the first command-slot mutation inside `check_load_activity_and_constraints`, and three of that method's callers run outside `_update_loads_lock`. `launch_command` and `force_relaunch_command` each hold the command they launched in a local and bail if the slot emptied, instead of acking `None`.
- **Behaviour change, stated honestly:** for a healthy load with an in-flight command, expiry can fire one cycle earlier than before; and for one with an *aligned* command in flight, that command is now abandoned rather than acked a cycle later. AC1/AC1b/AC3 pin both.
- **Existing suites were audited, not adapted.** All 55 `is_load_command_set` mock sites plus the QS-256 lifecycle suite pass **unchanged**.

## Tests

**23 ACs.** `tests/test_qs307_override_expiry_unfreeze.py` (new — AC1/AC1b, AC2–AC6, AC8, AC15–AC19, AC25, AC26), `tests/test_bug_304_command_deadlock.py` (AC9–AC14, AC21, AC22), and `tests/ha_tests/test_bug_304_uncontrollable_load.py` (AC7 — the `is_load_command_set` truth table, widened with an `unresponsive_since` column to pin that the predicate stays indifferent to it; it feeds three power-accounting call sites that reach the persisted forecast).

Two are worth knowing about specifically:

- **AC13 is the parity oracle** for `_unresponsive_needs_ack`: 1 alert / 105 simulated minutes, matching `main`. Any future simplification of the contact signal must be checked against it rather than against reasoning — that is how the third `ContactEvidence` value was re-justified.
- **AC25** drives the mid-`await` slot race deterministically, at both call sites and for both post-await branches.

Every fix was verified red-before-green by stashing the production change.

## Doc maintenance

Updated: `bistate-duration-devices.md` (the split gate and its load-bearing properties, including why the clock comparisons stay plain), `user-override.md` (an override always expires — and when it does, its own command is dropped), `load-base.md` (two clocks not one; the `ContactEvidence` contract), `notification-routing.md` (what the flag guarantees, and what #319 owns), `external-control-detection.md` (the cooldown rule split).

`Doc-OK`: `piloted-device-and-heat-pump.md` — `PilotedDevice` extends `AbstractDevice`, not `AbstractLoad`, so it has no override surface, and its `_notify_unresponsive` is the documented base no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when device overrides expire, including reset and cooldown handling.
  * Prevented loads from becoming permanently stuck after unavailable or unresponsive states.
  * Reduced repeated lost-control notifications until the device confirms contact.
  * Improved command reliability during competing or delayed operations.
  * Added safer handling for clock differences and restored device state.

* **Documentation**
  * Expanded guidance on override lifecycle, external-control detection, recovery behavior, and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->