### PR TITLE
QS-291: Parallelize context.py's two serial gh calls

### DIFF
--- a/docs/stories/QS-291.story.md
+++ b/docs/stories/QS-291.story.md
@@ -110,6 +110,8 @@ zero submissions (~0.1ms). Not worth a special case.
 | No subprocess timeout; a hung `gh` blocks the pool | Pre-existing (delta 2). Out of scope; #295. |
 | Concurrent `gh` prompting for auth | ~~Out of scope; rely on `gh` being pre-authenticated.~~ **Fixed** in review fix #01 S2: `utils.run` gained an opt-in `stdin` passthrough (default `None` = today's inherit for every other caller) and both concurrent submissions pass `subprocess.DEVNULL`. |
 | Concurrent `gh` racing on `~/.config/gh` token refresh | Accepted: 2 requests per startup, ~25/week. |
+| Thread-pool exhaustion (low `ulimit -u` / pids cgroup) makes `pool.submit` raise | **Accepted** (review fix #02 M1). An "inline fallback" is unsound: CPython's `submit` does `_work_queue.put(w)` *before* the `Thread.start()` that raises, so the work item cannot be un-queued and any idle worker re-runs it — a duplicate `gh` request, a slower-than-serial `shutdown(wait=True)`, and an abandoned future whose exception is discarded. A process already out of threads is an environment failure; do not add a fallback. |
+| `EMFILE` / fd exhaustion is not degraded | **Accepted.** Two overlapped `capture_output=True` children need ~8 pipe fds at peak vs ~4 serial, so a tight `ulimit -n` turns a previously-succeeding run into a traceback with no JSON on stdout. Consistent with the thread-exhaustion row above: neither resource-exhaustion mode is degraded. |
 
 ### Doc maintenance
 
@@ -192,13 +194,53 @@ recorded argv (`"42" in cmd`), since `cmd[:3]` dispatch ignores the issue number
 Non-AC: `context.py` median should land near 0.57s against the 1.022s baseline
 above. Protocol: 10 runs, 1.2s spacing, report the median. Never a blocker.
 
+**Measured, in order (same protocol every time):** 0.535s at first
+implementation; 0.585s after review fix #01 (with one round showing a 173s
+outlier from a stalled `gh` — the pre-existing #295 no-timeout hang, not this
+change); **0.559s** (min 0.500, max 0.748) after review fix #02, i.e. against
+the code actually shipping — **~0.46s / ~45% off startup** vs the 1.022s
+baseline (review fix #02 R3).
+
+### ACs added by review fix #01 (review fix #02 R5)
+
+These behaviours shipped with tests but traced only to prose, leaving most of
+the test file with no criterion to audit against. Promoted here.
+
+**AC5 — no concurrent failure is ever discarded.** `concurrent.futures` does
+not log an unretrieved future exception, so both futures are drained before
+anything propagates. Ordering is deterministic: a failure in the local git work
+inside the pool block is the primary error; otherwise the title error, then the
+PR error. The non-primary failure rides along as an `add_note` entry. Covered by
+`test_local_git_failure_surfaces_sibling_gh_error`,
+`test_both_gh_calls_raising_surfaces_both`, and
+`test_base_exception_in_worker_still_drains_sibling` — the last pins that the
+drain catches `BaseException`, not just `Exception` (review fix #02 R1).
+
+**AC6 — concurrent children do not share stdin.** Both `gh` submissions pass
+`subprocess.DEVNULL`; the local `git` calls keep `stdin is None`, i.e.
+`utils.run`'s default (inherit) is unchanged for every other caller in the
+tree. Covered by `test_parallel_gh_calls_get_devnull_stdin`, which asserts both
+halves.
+
+**AC7 — non-positive issue numbers are rejected, not degraded.** `--issue 0`
+and `--issue -1` exit 2 at the argparse boundary. A `QS_0` branch still reports
+`"issue": 0` faithfully but makes no `gh issue view` call and no story lookup.
+Covered by `test_non_positive_issue_override_is_rejected` (2 cases) and the
+`[issue-zero-branch]` row of `test_guard_combinations`.
+
+No AC exists for thread-pool exhaustion: that fix was reverted (review fix #02
+M1) and lives in the risk table as an accepted risk.
+
 ## Task breakdown
 
-### Task 1 — `tests/qs/test_context.py` (new file; 4 functions, 12 cases)
+### Task 1 — `tests/qs/test_context.py` (new file)
 
-The plan said "11 cases"; the arithmetic is 2 + 1 + 5 + 4 = **12**, and the
-file as landed defines 12 (review fix #01 S4). Review fix #01 then grew it
-further — see "Review fix #01" below.
+**No case count is stated here, deliberately.** The plan's original "11 cases"
+was already wrong on its own arithmetic (2 + 1 + 5 + 4 = 12); review fix #01's
+S4 corrected it to 12 and the very same commit falsified that too, and review
+fix #02's M1 changed it again. Counts rot on every round — this matches the N5
+decision already taken in the test module's docstring. Read the file
+(review fix #02 R2).
 
 Import `context` / `utils` **inside** each test — `tests/qs/conftest.py`'s
 unconditional autouse `_add_scripts_qs_to_syspath` inserts `scripts/qs/` at
@@ -270,7 +312,10 @@ RED check:
 source venv/bin/activate && python scripts/qs/quality_gate.py --quick tests/qs/test_context.py
 ```
 
-Expect `2 failed, 10 passed` (observed exactly).
+Expect `2 failed, 10 passed` — **scoped to the original Task-1 file state
+only** (the 12 cases that existed before any review fix). Observed exactly.
+Later rounds add and delete cases; do not re-read this line as a current
+expectation (review fix #02 R2).
 
 Style: `from __future__ import annotations`, docstrings, `-> None` (convention
 only — see the rejected-findings table).
@@ -338,10 +383,16 @@ Plan: `docs/stories/QS-291.story_review_fix_#01.md` — 4 should-fix,
   `--issue 0` / `--issue -1` are rejected at the argparse boundary (exit 2)
   instead of degrading silently. `QS_0` still reports `"issue": 0` but makes no
   `gh` call. Preserved-from-serial behaviour, deliberately changed here at the
-  user's request.
-- **N2 — thread exhaustion.** `_submit` catches `RuntimeError` from
-  `pool.submit` and runs the callable inline into an already-resolved future:
-  the overlap is lost, the context is not. No duplicated serial block.
+  user's request. **The plan's STOP trigger fired** — what landed is exactly the
+  "argparse validation plus a guard rewrite" pair it named, ~25 lines in
+  `context.py` plus a 2-case test. Splitting into a separate issue was
+  considered and declined: the change is self-contained, its in-repo blast
+  radius is nil (no caller anywhere passes `--issue` — grep-verified), and it
+  ships fully covered. Recorded rather than re-litigated (review fix #02 R4).
+- **N2 — thread exhaustion.** ~~`_submit` degrades to an inline call.~~
+  **REVERTED** in review fix #02 M1 — the fallback double-executed its callable
+  (`submit` queues before the thread start that raises). Now an accepted risk;
+  see the risk table.
 - **N4 — `raise_on`** is a validated sequence, so `"pr"` is honoured (it was a
   silent no-op) and one case can raise from both.
 - **N3 / N5 / N6** — dead `Lock` return dropped, module-docstring case count
@@ -351,6 +402,32 @@ Plan: `docs/stories/QS-291.story_review_fix_#01.md` — 4 should-fix,
 Behavioural delta 2 in the Design section is narrowed but not removed: the
 error path can still block on `shutdown(wait=True)`, and the no-timeout hang
 (#295) remains reachable — S1 makes it *visible* rather than silent.
+
+## Review fix #02 (applied)
+
+Plan: `docs/stories/QS-291.story_review_fix_#02.md` — 2 must-fix, 5 should-fix
+applied; 7 nice-to-have deferred there by the user's choice.
+
+- **M1 — N2 reverted.** `_submit` deleted, `pool.submit` called directly at both
+  sites (the S2 `stdin=subprocess.DEVNULL` kwarg survives the revert — `submit`
+  forwards `**kwargs`). Both `test_thread_exhaustion_*` tests deleted; they
+  monkeypatched `ThreadPoolExecutor.submit` wholesale, so they passed against
+  the broken code. Risk table gained the accepted-risk row.
+- **R1 — `_settle` catches `BaseException`,** as does the local-git drain, so a
+  worker's `BaseException` can no longer skip the drain. Recorded dissent from
+  the acceptance-auditor (the `Exception` catch matched the prior art the plan
+  itself pointed at) is preserved in the plan; the user chose the fix. Whether
+  `quality_gate.py::_run_cheap_gates_parallel` deserves the same treatment is a
+  **follow-up issue, not this PR**.
+- **R2 / R4 / R5** — see the Task-1 heading, the N1 bullet above, and "ACs added
+  by review fix #01" respectively.
+- **R3** — startup re-measured after all of the above; see the Non-AC line and
+  the PR body.
+- **M2** — PR #325's body rewritten against the final state.
+
+**Coverage caveat, two rounds running:** CodeRabbit has never actually reviewed
+this PR (rate-limited twice, then "no new commits" off an aborted run). Do not
+read a clean round as four-lens agreement until it reports.
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-291.story.md
+++ b/docs/stories/QS-291.story.md
@@ -1,0 +1,324 @@
+# QS-291 — Parallelize `context.py`'s two serial `gh` calls
+
+Issue: [#291](https://github.com/tmenguy/quiet-solar/issues/291) · Branch: `QS_291`
+Type: dev-infrastructure / startup-latency optimization
+Status: **DRAFT — rounds 1–3 folded in**
+
+Line numbers are hints; anchor edits on the named symbol.
+
+## Problem
+
+Every static agent runs `python scripts/qs/context.py` on startup. From the
+QS-288 audit (`QS-288.audit-report.md` §4, finding S-6), two independent network
+calls run serially inside `build_context`.
+
+**All figures below come from one paced session** (10 runs each, 1.2s spacing,
+`time.perf_counter()` around `subprocess.run`). Pacing matters: an unpaced
+60-call benchmark during planning saw medians blow out ~5× under what looked
+like secondary rate limiting, so mixing paced and unpaced numbers is invalid.
+
+| Measurement | median | min | max | Site |
+|---|---|---|---|---|
+| `gh issue view <N> --json title -q .title` | 0.423s | 0.401 | 0.506 | `context.py:44` (`_issue_title`) |
+| `gh pr list --head <b> --json number,url,state` | 0.459s | 0.431 | 0.641 | `utils.find_pr_for_branch`, from `context.py:60` |
+| the two, **serially** (as today) | 0.884s | 0.849 | 1.056 | — |
+| the two, **thread-pair prototype** | **0.449s** | 0.438 | 0.485 | — |
+| local `git` (1× `branch`, 3× `rev-parse`) | 0.047s | — | — | `utils.py:64,70` |
+| **`context.py` end-to-end** | **1.022s** | 0.948 | 1.105 | — |
+
+The pair wall (0.449s) lands at the slower call's median (0.459s) within noise —
+as theory predicts for `max(T, P)`. Residual `1.022 − 0.884 − 0.047 ≈ 0.09s` is
+interpreter start plus `context.py`'s imports.
+
+The two calls are independent: `_issue_title` needs only `issue`,
+`find_pr_for_branch` only `branch`.
+
+## Goal
+
+Overlap them. Projected: `1.022 − 0.884 + 0.449 − 0.022 ≈ **0.57s**` — a
+**~0.43s saving**, i.e. **~42% off an interactive startup**. (Secondary,
+weaker framing: ~11s/week at the issue's ~25 startups/week.)
+
+Stdout must stay **byte-identical** for identical repo state — agents parse it.
+The invocation-string contract in `.claude/settings.json:16-17` is untouched.
+
+### Non-goals
+
+1. **Title cache.** Post-overlap the wall is `max(title, pr)`; the two are
+   0.036s apart with overlapping ranges (0.401–0.506 vs 0.431–0.641), so which
+   one dominates is not stable and a title cache saves nothing reliably.
+   Rejected on staleness risk (renamed issues). **User-confirmed (round 0).**
+2. **Single GraphQL query.** Measured head-to-head, 8 paced trials: GraphQL
+   0.433s (0.358–0.476) vs thread pair 0.444s (0.425–0.517) — **within each
+   other's spread**. GraphQL is *not* slower; it simply shows no measurable
+   advantage, while needing `owner`/`name` resolution, a hand-written schema and
+   a new response shape. Rejected for the smaller diff, not for speed. It does
+   halve API pressure — if rate limiting ever bites, revisit.
+3. **A shared `utils` concurrency helper.** Build it when S-9 (#288's
+   finish-task double `gh pr view`) needs it. **User-confirmed (round 0).**
+4. **Deduplicating the three `get_repo_root()` calls.** Two of three land under
+   the overlap for free; the third (`context.py:72`) stays. #295 owns this.
+
+## Design
+
+`build_context` (`context.py:52-73`) runs four statements between `branch`/`issue`
+derivation and the `return`: `_issue_title`, `find_story_file`,
+`find_latest_review_fix`, `find_pr_for_branch`. Replace exactly those four with:
+
+```python
+with ThreadPoolExecutor(max_workers=2) as pool:
+    title_future = pool.submit(_issue_title, issue) if issue else None
+    pr_future = pool.submit(find_pr_for_branch, branch) if branch else None
+    # Local git work runs while both gh calls are in flight.
+    story_path: Path | None = find_story_file(issue) if issue else None
+    review_fix_path: Path | None = find_latest_review_fix(issue) if issue else None
+    title = title_future.result() if title_future else ""
+    pr_info = pr_future.result() if pr_future else None
+```
+
+Add `from concurrent.futures import ThreadPoolExecutor` after `import sys`.
+**Do not touch the `return` dict** (`context.py:62-73`) — reformatting it would
+produce a spurious diff, and its key order is AC1's contract.
+
+Why this works: `subprocess.run` blocks in `os.waitpid` with the **GIL
+released**, so the two `gh` children genuinely overlap. `shutdown(wait=True)` on
+`with`-exit is **deliberate** — it joins the other future rather than abandoning
+a live subprocess; do not "fix" it with `cancel_futures=True`. Prior art:
+`quality_gate.py` `_run_cheap_gates_parallel`. `build_context` has no importer
+outside `context.py:main()`.
+
+Moving the story lookups inside the block puts 0.022s of `git` under the
+overlap; the third `rev-parse` (in the `return` dict) stays on the critical path.
+
+**Three behavioural deltas** — do not claim "unchanged":
+
+1. **Both calls always execute.** Today a hard raise in `_issue_title` means
+   `find_pr_for_branch` never runs. Accepted: one extra request on a path that
+   already failed.
+2. **The error path can block.** `shutdown(wait=True)` waits for the other
+   subprocess. `utils.run` sets no timeout, so a hung `gh` already hangs
+   `context.py` today — this adds a second path to a pre-existing hang.
+3. **Traceback gains executor frames.** Exception type and exit code identical.
+
+Accepted waste: on detached HEAD both guards are false and the pool is built for
+zero submissions (~0.1ms). Not worth a special case.
+
+### Risks
+
+| Risk | Assessment |
+|---|---|
+| No subprocess timeout; a hung `gh` blocks the pool | Pre-existing (delta 2). Out of scope; #295. |
+| Concurrent `gh` prompting for auth | `capture_output=True` does **not** redirect stdin, so pass `stdin=subprocess.DEVNULL` is *not* in scope here — instead rely on `gh` being pre-authenticated in agent/CI contexts, where it never prompts. An unauthenticated `gh` fails fast on both calls today too. |
+| Concurrent `gh` racing on `~/.config/gh` token refresh | Accepted: 2 requests per startup, ~25/week. |
+
+### Doc maintenance
+
+**Doc-OK by manual sweep.** `check_doc_drift.py`'s `TRACKED_PREFIX` is
+`custom_components/quiet_solar/` (`check_doc_drift.py:70`), so it is
+structurally blind to `scripts/qs/` — a green run there is not evidence (#294
+owns widening it). Swept manually: no `docs/agents/**` `covers:` entry names
+`context.py`; `docs/workflow/**`, the agent files and `.claude/settings.json`
+reference only the unchanged invocation string. **Harness sync not triggered**
+(no `.<harness>/agents/*.md` changes). Only prose change: the docstring.
+
+## Acceptance criteria
+
+All four tests drive `context.main()`, so the `--issue` argparse surface stays
+covered. `main()` ends in `sys.exit(0)` (`context.py:83`), so every test wraps
+it: `with pytest.raises(SystemExit) as exc: context.main()` /
+`assert exc.value.code == 0`, reading stdout via `capsys`.
+
+**AC1 — stdout byte-identical.** With `sys.argv = ["context.py"]` (mandatory —
+`parse_args()` otherwise consumes pytest's own argv and exits 2), branch
+`QS_42`, and an **empty** `tmp_path` (no story fixtures — `Path.glob` on a
+missing `docs/stories` returns empty, it does not raise), stdout must equal
+`json.dumps(expected, indent=2) + "\n"` (`utils.output_json` uses `print`), with:
+
+```python
+expected = {
+    "harness": "claude-code", "branch": "QS_42", "issue": 42,
+    "title": "Fake title", "story_file": "", "story_exists": False,
+    "latest_review_fix": "", "pr_number": 7,
+    "pr_url": "https://github.com/tmenguy/quiet-solar/pull/7",
+    "worktree": str(tmp_path),
+}
+```
+
+`_issue_title` and `get_repo_root` both `.strip()`, so the fake's trailing
+newlines do not reach the output. A second case writes
+`tmp_path/docs/stories/QS-42.story.md` and asserts `story_file` /
+`story_exists` flip — otherwise the two moved statements are only pinned in
+their falsy form.
+
+**AC2 — the two `gh` calls overlap.** A fake `utils.run` makes **only**
+`cmd[0] == "gh"` wait on `threading.Barrier(2, timeout=5)`; `git` returns
+immediately (the pool block issues `git` concurrently, so an ungated barrier
+would be satisfied by git+gh and stop discriminating). Requires both guards true
+(branch `QS_42`). GREEN: `main()` exits 0, `not barrier.broken`, both `gh`
+argvs recorded. RED against serial code: the fake's `barrier.wait()` raises
+`BrokenBarrierError` inside `run_gh`, uncaught by `_issue_title` or
+`build_context`. The RED run costs ≥5s wall — that is the timeout, not a hang.
+Timing-bounded, not deterministic. *If the two calls are ever merged into one
+request, delete this test — do not "fix" it.*
+
+**AC3 — guard combinations.** One parametrized test, five rows (the full guard
+matrix — do not add a sixth):
+
+| `issue` | `branch` | argv | Expected | `git branch` calls |
+|---|---|---|---|---|
+| set | set | `[]`, branch `QS_42` | both `gh` commands recorded | 1 |
+| unset | set | `[]`, branch `main` | no `gh issue view`; `title == ""` | 1 |
+| unset | unset | `[]`, detached HEAD | **zero `gh` calls** — `get_issue_from_branch("")` → `None`, both guards false | **2** |
+| set | unset | `--issue 42`, detached HEAD | `gh issue view` only; `pr_number is None` | 1 |
+| set | set | `--issue 42`, branch `QS_99` | `gh issue view 42` **and** `gh pr list --head QS_99` — the override must not leak into the PR lookup | 1 |
+
+Row 3 records **two** `git branch --show-current`: `get_issue_from_branch("")`
+re-invokes `get_current_branch()` (`utils.py:76`). Rows 4–5 record one —
+`issue_override or …` short-circuits (`context.py:53`). Row 5 asserts on
+recorded argv (`"42" in cmd`), since `cmd[:3]` dispatch ignores the issue number.
+
+**AC4 — failure paths.** Four cases:
+
+- `returncode=1` on title / on PR / on both → the affected field degrades as
+  today (`title == ""`, `pr_number is None`, `pr_url == ""`), exit 0.
+  `run_gh` passes `check=False` and `_issue_title` only inspects `returncode`,
+  so a non-zero exit never raises.
+- **A raising fake** (`RuntimeError` on `gh issue view`) → `pytest.raises`, and
+  `gh pr list` **is** in the recorder. This is the only construction that pins
+  delta 1; the `returncode=1` cases cannot, because serial code records both
+  commands too.
+
+Non-AC: `context.py` median should land near 0.57s against the 1.022s baseline
+above. Protocol: 10 runs, 1.2s spacing, report the median. Never a blocker.
+
+## Task breakdown
+
+### Task 1 — `tests/qs/test_context.py` (new file; 4 functions, 11 cases)
+
+Import `context` / `utils` **inside** each test — `tests/qs/conftest.py`'s
+unconditional autouse `_add_scripts_qs_to_syspath` inserts `scripts/qs/` at
+fixture time and purges `sys.modules` on teardown.
+
+**Patch `utils.run`, and only `utils.run`.** `run_gh`/`run_git` resolve `run`
+from `utils.__dict__` at call time, so one patch catches everything. Patching
+`utils.run_gh` misses `_issue_title` (it holds its own reference); patching
+`context.run_gh` misses `find_pr_for_branch`.
+
+Provide one factory reused by all cases:
+
+```python
+def _make_fake_run(*, branch: str, title: str = "Fake title",
+                   gh_rc: dict[str, int] | None = None) -> tuple[Callable, list, threading.Lock]
+```
+
+matching `utils.run`'s signature
+`(cmd, *, check=True, capture=True, cwd=None) -> CompletedProcess[str]`,
+dispatching on `cmd[:3]` (the issue number is at index 3 and the branch at
+index 4, so `cmd[:3]` discriminates all four shapes — same pattern as
+`tests/test_qs_utils.py:32-38`):
+
+| `cmd[:3]` | stdout |
+|---|---|
+| `git branch --show-current` | per-row: `"QS_42\n"` / `"main\n"` / `""` / `"QS_99\n"` |
+| `git rev-parse --show-toplevel` | `f"{tmp_path}\n"` |
+| `gh issue view …` | bare title (`-q .title`, **not** JSON) |
+| `gh pr list …` | `'[{"number":7,"url":"https://github.com/tmenguy/quiet-solar/pull/7","state":"OPEN"}]'` |
+
+The fake must end `raise AssertionError(f"unexpected command: {cmd}")` —
+otherwise a future extra call silently returns an empty `CompletedProcess` and
+the characterization tests stop characterizing.
+
+Hermeticity:
+
+- Branch `QS_42`/`QS_99`, never `QS_291` — `find_story_file` /
+  `find_latest_review_fix` resolve their root via `get_repo_root()` then hit the
+  real disk, so a `QS_291` fake would pick up this story and drift when a
+  review-fix file lands. Faking `rev-parse` → `tmp_path` redirects them.
+- `monkeypatch.setenv("QS_HARNESS", "claude-code")` — `detect()` honours it
+  first (`harness.py:79-81`). Do **not** `delenv`; it raises on unset vars.
+- `returncode=1` only for `cmd[0] == "gh"`. The fake ignores `check`, so a
+  non-zero `git` response would silently return fake stdout rather than raise.
+- The recorder is written by **both pool workers and the main thread** (the
+  `git` calls moved inside the block). Guard with `threading.Lock`; all
+  assertions order-independent.
+
+| Test | Covers | Task-1 state |
+|---|---|---|
+| `test_stdout_is_byte_identical` (2 cases) | AC1 | GREEN |
+| `test_gh_calls_run_concurrently` | AC2 | **RED** |
+| `test_guard_combinations` (5 cases) | AC3 | GREEN |
+| `test_gh_failure_paths` (4 cases) | AC4 | GREEN |
+
+Only the barrier test is RED; the other ten are **characterization tests**
+pinning pre-change behaviour. Because Tasks 1–2 land as one commit, record the
+RED line **and** the pre-change GREEN summary in the PR body — after squashing,
+that is the only evidence they ever ran against serial code.
+
+RED check:
+
+```bash
+source venv/bin/activate && python scripts/qs/quality_gate.py --quick tests/qs/test_context.py
+```
+
+Expect `1 failed, 10 passed`.
+
+Style: `from __future__ import annotations`, docstrings, `-> None` (convention
+only — see the rejected-findings table).
+
+### Task 2 — Parallelize + docstring
+
+Apply the Design replacement plus the import. Add one RST bullet after the
+`harness` bullet (`context.py:20`), phrased to match the surrounding
+`key: source` list style, noting `title` and `pr_number` are fetched
+concurrently and must not be re-serialized.
+
+### Task 3 — Verify, then commit once
+
+Run **before** committing (`--impacted` is the mandatory pre-commit gate):
+
+```bash
+source venv/bin/activate && python scripts/qs/quality_gate.py --quick tests/qs
+```
+
+```bash
+source venv/bin/activate && python scripts/qs/check_doc_drift.py
+```
+
+```bash
+source venv/bin/activate && python scripts/qs/quality_gate.py --impacted
+```
+
+`--impacted` executes the new tests (testmon selection, `testpaths = tests`;
+it short-circuits *before* dev-only scope detection at `quality_gate.py:2461-2464`,
+so the dev-infra skip cannot suppress them) but attributes no coverage to
+`scripts/` — its `--cov` target is `custom_components/quiet_solar`
+(`quality_gate.py:1273`), so `context.py` never enters `coverage.xml` and
+diff-cover skips it. It will **not** fail on the new `scripts/` lines; AC3's
+five rows are the real branch coverage. Caveat: if no diff base resolves,
+`check_impacted` exits 0 *without running pytest at all*
+(`quality_gate.py:1462-1468`) — confirm the run printed a diff-base line before
+trusting the green.
+
+On failure: testmon selecting 0 tests is expected (QS-278); a changed-line miss
+self-heals and re-checks once (QS-283) — never delete `.testmondata`. If a miss
+persists on `scripts/` lines, **stop and escalate**; do not add
+`# pragma: no cover` and do not hand-roll a `coverage run`.
+
+Then `git add` all three files (the story is currently untracked) and commit
+once. Update this file's Status before committing.
+
+## Adversarial Review Notes
+
+Three rounds. Round-1 dispositions of the two findings missed in the first
+triage: *barrier timeout is a wall-clock assertion, not determinism* — accepted,
+AC2 now says "timing-bounded, not deterministic"; *both-guards-false path
+untested and builds a pool for nothing* — accepted, AC3 row 3 plus the
+"accepted waste" note. Full per-finding detail was not retained.
+
+**Rejected findings** (recorded so they do not resurface):
+
+| Finding | Why rejected |
+|---|---|
+| Add ruff/mypy steps for the new code | Neither the gate nor CI ever passes `scripts/` or `tests/` to ruff/mypy — both invoke them on `SRC_DIR` only (`quality_gate.py:752,785`; `pr-quality.yml:26,29,48`). Same reason kills the `Future[...]` mypy-strictness concern. |
+| Cut `test_gh_failure_paths` | Kept: cheapest pin on the one property the change claims to preserve, and its raising case is the only thing pinning delta 1. |
+| Cut `--quick tests/qs` from Task 3 | Kept as the fast targeted loop. |

--- a/docs/stories/QS-291.story.md
+++ b/docs/stories/QS-291.story.md
@@ -2,7 +2,7 @@
 
 Issue: [#291](https://github.com/tmenguy/quiet-solar/issues/291) · Branch: `QS_291`
 Type: dev-infrastructure / startup-latency optimization
-Status: **DRAFT — rounds 1–3 folded in**
+Status: **IMPLEMENTED** (rounds 1–3 folded in)
 
 Line numbers are hints; anchor edits on the named symbol.
 

--- a/docs/stories/QS-291.story.md
+++ b/docs/stories/QS-291.story.md
@@ -2,7 +2,7 @@
 
 Issue: [#291](https://github.com/tmenguy/quiet-solar/issues/291) · Branch: `QS_291`
 Type: dev-infrastructure / startup-latency optimization
-Status: **IMPLEMENTED** (rounds 1–3 folded in)
+Status: **IMPLEMENTED** — review fixes folded in
 
 Line numbers are hints; anchor edits on the named symbol.
 
@@ -61,24 +61,21 @@ The invocation-string contract in `.claude/settings.json:16-17` is untouched.
 
 ## Design
 
-`build_context` (`context.py:52-73`) runs four statements between `branch`/`issue`
+`build_context` originally ran four statements between `branch`/`issue`
 derivation and the `return`: `_issue_title`, `find_story_file`,
-`find_latest_review_fix`, `find_pr_for_branch`. Replace exactly those four with:
+`find_latest_review_fix`, `find_pr_for_branch`. Those four are replaced by a
+two-worker `ThreadPoolExecutor` block that submits the two `gh` calls and runs
+the local git lookups underneath them.
 
-```python
-with ThreadPoolExecutor(max_workers=2) as pool:
-    title_future = pool.submit(_issue_title, issue) if issue else None
-    pr_future = pool.submit(find_pr_for_branch, branch) if branch else None
-    # Local git work runs while both gh calls are in flight.
-    story_path: Path | None = find_story_file(issue) if issue else None
-    review_fix_path: Path | None = find_latest_review_fix(issue) if issue else None
-    title = title_future.result() if title_future else ""
-    pr_info = pr_future.result() if pr_future else None
-```
+**The source of truth for the block's shape is
+`scripts/qs/context.py::build_context` — read it there.** A prototype snippet
+used to live here and was still showing round-1 code (truthiness guards, bare
+`.result()`, no `stdin`, no `_settle`) three rounds later; it is deleted rather
+than re-synced, for the same reason the counts are (review fix #03 E). A copy
+cannot rot if it does not exist.
 
-Add `from concurrent.futures import ThreadPoolExecutor` after `import sys`.
-**Do not touch the `return` dict** (`context.py:62-73`) — reformatting it would
-produce a spurious diff, and its key order is AC1's contract.
+**Do not touch the `return` dict** — reformatting it would produce a spurious
+diff, and its key order is AC1's contract.
 
 Why this works: `subprocess.run` blocks in `os.waitpid` with the **GIL
 released**, so the two `gh` children genuinely overlap. `shutdown(wait=True)` on
@@ -125,7 +122,7 @@ reference only the unchanged invocation string. **Harness sync not triggered**
 
 ## Acceptance criteria
 
-All four tests drive `context.main()`, so the `--issue` argparse surface stays
+All tests drive `context.main()`, so the `--issue` argparse surface stays
 covered. `main()` ends in `sys.exit(0)` (`context.py:83`), so every test wraps
 it: `with pytest.raises(SystemExit) as exc: context.main()` /
 `assert exc.value.code == 0`, reading stdout via `capsys`.
@@ -215,6 +212,11 @@ PR error. The non-primary failure rides along as an `add_note` entry. Covered by
 `test_both_gh_calls_raising_surfaces_both`, and
 `test_base_exception_in_worker_still_drains_sibling` — the last pins that the
 drain catches `BaseException`, not just `Exception` (review fix #02 R1).
+`test_pr_only_failure_propagates_without_a_note` pins the "then the PR error"
+half of the ordering, which no case reached before (review fix #03 D), and
+`test_caller_side_interrupt_is_not_relabelled_as_a_gh_failure` pins the
+boundary the drain must **not** cross: an interrupt in our own `result()` wait
+is not a worker outcome and is neither settled nor noted (review fix #03 A).
 
 **AC6 — concurrent children do not share stdin.** Both `gh` submissions pass
 `subprocess.DEVNULL`; the local `git` calls keep `stdin is None`, i.e.
@@ -349,7 +351,7 @@ so the dev-infra skip cannot suppress them) but attributes no coverage to
 `scripts/` — its `--cov` target is `custom_components/quiet_solar`
 (`quality_gate.py:1273`), so `context.py` never enters `coverage.xml` and
 diff-cover skips it. It will **not** fail on the new `scripts/` lines; AC3's
-five rows are the real branch coverage. Caveat: if no diff base resolves,
+rows are the real branch coverage. Caveat: if no diff base resolves,
 `check_impacted` exits 0 *without running pytest at all*
 (`quality_gate.py:1462-1468`) — confirm the run printed a diff-base line before
 trusting the green.
@@ -416,9 +418,12 @@ applied; 7 nice-to-have deferred there by the user's choice.
 - **R1 — `_settle` catches `BaseException`,** as does the local-git drain, so a
   worker's `BaseException` can no longer skip the drain. Recorded dissent from
   the acceptance-auditor (the `Exception` catch matched the prior art the plan
-  itself pointed at) is preserved in the plan; the user chose the fix. Whether
-  `quality_gate.py::_run_cheap_gates_parallel` deserves the same treatment is a
-  **follow-up issue, not this PR**.
+  itself pointed at) is preserved in the plan; the user chose the fix. **The
+  dissent turned out to be right** — see review fix #03 A below. Whether
+  `quality_gate.py::_run_cheap_gates_parallel` deserves the same treatment is
+  **[#329](https://github.com/tmenguy/quiet-solar/issues/329)**, filed in round
+  3 (review fix #03 F) and carrying A's guard shape so the follow-up cannot
+  repeat this round's mistake.
 - **R2 / R4 / R5** — see the Task-1 heading, the N1 bullet above, and "ACs added
   by review fix #01" respectively.
 - **R3** — startup re-measured after all of the above; see the Non-AC line and
@@ -428,6 +433,61 @@ applied; 7 nice-to-have deferred there by the user's choice.
 **Coverage caveat, two rounds running:** CodeRabbit has never actually reviewed
 this PR (rate-limited twice, then "no new commits" off an aborted run). Do not
 read a clean round as four-lens agreement until it reports.
+
+## Review fix #03 (applied)
+
+Plan: `docs/stories/QS-291.story_review_fix_#03.md` — a deliberately narrow
+round: 3 code findings, 3 bookkeeping, **all 8 nice-to-haves deferred**. Two
+prior rounds each introduced a new must-fix while hardening this one function,
+so the scope was fixed in advance at "the minimum that closes the invariant".
+
+- **A (must-fix) — `_settle` no longer mislabels a caller-side interrupt.**
+  `except BaseException` could not tell *the worker failed* from *our own
+  `result()` wait was interrupted*; conflating them swallowed the interrupt,
+  discarded the worker's real exception, and attached a bogus
+  `concurrent gh call also failed: KeyboardInterrupt()` note. A
+  `done()`/`exception(timeout=0) is not exc` guard now re-raises a caller-side
+  interrupt instead of settling it. This is the second defect introduced by
+  round 2's R1 widening, which the acceptance-auditor had dissented against —
+  fixed forward rather than reverted, since reverting restores the original
+  narrower hole.
+  **Test-technique note.** The first attempt drove this end-to-end by patching
+  `concurrent.futures.Future.result` process-wide. That wedged `--impacted`
+  (46 min at 0.4% CPU, killed): with the HA suite in-process, a lingering
+  executor thread calling `result()` inside the patch window gets the test's
+  interrupt raised into it. It is the same wholesale-patch unsoundness that let
+  the deleted N2 tests pass against broken code. Replaced with a `Future`
+  subclass driving `_settle` directly — the one case in the file that does not
+  go through `main()`, deliberately, and the reason is in its docstring. The
+  worker-origin half stays end-to-end.
+- **C (should-fix) — the second `pool.submit` moved inside the `try`,** so the
+  existing drain covers it: if it raises (thread exhaustion) or an interrupt
+  lands between the two submits, `title_future` is already in flight and would
+  otherwise never be settled. A statement move, not new logic;
+  `stdin=subprocess.DEVNULL` preserved. **Reasoned but unpinned**: the plan made
+  a test optional, and the only available technique — patching
+  `ThreadPoolExecutor.submit` wholesale — is exactly what made the deleted N2
+  tests unsound, so no test was invented for it.
+- **D (should-fix) — `raise pr_exc` is now executed by a test.** It was the only
+  unexecuted statement in the module (`__main__` guard aside) and the gate
+  cannot see it: `--cov` is scoped to `custom_components/quiet_solar`, so
+  `scripts/qs` is never measured. Green on arrival — a coverage pin, not a
+  defect fix.
+- **B / E / F (bookkeeping).** Counts **deleted** rather than corrected for the
+  third time (`Status`, "All four tests", "AC3's five rows"), plus the mandated
+  sweep — the survivors are historically scoped or annotated. The Design
+  section's prototype snippet, still showing round-1 code, is deleted in favour
+  of pointing at `context.py::build_context`. The declared `quality_gate.py`
+  follow-up is filed as
+  [#329](https://github.com/tmenguy/quiet-solar/issues/329).
+
+**No re-measurement:** A adds two predicates on an error path and C moves a
+statement; neither touches the hot path. The median **0.559s** stands.
+
+**Coverage, final:** CodeRabbit never reviewed this PR across five attempts in
+three rounds. Round 3 diagnosed it as an exhausted Fair-Usage included-review
+budget — a billing matter, not something a new commit clears. This work ships
+at **3-reviewer coverage**, consciously accepted.
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-291.story.md
+++ b/docs/stories/QS-291.story.md
@@ -108,7 +108,7 @@ zero submissions (~0.1ms). Not worth a special case.
 | Risk | Assessment |
 |---|---|
 | No subprocess timeout; a hung `gh` blocks the pool | Pre-existing (delta 2). Out of scope; #295. |
-| Concurrent `gh` prompting for auth | `capture_output=True` does **not** redirect stdin, so pass `stdin=subprocess.DEVNULL` is *not* in scope here — instead rely on `gh` being pre-authenticated in agent/CI contexts, where it never prompts. An unauthenticated `gh` fails fast on both calls today too. |
+| Concurrent `gh` prompting for auth | ~~Out of scope; rely on `gh` being pre-authenticated.~~ **Fixed** in review fix #01 S2: `utils.run` gained an opt-in `stdin` passthrough (default `None` = today's inherit for every other caller) and both concurrent submissions pass `subprocess.DEVNULL`. |
 | Concurrent `gh` racing on `~/.config/gh` token refresh | Accepted: 2 requests per startup, ~25/week. |
 
 ### Doc maintenance
@@ -162,7 +162,8 @@ Timing-bounded, not deterministic. *If the two calls are ever merged into one
 request, delete this test — do not "fix" it.*
 
 **AC3 — guard combinations.** One parametrized test, five rows (the full guard
-matrix — do not add a sixth):
+matrix — do not add a sixth; **superseded**: review fix #01 N1 adds a sixth
+`QS_0` row to pin the `issue == 0` semantics):
 
 | `issue` | `branch` | argv | Expected | `git branch` calls |
 |---|---|---|---|---|
@@ -193,7 +194,11 @@ above. Protocol: 10 runs, 1.2s spacing, report the median. Never a blocker.
 
 ## Task breakdown
 
-### Task 1 — `tests/qs/test_context.py` (new file; 4 functions, 11 cases)
+### Task 1 — `tests/qs/test_context.py` (new file; 4 functions, 12 cases)
+
+The plan said "11 cases"; the arithmetic is 2 + 1 + 5 + 4 = **12**, and the
+file as landed defines 12 (review fix #01 S4). Review fix #01 then grew it
+further — see "Review fix #01" below.
 
 Import `context` / `utils` **inside** each test — `tests/qs/conftest.py`'s
 unconditional autouse `_add_scripts_qs_to_syspath` inserts `scripts/qs/` at
@@ -247,12 +252,17 @@ Hermeticity:
 | `test_stdout_is_byte_identical` (2 cases) | AC1 | GREEN |
 | `test_gh_calls_run_concurrently` | AC2 | **RED** |
 | `test_guard_combinations` (5 cases) | AC3 | GREEN |
-| `test_gh_failure_paths` (4 cases) | AC4 | GREEN |
+| `test_gh_failure_paths` (4 cases) | AC4 | 3 GREEN, **1 RED** |
 
-Only the barrier test is RED; the other ten are **characterization tests**
-pinning pre-change behaviour. Because Tasks 1–2 land as one commit, record the
-RED line **and** the pre-change GREEN summary in the PR body — after squashing,
-that is the only evidence they ever ran against serial code.
+The barrier test **and** `test_gh_failure_paths[title-raises]` are RED
+pre-change: the raising case is by AC4's own wording the only construction that
+pins behavioural delta 1 (both calls always execute), which serial code cannot
+satisfy. The plan's table mislabelled it GREEN; both the mislabel and the case
+count were derivable at plan time (review fix #01 S4). The other ten cases are
+**characterization tests** pinning pre-change behaviour. Because Tasks 1–2 land
+as one commit, record the RED line **and** the pre-change GREEN summary in the
+PR body — after squashing, that is the only evidence they ever ran against
+serial code.
 
 RED check:
 
@@ -260,7 +270,7 @@ RED check:
 source venv/bin/activate && python scripts/qs/quality_gate.py --quick tests/qs/test_context.py
 ```
 
-Expect `1 failed, 10 passed`.
+Expect `2 failed, 10 passed` (observed exactly).
 
 Style: `from __future__ import annotations`, docstrings, `-> None` (convention
 only — see the rejected-findings table).
@@ -306,6 +316,41 @@ persists on `scripts/` lines, **stop and escalate**; do not add
 
 Then `git add` all three files (the story is currently untracked) and commit
 once. Update this file's Status before committing.
+
+## Review fix #01 (applied)
+
+Plan: `docs/stories/QS-291.story_review_fix_#01.md` — 4 should-fix,
+6 nice-to-have, 0 must-fix, all applied. What changed against the design above:
+
+- **S1 — no dropped future exceptions.** Both futures are now drained through
+  `_settle` before anything propagates (an unretrieved future exception is
+  discarded silently — `concurrent.futures` never logs it). A failure in the
+  *local* git work inside the pool block propagates as the primary error with
+  the sibling `gh` failure attached via `add_note`; when both `gh` calls raise,
+  the title error surfaces first, deterministically, noting the other.
+  `shutdown(wait=True)` is unchanged and still deliberate.
+- **S2 — stdin.** See the risk table above.
+- **S3 — `latest_review_fix` truthy.** AC1's `with-story` case now writes two
+  review-fix files and asserts the newest, exercising both `str(review_fix_path)`
+  and `find_latest_review_fix`'s `sorted(...)[-1]`.
+- **N1 — `issue == 0`.** `issue_override is not None` replaces the truthiness
+  test, the presence guards became `issue is not None and issue > 0`, and
+  `--issue 0` / `--issue -1` are rejected at the argparse boundary (exit 2)
+  instead of degrading silently. `QS_0` still reports `"issue": 0` but makes no
+  `gh` call. Preserved-from-serial behaviour, deliberately changed here at the
+  user's request.
+- **N2 — thread exhaustion.** `_submit` catches `RuntimeError` from
+  `pool.submit` and runs the callable inline into an already-resolved future:
+  the overlap is lost, the context is not. No duplicated serial block.
+- **N4 — `raise_on`** is a validated sequence, so `"pr"` is honoured (it was a
+  silent no-op) and one case can raise from both.
+- **N3 / N5 / N6** — dead `Lock` return dropped, module-docstring case count
+  dropped rather than re-pinned, concurrency note moved out of the
+  "Source of truth" `key: source` list into a trailing sentence.
+
+Behavioural delta 2 in the Design section is narrowed but not removed: the
+error path can still block on `shutdown(wait=True)`, and the no-timeout hang
+(#295) remains reachable — S1 makes it *visible* rather than silent.
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-291.story.md
+++ b/docs/stories/QS-291.story.md
@@ -177,7 +177,7 @@ re-invokes `get_current_branch()` (`utils.py:76`). Rows 4–5 record one —
 `issue_override or …` short-circuits (`context.py:53`). Row 5 asserts on
 recorded argv (`"42" in cmd`), since `cmd[:3]` dispatch ignores the issue number.
 
-**AC4 — failure paths.** Four cases:
+**AC4 — failure paths:**
 
 - `returncode=1` on title / on PR / on both → the affected field degrades as
   today (`title == ""`, `pr_number is None`, `pr_url == ""`), exit 0.
@@ -203,9 +203,13 @@ baseline (review fix #02 R3).
 These behaviours shipped with tests but traced only to prose, leaving most of
 the test file with no criterion to audit against. Promoted here.
 
-**AC5 — no concurrent failure is ever discarded.** `concurrent.futures` does
-not log an unretrieved future exception, so both futures are drained before
-anything propagates. Ordering is deterministic: a failure in the local git work
+**AC5 — no *worker* failure is discarded.** `concurrent.futures` does not log
+an unretrieved future exception, so on every non-interrupt path both futures
+are drained before anything propagates. A caller-side interrupt is the
+deliberate exception: it propagates immediately from `_settle` and wins over
+draining the sibling, so that future may go unretrieved — the interrupt must
+win, and `__context__` still chains the local failure into the traceback (see
+deferred item 1). Ordering is deterministic: a failure in the local git work
 inside the pool block is the primary error; otherwise the title error, then the
 PR error. The non-primary failure rides along as an `add_note` entry. Covered by
 `test_local_git_failure_surfaces_sibling_gh_error`,
@@ -214,7 +218,7 @@ PR error. The non-primary failure rides along as an `add_note` entry. Covered by
 drain catches `BaseException`, not just `Exception` (review fix #02 R1).
 `test_pr_only_failure_propagates_without_a_note` pins the "then the PR error"
 half of the ordering, which no case reached before (review fix #03 D), and
-`test_caller_side_interrupt_is_not_relabelled_as_a_gh_failure` pins the
+`test_caller_side_interrupt_is_not_settled_as_a_worker_outcome` pins the
 boundary the drain must **not** cross: an interrupt in our own `result()` wait
 is not a worker outcome and is neither settled nor noted (review fix #03 A).
 

--- a/docs/stories/QS-291.story_review_fix_#01.md
+++ b/docs/stories/QS-291.story_review_fix_#01.md
@@ -1,0 +1,245 @@
+# QS-291 — Review fix plan #01
+
+## Summary
+- Source PR: #325
+- Source story: `docs/stories/QS-291.story.md`
+- Findings to fix: 10 (4 should-fix, 6 nice-to-have; 0 must-fix)
+- Next implement phase: `/implement-setup-task`
+
+### Review coverage caveat
+
+This round ran **3 of 4 reviewers**. `qs-review-coderabbit` returned no
+findings because the account hit its PR review limit ("Review limit
+reached", next window ~19:07Z); a re-trigger plus 5-minute poll produced
+zero reviews. The push that applies this plan will auto-trigger a fresh
+CodeRabbit review, so re-running `/review-task` afterwards picks up that
+lens. Do not read a clean re-review as "all four lenses agreed" unless
+CodeRabbit actually reported.
+
+### Dropped as invalid (verified against repo config — do not re-raise)
+
+- "Unreachable `AssertionError` in `fake_run` breaks the 100% coverage
+  gate" — coverage is scoped to `--cov=custom_components/quiet_solar`
+  (`scripts/qs/quality_gate.py:83`). `tests/qs` is not measured.
+- "Added lines exceed ~96 chars" — ruff is `line-length = 120` with
+  `E501` ignored (`pyproject.toml`).
+
+## Findings to fix
+
+### [should-fix] S1 — Unretrieved future exceptions and blocking join on error paths
+- File: `scripts/qs/context.py:65-72`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (merged —
+  three separate reports, one root cause)
+- Description: nothing wraps the two `.result()` calls, so three failure
+  shapes all degrade badly:
+  1. `title_future.result()` raises → `pr_future`'s exception is never
+     retrieved and is **silently discarded** (`concurrent.futures` does
+     not log unretrieved future exceptions).
+  2. The local git work inside the `with` block raises → neither future
+     is `.result()`-ed, both exceptions are lost, AND `with`-exit runs
+     `shutdown(wait=True)` which blocks on both live `gh` children.
+     Reproduced concretely: from inside a repo's `.git/` directory,
+     `git branch --show-current` returns `QS_42` rc=0 while
+     `git rev-parse --show-toplevel` fails rc=128, so `get_repo_root()`
+     (called by both moved lookups with `check=True`) raises
+     `CalledProcessError` after both futures were submitted. Same shape
+     whenever the worktree/`.git` link is removed between the branch read
+     and the story lookups (the `git worktree remove` window in
+     finish-task).
+  3. Both `gh` invocations raise hard (e.g. `gh` absent from `PATH` →
+     `FileNotFoundError`, which `check=False` does not intercept) → only
+     the title exception surfaces.
+  This makes the #295 no-timeout hang reachable from a **non-gh** error,
+  which the PR body's three declared behavioural deltas do not cover.
+- Proposed fix: retrieve both futures' outcomes before propagating, so no
+  exception is silently dropped and the surfaced error is deterministic.
+  Follow the existing in-repo prior art at
+  `scripts/qs/quality_gate.py:846-859`, which wraps `f.result()` per
+  future for exactly this reason. Keep `shutdown(wait=True)` — it is
+  deliberate and commented; do NOT introduce `cancel_futures=True`.
+  Preserve the existing contract: a hard raise must still propagate (that
+  is behavioural delta 1, pinned by the `title-raises` test case), and
+  `returncode != 0` must still degrade to `title == ""` /
+  `pr_number is None`.
+- Tests: add a case where the **local git work** raises while both `gh`
+  futures are in flight, asserting the git error propagates and the
+  sibling `gh` exception is not silently swallowed. Add a case where both
+  `gh` calls raise.
+
+### [should-fix] S2 — Both `gh` children inherit the same stdin
+- File: `scripts/qs/utils.py:21` (`run`), affecting `scripts/qs/context.py`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: `utils.run` passes no `stdin` to `subprocess.run`
+  (verified — only `capture_output`, `text`, `check`, `cwd`), so both
+  concurrent `gh` children inherit the same TTY. On an unauthenticated
+  terminal both can prompt at once and garble input; previously the calls
+  were serialized so at most one prompted.
+- Caveats the implementer MUST weigh before changing shared code:
+  - The source story's risk table already **discloses and accepts** this
+    auth-prompt row. This is a known, accepted risk, not a regression
+    discovered late.
+  - `utils.run` is the shared helper behind `run_gh` / `run_git` for the
+    whole `scripts/qs` tree. Adding `stdin=subprocess.DEVNULL`
+    unconditionally changes behaviour for **every** caller, some of which
+    may legitimately want an interactive `gh`.
+- Proposed fix (preferred): scope the change to the concurrent call site
+  rather than mutating the global default — add an opt-in parameter to
+  `utils.run` (e.g. `stdin=None` passthrough) and have `context.py`'s two
+  parallel submissions pass `subprocess.DEVNULL`. This removes the new
+  failure mode without changing any existing caller's behaviour. If the
+  implementer concludes even that is not worth it, record the decision in
+  the story instead of silently skipping.
+
+### [should-fix] S3 — `latest_review_fix` never exercised in its truthy form
+- File: `tests/qs/test_context.py` (the `with-story` case, AC1b)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC1b's stated rationale is that without a second case
+  "the two moved statements are only pinned in their falsy form" — but
+  only one of the two is actually un-falsified. `find_latest_review_fix`
+  returns `None` in all 12 cases, so `latest_review_fix` is asserted as
+  `""` everywhere, and both `str(review_fix_path)` at `context.py:81` and
+  the `sorted(...)[-1]` newest-file selection are never reached through
+  `context.main()`.
+- Proposed fix: in the `with-story` case, also write
+  `tmp_path/docs/stories/QS-42.story_review_fix_#01.md` and assert
+  `latest_review_fix` equals that path in the byte-identical stdout
+  comparison. Writing two review-fix files (`#01` and `#02`) would
+  additionally pin the `sorted(...)[-1]` selection; do that if it stays
+  cheap.
+
+### [should-fix] S4 — Committed story contradicts the implementation it describes
+- File: `docs/stories/QS-291.story.md`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: the story ships in this PR marked `Status: IMPLEMENTED`
+  while still carrying predictions the implementation disproved:
+  - says "4 functions, **11 cases**" — the file defines **12**
+    (2 + 1 + 5 + 4)
+  - says the RED check should show "`1 failed, 10 passed`" — actual was
+    `passed=10 failed=2`
+  - the Task-1 table marks `test_gh_failure_paths` GREEN pre-change, but
+    AC4 itself states the raising case is the only construction that pins
+    behavioural delta 1 — which serial code cannot satisfy, so it is RED
+    **by construction**. The mislabel and the arithmetic slip were both
+    derivable at plan time.
+  The PR body documents and justifies the deviation; the story does not.
+- Proposed fix: correct the case count (12), the RED expectation
+  (`2 failed, 10 passed`), and the Task-1 table row for
+  `test_gh_failure_paths` (RED pre-change, with the one-line reason).
+
+### [nice-to-have] N1 — `if issue` treats issue `0` as absent
+- File: `scripts/qs/context.py:56,66,69,70`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `issue_override or get_issue_from_branch(branch)` silently
+  discards `--issue 0` and falls back to the branch-derived issue. Branch
+  `QS_0` yields `"issue": 0` with empty `title`/`story_file` even when
+  `docs/stories/QS-0.story.md` exists, and no `gh` call is made.
+  `--issue -1` is truthy, so `gh issue view -1` is issued (rc≠0 →
+  `title: ""`) and `QS--1.story.md` is looked up — degrading silently
+  with exit 0. All of this is **preserved from the serial code**, not
+  introduced by #291; the parallelization merely re-encoded the guard in
+  three new places.
+- Scope warning: this changes `context.py` semantics that #291 never
+  touched. It was flagged to the user as belonging in its own issue; the
+  user chose to include it. If the implementer finds the fix expanding
+  beyond a couple of lines (e.g. argparse validation plus a guard
+  rewrite), STOP and propose splitting it into a separate issue rather
+  than growing this PR.
+- Proposed fix: use `is not None` for the override, and make the
+  issue-presence guards explicit (`issue is not None and issue > 0`), or
+  reject non-positive `--issue` at the argparse boundary. Pin the chosen
+  semantics with a test row for `0` in the guard matrix.
+
+### [nice-to-have] N2 — `pool.submit` can raise `RuntimeError: can't start new thread`
+- File: `scripts/qs/context.py:65`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: the serial code needed no threads, so thread-pool creation
+  is a new hard-failure mode with no fallback. Under a low pids limit or
+  low `ulimit -u` (a sandbox, or the pipeline fanning out several agents
+  that each spawn subprocesses), every agent startup tracebacks instead
+  of degrading a field.
+- Scope warning: flagged to the user as arguably YAGNI — the process is
+  near death anyway, and testing it requires faking thread exhaustion.
+  The user chose to include it. Prefer the smallest possible change; a
+  full serial-fallback code path duplicating the whole block is NOT
+  wanted. If the only honest options are "duplicate the block" or "do
+  nothing", do nothing and record that reasoning in the story.
+- Proposed fix: if a cheap guard exists (catching `RuntimeError` around
+  the pool construction and falling back to direct sequential calls to
+  the same two helpers, reusing the existing statements rather than
+  copying them), take it. Otherwise document the failure mode as accepted
+  in the story's risk table.
+
+### [nice-to-have] N3 — `_make_fake_run` returns an unused `Lock`
+- File: `tests/qs/test_context.py:~66`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: the factory returns a `threading.Lock` that no call site
+  uses — every caller binds it as `_lock`. Dead return value.
+- Proposed fix: drop the third tuple element and keep the lock internal
+  to the closure (it still guards the recorder list).
+
+### [nice-to-have] N4 — `raise_on` silently no-ops for unsupported values
+- File: `tests/qs/test_context.py:~72`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter
+- Description: `raise_on` only honours `"issue"`; any other value
+  (e.g. `"pr"`) is a silent no-op that still passes, so no case can
+  exercise a raising `find_pr_for_branch`. This is also what blocks the
+  "both raise" coverage noted in S1.
+- Proposed fix: narrow the type to `Literal["issue", "pr"] | None`, honour
+  `"pr"`, and assert on unexpected values. Then use `"pr"` for the S1
+  test additions.
+
+### [nice-to-have] N5 — Module docstring case count is wrong
+- File: `tests/qs/test_context.py:~2`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: the docstring says "Ten of the eleven-ish cases … The
+  barrier test and the raising case are the two", i.e. 10 + 2 = 12, while
+  calling the total "eleven-ish". The file defines 12.
+- Proposed fix: state 12 exactly, or drop the count. Keep it consistent
+  with the S4 story correction and with whatever the final case count is
+  after S1/S3/N4 add cases.
+
+### [nice-to-have] N6 — Docstring re-lists `title` and `pr_number`
+- File: `scripts/qs/context.py:21-22`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter + qs-review-acceptance-auditor
+- Description: the new bullet adds a second entry for `title` and
+  `pr_number` to a list headed "Source of truth", so those two keys now
+  appear twice in the same `key: source` list (lines 16, 18, then 21).
+- Proposed fix: move the concurrency note to a trailing sentence outside
+  the `key: source` list (or into `build_context`'s docstring), keeping
+  the "fetched concurrently / do not re-serialize" wording that Task 2
+  requires.
+
+## Ordering note
+
+Do N4 before S1 — the `"pr"` raise support is what makes S1's "both
+raise" test expressible. S3, S4, N3, N5, N6 are independent. Keep N1 and
+N2 last so that if either balloons past a few lines it can be dropped
+without unwinding the rest.
+
+## Verification
+
+- `python scripts/qs/quality_gate.py --quick tests/qs/test_context.py`
+  during the loop.
+- `python scripts/qs/quality_gate.py --quick tests/qs` — **required**
+  supplement: this change set touches `tests/qs`-pinned files that
+  testmon cannot see.
+- `python scripts/qs/quality_gate.py --impacted` before commit.
+- Re-measure startup after S1/N2 to confirm the overlap still holds
+  (the PR claims median 1.022s → 0.535s); the barrier test in
+  `test_gh_calls_run_concurrently` is the functional guard.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify — that re-review also picks up the
+CodeRabbit pass this round missed.

--- a/docs/stories/QS-291.story_review_fix_#02.md
+++ b/docs/stories/QS-291.story_review_fix_#02.md
@@ -1,0 +1,323 @@
+# QS-291 — Review fix plan #02
+
+## Summary
+- Source PR: #325
+- Source story: `docs/stories/QS-291.story.md`
+- Prior fix plan: `docs/stories/QS-291.story_review_fix_#01.md` (9 of 10
+  findings resolved as specified; S4 partial, and N2's fix introduced a
+  must-fix)
+- Findings to fix: 7 (1 must-fix resolved by **reverting** a prior fix,
+  1 must-fix, 5 should-fix)
+- Deferred: 7 nice-to-have (recorded at the end — do not silently drop)
+- Next implement phase: `/implement-setup-task`
+
+### Review coverage caveat — READ THIS
+
+Round 2, like round 1, ran **3 of 4 reviewers**. CodeRabbit has now failed
+**three times** and its state is actively misleading:
+
+1. 18:23Z — rate-limited, produced nothing.
+2. 20:45Z — `@coderabbitai review` → **"Review skipped — No new commits to
+   review since the last review."** Its incremental engine had marked
+   `17c35cba` reviewed based on the aborted 18:23 run.
+3. 20:50Z — `@coderabbitai full review` → included-review limit reached
+   again, next window ~21:38Z.
+
+Net: **zero reviews, zero inline comments across both rounds.** Commit
+`17c35cba` is poisoned for incremental review — only a `full review` after
+the cooldown, or a **new commit**, will produce real findings. The commit
+that applies this plan is that new commit, so CodeRabbit should trigger
+naturally. Verify it actually reported before treating the next round as
+clean. Do not read "no findings" as "reviewed".
+
+CodeRabbit did rate this change **effort 4 (Complex), ~45 minutes** and
+flagged #297 as a possibly-related PR touching `context.py` latency
+behaviour — worth a glance for conflict.
+
+## Findings to fix
+
+### [must-fix] M1 — REVERT the N2 thread-exhaustion fallback
+- File: `scripts/qs/context.py:63-82` (`_submit`), plus its two tests
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter; **independently reproduced by the
+  orchestrator**
+- Description: `_submit`'s "degrade to inline" fallback double-executes
+  its callable. CPython's `ThreadPoolExecutor.submit` does
+  `self._work_queue.put(w)` **before** `self._adjust_thread_count()`, and
+  it is `_adjust_thread_count` → `Thread.start()` that raises
+  `RuntimeError: can't start new thread`. So `except RuntimeError`
+  abandons the returned future but **cannot un-queue the work item**; any
+  live worker drains it FIFO as soon as it goes idle, on top of the inline
+  call. Reproduced with the real executor (failing `Thread.start` only for
+  the second submit, with worker 1 still busy so the idle-semaphore
+  short-circuit does not fire):
+
+  ```text
+  -> fallback triggered
+  executions: ['first', 'second', 'second']
+  second ran 2 times
+  ```
+
+  Three consequences, all inside the guard's own target environment:
+  (a) a duplicate `gh` request; (b) `shutdown(wait=True)` waits for the
+  duplicate, so the fallback is **slower than the serial code it
+  replaced** — 3 `gh` calls, not 2; (c) the abandoned future is never
+  retrieved, so an exception there is silently discarded — breaking the
+  exact S1 invariant fix plan #01 added. The mirror order fires too: if
+  the *first* submit fails, the newly started worker re-runs
+  `gh issue view`.
+  `test_thread_exhaustion_falls_back_to_sequential` cannot catch this
+  because it monkeypatches `ThreadPoolExecutor.submit` wholesale, so the
+  real queue side effect never happens — the test passes against broken
+  code.
+- **Resolution: revert N2 entirely. Do NOT attempt to fix `_submit`.**
+  Rationale, decided with the user: N2 was flagged as *arguably YAGNI*
+  when it was proposed, was included under a blanket "fix all", and has
+  produced this round's only code must-fix. Fixing it properly means
+  either draining the orphaned future or pre-warming threads — real
+  complexity to protect a process that is already out of threads. Fix plan
+  #01's own N2 escape hatch anticipated exactly this: *"If the only honest
+  options are 'duplicate the block' or 'do nothing', do nothing and record
+  that reasoning in the story."*
+- Proposed fix:
+  1. Delete `_submit` and call `pool.submit(...)` directly at both sites.
+  2. **Preserve S2**: the PR-lookup site must stay
+     `pool.submit(find_pr_for_branch, branch, stdin=subprocess.DEVNULL)`
+     — `submit` forwards `**kwargs` to the callable, so the `DEVNULL`
+     plumbing survives the revert. Do not drop it.
+  3. Delete both `test_thread_exhaustion_*` tests.
+  4. Record thread-pool exhaustion in the story's risk table as an
+     **accepted** risk, with one line on why (a low `ulimit -u` / pids
+     cgroup is an environment failure, and the inline workaround is
+     unsound because `submit` queues before it raises).
+  5. Keep `Callable` / `Future` imports only if still used after the
+     deletion — drop them otherwise so the gate stays clean.
+
+### [must-fix] M2 — PR body is stale; its delta list is provably incomplete
+- File: PR #325 description (not a repo file)
+- Severity: must-fix
+- Source: qs-review-acceptance-auditor
+- Description: the body is unchanged since round 1. It still enumerates
+  exactly **three** behavioural deltas and still claims "4 test functions
+  / 12 cases" and "AC3 the 5-row guard matrix", while the landed file has
+  **10 functions / 20 cases and a 6-row matrix**. Unmentioned behaviour
+  changes from round 2: `--issue 0` / `--issue -1` now exit 2 instead of
+  producing a context (a user-visible CLI contract change);
+  `utils.run` and `find_pr_for_branch` gained a shared-helper `stdin`
+  parameter. The story designates the PR body as the **only** durable
+  evidence for this work after squashing, so a stale body is a
+  traceability defect, not cosmetics.
+- Proposed fix: update the body to reflect the final state **after this
+  plan is applied** (i.e. with N2 reverted, so no inline-fallback delta):
+  - correct the test counts and the guard-matrix row count;
+  - add the `--issue` non-positive rejection as a behavioural delta, and
+    state explicitly that the in-repo blast radius is nil (every caller
+    invokes `python scripts/qs/context.py` with no `--issue` — verified by
+    grep);
+  - add the `utils.run` / `find_pr_for_branch` `stdin` parameter as a
+    shared-helper API addition, noting `stdin=None` default keeps every
+    existing caller byte-identical (`tests/test_qs_utils.py` 32 passed);
+  - record the N2 revert and the accepted risk;
+  - refresh the measured median per R3;
+  - state that CodeRabbit never reviewed this PR (see caveat above), so
+    reviewers know the coverage gap.
+
+### [should-fix] R1 — `_settle` catches `Exception`, not `BaseException`
+- File: `scripts/qs/context.py:96-99`, and the `except Exception as
+  local_exc` drain at `:140`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter
+  (qs-review-acceptance-auditor dissents — see below)
+- Description: `_settle`'s annotation returns `BaseException | None` but it
+  only catches `Exception`, so a `BaseException` escaping `future.result()`
+  bypasses the drain and the sibling exception is silently discarded — the
+  S1 hole, reopened on a narrow path. Concretely, SIGINT delivered to the
+  process alone (a harness cancelling the tool call, or
+  `kill -INT <pid>`, rather than a terminal Ctrl-C that hits the whole
+  process group) while a `gh` child is slow: measured with two 3s children
+  and a real `os.kill(os.getpid(), SIGINT)` at t+0.30s, the serial code
+  aborts at **t+0.55s**, this code at **t+3.06s**, with both children left
+  running to completion. `subprocess.run` has
+  `except BaseException: process.kill(); raise`, so the serial path was
+  promptly interruptible; combined with the pre-existing no-timeout hang
+  (#295), SIGINT may never abort and SIGKILL becomes necessary.
+- **Recorded dissent** (do not silently override): the acceptance-auditor
+  judged this *consistent with instructions*, because fix plan #01 pointed
+  the implementer at `quality_gate.py:846-848`, which catches `Exception`
+  the same way, and the `BaseException | None` annotation shows the
+  asymmetry was seen rather than missed. The user chose to fix it anyway
+  as a one-word change.
+- Proposed fix: catch `BaseException` in `_settle` (and in the local-git
+  drain at `:140`) so both futures are drained on any escape, then
+  re-raise. Keep the primary-error ordering unchanged (title error first,
+  then PR error). Add a test that a `BaseException` subclass raised by one
+  worker still drains the sibling. Consider whether
+  `quality_gate.py::_run_cheap_gates_parallel` deserves the same
+  treatment — if so, note it as a follow-up issue rather than widening
+  this PR.
+
+### [should-fix] R2 — S4 only partially resolved: story still contradicts the landed file
+- File: `docs/stories/QS-291.story.md` (Task 1 heading and RED-check line)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: fix plan #01's S4 corrected the counts to "12 cases" and
+  "2 failed, 10 passed" — and the same commit immediately falsified them
+  again. The heading still reads `### Task 1 — tests/qs/test_context.py
+  (new file; 4 functions, 12 cases)` and `Expect 2 failed, 10 passed`,
+  while the landed file has 10 functions / 20 cases and a larger RED set.
+  The story defers with "Review fix #01 then grew it further — see below",
+  but the "Review fix #01 (applied)" section never states final counts, so
+  **no correct number exists anywhere in the story**. This is the same
+  defect class S4 was raised for — the second miss on the same thing.
+- Proposed fix: scope the `2 failed, 10 passed` line explicitly to the
+  original Task-1 file state, and either state the post-fix counts once in
+  the "Review fix #01 (applied)" section or drop counts from the heading
+  entirely — matching the N5 decision already taken in the test module
+  docstring ("No case count is stated on purpose — it rots"). Dropping is
+  preferred: it is the option that cannot rot a third time. Counts change
+  again in this plan (N2's two tests are deleted), so do not hand-write a
+  new number without re-checking it.
+
+### [should-fix] R3 — Overlap never re-measured after the round-1 fixes
+- File: PR #325 body / `docs/stories/QS-291.story.md`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: fix plan #01's Verification section explicitly required
+  "Re-measure startup after S1/N2 to confirm the overlap still holds". It
+  was not done. The advertised median (1.022s → 0.535s, ~48%) predates
+  `_settle`, `_submit`, `_note_sibling` and the `stdin` plumbing, so the
+  published number comes from superseded code. The barrier test guards
+  that overlap *happens*, not the wall-clock figure the PR advertises.
+- Proposed fix: re-run the story's baseline protocol (10 runs, 1.2s
+  spacing) **after** applying this plan, and record the median in the PR
+  body and the story. Never a blocker per the story — but the published
+  number must match the shipped code. The N2 revert removes a branch from
+  the hot path, so the figure should be at least as good as before.
+
+### [should-fix] R4 — N1's STOP trigger was hit and the decision was not recorded
+- File: `docs/stories/QS-291.story.md` (the N1 bullet)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: fix plan #01's N1 said: *"If the implementer finds the fix
+  expanding beyond a couple of lines (e.g. argparse validation plus a
+  guard rewrite), STOP and propose splitting it into a separate issue."*
+  What landed is exactly that pair — a new `_issue_number` argparse
+  validator **and** the guard rewrite (`issue_override is not None` +
+  `has_issue`), ~25 added lines in `context.py` plus a new 2-case test.
+  The story records *why* N1 was in scope ("at the user's request") but
+  not that the split trigger was evaluated and declined, so it reads as
+  though the trigger was missed.
+- Proposed fix: add one sentence to the story's N1 bullet recording that
+  the STOP trigger fired, that the split was considered, and why shipping
+  it here was chosen anyway (the change is self-contained, has nil in-repo
+  blast radius, and is covered by tests). Keep the code as-is — this is a
+  bookkeeping fix, not a re-litigation.
+
+### [should-fix] R5 — Acceptance criteria never extended for the new behaviours
+- File: `docs/stories/QS-291.story.md` (Acceptance criteria section)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: the four behaviours added by fix plan #01 — S1 (drain both
+  / deterministic first / sibling note), S2 (`DEVNULL` on concurrent
+  children), N1 (non-positive `--issue` rejected), N2 (now reverted) — are
+  each tested, but trace only to prose in "Review fix #01 (applied)",
+  not to any acceptance criterion. **Six of the file's ten test functions
+  therefore have no AC behind them**, leaving the next round nothing to
+  audit against but a narrative.
+- Proposed fix: promote the surviving behaviours to explicit criteria
+  (AC5–AC7, or an "ACs added by review fix #01" subsection), each naming
+  its test function:
+  - AC5 (S1): `test_local_git_failure_surfaces_sibling_gh_error`,
+    `test_both_gh_calls_raising_surfaces_both`, plus the new R1
+    `BaseException` test
+  - AC6 (S2): `test_parallel_gh_calls_get_devnull_stdin` (including the
+    assertion that `git` calls keep `stdin is None`)
+  - AC7 (N1): `test_non_positive_issue_override_is_rejected` and the
+    `[issue-zero-branch]` matrix row
+  Do **not** write an AC for N2 — it is reverted; it belongs in the risk
+  table as an accepted risk instead.
+
+## Ordering note
+
+Do M1 (the revert) first — it deletes code and two tests, which changes
+the counts that R2 and M2 must state, and removes a branch before R3's
+measurement. Then R1 (touches the same function region), then R5 → R2 →
+R4 (story bookkeeping, cheapest last), then R3's measurement, and finally
+M2's PR-body rewrite so it can quote the final numbers.
+
+## Deferred — nice-to-have, NOT to be fixed in this round
+
+Recorded so they are not lost or silently re-raised. The user chose to
+defer all of these.
+
+Two of the round-2 nice-to-haves **disappear with the M1 revert** (they
+were artifacts of N2's tests) — expect them not to recur:
+- test monkeypatched `ThreadPoolExecutor.submit` globally, disabling every
+  in-process pool for that test's duration
+- `no_threads` helper duplicated verbatim across two tests
+
+Genuinely deferred (7):
+- `EMFILE` / fd exhaustion is not degraded — two overlapped
+  `capture_output=True` children need ~8 pipe fds at peak vs ~4 serial, so
+  a tight `ulimit -n` turns a previously-succeeding run into a hard
+  traceback with no JSON on stdout. With N2 reverted, "neither thread nor
+  fd exhaustion is degraded" is at least *consistent*; note it in the risk
+  table alongside the N2 entry.
+- `_issue_number` validates sign but not lexical form: `int(raw)` silently
+  accepts `1_0` → 10, `+42`, ` 42 `, and non-ASCII digits (`٤٢` → 42), so
+  `--issue 1_0` builds a full context for issue 10 at exit 0.
+- bare `Future` / `Future | None` and `_settle(...) -> tuple[Any, ...]`
+  erase the types of `title` and `pr_info`; `Future[str]` /
+  `Future[dict | None]` would keep `build_context`'s dict typed.
+- `utils.run`'s `stdin: int | None` is narrower than `subprocess.run`
+  accepts (`IO[Any]`, raw fd); `int | IO[Any] | None` would not block
+  future callers.
+- with `stdin=DEVNULL`, a `gh` auth prompt now fails non-interactively and
+  degrades to empty title / no PR at exit 0; a one-line stderr warning on
+  non-zero `gh` would stop agents consuming a silently empty context.
+- the 5s `threading.Barrier` timeout is a wall-clock dependency — each RED
+  run costs 5s and a loaded CI box can false-fail.
+- ~35 lines of rationale comments wrap ~15 lines of logic in
+  `build_context` and largely restate the story; trimming to the
+  non-obvious invariants (`shutdown(wait=True)`, drain-before-raise) would
+  age better.
+
+## Dropped as invalid — verified, do not re-raise
+
+Round 2:
+- "`stdin=` raises `TypeError` because `run_gh` was not widened" —
+  `run_gh(args, **kwargs)` forwards to `run` (`utils.py:47`).
+- "`ruff format --check` would rewrite two hand-wrapped test lines" —
+  ruff lint and format are both scoped to `SRC_DIR` =
+  `custom_components/quiet_solar` (`quality_gate.py:752`, `:771`), so
+  `tests/` and `scripts/` are not formatted by the gate.
+- "`--issue 0` exit-2 blast radius unconfirmed" — no caller anywhere
+  passes `--issue`; documented at story line 338.
+
+Round 1 (still standing):
+- "unreachable `AssertionError` breaks the 100% coverage gate" — coverage
+  is scoped to `--cov=custom_components/quiet_solar`
+  (`quality_gate.py:83`); `tests/qs` is not measured.
+- "added lines exceed ~96 chars" — ruff is `line-length = 120` with `E501`
+  ignored.
+
+## Verification
+
+- `python scripts/qs/quality_gate.py --quick tests/qs/test_context.py`
+  during the loop.
+- `python scripts/qs/quality_gate.py --quick tests/qs` — **required**
+  supplement: this change set touches `tests/qs`-pinned files that testmon
+  cannot see.
+- `python scripts/qs/quality_gate.py --impacted` before commit.
+- `pytest tests/test_qs_utils.py` — the shared `utils.run` signature is
+  still in play after the revert; 32 passed previously, keep it green.
+- The barrier test (`test_gh_calls_run_concurrently`) must still pass
+  after the revert — it is the functional guard that the overlap survives.
+- R3's 10-run / 1.2s measurement, recorded in the PR body and story.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and
+run `/review-task` again to re-verify — and **check that CodeRabbit
+actually posted a review this time**; the new commit should clear the
+incremental-skip state that blocked it twice.

--- a/docs/stories/QS-291.story_review_fix_#03.md
+++ b/docs/stories/QS-291.story_review_fix_#03.md
@@ -1,0 +1,281 @@
+# QS-291 — Review fix plan #03 (narrow)
+
+## Summary
+- Source PR: #325
+- Source story: `docs/stories/QS-291.story.md`
+- Prior plans: `#01` (applied `17c35cba`), `#02` (applied `fe8bbe51` — all
+  7 findings resolved except R2, now failing for the third time)
+- Findings to fix: **6** — 3 code (A, C, D), 3 bookkeeping (B, E, F)
+- Deferred: **all 8** nice-to-have findings. Not one of them is in scope.
+- Next implement phase: `/implement-setup-task`
+
+**This is a deliberately narrow round.** Two prior rounds each introduced a
+new must-fix while hardening this same function (N2's fallback
+double-executed; R1's `BaseException` widening discarded exceptions and
+swallowed interrupts). Both were orchestrator recommendations. The scope
+below is the minimum that closes the invariant; anything beyond it is
+out of scope by construction.
+
+### Hard rules for this round
+
+1. **Touch only `_settle`, the two `pool.submit` lines, one new test, and
+   the named story lines.** No other code changes.
+2. **No drive-by refactors, no nice-to-haves, no "while I'm here".**
+3. If any fix appears to need more than the shape described below, **STOP
+   and report back** rather than expanding. The last two rounds went wrong
+   by growing a fix past its brief.
+4. Do not touch `custom_components/` — this is `implement-setup-task`.
+
+### Review coverage — CodeRabbit has never reviewed this PR
+
+Five failed attempts across three rounds. Round 3 diagnosed the cause:
+not a cooldown but an **exhausted Fair-Usage included-review budget** —
+`@coderabbitai review` returned a 4-second silent skip, and
+`@coderabbitai full review` hit the limit immediately with a *fresh*
+28-minute window despite the prior window having expired 12h earlier.
+Final state: **0 reviews, 0 inline comments**; the 7 CodeRabbit comments
+are all bookkeeping, including an empty `## Walkthrough` stub from the
+original aborted run.
+
+Do not retry CodeRabbit as part of this round — it is a billing matter
+(enable usage-based reviews, or accept the gap), not something a new
+commit fixes. This PR will have shipped at **3-reviewer coverage**; that
+is a conscious acceptance, not an oversight.
+
+---
+
+## Part 1 — Code (3 findings)
+
+### [must-fix] A — `_settle` mislabels a caller-side interrupt as the worker's outcome
+- File: `scripts/qs/context.py:79`
+- Source: qs-review-edge-case-hunter; **independently reproduced by the
+  orchestrator**
+- Description: `except BaseException` cannot distinguish "the worker
+  failed" from "our own `future.result()` wait was interrupted". When a
+  SIGINT lands while the main thread blocks in `_settle`, it (a) discards
+  the worker's real exception, (b) swallows the interrupt, and (c)
+  mislabels it through `_note_sibling` as
+  `"concurrent gh call also failed: KeyboardInterrupt()"`.
+  Orchestrator repro (mimicking `_settle` verbatim against a worker that
+  raises `RuntimeError("LOST title failure")` after 1s, interrupt armed at
+  0.3s):
+
+  ```text
+  settle returned exc = KeyboardInterrupt()
+  worker's real exception retrieved? RuntimeError('LOST title failure')
+  -> worker failure discarded from caller's view: True
+  ```
+
+  The edge-case hunter's fuller repro absorbed **7 consecutive SIGINTs**,
+  ran to completion at 3.01s with nothing abortable, and lost the title
+  failure entirely. This is the AC5 / S1 invariant ("no concurrent failure
+  is ever discarded") broken by the very widening that was meant to
+  total it. Note the plain case does behave — with no prior failure,
+  `title_exc` *is* the `KeyboardInterrupt` and gets re-raised — so the
+  defect is the swallow + mislabel + discard combination.
+- **Recorded history**: fix plan #02's R1 requested this widening over the
+  acceptance-auditor's explicit dissent (it argued `except Exception`
+  matched the `quality_gate.py:846` prior art). The dissent was correct.
+  Fixing forward rather than reverting, because reverting restores the
+  original narrower hole.
+- Proposed fix — exactly this shape, no more:
+
+  ```python
+  except BaseException as exc:
+      if not future.done() or future.exception(timeout=0) is not exc:
+          raise  # our wait was interrupted; not the worker's failure
+      return default, exc
+  ```
+
+  `Future.exception(timeout=0)` on a done future returns without blocking,
+  and returns `None` for a successful future — both verified by the
+  orchestrator on the pinned 3.14.
+- Test: one case asserting that an interrupt raised at the caller while
+  `result()` blocks propagates the **interrupt** and does not attach a
+  `concurrent gh call also failed` note, while the worker's own exception
+  is not silently substituted. Keep the existing
+  `test_base_exception_in_worker_still_drains_sibling` — it pins the
+  worker-origin half and must stay green.
+
+### [should-fix] C — the second `pool.submit` sits outside the drain
+- File: `scripts/qs/context.py:119-121`
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter
+  (orchestrator confirmed the placement)
+- Description: both `pool.submit` calls execute before the `try` at
+  `:122`. If the second one raises — `RuntimeError: can't start new
+  thread` under a low `ulimit -u` / pids cgroup — `title_future` is
+  already in flight and is never settled, so its exception is discarded
+  silently (`concurrent.futures` never logs an unretrieved future
+  exception). Verified by the edge-case hunter: surfaced error is
+  `RuntimeError("can't start new thread")` with `__notes__ == []`, and the
+  title worker's failure vanishes. The story accepts thread exhaustion as
+  *not degraded*; it does not accept discarding a sibling failure. The
+  same window exists for an interrupt landing between the two submits.
+- Proposed fix: move the `pr_future` submit **inside the existing `try`**
+  so the existing drain covers it. This is a statement move, not new
+  logic — the drain, the notes and the ordering all stay as they are.
+  Keep `stdin=subprocess.DEVNULL` on that call (S2 must not regress —
+  it survived the #02 revert, do not lose it here).
+- Test: **optional, only if cheap.** A test would have to patch
+  `ThreadPoolExecutor.submit` to raise on the second call, and that
+  wholesale-patch technique is what made the deleted N2 tests unsound.
+  If it cannot be done cleanly in a few lines, skip the test and note in
+  the story that the move is reasoned-but-unpinned. Do not invent
+  machinery for it.
+
+### [should-fix] D — `raise pr_exc` is executed by no test
+- File: `scripts/qs/context.py:143`; test in `tests/qs/test_context.py`
+- Source: qs-review-blind-hunter + qs-review-acceptance-auditor
+  (coverage-confirmed: `context.py 60 stmts, missing 143, 187` — 187 is
+  the `__main__` guard, so `:143` is the only unexecuted statement)
+- Description: no case reaches the PR-error leg. The parametrized rows are
+  `title-fails` / `pr-fails` / `both-fail` / `title-raises`; the only
+  `raise_on=("pr",)` case also sets `git_root_fails=True` and so takes the
+  local-git path; the `("issue","pr")` case raises `title_exc` first. So
+  AC5's "otherwise the title error, **then the PR error**" clause is
+  unverified. If that line were deleted, a PR-only `gh` exception would be
+  swallowed and `context.py` would print a context with `pr_number: null`
+  at exit 0 — the S1 hole on the other half of the pair, and unlike A and
+  C this one sits on a **normal, non-interrupt** path. The quality gate
+  cannot catch it: `--cov` is scoped to `custom_components/quiet_solar`,
+  so `scripts/qs` is never measured.
+- Proposed fix: one new case with `raise_on=("pr",)` and
+  `git_root_fails=False`, asserting the `RuntimeError` propagates and
+  carries **no** sibling note (the title call succeeded). No production
+  change.
+
+---
+
+## Part 2 — Bookkeeping (3 findings)
+
+### [must-fix] B — stale counts, third occurrence: fix by DELETING counts
+- File: `docs/stories/QS-291.story.md` lines 5, 128, 352
+- Source: qs-review-acceptance-auditor (all three verified by the
+  orchestrator)
+- Description: this defect has now recurred in three consecutive rounds
+  (S4 → R2 → B), each time in a *different* line, because each round
+  **corrected** a number that the same commit then falsified again.
+  - `:5` — `Status: **IMPLEMENTED** (rounds 1–3 folded in)`; only #01 and
+    #02 are applied. Round 3 is the review that produced this plan.
+  - `:128` — "All **four** tests drive `context.main()`"; there are 9.
+  - `:352` — "AC3's **five** rows are the real branch coverage"; AC3 has
+    6 rows. Unlike `:166`, this carries no "superseded" annotation.
+- **Root-cause fix, and the point of this finding: do not write new
+  numbers.** Delete the counts instead, matching the N5 decision already
+  taken in the test module docstring ("No case count is stated on purpose
+  — it rots"). Specifically:
+  - `:5` → drop the parenthetical entirely, or write "review fixes folded
+    in" with no round numbers.
+  - `:128` → "All tests drive `context.main()`, so the `--issue` argparse
+    surface stays covered." (works verbatim without the number)
+  - `:352` → "AC3's rows are the real branch coverage."
+  Counts change again in this very round (D adds a case, A adds a case),
+  which is precisely why no hand-written number survives contact.
+  Historically-scoped lines are **fine and must be left alone**: the
+  `:294-297` table and the `2 failed, 10 passed` at `:315-318` are
+  explicitly about the original Task-1 file state.
+- Sweep obligation: after editing, grep the story for remaining
+  present-tense counts (`four`, `five`, `12 cases`, `11 cases`, digits
+  near "test"/"row"/"case") and confirm each survivor is either
+  historically scoped or deleted. This is the third miss; a partial sweep
+  is a fourth.
+
+### [should-fix] E — the story's "Design" code block is still the round-1 prototype
+- File: `docs/stories/QS-291.story.md` ("Design" section snippet)
+- Source: qs-review-blind-hunter
+- Description: the snippet still shows `if issue` truthiness guards,
+  `title_future.result()`, no `stdin=DEVNULL`, and no
+  `_settle`/`_note_sibling` — i.e. code that has not existed since round 1.
+  It is the first thing a reader anchors on, and the staleness class that
+  R2/S4 were raised for was never applied here.
+- Proposed fix: replace the snippet with the landed `build_context` body
+  **after this round's A and C changes**, or — preferred, and cheaper to
+  keep true — delete the snippet and point at
+  `scripts/qs/context.py::build_context` as the source of truth. Prefer
+  deletion for the same reason as B: a copy cannot rot if it does not
+  exist.
+
+### [should-fix] F — the declared `quality_gate.py` follow-up was never filed
+- File: n/a (GitHub issue) + `docs/stories/QS-291.story.md:418-421`
+- Source: qs-review-acceptance-auditor
+- Description: the story and PR body both state that whether
+  `quality_gate.py::_run_cheap_gates_parallel` needs the same
+  `BaseException` treatment "is a follow-up issue, not this PR" — but no
+  such issue exists (`gh issue list --state all --search BaseException` →
+  empty; #295 covers dead helpers/docstrings, not this).
+- Proposed fix: either open the issue and cite its number in the story, or
+  state in the story that it was evaluated and declined with one line of
+  reasoning. **Note for whoever files it**: finding A means the correct
+  treatment is *not* a plain `except BaseException` — that is what broke
+  here. Reference A's guard shape so the follow-up does not repeat this
+  round's mistake.
+
+---
+
+## Deferred — all 8 nice-to-have findings, explicitly out of scope
+
+Recorded so they are neither lost nor re-raised as new next round.
+
+1. An interrupt during `__exit__`'s `shutdown(wait=True)` substitutes
+   `KeyboardInterrupt` for the in-flight primary exception and does not
+   shorten the wait (workers are non-daemon and re-joined at interpreter
+   exit). Consistent with documented delta 2; only the type substitution
+   is undocumented.
+2. `--issue 1.5` (or `abc`, `0x10`, `""`) leaks the private helper name:
+   `invalid _issue_number value: '1.5'`. Catching `ValueError` inside
+   `_issue_number` would give the same exit 2 with a readable message.
+3. The local-failure drain adds one more entry path to the #295 no-timeout
+   hang; worth a risk-table sentence.
+4. `test_gh_failure_paths`'s `title-raises` row branches to a different
+   assertion shape with an early `return`; splitting it would remove the
+   in-test `if`.
+5. `_issue_title`'s comment says "see `utils.run`'s `stdin`" but the call
+   goes through `run_gh`'s `**kwargs`.
+6. `test_parallel_gh_calls_get_devnull_stdin` asserts `stdin is None` only
+   for `git branch --show-current`, not for the `git rev-parse
+   --show-toplevel` calls that actually moved inside the pool block.
+7. The `[issue-zero-branch]` row asserts no `gh issue view` but never
+   asserts `story_file == ""`, so half of AC7 is inferred.
+8. AC3's story table still lists five rows with the sixth in a
+   parenthetical, so the AC reads as a diff of itself.
+
+Items 6–8 are AC-tightening and would be reasonable in a follow-up issue
+alongside F; do not open one unless you want it.
+
+## Dropped as invalid — verified across rounds, do not re-raise
+
+- `run_gh` does **not** need widening for `stdin` — `run_gh(args, **kwargs)`
+  forwards (`utils.py:47`).
+- ruff lint/format are scoped to `custom_components/quiet_solar`
+  (`quality_gate.py:752`, `:771`), so `E501`/format findings on `tests/`
+  or `scripts/` are moot; `line-length = 120` with `E501` ignored anyway.
+- coverage is scoped to `--cov=custom_components/quiet_solar`
+  (`quality_gate.py:83`), so unreachable lines in `tests/qs` are not gate
+  failures — **and** `scripts/qs` coverage is never measured, which is why
+  finding D needed a human to notice.
+- `--issue 0` exit-2 blast radius is nil: no caller anywhere passes
+  `--issue` (grep-verified; documented at story `:338`).
+
+## Verification
+
+- `python scripts/qs/quality_gate.py --quick tests/qs/test_context.py`
+  during the loop.
+- `python scripts/qs/quality_gate.py --quick tests/qs` — **required**:
+  this change set touches `tests/qs`-pinned files testmon cannot see.
+- `python scripts/qs/quality_gate.py --impacted` before commit.
+- `test_gh_calls_run_concurrently` (the barrier test) must stay green —
+  it is the functional guard that the overlap survives C's statement move.
+- `test_base_exception_in_worker_still_drains_sibling` must stay green —
+  A must not regress the worker-origin half.
+- No re-measurement required: A and C do not touch the hot path (A adds
+  two predicates on an error path; C moves a statement). The story's
+  median 0.559s stands. Say so explicitly rather than leaving it implied.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return and
+run `/review-task`. Expect the next round to be a confirmation pass — if
+it surfaces a **new** must-fix inside `_settle` or `build_context`, that is
+the third consecutive round to do so, and the right response is to stop
+hardening and ship with the limitation documented rather than to attempt a
+fourth fix.

--- a/docs/stories/QS-291.story_review_fix_#04.md
+++ b/docs/stories/QS-291.story_review_fix_#04.md
@@ -1,0 +1,172 @@
+# QS-291 — Review fix plan #04 (documentation only)
+
+## Summary
+- Source PR: #325
+- Source story: `docs/stories/QS-291.story.md`
+- Prior plans: `#01` (`17c35cba`), `#02` (`fe8bbe51`), `#03` (`d64e1a8b`)
+- Round 4 found **0 must-fix**. Findings to fix: **4, all prose.**
+- Next implement phase: `/implement-setup-task`
+
+**No logic changes. Zero.** Round 4's three reviewers agree the code is
+done: 22 passed, coverage of `scripts/qs/context.py` leaves only line 205
+(the `__main__` guard) unexecuted, `tests/qs` 704 passed. Every `Future`
+state at `_settle`'s `except` was enumerated and driven through on 3.14.3.
+
+### Hard rules
+
+1. **Edit only**: 3 lines/blocks in `docs/stories/QS-291.story.md`, one
+   **comment** in `scripts/qs/context.py`, and the PR #325 body.
+2. **Do not change any executable line.** The only `context.py` edit is
+   comment text. If a diff line is not a comment or a doc, it is out of
+   scope.
+3. **Do not fix any deferred nice-to-have** (see list — all remain
+   deferred, none in scope).
+4. No new tests. No re-measurement (nothing touches the hot path).
+
+---
+
+## The 4 fixes
+
+### 1. AC5 cites a test name that does not exist
+- File: `docs/stories/QS-291.story.md:217`
+- Source: qs-review-acceptance-auditor
+- Current: `` `test_caller_side_interrupt_is_not_relabelled_as_a_gh_failure` pins the ``
+- Landed name (`tests/qs/test_context.py:563`):
+  `test_caller_side_interrupt_is_not_settled_as_a_worker_outcome`
+- Fix: rename the citation to the landed name. Nothing else on that line.
+
+### 2. AC5's "both futures are drained" is overstated, and so is one code comment
+- Files: `docs/stories/QS-291.story.md:206-208`; `scripts/qs/context.py:132-135`
+  (**comment text only**)
+- Source: qs-review-acceptance-auditor (story) + qs-review-blind-hunter
+  (comment)
+- Description: two claims outlived the code they describe.
+  - Story `:206-208` says "so both futures are drained before anything
+    propagates". Since #03's finding A, a caller-side interrupt inside
+    `_settle(title_future, …)` re-raises immediately, so `pr_future` is
+    never settled and its exception goes unretrieved.
+  - `context.py:132-135` says the `try` covers "an interrupt landing
+    between the two" submits — but `title_future = pool.submit(...)` and
+    the `pr_future` annotation both execute *before* the `try`, so that
+    window is not covered.
+- **Do NOT change the code.** This was settled in round 4 by 2 of 3
+  reviewers plus fix plan #03's stop rule: the interrupt must win, and
+  `__context__` still chains the local failure into the traceback. It is a
+  strict improvement on round 2, where the opposite choice caused a
+  must-fix. Blind-hunter proposed a `try`/`finally` per future; it reviews
+  the diff only and could not know the trade was chosen deliberately. Its
+  alternative suggestion — soften the comment — is the correct half.
+- Fix:
+  - Story: narrow the claim to worker failures on non-interrupt paths
+    (e.g. "no *worker* failure is discarded; a caller-side interrupt
+    propagates immediately and deliberately wins over draining the
+    sibling — see deferred item 1"). Keep the deterministic-ordering
+    sentence that follows.
+  - Comment: drop or qualify the "or an interrupt lands between the two"
+    clause so it claims only what the `try` actually covers (a raising
+    `pr_future` submit). Keep the `review fix #03 C` reference.
+
+### 3. One unscoped present-tense count survived B's sweep
+- File: `docs/stories/QS-291.story.md:180`
+- Source: qs-review-acceptance-auditor
+- Current: `**AC4 — failure paths.** Four cases:`
+- The count is *accurate* (4 params), so this is not a fourth stale count —
+  but it is neither historically scoped nor annotated, which is exactly
+  what #03's B mandate ("do not write new numbers") existed to remove.
+- Fix: `**AC4 — failure paths:**` — reads identically without the number.
+- Leave every other count alone: `:64`, `:296-299`, `:305`, `:318` are
+  historically scoped, `:163` is annotated superseded, `:477` is a quoted
+  deletion record, `:369`/`:410` are verified plan tallies.
+
+### 4. The PR body contradicts itself on round count and gate numbers
+- File: PR #325 body (not a repo file)
+- Source: qs-review-acceptance-auditor
+- Description: the body gained an accurate "Review round 3" section but
+  its older lines were not swept. This is the durable post-squash
+  evidence, so it is the one that matters most.
+- Fix, line by line:
+  - line 7 — "final state after **two** review-fix rounds" → **three**.
+  - line 11 — "Across **both** review rounds CodeRabbit produced zero
+    reviews…" → three rounds, and the count is now **six attempts**, not
+    three. Round 3 established the diagnosis: not a cooldown but a stuck
+    incremental state (plain `review` returns a 4–5s silent skip; it has
+    never submitted a review object on this PR) **plus** an exhausted
+    Fair-Usage budget gating `full review`. A check 4h17m past the stated
+    window expiry still got the instant skip, so waiting does not fix it.
+    State plainly that **no commit on this PR was ever reviewed by
+    CodeRabbit** and that all four rounds ran 3 of 4 reviewers.
+  - line 45 — `--quick tests/qs` **701 passed** → **704**.
+  - line 32 — the round-2 R1 bullet still says the `quality_gate.py`
+    question is a "follow-up, not this PR" without naming it. Add `#329`.
+    Harmless as history, but one cross-reference costs nothing.
+- Apply #03's B rule here too: prefer deleting a number over restating it
+  wherever the body does not need one. This defect class has now recurred
+  in **all four rounds**; the body is its last refuge.
+
+---
+
+## Deferred — every nice-to-have, none in scope
+
+Unchanged from #03's list of 8 (interrupt during `shutdown(wait=True)`
+substitutes the primary exception; `--issue 1.5` leaks the private helper
+name; the local drain adds an entry path to #295; `title-raises` branches
+in-test; `_issue_title`'s comment names `utils.run` rather than `run_gh`;
+the devnull test checks only `git branch`; `[issue-zero-branch]` omits
+`story_file`; AC3's table lists five rows with the sixth parenthetical),
+plus four raised in round 4:
+
+9. `has_issue` defeats mypy narrowing — `int | None` reaches `int`-typed
+   params. Runtime-safe; would matter only if `scripts/` enters mypy scope.
+10. A one-line note that `future.exception(timeout=0)` *raises*
+    `CancelledError` rather than returning it, so a cancelled future would
+    blow out of `_settle`'s handler. Unreachable today (nothing cancels;
+    `shutdown()` runs with `cancel_futures=False`, which the code forbids
+    changing) — both the edge-case hunter and blind-hunter noted it as
+    unreachable.
+11. A's test leaves the future `done()` in both params, so the
+    `not future.done()` half of the guard is never the deciding predicate;
+    a third case with an unset future would close it. Also
+    `assert _notes(...) == []` would make "neither settled nor noted"
+    literal rather than inferred.
+12. Worker-side `KeyboardInterrupt` is re-raised only after the sibling
+    `gh` child finishes under `shutdown(wait=True)` — Ctrl-C during
+    startup is less responsive than serial. Overlaps deferred item 1;
+    record as an accepted delta if ever addressed.
+
+Items 11 and 6–8 are AC-tightening and would suit a follow-up issue
+alongside #329 — do not open one unless you want it.
+
+## Dropped as invalid — verified repeatedly, do not re-raise
+
+Both of these were raised again in round 4, for the **third** time:
+- `run_gh` needs widening to forward `stdin` — it is
+  `run_gh(args, **kwargs)` and forwards (`utils.py:47`). Verified rounds
+  2, 3, 4.
+- the 101-char `_completed` signature is an E501/format violation — ruff
+  lint *and* format are scoped to `custom_components/quiet_solar`
+  (`quality_gate.py:752`, `:771`), and `line-length = 120` with `E501`
+  ignored regardless.
+
+Also standing: coverage is scoped to `custom_components/quiet_solar`
+(`quality_gate.py:83`), so `scripts/qs` is never gate-measured — which is
+why finding D needed a reviewer to notice; and `--issue 0`'s exit-2 blast
+radius is nil (no caller passes `--issue`).
+
+## Verification
+
+- `python scripts/qs/quality_gate.py --quick tests/qs` — **required**
+  (`tests/qs`-pinned non-Python files; testmon cannot see them). Expect
+  704 passed, i.e. the number going into the PR body.
+- `python scripts/qs/quality_gate.py --impacted` before commit.
+- Confirm `git diff` on `scripts/qs/context.py` shows **comment lines
+  only**. If it shows anything else, stop.
+- No re-measurement: nothing touches the hot path. The story's median
+  0.559s stands.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan, then `/finish-task` —
+round 4 already cleared the code, so no further `/review-task` round is
+expected. If a reviewer is run anyway and reports a **code** finding, note
+that round 4's three reviewers deliberately closed that discussion; do not
+reopen it without new evidence.

--- a/scripts/qs/context.py
+++ b/scripts/qs/context.py
@@ -18,16 +18,21 @@ Source of truth:
 - ``pr_number``: from ``gh pr list --head <branch>`` (if open)
 - ``worktree``: current working directory
 - ``harness``: from :mod:`scripts.qs.harness`
-- ``title`` and ``pr_number``: their two ``gh`` calls are fetched
-  concurrently (they dominate startup); do not re-serialize them
+
+The two ``gh`` calls behind ``title`` and ``pr_number`` are the only
+network work here and dominate startup latency, so they are fetched
+**concurrently** — do not re-serialize them.
 """
 
 from __future__ import annotations
 
 import argparse
+import subprocess
 import sys
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
+from typing import Any
 
 from harness import detect as detect_harness  # type: ignore[import-not-found]
 
@@ -44,16 +49,77 @@ from utils import (  # type: ignore[import-not-found]
 
 
 def _issue_title(issue: int) -> str:
-    result = run_gh(["issue", "view", str(issue), "--json", "title", "-q", ".title"], check=False)
+    result = run_gh(
+        ["issue", "view", str(issue), "--json", "title", "-q", ".title"],
+        check=False,
+        # Concurrent with the PR lookup — see ``utils.run``'s ``stdin``.
+        stdin=subprocess.DEVNULL,
+    )
     if result.returncode != 0:
         return ""
     return result.stdout.strip()
 
 
+def _submit(pool: ThreadPoolExecutor, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Future:
+    """Submit ``fn`` to ``pool``, degrading to an inline call if no thread starts.
+
+    ``ThreadPoolExecutor`` spawns worker threads lazily on ``submit``, so a
+    low ``ulimit -u`` / pids cgroup surfaces as
+    ``RuntimeError: can't start new thread`` here — a hard failure the
+    serial code never had. Running ``fn`` inline and wrapping the outcome
+    in an already-resolved future costs the overlap but keeps one single
+    retrieval path below, rather than duplicating the whole block into a
+    serial fallback (review fix #01 N2).
+    """
+    try:
+        return pool.submit(fn, *args, **kwargs)
+    except RuntimeError:
+        future: Future = Future()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except Exception as exc:
+            future.set_exception(exc)
+        return future
+
+
+def _settle(future: Future | None, default: Any) -> tuple[Any, BaseException | None]:
+    """Retrieve a future's outcome as ``(value, exception)`` without raising.
+
+    Draining *both* futures before anything propagates is the point:
+    ``concurrent.futures`` does not log an unretrieved future exception, so
+    a sibling failure would otherwise be discarded without a trace
+    (review fix #01 S1). Prior art:
+    ``quality_gate.py::_run_cheap_gates_parallel``.
+    """
+    if future is None:
+        return default, None
+    try:
+        return future.result(), None
+    except Exception as exc:
+        return default, exc
+
+
+def _note_sibling(exc: BaseException, sibling: BaseException | None) -> None:
+    """Attach ``sibling`` to ``exc`` so a concurrent failure stays visible."""
+    if sibling is not None:
+        exc.add_note(f"concurrent gh call also failed: {sibling!r}")
+
+
 def build_context(issue_override: int | None = None) -> dict:
-    """Assemble the context dictionary for the current task."""
+    """Assemble the context dictionary for the current task.
+
+    The ``title`` and ``pr_number`` lookups are issued concurrently; both
+    outcomes are always retrieved before either can propagate, and a hard
+    failure surfaces deterministically (title first) carrying any sibling
+    failure as a note.
+    """
     branch = get_current_branch()
-    issue = issue_override or get_issue_from_branch(branch)
+    issue = issue_override if issue_override is not None else get_issue_from_branch(branch)
+    # ``0`` is reported faithfully but is not a usable issue number, so
+    # guard explicitly instead of relying on truthiness — which conflates
+    # ``QS_0`` with "no issue" and silently discarded ``--issue 0``
+    # (review fix #01 N1; ``main()`` rejects non-positive overrides).
+    has_issue = issue is not None and issue > 0
 
     # The two ``gh`` calls are independent (one needs only ``issue``, the
     # other only ``branch``) and dominate startup, so they overlap.
@@ -63,13 +129,32 @@ def build_context(issue_override: int | None = None) -> dict:
     # abandoning a live subprocess — do not "fix" it with
     # ``cancel_futures=True``.
     with ThreadPoolExecutor(max_workers=2) as pool:
-        title_future = pool.submit(_issue_title, issue) if issue else None
-        pr_future = pool.submit(find_pr_for_branch, branch) if branch else None
-        # Local git work runs while both gh calls are in flight.
-        story_path: Path | None = find_story_file(issue) if issue else None
-        review_fix_path: Path | None = find_latest_review_fix(issue) if issue else None
-        title = title_future.result() if title_future else ""
-        pr_info = pr_future.result() if pr_future else None
+        title_future = _submit(pool, _issue_title, issue) if has_issue else None
+        pr_future = (
+            _submit(pool, find_pr_for_branch, branch, stdin=subprocess.DEVNULL) if branch else None
+        )
+        try:
+            # Local git work runs while both gh calls are in flight.
+            story_path: Path | None = find_story_file(issue) if has_issue else None
+            review_fix_path: Path | None = find_latest_review_fix(issue) if has_issue else None
+        except Exception as local_exc:
+            # The local work failed with both children still running: drain
+            # them so neither exception is discarded, then let the local
+            # error propagate as the primary one (review fix #01 S1).
+            for _value, exc in (_settle(title_future, ""), _settle(pr_future, None)):
+                _note_sibling(local_exc, exc)
+            raise
+        title, title_exc = _settle(title_future, "")
+        pr_info, pr_exc = _settle(pr_future, None)
+
+    # Raised outside the ``with`` so the pool has already joined both
+    # children. A hard ``gh`` failure still propagates unchanged in type
+    # and exit code (behavioural delta 1).
+    if title_exc is not None:
+        _note_sibling(title_exc, pr_exc)
+        raise title_exc
+    if pr_exc is not None:
+        raise pr_exc
 
     return {
         "harness": detect_harness(),
@@ -85,9 +170,26 @@ def build_context(issue_override: int | None = None) -> dict:
     }
 
 
+def _issue_number(raw: str) -> int:
+    """argparse ``type`` for ``--issue``: reject non-positive numbers.
+
+    ``--issue 0`` used to be silently discarded in favour of the
+    branch-derived issue, and ``--issue -1`` was truthy enough to issue a
+    doomed ``gh issue view -1`` and then degrade to an empty title with
+    exit 0. Failing at the boundary beats a useless context
+    (review fix #01 N1).
+    """
+    value = int(raw)
+    if value < 1:
+        raise argparse.ArgumentTypeError(f"issue number must be positive, got {value}")
+    return value
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Discover the current task's context.")
-    parser.add_argument("--issue", type=int, default=None, help="Force a specific issue number.")
+    parser.add_argument(
+        "--issue", type=_issue_number, default=None, help="Force a specific issue number."
+    )
     args = parser.parse_args()
 
     ctx = build_context(issue_override=args.issue)

--- a/scripts/qs/context.py
+++ b/scripts/qs/context.py
@@ -71,12 +71,23 @@ def _settle(future: Future | None, default: Any) -> tuple[Any, BaseException | N
     worker's ``BaseException`` would otherwise skip the drain and reopen
     that exact hole on a narrow path (review fix #02 R1). The caller
     re-raises, so nothing is swallowed.
+
+    The ``done()``/``exception()`` guard separates the two things a
+    ``BaseException`` here can mean: the *worker's* outcome (settle it) or
+    an interrupt landing in *our own* ``result()`` wait (propagate it). The
+    latter must not be settled — doing so swallowed the interrupt,
+    discarded the worker's real failure, and mislabelled the interrupt as a
+    concurrent ``gh`` failure (review fix #03 A). ``exception(timeout=0)``
+    does not block on a done future and returns ``None`` for a successful
+    one.
     """
     if future is None:
         return default, None
     try:
         return future.result(), None
     except BaseException as exc:
+        if not future.done() or future.exception(timeout=0) is not exc:
+            raise
         return default, exc
 
 
@@ -116,10 +127,17 @@ def build_context(issue_override: int | None = None) -> dict:
     # double-executes the call (review fix #02 M1). Do not add one.
     with ThreadPoolExecutor(max_workers=2) as pool:
         title_future = pool.submit(_issue_title, issue) if has_issue else None
-        pr_future = (
-            pool.submit(find_pr_for_branch, branch, stdin=subprocess.DEVNULL) if branch else None
-        )
+        pr_future: Future | None = None
         try:
+            # Inside the ``try`` so the drain below covers it: if this
+            # ``submit`` raises (thread exhaustion) or an interrupt lands
+            # between the two, ``title_future`` is already in flight and
+            # would otherwise never be settled (review fix #03 C).
+            pr_future = (
+                pool.submit(find_pr_for_branch, branch, stdin=subprocess.DEVNULL)
+                if branch
+                else None
+            )
             # Local git work runs while both gh calls are in flight.
             story_path: Path | None = find_story_file(issue) if has_issue else None
             review_fix_path: Path | None = find_latest_review_fix(issue) if has_issue else None

--- a/scripts/qs/context.py
+++ b/scripts/qs/context.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
-from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
@@ -60,28 +59,6 @@ def _issue_title(issue: int) -> str:
     return result.stdout.strip()
 
 
-def _submit(pool: ThreadPoolExecutor, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Future:
-    """Submit ``fn`` to ``pool``, degrading to an inline call if no thread starts.
-
-    ``ThreadPoolExecutor`` spawns worker threads lazily on ``submit``, so a
-    low ``ulimit -u`` / pids cgroup surfaces as
-    ``RuntimeError: can't start new thread`` here — a hard failure the
-    serial code never had. Running ``fn`` inline and wrapping the outcome
-    in an already-resolved future costs the overlap but keeps one single
-    retrieval path below, rather than duplicating the whole block into a
-    serial fallback (review fix #01 N2).
-    """
-    try:
-        return pool.submit(fn, *args, **kwargs)
-    except RuntimeError:
-        future: Future = Future()
-        try:
-            future.set_result(fn(*args, **kwargs))
-        except Exception as exc:
-            future.set_exception(exc)
-        return future
-
-
 def _settle(future: Future | None, default: Any) -> tuple[Any, BaseException | None]:
     """Retrieve a future's outcome as ``(value, exception)`` without raising.
 
@@ -89,13 +66,17 @@ def _settle(future: Future | None, default: Any) -> tuple[Any, BaseException | N
     ``concurrent.futures`` does not log an unretrieved future exception, so
     a sibling failure would otherwise be discarded without a trace
     (review fix #01 S1). Prior art:
-    ``quality_gate.py::_run_cheap_gates_parallel``.
+    ``quality_gate.py::_run_cheap_gates_parallel`` — which catches
+    ``Exception``; this catches ``BaseException`` deliberately, because a
+    worker's ``BaseException`` would otherwise skip the drain and reopen
+    that exact hole on a narrow path (review fix #02 R1). The caller
+    re-raises, so nothing is swallowed.
     """
     if future is None:
         return default, None
     try:
         return future.result(), None
-    except Exception as exc:
+    except BaseException as exc:
         return default, exc
 
 
@@ -128,16 +109,21 @@ def build_context(issue_override: int | None = None) -> dict:
     # ``with``-exit is deliberate: it joins the other future rather than
     # abandoning a live subprocess — do not "fix" it with
     # ``cancel_futures=True``.
+    #
+    # Thread-pool exhaustion (low ``ulimit -u`` / pids cgroup) is an
+    # accepted risk: ``submit`` queues the work item *before* the thread
+    # start that raises, so an "inline fallback" cannot un-queue it and
+    # double-executes the call (review fix #02 M1). Do not add one.
     with ThreadPoolExecutor(max_workers=2) as pool:
-        title_future = _submit(pool, _issue_title, issue) if has_issue else None
+        title_future = pool.submit(_issue_title, issue) if has_issue else None
         pr_future = (
-            _submit(pool, find_pr_for_branch, branch, stdin=subprocess.DEVNULL) if branch else None
+            pool.submit(find_pr_for_branch, branch, stdin=subprocess.DEVNULL) if branch else None
         )
         try:
             # Local git work runs while both gh calls are in flight.
             story_path: Path | None = find_story_file(issue) if has_issue else None
             review_fix_path: Path | None = find_latest_review_fix(issue) if has_issue else None
-        except Exception as local_exc:
+        except BaseException as local_exc:
             # The local work failed with both children still running: drain
             # them so neither exception is discarded, then let the local
             # error propagate as the primary one (review fix #01 S1).

--- a/scripts/qs/context.py
+++ b/scripts/qs/context.py
@@ -130,9 +130,10 @@ def build_context(issue_override: int | None = None) -> dict:
         pr_future: Future | None = None
         try:
             # Inside the ``try`` so the drain below covers it: if this
-            # ``submit`` raises (thread exhaustion) or an interrupt lands
-            # between the two, ``title_future`` is already in flight and
-            # would otherwise never be settled (review fix #03 C).
+            # ``submit`` raises (thread exhaustion), ``title_future`` is
+            # already in flight and would otherwise never be settled
+            # (review fix #03 C). The window *before* the ``try`` — the
+            # title submit itself — is not covered.
             pr_future = (
                 pool.submit(find_pr_for_branch, branch, stdin=subprocess.DEVNULL)
                 if branch

--- a/scripts/qs/context.py
+++ b/scripts/qs/context.py
@@ -18,12 +18,15 @@ Source of truth:
 - ``pr_number``: from ``gh pr list --head <branch>`` (if open)
 - ``worktree``: current working directory
 - ``harness``: from :mod:`scripts.qs.harness`
+- ``title`` and ``pr_number``: their two ``gh`` calls are fetched
+  concurrently (they dominate startup); do not re-serialize them
 """
 
 from __future__ import annotations
 
 import argparse
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from harness import detect as detect_harness  # type: ignore[import-not-found]
@@ -52,12 +55,21 @@ def build_context(issue_override: int | None = None) -> dict:
     branch = get_current_branch()
     issue = issue_override or get_issue_from_branch(branch)
 
-    title = _issue_title(issue) if issue else ""
-
-    story_path: Path | None = find_story_file(issue) if issue else None
-    review_fix_path: Path | None = find_latest_review_fix(issue) if issue else None
-
-    pr_info = find_pr_for_branch(branch) if branch else None
+    # The two ``gh`` calls are independent (one needs only ``issue``, the
+    # other only ``branch``) and dominate startup, so they overlap.
+    # ``subprocess.run`` blocks in ``os.waitpid`` with the GIL released, so
+    # the two children genuinely run at once. ``shutdown(wait=True)`` on
+    # ``with``-exit is deliberate: it joins the other future rather than
+    # abandoning a live subprocess — do not "fix" it with
+    # ``cancel_futures=True``.
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        title_future = pool.submit(_issue_title, issue) if issue else None
+        pr_future = pool.submit(find_pr_for_branch, branch) if branch else None
+        # Local git work runs while both gh calls are in flight.
+        story_path: Path | None = find_story_file(issue) if issue else None
+        review_fix_path: Path | None = find_latest_review_fix(issue) if issue else None
+        title = title_future.result() if title_future else ""
+        pr_info = pr_future.result() if pr_future else None
 
     return {
         "harness": detect_harness(),

--- a/scripts/qs/utils.py
+++ b/scripts/qs/utils.py
@@ -24,14 +24,24 @@ def run(
     check: bool = True,
     capture: bool = True,
     cwd: str | None = None,
+    stdin: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Run a command, returning the completed process."""
+    """Run a command, returning the completed process.
+
+    ``stdin`` is an **opt-in** passthrough to :func:`subprocess.run`.
+    ``capture_output=True`` does not redirect stdin, so by default a child
+    inherits the caller's TTY — which every existing caller relies on, and
+    which ``stdin=None`` preserves exactly. Callers that launch children
+    *concurrently* pass ``subprocess.DEVNULL`` so two of them cannot race
+    for the same terminal on an auth prompt (review fix QS-291 #01 S2).
+    """
     return subprocess.run(
         cmd,
         capture_output=capture,
         text=True,
         check=check,
         cwd=cwd,
+        stdin=stdin,
     )
 
 
@@ -288,11 +298,18 @@ def auto_commit_and_push(
     return {"committed": True, "pushed": pushed, "files": files}
 
 
-def find_pr_for_branch(branch: str) -> dict | None:
-    """Return ``{"pr_number", "url"}`` for the open PR on ``branch``, else None."""
+def find_pr_for_branch(branch: str, *, stdin: int | None = None) -> dict | None:
+    """Return ``{"pr_number", "url"}`` for the open PR on ``branch``, else None.
+
+    ``stdin`` is forwarded to :func:`run` — ``context.py`` passes
+    ``subprocess.DEVNULL`` because it issues this call concurrently with a
+    second ``gh`` child. Default ``None`` leaves every other caller's
+    behaviour untouched.
+    """
     result = run_gh(
         ["pr", "list", "--head", branch, "--json", "number,url,state"],
         check=False,
+        stdin=stdin,
     )
     if result.returncode != 0:
         return None

--- a/tests/qs/test_context.py
+++ b/tests/qs/test_context.py
@@ -10,8 +10,12 @@ behavioural contract of the overlap itself:
 - :func:`test_gh_calls_run_concurrently` (the barrier proof)
 - the ``title-raises`` case of :func:`test_gh_failure_paths` (delta 1)
 - :func:`test_local_git_failure_surfaces_sibling_gh_error`,
-  :func:`test_both_gh_calls_raising_surfaces_both` and
-  :func:`test_base_exception_in_worker_still_drains_sibling`
+  :func:`test_both_gh_calls_raising_surfaces_both`,
+  :func:`test_base_exception_in_worker_still_drains_sibling` and
+  :func:`test_pr_only_failure_propagates_without_a_note`
+- :func:`test_caller_side_interrupt_is_not_settled_as_a_worker_outcome` —
+  the one case that drives a helper directly rather than ``main()``; see
+  its docstring for why
 - :func:`test_parallel_gh_calls_get_devnull_stdin`
 
 No case count is stated on purpose — it rots (review fix #01 N5).
@@ -525,3 +529,74 @@ def test_base_exception_in_worker_still_drains_sibling(
 
     assert len(_select(recorder, GH_PR)) == 1
     assert any(GH_PR_BOOM in note for note in _notes(exc.value))
+
+
+def test_pr_only_failure_propagates_without_a_note(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A PR-only hard failure raises — the other half of the AC5 ordering.
+
+    No case reached the ``raise pr_exc`` leg: the parametrized rows never
+    raise from the PR side alone, the one ``raise_on=("pr",)`` case also
+    fails the local git work, and the both-raise case surfaces the title
+    error first. Deleting that leg would silently swallow a PR-side
+    exception and print a context with ``pr_number: null`` at exit 0 — on a
+    normal, non-interrupt path. `--cov` never measures `scripts/qs`, so the
+    gate cannot catch it; only this case can (review fix #03 D).
+    """
+    import context  # type: ignore[import-not-found]
+    import utils  # type: ignore[import-not-found]
+
+    fake_run, recorder = _make_fake_run(branch="QS_42", repo_root=tmp_path, raise_on=("pr",))
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["context.py"])
+
+    with pytest.raises(RuntimeError, match=GH_PR_BOOM) as exc:
+        context.main()
+
+    # The title call succeeded, so there is no sibling failure to note.
+    assert _notes(exc.value) == []
+    assert len(_select(recorder, GH_ISSUE)) == 1
+
+
+@pytest.mark.parametrize("worker_failed", [False, True], ids=["worker-ok", "worker-failed"])
+def test_caller_side_interrupt_is_not_settled_as_a_worker_outcome(worker_failed: bool) -> None:
+    """An interrupt hitting *our* ``result()`` wait is not the worker's outcome.
+
+    ``except BaseException`` alone cannot tell "the worker failed" from "the
+    wait we are sitting in was interrupted". Conflating them swallowed the
+    interrupt, discarded the worker's real failure, and mislabelled the
+    interrupt as ``concurrent gh call also failed: ...``. ``_settle`` must
+    re-raise instead of settling, which also makes the bogus note
+    unreachable — ``_note_sibling`` is only ever called on a *settled*
+    outcome (review fix #03 A).
+
+    This drives ``_settle`` directly rather than ``main()``, against the
+    module's convention, on purpose: the end-to-end alternative is patching
+    ``Future.result`` process-wide, which reaches far beyond the code under
+    test — the same unsoundness that made the deleted N2 tests pass against
+    broken code. A ``Future`` subclass touches nothing global. The
+    worker-origin half stays end-to-end in
+    :func:`test_base_exception_in_worker_still_drains_sibling`.
+    """
+    import context  # type: ignore[import-not-found]
+
+    class _InterruptedWait(context.Future):  # type: ignore[misc, name-defined]
+        """A future whose ``result()`` wait is interrupted at the caller."""
+
+        def result(self, timeout: float | None = None) -> object:
+            raise _Interrupt("interrupted while waiting")
+
+    future = _InterruptedWait()
+    worker_error = RuntimeError("worker's real failure")
+    if worker_failed:
+        future.set_exception(worker_error)
+    else:
+        future.set_result("worker value")
+
+    # The interrupt propagates rather than being recorded as an outcome.
+    with pytest.raises(_Interrupt, match="interrupted while waiting"):
+        context._settle(future, "default")
+
+    # And the worker's own exception was never substituted for it.
+    assert future.exception(timeout=0) is (worker_error if worker_failed else None)

--- a/tests/qs/test_context.py
+++ b/tests/qs/test_context.py
@@ -1,12 +1,20 @@
 """Tests for ``scripts/qs/context.py`` — stdout contract and gh overlap.
 
-Ten of the eleven-ish cases here are *characterization* tests: they pin
-``context.py``'s pre-change behaviour (byte-identical stdout, guard
-combinations, failure degradation) so that parallelizing the two ``gh``
-calls cannot change what agents parse. The barrier test
-(:func:`test_gh_calls_run_concurrently`) and the raising case of
-:func:`test_gh_failure_paths` are the two that only pass once the calls
-actually overlap.
+Most cases here are *characterization* tests: they pin ``context.py``'s
+pre-parallelization behaviour (byte-identical stdout, guard
+combinations, failure degradation) so that overlapping the two ``gh``
+calls cannot change what agents parse. Deliberately **not** in that set —
+these only pass once the calls actually overlap, and they are the
+behavioural contract of the overlap itself:
+
+- :func:`test_gh_calls_run_concurrently` (the barrier proof)
+- the ``title-raises`` case of :func:`test_gh_failure_paths` (delta 1)
+- :func:`test_local_git_failure_surfaces_sibling_gh_error` and
+  :func:`test_both_gh_calls_raising_surfaces_both`
+- :func:`test_parallel_gh_calls_get_devnull_stdin`
+- :func:`test_thread_exhaustion_falls_back_to_sequential`
+
+No case count is stated on purpose — it rots (review fix #01 N5).
 
 Everything patches **``utils.run`` and only ``utils.run``**: ``run_gh``
 and ``run_git`` resolve ``run`` from ``utils.__dict__`` at call time, so
@@ -25,8 +33,9 @@ from __future__ import annotations
 import json
 import subprocess
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
+from typing import Literal, NamedTuple
 
 import pytest
 
@@ -37,6 +46,18 @@ GIT_BRANCH = ["git", "branch", "--show-current"]
 GIT_ROOT = ["git", "rev-parse", "--show-toplevel"]
 GH_ISSUE = ["gh", "issue", "view"]
 GH_PR = ["gh", "pr", "list"]
+
+GH_ISSUE_BOOM = "boom: gh issue view"
+GH_PR_BOOM = "boom: gh pr list"
+
+RaiseTarget = Literal["issue", "pr"]
+
+
+class _Call(NamedTuple):
+    """One recorded ``utils.run`` invocation."""
+
+    cmd: list[str]
+    stdin: int | None
 
 
 def _completed(cmd: list[str], stdout: str, returncode: int = 0) -> subprocess.CompletedProcess[str]:
@@ -51,9 +72,10 @@ def _make_fake_run(
     title: str = "Fake title",
     gh_rc: dict[str, int] | None = None,
     barrier: threading.Barrier | None = None,
-    raise_on: str | None = None,
-) -> tuple[Callable[..., subprocess.CompletedProcess[str]], list[list[str]], threading.Lock]:
-    """Return ``(fake_run, recorder, lock)`` matching ``utils.run``'s signature.
+    raise_on: Sequence[RaiseTarget] = (),
+    git_root_fails: bool = False,
+) -> tuple[Callable[..., subprocess.CompletedProcess[str]], list[_Call]]:
+    """Return ``(fake_run, recorder)`` matching ``utils.run``'s signature.
 
     Dispatch is on ``cmd[:3]``: the issue number sits at index 3 and the
     branch at index 4, so the first three tokens discriminate all four
@@ -64,12 +86,24 @@ def _make_fake_run(
     issues ``git`` concurrently too, so an ungated barrier would be
     satisfied by git+gh and stop discriminating serial from parallel.
 
+    ``raise_on`` is a *sequence* of targets rather than a single value
+    (review fix #01 N4): both targets are honoured — a silent no-op for
+    ``"pr"`` is what blocked the "both raise" case — and a sequence is
+    what lets one case raise from both. Unsupported values assert rather
+    than no-op. ``git_root_fails`` makes ``git rev-parse --show-toplevel``
+    raise ``CalledProcessError`` the way ``check=True`` would, which is
+    how the local git work is failed while both ``gh`` futures are in
+    flight.
+
     The recorder is written from both pool workers and the main thread, so
-    it is guarded by ``lock``; all assertions on it must be
+    it is guarded by an internal lock; all assertions on it must be
     order-independent.
     """
+    assert not isinstance(raise_on, str), "raise_on takes a sequence, e.g. ('issue',)"
+    unsupported = set(raise_on) - {"issue", "pr"}
+    assert not unsupported, f"unsupported raise_on target(s): {sorted(unsupported)}"
     codes = gh_rc or {}
-    recorder: list[list[str]] = []
+    recorder: list[_Call] = []
     lock = threading.Lock()
 
     def fake_run(
@@ -78,30 +112,40 @@ def _make_fake_run(
         check: bool = True,
         capture: bool = True,
         cwd: str | None = None,
+        stdin: int | None = None,
     ) -> subprocess.CompletedProcess[str]:
         with lock:
-            recorder.append(list(cmd))
+            recorder.append(_Call(list(cmd), stdin))
         head = cmd[:3]
         if head == GIT_BRANCH:
             return _completed(cmd, f"{branch}\n" if branch else "")
         if head == GIT_ROOT:
+            if git_root_fails:
+                raise subprocess.CalledProcessError(128, cmd)
             return _completed(cmd, f"{repo_root}\n")
         if barrier is not None and cmd[0] == "gh":
             barrier.wait()
         if head == GH_ISSUE:
-            if raise_on == "issue":
-                raise RuntimeError("boom: gh issue view")
+            if "issue" in raise_on:
+                raise RuntimeError(GH_ISSUE_BOOM)
             return _completed(cmd, f"{title}\n", returncode=codes.get("issue", 0))
         if head == GH_PR:
+            if "pr" in raise_on:
+                raise RuntimeError(GH_PR_BOOM)
             return _completed(cmd, PR_JSON, returncode=codes.get("pr", 0))
         raise AssertionError(f"unexpected command: {cmd}")
 
-    return fake_run, recorder, lock
+    return fake_run, recorder
 
 
-def _select(recorder: list[list[str]], prefix: list[str]) -> list[list[str]]:
-    """Return every recorded command whose first three tokens match ``prefix``."""
-    return [cmd for cmd in recorder if cmd[:3] == prefix]
+def _select(recorder: list[_Call], prefix: list[str]) -> list[_Call]:
+    """Return every recorded call whose first three tokens match ``prefix``."""
+    return [call for call in recorder if call.cmd[:3] == prefix]
+
+
+def _notes(exc: BaseException) -> list[str]:
+    """Return an exception's ``__notes__`` (absent until one is added)."""
+    return list(getattr(exc, "__notes__", []))
 
 
 def _run_main(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> None:
@@ -137,15 +181,26 @@ def test_stdout_is_byte_identical(
     capsys: pytest.CaptureFixture[str],
     with_story: bool,
 ) -> None:
-    """stdout equals ``json.dumps(expected, indent=2) + "\\n"``, key order included."""
+    """stdout equals ``json.dumps(expected, indent=2) + "\\n"``, key order included.
+
+    The ``with-story`` case also writes **two** review-fix files so the
+    truthy branch of ``latest_review_fix`` and ``find_latest_review_fix``'s
+    ``sorted(...)[-1]`` newest-wins selection are both reached through
+    ``main()`` — without it, that key is only ever asserted as ``""``
+    (review fix #01 S3).
+    """
     import utils  # type: ignore[import-not-found]
 
-    story = tmp_path / "docs" / "stories" / "QS-42.story.md"
+    stories = tmp_path / "docs" / "stories"
+    story = stories / "QS-42.story.md"
+    review_fix = stories / "QS-42.story_review_fix_#02.md"
     if with_story:
-        story.parent.mkdir(parents=True)
+        stories.mkdir(parents=True)
         story.write_text("# story\n")
+        (stories / "QS-42.story_review_fix_#01.md").write_text("# fix 1\n")
+        review_fix.write_text("# fix 2\n")
 
-    fake_run, _recorder, _lock = _make_fake_run(branch="QS_42", repo_root=tmp_path)
+    fake_run, _recorder = _make_fake_run(branch="QS_42", repo_root=tmp_path)
     monkeypatch.setattr(utils, "run", fake_run)
 
     _run_main(monkeypatch, [])
@@ -157,7 +212,7 @@ def test_stdout_is_byte_identical(
         "title": "Fake title",
         "story_file": str(story) if with_story else "",
         "story_exists": with_story,
-        "latest_review_fix": "",
+        "latest_review_fix": str(review_fix) if with_story else "",
         "pr_number": 7,
         "pr_url": PR_URL,
         "worktree": str(tmp_path),
@@ -184,9 +239,7 @@ def test_gh_calls_run_concurrently(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     import utils  # type: ignore[import-not-found]
 
     barrier = threading.Barrier(2, timeout=5)
-    fake_run, recorder, _lock = _make_fake_run(
-        branch="QS_42", repo_root=tmp_path, barrier=barrier
-    )
+    fake_run, recorder = _make_fake_run(branch="QS_42", repo_root=tmp_path, barrier=barrier)
     monkeypatch.setattr(utils, "run", fake_run)
 
     _run_main(monkeypatch, [])
@@ -196,19 +249,45 @@ def test_gh_calls_run_concurrently(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     assert len(_select(recorder, GH_PR)) == 1
 
 
+def test_parallel_gh_calls_get_devnull_stdin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Concurrent ``gh`` children must not share the caller's stdin.
+
+    Serialized, at most one ``gh`` could ever prompt for auth; overlapped,
+    two children inheriting the same TTY can prompt at once and garble
+    input. Both submissions pass ``subprocess.DEVNULL`` — scoped to this
+    call site, so ``utils.run``'s default (inherit) is unchanged for every
+    other caller (review fix #01 S2).
+    """
+    import utils  # type: ignore[import-not-found]
+
+    fake_run, recorder = _make_fake_run(branch="QS_42", repo_root=tmp_path)
+    monkeypatch.setattr(utils, "run", fake_run)
+
+    _run_main(monkeypatch, [])
+
+    gh_calls = _select(recorder, GH_ISSUE) + _select(recorder, GH_PR)
+    assert len(gh_calls) == 2
+    assert [call.stdin for call in gh_calls] == [subprocess.DEVNULL] * 2
+    # The local git work is not concurrent with itself; leave it alone.
+    assert all(call.stdin is None for call in _select(recorder, GIT_BRANCH))
+
+
 # ---------------------------------------------------------------------------
 # AC3 — guard combinations
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    ("argv", "branch", "want_issue_cmd", "want_pr_head", "want_branch_calls"),
+    ("argv", "branch", "want_issue", "want_issue_cmd", "want_pr_head", "want_branch_calls"),
     [
-        pytest.param([], "QS_42", "42", "QS_42", 1, id="issue-and-branch"),
-        pytest.param([], "main", None, "main", 1, id="branch-only"),
-        pytest.param([], "", None, None, 2, id="detached-head"),
-        pytest.param(["--issue", "42"], "", "42", None, 1, id="override-detached"),
-        pytest.param(["--issue", "42"], "QS_99", "42", "QS_99", 1, id="override-other-branch"),
+        pytest.param([], "QS_42", 42, "42", "QS_42", 1, id="issue-and-branch"),
+        pytest.param([], "main", None, None, "main", 1, id="branch-only"),
+        pytest.param([], "", None, None, None, 2, id="detached-head"),
+        pytest.param(["--issue", "42"], "", 42, "42", None, 1, id="override-detached"),
+        pytest.param(["--issue", "42"], "QS_99", 42, "42", "QS_99", 1, id="override-other-branch"),
+        pytest.param([], "QS_0", 0, None, "QS_0", 1, id="issue-zero-branch"),
     ],
 )
 def test_guard_combinations(
@@ -217,6 +296,7 @@ def test_guard_combinations(
     capsys: pytest.CaptureFixture[str],
     argv: list[str],
     branch: str,
+    want_issue: int | None,
     want_issue_cmd: str | None,
     want_pr_head: str | None,
     want_branch_calls: int,
@@ -225,38 +305,72 @@ def test_guard_combinations(
 
     The detached-HEAD row records **two** ``git branch --show-current``:
     ``get_issue_from_branch("")`` re-invokes ``get_current_branch()``. The
-    override rows record one — ``issue_override or ...`` short-circuits.
-    The last row is the leak check: the ``--issue`` override must not
-    reach the PR lookup.
+    override rows record one — the override short-circuits. The
+    ``override-other-branch`` row is the leak check: the ``--issue``
+    override must not reach the PR lookup.
+
+    The sixth row pins the ``issue == 0`` semantics (review fix #01 N1):
+    ``QS_0`` reports ``"issue": 0`` faithfully but is **not** a usable
+    issue number, so no ``gh issue view`` and no story lookup happen. The
+    source story said "do not add a sixth row"; N1 supersedes that.
     """
     import utils  # type: ignore[import-not-found]
 
-    fake_run, recorder, _lock = _make_fake_run(branch=branch, repo_root=tmp_path)
+    fake_run, recorder = _make_fake_run(branch=branch, repo_root=tmp_path)
     monkeypatch.setattr(utils, "run", fake_run)
 
     _run_main(monkeypatch, argv)
     ctx = json.loads(capsys.readouterr().out)
 
-    issue_cmds = _select(recorder, GH_ISSUE)
+    assert ctx["issue"] == want_issue
+
+    issue_calls = _select(recorder, GH_ISSUE)
     if want_issue_cmd is None:
-        assert issue_cmds == []
+        assert issue_calls == []
         assert ctx["title"] == ""
     else:
-        assert len(issue_cmds) == 1
-        assert want_issue_cmd in issue_cmds[0]
+        assert len(issue_calls) == 1
+        assert want_issue_cmd in issue_calls[0].cmd
         assert ctx["title"] == "Fake title"
 
-    pr_cmds = _select(recorder, GH_PR)
+    pr_calls = _select(recorder, GH_PR)
     if want_pr_head is None:
-        assert pr_cmds == []
+        assert pr_calls == []
         assert ctx["pr_number"] is None
         assert ctx["pr_url"] == ""
     else:
-        assert len(pr_cmds) == 1
-        assert pr_cmds[0][pr_cmds[0].index("--head") + 1] == want_pr_head
+        assert len(pr_calls) == 1
+        pr_cmd = pr_calls[0].cmd
+        assert pr_cmd[pr_cmd.index("--head") + 1] == want_pr_head
         assert ctx["pr_number"] == 7
 
     assert len(_select(recorder, GIT_BRANCH)) == want_branch_calls
+
+
+@pytest.mark.parametrize("raw", ["0", "-1"], ids=["zero", "negative"])
+def test_non_positive_issue_override_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, raw: str
+) -> None:
+    """``--issue 0`` / ``--issue -1`` fail at the argparse boundary.
+
+    Previously ``issue_override or ...`` silently discarded ``0`` and fell
+    back to the branch-derived issue, while ``-1`` was truthy enough to
+    issue ``gh issue view -1`` and degrade to an empty title with exit 0.
+    Both now exit 2 instead of producing a useless context
+    (review fix #01 N1).
+    """
+    import context  # type: ignore[import-not-found]
+    import utils  # type: ignore[import-not-found]
+
+    fake_run, recorder = _make_fake_run(branch="QS_42", repo_root=tmp_path)
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["context.py", "--issue", raw])
+
+    with pytest.raises(SystemExit) as exc:
+        context.main()
+
+    assert exc.value.code == 2
+    assert recorder == []
 
 
 # ---------------------------------------------------------------------------
@@ -267,10 +381,10 @@ def test_guard_combinations(
 @pytest.mark.parametrize(
     ("gh_rc", "raise_on"),
     [
-        pytest.param({"issue": 1}, None, id="title-fails"),
-        pytest.param({"pr": 1}, None, id="pr-fails"),
-        pytest.param({"issue": 1, "pr": 1}, None, id="both-fail"),
-        pytest.param(None, "issue", id="title-raises"),
+        pytest.param({"issue": 1}, (), id="title-fails"),
+        pytest.param({"pr": 1}, (), id="pr-fails"),
+        pytest.param({"issue": 1, "pr": 1}, (), id="both-fail"),
+        pytest.param(None, ("issue",), id="title-raises"),
     ],
 )
 def test_gh_failure_paths(
@@ -278,7 +392,7 @@ def test_gh_failure_paths(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     gh_rc: dict[str, int] | None,
-    raise_on: str | None,
+    raise_on: Sequence[RaiseTarget],
 ) -> None:
     """A failing ``gh`` degrades its own field; a raising one still issues both calls.
 
@@ -292,14 +406,14 @@ def test_gh_failure_paths(
     import context  # type: ignore[import-not-found]
     import utils  # type: ignore[import-not-found]
 
-    fake_run, recorder, _lock = _make_fake_run(
+    fake_run, recorder = _make_fake_run(
         branch="QS_42", repo_root=tmp_path, gh_rc=gh_rc, raise_on=raise_on
     )
     monkeypatch.setattr(utils, "run", fake_run)
     monkeypatch.setattr("sys.argv", ["context.py"])
 
-    if raise_on is not None:
-        with pytest.raises(RuntimeError, match="boom: gh issue view"):
+    if raise_on:
+        with pytest.raises(RuntimeError, match=GH_ISSUE_BOOM):
             context.main()
         assert len(_select(recorder, GH_PR)) == 1
         return
@@ -315,3 +429,114 @@ def test_gh_failure_paths(
     else:
         assert ctx["pr_number"] == 7
         assert ctx["pr_url"] == PR_URL
+
+
+def test_both_gh_calls_raising_surfaces_both(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When both ``gh`` calls raise, neither exception is silently discarded.
+
+    ``concurrent.futures`` never logs an unretrieved future exception, so
+    without draining both futures the PR failure would vanish without a
+    trace. The title error propagates (deterministic ordering) carrying
+    the sibling failure as a note (review fix #01 S1).
+    """
+    import context  # type: ignore[import-not-found]
+    import utils  # type: ignore[import-not-found]
+
+    fake_run, recorder = _make_fake_run(
+        branch="QS_42", repo_root=tmp_path, raise_on=("issue", "pr")
+    )
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["context.py"])
+
+    with pytest.raises(RuntimeError, match=GH_ISSUE_BOOM) as exc:
+        context.main()
+
+    assert len(_select(recorder, GH_ISSUE)) == 1
+    assert len(_select(recorder, GH_PR)) == 1
+    assert any(GH_PR_BOOM in note for note in _notes(exc.value))
+
+
+def test_local_git_failure_surfaces_sibling_gh_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failing local git lookup propagates without swallowing the ``gh`` error.
+
+    Reproduces the real shape: ``git branch --show-current`` succeeds while
+    ``git rev-parse --show-toplevel`` fails (rc=128 from inside a ``.git/``
+    directory, or the ``git worktree remove`` window), so ``get_repo_root()``
+    raises inside the pool block *after* both futures were submitted. The
+    git error is what surfaces; the concurrent ``gh`` failure rides along
+    as a note instead of disappearing (review fix #01 S1).
+    """
+    import context  # type: ignore[import-not-found]
+    import utils  # type: ignore[import-not-found]
+
+    fake_run, recorder = _make_fake_run(
+        branch="QS_42", repo_root=tmp_path, raise_on=("pr",), git_root_fails=True
+    )
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["context.py"])
+
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        context.main()
+
+    assert exc.value.returncode == 128
+    assert any(GH_PR_BOOM in note for note in _notes(exc.value))
+    # Both futures were in flight when the local work blew up.
+    assert len(_select(recorder, GH_ISSUE)) == 1
+    assert len(_select(recorder, GH_PR)) == 1
+
+
+def test_thread_exhaustion_falls_back_to_sequential(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``pool.submit`` raising ``RuntimeError`` degrades to inline calls.
+
+    Thread-pool creation is a failure mode the serial code never had: under
+    a low ``ulimit -u`` / pids cgroup, ``submit`` raises
+    ``RuntimeError: can't start new thread`` and every agent startup would
+    traceback. The fallback runs the same two helpers inline — slower, but
+    a full context and exit 0 (review fix #01 N2).
+    """
+    import context  # type: ignore[import-not-found]
+    import utils  # type: ignore[import-not-found]
+
+    def no_threads(self: object, fn: Callable, /, *args: object, **kwargs: object) -> object:
+        raise RuntimeError("can't start new thread")
+
+    fake_run, recorder = _make_fake_run(branch="QS_42", repo_root=tmp_path)
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr(context.ThreadPoolExecutor, "submit", no_threads)
+
+    _run_main(monkeypatch, [])
+    ctx = json.loads(capsys.readouterr().out)
+
+    assert ctx["title"] == "Fake title"
+    assert ctx["pr_number"] == 7
+    assert len(_select(recorder, GH_ISSUE)) == 1
+    assert len(_select(recorder, GH_PR)) == 1
+
+
+def test_thread_exhaustion_fallback_still_propagates_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The inline fallback keeps the raising contract identical to the pooled path."""
+    import context  # type: ignore[import-not-found]
+    import utils  # type: ignore[import-not-found]
+
+    def no_threads(self: object, fn: Callable, /, *args: object, **kwargs: object) -> object:
+        raise RuntimeError("can't start new thread")
+
+    fake_run, recorder = _make_fake_run(
+        branch="QS_42", repo_root=tmp_path, raise_on=("issue",)
+    )
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr(context.ThreadPoolExecutor, "submit", no_threads)
+    monkeypatch.setattr("sys.argv", ["context.py"])
+
+    with pytest.raises(RuntimeError, match=GH_ISSUE_BOOM):
+        context.main()
+
+    assert len(_select(recorder, GH_PR)) == 1

--- a/tests/qs/test_context.py
+++ b/tests/qs/test_context.py
@@ -1,0 +1,317 @@
+"""Tests for ``scripts/qs/context.py`` — stdout contract and gh overlap.
+
+Ten of the eleven-ish cases here are *characterization* tests: they pin
+``context.py``'s pre-change behaviour (byte-identical stdout, guard
+combinations, failure degradation) so that parallelizing the two ``gh``
+calls cannot change what agents parse. The barrier test
+(:func:`test_gh_calls_run_concurrently`) and the raising case of
+:func:`test_gh_failure_paths` are the two that only pass once the calls
+actually overlap.
+
+Everything patches **``utils.run`` and only ``utils.run``**: ``run_gh``
+and ``run_git`` resolve ``run`` from ``utils.__dict__`` at call time, so
+a single patch catches every subprocess. Patching ``utils.run_gh`` would
+miss ``context._issue_title`` (it holds its own reference); patching
+``context.run_gh`` would miss ``utils.find_pr_for_branch``.
+
+``context`` / ``utils`` are imported *inside* each test because
+``tests/qs/conftest.py``'s autouse ``_add_scripts_qs_to_syspath`` fixture
+inserts ``scripts/qs/`` at fixture time and purges those modules on
+teardown.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+PR_URL = "https://github.com/tmenguy/quiet-solar/pull/7"
+PR_JSON = f'[{{"number": 7, "url": "{PR_URL}", "state": "OPEN"}}]'
+
+GIT_BRANCH = ["git", "branch", "--show-current"]
+GIT_ROOT = ["git", "rev-parse", "--show-toplevel"]
+GH_ISSUE = ["gh", "issue", "view"]
+GH_PR = ["gh", "pr", "list"]
+
+
+def _completed(cmd: list[str], stdout: str, returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    """Build a ``CompletedProcess`` the way ``utils.run`` would."""
+    return subprocess.CompletedProcess(args=cmd, returncode=returncode, stdout=stdout, stderr="")
+
+
+def _make_fake_run(
+    *,
+    branch: str,
+    repo_root: Path,
+    title: str = "Fake title",
+    gh_rc: dict[str, int] | None = None,
+    barrier: threading.Barrier | None = None,
+    raise_on: str | None = None,
+) -> tuple[Callable[..., subprocess.CompletedProcess[str]], list[list[str]], threading.Lock]:
+    """Return ``(fake_run, recorder, lock)`` matching ``utils.run``'s signature.
+
+    Dispatch is on ``cmd[:3]``: the issue number sits at index 3 and the
+    branch at index 4, so the first three tokens discriminate all four
+    command shapes. ``gh_rc`` maps ``"issue"`` / ``"pr"`` to a return code
+    (non-zero only ever for ``gh`` — the fake ignores ``check``, so a
+    non-zero ``git`` response would silently return fake stdout instead of
+    raising). ``barrier`` gates **only** ``gh`` commands: the pool block
+    issues ``git`` concurrently too, so an ungated barrier would be
+    satisfied by git+gh and stop discriminating serial from parallel.
+
+    The recorder is written from both pool workers and the main thread, so
+    it is guarded by ``lock``; all assertions on it must be
+    order-independent.
+    """
+    codes = gh_rc or {}
+    recorder: list[list[str]] = []
+    lock = threading.Lock()
+
+    def fake_run(
+        cmd: list[str],
+        *,
+        check: bool = True,
+        capture: bool = True,
+        cwd: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        with lock:
+            recorder.append(list(cmd))
+        head = cmd[:3]
+        if head == GIT_BRANCH:
+            return _completed(cmd, f"{branch}\n" if branch else "")
+        if head == GIT_ROOT:
+            return _completed(cmd, f"{repo_root}\n")
+        if barrier is not None and cmd[0] == "gh":
+            barrier.wait()
+        if head == GH_ISSUE:
+            if raise_on == "issue":
+                raise RuntimeError("boom: gh issue view")
+            return _completed(cmd, f"{title}\n", returncode=codes.get("issue", 0))
+        if head == GH_PR:
+            return _completed(cmd, PR_JSON, returncode=codes.get("pr", 0))
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    return fake_run, recorder, lock
+
+
+def _select(recorder: list[list[str]], prefix: list[str]) -> list[list[str]]:
+    """Return every recorded command whose first three tokens match ``prefix``."""
+    return [cmd for cmd in recorder if cmd[:3] == prefix]
+
+
+def _run_main(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> None:
+    """Drive ``context.main()`` under ``argv``; the caller reads stdout via capsys.
+
+    ``sys.argv`` must be set explicitly — otherwise ``parse_args()``
+    consumes pytest's own argv and exits 2. ``main()`` always ends in
+    ``sys.exit(0)`` on success, so the caller asserts on the exit code.
+    """
+    import context  # type: ignore[import-not-found]
+
+    monkeypatch.setattr("sys.argv", ["context.py", *argv])
+    with pytest.raises(SystemExit) as exc:
+        context.main()
+    assert exc.value.code == 0
+
+
+@pytest.fixture(autouse=True)
+def _claude_code_harness(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin ``detect()`` to ``claude-code`` — it honours ``QS_HARNESS`` first."""
+    monkeypatch.setenv("QS_HARNESS", "claude-code")
+
+
+# ---------------------------------------------------------------------------
+# AC1 — stdout is byte-identical
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("with_story", [False, True], ids=["no-story", "with-story"])
+def test_stdout_is_byte_identical(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    with_story: bool,
+) -> None:
+    """stdout equals ``json.dumps(expected, indent=2) + "\\n"``, key order included."""
+    import utils  # type: ignore[import-not-found]
+
+    story = tmp_path / "docs" / "stories" / "QS-42.story.md"
+    if with_story:
+        story.parent.mkdir(parents=True)
+        story.write_text("# story\n")
+
+    fake_run, _recorder, _lock = _make_fake_run(branch="QS_42", repo_root=tmp_path)
+    monkeypatch.setattr(utils, "run", fake_run)
+
+    _run_main(monkeypatch, [])
+
+    expected = {
+        "harness": "claude-code",
+        "branch": "QS_42",
+        "issue": 42,
+        "title": "Fake title",
+        "story_file": str(story) if with_story else "",
+        "story_exists": with_story,
+        "latest_review_fix": "",
+        "pr_number": 7,
+        "pr_url": PR_URL,
+        "worktree": str(tmp_path),
+    }
+    assert capsys.readouterr().out == json.dumps(expected, indent=2) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# AC2 — the two gh calls overlap
+# ---------------------------------------------------------------------------
+
+
+def test_gh_calls_run_concurrently(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Both ``gh`` calls must be in flight at once.
+
+    Timing-bounded, not deterministic: against serial code the first
+    ``gh`` call's ``barrier.wait()`` raises ``BrokenBarrierError`` after
+    the 5s timeout (uncaught by ``_issue_title`` or ``build_context``), so
+    a RED run costs >=5s wall — that is the timeout, not a hang.
+
+    *If the two calls are ever merged into one request, delete this test —
+    do not "fix" it.*
+    """
+    import utils  # type: ignore[import-not-found]
+
+    barrier = threading.Barrier(2, timeout=5)
+    fake_run, recorder, _lock = _make_fake_run(
+        branch="QS_42", repo_root=tmp_path, barrier=barrier
+    )
+    monkeypatch.setattr(utils, "run", fake_run)
+
+    _run_main(monkeypatch, [])
+
+    assert not barrier.broken
+    assert len(_select(recorder, GH_ISSUE)) == 1
+    assert len(_select(recorder, GH_PR)) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC3 — guard combinations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("argv", "branch", "want_issue_cmd", "want_pr_head", "want_branch_calls"),
+    [
+        pytest.param([], "QS_42", "42", "QS_42", 1, id="issue-and-branch"),
+        pytest.param([], "main", None, "main", 1, id="branch-only"),
+        pytest.param([], "", None, None, 2, id="detached-head"),
+        pytest.param(["--issue", "42"], "", "42", None, 1, id="override-detached"),
+        pytest.param(["--issue", "42"], "QS_99", "42", "QS_99", 1, id="override-other-branch"),
+    ],
+)
+def test_guard_combinations(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    argv: list[str],
+    branch: str,
+    want_issue_cmd: str | None,
+    want_pr_head: str | None,
+    want_branch_calls: int,
+) -> None:
+    """Each guard combination issues exactly the ``gh`` calls it should.
+
+    The detached-HEAD row records **two** ``git branch --show-current``:
+    ``get_issue_from_branch("")`` re-invokes ``get_current_branch()``. The
+    override rows record one — ``issue_override or ...`` short-circuits.
+    The last row is the leak check: the ``--issue`` override must not
+    reach the PR lookup.
+    """
+    import utils  # type: ignore[import-not-found]
+
+    fake_run, recorder, _lock = _make_fake_run(branch=branch, repo_root=tmp_path)
+    monkeypatch.setattr(utils, "run", fake_run)
+
+    _run_main(monkeypatch, argv)
+    ctx = json.loads(capsys.readouterr().out)
+
+    issue_cmds = _select(recorder, GH_ISSUE)
+    if want_issue_cmd is None:
+        assert issue_cmds == []
+        assert ctx["title"] == ""
+    else:
+        assert len(issue_cmds) == 1
+        assert want_issue_cmd in issue_cmds[0]
+        assert ctx["title"] == "Fake title"
+
+    pr_cmds = _select(recorder, GH_PR)
+    if want_pr_head is None:
+        assert pr_cmds == []
+        assert ctx["pr_number"] is None
+        assert ctx["pr_url"] == ""
+    else:
+        assert len(pr_cmds) == 1
+        assert pr_cmds[0][pr_cmds[0].index("--head") + 1] == want_pr_head
+        assert ctx["pr_number"] == 7
+
+    assert len(_select(recorder, GIT_BRANCH)) == want_branch_calls
+
+
+# ---------------------------------------------------------------------------
+# AC4 — failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("gh_rc", "raise_on"),
+    [
+        pytest.param({"issue": 1}, None, id="title-fails"),
+        pytest.param({"pr": 1}, None, id="pr-fails"),
+        pytest.param({"issue": 1, "pr": 1}, None, id="both-fail"),
+        pytest.param(None, "issue", id="title-raises"),
+    ],
+)
+def test_gh_failure_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    gh_rc: dict[str, int] | None,
+    raise_on: str | None,
+) -> None:
+    """A failing ``gh`` degrades its own field; a raising one still issues both calls.
+
+    ``run_gh`` passes ``check=False`` and ``_issue_title`` only inspects
+    ``returncode``, so a non-zero exit never raises — exit stays 0 and the
+    affected field degrades. The raising case is the only construction
+    that pins behavioural delta 1 (both calls always execute): the
+    ``returncode=1`` cases cannot, because serial code records both
+    commands too.
+    """
+    import context  # type: ignore[import-not-found]
+    import utils  # type: ignore[import-not-found]
+
+    fake_run, recorder, _lock = _make_fake_run(
+        branch="QS_42", repo_root=tmp_path, gh_rc=gh_rc, raise_on=raise_on
+    )
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["context.py"])
+
+    if raise_on is not None:
+        with pytest.raises(RuntimeError, match="boom: gh issue view"):
+            context.main()
+        assert len(_select(recorder, GH_PR)) == 1
+        return
+
+    _run_main(monkeypatch, [])
+    ctx = json.loads(capsys.readouterr().out)
+
+    codes = gh_rc or {}
+    assert ctx["title"] == ("" if codes.get("issue") else "Fake title")
+    if codes.get("pr"):
+        assert ctx["pr_number"] is None
+        assert ctx["pr_url"] == ""
+    else:
+        assert ctx["pr_number"] == 7
+        assert ctx["pr_url"] == PR_URL

--- a/tests/qs/test_context.py
+++ b/tests/qs/test_context.py
@@ -9,10 +9,10 @@ behavioural contract of the overlap itself:
 
 - :func:`test_gh_calls_run_concurrently` (the barrier proof)
 - the ``title-raises`` case of :func:`test_gh_failure_paths` (delta 1)
-- :func:`test_local_git_failure_surfaces_sibling_gh_error` and
-  :func:`test_both_gh_calls_raising_surfaces_both`
+- :func:`test_local_git_failure_surfaces_sibling_gh_error`,
+  :func:`test_both_gh_calls_raising_surfaces_both` and
+  :func:`test_base_exception_in_worker_still_drains_sibling`
 - :func:`test_parallel_gh_calls_get_devnull_stdin`
-- :func:`test_thread_exhaustion_falls_back_to_sequential`
 
 No case count is stated on purpose — it rots (review fix #01 N5).
 
@@ -53,6 +53,15 @@ GH_PR_BOOM = "boom: gh pr list"
 RaiseTarget = Literal["issue", "pr"]
 
 
+class _Interrupt(BaseException):
+    """A ``BaseException`` that is *not* an ``Exception`` (review fix #02 R1).
+
+    Stands in for the real ones a worker can surface —
+    ``KeyboardInterrupt`` from a SIGINT delivered to the process alone, or
+    ``SystemExit`` — without those two's side effects on the test runner.
+    """
+
+
 class _Call(NamedTuple):
     """One recorded ``utils.run`` invocation."""
 
@@ -73,6 +82,7 @@ def _make_fake_run(
     gh_rc: dict[str, int] | None = None,
     barrier: threading.Barrier | None = None,
     raise_on: Sequence[RaiseTarget] = (),
+    raise_cls: type[BaseException] = RuntimeError,
     git_root_fails: bool = False,
 ) -> tuple[Callable[..., subprocess.CompletedProcess[str]], list[_Call]]:
     """Return ``(fake_run, recorder)`` matching ``utils.run``'s signature.
@@ -90,7 +100,8 @@ def _make_fake_run(
     (review fix #01 N4): both targets are honoured — a silent no-op for
     ``"pr"`` is what blocked the "both raise" case — and a sequence is
     what lets one case raise from both. Unsupported values assert rather
-    than no-op. ``git_root_fails`` makes ``git rev-parse --show-toplevel``
+    than no-op; ``raise_cls`` picks the class they raise, defaulting to
+    ``RuntimeError``. ``git_root_fails`` makes ``git rev-parse --show-toplevel``
     raise ``CalledProcessError`` the way ``check=True`` would, which is
     how the local git work is failed while both ``gh`` futures are in
     flight.
@@ -127,11 +138,11 @@ def _make_fake_run(
             barrier.wait()
         if head == GH_ISSUE:
             if "issue" in raise_on:
-                raise RuntimeError(GH_ISSUE_BOOM)
+                raise raise_cls(GH_ISSUE_BOOM)
             return _completed(cmd, f"{title}\n", returncode=codes.get("issue", 0))
         if head == GH_PR:
             if "pr" in raise_on:
-                raise RuntimeError(GH_PR_BOOM)
+                raise raise_cls(GH_PR_BOOM)
             return _completed(cmd, PR_JSON, returncode=codes.get("pr", 0))
         raise AssertionError(f"unexpected command: {cmd}")
 
@@ -489,54 +500,28 @@ def test_local_git_failure_surfaces_sibling_gh_error(
     assert len(_select(recorder, GH_PR)) == 1
 
 
-def test_thread_exhaustion_falls_back_to_sequential(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+def test_base_exception_in_worker_still_drains_sibling(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """``pool.submit`` raising ``RuntimeError`` degrades to inline calls.
+    """A ``BaseException`` from a worker must not skip the drain.
 
-    Thread-pool creation is a failure mode the serial code never had: under
-    a low ``ulimit -u`` / pids cgroup, ``submit`` raises
-    ``RuntimeError: can't start new thread`` and every agent startup would
-    traceback. The fallback runs the same two helpers inline — slower, but
-    a full context and exit 0 (review fix #01 N2).
+    ``ThreadPoolExecutor`` catches ``BaseException`` in its work item and
+    hands it to the future, so ``future.result()`` can re-raise one. Under
+    an ``except Exception`` drain that escape route bypasses the sibling
+    retrieval and silently discards the other failure — the S1 hole,
+    reopened on a narrow path (review fix #02 R1).
     """
     import context  # type: ignore[import-not-found]
     import utils  # type: ignore[import-not-found]
 
-    def no_threads(self: object, fn: Callable, /, *args: object, **kwargs: object) -> object:
-        raise RuntimeError("can't start new thread")
-
-    fake_run, recorder = _make_fake_run(branch="QS_42", repo_root=tmp_path)
-    monkeypatch.setattr(utils, "run", fake_run)
-    monkeypatch.setattr(context.ThreadPoolExecutor, "submit", no_threads)
-
-    _run_main(monkeypatch, [])
-    ctx = json.loads(capsys.readouterr().out)
-
-    assert ctx["title"] == "Fake title"
-    assert ctx["pr_number"] == 7
-    assert len(_select(recorder, GH_ISSUE)) == 1
-    assert len(_select(recorder, GH_PR)) == 1
-
-
-def test_thread_exhaustion_fallback_still_propagates_failures(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """The inline fallback keeps the raising contract identical to the pooled path."""
-    import context  # type: ignore[import-not-found]
-    import utils  # type: ignore[import-not-found]
-
-    def no_threads(self: object, fn: Callable, /, *args: object, **kwargs: object) -> object:
-        raise RuntimeError("can't start new thread")
-
     fake_run, recorder = _make_fake_run(
-        branch="QS_42", repo_root=tmp_path, raise_on=("issue",)
+        branch="QS_42", repo_root=tmp_path, raise_on=("issue", "pr"), raise_cls=_Interrupt
     )
     monkeypatch.setattr(utils, "run", fake_run)
-    monkeypatch.setattr(context.ThreadPoolExecutor, "submit", no_threads)
     monkeypatch.setattr("sys.argv", ["context.py"])
 
-    with pytest.raises(RuntimeError, match=GH_ISSUE_BOOM):
+    with pytest.raises(_Interrupt, match=GH_ISSUE_BOOM) as exc:
         context.main()
 
     assert len(_select(recorder, GH_PR)) == 1
+    assert any(GH_PR_BOOM in note for note in _notes(exc.value))


### PR DESCRIPTION
## Summary

- `build_context` overlaps its two independent `gh` calls (`gh issue view` for the title, `gh pr list` for the PR) in a two-worker `ThreadPoolExecutor`; the two local story lookups moved inside the block so their `git` work runs under the overlap. The `return` dict is untouched — stdout is byte-identical for identical repo state.
- `tests/qs/test_context.py` (new), patching **`utils.run` only**, hermetic against `tmp_path` (faked `rev-parse`). Covers AC1 byte-identical stdout, AC2 the barrier-based overlap proof, AC3 the guard matrix, AC4 failure paths, and AC5–AC7 added by review round 1. (No counts stated — they went stale in three consecutive rounds; read the file.)
- **Measured against the code actually shipping** (10 runs, 1.2s spacing, the story's baseline protocol): **median 1.022s → 0.559s** (min 0.500, max 0.748) — **~0.46s / ~45% off every agent startup**.

This body describes the **final** state after four review rounds; it is the durable evidence for the whole change after squashing.

## ⚠️ Review coverage gap — CodeRabbit has never reviewed this PR

**No commit on this PR was ever reviewed by CodeRabbit** — zero reviews and zero inline comments across six attempts in four rounds, so all four rounds ran **3 of 4 reviewers**. The diagnosis (established in round 3) is two independent blockers: a stuck incremental state, where a plain `@coderabbitai review` returns a 4–5s silent skip and has never submitted a review object on this PR; and an exhausted Fair-Usage budget gating `full review`. A check 4h17m past the stated window expiry still got the instant skip, so **waiting does not fix it** — it is a billing/state matter, not a cooldown. Do not read the absence of CodeRabbit findings as agreement. Its only substantive output was rating the change *effort 4 (Complex), ~45 min* and flagging #297 as a possibly-related PR touching `context.py` latency behaviour.

## Behavioural deltas

1. **Both `gh` calls always execute.** Previously a hard raise in `_issue_title` meant `find_pr_for_branch` never ran. One extra request on a path that already failed.
2. **The error path can block.** `shutdown(wait=True)` joins the other subprocess. `utils.run` sets no timeout, so a hung `gh` already hangs `context.py` today; this adds a second path to a pre-existing hang (#295). Observed live once during benchmarking: a single run took **173s** on a stalled `gh`. That is #295, not this change — but the overlap widens the window.
3. **Tracebacks gain executor frames**, plus an `add_note` line when a concurrent call also failed. Exception type and exit code unchanged.
4. **`--issue 0` / `--issue -1` now exit 2** instead of producing a context. Previously `0` was silently discarded in favour of the branch-derived issue, and `-1` was truthy enough to issue a doomed `gh issue view -1` and degrade to an empty title at exit 0. **In-repo blast radius is nil**: of 48 references to `context.py` in the repo, not one passes `--issue` (grep-verified; the only occurrence is in this PR's own test). A `QS_0` branch still reports `"issue": 0` faithfully, but makes no `gh` call.
5. **Shared-helper API addition:** `utils.run` and `find_pr_for_branch` gained an opt-in `stdin` parameter, forwarded to `subprocess.run`. The `stdin=None` default is exactly today's behaviour (inherit), so **every existing caller is byte-identical** — `tests/test_qs_utils.py` 32 passed. Only `context.py`'s two concurrent submissions pass `subprocess.DEVNULL`, so two children cannot race for the same TTY on an auth prompt.

`shutdown(wait=True)` is deliberate and commented in the source — it joins the sibling future rather than abandoning a live subprocess. Do not "fix" it with `cancel_futures=True`.

## Review round 1 (fix plan #01 — 4 should-fix, 6 nice-to-have)

- **S1** both futures are drained before anything propagates (`concurrent.futures` never logs an unretrieved future exception); a failure in the local git work is the primary error, otherwise title-then-PR, with the sibling failure attached via `add_note`.
- **S2** the `stdin` plumbing above. **S3** `latest_review_fix` pinned in its truthy form, including the `sorted(...)[-1]` newest-wins selection. **S4** story counts corrected.
- **N1** the `--issue` semantics above. **N3/N4/N5/N6** test-harness and docstring cleanups.

## Review round 2 (fix plan #02 — 2 must-fix, 5 should-fix)

- **M1 — a fix from round 1 was reverted.** Round 1's N2 added a "degrade to an inline call when `pool.submit` raises `RuntimeError`" fallback. It was **unsound**: CPython's `submit` does `_work_queue.put(w)` *before* the `_adjust_thread_count()` → `Thread.start()` that raises, so `except RuntimeError` cannot un-queue the work item and any idle worker drains it **on top of** the inline call — a duplicate `gh` request, a `shutdown(wait=True)` slower than the serial code it replaced, and an abandoned future whose exception is silently discarded (breaking S1's own invariant). Its two tests could not catch it: they monkeypatched `ThreadPoolExecutor.submit` wholesale, so the real queue side effect never happened and they **passed against broken code**. `_submit` and both tests are deleted; thread-pool exhaustion is now an **accepted risk** in the story's risk table (a process already out of threads is an environment failure), alongside `EMFILE`/fd exhaustion, which is likewise not degraded.
- **R1** `_settle` and the local-git drain catch `BaseException`, not `Exception`, so a worker's `BaseException` cannot skip the drain. Whether `quality_gate.py::_run_cheap_gates_parallel` deserves the same treatment is a deliberate **follow-up, not this PR** — filed in round 3 as #329.
- **R2/R4/R5** story bookkeeping: case counts dropped rather than re-pinned (they rotted twice), N1's STOP-trigger evaluation recorded, and AC5–AC7 promoted from prose so the tests trace to criteria. **R3** the re-measurement quoted above.

## TDD evidence

Each round's RED run, recorded because the commits will squash:

| Round | RED | GREEN |
|---|---|---|
| Initial | `10 passed, 2 failed` — barrier test + `title-raises` (RED by construction: it pins delta 1, which serial code cannot satisfy) | `12 passed` |
| Fix #01 | `13 passed, 7 failed` | `20 passed` |
| Fix #02 | `18 passed, 1 failed` — the `BaseException` drain test, verified against the old `except Exception` before fixing | `19 passed` |

Gates, final: `--quick tests/qs` 704 passed · `tests/test_qs_utils.py` 32 passed · `--impacted` PASS (diff base `origin/main` printed, tests actually ran) · `check_doc_drift.py` exit 0.

## Review round 3 (fix plan #03 — narrow: 2 must-fix, 4 should-fix, all 8 nice-to-haves deferred)

Round 2's `BaseException` widening turned out to have its own defect, and round 3 was scoped in advance to the minimum that closes the invariant.

- **A (must-fix)** — `except BaseException` could not distinguish *the worker failed* from *our own `future.result()` wait was interrupted*. A SIGINT mid-wait was swallowed, the worker's real exception discarded, and the interrupt mislabelled as `concurrent gh call also failed: KeyboardInterrupt()` (repro: 7 consecutive SIGINTs absorbed, nothing abortable). `_settle` now re-raises when `not future.done() or future.exception(timeout=0) is not exc`. The acceptance-auditor's round-2 dissent against the widening was correct; fixed forward rather than reverted, since reverting restores the original narrower hole.
- **C (should-fix)** — the second `pool.submit` moved inside the `try`, so the existing drain covers it: previously, if it raised (thread exhaustion) or an interrupt landed between the two submits, `title_future` was already in flight and never settled. Statement move only; `stdin=DEVNULL` preserved. **Reasoned but unpinned** — the only available test technique is the wholesale `submit` patch that made the deleted N2 tests unsound.
- **D (should-fix)** — `raise pr_exc` was the module's only unexecuted statement and no test reached it; `--cov` never measures `scripts/qs`, so the gate could not catch it. Now pinned. Green on arrival: a coverage pin, not a defect fix.
- **B/E/F (bookkeeping)** — stale counts **deleted** rather than corrected a third time (with the mandated sweep); the story's Design snippet, still showing round-1 code, deleted in favour of pointing at the source; the declared `quality_gate.py` follow-up filed as #329, carrying A's guard shape so it cannot repeat this mistake.

**Test-technique note.** A's first draft patched `Future.result` process-wide and wedged `--impacted` (46 min at 0.4% CPU): with the HA suite in-process, a lingering executor thread calling `result()` inside the patch window takes the test's interrupt. Replaced with a `Future` subclass driving `_settle` directly — the one case in the file that does not go through `main()`.

**No re-measurement:** A adds two predicates on an error path, C moves a statement. Neither touches the hot path; the 0.559s median stands.

## Review round 4 (fix plan #04 — documentation only)

**0 must-fix.** Round 4's three reviewers closed the code: every `Future` state at `_settle`'s `except` was enumerated and driven through on 3.14.3, and coverage of `scripts/qs/context.py` leaves only the `__main__` guard unexecuted. The four findings were all prose, and applying them changed **no executable line** — the sole `context.py` edit is comment text (`git diff` verified comments-only):

- AC5 cited a test name that no longer existed (renamed in round 3).
- AC5's "both futures are drained" was overstated: since round 3's finding A a caller-side interrupt re-raises immediately, so the sibling may go unretrieved. Narrowed to worker failures on non-interrupt paths. **The behaviour was deliberately left alone** — the interrupt must win, `__context__` still chains the local failure, and 2 of 3 reviewers plus round 3's stop rule settled it. The blind-hunter's `try`/`finally`-per-future alternative reviews the diff only and could not know the trade was chosen.
- The same overstatement in a `context.py` comment ("an interrupt lands between the two" submits) — the title submit executes before the `try`, so that window is not covered. Comment narrowed to what the `try` actually covers.
- One accurate-but-unscoped count ("Four cases") removed, per the round-3 rule that this PR's most persistent defect class is hand-written counts.

## Doc maintenance

`check_doc_drift.py` exits 0, but that green is **not evidence**: its `TRACKED_PREFIX` is `custom_components/quiet_solar/`, so it is structurally blind to `scripts/qs/` (#294 owns widening it). Swept manually instead: no `docs/agents/**` `covers:` entry names `context.py` or `utils.py`; `docs/workflow/**`, the agent files and `.claude/settings.json` reference only the invocation string, which is unchanged. No `.<harness>/agents/*.md` changes, so harness sync is not triggered.

Fixes #291


