### PR TITLE
QS-290: cut the fixed pytest overhead of --impacted / --quick

### DIFF
--- a/.claude/agents/qs-implement-setup-task.md
+++ b/.claude/agents/qs-implement-setup-task.md
@@ -91,9 +91,15 @@ under `custom_components/quiet_solar/` are 100% covered, self-healing a
 drifted testmon baseline automatically (no manual file deletion ever).
 Dev-only changes (`scripts/`, `docs/`, agent files) carry no delta to
 `custom_components/quiet_solar/` coverage specifically, so that side of
-`--impacted` is a fast no-op — but the gate/tooling's own correctness is
-still guarded by its testmon-selected tests under `--impacted` (and the
-whole-repo gate in CI). The whole-repo 100% gate is enforced in **CI** on every PR — the
+`--impacted` is a fast no-op. When your change set **does** contain a
+`.py` file, the gate/tooling's own correctness is still guarded by its
+testmon-selected tests (plus the whole-repo gate in CI). But a change
+set with **no `.py` file at all** — docs-only, agent-file-only, a
+commands-only edit — makes `--impacted` exit early and check
+**nothing** (QS-290): testmon fingerprints AST blocks in `.py` files
+only, so it could never select a test. That green is honest but empty,
+and the `--quick tests/qs` run below is then your ONLY real
+verification, not a supplement. The whole-repo 100% gate is enforced in **CI** on every PR — the
 only local full-gate run is an explicit user request:
 
 ```bash

--- a/.claude/agents/qs-implement-setup-task.md
+++ b/.claude/agents/qs-implement-setup-task.md
@@ -5,8 +5,8 @@ description: >-
   .cursor/, .opencode/, legacy/, docs/, .github/, top-level
   config). Same TDD flow as qs-implement-task but narrower edit scope;
   the pre-commit gate is --impacted (coverage-vacuous on dev-only
-  trees). Use when /create-plan selected implement-setup-task as the
-  next phase.
+  trees, and a no-op entirely when the change set contains no .py file).
+  Use when /create-plan selected implement-setup-task as the next phase.
 tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch, LSP
 ---
 
@@ -14,8 +14,9 @@ tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch, LSP
 
 Narrower-scoped variant of `qs-implement-task`. Edits only dev-environment
 paths. The pre-commit gate is `--impacted` (coverage-vacuous on
-dev-only trees; the tooling's own testmon-selected tests still run —
-see step 4).
+dev-only trees). Read step 4 before trusting a green: when the change
+set contains a `.py` file the tooling's own testmon-selected tests run,
+but a change set with no `.py` file at all is checked by nothing.
 
 ## Discover the task context first
 
@@ -86,20 +87,37 @@ substitute, the full gate locally:
 python scripts/qs/quality_gate.py --impacted
 ```
 
-It runs the testmon-selected tests and verifies any changed lines
-under `custom_components/quiet_solar/` are 100% covered, self-healing a
+When the change set contains a `.py` file it runs the testmon-selected
+tests and verifies any changed lines under
+`custom_components/quiet_solar/` are 100% covered, self-healing a
 drifted testmon baseline automatically (no manual file deletion ever).
 Dev-only changes (`scripts/`, `docs/`, agent files) carry no delta to
 `custom_components/quiet_solar/` coverage specifically, so that side of
-`--impacted` is a fast no-op. When your change set **does** contain a
-`.py` file, the gate/tooling's own correctness is still guarded by its
-testmon-selected tests (plus the whole-repo gate in CI). But a change
-set with **no `.py` file at all** — docs-only, agent-file-only, a
-commands-only edit — makes `--impacted` exit early and check
-**nothing** (QS-290): testmon fingerprints AST blocks in `.py` files
-only, so it could never select a test. That green is honest but empty,
-and the `--quick tests/qs` run below is then your ONLY real
-verification, not a supplement. The whole-repo 100% gate is enforced in **CI** on every PR — the
+`--impacted` is a fast no-op.
+
+`.py` presence decides whether the gate *runs* anything — it does not by
+itself tell you the run verified anything:
+
+- **Change set contains a `.py` file.** The pass runs, and the
+  gate/tooling's own correctness is guarded to the extent testmon
+  selects tests for it (plus the whole-repo gate in CI). Two caveats: a
+  `.py` edit can still select **zero** tests (testmon fingerprints AST
+  blocks, so a comment-only or formatting-only edit selects nothing),
+  and the impacted pass **excludes `tests/test_quality_gate.py`** by
+  path — so a change to `scripts/qs/quality_gate.py` is *never* covered
+  by `--impacted`. For quality-gate changes always also run
+  `python scripts/qs/quality_gate.py --quick tests/test_quality_gate.py`.
+- **Change set has no `.py` file at all** — docs-only, agent-file-only, a
+  commands-only edit. `--impacted` exits early and checks **nothing**
+  (QS-290): testmon could never select a test and diff-cover has no
+  Python lines to score. That green is honest but empty, so the
+  `--quick tests/qs` run below is your ONLY real verification, not a
+  supplement.
+- **A git probe failed.** The early exit **fails closed** — no exit, the
+  full pipeline runs. So "no output about the exit" never means "the
+  exit silently fired".
+
+The whole-repo 100% gate is enforced in **CI** on every PR — the
 only local full-gate run is an explicit user request:
 
 ```bash
@@ -138,7 +156,7 @@ explaining why the docs are unaffected. See
 ### 5. Commit, push, open PR (automatic)
 
 ```bash
-git add scripts/ .claude/ .cursor/ .opencode/ legacy/ docs/ .github/ CLAUDE.md AGENTS.md .cursorrules opencode.json
+git add scripts/ tests/qs/ tests/test_quality_gate.py .claude/ .cursor/ .opencode/ legacy/ docs/ .github/ CLAUDE.md AGENTS.md .cursorrules opencode.json
 git commit -m "QS-{{issue}}: {{short summary}}"
 git push origin {{branch}}
 

--- a/.cursor/agents/qs-implement-setup-task.md
+++ b/.cursor/agents/qs-implement-setup-task.md
@@ -4,7 +4,8 @@ description: >-
   Phase 3 variant for dev-environment changes only (scripts/, .claude/,
   .cursor/, .opencode/, legacy/, docs/, .github/, top-level
   config). Same TDD flow with narrower edit scope; the pre-commit gate
-  is --impacted (coverage-vacuous on dev-only trees).
+  is --impacted (coverage-vacuous on dev-only trees, and a no-op
+  entirely when the change set contains no .py file).
 model: inherit
 readonly: false
 is_background: false
@@ -14,8 +15,9 @@ is_background: false
 
 Narrower-scoped variant of `qs-implement-task`. Edits only dev-environment
 paths. The pre-commit gate is `--impacted` (coverage-vacuous on
-dev-only trees; the tooling's own testmon-selected tests still run —
-see step 4).
+dev-only trees). Read step 4 before trusting a green: when the change
+set contains a `.py` file the tooling's own testmon-selected tests run,
+but a change set with no `.py` file at all is checked by nothing.
 
 ## Discover the task context first
 
@@ -86,20 +88,37 @@ substitute, the full gate locally:
 python scripts/qs/quality_gate.py --impacted
 ```
 
-It runs the testmon-selected tests and verifies any changed lines
-under `custom_components/quiet_solar/` are 100% covered, self-healing a
+When the change set contains a `.py` file it runs the testmon-selected
+tests and verifies any changed lines under
+`custom_components/quiet_solar/` are 100% covered, self-healing a
 drifted testmon baseline automatically (no manual file deletion ever).
 Dev-only changes (`scripts/`, `docs/`, agent files) carry no delta to
 `custom_components/quiet_solar/` coverage specifically, so that side of
-`--impacted` is a fast no-op. When your change set **does** contain a
-`.py` file, the gate/tooling's own correctness is still guarded by its
-testmon-selected tests (plus the whole-repo gate in CI). But a change
-set with **no `.py` file at all** — docs-only, agent-file-only, a
-commands-only edit — makes `--impacted` exit early and check
-**nothing** (QS-290): testmon fingerprints AST blocks in `.py` files
-only, so it could never select a test. That green is honest but empty,
-and the `--quick tests/qs` run below is then your ONLY real
-verification, not a supplement. The whole-repo 100% gate is enforced in **CI** on every PR — the
+`--impacted` is a fast no-op.
+
+`.py` presence decides whether the gate *runs* anything — it does not by
+itself tell you the run verified anything:
+
+- **Change set contains a `.py` file.** The pass runs, and the
+  gate/tooling's own correctness is guarded to the extent testmon
+  selects tests for it (plus the whole-repo gate in CI). Two caveats: a
+  `.py` edit can still select **zero** tests (testmon fingerprints AST
+  blocks, so a comment-only or formatting-only edit selects nothing),
+  and the impacted pass **excludes `tests/test_quality_gate.py`** by
+  path — so a change to `scripts/qs/quality_gate.py` is *never* covered
+  by `--impacted`. For quality-gate changes always also run
+  `python scripts/qs/quality_gate.py --quick tests/test_quality_gate.py`.
+- **Change set has no `.py` file at all** — docs-only, agent-file-only, a
+  commands-only edit. `--impacted` exits early and checks **nothing**
+  (QS-290): testmon could never select a test and diff-cover has no
+  Python lines to score. That green is honest but empty, so the
+  `--quick tests/qs` run below is your ONLY real verification, not a
+  supplement.
+- **A git probe failed.** The early exit **fails closed** — no exit, the
+  full pipeline runs. So "no output about the exit" never means "the
+  exit silently fired".
+
+The whole-repo 100% gate is enforced in **CI** on every PR — the
 only local full-gate run is an explicit user request:
 
 ```bash
@@ -138,7 +157,7 @@ explaining why the docs are unaffected. See
 ### 5. Commit, push, open PR (automatic)
 
 ```bash
-git add scripts/ .claude/ .cursor/ .opencode/ legacy/ docs/ .github/ CLAUDE.md AGENTS.md .cursorrules opencode.json
+git add scripts/ tests/qs/ tests/test_quality_gate.py .claude/ .cursor/ .opencode/ legacy/ docs/ .github/ CLAUDE.md AGENTS.md .cursorrules opencode.json
 git commit -m "QS-{{issue}}: {{short summary}}"
 git push origin {{branch}}
 

--- a/.cursor/agents/qs-implement-setup-task.md
+++ b/.cursor/agents/qs-implement-setup-task.md
@@ -91,9 +91,15 @@ under `custom_components/quiet_solar/` are 100% covered, self-healing a
 drifted testmon baseline automatically (no manual file deletion ever).
 Dev-only changes (`scripts/`, `docs/`, agent files) carry no delta to
 `custom_components/quiet_solar/` coverage specifically, so that side of
-`--impacted` is a fast no-op — but the gate/tooling's own correctness is
-still guarded by its testmon-selected tests under `--impacted` (and the
-whole-repo gate in CI). The whole-repo 100% gate is enforced in **CI** on every PR — the
+`--impacted` is a fast no-op. When your change set **does** contain a
+`.py` file, the gate/tooling's own correctness is still guarded by its
+testmon-selected tests (plus the whole-repo gate in CI). But a change
+set with **no `.py` file at all** — docs-only, agent-file-only, a
+commands-only edit — makes `--impacted` exit early and check
+**nothing** (QS-290): testmon fingerprints AST blocks in `.py` files
+only, so it could never select a test. That green is honest but empty,
+and the `--quick tests/qs` run below is then your ONLY real
+verification, not a supplement. The whole-repo 100% gate is enforced in **CI** on every PR — the
 only local full-gate run is an explicit user request:
 
 ```bash

--- a/.opencode/agents/qs-implement-setup-task.md
+++ b/.opencode/agents/qs-implement-setup-task.md
@@ -3,7 +3,8 @@ description: >-
   Phase 3 variant for dev-environment changes only (scripts/, .claude/,
   .cursor/, .opencode/, legacy/, docs/, .github/, top-level config).
   Same TDD flow as qs-implement-task but narrower edit scope; the
-  pre-commit gate is --impacted (coverage-vacuous on dev-only trees).
+  pre-commit gate is --impacted (coverage-vacuous on dev-only trees, and
+  a no-op entirely when the change set contains no .py file).
   Use when create-plan selected implement-setup-task as the next
   phase.
 mode: primary
@@ -68,8 +69,9 @@ permission:
 
 Narrower-scoped variant of `qs-implement-task`. Edits only dev-environment
 paths. The pre-commit gate is `--impacted` (coverage-vacuous on
-dev-only trees; the tooling's own testmon-selected tests still run —
-see step 4).
+dev-only trees). Read step 4 before trusting a green: when the change
+set contains a `.py` file the tooling's own testmon-selected tests run,
+but a change set with no `.py` file at all is checked by nothing.
 
 ## Discover the task context first
 
@@ -140,20 +142,37 @@ substitute, the full gate locally:
 python scripts/qs/quality_gate.py --impacted
 ```
 
-It runs the testmon-selected tests and verifies any changed lines
-under `custom_components/quiet_solar/` are 100% covered, self-healing a
+When the change set contains a `.py` file it runs the testmon-selected
+tests and verifies any changed lines under
+`custom_components/quiet_solar/` are 100% covered, self-healing a
 drifted testmon baseline automatically (no manual file deletion ever).
 Dev-only changes (`scripts/`, `docs/`, agent files) carry no delta to
 `custom_components/quiet_solar/` coverage specifically, so that side of
-`--impacted` is a fast no-op. When your change set **does** contain a
-`.py` file, the gate/tooling's own correctness is still guarded by its
-testmon-selected tests (plus the whole-repo gate in CI). But a change
-set with **no `.py` file at all** — docs-only, agent-file-only, a
-commands-only edit — makes `--impacted` exit early and check
-**nothing** (QS-290): testmon fingerprints AST blocks in `.py` files
-only, so it could never select a test. That green is honest but empty,
-and the `--quick tests/qs` run below is then your ONLY real
-verification, not a supplement. The whole-repo 100% gate is enforced in **CI** on every PR — the
+`--impacted` is a fast no-op.
+
+`.py` presence decides whether the gate *runs* anything — it does not by
+itself tell you the run verified anything:
+
+- **Change set contains a `.py` file.** The pass runs, and the
+  gate/tooling's own correctness is guarded to the extent testmon
+  selects tests for it (plus the whole-repo gate in CI). Two caveats: a
+  `.py` edit can still select **zero** tests (testmon fingerprints AST
+  blocks, so a comment-only or formatting-only edit selects nothing),
+  and the impacted pass **excludes `tests/test_quality_gate.py`** by
+  path — so a change to `scripts/qs/quality_gate.py` is *never* covered
+  by `--impacted`. For quality-gate changes always also run
+  `python scripts/qs/quality_gate.py --quick tests/test_quality_gate.py`.
+- **Change set has no `.py` file at all** — docs-only, agent-file-only, a
+  commands-only edit. `--impacted` exits early and checks **nothing**
+  (QS-290): testmon could never select a test and diff-cover has no
+  Python lines to score. That green is honest but empty, so the
+  `--quick tests/qs` run below is your ONLY real verification, not a
+  supplement.
+- **A git probe failed.** The early exit **fails closed** — no exit, the
+  full pipeline runs. So "no output about the exit" never means "the
+  exit silently fired".
+
+The whole-repo 100% gate is enforced in **CI** on every PR — the
 only local full-gate run is an explicit user request:
 
 ```bash
@@ -192,7 +211,7 @@ explaining why the docs are unaffected. See
 ### 5. Commit, push, open PR (automatic)
 
 ```bash
-git add scripts/ .claude/ .cursor/ .opencode/ legacy/ docs/ .github/ CLAUDE.md AGENTS.md .cursorrules opencode.json
+git add scripts/ tests/qs/ tests/test_quality_gate.py .claude/ .cursor/ .opencode/ legacy/ docs/ .github/ CLAUDE.md AGENTS.md .cursorrules opencode.json
 git commit -m "QS-{{issue}}: {{short summary}}"
 git push origin {{branch}}
 

--- a/.opencode/agents/qs-implement-setup-task.md
+++ b/.opencode/agents/qs-implement-setup-task.md
@@ -145,9 +145,15 @@ under `custom_components/quiet_solar/` are 100% covered, self-healing a
 drifted testmon baseline automatically (no manual file deletion ever).
 Dev-only changes (`scripts/`, `docs/`, agent files) carry no delta to
 `custom_components/quiet_solar/` coverage specifically, so that side of
-`--impacted` is a fast no-op — but the gate/tooling's own correctness is
-still guarded by its testmon-selected tests under `--impacted` (and the
-whole-repo gate in CI). The whole-repo 100% gate is enforced in **CI** on every PR — the
+`--impacted` is a fast no-op. When your change set **does** contain a
+`.py` file, the gate/tooling's own correctness is still guarded by its
+testmon-selected tests (plus the whole-repo gate in CI). But a change
+set with **no `.py` file at all** — docs-only, agent-file-only, a
+commands-only edit — makes `--impacted` exit early and check
+**nothing** (QS-290): testmon fingerprints AST blocks in `.py` files
+only, so it could never select a test. That green is honest but empty,
+and the `--quick tests/qs` run below is then your ONLY real
+verification, not a supplement. The whole-repo 100% gate is enforced in **CI** on every PR — the
 only local full-gate run is an explicit user request:
 
 ```bash

--- a/docs/agents/concepts/testing-layers.md
+++ b/docs/agents/concepts/testing-layers.md
@@ -77,6 +77,11 @@ NON-NEGOTIABLE — and a test-impact subset can never prove it. So the
 guarantee is split: `--impacted` proves *changed lines* locally; the
 **whole-repo 100% gate runs authoritatively in CI** on every PR.
 
+**Non-Python change sets check nothing (QS-290).** A change set with no
+`.py` file exits early and verifies nothing — see
+[project-rules.md](../../workflow/project-rules.md) "Non-Python change
+sets" for the canonical statement and what to run instead.
+
 **Hard limitation — read this.** `--impacted` guarantees the lines you
 *changed* are covered. It does **not** detect coverage lost in
 *unchanged* code — e.g. deleting a test that was the sole cover of an

--- a/docs/stories/QS-290.story.md
+++ b/docs/stories/QS-290.story.md
@@ -1,0 +1,611 @@
+# QS-290 — Cut the fixed pytest overhead of `--impacted` / `--quick`
+
+- Issue: #290 (from the QS-288 audit — findings S-1, S-4, S-5, S-7, D-18)
+- Branch: `QS_290`
+- Story version: v4 (v3 + adversarial review round 2 folded)
+- Next phase: **implement-setup-task** — zero production code; the change
+  set is `scripts/qs/quality_gate.py`, `docs/`, and dev tooling tests,
+  which that agent's scope rule explicitly admits ("If you need to edit
+  `custom_components/quiet_solar/` or `tests/` *other than dev tooling
+  tests*, STOP").
+
+> **Handoff warning — stage `tests/` by hand.** Neither implement agent's
+> `git add` line covers this change set. `qs-implement-setup-task:135`
+> stages `scripts/ .claude/ .cursor/ .opencode/ legacy/ docs/ .github/ …`
+> — **no `tests/`**, even though it permits dev tooling tests;
+> `qs-implement-task:154` stages `custom_components/quiet_solar/ tests/
+> docs/stories/` — no `scripts/`, no `docs/workflow/`. Run
+> `git status` before committing and stage
+> `tests/test_quality_gate.py` explicitly, or the tests this story
+> mandates will be written and then left uncommitted. This is a pipeline
+> defect, not a story defect — worth its own follow-up issue.
+
+## Problem
+
+Every inner-loop gate invocation pays a **fixed** cost unrelated to the
+size of the change being checked.
+
+### Measured baseline (this worktree)
+
+10 cores, Python 3.14.3, worktree `QS_290` at `b7b324d3`, `/usr/bin/time -p`
+wall, warm. The suite collects **6912** tests;
+`tests/test_quality_gate.py` (which the inner loop `--ignore`s) holds
+**480** of them.
+
+**The zero-work `--impacted` cost is not a single number** — it depends
+on testmon/coverage environment state. Every value below is pure
+overhead (0 tests selected, verdict vacuous):
+
+| Environment state | Gate wall |
+| --- | --- |
+| Synced DB, small `.coverage` | **10.7 s** |
+| Synced DB, large accumulated `.coverage` | **22.7 / 23.3 / 23.5 s** |
+| Stale / mode-flipped DB (3682 selected — shown for scale, not zero-work) | 425 – 635 s |
+
+Only the fast state was attributed **in-gate** (instrumented run):
+3.19 s collect-only + 6.89 s testmon `-n auto` + ~0.6 s git/diff-cover
+≈ the 10.7 s observed. The slow state is **not attributed** — standalone
+probes are not additive and summing them exceeded the observed wall.
+
+I did not isolate *why* the same 0-test run costs 10.7 s in one state and
+~23 s in another. It tracks whether testmon takes its skip-collection
+fast path and how large the accumulated `.coverage` is. Both states are
+real and reproducible; the savings below hold in both.
+
+Component probes (standalone, N as shown):
+
+| Probe | Wall |
+| --- | --- |
+| `pytest --collect-only -q tests/` (whole tree) | 3.2 – 6.3 s (cache-warmth dependent) |
+| testmon pass, 0 selected, **serial** | 6.6 s / 1.2 s (skip-collection state) |
+| testmon pass, 0 selected, `-n 2` / `-n 4` / `-n 6` / `-n auto`(10) | 8.9 / 10.3 / 12.6 / 19.0 s |
+| `--quick …/test_phase_mapping.py` (43 tests), **gate wall** | xdist 20.1 / 22.4 s · serial 14.8 / 16.4 s |
+| …same, **pytest phase only** (gate overhead excluded) | xdist 16.8 s · serial 11.5 s · its collect-only 2.9 s |
+| `--quick tests/test_ha_person_comprehensive.py` (35 real-HA tests) | xdist 6.78 s · serial 6.34 s |
+| `--quick tests/qs` | xdist 81.6 s · serial 170.9 s |
+
+Where the fixed cost comes from:
+
+- **The collect-only denominator subprocess** — `pytest --collect-only -q
+  tests/`, whose only product is a progress denominator. **30 % of the
+  whole gate** in the fast state (3.19 s of 10.7 s). For the testmon path
+  the denominator is also *wrong*: runs printed `done (0/6912)` and
+  `done (3682/6912)` — the whole tree, not the selected set.
+- **Per-worker whole-tree collection** — `-n auto` starts 10 workers,
+  each re-importing the HA-heavy conftest under coverage before testmon
+  deselects. Within the impacted path this is independent of how many
+  tests are *selected*, but it is not a universal constant: it scales
+  with collection scope (a narrowed 43-test `--quick` boots in 16.8 s,
+  not 19 s).
+- **`git fetch origin main` on every run** (~0.5 s local, 15 s cap).
+- **Non-`.py` change sets pay all of it** for a structurally vacuous
+  verdict.
+
+Plus one cosmetic defect (D-18): `--full` forces `scope = "full"` but
+keeps `_detect_scope`'s reason, printing
+`scope: FULL (only dev/test files changed (1 files))`.
+
+### Verified: testmon is blind to non-`.py` changes
+
+The S-4 argument rests on this, so it was tested with a positive control:
+
+| Step | Change | Tests selected |
+| --- | --- | --- |
+| 1 | added a real function to `tests/qs/docs/test_overview_structure.py` | **15** |
+| 2–3 | reverted; DB re-synced | 0 |
+| 4 | edited `docs/workflow/overview.md` — the file that *same test module reads and asserts on at runtime* | **0** |
+
+Appending a `# comment` to a `.py` file also selects 0 (testmon
+fingerprints AST blocks, not mtimes). So a non-`.py` change cannot select
+a test even when a test's assertions depend on that file's contents.
+`--impacted` is *already* blind here; the early exit changes the cost,
+not the verdict.
+
+**Caveat (review):** this control was run on a *synced* DB. On a stale
+DB a non-`.py` run today select-alls and re-syncs the baseline as a side
+effect; after the early exit it will not, deferring that re-sync to the
+next `.py` run. That is a cost shift, not a verdict change — the stale-DB
+run's verdict is equally vacuous (no `.py` lines for diff-cover to
+score). Called out in the docs task.
+
+## Goal
+
+1. A non-`.py` `--impacted` run spawns no pytest, no diff-cover and no
+   `git fetch` (from 10.7 – 23.5 s of work to two git calls).
+2. A `.py` `--impacted` run drops the collect-only subprocess:
+   **10.7 s → ~7.5 s** fast state, **~23 s → ~18 s** slow state.
+3. Small `--quick` runs stop paying xdist spin-up: 43-test reference
+   **20.1 s → ≤ 17 s**; `tests/qs` keeps `-n auto`.
+4. Repeat **`.py`** `--impacted` runs stop re-fetching `origin/main`
+   within a 10-minute window (non-`.py` runs never reach the fetch).
+5. `--full` prints a scope reason that is true.
+
+Non-goals: no change to the full gate's semantics, to CI, or to the
+QS-283 self-heal path. The diff-cover verdict *logic* is untouched,
+though a fetch-TTL hit may conservatively change a verdict (PASS→FAIL
+only — see §4).
+
+## Design
+
+All changes in `scripts/qs/quality_gate.py` plus tests and two docs.
+Anchored by **function/test name**; line numbers are hints only.
+
+### 1. (S-4) Non-`.py` early exit in `check_impacted`
+
+**Seat:** after `_impacted_tooling_available()`, after
+`_clean_orphan_cov_shards()`, before `_resolve_diff_base()` — i.e.
+before the `git fetch`.
+
+**This requires hoisting the hygiene call.** Today's order is tooling
+guard → `_resolve_diff_base()` → `was_incremental = stat()` →
+`_clean_orphan_cov_shards()` → `_run_impacted_pass()`. Task: move
+`_clean_orphan_cov_shards()` up to immediately after the tooling guard,
+keep the `was_incremental` `stat()` where it is, and update its comment
+("capture the incremental signal BEFORE any hygiene step can purge the
+DB") — `_clean_orphan_cov_shards` never touches `.testmondata`, so the
+invariant still holds but the comment's rationale must not go stale.
+
+**The exit test must use the merge-base** (review: this was a real
+false-PASS hole in v3). v3 proposed `git diff --name-only <base>`
+(base tree vs working tree). That is **not** a superset of diff-cover's
+three-dot range: a `.py` file your branch changed *that main already
+contains with identical content* (cherry-pick, squash-merge already
+landed, revert-and-reapply) is absent from it but present in
+`base...HEAD` — diff-cover would score those lines while the exit fired.
+It also breaks the feature in the common case: two-dot includes main's
+own `.py` commits, so a branch even slightly behind main would never
+early-exit.
+
+```python
+def _impacted_early_exit_paths() -> list[str] | None:
+    """Paths diff-cover would consider. None = unknown → do NOT early-exit."""
+    # 1. base:  ["git", "rev-parse", "--verify", "origin/main"]  (then "main")
+    # 2. mb:    ["git", "merge-base", base, "HEAD"]
+    # 3.        ["git", "diff", "--name-only", mb]        # committed+staged+unstaged
+    # 4.        ["git", "ls-files", "--others", "--exclude-standard"]  # untracked
+```
+
+`git diff --name-only <merge-base>` (merge-base tree vs **working
+tree**) covers three-dot's committed range plus staged and unstaged
+edits — a genuine superset in both directions.
+
+**Zero-arg and total** (review): the helper resolves the base itself
+rather than taking it as a parameter. If the base resolve stayed in
+`check_impacted`, its `_run` call would sit outside the seam and would
+still fire in every test that patches `_run` — defeating the "patch the
+seam" remedy below. One `patch.object(quality_gate,
+"_impacted_early_exit_paths", …)` must silence *every* git call at this
+seat.
+
+**Fail-closed:** any non-zero return from any of the four calls → `None`
+→ no early exit. `_get_changed_files` silently drops failed calls; here
+that would convert a git failure into a false PASS. Do not copy it.
+
+**Weaker base ladder is deliberate.** `_resolve_diff_base` has a third
+rung (`@{u}` merge-base) and an NH2 reachability probe for shallow CI
+clones. The exit's ladder is `origin/main` → `main` → give up (no exit).
+An unresolvable or unreachable base means no early exit — conservative.
+
+**Output** via `_emit` (which prefixes every line), ASCII only, one
+static hint (review: a two-branch path-aware hint was a feature grown by
+review for a string no verdict depends on):
+
+```text
+[impacted] PASS (no Python files changed - diff-coverage is vacuous)
+[impacted] note: testmon fingerprints only .py, so this run could never
+[impacted] select a test. For non-Python changes run `--quick tests/qs`
+[impacted] (or `--quick tests/test_dashboard_rendering.py` for ui assets).
+```
+
+### 2. (S-5) Denominator from the run itself, no collect-only
+
+**Redesigned in round 2 — measured.** v3 invented a count-only progress
+format because I had measured that xdist's `-q` output carries no item
+header. A reviewer challenged whether `-q` was *suppressing* a count
+rather than there being none. Re-measured: adding
+`-o console_output_style=count` makes pytest print `[43/43]` under `-q`
+in **both** serial and xdist, and under deselection it reports the
+**selected** count (`-k` filter leaving 7 of 43 → `[7/7]`, "36
+deselected"). That is literally what issue #290 asked for: "derive
+progress totals from the testmon run itself."
+
+So:
+
+- `_build_testmon_cmd` gains `-o console_output_style=count`;
+- `_stream_pytest` learns `total_tests` from the first `[N/M]` suffix it
+  sees in the stream, instead of an upfront subprocess;
+- `_PERCENT_SUFFIX_RE` must also strip the `[N/M]` shape, or a progress
+  line stops being "all progress characters" and the dot tally breaks;
+- the emitted line keeps **today's** format
+  `  pytest: 45% (150/330) | passed=… failed=… errors=…`.
+
+This deletes v3's bespoke count-only format, its `_SEED_PROGRESS_RE`
+non-collision analysis, and its contrived AC fixture. QS-299's
+`--seed-testmon-follow` keeps parsing the same shape it always has.
+
+One parameter, not two (four reviewers flagged v3's pair):
+
+```python
+def _stream_pytest(cmd, total_tests: int | None = None) -> dict:
+    #   None  → collect it yourself against TESTS_DIR (full gate, seed)
+    #   N     → use the caller's count, spawn nothing (--quick; 0 = learn
+    #           from the stream / no denominator until then)
+```
+
+`collect_targets` is deleted in the same commit — verified sole caller is
+`check_pytest_files` (`:746`), so the full-gate and seed paths (which
+pass `None`) keep whole-tree collection semantics and **AC5 holds**.
+
+**`--seed-testmon` keeps its collect-only denominator.** Unchanged path;
+its 3–5 s is noise inside a ~20-minute select-all.
+
+### 3. (S-1) Serial fast path for small test-file runs
+
+Compute the count once, use it for the worker decision:
+
+- extract `_collect_test_count(targets) -> int | None` (same argv,
+  `encoding="utf-8"`, `errors="replace"`, no `COVERAGE_CORE`), keeping
+  `subprocess.Popen` so `test_quick_collect_only_uses_cited_paths_not_tests_dir`'s
+  "exactly 2 Popen calls" assertion stays true;
+- **`None` = unknown** → `-n auto` **and** `total_tests=0`. Forwarding
+  `None` as `total_tests` would re-trigger a whole-tree collect (the
+  overload the delta-auditor caught) and spawn a third subprocess.
+
+| Condition | Workers |
+| --- | --- |
+| `QS_QG_PYTEST_WORKERS` **present in the environment** | honored verbatim |
+| xdist unavailable | serial (today) |
+| count is `None` | `-n auto`, `total_tests=0` |
+| `count <= _SERIAL_MAX_TESTS` (module constant, **50**) | **serial** |
+| otherwise | `-n auto` |
+
+Explicitness must be tested with `os.environ.get("QS_QG_PYTEST_WORKERS")
+is not None` — `_pytest_workers()` returns `"auto"` both when unset and
+when set to `auto`, so its return value cannot carry provenance.
+
+Lands in `check_pytest_files`, which also serves the **dev-only** and
+**ui-only** scopes — intentional (those run 1–3 changed test files).
+Hence the neutral `[pytest]` prefix, ASCII, written directly to stderr
+(not via `_emit`, which would double-prefix):
+`[pytest] 43 tests <= 50 - single-process (skipping xdist spin-up)`.
+
+**Threshold.** 50 is a deliberately conservative constant, not a tuned
+value. Supporting evidence: 43 tests → serial 11.5 s vs xdist 16.8 s
+(pytest phase); 35 real-HA tests → serial 6.34 s vs xdist 6.78 s (i.e.
+serial ≈ xdist, no penalty — the honest reading of a 0.44 s delta at
+n=1). Above the threshold nothing changes; below it the worst case is a
+sub-50 target of unusually slow tests losing a bounded few seconds, and
+`QS_QG_PYTEST_WORKERS=auto` forces xdist back. Not an env knob.
+
+**Four** strings become false: the module docstring (`:18`), `--quick`'s
+argparse help (`:2275`), the `[quick] running …` banner (`:2446` — a
+split literal, which a naive `grep "xdist + sysmon"` misses, pinned by
+`test_quick_emits_banner`), and `docs/workflow/project-rules.md:59`.
+
+### 4. (S-7) TTL-cache the `--impacted` `git fetch`
+
+In `_resolve_diff_base`, before the fetch: resolve the marker via
+`git rev-parse --git-path FETCH_HEAD` and skip the fetch when its mtime
+is younger than `_FETCH_TTL_SECONDS` (module constant, 600 s). Emit
+`[impacted] diff base: fetch skipped (FETCH_HEAD 3m old)`.
+
+**Verified:** `git rev-parse --git-path FETCH_HEAD` →
+`…/.git/worktrees/QS_290/FETCH_HEAD`. The marker is per-worktree, and in
+a linked worktree `.git` is a *file*, so a literal `.git/FETCH_HEAD`
+would be a path under a non-directory — the TTL would silently never hit.
+
+**Staleness direction.** A stale base is older, so the changed-line set
+is a superset: a TTL hit can turn a PASS into a FAIL, never a FAIL into a
+PASS. Recorded as the rationale; **not** turned into a test (review: it
+is a property of git's merge-base semantics, not of code this story
+writes — any such test would assert the mock). Caveat: after a
+force-push/rebase of main the stale ref may not be an ancestor at all;
+the TTL is 10 minutes and the existing code already tolerates a stale
+base when a fetch fails, so this is not a new class of risk.
+
+Missing/unreadable marker, or any `rev-parse` failure → fetch as today.
+If the base fails to resolve *after* a TTL-skipped fetch, retry once
+with the fetch.
+
+### 5. (D-18) Truthful `--full` scope reason + pluralization
+
+- `main()`: substitute the reason **only when the detected scope was not
+  already `full`** (otherwise it would clobber the useful
+  `production files changed: …`).
+- `_detect_scope`: `({n} file{'s' if n != 1 else ''})` for the dev-only
+  and ui-only reasons.
+
+### Existing-test blast radius
+
+Verified against the file; anchor by **test name** (line numbers move as
+tasks land).
+
+**`check_impacted()` call sites: 16** — 11 in `TestCheckImpacted`
+(`:2538`), 4 in `TestCheckImpactedSelfHeal` (`:2860`), 1 at `:5083`.
+Under the new seat, with `_run` patched wholesale, the four git calls
+return rc≠0 → fail-closed → no early exit → most tests are unaffected.
+The exceptions:
+
+| Test | Failure mode | Remedy |
+| --- | --- | --- |
+| `test_existing_baseline_keeps_accumulated_coverage` | **vacuous green** — asserts only `== 0` and `mock_reset.assert_not_called()` | Patch the seam to a `.py` path |
+| `test_no_base_locally_warns_and_passes` | **vacuous green** — asserts `== 0`, does not patch `_run`, so on a non-`.py` tree the exit fires before the no-base branch | Patch the seam |
+| `test_no_base_in_ci_returns_4` | **env-dependent** — returns 0 instead of 4 whenever the working tree happens to be non-`.py` | Patch the seam |
+| `test_selected_tests_fail_returns_1`, `test_missing_coverage_xml_returns_1`, `test_stale_coverage_xml_cleared_so_emission_failure_fails` | **red** — `mock_run.assert_not_called()` | Patch the seam (with it patched, no git call reaches `_run`) |
+| `test_pass_returns_0`, `test_fresh_baseline_resets_accumulated_coverage` | **red** — assert `_ensure_testmon_db_safe` / `_reset_coverage_data` were called | Patch the seam |
+| `TestCheckImpactedSelfHeal._run` driver | Patches `_run_impacted_pass` but **not** `_run` → would shell out to real git | Patch the seam in the driver |
+
+Mechanical re-verification step for the task: after patching the seam
+everywhere, temporarily `raise` inside the early-exit branch and confirm
+all 16 still pass — proving none of them reach it.
+
+| Other site | Breakage | Remedy |
+| --- | --- | --- |
+| `test_fetches_origin_main_first`, `test_fetch_is_bounded_by_timeout` | Assert the fetch is `_run` call **index 0**; `rev-parse --git-path` now precedes it | Select the fetch by predicate |
+| `TestResolveDiffBase._router` | Defensive only: an unmatched `rev-parse` falls into the `@{u}` arm returning rc 1 → "fetch as today", so tests pass by luck | Add an explicit `--git-path` arm |
+| `test_check_pytest_files_uses_workers_when_resolver_returns_value` | `fake_stream` lacks `total_tests`; and a 0-count target now picks serial, failing the `auto`/`4` params | Patch `_collect_test_count` above threshold; update the fake's signature |
+| `test_quick_collect_only_uses_cited_paths_not_tests_dir` | Asserts exactly 2 `Popen` calls and no `TESTS_DIR` in the collect argv | Must still hold — keep `_collect_test_count` on `Popen` |
+| `test_quick_emits_banner` | Asserts `"xdist + sysmon" in err` | Update to the new banner text |
+| `TestPopenUtf8Encoding` | Exercises `check_pytest()` only — unaffected | Confirm via AC11 |
+| `TestProjectRulesDocGuards` | 5 presence-only assertions; **expected red set is empty** (verified) | Add two new guards for the new doc text |
+
+### Rejected alternatives (measured)
+
+- **Serial fast path for `--impacted`.** Selection size is unknowable
+  before the run; guessing wrong is catastrophic (the 3682-test
+  selection ran 425.6 s on 10 workers; `tests/qs` serial-vs-xdist is
+  170.9 s vs 81.6 s, so the serial penalty on large sets is ~2×).
+- **A `--testmon --collect-only` probe to learn the count first.**
+  Measured 6.1 s — as expensive as the entire serial pass (6.6 s). Also
+  unreliable: a later re-probe returned "no tests collected" for a
+  genuinely changed tree.
+- **Parsing xdist's collection header.** No such header exists under
+  `-q` — superseded anyway by `console_output_style=count` (§2), which
+  is the better answer to the same question.
+- **Escalating a serial run to xdist mid-flight.** Requires killing a
+  coverage-writing pytest — the exact failure mode QS-283's self-heal
+  cleans up after.
+- **Capping `-n auto` at `-n 4` for the inner-loop testmon pass.**
+  Controlled A/B, identical 3682-test selection replayed from the same
+  snapshot, `.coverage` wiped before both:
+
+  | Workers | Wall | CPU (user) |
+  | --- | --- | --- |
+  | `-n 4` | 499.9 s | 1863 s |
+  | `-n auto` (10) | 425.6 s | 2579 s |
+
+  Per-test execution 110.4 ms at `-n auto` vs 133.0 ms at `-n 4`; the cap
+  buys 8.7 s of boot and loses 22.5 ms/test ⇒ **break-even at 386
+  selected tests**, i.e. the cap wins only at **≥ 8.5 small runs per
+  large one**. Rejected: a fresh worktree's first run hits a stale
+  baseline (observed: 3682 tests), so the ratio is marginal, and the cap
+  adds a tuning surface while making the worst case worse.
+
+### Deferred, explicitly
+
+**S-1(c) "audit auto-loaded plugins for the quick path" is not in this
+story.** Same target (per-worker collection cost), different
+intervention (`pytest --trace-config`, then `-p no:…`), with its own
+regression surface — the HA stack auto-loads plugins whose absence
+changes behavior subtly. Task 8 files a follow-up issue, runs
+`pytest --trace-config` once, and pastes the plugin list into it so the
+issue is actionable rather than a placeholder; the issue number is
+written back into this section and the PR body (repo precedent:
+`5c69a2ce`).
+
+**Owner decision required:** does #290 close on merge with S-1(c)
+tracked separately, or stay open? Default assumption: **closes**.
+
+### Note — nothing machine-enforces `scripts/`
+
+Verified in `.github/workflows/pr-quality.yml`: CI runs `ruff check`,
+`ruff format --check`, `mypy` and
+`pytest --cov=custom_components/quiet_solar --cov-fail-under=100`
+**only against `custom_components/quiet_solar/`** (`:26,29,48,70`). So
+no gate — local or CI — lints, type-checks or measures coverage of
+`scripts/`. Two consequences: (a) every new branch in this story gets a
+test by discipline, not because a tool will complain; (b) the mandatory
+pre-commit runs are `--quick tests/test_quality_gate.py` and
+`--quick tests/qs` (the inner loop `--ignore`s this story's own test
+file). `docs/workflow/project-context.md:152` describes CI as
+"whole-repo `--cov-fail-under=100`", which is loose wording for
+"whole-suite"; correcting it is out of scope here.
+
+## Acceptance criteria
+
+**AC1 — non-`.py` early exit.** With no `.py` in the merge-base diff ∪
+untracked set, `check_impacted` returns 0 having spawned **no** pytest,
+**no** diff-cover and **no** `git fetch`, and emits the PASS line plus a
+hint (assert substrings `no Python files changed` and `--quick tests/qs`).
+
+**AC2 — no false PASS.** Each defeats the exit on its own: untracked
+`.py`; staged-only; unstaged-only; committed-only; deleted `.py`; a
+non-zero exit from any of the four git calls (fail-closed); and **a
+`.py` file whose content matches main's** (the merge-base case — the
+hole a two-dot diff would have opened).
+
+**AC3 — ordering.** Assert with an `attach_mock` manager that
+`_clean_orphan_cov_shards` runs before the seam, and that no
+`["git", "fetch", …]` argv is spawned on the exit path.
+
+**AC4 — no collect-only on the impacted pass.** On a change set
+**containing a `.py` file** (so the exit provably does not fire), a
+testmon pass *is* spawned and no spawned argv contains `--collect-only`.
+
+**AC5 — `--seed-testmon` keeps its denominator (QS-299 guard).**
+`seed_testmon` still triggers the whole-tree collect-only, and a progress
+line captured from a **real `_stream_pytest` emission** (fake pytest
+stdout through the real formatter) still parses via `_parse_seed_progress`.
+
+**AC6 — denominator from the run's own output.** `_build_testmon_cmd`
+contains `-o console_output_style=count`. Feeding `_stream_pytest`
+(with `total_tests=0`) a stream whose progress lines carry `[N/M]`
+yields the existing `pytest: pct% (cur/total)` line with `total = M`,
+and the `[N/M]` suffix is stripped so the dot tally still counts. With
+no `[N/M]` ever seen, no percentage line is emitted and the terminal
+line falls back to the observed count.
+
+**AC7 — serial fast path** (scoped to `check_pytest_files`; an
+`--impacted` invocation spawns zero collect-only subprocesses per AC4).
+≤ 50 collected → no `-n`; > 50 → `-n auto`; `None` → `-n auto` **and**
+`total_tests=0`. Exactly one `--collect-only` subprocess per
+`check_pytest_files` call. Covers the dev-only scope path too.
+
+**AC8 — override.** Detected via `os.environ.get(...) is not None`:
+`0` forces serial for a 1000-test target; `8` forces `-n 8` for a
+3-test target.
+
+**AC9 — fetch TTL.** Inside TTL → no `git fetch` spawned + skip line;
+outside TTL, missing marker, or `rev-parse` failure → fetch exactly as
+today including its failure warning; base-resolution failure after a
+skip → one retry with the fetch. Marker path from
+`git rev-parse --git-path FETCH_HEAD`.
+
+**AC10 — D-18.** `--full` on a dev-only tree prints
+`scope: FULL (--full flag)`; `--full` with production changes **keeps**
+`production files changed: …`; `_detect_scope` renders `(1 file)` /
+`(2 files)` for the dev-only and ui-only reasons.
+
+**AC11 — full gate untouched.** `check_pytest` still collects the whole
+tree for its denominator and still requests `-n auto`;
+`TestPopenUtf8Encoding`'s two-`Popen` assertion still holds.
+
+**AC12 — measured.** One before/after in the PR body:
+`--quick tests/qs/launchers/test_phase_mapping.py`, **median of 3**,
+target **≤ 17 s** (from 20.1 / 22.4 s; the serial path itself measured
+14.8–16.4 s, so a tighter bound is inside the noise). Do not interleave
+serial and xdist testmon runs while measuring (observed: alternating
+modes invalidates fingerprints and produced a spurious 520 s run). The
+non-`.py` and `tests/qs` claims are **structural, not timed** — AC1
+asserts nothing is spawned and AC7 asserts `-n auto` survives, which is
+stronger than a wall-clock number and costs no measurement time.
+
+**AC13 — exit-code fidelity (permanent, not a throwaway).** A unit test
+that a non-zero pytest exit propagates through `_stream_pytest` /
+`check_pytest_files` on **both** argv shapes (serial and `-n auto`), and
+that the reported test count matches the count pytest reported. This
+story rewrites the code path used to verify itself; a vacuous green is
+the specific risk, and a permanent test is strictly better than an
+add-run-delete ritual.
+
+## Task breakdown (TDD)
+
+Each task: failing test(s) first, then the change, then
+`--quick tests/test_quality_gate.py`.
+
+1. **D-18.** New `_detect_scope` reason tests — there is currently **no**
+   assertion on the dev-only reason string (`:461`, `:1976` are *inputs*
+   to a patched `_detect_scope`). Plus the `--full` substitution and its
+   scope-already-full case. → AC10.
+2. **S-1 extraction.** Extract `_collect_test_count` (returning
+   `int | None`), add `total_tests` to `_stream_pytest`, delete
+   `collect_targets`, rewire `check_pytest_files` with the worker
+   decision, update the **two in-code** strings (`:18`, `:2275`) and the
+   `:2446` banner. Fix the three named tests. → AC7, AC8, AC11, AC13.
+3. **S-5.** `-o console_output_style=count` in `_build_testmon_cmd`;
+   `[N/M]` parsing + suffix stripping in `_stream_pytest`;
+   `_run_impacted_pass` passes `total_tests=0`; seed-path regression
+   guard. → AC4, AC5, AC6.
+4. **S-7 fetch TTL**, including the `_router` arm and the two index-0
+   fixes. → AC9.
+5. **S-4 early exit.** Hoist `_clean_orphan_cov_shards` (+ comment
+   update), add the zero-arg seam, patch it into all 16 `check_impacted`
+   call sites, run the `raise`-in-the-branch re-verification, then the
+   AC1–AC3 tests. → AC1–AC3.
+6. **Measure** per AC12.
+7. **Docs** — `docs/workflow/project-rules.md` (the early exit, that it
+   makes `--quick tests/qs` the only check for non-Python changes, the
+   deferred-baseline-resync caveat, the serial fast path, and the `:59`
+   line — **all** `project-rules.md` edits belong to this task, not
+   task 2, since touching it makes `--quick tests/qs` mandatory for that
+   commit); a one-line cross-reference in
+   `docs/agents/concepts/testing-layers.md` pointing at the canonical
+   statement rather than restating it; two new guards in
+   `TestProjectRulesDocGuards`. `AGENTS.md` untouched.
+8. **File the deferred S-1(c) issue**, paste the `--trace-config` plugin
+   list into it, write the number back here and in the PR body.
+9. **Pre-commit:** `--quick tests/test_quality_gate.py`, then
+   `--quick tests/qs`, then
+   `python scripts/qs/check_doc_drift.py --paths <changed>`, then
+   `--impacted` (a smoke test only — the committed-vs-base union
+   contains `.py`, so the exit will not fire, and the run is
+   coverage-vacuous for `scripts/`).
+
+## Doc maintenance
+
+`check_doc_drift.py` on the planned paths → **no violations** (only the
+four pre-existing `testing-layers.md` `covers:`-outside-
+`custom_components/` warnings, audit D-12). Re-run at task 9 with the
+final path list — the pre-implementation run cannot be predictive, since
+the checker flags docs whose source was modified without co-modification.
+
+**Doc-OK: `.claude/agents/**`, `.cursor/agents/**`, `.opencode/agents/**`.**
+No agent protocol changes: commands and exit-code contracts are
+identical. Task 7 includes a grep of the three agent dirs for `--impacted`
+prose to confirm none of it becomes false (a non-`.py` PASS now means
+"nothing was checked"); if any does, that pulls in the three-way
+harness-sync obligation and is recorded before proceeding.
+
+**Doc-OK: `phase-protocols.md`, `overview.md`, `harness.md`,
+`project-context.md`** — none document the gate's internal fast paths.
+
+**Doc-OK: `docs/stories/QS-288.audit-report.md`** — historical record.
+
+## Adversarial Review Notes
+
+### Round 1 (critic, concrete-planner, dev-proxy, scope-guardian) — all resolved in v3
+
+25 findings accepted and folded: cost attribution re-measured in-gate;
+the 635 s outlier excluded from arithmetic; the early exit moved above
+the fetch and after hygiene; two knobs collapsed to one; the existing-test
+blast radius enumerated; `int | None` for the collect count; the
+`[quick]`→`[pytest]` prefix; env knobs demoted to module constants; git
+call arity reduced; `_emit` prefixing; the `--full` clobber; the S-1(c)
+deferral made explicit; testmon blindness proven with a positive control;
+ASCII output; one fewer doc.
+
+Rejected in round 1, with evidence: "CI will fail on ruff/mypy" (CI
+covers only `custom_components/`); "parse xdist's collection header"
+(no header under `-q`) — **superseded in round 2 by
+`console_output_style=count`, which achieves the same goal**; "boot tax
+isn't fixed" (prose corrected, arithmetic unaffected).
+
+### Round 2 (same four + delta-auditor)
+
+**Accepted — design changes:** merge-base instead of two-dot (closed a
+real false-PASS hole *and* the "branch behind main never exits" hole);
+`console_output_style=count` (deletes the bespoke progress format);
+zero-arg total seam; the `_clean_orphan_cov_shards` hoist that the v3
+seat silently required; `None` count → `total_tests=0` + `-n auto`
+(overload collision); `os.environ.get(...) is not None` for explicitness;
+the fourth `xdist + sysmon` string (a split literal my grep missed);
+blast-radius corrected per-test with failure modes.
+
+**Accepted — trims** (the reviewers were right that v3 over-corrected by
+answering arguments with procedures): the scratch-worktree measurement
+protocol is **deleted** (`refs/remotes` is shared across worktrees, so
+`update-ref` would corrupt sibling worktrees' verdicts, and a fetch
+destroys the faked base inside the "before" run); the non-`.py` and
+`tests/qs` claims are structural, not timed; AC13 became a permanent
+test instead of a throwaway ritual; the CI-scope finding moved out of the
+AC list into a note; the staleness-direction test dropped (it would
+assert git, not us); the path-aware hint collapsed to one static line.
+
+**Rejected, with evidence:**
+
+| Finding | Why rejected |
+| --- | --- |
+| concrete-planner (critical): `quality_gate.py:416` is a Python-2 `except` → the module does not parse, tests cannot be collected, add a "task 0" | **False.** PEP 758 (Python 3.14) allows unparenthesized `except A, B:`; this project requires 3.14+. `ast.parse` on the file succeeds and the gate was executed ~20 times during planning. Acting on this would have sent the implementer after a nonexistent bug |
+| concrete-planner: "21 `check_impacted` call sites (11 + 10)" | **Miscounted.** 16 total: 11 in `TestCheckImpacted`, 4 in `TestCheckImpactedSelfHeal`, 1 at `:5083`. The per-test failure-mode analysis was still valuable and is folded in |
+| critic: "2439 tests attributed to one ignored module — the denominators may be wrong" | Suspicion correct, reason wrong. `tests/test_quality_gate.py` holds **480** tests; the 6912→4473 gap is testmon's own collection-skipping, not the `--ignore`. Baseline corrected |
+| critic (redesign): attack the 60 % that remains (per-worker collection) instead of the 30 % | That is S-1(c), explicitly deferred with a filed issue — and the two tractable attacks on it are already measured and rejected above |
+| dev-proxy: `project-context.md:152` contradicts the CI-scope claim | `pr-quality.yml` is authoritative; the doc's "whole-repo" is loose wording for "whole-suite". Noted, correction out of scope |
+
+### Shipped without a round 3 (owner decision)
+
+v4 changed materially after round 2 (merge-base, `console_output_style=count`,
+the deleted measurement protocol), so `changed-since-last-review` was
+**true** at FINALIZE. The owner chose to ship rather than run another
+pass: the two new design points are measured, and the residual risk is
+implementation detail that TDD plus the phase-4 review covers better
+than a third planning round. No open criticals were outstanding.

--- a/docs/stories/QS-290.story.md
+++ b/docs/stories/QS-290.story.md
@@ -393,6 +393,13 @@ issue is actionable rather than a placeholder; the issue number is
 written back into this section and the PR body (repo precedent:
 `5c69a2ce`).
 
+**Filed as #322** — carries the real 20-entry third-party plugin list
+from `pytest --trace-config`, first-probe candidates (`pytest_picked`,
+`pytest_github_actions_annotate_failures`, `pytest_sugar` — the last one
+also a progress-parsing hazard for `_stream_pytest`), an explicit
+do-not-touch list, and the three already-measured rejected alternatives
+so they are not redone.
+
 **Owner decision required:** does #290 close on merge with S-1(c)
 tracked separately, or stay open? Default assumption: **closes**.
 

--- a/docs/stories/QS-290.story.md
+++ b/docs/stories/QS-290.story.md
@@ -429,6 +429,39 @@ file). `docs/workflow/project-context.md:152` describes CI as
 
 ## Acceptance criteria
 
+> **Amendments from the review rounds.** The ACs below are the originals,
+> kept verbatim per this story's convention of recording deltas rather
+> than rewriting history. Five have since been superseded in *mechanism*
+> — never in intent — and every deviation is itself tested. Read the AC
+> together with its amendment:
+>
+> - **AC2** says "any of the **four** git calls". The early-exit union
+>   now has **five**: round-1 must-fix 2 added the committed range
+>   (`git diff <mb> HEAD`) and round-2 must-fix 1 added the index rung
+>   (`git diff --cached <mb>`), because a `.py` staged but reverted in
+>   the worktree appeared in no rung while diff-cover still scored it.
+>   AC2's list of defeating cases grew to match. Deliberately no fixed
+>   count anywhere in the code — see the note at the Goal section.
+> - **AC6 / AC7** say `total_tests=0`. The code passes
+>   `_LEARN_FROM_STREAM` (a negative sentinel): round-1 nice-to-have 17
+>   made `0` a genuine, authoritative "this target has no tests", so it
+>   could no longer double as "unknown — learn it from the stream".
+> - **AC8** says explicitness is "Detected via
+>   `os.environ.get(...) is not None`". It is now
+>   `_workers_env_is_explicit()`, which additionally requires the value
+>   to be *valid*: round-1 nice-to-have 11 found that a typo
+>   (`autoo`, `4x`) was being honoured as a deliberate xdist request and
+>   silently cost small targets the fast path.
+> - **AC9** says "Inside TTL → no `git fetch` spawned". True **outside
+>   CI only**: round-1 should-fix 4 made CI bypass the TTL entirely,
+>   enforcing what `_FETCH_TTL_SECONDS`' own comment already claimed.
+>   The TTL also now requires the marker to be non-empty, to record a
+>   fetch of *origin's* `main`, and to carry a non-future mtime.
+> - The skip line quoted at the Design section (§4) as
+>   `fetch skipped (FETCH_HEAD 3m old)` is retired; it now reads
+>   `fetch skipped (origin/main fetched 3m ago)`, which is what the
+>   marker can actually support.
+
 **AC1 — non-`.py` early exit.** With no `.py` in the merge-base diff ∪
 untracked set, `check_impacted` returns 0 having spawned **no** pytest,
 **no** diff-cover and **no** `git fetch`, and emits the PASS line plus a

--- a/docs/stories/QS-290.story.md
+++ b/docs/stories/QS-290.story.md
@@ -19,6 +19,13 @@
 > `tests/test_quality_gate.py` explicitly, or the tests this story
 > mandates will be written and then left uncommitted. This is a pipeline
 > defect, not a story defect — worth its own follow-up issue.
+>
+> **Resolved for `qs-implement-setup-task` (review fix #01 should-fix 9).**
+> All three harness copies now stage `tests/qs/` and
+> `tests/test_quality_gate.py`, so the dev-tooling tests this story
+> mandates can no longer be silently left behind. The mirror-image gap in
+> `qs-implement-task` (stages `tests/` but neither `scripts/` nor
+> `docs/workflow/`) is out of this fix plan's scope and remains open.
 
 ## Problem
 
@@ -111,7 +118,9 @@ score). Called out in the docs task.
 ## Goal
 
 1. A non-`.py` `--impacted` run spawns no pytest, no diff-cover and no
-   `git fetch` (from 10.7 – 23.5 s of work to two git calls).
+   `git fetch` (from 10.7 – 23.5 s of work down to a handful of local
+   git calls — five as implemented; review fix #01 must-fix 2 added the
+   committed-range rung, which is why a fixed count does not belong here).
 2. A `.py` `--impacted` run drops the collect-only subprocess:
    **10.7 s → ~7.5 s** fast state, **~23 s → ~18 s** slow state.
 3. Small `--quick` runs stop paying xdist spin-up: 43-test reference
@@ -498,7 +507,7 @@ add-run-delete ritual.
 ## Task breakdown (TDD)
 
 Each task: failing test(s) first, then the change, then
-`--quick tests/test_quality_gate.py`.
+`python scripts/qs/quality_gate.py --quick tests/test_quality_gate.py`.
 
 1. **D-18.** New `_detect_scope` reason tests — there is currently **no**
    assertion on the dev-only reason string (`:461`, `:1976` are *inputs*
@@ -531,10 +540,11 @@ Each task: failing test(s) first, then the change, then
    `TestProjectRulesDocGuards`. `AGENTS.md` untouched.
 8. **File the deferred S-1(c) issue**, paste the `--trace-config` plugin
    list into it, write the number back here and in the PR body.
-9. **Pre-commit:** `--quick tests/test_quality_gate.py`, then
-   `--quick tests/qs`, then
+9. **Pre-commit:**
+   `python scripts/qs/quality_gate.py --quick tests/test_quality_gate.py`,
+   then `python scripts/qs/quality_gate.py --quick tests/qs`, then
    `python scripts/qs/check_doc_drift.py --paths <changed>`, then
-   `--impacted` (a smoke test only — the committed-vs-base union
+   `python scripts/qs/quality_gate.py --impacted` (a smoke test only — the committed-vs-base union
    contains `.py`, so the exit will not fire, and the run is
    coverage-vacuous for `scripts/`).
 

--- a/docs/stories/QS-290.story_review_fix_#01.md
+++ b/docs/stories/QS-290.story_review_fix_#01.md
@@ -1,0 +1,366 @@
+# QS-290 — Review fix plan #01
+
+## Summary
+- Source PR: #323
+- Source story: `docs/stories/QS-290.story.md`
+- Findings to fix: 21 (3 must-fix, 6 should-fix, 12 nice-to-have)
+- Next implement phase: `/implement-setup-task`
+
+Every touched path is under a dev-environment prefix (`scripts/`,
+`tests/`, `.claude/`, `.cursor/`, `.opencode/`, `docs/`), so the
+dev-env implement variant applies.
+
+The acceptance-auditor traced all 13 ACs to implementation **and**
+tests with zero findings. Every must-fix below is a correctness hole
+the ACs did not ask about — the story's ACs were satisfied by code
+that is still wrong on paths the ACs never named.
+
+### Ordering note
+
+Must-fix #1 and #2 both rewrite `_impacted_early_exit_paths`. Do them
+as **one pass**, not two patches — and fold should-fix #7 and
+nice-to-have #20 in while the function is open. Must-fix #3 and
+should-fix #4/#5/#6 all rewrite `_fetch_head_age` /
+`_resolve_diff_base`; likewise one pass.
+
+---
+
+## Findings to fix
+
+### [must-fix] 1. `core.quotePath` C-quoting makes the early exit fail open
+
+- File: `scripts/qs/quality_gate.py:1349,1353` (producer),
+  `scripts/qs/quality_gate.py:1783` (consumer `p.endswith(".py")`)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter (verified against real git),
+  qs-review-coderabbit (filed 🟡 Minor — **escalated**, see below)
+- Description: `core.quotePath` defaults to true (confirmed unset in
+  this repo). `git diff --name-only` and `git ls-files --others` then
+  emit non-ASCII paths C-quoted **with surrounding double quotes**:
+  `"t\303\251st_\303\251.py"`. That string does not end in `.py`, so
+  a change set whose only Python file has a non-ASCII character
+  anywhere in its path (e.g. `tests/test_données.py`, or any `.py`
+  under `fixtures/données/`) takes the "no Python files changed"
+  early exit. `--impacted` returns 0 having run neither testmon nor
+  diff-cover. This is a silent fail-**open** in the one function
+  whose docstring makes fail-closed its contract (AC2).
+  CodeRabbit rated this Minor; the edge-case-hunter reproduced it
+  against real git and rated it must-fix. Take the higher severity —
+  a false PASS in the gate is exactly the failure class AC2 exists to
+  prevent.
+- Proposed fix: switch both git invocations to NUL-delimited output
+  (`git diff --name-only -z <range>`, `git ls-files --others
+  --exclude-standard -z`) and split on `\0` instead of `splitlines()`.
+  This emits the raw byte path and removes the entire quoting class.
+  `-c core.quotePath=false` is the weaker alternative — it still
+  breaks on a path containing a literal newline, which `-z` handles.
+  Drop the now-wrong `line.strip()` (a `-z` field is already exact,
+  and stripping would corrupt a path with leading/trailing spaces).
+  Test: a real-git throwaway repo (matching the existing AC2 test
+  style at `tests/test_quality_gate.py:3516-3674`) whose only changed
+  `.py` is `tests/test_données.py`, asserting the early exit does
+  **not** fire. Add an untracked-file variant — `ls-files --others`
+  quotes too.
+
+### [must-fix] 2. Two-dot merge-base diff is not a superset of diff-cover's three-dot range
+
+- File: `scripts/qs/quality_gate.py:1349`
+  (`_impacted_early_exit_paths`)
+- Severity: must-fix
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+  (independently; edge-case-hunter verified)
+- Description: the code runs `git diff --name-only <merge_base>`,
+  which compares the merge-base **tree against the working tree**.
+  The docstring claims supersetness of diff-cover's `base...HEAD` "in
+  both directions"; the claim fails when a `.py` file is changed in a
+  branch **commit** but restored to merge-base content in the working
+  tree. Verified: three-dot reports `foo.py`, the PR's set reports
+  only `README.md`. The exit then fires and returns 0, while
+  diff-cover would have scored `foo.py`'s committed added lines —
+  lines absent from the coverage report, i.e. a very likely FAIL
+  converted into a PASS. Reproduces on a manual revert or a
+  `git checkout <mb> -- file` followed by an unstage.
+- Proposed fix: union in the committed range —
+  `git diff --name-only -z <merge_base> HEAD` (two-dot against an
+  already-computed merge-base is equivalent to `<mb>...HEAD`) — as a
+  fourth git call, failing closed on non-zero rc exactly like the
+  other three. Correct the docstring's supersetness claim to describe
+  the union rather than asserting a property of a single diff.
+  Test: real-git throwaway repo reproducing the revert-in-worktree
+  case, asserting no early exit.
+
+### [must-fix] 3. A failed `git fetch` bumps `FETCH_HEAD`, so the TTL reads failure as freshness
+
+- File: `scripts/qs/quality_gate.py:1186-1210` (`_fetch_head_age`),
+  `scripts/qs/quality_gate.py:1259-1266` (`_resolve_diff_base`)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter (verified against real git)
+- Description: a failed fetch still bumps `FETCH_HEAD`'s mtime —
+  verified with the remote deleted mid-test: rc=128, mtime advanced,
+  file **truncated to 0 bytes**. So the first `--impacted` of an
+  offline / dropped-VPN / hung-remote session warns
+  `git fetch origin main failed/timed out — diff base may be stale vs
+  CI`, and then every run for the next 10 minutes prints
+  `diff base: fetch skipped (FETCH_HEAD 0m old)` and never retries —
+  including after connectivity returns seconds later. Net effect: the
+  QS-276 S1 warning, which exists **precisely** so a silently-failed
+  fetch stays observable, is suppressed for the whole TTL window
+  while the base stays stale, producing spurious diff-cover FAILs the
+  developer cannot explain. The TTL turns an existing safety net off.
+- Proposed fix: a successful fetch (even a no-op re-fetch) leaves a
+  non-empty `FETCH_HEAD` (213 bytes in the reviewer's test); a failed
+  one leaves 0 bytes. Treat `st_size == 0` as `None` (unknown → do
+  not skip) in `_fetch_head_age`. Test: `os.utime` a 0-byte marker
+  fresh and assert the fetch still happens.
+
+### [should-fix] 4. TTL is not bypassed in CI, contradicting its own rationale
+
+- File: `scripts/qs/quality_gate.py:1259` (`_resolve_diff_base`),
+  `scripts/qs/quality_gate.py:1112` (`_FETCH_TTL_SECONDS` comment)
+- Severity: should-fix
+- Source: qs-review-blind-hunter (should-fix),
+  qs-review-edge-case-hunter (nice-to-have) — took the higher
+- Description: the constant's comment asserts "CI always fetches
+  fresh", but nothing enforces it. `actions/checkout` fetches and
+  leaves a seconds-old `FETCH_HEAD`, so a CI `--impacted` skips its
+  own fetch and resolves against whatever base checkout happened to
+  leave. Latent today (no workflow invokes `--impacted`), but the
+  exit-4 CI branch exists for other harnesses and the retry-once path
+  only rescues `base is None`, not resolvable-but-stale.
+- Proposed fix: gate the skip on `not _is_ci()` (the helper already
+  exists just above `_fetch_head_age`). If instead the TTL is
+  *intended* to apply in CI, delete the claim from the comment —
+  but the bypass is the safer default.
+
+### [should-fix] 5. `FETCH_HEAD` tracks any fetch, not `origin/main`
+
+- File: `scripts/qs/quality_gate.py:1186-1208` (`_fetch_head_age`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+- Description: `FETCH_HEAD` records the last fetch of *anything*.
+  `gh pr checkout <n>` (fetches `refs/pull/N/head`), `git fetch origin
+  <other-branch>`, a second remote, an editor plugin fetching tags —
+  each rewrites the marker without advancing `origin/main`. So
+  `gh pr checkout` followed immediately by `--impacted` reports
+  `fetch skipped (FETCH_HEAD 0s old)` although `origin/main` may be
+  days old. The "staleness is bounded at 10 minutes" argument that
+  justifies the whole TTL does not hold, and the skip line asserts
+  something the marker cannot support.
+- Proposed fix: key the TTL on
+  `git rev-parse --git-path refs/remotes/origin/main` instead, which
+  measures the thing the TTL claims; fall back to fetching when that
+  ref is packed or absent. Whatever is chosen, the skip line's wording
+  and the docstring must not claim more than the marker supports.
+
+### [should-fix] 6. A future `FETCH_HEAD` mtime is clamped to "maximally fresh"
+
+- File: `scripts/qs/quality_gate.py:1210`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `return max(0.0, time.time() - mtime)` converts an
+  impossible timestamp into age `0.0`, so the fetch is skipped for the
+  **entire duration of the skew**, not for 10 minutes. Reproduces on
+  an NTP step correction, VM suspend/resume, dual boot, container
+  clock drift, or a network share whose server clock runs ahead: every
+  `--impacted` prints `fetch skipped (FETCH_HEAD 0s old)` and the base
+  never refreshes.
+- Proposed fix: a future mtime should return `None` — the module's own
+  established convention for "unknown, do not skip".
+
+### [should-fix] 7. `_collect_test_count` ignores the collection return code
+
+- File: `scripts/qs/quality_gate.py:621-660`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `count_proc.returncode` is never inspected, so a
+  partially-failed collection (`"5 tests collected, 2 errors"`) yields
+  a small count and silently triggers the serial fast path on bad
+  data. The docstring already argues carefully that `None` means
+  *unknown* and must degrade to `-n auto`; a non-zero rc is exactly
+  that case and is currently not honoured.
+- Proposed fix: treat non-zero `returncode` as `None`.
+
+### [should-fix] 8. Harness agent files overstate `.py`-presence as a complete verification decision
+
+- Files: `.claude/agents/qs-implement-setup-task.md:94-102`,
+  `.cursor/agents/qs-implement-setup-task.md:94-102`,
+  `.opencode/agents/qs-implement-setup-task.md:148-156`
+- Severity: should-fix
+- Source: qs-review-coderabbit (🟠 Major)
+- Description: the three copies present `.py` presence or absence as a
+  complete verification decision. Two qualifications are missing:
+  failed git probes do **not** take the early exit (fail-closed), and
+  a `.py` change can still select zero tests or hit the impacted
+  pass's `tests/test_quality_gate.py` exclusion.
+- Proposed fix: qualify both statements and name the explicit quick
+  test for quality-gate changes. Keep all three harness copies
+  byte-identical in the shared region (co-modification rule).
+
+### [should-fix] 9. The agents' automatic `git add` omits `tests/`
+
+- Files: the same three `qs-implement-setup-task.md` copies;
+  cross-referenced at `docs/stories/QS-290.story.md:12-21`
+- Severity: should-fix
+- Source: qs-review-coderabbit (🟠 Major)
+- Description: the new regression test is
+  `tests/qs/agents/test_impacted_non_py_honesty.py`, but the automatic
+  `git add` commands in the three implement-agent files do not include
+  `tests/`. An agent can therefore commit the prose changes while
+  leaving the guard uncommitted. This PR honoured the story's
+  hand-staging warning manually, so the guard did land — but the
+  contract that made it necessary is still broken for the next story.
+- Proposed fix: add the dev-tooling test directory (`tests/qs/`) to
+  each staging command.
+
+### [nice-to-have] 10. Zero-selected `--impacted` now prints no pytest line at all
+
+- File: `scripts/qs/quality_gate.py:765`
+- Source: qs-review-edge-case-hunter
+- Description: with `total_tests=0` and `final_total == 0`, the
+  `if total_tests > 0 or final_total > 0` guard is false, so the
+  `pytest: done (…)` line disappears entirely on the single most
+  common inner-loop invocation — a `.py` change testmon deselects to
+  0 tests. The old `done (0/6912)` was wrong about the denominator but
+  did confirm the pass executed; now there is nothing between
+  `selecting impacted tests (testmon)…` and the verdict.
+- Proposed fix: emit `done (0/0)` (or `done (0/?)`) to keep the
+  signal.
+
+### [nice-to-have] 11. A malformed `QS_QG_PYTEST_WORKERS` counts as an explicit request
+
+- File: `scripts/qs/quality_gate.py:298-326`
+- Source: qs-review-edge-case-hunter
+- Description: `_pytest_workers()` warns and returns `"auto"` for
+  `autoo` / `-1` / `4x`; the `os.environ.get(...) is not None`
+  provenance check then treats the typo as deliberate and forces xdist
+  onto a 3-test target, silently losing the fast path this PR adds.
+- Proposed fix: treat "invalid" the same as "unset" for the
+  provenance check.
+
+### [nice-to-have] 12. The TTL retry re-walks the ladder, duplicating the NH2 warning
+
+- File: `scripts/qs/quality_gate.py:1259-1270`
+- Source: qs-review-edge-case-hunter
+- Description: on a shallow clone with a fresh `FETCH_HEAD`: skip →
+  ladder warns and returns `None` → fetch → ladder warns again. Purely
+  cosmetic duplicate diagnostics.
+- Proposed fix: suppress the duplicate on the retry pass.
+
+### [nice-to-have] 13. `check_pytest_files` docstring contradicts the new banner
+
+- File: `scripts/qs/quality_gate.py` (`check_pytest_files` docstring)
+- Source: qs-review-blind-hunter
+- Description: still says "Silent serial fallback … no stderr warning;
+  only the full gate warns", but `_resolve_files_workers` now prints
+  `[pytest] N tests <= 50 - single-process` on exactly the
+  `--quick` / dev-only paths that sentence covers.
+- Proposed fix: update the docstring.
+
+### [nice-to-have] 14. `_COUNT_SUFFIX_RE` group 1 is never used
+
+- File: `scripts/qs/quality_gate.py:522`
+- Source: qs-review-blind-hunter
+- Description: `(\d+)` for `current` is captured but unused; a future
+  edit could silently shift `group(2)`.
+- Proposed fix: make group 1 non-capturing.
+
+### [nice-to-have] 15. `_run_main_full` has a dead return
+
+- File: `tests/test_quality_gate.py`
+  (`TestFullFlagScopeReason._run_main_full`)
+- Source: qs-review-blind-hunter
+- Description: always `return ""` and every caller ignores it.
+- Proposed fix: annotate `-> None` and drop the return.
+
+### [nice-to-have] 16. `_patch_early_exit` papers over a type error with a blanket ignore
+
+- File: `tests/test_quality_gate.py` (`_patch_early_exit`)
+- Source: qs-review-blind-hunter
+- Description: a default `"keep-py"` string on a `list[str] | None`
+  parameter, silenced with `# type: ignore[assignment]`.
+- Proposed fix: use a module-level sentinel object; the ignore then
+  disappears.
+
+### [nice-to-have] 17. `0` doubles as "unknown" and "genuinely zero" in `_stream_pytest`
+
+- File: `scripts/qs/quality_gate.py` (`_stream_pytest`)
+- Source: qs-review-blind-hunter
+- Description: a target that really collects 0 tests will still try to
+  learn a total from the stream. Harmless today, but it does not match
+  the `None`-vs-`0` care taken in `_collect_test_count`.
+- Proposed fix: use a `None` sentinel for "unknown denominator".
+  Coordinate with #10, which touches the same guard.
+
+### [nice-to-have] 18. project-rules' UI-asset hint contradicts `_IMPACTED_NON_PY_LINES`
+
+- File: `docs/workflow/project-rules.md`
+- Source: qs-review-blind-hunter
+- Description: the non-Python section lists `.j2` / JS / CSS under
+  "`--quick tests/qs` is **the** verification", while
+  `_IMPACTED_NON_PY_LINES` points UI assets at
+  `--quick tests/test_dashboard_rendering.py`. The two hints disagree.
+- Proposed fix: make the doc match the code (or vice versa — the code
+  is the more specific and more useful of the two).
+
+### [nice-to-have] 19. "two git calls" is really four or five
+
+- Files: `docs/workflow/project-rules.md:38-46`,
+  `docs/stories/QS-290.story.md:111-115` (and the PR body's Summary)
+- Source: qs-review-coderabbit
+- Description: the early-exit path performs four git calls today, and
+  five after must-fix #2 lands. It avoids `git fetch`, but it does not
+  reduce the work to two calls.
+- Proposed fix: replace "two git calls" with an accurate count or a
+  non-numeric description ("a handful of local git calls, no fetch").
+  Note this number **changes** as part of this fix plan, so prefer the
+  non-numeric wording. The PR body is a manual edit at finish time,
+  not a file in this plan.
+
+### [nice-to-have] 20. The story shows non-executable quality-gate commands
+
+- File: `docs/stories/QS-290.story.md:500-501`, `:534-537`
+- Source: qs-review-coderabbit
+- Description: the task breakdown and pre-commit list show
+  `--quick tests/...` without `python scripts/qs/quality_gate.py`.
+  Copying those entries fails — `--quick` is an option, not a command.
+- Proposed fix: use the full command in both locations.
+
+### [nice-to-have] 21. The honesty test asserts an exact string, not a semantic
+
+- File: `tests/qs/agents/test_impacted_non_py_honesty.py:47-73`
+- Source: qs-review-coderabbit
+- Description: `FALSIFIED_CLAIM` rejects one exact string and line
+  break. A copy-edit can restore an unconditional claim in different
+  wording while every test still passes.
+- Proposed fix: assert that the testmon statement is explicitly scoped
+  to a change set containing a `.py` file, rather than
+  string-matching one phrasing. Note this test is itself edited by
+  should-fix #8 — do both together.
+
+---
+
+## Invalid / not fixed
+
+- **Missing `io` / `os` / `time` imports in `tests/test_quality_gate.py`**
+  (qs-review-blind-hunter, should-fix). False positive — the
+  blind-hunter self-flagged it as assumed without repo access. All
+  three are imported at lines 5, 7 and 15.
+
+## Non-blocking note carried forward
+
+The acceptance-auditor observed that AC12's measured "before" leg
+(8.92 s) sits far below the story's planning baseline (20.1 / 22.4 s),
+so the realized `--quick` saving is ~1.6 s rather than the predicted
+~5 s. The AC's literal bar (≤ 17 s, median of 3, same target) is met
+and the PR discloses the discrepancy rather than reprinting planned
+numbers, so this is **not** a defect and needs no fix. But anyone
+citing "43 tests: serial 11.5 s vs xdist 16.8 s" downstream should
+know the same-machine A/B reproduced about a third of that delta.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. Work the two
+grouped passes first (`_impacted_early_exit_paths` for #1/#2/#20-adjacent,
+then `_fetch_head_age`/`_resolve_diff_base` for #3/#4/#5/#6), since
+those rewrites subsume several smaller items. Then return and run
+`/review-task` again to re-verify.

--- a/docs/stories/QS-290.story_review_fix_#02.md
+++ b/docs/stories/QS-290.story_review_fix_#02.md
@@ -1,0 +1,374 @@
+# QS-290 — Review fix plan #02
+
+## Summary
+- Source PR: #323
+- Source story: `docs/stories/QS-290.story.md`
+- Prior fix plan: `docs/stories/QS-290.story_review_fix_#01.md` (applied
+  in `684c556e`)
+- Findings to fix: 15 (1 must-fix, 7 should-fix, 7 nice-to-have)
+- Next implement phase: `/implement-setup-task`
+
+Touched paths — `scripts/qs/quality_gate.py`,
+`tests/test_quality_gate.py`, `docs/stories/QS-290.story.md` — are all
+under dev-environment prefixes, so the dev-env implement variant
+applies. Should-fix 7 targets the **PR body**, which is not a file: it
+is a `gh pr edit` at finish time.
+
+### Round-1 status: all three must-fixes genuinely fixed
+
+Verified against real git by the edge-case-hunter, not merely asserted:
+`core.quotePath` (`-z` now emits raw byte paths), the committed-range
+union, and the 0-byte `FETCH_HEAD` discriminator for a failed fetch.
+No AC regressed; all 13 still trace to code and tests; CI is fully
+green (Tests/100% coverage, MyPy, Ruff, HACS).
+
+### CodeRabbit coverage gap
+
+CodeRabbit produced **no data** for `684c556e` — rate limited, and it
+correctly declined to replay its 8 stale round-1 threads. This plan
+therefore rests on three reviewers. The limit resets around 21:39Z, so
+the round-3 review after this plan lands will give CodeRabbit a pass on
+the *final* code, which is strictly more useful than a pass on this
+intermediate state. No action here; recorded so the gap is not
+mistaken for a clean CodeRabbit result.
+
+### Ordering note
+
+Must-fix 1 and nice-to-have 12 both touch `_impacted_early_exit_paths`
+and its docstring; do them together. Should-fix 3 and 4 both touch
+`_collect_test_count`; likewise. Should-fix 5, 6 and 7 are the
+documentation-drift cluster created by fix plan #01 itself — do them
+last, once the code above has stopped moving, so the text describes
+the final state.
+
+---
+
+## Findings to fix
+
+### [must-fix] 1. The index is invisible to all three rungs — staged `.py` still fails open
+
+- File: `scripts/qs/quality_gate.py:1520`
+  (`_impacted_early_exit_paths`)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter (verified against real git;
+  independently reproduced by the orchestrator)
+- Description: the three rungs are merge-base↔**worktree**
+  (`git diff --name-only <mb>`, which *bypasses* the index),
+  merge-base↔**HEAD**, and untracked-only. A `.py` file whose **staged**
+  content differs from the merge-base while its **worktree** content
+  equals the merge-base appears in none of them. diff-cover is not
+  blind here: `GitDiffReporter` is constructed without
+  `ignore_staged`, so `GitDiffTool.diff_staged()` (`git diff --cached
+  -U0`) is part of its range — confirmed in the installed diff_cover
+  10.3.0 source. The gate therefore returns 0 having run neither
+  testmon nor diff-cover.
+
+  This is the same fail-**open** class as round-1 must-fix 2, one rung
+  over, and it matters more: the index is precisely what `git commit`
+  — the very next step after this pre-commit gate — will land.
+
+  Reproduced against real git (orchestrator's independent run):
+
+  ```
+  git checkout -b feat main
+  echo edited > README.md                       # the non-.py part
+  printf 'def f():\n    return 2\n' > mod.py
+  git add mod.py                                # index != merge-base
+  printf 'def f():\n    return 1\n' > mod.py    # worktree == merge-base
+  ```
+
+  ```
+  rung1 (mb vs worktree): [README.md ]
+  rung2 (mb vs HEAD):     []
+  rung3 (untracked):      []
+  MISSING cached rung:    [mod.py ]
+  ```
+
+  → no `.py` in the union → `PASS (no Python files changed …)`, while
+  `git diff --cached -U0` shows `+    return 2` and `git commit` lands
+  it. Same trigger class via `git apply --cached`, or `git add -p`
+  followed by `git restore --source=HEAD --worktree <file>`.
+- Proposed fix: add a fourth rung, symmetric with the existing two:
+  `["git", "diff", "--name-only", "-z", "--cached", merge_base]`
+  (merge-base vs index), failing closed on non-zero rc like the rest.
+  Test: a real-git throwaway repo reproducing the sequence above,
+  asserting the early exit does **not** fire. Note the existing
+  `TestImpactedEarlyExitPaths::test_staged_only_py_defeats_the_exit`
+  does *not* cover this — it stages **and** leaves the worktree
+  changed, so it passes through rung 1; the new test must revert the
+  worktree. Extend the `diff` id in
+  `test_fail_closed_on_any_git_failure` to the new call.
+- Docstring/doc consequence: the helper's "1./2./3." enumeration and
+  `docs/workflow/project-rules.md:44` ("committed + staged + unstaged
+  + untracked, a superset of diff-cover's three-dot range") both
+  currently **overclaim** — "staged" only holds while index ==
+  worktree. Both must become true statements once the rung lands.
+
+### [should-fix] 2. `_fetch_head_records_main` ignores the remote
+
+- File: `scripts/qs/quality_gate.py:1262`
+  (`_FETCH_HEAD_MAIN_FIELD`), `:1265` (`_fetch_head_records_main`),
+  `:1292`
+- Severity: should-fix
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+  (independently)
+- Description: `_FETCH_HEAD_MAIN_FIELD = "branch 'main' of "` matches
+  the prefix and ignores everything after `of `, i.e. the remote URL.
+  So *any* remote's `main` arms the TTL and `_resolve_diff_base` then
+  prints `fetch skipped (origin/main fetched Nm ago)` — a claim about
+  `origin` the marker does not support. Verified in a two-remote
+  clone: after `git fetch upstream main`, `FETCH_HEAD` reads
+  `branch 'main' of …/remote_up` and the check returns True while
+  `origin/main` — the ref the base ladder actually resolves — was
+  never fetched and may be arbitrarily stale. Reproduces on the
+  standard fork workflow (`origin` = fork, `upstream` = canonical).
+  This is the residual half of round-1 should-fix 5: the marker must
+  measure what the TTL claims.
+- Proposed fix: also require the trailing URL to equal
+  `git remote get-url origin`, falling through to a fetch when that
+  probe fails. If that is judged too costly, the alternative is to
+  weaken the skip line's wording to "main fetched Nm ago" — but the
+  URL is already in the field being parsed, so the check is nearly
+  free.
+
+### [should-fix] 3. `check_pytest_files` never learns its denominator
+
+- File: `scripts/qs/quality_gate.py:949` and the `check_pytest_files`
+  argv construction
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: on an unknown count the function forwards
+  `_LEARN_FROM_STREAM`, but its argv is `[..., *abs_files, "-q"]` with
+  no `-o console_output_style=count`. pytest then emits `[NN%]`, the
+  `[N/M]` shape never appears, and the denominator is never learned —
+  so mid-run progress silently vanishes on exactly that path. The old
+  whole-tree `--collect-only` used to supply a denominator here.
+- Proposed fix: add `-o console_output_style=count` to the
+  `check_pytest_files` argv, matching the impacted pass. Test that
+  progress is emitted on the unknown-count path.
+
+### [should-fix] 4. pytest exit 5 is a known zero, not "unknown"
+
+- File: `scripts/qs/quality_gate.py:662-700` (`_collect_test_count`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter (should-fix),
+  qs-review-edge-case-hunter (nice-to-have) — took the higher
+- Description: pytest exits **5** for "no tests collected", which is a
+  *known* count of zero, not unknown. Round-1 should-fix 7 mapped all
+  non-zero rc to `None`, so `_resolve_files_workers(None)` returns
+  `-n auto` and spins up xdist for a target with zero tests — the
+  exact fixed overhead S-1 exists to remove. It also makes the
+  "a genuine 0 is authoritative" branch unreachable from this caller.
+  Reproduces when `--quick <path>` names a file or directory
+  containing no tests (verified: `pytest --collect-only -q
+  test_empty.py` → `no tests collected in 0.01s`, rc=5).
+- Proposed fix: distinguish `rc == 5` (→ `0`) from other non-zero
+  codes (→ `None`). This preserves round-1 should-fix 7's protection
+  against the partial-collection case (`5 tests collected, 2 errors`,
+  which exits **2**).
+
+### [should-fix] 5. The collect probe is unbounded
+
+- File: `scripts/qs/quality_gate.py:692`
+  (`count_proc.communicate()`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter (flagged as assumed; **confirmed** by
+  the orchestrator)
+- Description: the probe's `Popen` / `communicate()` has no timeout,
+  unlike every other inner-loop subprocess in this module — `_run`
+  accepts a `timeout` (`:145`, QS-276 review-fix S1) and the hot-path
+  callers use it (`git fetch` at `:1363` with
+  `_FETCH_TIMEOUT_SECONDS`, diff-cover at `:1866` with
+  `_DIFF_COVER_TIMEOUT_SECONDS`). A hung collection therefore blocks
+  the sub-15 s promise indefinitely.
+- Proposed fix: bound `communicate()` with a timeout and treat expiry
+  as `None` (unknown → `-n auto`), consistent with the module's
+  existing degradation convention. Kill the child on expiry so the
+  probe cannot outlive the gate.
+
+### [should-fix] 6. The story's AC section still describes pre-fix behaviour
+
+- File: `docs/stories/QS-290.story.md:460`, `:467`, `:470`, `:474`,
+  `:299`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: the story is a committed artifact of this PR and *was*
+  amended in two places for round 1 (`:23`, `:122`), so the omission
+  reads as an oversight rather than policy. Four ACs now read as
+  literally false against the code:
+  - **AC6** (`:460`) and **AC7** (`:467`) say `total_tests=0`; the code
+    passes `_LEARN_FROM_STREAM` (`quality_gate.py:563`) because
+    round-1 nice-to-have 17 made `0` a genuine authoritative count.
+  - **AC8** (`:470`) says "Detected via `os.environ.get(...) is not
+    None`"; round-1 nice-to-have 11 replaced that with a validity
+    check (`_workers_env_is_explicit`), so a malformed value is now
+    *not* explicit.
+  - **AC9** (`:474`) says "Inside TTL → no `git fetch` spawned"; round-1
+    should-fix 4 made that true only outside CI.
+  - `:299` still shows the retired skip line
+    `fetch skipped (FETCH_HEAD 3m old)`.
+  Every one of these deviations **is** tested — this is a
+  documentation-traceability gap, not a behaviour gap.
+- Proposed fix: add a short amendment note in the AC section in the
+  same style as `:122`, rather than silently rewriting the original
+  ACs (the story's own convention is to record the delta).
+
+### [should-fix] 7. Three "two git calls" claims survived round 1
+
+- Files: `scripts/qs/quality_gate.py:1944-1945`,
+  `tests/test_quality_gate.py:4077`, `tests/test_quality_gate.py:71`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: round-1 nice-to-have 19 was only partially applied.
+  `docs/workflow/project-rules.md:39` was correctly changed to "a
+  handful of local git calls", but three claims survive:
+  - `quality_gate.py:1944-1945` — "the diff-cover spawn: two git calls
+    instead of 10.7-23.5 s of work";
+  - `tests/test_quality_gate.py:4077` — "(10.7–23.5 s → two git
+    calls)";
+  - `tests/test_quality_gate.py:71` — "ONE patch here silences **ALL
+    FOUR** git calls at that seat".
+
+  All three were missed because the literal is **line-wrapped**, so a
+  `grep "two git calls"` finds nothing — the same split-literal trap
+  the story itself calls out at `:292`. The path makes five calls
+  after must-fix 1 lands, and the story at `:122` explicitly says "a
+  fixed count does not belong here", so these contradict the story's
+  own resolution.
+- Proposed fix: use non-numeric wording, as `project-rules.md:39`
+  already does. Search with a whitespace-tolerant pattern (e.g.
+  `grep -rn "two[[:space:]]\+git" --include=*.py --include=*.md .`
+  plus a wrapped-literal sweep for `git calls`), not a plain string
+  grep.
+
+### [should-fix] 8. The PR body Summary describes pre-fix behaviour
+
+- Target: PR #323 body (not a file — `gh pr edit` at finish time)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: two Summary statements are captures from before
+  `684c556e`:
+  - the **S-4** bullet claims "10.7–23.5 s → two git calls";
+  - the **S-7** bullet quotes as live evidence
+    `diff base: fetch skipped (FETCH_HEAD 2m old)` — a string the code
+    can no longer emit. It now prints
+    `fetch skipped (origin/main fetched 2m ago)`, pinned by
+    `tests/test_quality_gate.py:3020`.
+  The body is the artifact a merge reviewer reads, so stale evidence
+  there is worse than stale prose in a story file.
+- Proposed fix: refresh both bullets before merge. Prefer re-running
+  the gate and pasting real current output over hand-editing the
+  quoted line.
+
+### [nice-to-have] 9. `_workers_env_is_explicit` has an unreachable branch
+
+- File: `scripts/qs/quality_gate.py:298-318`
+- Source: qs-review-blind-hunter
+- Description: the `val == "" or val == "0"` → `True` branch is
+  unreachable from `_resolve_files_workers`, because the
+  `workers is None` return fires first. The docstring's decision table
+  credits explicitness for the `0` → serial behaviour it does not
+  actually implement.
+- Proposed fix: either route the `0` case through this function so the
+  table becomes true, or correct the table. Do not simply delete the
+  branch — AC8 requires `0` → serial on a large target, which is
+  currently satisfied by the earlier return.
+
+### [nice-to-have] 10. The `--quick` banner promises xdist unconditionally
+
+- File: `scripts/qs/quality_gate.py:2942`
+- Source: qs-review-blind-hunter
+- Description: `"xdist above {N} tests"` is printed unconditionally,
+  so it still promises xdist when xdist is absent or
+  `QS_QG_PYTEST_WORKERS=0` — the same over-claim this PR removes from
+  the `"xdist + sysmon"` wording elsewhere.
+- Proposed fix: make the banner conditional on xdist actually being
+  available and not explicitly disabled.
+
+### [nice-to-have] 11. The denominator can be seeded from a non-progress line
+
+- File: `scripts/qs/quality_gate.py:555` (`_COUNT_SUFFIX_RE`), `:784`
+  (`_stream_pytest` learn block)
+- Source: qs-review-blind-hunter and qs-review-edge-case-hunter
+  (converging on the same defect from two directions)
+- Description: the regex strips **any** trailing `[N/M]`, and the
+  learn block latches the **first** line anywhere in the stream
+  matching that shape (guarded by `total_tests == 0`) rather than the
+  first *progress* line. Collection errors print before any progress
+  line, so a traceback or source line ending in that shape — e.g.
+  `RATIO = SCALE[1/2]`, or a parametrize id like `test_x[1/2]` echoed
+  at end-of-line — sets a bogus denominator for the whole run, and
+  `_clean_pytest_line` mangles the display of such ids. Cosmetic only:
+  the verdict still comes from `proc.returncode`. But the progress
+  line can then read `pytest: 100% (2/2)` for a 40-test run.
+- Proposed fix: restrict the learn search to lines that are
+  all-progress-characters after `_clean_pytest_line`.
+
+### [nice-to-have] 12. The non-`.py` exit now precedes the no-base check
+
+- File: `scripts/qs/quality_gate.py:1953-1965` (`check_impacted`)
+- Source: qs-review-blind-hunter
+- Description: because the early exit is evaluated before
+  `_resolve_diff_base`, a docs-only PR in CI with an unresolvable base
+  now returns 0 instead of the diagnostic exit 4. Defensible — the
+  verdict genuinely is vacuous — but it is a silent behaviour change
+  on the CI branch.
+- Proposed fix: record it in the `check_impacted` docstring next to
+  the existing ordering rationale.
+
+### [nice-to-have] 13. Merge-base is computed before the fetch
+
+- File: `scripts/qs/quality_gate.py:1953` (`check_impacted`)
+- Source: qs-review-edge-case-hunter
+- Description: the early exit computes its merge-base *before*
+  `_resolve_diff_base`'s fetch, so the two can disagree when the fetch
+  rewrites `origin/main`'s history. An advance is safe (an older
+  merge-base yields a larger set), but a **force-push/rebase of
+  `main`** can move the post-fetch merge-base backwards, adding `.py`
+  files to diff-cover's range that the pre-fetch set never contained.
+  Bounded and rare.
+- Proposed fix: a docstring caveat beside the existing "scoped to the
+  merge-base" argument. Do **not** reorder the fetch — that would
+  reintroduce the fetch cost the early exit exists to avoid.
+
+### [nice-to-have] 14. A test docstring contradicts its own assertion
+
+- File: `tests/test_quality_gate.py`
+  (`test_shallow_clone_warning_is_not_duplicated_by_the_retry`)
+- Source: qs-review-blind-hunter
+- Description: the docstring says the line "must not print twice for
+  one invocation" while the assertion requires exactly 2 (one per
+  candidate ref). The real intent survives only in the failure
+  message.
+- Proposed fix: reword the docstring to match what is asserted —
+  one warning per candidate ref, not one per invocation.
+
+### [nice-to-have] 15. Docstrings cite review-artifact indices
+
+- Files: `scripts/qs/quality_gate.py`, `tests/test_quality_gate.py`
+  (several sites, e.g. `:302`, `:1268`)
+- Source: qs-review-blind-hunter
+- Description: comments repeatedly cite "review-fix #01 nice-to-have
+  11 / 14 / 17". That numbering is meaningless to anyone reading the
+  code once the review artifact is out of view, and this plan adds a
+  second numbering namespace that will collide with it.
+- Proposed fix: state the rationale directly and drop the index. Keep
+  the `QS-290` / story references, which are stable and discoverable.
+
+---
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. Work must-fix 1
+first — it is the only verdict-changing defect, and its docstring
+consequences overlap nice-to-have 12. Then the `_collect_test_count`
+pair (should-fix 4 + 5), then the remaining code items, and finally
+the documentation-drift cluster (should-fix 6, 7 and the PR-body edit
+8) once the code has stopped moving.
+
+For should-fix 7 specifically: **do not verify with a plain string
+grep** — all three surviving instances were missed in round 1 because
+the literal is line-wrapped.
+
+When done, return and run `/review-task` again. Round 3 should also
+recover the CodeRabbit pass that was rate-limited out of round 2.

--- a/docs/stories/QS-290.story_review_fix_#03.md
+++ b/docs/stories/QS-290.story_review_fix_#03.md
@@ -1,0 +1,413 @@
+# QS-290 — Review fix plan #03
+
+## Summary
+- Source PR: #323
+- Source story: `docs/stories/QS-290.story.md`
+- Prior fix plans: `#01` (applied in `684c556e`), `#02` (applied in
+  `bd81a13e` + `f21f4dac`)
+- Findings to fix: 16 (1 must-fix, 6 should-fix, 9 nice-to-have)
+- Next implement phase: `/implement-setup-task`
+
+All touched paths — `scripts/qs/quality_gate.py`,
+`tests/test_quality_gate.py`, `docs/workflow/project-rules.md`,
+`docs/stories/QS-290.story.md` — are under dev-environment prefixes.
+
+Round-2 status: every round-2 finding is resolved, including the three
+documentation-traceability items and the deferred PR-body edit (the
+body now quotes only strings the current code can actually emit). All
+13 ACs still trace to code and tests; CI is green.
+
+### Closed with evidence: there is no fourth git variant
+
+`_impacted_early_exit_paths` failed open three times across rounds 1–2,
+each time because its hand-derived change set was narrower than
+diff-cover's. Round 3 settled the question rather than waiting for a
+fourth counterexample. diff-cover 10.3.0's range was enumerated **from
+source** (`diff_reporter.py::_get_included_diff_results`,
+`src_paths_changed`, `git_diff.py`) against the argv the gate actually
+builds: it consults exactly four git invocations —
+`diff -U0 <base>...HEAD`, `diff -U0 --cached`, `diff -U0`, and
+`ls-files --others`. The gate's four rungs `{MB→W, MB→HEAD, MB→INDEX,
+untracked}` are a path-level superset by set algebra, confirmed by 25
+hand-built real-git scenarios (intent-to-add, `rm --cached`, renames
+across extensions, unresolved merge conflicts, `--assume-unchanged`,
+`--skip-worktree`, mode-only changes, symlinks, orphan branches,
+detached HEAD, criss-cross merge-base ambiguity) **and** a 120-trial
+randomized differential fuzz over independent
+`(merge-base, HEAD, index, worktree)` content. Zero divergences.
+
+**Do not re-litigate the git rungs in a future round.** If a fifth rung
+is ever proposed, it needs a counterexample this enumeration missed.
+
+### CodeRabbit: unavailable, and not self-resolving
+
+CodeRabbit has produced no data since `ff39ac10`. Round 3 triggered a
+review and received a **newly created** `Review rate limited` status ten
+seconds later — an account-level cap, not the 60-minute cooldown
+assumed in round 2. Waiting will not fix it. Note also that four stale
+CodeRabbit inline comments now display `commit_id: f21f4dac` because
+GitHub re-anchors still-valid line comments forward as a PR advances;
+their `original_commit_id` is from Aug 1. They must not be read as
+current findings. This PR is proceeding on three-reviewer coverage
+unless the billing cap is lifted.
+
+### Ordering note
+
+The must-fix and should-fix 1 are two halves of the same defect (both
+concern what the early exit skips in the testmon layer) — do them
+together. Should-fix 4 and nice-to-have 11 both touch the `--quick`
+banner. Nice-to-have 15 (story Design section) should come last, after
+the rung/claim wording has settled.
+
+---
+
+## Findings to fix
+
+### [must-fix] 1. The early exit is a verdict change on a cold testmon baseline
+
+- File: `scripts/qs/quality_gate.py:2050` (`check_impacted`), plus the
+  false claim at `:2044-2048`, `docs/workflow/project-rules.md:159-160`,
+  and the guard test at `tests/test_quality_gate.py:6451`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter (proven with this repo's own
+  venv/testmon; ordering independently confirmed by the orchestrator)
+- Description: the early exit rests on **two** premises — "no `.py` in
+  the change set" and "testmon fingerprints AST blocks in `.py` files
+  only, so this run could never select a test". The second premise is
+  **false whenever `.testmondata` is cold**: with no baseline, testmon
+  select-alls. Proven against real testmon in an isolated repo with
+  only a non-`.py` file touched:
+
+  ```
+  COLD (no .testmondata), note.txt changed  -> ..  2 passed     # select-all
+  WARM,                   note.txt changed  ->    no tests ran  # 0 selected
+  COLD again (DB removed),note.txt changed  -> ..  2 passed     # select-all
+  ```
+
+  So the pre-PR run genuinely executed the whole suite and could exit
+  **1**; post-PR it returns **0** having run nothing. That is a verdict
+  change, not a cost shift — the same fail-open family as rounds 1–3,
+  one layer over from git.
+
+  Reproduces when: in a fresh worktree (or right after
+  `_ensure_testmon_db_safe` purges a corrupt / schema-mismatched DB, or
+  after `_purge_testmon_db`), make a change set with **no `.py` file**
+  that breaks a doc-pinned test — e.g. delete the string
+  `exits early and checks **nothing**` from
+  `docs/workflow/project-rules.md`, which
+  `TestProjectRulesDocGuards::test_non_python_early_exit_documented`
+  asserts; or edit `.claude/agents/qs-implement-setup-task.md`, pinned
+  by this PR's own `tests/qs/agents/test_impacted_non_py_honesty.py`.
+  Pre-PR: select-all runs, the guard fails, `_IMPACTED_TESTS_FAILED` →
+  exit 1. Post-PR:
+  `[impacted] PASS (no Python files changed - diff-coverage is vacuous)`
+  → exit 0.
+
+  The irony is load-bearing: **this PR's own guard tests are exactly
+  the tests that a cold-baseline doc-only change would stop running.**
+- Proposed fix (code): gate the early exit on the same warm-baseline
+  signal already computed 30 lines below at `:2082`
+  (`TESTMON_DATA.stat().st_size > 0`, with the existing `OSError` →
+  non-incremental tolerance). A cold baseline must fall through to the
+  full pass exactly as before. Hoist that probe above the seam and
+  reuse it — do not duplicate the logic.
+- Proposed fix (prose — **not optional**): three places currently
+  assert the false claim and must be corrected together, or the repo
+  keeps asserting something untrue:
+  - `quality_gate.py:2044-2048` — "That is a cost shift, not a verdict
+    change — the stale-DB run's verdict was equally vacuous."
+  - `docs/workflow/project-rules.md:159-160` — "changes cost, never a
+    verdict: the stale-DB run's verdict was equally vacuous, and a
+    stale baseline is always safe — it over-selects." Over-selecting is
+    precisely what makes it **not** vacuous: over-selected tests can
+    fail.
+  - the story's corresponding claim.
+- Caution: `TestProjectRulesDocGuards::test_non_python_early_exit_documented`
+  (`tests/test_quality_gate.py:6451`) **pins** the project-rules
+  wording. Update the guard alongside the prose, or it will either
+  fail or — worse — keep pinning a claim now known to be false.
+- Test: a real-testmon (or faithfully faked) case asserting that with a
+  cold/absent `.testmondata` and a non-`.py` change set, the early exit
+  does **not** fire and the impacted pass runs. Pair it with the warm
+  case asserting the exit still fires, so the fast path is not silently
+  disabled.
+
+### [should-fix] 2. Testmon DB hygiene never runs on a non-`.py` change set
+
+- File: `scripts/qs/quality_gate.py:2050`, `:1917`
+  (`_ensure_testmon_db_safe` inside `_run_impacted_pass`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: a corollary of the must-fix with its own lifetime.
+  Because the early exit precedes `_run_impacted_pass`,
+  `_ensure_testmon_db_safe()` never runs on a non-`.py` change set, so
+  a corrupt / schema-mismatched `.testmondata` is neither detected nor
+  purged. Reproduces when `.testmondata` is left corrupt by a killed
+  run and the developer then makes only doc/agent-file edits for a
+  stretch: every one of those runs returns 0 in milliseconds, the DB
+  stays corrupt, and the *first* subsequent `.py` run pays the purge
+  plus a full select-all with `_reset_coverage_data()`.
+  `_clean_orphan_cov_shards()` was correctly hoisted above the exit at
+  `:2034` (AC3); the testmon-DB hygiene was not.
+- Proposed fix: hoist `_ensure_testmon_db_safe()` above the seam too,
+  alongside the shard cleanup. Note AC3's test asserts the hygiene
+  ordering via `attach_mock` — extend it rather than write a parallel
+  one.
+
+### [should-fix] 3. The collect probe's timeout path leaves an unreaped child
+
+- File: `scripts/qs/quality_gate.py:719`
+- Severity: should-fix
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+  (independently; confirmed by the orchestrator)
+- Description: on `TimeoutExpired` the code calls `count_proc.kill()`
+  and returns immediately — no `communicate()` / `wait()` after the
+  kill. The child is left unreaped and both `PIPE` fds stay open for
+  the rest of the gate; CPython then emits
+  `ResourceWarning: subprocess N is still running` at GC, on stderr, in
+  the middle of gate output. Reproduces when a cold whole-tree
+  `--collect-only` exceeds `_COLLECT_TIMEOUT_SECONDS = 60` — the
+  docstring itself notes a cold collection legitimately takes 3–6 s, so
+  a loaded machine or a cold network worktree gets there.
+- Proposed fix: the standard idiom, `proc.kill(); proc.communicate()`.
+  The documented intent ("the child is killed so it cannot outlive the
+  gate") needs the second call to actually hold.
+
+### [should-fix] 4. `_COLLECTED_RE` cannot parse pytest's deselection form
+
+- File: `scripts/qs/quality_gate.py:664`, used at `:726`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter (confirmed by the orchestrator)
+- Description: the regex is `(\d+) tests? collected` and is applied
+  with `.match()`, which anchors at position 0. Verified against this
+  venv's pytest:
+
+  ```
+  '3 tests collected in 0.00s'                   match=True   search=True
+  '1/3 tests collected (2 deselected) in 0.00s'  match=False  search=True
+  ```
+
+  On any collection-time deselection the count parse returns `None`,
+  `_resolve_files_workers` therefore always answers `-n auto`, and
+  **the entire S-1 serial fast path silently stops existing** — no
+  warning, no symptom other than the lost seconds this story exists to
+  save. Reproduces when an `-m "not slow"` / `-k` is added to
+  `pytest.ini`'s `addopts` (the file already declares a `slow` marker),
+  or a `pytest_collection_modifyitems` deselect hook appears in a
+  conftest. Nothing in the repo triggers it today, which is exactly why
+  the regression would go unnoticed.
+- Proposed fix: handle the `N/M tests collected` form explicitly —
+  the selected count is the numerator. Use `.search()` or anchor on the
+  optional `\d+/` prefix; do not simply switch to `.search()` without
+  deciding which number is wanted. Test both forms.
+
+### [should-fix] 5. The `--quick` banner warns twice and over-claims its rule
+
+- File: `scripts/qs/quality_gate.py:3041` (banner),
+  `:298-318`/`:320-368` (`_pytest_workers` / `_resolve_files_workers`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter (2 findings),
+  qs-review-edge-case-hunter (1) — merged, same site
+- Description: two defects in the same banner.
+  - `_pytest_workers()` is now invoked once to word the banner and
+    again inside `_resolve_files_workers`, so a malformed
+    `QS_QG_PYTEST_WORKERS` prints
+    `[pytest] invalid QS_QG_PYTEST_WORKERS='autoo', falling back to
+    "auto"` **twice**. Reproduces with
+    `QS_QG_PYTEST_WORKERS=autoo python scripts/qs/quality_gate.py
+    --quick tests/qs`.
+  - `xdist above {_SERIAL_MAX_TESTS} tests` is printed whenever
+    `_pytest_workers()` is non-None, but an *explicit* valid value
+    bypasses the threshold entirely: `QS_QG_PYTEST_WORKERS=4 --quick
+    tests/test_foo.py` prints `xdist above 50 tests` while
+    `_resolve_files_workers`' first rung returns `-n 4` regardless of
+    the count. The banner describes a decision rule the run does not
+    use — the same over-claim class this PR removes elsewhere.
+- Proposed fix: compute the worker decision once and pass it down;
+  word the banner from the decision actually taken.
+
+### [should-fix] 6. The ui-only scope reason lost a load-bearing word
+
+- File: `scripts/qs/quality_gate.py` (`_detect_scope`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: the ui-only reason changed from `..., N total)` to
+  `..., N files)`. `(2 UI assets, 3 files)` now reads as 3 files
+  *besides* the 2 UI assets, where the intent is 3 files in total. The
+  dropped word was carrying the meaning.
+- Proposed fix: restore "total" (or reword so the relationship is
+  unambiguous). Check the pluralization tests added for AC10 still
+  pin the final wording.
+
+### [should-fix] 7. The amendment note miscounts the rungs it exists to correct
+
+- File: `docs/stories/QS-290.story.md:441`, `:122`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: the amendment block added in round 2 states "The
+  early-exit union now has **five**", but `_impacted_early_exit_paths`
+  has **four listing rungs** and issues **six git calls**
+  (`rev-parse --verify` ×1–2, `merge-base`, then `diff <mb>`,
+  `diff <mb> HEAD`, `diff --cached <mb>`, `ls-files --others`) —
+  neither of which is five. The same stale five appears at `:122`
+  ("five as implemented"). This is the third round running that a
+  hardcoded git-call count has gone stale, and it is now stale *inside
+  the very paragraph* arguing "deliberately no fixed count anywhere in
+  the code".
+- Proposed fix: replace both with the rung **names**, or with the
+  non-numeric wording already adopted everywhere else. Given the
+  track record, prefer naming the rungs — a name cannot drift the way
+  a count does.
+
+### [nice-to-have] 8. The early-exit git calls are unbounded
+
+- File: `scripts/qs/quality_gate.py:1607`
+- Source: qs-review-edge-case-hunter
+- Description: the five `_run` git calls are the only unbounded
+  subprocesses left on the `--impacted` hot path, against this file's
+  own stated invariant (`_COLLECT_TIMEOUT_SECONDS`,
+  `_FETCH_TIMEOUT_SECONDS`, `_DIFF_COVER_TIMEOUT_SECONDS` all exist
+  because "nothing on the inner-loop hot path may block
+  indefinitely"). Reproduces on a slow network mount:
+  `git diff <merge-base>` lstats every tracked file and
+  `git ls-files --others` walks the whole tree.
+- Proposed fix: one keyword argument — a timeout maps to rc 124, which
+  the existing `returncode != 0` branch already turns into the correct
+  fail-closed `None`.
+
+### [nice-to-have] 9. Mid-run progress never prints for small selections
+
+- File: `scripts/qs/quality_gate.py:812`
+- Source: qs-review-edge-case-hunter
+- Description: pytest right-aligns the `[N/M]` suffix at ~column 74 and
+  only flushes a progress line when it is full, so on any selection
+  under ~72 tests the first (and only) progress line arrives **after
+  the run is over**. `total_tests` stays 0 for the whole run,
+  `milestone_every` stays at the 50 fallback, and nothing prints
+  mid-run. The terminal `done (N/M)` is still correct (`denom` falls
+  back to `final_total`), so this is presentation only — but it means
+  the S-5 denominator is, in the common inner-loop case, never
+  actually used mid-run.
+- Proposed fix: none required beyond honesty; if the mid-run signal is
+  wanted for small runs, it needs a different source than the
+  right-aligned suffix. At minimum, do not claim mid-run progress that
+  does not appear.
+
+### [nice-to-have] 10. Duplicate docstring heading
+
+- File: `scripts/qs/quality_gate.py` (`_resolve_files_workers`)
+- Source: qs-review-blind-hunter
+- Description: `Decision order:` is immediately followed by
+  `Checked in this order — the order matters, and the table is the
+  contract:` — a leftover duplicate heading from the fix-plan edits.
+- Proposed fix: keep one.
+
+### [nice-to-have] 11. Docstrings narrate their own edit history
+
+- File: `scripts/qs/quality_gate.py` (throughout)
+- Source: qs-review-blind-hunter
+- Description: several docstrings now recount review-thread context —
+  `this docstring previously claimed "no stderr warning"`,
+  `The previous max(0.0, …) clamped…`, `four reviewers rejected
+  re-splitting`. That is provenance, not API contract, and will read as
+  noise to the next maintainer.
+- Proposed fix: state the current contract; move the rationale to the
+  commit message or drop it. Keep the `QS-290` references, which are
+  stable and discoverable — and note this overlaps round-2
+  nice-to-have 15 (dropping review-artifact indices), which was about
+  the same instinct.
+
+### [nice-to-have] 12. The early exit taxes every `--impacted` run
+
+- File: `scripts/qs/quality_gate.py` (`check_impacted`)
+- Source: qs-review-blind-hunter
+- Description: `_impacted_early_exit_paths()` adds ~6 git subprocesses
+  — plus a second merge-base resolution that `_resolve_diff_base` then
+  redoes — to *every* `--impacted` run, including the `.py` runs where
+  the exit can never fire. A small tax on the hot path this story
+  exists to speed up.
+- Proposed fix: consider reusing the merge-base between the two
+  resolvers. Measure before optimizing — the git calls are local and
+  cheap, and correctness here has already cost three rounds, so do not
+  trade any of it for microseconds.
+
+### [nice-to-have] 13. Stale test-class docstring
+
+- File: `tests/test_quality_gate.py`
+  (`TestStreamPytestLearnsDenominator`)
+- Source: qs-review-blind-hunter
+- Description: says "with `total_tests=0`"; every test in the class now
+  passes `_LEARN_FROM_STREAM`. Stale since the sentinel change.
+- Proposed fix: update the docstring.
+
+### [nice-to-have] 14. Mislabeled parametrize ids
+
+- File: `tests/test_quality_gate.py`
+  (`test_stream_pytest_surfaces_raw_returncode`)
+- Source: qs-review-blind-hunter
+- Description: `ids=["failures", "collect-error", "internal"]` for
+  `rc=[1, 2, 5]` mislabels them — 5 is "no tests collected", 2 is
+  "interrupted". The sibling `test_other_nonzero_codes_stay_unknown`
+  gets the same mapping right, so the file contradicts itself.
+- Proposed fix: correct the ids to match pytest's actual exit codes.
+
+### [nice-to-have] 15. A type annotation that collapses to `object`
+
+- File: `tests/test_quality_gate.py` (`_patch_early_exit`)
+- Source: qs-review-blind-hunter
+- Description: `paths: list[str] | None | object` collapses to plain
+  `object`, so the annotation documents intent but provides no
+  checking. `Union[list[str], None, Literal[_KEEP_PY]]` is not
+  expressible for a sentinel object.
+- Proposed fix: a plain `object` with an explanatory comment is more
+  honest than a union that reads as precise and is not.
+
+### [nice-to-have] 16. Two story Design-section spots describe the old rung set
+
+- File: `docs/stories/QS-290.story.md:168-175`, `:335`
+- Source: qs-review-acceptance-auditor
+- Description: not covered by the amendment block, which scopes itself
+  to the AC list. `:168-175` is the four-item numbered sketch (no
+  committed range, no `--cached` rung, no `-z`); `:335` says "with
+  `_run` patched wholesale, the four git calls return rc≠0". Both are
+  historical planning text and the code docstring is now the accurate
+  and far richer source.
+- Proposed fix: a one-line pointer from §1 to the implementation
+  docstring, rather than trying to keep the sketch in sync — that
+  syncing is what has drifted three rounds running.
+
+---
+
+## Invalid / not fixed
+
+- **`E501` on the long docstring lines** (qs-review-blind-hunter,
+  should-fix). Invalid — `E501` is explicitly in `pyproject.toml`'s
+  `ignore` list ("line too long (handled by formatter)"),
+  `ruff check` passes clean on both files, and `check_ruff_lint` lints
+  only `SRC_DIR`, so `scripts/` is never linted by the gate at all. CI
+  ruff is green. The reviewer self-flagged this as assumed without repo
+  context.
+- **Missing `io` import in `tests/test_quality_gate.py`**
+  (qs-review-blind-hunter, nice-to-have). Invalid — `io` is imported at
+  line 5, as are `os` (7), `re` (8), `subprocess` (12) and `time` (15).
+  This is the second round this same false positive has appeared; it is
+  a structural consequence of the blind reviewer having no repo access,
+  not a reviewer error.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan.
+
+Do the must-fix **and should-fix 2 together** — they are two halves of
+"what the early exit skips in the testmon layer", and the AC3 hygiene
+ordering test covers both. Remember the must-fix has a prose half in
+three files plus a guard test that pins the wording; a code-only fix
+leaves the repo asserting something false.
+
+Then should-fix 3–7, then the nice-to-haves. Leave nice-to-have 16
+(story Design section) last, once the rung wording has settled.
+
+When done, return and run `/review-task`. If round 4 is clean, the
+next phase is `/finish-task` — note that CodeRabbit will still be
+absent unless the account cap is lifted, so the merge decision rests on
+three-reviewer coverage plus green CI.

--- a/docs/stories/QS-290.story_review_fix_#04.md
+++ b/docs/stories/QS-290.story_review_fix_#04.md
@@ -1,0 +1,164 @@
+# QS-290 — Review fix plan #04 (final, closing)
+
+## Summary
+- Source PR: #323
+- Findings to fix: **4** — everything else from round 3 is closed
+  **won't-fix** below.
+- Next implement phase: `/implement-setup-task`
+- Intent: **close this PR out.** No rewording, no doc-count edits, no
+  docstring cleanup. Only defects that change a verdict or silently
+  disable the feature this story ships.
+
+### Why this plan is short
+
+Rounds 1–3 produced 52 findings and three fix commits. A large share of
+those were prose items — restate a count, reword a docstring, drop an
+index — and each edit to that prose produced the *next* round's
+findings. The "five rungs" miscount has drifted three rounds running
+precisely because the sentence containing it keeps being rewritten. That
+loop is the cost, not the code.
+
+So: fix what is broken, change nothing that is merely imprecise, and
+stop.
+
+### Scope rule for this plan
+
+Touch `scripts/qs/quality_gate.py` and `tests/test_quality_gate.py`
+only, plus the two prose spots item 1 genuinely requires. **Do not**
+open the story file. **Do not** reword anything not listed here, even
+if it is wrong — see won't-fix.
+
+---
+
+## Findings to fix
+
+### 1. [must-fix] Cold testmon baseline makes the early exit a verdict change
+
+- File: `scripts/qs/quality_gate.py:2050` (`check_impacted`)
+- Source: qs-review-edge-case-hunter (proven against real testmon)
+
+The early exit assumes testmon "could never select a test" for a
+non-`.py` change set. That is false when `.testmondata` is cold —
+testmon then select-alls:
+
+```
+COLD (no .testmondata), note.txt changed  -> ..  2 passed     # select-all
+WARM,                   note.txt changed  ->    no tests ran  # 0 selected
+```
+
+A doc-only change that breaks a doc-pinned guard test exited **1**
+before this PR and returns **0** after it. That is a false PASS in a
+quality gate — the one defect class that must not ship. Note this PR's
+own guard tests (`test_impacted_non_py_honesty.py`,
+`TestProjectRulesDocGuards`) are exactly the tests a cold-baseline
+doc-only change would stop running.
+
+**Fix:** gate the early exit on the warm-baseline signal already
+computed 30 lines below at `:2082`
+(`TESTMON_DATA.stat().st_size > 0`, with its existing `OSError` →
+non-incremental tolerance). Hoist that probe above the seam and reuse
+it. Cold baseline falls through to the full pass, exactly as before.
+
+**Required prose (only because it is now provably false, and a test
+pins it):**
+- `quality_gate.py:2044-2048` — "a cost shift, not a verdict change".
+- `docs/workflow/project-rules.md:159-160` — "changes cost, never a
+  verdict … a stale baseline is always safe — it over-selects."
+  Over-selecting is what makes it *not* vacuous: over-selected tests
+  can fail.
+- `TestProjectRulesDocGuards::test_non_python_early_exit_documented`
+  (`tests/test_quality_gate.py:6451`) pins that wording — update the
+  guard in the same commit or it pins a false claim.
+
+Keep both edits to the minimum that makes the sentence true. Do not
+restructure the surrounding paragraphs.
+
+**Test:** cold/absent `.testmondata` + non-`.py` change set → exit does
+**not** fire; warm + non-`.py` → exit still fires (so the fast path is
+not silently disabled).
+
+### 2. [should-fix] Hoist `_ensure_testmon_db_safe` with the same edit
+
+- File: `scripts/qs/quality_gate.py:2050`, `:1917`
+
+Same seam, same commit. Because the exit precedes `_run_impacted_pass`,
+DB hygiene never runs on a non-`.py` change set, so a corrupt
+`.testmondata` is never purged — the developer doing a doc-only stretch
+keeps returning 0 in milliseconds while the DB stays broken.
+`_clean_orphan_cov_shards()` was already hoisted above the seam at
+`:2034`; this is the one that was missed. Extend the existing AC3
+`attach_mock` ordering test rather than adding a parallel one.
+
+### 3. [should-fix] Reap the killed collect probe
+
+- File: `scripts/qs/quality_gate.py:719`
+
+`count_proc.kill()` then `return None`, with no `communicate()` — the
+child is unreaped and both pipes stay open, so CPython prints
+`ResourceWarning: subprocess N is still running` into the middle of
+gate output. One line: `proc.kill(); proc.communicate()`.
+
+### 4. [should-fix] `_COLLECTED_RE` cannot parse the deselection form
+
+- File: `scripts/qs/quality_gate.py:664`, used at `:726`
+
+```
+'3 tests collected in 0.00s'                   match=True   search=True
+'1/3 tests collected (2 deselected) in 0.00s'  match=False  search=True
+```
+
+`.match()` anchors at position 0 and dies on the `3/` prefix →
+`_collect_test_count` returns `None` → `_resolve_files_workers` always
+answers `-n auto` → **the serial fast path this story exists to deliver
+silently stops existing.** No warning, no symptom but the lost seconds.
+Triggered by any `-k`/`-m` in `pytest.ini`'s `addopts` (a `slow` marker
+is already declared) or a `pytest_collection_modifyitems` deselect hook.
+
+Handle the `N/M tests collected` form; the selected count is the
+**numerator**. Test both forms.
+
+---
+
+## Won't-fix — closed, do not reopen
+
+These are recorded as deliberate decisions. Round-4 reviewers will
+likely re-report some; that is expected and the correct triage response
+is **skip**.
+
+| # | Finding | Why closed |
+| --- | --- | --- |
+| R3-5 | `--quick` banner warns twice / over-claims threshold | Cosmetic stderr on a malformed env var. Fixing it means touching the worker-decision plumbing again — the exact churn that generated rounds 2 and 3. |
+| R3-6 | `_detect_scope` `N files` vs `N total` | Wording. Ambiguous, not wrong. |
+| R3-7 | Story amendment says "five" rungs (really 4 rungs / 6 calls) | **The count has drifted three rounds because we keep rewriting it.** Editing it a fourth time is the bug, not the fix. The code docstring is accurate; the story is a historical artifact. |
+| R3-8 | Early-exit git calls unbounded | Local git on a local worktree. Real but hypothetical (slow network mount). File separately if it ever bites. |
+| R3-9 | No mid-run progress under ~72 tests | Presentation only; `done (N/M)` is correct. |
+| R3-10 | Duplicate docstring heading | Cosmetic. |
+| R3-11 | Docstrings narrate edit history | Cosmetic, and rewriting docstrings is a churn generator. |
+| R3-12 | Early exit taxes `.py` runs with ~6 git calls | Correctness here cost three rounds. Do not trade it for microseconds. |
+| R3-13 | Stale `TestStreamPytestLearnsDenominator` docstring | Cosmetic. |
+| R3-14 | Mislabeled parametrize ids (rc 1/2/5) | Cosmetic. |
+| R3-15 | `_patch_early_exit` annotation collapses to `object` | Cosmetic. |
+| R3-16 | Story Design section describes old rung set | Historical planning text; code docstring is the live source. |
+
+Also closed, from round 3:
+
+- **No fourth git-plumbing variant exists.** diff-cover 10.3.0's range
+  was enumerated from source and checked against the four rungs via 25
+  real-git scenarios and a 120-trial differential fuzz — zero
+  divergences. Do not re-litigate the rungs without a counterexample
+  that enumeration missed.
+- **Two invalid findings** will likely recur: `E501` (explicitly in
+  `pyproject.toml`'s `ignore`; the gate lints `SRC_DIR` only) and a
+  missing `io` import (present at line 5). Both are artifacts of the
+  blind reviewer having no repo access.
+
+---
+
+## How to apply
+
+One commit. Items 1 and 2 are the same seam — do them together. Items 3
+and 4 are one line each plus tests.
+
+Then `/review-task` once more. **Expect** the won't-fix list to
+re-surface; triage those as skip. If nothing new and verdict-changing
+appears, go to `/finish-task`.

--- a/docs/stories/QS-290.story_review_fix_#05.md
+++ b/docs/stories/QS-290.story_review_fix_#05.md
@@ -1,0 +1,183 @@
+# QS-290 — Review fix plan #05 (closing)
+
+## Summary
+- Source PR: #323
+- Findings to fix: **4**
+- Deliberately deferred to a follow-up issue: **1** (state 3 below)
+- Next implement phase: `/implement-setup-task`
+- Intent: close the PR. Same rule as plan #04 — no rewording, no
+  docstring cleanup, no story-file edits. Only the items listed.
+
+Round 4 confirmed all four plan-#04 items are genuinely fixed, all 13
+ACs trace, and CI is green (619 + 700 tests). This plan closes the two
+cheap halves of the remaining defect and files the expensive half.
+
+### Scope rule
+
+Touch `scripts/qs/quality_gate.py`, `tests/test_quality_gate.py`, and
+the one prose sentence item 1b requires. Nothing else. The 12 won't-fix
+items from plan #04 stay closed.
+
+---
+
+## Findings to fix
+
+### 1a. [must-fix, partial] `-wal`/`-shm` alongside the primary means not-warm
+
+- File: `scripts/qs/quality_gate.py:1915` (`_testmon_baseline_warm`)
+- Source: qs-review-edge-case-hunter (reproduced against real testmon
+  2.2.0)
+
+`st_size > 0` is a proxy for "testmon has a usable baseline". The proxy
+is unsound in three states where the DB is non-empty **and** survives
+`_ensure_testmon_db_safe`, but testmon still select-alls — so the exit
+returns 0 where the pre-PR gate ran the suite. This item closes the two
+transient ones:
+
+1. **Interrupted testmon run.** A killed `pytest --testmon` /
+   `--seed-testmon` (Ctrl-C, OOM, sleep) leaves `.testmondata` 4096 B
+   plus stale `-wal`/`-shm`. `PRAGMA user_version` reads 14
+   (= `DATA_VERSION`), so hygiene does not purge, and the
+   orphan-sidecar branch at `:1706` only fires when the primary is
+   **absent** — which is not this state. Real testmon against that DB
+   with only `note.txt` changed: `4 passed` (select-all); control with
+   a cleanly seeded DB: `no tests ran`.
+2. **Concurrent rebuild.** A doc-only `--impacted` while a
+   `--seed-testmon` / `_rebuild_testmon_baseline` pass is in flight. At
+   t=2 s of a live seed the DB is 4096 B, `user_version` 14, 4
+   `test_execution` rows — warm and hygiene-clean — and a concurrent
+   doc-only `--testmon` run printed `4 passed`. On a 7 000-test suite
+   that window is minutes long.
+
+**Fix:** treat the presence of `-wal` or `-shm` **alongside** the
+primary as not-warm. One `exists()` pair, and it closes both states —
+an interrupted run and an in-flight rebuild both leave sidecars.
+
+Do **not** attempt the environment-fingerprint check here; that is
+item 1b's follow-up.
+
+**Test:** primary + `-wal` present → not warm → exit does not fire;
+primary alone → warm → exit fires. Note the existing `_warm_baseline`
+autouse fixture writes `b"warm-baseline"` (13 bytes, not a SQLite
+file), so it pins *size*, not usability — the new tests must not
+inherit that shortcut for the sidecar assertions.
+
+### 1b. [deferred] File the environment-fingerprint state as a follow-up
+
+- Source: same reviewer, same reproduction set (state 3)
+
+**Not fixed in this PR.** Installing/upgrading/removing any package, or
+a Python **micro** bump (3.14.3 → 3.14.4), changes testmon's
+environment fingerprint: `db.py:647-711` drops the old `environment`
+row and creates a fresh `exec_id` with no history, and testmon says so
+itself — *"The packages installed in your Python environment have been
+changed. All tests have to be re-executed."* (`pytest_testmon.py:336`).
+`st_size > 0` is True and `user_version` is 14 throughout.
+
+This state is **persistent**, not transient: because the exit never
+runs pytest, the fingerprint is never refreshed, so every doc-only run
+stays a false PASS until the next `.py` change set.
+
+Accepted for now because `--impacted` is the **local** pre-commit gate
+and CI runs the whole suite authoritatively on every PR, so the blast
+radius is a developer learning from CI instead of locally — not broken
+code reaching main.
+
+**Required:**
+- File a GitHub issue describing state 3, its reproduction, and the
+  reviewer's proposed check (require the `environment` row matching
+  `(environment_name, drop_patch_version(get_system_packages()),
+  f"{major}.{minor}.{micro}")` to exist with `test_execution` rows;
+  the `_testmon_schema_version()` subprocess probe already costs only
+  ~0.07 s, so the budget exists).
+- Cite the issue number in a one-line comment at
+  `_testmon_baseline_warm`.
+- **One sentence** of prose so the repo does not over-claim: the
+  non-`.py` early exit is verdict-neutral only while testmon's
+  baseline is usable, and a package-environment change can still make
+  it optimistic. Put it where the current claim lives
+  (`docs/workflow/project-rules.md`, the sentence plan #04 already
+  corrected) and update
+  `TestProjectRulesDocGuards::test_non_python_early_exit_documented`
+  if it pins the changed text. One sentence — do not restructure.
+
+### 2. [should-fix] Two tests run the hoisted hygiene helpers for real
+
+- File: `tests/test_quality_gate.py:3896`
+  (`test_no_base_in_ci_returns_4`), `:3905`
+  (`test_no_base_locally_warns_and_passes`)
+- Source: qs-review-blind-hunter (confirmed by the orchestrator)
+
+Both gained `_patch_early_exit()` but patch neither
+`_clean_orphan_cov_shards` nor `_ensure_testmon_db_safe`. Since both
+helpers were hoisted above the `base is None` return, they now execute
+for real against the live repo, where previously they were unreachable
+from these tests. The sibling `test_selected_tests_fail_returns_1`
+(`:3914`) patches `_ensure_testmon_db_safe`; these two were missed.
+
+This is not cosmetic: `_clean_orphan_cov_shards()` globs
+`.coverage.*` and unlinks, and its docstring justifies safety with
+"called BEFORE the pytest subprocess spawns, so it can never reap a
+live worker's shard mid-run (single-writer assumption)". Running it
+*inside* a suite that is itself executing under coverage + xdist
+violates exactly that assumption, so it can delete live worker shards
+of the run in progress. `_ensure_testmon_db_safe()` can additionally
+purge the real `.testmondata` on a schema mismatch.
+
+**Fix:** patch both helpers in these two tests, matching the sibling.
+
+### 3. [nice-to-have] Anchor `_COLLECTED_RE`
+
+- File: `scripts/qs/quality_gate.py:672`, used at `:753`
+- Source: qs-review-edge-case-hunter
+
+Plan #04 said "use `.search()` **or** anchor"; the implementation took
+`.search()`, which is unanchored, so a parametrized test **id** can
+satisfy the pattern before the real summary line. Verified:
+`@pytest.mark.parametrize("s", ["12/340 tests collected (328
+deselected)\n"])` produces an id the probe parses, returning 12 for a
+3-test file. Latent only because `TestCollectTestCount` currently pins
+`ids=[...]` — dropping that `ids=` silently corrupts both the worker
+decision and the progress denominator, with no symptom.
+
+**Fix:** `re.compile(r"^(?:(\d+)/)?(\d+) tests? collected")` with
+`.match(line.strip())`. Handles both forms and is immune, since real
+ids always start with the file path. (The loose guidance in plan #04
+is what opened this — anchoring was the right call.)
+
+### 4. [nice-to-have] Bound the reaping `communicate()`
+
+- File: `scripts/qs/quality_gate.py:734`
+- Source: qs-review-edge-case-hunter
+
+The reap added by plan #04 item 3 is unbounded. If collection leaves a
+grandchild holding the inherited stdout/stderr pipes (a conftest or
+plugin that spawns a helper at import), `SIGKILL` reaches only the
+direct child and the 60 s `_COLLECT_TIMEOUT_SECONDS` becomes an
+unbounded hang of the whole gate — a worse failure than the
+`ResourceWarning` the reap removes.
+
+**Fix:** `communicate(timeout=...)` with a short bound, swallowing a
+second `TimeoutExpired`. Keeps both the reap and the bound.
+
+---
+
+## Still closed — do not reopen
+
+The 12 won't-fix items from plan #04 remain closed, as do:
+
+- **No fourth git-plumbing variant** (round-3 source enumeration of
+  diff-cover 10.3.0 + 25 real-git scenarios + 120-trial fuzz, zero
+  divergences).
+- **`E501`** (in `pyproject.toml`'s `ignore`; the gate lints `SRC_DIR`
+  only) and the **`io` import** (present at line 5) — both recur every
+  round as artifacts of the blind reviewer having no repo access.
+
+## How to apply
+
+One commit. Item 1a is a two-line predicate change plus tests; item 2
+is two `patch.object` additions; items 3 and 4 are one line each.
+Item 1b is an issue plus one comment line and one sentence.
+
+Then `/review-task`. If nothing new and verdict-changing appears, go to
+`/finish-task`.

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -158,7 +158,11 @@ while it has a baseline: against a cold or purged one testmon
 select-alls, and those over-selected tests can fail. Skipping them would
 turn a real failure into a PASS, so a cold baseline falls through to the
 full run instead. On a warm baseline the deferred re-sync is a pure cost
-shift: the next `.py` run selects more tests than usual, once.
+shift: the next `.py` run selects more tests than usual, once. One gap
+remains (#341): after a package install/upgrade/removal or a Python
+micro bump, testmon resets its environment fingerprint and would
+select-all, but the baseline still looks warm — so a non-`.py` run can
+be optimistic there until the next `.py` change set.
 
 **Raw-`pytest` grammar rule.** Allowed: `pytest <path>::<nodeid> [-v]`
 — the positional argument MUST contain `::`. Forbidden as a habitual

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -35,6 +35,19 @@ all four; use it only for ad-hoc single-node debugging.
 # changed-line miss from an INCREMENTAL run it automatically rebuilds
 # the baseline and re-checks once — recovering from a drifted baseline
 # left by a killed run with NO manual file deletion ever required.
+# QS-290: a change set with NO .py file at all EXITS EARLY — no pytest,
+# no diff-cover, no `git fetch` (two git calls instead of 10-24 s).
+# testmon fingerprints AST blocks in .py files only, so such a run could
+# never select a test, and diff-cover has no Python lines to score: the
+# verdict was ALREADY vacuous, the exit only stops paying for it. The
+# change set is computed against the MERGE-BASE (committed + staged +
+# unstaged + untracked), a superset of diff-cover's three-dot range, and
+# any git failure fails CLOSED (no exit). See "non-Python change sets"
+# below for what to run instead.
+# QS-290: the `origin/main` fetch is TTL-cached on FETCH_HEAD's mtime
+# (10 min), so a TDD burst stops re-fetching. A stale base is OLDER, so
+# the changed-line set is a superset — a TTL hit can only turn a PASS
+# into a FAIL, never a FAIL into a PASS.
 python scripts/qs/quality_gate.py --impacted
 
 # Full quality gate (pytest 100% cov + ruff + mypy + translations;
@@ -56,7 +69,15 @@ python scripts/qs/quality_gate.py --fix
 python scripts/qs/quality_gate.py --json
 
 # Fast iteration on one or more EXPLICIT test paths (files or dirs).
-# Uses xdist + sysmon, skips coverage / ruff / mypy / translations.
+# Uses sysmon, skips coverage / ruff / mypy / translations.
+# QS-290: xdist is used only ABOVE a small-run threshold (50 collected
+# tests). At or below it the run is single-process — xdist's per-worker
+# collection re-imports the HA-heavy conftest and costs more than the
+# parallelism saves (43 tests: serial 11.5 s vs xdist 16.8 s). The
+# decision is announced on stderr. `QS_QG_PYTEST_WORKERS=auto` forces
+# xdist back; an explicit value of that var always wins over the
+# threshold, in both directions. Large targets (e.g. `tests/qs`, 680+
+# tests) keep `-n auto` unchanged.
 # The canonical TDD red/green/refactor command while you iterate on a
 # known test target; --impacted is the pre-commit gate that finds the
 # impacted tests for you.
@@ -105,6 +126,24 @@ coverage, self-heals a drifted baseline); `--quick` is for hammering
 an explicit test path you already know; `--cache` accelerates repeated
 *full*-gate runs. `--impacted` is mutually exclusive with
 `--quick`/`--cache`/`--no-cache`/`--full`/`--fix`.
+
+**Non-Python change sets — `--quick tests/qs` is the ONLY real check
+(QS-290).** When a change set contains no `.py` file at all (agent
+files, commands, workflow docs, `.j2` templates, JS/CSS assets),
+`--impacted` exits early and checks **nothing**: testmon fingerprints
+AST blocks in `.py` files only, so it could never select a test, and
+diff-cover has no Python lines to score. Its green is honest but
+empty — it was equally empty before the early exit, which merely
+stopped paying 10–24 s for it. So for such change sets
+`python scripts/qs/quality_gate.py --quick tests/qs` is not a
+supplement, it is **the** verification, and it stays mandatory.
+
+*Deferred baseline re-sync (accepted cost shift).* A non-`.py` run on a
+**stale** `.testmondata` used to select-all and re-sync the baseline as
+a side effect; it no longer does, so that re-sync is deferred to your
+next `.py` run (which will select more tests than usual, once). This
+changes cost, never a verdict: the stale-DB run's verdict was equally
+vacuous, and a stale baseline is always safe — it over-selects.
 
 **Raw-`pytest` grammar rule.** Allowed: `pytest <path>::<nodeid> [-v]`
 — the positional argument MUST contain `::`. Forbidden as a habitual

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -36,7 +36,8 @@ all four; use it only for ad-hoc single-node debugging.
 # the baseline and re-checks once — recovering from a drifted baseline
 # left by a killed run with NO manual file deletion ever required.
 # QS-290: a change set with NO .py file at all EXITS EARLY — no pytest,
-# no diff-cover, no `git fetch` (two git calls instead of 10-24 s).
+# no diff-cover, no `git fetch` — a handful of local git calls instead
+# of 10-24 s of work.
 # testmon fingerprints AST blocks in .py files only, so such a run could
 # never select a test, and diff-cover has no Python lines to score: the
 # verdict was ALREADY vacuous, the exit only stops paying for it. The
@@ -44,10 +45,16 @@ all four; use it only for ad-hoc single-node debugging.
 # unstaged + untracked), a superset of diff-cover's three-dot range, and
 # any git failure fails CLOSED (no exit). See "non-Python change sets"
 # below for what to run instead.
-# QS-290: the `origin/main` fetch is TTL-cached on FETCH_HEAD's mtime
-# (10 min), so a TDD burst stops re-fetching. A stale base is OLDER, so
-# the changed-line set is a superset — a TTL hit can only turn a PASS
-# into a FAIL, never a FAIL into a PASS.
+# QS-290: the `origin/main` fetch is TTL-cached (10 min) on FETCH_HEAD,
+# so a TDD burst stops re-fetching. A stale base is OLDER, so the
+# changed-line set is a superset — a TTL hit can only turn a PASS into a
+# FAIL, never a FAIL into a PASS. The skip is deliberately conservative:
+# it requires FETCH_HEAD to be non-empty (a FAILED fetch truncates it to
+# 0 bytes while still bumping the mtime), to actually record a `main`
+# fetch (a `gh pr checkout` or another-branch fetch rewrites it without
+# advancing origin/main), and to carry a non-future mtime (clock skew).
+# Any of those being off just means "fetch as usual". CI always bypasses
+# the TTL entirely.
 python scripts/qs/quality_gate.py --impacted
 
 # Full quality gate (pytest 100% cov + ruff + mypy + translations;
@@ -127,16 +134,23 @@ an explicit test path you already know; `--cache` accelerates repeated
 *full*-gate runs. `--impacted` is mutually exclusive with
 `--quick`/`--cache`/`--no-cache`/`--full`/`--fix`.
 
-**Non-Python change sets — `--quick tests/qs` is the ONLY real check
-(QS-290).** When a change set contains no `.py` file at all (agent
-files, commands, workflow docs, `.j2` templates, JS/CSS assets),
-`--impacted` exits early and checks **nothing**: testmon fingerprints
-AST blocks in `.py` files only, so it could never select a test, and
-diff-cover has no Python lines to score. Its green is honest but
-empty — it was equally empty before the early exit, which merely
-stopped paying 10–24 s for it. So for such change sets
-`python scripts/qs/quality_gate.py --quick tests/qs` is not a
-supplement, it is **the** verification, and it stays mandatory.
+**Non-Python change sets — `--quick` is the ONLY real check (QS-290).**
+When a change set contains no `.py` file at all, `--impacted` exits
+early and checks **nothing**: testmon fingerprints AST blocks in `.py`
+files only, so it could never select a test, and diff-cover has no
+Python lines to score. Its green is honest but empty — it was equally
+empty before the early exit, which merely stopped paying 10–24 s for it.
+So a `--quick` run is not a supplement there, it is **the**
+verification, and it stays mandatory. Which target depends on what
+changed — matching the hint the gate itself prints:
+
+| Non-Python change | Run |
+| --- | --- |
+| agent files, commands, workflow docs, `.claude/settings.json` | `python scripts/qs/quality_gate.py --quick tests/qs` |
+| `ui/*.j2` templates, `ui/resources/**` JS/CSS | `python scripts/qs/quality_gate.py --quick tests/test_dashboard_rendering.py` |
+
+(A failed git probe does **not** take the early exit — it fails closed
+and the full pipeline runs.)
 
 *Deferred baseline re-sync (accepted cost shift).* A non-`.py` run on a
 **stale** `.testmondata` used to select-all and re-sync the baseline as

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -152,12 +152,13 @@ changed — matching the hint the gate itself prints:
 (A failed git probe does **not** take the early exit — it fails closed
 and the full pipeline runs.)
 
-*Deferred baseline re-sync (accepted cost shift).* A non-`.py` run on a
-**stale** `.testmondata` used to select-all and re-sync the baseline as
-a side effect; it no longer does, so that re-sync is deferred to your
-next `.py` run (which will select more tests than usual, once). This
-changes cost, never a verdict: the stale-DB run's verdict was equally
-vacuous, and a stale baseline is always safe — it over-selects.
+*Cold baselines do not take the exit.* The exit requires a **warm**
+`.testmondata`, because "testmon could never select a test" is only true
+while it has a baseline: against a cold or purged one testmon
+select-alls, and those over-selected tests can fail. Skipping them would
+turn a real failure into a PASS, so a cold baseline falls through to the
+full run instead. On a warm baseline the deferred re-sync is a pure cost
+shift: the next `.py` run selects more tests than usual, once.
 
 **Raw-`pytest` grammar rule.** Allowed: `pytest <path>::<nodeid> [-v]`
 — the positional argument MUST contain `::`. Forbidden as a habitual

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -661,7 +661,18 @@ def _parse_pytest_output(text: str) -> dict[str, int]:
     return summary if summary is not None else tally
 
 
-_COLLECTED_RE = re.compile(r"(\d+) tests? collected")
+# pytest prints `N tests collected` normally, and `S/N tests collected
+# (D deselected)` whenever anything deselects — a `-k`/`-m` in `pytest.ini`'s
+# `addopts` (a `slow` marker is already declared here) or a
+# `pytest_collection_modifyitems` hook. Both forms verified against real pytest.
+# The optional leading group captures the SELECTED count, which is what actually
+# runs and therefore the only count the worker decision may use.
+#
+# This is matched with `.search`, not `.match`: anchoring at position 0 made the
+# `S/` prefix unparseable, so the probe returned None, `_resolve_files_workers`
+# always answered `-n auto`, and the serial fast path silently stopped existing
+# — no warning, no symptom but the lost seconds.
+_COLLECTED_RE = re.compile(r"(?:(\d+)/)?(\d+) tests? collected")
 
 # pytest's exit code for "no tests were collected" — a KNOWN zero, not a failure.
 _PYTEST_RC_NO_TESTS = 5
@@ -716,16 +727,21 @@ def _collect_test_count(targets: list[str]) -> int | None:
     try:
         count_stdout, _ = count_proc.communicate(timeout=_COLLECT_TIMEOUT_SECONDS)
     except subprocess.TimeoutExpired:
+        # Reap it. `kill()` alone leaves the child unwaited with both pipes
+        # open, so CPython emits `ResourceWarning: subprocess N is still
+        # running` into the middle of the gate's own output.
         count_proc.kill()
+        count_proc.communicate()
         return None
     if count_proc.returncode == _PYTEST_RC_NO_TESTS:
         return 0
     if count_proc.returncode != 0:
         return None
     for line in count_stdout.split("\n"):
-        m = _COLLECTED_RE.match(line.strip())
+        m = _COLLECTED_RE.search(line)
         if m:
-            return int(m.group(1))
+            selected, collected = m.groups()
+            return int(selected if selected is not None else collected)
     return None
 
 
@@ -1896,33 +1912,54 @@ _IMPACTED_DIFF_COVER_TIMEOUT = "diff_cover_timeout"
 _IMPACTED_CHANGED_LINES_UNCOVERED = "changed_lines_uncovered"
 
 
+def _testmon_baseline_warm() -> bool:
+    """True iff `.testmondata` is present and non-empty, i.e. testmon has a
+    baseline to select against and will NOT select-all.
+
+    Existence AND size come from a SINGLE `stat()` inside a try/except so the
+    file vanishing between a probe and a read (a concurrent
+    `--seed-testmon`/`--impacted` run, another worktree, a mid-purge) cannot
+    crash the gate. A vanished or unreadable baseline reads as cold, matching
+    the module's tolerate-vanish concurrency model.
+    """
+    try:
+        return TESTMON_DATA.stat().st_size > 0
+    except OSError:
+        # FileNotFoundError (vanished baseline) plus any other transient stat
+        # failure — treat all as cold.
+        return False
+
+
 def _run_impacted_pass(base: str) -> tuple[str, bool]:
     """Run ONE testmon-selected pass against `base`; return `(verdict, ran_select_all)`.
 
-    Pipeline: DB hygiene (`_ensure_testmon_db_safe`, which may purge a corrupt /
-    schema-mismatched baseline) → reset accumulated coverage iff the baseline is
-    now absent (so the pass starts clean) → testmon-selected tests under `--cov`
-    (writes coverage.xml) → diff-cover --fail-under=100 on the changed lines.
-    Factored out of `check_impacted` (QS-283 A4) so the self-heal retry can
-    re-run the SAME pass against the already-resolved base — no second
-    `git fetch` / tooling probe.
+    Pipeline: reset accumulated coverage iff the baseline is absent (so the pass
+    starts clean) → testmon-selected tests under `--cov` (writes coverage.xml) →
+    diff-cover --fail-under=100 on the changed lines. Factored out of
+    `check_impacted` (QS-283 A4) so the self-heal retry can re-run the SAME pass
+    against the already-resolved base — no second `git fetch` / tooling probe.
 
-    `ran_select_all` reports whether THIS pass ran as a select-all: it is the
-    post-hygiene `.testmondata` absence, so it is True both for a genuinely
-    fresh baseline AND when hygiene just purged a corrupt/schema-mismatched DB
-    mid-pass. `check_impacted` uses it to suppress a pointless self-heal retry
-    when the first pass already select-all'd (review fix #01). Returns one of
-    the `_IMPACTED_*` verdicts paired with that flag.
+    DB hygiene (`_ensure_testmon_db_safe`) is the CALLER's job, run once before
+    the non-`.py` early exit. It used to live here, which meant a change set
+    that took the exit never got its `.testmondata` checked at all — a corrupt
+    baseline survived indefinitely while a developer on a doc-only stretch kept
+    getting 0 back in milliseconds.
+
+    `ran_select_all` reports whether THIS pass ran as a select-all: the
+    `.testmondata` absence, so it is True both for a genuinely fresh baseline
+    AND when the caller's hygiene just purged a corrupt/schema-mismatched DB.
+    `check_impacted` uses it to suppress a pointless self-heal retry when the
+    first pass already select-all'd. Returns one of the `_IMPACTED_*` verdicts
+    paired with that flag.
     """
-    _ensure_testmon_db_safe()
     # QS-278: a missing `.testmondata` here (first-ever run, or just purged by
-    # the hygiene above as corrupt/schema-mismatched) means testmon is about to
+    # the caller's hygiene as corrupt/schema-mismatched) means testmon is about to
     # select ALL tests — a fresh baseline. Reset the accumulated `--cov-append`
     # coverage data so it reflects only this clean full run, never stale lines
     # from an earlier branch state. When the DB exists, accumulation is
     # intentional. `ran_select_all` records this select-all decision for the
-    # caller's self-heal gate (review fix #01: a baseline purged mid-pass means
-    # this pass IS the clean select-all, so no retry can improve on it).
+    # caller's self-heal gate: a baseline purged by hygiene means this pass IS
+    # the clean select-all, so no retry can improve on it.
     ran_select_all = not TESTMON_DATA.exists()
     if ran_select_all:
         _reset_coverage_data()
@@ -2033,6 +2070,23 @@ def check_impacted() -> int:
     # run's report.
     _clean_orphan_cov_shards()
 
+    # QS-283 A4 trigger gate: capture the incremental signal BEFORE any
+    # DB-purging hygiene step runs. A non-empty `.testmondata` means testmon has
+    # a warm baseline and is about to INCREMENTALLY select a subset — the only
+    # case where a changed-line FAIL might be a testmon/coverage desync worth
+    # self-healing. An absent/empty DB means this run already select-alls
+    # (ground truth), so a FAIL is genuine and the retry is skipped — no wasted
+    # select-all on the normal TDD-red case. (`_clean_orphan_cov_shards` above
+    # only ever touches `.coverage.*` shards, never `.testmondata`, so it cannot
+    # disturb this signal.)
+    was_incremental = _testmon_baseline_warm()
+
+    # DB hygiene must run BEFORE the early exit, not inside `_run_impacted_pass`:
+    # the exit returns without ever reaching that pass, so a corrupt
+    # `.testmondata` would never be purged and a developer on a doc-only stretch
+    # would keep getting 0 back in milliseconds while the DB stayed broken.
+    _ensure_testmon_db_safe()
+
     # QS-290 (S-4): a change set with no `.py` file at all makes this whole
     # gate structurally vacuous — testmon fingerprints only `.py`, so it could
     # never select a test, and diff-cover has no Python lines to score. Exit
@@ -2042,16 +2096,25 @@ def check_impacted() -> int:
     # `None` means "unknown" (a git failure) and must fall through — see
     # `_impacted_early_exit_paths`.
     #
-    # Caveat (recorded in docs/workflow/project-rules.md): on a STALE testmon DB
-    # a non-`.py` run today select-alls and re-syncs the baseline as a side
-    # effect; it no longer will, deferring that re-sync to the next `.py` run.
-    # That is a cost shift, not a verdict change — the stale-DB run's verdict was
-    # equally vacuous.
-    early_exit_paths = _impacted_early_exit_paths()
-    if early_exit_paths is not None and not any(p.endswith(".py") for p in early_exit_paths):
-        for line in _IMPACTED_NON_PY_LINES:
-            _emit("impacted", line)
-        return 0
+    # GATED ON A WARM BASELINE, and the probe is re-read POST-hygiene. "testmon
+    # could never select a test" holds only while `.testmondata` is usable:
+    # against a cold one testmon select-alls, proven with real testmon —
+    #
+    #     COLD (no .testmondata), note.txt changed -> 1 passed     (select-all)
+    #     WARM,                   note.txt changed -> no tests ran (0 selected)
+    #
+    # so on a cold baseline a doc-only change that breaks a doc-pinned guard
+    # test exited 1 before this feature and would return 0 after it: a false
+    # PASS, which is the one defect class a quality gate must never ship. The
+    # probe must be the POST-hygiene one — a corrupt DB looks warm but has just
+    # been purged, after which testmon select-alls too. Cold falls through to
+    # the full pass, exactly as before this feature existed.
+    if _testmon_baseline_warm():
+        early_exit_paths = _impacted_early_exit_paths()
+        if early_exit_paths is not None and not any(p.endswith(".py") for p in early_exit_paths):
+            for line in _IMPACTED_NON_PY_LINES:
+                _emit("impacted", line)
+            return 0
 
     base = _resolve_diff_base()
     if base is None:
@@ -2060,30 +2123,6 @@ def check_impacted() -> int:
             return 4
         _emit("impacted", "no diff base resolvable — skipping diff-coverage check (offline/fresh worktree)")
         return 0
-
-    # QS-283 A4 trigger gate: capture the incremental signal BEFORE any
-    # DB-purging hygiene step runs — i.e. before `_run_impacted_pass` calls
-    # `_ensure_testmon_db_safe`. (QS-290: `_clean_orphan_cov_shards` now runs
-    # earlier, above the early exit, but it only ever touches `.coverage.*`
-    # shards and never `.testmondata`, so the invariant is unaffected.)
-    # A non-empty `.testmondata` means testmon
-    # has a warm baseline and is about to INCREMENTALLY select a subset — the
-    # only case where a changed-line FAIL might be a testmon/coverage desync
-    # worth self-healing. An absent/empty DB means this run already select-alls
-    # (ground truth), so a FAIL is genuine and the retry is skipped — no wasted
-    # select-all on the normal TDD-red case.
-    #
-    # Review fix #02: derive existence AND size from a SINGLE `stat()` inside a
-    # try/except so the file vanishing (a concurrent `--seed-testmon`/`--impacted`
-    # run, another worktree, or a mid-`_purge_testmon_db`) between a probe and a
-    # read cannot crash the gate — a vanished/unreadable baseline is treated as
-    # non-incremental, matching the module's tolerate-vanish concurrency model.
-    try:
-        was_incremental = TESTMON_DATA.stat().st_size > 0
-    except OSError:
-        # OSError covers FileNotFoundError (vanished baseline) plus any other
-        # transient stat failure — treat all as non-incremental.
-        was_incremental = False
 
     verdict, ran_select_all = _run_impacted_pass(base)
     if verdict == _IMPACTED_PASS:

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -668,11 +668,16 @@ def _parse_pytest_output(text: str) -> dict[str, int]:
 # The optional leading group captures the SELECTED count, which is what actually
 # runs and therefore the only count the worker decision may use.
 #
-# This is matched with `.search`, not `.match`: anchoring at position 0 made the
-# `S/` prefix unparseable, so the probe returned None, `_resolve_files_workers`
-# always answered `-n auto`, and the serial fast path silently stopped existing
-# — no warning, no symptom but the lost seconds.
-_COLLECTED_RE = re.compile(r"(?:(\d+)/)?(\d+) tests? collected")
+# ANCHORED at column 0 and matched against the stripped line. Both halves
+# matter: without the optional `S/` group the deselection form was unparseable,
+# so the probe returned None, `_resolve_files_workers` always answered
+# `-n auto`, and the serial fast path silently stopped existing. But an
+# UNANCHORED search is equally unsafe in the other direction — `--collect-only`
+# echoes parametrized test IDs, and an id embedding this shape (verified:
+# a param value of `"12/340 tests collected (328 deselected)"`) would be parsed
+# as the summary and yield 12 for a 3-test file. Real ids always begin with the
+# file path, so anchoring is immune.
+_COLLECTED_RE = re.compile(r"^(?:(\d+)/)?(\d+) tests? collected")
 
 # pytest's exit code for "no tests were collected" — a KNOWN zero, not a failure.
 _PYTEST_RC_NO_TESTS = 5
@@ -682,6 +687,10 @@ _PYTEST_RC_NO_TESTS = 5
 # indefinitely. Generous, since a cold whole-tree collection legitimately takes
 # 3-6 s; expiry degrades to "unknown" (`-n auto`), never to a wrong count.
 _COLLECT_TIMEOUT_SECONDS = 60.0
+
+# Bound for reaping an already-killed probe. Short: the child is dead, so this
+# only waits on pipes a grandchild might still hold.
+_COLLECT_REAP_TIMEOUT_SECONDS = 5.0
 
 
 def _collect_test_count(targets: list[str]) -> int | None:
@@ -730,15 +739,23 @@ def _collect_test_count(targets: list[str]) -> int | None:
         # Reap it. `kill()` alone leaves the child unwaited with both pipes
         # open, so CPython emits `ResourceWarning: subprocess N is still
         # running` into the middle of the gate's own output.
+        #
+        # The reap is itself bounded: SIGKILL reaches only the direct child, so
+        # a grandchild holding the inherited pipes (a conftest or plugin that
+        # spawns a helper at import) would otherwise turn this into an
+        # indefinite stall of the whole gate — strictly worse than the
+        # ResourceWarning. A wedged reap is given up on; the warning is the
+        # lesser evil.
         count_proc.kill()
-        count_proc.communicate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            count_proc.communicate(timeout=_COLLECT_REAP_TIMEOUT_SECONDS)
         return None
     if count_proc.returncode == _PYTEST_RC_NO_TESTS:
         return 0
     if count_proc.returncode != 0:
         return None
     for line in count_stdout.split("\n"):
-        m = _COLLECTED_RE.search(line)
+        m = _COLLECTED_RE.match(line.strip())
         if m:
             selected, collected = m.groups()
             return int(selected if selected is not None else collected)
@@ -1913,21 +1930,51 @@ _IMPACTED_CHANGED_LINES_UNCOVERED = "changed_lines_uncovered"
 
 
 def _testmon_baseline_warm() -> bool:
-    """True iff `.testmondata` is present and non-empty, i.e. testmon has a
-    baseline to select against and will NOT select-all.
+    """True iff testmon has a baseline it will actually select against, i.e.
+    it will NOT select-all.
 
     Existence AND size come from a SINGLE `stat()` inside a try/except so the
     file vanishing between a probe and a read (a concurrent
     `--seed-testmon`/`--impacted` run, another worktree, a mid-purge) cannot
     crash the gate. A vanished or unreadable baseline reads as cold, matching
     the module's tolerate-vanish concurrency model.
+
+    **A `-wal`/`-shm` sidecar next to the primary reads as COLD.** Size alone is
+    only a proxy for usability, and it is unsound in exactly the states that
+    leave sidecars behind — verified against real testmon 2.2.0:
+
+    - an INTERRUPTED run (Ctrl-C, OOM, laptop sleep) leaves `.testmondata` at
+      4096 B with a populated `-wal`. `PRAGMA user_version` still reads 14, so
+      `_ensure_testmon_db_safe` does not purge it, and its orphan-sidecar branch
+      only fires when the primary is ABSENT. A non-`.py` change against that DB
+      ran **40 passed** (select-all) where a cleanly seeded one ran `no tests`;
+    - an IN-FLIGHT `--seed-testmon` / `_rebuild_testmon_baseline`, whose window
+      is minutes long on a 7 000-test suite.
+
+    In both, treating the baseline as warm would let the non-`.py` early exit
+    return 0 where the pre-exit gate ran the suite. One `exists()` pair closes
+    both, and errs the safe way: a spurious cold reading only costs a full pass.
+
+    KNOWN GAP — see issue #341. A package install/upgrade/removal, or a Python
+    MICRO bump, resets testmon's environment fingerprint so it select-alls while
+    the file looks perfectly warm (size > 0, `user_version` 14, no sidecars).
+    That state is persistent rather than transient, because the exit never runs
+    pytest and so never refreshes the fingerprint. Accepted for now: `--impacted`
+    is the LOCAL pre-commit gate and CI runs the whole suite authoritatively, so
+    the blast radius is a developer learning from CI rather than broken code
+    reaching main.
     """
     try:
-        return TESTMON_DATA.stat().st_size > 0
+        if TESTMON_DATA.stat().st_size <= 0:
+            return False
     except OSError:
         # FileNotFoundError (vanished baseline) plus any other transient stat
         # failure — treat all as cold.
         return False
+    return not any(
+        (TESTMON_DATA.parent / (TESTMON_DATA.name + suffix)).exists()
+        for suffix in ("-wal", "-shm")
+    )
 
 
 def _run_impacted_pass(base: str) -> tuple[str, bool]:

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -15,9 +15,11 @@ Options:
     --no-cache               Force fresh run even when --cache is present
     --full                   Force full gate run even if only dev/test files changed
     --quick PATH [PATH ...]  Fast iteration: run only the cited test paths (files
-                             or directories) with xdist + sysmon; skip ruff/mypy/
-                             translations/coverage/cache/scope. Mutex with
-                             --cache/--no-cache/--full/--fix.
+                             or directories) with sysmon; skip ruff/mypy/
+                             translations/coverage/cache/scope. xdist is used
+                             only above a small-run threshold (QS-290) — small
+                             targets run single-process to skip the spin-up.
+                             Mutex with --cache/--no-cache/--full/--fix.
     --impacted               Inner-loop gate (QS-276): run only the testmon-selected
                              tests under --cov=<package>, write coverage.xml, then
                              diff-cover --fail-under=100 against the resolved diff
@@ -239,6 +241,9 @@ def _has_xdist() -> bool:
     return _HAS_XDIST_CACHE
 
 
+_WORKERS_ENV = "QS_QG_PYTEST_WORKERS"
+
+
 def _pytest_workers() -> str | None:
     """Return the worker count for `pytest -n`, or None for serial mode.
 
@@ -257,7 +262,7 @@ def _pytest_workers() -> str | None:
     """
     if not _has_xdist():
         return None
-    raw = os.environ.get("QS_QG_PYTEST_WORKERS", "auto")
+    raw = os.environ.get(_WORKERS_ENV, "auto")
     val = raw.strip()
     if val == "" or val == "0":
         return None
@@ -266,14 +271,67 @@ def _pytest_workers() -> str | None:
     try:
         parsed = int(val)
     except ValueError:
-        sys.stderr.write(f'[pytest] invalid QS_QG_PYTEST_WORKERS={raw!r}, falling back to "auto"\n')
+        sys.stderr.write(f'[pytest] invalid {_WORKERS_ENV}={raw!r}, falling back to "auto"\n')
         sys.stderr.flush()
         return "auto"
     if parsed > 0:
         return str(parsed)
-    sys.stderr.write(f'[pytest] invalid QS_QG_PYTEST_WORKERS={raw!r}, falling back to "auto"\n')
+    sys.stderr.write(f'[pytest] invalid {_WORKERS_ENV}={raw!r}, falling back to "auto"\n')
     sys.stderr.flush()
     return "auto"
+
+
+# QS-290 (S-1): at or below this many collected tests, `check_pytest_files`
+# runs single-process — xdist's per-worker whole-target collection costs more
+# than the parallelism saves.
+#
+# 50 is a deliberately CONSERVATIVE constant, not a tuned value. Supporting
+# measurements (10 cores): 43 tests → serial 11.5 s vs xdist 16.8 s (pytest
+# phase); 35 real-HA tests → serial 6.34 s vs xdist 6.78 s (i.e. serial is at
+# worst neutral there). Above the threshold nothing changes. Below it, the
+# worst case is a sub-50 target of unusually slow tests losing a bounded few
+# seconds — and `QS_QG_PYTEST_WORKERS=auto` forces xdist back. Deliberately
+# NOT an env knob: one more tuning surface for a bounded, recoverable cost.
+_SERIAL_MAX_TESTS = 50
+
+
+def _resolve_files_workers(count: int | None) -> str | None:
+    """Worker count for `check_pytest_files`, or None for single-process.
+
+    QS-290 (S-1). Decision order:
+
+    | Condition                          | Result                     |
+    | ---------------------------------- | -------------------------- |
+    | `QS_QG_PYTEST_WORKERS` **present** | `_pytest_workers()` verbatim |
+    | xdist unavailable                  | serial (unchanged)         |
+    | `count is None` (unknown)          | `-n auto`                  |
+    | `count <= _SERIAL_MAX_TESTS`       | serial (fast path)         |
+    | otherwise                          | `-n auto`                  |
+
+    Explicitness is detected with `os.environ.get(...) is not None`, NOT from
+    `_pytest_workers()`'s return value: that returns `"auto"` both when the
+    var is unset and when it is set to `auto`, so it cannot carry provenance.
+    An explicit request must win over the threshold in BOTH directions
+    (`0` → serial on a huge target; `8` → `-n 8` on a tiny one).
+
+    Emits the fast-path rationale on stderr directly rather than via `_emit`
+    (which would double-prefix). The `[pytest]` prefix is neutral because this
+    also serves the dev-only / ui-only scopes, not just `--quick`.
+    """
+    workers = _pytest_workers()
+    if workers is None:
+        # xdist missing, or an explicit serial request — nothing to demote.
+        return None
+    if os.environ.get(_WORKERS_ENV) is not None:
+        return workers
+    if count is not None and count <= _SERIAL_MAX_TESTS:
+        sys.stderr.write(
+            f"[pytest] {count} tests <= {_SERIAL_MAX_TESTS} - single-process "
+            f"(skipping xdist spin-up)\n"
+        )
+        sys.stderr.flush()
+        return None
+    return workers
 
 
 def _pytest_env() -> dict[str, str]:
@@ -369,6 +427,17 @@ def _is_ui_asset(filepath: str) -> bool:
     return filepath.endswith(".j2")
 
 
+def _plural(count: int, noun: str) -> str:
+    """Render `"<count> <noun>"`, appending `s` to the noun unless count == 1.
+
+    QS-290 (D-18): the dev-only / ui-only scope reasons printed
+    `(1 files)`. Only regular `-s` plurals are needed here (`file`,
+    `UI asset`), so a naive suffix is correct and keeps the two reason
+    strings using ONE rule rather than drifting apart.
+    """
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
 def _detect_scope(changed_files: list[str]) -> dict:
     """Determine which gates to run based on changed files.
 
@@ -396,14 +465,14 @@ def _detect_scope(changed_files: list[str]) -> dict:
             "changed_test_files": test_files,
             "reason": (
                 f"only UI assets and dev files changed "
-                f"({len(ui_assets)} UI asset(s), {len(changed_files)} total)"
+                f"({_plural(len(ui_assets), 'UI asset')}, {_plural(len(changed_files), 'file')})"
             ),
         }
 
     return {
         "scope": "dev-only",
         "changed_test_files": test_files,
-        "reason": f"only dev/test files changed ({len(changed_files)} files)",
+        "reason": f"only dev/test files changed ({_plural(len(changed_files), 'file')})",
     }
 
 
@@ -444,6 +513,13 @@ def _is_cache_valid(cache: dict | None, branch: str, commit: str, is_clean: bool
 _PROGRESS_CHARS = ".FEsxX"
 _XDIST_PREFIX_RE = re.compile(r"^\[gw\d+\]\s*")
 _PERCENT_SUFFIX_RE = re.compile(r"\s*\[\s*\d+%\]\s*$")
+# QS-290 (S-5): under `-o console_output_style=count` pytest replaces the
+# `[NN%]` suffix with `[<current>/<total>]` (space-padded to align, e.g.
+# `[ 69/682]`) — in BOTH serial and xdist mode under `-q`, and reporting the
+# SELECTED total under deselection. `_clean_pytest_line` must strip this shape
+# too: otherwise a progress line stops being "all progress characters" and
+# both the mid-run tally and `_parse_pytest_output` silently under-count.
+_COUNT_SUFFIX_RE = re.compile(r"\s*\[\s*(\d+)\s*/\s*(\d+)\s*\]\s*$")
 # S2: track xfailed/xpassed/skipped as separate keys; recognize the
 # `error`/`errors` singular/plural collapse on the parser side.
 _COUNT_RE = re.compile(r"(\d+) (passed|failed|errors?|skipped|xfailed|xpassed)")
@@ -462,9 +538,16 @@ def _new_count_dict() -> dict[str, int]:
 
 
 def _clean_pytest_line(line: str) -> str:
-    """Strip xdist worker prefix and trailing `[NN%]` from a pytest stdout line."""
+    """Strip the xdist worker prefix and the trailing progress suffix from a
+    pytest stdout line.
+
+    Both suffix shapes are handled: `[NN%]` (pytest's default
+    `console_output_style=progress`) and `[N/M]` (the `count` style the
+    `--impacted` pass now requests — QS-290 S-5).
+    """
     line = _XDIST_PREFIX_RE.sub("", line)
     line = _PERCENT_SUFFIX_RE.sub("", line)
+    line = _COUNT_SUFFIX_RE.sub("", line)
     return line.rstrip()
 
 
@@ -532,38 +615,28 @@ def _parse_pytest_output(text: str) -> dict[str, int]:
     return summary if summary is not None else tally
 
 
-def _stream_pytest(
-    cmd: list[str],
-    collect_targets: list[str] | None = None,
-) -> dict:
-    """Run pytest with real-time progress reporting.
+_COLLECTED_RE = re.compile(r"(\d+) tests? collected")
 
-    Prints a progress line every ~10% of tests. Returns the same dict
-    format as check_pytest(). The main subprocess runs with
-    `COVERAGE_CORE=sysmon` for faster coverage tracking; the upfront
-    `--collect-only` count subprocess uses the parent env (coverage is
-    not active during collection).
 
-    `collect_targets` (review-fix #01 finding 2): when provided, the
-    upfront `--collect-only` subprocess walks ONLY those paths instead
-    of the whole `TESTS_DIR` tree. `check_pytest_files` passes the same
-    `abs_files` it gives to the main run so `--quick tests/test_foo.py`
-    doesn't pay the 1–3 s cold cost of collecting the entire suite.
-    The full-coverage caller (`check_pytest`) passes `None` and keeps
-    the whole-tree collection semantics.
+def _collect_test_count(targets: list[str]) -> int | None:
+    """Return the number of tests `pytest --collect-only -q` finds under `targets`.
 
-    Both subprocess invocations explicitly pass `encoding="utf-8"` and
-    `errors="replace"` so decoding pytest output never crashes under
-    `LANG=C` / `LC_ALL=POSIX` (S5). The default `text=True` would fall
-    back to the system locale and raise `UnicodeDecodeError` mid-stream
-    on non-ASCII content (Unicode ellipses, curly quotes in parametrize
-    ids, non-ASCII assertion messages).
+    QS-290 (S-1): extracted from `_stream_pytest` so ONE probe can serve
+    two consumers — the progress denominator AND the xdist-or-serial worker
+    decision in `check_pytest_files`.
+
+    Returns `None` — explicitly NOT 0 — when the count line is absent
+    (a collection error, an unexpected pytest output format). The
+    distinction matters: `None` means *unknown*, and a caller must then
+    fall back to `-n auto` rather than mistake it for a tiny run that
+    deserves the serial fast path.
+
+    Uses `subprocess.Popen` directly (rather than `_run`) so the test
+    suite can assert this subprocess gets utf-8/replace decoding AND does
+    NOT inherit `COVERAGE_CORE` — coverage is inactive during collection,
+    and the count must never pay the sysmon tracer's cost.
     """
-    # First, collect test count — single-process, no coverage env override.
-    # We use Popen directly (instead of `_run`) so the test suite can verify
-    # this subprocess gets utf-8 encoding AND does NOT inherit COVERAGE_CORE.
-    count_targets = collect_targets if collect_targets is not None else [str(TESTS_DIR)]
-    count_cmd = [VENV_PYTHON, "-m", "pytest", "--collect-only", "-q", *count_targets]
+    count_cmd = [VENV_PYTHON, "-m", "pytest", "--collect-only", "-q", *targets]
     count_proc = subprocess.Popen(
         count_cmd,
         stdout=subprocess.PIPE,
@@ -573,12 +646,47 @@ def _stream_pytest(
         cwd=str(REPO_ROOT),
     )
     count_stdout, _ = count_proc.communicate()
-    total_tests = 0
     for line in count_stdout.split("\n"):
-        m = re.match(r"(\d+) tests? collected", line.strip())
+        m = _COLLECTED_RE.match(line.strip())
         if m:
-            total_tests = int(m.group(1))
-            break
+            return int(m.group(1))
+    return None
+
+
+def _stream_pytest(
+    cmd: list[str],
+    total_tests: int | None = None,
+) -> dict:
+    """Run pytest with real-time progress reporting.
+
+    Prints a progress line every ~10% of tests. Returns the same dict
+    format as check_pytest(). The main subprocess runs with
+    `COVERAGE_CORE=sysmon` for faster coverage tracking.
+
+    `total_tests` (QS-290, S-1/S-5) — ONE parameter, two modes:
+
+    - `None` → collect the denominator here, against the whole `TESTS_DIR`
+      tree. That is the full gate's (`check_pytest`) and the seed path's
+      (`seed_testmon`) semantics: they really do run everything.
+    - an `int` → the caller already knows the count; spawn NOTHING extra.
+      `check_pytest_files` passes the count it needed anyway for its
+      worker decision, and `_run_impacted_pass` passes `0` — testmon's
+      selection size is unknowable up front, so the denominator is learned
+      from the run's own `[N/M]` progress suffix instead (S-5).
+
+    It replaced the old `collect_targets` parameter: with both present,
+    forwarding an unknown (`None`) count re-triggered a whole-tree collect
+    and spawned a third subprocess.
+
+    Both subprocess invocations explicitly pass `encoding="utf-8"` and
+    `errors="replace"` so decoding pytest output never crashes under
+    `LANG=C` / `LC_ALL=POSIX` (S5). The default `text=True` would fall
+    back to the system locale and raise `UnicodeDecodeError` mid-stream
+    on non-ASCII content (Unicode ellipses, curly quotes in parametrize
+    ids, non-ASCII assertion messages).
+    """
+    if total_tests is None:
+        total_tests = _collect_test_count([str(TESTS_DIR)]) or 0
 
     milestone_every = max(1, total_tests // 10) if total_tests > 0 else 50
 
@@ -610,6 +718,22 @@ def _stream_pytest(
     assert proc.stdout is not None
     for line in proc.stdout:
         stdout_lines.append(line)
+
+        # QS-290 (S-5): learn the denominator from the run's OWN output. Under
+        # `-o console_output_style=count` every progress line carries a
+        # `[current/total]` suffix whose total is the SELECTED count — exactly
+        # what a testmon pass cannot know up front, and previously the reason a
+        # whole-tree `--collect-only` subprocess was spawned to produce a
+        # denominator that was also WRONG for this path (it printed
+        # `done (0/6912)` for a 0-selected run). Only fill an unknown (0)
+        # denominator: a caller-supplied count already paid for a real
+        # collection and stays authoritative.
+        if total_tests == 0:
+            seen = _COUNT_SUFFIX_RE.search(_XDIST_PREFIX_RE.sub("", line).rstrip())
+            if seen:
+                total_tests = int(seen.group(2))
+                milestone_every = max(1, total_tests // 10)
+
         cleaned = _clean_pytest_line(line)
 
         # Mid-run progress: count chars on dotted-progress lines.
@@ -718,8 +842,8 @@ def check_pytest() -> dict:
             sys.stderr.write("[pytest] xdist not available, running single-process\n")
         else:
             # xdist available, but user-forced serial via QS_QG_PYTEST_WORKERS=0 or "".
-            raw = os.environ.get("QS_QG_PYTEST_WORKERS", "").strip()
-            sys.stderr.write(f"[pytest] QS_QG_PYTEST_WORKERS={raw!r} — running single-process by request\n")
+            raw = os.environ.get(_WORKERS_ENV, "").strip()
+            sys.stderr.write(f"[pytest] {_WORKERS_ENV}={raw!r} — running single-process by request\n")
         sys.stderr.flush()
     return _stream_pytest(cmd)
 
@@ -732,18 +856,33 @@ def check_pytest_files(test_files: list[str]) -> dict:
     here too. Silent serial fallback when xdist is missing or explicitly
     disabled (no stderr warning; only the full gate warns to avoid duplicate
     noise from the dev-only fast path and `--quick`).
+
+    QS-290 (S-1) serial fast path: xdist's spin-up (one whole-target
+    collection per worker, each re-importing the HA-heavy conftest) costs
+    several seconds regardless of how few tests run. Measured on a 43-test
+    target: serial 11.5 s vs xdist 16.8 s (pytest phase). So a target at or
+    below `_SERIAL_MAX_TESTS` runs single-process. One `--collect-only`
+    probe (`_collect_test_count`) serves BOTH that decision and the progress
+    denominator.
+
+    Also serves `main()`'s dev-only and ui-only scopes — intentional: those
+    run 1–3 changed test files, exactly the shape the fast path targets.
     """
     if not test_files:
         return {"name": "pytest (no test files changed)", "passed": True, "detail": ""}
 
     abs_files = [str(REPO_ROOT / f) for f in test_files]
-    workers = _pytest_workers()
+    # Narrow the collect-only probe to the cited paths so we don't walk the
+    # whole `tests/` tree just to count one file's tests (review-fix #01
+    # finding 2).
+    count = _collect_test_count(abs_files)
+    workers = _resolve_files_workers(count)
     cmd = [VENV_PYTHON, "-m", "pytest", *abs_files, "-q"]
     if workers is not None:
         cmd.extend(["-n", workers])
-    # Narrow the collect-only subprocess to the same paths so we don't
-    # walk the whole `tests/` tree just to count one file's tests.
-    return _stream_pytest(cmd, collect_targets=abs_files)
+    # An unknown count (`None`) must NOT be forwarded: `_stream_pytest` would
+    # read it as "collect the whole tree yourself" and spawn a second probe.
+    return _stream_pytest(cmd, total_tests=count if count is not None else 0)
 
 
 def check_ruff_lint(fix: bool = False) -> dict:
@@ -959,6 +1098,19 @@ COVERAGE_DATA = REPO_ROOT / ".coverage"
 # the gate. CI re-fetches authoritatively, so a short bound is safe.
 _FETCH_TIMEOUT_SECONDS = 15.0
 
+# QS-290 (S-7): skip the `--impacted` `git fetch origin main` when the
+# per-worktree `FETCH_HEAD` marker is younger than this. Repeat inner-loop
+# runs within a TDD burst re-fetch the same ref for nothing.
+#
+# Safe by construction: a stale base is OLDER, so diff-cover's changed-line
+# set is a SUPERSET — a TTL hit can turn a PASS into a FAIL, never a FAIL into
+# a PASS. (Not turned into a test: that is a property of git's merge-base
+# semantics, so any such test would assert the mock.) After a force-push of
+# main the stale ref may not be an ancestor at all, but the window is 10
+# minutes and the existing code already tolerates a stale base when a fetch
+# fails — so this is not a new class of risk. CI always fetches fresh.
+_FETCH_TTL_SECONDS = 600.0
+
 # QS-276 review-fix NH1: bound the diff-cover subprocess too — a
 # pathological hang there would break the same sub-15s inner-loop promise
 # as an unbounded fetch (S1). diff-cover only parses an already-written
@@ -1031,6 +1183,56 @@ def _is_ci() -> bool:
     return os.environ.get("GITHUB_ACTIONS", "").strip().lower() in _CI_TRUTHY
 
 
+def _fetch_head_age() -> float | None:
+    """Age in seconds of the per-worktree `FETCH_HEAD` marker, or None.
+
+    QS-290 (S-7). The marker path is resolved via
+    `git rev-parse --git-path FETCH_HEAD` rather than hardcoded: in a LINKED
+    worktree it lives at `<main>/.git/worktrees/<name>/FETCH_HEAD` and `.git`
+    itself is a *file*, so a literal `.git/FETCH_HEAD` would be a path under a
+    non-directory and the TTL would silently never hit.
+
+    None (= "unknown, do not skip") on any `rev-parse` failure, empty output,
+    or an unreadable / absent marker, so an unknown always degrades to
+    fetching exactly as before the TTL existed.
+    """
+    probe = _run(["git", "rev-parse", "--git-path", "FETCH_HEAD"])
+    if probe.returncode != 0:
+        return None
+    raw = probe.stdout.strip()
+    if not raw:
+        return None
+    try:
+        mtime = (REPO_ROOT / raw).stat().st_mtime
+    except OSError:
+        # Absent marker (never fetched in this worktree) or an unreadable path.
+        return None
+    return max(0.0, time.time() - mtime)
+
+
+def _fmt_fetch_age(age: float) -> str:
+    """Render a FETCH_HEAD age compactly for the skip line: `12s` / `3m`."""
+    return f"{int(age)}s" if age < 60 else f"{int(age // 60)}m"
+
+
+def _fetch_origin_main() -> None:
+    """Best-effort `git fetch origin main`, warning on failure.
+
+    Ignore failure — an offline dev still resolves a local `main` or the
+    upstream merge-base. QS-276 review-fix S1: bound the fetch so a hung/slow
+    remote can't block the sub-15s inner loop, and WARN on a non-zero result so
+    a silently-failed fetch (offline / timeout) — which leaves a stale
+    `origin/main` whose changed-line set may diverge from CI's — is observable
+    instead of pretending the base was fetched fresh.
+    """
+    fetch = _run(["git", "fetch", "origin", "main"], timeout=_FETCH_TIMEOUT_SECONDS)
+    if fetch.returncode != 0:
+        _emit(
+            "impacted",
+            "warning: `git fetch origin main` failed/timed out — diff base may be stale vs CI",
+        )
+
+
 def _resolve_diff_base() -> str | None:
     """Resolve the `--impacted` diff base via the fallback ladder.
 
@@ -1048,21 +1250,32 @@ def _resolve_diff_base() -> str | None:
     spuriously huge changed-line set. An unreachable ref is skipped (and
     a warning emitted); if nothing reachable resolves, we return None and
     the caller applies the no-base policy (warn-skip locally, exit 4 CI).
+
+    QS-290 (S-7): the fetch is TTL-cached on `FETCH_HEAD`'s mtime. If the base
+    then fails to resolve, the fetch is retried ONCE — a skipped fetch must
+    never be the reason we give up (a fresh worktree with a stale marker copy
+    could otherwise report "no diff base" and exit 4 in CI).
     """
-    # Best-effort fresh fetch; ignore failure — an offline dev still
-    # resolves a local `main` or the upstream merge-base below.
-    #
-    # QS-276 review-fix S1: bound the fetch so a hung/slow remote can't
-    # block the sub-15s inner loop, and WARN on a non-zero result so a
-    # silently-failed fetch (offline / timeout) — which leaves a stale
-    # `origin/main` whose changed-line set may diverge from CI's — is
-    # observable instead of pretending the base was fetched fresh.
-    fetch = _run(["git", "fetch", "origin", "main"], timeout=_FETCH_TIMEOUT_SECONDS)
-    if fetch.returncode != 0:
-        _emit(
-            "impacted",
-            "warning: `git fetch origin main` failed/timed out — diff base may be stale vs CI",
-        )
+    age = _fetch_head_age()
+    if age is not None and age < _FETCH_TTL_SECONDS:
+        skipped_fetch = True
+        _emit("impacted", f"diff base: fetch skipped (FETCH_HEAD {_fmt_fetch_age(age)} old)")
+    else:
+        skipped_fetch = False
+        _fetch_origin_main()
+    base = _resolve_base_ladder()
+    if base is None and skipped_fetch:
+        _fetch_origin_main()
+        base = _resolve_base_ladder()
+    return base
+
+
+def _resolve_base_ladder() -> str | None:
+    """Walk `origin/main` → `main` → upstream merge-base; no fetching.
+
+    Split out of `_resolve_diff_base` (QS-290 S-7) so the TTL retry can re-walk
+    the ladder after a fetch without recursing or re-probing the marker.
+    """
     for ref in ("origin/main", "main"):
         if _run(["git", "rev-parse", "--verify", ref]).returncode != 0:
             continue
@@ -1081,6 +1294,80 @@ def _resolve_diff_base() -> str | None:
             _emit("impacted", f"diff base: {sha} (merge-base with {tracked})")
             return sha
     return None
+
+
+def _impacted_early_exit_paths() -> list[str] | None:
+    """Every path diff-cover would consider, or None when that is unknown.
+
+    QS-290 (S-4). `check_impacted` uses this to detect a change set with no
+    `.py` file at all, for which the whole gate is structurally vacuous:
+    testmon fingerprints AST blocks in `.py` files ONLY (a positive control
+    confirmed that editing `docs/workflow/overview.md` — the very file a test
+    module reads and asserts on at runtime — selects ZERO tests), and
+    diff-cover has no Python lines to score. `--impacted` was ALREADY blind
+    here; skipping the work changes the cost, not the verdict.
+
+    **Merge-base, not two-dot.** `git diff --name-only <merge-base>` compares
+    the merge-base tree against the WORKING tree, so it is a genuine superset
+    of diff-cover's three-dot `base...HEAD` range in both directions:
+
+    - it covers committed + staged + unstaged edits, plus (via `ls-files
+      --others`) untracked files, which `--include-untracked` makes diff-cover
+      score;
+    - it still contains a `.py` file your branch changed that main already
+      holds with IDENTICAL content (a landed cherry-pick / squash-merge), which
+      a two-dot `git diff <main-tip>` would silently omit while diff-cover
+      scored it — a false PASS;
+    - it excludes main's OWN commits since the fork, which a two-dot diff would
+      drag in, making any branch slightly behind main never early-exit.
+
+    **Zero-arg and total** so ONE `patch.object` in a test silences every git
+    call at this seat. If the base resolve lived in `check_impacted`, its `_run`
+    call would sit outside the seam and still fire wherever `_run` is patched
+    wholesale.
+
+    **Fail-closed.** Any non-zero return, or an empty merge-base, yields None →
+    no early exit. `_get_changed_files` silently drops failed calls; copying
+    that here would convert a git failure into a false PASS. Do not.
+
+    **Deliberately weaker base ladder** than `_resolve_diff_base`: `origin/main`
+    → `main` → give up. No `@{u}` rung and no NH2 reachability probe. An
+    unresolvable base simply means no early exit, which is the conservative
+    outcome, so the extra rungs would buy nothing but surface area.
+    """
+    base = next(
+        (ref for ref in ("origin/main", "main") if _run(["git", "rev-parse", "--verify", ref]).returncode == 0),
+        None,
+    )
+    if base is None:
+        return None
+    mb = _run(["git", "merge-base", base, "HEAD"])
+    merge_base = mb.stdout.strip()
+    if mb.returncode != 0 or not merge_base:
+        return None
+    # Committed + staged + unstaged, merge-base tree vs working tree.
+    diff = _run(["git", "diff", "--name-only", merge_base])
+    if diff.returncode != 0:
+        return None
+    # Untracked files — diff-cover scores them via `--include-untracked`.
+    others = _run(["git", "ls-files", "--others", "--exclude-standard"])
+    if others.returncode != 0:
+        return None
+    return sorted(
+        {line.strip() for line in (diff.stdout + "\n" + others.stdout).splitlines() if line.strip()}
+    )
+
+
+# QS-290 (S-4): the non-`.py` PASS explanation. ASCII only, emitted through
+# `_emit` (which prefixes every line). ONE static hint — a path-aware
+# two-branch variant was a feature grown by review for a string no verdict
+# depends on.
+_IMPACTED_NON_PY_LINES = (
+    "PASS (no Python files changed - diff-coverage is vacuous)",
+    "note: testmon fingerprints only .py, so this run could never",
+    "select a test. For non-Python changes run `--quick tests/qs`",
+    "(or `--quick tests/test_dashboard_rendering.py` for ui assets).",
+)
 
 
 def _testmon_schema_version() -> int | None:
@@ -1282,6 +1569,13 @@ def _build_testmon_cmd() -> list[str]:
         "--cov-report=",
         f"--cov-report=xml:{COVERAGE_XML}",
         "-q",
+        # QS-290 (S-5): print `[current/total]` instead of `[NN%]` so
+        # `_stream_pytest` can read the SELECTED-test denominator off the run
+        # itself. This replaced a whole-tree `--collect-only` subprocess that
+        # cost ~30% of the whole zero-work gate AND produced the wrong number
+        # for this path (`done (0/6912)` — the tree, not the selection).
+        "-o",
+        "console_output_style=count",
     ]
     if _TESTMON_SUPPORTS_XDIST:
         workers = _pytest_workers()
@@ -1380,7 +1674,10 @@ def _run_impacted_pass(base: str) -> tuple[str, bool]:
     # against stale data instead of failing loudly.
     COVERAGE_XML.unlink(missing_ok=True)
     _emit("impacted", f"selecting impacted tests (testmon) vs base {base}")
-    result = _stream_pytest(_build_testmon_cmd())
+    # QS-290 (S-5): `total_tests=0` — spawn NO collect-only probe. testmon's
+    # selection size is unknowable before the run, so the denominator is
+    # learned from the pass's own `[N/M]` progress suffix instead.
+    result = _stream_pytest(_build_testmon_cmd(), total_tests=0)
     if not result["passed"]:
         _emit("impacted", "FAIL (selected tests failed)")
         return _IMPACTED_TESTS_FAILED, ran_select_all
@@ -1428,9 +1725,9 @@ def _run_impacted_pass(base: str) -> tuple[str, bool]:
 def check_impacted() -> int:
     """Run the `--impacted` inner-loop gate; return the process exit code.
 
-    Pipeline: tooling probe → diff-base ladder → orphan-shard hygiene →
-    one `_run_impacted_pass` → (on an incremental changed-line FAIL) exactly
-    one self-heal rebuild + retry.
+    Pipeline: tooling probe → orphan-shard hygiene → non-`.py` early exit
+    (QS-290 S-4) → diff-base ladder → one `_run_impacted_pass` → (on an
+    incremental changed-line FAIL) exactly one self-heal rebuild + retry.
 
     Exit codes: 0 pass · 1 selected-test failure OR diff-coverage <100% ·
     3 testmon / diff-cover not importable · 4 no diff base resolvable in
@@ -1459,6 +1756,35 @@ def check_impacted() -> int:
         _emit("impacted", "pytest-testmon / diff-cover not importable — install requirements_test.txt")
         return 3
 
+    # QS-283 A1: reap orphaned `.coverage.*` shards from a killed prior run
+    # before the cov pass, so stale fragments can't `--cov-append` into this
+    # run's coverage.xml. The combined `.coverage` survives (warm baseline).
+    #
+    # QS-290 (S-4): HOISTED above the early exit. The exit returns before the
+    # old seat (just before `_run_impacted_pass`) would ever be reached, so
+    # without the hoist a non-`.py` run would stop reaping orphan shards
+    # entirely and a crash's stale fragments could survive into the next `.py`
+    # run's report.
+    _clean_orphan_cov_shards()
+
+    # QS-290 (S-4): a change set with no `.py` file at all makes this whole
+    # gate structurally vacuous — testmon fingerprints only `.py`, so it could
+    # never select a test, and diff-cover has no Python lines to score. Exit
+    # before the `git fetch`, the pytest spawn and the diff-cover spawn: two git
+    # calls instead of 10.7-23.5 s of work. `None` means "unknown" (a git
+    # failure) and must fall through — see `_impacted_early_exit_paths`.
+    #
+    # Caveat (recorded in docs/workflow/project-rules.md): on a STALE testmon DB
+    # a non-`.py` run today select-alls and re-syncs the baseline as a side
+    # effect; it no longer will, deferring that re-sync to the next `.py` run.
+    # That is a cost shift, not a verdict change — the stale-DB run's verdict was
+    # equally vacuous.
+    early_exit_paths = _impacted_early_exit_paths()
+    if early_exit_paths is not None and not any(p.endswith(".py") for p in early_exit_paths):
+        for line in _IMPACTED_NON_PY_LINES:
+            _emit("impacted", line)
+        return 0
+
     base = _resolve_diff_base()
     if base is None:
         if _is_ci():
@@ -1468,7 +1794,11 @@ def check_impacted() -> int:
         return 0
 
     # QS-283 A4 trigger gate: capture the incremental signal BEFORE any
-    # hygiene step can purge the DB. A non-empty `.testmondata` means testmon
+    # DB-purging hygiene step runs — i.e. before `_run_impacted_pass` calls
+    # `_ensure_testmon_db_safe`. (QS-290: `_clean_orphan_cov_shards` now runs
+    # earlier, above the early exit, but it only ever touches `.coverage.*`
+    # shards and never `.testmondata`, so the invariant is unaffected.)
+    # A non-empty `.testmondata` means testmon
     # has a warm baseline and is about to INCREMENTALLY select a subset — the
     # only case where a changed-line FAIL might be a testmon/coverage desync
     # worth self-healing. An absent/empty DB means this run already select-alls
@@ -1486,11 +1816,6 @@ def check_impacted() -> int:
         # OSError covers FileNotFoundError (vanished baseline) plus any other
         # transient stat failure — treat all as non-incremental.
         was_incremental = False
-
-    # QS-283 A1: reap orphaned `.coverage.*` shards from a killed prior run
-    # before the cov pass, so stale fragments can't `--cov-append` into this
-    # run's coverage.xml. The combined `.coverage` survives (warm baseline).
-    _clean_orphan_cov_shards()
 
     verdict, ran_select_all = _run_impacted_pass(base)
     if verdict == _IMPACTED_PASS:
@@ -2272,8 +2597,8 @@ def main() -> None:
         metavar="PATH",
         help=(
             "Fast iteration mode: run only the cited test paths (files "
-            "or directories) with xdist + sysmon; skip ruff/mypy/"
-            "translations/coverage."
+            "or directories) with sysmon; skip ruff/mypy/"
+            "translations/coverage. xdist only above a small-run threshold."
         ),
     )
     parser.add_argument(
@@ -2443,8 +2768,8 @@ def main() -> None:
 
     if args.quick:
         sys.stderr.write(
-            f"[quick] running {len(args.quick)} path(s) with xdist + "
-            f"sysmon (no coverage / ruff / mypy / translations)\n"
+            f"[quick] running {len(args.quick)} path(s) with sysmon, xdist above "
+            f"{_SERIAL_MAX_TESTS} tests (no coverage / ruff / mypy / translations)\n"
         )
         sys.stderr.flush()
         result = check_pytest_files(args.quick)
@@ -2499,6 +2824,14 @@ def main() -> None:
     scope_info = _detect_scope(changed_files)
     scope = scope_info["scope"]
     if args.full:
+        # QS-290 (D-18): `--full` overrides the detected scope, so keeping
+        # `_detect_scope`'s reason printed the self-contradicting
+        # `scope: FULL (only dev/test files changed (1 file))`. Substitute a
+        # reason that is true — but ONLY when the detection did not already say
+        # `full`, otherwise we would clobber the genuinely useful
+        # `production files changed: …` explanation with a redundant one.
+        if scope != "full":
+            scope_info = {**scope_info, "reason": "--full flag"}
         scope = "full"
 
     if scope == "dev-only":

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -299,8 +299,7 @@ def _workers_env_is_explicit() -> bool:
     """True iff `QS_QG_PYTEST_WORKERS` carries a value we can act on verbatim.
 
     Provenance cannot come from `_pytest_workers()`'s return value (`"auto"` for
-    both unset and `auto`), so it is read from the environment here. Review-fix
-    #01 nice-to-have 11: a MALFORMED value is deliberately NOT explicit —
+    both unset and `auto`), so it is read from the environment here. A MALFORMED value is deliberately NOT explicit —
     `_pytest_workers()` already warns and falls back to `"auto"` for `autoo` /
     `-1` / `4x`, and honouring the typo as a deliberate xdist request silently
     cost a small target its serial fast path. Accepted spellings mirror
@@ -324,6 +323,8 @@ def _resolve_files_workers(count: int | None) -> str | None:
 
     QS-290 (S-1). Decision order:
 
+    Checked in this order — the order matters, and the table is the contract:
+
     | Condition                            | Result                       |
     | ------------------------------------ | ---------------------------- |
     | `QS_QG_PYTEST_WORKERS` **valid**     | `_pytest_workers()` verbatim |
@@ -339,7 +340,7 @@ def _resolve_files_workers(count: int | None) -> str | None:
     (`0` → serial on a huge target; `8` → `-n 8` on a tiny one).
 
     A MALFORMED value (`autoo`, `-1`, `4x`) counts as UNSET, not as an explicit
-    request (review-fix #01 nice-to-have 11): `_pytest_workers()` warns and falls
+    request: `_pytest_workers()` warns and falls
     back to `"auto"` for those, and treating the typo as deliberate silently
     forced xdist onto a 3-test target, losing the fast path with no way for the
     user to tell why. The warning still fires — only the provenance changes.
@@ -349,11 +350,15 @@ def _resolve_files_workers(count: int | None) -> str | None:
     also serves the dev-only / ui-only scopes, not just `--quick`.
     """
     workers = _pytest_workers()
-    if workers is None:
-        # xdist missing, or an explicit serial request — nothing to demote.
-        return None
+    # Explicitness is checked FIRST so an explicit request is honoured *as such*
+    # (including `0`/`""` → None → serial), rather than arriving at the same
+    # answer via a `workers is None` short-circuit that made the decision table
+    # above describe a path the code did not take.
     if _workers_env_is_explicit():
         return workers
+    if workers is None:
+        # xdist missing — nothing to demote.
+        return None
     if count is not None and count <= _SERIAL_MAX_TESTS:
         sys.stderr.write(
             f"[pytest] {count} tests <= {_SERIAL_MAX_TESTS} - single-process "
@@ -554,7 +559,7 @@ _PERCENT_SUFFIX_RE = re.compile(r"\s*\[\s*\d+%\]\s*$")
 # denominator is read from.
 _COUNT_SUFFIX_RE = re.compile(r"\s*\[\s*(?:\d+)\s*/\s*(\d+)\s*\]\s*$")
 
-# QS-290 review-fix #01 nice-to-have 17: `total_tests` sentinel meaning "unknown
+# QS-290 `total_tests` sentinel meaning "unknown
 # — learn the denominator from the run's own `[N/M]` output". A negative value is
 # impossible as a real test count, so it can never collide with a genuine 0
 # (which means "this target really has no tests" and IS authoritative). Kept as a
@@ -658,6 +663,15 @@ def _parse_pytest_output(text: str) -> dict[str, int]:
 
 _COLLECTED_RE = re.compile(r"(\d+) tests? collected")
 
+# pytest's exit code for "no tests were collected" — a KNOWN zero, not a failure.
+_PYTEST_RC_NO_TESTS = 5
+
+# Bound the collect-only probe, matching `_FETCH_TIMEOUT_SECONDS` /
+# `_DIFF_COVER_TIMEOUT_SECONDS`: nothing on the inner-loop hot path may block
+# indefinitely. Generous, since a cold whole-tree collection legitimately takes
+# 3-6 s; expiry degrades to "unknown" (`-n auto`), never to a wrong count.
+_COLLECT_TIMEOUT_SECONDS = 60.0
+
 
 def _collect_test_count(targets: list[str]) -> int | None:
     """Return the number of tests `pytest --collect-only -q` finds under `targets`.
@@ -666,14 +680,24 @@ def _collect_test_count(targets: list[str]) -> int | None:
     two consumers — the progress denominator AND the xdist-or-serial worker
     decision in `check_pytest_files`.
 
-    Returns `None` — explicitly NOT 0 — when the count is unknown: the count
-    line is absent (an unexpected pytest output format), **or pytest exited
-    non-zero** (review-fix #01 should-fix 7 — a partially-failed collection
-    prints `"5 tests collected, 2 errors"`, so a parseable count is NOT proof
-    the collection succeeded, and trusting it routed a broken collection onto
-    the serial fast path). The distinction matters: `None` means *unknown*, and
-    a caller must then fall back to `-n auto` rather than mistake it for a tiny
-    run that deserves the serial fast path.
+    Returns `None` — explicitly NOT 0 — when the count is unknown, because
+    `None` must degrade to `-n auto` while `0` is an authoritative count that
+    takes the serial fast path. Unknown means:
+
+    - the count line is absent (an unexpected pytest output format);
+    - **the probe timed out** — every other inner-loop subprocess here is
+      bounded (`_run`'s `timeout`, used for `git fetch` and diff-cover), so an
+      unbounded collection could block the sub-15 s promise indefinitely. The
+      child is killed so it cannot outlive the gate;
+    - **pytest exited non-zero, except 5.** A partially-failed collection prints
+      `"5 tests collected, 2 errors"` and exits 2, so a parseable count is NOT
+      proof the collection succeeded — trusting it routed a broken collection
+      onto the serial fast path.
+
+    Exit **5** is the deliberate exception: it is pytest's "no tests collected",
+    i.e. a KNOWN zero, and returns `0`. Folding it into "unknown" made
+    `_resolve_files_workers` boot xdist for a target with no tests at all —
+    exactly the fixed overhead this whole change exists to remove.
 
     Uses `subprocess.Popen` directly (rather than `_run`) so the test
     suite can assert this subprocess gets utf-8/replace decoding AND does
@@ -689,7 +713,13 @@ def _collect_test_count(targets: list[str]) -> int | None:
         errors="replace",
         cwd=str(REPO_ROOT),
     )
-    count_stdout, _ = count_proc.communicate()
+    try:
+        count_stdout, _ = count_proc.communicate(timeout=_COLLECT_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        count_proc.kill()
+        return None
+    if count_proc.returncode == _PYTEST_RC_NO_TESTS:
+        return 0
     if count_proc.returncode != 0:
         return None
     for line in count_stdout.split("\n"):
@@ -721,8 +751,7 @@ def _stream_pytest(
     - any other `int` → the caller already knows the count; spawn NOTHING extra
       and treat it as authoritative. `check_pytest_files` passes the count it
       needed anyway for its worker decision. A genuine `0` is authoritative
-      too — a stray `[N/M]` must not redefine it (review-fix #01
-      nice-to-have 17).
+      too — a stray `[N/M]` must not redefine it.
 
     It replaced the old `collect_targets` parameter: with both present,
     forwarding an unknown (`None`) count re-triggered a whole-tree collect
@@ -772,6 +801,9 @@ def _stream_pytest(
     for line in proc.stdout:
         stdout_lines.append(line)
 
+        cleaned = _clean_pytest_line(line)
+        is_progress_line = bool(cleaned) and all(c in _PROGRESS_CHARS for c in cleaned)
+
         # QS-290 (S-5): learn the denominator from the run's OWN output. Under
         # `-o console_output_style=count` every progress line carries a
         # `[current/total]` suffix whose total is the SELECTED count — exactly
@@ -781,16 +813,20 @@ def _stream_pytest(
         # `done (0/6912)` for a 0-selected run). Only fill a denominator the
         # caller declared UNKNOWN: a caller-supplied count already paid for a
         # real collection and stays authoritative — including a genuine 0.
-        if learn_from_stream and total_tests == 0:
+        #
+        # `is_progress_line` is required, not just the `[N/M]` shape: collection
+        # errors print BEFORE any progress line, so a traceback or source line
+        # ending in that shape (`RATIO = SCALE[1/2]`, an echoed parametrize id)
+        # would otherwise latch a bogus denominator for the whole run and make
+        # the progress line read `100% (2/2)` for a 40-test run.
+        if learn_from_stream and total_tests == 0 and is_progress_line:
             seen = _COUNT_SUFFIX_RE.search(_XDIST_PREFIX_RE.sub("", line).rstrip())
             if seen:
                 total_tests = int(seen.group(1))
                 milestone_every = max(1, total_tests // 10)
 
-        cleaned = _clean_pytest_line(line)
-
         # Mid-run progress: count chars on dotted-progress lines.
-        if cleaned and all(c in _PROGRESS_CHARS for c in cleaned):
+        if is_progress_line:
             live_passed += cleaned.count(".")
             live_failed += cleaned.count("F")
             live_errors += cleaned.count("E")
@@ -813,7 +849,7 @@ def _stream_pytest(
     # Final count line uses the authoritative parser (summary line wins).
     # S2: include skipped/xfailed/xpassed in the total so suites with xfail
     # markers don't appear short. Suppress zero-count labels for readability.
-    # Review-fix #01 nice-to-have 10: emitted UNCONDITIONALLY. The previous
+    # Emitted UNCONDITIONALLY. The previous
     # `total_tests > 0 or final_total > 0` guard silently dropped this line on a
     # 0-test run — which is the single most common inner-loop invocation, a `.py`
     # edit testmon deselects to 0 tests — leaving nothing at all between
@@ -916,7 +952,7 @@ def check_pytest_files(test_files: list[str]) -> dict:
     disabled (only the full gate warns about those, to avoid duplicate noise
     from the dev-only fast path and `--quick`) — but the QS-290 threshold
     demotion below DOES announce itself, since that one is our own decision
-    rather than the environment's (review-fix #01 nice-to-have 13: this
+    rather than the environment's (this
     docstring previously claimed "no stderr warning" without qualification).
 
     QS-290 (S-1) serial fast path: xdist's spin-up (one whole-target
@@ -939,13 +975,17 @@ def check_pytest_files(test_files: list[str]) -> dict:
     # finding 2).
     count = _collect_test_count(abs_files)
     workers = _resolve_files_workers(count)
-    cmd = [VENV_PYTHON, "-m", "pytest", *abs_files, "-q"]
+    # `-o console_output_style=count` matches the impacted pass. It is what makes
+    # the unknown-count path (`_LEARN_FROM_STREAM` below) able to learn a
+    # denominator at all: under the default style pytest prints `[NN%]`, the
+    # `[N/M]` shape never appears, and mid-run progress silently vanishes.
+    cmd = [VENV_PYTHON, "-m", "pytest", *abs_files, "-q", "-o", "console_output_style=count"]
     if workers is not None:
         cmd.extend(["-n", workers])
     # An unknown count (`None`) must NOT be forwarded: `_stream_pytest` would
     # read it as "collect the whole tree yourself" and spawn a second probe. It
     # maps to the explicit learn-from-the-stream sentinel rather than to `0`,
-    # which is a real (authoritative) count — review-fix #01 nice-to-have 17.
+    # which is a real (authoritative) count.
     return _stream_pytest(cmd, total_tests=count if count is not None else _LEARN_FROM_STREAM)
 
 
@@ -1176,7 +1216,7 @@ _FETCH_TIMEOUT_SECONDS = 15.0
 # fails — so this is not a new class of risk.
 #
 # CI always fetches fresh — and `_resolve_diff_base` now ENFORCES that by
-# bypassing the TTL under `_is_ci()` (review-fix #01 should-fix 4). Previously
+# bypassing the TTL under `_is_ci()`. Previously
 # this line was an unbacked assertion: `actions/checkout` leaves a seconds-old
 # `FETCH_HEAD`, which would have made CI skip its own fetch.
 _FETCH_TTL_SECONDS = 600.0
@@ -1253,44 +1293,75 @@ def _is_ci() -> bool:
     return os.environ.get("GITHUB_ACTIONS", "").strip().lower() in _CI_TRUTHY
 
 
-# QS-290 S-7 / review-fix #01 should-fix 5: `FETCH_HEAD`'s last field for a
-# fetched branch is `branch '<name>' of <remote-url>`, tab-separated after the
-# sha and an optional `not-for-merge` flag. Verified against real git for
-# `git fetch origin main`, `git fetch origin <other>`, and a bare
+# QS-290 S-7: `FETCH_HEAD`'s last field for a fetched branch is
+# `branch '<name>' of <remote-url>`, tab-separated after the sha and an optional
+# `not-for-merge` flag. Verified against real git for `git fetch origin main`,
+# `git fetch origin <other>`, `git fetch upstream main`, and a bare
 # `git fetch origin` (which lists main plus `not-for-merge` siblings). Kept in
 # sync with the branch `_fetch_origin_main` actually fetches.
 _FETCH_HEAD_MAIN_FIELD = "branch 'main' of "
 
 
-def _fetch_head_records_main(marker: Path) -> bool:
-    """True iff `FETCH_HEAD`'s content records a fetch that brought `main` down.
+def _normalize_remote_url(url: str) -> str:
+    """Canonicalize a remote URL for comparison against `FETCH_HEAD`'s spelling.
 
-    Review-fix #01 should-fix 5: `FETCH_HEAD` records the last fetch of
-    *anything*. `gh pr checkout <n>` (fetches `refs/pull/N/head`),
-    `git fetch origin <other-branch>`, a second remote, an editor plugin
-    fetching tags — each rewrites the marker without advancing `origin/main`.
-    A fresh mtime alone therefore cannot support the claim the skip line makes,
-    and the "staleness is bounded at 10 minutes" argument justifying the whole
-    TTL would not hold.
-
-    Reading the content is what makes the marker measure the thing the TTL
-    claims. `main` flagged `not-for-merge` still counts — the ref came down,
-    which is all the TTL needs.
-
-    (Keying the TTL on `refs/remotes/origin/main`'s mtime instead — the
-    reviewer's literal suggestion — was rejected on measurement: after a clone
-    that ref is PACKED, so the loose path does not exist at all, and even when
-    loose git does not rewrite it when a fetch finds no new commits. A quiet
-    main is the common case, so that marker would make the TTL never hit and
-    delete the feature's entire benefit.)
+    git STRIPS a trailing `.git` when writing `FETCH_HEAD` but
+    `git remote get-url origin` keeps it — verified on this repo
+    (`https://github.com/tmenguy/quiet-solar.git` vs
+    `…/quiet-solar`) and in a local clone with an explicit `.git` path. Comparing
+    raw strings would therefore never match, silently disabling the TTL
+    everywhere.
     """
+    trimmed = url.strip().rstrip("/")
+    return trimmed[: -len(".git")] if trimmed.endswith(".git") else trimmed
+
+
+def _fetch_head_records_origin_main(marker: Path) -> bool:
+    """True iff `FETCH_HEAD` records a fetch that brought **origin's** `main` down.
+
+    `FETCH_HEAD` records the last fetch of *anything*. `gh pr checkout <n>`
+    (fetches `refs/pull/N/head`), `git fetch origin <other-branch>`, an editor
+    plugin fetching tags — each rewrites the marker without advancing
+    `origin/main`. A fresh mtime alone therefore cannot support the claim the
+    skip line makes, and the "staleness is bounded at 10 minutes" argument
+    justifying the whole TTL would not hold.
+
+    The REMOTE matters too, not just the branch name: matching only the
+    `branch 'main' of ` prefix accepted any remote's main. Verified in a
+    two-remote clone — after `git fetch upstream main` the marker reads
+    `branch 'main' of …/upstream` while `origin/main`, the ref the base ladder
+    actually resolves, was never fetched and may be arbitrarily stale. That is
+    the standard fork workflow (`origin` = fork, `upstream` = canonical). The URL
+    is already in the field being parsed, so checking it costs one cheap
+    `git remote get-url`.
+
+    `main` flagged `not-for-merge` still counts — the ref came down, which is all
+    the TTL needs. Any probe failure, unreadable marker, or absent `origin`
+    returns False, i.e. "fetch as usual".
+
+    (Keying the TTL on `refs/remotes/origin/main`'s mtime instead was rejected on
+    measurement: after a clone that ref is PACKED, so the loose path does not
+    exist at all, and even when loose git does not rewrite it when a fetch finds
+    no new commits. A quiet main is the common case, so that marker would make
+    the TTL never hit and delete the feature's entire benefit.)
+    """
+    remote = _run(["git", "remote", "get-url", "origin"])
+    if remote.returncode != 0:
+        return False
+    origin_url = _normalize_remote_url(remote.stdout)
+    if not origin_url:
+        return False
     try:
         content = marker.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return False
-    return any(
-        line.split("\t")[-1].startswith(_FETCH_HEAD_MAIN_FIELD) for line in content.splitlines()
-    )
+    for line in content.splitlines():
+        field = line.split("\t")[-1].strip()
+        if not field.startswith(_FETCH_HEAD_MAIN_FIELD):
+            continue
+        if _normalize_remote_url(field[len(_FETCH_HEAD_MAIN_FIELD) :]) == origin_url:
+            return True
+    return False
 
 
 def _fetch_head_age() -> float | None:
@@ -1307,7 +1378,7 @@ def _fetch_head_age() -> float | None:
 
     - any `rev-parse` failure or empty output;
     - an absent / unreadable marker;
-    - **a 0-byte marker** (review-fix #01 must-fix 3). A FAILED fetch still
+    - **a 0-byte marker**. A FAILED fetch still
       bumps the mtime but truncates the file — verified against real git with
       the remote removed: rc=128, mtime advanced, size 0. Reading that as
       freshness meant the first offline run warned "diff base may be stale vs
@@ -1315,9 +1386,9 @@ def _fetch_head_age() -> float | None:
       retrying even seconds after connectivity returned. The TTL would have
       switched OFF the very warning QS-276 S1 added to keep a failed fetch
       observable;
-    - a marker that records a fetch of something other than `main`
-      (should-fix 5, see `_fetch_head_records_main`);
-    - **a future mtime** (review-fix #01 should-fix 6). The previous
+    - a marker that records a fetch of something other than **origin's** `main`
+      (see `_fetch_head_records_origin_main`);
+    - **a future mtime**. The previous
       `max(0.0, …)` clamped an impossible timestamp to age 0.0, skipping the
       fetch for the entire duration of the skew rather than for 10 minutes —
       reproducible via an NTP step correction, VM suspend/resume, dual boot, or
@@ -1337,7 +1408,7 @@ def _fetch_head_age() -> float | None:
         return None
     if stat.st_size == 0:
         return None
-    if not _fetch_head_records_main(marker):
+    if not _fetch_head_records_origin_main(marker):
         return None
     age = time.time() - stat.st_mtime
     if age < 0:
@@ -1391,7 +1462,7 @@ def _resolve_diff_base() -> str | None:
     skipped fetch must never be the reason we give up (a fresh worktree with a
     stale marker copy could otherwise report "no diff base" and exit 4 in CI).
 
-    Review-fix #01 should-fix 4: the TTL is **bypassed under CI**. The
+    The TTL is **bypassed under CI**. The
     `_FETCH_TTL_SECONDS` rationale asserts "CI always fetches fresh", and
     nothing enforced it — `actions/checkout` leaves a seconds-old `FETCH_HEAD`,
     so a CI `--impacted` would have skipped its own fetch and resolved against
@@ -1409,7 +1480,7 @@ def _resolve_diff_base() -> str | None:
     base = _resolve_base_ladder()
     if base is None and skipped_fetch:
         _fetch_origin_main()
-        # Review-fix #01 nice-to-have 12: the first walk already emitted any NH2
+        # The first walk already emitted any NH2
         # shallow-clone warning; repeating it for the same invocation is noise.
         base = _resolve_base_ladder(warn=False)
     return base
@@ -1421,8 +1492,7 @@ def _resolve_base_ladder(warn: bool = True) -> str | None:
     Split out of `_resolve_diff_base` (QS-290 S-7) so the TTL retry can re-walk
     the ladder after a fetch without recursing or re-probing the marker.
 
-    `warn=False` suppresses only the NH2 unreachable-ref warning (review-fix #01
-    nice-to-have 12) — the chosen-base line still prints, since the retry is
+    `warn=False` suppresses only the NH2 unreachable-ref warning — the chosen-base line still prints, since the retry is
     exactly the pass whose outcome the reader needs.
     """
     for ref in ("origin/main", "main"):
@@ -1457,40 +1527,57 @@ def _impacted_early_exit_paths() -> list[str] | None:
     diff-cover has no Python lines to score. `--impacted` was ALREADY blind
     here; skipping the work changes the cost, not the verdict.
 
-    **A UNION of three listings, all scoped to the merge-base.** No single git
-    diff is a superset of diff-cover's three-dot `base...HEAD` range, so we take
-    the union of three (review-fix #01 must-fix 2 — a single working-tree diff
-    was NOT a superset, and the earlier docstring wrongly claimed it was):
+    **A UNION of four listings, all scoped to the merge-base.** No single git
+    diff is a superset of diff-cover's `base...HEAD` range plus the working
+    state, and each rung below exists because omitting it produced a
+    demonstrable false PASS. Each is independently necessary:
 
     1. `git diff <merge-base>` — merge-base tree vs the WORKING tree. Covers
-       staged and unstaged edits. Note this ALONE is not enough: a `.py`
-       changed in a branch commit but restored to merge-base content in the
-       worktree disappears from it, while diff-cover still scores that commit's
-       added lines. That was a real false PASS.
+       unstaged edits (and staged ones only while index == worktree; it
+       *bypasses* the index, hence rung 4).
     2. `git diff <merge-base> HEAD` — the committed range. Two-dot against an
        already-resolved merge-base is exactly `base...HEAD`, i.e. precisely
-       diff-cover's range, so this rung makes the superset claim true by
-       construction rather than by argument.
+       diff-cover's range. Without it, a `.py` changed in a branch commit but
+       restored to merge-base content in the worktree vanished from the union
+       while diff-cover still scored that commit's added lines.
     3. `git ls-files --others --exclude-standard` — untracked files, which
        diff-cover scores via `--include-untracked`.
+    4. `git diff --cached <merge-base>` — merge-base tree vs the **INDEX**.
+       Without it, a `.py` whose staged content differs from the merge-base
+       while its worktree content equals it appeared in NO rung — yet
+       diff-cover scores it (`GitDiffReporter` is constructed with
+       `ignore_staged=False`, so `git diff --cached -U0` is in its range) and
+       it is exactly what the `git commit` right after this pre-commit gate
+       lands. Reachable via `git add` + `git restore --worktree`, `git add -p`,
+       or `git apply --cached`.
 
     Scoping every rung to the merge-base (rather than to main's tip) also keeps
     main's OWN commits since the fork out of the set — a two-dot diff against
     the tip would drag them in and stop any branch behind main from ever
     early-exiting.
 
-    **NUL-delimited, never line-delimited** (review-fix #01 must-fix 1).
-    `core.quotePath` defaults to TRUE, so `git diff --name-only` and
-    `git ls-files --others` C-quote non-ASCII paths *and wrap them in double
-    quotes*: `"tests/test_donn\\303\\251es.py"`. That does not end in `.py`, so
-    a change set whose only Python file had a non-ASCII character anywhere in
-    its path took the "no Python files changed" exit and the gate returned 0
-    having run neither testmon nor diff-cover — a silent fail-OPEN in the one
-    function whose contract is fail-closed. `-z` emits the raw byte path and
-    removes the entire quoting class; `-c core.quotePath=false` would be weaker,
-    still breaking on a path containing a literal newline. For the same reason
-    fields are NOT stripped: a `-z` field is already exact, and stripping would
-    corrupt a path with leading or trailing spaces.
+    **Caveat — the merge-base here predates `_resolve_diff_base`'s fetch.** The
+    early exit runs before the fetch (that is the point: the fetch is one of the
+    costs it avoids), so this merge-base can differ from the one diff-cover
+    later uses. An *advance* of `origin/main` is safe — it can only move the
+    merge-base forward, yielding a SMALLER post-fetch changed set than the one
+    scored here. A force-push / rebase of `main` can move it backwards and so
+    add `.py` files to diff-cover's range that this set never contained. That is
+    bounded and rare, and reordering the fetch would reintroduce exactly the
+    cost this exit exists to remove.
+
+    **NUL-delimited, never line-delimited.** `core.quotePath` defaults to TRUE,
+    so `git diff --name-only` and `git ls-files --others` C-quote non-ASCII
+    paths *and wrap them in double quotes*: `"tests/test_donn\\303\\251es.py"`.
+    That does not end in `.py`, so a change set whose only Python file had a
+    non-ASCII character anywhere in its path took the "no Python files changed"
+    exit and the gate returned 0 having run neither testmon nor diff-cover — a
+    silent fail-OPEN in the one function whose contract is fail-closed. `-z`
+    emits the raw byte path and removes the entire quoting class;
+    `-c core.quotePath=false` would be weaker, still breaking on a path
+    containing a literal newline. For the same reason fields are NOT stripped: a
+    `-z` field is already exact, and stripping would corrupt a path with leading
+    or trailing spaces.
 
     **Zero-arg and total** so ONE `patch.object` in a test silences every git
     call at this seat. If the base resolve lived in `check_impacted`, its `_run`
@@ -1520,6 +1607,7 @@ def _impacted_early_exit_paths() -> list[str] | None:
     for cmd in (
         ["git", "diff", "--name-only", "-z", merge_base],
         ["git", "diff", "--name-only", "-z", merge_base, "HEAD"],
+        ["git", "diff", "--name-only", "-z", "--cached", merge_base],
         ["git", "ls-files", "--others", "--exclude-standard", "-z"],
     ):
         listing = _run(cmd)
@@ -1900,6 +1988,13 @@ def check_impacted() -> int:
     (QS-290 S-4) → diff-base ladder → one `_run_impacted_pass` → (on an
     incremental changed-line FAIL) exactly one self-heal rebuild + retry.
 
+    Ordering consequence worth knowing: because the early exit is evaluated
+    BEFORE `_resolve_diff_base`, a non-`.py` change set in CI whose base cannot
+    be resolved now returns 0 rather than the diagnostic exit 4. That is
+    deliberate — the verdict genuinely is vacuous either way, and there is
+    nothing for a resolvable base to add — but it IS a behaviour change on the
+    CI branch, so it is recorded here rather than left to be rediscovered.
+
     Exit codes: 0 pass · 1 selected-test failure OR diff-coverage <100% ·
     3 testmon / diff-cover not importable · 4 no diff base resolvable in
     CI (warn-and-skip → 0 locally so an offline dev isn't blocked).
@@ -1941,9 +2036,11 @@ def check_impacted() -> int:
     # QS-290 (S-4): a change set with no `.py` file at all makes this whole
     # gate structurally vacuous — testmon fingerprints only `.py`, so it could
     # never select a test, and diff-cover has no Python lines to score. Exit
-    # before the `git fetch`, the pytest spawn and the diff-cover spawn: two git
-    # calls instead of 10.7-23.5 s of work. `None` means "unknown" (a git
-    # failure) and must fall through — see `_impacted_early_exit_paths`.
+    # before the `git fetch`, the pytest spawn and the diff-cover spawn: a
+    # handful of local git calls instead of 10.7-23.5 s of work. (Deliberately
+    # not a fixed count — the number of rungs has already changed twice.)
+    # `None` means "unknown" (a git failure) and must fall through — see
+    # `_impacted_early_exit_paths`.
     #
     # Caveat (recorded in docs/workflow/project-rules.md): on a STALE testmon DB
     # a non-`.py` run today select-alls and re-syncs the baseline as a side
@@ -2938,9 +3035,17 @@ def main() -> None:
                 parser.error(f"--quick path must be inside the repo: {raw}")
 
     if args.quick:
+        # Don't promise xdist we won't deliver: `_pytest_workers()` returns None
+        # exactly when xdist is absent or explicitly disabled, in which case the
+        # threshold is irrelevant and the run is serial regardless of size.
+        mode = (
+            "single-process"
+            if _pytest_workers() is None
+            else f"xdist above {_SERIAL_MAX_TESTS} tests"
+        )
         sys.stderr.write(
-            f"[quick] running {len(args.quick)} path(s) with sysmon, xdist above "
-            f"{_SERIAL_MAX_TESTS} tests (no coverage / ruff / mypy / translations)\n"
+            f"[quick] running {len(args.quick)} path(s) with sysmon, {mode}"
+            f" (no coverage / ruff / mypy / translations)\n"
         )
         sys.stderr.flush()
         result = check_pytest_files(args.quick)

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -295,24 +295,54 @@ def _pytest_workers() -> str | None:
 _SERIAL_MAX_TESTS = 50
 
 
+def _workers_env_is_explicit() -> bool:
+    """True iff `QS_QG_PYTEST_WORKERS` carries a value we can act on verbatim.
+
+    Provenance cannot come from `_pytest_workers()`'s return value (`"auto"` for
+    both unset and `auto`), so it is read from the environment here. Review-fix
+    #01 nice-to-have 11: a MALFORMED value is deliberately NOT explicit —
+    `_pytest_workers()` already warns and falls back to `"auto"` for `autoo` /
+    `-1` / `4x`, and honouring the typo as a deliberate xdist request silently
+    cost a small target its serial fast path. Accepted spellings mirror
+    `_pytest_workers()` exactly: empty, `0`, case-insensitive `auto`, or a
+    positive integer.
+    """
+    raw = os.environ.get(_WORKERS_ENV)
+    if raw is None:
+        return False
+    val = raw.strip()
+    if val == "" or val == "0" or val.lower() == "auto":
+        return True
+    try:
+        return int(val) > 0
+    except ValueError:
+        return False
+
+
 def _resolve_files_workers(count: int | None) -> str | None:
     """Worker count for `check_pytest_files`, or None for single-process.
 
     QS-290 (S-1). Decision order:
 
-    | Condition                          | Result                     |
-    | ---------------------------------- | -------------------------- |
-    | `QS_QG_PYTEST_WORKERS` **present** | `_pytest_workers()` verbatim |
-    | xdist unavailable                  | serial (unchanged)         |
-    | `count is None` (unknown)          | `-n auto`                  |
-    | `count <= _SERIAL_MAX_TESTS`       | serial (fast path)         |
-    | otherwise                          | `-n auto`                  |
+    | Condition                            | Result                       |
+    | ------------------------------------ | ---------------------------- |
+    | `QS_QG_PYTEST_WORKERS` **valid**     | `_pytest_workers()` verbatim |
+    | xdist unavailable                    | serial (unchanged)           |
+    | `count is None` (unknown)            | `-n auto`                    |
+    | `count <= _SERIAL_MAX_TESTS`         | serial (fast path)           |
+    | otherwise                            | `-n auto`                    |
 
-    Explicitness is detected with `os.environ.get(...) is not None`, NOT from
+    Explicitness is detected from the environment, NOT from
     `_pytest_workers()`'s return value: that returns `"auto"` both when the
     var is unset and when it is set to `auto`, so it cannot carry provenance.
     An explicit request must win over the threshold in BOTH directions
     (`0` → serial on a huge target; `8` → `-n 8` on a tiny one).
+
+    A MALFORMED value (`autoo`, `-1`, `4x`) counts as UNSET, not as an explicit
+    request (review-fix #01 nice-to-have 11): `_pytest_workers()` warns and falls
+    back to `"auto"` for those, and treating the typo as deliberate silently
+    forced xdist onto a 3-test target, losing the fast path with no way for the
+    user to tell why. The warning still fires — only the provenance changes.
 
     Emits the fast-path rationale on stderr directly rather than via `_emit`
     (which would double-prefix). The `[pytest]` prefix is neutral because this
@@ -322,7 +352,7 @@ def _resolve_files_workers(count: int | None) -> str | None:
     if workers is None:
         # xdist missing, or an explicit serial request — nothing to demote.
         return None
-    if os.environ.get(_WORKERS_ENV) is not None:
+    if _workers_env_is_explicit():
         return workers
     if count is not None and count <= _SERIAL_MAX_TESTS:
         sys.stderr.write(
@@ -519,7 +549,18 @@ _PERCENT_SUFFIX_RE = re.compile(r"\s*\[\s*\d+%\]\s*$")
 # SELECTED total under deselection. `_clean_pytest_line` must strip this shape
 # too: otherwise a progress line stops being "all progress characters" and
 # both the mid-run tally and `_parse_pytest_output` silently under-count.
-_COUNT_SUFFIX_RE = re.compile(r"\s*\[\s*(\d+)\s*/\s*(\d+)\s*\]\s*$")
+# Only the TOTAL is captured: the leading `current` is non-capturing (review-fix
+# #01 nice-to-have 14) so a future edit cannot silently shift the group index the
+# denominator is read from.
+_COUNT_SUFFIX_RE = re.compile(r"\s*\[\s*(?:\d+)\s*/\s*(\d+)\s*\]\s*$")
+
+# QS-290 review-fix #01 nice-to-have 17: `total_tests` sentinel meaning "unknown
+# — learn the denominator from the run's own `[N/M]` output". A negative value is
+# impossible as a real test count, so it can never collide with a genuine 0
+# (which means "this target really has no tests" and IS authoritative). Kept as a
+# sentinel value rather than a second parameter: four reviewers rejected
+# re-splitting the one-parameter design.
+_LEARN_FROM_STREAM = -1
 # S2: track xfailed/xpassed/skipped as separate keys; recognize the
 # `error`/`errors` singular/plural collapse on the parser side.
 _COUNT_RE = re.compile(r"(\d+) (passed|failed|errors?|skipped|xfailed|xpassed)")
@@ -625,11 +666,14 @@ def _collect_test_count(targets: list[str]) -> int | None:
     two consumers — the progress denominator AND the xdist-or-serial worker
     decision in `check_pytest_files`.
 
-    Returns `None` — explicitly NOT 0 — when the count line is absent
-    (a collection error, an unexpected pytest output format). The
-    distinction matters: `None` means *unknown*, and a caller must then
-    fall back to `-n auto` rather than mistake it for a tiny run that
-    deserves the serial fast path.
+    Returns `None` — explicitly NOT 0 — when the count is unknown: the count
+    line is absent (an unexpected pytest output format), **or pytest exited
+    non-zero** (review-fix #01 should-fix 7 — a partially-failed collection
+    prints `"5 tests collected, 2 errors"`, so a parseable count is NOT proof
+    the collection succeeded, and trusting it routed a broken collection onto
+    the serial fast path). The distinction matters: `None` means *unknown*, and
+    a caller must then fall back to `-n auto` rather than mistake it for a tiny
+    run that deserves the serial fast path.
 
     Uses `subprocess.Popen` directly (rather than `_run`) so the test
     suite can assert this subprocess gets utf-8/replace decoding AND does
@@ -646,6 +690,8 @@ def _collect_test_count(targets: list[str]) -> int | None:
         cwd=str(REPO_ROOT),
     )
     count_stdout, _ = count_proc.communicate()
+    if count_proc.returncode != 0:
+        return None
     for line in count_stdout.split("\n"):
         m = _COLLECTED_RE.match(line.strip())
         if m:
@@ -663,16 +709,20 @@ def _stream_pytest(
     format as check_pytest(). The main subprocess runs with
     `COVERAGE_CORE=sysmon` for faster coverage tracking.
 
-    `total_tests` (QS-290, S-1/S-5) — ONE parameter, two modes:
+    `total_tests` (QS-290, S-1/S-5) — ONE parameter, three modes:
 
     - `None` → collect the denominator here, against the whole `TESTS_DIR`
       tree. That is the full gate's (`check_pytest`) and the seed path's
       (`seed_testmon`) semantics: they really do run everything.
-    - an `int` → the caller already knows the count; spawn NOTHING extra.
-      `check_pytest_files` passes the count it needed anyway for its
-      worker decision, and `_run_impacted_pass` passes `0` — testmon's
-      selection size is unknowable up front, so the denominator is learned
-      from the run's own `[N/M]` progress suffix instead (S-5).
+    - `_LEARN_FROM_STREAM` → unknown; read it off the run's own `[N/M]`
+      progress suffix (S-5). `_run_impacted_pass` uses this because testmon's
+      selection size is unknowable up front, and `check_pytest_files` uses it
+      when its collect probe came back unknown.
+    - any other `int` → the caller already knows the count; spawn NOTHING extra
+      and treat it as authoritative. `check_pytest_files` passes the count it
+      needed anyway for its worker decision. A genuine `0` is authoritative
+      too — a stray `[N/M]` must not redefine it (review-fix #01
+      nice-to-have 17).
 
     It replaced the old `collect_targets` parameter: with both present,
     forwarding an unknown (`None`) count re-triggered a whole-tree collect
@@ -685,7 +735,10 @@ def _stream_pytest(
     on non-ASCII content (Unicode ellipses, curly quotes in parametrize
     ids, non-ASCII assertion messages).
     """
-    if total_tests is None:
+    learn_from_stream = total_tests == _LEARN_FROM_STREAM
+    if learn_from_stream:
+        total_tests = 0
+    elif total_tests is None:
         total_tests = _collect_test_count([str(TESTS_DIR)]) or 0
 
     milestone_every = max(1, total_tests // 10) if total_tests > 0 else 50
@@ -725,13 +778,13 @@ def _stream_pytest(
         # what a testmon pass cannot know up front, and previously the reason a
         # whole-tree `--collect-only` subprocess was spawned to produce a
         # denominator that was also WRONG for this path (it printed
-        # `done (0/6912)` for a 0-selected run). Only fill an unknown (0)
-        # denominator: a caller-supplied count already paid for a real
-        # collection and stays authoritative.
-        if total_tests == 0:
+        # `done (0/6912)` for a 0-selected run). Only fill a denominator the
+        # caller declared UNKNOWN: a caller-supplied count already paid for a
+        # real collection and stays authoritative — including a genuine 0.
+        if learn_from_stream and total_tests == 0:
             seen = _COUNT_SUFFIX_RE.search(_XDIST_PREFIX_RE.sub("", line).rstrip())
             if seen:
-                total_tests = int(seen.group(2))
+                total_tests = int(seen.group(1))
                 milestone_every = max(1, total_tests // 10)
 
         cleaned = _clean_pytest_line(line)
@@ -760,20 +813,26 @@ def _stream_pytest(
     # Final count line uses the authoritative parser (summary line wins).
     # S2: include skipped/xfailed/xpassed in the total so suites with xfail
     # markers don't appear short. Suppress zero-count labels for readability.
+    # Review-fix #01 nice-to-have 10: emitted UNCONDITIONALLY. The previous
+    # `total_tests > 0 or final_total > 0` guard silently dropped this line on a
+    # 0-test run — which is the single most common inner-loop invocation, a `.py`
+    # edit testmon deselects to 0 tests — leaving nothing at all between
+    # `selecting impacted tests (testmon)…` and the verdict. The old
+    # `done (0/6912)` had the wrong denominator but did confirm the pass ran;
+    # `done (0/0)` is both honest and present.
     counts = _parse_pytest_output(stdout_text)
     final_total = sum(counts[k] for k in _COUNT_KEYS)
-    if total_tests > 0 or final_total > 0:
-        denom = total_tests if total_tests > 0 else final_total
-        parts = [
-            f"passed={counts['passed']}",
-            f"failed={counts['failed']}",
-            f"errors={counts['errors']}",
-        ]
-        for optional_key in ("skipped", "xfailed", "xpassed"):
-            if counts[optional_key]:
-                parts.append(f"{optional_key}={counts[optional_key]}")
-        sys.stderr.write(f"  pytest: done ({final_total}/{denom}) | {' '.join(parts)}\n")
-        sys.stderr.flush()
+    denom = total_tests if total_tests > 0 else final_total
+    parts = [
+        f"passed={counts['passed']}",
+        f"failed={counts['failed']}",
+        f"errors={counts['errors']}",
+    ]
+    for optional_key in ("skipped", "xfailed", "xpassed"):
+        if counts[optional_key]:
+            parts.append(f"{optional_key}={counts[optional_key]}")
+    sys.stderr.write(f"  pytest: done ({final_total}/{denom}) | {' '.join(parts)}\n")
+    sys.stderr.flush()
 
     passed = proc.returncode == 0
     coverage = None
@@ -853,9 +912,12 @@ def check_pytest_files(test_files: list[str]) -> dict:
 
     Honours `_pytest_workers()` for xdist parallelization — same resolver as
     the full gate (`check_pytest`), so `QS_QG_PYTEST_WORKERS` overrides apply
-    here too. Silent serial fallback when xdist is missing or explicitly
-    disabled (no stderr warning; only the full gate warns to avoid duplicate
-    noise from the dev-only fast path and `--quick`).
+    here too. Serial fallback is SILENT when xdist is missing or explicitly
+    disabled (only the full gate warns about those, to avoid duplicate noise
+    from the dev-only fast path and `--quick`) — but the QS-290 threshold
+    demotion below DOES announce itself, since that one is our own decision
+    rather than the environment's (review-fix #01 nice-to-have 13: this
+    docstring previously claimed "no stderr warning" without qualification).
 
     QS-290 (S-1) serial fast path: xdist's spin-up (one whole-target
     collection per worker, each re-importing the HA-heavy conftest) costs
@@ -881,8 +943,10 @@ def check_pytest_files(test_files: list[str]) -> dict:
     if workers is not None:
         cmd.extend(["-n", workers])
     # An unknown count (`None`) must NOT be forwarded: `_stream_pytest` would
-    # read it as "collect the whole tree yourself" and spawn a second probe.
-    return _stream_pytest(cmd, total_tests=count if count is not None else 0)
+    # read it as "collect the whole tree yourself" and spawn a second probe. It
+    # maps to the explicit learn-from-the-stream sentinel rather than to `0`,
+    # which is a real (authoritative) count — review-fix #01 nice-to-have 17.
+    return _stream_pytest(cmd, total_tests=count if count is not None else _LEARN_FROM_STREAM)
 
 
 def check_ruff_lint(fix: bool = False) -> dict:
@@ -1099,8 +1163,9 @@ COVERAGE_DATA = REPO_ROOT / ".coverage"
 _FETCH_TIMEOUT_SECONDS = 15.0
 
 # QS-290 (S-7): skip the `--impacted` `git fetch origin main` when the
-# per-worktree `FETCH_HEAD` marker is younger than this. Repeat inner-loop
-# runs within a TDD burst re-fetch the same ref for nothing.
+# per-worktree `FETCH_HEAD` marker shows `origin/main` was fetched more
+# recently than this. Repeat inner-loop runs within a TDD burst re-fetch the
+# same ref for nothing.
 #
 # Safe by construction: a stale base is OLDER, so diff-cover's changed-line
 # set is a SUPERSET — a TTL hit can turn a PASS into a FAIL, never a FAIL into
@@ -1108,7 +1173,12 @@ _FETCH_TIMEOUT_SECONDS = 15.0
 # semantics, so any such test would assert the mock.) After a force-push of
 # main the stale ref may not be an ancestor at all, but the window is 10
 # minutes and the existing code already tolerates a stale base when a fetch
-# fails — so this is not a new class of risk. CI always fetches fresh.
+# fails — so this is not a new class of risk.
+#
+# CI always fetches fresh — and `_resolve_diff_base` now ENFORCES that by
+# bypassing the TTL under `_is_ci()` (review-fix #01 should-fix 4). Previously
+# this line was an unbacked assertion: `actions/checkout` leaves a seconds-old
+# `FETCH_HEAD`, which would have made CI skip its own fetch.
 _FETCH_TTL_SECONDS = 600.0
 
 # QS-276 review-fix NH1: bound the diff-cover subprocess too — a
@@ -1183,8 +1253,48 @@ def _is_ci() -> bool:
     return os.environ.get("GITHUB_ACTIONS", "").strip().lower() in _CI_TRUTHY
 
 
+# QS-290 S-7 / review-fix #01 should-fix 5: `FETCH_HEAD`'s last field for a
+# fetched branch is `branch '<name>' of <remote-url>`, tab-separated after the
+# sha and an optional `not-for-merge` flag. Verified against real git for
+# `git fetch origin main`, `git fetch origin <other>`, and a bare
+# `git fetch origin` (which lists main plus `not-for-merge` siblings). Kept in
+# sync with the branch `_fetch_origin_main` actually fetches.
+_FETCH_HEAD_MAIN_FIELD = "branch 'main' of "
+
+
+def _fetch_head_records_main(marker: Path) -> bool:
+    """True iff `FETCH_HEAD`'s content records a fetch that brought `main` down.
+
+    Review-fix #01 should-fix 5: `FETCH_HEAD` records the last fetch of
+    *anything*. `gh pr checkout <n>` (fetches `refs/pull/N/head`),
+    `git fetch origin <other-branch>`, a second remote, an editor plugin
+    fetching tags — each rewrites the marker without advancing `origin/main`.
+    A fresh mtime alone therefore cannot support the claim the skip line makes,
+    and the "staleness is bounded at 10 minutes" argument justifying the whole
+    TTL would not hold.
+
+    Reading the content is what makes the marker measure the thing the TTL
+    claims. `main` flagged `not-for-merge` still counts — the ref came down,
+    which is all the TTL needs.
+
+    (Keying the TTL on `refs/remotes/origin/main`'s mtime instead — the
+    reviewer's literal suggestion — was rejected on measurement: after a clone
+    that ref is PACKED, so the loose path does not exist at all, and even when
+    loose git does not rewrite it when a fetch finds no new commits. A quiet
+    main is the common case, so that marker would make the TTL never hit and
+    delete the feature's entire benefit.)
+    """
+    try:
+        content = marker.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return any(
+        line.split("\t")[-1].startswith(_FETCH_HEAD_MAIN_FIELD) for line in content.splitlines()
+    )
+
+
 def _fetch_head_age() -> float | None:
-    """Age in seconds of the per-worktree `FETCH_HEAD` marker, or None.
+    """Age in seconds since `origin/main` was last fetched, or None if unknown.
 
     QS-290 (S-7). The marker path is resolved via
     `git rev-parse --git-path FETCH_HEAD` rather than hardcoded: in a LINKED
@@ -1192,9 +1302,26 @@ def _fetch_head_age() -> float | None:
     itself is a *file*, so a literal `.git/FETCH_HEAD` would be a path under a
     non-directory and the TTL would silently never hit.
 
-    None (= "unknown, do not skip") on any `rev-parse` failure, empty output,
-    or an unreadable / absent marker, so an unknown always degrades to
-    fetching exactly as before the TTL existed.
+    None (= "unknown, do not skip") on every uncertainty, so an unknown always
+    degrades to fetching exactly as before the TTL existed:
+
+    - any `rev-parse` failure or empty output;
+    - an absent / unreadable marker;
+    - **a 0-byte marker** (review-fix #01 must-fix 3). A FAILED fetch still
+      bumps the mtime but truncates the file — verified against real git with
+      the remote removed: rc=128, mtime advanced, size 0. Reading that as
+      freshness meant the first offline run warned "diff base may be stale vs
+      CI" and then every run for the next 10 minutes silently skipped, never
+      retrying even seconds after connectivity returned. The TTL would have
+      switched OFF the very warning QS-276 S1 added to keep a failed fetch
+      observable;
+    - a marker that records a fetch of something other than `main`
+      (should-fix 5, see `_fetch_head_records_main`);
+    - **a future mtime** (review-fix #01 should-fix 6). The previous
+      `max(0.0, …)` clamped an impossible timestamp to age 0.0, skipping the
+      fetch for the entire duration of the skew rather than for 10 minutes —
+      reproducible via an NTP step correction, VM suspend/resume, dual boot, or
+      a network share whose server clock runs ahead.
     """
     probe = _run(["git", "rev-parse", "--git-path", "FETCH_HEAD"])
     if probe.returncode != 0:
@@ -1202,16 +1329,24 @@ def _fetch_head_age() -> float | None:
     raw = probe.stdout.strip()
     if not raw:
         return None
+    marker = REPO_ROOT / raw
     try:
-        mtime = (REPO_ROOT / raw).stat().st_mtime
+        stat = marker.stat()
     except OSError:
         # Absent marker (never fetched in this worktree) or an unreadable path.
         return None
-    return max(0.0, time.time() - mtime)
+    if stat.st_size == 0:
+        return None
+    if not _fetch_head_records_main(marker):
+        return None
+    age = time.time() - stat.st_mtime
+    if age < 0:
+        return None
+    return age
 
 
 def _fmt_fetch_age(age: float) -> str:
-    """Render a FETCH_HEAD age compactly for the skip line: `12s` / `3m`."""
+    """Render the since-last-fetch age compactly for the skip line: `12s` / `3m`."""
     return f"{int(age)}s" if age < 60 else f"{int(age // 60)}m"
 
 
@@ -1251,30 +1386,44 @@ def _resolve_diff_base() -> str | None:
     a warning emitted); if nothing reachable resolves, we return None and
     the caller applies the no-base policy (warn-skip locally, exit 4 CI).
 
-    QS-290 (S-7): the fetch is TTL-cached on `FETCH_HEAD`'s mtime. If the base
-    then fails to resolve, the fetch is retried ONCE — a skipped fetch must
-    never be the reason we give up (a fresh worktree with a stale marker copy
-    could otherwise report "no diff base" and exit 4 in CI).
+    QS-290 (S-7): the fetch is TTL-cached on when `origin/main` was last
+    fetched. If the base then fails to resolve, the fetch is retried ONCE — a
+    skipped fetch must never be the reason we give up (a fresh worktree with a
+    stale marker copy could otherwise report "no diff base" and exit 4 in CI).
+
+    Review-fix #01 should-fix 4: the TTL is **bypassed under CI**. The
+    `_FETCH_TTL_SECONDS` rationale asserts "CI always fetches fresh", and
+    nothing enforced it — `actions/checkout` leaves a seconds-old `FETCH_HEAD`,
+    so a CI `--impacted` would have skipped its own fetch and resolved against
+    whatever base checkout happened to leave. The retry-once path only rescues
+    `base is None`, not resolvable-but-stale, so the bypass is the safe default.
     """
-    age = _fetch_head_age()
+    # CI: don't even probe the marker — the answer cannot change the decision.
+    age = None if _is_ci() else _fetch_head_age()
     if age is not None and age < _FETCH_TTL_SECONDS:
         skipped_fetch = True
-        _emit("impacted", f"diff base: fetch skipped (FETCH_HEAD {_fmt_fetch_age(age)} old)")
+        _emit("impacted", f"diff base: fetch skipped (origin/main fetched {_fmt_fetch_age(age)} ago)")
     else:
         skipped_fetch = False
         _fetch_origin_main()
     base = _resolve_base_ladder()
     if base is None and skipped_fetch:
         _fetch_origin_main()
-        base = _resolve_base_ladder()
+        # Review-fix #01 nice-to-have 12: the first walk already emitted any NH2
+        # shallow-clone warning; repeating it for the same invocation is noise.
+        base = _resolve_base_ladder(warn=False)
     return base
 
 
-def _resolve_base_ladder() -> str | None:
+def _resolve_base_ladder(warn: bool = True) -> str | None:
     """Walk `origin/main` → `main` → upstream merge-base; no fetching.
 
     Split out of `_resolve_diff_base` (QS-290 S-7) so the TTL retry can re-walk
     the ladder after a fetch without recursing or re-probing the marker.
+
+    `warn=False` suppresses only the NH2 unreachable-ref warning (review-fix #01
+    nice-to-have 12) — the chosen-base line still prints, since the retry is
+    exactly the pass whose outcome the reader needs.
     """
     for ref in ("origin/main", "main"):
         if _run(["git", "rev-parse", "--verify", ref]).returncode != 0:
@@ -1284,7 +1433,8 @@ def _resolve_base_ladder() -> str | None:
             # NH2 (#05): name the chosen base so an unexpected diff-cover range is debuggable.
             _emit("impacted", f"diff base: {ref}")
             return ref
-        _emit("impacted", f"warning: {ref} has no merge-base with HEAD (shallow clone?) — skipping")
+        if warn:
+            _emit("impacted", f"warning: {ref} has no merge-base with HEAD (shallow clone?) — skipping")
     upstream = _run(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
     tracked = upstream.stdout.strip()
     if upstream.returncode == 0 and tracked:
@@ -1307,19 +1457,40 @@ def _impacted_early_exit_paths() -> list[str] | None:
     diff-cover has no Python lines to score. `--impacted` was ALREADY blind
     here; skipping the work changes the cost, not the verdict.
 
-    **Merge-base, not two-dot.** `git diff --name-only <merge-base>` compares
-    the merge-base tree against the WORKING tree, so it is a genuine superset
-    of diff-cover's three-dot `base...HEAD` range in both directions:
+    **A UNION of three listings, all scoped to the merge-base.** No single git
+    diff is a superset of diff-cover's three-dot `base...HEAD` range, so we take
+    the union of three (review-fix #01 must-fix 2 — a single working-tree diff
+    was NOT a superset, and the earlier docstring wrongly claimed it was):
 
-    - it covers committed + staged + unstaged edits, plus (via `ls-files
-      --others`) untracked files, which `--include-untracked` makes diff-cover
-      score;
-    - it still contains a `.py` file your branch changed that main already
-      holds with IDENTICAL content (a landed cherry-pick / squash-merge), which
-      a two-dot `git diff <main-tip>` would silently omit while diff-cover
-      scored it — a false PASS;
-    - it excludes main's OWN commits since the fork, which a two-dot diff would
-      drag in, making any branch slightly behind main never early-exit.
+    1. `git diff <merge-base>` — merge-base tree vs the WORKING tree. Covers
+       staged and unstaged edits. Note this ALONE is not enough: a `.py`
+       changed in a branch commit but restored to merge-base content in the
+       worktree disappears from it, while diff-cover still scores that commit's
+       added lines. That was a real false PASS.
+    2. `git diff <merge-base> HEAD` — the committed range. Two-dot against an
+       already-resolved merge-base is exactly `base...HEAD`, i.e. precisely
+       diff-cover's range, so this rung makes the superset claim true by
+       construction rather than by argument.
+    3. `git ls-files --others --exclude-standard` — untracked files, which
+       diff-cover scores via `--include-untracked`.
+
+    Scoping every rung to the merge-base (rather than to main's tip) also keeps
+    main's OWN commits since the fork out of the set — a two-dot diff against
+    the tip would drag them in and stop any branch behind main from ever
+    early-exiting.
+
+    **NUL-delimited, never line-delimited** (review-fix #01 must-fix 1).
+    `core.quotePath` defaults to TRUE, so `git diff --name-only` and
+    `git ls-files --others` C-quote non-ASCII paths *and wrap them in double
+    quotes*: `"tests/test_donn\\303\\251es.py"`. That does not end in `.py`, so
+    a change set whose only Python file had a non-ASCII character anywhere in
+    its path took the "no Python files changed" exit and the gate returned 0
+    having run neither testmon nor diff-cover — a silent fail-OPEN in the one
+    function whose contract is fail-closed. `-z` emits the raw byte path and
+    removes the entire quoting class; `-c core.quotePath=false` would be weaker,
+    still breaking on a path containing a literal newline. For the same reason
+    fields are NOT stripped: a `-z` field is already exact, and stripping would
+    corrupt a path with leading or trailing spaces.
 
     **Zero-arg and total** so ONE `patch.object` in a test silences every git
     call at this seat. If the base resolve lived in `check_impacted`, its `_run`
@@ -1345,17 +1516,17 @@ def _impacted_early_exit_paths() -> list[str] | None:
     merge_base = mb.stdout.strip()
     if mb.returncode != 0 or not merge_base:
         return None
-    # Committed + staged + unstaged, merge-base tree vs working tree.
-    diff = _run(["git", "diff", "--name-only", merge_base])
-    if diff.returncode != 0:
-        return None
-    # Untracked files — diff-cover scores them via `--include-untracked`.
-    others = _run(["git", "ls-files", "--others", "--exclude-standard"])
-    if others.returncode != 0:
-        return None
-    return sorted(
-        {line.strip() for line in (diff.stdout + "\n" + others.stdout).splitlines() if line.strip()}
-    )
+    paths: set[str] = set()
+    for cmd in (
+        ["git", "diff", "--name-only", "-z", merge_base],
+        ["git", "diff", "--name-only", "-z", merge_base, "HEAD"],
+        ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+    ):
+        listing = _run(cmd)
+        if listing.returncode != 0:
+            return None
+        paths.update(field for field in listing.stdout.split("\0") if field)
+    return sorted(paths)
 
 
 # QS-290 (S-4): the non-`.py` PASS explanation. ASCII only, emitted through
@@ -1674,10 +1845,10 @@ def _run_impacted_pass(base: str) -> tuple[str, bool]:
     # against stale data instead of failing loudly.
     COVERAGE_XML.unlink(missing_ok=True)
     _emit("impacted", f"selecting impacted tests (testmon) vs base {base}")
-    # QS-290 (S-5): `total_tests=0` — spawn NO collect-only probe. testmon's
-    # selection size is unknowable before the run, so the denominator is
-    # learned from the pass's own `[N/M]` progress suffix instead.
-    result = _stream_pytest(_build_testmon_cmd(), total_tests=0)
+    # QS-290 (S-5): spawn NO collect-only probe. testmon's selection size is
+    # unknowable before the run, so the denominator is learned from the pass's
+    # own `[N/M]` progress suffix instead.
+    result = _stream_pytest(_build_testmon_cmd(), total_tests=_LEARN_FROM_STREAM)
     if not result["passed"]:
         _emit("impacted", "FAIL (selected tests failed)")
         return _IMPACTED_TESTS_FAILED, ran_select_all

--- a/tests/qs/agents/test_impacted_non_py_honesty.py
+++ b/tests/qs/agents/test_impacted_non_py_honesty.py
@@ -17,20 +17,20 @@ The contract pinned here:
 
 1. no claim that testmon-selected tests guard anything may stand
    UNSCOPED — each must carry the "change set contains a `.py` file"
-   condition (review-fix #01 nice-to-have 21 asserts this **semantically**
-   rather than by rejecting one exact phrasing);
+   condition. This is asserted **semantically**, not by rejecting one
+   exact phrasing: an earlier version matched a single literal string
+   (line break included), which a copy-edit could sidestep while
+   restoring an equally false claim in different words;
 2. the body must state that a non-`.py` change set checks nothing;
 3. it must name `--quick tests/qs` as the verification in that case,
    not merely as a supplement;
 4. it must say the early exit **fails closed** on a git-probe failure,
-   so "no exit message" never reads as "the exit fired silently"
-   (review-fix #01 should-fix 8);
+   so "no exit message" never reads as "the exit fired silently";
 5. it must name `--quick tests/test_quality_gate.py` for gate changes,
    since the impacted pass `--ignore`s that file BY PATH — a `.py`
-   change is not automatically a verified one (should-fix 8);
+   change is not automatically a verified one;
 6. its automatic `git add` must stage the dev-tooling tests, or a guard
-   like this one can be written and then left uncommitted
-   (should-fix 9).
+   like this one can be written and then left uncommitted.
 
 Mirrored across all three harnesses (Claude / Cursor / OpenCode) so an
 edit to one harness alone fails, matching the harness-sync rule in
@@ -56,7 +56,7 @@ HARNESS_DIRS: tuple[Path, ...] = (
 
 AGENT_NAME = "qs-implement-setup-task"
 
-# Review-fix #01 nice-to-have 21: assert the SEMANTIC, not one phrasing.
+# Assert the SEMANTIC, not one phrasing.
 # The original guard rejected a single exact string (including its line break),
 # so a copy-edit could restore an unconditional claim in different words while
 # every test still passed.
@@ -152,7 +152,7 @@ def test_names_quick_tests_qs_as_the_verification(harness_dir: Path) -> None:
 
 @pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
 def test_states_the_early_exit_fails_closed(harness_dir: Path) -> None:
-    """Review-fix #01 should-fix 8: `.py` presence is not the WHOLE decision.
+    """`.py` presence is not the WHOLE decision.
 
     A failed git probe does not take the exit — silence about the exit never
     means the exit fired.
@@ -166,7 +166,7 @@ def test_states_the_early_exit_fails_closed(harness_dir: Path) -> None:
 
 @pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
 def test_names_the_quality_gate_self_test_target(harness_dir: Path) -> None:
-    """Review-fix #01 should-fix 8: a `.py` change is not automatically covered.
+    """A `.py` change is not automatically covered.
 
     The impacted pass excludes `tests/test_quality_gate.py` BY PATH, so a change
     to the gate itself is never verified by `--impacted` — the agent must be told
@@ -185,7 +185,7 @@ def test_names_the_quality_gate_self_test_target(harness_dir: Path) -> None:
 
 @pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
 def test_staging_command_includes_dev_tooling_tests(harness_dir: Path) -> None:
-    """Review-fix #01 should-fix 9: the automatic `git add` must stage the tests.
+    """The automatic `git add` must stage the tests.
 
     This agent is permitted to write dev-tooling tests, but its staging command
     omitted `tests/` entirely — so an agent could commit prose changes while

--- a/tests/qs/agents/test_impacted_non_py_honesty.py
+++ b/tests/qs/agents/test_impacted_non_py_honesty.py
@@ -1,0 +1,100 @@
+"""Pin the honesty of `qs-implement-setup-task`'s `--impacted` prose.
+
+QS-290 (S-4) gave `--impacted` an early exit: a change set with no `.py`
+file at all spawns no pytest, no diff-cover and no `git fetch`, and
+returns 0. testmon fingerprints AST blocks in `.py` files only, so such
+a run could never have selected a test anyway — the exit changed the
+cost (10-24 s → two git calls), not the verdict.
+
+That makes one sentence in `qs-implement-setup-task.md` actively
+misleading, and it matters *most* in exactly that agent: it is the
+dev-environment implement variant, so its change sets are the ones most
+likely to be pure non-`.py` (a docs-only edit, an agent-file-only edit).
+The agent must not read "`--impacted` guards the tooling" and conclude a
+green means something when nothing ran.
+
+The contract pinned here:
+
+1. the agent body must NOT claim, unconditionally, that the tooling's
+   own correctness is guarded by `--impacted`'s testmon-selected tests;
+2. it must state that a non-`.py` change set checks nothing;
+3. it must name `--quick tests/qs` as the verification in that case,
+   not merely as a supplement.
+
+Mirrored across all three harnesses (Claude / Cursor / OpenCode) so an
+edit to one harness alone fails, matching the harness-sync rule in
+`docs/workflow/project-rules.md`.
+
+Pattern follows `test_doc_maintenance_parity.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+HARNESS_DIRS: tuple[Path, ...] = (
+    REPO_ROOT / ".claude" / "agents",
+    REPO_ROOT / ".cursor" / "agents",
+    REPO_ROOT / ".opencode" / "agents",
+)
+
+AGENT_NAME = "qs-implement-setup-task"
+
+# The exact wording that QS-290 falsified. Kept verbatim as a tripwire: a
+# revert or a copy-paste from an older harness copy re-introduces it.
+FALSIFIED_CLAIM = (
+    "but the gate/tooling's own correctness is\nstill guarded by its "
+    "testmon-selected tests under `--impacted`"
+)
+
+
+def _harness_id(p: Path) -> str:
+    return p.parent.name.lstrip(".")
+
+
+def _body(harness_dir: Path) -> str:
+    path = harness_dir / f"{AGENT_NAME}.md"
+    assert path.is_file(), f"Missing agent file: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_does_not_claim_impacted_guards_the_tooling(harness_dir: Path) -> None:
+    """The unconditional "`--impacted` guards the tooling" claim must be gone."""
+    assert FALSIFIED_CLAIM not in _body(harness_dir), (
+        f"{harness_dir / f'{AGENT_NAME}.md'}: this claim is false for a "
+        "change set with no `.py` file — QS-290's early exit runs nothing "
+        "at all there. Say it is guarded only when the change set DOES "
+        "contain a `.py` file."
+    )
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_states_non_py_change_sets_check_nothing(harness_dir: Path) -> None:
+    """The agent must know that a non-`.py` green means nothing ran."""
+    body = _body(harness_dir)
+    assert "no `.py` file at all" in body, (
+        f"{harness_dir / f'{AGENT_NAME}.md'}: must state that a change set "
+        "with no `.py` file makes `--impacted` exit early."
+    )
+    assert "check\n**nothing**" in body or "check **nothing**" in body, (
+        f"{harness_dir / f'{AGENT_NAME}.md'}: must say the non-`.py` run "
+        "checks NOTHING — 'fast no-op' alone reads as 'cheap but still valid'."
+    )
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_names_quick_tests_qs_as_the_verification(harness_dir: Path) -> None:
+    """`--quick tests/qs` is THE check for a non-`.py` change set."""
+    body = _body(harness_dir)
+    assert "not a supplement" in body, (
+        f"{harness_dir / f'{AGENT_NAME}.md'}: must promote `--quick tests/qs` "
+        "from supplement to sole verification for non-`.py` change sets."
+    )
+    assert "quality_gate.py --quick tests/qs" in body, (
+        f"{harness_dir / f'{AGENT_NAME}.md'}: the runnable command must stay present."
+    )

--- a/tests/qs/agents/test_impacted_non_py_honesty.py
+++ b/tests/qs/agents/test_impacted_non_py_honesty.py
@@ -1,25 +1,36 @@
 """Pin the honesty of `qs-implement-setup-task`'s `--impacted` prose.
 
 QS-290 (S-4) gave `--impacted` an early exit: a change set with no `.py`
-file at all spawns no pytest, no diff-cover and no `git fetch`, and
-returns 0. testmon fingerprints AST blocks in `.py` files only, so such
-a run could never have selected a test anyway — the exit changed the
-cost (10-24 s → two git calls), not the verdict.
+file at all spawns no pytest, no diff-cover and no `git fetch`, just a
+handful of local git calls, and returns 0. testmon fingerprints AST
+blocks in `.py` files only, so such a run could never have selected a
+test anyway — the exit changed the cost, not the verdict.
 
-That makes one sentence in `qs-implement-setup-task.md` actively
-misleading, and it matters *most* in exactly that agent: it is the
-dev-environment implement variant, so its change sets are the ones most
-likely to be pure non-`.py` (a docs-only edit, an agent-file-only edit).
-The agent must not read "`--impacted` guards the tooling" and conclude a
-green means something when nothing ran.
+That makes the agent's `--impacted` prose actively misleading, and it
+matters *most* in exactly this agent: it is the dev-environment
+implement variant, so its change sets are the ones most likely to be
+pure non-`.py` (a docs-only edit, an agent-file-only edit). The agent
+must not read "`--impacted` guards the tooling" and conclude a green
+means something when nothing ran.
 
 The contract pinned here:
 
-1. the agent body must NOT claim, unconditionally, that the tooling's
-   own correctness is guarded by `--impacted`'s testmon-selected tests;
-2. it must state that a non-`.py` change set checks nothing;
+1. no claim that testmon-selected tests guard anything may stand
+   UNSCOPED — each must carry the "change set contains a `.py` file"
+   condition (review-fix #01 nice-to-have 21 asserts this **semantically**
+   rather than by rejecting one exact phrasing);
+2. the body must state that a non-`.py` change set checks nothing;
 3. it must name `--quick tests/qs` as the verification in that case,
-   not merely as a supplement.
+   not merely as a supplement;
+4. it must say the early exit **fails closed** on a git-probe failure,
+   so "no exit message" never reads as "the exit fired silently"
+   (review-fix #01 should-fix 8);
+5. it must name `--quick tests/test_quality_gate.py` for gate changes,
+   since the impacted pass `--ignore`s that file BY PATH — a `.py`
+   change is not automatically a verified one (should-fix 8);
+6. its automatic `git add` must stage the dev-tooling tests, or a guard
+   like this one can be written and then left uncommitted
+   (should-fix 9).
 
 Mirrored across all three harnesses (Claude / Cursor / OpenCode) so an
 edit to one harness alone fails, matching the harness-sync rule in
@@ -30,6 +41,7 @@ Pattern follows `test_doc_maintenance_parity.py`.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -44,11 +56,19 @@ HARNESS_DIRS: tuple[Path, ...] = (
 
 AGENT_NAME = "qs-implement-setup-task"
 
-# The exact wording that QS-290 falsified. Kept verbatim as a tripwire: a
-# revert or a copy-paste from an older harness copy re-introduces it.
-FALSIFIED_CLAIM = (
-    "but the gate/tooling's own correctness is\nstill guarded by its "
-    "testmon-selected tests under `--impacted`"
+# Review-fix #01 nice-to-have 21: assert the SEMANTIC, not one phrasing.
+# The original guard rejected a single exact string (including its line break),
+# so a copy-edit could restore an unconditional claim in different words while
+# every test still passed.
+#
+# The semantic: wherever the body claims testmon-selected tests guard the
+# tooling, that claim must be scoped to a change set that CONTAINS a `.py`
+# file. So every mention of testmon selection must sit inside a paragraph that
+# also states the `.py` condition.
+_TESTMON_CLAIM_RE = re.compile(r"testmon[- ]selected tests", re.IGNORECASE)
+_PY_CONDITION_RE = re.compile(
+    r"(contains? a `\.py` file|does\*{0,2} contain a `\.py` file|`\.py` presence)",
+    re.IGNORECASE,
 )
 
 
@@ -62,26 +82,56 @@ def _body(harness_dir: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _flat(harness_dir: Path) -> str:
+    """The body with all runs of whitespace collapsed to single spaces."""
+    return " ".join(_body(harness_dir).split())
+
+
+def _paragraphs(body: str) -> list[str]:
+    """Split on blank lines, then flatten each block's internal wrapping.
+
+    These files are hard-wrapped at ~70 columns, so a sentence and its
+    qualifying clause routinely sit on different lines; matching per-line would
+    make the guard depend on where the wrap happens to fall.
+    """
+    return [" ".join(block.split()) for block in body.split("\n\n")]
+
+
 @pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
-def test_does_not_claim_impacted_guards_the_tooling(harness_dir: Path) -> None:
-    """The unconditional "`--impacted` guards the tooling" claim must be gone."""
-    assert FALSIFIED_CLAIM not in _body(harness_dir), (
-        f"{harness_dir / f'{AGENT_NAME}.md'}: this claim is false for a "
-        "change set with no `.py` file — QS-290's early exit runs nothing "
-        "at all there. Say it is guarded only when the change set DOES "
-        "contain a `.py` file."
+def test_testmon_guarantee_is_scoped_to_py_change_sets(harness_dir: Path) -> None:
+    """Any "testmon-selected tests guard this" claim must carry the `.py` condition.
+
+    Unconditionally, that claim is FALSE: QS-290's early exit runs nothing at
+    all for a change set with no `.py` file.
+    """
+    body = _body(harness_dir)
+    claiming = [p for p in _paragraphs(body) if _TESTMON_CLAIM_RE.search(p)]
+    assert claiming, (
+        f"{harness_dir / f'{AGENT_NAME}.md'}: expected the body to discuss what "
+        "testmon-selected tests do and do not guarantee; found no mention at all."
     )
+    for para in claiming:
+        assert _PY_CONDITION_RE.search(para), (
+            f"{harness_dir / f'{AGENT_NAME}.md'}: this claim is unscoped, so it is "
+            "false for a change set with no `.py` file (the early exit runs "
+            f"nothing there). Qualify it with the `.py` condition:\n\n{para}"
+        )
 
 
 @pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
 def test_states_non_py_change_sets_check_nothing(harness_dir: Path) -> None:
-    """The agent must know that a non-`.py` green means nothing ran."""
-    body = _body(harness_dir)
+    """The agent must know that a non-`.py` green means nothing ran.
+
+    Assertions run against whitespace-normalized text: these files are
+    hard-wrapped, so a phrase's line break is an accident of formatting and must
+    not be part of the contract.
+    """
+    body = _flat(harness_dir)
     assert "no `.py` file at all" in body, (
         f"{harness_dir / f'{AGENT_NAME}.md'}: must state that a change set "
         "with no `.py` file makes `--impacted` exit early."
     )
-    assert "check\n**nothing**" in body or "check **nothing**" in body, (
+    assert "checks **nothing**" in body, (
         f"{harness_dir / f'{AGENT_NAME}.md'}: must say the non-`.py` run "
         "checks NOTHING — 'fast no-op' alone reads as 'cheap but still valid'."
     )
@@ -90,7 +140,7 @@ def test_states_non_py_change_sets_check_nothing(harness_dir: Path) -> None:
 @pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
 def test_names_quick_tests_qs_as_the_verification(harness_dir: Path) -> None:
     """`--quick tests/qs` is THE check for a non-`.py` change set."""
-    body = _body(harness_dir)
+    body = _flat(harness_dir)
     assert "not a supplement" in body, (
         f"{harness_dir / f'{AGENT_NAME}.md'}: must promote `--quick tests/qs` "
         "from supplement to sole verification for non-`.py` change sets."
@@ -98,3 +148,59 @@ def test_names_quick_tests_qs_as_the_verification(harness_dir: Path) -> None:
     assert "quality_gate.py --quick tests/qs" in body, (
         f"{harness_dir / f'{AGENT_NAME}.md'}: the runnable command must stay present."
     )
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_states_the_early_exit_fails_closed(harness_dir: Path) -> None:
+    """Review-fix #01 should-fix 8: `.py` presence is not the WHOLE decision.
+
+    A failed git probe does not take the exit — silence about the exit never
+    means the exit fired.
+    """
+    body = _flat(harness_dir)
+    assert "fails closed" in body, (
+        f"{harness_dir / f'{AGENT_NAME}.md'}: must say the early exit fails "
+        "CLOSED on a git-probe failure."
+    )
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_names_the_quality_gate_self_test_target(harness_dir: Path) -> None:
+    """Review-fix #01 should-fix 8: a `.py` change is not automatically covered.
+
+    The impacted pass excludes `tests/test_quality_gate.py` BY PATH, so a change
+    to the gate itself is never verified by `--impacted` — the agent must be told
+    the explicit target.
+    """
+    body = _flat(harness_dir)
+    assert "quality_gate.py --quick tests/test_quality_gate.py" in body, (
+        f"{harness_dir / f'{AGENT_NAME}.md'}: must name the explicit quick "
+        "target for quality-gate changes (the impacted pass --ignores that file)."
+    )
+    assert "select" in body and "zero" in body, (
+        f"{harness_dir / f'{AGENT_NAME}.md'}: must warn that a `.py` edit can "
+        "still select zero tests."
+    )
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_staging_command_includes_dev_tooling_tests(harness_dir: Path) -> None:
+    """Review-fix #01 should-fix 9: the automatic `git add` must stage the tests.
+
+    This agent is permitted to write dev-tooling tests, but its staging command
+    omitted `tests/` entirely — so an agent could commit prose changes while
+    silently leaving the regression guard uncommitted. (This very PR only landed
+    its guard because the story carried a hand-staging warning.)
+    """
+    body = _body(harness_dir)
+    add_lines = [ln for ln in body.splitlines() if ln.strip().startswith("git add ")]
+    assert add_lines, f"{harness_dir / f'{AGENT_NAME}.md'}: no `git add` command found"
+    for line in add_lines:
+        assert "tests/qs/" in line, (
+            f"{harness_dir / f'{AGENT_NAME}.md'}: staging command omits dev-tooling "
+            f"tests, so a new guard can be written and then left uncommitted:\n{line}"
+        )
+        assert "tests/test_quality_gate.py" in line, (
+            f"{harness_dir / f'{AGENT_NAME}.md'}: staging command omits the "
+            f"quality-gate self-tests:\n{line}"
+        )

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -2037,6 +2037,26 @@ class TestCollectTestCount:
         with patch.object(quality_gate.subprocess, "Popen", fake):
             assert quality_gate._collect_test_count(["/x"]) == expected
 
+    def test_a_parametrize_id_cannot_masquerade_as_the_summary(self) -> None:
+        """`.search()` is unanchored, so a parametrized test ID printed by
+        `--collect-only` can satisfy the pattern BEFORE the real summary line.
+
+        Verified: a param value of `"12/340 tests collected (328 deselected)"`
+        yields an id the probe parses, returning 12 for a 3-test file — silently
+        corrupting both the worker decision and the progress denominator, with
+        no symptom. Latent today only because `TestCollectTestCount` happens to
+        pin `ids=[...]`; dropping that would arm it. Real ids always begin with
+        the file path, so anchoring at column 0 is immune.
+        """
+        fake = _fake_popen(
+            collect_stdout=(
+                "tests/test_x.py::test_p[12/340 tests collected (328 deselected)]\n"
+                "3 tests collected in 0.01s\n"
+            )
+        )
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            assert quality_gate._collect_test_count(["/x"]) == 3
+
     def test_returns_one_for_singular_wording(self) -> None:
         fake = _fake_popen(collect_stdout="1 test collected in 0.1s\n")
         with patch.object(quality_gate.subprocess, "Popen", fake):
@@ -2114,6 +2134,33 @@ class TestCollectTestCount:
             assert quality_gate._collect_test_count(["/x"]) is None
         assert seen.get("timeout") == quality_gate._COLLECT_TIMEOUT_SECONDS
         assert killed, "the hung probe must be killed so it cannot outlive the gate"
+
+    def test_reaping_communicate_is_bounded(self) -> None:
+        """The reap must not become an unbounded hang.
+
+        If collection leaves a grandchild holding the inherited stdout/stderr
+        pipes (a conftest or plugin that spawns a helper at import), `SIGKILL`
+        reaches only the direct child, so an unbounded reap turns the 60 s
+        collect budget into an indefinite stall of the whole gate — strictly
+        worse than the `ResourceWarning` the reap exists to remove.
+        """
+        seen: list[dict] = []
+
+        class WedgedPopen(_CountingFakePopen):
+            calls: list[list[str]] = []
+
+            def communicate(self, *a, **kw):  # type: ignore[no-untyped-def]
+                seen.append(kw)
+                raise subprocess.TimeoutExpired(cmd=["pytest"], timeout=kw.get("timeout"))
+
+            def kill(self):  # type: ignore[no-untyped-def]
+                pass
+
+        with patch.object(quality_gate.subprocess, "Popen", WedgedPopen):
+            # A second TimeoutExpired from the reap must be swallowed, not raised.
+            assert quality_gate._collect_test_count(["/x"]) is None
+        assert len(seen) == 2, seen
+        assert seen[1].get("timeout") == quality_gate._COLLECT_REAP_TIMEOUT_SECONDS
 
     def test_killed_probe_is_reaped(self) -> None:
         """`kill()` alone leaves the child unreaped with both pipes open, so
@@ -3896,6 +3943,8 @@ class TestCheckImpacted:
     def test_no_base_in_ci_returns_4(self) -> None:
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
             _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value=None),
             patch.object(quality_gate, "_is_ci", return_value=True),
@@ -3905,6 +3954,8 @@ class TestCheckImpacted:
     def test_no_base_locally_warns_and_passes(self) -> None:
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
             _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value=None),
             patch.object(quality_gate, "_is_ci", return_value=False),
@@ -4512,6 +4563,70 @@ class TestImpactedNonPyEarlyExit:
         ):
             assert quality_gate.check_impacted() == 4
 
+    @pytest.mark.parametrize("sidecar", ["-wal", "-shm"], ids=["wal", "shm"])
+    def test_sidecars_alongside_the_primary_are_not_warm(
+        self, tmp_path: Path, sidecar: str
+    ) -> None:
+        """`st_size > 0` is only a PROXY for "testmon has a usable baseline",
+        and it is unsound while sidecars sit next to the primary.
+
+        Reproduced against real testmon 2.2.0 — a `pytest --testmon` killed
+        mid-run leaves:
+
+            .testmondata 4096 B   .testmondata-wal 140112   .testmondata-shm 32768
+
+        `PRAGMA user_version` still reads 14, so `_ensure_testmon_db_safe` does
+        NOT purge, and the orphan-sidecar branch only fires when the primary is
+        ABSENT — which this is not. So the baseline reads "warm" while testmon
+        actually select-alls: a non-`.py` change against that DB ran **40
+        passed**, versus `no tests ran` against a cleanly seeded one.
+
+        The same sidecar signature covers an in-flight `--seed-testmon` /
+        rebuild, whose window is minutes long on a 7 000-test suite.
+
+        Note this test does NOT use the class's `_warm_baseline` fixture shape:
+        that writes 13 bytes of non-SQLite, which pins *size*, not usability.
+        """
+        db = tmp_path / ".testmondata"
+        db.write_bytes(b"\x00" * 4096)
+        assert quality_gate.__dict__  # sanity: module imported
+        with patch.object(quality_gate, "TESTMON_DATA", db):
+            assert quality_gate._testmon_baseline_warm() is True  # control
+            (tmp_path / f".testmondata{sidecar}").write_bytes(b"x")
+            assert quality_gate._testmon_baseline_warm() is False
+
+    def test_sidecar_state_does_not_early_exit(self, tmp_path: Path) -> None:
+        """End-to-end: an interrupted/in-flight baseline must fall through to
+        the full pass rather than returning a vacuous 0."""
+        db = tmp_path / ".testmondata"
+        db.write_bytes(b"\x00" * 4096)
+        (tmp_path / ".testmondata-wal").write_bytes(b"stale frames")
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "TESTMON_DATA", db),
+            _patch_early_exit(["docs/a.md"]),
+            patch.object(quality_gate, "_resolve_diff_base", return_value=None),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+        ):
+            assert quality_gate.check_impacted() == 4
+
+    def test_primary_alone_still_early_exits(self, tmp_path: Path) -> None:
+        """Negative half: no sidecars → warm → the fast path survives."""
+        db = tmp_path / ".testmondata"
+        db.write_bytes(b"\x00" * 4096)
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "TESTMON_DATA", db),
+            _patch_early_exit(["docs/a.md"]),
+            patch.object(quality_gate, "_resolve_diff_base") as mock_base,
+        ):
+            assert quality_gate.check_impacted() == 0
+        mock_base.assert_not_called()
+
     def test_cold_baseline_does_not_early_exit(self, tmp_path: Path) -> None:
         """A COLD `.testmondata` makes the exit a VERDICT change, not a cost shift.
 
@@ -4614,14 +4729,16 @@ class TestImpactedNonPyEarlyExit:
         ):
             assert quality_gate.check_impacted() == 4
 
-    def test_hygiene_runs_before_the_seam(self) -> None:
+    def test_hygiene_runs_before_the_seam(self, tmp_path: Path) -> None:
         """AC3: `_clean_orphan_cov_shards` must be hoisted ABOVE the seam — the
         exit returns before the old seat would ever have been reached, so
         without the hoist an orphan-shard-leaving crash would never be reaped
         on a non-`.py` run."""
         manager = MagicMock()
-        warm = MagicMock()
-        warm.stat.return_value.st_size = 1
+        # A real path, not a MagicMock: the warm probe now also checks for
+        # `-wal`/`-shm` siblings, and every attribute of a MagicMock is truthy.
+        warm = tmp_path / ".testmondata"
+        warm.write_bytes(b"\x00" * 4096)
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "TESTMON_DATA", warm),
@@ -6670,6 +6787,9 @@ class TestProjectRulesDocGuards:
         assert "changes cost, never a verdict" not in flat, (
             "this claim is false for a cold baseline — the exit is gated on warmth"
         )
+        # The warmth gate is not airtight: testmon's environment fingerprint
+        # (#341) still slips through, so the doc must not claim it is.
+        assert "#341" in flat, "the known-gap caveat must stay documented"
 
     def test_serial_fast_path_documented(self) -> None:
         """QS-290 (S-1, task 7): `--quick`'s comment block claimed

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -2009,6 +2009,34 @@ class TestCollectTestCount:
         assert "--collect-only" in fake.calls[0]
         assert "/x/tests" in fake.calls[0]
 
+    @pytest.mark.parametrize(
+        ("stdout", "expected"),
+        [
+            ("3 tests collected in 0.00s\n", 3),
+            ("1/3 tests collected (2 deselected) in 0.00s\n", 1),
+            ("12/340 tests collected (328 deselected) in 1.20s\n", 12),
+        ],
+        ids=["plain", "deselected", "deselected-large"],
+    )
+    def test_parses_the_deselection_form(self, stdout: str, expected: int) -> None:
+        """pytest prints `N/M tests collected (K deselected)` whenever anything
+        deselects — a `-k`/`-m` in `pytest.ini`'s `addopts` (a `slow` marker is
+        already declared here) or a `pytest_collection_modifyitems` hook.
+
+        Verified against real pytest:
+            plain:       `3 tests collected in 0.01s`
+            deselected:  `1/3 tests collected (2 deselected) in 0.00s`
+
+        `.match()` anchors at position 0, so the `1/` prefix made this return
+        `None` → `_resolve_files_workers` always answered `-n auto` → the serial
+        fast path this story exists to deliver silently stopped existing, with
+        no warning and no symptom but the lost seconds. The SELECTED count is
+        the numerator — that is what actually runs.
+        """
+        fake = _fake_popen(collect_stdout=stdout)
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            assert quality_gate._collect_test_count(["/x"]) == expected
+
     def test_returns_one_for_singular_wording(self) -> None:
         fake = _fake_popen(collect_stdout="1 test collected in 0.1s\n")
         with patch.object(quality_gate.subprocess, "Popen", fake):
@@ -2068,10 +2096,16 @@ class TestCollectTestCount:
 
         class HangingPopen(_CountingFakePopen):
             calls: list[list[str]] = []
+            _n = 0
 
             def communicate(self, *a, **kw):  # type: ignore[no-untyped-def]
-                seen.update(kw)
-                raise subprocess.TimeoutExpired(cmd=["pytest"], timeout=kw.get("timeout"))
+                type(self)._n += 1
+                if type(self)._n == 1:
+                    seen.update(kw)
+                    raise subprocess.TimeoutExpired(cmd=["pytest"], timeout=kw.get("timeout"))
+                # A real `communicate()` after `kill()` returns normally — it is
+                # how the child gets reaped.
+                return ("", "")
 
             def kill(self):  # type: ignore[no-untyped-def]
                 killed.append(True)
@@ -2080,6 +2114,29 @@ class TestCollectTestCount:
             assert quality_gate._collect_test_count(["/x"]) is None
         assert seen.get("timeout") == quality_gate._COLLECT_TIMEOUT_SECONDS
         assert killed, "the hung probe must be killed so it cannot outlive the gate"
+
+    def test_killed_probe_is_reaped(self) -> None:
+        """`kill()` alone leaves the child unreaped with both pipes open, so
+        CPython prints `ResourceWarning: subprocess N is still running` into the
+        middle of gate output. The kill must be followed by a `communicate()`.
+        """
+        events: list[str] = []
+
+        class HangingPopen(_CountingFakePopen):
+            calls: list[list[str]] = []
+
+            def communicate(self, *a, **kw):  # type: ignore[no-untyped-def]
+                events.append("communicate")
+                if len(events) == 1:  # the first (timed-out) wait
+                    raise subprocess.TimeoutExpired(cmd=["pytest"], timeout=1)
+                return ("", "")
+
+            def kill(self):  # type: ignore[no-untyped-def]
+                events.append("kill")
+
+        with patch.object(quality_gate.subprocess, "Popen", HangingPopen):
+            assert quality_gate._collect_test_count(["/x"]) is None
+        assert events == ["communicate", "kill", "communicate"], events
 
     def test_pins_utf8_replace_and_no_coverage_core(self) -> None:
         """Same encoding contract as the run it precedes (S5), and the probe
@@ -4377,9 +4434,24 @@ class TestImpactedNonPyEarlyExit:
     testmon fingerprints AST blocks in `.py` files only — verified with a
     positive control: editing `docs/workflow/overview.md`, the very file a
     test module reads and asserts on at runtime, selects ZERO tests. So
-    `--impacted` was ALREADY blind here; the early exit changes the cost
-    (10.7–23.5 s → a handful of local git calls), not the verdict.
+    `--impacted` was ALREADY blind here — provided the baseline is WARM.
+    Against a cold `.testmondata` testmon select-alls instead, so the exit is
+    gated on warmth; see the cold-baseline tests below.
     """
+
+    @pytest.fixture(autouse=True)
+    def _warm_baseline(self, tmp_path_factory: pytest.TempPathFactory):
+        """Pin a warm baseline: the exit now requires one.
+
+        Without this the "exit fires" tests inherit the ambient `.testmondata` —
+        green locally, red on CI, which has no baseline at all. (Same class of
+        environment assumption that broke `test_quick_emits_banner` on CI.)
+        Tests exercising the COLD path re-patch `TESTMON_DATA` themselves.
+        """
+        db = tmp_path_factory.mktemp("warm") / ".testmondata"
+        db.write_bytes(b"warm-baseline")
+        with patch.object(quality_gate, "TESTMON_DATA", db):
+            yield
 
     def test_returns_0_without_spawning_anything(
         self, capsys: pytest.CaptureFixture[str]
@@ -4387,6 +4459,7 @@ class TestImpactedNonPyEarlyExit:
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
             _patch_early_exit(["docs/workflow/project-rules.md", "CLAUDE.md"]),
             patch.object(quality_gate, "_resolve_diff_base") as mock_base,
             patch.object(quality_gate, "_stream_pytest") as mock_stream,
@@ -4406,6 +4479,7 @@ class TestImpactedNonPyEarlyExit:
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
             _patch_early_exit(["docs/a.md"]),
             patch.object(quality_gate, "_run", return_value=_cp(0)) as mock_run,
             patch.object(quality_gate, "_stream_pytest"),
@@ -4419,6 +4493,7 @@ class TestImpactedNonPyEarlyExit:
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
             _patch_early_exit([]),
             patch.object(quality_gate, "_resolve_diff_base") as mock_base,
         ):
@@ -4430,7 +4505,110 @@ class TestImpactedNonPyEarlyExit:
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
             patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
             _patch_early_exit(None),
+            patch.object(quality_gate, "_resolve_diff_base", return_value=None),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+        ):
+            assert quality_gate.check_impacted() == 4
+
+    def test_cold_baseline_does_not_early_exit(self, tmp_path: Path) -> None:
+        """A COLD `.testmondata` makes the exit a VERDICT change, not a cost shift.
+
+        The exit assumes testmon "could never select a test" for a non-`.py`
+        change set. That holds only for a WARM baseline. Proven against real
+        testmon:
+
+            COLD (no .testmondata), note.txt changed -> 1 passed     (select-all)
+            WARM,                   note.txt changed -> no tests ran (0 selected)
+
+        So a doc-only change that breaks a doc-pinned guard test exited 1 before
+        this PR and would return 0 after — a false PASS, the one defect class a
+        quality gate must never ship. This PR's OWN guard tests
+        (`test_impacted_non_py_honesty.py`, `TestProjectRulesDocGuards`) are
+        precisely the tests a cold-baseline doc-only change would stop running.
+        """
+        absent = tmp_path / ".testmondata"  # never created → cold
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "TESTMON_DATA", absent),
+            _patch_early_exit(["docs/a.md"]),
+            patch.object(quality_gate, "_resolve_diff_base", return_value=None),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+        ):
+            # Falls through to the full pipeline; the no-base CI branch proves
+            # we got past the seam rather than returning its 0.
+            assert quality_gate.check_impacted() == 4
+
+    def test_empty_baseline_does_not_early_exit(self, tmp_path: Path) -> None:
+        """A present-but-zero-length `.testmondata` is equally cold."""
+        empty = tmp_path / ".testmondata"
+        empty.write_bytes(b"")
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "TESTMON_DATA", empty),
+            _patch_early_exit(["docs/a.md"]),
+            patch.object(quality_gate, "_resolve_diff_base", return_value=None),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+        ):
+            assert quality_gate.check_impacted() == 4
+
+    def test_corrupt_baseline_purged_by_hygiene_does_not_early_exit(
+        self, tmp_path: Path
+    ) -> None:
+        """The warm probe must be read AFTER hygiene.
+
+        A present, non-empty but CORRUPT `.testmondata` looks warm, yet
+        `_ensure_testmon_db_safe` purges it — after which testmon select-alls.
+        Gating on the pre-hygiene signal alone would leave exactly the hole
+        this fix closes.
+        """
+        db = tmp_path / ".testmondata"
+        db.write_bytes(b"not a sqlite database")
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "COVERAGE_DATA", tmp_path / ".coverage"),
+            patch.object(quality_gate, "TESTMON_DATA", db),
+            _patch_early_exit(["docs/a.md"]),
+            patch.object(quality_gate, "_resolve_diff_base", return_value=None),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+        ):
+            # Real hygiene runs, detects corruption, purges → cold → no exit.
+            assert quality_gate.check_impacted() == 4
+        assert not db.exists(), "the corrupt baseline must have been purged"
+
+    def test_warm_baseline_still_early_exits(self, tmp_path: Path) -> None:
+        """The negative half: the fast path must NOT be silently disabled."""
+        warm = tmp_path / ".testmondata"
+        warm.write_bytes(b"warm-baseline")
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "TESTMON_DATA", warm),
+            _patch_early_exit(["docs/a.md"]),
+            patch.object(quality_gate, "_resolve_diff_base") as mock_base,
+            patch.object(quality_gate, "_stream_pytest") as mock_stream,
+        ):
+            assert quality_gate.check_impacted() == 0
+        mock_base.assert_not_called()
+        mock_stream.assert_not_called()
+
+    def test_vanished_baseline_does_not_early_exit(self) -> None:
+        """An unreadable / vanished baseline is treated as cold, not warm."""
+        fake_db = MagicMock()
+        fake_db.stat.side_effect = FileNotFoundError
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "TESTMON_DATA", fake_db),
+            _patch_early_exit(["docs/a.md"]),
             patch.object(quality_gate, "_resolve_diff_base", return_value=None),
             patch.object(quality_gate, "_is_ci", return_value=True),
         ):
@@ -4442,17 +4620,26 @@ class TestImpactedNonPyEarlyExit:
         without the hoist an orphan-shard-leaving crash would never be reaped
         on a non-`.py` run."""
         manager = MagicMock()
+        warm = MagicMock()
+        warm.stat.return_value.st_size = 1
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "TESTMON_DATA", warm),
             patch.object(quality_gate, "_clean_orphan_cov_shards") as mock_clean,
+            patch.object(quality_gate, "_ensure_testmon_db_safe") as mock_safe,
             patch.object(
                 quality_gate, "_impacted_early_exit_paths", return_value=["docs/a.md"]
             ) as mock_seam,
         ):
             manager.attach_mock(mock_clean, "clean")
+            manager.attach_mock(mock_safe, "safe")
             manager.attach_mock(mock_seam, "seam")
             assert quality_gate.check_impacted() == 0
-        assert [c[0] for c in manager.mock_calls] == ["clean", "seam"], manager.mock_calls
+        # DB hygiene is hoisted above the seam too: the exit returns before
+        # `_run_impacted_pass`, so otherwise a corrupt `.testmondata` is NEVER
+        # purged and a developer on a doc-only stretch keeps returning 0 in
+        # milliseconds while the DB stays broken.
+        assert [c[0] for c in manager.mock_calls] == ["clean", "safe", "seam"], manager.mock_calls
 
     def test_py_in_change_set_runs_the_pass_with_no_collect_only(self, tmp_path: Path) -> None:
         """AC4: on a change set CONTAINING a `.py` file the exit provably does
@@ -4623,6 +4810,7 @@ class TestCheckImpactedSelfHeal:
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "TESTMON_DATA", db),
             patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "_rebuild_testmon_baseline") as mock_rebuild,
             patch.object(quality_gate, "_run_impacted_pass", mock_pass),
         ):
@@ -4692,11 +4880,19 @@ class TestCheckImpactedSelfHeal:
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "TESTMON_DATA", fake_db),
             patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            # Hygiene is hoisted into `check_impacted`, so it is no longer
+            # covered by the `_run_impacted_pass` mock. Left real, it would
+            # `sqlite3.connect(str(MagicMock))` and create a file literally
+            # named `<MagicMock id=...>` in the repo root.
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "_rebuild_testmon_baseline") as mock_rebuild,
             patch.object(quality_gate, "_run_impacted_pass", mock_pass),
         ):
             assert quality_gate.check_impacted() == 1  # must not raise
-        fake_db.stat.assert_called_once()
+        # The warm probe is read TWICE now: once pre-hygiene (the QS-283
+        # self-heal signal) and once post-hygiene (the early-exit gate). What
+        # matters is that a vanishing baseline raises through neither.
+        assert fake_db.stat.call_count >= 1
         mock_rebuild.assert_not_called()  # non-incremental → no self-heal retry
         assert mock_pass.call_count == 1
         assert "rebuilding testmon baseline" not in capsys.readouterr().err
@@ -6467,8 +6663,13 @@ class TestProjectRulesDocGuards:
                 )
         # should-fix 8's fail-closed qualification belongs in the doc too.
         assert "fails closed" in flat
-        # The deferred-baseline-resync caveat (a cost shift, not a verdict change).
-        assert "Deferred baseline re-sync" in flat
+        # The exit is only sound on a WARM baseline; the doc must not promise a
+        # blanket "cost shift, never a verdict" — against a cold baseline
+        # testmon select-alls and those tests can fail.
+        assert "Cold baselines do not take the exit" in flat
+        assert "changes cost, never a verdict" not in flat, (
+            "this claim is false for a cold baseline — the exit is gated on warmth"
+        )
 
     def test_serial_fast_path_documented(self) -> None:
         """QS-290 (S-1, task 7): `--quick`'s comment block claimed

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -55,6 +55,28 @@ def _patch_full_scope():
     )
 
 
+_DEFAULT_EARLY_EXIT_PATHS = ["custom_components/quiet_solar/home_model/load.py"]
+
+
+def _patch_early_exit(paths: list[str] | None = "keep-py"):  # type: ignore[assignment]
+    """Patch QS-290's non-`.py` early-exit seam in `check_impacted`.
+
+    The seam (`_impacted_early_exit_paths`) is deliberately zero-arg and total:
+    ONE patch here silences ALL FOUR git calls at that seat. Every
+    `check_impacted` test must patch it, because the default working-tree state
+    is not controllable from a unit test — a genuinely non-`.py` tree would make
+    the exit fire and turn assertions about the downstream pipeline into
+    vacuous greens (or env-dependent failures, e.g. `test_no_base_in_ci_returns_4`
+    returning 0).
+
+    Default (the `"keep-py"` sentinel): a single `.py` path, so the exit
+    provably does NOT fire. `None` is a meaningful value here (git failed →
+    unknown → no exit), hence a sentinel rather than `None` as the default.
+    """
+    resolved = _DEFAULT_EARLY_EXIT_PATHS if paths == "keep-py" else paths
+    return patch.object(quality_gate, "_impacted_early_exit_paths", return_value=resolved)
+
+
 def _patch_all_gates(results: list[dict] | None = None):
     """Context manager that patches all five gate check functions."""
     r = results or _make_all_pass_results()
@@ -1635,7 +1657,10 @@ class TestQuickMode:
             quality_gate.main()
         err = capsys.readouterr().err
         assert err.startswith("[quick] running "), f"banner missing/wrong: {err!r}"
-        assert "xdist + sysmon" in err, f"banner missing 'xdist + sysmon': {err!r}"
+        # QS-290 (S-1): xdist is now conditional on the small-run threshold, so
+        # the banner must not promise it unconditionally.
+        assert "xdist + sysmon" not in err, f"banner still claims unconditional xdist: {err!r}"
+        assert f"xdist above {quality_gate._SERIAL_MAX_TESTS} tests" in err, f"banner missing threshold: {err!r}"
 
     def test_quick_rejects_empty_args(
         self,
@@ -1690,19 +1715,26 @@ class TestQuickMode:
         workers_value: str | None,
         expected_in_cmd: bool,
     ) -> None:
-        """`check_pytest_files` adds `-n <workers>` iff `_pytest_workers()` returns one."""
+        """`check_pytest_files` adds `-n <workers>` iff `_pytest_workers()` returns one.
+
+        QS-290: the collected count is pinned ABOVE `_SERIAL_MAX_TESTS` so the
+        serial fast path cannot demote the `auto`/`4` params — this test is
+        about the resolver's value reaching the argv, not the threshold.
+        """
         captured: dict = {}
 
-        def fake_stream(
-            cmd: list[str],
-            collect_targets: list[str] | None = None,
-        ) -> dict:
+        def fake_stream(cmd: list[str], total_tests: int | None = None) -> dict:
             captured["cmd"] = cmd
-            captured["collect_targets"] = collect_targets
+            captured["total_tests"] = total_tests
             return {"name": "pytest", "passed": True, "detail": ""}
 
         with (
             patch.object(quality_gate, "_pytest_workers", return_value=workers_value),
+            patch.object(
+                quality_gate,
+                "_collect_test_count",
+                return_value=quality_gate._SERIAL_MAX_TESTS + 1,
+            ),
             patch.object(quality_gate, "_stream_pytest", side_effect=fake_stream),
         ):
             quality_gate.check_pytest_files(["tests/test_x.py"])
@@ -1853,6 +1885,474 @@ class TestQuickMode:
         assert "must be non-empty" in err, f"empty-path message missing/changed: {err!r}"
 
 
+# --- QS-290 S-1: serial fast path for small test-file runs ---
+
+
+class _CountingFakePopen:
+    """A `subprocess.Popen` stand-in that records every spawned argv.
+
+    `collect_stdout` is what the `--collect-only` probe reads via
+    `communicate()`; `run_stdout` is streamed line-by-line as the main
+    pytest run's stdout. `returncode` is what the main run exits with.
+    """
+
+    calls: list[list[str]] = []
+    collect_stdout = "0 tests collected\n"
+    run_stdout = ""
+    run_returncode = 0
+
+    def __init__(self, cmd, **kwargs):  # type: ignore[no-untyped-def]
+        type(self).calls.append(list(cmd))
+        self._is_collect = "--collect-only" in cmd
+        text = type(self).collect_stdout if self._is_collect else type(self).run_stdout
+        self.stdout = io.StringIO(text)
+        self.stderr = io.StringIO("")
+        self.returncode = 0 if self._is_collect else type(self).run_returncode
+
+    def communicate(self, *a, **kw):  # type: ignore[no-untyped-def]
+        return (self.stdout.getvalue(), "")
+
+    def wait(self):  # type: ignore[no-untyped-def]
+        return self.returncode
+
+
+def _fake_popen(
+    *,
+    collect_stdout: str = "0 tests collected\n",
+    run_stdout: str = "",
+    run_returncode: int = 0,
+) -> type[_CountingFakePopen]:
+    """Build a fresh `_CountingFakePopen` subclass with its own `calls` list."""
+    return type(
+        "FakePopen",
+        (_CountingFakePopen,),
+        {
+            "calls": [],
+            "collect_stdout": collect_stdout,
+            "run_stdout": run_stdout,
+            "run_returncode": run_returncode,
+        },
+    )
+
+
+class TestCollectTestCount:
+    """QS-290 (S-1): `_collect_test_count` is the extracted collect-only probe.
+
+    It returns `int` on a parseable count and `None` when the count is
+    unknown — `None` is NOT 0: callers must fall back to `-n auto` rather
+    than mistake an unparseable probe for a tiny run.
+    """
+
+    def test_returns_parsed_count(self) -> None:
+        fake = _fake_popen(collect_stdout="123 tests collected in 1.2s\n")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            assert quality_gate._collect_test_count(["/x/tests"]) == 123
+        assert len(fake.calls) == 1
+        assert "--collect-only" in fake.calls[0]
+        assert "/x/tests" in fake.calls[0]
+
+    def test_returns_one_for_singular_wording(self) -> None:
+        fake = _fake_popen(collect_stdout="1 test collected in 0.1s\n")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            assert quality_gate._collect_test_count(["/x"]) == 1
+
+    def test_returns_none_when_unparseable(self) -> None:
+        fake = _fake_popen(collect_stdout="ERROR: file or directory not found\n")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            assert quality_gate._collect_test_count(["/x"]) is None
+
+    def test_pins_utf8_replace_and_no_coverage_core(self) -> None:
+        """Same encoding contract as the run it precedes (S5), and the probe
+        must NOT inherit `COVERAGE_CORE` (coverage is inactive at collection)."""
+        seen: dict = {}
+
+        class FakePopen(_CountingFakePopen):
+            calls: list[list[str]] = []
+
+            def __init__(self, cmd, **kwargs):  # type: ignore[no-untyped-def]
+                seen.update(kwargs)
+                super().__init__(cmd, **kwargs)
+
+        with patch.object(quality_gate.subprocess, "Popen", FakePopen):
+            quality_gate._collect_test_count(["/x"])
+        assert seen.get("encoding") == "utf-8"
+        assert seen.get("errors") == "replace"
+        assert "env" not in seen, f"the probe must inherit the parent env verbatim: {seen!r}"
+
+
+class TestStreamPytestTotalTests:
+    """QS-290 (S-1/S-5): `_stream_pytest` takes ONE `total_tests` parameter.
+
+    `None` → collect the whole `TESTS_DIR` denominator itself (the full-gate
+    and seed paths). An int → trust the caller and spawn NOTHING extra.
+    The old `collect_targets` parameter is gone.
+    """
+
+    def test_int_total_spawns_no_collect_subprocess(self) -> None:
+        fake = _fake_popen(run_stdout="..\n2 passed in 0.1s\n")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            quality_gate._stream_pytest(["pytest"], total_tests=7)
+        assert len(fake.calls) == 1, f"expected only the run, got {fake.calls!r}"
+        assert not any("--collect-only" in c for c in fake.calls)
+
+    def test_none_total_collects_tests_dir(self) -> None:
+        fake = _fake_popen(collect_stdout="9 tests collected\n", run_stdout="")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            quality_gate._stream_pytest(["pytest"], total_tests=None)
+        assert len(fake.calls) == 2
+        assert str(quality_gate.TESTS_DIR) in fake.calls[0]
+
+    def test_collect_targets_parameter_is_gone(self) -> None:
+        """The two-parameter overload the delta-auditor flagged must not exist."""
+        import inspect
+
+        params = inspect.signature(quality_gate._stream_pytest).parameters
+        assert "collect_targets" not in params
+        assert list(params) == ["cmd", "total_tests"], list(params)
+
+
+class TestSerialFastPath:
+    """QS-290 (S-1, AC7/AC8): `check_pytest_files` skips the xdist spin-up for
+    small targets, using ONE collect-only probe for both the denominator and
+    the worker decision."""
+
+    @staticmethod
+    def _run(
+        count: int | None,
+        *,
+        env_workers: str | None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> dict:
+        if env_workers is None:
+            monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        else:
+            monkeypatch.setenv("QS_QG_PYTEST_WORKERS", env_workers)
+        captured: dict = {}
+
+        def fake_stream(cmd: list[str], total_tests: int | None = None) -> dict:
+            captured["cmd"] = cmd
+            captured["total_tests"] = total_tests
+            return {"name": "pytest", "passed": True, "detail": ""}
+
+        with (
+            patch.object(quality_gate, "_has_xdist", return_value=True),
+            patch.object(quality_gate, "_collect_test_count", return_value=count),
+            patch.object(quality_gate, "_stream_pytest", side_effect=fake_stream),
+        ):
+            quality_gate.check_pytest_files(["tests/test_x.py"])
+        return captured
+
+    def test_at_threshold_runs_serial(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cap = self._run(quality_gate._SERIAL_MAX_TESTS, env_workers=None, monkeypatch=monkeypatch)
+        assert "-n" not in cap["cmd"], cap["cmd"]
+        assert cap["total_tests"] == quality_gate._SERIAL_MAX_TESTS
+        err = capsys.readouterr().err
+        assert err.startswith("[pytest] "), err
+        assert f"{quality_gate._SERIAL_MAX_TESTS} tests <= {quality_gate._SERIAL_MAX_TESTS}" in err, err
+        assert "single-process" in err, err
+
+    def test_just_above_threshold_uses_xdist(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cap = self._run(quality_gate._SERIAL_MAX_TESTS + 1, env_workers=None, monkeypatch=monkeypatch)
+        assert cap["cmd"][cap["cmd"].index("-n") + 1] == "auto"
+        assert cap["total_tests"] == quality_gate._SERIAL_MAX_TESTS + 1
+
+    def test_unknown_count_uses_xdist_and_zero_total(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AC7: `None` is unknown → `-n auto` AND `total_tests=0`. Forwarding
+        `None` would re-trigger a whole-tree collect inside `_stream_pytest`."""
+        cap = self._run(None, env_workers=None, monkeypatch=monkeypatch)
+        assert cap["cmd"][cap["cmd"].index("-n") + 1] == "auto"
+        assert cap["total_tests"] == 0
+
+    def test_env_zero_forces_serial_on_a_big_target(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AC8: an explicit `0` is honored verbatim even for 1000 tests."""
+        cap = self._run(1000, env_workers="0", monkeypatch=monkeypatch)
+        assert "-n" not in cap["cmd"], cap["cmd"]
+
+    def test_env_eight_forces_xdist_on_a_tiny_target(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """AC8: an explicit `8` beats the threshold for a 3-test target — and the
+        serial banner must NOT be printed."""
+        cap = self._run(3, env_workers="8", monkeypatch=monkeypatch)
+        assert cap["cmd"][cap["cmd"].index("-n") + 1] == "8"
+        assert "single-process" not in capsys.readouterr().err
+
+    def test_env_auto_forces_xdist_on_a_tiny_target(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`_pytest_workers()` returns `"auto"` both when unset and when set to
+        `auto`, so provenance must come from `os.environ.get(...) is not None`."""
+        cap = self._run(3, env_workers="auto", monkeypatch=monkeypatch)
+        assert cap["cmd"][cap["cmd"].index("-n") + 1] == "auto"
+
+    def test_no_xdist_stays_serial_without_banner(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+
+        def fake_stream(cmd: list[str], total_tests: int | None = None) -> dict:
+            return {"name": "pytest", "passed": True, "detail": ""}
+
+        with (
+            patch.object(quality_gate, "_has_xdist", return_value=False),
+            patch.object(quality_gate, "_collect_test_count", return_value=3),
+            patch.object(quality_gate, "_stream_pytest", side_effect=fake_stream),
+        ):
+            quality_gate.check_pytest_files(["tests/test_x.py"])
+        assert "single-process" not in capsys.readouterr().err
+
+    def test_exactly_one_collect_only_subprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AC7: one `--collect-only` spawn per `check_pytest_files` call — the
+        count feeds BOTH the worker decision and the progress denominator."""
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        fake = _fake_popen(collect_stdout="3 tests collected\n")
+        with (
+            patch.object(quality_gate, "_has_xdist", return_value=True),
+            patch.object(quality_gate.subprocess, "Popen", fake),
+        ):
+            quality_gate.check_pytest_files(["tests/test_x.py"])
+        collect_spawns = [c for c in fake.calls if "--collect-only" in c]
+        assert len(collect_spawns) == 1, f"expected 1 collect-only spawn, got {fake.calls!r}"
+        assert len(fake.calls) == 2, fake.calls
+
+    def test_dev_only_scope_path_gets_the_fast_path(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """AC7: the fast path lands in `check_pytest_files`, which also serves
+        `main()`'s dev-only scope — intentional (1–3 changed test files)."""
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        captured: dict = {}
+
+        def fake_stream(cmd: list[str], total_tests: int | None = None) -> dict:
+            captured["cmd"] = cmd
+            return {"name": "pytest", "passed": True, "detail": ""}
+
+        with (
+            patch("sys.argv", ["quality_gate.py", "--json"]),
+            patch.object(quality_gate, "_get_changed_files", return_value=["tests/test_x.py"]),
+            patch.object(quality_gate, "_has_xdist", return_value=True),
+            patch.object(quality_gate, "_collect_test_count", return_value=4),
+            patch.object(quality_gate, "_stream_pytest", side_effect=fake_stream),
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+        assert "-n" not in captured["cmd"], captured["cmd"]
+        assert "single-process" in capsys.readouterr().err
+
+
+class TestFullGateUntouchedByFastPath:
+    """QS-290 AC11: `check_pytest` keeps whole-tree collection AND `-n auto`."""
+
+    def test_full_gate_still_collects_tests_dir_and_requests_auto(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        fake = _fake_popen(collect_stdout="3 tests collected\n")
+        with (
+            patch.object(quality_gate, "_has_xdist", return_value=True),
+            patch.object(quality_gate.subprocess, "Popen", fake),
+        ):
+            quality_gate.check_pytest()
+        assert len(fake.calls) == 2, fake.calls
+        assert str(quality_gate.TESTS_DIR) in fake.calls[0]
+        run_cmd = fake.calls[1]
+        # A 3-test whole-tree count must NOT demote the full gate to serial.
+        assert run_cmd[run_cmd.index("-n") + 1] == "auto", run_cmd
+
+
+class TestPytestExitCodeFidelity:
+    """QS-290 AC13 (permanent): a non-zero pytest exit propagates through
+    `_stream_pytest` / `check_pytest_files` on BOTH argv shapes, and the
+    reported count matches what pytest reported.
+
+    This story rewrites the very code path used to verify itself, so a
+    vacuous green is the specific risk worth a permanent guard.
+    """
+
+    _STDOUT = "..F\n2 passed, 1 failed in 0.3s\n"
+
+    @pytest.mark.parametrize(
+        ("count", "expect_xdist"),
+        [(3, False), (500, True)],
+        ids=["serial", "xdist"],
+    )
+    def test_failure_propagates_and_count_is_reported(
+        self,
+        count: int,
+        expect_xdist: bool,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        fake = _fake_popen(
+            collect_stdout=f"{count} tests collected\n",
+            run_stdout=self._STDOUT,
+            run_returncode=1,
+        )
+        with (
+            patch.object(quality_gate, "_has_xdist", return_value=True),
+            patch.object(quality_gate.subprocess, "Popen", fake),
+        ):
+            result = quality_gate.check_pytest_files(["tests/test_x.py"])
+
+        assert result["passed"] is False
+        assert result["returncode"] == 1
+        run_cmd = fake.calls[1]
+        assert ("-n" in run_cmd) is expect_xdist, run_cmd
+        err = capsys.readouterr().err
+        # pytest reported 2 passed + 1 failed → the terminal line reports 3.
+        assert "done (3/" in err, err
+        assert "passed=2 failed=1" in err, err
+
+    @pytest.mark.parametrize("rc", [1, 2, 5], ids=["failures", "collect-error", "internal"])
+    def test_stream_pytest_surfaces_raw_returncode(self, rc: int) -> None:
+        fake = _fake_popen(run_stdout=self._STDOUT, run_returncode=rc)
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            result = quality_gate._stream_pytest(["pytest"], total_tests=3)
+        assert result["returncode"] == rc
+        assert result["passed"] is False
+
+
+# --- QS-290 S-5: denominator from the run's own output, no collect-only ---
+
+
+class TestCountProgressSuffix:
+    """QS-290 (S-5, AC6): `-o console_output_style=count` makes pytest print
+    `[N/M]` instead of `[NN%]`, under `-q` in BOTH serial and xdist mode, and
+    it reports the SELECTED count under deselection. `_clean_pytest_line` must
+    strip that shape too, or a progress line stops being "all progress
+    characters" and the dot tally silently breaks.
+    """
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "... [3/3]",
+            "...                     [  3/682]",
+            "[gw0] ...                [ 69/682]",
+            "... [43%]",
+        ],
+        ids=["count-tight", "count-padded", "xdist-count", "legacy-percent"],
+    )
+    def test_progress_suffixes_are_stripped(self, raw: str) -> None:
+        assert quality_gate._clean_pytest_line(raw) == "..."
+
+    def test_stripped_line_still_tallies(self) -> None:
+        text = "..F                    [  3/100]\n"
+        counts = quality_gate._parse_pytest_output(text)
+        assert counts["passed"] == 2
+        assert counts["failed"] == 1
+
+    def test_build_testmon_cmd_requests_count_style(self) -> None:
+        """AC6: the impacted pass asks pytest for the count style so the
+        denominator can be read off the run itself."""
+        with patch.object(quality_gate, "_pytest_workers", return_value=None):
+            cmd = quality_gate._build_testmon_cmd()
+        assert "-o" in cmd
+        assert cmd[cmd.index("-o") + 1] == "console_output_style=count"
+
+
+class TestStreamPytestLearnsDenominator:
+    """QS-290 (S-5, AC6): with `total_tests=0`, `_stream_pytest` learns the
+    denominator from the first `[N/M]` suffix in the stream instead of paying
+    for an upfront `--collect-only` subprocess.
+    """
+
+    def test_learns_total_from_stream_and_emits_existing_format(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        stream = "..                 [ 2/20]\n..                 [ 4/20]\n4 passed in 0.2s\n"
+        fake = _fake_popen(run_stdout=stream)
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            quality_gate._stream_pytest(["pytest"], total_tests=0)
+        assert len(fake.calls) == 1, f"no collect-only may be spawned: {fake.calls!r}"
+        err = capsys.readouterr().err
+        # The emitted line keeps TODAY's format — QS-299's --seed-testmon-follow
+        # parses this exact shape.
+        assert "  pytest: 10% (2/20) | passed=2 failed=0 errors=0" in err, err
+        assert "  pytest: done (4/20) | passed=4 failed=0 errors=0" in err, err
+
+    def test_no_count_suffix_emits_no_percentage_and_falls_back(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """AC6: with no `[N/M]` ever seen, no percentage line is emitted and the
+        terminal line's denominator falls back to the observed count."""
+        fake = _fake_popen(run_stdout="...\n3 passed in 0.1s\n")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            quality_gate._stream_pytest(["pytest"], total_tests=0)
+        err = capsys.readouterr().err
+        assert "%" not in err, err
+        assert "  pytest: done (3/3) | passed=3 failed=0 errors=0" in err, err
+
+    def test_caller_count_wins_over_the_stream(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A caller-supplied count is authoritative — the stream must not
+        overwrite it (the `--quick` path already paid for a real collection)."""
+        fake = _fake_popen(run_stdout="..                 [ 2/20]\n2 passed in 0.1s\n")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            quality_gate._stream_pytest(["pytest"], total_tests=2)
+        assert "  pytest: done (2/2) |" in capsys.readouterr().err
+
+    def test_emitted_progress_line_round_trips_through_parse_seed_progress(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """AC5/AC6 (QS-299 guard): a progress line captured from a REAL
+        `_stream_pytest` emission — fake pytest stdout through the real
+        formatter — still parses via `_parse_seed_progress`."""
+        stream = "..                 [ 2/20]\n..                 [ 4/20]\n4 passed in 0.2s\n"
+        fake = _fake_popen(run_stdout=stream)
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            quality_gate._stream_pytest(["pytest"], total_tests=0)
+        assert quality_gate._parse_seed_progress(capsys.readouterr().err) == (20, 4, 20)
+
+
+class TestImpactedPassNoCollectOnly:
+    """QS-290 (S-5, AC4/AC5): the impacted pass spawns no collect-only probe;
+    the seed path keeps its whole-tree denominator."""
+
+    def test_run_impacted_pass_passes_zero_total(self, tmp_path: Path) -> None:
+        xml = tmp_path / "coverage.xml"
+        captured: dict = {}
+
+        def fake_stream(cmd: list[str], total_tests: int | None = None) -> dict:
+            captured["total_tests"] = total_tests
+            xml.write_text("<coverage/>")
+            return {"name": "pytest", "passed": True}
+
+        with (
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "TESTMON_DATA", tmp_path / ".testmondata"),
+            patch.object(quality_gate, "_reset_coverage_data"),
+            patch.object(quality_gate, "COVERAGE_XML", xml),
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
+            patch.object(quality_gate, "_stream_pytest", side_effect=fake_stream),
+            patch.object(quality_gate, "_run", return_value=_cp(0, stdout="100%")),
+        ):
+            quality_gate._run_impacted_pass("origin/main")
+        assert captured["total_tests"] == 0, (
+            "the impacted pass must not ask _stream_pytest to collect a denominator"
+        )
+
+    def test_seed_testmon_keeps_its_collect_only_denominator(self) -> None:
+        """AC5: unchanged path — its 3–5 s is noise inside a ~20-minute select-all."""
+        captured: dict = {}
+
+        def fake_stream(cmd: list[str], total_tests: int | None = None) -> dict:
+            captured["total_tests"] = total_tests
+            return {"name": "pytest", "passed": True, "returncode": 0}
+
+        with (
+            patch.object(quality_gate, "_testmon_available", return_value=True),
+            patch.object(quality_gate, "_claim_and_preempt"),
+            patch.object(quality_gate, "_rebuild_testmon_baseline"),
+            patch.object(quality_gate, "_write_completion_if_owner"),
+            patch.object(quality_gate, "_stream_pytest", side_effect=fake_stream),
+        ):
+            assert quality_gate.seed_testmon(token="T") == 0
+        assert captured["total_tests"] is None, (
+            "seed_testmon must keep the whole-tree collect-only denominator"
+        )
+
+
 # --- QS-208 T1.1: _is_ui_asset detector ---
 
 
@@ -1953,6 +2453,96 @@ class TestDetectScopeUIOnly:
         )
         assert info["scope"] == "ui-only"
         assert info["changed_test_files"] == ["tests/test_dashboard_rendering.py"]
+
+
+# --- QS-290 D-18: truthful --full scope reason + reason pluralization ---
+
+
+class TestDetectScopeReasonPluralization:
+    """QS-290 (D-18, AC10): the dev-only / ui-only reason strings must agree
+    with themselves grammatically — `(1 file)`, not `(1 files)`.
+
+    There was previously NO assertion anywhere on the dev-only reason
+    string (the `_detect_scope` call sites in the main() tests supply it as
+    a patched *input*), so the mis-pluralization survived untested.
+    """
+
+    def test_dev_only_singular(self) -> None:
+        info = quality_gate._detect_scope(["docs/workflow/project-rules.md"])
+        assert info["scope"] == "dev-only"
+        assert info["reason"] == "only dev/test files changed (1 file)"
+
+    def test_dev_only_plural(self) -> None:
+        info = quality_gate._detect_scope(["docs/a.md", "scripts/qs/quality_gate.py"])
+        assert info["scope"] == "dev-only"
+        assert info["reason"] == "only dev/test files changed (2 files)"
+
+    def test_ui_only_singular(self) -> None:
+        info = quality_gate._detect_scope(["custom_components/quiet_solar/ui/a.j2"])
+        assert info["scope"] == "ui-only"
+        assert info["reason"] == "only UI assets and dev files changed (1 UI asset, 1 file)"
+
+    def test_ui_only_plural(self) -> None:
+        info = quality_gate._detect_scope(
+            [
+                "custom_components/quiet_solar/ui/a.j2",
+                "custom_components/quiet_solar/ui/resources/b.js",
+                "docs/c.md",
+            ]
+        )
+        assert info["scope"] == "ui-only"
+        assert info["reason"] == "only UI assets and dev files changed (2 UI assets, 3 files)"
+
+
+class TestFullFlagScopeReason:
+    """QS-290 (D-18, AC10): `--full` forces `scope = "full"` but used to keep
+    `_detect_scope`'s reason, printing the self-contradicting
+    `scope: FULL (only dev/test files changed (1 files))`.
+    """
+
+    @staticmethod
+    def _run_main_full(scope_info: dict) -> str:
+        """Drive `main() --full` with a patched `_detect_scope`; return stderr."""
+        with (
+            patch("sys.argv", ["quality_gate.py", "--full", "--json"]),
+            patch.object(quality_gate, "_get_changed_files", return_value=["x"]),
+            patch.object(quality_gate, "_detect_scope", return_value=scope_info),
+            _patch_all_gates(),
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+        return ""
+
+    def test_full_flag_on_dev_only_tree_prints_flag_reason(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._run_main_full(
+            {
+                "scope": "dev-only",
+                "changed_test_files": [],
+                "reason": "only dev/test files changed (1 file)",
+            }
+        )
+        err = capsys.readouterr().err
+        assert "scope: FULL (--full flag)" in err, err
+        assert "only dev/test files changed" not in err, err
+
+    def test_full_flag_keeps_production_reason_when_already_full(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The substitution must NOT clobber a genuinely useful full-scope
+        reason (`production files changed: …`) when the detected scope was
+        already `full`."""
+        self._run_main_full(
+            {
+                "scope": "full",
+                "changed_test_files": [],
+                "reason": "production files changed: custom_components/quiet_solar/home_model/load.py",
+            }
+        )
+        err = capsys.readouterr().err
+        assert "scope: FULL (production files changed: " in err, err
+        assert "--full flag" not in err, err
 
 
 # --- QS-208 T1.3 + T1.4: main() dispatches ui-only branch correctly ---
@@ -2143,18 +2733,26 @@ class TestResolveDiffBase:
         upstream: tuple[int, str] = (1, ""),
         merge_base: tuple[int, str] = (1, ""),
         reachable: dict[str, int] | None = None,
+        git_path: tuple[int, str] = (1, ""),
     ):
         """Build a `_run` side_effect keyed on the git subcommand.
 
         `reachable` (NH2) maps a candidate ref → returncode for the
         `git merge-base <ref> HEAD` reachability probe; default 0
         (reachable) so the pre-NH2 tests keep passing unchanged.
+
+        `git_path` (QS-290 S-7) answers `git rev-parse --git-path FETCH_HEAD`.
+        The default `(1, "")` means "no marker resolvable" → fetch exactly as
+        before the TTL existed. Without this EXPLICIT arm an unmatched
+        `--git-path` fell into the `@{u}` arm and passed only by luck.
         """
         reachable = reachable or {}
 
         def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
             if cmd[:2] == ["git", "fetch"]:
                 return _cp(0)
+            if cmd[:3] == ["git", "rev-parse", "--git-path"]:
+                return _cp(git_path[0], stdout=git_path[1])
             if cmd[:3] == ["git", "rev-parse", "--verify"]:
                 return _cp(rev_parse.get(cmd[3], 1))
             if cmd[:2] == ["git", "rev-parse"]:  # @{u} upstream lookup
@@ -2175,11 +2773,22 @@ class TestResolveDiffBase:
         # review-fix NH2 (#05): the chosen base is announced for debuggability.
         assert "diff base: origin/main" in capsys.readouterr().err
 
-    def test_fetches_origin_main_first(self) -> None:
+    @staticmethod
+    def _fetch_calls(mock_run) -> list:  # type: ignore[no-untyped-def]
+        """Select the `git fetch` invocations by PREDICATE, not by index.
+
+        QS-290 (S-7) put the `rev-parse --git-path FETCH_HEAD` TTL probe ahead
+        of the fetch, so index 0 is no longer the fetch.
+        """
+        return [c for c in mock_run.call_args_list if c.args[0][:2] == ["git", "fetch"]]
+
+    def test_fetches_origin_main_before_resolving_refs(self) -> None:
         with patch.object(quality_gate, "_run", side_effect=self._router({"origin/main": 0})) as mock_run:
             quality_gate._resolve_diff_base()
-        first = mock_run.call_args_list[0].args[0]
-        assert first == ["git", "fetch", "origin", "main"]
+        argvs = [c.args[0] for c in mock_run.call_args_list]
+        fetch_idx = argvs.index(["git", "fetch", "origin", "main"])
+        verify_idx = next(i for i, a in enumerate(argvs) if a[:3] == ["git", "rev-parse", "--verify"])
+        assert fetch_idx < verify_idx, argvs
 
     def test_falls_back_to_local_main(self) -> None:
         with patch.object(quality_gate, "_run", side_effect=self._router({"origin/main": 1, "main": 0})):
@@ -2214,9 +2823,9 @@ class TestResolveDiffBase:
         """review-fix S1: the hot-path fetch must pass a subprocess timeout."""
         with patch.object(quality_gate, "_run", side_effect=self._router({"origin/main": 0})) as mock_run:
             quality_gate._resolve_diff_base()
-        fetch_call = mock_run.call_args_list[0]
-        assert fetch_call.args[0] == ["git", "fetch", "origin", "main"]
-        assert fetch_call.kwargs.get("timeout") == quality_gate._FETCH_TIMEOUT_SECONDS
+        fetch_calls = self._fetch_calls(mock_run)
+        assert len(fetch_calls) == 1, [c.args[0] for c in mock_run.call_args_list]
+        assert fetch_calls[0].kwargs.get("timeout") == quality_gate._FETCH_TIMEOUT_SECONDS
 
     def test_fetch_failure_emits_warning(self, capsys: pytest.CaptureFixture[str]) -> None:
         """review-fix S1: a non-zero/timed-out fetch warns so a stale base is observable."""
@@ -2254,6 +2863,143 @@ class TestResolveDiffBase:
         )
         with patch.object(quality_gate, "_run", side_effect=router):
             assert quality_gate._resolve_diff_base() is None
+
+
+class TestFetchTtl:
+    """QS-290 (S-7, AC9): `--impacted` TTL-caches its `git fetch origin main`.
+
+    Repeat `.py` runs inside a 10-minute window skip the ~0.5 s (15 s-capped)
+    fetch. Staleness direction is safe by construction: an older base yields a
+    SUPERSET of changed lines, so a TTL hit can turn a PASS into a FAIL, never
+    a FAIL into a PASS.
+    """
+
+    def _router(self, marker: Path | None, **kw):  # type: ignore[no-untyped-def]
+        return TestResolveDiffBase._router(
+            kw.pop("rev_parse", {"origin/main": 0}),
+            git_path=(0, str(marker)) if marker is not None else (1, ""),
+            **kw,
+        )
+
+    @staticmethod
+    def _marker(tmp_path: Path, age_seconds: float) -> Path:
+        marker = tmp_path / "FETCH_HEAD"
+        marker.write_text("deadbeef\t\tbranch 'main' of github\n")
+        stamp = time.time() - age_seconds
+        os.utime(marker, (stamp, stamp))
+        return marker
+
+    def test_marker_path_comes_from_git_rev_parse_git_path(self, tmp_path: Path) -> None:
+        """AC9: the marker is resolved via git, never hardcoded — in a LINKED
+        worktree `.git` is a FILE, so a literal `.git/FETCH_HEAD` would be a
+        path under a non-directory and the TTL would silently never hit."""
+        marker = self._marker(tmp_path, age_seconds=60)
+        with patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run:
+            quality_gate._resolve_diff_base()
+        probes = [c.args[0] for c in mock_run.call_args_list if c.args[0][:2] == ["git", "rev-parse"]]
+        assert ["git", "rev-parse", "--git-path", "FETCH_HEAD"] in probes, probes
+
+    def test_inside_ttl_skips_fetch_and_emits_skip_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        marker = self._marker(tmp_path, age_seconds=180)
+        with patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert TestResolveDiffBase._fetch_calls(mock_run) == []
+        err = capsys.readouterr().err
+        assert "fetch skipped (FETCH_HEAD 3m old)" in err, err
+
+    def test_skip_line_renders_seconds_under_a_minute(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        marker = self._marker(tmp_path, age_seconds=12)
+        with patch.object(quality_gate, "_run", side_effect=self._router(marker)):
+            quality_gate._resolve_diff_base()
+        assert "fetch skipped (FETCH_HEAD 12s old)" in capsys.readouterr().err
+
+    def test_outside_ttl_fetches(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        marker = self._marker(tmp_path, age_seconds=quality_gate._FETCH_TTL_SECONDS + 5)
+        with patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+        assert "fetch skipped" not in capsys.readouterr().err
+
+    def test_missing_marker_fetches(self, tmp_path: Path) -> None:
+        absent = tmp_path / "FETCH_HEAD"  # never created
+        with patch.object(quality_gate, "_run", side_effect=self._router(absent)) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    def test_rev_parse_failure_fetches(self) -> None:
+        """A failing `--git-path` probe → fetch exactly as before the TTL."""
+        with patch.object(quality_gate, "_run", side_effect=self._router(None)) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    def test_empty_git_path_stdout_fetches(self) -> None:
+        """A zero-rc probe with empty stdout is unusable — fetch."""
+        router = TestResolveDiffBase._router({"origin/main": 0}, git_path=(0, "  \n"))
+        with patch.object(quality_gate, "_run", side_effect=router) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    def test_fetch_failure_warning_survives_the_ttl_path(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """AC9: on the fetch-taken path the S1 stale-base warning is unchanged."""
+
+        def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
+            if cmd[:3] == ["git", "rev-parse", "--git-path"]:
+                return _cp(1)
+            if cmd[:2] == ["git", "fetch"]:
+                return _cp(124, stderr="timed out after 15.0s")
+            if cmd[:3] == ["git", "rev-parse", "--verify"] and cmd[3] == "origin/main":
+                return _cp(0)
+            if cmd[:2] == ["git", "merge-base"]:
+                return _cp(0)
+            return _cp(1)
+
+        with patch.object(quality_gate, "_run", side_effect=_side_effect):
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert "git fetch origin main` failed/timed out" in capsys.readouterr().err
+
+    def test_unresolvable_base_after_a_skip_retries_with_the_fetch(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """AC9: if the base fails to resolve after a TTL-skipped fetch, retry
+        ONCE with the fetch — the skip must never be the reason we give up."""
+        marker = self._marker(tmp_path, age_seconds=60)
+        state = {"fetched": False}
+
+        def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
+            if cmd[:3] == ["git", "rev-parse", "--git-path"]:
+                return _cp(0, stdout=str(marker))
+            if cmd[:2] == ["git", "fetch"]:
+                state["fetched"] = True
+                return _cp(0)
+            if cmd[:3] == ["git", "rev-parse", "--verify"]:
+                # origin/main only becomes resolvable once the fetch has run.
+                return _cp(0 if state["fetched"] and cmd[3] == "origin/main" else 1)
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _cp(1)
+            if cmd[:2] == ["git", "merge-base"]:
+                return _cp(0)
+            raise AssertionError(f"unexpected cmd {cmd!r}")
+
+        with patch.object(quality_gate, "_run", side_effect=_side_effect) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1, "exactly one retry fetch"
+        err = capsys.readouterr().err
+        assert "fetch skipped" in err, err
+
+    def test_no_infinite_retry_when_the_fetch_cannot_help(self, tmp_path: Path) -> None:
+        """The retry is bounded: an unresolvable base still returns None after
+        exactly one extra fetch."""
+        marker = self._marker(tmp_path, age_seconds=60)
+        router = self._router(marker, rev_parse={"origin/main": 1, "main": 1}, upstream=(1, ""))
+        with patch.object(quality_gate, "_run", side_effect=router) as mock_run:
+            assert quality_gate._resolve_diff_base() is None
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
 
 
 class TestRunTimeout:
@@ -2565,6 +3311,7 @@ class TestCheckImpacted:
     def test_no_base_in_ci_returns_4(self) -> None:
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value=None),
             patch.object(quality_gate, "_is_ci", return_value=True),
         ):
@@ -2573,6 +3320,7 @@ class TestCheckImpacted:
     def test_no_base_locally_warns_and_passes(self) -> None:
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value=None),
             patch.object(quality_gate, "_is_ci", return_value=False),
         ):
@@ -2581,6 +3329,7 @@ class TestCheckImpacted:
     def test_selected_tests_fail_returns_1(self) -> None:
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             # Isolate _run to the diff-cover call: the cmd builder probes
@@ -2604,6 +3353,7 @@ class TestCheckImpacted:
 
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             # QS-283 A4: an absent DB → select-all (was_incremental False), so a
@@ -2633,6 +3383,7 @@ class TestCheckImpacted:
 
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "COVERAGE_XML", xml),
@@ -2650,6 +3401,7 @@ class TestCheckImpacted:
         missing = tmp_path / "coverage.xml"  # never created
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "COVERAGE_XML", missing),
@@ -2669,6 +3421,7 @@ class TestCheckImpacted:
 
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe") as mock_safe,
             patch.object(quality_gate, "COVERAGE_XML", xml),
@@ -2694,6 +3447,7 @@ class TestCheckImpacted:
         xml.write_text("<coverage>STALE from a previous run</coverage>")
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "COVERAGE_XML", xml),
@@ -2718,6 +3472,7 @@ class TestCheckImpacted:
 
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "TESTMON_DATA", absent_db),
@@ -2744,6 +3499,7 @@ class TestCheckImpacted:
 
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "_ensure_testmon_db_safe"),
             patch.object(quality_gate, "TESTMON_DATA", present_db),
@@ -2755,6 +3511,284 @@ class TestCheckImpacted:
         ):
             assert quality_gate.check_impacted() == 0
         mock_reset.assert_not_called()
+
+
+class TestImpactedEarlyExitPaths:
+    """QS-290 (S-4, AC2): `_impacted_early_exit_paths` against REAL git.
+
+    The helper must return a genuine SUPERSET of the paths diff-cover would
+    consider, or the early exit becomes a false PASS. It is exercised against
+    throwaway repos rather than mocks precisely because the claim under test is
+    about git's diff semantics, not about our control flow.
+
+    Zero-arg and total by design: it resolves the base itself. With the base
+    resolve left in `check_impacted`, that `_run` call would sit OUTSIDE the
+    seam and still fire in every test that patches `_run` wholesale — defeating
+    the "patch one seam" remedy the 16 existing call sites rely on.
+    """
+
+    @staticmethod
+    def _git(repo: Path, *args: str) -> str:
+        return subprocess.run(
+            ["git", *args], cwd=str(repo), check=True, capture_output=True, text=True
+        ).stdout
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        """A repo on branch `feature`, forked from `main`, with one doc edit."""
+        repo = tmp_path / "repo"
+        (repo / "docs").mkdir(parents=True)
+        (repo / "docs" / "a.md").write_text("base\n")
+        (repo / "mod.py").write_text("A = 1\n")
+        self._git(repo, "init", "-q", "-b", "main")
+        self._git(repo, "config", "user.email", "t@t.co")
+        self._git(repo, "config", "user.name", "t")
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-qm", "base")
+        self._git(repo, "checkout", "-qb", "feature")
+        (repo / "docs" / "a.md").write_text("edited\n")
+        return repo
+
+    def _paths(self, repo: Path) -> list[str] | None:
+        with patch.object(quality_gate, "REPO_ROOT", repo):
+            return quality_gate._impacted_early_exit_paths()
+
+    @staticmethod
+    def _has_py(paths: list[str] | None) -> bool:
+        assert paths is not None
+        return any(p.endswith(".py") for p in paths)
+
+    def test_doc_only_change_has_no_python(self, repo: Path) -> None:
+        paths = self._paths(repo)
+        assert paths == ["docs/a.md"], paths
+
+    def test_untracked_py_defeats_the_exit(self, repo: Path) -> None:
+        (repo / "brand_new.py").write_text("def f():\n    return 1\n")
+        assert self._has_py(self._paths(repo))
+
+    def test_staged_only_py_defeats_the_exit(self, repo: Path) -> None:
+        (repo / "mod.py").write_text("A = 2\n")
+        self._git(repo, "add", "mod.py")
+        assert self._has_py(self._paths(repo))
+
+    def test_unstaged_only_py_defeats_the_exit(self, repo: Path) -> None:
+        (repo / "mod.py").write_text("A = 2\n")
+        assert self._has_py(self._paths(repo))
+
+    def test_committed_only_py_defeats_the_exit(self, repo: Path) -> None:
+        (repo / "mod.py").write_text("A = 2\n")
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-qm", "code")
+        assert self._has_py(self._paths(repo))
+
+    def test_deleted_py_defeats_the_exit(self, repo: Path) -> None:
+        self._git(repo, "rm", "-q", "mod.py")
+        assert self._has_py(self._paths(repo))
+
+    def test_py_matching_mains_content_defeats_the_exit(self, repo: Path) -> None:
+        """The merge-base case — the false-PASS hole a two-dot diff would open.
+
+        The branch changes `mod.py`, and main independently lands the SAME
+        content (cherry-pick / squash-merge already merged). `git diff
+        <main-tip>` sees identical content and lists nothing, while diff-cover's
+        three-dot `main...HEAD` range DOES score those lines.
+        """
+        (repo / "mod.py").write_text("A = 2\n")
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-qm", "feature change")
+        self._git(repo, "checkout", "-q", "main")
+        (repo / "mod.py").write_text("A = 2\n")
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-qm", "same content on main")
+        self._git(repo, "checkout", "-q", "feature")
+
+        # Contrast: the rejected two-dot form is blind to the .py here.
+        assert "mod.py" not in self._git(repo, "diff", "--name-only", "main")
+        # The three-dot range diff-cover uses is NOT blind.
+        assert "mod.py" in self._git(repo, "diff", "--name-only", "main...HEAD")
+        # So neither is our merge-base-based helper.
+        assert self._has_py(self._paths(repo))
+
+    def test_branch_behind_main_still_early_exits(self, repo: Path) -> None:
+        """The other hole a two-dot diff would open: main's OWN `.py` commits
+        would appear in `git diff main`, so a branch even slightly behind main
+        could never early-exit — the feature would be dead on arrival."""
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-qm", "doc edit")
+        self._git(repo, "checkout", "-q", "main")
+        (repo / "other.py").write_text("B = 1\n")
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-qm", "main advances")
+        self._git(repo, "checkout", "-q", "feature")
+
+        # Contrast: two-dot drags in main's own new .py.
+        assert "other.py" in self._git(repo, "diff", "--name-only", "main")
+        # Merge-base scoping keeps the change set ours alone.
+        assert self._paths(repo) == ["docs/a.md"]
+
+    def test_prefers_origin_main_over_local_main(self, repo: Path) -> None:
+        """Base ladder rung 1. `origin/main` is created as a real remote-tracking
+        ref pointing at the fork point, so a resolvable `origin/main` is used."""
+        head = self._git(repo, "rev-parse", "main").strip()
+        self._git(repo, "update-ref", "refs/remotes/origin/main", head)
+        with patch.object(quality_gate, "_run", wraps=quality_gate._run) as spy:
+            self._paths(repo)
+        verified = [c.args[0][3] for c in spy.call_args_list if c.args[0][:3] == ["git", "rev-parse", "--verify"]]
+        assert verified == ["origin/main"], verified
+
+    @pytest.mark.parametrize(
+        "failing",
+        [
+            ("git", "rev-parse", "--verify"),
+            ("git", "merge-base"),
+            ("git", "diff"),
+            ("git", "ls-files"),
+        ],
+        ids=["base", "merge-base", "diff", "ls-files"],
+    )
+    def test_fail_closed_on_any_git_failure(self, failing: tuple[str, ...]) -> None:
+        """AC2: a non-zero return from ANY of the four calls → None → no exit.
+
+        `_get_changed_files` silently drops failed calls; copying that here
+        would convert a git failure into a false PASS.
+        """
+        prefix = list(failing)
+
+        def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
+            if cmd[: len(prefix)] == prefix:
+                return _cp(128, stderr="fatal: git said no")
+            if cmd[:2] == ["git", "merge-base"]:
+                return _cp(0, stdout="deadbeef\n")
+            return _cp(0, stdout="")
+
+        with patch.object(quality_gate, "_run", side_effect=_side_effect):
+            assert quality_gate._impacted_early_exit_paths() is None
+
+    def test_empty_merge_base_stdout_fails_closed(self) -> None:
+        """A zero-rc `merge-base` with no sha is unusable — do NOT early-exit."""
+
+        def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
+            return _cp(0, stdout="")
+
+        with patch.object(quality_gate, "_run", side_effect=_side_effect):
+            assert quality_gate._impacted_early_exit_paths() is None
+
+
+class TestImpactedNonPyEarlyExit:
+    """QS-290 (S-4, AC1/AC3/AC4): a non-`.py` `--impacted` run does no work.
+
+    testmon fingerprints AST blocks in `.py` files only — verified with a
+    positive control: editing `docs/workflow/overview.md`, the very file a
+    test module reads and asserts on at runtime, selects ZERO tests. So
+    `--impacted` was ALREADY blind here; the early exit changes the cost
+    (10.7–23.5 s → two git calls), not the verdict.
+    """
+
+    def test_returns_0_without_spawning_anything(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            _patch_early_exit(["docs/workflow/project-rules.md", "CLAUDE.md"]),
+            patch.object(quality_gate, "_resolve_diff_base") as mock_base,
+            patch.object(quality_gate, "_stream_pytest") as mock_stream,
+            patch.object(quality_gate, "_run") as mock_run,
+        ):
+            assert quality_gate.check_impacted() == 0
+        mock_base.assert_not_called()  # no base resolve → no git fetch
+        mock_stream.assert_not_called()  # no pytest
+        mock_run.assert_not_called()  # no diff-cover, no git at all
+        err = capsys.readouterr().err
+        assert "no Python files changed" in err, err
+        assert "--quick tests/qs" in err, err
+
+    def test_no_git_fetch_argv_on_the_exit_path(self) -> None:
+        """AC3: assert on the argv, not just on `_resolve_diff_base` — the
+        fetch must be unreachable however it is spelled."""
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            _patch_early_exit(["docs/a.md"]),
+            patch.object(quality_gate, "_run", return_value=_cp(0)) as mock_run,
+            patch.object(quality_gate, "_stream_pytest"),
+        ):
+            assert quality_gate.check_impacted() == 0
+        argvs = [c.args[0] for c in mock_run.call_args_list]
+        assert not any(a[:2] == ["git", "fetch"] for a in argvs), argvs
+
+    def test_empty_change_set_also_exits(self) -> None:
+        """Nothing changed at all → diff-cover has nothing to score → vacuous."""
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            _patch_early_exit([]),
+            patch.object(quality_gate, "_resolve_diff_base") as mock_base,
+        ):
+            assert quality_gate.check_impacted() == 0
+        mock_base.assert_not_called()
+
+    def test_unknown_paths_do_not_exit(self) -> None:
+        """`None` (a git failure) must fall through to the full pipeline."""
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            _patch_early_exit(None),
+            patch.object(quality_gate, "_resolve_diff_base", return_value=None),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+        ):
+            assert quality_gate.check_impacted() == 4
+
+    def test_hygiene_runs_before_the_seam(self) -> None:
+        """AC3: `_clean_orphan_cov_shards` must be hoisted ABOVE the seam — the
+        exit returns before the old seat would ever have been reached, so
+        without the hoist an orphan-shard-leaving crash would never be reaped
+        on a non-`.py` run."""
+        manager = MagicMock()
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards") as mock_clean,
+            patch.object(
+                quality_gate, "_impacted_early_exit_paths", return_value=["docs/a.md"]
+            ) as mock_seam,
+        ):
+            manager.attach_mock(mock_clean, "clean")
+            manager.attach_mock(mock_seam, "seam")
+            assert quality_gate.check_impacted() == 0
+        assert [c[0] for c in manager.mock_calls] == ["clean", "seam"], manager.mock_calls
+
+    def test_py_in_change_set_runs_the_pass_with_no_collect_only(self, tmp_path: Path) -> None:
+        """AC4: on a change set CONTAINING a `.py` file the exit provably does
+        not fire — a testmon pass IS spawned, and no spawned argv contains
+        `--collect-only` (the denominator now comes from the run itself)."""
+        xml = tmp_path / "coverage.xml"
+        base_fake = _fake_popen(run_stdout="..            [ 2/2]\n2 passed in 0.1s\n")
+
+        class fake(base_fake):  # noqa: N801 — a throwaway Popen stand-in
+            """Writes coverage.xml on exit, like the real pytest-cov run."""
+
+            calls: list[list[str]] = []
+
+            def wait(self):  # type: ignore[no-untyped-def]
+                xml.write_text("<coverage/>")
+                return super().wait()
+
+        with (
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            patch.object(quality_gate, "_clean_orphan_cov_shards"),
+            _patch_early_exit(["docs/a.md", "custom_components/quiet_solar/home_model/load.py"]),
+            patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
+            patch.object(quality_gate, "_ensure_testmon_db_safe"),
+            patch.object(quality_gate, "TESTMON_DATA", tmp_path / ".testmondata"),
+            patch.object(quality_gate, "_reset_coverage_data"),
+            patch.object(quality_gate, "COVERAGE_XML", xml),
+            patch.object(quality_gate, "_build_testmon_cmd", return_value=["pytest"]),
+            patch.object(quality_gate.subprocess, "Popen", fake),
+            patch.object(quality_gate, "_run", return_value=_cp(0, stdout="100%")),
+        ):
+            assert quality_gate.check_impacted() == 0
+        assert len(fake.calls) == 1, f"expected exactly the testmon pass, got {fake.calls!r}"
+        assert not any("--collect-only" in c for c in fake.calls), fake.calls
 
 
 class TestTestmonSchemaVersion:
@@ -2888,6 +3922,7 @@ class TestCheckImpactedSelfHeal:
         mock_pass = MagicMock(side_effect=list(zip(verdicts, flags)))
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "TESTMON_DATA", db),
             patch.object(quality_gate, "_clean_orphan_cov_shards"),
@@ -2956,6 +3991,7 @@ class TestCheckImpactedSelfHeal:
         mock_pass = MagicMock(side_effect=[(self.CHANGED, False)])
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "TESTMON_DATA", fake_db),
             patch.object(quality_gate, "_clean_orphan_cov_shards"),
@@ -3022,6 +4058,7 @@ class TestCheckImpactedSelfHeal:
 
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "TESTMON_DATA", db),
             patch.object(quality_gate, "COVERAGE_DATA", tmp_path / ".coverage"),
@@ -3068,6 +4105,7 @@ class TestCheckImpactedSelfHeal:
 
         with (
             patch.object(quality_gate, "_impacted_tooling_available", return_value=True),
+            _patch_early_exit(),
             patch.object(quality_gate, "_resolve_diff_base", return_value="origin/main"),
             patch.object(quality_gate, "TESTMON_DATA", db),
             patch.object(quality_gate, "COVERAGE_DATA", tmp_path / ".coverage"),
@@ -4701,6 +5739,37 @@ class TestProjectRulesDocGuards:
         ).read_text()
         assert "quality_gate.py --seed-testmon-status" in proto
         assert ".testmondata.seed.log" in proto
+
+    def test_non_python_early_exit_documented(self) -> None:
+        """QS-290 (S-4, task 7): the canonical statement that a non-`.py`
+        `--impacted` run checks NOTHING, and that `--quick tests/qs` is the
+        verification rather than a supplement, must live in project-rules.md —
+        it is the one behavioural consequence a reader could otherwise
+        mistake for a real green."""
+        rules = self._rules()
+        assert "Non-Python change sets" in rules
+        assert "exits early" in rules
+        assert "quality_gate.py --quick tests/qs` is not a" in rules
+        # The deferred-baseline-resync caveat (a cost shift, not a verdict change).
+        assert "Deferred baseline re-sync" in rules
+
+    def test_serial_fast_path_documented(self) -> None:
+        """QS-290 (S-1, task 7): `--quick`'s comment block claimed
+        "Uses xdist + sysmon" unconditionally. That is now false below the
+        threshold."""
+        rules = self._rules()
+        assert "Uses xdist + sysmon" not in rules, "the unconditional-xdist claim must be gone"
+        assert "single-process" in rules
+        assert f"{quality_gate._SERIAL_MAX_TESTS} collected" in rules
+
+    def test_testing_layers_cross_references_rather_than_restating(self) -> None:
+        """The agent-facing concept doc points at the canonical statement
+        instead of duplicating it (a second copy is a second thing to drift)."""
+        layers = (
+            Path(__file__).resolve().parent.parent / "docs" / "agents" / "concepts" / "testing-layers.md"
+        ).read_text()
+        assert "Non-Python change sets" in layers
+        assert "project-rules.md" in layers
 
     def test_seed_testmon_follow_documented_in_both_places(self) -> None:
         """QS-299 AC#10: `--seed-testmon-follow` appears in BOTH the command-help

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -1647,15 +1647,25 @@ class TestQuickMode:
 
     def test_quick_emits_banner(
         self,
+        monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """`--quick` prints a `[quick] running ...` banner to stderr."""
+        """`--quick` prints a `[quick] running ...` banner to stderr.
+
+        The xdist half of the banner is environment-dependent (see the two
+        tests below), so this pins the environment explicitly rather than
+        inheriting it. Without that, the test passes locally — where the venv
+        has xdist — and fails on CI, which has no venv at all and so correctly
+        prints `single-process`.
+        """
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
         result = {"name": "pytest", "passed": True, "detail": ""}
         with (
             patch(
                 "sys.argv",
                 ["quality_gate.py", "--quick", "tests/test_foo.py", "tests/ha_tests"],
             ),
+            patch.object(quality_gate, "_has_xdist", return_value=True),
             patch.object(quality_gate, "check_pytest_files", return_value=result),
             pytest.raises(SystemExit),
         ):

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -57,7 +57,7 @@ def _patch_full_scope():
 
 _DEFAULT_EARLY_EXIT_PATHS = ["custom_components/quiet_solar/home_model/load.py"]
 
-# Review-fix #01 nice-to-have 16: a real sentinel object, so the default is not a
+# A real sentinel object, so the default is not a
 # `str` masquerading as a `list[str] | None` behind a blanket `type: ignore`.
 # `None` cannot be the default here — it is a MEANINGFUL value (git failed →
 # unknown → no early exit) that several tests pass deliberately.
@@ -68,7 +68,7 @@ def _patch_early_exit(paths: list[str] | None | object = _KEEP_PY):
     """Patch QS-290's non-`.py` early-exit seam in `check_impacted`.
 
     The seam (`_impacted_early_exit_paths`) is deliberately zero-arg and total:
-    ONE patch here silences ALL FOUR git calls at that seat. Every
+    ONE patch here silences EVERY git call at that seat. Every
     `check_impacted` test must patch it, because the default working-tree state
     is not controllable from a unit test — a genuinely non-`.py` tree would make
     the exit fire and turn assertions about the downstream pipeline into
@@ -1667,6 +1667,44 @@ class TestQuickMode:
         assert "xdist + sysmon" not in err, f"banner still claims unconditional xdist: {err!r}"
         assert f"xdist above {quality_gate._SERIAL_MAX_TESTS} tests" in err, f"banner missing threshold: {err!r}"
 
+    def test_quick_banner_does_not_promise_xdist_when_unavailable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The banner printed "xdist above N tests" unconditionally, so it still
+        promised xdist when xdist is absent or `QS_QG_PYTEST_WORKERS=0` — the same
+        over-claim this change removes from the "xdist + sysmon" wording."""
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        result = {"name": "pytest", "passed": True, "detail": ""}
+        with (
+            patch("sys.argv", ["quality_gate.py", "--quick", "tests/test_foo.py"]),
+            patch.object(quality_gate, "_has_xdist", return_value=False),
+            patch.object(quality_gate, "check_pytest_files", return_value=result),
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+        err = capsys.readouterr().err
+        assert err.startswith("[quick] running "), err
+        assert "xdist" not in err, err
+        assert "single-process" in err, err
+
+    def test_quick_banner_does_not_promise_xdist_when_disabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("QS_QG_PYTEST_WORKERS", "0")
+        result = {"name": "pytest", "passed": True, "detail": ""}
+        with (
+            patch("sys.argv", ["quality_gate.py", "--quick", "tests/test_foo.py"]),
+            patch.object(quality_gate, "_has_xdist", return_value=True),
+            patch.object(quality_gate, "check_pytest_files", return_value=result),
+            pytest.raises(SystemExit),
+        ):
+            quality_gate.main()
+        assert "xdist" not in capsys.readouterr().err
+
     def test_quick_rejects_empty_args(
         self,
         capsys: pytest.CaptureFixture[str],
@@ -1972,7 +2010,7 @@ class TestCollectTestCount:
             assert quality_gate._collect_test_count(["/x"]) is None
 
     def test_nonzero_returncode_is_unknown(self) -> None:
-        """Review-fix #01 should-fix 7: a partially-failed collection prints a
+        """A partially-failed collection prints a
         parseable count (`"5 tests collected, 2 errors"`) alongside a non-zero
         exit. Trusting that number silently routed a broken collection onto the
         serial fast path. A non-zero rc is exactly the "unknown" the docstring
@@ -1989,6 +2027,49 @@ class TestCollectTestCount:
         fake = _fake_popen(collect_stdout="5 tests collected in 0.4s\n")
         with patch.object(quality_gate.subprocess, "Popen", fake):
             assert quality_gate._collect_test_count(["/x"]) == 5
+
+    def test_exit_5_is_a_known_zero_not_unknown(self) -> None:
+        """pytest exits **5** for "no tests collected" — a KNOWN count of zero.
+
+        Verified: `pytest --collect-only -q test_empty.py` prints
+        `no tests collected` and exits 5. Folding that into "unknown" made
+        `_resolve_files_workers` return `-n auto` and spin up xdist for a target
+        with zero tests — precisely the fixed overhead S-1 exists to remove — and
+        left the "a genuine 0 is authoritative" branch unreachable from this
+        caller. A partial collection (`5 tests collected, 2 errors`) exits **2**,
+        so the protection against trusting that count is untouched.
+        """
+        fake = _fake_popen(collect_stdout="no tests collected in 0.01s\n", collect_returncode=5)
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            assert quality_gate._collect_test_count(["/x"]) == 0
+
+    @pytest.mark.parametrize("rc", [1, 2, 3, 4], ids=["failures", "interrupted", "internal", "usage"])
+    def test_other_nonzero_codes_stay_unknown(self, rc: int) -> None:
+        fake = _fake_popen(collect_stdout="5 tests collected, 2 errors\n", collect_returncode=rc)
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            assert quality_gate._collect_test_count(["/x"]) is None
+
+    def test_probe_is_bounded_by_a_timeout(self) -> None:
+        """Every other inner-loop subprocess in this module is bounded (`_run`'s
+        `timeout`, used for `git fetch` and diff-cover). An unbounded collection
+        probe could block the sub-15 s promise indefinitely."""
+        seen: dict = {}
+        killed: list[bool] = []
+
+        class HangingPopen(_CountingFakePopen):
+            calls: list[list[str]] = []
+
+            def communicate(self, *a, **kw):  # type: ignore[no-untyped-def]
+                seen.update(kw)
+                raise subprocess.TimeoutExpired(cmd=["pytest"], timeout=kw.get("timeout"))
+
+            def kill(self):  # type: ignore[no-untyped-def]
+                killed.append(True)
+
+        with patch.object(quality_gate.subprocess, "Popen", HangingPopen):
+            assert quality_gate._collect_test_count(["/x"]) is None
+        assert seen.get("timeout") == quality_gate._COLLECT_TIMEOUT_SECONDS
+        assert killed, "the hung probe must be killed so it cannot outlive the gate"
 
     def test_pins_utf8_replace_and_no_coverage_core(self) -> None:
         """Same encoding contract as the run it precedes (S5), and the probe
@@ -2039,7 +2120,7 @@ class TestStreamPytestTotalTests:
         assert "collect_targets" not in params
         assert list(params) == ["cmd", "total_tests"], list(params)
 
-    # --- review-fix #01 nice-to-have 17: 0 must not double as "unknown" ---
+    # --- 0 must not double as "unknown" ---
 
     def test_learn_sentinel_is_distinct_from_a_genuine_zero(self) -> None:
         """`0` meant both "genuinely no tests" and "unknown, learn from the
@@ -2068,7 +2149,7 @@ class TestStreamPytestTotalTests:
             quality_gate._stream_pytest(["pytest"], total_tests=quality_gate._LEARN_FROM_STREAM)
         assert "(2/20)" in capsys.readouterr().err
 
-    # --- review-fix #01 nice-to-have 10: keep a terminal line on a 0-test run ---
+    # --- Keep a terminal line on a 0-test run ---
 
     def test_zero_selected_run_still_reports_done(
         self, capsys: pytest.CaptureFixture[str]
@@ -2139,7 +2220,7 @@ class TestSerialFastPath:
         `_stream_pytest` would read as "collect the whole tree yourself" and
         spawn a second probe).
 
-        Review-fix #01 nice-to-have 17: the forwarded value is now the explicit
+        The forwarded value is now the explicit
         `_LEARN_FROM_STREAM` sentinel rather than `0`, so a genuine zero-test
         target stays distinguishable from an unknown one.
         """
@@ -2147,7 +2228,35 @@ class TestSerialFastPath:
         assert cap["cmd"][cap["cmd"].index("-n") + 1] == "auto"
         assert cap["total_tests"] == quality_gate._LEARN_FROM_STREAM
 
-    # --- review-fix #01 nice-to-have 11: a typo is not an explicit request ---
+    def test_explicit_zero_is_routed_through_the_provenance_check(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`QS_QG_PYTEST_WORKERS=0` must be honoured *as an explicit request*, not
+        as a side effect of an earlier `workers is None` return.
+
+        Observable difference: an explicit serial request is the user's decision,
+        so the threshold banner (which explains OUR decision) must stay silent —
+        and it must stay silent even on a target that would trip the threshold.
+        """
+        cap = self._run(3, env_workers="0", monkeypatch=monkeypatch)
+        assert "-n" not in cap["cmd"], cap["cmd"]
+        assert "single-process (skipping xdist spin-up)" not in capsys.readouterr().err
+
+    @pytest.mark.parametrize("value", ["", "0", "auto", "4"], ids=["empty", "zero", "auto", "count"])
+    def test_valid_values_are_explicit(self, value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("QS_QG_PYTEST_WORKERS", value)
+        assert quality_gate._workers_env_is_explicit() is True
+
+    @pytest.mark.parametrize("value", ["autoo", "-1", "4x", "abc"], ids=["typo", "neg", "suffix", "word"])
+    def test_malformed_values_are_not_explicit(self, value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("QS_QG_PYTEST_WORKERS", value)
+        assert quality_gate._workers_env_is_explicit() is False
+
+    def test_unset_is_not_explicit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        assert quality_gate._workers_env_is_explicit() is False
+
+    # --- a malformed value is not an explicit request ---
 
     @pytest.mark.parametrize("bad", ["autoo", "-1", "4x"], ids=["typo", "negative", "suffix"])
     def test_malformed_env_value_does_not_count_as_explicit(
@@ -2198,6 +2307,42 @@ class TestSerialFastPath:
         ):
             quality_gate.check_pytest_files(["tests/test_x.py"])
         assert "single-process" not in capsys.readouterr().err
+
+    def test_argv_requests_the_count_progress_style(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On an unknown count `check_pytest_files` forwards `_LEARN_FROM_STREAM`,
+        but with a plain `-q` argv pytest prints `[NN%]` — the `[N/M]` shape never
+        appears and the denominator is never learned, so mid-run progress silently
+        vanished on exactly that path (the retired whole-tree `--collect-only`
+        used to supply a denominator here)."""
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        cap = self._run(None, env_workers=None, monkeypatch=monkeypatch)
+        cmd = cap["cmd"]
+        assert "-o" in cmd, cmd
+        assert cmd[cmd.index("-o") + 1] == "console_output_style=count", cmd
+
+    def test_progress_is_emitted_on_the_unknown_count_path(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """End-to-end: unknown count → the run's own `[N/M]` yields progress."""
+        monkeypatch.delenv("QS_QG_PYTEST_WORKERS", raising=False)
+        fake = _fake_popen(
+            collect_stdout="ERROR: unparseable\n",
+            collect_returncode=3,
+            run_stdout="..  [ 2/20]\n..  [ 4/20]\n4 passed in 0.2s\n",
+        )
+        with (
+            patch.object(quality_gate, "_has_xdist", return_value=True),
+            patch.object(quality_gate.subprocess, "Popen", fake),
+        ):
+            quality_gate.check_pytest_files(["tests/test_x.py"])
+        assert "(2/20)" in capsys.readouterr().err
+
+    def test_zero_test_target_runs_serial(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`--quick` on a path with no tests (pytest rc 5 → a KNOWN 0) takes the
+        serial fast path instead of booting xdist for nothing."""
+        cap = self._run(0, env_workers=None, monkeypatch=monkeypatch)
+        assert "-n" not in cap["cmd"], cap["cmd"]
+        assert cap["total_tests"] == 0
 
     def test_exactly_one_collect_only_subprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """AC7: one `--collect-only` spawn per `check_pytest_files` call — the
@@ -2342,7 +2487,7 @@ class TestCountProgressSuffix:
         assert counts["failed"] == 1
 
     def test_count_suffix_re_captures_only_the_total(self) -> None:
-        """Review-fix #01 nice-to-have 14: the `current` group was captured but
+        """The `current` group was captured but
         never used, so a future edit could silently shift `group(2)`."""
         m = quality_gate._COUNT_SUFFIX_RE.search("...   [ 69/682]")
         assert m is not None
@@ -2388,6 +2533,29 @@ class TestStreamPytestLearnsDenominator:
         err = capsys.readouterr().err
         assert "%" not in err, err
         assert "  pytest: done (3/3) | passed=3 failed=0 errors=0" in err, err
+
+    def test_non_progress_line_cannot_seed_the_denominator(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The learn block latched the FIRST line anywhere in the stream matching
+        `[N/M]`, not the first *progress* line. Collection errors print before any
+        progress, so a traceback or source line ending in that shape — e.g.
+        `RATIO = SCALE[1/2]` — set a bogus denominator for the whole run and the
+        progress line then read `100% (2/2)` for a 40-test run. Cosmetic (the
+        verdict comes from the exit code), but actively misleading.
+        """
+        stream = (
+            "ERROR collecting tests/test_x.py\n"
+            "    RATIO = SCALE[1/2]\n"
+            "....  [ 4/40]\n"
+            "4 passed in 0.2s\n"
+        )
+        fake = _fake_popen(run_stdout=stream)
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            quality_gate._stream_pytest(["pytest"], total_tests=quality_gate._LEARN_FROM_STREAM)
+        err = capsys.readouterr().err
+        assert "/2)" not in err, f"a non-progress line seeded the denominator: {err!r}"
+        assert "(4/40)" in err, err
 
     def test_caller_count_wins_over_the_stream(self, capsys: pytest.CaptureFixture[str]) -> None:
         """A caller-supplied count is authoritative — the stream must not
@@ -2609,7 +2777,7 @@ class TestFullFlagScopeReason:
     def _run_main_full(scope_info: dict) -> None:
         """Drive `main() --full` with a patched `_detect_scope`.
 
-        Callers read stderr via `capsys` (review-fix #01 nice-to-have 15: this
+        Callers read stderr via `capsys` (this
         used to `return ""`, which every caller ignored).
         """
         with (
@@ -2842,12 +3010,16 @@ class TestResolveDiffBase:
         merge_base: tuple[int, str] = (1, ""),
         reachable: dict[str, int] | None = None,
         git_path: tuple[int, str] = (1, ""),
+        remote_url: tuple[int, str] = (0, "github"),
     ):
         """Build a `_run` side_effect keyed on the git subcommand.
 
         `reachable` (NH2) maps a candidate ref → returncode for the
         `git merge-base <ref> HEAD` reachability probe; default 0
         (reachable) so the pre-NH2 tests keep passing unchanged.
+
+        `remote_url` answers `git remote get-url origin`; the default matches the
+        `_marker` helper's FETCH_HEAD content so the TTL can arm.
 
         `git_path` (QS-290 S-7) answers `git rev-parse --git-path FETCH_HEAD`.
         The default `(1, "")` means "no marker resolvable" → fetch exactly as
@@ -2861,6 +3033,8 @@ class TestResolveDiffBase:
                 return _cp(0)
             if cmd[:3] == ["git", "rev-parse", "--git-path"]:
                 return _cp(git_path[0], stdout=git_path[1])
+            if cmd[:2] == ["git", "remote"]:
+                return _cp(remote_url[0], stdout=remote_url[1])
             if cmd[:3] == ["git", "rev-parse", "--verify"]:
                 return _cp(rev_parse.get(cmd[3], 1))
             if cmd[:2] == ["git", "rev-parse"]:  # @{u} upstream lookup
@@ -2989,9 +3163,74 @@ class TestFetchTtl:
             **kw,
         )
 
+    # --- the TTL must be armed only by a fetch of ORIGIN's main ---
+
+    def test_marker_recording_another_remotes_main_still_fetches(self, tmp_path: Path) -> None:
+        """`branch 'main' of <url>` carries the URL, and matching only the prefix
+        accepted ANY remote's main. Verified in a two-remote clone: after
+        `git fetch upstream main` the marker reads `branch 'main' of …/upstream`
+        while `origin/main` — the ref the base ladder actually resolves — was
+        never fetched and may be arbitrarily stale. That is the standard fork
+        workflow (`origin` = fork, `upstream` = canonical), and the skip line
+        claims `origin/main`, so the marker must support that claim.
+        """
+        marker = self._marker(
+            tmp_path, age_seconds=1, content="beef\t\tbranch 'main' of https://host/upstream\n"
+        )
+        router = self._router(marker, remote_url=(0, "https://host/fork"))
+        with patch.object(quality_gate, "_run", side_effect=router) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    def test_marker_recording_origins_main_skips(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        marker = self._marker(
+            tmp_path, age_seconds=30, content="beef\t\tbranch 'main' of https://host/fork\n"
+        )
+        router = self._router(marker, remote_url=(0, "https://host/fork"))
+        with patch.object(quality_gate, "_run", side_effect=router) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert TestResolveDiffBase._fetch_calls(mock_run) == []
+        assert "fetch skipped" in capsys.readouterr().err
+
+    def test_dot_git_suffix_does_not_break_the_match(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """git STRIPS a trailing `.git` when writing FETCH_HEAD but
+        `git remote get-url origin` keeps it — verified on this very repo
+        (`…/quiet-solar.git` vs `…/quiet-solar`) and in a local clone with an
+        explicit `.git` path. A naive equality check would therefore never match
+        and would silently disable the TTL everywhere — the same
+        feature-deleting trap that ruled out keying on `refs/remotes/origin/main`.
+        """
+        marker = self._marker(
+            tmp_path, age_seconds=30, content="beef\t\tbranch 'main' of https://host/repo\n"
+        )
+        router = self._router(marker, remote_url=(0, "https://host/repo.git"))
+        with patch.object(quality_gate, "_run", side_effect=router) as mock_run:
+            quality_gate._resolve_diff_base()
+        assert TestResolveDiffBase._fetch_calls(mock_run) == []
+        assert "fetch skipped" in capsys.readouterr().err
+
+    def test_unresolvable_origin_url_still_fetches(self, tmp_path: Path) -> None:
+        """No `origin` remote at all (or any probe failure) → unknown → fetch."""
+        marker = self._marker(tmp_path, age_seconds=30)
+        router = self._router(marker, remote_url=(128, ""))
+        with patch.object(quality_gate, "_run", side_effect=router) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    def test_empty_origin_url_still_fetches(self, tmp_path: Path) -> None:
+        marker = self._marker(tmp_path, age_seconds=30)
+        router = self._router(marker, remote_url=(0, "  \n"))
+        with patch.object(quality_gate, "_run", side_effect=router) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
     @pytest.fixture(autouse=True)
     def _not_ci(self):
-        """Review-fix #01 should-fix 4: the TTL is now bypassed under CI, so
+        """The TTL is now bypassed under CI, so
         every test here must state that it is exercising the LOCAL path."""
         with patch.object(quality_gate, "_is_ci", return_value=False):
             yield
@@ -3093,6 +3332,8 @@ class TestFetchTtl:
         def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
             if cmd[:3] == ["git", "rev-parse", "--git-path"]:
                 return _cp(0, stdout=str(marker))
+            if cmd[:2] == ["git", "remote"]:
+                return _cp(0, stdout="github")
             if cmd[:2] == ["git", "fetch"]:
                 state["fetched"] = True
                 return _cp(0)
@@ -3120,7 +3361,7 @@ class TestFetchTtl:
             assert quality_gate._resolve_diff_base() is None
         assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
 
-    # --- review-fix #01 must-fix 3: a FAILED fetch must not read as freshness ---
+    # --- A FAILED fetch must not read as freshness ---
 
     def test_zero_byte_marker_still_fetches(self, tmp_path: Path) -> None:
         """A failed fetch (offline / dropped VPN / hung remote) still bumps
@@ -3145,6 +3386,8 @@ class TestFetchTtl:
         def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
             if cmd[:3] == ["git", "rev-parse", "--git-path"]:
                 return _cp(0, stdout=str(marker))
+            if cmd[:2] == ["git", "remote"]:
+                return _cp(0, stdout="github")
             if cmd[:2] == ["git", "fetch"]:
                 return _cp(128, stderr="Could not read from remote repository.")
             if cmd[:3] == ["git", "rev-parse", "--verify"] and cmd[3] == "origin/main":
@@ -3157,7 +3400,7 @@ class TestFetchTtl:
             quality_gate._resolve_diff_base()
         assert "git fetch origin main` failed/timed out" in capsys.readouterr().err
 
-    # --- review-fix #01 should-fix 4: never skip in CI ---
+    # --- Never skip in CI ---
 
     def test_ci_bypasses_the_ttl(self, tmp_path: Path) -> None:
         """`actions/checkout` leaves a seconds-old `FETCH_HEAD`, so without an
@@ -3183,7 +3426,7 @@ class TestFetchTtl:
         probes = [c.args[0] for c in mock_run.call_args_list if c.args[0][:3] == ["git", "rev-parse", "--git-path"]]
         assert probes == [], probes
 
-    # --- review-fix #01 should-fix 5: the marker must record a MAIN fetch ---
+    # --- The marker must record a MAIN fetch ---
 
     def test_marker_recording_another_branch_still_fetches(self, tmp_path: Path) -> None:
         """`FETCH_HEAD` records the last fetch of *anything*. `gh pr checkout
@@ -3210,8 +3453,8 @@ class TestFetchTtl:
             tmp_path,
             age_seconds=30,
             content=(
-                "aaaa1111\t\tbranch 'main' of /tmp/up\n"
-                "bbbb2222\tnot-for-merge\tbranch 'other' of /tmp/up\n"
+                "aaaa1111\t\tbranch 'main' of github\n"
+                "bbbb2222\tnot-for-merge\tbranch 'other' of github\n"
             ),
         )
         with patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run:
@@ -3223,7 +3466,7 @@ class TestFetchTtl:
         """main can appear flagged `not-for-merge` (e.g. fetched while on another
         branch). The ref still came down, so the skip is legitimate."""
         marker = self._marker(
-            tmp_path, age_seconds=30, content="aaaa1111\tnot-for-merge\tbranch 'main' of /tmp/up\n"
+            tmp_path, age_seconds=30, content="aaaa1111\tnot-for-merge\tbranch 'main' of github\n"
         )
         with patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run:
             quality_gate._resolve_diff_base()
@@ -3237,7 +3480,7 @@ class TestFetchTtl:
             assert quality_gate._resolve_diff_base() == "origin/main"
         assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
 
-    # --- review-fix #01 should-fix 6: a future mtime is unknown, not fresh ---
+    # --- A future mtime is unknown, not fresh ---
 
     def test_future_mtime_still_fetches(self, tmp_path: Path) -> None:
         """`max(0.0, now - mtime)` turned an impossible timestamp into age 0.0,
@@ -3250,14 +3493,18 @@ class TestFetchTtl:
             assert quality_gate._resolve_diff_base() == "origin/main"
         assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
 
-    # --- review-fix #01 nice-to-have 12: no duplicate NH2 warning on the retry ---
+    # --- No duplicate NH2 warning on the retry ---
 
     def test_shallow_clone_warning_is_not_duplicated_by_the_retry(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """Skip → ladder warns and returns None → fetch → ladder walks again.
-        The NH2 "no merge-base with HEAD (shallow clone?)" line must not print
-        twice for one invocation."""
+
+        The NH2 "no merge-base with HEAD (shallow clone?)" line must be emitted
+        ONCE PER CANDIDATE REF (two here: `origin/main` and `main`) — i.e. only
+        on the first walk. Before the fix the retry walked the ladder again and
+        printed all of them a second time, for four lines total.
+        """
         marker = self._marker(tmp_path, age_seconds=60)
         router = self._router(
             marker,
@@ -3897,7 +4144,7 @@ class TestImpactedEarlyExitPaths:
         # Merge-base scoping keeps the change set ours alone.
         assert self._paths(repo) == ["docs/a.md"]
 
-    # --- review-fix #01 must-fix 1: core.quotePath must not fail the exit OPEN ---
+    # --- Core.quotePath must not fail the exit OPEN ---
 
     NON_ASCII_PY = "tests/test_données.py"
 
@@ -3952,7 +4199,7 @@ class TestImpactedEarlyExitPaths:
         assert weird in paths, paths
         assert self._has_py(paths)
 
-    # --- review-fix #01 must-fix 2: union the committed range ---
+    # --- Union the committed range ---
 
     def test_py_reverted_in_the_worktree_defeats_the_exit(self, repo: Path) -> None:
         """`git diff <mb>` compares the merge-base tree to the WORKING tree, so
@@ -3973,6 +4220,40 @@ class TestImpactedEarlyExitPaths:
         assert "mod.py" in self._git(repo, "diff", "--name-only", "main...HEAD")
         # So the union must see it.
         assert self._has_py(self._paths(repo))
+
+    def test_staged_py_reverted_in_the_worktree_defeats_the_exit(self, repo: Path) -> None:
+        """The INDEX is invisible to the other three rungs.
+
+        `git diff <mb>` bypasses the index, `git diff <mb> HEAD` sees only
+        commits, and `ls-files --others` only untracked files. So a `.py` whose
+        STAGED content differs from the merge-base while its WORKTREE content
+        equals it appears in none of them — yet diff-cover scores it
+        (`GitDiffReporter` is built with `ignore_staged=False`, so
+        `git diff --cached -U0` is in its range) and, worse, it is exactly what
+        the `git commit` immediately after this pre-commit gate will land.
+
+        Same trigger class via `git apply --cached`, or `git add -p` followed by
+        `git restore --source=HEAD --worktree <file>`.
+        """
+        mb = self._git(repo, "merge-base", "main", "HEAD").strip()
+        (repo / "mod.py").write_text("A = 2\n")
+        self._git(repo, "add", "mod.py")
+        # Revert the WORKTREE to merge-base content, leaving the index changed —
+        # one of the real trigger sequences (`git add -p` then restore).
+        self._git(repo, "restore", "--source", mb, "--worktree", "mod.py")
+        assert (repo / "mod.py").read_text() == "A = 1\n"
+
+        # Premise: none of the other three rungs can see it.
+        assert "mod.py" not in self._git(repo, "diff", "--name-only", mb)
+        assert "mod.py" not in self._git(repo, "diff", "--name-only", mb, "HEAD")
+        assert "mod.py" not in self._git(repo, "ls-files", "--others", "--exclude-standard")
+        # ...while what `git commit` would land plainly contains it.
+        assert "mod.py" in self._git(repo, "diff", "--cached", "--name-only", mb)
+
+        paths = self._paths(repo)
+        assert paths is not None
+        assert "mod.py" in paths, paths
+        assert self._has_py(paths)
 
     def test_committed_range_is_unioned_not_substituted(self, repo: Path) -> None:
         """The committed range is an ADDITION: a worktree-only edit that was
@@ -4009,8 +4290,8 @@ class TestImpactedEarlyExitPaths:
         `_get_changed_files` silently drops failed calls; copying that here
         would convert a git failure into a false PASS.
 
-        Review-fix #01 must-fix 2 added a fifth call (the committed range); it
-        is covered by the `diff` id, which matches both diff invocations.
+        The two `git diff` rungs are both covered by the `diff` id, which
+        matches either invocation; the index rung has its own case below.
         """
         prefix = list(failing)
 
@@ -4025,7 +4306,7 @@ class TestImpactedEarlyExitPaths:
             assert quality_gate._impacted_early_exit_paths() is None
 
     def test_fail_closed_when_only_the_committed_range_fails(self) -> None:
-        """Review-fix #01 must-fix 2: the NEW call must fail closed on its own,
+        """The NEW call must fail closed on its own,
         not merely be covered by a prefix that also matches the older one."""
 
         def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
@@ -4039,8 +4320,21 @@ class TestImpactedEarlyExitPaths:
         with patch.object(quality_gate, "_run", side_effect=_side_effect):
             assert quality_gate._impacted_early_exit_paths() is None
 
+    def test_fail_closed_when_only_the_index_rung_fails(self) -> None:
+        """The index rung must fail closed on its own."""
+
+        def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
+            if cmd[:2] == ["git", "merge-base"]:
+                return _cp(0, stdout="deadbeef\n")
+            if cmd[:2] == ["git", "diff"] and "--cached" in cmd:
+                return _cp(128, stderr="fatal")
+            return _cp(0, stdout="")
+
+        with patch.object(quality_gate, "_run", side_effect=_side_effect):
+            assert quality_gate._impacted_early_exit_paths() is None
+
     def test_all_git_output_is_nul_delimited(self) -> None:
-        """Review-fix #01 must-fix 1: every path-listing call must pass `-z`, or
+        """Every path-listing call must pass `-z`, or
         the C-quoting fail-open returns through whichever one was missed."""
         seen: list[list[str]] = []
 
@@ -4053,7 +4347,7 @@ class TestImpactedEarlyExitPaths:
         with patch.object(quality_gate, "_run", side_effect=_side_effect):
             quality_gate._impacted_early_exit_paths()
         listing = [c for c in seen if c[:2] == ["git", "diff"] or c[:2] == ["git", "ls-files"]]
-        assert len(listing) == 3, listing
+        assert len(listing) == 4, listing
         for cmd in listing:
             assert "-z" in cmd, f"path-listing call without -z: {cmd!r}"
 
@@ -4074,7 +4368,7 @@ class TestImpactedNonPyEarlyExit:
     positive control: editing `docs/workflow/overview.md`, the very file a
     test module reads and asserts on at runtime, selects ZERO tests. So
     `--impacted` was ALREADY blind here; the early exit changes the cost
-    (10.7–23.5 s → two git calls), not the verdict.
+    (10.7–23.5 s → a handful of local git calls), not the verdict.
     """
 
     def test_returns_0_without_spawning_anything(

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -57,8 +57,14 @@ def _patch_full_scope():
 
 _DEFAULT_EARLY_EXIT_PATHS = ["custom_components/quiet_solar/home_model/load.py"]
 
+# Review-fix #01 nice-to-have 16: a real sentinel object, so the default is not a
+# `str` masquerading as a `list[str] | None` behind a blanket `type: ignore`.
+# `None` cannot be the default here — it is a MEANINGFUL value (git failed →
+# unknown → no early exit) that several tests pass deliberately.
+_KEEP_PY = object()
 
-def _patch_early_exit(paths: list[str] | None = "keep-py"):  # type: ignore[assignment]
+
+def _patch_early_exit(paths: list[str] | None | object = _KEEP_PY):
     """Patch QS-290's non-`.py` early-exit seam in `check_impacted`.
 
     The seam (`_impacted_early_exit_paths`) is deliberately zero-arg and total:
@@ -69,11 +75,10 @@ def _patch_early_exit(paths: list[str] | None = "keep-py"):  # type: ignore[assi
     vacuous greens (or env-dependent failures, e.g. `test_no_base_in_ci_returns_4`
     returning 0).
 
-    Default (the `"keep-py"` sentinel): a single `.py` path, so the exit
-    provably does NOT fire. `None` is a meaningful value here (git failed →
-    unknown → no exit), hence a sentinel rather than `None` as the default.
+    Default (the `_KEEP_PY` sentinel): a single `.py` path, so the exit provably
+    does NOT fire.
     """
-    resolved = _DEFAULT_EARLY_EXIT_PATHS if paths == "keep-py" else paths
+    resolved = _DEFAULT_EARLY_EXIT_PATHS if paths is _KEEP_PY else paths
     return patch.object(quality_gate, "_impacted_early_exit_paths", return_value=resolved)
 
 
@@ -1898,6 +1903,7 @@ class _CountingFakePopen:
 
     calls: list[list[str]] = []
     collect_stdout = "0 tests collected\n"
+    collect_returncode = 0
     run_stdout = ""
     run_returncode = 0
 
@@ -1907,7 +1913,9 @@ class _CountingFakePopen:
         text = type(self).collect_stdout if self._is_collect else type(self).run_stdout
         self.stdout = io.StringIO(text)
         self.stderr = io.StringIO("")
-        self.returncode = 0 if self._is_collect else type(self).run_returncode
+        self.returncode = (
+            type(self).collect_returncode if self._is_collect else type(self).run_returncode
+        )
 
     def communicate(self, *a, **kw):  # type: ignore[no-untyped-def]
         return (self.stdout.getvalue(), "")
@@ -1919,6 +1927,7 @@ class _CountingFakePopen:
 def _fake_popen(
     *,
     collect_stdout: str = "0 tests collected\n",
+    collect_returncode: int = 0,
     run_stdout: str = "",
     run_returncode: int = 0,
 ) -> type[_CountingFakePopen]:
@@ -1929,6 +1938,7 @@ def _fake_popen(
         {
             "calls": [],
             "collect_stdout": collect_stdout,
+            "collect_returncode": collect_returncode,
             "run_stdout": run_stdout,
             "run_returncode": run_returncode,
         },
@@ -1960,6 +1970,25 @@ class TestCollectTestCount:
         fake = _fake_popen(collect_stdout="ERROR: file or directory not found\n")
         with patch.object(quality_gate.subprocess, "Popen", fake):
             assert quality_gate._collect_test_count(["/x"]) is None
+
+    def test_nonzero_returncode_is_unknown(self) -> None:
+        """Review-fix #01 should-fix 7: a partially-failed collection prints a
+        parseable count (`"5 tests collected, 2 errors"`) alongside a non-zero
+        exit. Trusting that number silently routed a broken collection onto the
+        serial fast path. A non-zero rc is exactly the "unknown" the docstring
+        already argues must degrade to `-n auto`."""
+        fake = _fake_popen(
+            collect_stdout="5 tests collected, 2 errors in 0.4s\n",
+            collect_returncode=2,
+        )
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            assert quality_gate._collect_test_count(["/x"]) is None
+
+    def test_zero_returncode_with_a_count_is_trusted(self) -> None:
+        """The negative half: a clean collection is still used."""
+        fake = _fake_popen(collect_stdout="5 tests collected in 0.4s\n")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            assert quality_gate._collect_test_count(["/x"]) == 5
 
     def test_pins_utf8_replace_and_no_coverage_core(self) -> None:
         """Same encoding contract as the run it precedes (S5), and the probe
@@ -2010,6 +2039,53 @@ class TestStreamPytestTotalTests:
         assert "collect_targets" not in params
         assert list(params) == ["cmd", "total_tests"], list(params)
 
+    # --- review-fix #01 nice-to-have 17: 0 must not double as "unknown" ---
+
+    def test_learn_sentinel_is_distinct_from_a_genuine_zero(self) -> None:
+        """`0` meant both "genuinely no tests" and "unknown, learn from the
+        stream", which contradicted the `None`-vs-`0` care taken in
+        `_collect_test_count`. A named negative sentinel is impossible as a real
+        count, so it cannot collide, and keeps ONE parameter (four reviewers
+        rejected re-splitting it)."""
+        assert quality_gate._LEARN_FROM_STREAM < 0
+
+    def test_genuine_zero_does_not_learn_from_the_stream(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A caller that KNOWS the target collects 0 tests is authoritative; a
+        stray `[N/M]` must not silently redefine its denominator."""
+        fake = _fake_popen(run_stdout="..            [ 2/99]\n2 passed in 0.1s\n")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            quality_gate._stream_pytest(["pytest"], total_tests=0)
+        err = capsys.readouterr().err
+        assert "/99" not in err, err
+
+    def test_learn_sentinel_does_learn_from_the_stream(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        fake = _fake_popen(run_stdout="..            [ 2/20]\n2 passed in 0.1s\n")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            quality_gate._stream_pytest(["pytest"], total_tests=quality_gate._LEARN_FROM_STREAM)
+        assert "(2/20)" in capsys.readouterr().err
+
+    # --- review-fix #01 nice-to-have 10: keep a terminal line on a 0-test run ---
+
+    def test_zero_selected_run_still_reports_done(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The single most common inner-loop invocation is a `.py` change that
+        testmon deselects to 0 tests. The `total_tests > 0 or final_total > 0`
+        guard made the `pytest: done (…)` line vanish there, leaving NOTHING
+        between `selecting impacted tests (testmon)…` and the verdict. The old
+        `done (0/6912)` had the wrong denominator but did confirm the pass ran.
+        """
+        fake = _fake_popen(run_stdout="no tests ran in 0.4s\n")
+        with patch.object(quality_gate.subprocess, "Popen", fake):
+            quality_gate._stream_pytest(["pytest"], total_tests=quality_gate._LEARN_FROM_STREAM)
+        err = capsys.readouterr().err
+        assert "pytest: done (0/0)" in err, err
+        assert "passed=0 failed=0 errors=0" in err, err
+
 
 class TestSerialFastPath:
     """QS-290 (S-1, AC7/AC8): `check_pytest_files` skips the xdist spin-up for
@@ -2058,12 +2134,34 @@ class TestSerialFastPath:
         assert cap["cmd"][cap["cmd"].index("-n") + 1] == "auto"
         assert cap["total_tests"] == quality_gate._SERIAL_MAX_TESTS + 1
 
-    def test_unknown_count_uses_xdist_and_zero_total(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """AC7: `None` is unknown → `-n auto` AND `total_tests=0`. Forwarding
-        `None` would re-trigger a whole-tree collect inside `_stream_pytest`."""
+    def test_unknown_count_uses_xdist_and_learn_sentinel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AC7: `None` is unknown → `-n auto`, and NOT forwarded as `None` (which
+        `_stream_pytest` would read as "collect the whole tree yourself" and
+        spawn a second probe).
+
+        Review-fix #01 nice-to-have 17: the forwarded value is now the explicit
+        `_LEARN_FROM_STREAM` sentinel rather than `0`, so a genuine zero-test
+        target stays distinguishable from an unknown one.
+        """
         cap = self._run(None, env_workers=None, monkeypatch=monkeypatch)
         assert cap["cmd"][cap["cmd"].index("-n") + 1] == "auto"
-        assert cap["total_tests"] == 0
+        assert cap["total_tests"] == quality_gate._LEARN_FROM_STREAM
+
+    # --- review-fix #01 nice-to-have 11: a typo is not an explicit request ---
+
+    @pytest.mark.parametrize("bad", ["autoo", "-1", "4x"], ids=["typo", "negative", "suffix"])
+    def test_malformed_env_value_does_not_count_as_explicit(
+        self, bad: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`_pytest_workers()` warns and falls back to `"auto"` for a malformed
+        value. The `os.environ.get(...) is not None` provenance check then read
+        the typo as deliberate and forced xdist onto a 3-test target, silently
+        losing the fast path. "Invalid" must behave as "unset"."""
+        cap = self._run(3, env_workers=bad, monkeypatch=monkeypatch)
+        assert "-n" not in cap["cmd"], cap["cmd"]
+        err = capsys.readouterr().err
+        assert "invalid QS_QG_PYTEST_WORKERS" in err, err  # the warning still fires
+        assert "single-process" in err, err
 
     def test_env_zero_forces_serial_on_a_big_target(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """AC8: an explicit `0` is honored verbatim even for 1000 tests."""
@@ -2243,6 +2341,13 @@ class TestCountProgressSuffix:
         assert counts["passed"] == 2
         assert counts["failed"] == 1
 
+    def test_count_suffix_re_captures_only_the_total(self) -> None:
+        """Review-fix #01 nice-to-have 14: the `current` group was captured but
+        never used, so a future edit could silently shift `group(2)`."""
+        m = quality_gate._COUNT_SUFFIX_RE.search("...   [ 69/682]")
+        assert m is not None
+        assert m.groups() == ("682",), m.groups()
+
     def test_build_testmon_cmd_requests_count_style(self) -> None:
         """AC6: the impacted pass asks pytest for the count style so the
         denominator can be read off the run itself."""
@@ -2264,7 +2369,7 @@ class TestStreamPytestLearnsDenominator:
         stream = "..                 [ 2/20]\n..                 [ 4/20]\n4 passed in 0.2s\n"
         fake = _fake_popen(run_stdout=stream)
         with patch.object(quality_gate.subprocess, "Popen", fake):
-            quality_gate._stream_pytest(["pytest"], total_tests=0)
+            quality_gate._stream_pytest(["pytest"], total_tests=quality_gate._LEARN_FROM_STREAM)
         assert len(fake.calls) == 1, f"no collect-only may be spawned: {fake.calls!r}"
         err = capsys.readouterr().err
         # The emitted line keeps TODAY's format — QS-299's --seed-testmon-follow
@@ -2279,7 +2384,7 @@ class TestStreamPytestLearnsDenominator:
         terminal line's denominator falls back to the observed count."""
         fake = _fake_popen(run_stdout="...\n3 passed in 0.1s\n")
         with patch.object(quality_gate.subprocess, "Popen", fake):
-            quality_gate._stream_pytest(["pytest"], total_tests=0)
+            quality_gate._stream_pytest(["pytest"], total_tests=quality_gate._LEARN_FROM_STREAM)
         err = capsys.readouterr().err
         assert "%" not in err, err
         assert "  pytest: done (3/3) | passed=3 failed=0 errors=0" in err, err
@@ -2301,7 +2406,7 @@ class TestStreamPytestLearnsDenominator:
         stream = "..                 [ 2/20]\n..                 [ 4/20]\n4 passed in 0.2s\n"
         fake = _fake_popen(run_stdout=stream)
         with patch.object(quality_gate.subprocess, "Popen", fake):
-            quality_gate._stream_pytest(["pytest"], total_tests=0)
+            quality_gate._stream_pytest(["pytest"], total_tests=quality_gate._LEARN_FROM_STREAM)
         assert quality_gate._parse_seed_progress(capsys.readouterr().err) == (20, 4, 20)
 
 
@@ -2309,7 +2414,7 @@ class TestImpactedPassNoCollectOnly:
     """QS-290 (S-5, AC4/AC5): the impacted pass spawns no collect-only probe;
     the seed path keeps its whole-tree denominator."""
 
-    def test_run_impacted_pass_passes_zero_total(self, tmp_path: Path) -> None:
+    def test_run_impacted_pass_learns_its_denominator(self, tmp_path: Path) -> None:
         xml = tmp_path / "coverage.xml"
         captured: dict = {}
 
@@ -2328,7 +2433,7 @@ class TestImpactedPassNoCollectOnly:
             patch.object(quality_gate, "_run", return_value=_cp(0, stdout="100%")),
         ):
             quality_gate._run_impacted_pass("origin/main")
-        assert captured["total_tests"] == 0, (
+        assert captured["total_tests"] == quality_gate._LEARN_FROM_STREAM, (
             "the impacted pass must not ask _stream_pytest to collect a denominator"
         )
 
@@ -2501,8 +2606,12 @@ class TestFullFlagScopeReason:
     """
 
     @staticmethod
-    def _run_main_full(scope_info: dict) -> str:
-        """Drive `main() --full` with a patched `_detect_scope`; return stderr."""
+    def _run_main_full(scope_info: dict) -> None:
+        """Drive `main() --full` with a patched `_detect_scope`.
+
+        Callers read stderr via `capsys` (review-fix #01 nice-to-have 15: this
+        used to `return ""`, which every caller ignored).
+        """
         with (
             patch("sys.argv", ["quality_gate.py", "--full", "--json"]),
             patch.object(quality_gate, "_get_changed_files", return_value=["x"]),
@@ -2511,7 +2620,6 @@ class TestFullFlagScopeReason:
             pytest.raises(SystemExit),
         ):
             quality_gate.main()
-        return ""
 
     def test_full_flag_on_dev_only_tree_prints_flag_reason(
         self, capsys: pytest.CaptureFixture[str]
@@ -2881,10 +2989,21 @@ class TestFetchTtl:
             **kw,
         )
 
+    @pytest.fixture(autouse=True)
+    def _not_ci(self):
+        """Review-fix #01 should-fix 4: the TTL is now bypassed under CI, so
+        every test here must state that it is exercising the LOCAL path."""
+        with patch.object(quality_gate, "_is_ci", return_value=False):
+            yield
+
     @staticmethod
-    def _marker(tmp_path: Path, age_seconds: float) -> Path:
+    def _marker(
+        tmp_path: Path,
+        age_seconds: float,
+        content: str = "deadbeef\t\tbranch 'main' of github\n",
+    ) -> Path:
         marker = tmp_path / "FETCH_HEAD"
-        marker.write_text("deadbeef\t\tbranch 'main' of github\n")
+        marker.write_text(content)
         stamp = time.time() - age_seconds
         os.utime(marker, (stamp, stamp))
         return marker
@@ -2907,7 +3026,7 @@ class TestFetchTtl:
             assert quality_gate._resolve_diff_base() == "origin/main"
         assert TestResolveDiffBase._fetch_calls(mock_run) == []
         err = capsys.readouterr().err
-        assert "fetch skipped (FETCH_HEAD 3m old)" in err, err
+        assert "fetch skipped (origin/main fetched 3m ago)" in err, err
 
     def test_skip_line_renders_seconds_under_a_minute(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -2915,7 +3034,7 @@ class TestFetchTtl:
         marker = self._marker(tmp_path, age_seconds=12)
         with patch.object(quality_gate, "_run", side_effect=self._router(marker)):
             quality_gate._resolve_diff_base()
-        assert "fetch skipped (FETCH_HEAD 12s old)" in capsys.readouterr().err
+        assert "fetch skipped (origin/main fetched 12s ago)" in capsys.readouterr().err
 
     def test_outside_ttl_fetches(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         marker = self._marker(tmp_path, age_seconds=quality_gate._FETCH_TTL_SECONDS + 5)
@@ -3000,6 +3119,158 @@ class TestFetchTtl:
         with patch.object(quality_gate, "_run", side_effect=router) as mock_run:
             assert quality_gate._resolve_diff_base() is None
         assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    # --- review-fix #01 must-fix 3: a FAILED fetch must not read as freshness ---
+
+    def test_zero_byte_marker_still_fetches(self, tmp_path: Path) -> None:
+        """A failed fetch (offline / dropped VPN / hung remote) still bumps
+        `FETCH_HEAD`'s mtime but TRUNCATES it to 0 bytes — verified against real
+        git: rc=128, mtime advanced, size 0. Treating that as freshness
+        suppressed the QS-276 S1 stale-base warning for the whole 10-minute
+        window and never retried, even seconds after connectivity returned. The
+        TTL would have turned an existing safety net OFF.
+        """
+        marker = self._marker(tmp_path, age_seconds=5, content="")
+        with patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    def test_failed_fetch_warning_is_not_suppressed_on_the_next_run(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The consequence that actually bites: the S1 warning must keep firing
+        run after run while the remote is unreachable."""
+        marker = self._marker(tmp_path, age_seconds=5, content="")
+
+        def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
+            if cmd[:3] == ["git", "rev-parse", "--git-path"]:
+                return _cp(0, stdout=str(marker))
+            if cmd[:2] == ["git", "fetch"]:
+                return _cp(128, stderr="Could not read from remote repository.")
+            if cmd[:3] == ["git", "rev-parse", "--verify"] and cmd[3] == "origin/main":
+                return _cp(0)
+            if cmd[:2] == ["git", "merge-base"]:
+                return _cp(0)
+            return _cp(1)
+
+        with patch.object(quality_gate, "_run", side_effect=_side_effect):
+            quality_gate._resolve_diff_base()
+        assert "git fetch origin main` failed/timed out" in capsys.readouterr().err
+
+    # --- review-fix #01 should-fix 4: never skip in CI ---
+
+    def test_ci_bypasses_the_ttl(self, tmp_path: Path) -> None:
+        """`actions/checkout` leaves a seconds-old `FETCH_HEAD`, so without an
+        explicit bypass a CI `--impacted` would skip its own fetch and resolve
+        against whatever base checkout happened to leave. The constant's comment
+        already claimed "CI always fetches fresh"; now something enforces it."""
+        marker = self._marker(tmp_path, age_seconds=1)
+        with (
+            patch.object(quality_gate, "_is_ci", return_value=True),
+            patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run,
+        ):
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    def test_ci_bypass_does_not_even_probe_the_marker(self, tmp_path: Path) -> None:
+        """Cheaper and clearer: under CI the marker is irrelevant, so don't ask."""
+        marker = self._marker(tmp_path, age_seconds=1)
+        with (
+            patch.object(quality_gate, "_is_ci", return_value=True),
+            patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run,
+        ):
+            quality_gate._resolve_diff_base()
+        probes = [c.args[0] for c in mock_run.call_args_list if c.args[0][:3] == ["git", "rev-parse", "--git-path"]]
+        assert probes == [], probes
+
+    # --- review-fix #01 should-fix 5: the marker must record a MAIN fetch ---
+
+    def test_marker_recording_another_branch_still_fetches(self, tmp_path: Path) -> None:
+        """`FETCH_HEAD` records the last fetch of *anything*. `gh pr checkout
+        <n>`, `git fetch origin <other-branch>`, a tag fetch from an editor
+        plugin — each rewrites the marker without advancing `origin/main`. So a
+        fresh mtime alone cannot support the claim that origin/main is fresh.
+        Verified against real git: `git fetch origin other` writes
+        `branch 'other' of …`.
+        """
+        marker = self._marker(
+            tmp_path, age_seconds=1, content="cafe1234\t\tbranch 'other' of /tmp/up\n"
+        )
+        with patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    def test_marker_recording_main_among_several_refs_skips(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A bare `git fetch origin` brings main down too and marks the other
+        refs `not-for-merge`; that IS a legitimate skip. Verified format:
+        `<sha>\\tnot-for-merge\\tbranch 'other' of …`."""
+        marker = self._marker(
+            tmp_path,
+            age_seconds=30,
+            content=(
+                "aaaa1111\t\tbranch 'main' of /tmp/up\n"
+                "bbbb2222\tnot-for-merge\tbranch 'other' of /tmp/up\n"
+            ),
+        )
+        with patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert TestResolveDiffBase._fetch_calls(mock_run) == []
+        assert "fetch skipped" in capsys.readouterr().err
+
+    def test_main_only_as_not_for_merge_still_counts(self, tmp_path: Path) -> None:
+        """main can appear flagged `not-for-merge` (e.g. fetched while on another
+        branch). The ref still came down, so the skip is legitimate."""
+        marker = self._marker(
+            tmp_path, age_seconds=30, content="aaaa1111\tnot-for-merge\tbranch 'main' of /tmp/up\n"
+        )
+        with patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run:
+            quality_gate._resolve_diff_base()
+        assert TestResolveDiffBase._fetch_calls(mock_run) == []
+
+    def test_unreadable_marker_still_fetches(self, tmp_path: Path) -> None:
+        """A directory where the marker should be (or any read error) is unknown."""
+        weird = tmp_path / "FETCH_HEAD"
+        weird.mkdir()
+        with patch.object(quality_gate, "_run", side_effect=self._router(weird)) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    # --- review-fix #01 should-fix 6: a future mtime is unknown, not fresh ---
+
+    def test_future_mtime_still_fetches(self, tmp_path: Path) -> None:
+        """`max(0.0, now - mtime)` turned an impossible timestamp into age 0.0,
+        so the fetch was skipped for the ENTIRE duration of the skew, not for 10
+        minutes. Reproduces on an NTP step, VM suspend/resume, dual boot, or a
+        network share whose server clock runs ahead. `None` — the module's
+        established "unknown, do not skip" convention — is the right answer."""
+        marker = self._marker(tmp_path, age_seconds=-3600)  # one hour in the FUTURE
+        with patch.object(quality_gate, "_run", side_effect=self._router(marker)) as mock_run:
+            assert quality_gate._resolve_diff_base() == "origin/main"
+        assert len(TestResolveDiffBase._fetch_calls(mock_run)) == 1
+
+    # --- review-fix #01 nice-to-have 12: no duplicate NH2 warning on the retry ---
+
+    def test_shallow_clone_warning_is_not_duplicated_by_the_retry(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Skip → ladder warns and returns None → fetch → ladder walks again.
+        The NH2 "no merge-base with HEAD (shallow clone?)" line must not print
+        twice for one invocation."""
+        marker = self._marker(tmp_path, age_seconds=60)
+        router = self._router(
+            marker,
+            rev_parse={"origin/main": 0, "main": 0},
+            reachable={"origin/main": 1, "main": 1},
+            upstream=(1, ""),
+        )
+        with patch.object(quality_gate, "_run", side_effect=router):
+            assert quality_gate._resolve_diff_base() is None
+        err = capsys.readouterr().err
+        assert err.count("no merge-base with HEAD") == 2, (
+            f"expected one warning per candidate ref on the FIRST walk only; got:\n{err}"
+        )
 
 
 class TestRunTimeout:
@@ -3626,6 +3897,92 @@ class TestImpactedEarlyExitPaths:
         # Merge-base scoping keeps the change set ours alone.
         assert self._paths(repo) == ["docs/a.md"]
 
+    # --- review-fix #01 must-fix 1: core.quotePath must not fail the exit OPEN ---
+
+    NON_ASCII_PY = "tests/test_données.py"
+
+    def test_non_ascii_tracked_py_defeats_the_exit(self, repo: Path) -> None:
+        """`core.quotePath` defaults to TRUE, so `git diff --name-only` emits
+        `"tests/test_donn\\303\\251es.py"` — C-quoted, WITH surrounding double
+        quotes. That string does not end in `.py`, so the only Python file in
+        the change set became invisible and the gate returned 0 having run
+        NOTHING: a silent fail-OPEN in the one function whose contract is
+        fail-closed. NUL-delimited output removes the whole quoting class.
+        """
+        (repo / "tests").mkdir()
+        (repo / self.NON_ASCII_PY).write_text("def f():\n    return 1\n")
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-qm", "non-ascii py")
+        paths = self._paths(repo)
+        assert paths is not None
+        assert self.NON_ASCII_PY in paths, paths
+        assert not any(p.startswith('"') for p in paths), f"C-quoted path leaked: {paths!r}"
+        assert self._has_py(paths)
+
+    def test_non_ascii_untracked_py_defeats_the_exit(self, repo: Path) -> None:
+        """`git ls-files --others` quotes too, so the untracked half needs `-z`
+        just as much as the diff half."""
+        (repo / "tests").mkdir()
+        (repo / self.NON_ASCII_PY).write_text("def f():\n    return 1\n")
+        paths = self._paths(repo)
+        assert paths is not None
+        assert self.NON_ASCII_PY in paths, paths
+        assert self._has_py(paths)
+
+    def test_quote_path_is_actually_on_in_this_repo(self, repo: Path) -> None:
+        """Pin the premise: if git ever changed its default, or the repo set
+        `core.quotePath=false`, the two tests above would pass vacuously and
+        stop guarding anything."""
+        (repo / "tests").mkdir()
+        (repo / self.NON_ASCII_PY).write_text("x = 1\n")
+        quoted = self._git(repo, "ls-files", "--others", "--exclude-standard")
+        assert '\\303\\251' in quoted, (
+            f"expected C-quoted output from plain git (proving -z is load-bearing); got {quoted!r}"
+        )
+
+    def test_path_with_a_literal_newline_defeats_the_exit(self, repo: Path) -> None:
+        """Why `-z` rather than `-c core.quotePath=false`: the latter still
+        breaks on a path containing a literal newline, which splits into two
+        bogus fields."""
+        weird = "tests/we\nird.py"
+        (repo / "tests").mkdir()
+        (repo / weird).write_text("y = 1\n")
+        paths = self._paths(repo)
+        assert paths is not None
+        assert weird in paths, paths
+        assert self._has_py(paths)
+
+    # --- review-fix #01 must-fix 2: union the committed range ---
+
+    def test_py_reverted_in_the_worktree_defeats_the_exit(self, repo: Path) -> None:
+        """`git diff <mb>` compares the merge-base tree to the WORKING tree, so
+        a `.py` changed in a branch COMMIT but restored to merge-base content in
+        the worktree vanished from it — while diff-cover's three-dot
+        `base...HEAD` still scores that commit's added lines. The exit fired and
+        returned 0 on a change set diff-cover would very likely have FAILed.
+        """
+        (repo / "mod.py").write_text("A = 1\n\n\ndef added():\n    return 2\n")
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-qm", "add a function")
+        # Restore merge-base content in the worktree only (commit still has it).
+        (repo / "mod.py").write_text("A = 1\n")
+
+        # Premise: the working-tree diff alone is blind here...
+        assert "mod.py" not in self._git(repo, "diff", "--name-only", "main")
+        # ...while the range diff-cover actually uses is not.
+        assert "mod.py" in self._git(repo, "diff", "--name-only", "main...HEAD")
+        # So the union must see it.
+        assert self._has_py(self._paths(repo))
+
+    def test_committed_range_is_unioned_not_substituted(self, repo: Path) -> None:
+        """The committed range is an ADDITION: a worktree-only edit that was
+        never committed must still be reported."""
+        (repo / "unstaged.py").write_text("Z = 1\n")
+        self._git(repo, "add", "unstaged.py")
+        paths = self._paths(repo)
+        assert paths is not None
+        assert "unstaged.py" in paths, paths
+
     def test_prefers_origin_main_over_local_main(self, repo: Path) -> None:
         """Base ladder rung 1. `origin/main` is created as a real remote-tracking
         ref pointing at the fork point, so a resolvable `origin/main` is used."""
@@ -3641,16 +3998,19 @@ class TestImpactedEarlyExitPaths:
         [
             ("git", "rev-parse", "--verify"),
             ("git", "merge-base"),
-            ("git", "diff"),
+            ("git", "diff", "--name-only", "-z"),
             ("git", "ls-files"),
         ],
         ids=["base", "merge-base", "diff", "ls-files"],
     )
     def test_fail_closed_on_any_git_failure(self, failing: tuple[str, ...]) -> None:
-        """AC2: a non-zero return from ANY of the four calls → None → no exit.
+        """AC2: a non-zero return from ANY git call → None → no exit.
 
         `_get_changed_files` silently drops failed calls; copying that here
         would convert a git failure into a false PASS.
+
+        Review-fix #01 must-fix 2 added a fifth call (the committed range); it
+        is covered by the `diff` id, which matches both diff invocations.
         """
         prefix = list(failing)
 
@@ -3663,6 +4023,39 @@ class TestImpactedEarlyExitPaths:
 
         with patch.object(quality_gate, "_run", side_effect=_side_effect):
             assert quality_gate._impacted_early_exit_paths() is None
+
+    def test_fail_closed_when_only_the_committed_range_fails(self) -> None:
+        """Review-fix #01 must-fix 2: the NEW call must fail closed on its own,
+        not merely be covered by a prefix that also matches the older one."""
+
+        def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
+            if cmd[:2] == ["git", "merge-base"]:
+                return _cp(0, stdout="deadbeef\n")
+            # The committed range is the only diff with a trailing "HEAD".
+            if cmd[:2] == ["git", "diff"] and cmd[-1] == "HEAD":
+                return _cp(128, stderr="fatal")
+            return _cp(0, stdout="")
+
+        with patch.object(quality_gate, "_run", side_effect=_side_effect):
+            assert quality_gate._impacted_early_exit_paths() is None
+
+    def test_all_git_output_is_nul_delimited(self) -> None:
+        """Review-fix #01 must-fix 1: every path-listing call must pass `-z`, or
+        the C-quoting fail-open returns through whichever one was missed."""
+        seen: list[list[str]] = []
+
+        def _side_effect(cmd: list[str], *_a, **_k) -> subprocess.CompletedProcess[str]:
+            seen.append(cmd)
+            if cmd[:2] == ["git", "merge-base"]:
+                return _cp(0, stdout="deadbeef\n")
+            return _cp(0, stdout="")
+
+        with patch.object(quality_gate, "_run", side_effect=_side_effect):
+            quality_gate._impacted_early_exit_paths()
+        listing = [c for c in seen if c[:2] == ["git", "diff"] or c[:2] == ["git", "ls-files"]]
+        assert len(listing) == 3, listing
+        for cmd in listing:
+            assert "-z" in cmd, f"path-listing call without -z: {cmd!r}"
 
     def test_empty_merge_base_stdout_fails_closed(self) -> None:
         """A zero-rc `merge-base` with no sha is unusable — do NOT early-exit."""
@@ -5713,6 +6106,17 @@ class TestProjectRulesDocGuards:
             Path(__file__).resolve().parent.parent / "docs" / "workflow" / "project-rules.md"
         ).read_text()
 
+    def _rules_flat(self) -> str:
+        """`project-rules.md` with runs of whitespace collapsed to single spaces.
+
+        Review-fix #01 lesson (same root cause as nice-to-have 21): the doc is
+        hard-wrapped, so where a phrase happens to break across lines is an
+        accident of formatting and must not be part of a guard's contract.
+        Phrase guards run against this; guards for runnable single-line commands
+        keep using the raw text.
+        """
+        return " ".join(self._rules().split())
+
     def test_seed_testmon_carveout_heading_present(self) -> None:
         rules = self._rules()
         assert "Carve-out — `--seed-testmon`" in rules
@@ -5746,21 +6150,30 @@ class TestProjectRulesDocGuards:
         verification rather than a supplement, must live in project-rules.md —
         it is the one behavioural consequence a reader could otherwise
         mistake for a real green."""
-        rules = self._rules()
-        assert "Non-Python change sets" in rules
-        assert "exits early" in rules
-        assert "quality_gate.py --quick tests/qs` is not a" in rules
+        flat = self._rules_flat()
+        assert "Non-Python change sets" in flat
+        assert "exits early and checks **nothing**" in flat
+        assert "is not a supplement there, it is **the** verification" in flat
+        # nice-to-have 18: the doc's UI hint must agree with `_IMPACTED_NON_PY_LINES`.
+        for hint in quality_gate._IMPACTED_NON_PY_LINES:
+            for target in re.findall(r"--quick [\w./]+", hint):
+                assert f"quality_gate.py {target}" in self._rules(), (
+                    f"the gate prints {target!r} but project-rules.md does not: the two "
+                    "hints must not send the reader to different commands"
+                )
+        # should-fix 8's fail-closed qualification belongs in the doc too.
+        assert "fails closed" in flat
         # The deferred-baseline-resync caveat (a cost shift, not a verdict change).
-        assert "Deferred baseline re-sync" in rules
+        assert "Deferred baseline re-sync" in flat
 
     def test_serial_fast_path_documented(self) -> None:
         """QS-290 (S-1, task 7): `--quick`'s comment block claimed
         "Uses xdist + sysmon" unconditionally. That is now false below the
         threshold."""
-        rules = self._rules()
-        assert "Uses xdist + sysmon" not in rules, "the unconditional-xdist claim must be gone"
-        assert "single-process" in rules
-        assert f"{quality_gate._SERIAL_MAX_TESTS} collected" in rules
+        flat = self._rules_flat()
+        assert "Uses xdist + sysmon" not in flat, "the unconditional-xdist claim must be gone"
+        assert "single-process" in flat
+        assert f"{quality_gate._SERIAL_MAX_TESTS} collected" in flat
 
     def test_testing_layers_cross_references_rather_than_restating(self) -> None:
         """The agent-facing concept doc points at the canonical statement


### PR DESCRIPTION
## Summary
- **S-4 — non-`.py` early exit.** A change set with no `.py` file spawns no pytest, no diff-cover and no `git fetch` (10.7–23.5 s → a handful of local git calls). testmon fingerprints AST blocks in `.py` files only, so such a run could never select a test and diff-cover has no Python lines to score — the verdict was **already** vacuous; only the cost changes. The change set is computed against the **merge-base** (committed + staged + unstaged + untracked), a genuine superset of diff-cover's three-dot range, and any git failure fails **closed**.
- **S-5 — denominator from the run itself.** `-o console_output_style=count` lets `_stream_pytest` read `[N/M]` off the stream, deleting the whole-tree `--collect-only` subprocess that cost ~30% of the zero-work gate *and* reported the wrong number (`done (0/6912)` — the tree, not the selection). Verified live in this PR's own gate run: `pytest: 100% (9/9)`.
- **S-1 — serial fast path.** `--quick` / dev-only / ui-only runs at or below 50 collected tests go single-process. One collect-only probe now serves both the worker decision and the denominator. `QS_QG_PYTEST_WORKERS` always wins, in both directions.
- **S-7 — fetch TTL.** The `--impacted` fetch is TTL-cached (10 min) on the per-worktree `FETCH_HEAD` mtime, resolved via `git rev-parse --git-path`. Also verified live — see the refreshed gate output under “Review fix plan #02 applied” below.
- **D-18 — truthful `--full` reason**, without clobbering `production files changed: …`, plus reason pluralization.

Fixes #290

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

## Measured (AC12)

True A/B on one machine (10 cores, warm), median of 3, gate wall via
`/usr/bin/time -p`, on `--quick tests/qs/launchers/test_phase_mapping.py`
(43 tests) — the "before" leg measured by stashing only
`scripts/qs/quality_gate.py`, so the tests are identical across legs:

| | Runs | Median |
| --- | --- | --- |
| before (xdist `-n auto`) | 8.92 / 9.31 / 8.92 s | **8.92 s** |
| after (serial fast path) | 7.59 / 7.26 / 7.32 s | **7.32 s** |

Target was **≤ 17 s** — met with a wide margin. Note the absolute
"before" here (8.9 s) is well under the story's planning baseline
(20.1 / 22.4 s), which was captured on a colder cache; the direction and
the target both hold, and I am reporting what this machine actually did
rather than the planned numbers.

The other two claims are **structural, not timed**, which is stronger
than a wall-clock number and costs no measurement time:

- non-`.py` `--impacted` spawns nothing — asserted directly
  (`_resolve_diff_base`, `_stream_pytest` and `_run` all
  `assert_not_called`, plus an argv-level assertion that no
  `["git", "fetch", …]` is spawned);
- `--quick tests/qs` keeps `-n auto` — 691 tests, no serial banner in
  the real pre-commit run.

Both TTL and count-denominator behaviour also showed up live in this
PR's own pre-commit `--impacted`:

```
[impacted] diff base: fetch skipped (origin/main fetched 21s ago)
[impacted] selecting impacted tests (testmon) vs base origin/main
  pytest: done (0/0) | passed=0 failed=0 errors=0
```

(Refreshed after review fix #02 — the skip line's earlier wording is
retired. See that section below for what each line demonstrates.)

## Verification notes

- **The `raise`-in-the-branch re-verification ran.** With an
  `AssertionError` planted inside the early-exit branch, all 21
  pre-existing `TestCheckImpacted*` tests still passed and exactly the 4
  new early-exit tests failed — proving none of the pre-existing
  `check_impacted` call sites reach the new branch, and that the 4 new
  ones genuinely do.
- **AC2 is tested against real git**, not mocks, in throwaway repos —
  including both false-PASS holes a two-dot diff would have opened: a
  `.py` whose content main already holds identically (landed
  cherry-pick), and a branch behind main (which a two-dot diff would
  have stopped from ever early-exiting).
- **AC13 is a permanent test**, not a throwaway ritual: this story
  rewrites the very code path used to verify itself, so exit-code
  fidelity is pinned on both argv shapes (serial and `-n auto`).

## Deferred

S-1(c) — auditing auto-loaded pytest plugins to cut per-worker
collection cost — is **not** in this PR. Filed as #322, carrying the
real 20-entry third-party plugin list from `pytest --trace-config`,
first-probe candidates (including `pytest_sugar`, which is also a
progress-parsing hazard for `_stream_pytest`), an explicit do-not-touch
list, and the three alternatives QS-290 already measured and rejected so
they are not redone.

Per the story, #290 is expected to **close on merge** with S-1(c)
tracked separately in #322.

## Doc maintenance

`python scripts/qs/check_doc_drift.py` on the staged diff exits **0** —
only the four pre-existing `testing-layers.md` "`covers:` entry outside
`custom_components/`" warnings (audit D-12), unrelated to this change.

Docs updated:

- `docs/workflow/project-rules.md` — the early exit and its
  deferred-baseline-resync caveat, a new **"Non-Python change sets"**
  section stating that `--quick tests/qs` is *the* verification there
  rather than a supplement, the serial fast path, the fetch TTL, and the
  now-false "Uses xdist + sysmon" line. Pinned by 3 new guards in
  `TestProjectRulesDocGuards`.
- `docs/agents/concepts/testing-layers.md` — a one-line cross-reference
  to the canonical statement rather than a second copy to drift.

**Deviation from the story, deliberate.** The story pre-declared
`.claude/agents/**`, `.cursor/agents/**` and `.opencode/agents/**`
**Doc-OK**, and asked task 7 to grep them and *record* any prose that
becomes false. It did:

> …the gate/tooling's own correctness is still guarded by its
> testmon-selected tests under `--impacted`

in `qs-implement-setup-task.md`. Strictly this was already untrue in
substance — testmon selected 0 tests for a non-`.py` change set before
this PR too — so it does not *become* false. I corrected it anyway,
because that agent is the **dev-environment** implement variant: its
change sets are the ones most likely to be pure non-`.py` (docs-only,
agent-file-only), so it is the single place where reading "`--impacted`
guards the tooling" and trusting the green does real damage. The
sentence was unpinned by any test, the edit is the same in all three
harnesses (satisfying the co-modification rule), and a new
`tests/qs/agents/test_impacted_non_py_honesty.py` pins it so it cannot
drift back. No protocol, command or exit-code contract changed.

`AGENTS.md` untouched, as the story specified.

## Review fix plan #01 applied

All 21 findings fixed (3 must-fix, 6 should-fix, 12 nice-to-have) — commit
`684c556e`. The acceptance-auditor traced all 13 ACs to implementation and
tests with zero findings, so every must-fix below is a correctness hole the
ACs never named.

The three must-fix were reproduced against **real git**, and each now has a
real-git regression test rather than a mocked one:

| # | Hole | Why it mattered |
| --- | --- | --- |
| 1 | `core.quotePath` C-quoting | `"tests/test_donn\303\251es.py"` does not end in `.py`, so a change set whose only Python file had a non-ASCII character anywhere in its path took the early exit — a silent fail-**open** in the one function whose contract is fail-closed. Both listings now use `-z`. |
| 2 | working-tree diff was not a superset | A `.py` changed in a branch **commit** but restored to merge-base content in the worktree vanished from the set while diff-cover still scored that commit's added lines. The committed range (`git diff <mb> HEAD`) is now unioned in. |
| 3 | a failed fetch bumps `FETCH_HEAD` | Verified: rc=128, mtime advanced, file truncated to 0 bytes. The TTL read failure as freshness, so the QS-276 S1 stale-base warning was suppressed for the whole 10-minute window and never retried. The TTL was switching off an existing safety net. |

### Two places I did not follow the plan literally

Both are measurement-driven, and both are recorded rather than silent:

- **should-fix 5** proposed keying the TTL on `refs/remotes/origin/main`'s
  mtime. Measured: after a clone that ref is **packed**, so the loose path
  does not exist at all — and even when loose, git does not rewrite it when a
  fetch finds no new commits. A quiet `main` is the common case, so that
  marker would make the TTL never hit and delete the feature's entire
  benefit. I implemented the finding's *intent* — "the marker must measure
  what the TTL claims" — by reading `FETCH_HEAD`'s **content** and requiring
  it to record a `branch 'main' of …` fetch. That closes the actual hole (a
  `gh pr checkout` writes `branch 'other'`) and keeps the feature working.
  The plan's own "whatever is chosen, the wording must not claim more than
  the marker supports" is satisfied: the skip line now reads
  `fetch skipped (origin/main fetched 3m ago)`.
- **nice-to-have 19** asked for an accurate git-call count or non-numeric
  wording. I took the non-numeric wording, as the plan preferred — this
  commit itself changes the count from four to five.

### The semantic guard earned its keep immediately

Rewriting the honesty test for **nice-to-have 21** (assert the semantic —
every "testmon-selected tests guard this" claim must carry the "change set
contains a `.py` file" condition — instead of rejecting one exact string)
immediately failed on **two further unscoped claims the plan had not
listed**: the agent's YAML `description` and its intro paragraph. Both are
fixed. An exact-string guard would have passed over both.

Related lesson, applied repo-wide in this commit: phrase-based doc guards now
normalize whitespace before matching, so where a hard-wrapped line happens to
break is no longer part of any contract. Three guards had already broken on
exactly that during this fix pass.

### Verification

- `--quick tests/test_quality_gate.py` — **581 passed**
- `--quick tests/qs` — **700 passed**
- `check_doc_drift.py` on the staged diff — **exit 0** (only the four
  pre-existing `testing-layers.md` warnings, audit D-12)
- `--impacted` — PASS
- `ruff check` and `mypy` clean on all changed Python

The `--impacted` run also shows nice-to-have 10's fix in place —
`pytest: done (18/18)` where a 0-selected run would previously have printed
no terminal line at all, the single most common inner-loop invocation.

The one plan item marked **invalid** (missing `io`/`os`/`time` imports) was
correctly a false positive — the blind-hunter self-flagged it as assumed
without repo access; all three are imported. The non-blocking AC12 note needs
no fix and is already disclosed above.

## Review fix plan #02 applied

All 15 findings fixed (1 must-fix, 7 should-fix, 7 nice-to-have) — commit
`bd81a13e`. Round 1's three must-fixes were re-verified as genuinely fixed.

### must-fix: the index was invisible to every early-exit rung

Same fail-**open** class as round 1's must-fix 2, one git rung over — and it
matters more, because the index is precisely what the `git commit`
immediately after this pre-commit gate will land. Reproduced against real
git:

```
git checkout -b feat main
echo edited > README.md
printf 'def f():\n    return 2\n' > mod.py
git add mod.py                                # index != merge-base
printf 'def f():\n    return 1\n' > mod.py    # worktree == merge-base
```

```
rung1 (mb vs worktree): [README.md]
rung2 (mb vs HEAD):     []
rung3 (untracked):      []
MISSING cached rung:    [mod.py]
```

I also confirmed the diff-cover half rather than taking it on trust:
`GitDiffReporter` is constructed with `ignore_staged=False` in the installed
10.3.0, so `git diff --cached -U0` genuinely is in its range. Added a fourth
rung, `git diff --name-only -z --cached <mb>`, failing closed like the rest.

### One measurement that changed the shape of a fix

**should-fix 2** asked for the `FETCH_HEAD` remote check. Implementing it
naively would have *silently disabled the TTL everywhere*: git **strips** a
trailing `.git` when writing `FETCH_HEAD`, while `git remote get-url origin`
keeps it. On this very repo:

```
get-url:    https://github.com/tmenguy/quiet-solar.git
FETCH_HEAD: branch 'main' of https://github.com/tmenguy/quiet-solar
```

A raw equality check would never match. The comparison is normalized, and
that normalization has its own test — otherwise this would have been the
second feature-deleting trap in the same finding family (the first being the
`refs/remotes/origin/main` proposal rejected in round 1).

### should-fix 7 — the wrapped-literal sweep

All three surviving "two git calls" claims were invisible to a string grep
because the literal wraps mid-phrase, e.g.:

```python
# ...the diff-cover spawn: two git
# calls instead of 10.7-23.5 s of work.
```

Verified gone with a whitespace-tolerant regex over the flattened text, as
the plan required — not `grep "two git calls"`. Zero numeric git-call claims
remain in code or docs; the count has now changed twice, which is exactly why
the wording is non-numeric.

### Refreshed live evidence (should-fix 8)

Both Summary bullets are re-based on real current output rather than
hand-edited. From the pre-commit `--impacted` on this commit:

```
[impacted] diff base: fetch skipped (origin/main fetched 21s ago)
[impacted] selecting impacted tests (testmon) vs base origin/main
  pytest: done (0/0) | passed=0 failed=0 errors=0
```

Three fixes visible at once: the TTL skip with its corrected wording (round 1
should-fix 5 + round 2 should-fix 2), and `done (0/0)` — round 2's
nice-to-have 10, restoring the terminal line on a 0-selected run, which is the
single most common inner-loop invocation and previously printed **nothing**
between the "selecting" line and the verdict.

### Verification

- `--quick tests/test_quality_gate.py` — **610 passed**
- `--quick tests/qs` — **700 passed**
- `check_doc_drift.py` on the staged diff — **exit 0** (only the four
  pre-existing `testing-layers.md` warnings, audit D-12)
- `--impacted` — PASS (hit a stale baseline and select-all'd 6450 tests, then
  a warm re-run confirming the fast path)
- `ruff check` and `mypy` clean

### CI caught one thing local runs structurally could not

Making the `--quick` banner conditional on xdist (nice-to-have 10) turned its
wording into an **environment-dependent** string, and the pre-existing
`test_quick_emits_banner` asserted one environment's wording without pinning
it. Locally the venv has xdist, so the banner reads `xdist above 50 tests` and
the test passed every local gate; CI has no venv at all, so the banner
correctly reads `single-process` and the test failed. Fixed in `f21f4dac`.

Rather than fix it and re-push blind, I reproduced CI's environment locally —
`VENV_PYTHON` pointed at a nonexistent path with the xdist cache forced
`False` — which reproduced CI's exact 10-skip pattern and passed **600/600**.
That sweep confirmed the banner test was the *only* latent environment
assumption, instead of discovering them one CI round at a time. The suite now
passes in both directions: 610 with a venv, 600 + 10 skips without.

This is also a live example of the local-vs-CI split the project documents:
`--impacted` and `--quick` cannot see it, and CI's whole-suite run is what
actually catches it.

The story's AC section now carries an amendment note (should-fix 6) recording
the five ACs whose *mechanism* the review rounds superseded — intent unchanged,
every deviation tested — rather than silently rewriting the originals, per this
story's record-the-delta convention.

**CodeRabbit was rate-limited out of round 2** and produced no data for
`684c556e`, so that round rested on three reviewers. Round 3 will give it a
pass on the final code, which is more useful than one on an intermediate state.

## Review fix plan #04 applied — closing

Commit `f2dd0e70`. Four defects only, per the plan's scope rule: things that
change a verdict or silently disable the feature. **Plan #03's remaining 12
findings are closed won't-fix by #04 and were deliberately not applied** — its
reasoning being that the prose-rewording rounds were themselves generating the
next round's findings.

### The must-fix was a false PASS in this PR's own feature

The early exit assumed testmon "could never select a test" for a non-`.py`
change set. That is true only while `.testmondata` is **warm**. Reproduced
against real testmon:

```
COLD (no .testmondata), only note.txt changed  ->  1 passed      (select-all)
WARM,                   only note.txt changed  ->  no tests ran  (0 selected)
```

So on a cold baseline a doc-only change that breaks a doc-pinned guard test
**exited 1 before this PR and returned 0 after it** — and the tests it would
stop running are this PR's own guards (`test_impacted_non_py_honesty.py`,
`TestProjectRulesDocGuards`). The exit is now gated on a warm baseline.

One deliberate strengthening beyond the literal instruction: the plan said to
reuse the existing probe, which is read *pre*-hygiene. I read it **post**-hygiene
instead, because a corrupt `.testmondata` looks warm and is then purged — after
which testmon select-alls too. Gating on the pre-hygiene signal alone would have
left the identical hole one step over. Both signals are now kept: pre-hygiene for
QS-283's self-heal decision, post-hygiene for the exit gate, each with its own test.

### The silent-disable

`_COLLECTED_RE` could not parse pytest's deselection output:

```
plain:       3 tests collected in 0.01s
deselected:  1/3 tests collected (2 deselected) in 0.00s
```

`.match()` anchors at position 0, so the `1/` prefix made the probe return
`None` → `_resolve_files_workers` always answered `-n auto` → **the serial fast
path this whole story exists to deliver silently stopped existing**, with no
warning and no symptom but the lost seconds. Triggered by any `-k`/`-m` in
`addopts` (a `slow` marker is already declared) or a
`pytest_collection_modifyitems` hook.

### Two collateral defects the hoist exposed, both caught locally

- Tests that mock `_run_impacted_pass` no longer had hygiene mocked along with
  it. With a `MagicMock` `TESTMON_DATA`, the now-real
  `sqlite3.connect(str(mock))` created files **literally named
  `<MagicMock id=...>` in the repo root**. Caught by an untracked-file check
  before staging; hygiene is now stubbed in those drivers.
- `TestImpactedNonPyEarlyExit` needs a warm baseline for the exit to fire at
  all, so it pins one. Without that, those tests would inherit the ambient
  `.testmondata` — green locally, red on CI, which has no baseline. Exactly the
  environment assumption that broke `test_quick_emits_banner` on CI last round,
  so I pinned it up front this time rather than learning it from CI twice.

### Prose

Only the two spots item 1 requires — both were provably false once the gate
became warm-dependent ("changes cost, never a verdict") — plus the guard that
pins them. Nothing else reworded, deliberately.

### Verification

- `--quick tests/test_quality_gate.py` — **619 passed**
- `--quick tests/qs` — **700 passed**
- `check_doc_drift.py` on the staged diff — **exit 0**
- `--impacted` — PASS
- `ruff` + `mypy` clean; working tree free of stray artifacts

## Review fix plan #05 applied — closing

Commit `62e577a4`. Four items plus one deferred issue; the 12 won't-fix items
from #04 stay closed.

### must-fix 1a — reproduced against real testmon

`st_size > 0` was only a *proxy* for "testmon has a usable baseline". I killed a
`pytest --testmon` mid-flight and got exactly the state the reviewer described:

```
.testmondata 4096 B  +  .testmondata-wal 140112  +  .testmondata-shm 32768
PRAGMA user_version == 14   -> _ensure_testmon_db_safe does NOT purge
st_size > 0                 -> _testmon_baseline_warm() said WARM
actual testmon behaviour    -> 40 passed   (select-all)
```

So the early exit returned 0 where the pre-exit gate ran 40 tests. An in-flight
`--seed-testmon`/rebuild leaves the same signature, and on a 7000-test suite
that window is minutes long. Sidecars alongside the primary now read as cold.

Two things about reproducing it that are worth writing down, because both cost
me a false negative first:

- **Empty sidecar files do not reproduce it.** My first attempt just `touch`ed
  `-wal`/`-shm`; testmon still selected 0. It needs a genuinely populated WAL
  from an interrupted write.
- **Probing the DB with sqlite3 first destroys the state** — reading
  `PRAGMA user_version` checkpoints the WAL into the primary (4096 B → 65536 B)
  and the run then behaves warm. The observation has to come after the testmon
  run, not before.

### 1b — deferred, filed as #341

One state remains: a package install/upgrade/removal, or a Python **micro**
bump, resets testmon's environment fingerprint so it select-alls while the file
still looks warm (size > 0, `user_version` 14, no sidecars). Unlike the two
states fixed above this one is **persistent** — the exit never runs pytest, so
the fingerprint is never refreshed.

Accepted because `--impacted` is the *local* gate and CI runs the suite
authoritatively, so the blast radius is a developer learning from CI rather than
broken code reaching `main`. Cited in `_testmon_baseline_warm`, plus one
sentence in `project-rules.md` so the repo does not over-claim
verdict-neutrality — pinned by the doc guard.

### should-fix 2 — not cosmetic

`test_no_base_in_ci_returns_4` and `test_no_base_locally_warns_and_passes` were
running the hoisted hygiene helpers **for real against the live repo**.
`_clean_orphan_cov_shards()` globs `.coverage.*` and unlinks, and its own
docstring justifies safety with *"called BEFORE the pytest subprocess spawns"* —
running it inside a suite that is itself executing under coverage + xdist
violates exactly that assumption and can delete the in-progress run's worker
shards. Both now patched, matching their sibling.

### nice-to-have 3 and 4

- Anchored `_COLLECTED_RE`. #04 offered "`.search()` **or** anchor" and the
  implementation took `.search()` — which a parametrized test **id** can satisfy
  before the real summary line (a param value of
  `"12/340 tests collected (328 deselected)"` yields 12 for a 3-test file).
  Real ids always begin with the file path, so `^`-anchoring is immune. The
  loose guidance is what opened this; anchoring was the right call.
- Bounded the reaping `communicate()`. `SIGKILL` reaches only the direct child,
  so a grandchild holding the inherited pipes would have turned the 60 s collect
  budget into an indefinite stall — worse than the `ResourceWarning` the reap
  removes.

### Collateral

`test_hygiene_runs_before_the_seam` used a `MagicMock` for `TESTMON_DATA`, and
every attribute of a `MagicMock` is truthy, so the new sidecar probe read it as
cold. Switched to a real tmp path.

### Verification

- `--quick tests/test_quality_gate.py` — **625 passed**
- `--quick tests/qs` — **700 passed**
- `check_doc_drift.py` on the staged diff — **exit 0**
- `--impacted` — PASS
- `ruff` + `mypy` clean; working tree free of stray artifacts

---
Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warm-baseline changes without Python files now skip unnecessary verification.
  * Small test runs default to serial execution, with optional worker overrides.
  * Recent base-branch fetches can be reused for up to 10 minutes.

* **Bug Fixes**
  * Improved progress reporting, scope explanations, Git failure handling, and change detection.

* **Documentation**
  * Updated quality-gate guidance and added the QS-290 implementation plan.

* **Tests**
  * Added comprehensive regression coverage for updated quality-gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




