### PR TITLE
QS-320: Phantom ack — a button press that replaces the command slot mid-await can confirm a command that was never executed

### DIFF
--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -202,6 +202,11 @@ class AbstractDevice:
         # can clear them — that wipe destroys the command the clock describes.
         self.unresponsive_since: datetime | None = None
         self._last_supersede_time: datetime | None = None
+        # QS-320: the dispatch tag the post-await guards compare. NEVER reset it —
+        # not here beyond this priming, not in `reset()`, not in
+        # `constraint_reset_and_reset_commands_if_needed`, not in
+        # `abandon_running_command`. See `_install_running_command`.
+        self._running_command_generation: int = 0
         # QS-307: the per-EPISODE latch, as against `unresponsive_since`'s
         # per-command clock. Gates the shout, never the clock. See
         # `_clear_unresponsive` and `docs/agents/concepts/load-base.md`.
@@ -931,6 +936,70 @@ class AbstractDevice:
         # must not end a lost-control episode (QS-307).
         self._clear_unresponsive(reason, contact=ContactEvidence.UNKNOWN)
 
+    def _install_running_command(self, command: LoadCommand, time: datetime) -> int:
+        """Install a dispatch in the command slot and return its generation tag.
+
+        The one way in. The generation is what the post-await guards compare, so
+        bumping it here rather than at the call site is what stops a future install
+        site from silently re-opening QS-320.
+
+        NEVER reset `_running_command_generation` — not in `reset()`, not in
+        `abandon_running_command`, not anywhere. A reset lets a stale tag captured
+        before the reset compare equal to a fresh one after it, which re-opens
+        QS-320 on exactly the route this guard exists to close.
+
+        Absorb deliberately does NOT come through here: it swaps in an
+        equal-valued object for the SAME dispatch and leaves the launch stamps
+        alone, so the caller already in flight still owns its paperwork.
+        """
+        self._running_command_generation += 1
+        self.running_command = command
+        self.running_command_first_launch = time
+        self.running_command_last_launch = time
+        return self._running_command_generation
+
+    def _slot_still_holds(
+        self, launched_command: LoadCommand, launched_generation: int, site: str, ctxt: str | None = None
+    ) -> bool:
+        """Return True when the slot still holds the dispatch we launched.
+
+        QS-320: the question a post-await completion path must ask is "is the slot
+        still holding the dispatch I made?", not "is the slot empty?". #316's
+        `is None` check answered the second one, so a button press that REPLACED the
+        in-flight command mid-await sailed through it, and the resumer then stamped
+        and acked the new occupant off the *previous* command's result — a phantom ack
+        of a command no service call ever confirmed, with the load left physically
+        running and nothing to retry it.
+
+        Comparing the command value cannot work in either direction. Absorb swaps in
+        an equal-valued object for the SAME dispatch, so an identity test
+        over-triggers and skips paperwork that is genuinely ours. The
+        reset-then-reinstall route (the "clean and reset" button) installs a
+        field-identical command from a DIFFERENT dispatch, so a value test
+        under-triggers and leaves QS-320 wide open. The generation compares
+        dispatches, which is the thing that actually differs.
+
+        `launched_command` is non-`None` at all three call sites by construction —
+        each capture sits inside an existing `is not None` test — so the failure-path
+        dereference is safe. `union-attr` is disabled project-wide, so mypy would NOT
+        catch a regression here.
+        """
+        if self.running_command is not None and self._running_command_generation == launched_generation:
+            return True
+
+        # `info`, matching the two messages this replaces: rare by construction, and
+        # exactly the line an operator needs when a load misbehaves. The
+        # dropped-vs-replaced distinction is the whole subject of QS-320.
+        _LOGGER.info(
+            "%s: command %s for load %s was %s while a call to the device was in flight, ctxt: %s",
+            site,
+            launched_command.command,
+            self.name,
+            "dropped" if self.running_command is None else "replaced",
+            ctxt,
+        )
+        return False
+
     async def launch_command(self, time: datetime, command: LoadCommand, ctxt="NO CTXT"):
         if self.qs_enable_device is False:
             return
@@ -1010,9 +1079,7 @@ class AbstractDevice:
             self._last_supersede_time = time
             self.abandon_running_command(reason=f"superseded by {command.command}")
 
-        self.running_command = command
-        self.running_command_first_launch = time
-        self.running_command_last_launch = time
+        launched_generation = self._install_running_command(command, time)
 
         _LOGGER.info("launch_command: %s for this load %s), ctxt: %s", command, self.name, ctxt)
 
@@ -1047,16 +1114,10 @@ class AbstractDevice:
                 is_command_set = None
             self._anchor_causality_guard_if_executed(is_command_set, time)
 
-        if self.running_command is None:
-            # QS-307: same guard, same reason as in `force_relaunch_command`. Placed
-            # here, at 8 spaces, so it covers BOTH awaits above — the probe and the
-            # conditional execute. Do not move it inside the `else:`.
-            _LOGGER.info(
-                "launch_command: command %s for load %s was dropped while a call to the device was in flight, ctxt: %s",
-                command.command,
-                self.name,
-                ctxt,
-            )
+        if not self._slot_still_holds(command, launched_generation, "launch_command", ctxt):
+            # QS-307/QS-320: same guard, same reason as in `force_relaunch_command`.
+            # Placed here, at 8 spaces, so it covers BOTH awaits above — the probe and
+            # the conditional execute. Do not move it inside the `else:`.
             return
 
         if is_command_set is None:
@@ -1066,7 +1127,9 @@ class AbstractDevice:
             )
         elif is_command_set is True:
             _LOGGER.info("launch_command: ack command %s for this load %s), ctxt: %s", command, self.name, ctxt)
-            self._ack_command(time, self.running_command)
+            # QS-320: the local, not the slot — post-guard they are the same dispatch,
+            # and reading the slot is how the phantom ack happened
+            self._ack_command(time, command)
 
         return
 
@@ -1085,18 +1148,36 @@ class AbstractDevice:
 
         command_acked_or_good = True
 
-        if self.running_command is not None:
+        probed_command = self.running_command
+        if probed_command is not None:
+            # QS-320: this site's await is the probe, and real subclasses await genuine
+            # I/O there — `QSChargerGeneric.probe_if_command_set` awaits
+            # `_do_update_charger_state`, a real `hass.services.async_call`. So this is
+            # NOT dead code: the slot can be replaced or emptied underneath it.
+            probed_generation = self._running_command_generation
             _LOGGER.info(
-                f"check command {self.running_command.command} for this load {self.name}) (#{self.running_command_num_relaunch_after_invalid})"
+                f"check command {probed_command.command} for this load {self.name}) (#{self.running_command_num_relaunch_after_invalid})"
             )
 
-            is_command_set = await self.probe_if_command_set(time, self.running_command)
-            if is_command_set is None:
+            is_command_set = await self.probe_if_command_set(time, probed_command)
+            slot_is_ours = self._slot_still_holds(probed_command, probed_generation, "check_commands")
+            if not slot_is_ours:
+                # the probe told us nothing about whatever is in the slot now, so
+                # "not confirmed this cycle, re-check next cycle" is the safe answer.
+                # It starts no relaunch and raises no alarm by itself.
+                command_acked_or_good = False
+            # A flag rather than an `else:` wrapper or an early `return`: the wrapper
+            # would re-indent the whole body for no behaviour, and the early return
+            # would skip the stacked-promotion tail below, delaying an emptied-slot
+            # promotion by a cycle — a behaviour change on an unrelated path.
+            if slot_is_ours and is_command_set is None:
                 command_acked_or_good = False
                 # impossible to run this command for this load ...
+                # QS-320: gated deliberately — a probe about the PREVIOUS occupant must
+                # not hand its successor a strike towards the invalid-probe give-up.
                 self.running_command_num_relaunch_after_invalid += 1
                 _LOGGER.info(
-                    f"impossible to check command {self.running_command.command} for this load {self.name}) (#{self.running_command_num_relaunch_after_invalid})"
+                    f"impossible to check command {probed_command.command} for this load {self.name}) (#{self.running_command_num_relaunch_after_invalid})"
                 )
                 if self.running_command_num_relaunch_after_invalid >= NUM_MAX_INVALID_PROBES_COMMANDS:
                     # will kill completely the command ....
@@ -1106,10 +1187,12 @@ class AbstractDevice:
                     # because the device cannot be reached — see `_clear_unresponsive`.
                     self._clear_unresponsive("the probe went unavailable", contact=ContactEvidence.UNREACHABLE)
 
-            if is_command_set is True:
-                self._ack_command(time, self.running_command)
+            # Kept as a SEPARATE statement from the block above, not an `elif`: a
+            # `None` probe must still fall through here and assign `res`.
+            if slot_is_ours and is_command_set is True:
+                self._ack_command(time, probed_command)
                 command_acked_or_good = True
-            elif self.running_command_last_launch is not None:
+            elif slot_is_ours and self.running_command_last_launch is not None:
                 res = time - self.running_command_last_launch
                 command_acked_or_good = False
 
@@ -1141,16 +1224,21 @@ class AbstractDevice:
         branch of `QSBiStateDuration.check_load_activity_and_constraints` drops an
         override-aligned command, and three of that method's callers (the bistate
         mode select, the on-duration number, the reset-override button) run outside
-        the lock. So the slot CAN be emptied across an await. `launch_command` and
-        `force_relaunch_command` both hold the command they launched in a local and
-        bail out if the slot is EMPTY, rather than writing counters for, acking, or
-        dereferencing a command that is gone.
+        the lock — and so do the "mark constraint done" and "clean and reset" buttons,
+        which launch a command of their own. So the slot can be emptied OR REPLACED
+        across an await.
 
-        Scope of those guards, precisely: they cover the slot being **emptied**, not
-        **replaced**. A replaced slot passes an `is None` test, so a button press that
-        supersedes the in-flight command mid-await can still stamp its launch time or
-        ack it off the previous command's result. That is pre-existing — it behaves
-        identically on `main` — and is tracked in #320, deliberately not fixed here.
+        Scope of those guards, precisely (QS-320): the invariant is **ownership**, not
+        emptiness. A completion path writes nothing about its own dispatch's outcome
+        unless the slot still carries that dispatch's generation tag — an emptied slot
+        and a slot replaced by a newer dispatch both fail that test, and only the
+        latter passes an `is None` check. All three sites — `launch_command`,
+        `check_commands` and `force_relaunch_command` — hold the command they launched
+        in a local, capture its tag from `_install_running_command`, and consult
+        `_slot_still_holds` after their awaits before stamping, acking, counting or
+        dereferencing. Side effects that merely record that a service call physically
+        landed stay unconditional: `_anchor_causality_guard_if_executed` sits ABOVE
+        the guard on purpose.
 
         The clock is still only cleared alongside the command state it describes.
         """
@@ -1324,8 +1412,10 @@ class AbstractDevice:
                 self._drop_running_command("suppressed by user override")
                 return
 
-            # Held locally: the slot can empty across the await (see the re-check).
+            # Held locally, with its dispatch tag: the slot can be emptied OR replaced
+            # across the await (see the re-check).
             launched_command = self.running_command
+            launched_generation = self._running_command_generation
             _LOGGER.info(
                 "force launch command %s for this load %s (#%s)",
                 launched_command.command,
@@ -1350,25 +1440,21 @@ class AbstractDevice:
             # guard must know even if the slot is now empty.
             self._anchor_causality_guard_if_executed(is_command_set, time)
 
-            if self.running_command is None:
-                # QS-307: the slot emptied across the await — a user action can reach
-                # the override expiry outside `_update_loads_lock`. Everything below
-                # describes the command that is now gone, so stop.
-                _LOGGER.info(
-                    "force_relaunch_command: command %s for load %s was dropped while its service call was in flight",
-                    launched_command.command,
-                    self.name,
-                )
+            if not self._slot_still_holds(launched_command, launched_generation, "force_relaunch_command"):
+                # QS-307/QS-320: the slot was emptied or replaced across the await — a
+                # user action can reach the override expiry, or press a button, outside
+                # `_update_loads_lock`. Everything below describes the dispatch that no
+                # longer owns the slot, so stop.
                 return
 
             self.running_command_last_launch = time
             if is_command_set is None:
-                _LOGGER.info(
-                    "impossible to force command %s for this load %s)", self.running_command.command, self.name
-                )
+                _LOGGER.info("impossible to force command %s for this load %s)", launched_command.command, self.name)
             elif is_command_set is True:
-                self._ack_command(time, self.running_command)
+                self._ack_command(time, launched_command)
             else:
+                # The nested call takes its own local and tag, so it re-establishes
+                # ownership rather than inheriting ours.
                 await self.check_commands(time)
 
     async def execute_command(self, time: datetime, command: LoadCommand) -> bool | None:

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -697,9 +697,21 @@ class AbstractDevice:
         Shared by `launch_command` and `force_relaunch_command` — set ONLY
         when `execute_command` returned True (never on the probe-already-set
         branch, never in `_ack_command`).
+
+        QS-320 review fix #01/1: MONOTONIC — the anchor never moves backwards.
+        Both call sites deliberately sit ABOVE the `_slot_still_holds` ownership
+        guard (a service call physically landed, whoever owns the slot), so a
+        superseded dispatch resuming after its replacement already anchored a
+        newer instant would otherwise REWIND the causality floor — and the
+        freshness test in `check_load_activity_and_constraints` would then read a
+        state change QS itself caused as an external user override. `None` means
+        "no anchor" and accepts any value; the restore-time write and the
+        `user_clean_and_reset` clear stay plain assignments on purpose.
         """
         if is_command_set is True:
-            self.last_command_execution_time = time
+            prev = self.last_command_execution_time
+            if prev is None or time > prev:
+                self.last_command_execution_time = time
 
     def is_command_suppressed_by_override(self, time: datetime, command: LoadCommand) -> bool:
         """Return True when an active user override must swallow this command.
@@ -746,7 +758,11 @@ class AbstractDevice:
         exception: `abandon_running_command` preserves the clock and
         `launch_command` hands it to the successor on purpose, so the load keeps
         superseding instead of stacking and holds QS-304's saturated 300 s cadence.
-        Do NOT "restore the invariant" by releasing it there.
+        Do NOT "restore the invariant" by releasing it there. That exception covers
+        the *silent* hand-off only — when the device then PROVES contact (a `True`
+        result reaching a disowned-slot bail-out in `launch_command` or
+        `check_commands`), the CONFIRMED clear ends the episode for the successor
+        too; the two rules do not contradict (QS-320 review fix #01/2).
 
         So `unresponsive_since` tracks the command in flight. "Are we still in an
         unresolved lost-control EPISODE" is a different question, answered by
@@ -958,9 +974,7 @@ class AbstractDevice:
         self.running_command_last_launch = time
         return self._running_command_generation
 
-    def _slot_still_holds(
-        self, launched_command: LoadCommand, launched_generation: int, site: str, ctxt: str | None = None
-    ) -> bool:
+    def _slot_still_holds(self, launched_command_name: str, launched_generation: int, site: str, ctxt: str) -> bool:
         """Return True when the slot still holds the dispatch we launched.
 
         QS-320: the question a post-await completion path must ask is "is the slot
@@ -979,10 +993,9 @@ class AbstractDevice:
         under-triggers and leaves QS-320 wide open. The generation compares
         dispatches, which is the thing that actually differs.
 
-        `launched_command` is non-`None` at all three call sites by construction —
-        each capture sits inside an existing `is not None` test — so the failure-path
-        dereference is safe. `union-attr` is disabled project-wide, so mypy would NOT
-        catch a regression here.
+        Takes the command NAME (a plain `str`), not the `LoadCommand`: the value is
+        only ever logged, and a `str` removes any dereference-safety question from
+        the failure path (review fix #01/10).
         """
         if self.running_command is not None and self._running_command_generation == launched_generation:
             return True
@@ -993,7 +1006,7 @@ class AbstractDevice:
         _LOGGER.info(
             "%s: command %s for load %s was %s while a call to the device was in flight, ctxt: %s",
             site,
-            launched_command.command,
+            launched_command_name,
             self.name,
             "dropped" if self.running_command is None else "replaced",
             ctxt,
@@ -1114,16 +1127,28 @@ class AbstractDevice:
                 is_command_set = None
             self._anchor_causality_guard_if_executed(is_command_set, time)
 
-        if not self._slot_still_holds(command, launched_generation, "launch_command", ctxt):
+        if not self._slot_still_holds(command.command, launched_generation, "launch_command", ctxt):
             # QS-307/QS-320: same guard, same reason as in `force_relaunch_command`.
             # Placed here, at 8 spaces, so it covers BOTH awaits above — the probe and
             # the conditional execute. Do not move it inside the `else:`.
+            if is_command_set is True:
+                # QS-320 review fix #01/2: a `True` result proves the device ANSWERED.
+                # Contact is dispatch-independent (see `ContactEvidence.CONFIRMED`), so
+                # the episode ends even though the ack is withheld — on `main` the
+                # phantom ack cleared it as a side effect; the signal now stands alone.
+                self._clear_unresponsive(
+                    "the device answered while the command slot changed hands",
+                    contact=ContactEvidence.CONFIRMED,
+                )
             return
 
         if is_command_set is None:
             # hum we may have an impossibility to launch this command
             _LOGGER.info(
-                f"launch_command: Impossible to launch this command {command.command} on this load {self.name}, ctxt: {ctxt}"
+                "launch_command: Impossible to launch this command %s on this load %s, ctxt: %s",
+                command.command,
+                self.name,
+                ctxt,
             )
         elif is_command_set is True:
             _LOGGER.info("launch_command: ack command %s for this load %s), ctxt: %s", command, self.name, ctxt)
@@ -1156,16 +1181,35 @@ class AbstractDevice:
             # NOT dead code: the slot can be replaced or emptied underneath it.
             probed_generation = self._running_command_generation
             _LOGGER.info(
-                f"check command {probed_command.command} for this load {self.name}) (#{self.running_command_num_relaunch_after_invalid})"
+                "check command %s for this load %s) (#%s)",
+                probed_command.command,
+                self.name,
+                self.running_command_num_relaunch_after_invalid,
             )
 
             is_command_set = await self.probe_if_command_set(time, probed_command)
-            slot_is_ours = self._slot_still_holds(probed_command, probed_generation, "check_commands")
+            slot_is_ours = self._slot_still_holds(
+                probed_command.command,
+                probed_generation,
+                "check_commands",
+                f"invalid probes #{self.running_command_num_relaunch_after_invalid}",
+            )
             if not slot_is_ours:
                 # the probe told us nothing about whatever is in the slot now, so
                 # "not confirmed this cycle, re-check next cycle" is the safe answer.
                 # It starts no relaunch and raises no alarm by itself.
                 command_acked_or_good = False
+                if is_command_set is True:
+                    # QS-320 review fix #01/2: a `True` probe proves the device
+                    # ANSWERED — dispatch-independent contact, so the lost-control
+                    # episode ends even though the ack, the stamp and the counters
+                    # stay withheld. Gated on `is True`: a `None`/`False` probe is
+                    # not contact. NOT mirrored in `force_relaunch_command` — the
+                    # probe/execute asymmetry is deliberate, see its guard.
+                    self._clear_unresponsive(
+                        "the probe confirmed contact while the command slot changed hands",
+                        contact=ContactEvidence.CONFIRMED,
+                    )
             # A flag rather than an `else:` wrapper or an early `return`: the wrapper
             # would re-indent the whole body for no behaviour, and the early return
             # would skip the stacked-promotion tail below, delaying an emptied-slot
@@ -1177,7 +1221,10 @@ class AbstractDevice:
                 # not hand its successor a strike towards the invalid-probe give-up.
                 self.running_command_num_relaunch_after_invalid += 1
                 _LOGGER.info(
-                    f"impossible to check command {probed_command.command} for this load {self.name}) (#{self.running_command_num_relaunch_after_invalid})"
+                    "impossible to check command %s for this load %s) (#%s)",
+                    probed_command.command,
+                    self.name,
+                    self.running_command_num_relaunch_after_invalid,
                 )
                 if self.running_command_num_relaunch_after_invalid >= NUM_MAX_INVALID_PROBES_COMMANDS:
                     # will kill completely the command ....
@@ -1189,6 +1236,10 @@ class AbstractDevice:
 
             # Kept as a SEPARATE statement from the block above, not an `elif`: a
             # `None` probe must still fall through here and assign `res`.
+            # On a disowned slot `res` deliberately stays `timedelta(0)` — the same
+            # value as "just launched". Safe ONLY because both callers discard the
+            # first tuple element today; a future consumer of the delay must not
+            # read a superseded dispatch as fresh (review fix #01/9).
             if slot_is_ours and is_command_set is True:
                 self._ack_command(time, probed_command)
                 command_acked_or_good = True
@@ -1235,10 +1286,16 @@ class AbstractDevice:
         latter passes an `is None` check. All three sites — `launch_command`,
         `check_commands` and `force_relaunch_command` — hold the command they launched
         in a local, capture its tag from `_install_running_command`, and consult
-        `_slot_still_holds` after their awaits before stamping, acking, counting or
-        dereferencing. Side effects that merely record that a service call physically
+        `_slot_still_holds` after their awaits before stamping, acking or
+        dereferencing. The one counter the guard gates is
+        `running_command_num_relaunch_after_invalid` (a probe about the previous
+        occupant must not strike the successor); `running_command_num_relaunch` is
+        deliberately OUTSIDE the guard — it increments before the await and a
+        superseding successor inherits the rung by design (AC9, QS-304's saturated
+        cadence — `abandon_running_command` preserves it across a supersede for the
+        same reason). Side effects that merely record that a service call physically
         landed stay unconditional: `_anchor_causality_guard_if_executed` sits ABOVE
-        the guard on purpose.
+        the guard on purpose, and is monotonic so a stale resumer cannot rewind it.
 
         The clock is still only cleared alongside the command state it describes.
         """
@@ -1440,11 +1497,24 @@ class AbstractDevice:
             # guard must know even if the slot is now empty.
             self._anchor_causality_guard_if_executed(is_command_set, time)
 
-            if not self._slot_still_holds(launched_command, launched_generation, "force_relaunch_command"):
+            if not self._slot_still_holds(
+                launched_command.command,
+                launched_generation,
+                "force_relaunch_command",
+                f"relaunch #{self.running_command_num_relaunch}",
+            ):
                 # QS-307/QS-320: the slot was emptied or replaced across the await — a
                 # user action can reach the override expiry, or press a button, outside
                 # `_update_loads_lock`. Everything below describes the dispatch that no
                 # longer owns the slot, so stop.
+                #
+                # Review fix #01/2, DELIBERATE asymmetry: no CONFIRMED clear here,
+                # unlike the disowned-slot paths in `launch_command` and
+                # `check_commands`. This is the relaunch ladder for a command that
+                # is ALREADY failing to confirm — a `True` from its execute under a
+                # disowned slot is not taken as proof the episode is over. AC1 pins
+                # it: `unresponsive_since` survives this bail-out. Do not "complete
+                # the symmetry" without renegotiating that test.
                 return
 
             self.running_command_last_launch = time

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -876,8 +876,20 @@ class AbstractDevice:
         - the successor's OWN supersede-throttle stamp survives the clear's
           unconditional null: it was written by the racing press seconds ago and
           keeps the one-service-call-per-window invariant honest.
+
+        The zero-relaunches premise is BEST-EFFORT (review fix #03/4): across a
+        pathologically long probe await (> 300 s — a device probe with no client
+        timeout), the successor may have earned rungs of its own, which this
+        discards, restarting its backoff at 50 s. Failure direction is benign —
+        briefly faster retries against a device that just proved contact, never
+        a re-announce (rung 0 moves the threshold away and the latch is down).
         """
         self.running_command_num_relaunch = 0
+        # The snapshot/restore is only MEANINGFUL on the replaced arm, where the
+        # stamp is the racing press's own (review fix #03/7). On the dropped
+        # (emptied-slot) arm it restores whatever the drop path left — today
+        # `None`, benign. A future drop-path change must not rely on this restore
+        # to re-arm a stale throttle stamp.
         successor_supersede_time = self._last_supersede_time
         self._clear_unresponsive(reason, contact=ContactEvidence.CONFIRMED)
         self._last_supersede_time = successor_supersede_time
@@ -1272,7 +1284,7 @@ class AbstractDevice:
             # NOT dead code: the slot can be replaced or emptied underneath it.
             probed_generation = self._running_command_generation
             _LOGGER.info(
-                "check command %s for this load %s) (#%s)",
+                "check command %s for this load %s (#%s)",
                 probed_command.command,
                 self.name,
                 self.running_command_num_relaunch_after_invalid,
@@ -1289,6 +1301,14 @@ class AbstractDevice:
                 # the probe told us nothing about whatever is in the slot now, so
                 # "not confirmed this cycle, re-check next cycle" is the safe answer.
                 # It starts no relaunch and raises no alarm by itself.
+                #
+                # Known one-cycle false negative (review fix #03/2, not a bug): an
+                # equal-valued press landing mid-probe ABSORBS (generation-neutral)
+                # and its own path can then ack, emptying the slot — the resumer
+                # reads slot None + generation unchanged as "dropped" and returns
+                # False for a dispatch that WAS acked. Nothing is lost: the ack is
+                # already recorded, it self-heals next cycle, and the error
+                # direction is conservative — the opposite of the QS-320 bug.
                 command_acked_or_good = False
                 if is_command_set is True:
                     # QS-320 review fix #01/2: a `True` probe proves the device
@@ -1642,7 +1662,7 @@ class AbstractDevice:
 
             self.running_command_last_launch = time
             if is_command_set is None:
-                _LOGGER.info("impossible to force command %s for this load %s)", launched_command.command, self.name)
+                _LOGGER.info("impossible to force command %s for this load %s", launched_command.command, self.name)
             elif is_command_set is True:
                 self._ack_command(time, launched_command)
             else:

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -719,6 +719,13 @@ class AbstractDevice:
         state change QS itself caused as an external user override. `None` means
         "no anchor" and accepts any value; the restore-time write and the
         `user_clean_and_reset` clear stay plain assignments on purpose.
+
+        Known limitation (review fix #02/8, documented on purpose, no code): after
+        a backwards wall-clock step (NTP correction), subsequent real executions
+        carry older timestamps and are refused, pinning the anchor "in the
+        future" — genuine user flips are then suppressed as QS-caused until wall
+        time catches up. Environmental and rare; the monotonic property is worth
+        more than this corner, so do NOT add clock-step detection here.
         """
         if is_command_set is True:
             prev = self.last_command_execution_time
@@ -845,6 +852,35 @@ class AbstractDevice:
             _LOGGER.info("Lost-control clock released without contact for load %s: %s", self.name, reason)
         else:
             _LOGGER.info("Lost-control state cleared for load %s: %s", self.name, reason)
+
+    def _confirmed_contact_on_disowned_slot(self, reason: str) -> None:
+        """End the lost-control episode on proven contact when the slot changed hands.
+
+        QS-320 review fix #02/1: the CONFIRMED clear alone backfired under QS-319.
+        Whenever it fires on a REPLACED slot the successor holds a rung inherited
+        from the superseded command (`abandon_running_command` preserves it), and
+        that rung is saturated by construction — a press can only supersede while
+        `is_uncontrollable`. Clearing clock + latch while leaving the rung at max
+        let the very next `_escalate_or_recover` pass re-mark the clock and take
+        the ANNOUNCE branch: a fresh "Lost control" ERROR with an inherited count,
+        a second push and an on→off→on flap of the PROBLEM sensor — milliseconds
+        after the device demonstrably answered.
+
+        So, on top of the clear:
+
+        - the successor's rung resets to 0 — the ladder's premise is "device not
+          answering" and the contact just disproved it; the successor has made
+          zero relaunches of its own (precedent: the empty-slot housekeeping arm
+          resets the rung too). AC9's inheritance pin is untouched — that covers
+          the supersede/relaunch hand-off, a different event;
+        - the successor's OWN supersede-throttle stamp survives the clear's
+          unconditional null: it was written by the racing press seconds ago and
+          keeps the one-service-call-per-window invariant honest.
+        """
+        self.running_command_num_relaunch = 0
+        successor_supersede_time = self._last_supersede_time
+        self._clear_unresponsive(reason, contact=ContactEvidence.CONFIRMED)
+        self._last_supersede_time = successor_supersede_time
 
     def _acknowledge_lost_control(self, reason: str) -> None:
         """Treat explicit user remediation as acknowledging an open episode.
@@ -1047,6 +1083,12 @@ class AbstractDevice:
         Takes the command NAME (a plain `str`), not the `LoadCommand`: the value is
         only ever logged, and a `str` removes any dereference-safety question from
         the failure path (review fix #01/10).
+
+        The "dropped"/"replaced" log label is BEST-EFFORT (review fix #02/4): it
+        reflects the slot state at resume time, not the full intervening history.
+        A slot that was replaced, whose replacement then emptied before this
+        resumer ran, logs as "dropped". The guard's verdict is unaffected — only
+        the label's forensic value is.
         """
         if self.running_command is not None and self._running_command_generation == launched_generation:
             return True
@@ -1187,10 +1229,8 @@ class AbstractDevice:
                 # Contact is dispatch-independent (see `ContactEvidence.CONFIRMED`), so
                 # the episode ends even though the ack is withheld — on `main` the
                 # phantom ack cleared it as a side effect; the signal now stands alone.
-                self._clear_unresponsive(
-                    "the device answered while the command slot changed hands",
-                    contact=ContactEvidence.CONFIRMED,
-                )
+                # #02/1: via the helper, so the successor's inherited rung goes too.
+                self._confirmed_contact_on_disowned_slot("the device answered while the command slot changed hands")
             return
 
         if is_command_set is None:
@@ -1257,9 +1297,9 @@ class AbstractDevice:
                     # stay withheld. Gated on `is True`: a `None`/`False` probe is
                     # not contact. NOT mirrored in `force_relaunch_command` — the
                     # probe/execute asymmetry is deliberate, see its guard.
-                    self._clear_unresponsive(
-                        "the probe confirmed contact while the command slot changed hands",
-                        contact=ContactEvidence.CONFIRMED,
+                    # #02/1: via the helper, so the successor's inherited rung goes too.
+                    self._confirmed_contact_on_disowned_slot(
+                        "the probe confirmed contact while the command slot changed hands"
                     )
             # A flag rather than an `else:` wrapper or an early `return`: the wrapper
             # would re-indent the whole body for no behaviour, and the early return
@@ -1461,9 +1501,10 @@ class AbstractDevice:
                 # never obeys — without shouting twice. Written BEFORE the await for
                 # the same reason `unresponsive_since` is: a notify service that
                 # raises must not resurrect the storm. The episode ends on exactly
-                # three things — a real ack, explicit user remediation
-                # (`_acknowledge_lost_control`), or a process restart / config-entry
-                # reload, where nothing restores the latch.
+                # four things — a real ack, proven contact on a slot that changed
+                # hands (`_confirmed_contact_on_disowned_slot`, QS-320), explicit
+                # user remediation (`_acknowledge_lost_control`), or a process
+                # restart / config-entry reload, where nothing restores the latch.
                 self._unresponsive_needs_ack = True
                 unresponsive_command = self.running_command
         else:
@@ -2008,8 +2049,10 @@ class AbstractLoad(AbstractDevice):
         branch itself, so an announced episode is alerted exactly once — including
         for a device that stays *reachable* and simply never obeys, which used to
         re-cross the ladder wall and push about every 18.5 minutes forever. The
-        episode ends on a real ack, on explicit user remediation, or on a process
-        restart / config-entry reload (where nothing restores the latch).
+        episode ends on a real ack, on proven contact on a slot that changed hands
+        (`_confirmed_contact_on_disowned_slot`, QS-320), on explicit user
+        remediation, or on a process restart / config-entry reload (where nothing
+        restores the latch).
         """
         await self.on_device_state_change(
             time,

--- a/docs/agents/concepts/external-control-detection.md
+++ b/docs/agents/concepts/external-control-detection.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
   - custom_components/quiet_solar/ha_model/device.py
-last_verified: 2026-07-31
+last_verified: 2026-08-01
 ---
 
 # External control detection

--- a/docs/agents/concepts/external-control-detection.md
+++ b/docs/agents/concepts/external-control-detection.md
@@ -5,7 +5,7 @@ kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
   - custom_components/quiet_solar/ha_model/device.py
-last_verified: 2026-08-01
+last_verified: 2026-08-02
 ---
 
 # External control detection
@@ -74,7 +74,10 @@ Three guards then keep false positives out of the bistate detection in
    `last_changed` is NEWER than the load's
    `last_command_execution_time` (set on real service-call executions
    and anchored at storage restore when a `current_command` is
-   restored). A stale state — e.g. a lagging template-switch mirror
+   restored; **monotonic** since QS-320 review fix #01/1, so a
+   superseded dispatch resuming mid-race cannot rewind the floor and
+   turn QS's own state change into a classified override). A stale
+   state — e.g. a lagging template-switch mirror
    right after an HA restart — is not a user action. Conservative
    edge: `last_changed = None` while an anchor exists cannot prove
    freshness → no override is classified.

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -117,9 +117,13 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   the episode while the device may well still be broken; the next ladder climb
   then opens a new one and the sensor comes back on.
 
-  An episode ends on exactly three things, and every statement of the rule —
+  An episode ends on exactly four things, and every statement of the rule —
   here, in the code comments, and in `notification-routing.md` — must list all
-  three: a **real ack**, **explicit user remediation**
+  four: a **real ack**, **proven contact on a slot that changed hands**
+  (`_confirmed_contact_on_disowned_slot`, QS-320 — the disowned-slot bail-outs
+  in `launch_command`/`check_commands` when the result was `True`; it also
+  resets the successor's inherited rung so the ladder cannot instantly
+  re-announce), **explicit user remediation**
   (`_acknowledge_lost_control`), or a **process restart / config-entry reload**,
   where nothing restores the latch. The latch is now set by the *announce*
   branch of `_escalate_or_recover` too, before the await, so a notify service
@@ -130,9 +134,12 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   forgotten kwarg is a `TypeError` and a typo an `AttributeError` — defaulting
   to the episode-ending value would let a future caller end an incident by
   omission.
-  - `CONFIRMED` (the real ack in `_ack_command` — since QS-319 the **only**
-    caller) **clears** the latch, *unconditionally* — an ack is contact whether
-    or not there was a clock left to release.
+  - `CONFIRMED` (three callers on the merged tree: the real ack in
+    `_ack_command`, and — via `_confirmed_contact_on_disowned_slot`, QS-320 —
+    the disowned-slot bail-outs in `launch_command` and `check_commands`)
+    **clears** the latch, *unconditionally* — an ack is contact whether
+    or not there was a clock left to release, and so is a `True` result about
+    a slot that changed hands.
   - `UNREACHABLE` (the invalid-probe give-up, the only such caller)
     **latches** it — but only when it actually released a live clock. Latching
     a release that released nothing swallowed the load's first genuine push
@@ -417,8 +424,11 @@ Switching-cost protection (`AbstractDevice`):
   dispatch must stay generation-neutral). The generation is **never
   reset** — not by `reset()`, not by `abandon_running_command` — because
   a rewind would let a tag captured before the reset compare equal to
-  one issued after it. It is a convention with an obvious front door,
-  not enforcement: there is no lint.
+  one issued after it. The write-site half of the convention IS now
+  test-enforced: `test_every_running_command_write_site_is_sanctioned`
+  fails on any `self.running_command` write outside the five sanctioned
+  class-qualified sites. Only the never-reset-the-generation half
+  remains convention, protected by docstring and AC13 alone.
 - `last_command_execution_time` — in-memory causality anchor, set
   only on real `execute_command` successes (via the shared
   `_anchor_causality_guard_if_executed` helper called from

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -4,7 +4,7 @@ slug: load-base
 kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
-last_verified: 2026-08-01
+last_verified: 2026-08-02
 ---
 
 # AbstractDevice & AbstractLoad
@@ -135,14 +135,18 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   That it also quiets the two pre-existing drop paths (where `main` does
   re-announce) is a bonus, not the justification. Do not read it as a general
   alert-deduplication guarantee: see the storm caveat below.
-- **Five releasers, one writer.** `_clear_unresponsive` is the only writer;
+- **Seven releasers, one writer.** `_clear_unresponsive` is the only writer;
   it is reached by an ack, by the empty-slot re-arm, by
   `_drop_running_command` (**unconditionally** — an emptied slot has no
   owner for the clock whether or not a confirmed command ever existed), by
   the `NUM_MAX_INVALID_PROBES_COMMANDS` give-up in `check_commands`
-  (QS-307, the one `UNREACHABLE` caller), and by a
-  `keep_commands=False` wipe. All five release the *clock*; which of them end
-  an *episode* is the `contact` question above. It also clears the
+  (QS-307, the one `UNREACHABLE` caller), by a
+  `keep_commands=False` wipe, and — QS-320 review fix #01/2 — by the
+  disowned-slot bail-outs in `launch_command` and `check_commands` when the
+  result was `True`: proven contact ends the episode even though the ack is
+  withheld. `force_relaunch_command`'s bail-out deliberately does NOT clear
+  (AC1 pins `unresponsive_since` surviving it). All of them release the
+  *clock*; which of them end an *episode* is the `contact` question above. It also clears the
   supersede anchor
   *ahead of* its own early return, so the two fields cannot
   desynchronise.
@@ -271,9 +275,9 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   launches `CMD_IDLE` of its own (QS-320). The invariant relied upon is
   therefore **ownership**, not emptiness: a completion path writes
   nothing about its own dispatch's outcome unless
-  `_slot_still_holds(launched_command, launched_generation, site)` says
-  the slot still carries that dispatch's `_running_command_generation`
-  tag. The clock is still only ever cleared alongside the command state
+  `_slot_still_holds(launched_command_name, launched_generation, site,
+  ctxt)` says the slot still carries that dispatch's
+  `_running_command_generation` tag. The clock is still only ever cleared alongside the command state
   it describes.
 
 Switching-cost protection (`AbstractDevice`):
@@ -331,8 +335,9 @@ Switching-cost protection (`AbstractDevice`):
   driver and has no notification channel) and is overridden on
   `AbstractLoad` to push one `DEVICE_STATUS_CHANGE_ERROR`.
 - `_install_running_command(command, time)` /
-  `_slot_still_holds(launched_command, launched_generation, site, ctxt)`
-  / `_running_command_generation` — the QS-320 dispatch-ownership
+  `_slot_still_holds(launched_command_name, launched_generation, site,
+  ctxt)` — the name is a plain `str`, only ever logged — /
+  `_running_command_generation` — the QS-320 dispatch-ownership
   surface, all on `AbstractDevice`. The installer is the **one way in**
   to the command slot and returns the tag the guards compare; absorb
   deliberately bypasses it (an equal-valued object for the *same*
@@ -348,7 +353,11 @@ Switching-cost protection (`AbstractDevice`):
   probe-already-set branch) and
   initialized to "now" at storage restore when a `current_command` is
   restored. Never serialized. Cleared by `user_clean_and_reset`,
-  which also clears ALL user-override fields (QS-256).
+  which also clears ALL user-override fields (QS-256). The helper is
+  **monotonic** (QS-320 review fix #01/1): it sits above the ownership
+  guard, so a superseded dispatch resuming after its replacement
+  anchored a newer instant must not rewind the causality floor — a
+  rewound floor classifies QS's own state change as a user override.
 
 ## Common mistakes
 

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -4,7 +4,7 @@ slug: load-base
 kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
-last_verified: 2026-07-31
+last_verified: 2026-08-01
 ---
 
 # AbstractDevice & AbstractLoad
@@ -184,9 +184,10 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
   decides to supersede, then still has to pass the
   override-suppression and `current_command == command` gates. Both the
   `_last_supersede_time` stamp and the abandon therefore happen next to
-  `self.running_command = command`, so a supersede that launches
-  nothing neither burns the 300 s window nor leaves a spent rung
-  behind. The two gate-returns route through `_drop_running_command`.
+  the `_install_running_command(command, time)` call, so a supersede
+  that launches nothing neither burns the 300 s window nor leaves a
+  spent rung behind. The two gate-returns route through
+  `_drop_running_command`.
 - **The clock dies with the command state it describes.**
   `constraint_reset_and_reset_commands_if_needed(keep_commands=False)`
   wipes `current_command` *and* `running_command`, so it also releases
@@ -264,10 +265,16 @@ Relaunch, escalation and supersession (`AbstractDevice`, QS-304):
 - **No lock.** `QSDataHandler._update_loads_lock` guards only
   `async_update_loads`; `button.py` calls `user_clean_and_reset`,
   `user_clean_constraints`, `mark_current_constraint_has_done` and
-  `async_reset_override_state` straight from a press, unlocked. The
-  invariant relied upon is narrower: each command-slot mutation happens
-  between `await`s, and the clock is only ever cleared alongside the
-  command state it describes.
+  `async_reset_override_state` straight from a press, unlocked. So the
+  command slot **can** be mutated across an `await`: emptied by the
+  override-expiry drop (QS-307), or **replaced** by a press that
+  launches `CMD_IDLE` of its own (QS-320). The invariant relied upon is
+  therefore **ownership**, not emptiness: a completion path writes
+  nothing about its own dispatch's outcome unless
+  `_slot_still_holds(launched_command, launched_generation, site)` says
+  the slot still carries that dispatch's `_running_command_generation`
+  tag. The clock is still only ever cleared alongside the command state
+  it describes.
 
 Switching-cost protection (`AbstractDevice`):
 
@@ -323,6 +330,17 @@ Switching-cost protection (`AbstractDevice`):
   a documented no-op on `AbstractDevice` (the battery reaches the same
   driver and has no notification channel) and is overridden on
   `AbstractLoad` to push one `DEVICE_STATUS_CHANGE_ERROR`.
+- `_install_running_command(command, time)` /
+  `_slot_still_holds(launched_command, launched_generation, site, ctxt)`
+  / `_running_command_generation` — the QS-320 dispatch-ownership
+  surface, all on `AbstractDevice`. The installer is the **one way in**
+  to the command slot and returns the tag the guards compare; absorb
+  deliberately bypasses it (an equal-valued object for the *same*
+  dispatch must stay generation-neutral). The generation is **never
+  reset** — not by `reset()`, not by `abandon_running_command` — because
+  a rewind would let a tag captured before the reset compare equal to
+  one issued after it. It is a convention with an obvious front door,
+  not enforcement: there is no lint.
 - `last_command_execution_time` — in-memory causality anchor, set
   only on real `execute_command` successes (via the shared
   `_anchor_causality_guard_if_executed` helper called from

--- a/docs/agents/concepts/notification-routing.md
+++ b/docs/agents/concepts/notification-routing.md
@@ -7,7 +7,7 @@ covers:
   - custom_components/quiet_solar/ha_model/person.py
   - custom_components/quiet_solar/ha_model/device.py
   - custom_components/quiet_solar/home_model/load.py
-last_verified: 2026-08-01
+last_verified: 2026-08-02
 ---
 
 # Notification routing
@@ -75,15 +75,21 @@ alarm at 3am is supposed to wake you).
   **One alert per announced episode** (QS-319). `_unresponsive_needs_ack` is
   set by the announce branch of `_escalate_or_recover` itself, *before* the
   await, so a notify service that raises cannot resurrect the storm. An
-  episode ends on exactly three things, and every statement of the rule must
-  list all three:
+  episode ends on exactly four things, and every statement of the rule must
+  list all four:
 
   1. a **real ack** (`_ack_command` → `_clear_unresponsive(...,
      CONFIRMED)`) — the device answered;
-  2. **explicit user remediation** — `_acknowledge_lost_control`, called from
+  2. **proven contact on a slot that changed hands** (QS-320,
+     `_confirmed_contact_on_disowned_slot`) — a `True` result reaching the
+     disowned-slot bail-out in `launch_command` or `check_commands`: the
+     device answered about a dispatch that was superseded mid-await, so the
+     ack is withheld but the episode still ends, and the successor's
+     inherited rung resets so the ladder cannot instantly re-announce;
+  3. **explicit user remediation** — `_acknowledge_lost_control`, called from
      `user_clean_and_reset` (the reset button) and from the
      `qs_enable_device` setter's `enabled != self._enabled` guard;
-  3. a **process restart or config-entry reload**, where nothing restores the
+  4. a **process restart or config-entry reload**, where nothing restores the
      latch (see below).
 
   This covers both shapes. A device dropping off the network intermittently

--- a/docs/agents/concepts/piloted-device-and-heat-pump.md
+++ b/docs/agents/concepts/piloted-device-and-heat-pump.md
@@ -6,7 +6,7 @@ covers:
   - custom_components/quiet_solar/home_model/load.py
   - custom_components/quiet_solar/ha_model/heat_pump.py
   - custom_components/quiet_solar/ha_model/climate_controller.py
-last_verified: 2026-07-30
+last_verified: 2026-08-01
 ---
 
 # PilotedDevice and heat pump

--- a/docs/agents/concepts/piloted-device-and-heat-pump.md
+++ b/docs/agents/concepts/piloted-device-and-heat-pump.md
@@ -6,7 +6,7 @@ covers:
   - custom_components/quiet_solar/home_model/load.py
   - custom_components/quiet_solar/ha_model/heat_pump.py
   - custom_components/quiet_solar/ha_model/climate_controller.py
-last_verified: 2026-08-01
+last_verified: 2026-08-02
 ---
 
 # PilotedDevice and heat pump

--- a/docs/agents/concepts/user-override.md
+++ b/docs/agents/concepts/user-override.md
@@ -4,7 +4,7 @@ slug: user-override
 kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
-last_verified: 2026-08-01
+last_verified: 2026-08-02
 ---
 
 # User override

--- a/docs/agents/concepts/user-override.md
+++ b/docs/agents/concepts/user-override.md
@@ -4,7 +4,7 @@ slug: user-override
 kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
-last_verified: 2026-07-31
+last_verified: 2026-08-01
 ---
 
 # User override
@@ -88,10 +88,15 @@ an externally-detected override are constraint-driven:
   it owns that drop — for the *aligned* command only; anything else is
   a genuine solver intent. Note this is the first command-slot mutation
   inside `check_load_activity_and_constraints`, and three of that
-  method's callers run outside `_update_loads_lock`, so both
-  `launch_command` and `force_relaunch_command` re-check the slot after
-  their `await` rather than assuming they still own the command they
-  launched. See [load-base.md](load-base.md).
+  method's callers run outside `_update_loads_lock` — as do the buttons
+  that launch a `CMD_IDLE` of their own. So all **three** completion
+  paths (`launch_command`, `check_commands` and
+  `force_relaunch_command`) re-check the slot after their `await`, and
+  what they check is **ownership**, not emptiness: `_slot_still_holds`
+  compares the dispatch's `_running_command_generation` tag, because a
+  slot that was *replaced* (rather than emptied) passes an `is None`
+  test and would otherwise be acked off the previous command's result
+  (QS-320). See [load-base.md](load-base.md).
 - A state mismatch only classifies as a NEW override when the entity
   state is newer than `last_command_execution_time` (causality guard)
   and the 180s post-override cooldown has elapsed.

--- a/docs/stories/QS-320.story.md
+++ b/docs/stories/QS-320.story.md
@@ -1,0 +1,710 @@
+# QS-320 — Phantom ack: a button press that replaces the command slot mid-await can confirm a command that was never executed
+
+- **Issue:** [#320](https://github.com/tmenguy/quiet-solar/issues/320)
+- **Branch:** `QS_320`
+- **Follows:** #307 (merged as [#316](https://github.com/tmenguy/quiet-solar/pull/316)),
+  which guarded the *emptied*-slot case at two call sites and explicitly deferred
+  the *replaced* case here.
+- **Pre-existing, not a regression.** Reproduces on `main` (`8ea823dc`).
+- **Line numbers are as of `b7b324d3`.** **Task 1 invalidates every `load.py`
+  number below `:204`** — later tasks locate code by symbol + the quoted anchor
+  phrase given in each row.
+
+## The bug in one sentence
+
+A call to the device finishes, and writes its result onto whatever command is in
+the slot at that moment — which may not be the command it called about.
+
+## The symptom
+
+You press **"clean and reset"** (or **"mark constraint done"**) on a load while QS
+happens to be mid-call to that device. Then:
+
+- QS records "the device confirmed `idle`" — but no service call for `idle` ever
+  completed. It is recording the *previous* command's answer under the *new*
+  command's name.
+- The load is physically still **running**. QS believes it is idle.
+- **Nothing ever retries.** The slot is empty and `current_command` says idle, so
+  the load looks healthy; next time the solver wants idle it does nothing at all,
+  because it thinks it is already there.
+- Collateral: the "QS lost control of this load" alarm clears on fabricated
+  evidence, and the daily on/off budget is charged a state change that never
+  happened.
+
+Net: **you press the stop button, and the load keeps running forever while the
+dashboard says it stopped.**
+
+## Problem
+
+Two fields carry the command lifecycle, both on `AbstractDevice`:
+
+- `running_command` — a command **dispatched but not yet confirmed**;
+- `current_command` — the **last command the device confirmed**. This is QS's
+  belief about physical reality, and it feeds `is_load_command_set`, the
+  controlled-consumption accounting and the solver.
+
+Three methods dispatch a call, `await` it, then finish the paperwork by re-reading
+`self.running_command`. Two re-check the slot first but ask the wrong question —
+`if self.running_command is None`
+([`launch_command`:1050](../../custom_components/quiet_solar/home_model/load.py),
+[`force_relaunch_command`:1353](../../custom_components/quiet_solar/home_model/load.py)).
+That detects the slot being **emptied**, not **replaced**. The third
+([`check_commands`:1088-1114](../../custom_components/quiet_solar/home_model/load.py))
+has a pre-await `if self.running_command is not None:` wrapper but **no post-await
+re-check at all**, and holds no local.
+
+### The trigger
+
+Two button paths call `launch_command` directly and run **outside**
+`_update_loads_lock`, straight from an HA button press. Both buttons are registered
+for **every** load and device:
+
+- [`button.py:190`](../../custom_components/quiet_solar/button.py) →
+  `mark_current_constraint_has_done` → `launch_command(CMD_IDLE)` (`load.py:2338`)
+- [`button.py:213`](../../custom_components/quiet_solar/button.py) →
+  `user_clean_and_reset` → `launch_command(CMD_IDLE)` (`load.py:2357`)
+
+They reach the slot by **two structurally different routes**:
+
+| route | how the slot changes | preconditions |
+| --- | --- | --- |
+| **A — supersede** (`mark_current_constraint_has_done`) | `abandon_running_command` empties, then a fresh install at `:1013` | load `is_uncontrollable`, `_last_supersede_time is None`, not override-suppressed, `current_command != CMD_IDLE` |
+| **B — reset-then-install** (`user_clean_and_reset`) | `reset()` nulls `current_command`, `running_command`, all four counters **and** the lost-control clock, then a fresh install at `:1013` | none — `reset()` is unconditional |
+
+Route B matters disproportionately: it can install a **field-identical** `CMD_IDLE`
+over an in-flight `CMD_IDLE`. See D1.
+
+### The sequence (route A)
+
+1. The relaunch ladder calls `force_relaunch_command`, which awaits
+   `execute_command` → a real `hass.services.async_call`. It suspends, holding
+   `launched_command = CMD_ON`.
+2. The user presses "mark current constraint done". Unlocked, it calls
+   `launch_command(CMD_IDLE)`.
+3. Uncontrollable and not throttled, so `launch_command` supersedes: slot emptied,
+   then `CMD_IDLE` installed with its own launch stamps.
+4. The **first** call resumes. `self.running_command is None` is `False`, so the
+   guard passes, and it finishes `CMD_ON`'s paperwork **against the new occupant**:
+   `running_command_last_launch = time` for `CMD_IDLE`, and — if `CMD_ON`'s probe
+   returned `True` — `_ack_command(time, CMD_IDLE)`.
+
+### What that one `_ack_command` does
+
+[:651](../../custom_components/quiet_solar/home_model/load.py) — four corruptions:
+`current_command` set to a command the device never confirmed;
+`_clear_unresponsive(..., CONFIRMED)` ending the lost-control episode on fabricated
+evidence; `num_on_off += 1` charging a phantom transition to the daily budget and
+re-arming the 10-minute hysteresis; all four relaunch counters zeroed.
+
+**Then the genuine command is dropped.** The button's own `launch_command` resumes,
+finds `running_command is None`, hits #316's emptied-slot guard and returns
+**without acking**. The ack goes to the command that was not sent and is withheld
+from the one that was.
+
+**The state is durable:** `_relaunch_stale_command` returns immediately on an empty
+slot; `_stacked_command` was cleared at `:979`; `is_load_command_set` is `True`; and
+the next solver `CMD_IDLE` hits the `current_command == command` early return at
+`:998`.
+
+### Root cause
+
+1. **The guard answers the wrong question.** It needs *"is the slot still holding
+   the dispatch I made?"*. `is None` tests one known symptom (#316's override-expiry
+   drop, which empties) that got mistaken for the invariant.
+2. **The completion path re-reads shared state instead of using its own local.**
+3. **A load-bearing assumption that stopped being true.** The lifecycle was written
+   under "each command-slot mutation happens between `await`s", which held while
+   every `launch_command` caller ran inside `_update_loads_lock`. The buttons don't.
+   The docstring at `:1139-1153` is the fossil record: #316 corrected the invariant
+   for the emptied case and wrote down that the replaced case was left open.
+
+## Goal
+
+Tag each dispatch. On completion, write nothing **about that dispatch's outcome**
+unless the slot still carries the same tag. (Side effects that merely record that a
+service call physically landed stay unconditional — see D5's treatment of
+`_anchor_causality_guard_if_executed`.)
+
+## Scope — three sites
+
+The issue names two sites and says `check_commands` is "not realistically
+reachable — the bistate `probe_if_command_set` never yields. **Worth confirming**
+rather than guarding speculatively." Confirmed reachable, so it is in scope:
+
+- `QSChargerGeneric.probe_if_command_set` (`charger.py:5242`) awaits
+  `_do_update_charger_state` → a real `hass.services.async_call`, then
+  `_ensure_correct_state`. `QSBattery.probe_if_command_set` (`battery.py:100`)
+  awaits `is_charge_from_grid()`. Only the bistate probe is synchronous.
+- Both trigger buttons exist on chargers; `QSChargerGeneric` overrides
+  `user_clean_and_reset` (`charger.py:2259`).
+
+`check_commands` also carries an **unguarded emptied-slot** hole: with no post-await
+check, an emptied slot reaches `_ack_command(time, self.running_command)` =
+`_ack_command(time, None)`, which **nulls `current_command`**, wiping the confirmed
+command of record.
+
+> **The invalid-probe give-up is NOT reachable during a race** and is deliberately
+> not guarded as a separate case. Every action that empties or replaces the slot
+> zeroes `running_command_num_relaunch_after_invalid` first
+> (`abandon_running_command`:835, `constraint_reset_and_reset_commands_if_needed`:426,
+> `_ack_command`:662), so the post-race `+= 1` yields `1` and `1 >= 10` never fires.
+> The same `slot_is_ours` gate covers the branch anyway; what the race *can* do is
+> hand the successor a spurious strike, which is AC6.
+
+**The fix is complete at three sites.** Re-run these to confirm before implementing:
+
+```bash
+grep -rn --include='*.py' "async def launch_command\|async def force_relaunch_command\|async def check_commands" custom_components/quiet_solar/
+grep -rn --include='*.py' "_ack_command(\|\.running_command = \|running_command_last_launch = " custom_components/quiet_solar/ | grep -v home_model/load.py
+```
+
+Both must return only `home_model/load.py` hits (the second, nothing).
+
+**Reachability evidence is static; the behavioural test is device-agnostic.** The
+guard lives on `AbstractDevice`, so the tests exercise it through a synthetic
+awaiting probe rather than a charger. No charger-level test — a deliberate trade,
+recorded in Residual risks. Task 7 puts a one-line comment at the `check_commands`
+guard naming `QSChargerGeneric.probe_if_command_set` as the reason the site is not
+dead code, so the evidence decays loudly.
+
+Not in scope: widening `_update_loads_lock` over the button handlers (D6), and any
+change to absorb/stack/supersede policy.
+
+## Design
+
+### D1 — tag the dispatch, don't compare the command
+
+A monotonic `int` on `AbstractDevice`, **never reset for the object's lifetime**:
+
+```python
+self._running_command_generation: int = 0
+```
+
+Each site captures it next to its local; the guard is:
+
+```
+slot still ours  ⇔  running_command is not None  AND  generation unchanged
+```
+
+**Why not compare the command value** — both directions fail:
+
+- **Identity (`is not launched_command`, the issue's candidate) over-triggers.**
+  The **absorb** branch (`:943-952`) fires when the incoming command `==` the one in
+  flight and does `self.running_command = command`, swapping in a **new object of
+  equal value**. Both buttons launch `CMD_IDLE`, so when the in-flight command
+  already *is* `CMD_IDLE` the press takes absorb. An identity guard reads that as
+  "replaced" and bails out of `force_relaunch_command` **before**
+  `running_command_last_launch = time`. The stamp stays stale, the backoff gate is
+  then permanently open, and the load makes a service call every cycle while the
+  rung climbs to a **false** lost-control escalation.
+- **Value equality (`!=`, or an exact all-field comparison) under-triggers.** Route
+  B empties the slot then performs a **real install** with fresh launch stamps. If
+  the in-flight command was already `CMD_IDLE`, the new dispatch compares **equal on
+  every field**, the guard passes, and the stale resumer stamps and acks *a
+  different dispatch whose service call is still in flight*. That is QS-320 itself.
+
+The two cases differ in **which dispatch installed the record**, not in the record.
+Absorb is benign precisely because it leaves the satellites
+(`running_command_first_launch` / `last_launch` / the counters) alone; route B is
+harmful precisely because it replaces them.
+
+| case | slot | generation | verdict |
+| --- | --- | --- | --- |
+| absorb swaps an equal object | non-`None` | unchanged | **passes** |
+| route A supersede | non-`None` | bumped | trips |
+| route B reset-then-install of an identical `CMD_IDLE` | non-`None` | bumped | **trips** |
+| slot emptied, no successor | `None` | unchanged | trips |
+
+**Soundness — the complete enumeration** of writes to `self.running_command` in
+`custom_components/`: `constraint_reset_and_reset_commands_if_needed`:417 (`None`),
+`_ack_command`:660 (`None`), `abandon_running_command`:834 (`None`), absorb:945,
+install:1013. Only `:1013` creates a new dispatch; the three `None`-writes are
+caught by the `is not None` arm or by a subsequent bumped install; absorb is the
+sole non-bumping non-`None` write and provably preserves the dispatch. **There is no
+sequence yielding non-`None` + unchanged generation + different dispatch.**
+
+`home_model/commands.py` is **not touched** by this story.
+
+Rejected: reusing `running_command_first_launch` as the tag (no new state). Two
+installs can share a timestamp — `update_loads` calls `launch_command` twice per
+cycle for the same load with the same `time`, and tests routinely freeze the clock —
+so the tag would silently collide.
+
+### D2 — one installer, documented
+
+```python
+def _install_running_command(self, command: LoadCommand, time: datetime) -> int:
+    """Install a dispatch in the command slot and return its generation tag.
+
+    The one way in. The generation is what the post-await guards compare, so
+    bumping it here rather than at the call site is what stops a future install
+    site from silently re-opening QS-320.
+
+    NEVER reset `_running_command_generation` — not in `reset()`, not in
+    `abandon_running_command`, not anywhere. A reset lets a stale tag captured
+    before the reset compare equal to a fresh one after it, which re-opens
+    QS-320 on exactly the route this guard exists to close.
+
+    Absorb (`:945`) deliberately does NOT come through here: it swaps in an
+    equal-valued object for the SAME dispatch and leaves the launch stamps
+    alone, so the caller already in flight still owns its paperwork.
+    """
+    self._running_command_generation += 1
+    self.running_command = command
+    self.running_command_first_launch = time
+    self.running_command_last_launch = time
+    return self._running_command_generation
+```
+
+Replaces these three statements at `:1013-1015` verbatim (no others):
+
+```python
+self.running_command = command
+self.running_command_first_launch = time
+self.running_command_last_launch = time
+```
+
+There is no `await` between the supersede block at `:1007-1011` and them.
+
+One call site today. This is a **convention with an obvious front door**, not
+enforcement — the residual risk below says so plainly. A property setter that bumped
+on *every* write was considered and rejected: it would bump on absorb, which must
+stay generation-neutral.
+
+### D3 — one guard, one message
+
+```python
+def _slot_still_holds(
+    self, launched_command: LoadCommand, launched_generation: int, site: str, ctxt: str | None = None
+) -> bool:
+    """Return True when the slot still holds the dispatch we launched."""
+    if self.running_command is not None and self._running_command_generation == launched_generation:
+        return True
+    _LOGGER.info(
+        "%s: command %s for load %s was %s while a call to the device was in flight, ctxt: %s",
+        site,
+        launched_command.command,
+        self.name,
+        "dropped" if self.running_command is None else "replaced",
+        ctxt,
+    )
+    return False
+```
+
+- `launched_command` is non-`None` at all three sites by construction (each capture
+  sits inside an existing `is not None` test), so the failure-path dereference is
+  safe. `union-attr` is disabled (`pyproject.toml:62-63`), so mypy will not catch a
+  regression here — hence this sentence.
+- `site` and `ctxt` are separate: folding them loses the method name at
+  `launch_command` and the caller context at the other two.
+- The message distinguishes **dropped** from **replaced** — that axis is the subject
+  of this story. Both arms are pinned by `caplog` in AC12.
+- Level stays `info`, matching the two messages it replaces (`:1054`, `:1357`, both
+  `info`). A **deliberate exception** to project-context's "debug for non-user-facing
+  messages": the event is rare by construction and is exactly the line an operator
+  needs when a load misbehaves.
+
+Placement: next to `_seconds_since` (`:874`) and
+`_anchor_causality_guard_if_executed` (`:689`), on **`AbstractDevice`** — not
+`AbstractLoad`. All five lifecycle methods are `AbstractDevice` members
+(`class AbstractDevice`:149, `PilotedDevice`:1382, `AbstractLoad`:1453). `QSBattery`
+is `AbstractDevice`-side and traverses these paths.
+
+### D4 — post-guard, dereference the local
+
+| method | anchor phrase | change |
+| --- | --- | --- |
+| `launch_command` | `ack command %s for this load %s)` | `self.running_command` → `command` |
+| `check_commands` | `f"check command {…}` | `self.running_command.command` → `probed_command.command` |
+| `check_commands` | `f"impossible to check command {…}` | `self.running_command.command` → `probed_command.command` |
+| `check_commands` | inside `if is_command_set is True:` | `self._ack_command(time, self.running_command)` → `probed_command` |
+| `force_relaunch_command` | `impossible to force command %s` | `self.running_command.command` → `launched_command.command` |
+| `force_relaunch_command` | `elif is_command_set is True:` | `self._ack_command(time, self.running_command)` → `launched_command` |
+
+**Left as-is, deliberately:** `check_commands`' `self.running_command_last_launch`
+read (`:1112`) and `force_relaunch_command`'s `self.running_command_last_launch =
+time` write (`:1364`) — satellite fields with no local, which post-guard belong to
+our dispatch by definition. `check_commands`' give-up `_ack_command(time, None)`
+(`:1103`) — it passes `None`, not the slot, and sits behind the `slot_is_ours` gate.
+`launch_command`'s pre-await `probe_if_command_set(time, self.running_command)`
+(`:1020`) — pre-await, harmless either way.
+
+Post-await dereferences *outside* the three sites (`:1188`, `:1202`, `:1230-1263`,
+`:1306-1324`) are fresh-state reads with no launched dispatch to own.
+
+**Why this is behaviour-neutral:** post-guard the local and the slot hold
+equal-valued records of the same dispatch, and `LoadCommand.__eq__`
+(`commands.py:33`) compares **both** declared fields, so an absorbed object is
+field-identical. (Note `load.py:1000`'s comment claims "`command ==` may have been
+overcharged to not test everything" — false today; only `LoadCommand` and
+`LoadConstraint` define `__eq__`.) Not a mypy requirement — an earlier draft claimed
+that; `union-attr` is disabled.
+
+### D5 — the three call sites
+
+**`launch_command`.** `launched_generation = self._install_running_command(command,
+time)` replaces `:1013-1015`; the guard replaces the `is None` check at `:1050`:
+
+```python
+if not self._slot_still_holds(command, launched_generation, "launch_command", ctxt):
+    return
+```
+
+Stays at 8 spaces so it covers **both** awaits (probe `:1020`, execute `:1040`).
+`:1013` **dominates** `:1050` — absorb (`:945`), stack (`:958`), override-drop
+(`:996`) and the equal-command return (`:1005`) all `return` earlier — so
+`launched_generation` is always bound.
+
+**`force_relaunch_command`.** Capture `launched_generation =
+self._running_command_generation` alongside `launched_command` at `:1328`; the guard
+replaces the `is None` check at `:1353`. Statement order after the guard:
+`running_command_last_launch = time` → `if is_command_set is None:` (log) /
+`elif is True:` (ack) / `else: await self.check_commands(time)`. **The only await is
+the mutually exclusive `else` arm**, so no await separates the guard from the stamp
+or the ack. That nested `check_commands` takes its own local and tag, so it
+re-establishes ownership rather than inheriting it.
+
+`_anchor_causality_guard_if_executed` (`:1351`) stays **above** the guard: a service
+call really landed, so the causality guard must know even if the slot changed hands.
+`running_command_num_relaunch += 1` (`:1335`) stays **before** the await — see D7.
+
+**`check_commands`.** A pre-await `if self.running_command is not None:` wrapper
+already exists; it becomes a local plus a tag, at the **same indentation**, and the
+two result-consuming blocks are gated by a flag:
+
+```python
+probed_command = self.running_command
+if probed_command is not None:
+    probed_generation = self._running_command_generation
+    _LOGGER.info(...)                                    # probed_command.command
+    is_command_set = await self.probe_if_command_set(time, probed_command)
+    slot_is_ours = self._slot_still_holds(probed_command, probed_generation, "check_commands")
+    if not slot_is_ours:
+        command_acked_or_good = False
+    if slot_is_ours and is_command_set is None:
+        ...                                              # body unchanged, not re-indented
+    if slot_is_ours and is_command_set is True:
+        ...                                              # body unchanged, not re-indented
+    elif slot_is_ours and self.running_command_last_launch is not None:
+        ...                                              # body unchanged, not re-indented
+```
+
+**Why a flag, not an `else:` wrapper or an early `return`:**
+
+- An `else:` wrapper re-indents the whole body. That does not *fail* the gate —
+  QS-283's `--impacted` rebuilds the baseline and re-checks once on a changed-line
+  miss — but it forces a full-baseline rebuild on every run of this change and
+  produces a diff in which the real edit is invisible.
+- An early `return` skips the stacked-promotion tail (`:1116`), delaying an
+  emptied-slot promotion by a cycle — a behaviour change on an unrelated path. **This
+  is the load-bearing reason.**
+
+The flag touches three `if` lines and adds two, changes no indentation, and keeps the
+`if is_command_set is None:` and `if is_command_set is True: … elif …` blocks as
+**two separate statements**, so a `None` probe still falls through and assigns `res`.
+That property is currently **unpinned** — `test_check_commands_running_command_invalid_increments_count`
+(`tests/test_load_model.py:1493`) and `test_check_commands_max_invalid_kills_command`
+(`:1511`) are the `None`-probe tests and neither asserts `res` — so task 8 adds an
+assertion for it.
+
+The two locals: **`res`** (`timedelta`, first return element) and
+**`command_acked_or_good`** (`bool`, second element). On bail-out `res` keeps its
+initial `timedelta(0)` and `command_acked_or_good` becomes `False`.
+
+`command_acked_or_good` feeds `QSHome.check_loads_commands`' `all_ok`, whose only
+consumers are `finish_off_grid_switch` (holds the off-grid transition open until all
+loads confirm) and the `update_loads` cycle. `False` means "not confirmed this
+cycle, re-check next cycle" — it starts no relaunch and raises no alarm by itself,
+so it is the safe answer for a probe that told us nothing. `res` is discarded by both
+callers (`_wait_time` at `:1158`, unused at `:1372`).
+
+**Deliberate behaviour change:** the bail also skips
+`running_command_num_relaunch_after_invalid += 1` (`:1097`). The probe told us
+nothing about the current occupant, so the successor must not inherit a strike.
+Pinned by AC6, commented in code.
+
+### D6 — rejected alternatives
+
+- **Widening `_update_loads_lock` over the button handlers.** A press would block for
+  a whole solver cycle, and `check_loads_commands` already runs inside that lock.
+  #316 settled the precedent: post-await re-check, not a wider lock.
+- **Making absorb stop swapping the object** so identity is stable. The swap is
+  deliberate; changing dispatch policy to serve a guard is backwards.
+- **A property setter or lint rule** forbidding un-tagged slot writes. A setter would
+  bump on absorb, which must stay neutral; a custom lint is disproportionate for a
+  one-install-site invariant in one file. D2's front door plus the residual risk is
+  the accepted level of protection.
+
+### D7 — what this story deliberately does NOT change
+
+`running_command_num_relaunch += 1` happens **before** the await in
+`force_relaunch_command`, so when the guard bails, a route-A successor inherits
+`rung + 1`. That is the existing saturated-cadence design —
+`abandon_running_command` preserves the rung across a supersede on purpose (docstring
+`:822`) — not a defect introduced here. Route B's `reset()` zeroes it instead
+(`:425`). Pinned by AC9 (route A only) so a later reader does not "restore the
+invariant".
+
+## Acceptance criteria
+
+Every race test: call the site under test **directly** (not via
+`check_and_relaunch_command`, whose `finally` re-enters the chain), set
+`pump.obeys = False`, and use **two distinct instants** — `T_RELAUNCH` for the outer
+call, `T_PRESS = T_RELAUNCH + 1s` for the race — so a stamp written by the resumer is
+distinguishable from the press's own.
+
+- **AC1 — route A, `force_relaunch_command`.** Entity `"on"` (so the nested
+  `CMD_IDLE` probe returns `False` → executes → `False` → no self-ack, slot holds
+  `CMD_IDLE`). After the race: `running_command_last_launch == T_PRESS` (**not**
+  `T_RELAUNCH`), `current_command == CMD_ON`, `num_on_off` unchanged,
+  `unresponsive_since` still set. **Must fail pre-fix.**
+- **AC2 — route A, `launch_command`.** Entity `STATE_UNAVAILABLE` (so both probes
+  return `None`, the outer falls through to `execute_command` where the race is
+  injected, and the nested press executes and returns `False`). Assertions spelled
+  out, not delegated to AC1: `current_command == CMD_ON`, `running_command ==
+  CMD_IDLE`, no ack of `CMD_IDLE`. **Must fail pre-fix.**
+- **AC3 — route B, the case value-equality misses.** In-flight `CMD_IDLE`, press
+  `user_clean_and_reset()`, which installs a **field-identical** `CMD_IDLE`. The
+  resumer must not stamp and must not ack. `current_command is None` here (the
+  `reset()`'s own doing). Under a value-equality guard the buggy ack still occurs, so
+  **this test must FAIL under value equality and PASS under the generation tag**.
+  Asserts no `_ack_command`; does **not** compare stamps —
+  `AbstractLoad.user_clean_and_reset` uses `datetime.now()` (`:2355`), not the test
+  clock, so wrap in `freeze_time` if a stamp assertion is ever added. **Must fail
+  pre-fix.**
+- **AC4 — absorb must NOT trip the guard.** Own recipe, the mirror of AC1: in-flight
+  `CMD_IDLE`, race action `lambda t: pump.launch_command(t, CMD_IDLE, ctxt=...)`
+  taking the absorb branch. Pre-race `running_command == CMD_IDLE`; post-race the
+  slot object identity changed, the generation is **unchanged**, and
+  `force_relaunch_command` still stamped and still acked. Green both pre- and
+  post-fix; it pins the design against the identity variant.
+- **AC5 — `check_commands`, replaced slot.** Racing probe returns `True`; the
+  replacement is unacked. No `_ack_command` of the replacement;
+  `command_acked_or_good is False`. **Must fail pre-fix.**
+- **AC6 — no strike passed to the successor.** Racing probe returns `None`; after the
+  race the new occupant's `running_command_num_relaunch_after_invalid` is `0`
+  (pre-fix: `1`). **Must fail pre-fix.**
+- **AC7 — `check_commands`, emptied-during-await.** Race action
+  `lambda t: pump._drop_running_command("test")`, with `pump._stacked_command =
+  copy_command(CMD_ON)` pre-seeded (abandon leaves it alone, `:825`). After:
+  `current_command` survives, and the stacked-promotion tail still ran in the same
+  cycle (`_stacked_command is None`). **Must fail pre-fix.**
+- **AC8 — the load is not stranded.** In AC1/AC2: `running_command` is the
+  replacement, unacked, and `is_load_command_set(t) is False`. Holds only while the
+  replacement is unacked, which AC1/AC2's entity states guarantee.
+- **AC9 — the rung is deliberately inherited**, route A only, in the AC1 test:
+  `running_command_num_relaunch == <pre> + 1` (D7).
+- **AC10 — the causality anchor still fires.** AC1's test with `race_result=True`
+  (the existing `_RacingPump.race_result` attribute, `tests/…:131`):
+  `last_command_execution_time == T_RELAUNCH` after the guard bails. Green both ways.
+- **AC11 — #316's emptied-slot behaviour is unchanged.** Both existing `_RacingPump`
+  tests stay green with assertions **unmodified** (task 2 is additive-only), and the
+  task-2 revert check confirms they still fail with #316's guards removed.
+- **AC12 — both log arms are pinned** by `caplog`: "dropped" in AC7, "replaced" in
+  AC1.
+- **AC13 — the generation is monotonic**: bumped by an install, **not** bumped by
+  absorb (AC4), and strictly increasing across a `reset()` + reinstall.
+
+Docs:
+
+- **AC14** — `check_and_relaunch_command`'s docstring no longer contains "That is
+  pre-existing … tracked in #320, deliberately not fixed here", and states the
+  ownership invariant instead.
+- **AC15** — `load-base.md`: the "No lock" bullet (`:264-270`) no longer asserts
+  "each command-slot mutation happens between `await`s"; the sentence at `:186-188`
+  quoting `self.running_command = command` is reworded to the
+  `_install_running_command` call; the QS-304 API-surface bullet (`:317-325`) gains
+  `_install_running_command` / `_slot_still_holds` / `_running_command_generation`.
+  `user-override.md`'s two-sites bullet (`:92`) names three and says the check is
+  ownership, not emptiness. All four Doc-OK/updated docs bump `last_verified`.
+
+## Task breakdown
+
+One commit, taken after task 10. Tasks 4-8 are red in the working tree only.
+
+1. **REFACTOR** — `load.py`: add `_running_command_generation: int = 0` to
+   `AbstractDevice.__init__` (next to `_last_supersede_time`, `:204`) with the
+   "never reset this" comment, and `_install_running_command` (D2) replacing the
+   three statements at `:1013-1015`. **Do not add the field to `reset()`,
+   `constraint_reset_and_reset_commands_if_needed` or `abandon_running_command`.**
+   Suite stays green.
+2. **REFACTOR** — `tests/test_qs307_override_expiry_unfreeze.py`: make `_RacingPump`'s
+   mid-await action pluggable — add a `race_action` attribute defaulting to today's
+   `await self.check_load_activity_and_constraints(race_at)` (`:140`). **Additive
+   only**; the two existing tests keep their bodies and assertions verbatim.
+   Then verify AC11 is non-vacuous: temporarily revert the
+   `if self.running_command is None: return` guards in `launch_command` and
+   `force_relaunch_command`, run
+   `python scripts/qs/quality_gate.py --quick tests/test_qs307_override_expiry_unfreeze.py`,
+   confirm both #316 tests fail, restore. Record the result in the commit message.
+3. **REFACTOR** — same file: add `_ProbeRacingPump(_RacingPump)` overriding
+   `probe_if_command_set`, with `probe_race_at`, `probe_race_action` and
+   `probe_race_result: bool | None = True`. **One-shot** semantics (copy
+   `race_at, self.race_at = self.race_at, None`, `:139`): the injected press
+   re-enters `probe_if_command_set` at `:1020`, so a re-arming hook recurses.
+   **Race actions must go through a real `launch_command` / `user_clean_and_reset` /
+   `_drop_running_command`** — a direct `pump.running_command = …` (which this file
+   does in ~10 setup places) would replace the slot *without* bumping the generation,
+   and the test would pass vacuously.
+4. **RED** — new "QS-320 — the replaced slot" section: AC1, AC8, AC9, AC10. Route A
+   setup, spelled out because the obvious version reaches a **different branch**
+   (`_make_pump` never sets `unresponsive_since` → stack branch; `_arm_override`
+   makes `CMD_IDLE` override-suppressed → drop; `current_command == CMD_IDLE` →
+   drop), and because `_ack_command` nulls the slot:
+
+   ```python
+   pump.external_user_initiated_state = None            # no _arm_override
+   pump._ack_command(t0, copy_command(CMD_ON))          # current_command = CMD_ON, slot -> None
+   pump.running_command = copy_command(CMD_ON)          # setup-only direct write
+   pump.running_command_first_launch = pump.running_command_last_launch = t0
+   pump.unresponsive_since = t0
+   pump._last_supersede_time = None
+   pump.hass.states.set(PUMP_ENTITY, "on", last_changed=t0)
+   assert pump.is_uncontrollable is True                # pre-race: the branch is armed
+   ...
+   assert pump.running_command == CMD_IDLE              # post-race: supersede really ran
+   assert pump.current_command == CMD_ON                # post-race: not the emptied case
+   ```
+
+   The race action is `lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark
+   constraint done")` — the button (`button.py:190`) is a thin wrapper, and
+   `mark_current_constraint_has_done` itself needs an active constraint that this
+   recipe deliberately does not create.
+5. **RED** — AC2 (route A at `launch_command`, entity `STATE_UNAVAILABLE`) and AC4
+   (absorb, own recipe).
+6. **RED** — AC3, route B. No preconditions needed; race action
+   `pump.user_clean_and_reset()`.
+7. **RED** — AC5, AC6, AC7 via `_ProbeRacingPump`.
+8. **RED/REFACTOR** — `tests/test_load_model.py`: add the missing `res` assertion on
+   a `None` probe (set `running_command_last_launch`, assert `res == time - last_launch`),
+   so D5's load-bearing "two separate statements" property is pinned.
+9. **GREEN** — `load.py`: add `_slot_still_holds` (D3), apply the three call sites
+   (D5) with the charger comment at the `check_commands` guard, convert the six
+   dereferences (D4). Expect AC1/AC2/AC3/AC5/AC6/AC7/AC11 to flip red→green;
+   AC4/AC9/AC10 were green throughout.
+10. **Docs** — `check_and_relaunch_command`'s docstring (anchor: "Scope of those
+    guards, precisely") per AC14; `load-base.md` and `user-override.md` per AC15;
+    bump `last_verified` on **all four** docs the drift checker surfaces, including
+    the two Doc-OK ones.
+11. **Gate** — `python scripts/qs/quality_gate.py --impacted`, then
+    `python scripts/qs/quality_gate.py --quick tests/qs` (cheap insurance), then
+    `python scripts/qs/check_doc_drift.py --paths <the changed files>` must exit 0.
+
+## Doc maintenance
+
+The drift checker **exits 1** on any stale doc — a prose "Doc-OK" verdict does not
+clear it; only appearing in the modified set does. It is not wired into
+`quality_gate.py` or CI, but the implement phase runs it. So all four surfaced docs
+get a `last_verified` bump; two also get content changes.
+
+- `load-base.md` → content + bump (task 10).
+- `user-override.md` → content + bump (task 10).
+- `external-control-detection.md` → **bump only**. Its sole command-slot mention is a
+  passing `current_command` in the causality bullet (`:76`), which this change does
+  not alter.
+- `piloted-device-and-heat-pump.md` → **bump only**. It references `load.py` at
+  `:6`, `:16`, `:25-28` and `:62`, but only for the QS-306 `_has_state_to_reset()`
+  reset-logging hook and the fields it covers — no post-await or ownership content.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `custom_components/quiet_solar/home_model/load.py` | generation field, `_install_running_command`, `_slot_still_holds`, three call sites, six dereferences, docstring |
+| `tests/test_qs307_override_expiry_unfreeze.py` | `race_action`, `_ProbeRacingPump`, AC1-AC13 |
+| `tests/test_load_model.py` | the missing `res` assertion (task 8) |
+| `docs/agents/concepts/load-base.md` | AC15 |
+| `docs/agents/concepts/user-override.md` | AC15 |
+| `docs/agents/concepts/external-control-detection.md` | `last_verified` bump only |
+| `docs/agents/concepts/piloted-device-and-heat-pump.md` | `last_verified` bump only |
+
+**Test placement.** The QS-320 cases go in
+`tests/test_qs307_override_expiry_unfreeze.py`: `_RacingPump` is *the* mid-await race
+harness, the emptied and replaced cases are one family a reader needs in one view,
+and extracting the harness into a `tests/qs307_helpers.py` would move ~100 lines
+through a file that just came through five review rounds, for navigational benefit
+only. The module docstring gains a line saying it hosts both stories' race cases.
+
+## Residual risks for the implement phase
+
+- **The tag is a convention with a front door, not enforcement.** If a future change
+  installs a dispatch without `_install_running_command`, or resets the counter, the
+  guard silently weakens. D2's docstring and AC13 are the defence; there is no lint.
+- **No charger-level test.** The `check_commands` reachability argument rests on
+  `QSChargerGeneric.probe_if_command_set` awaiting real I/O while the test uses a
+  bistate pump. AC5/AC7 prove the guard fires, not that the charger reaches it. The
+  in-code comment at the guard is the mitigation.
+- **AC4 fails silently if the fix drifts to identity; AC3 fails silently if it drifts
+  to value equality.** Both must assert the positive outcome.
+- **D4's neutrality depends on `LoadCommand.__eq__` being all-field.** If a subclass
+  ever overrides it loosely, acking the local starts recording the *older* field
+  values on the absorb path.
+
+## Adversarial Review Notes
+
+### Round 1 (4 global reviewers), 2026-08-01 — story v1
+
+30 findings. Headline: the then-proposed value-equality primitive (`is_same_command`
+in `commands.py`) was rejected by three reviewers independently; it left QS-320 open
+on route B. Replaced with the generation tag, which removed `commands.py`,
+`tests/test_commands.py`, `commands.md`, 3 tasks and 1 AC from the plan. Also
+corrected: a false mypy justification (`union-attr` is disabled), two false "verified
+by grep" Doc-OK claims, and the wrong host class throughout (`AbstractDevice`, not
+`AbstractLoad`). Full round-1 detail is superseded by round 2 below.
+
+### Round 2 (4 global reviewers + delta-auditor), 2026-08-01 — story v2
+
+**The design was verified sound.** The concrete-planner enumerated every write to
+`self.running_command` in the package and confirmed no sequence yields "non-`None` +
+unchanged generation + different dispatch"; every line number and symbol in the story
+resolved. All three `critical` findings were in the **test plan**, not the fix.
+
+| # | Reviewer | Cat | Finding | State |
+| --- | --- | --- | --- | --- |
+| 1 | planner + critic | critical | Task 4's recipe never installs a command (`_ack_command` nulls the slot), so its own `is_uncontrollable` assert fails | **resolved** — full recipe, task 4 |
+| 2 | planner + critic | critical | Natural entity state makes AC1/AC2 exercise the **emptied** case; tests would pass pre-fix | **resolved** — entity state pinned per AC, `current_command == CMD_ON` post-assertion, "must fail pre-fix" on every race AC |
+| 3 | planner | critical | Task 6's give-up recipe unreachable — every slot mutation zeroes the strike counter | **resolved** — give-up documented as unreachable during a race; AC6 restated as the spurious-strike case |
+| 4 | delta-auditor + dev-proxy | critical | "Never reset the generation" load-bearing and pinned by nothing | **resolved** — D2 docstring, task 1 instruction, AC13 |
+| 5 | dev-proxy | critical | Doc-OK has no mechanism; the checker exits 1 | **resolved** — verified exit 1; all four docs bump `last_verified`, task 11 asserts exit 0 |
+| 6 | delta-auditor | critical | AC6 contradicted task 6 | **resolved** — restated |
+| 7 | scope-guardian | redesign | Split the third site into its own issue | **rejected by the user** — same one-line fix, same file, confirmed reachable; leaving a known corruption path open while editing neighbouring lines is not worth the split |
+| 8 | scope-guardian | improve | `_install_running_command` has one call site; inline it | **rejected by the user** — the "never reset / never bypass" warning label needs somewhere to live. Directly conflicts with round-1's critic, which wanted a property setter; both extremes rejected, D6 records why |
+| 9 | planner | redesign | AC1 vacuous if the press shares the relaunch timestamp | **resolved** — `T_RELAUNCH` / `T_PRESS` |
+| 10 | critic | critical | Slot-write enumeration covered only *other* files | **resolved** — full in-file enumeration in D1, greps in Scope for re-running |
+| 11 | critic | redesign | Two callers could hold the same generation | **rejected** — absorb `return`s immediately and never becomes a completer; the planner's enumeration confirms no such sequence exists |
+| 12 | delta-auditor | redesign | An `await` might sit between the guard and `force_relaunch_command`'s writes | **rejected** — the only await is the mutually exclusive `else` arm; statement order now stated in D5 |
+| 13 | delta-auditor + critic | improve | Plan contradicted itself on whether `check_commands` has a pre-await `None` check | **resolved** — it does; D5 says so, and the flag adds no re-indent |
+| 14 | dev-proxy | improve | The `diff-cover` justification overstated (QS-283 self-heals) | **resolved** — restated; the early-`return` behaviour change is now the load-bearing reason |
+| 15 | planner | improve | `test_load_model.py` citation wrong; the `res` property is unpinned | **resolved** — re-cited `:1493`/`:1511`, task 8 adds the assertion |
+| 16 | critic + dev-proxy | improve | No downstream analysis of `command_acked_or_good = False` | **resolved** — D5 names both consumers |
+| 17 | planner + dev-proxy | improve | `load-base.md:186-188` quotes code task 1 deletes; API-surface bullet missing the new symbols | **resolved** — AC15 |
+| 18 | planner + dev-proxy | improve | D4 neutrality cited the wrong evidence | **resolved** — restated on `__eq__` completeness; added to residual risks |
+| 19 | planner + dev-proxy | improve | D4 table missed `:1364`, `:1103`, `:1020`; completeness claim unproven | **resolved** — "left as-is" list + out-of-scope deref sentence |
+| 20 | dev-proxy + delta-auditor + critic | improve | Line-number note named the wrong task; D4 was line-keyed | **resolved** — task 1, anchor phrases |
+| 21 | critic + planner | improve | AC4 had no recipe and task 4's recipe produces the opposite branch | **resolved** — AC4 owns a mirror recipe |
+| 22 | planner + dev-proxy | improve | Task labels wrong; half of task 4's ACs are green pre-fix | **resolved** — REFACTOR labels, per-AC "must fail pre-fix" |
+| 23 | critic + delta-auditor | improve | The log ternary had no assertion | **resolved** — AC12 |
+| 24 | critic | improve | No AC covered the generation itself | **resolved** — AC13 |
+| 25 | scope-guardian | improve | AC9 pins unchanged behaviour | **kept, narrowed** — route A only, inside AC1's test |
+| 26 | delta-auditor + dev-proxy | improve | AC11's pointer stale, no verification step | **resolved** — task 2 |
+| 27 | delta-auditor + dev-proxy | clarify | `launched_generation` possibly unbound | **resolved** — D5 states `:1013` dominates `:1050` |
+| 28 | planner | clarify | Which callable each race action invokes | **resolved** — named per AC in tasks 4-7 |
+| 29 | planner | clarify | `_ProbeRacingPump` had no result attribute | **resolved** — `probe_race_result` |
+| 30 | planner | clarify | A hand-set slot inside a race action passes vacuously | **resolved** — task 3 warning |
+| 31 | planner | clarify | AC7's promotion clause not observable | **resolved** — `_stacked_command` seeded, action named |
+| 32 | planner | clarify | Tests might drive the chain via `check_and_relaunch_command` | **resolved** — "call the site directly" |
+| 33 | dev-proxy + planner | clarify | AC probe returns, `NUM_MAX_INVALID_PROBES_COMMANDS` home, `race_result`, `T_RACE` unstated | **resolved** — constant is `load.py:53`; probe returns stated per AC |
+| 34 | scope-guardian | clarify | Reachability evidence lives only in a story file | **resolved** — in-code comment at the `check_commands` guard |
+| 35 | scope-guardian | clarify | Why not reuse `running_command_first_launch` as the tag | **resolved** — D1 records the timestamp-collision rejection |
+| 36 | dev-proxy | improve | `info` level against the debug-default rule | **resolved** — D3 marks it a deliberate exception |
+| 37 | scope-guardian + delta-auditor | clarify | D2 "can never be missed" overclaims vs residual risks | **resolved** — "one way in", convention-not-enforcement, stated in both places |
+| 38 | critic | clarify | Goal contradicted the causality-anchor exception | **resolved** — Goal reworded |
+| 39 | critic + delta-auditor | clarify | AC2 delegated its assertions; AC3's wording ambiguous; AC8's precondition in the wrong task | **resolved** |
+
+### Shipped state
+
+Story v3 (this text) folds in all 39 round-2 findings and was **not itself
+re-reviewed** — a third round was offered and declined. Zero open criticals at
+finalize. The two accepted trades are in Residual risks: the generation tag is
+protected by a docstring rather than a lint, and there is no charger-level test for
+the `check_commands` site.

--- a/docs/stories/QS-320.story_review_fix_#01.md
+++ b/docs/stories/QS-320.story_review_fix_#01.md
@@ -1,0 +1,303 @@
+# QS-320 — Review fix plan #01
+
+## Summary
+- Source PR: #326
+- Source story: `docs/stories/QS-320.story.md`
+- Findings to fix: 11 (6 should-fix, 5 nice-to-have)
+- Next implement phase: `/implement-task`
+- Triage decision: **fix all** (option A — finding 1 included, verified first)
+
+Reviewer coverage caveat: CodeRabbit produced **no** findings because it was
+rate-limited, not because it found the PR clean. It has marked `e764fbb6` as
+already-reviewed, so re-triggering will no-op; the fix commit from this plan is
+what re-arms it for the next `/review-task` pass.
+
+## Findings to fix
+
+### [should-fix] 1. Causality anchor can move backwards → spurious user override
+
+- File: `custom_components/quiet_solar/home_model/load.py:1115`, `:1441`
+- Severity: should-fix (verified CONFIRMED — empirically reproduced)
+- Source: qs-review-blind-hunter, confirmed by follow-up verification agent
+
+**Description.** `_anchor_causality_guard_if_executed` (`load.py:694-702`) writes
+`last_command_execution_time = time` by **plain unconditional assignment**. The
+call deliberately sits ABOVE the `_slot_still_holds` ownership guard at both
+sites, which is correct in intent — a service call that physically landed should
+be recorded regardless of slot ownership. What the design did not consider is
+that the *replacing* dispatch may have already written a **newer** anchor.
+
+Race, reproduced with the repo's own `_RacingPump` harness:
+
+1. `force_relaunch_command(T_RELAUNCH)` executes and awaits.
+2. A button press lands mid-await, supersedes, executes, writes anchor
+   `= T_PRESS` (1s newer), acks.
+3. The outer dispatch resumes, writes anchor `= T_RELAUNCH` at `:1441` — one
+   second **older** — then bails at `:1443`. The rewind persists.
+
+The single consumer is `ha_model/bistate_duration.py:851-887`, a bare freshness
+floor with no tolerance window:
+
+```python
+elif state_last_changed <= self.last_command_execution_time:
+    is_command_overridden_state_changed = False
+```
+
+A rewound anchor **lifts the floor**, so a state change QS itself caused now
+fails the test and is classified as an external user override. Verified
+end-to-end: correct anchor → `external_user_initiated_state = None`, 0 override
+constraints; rewound anchor → `bistate OVERRIDE BY USER on switch.pool_pump`,
+1 override constraint pushed. Consequence: the load is frozen for
+`override_duration` hours on a command QS issued itself.
+
+**Proposed fix.** Make the helper monotonic — never let the anchor go backwards:
+
+```python
+if is_command_set is True:
+    prev = self.last_command_execution_time
+    if prev is None or time > prev:
+        self.last_command_execution_time = time
+```
+
+Keep the call above the ownership guard (that part of the design is right).
+
+Constraints on the implementation:
+- `None` must mean "no anchor" and accept any value (not be treated as
+  `-infinity` via a comparison that raises).
+- The two non-helper writers stay as they are: `load.py:590` (restore → `now`)
+  must remain a plain assignment, `load.py:2440` (`user_clean_and_reset` →
+  `None`) must remain a clear.
+
+**Verified safe.** Full-suite A/B with the monotonic patch: baseline 30 failed /
+6891 passed, monotonic 30 failed / 6891 passed, failure sets identical (26 are
+`ModuleNotFoundError: scipy`, 4 pre-existing `ha_tests/test_sensor.py`).
+Targeted run of the 10 anchor/override/bistate files under the patch: 681
+passed.
+
+**No acceptance test needs rewriting.** `tests/test_qs307_override_expiry_unfreeze.py:1019`
+(`assert pump.last_command_execution_time == T_RELAUNCH`) does *not* enshrine
+the rewind: `_arm_for_supersede` sets `pump.obeys = False` (`:935`), so the
+press's execute returns `False` and never anchors. The assertion is satisfied by
+the outer write alone and is compatible with the fix.
+
+**New test required.** Add a race test with `obeys = True` so the press *does*
+anchor, asserting the anchor holds the newer instant after the superseded
+dispatch resumes.
+
+### [should-fix] 2. Confirmed contact discarded when the slot is not ours
+
+- File: `custom_components/quiet_solar/home_model/load.py:1192` (same hole at `:1117`)
+- Severity: should-fix (new regression introduced by this PR)
+- Source: qs-review-edge-case-hunter
+
+**Description.** When `check_commands` finds the slot replaced after its await,
+it skips the ack — correct — but it also skips `_clear_unresponsive(CONFIRMED)`.
+A probe that *proves* the device answered therefore discards the contact
+evidence, and a live lost-control episode survives demonstrated contact.
+`ContactEvidence.CONFIRMED` is documented at `load.py:787-788` as
+dispatch-independent ("an ack is contact whether or not a clock was live"), and
+`_ack_command` (`load.py:678`) is now the only reachable CONFIRMED writer on this
+path. The `_escalate_or_recover` fallback at `load.py:1375` only fires when the
+slot is **empty**, which is exactly the case that does not apply here.
+
+Reproduces when: a load is in a lost-control episode (`unresponsive_since` set,
+dispatch A at generation G); `check_commands` awaits a real probe; mid-probe the
+"mark constraint done" button runs `mark_current_constraint_has_done` →
+`launch_command(CMD_IDLE)`, which supersedes and installs G+1; the probe returns
+`True`. `slot_is_ours` is False, so both the ack and the unresponsive-clear are
+skipped — `unresponsive_since` and `_unresponsive_needs_ack` survive proven
+contact.
+
+Consequence: `is_uncontrollable` stays True for at least another cycle, so the
+next solver command supersedes (an extra service call) instead of stacking, and
+the episode-resolved latch/log is delayed.
+
+**This is a new discard.** On `main` the True probe cleared the episode as a side
+effect of the phantom ack this PR correctly removes. The contact signal needs its
+own home rather than riding on the ack.
+
+**Proposed fix.** Split contact evidence from the ack: when the probe confirms
+contact but the slot is no longer ours, still call
+`_clear_unresponsive(reason, contact=ContactEvidence.CONFIRMED)` while continuing
+to skip the ack, the stamp and the counters. Apply at both `:1192` and `:1117`.
+Add a test asserting `unresponsive_since is None` after a confirming probe whose
+slot was replaced mid-await.
+
+### [should-fix] 3. `running_command_num_relaunch` is never disowned — docstring contradiction
+
+- File: `custom_components/quiet_solar/home_model/load.py:1425`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+
+**Description.** `self.running_command_num_relaunch += 1` is written *before* the
+await and is never disowned when `_slot_still_holds` fails at `:1443`. This
+contradicts the invariant this same PR introduces in `check_and_relaunch_command`'s
+docstring (`load.py:1237-1239`: "consult `_slot_still_holds` after their awaits
+before stamping, acking, **counting** or dereferencing") and the symmetric gating
+the same diff applies to the sibling counter
+`running_command_num_relaunch_after_invalid` at `:1173-1178`.
+
+Effect: a superseding successor inherits a ladder rung it never earned — one step
+closer to `NUM_MAX_COMMAND_RELAUNCH` and one rung longer on the backoff.
+
+**Resolution — amend the docstring, do not move the code.** Story AC9 declares
+this inheritance deliberate (route A inherits the ladder rung, QS-304's saturated
+cadence), and the acceptance auditor confirmed AC9 is implemented and tested as
+specified. The defect is that the new docstring over-claims. Narrow the
+docstring's ownership claim to exclude `running_command_num_relaunch`, and state
+explicitly that the rung is inherited by design with a pointer to AC9/QS-304.
+
+### [should-fix] 4. AC4's "still stamped" assertion is vacuous
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py` (the
+  `test_an_absorbed_command_still_belongs_to_the_caller_in_flight` case)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+
+**Description.** AC4 requires that an absorbed command is "still stamped"
+post-race. The test asserts `pump.running_command_last_launch == T_RELAUNCH`, but
+the setup already sets `running_command_last_launch = T_RELAUNCH` and
+`force_relaunch_command(T_RELAUNCH)` writes the same instant — so the assertion
+holds identically whether the stamp was rewritten or the guard bailed before it.
+The clause the AC exists to prove is unobservable.
+
+**Proposed fix.** Set the setup stamp to an earlier instant (e.g.
+`T_RELAUNCH - timedelta(seconds=1)`) and assert `== T_RELAUNCH` post-race, making
+the rewrite observable. This closes residual-risk bullet 3 in the story.
+
+### [should-fix] 5. No recorded red-first evidence for the six race tests
+
+- File: PR #326 body / commit message
+- Severity: should-fix (traceability, not correctness)
+- Source: qs-review-acceptance-auditor
+
+**Description.** The story marks AC1/AC2/AC3/AC5/AC6/AC7 "**Must fail pre-fix**",
+and task 2's revert check is minuted in commit `e764fbb6` for AC11 only. There is
+no comparable recorded evidence that the six new race tests were observed red
+before the `load.py` change. The auditor inspected the recipes and judged them
+non-vacuous (AC3's `assert running_command == CMD_IDLE` proves the reinstall
+happened; AC1's `T_PRESS` stamp differs from `T_RELAUNCH`), so this is a
+traceability gap rather than a suspected failure.
+
+**Proposed fix.** Re-run the six tests with the `load.py` guards reverted, record
+the observed failure count per AC, and add the result as a short note in the PR
+body (and/or the fix commit message), matching the format already used for AC11.
+
+### [should-fix] 6. The "one way in" install invariant is unenforced
+
+- File: `custom_components/quiet_solar/home_model/load.py:956`, `:1190`
+- Severity: should-fix (hardening)
+- Source: qs-review-blind-hunter
+
+**Description.** `probed_generation = self._running_command_generation` is read
+off the slot rather than returned by an install. That is sound only while *every*
+non-`None` slot write bumps the tag. The edge-case-hunter verified this holds
+today — it traced every writer of `running_command` (`load.py:422`, `:665`,
+`:839`, `:956`, `:1014`) and confirmed the only non-bumping install is `absorb`,
+which requires `==` on a 2-field dataclass whose fields `copy_command` reproduces
+exactly. But the invariant is currently maintained only by a comment that itself
+admits "there is no lint", and this PR exists precisely because a future install
+site can silently reopen QS-320.
+
+**Proposed fix.** Make the invariant enforced rather than documented: either route
+all non-`None` slot writes through a property setter on `running_command` that
+bumps the generation, or add an assertion in `_install_running_command` plus a
+test that fails if a new direct-write site appears. Prefer the lowest-ceremony
+option that actually fails loudly; do not restructure the install path beyond
+what the invariant needs.
+
+### [nice-to-have] 7. `ctxt: None` in the operator-facing log at 2 of 3 sites
+
+- File: `custom_components/quiet_solar/home_model/load.py:961` (sites `:1163`, `:1443`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (deduplicated)
+
+**Description.** `_slot_still_holds(ctxt: str | None = None)` is only passed a
+`ctxt` at the `launch_command` site; the other two emit `ctxt: None` in the very
+INFO line an operator reads when a load misbehaves.
+
+**Proposed fix.** Pass a meaningful discriminator at both remaining sites —
+`check_commands` has `running_command_num_relaunch_after_invalid` to hand
+(already in its own log line at `:1158`), `force_relaunch_command` has
+`running_command_num_relaunch` — or omit the field entirely when absent.
+
+### [nice-to-have] 8. `probe_if_command_set` is the only I/O await not wrapped
+
+- File: `custom_components/quiet_solar/home_model/load.py:1162`
+- Severity: nice-to-have (pre-existing)
+- Source: qs-review-edge-case-hunter
+
+**Description.** `launch_command` wraps both its probe (`:1088`) and its execute
+(`:1108`); `force_relaunch_command` wraps its execute (`:1428`). `check_commands`'
+probe is unwrapped, so a raising subclass probe escapes before `slot_is_ours` is
+computed and before the stacked-promotion tail at `:1199` — the new ownership
+bookkeeping is bypassed wholesale for that cycle and no invalid-probe strike is
+counted. Contained today by `QSHome.check_loads_commands`' per-load handler
+(`all_ok → False`), but it is now the odd one out in a trio this PR explicitly
+normalises.
+
+**Proposed fix.** Wrap it in `try/except` consistently with the sibling sites,
+counting an invalid-probe strike on failure.
+
+### [nice-to-have] 9. `res` stays `timedelta(0)` when the slot is not ours
+
+- File: `custom_components/quiet_solar/home_model/load.py:1195`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+
+**Description.** When the slot is not ours, `res` remains `timedelta(0)`, which is
+indistinguishable from "just launched". Harmless *only* because every caller
+discards the first tuple element (`_wait_time` unused at `:1246`; `:1458`
+discards the tuple). A future caller that starts consuming the delay would read a
+superseded dispatch as freshly launched.
+
+**Proposed fix.** Add a one-line comment pinning the dead-value assumption, since
+the PR otherwise documents every deliberate non-write at this site.
+
+### [nice-to-have] 10. `launched_command` is dereferenced only for the log line
+
+- File: `custom_components/quiet_solar/home_model/load.py:975`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+
+**Description.** `launched_command` is used solely to build the log message, and
+the docstring has to argue at length that it is non-`None` by construction.
+
+**Proposed fix.** Pass `launched_command.command` (a plain `str`) instead, which
+removes the dereference-safety argument entirely and lets the docstring shrink.
+
+### [nice-to-have] 11. `_spy_on_acks` monkey-patches without restore
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py` (`_spy_on_acks`, ~`:950`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+
+**Description.** `pump._ack_command` is replaced without restore. Per-instance, so
+harmless today.
+
+**Proposed fix.** Use `monkeypatch.setattr` so it stays harmless if the fixture's
+scope ever widens.
+
+## Not in scope (recorded, deliberately excluded)
+
+Two blind-hunter findings were **refuted** during consolidation by the
+edge-case-hunter's repo-level tracing, and must not be "fixed":
+
+- *Promotion tail reopens QS-320* — promotion does route through
+  `_install_running_command`; every `running_command` writer was traced.
+- *Absorb + `LoadCommand.__eq__` acks a stale object* — `LoadCommand` is a
+  2-field dataclass, `copy_command` reproduces both fields exactly, and no
+  subclass exists (the "overcharged `__eq__`" comment at `load.py:1069` is
+  vestigial).
+
+Both were explicitly tagged "assumed without repo context" by the blind hunter,
+whose lens is diff-only by design.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. Findings 1 and 2 are behavioural and
+need new tests; 3 and 5 are documentation/traceability; 4 tightens an existing
+test; 6 is hardening; 7-11 are polish.
+
+When done, return and run `/review-task` again to re-verify — the fix commit will
+also re-arm CodeRabbit, whose lens was missing from this round.

--- a/docs/stories/QS-320.story_review_fix_#01.md
+++ b/docs/stories/QS-320.story_review_fix_#01.md
@@ -287,6 +287,16 @@ the existing `slot_is_ours`-gated block at `:1173-1178` counts the strike.
 Counting inside the `except` would either bypass the QS-320 ownership gate or
 double-count.
 
+**Disposition (round 2).** Skipped as unimplementable without renegotiating a
+test-pinned QS-304 contract: three tests assert with `pytest.raises` that a
+raising probe propagates out of `check_commands`
+(`tests/test_bug_304_command_deadlock.py:1004`, `:1023`, `:1271`), and
+`check_and_relaunch_command`'s docstring pins "the device exception is
+deliberately not swallowed — `QSHome.check_loads_commands` owns the per-load
+try/except". The round-2 acceptance auditor independently verified the conflict
+is real and the skip correct; the user adjudicated it as final (option a). The
+bare probe in `check_commands` is deliberate. No new issue.
+
 ### [nice-to-have] 9. `res` stays `timedelta(0)` when the slot is not ours
 
 - File: `custom_components/quiet_solar/home_model/load.py:1195`

--- a/docs/stories/QS-320.story_review_fix_#01.md
+++ b/docs/stories/QS-320.story_review_fix_#01.md
@@ -3,14 +3,14 @@
 ## Summary
 - Source PR: #326
 - Source story: `docs/stories/QS-320.story.md`
-- Findings to fix: 11 (6 should-fix, 5 nice-to-have)
+- Findings to fix: 12 (6 should-fix, 6 nice-to-have)
 - Next implement phase: `/implement-task`
 - Triage decision: **fix all** (option A — finding 1 included, verified first)
-
-Reviewer coverage caveat: CodeRabbit produced **no** findings because it was
-rate-limited, not because it found the PR clean. It has marked `e764fbb6` as
-already-reviewed, so re-triggering will no-op; the fix commit from this plan is
-what re-arms it for the next `/review-task` pass.
+- Plan revision 2: every finding re-verified against HEAD `570f52a6` by an
+  independent agent; corrections applied inline (notably findings 2 and 6).
+  CodeRabbit's lens is now **covered**: the plan-commit push re-armed it, it
+  reviewed at 2026-08-01T19:40Z and produced exactly one nitpick, included
+  below as finding 12. All four reviewer lenses have reported on this PR.
 
 ## Findings to fix
 
@@ -119,9 +119,35 @@ own home rather than riding on the ack.
 **Proposed fix.** Split contact evidence from the ack: when the probe confirms
 contact but the slot is no longer ours, still call
 `_clear_unresponsive(reason, contact=ContactEvidence.CONFIRMED)` while continuing
-to skip the ack, the stamp and the counters. Apply at both `:1192` and `:1117`.
-Add a test asserting `unresponsive_since is None` after a confirming probe whose
-slot was replaced mid-await.
+to skip the ack, the stamp and the counters. Add a test asserting
+`unresponsive_since is None` after a confirming probe whose slot was replaced
+mid-await.
+
+**HARD SCOPE — verified constraints (do not deviate):**
+
+- Apply at `:1192` and `:1117` **ONLY**. A third instance of the same discard
+  exists in `force_relaunch_command` (execute returns `True`, the guard at
+  `:1443` returns before the ack at `:1454`) — **do NOT "complete the symmetry"
+  there.** The shipped AC1 test asserts `pump.unresponsive_since == T_RELAUNCH`
+  ("the lost-control episode is not over") at
+  `tests/test_qs307_override_expiry_unfreeze.py:1007` in exactly that
+  configuration; extending the fix to `:1443` goes red. State in the fix commit
+  that the probe/execute asymmetry (a confirming *probe* clears the episode, a
+  `True` *execute* under a disowned slot does not) is deliberate, so it does not
+  resurface next review round.
+- Gate the clear on `is_command_set is True` (a `None`/`False` probe result is
+  not contact).
+- At the `:1192` site, `command_acked_or_good` must stay `False` — AC5 asserts
+  it at `tests/test_qs307_override_expiry_unfreeze.py:1162`.
+- The CONFIRMED clear also drops the shout latch and wipes
+  `_last_supersede_time` (flipping the successor from supersede-mode to
+  stack-mode). This is consistent with the contract at `load.py:787-788`, and
+  with pre-PR `main`, where the phantom ack produced the identical clear — but
+  a literal reader of the `is_uncontrollable` docstring at `load.py:743-749`
+  ("hands the clock to the successor on purpose … Do NOT restore the
+  invariant") will see a contradiction. Add one clarifying sentence there
+  distinguishing *proven contact* (this fix, clears) from *silent supersede*
+  (that docstring, must not clear).
 
 ### [should-fix] 3. `running_command_num_relaunch` is never disowned — docstring contradiction
 
@@ -171,40 +197,54 @@ the rewrite observable. This closes residual-risk bullet 3 in the story.
 - Severity: should-fix (traceability, not correctness)
 - Source: qs-review-acceptance-auditor
 
-**Description.** The story marks AC1/AC2/AC3/AC5/AC6/AC7 "**Must fail pre-fix**",
-and task 2's revert check is minuted in commit `e764fbb6` for AC11 only. There is
-no comparable recorded evidence that the six new race tests were observed red
-before the `load.py` change. The auditor inspected the recipes and judged them
-non-vacuous (AC3's `assert running_command == CMD_IDLE` proves the reinstall
-happened; AC1's `T_PRESS` stamp differs from `T_RELAUNCH`), so this is a
-traceability gap rather than a suspected failure.
+**Description.** The story marks AC1/AC2/AC3/AC5/AC6/AC7 "**Must fail pre-fix**".
+The PR body already carries an *unquantified* claim ("AC1/AC2/AC3/AC5/AC6/AC7
+were verified to fail pre-fix behaviourally"), but only AC11's revert check is
+minuted with numbers ("3 of 4 parametrized cases fail", commit `e764fbb6`). The
+gap is the missing quantification, not a void: the auditor inspected the recipes
+and judged them non-vacuous (AC3's `assert running_command == CMD_IDLE` proves
+the reinstall happened; AC1's `T_PRESS` stamp differs from `T_RELAUNCH`).
 
 **Proposed fix.** Re-run the six tests with the `load.py` guards reverted, record
-the observed failure count per AC, and add the result as a short note in the PR
-body (and/or the fix commit message), matching the format already used for AC11.
+the observed failure count per AC, and upgrade the PR body's existing claim with
+those numbers (and/or minute them in the fix commit message), matching the format
+already used for AC11.
 
 ### [should-fix] 6. The "one way in" install invariant is unenforced
 
-- File: `custom_components/quiet_solar/home_model/load.py:956`, `:1190`
+- File: `custom_components/quiet_solar/home_model/load.py:956`, `:1157`
 - Severity: should-fix (hardening)
 - Source: qs-review-blind-hunter
 
-**Description.** `probed_generation = self._running_command_generation` is read
-off the slot rather than returned by an install. That is sound only while *every*
-non-`None` slot write bumps the tag. The edge-case-hunter verified this holds
-today — it traced every writer of `running_command` (`load.py:422`, `:665`,
-`:839`, `:956`, `:1014`) and confirmed the only non-bumping install is `absorb`,
-which requires `==` on a 2-field dataclass whose fields `copy_command` reproduces
-exactly. But the invariant is currently maintained only by a comment that itself
-admits "there is no lint", and this PR exists precisely because a future install
-site can silently reopen QS-320.
+**Description.** `probed_generation = self._running_command_generation`
+(`:1157`) is read off the slot rather than returned by an install. That is sound
+only while *every* new-dispatch slot write bumps the tag. The edge-case-hunter
+verified this holds today — it traced every writer of `running_command`
+(`load.py:422`, `:665`, `:839`, `:956`, `:1014`) and confirmed the only
+non-bumping install is `absorb`, which requires `==` on a 2-field dataclass whose
+fields `copy_command` reproduces exactly. But the invariant is currently
+maintained only by a comment that itself admits "there is no lint", and this PR
+exists precisely because a future install site can silently reopen QS-320.
 
-**Proposed fix.** Make the invariant enforced rather than documented: either route
-all non-`None` slot writes through a property setter on `running_command` that
-bumps the generation, or add an assertion in `_install_running_command` plus a
-test that fails if a new direct-write site appears. Prefer the lowest-ceremony
-option that actually fails loudly; do not restructure the install path beyond
-what the invariant needs.
+**Proposed fix — the enforcement lives in a test, NOT in the installer.**
+
+- **A property setter that bumps on every non-`None` write is OFF THE TABLE.**
+  The story already considered and rejected it (`docs/stories/QS-320.story.md`
+  ~line 270): it would bump on absorb, which must stay generation-neutral.
+  It breaks two green tests (AC4 asserts the generation is unchanged across
+  absorb at `tests/test_qs307_override_expiry_unfreeze.py:1124`; AC13 at
+  `:963`), and a value-equality exemption reopens QS-320 route B per
+  `load.py:977-980`.
+- An assertion *inside* `_install_running_command` enforces nothing — that is
+  the site that already bumps correctly.
+- **Do this instead:** add a lint-style test that scans
+  `custom_components/quiet_solar/home_model/load.py` (or the package) for
+  direct `self.running_command =` assignments and fails unless they are exactly
+  the five sanctioned sites (`:422` reset-wipe, `:665` ack-clear, `:839`
+  abandon-clear, `:956` install, `:1014` absorb) — matched structurally (e.g.
+  by enclosing function name), not by line number, so the test does not rot on
+  unrelated edits. A sixth site appearing = red, with a message pointing at
+  `_install_running_command`.
 
 ### [nice-to-have] 7. `ctxt: None` in the operator-facing log at 2 of 3 sites
 
@@ -218,8 +258,13 @@ INFO line an operator reads when a load misbehaves.
 
 **Proposed fix.** Pass a meaningful discriminator at both remaining sites —
 `check_commands` has `running_command_num_relaunch_after_invalid` to hand
-(already in its own log line at `:1158`), `force_relaunch_command` has
+(already in its own log line at `:1159`), `force_relaunch_command` has
 `running_command_num_relaunch` — or omit the field entirely when absent.
+The `_race_log` test helper (`tests/test_qs307_override_expiry_unfreeze.py:895-903`)
+matches a substring unaffected by the ctxt value, so no test churn.
+
+**Coordinate with findings 10 and 12:** all three rewrite the same
+`_slot_still_holds` signature/log-line region — make it one edit, not three.
 
 ### [nice-to-have] 8. `probe_if_command_set` is the only I/O await not wrapped
 
@@ -227,17 +272,20 @@ INFO line an operator reads when a load misbehaves.
 - Severity: nice-to-have (pre-existing)
 - Source: qs-review-edge-case-hunter
 
-**Description.** `launch_command` wraps both its probe (`:1088`) and its execute
-(`:1108`); `force_relaunch_command` wraps its execute (`:1428`). `check_commands`'
+**Description.** `launch_command` wraps both its probe (`:1087`) and its execute
+(`:1107`); `force_relaunch_command` wraps its execute (`:1427`). `check_commands`'
 probe is unwrapped, so a raising subclass probe escapes before `slot_is_ours` is
 computed and before the stacked-promotion tail at `:1199` — the new ownership
 bookkeeping is bypassed wholesale for that cycle and no invalid-probe strike is
 counted. Contained today by `QSHome.check_loads_commands`' per-load handler
-(`all_ok → False`), but it is now the odd one out in a trio this PR explicitly
-normalises.
+(`home.py:2882`, `all_ok → False`), but it is now the odd one out in a trio this
+PR explicitly normalises.
 
-**Proposed fix.** Wrap it in `try/except` consistently with the sibling sites,
-counting an invalid-probe strike on failure.
+**Proposed fix.** Wrap it in `try/except` consistently with the sibling sites.
+**Constraint:** on exception, set `is_command_set = None` and fall through, so
+the existing `slot_is_ours`-gated block at `:1173-1178` counts the strike.
+Counting inside the `except` would either bypass the QS-320 ownership gate or
+double-count.
 
 ### [nice-to-have] 9. `res` stays `timedelta(0)` when the slot is not ours
 
@@ -268,15 +316,36 @@ removes the dereference-safety argument entirely and lets the docstring shrink.
 
 ### [nice-to-have] 11. `_spy_on_acks` monkey-patches without restore
 
-- File: `tests/test_qs307_override_expiry_unfreeze.py` (`_spy_on_acks`, ~`:950`)
+- File: `tests/test_qs307_override_expiry_unfreeze.py:867-883` (`_spy_on_acks`)
 - Severity: nice-to-have
 - Source: qs-review-blind-hunter
 
 **Description.** `pump._ack_command` is replaced without restore. Per-instance, so
 harmless today.
 
-**Proposed fix.** Use `monkeypatch.setattr` so it stays harmless if the fixture's
-scope ever widens.
+**Proposed fix.** Use `monkeypatch.setattr` — this means threading the fixture
+through the ~6 tests calling the helper, and it removes the
+`# type: ignore[method-assign]` at `:882` as a bonus. If the threading churn
+outweighs the benefit, a brief comment on the helper is an acceptable fallback.
+
+### [nice-to-have] 12. f-string log calls on hot paths (CodeRabbit)
+
+- File: `custom_components/quiet_solar/home_model/load.py:1158-1160`,
+  `:1179-1181`, plus a third instance CodeRabbit did not cite at `:1125-1127`
+  (`launch_command`)
+- Severity: nice-to-have
+- Source: qs-review-coderabbit (verified; third site found during plan
+  verification)
+
+**Description.** Three `_LOGGER.info` calls build their message with f-strings.
+They format even when INFO is disabled, and two sit on the `check_commands` path
+that runs every periodic cycle for every load. Coding guidelines: "Use lazy `%s`
+logging arguments, never f-strings in log calls, and do not end log messages
+with periods."
+
+**Proposed fix.** Convert all three to lazy `%s` arguments, consistent with the
+`_slot_still_holds` log at `:993-1000`. Natural rider on finding 7's edit —
+same log-line region.
 
 ## Not in scope (recorded, deliberately excluded)
 
@@ -297,7 +366,13 @@ whose lens is diff-only by design.
 
 Run `/implement-task` against this fix plan. Findings 1 and 2 are behavioural and
 need new tests; 3 and 5 are documentation/traceability; 4 tightens an existing
-test; 6 is hardening; 7-11 are polish.
+test; 6 is hardening (test-side); 7-12 are polish. Bundle 7, 10 and 12 into one
+edit of the `_slot_still_holds` region.
 
-When done, return and run `/review-task` again to re-verify — the fix commit will
-also re-arm CodeRabbit, whose lens was missing from this round.
+The two red lines an implementer must not cross, both test-pinned:
+- Finding 2: do not extend the contact-clear to `force_relaunch_command`
+  (breaks AC1's `unresponsive_since == T_RELAUNCH` at tests `:1007`).
+- Finding 6: do not add a bump-on-write property setter (breaks AC4's
+  generation-unchanged at tests `:1124` and AC13 at `:963`).
+
+When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-320.story_review_fix_#02.md
+++ b/docs/stories/QS-320.story_review_fix_#02.md
@@ -1,0 +1,287 @@
+# QS-320 — Review fix plan #02
+
+## Summary
+- Source PR: #326
+- Source story: `docs/stories/QS-320.story.md`
+- Previous plan: `docs/stories/QS-320.story_review_fix_#01.md` (applied in `287ee00a`)
+- Findings to fix: 9 (3 should-fix, 1 adjudication record, 5 nice-to-have)
+- Next implement phase: `/implement-task`
+- Triage decision: fix all; finding 3 resolved as option (a) — accept the F8 skip
+  as final and record it.
+
+Round-2 review state: all four lenses reported (blind-hunter, edge-case-hunter,
+acceptance-auditor, CodeRabbit incremental on `287ee00a`). Plan #01 audit:
+11/12 findings implemented per hard constraints, both round-1 gaps closed, zero
+regressions across the 15 original ACs, all 307 touched-file tests green.
+
+**Post-merge revision.** QS-319 (one lost-control alert per episode, PR #327)
+landed on `main` after this round's review and was merged into this branch as
+`0d73180d` (`load.py` auto-merged; doc conflicts hand-resolved; 364 tests green
+on the merged tree; the plan-#01 lint test passes — QS-319 added no new
+`running_command` writer and never touches the QS-320 surface). Every load.py
+line reference below is against the MERGED tree at `0d73180d`. Finding 1 was
+re-verified end-to-end on the merged code and rewritten for QS-319's announce
+semantics; finding 9 (doc contradictions created by the merge) is new.
+
+## Findings to fix
+
+### [should-fix] 1. Contact-clear on a replaced slot triggers a full QS-319 re-announce
+
+- File: `custom_components/quiet_solar/home_model/load.py:1248-1263`
+  (`check_commands` disowned-slot clear) and `:1181-1194` (`launch_command`
+  disowned-slot clear), interacting with `_clear_unresponsive` (`:796-847`,
+  stamp null at `:830`, latch clear at `:832-835`) and `_escalate_or_recover`
+  (`:1419`, gate `:1421-1429`, announce branch `:1449-1468`, push gate
+  `:1507-1523`)
+- Severity: should-fix (behavioural regression introduced by plan #01's F2;
+  post-merge, the sole remaining hole in QS-319's once-per-episode guarantee)
+- Source: qs-review-edge-case-hunter; re-verified end-to-end on the merged
+  tree (`0d73180d`)
+
+**Description.** The F2 CONFIRMED clear is correct in intent but backfires in
+exactly the replaced-slot case it was built for:
+
+1. **Saturated rung.** `unresponsive_since` is only ever set when
+   `running_command_num_relaunch >= NUM_MAX_COMMAND_RELAUNCH`, and a racing
+   press can only *supersede* (not stack) while the load is uncontrollable —
+   so whenever the clear fires on a replaced slot, the successor holds an
+   inherited rung ≥ max (preserved by `abandon_running_command` `:888-909`,
+   untouched by `_install_running_command` `:1006-1026`).
+2. **The clear drops both clock AND latch** (`:835`, `:840`) — and under
+   QS-319 the latch is what stands between a re-mark and a re-announce.
+   `_escalate_or_recover`'s gate (`:1421-1429`: slot non-empty + rung ≥ max +
+   no clock) passes for the successor; with the latch down it takes the
+   **announce branch, not the quiet re-arm**: fresh
+   `Lost control of load …: command … not confirmed after N relaunches in
+   this episode` ERROR (`:1450-1458`) with an inherited count for a command
+   with zero relaunches of its own, latch re-set (`:1467`), push delivered
+   (`:1523`) — milliseconds after the device demonstrably answered. QS-319's
+   send-time latch re-check (`:1507`) does not block it. Timing: same
+   `check_and_relaunch_command` call for the `check_commands` site (via
+   `_finish_command_cycle` `:1376`), next cycle for `launch_command`.
+3. **Wiped throttle.** The clear also nulls `_last_supersede_time` (`:830`) —
+   here the stamp the *successor's own* supersede wrote seconds earlier
+   (`:1143`), inside the one-per-window bound documented at `:64-73`.
+
+**QS-319-specific consequences (why this got worse post-merge):**
+
+- QS-319 flipped the ordinary empty-slot release to `UNKNOWN` (`:1490-1505`),
+  so the latch now survives every normal slot-emptying cycle. The two
+  disowned-slot CONFIRMED clears are therefore the **only** non-ack, non-user
+  path that drops the latch — this race is the one remaining defeat of the
+  "one alert per announced episode" guarantee, at one full re-announce per
+  race occurrence.
+- The duplicate push is tag-collapsed (`_notify_unresponsive` `:1994-2022`
+  sends `NOTIFICATION_TAG_LOST_CONTROL_PREFIX + device_id`), so it *replaces*
+  the previous card rather than stacking — mitigated, not fixed; the spurious
+  ERROR log is not collapsed at all.
+- The `qs_load_lost_control` PROBLEM binary sensor
+  (`has_unacknowledged_lost_control` `:869-886`, `binary_sensor.py:62-71`)
+  **flaps on → off → on**. At the `launch_command` site the off persists
+  across at least one full cycle boundary — a spurious "problem resolved" /
+  "new problem" edge for any automation on that sensor.
+
+Reproduces when: announced lost-control episode (rung saturated),
+≥ `SUPERSEDE_MIN_INTERVAL_S` since the last supersede, a user press supersedes
+mid-await, and the stale dispatch's I/O returns `True`.
+
+**Proposed fix.** At the two disowned-slot clear sites (`:1260-1263`,
+`:1190-1193`), when the CONFIRMED clear fires:
+
+- **Reset the successor's inherited rung** (`running_command_num_relaunch = 0`)
+  — the load-bearing half. The ladder's premise is "device not answering"; a
+  confirming probe disproves it, and the successor has performed zero
+  relaunches of its own. With rung 0 the gate at `:1427` fails: no re-mark, no
+  re-announce, no push, no sensor re-flap, and the latch stays down — exactly
+  QS-319's intended "CONFIRMED ends the episode" semantic (`:815-816`).
+  Precedent: the empty-slot housekeeping arm already resets the rung
+  (`:1483`).
+- **Preserve the successor's supersede throttle stamp** — belt-and-braces
+  once the rung reset lands (with the clock down, the throttle is unreachable
+  until ~1050 s of fresh relaunches re-arm it), but keep it: it keeps the
+  `:64-73` one-per-window invariant honest and is race-proof against future
+  rung writers. Snapshot/restore around the call or a keep flag on
+  `_clear_unresponsive` — prefer whichever keeps the other call sites
+  byte-identical; note a keep flag touches comment text QS-319 rewrote
+  (`:826-829` and `load-base.md:183-184`), so update those lines with it.
+
+**Constraints (test-pinned, do not break):**
+
+- `force_relaunch_command` stays untouched (plan #01 F2 hard scope; its
+  deliberate no-clear comment now at `:1593-1599`; AC1 pins
+  `unresponsive_since == T_RELAUNCH` at
+  `tests/test_qs307_override_expiry_unfreeze.py:1069`).
+- AC9's rung *inheritance on supersede/relaunch handoff* is untouched
+  (`:1343-1347` pins it) — this fix resets the rung only on the
+  CONFIRMED-contact-on-disowned-slot path, a different event.
+- AC5/AC6 pins hold: `command_acked_or_good is False`, `None` probe is not
+  contact.
+- The existing clear-site tests (tests `:1147`, `:1286-1294`) call
+  `check_commands`/`launch_command` directly and never run
+  `_escalate_or_recover` — no collision with the new race tests.
+- The owned-slot ack path and the emptied-slot path are clean — do not touch.
+
+**Tests required.** Reproduce the scenario at both sites (saturated rung, open
+supersede window, press supersedes mid-await, stale I/O returns `True`) and
+assert: successor rung == 0; no `Lost control of load` ERROR and no second
+push on the following `check_and_relaunch_command` cycle;
+**`has_unacknowledged_lost_control` is False and stays False across that
+cycle** (the QS-319 pin — no sensor re-flap); and `_last_supersede_time` still
+holds the successor's stamp.
+
+### [should-fix] 2. Install-site lint keys are ambiguous — qualify by class
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py:978-1033`
+  (`test_every_running_command_write_site_is_sanctioned`; sanctioned dict
+  `:997-1003`, walker `:1005-1027`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+
+**Description.** Sanction keys are `(basename, function-name)` with no class
+qualification, and the ambiguity is concrete today:
+`constraint_reset_and_reset_commands_if_needed` is defined twice in load.py
+(`AbstractDevice:412` and `AbstractLoad:1718`, merged tree). A future direct
+`self.running_command = ...` write in the `AbstractLoad` override — or in any
+future override of a sanctioned function name — is silently sanctioned by
+name-match, which is exactly the hole the lint exists to close.
+
+**Proposed fix.** Key by `(filename, class-qualified name, function)` — track a
+qualname stack while walking the AST (push on `ClassDef`/`FunctionDef`/
+`AsyncFunctionDef`, pop on exit). Update the five sanctioned entries to their
+qualified forms. Verify the test still goes red on an unsanctioned write (e.g.
+temporarily add one locally).
+
+### [adjudication record] 3. Plan #01 finding 8 — skip accepted as final
+
+- File: `docs/stories/QS-320.story_review_fix_#01.md` (F8 section + summary)
+- Severity: record-keeping (user-adjudicated this round, option a)
+- Source: qs-review-acceptance-auditor + qs-review-coderabbit (merged)
+
+**Description.** Plan #01's F8 (wrap `check_commands`' probe) was deliberately
+skipped by the implementer: the plan's prescribed fix would swallow an
+exception that three QS-304 tests pin as deliberately NOT swallowed
+(`pytest.raises` at `tests/test_bug_304_command_deadlock.py:1004`, `:1023`,
+`:1271`). The round-2 acceptance auditor independently verified the conflict is
+real and the skip correct. The escape is contained by
+`QSHome.check_loads_commands`' per-load handler (`home.py:2882`). The user
+accepted the skip as final (option a) — no new issue.
+
+**Proposed fix.** Append a short "Disposition (round 2)" note to plan #01's F8
+section stating: skipped as unimplementable without renegotiating the
+test-pinned QS-304 contract; adjudicated and accepted as final in round 2; the
+bare probe is deliberate. Do not rewrite the original F8 text (the plan is a
+historical record). This note also resolves CodeRabbit's stale-status comment
+on the plan file.
+
+### [nice-to-have] 4. "dropped vs replaced" log label is best-effort
+
+- File: `custom_components/quiet_solar/home_model/load.py` (`_slot_still_holds`
+  docstring/log)
+- Source: qs-review-blind-hunter
+
+A slot that was *replaced*, whose replacement then emptied before the original
+resumer ran, logs as "dropped". Since dropped-vs-replaced is the whole subject
+of QS-320, note in the docstring that the label reflects the slot state at
+resume time, not the full intervening history. Docstring-only; no logic change.
+
+### [nice-to-have] 5. `ast.parse` without `filename=` in the lint test
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py` (lint test parse call)
+- Source: qs-review-blind-hunter
+
+A syntax error in any scanned file reports `<unknown>`. Pass
+`filename=str(py_file)`.
+
+### [nice-to-have] 6. Lint misses non-`Assign` binding forms
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py:1014-1027`
+- Source: qs-review-edge-case-hunter
+
+Tuple/starred unpacking targets, `for self.running_command in ...:`
+(`ast.For.target`), `with ... as self.running_command:`
+(`ast.withitem.optional_vars`) and `setattr(self, "running_command", ...)` all
+evade the walker. Recurse into `Tuple`/`Starred` targets and cover `For` /
+`withitem` targets; for `setattr`, flag any call whose second arg is the string
+literal `"running_command"`. Keep the same sanction mechanism.
+
+### [nice-to-have] 7. Lint failure message covers only the added-site direction
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py:1030-1034`
+- Source: qs-review-edge-case-hunter
+
+If a sanctioned function is renamed, `found != sanctioned` fails with an empty
+"unsanctioned" list, pointing the maintainer the wrong way. Report both set
+differences (`found - sanctioned` and `sanctioned - found`) with distinct
+labels.
+
+### [nice-to-have] 8. Monotonic anchor under a backwards wall-clock step — document the limitation
+
+- File: `custom_components/quiet_solar/home_model/load.py:706-726`
+  (`_anchor_causality_guard_if_executed`, guard body `:723-726`)
+- Source: qs-review-edge-case-hunter (flagged "for the record only")
+
+After an NTP step-back, subsequent real executions carry older timestamps and
+are refused by `time > prev`, pinning the anchor "in the future"; genuine user
+flips are then suppressed as QS-caused until wall time catches up (pre-fix, the
+plain assignment self-healed on the next execution). Environmental and rare;
+the monotonic property is worth more than this corner. **Fix = document only:**
+add the limitation to the helper's docstring. Do not add clock-step detection.
+
+### [should-fix] 9. Post-merge doc contradictions: episode-ender lists and stale lint claim
+
+- Files: `docs/agents/concepts/load-base.md`, `docs/agents/concepts/notification-routing.md`,
+  `custom_components/quiet_solar/home_model/load.py` (comments/docstrings only)
+- Severity: should-fix (docs are drift-tracked and now self-contradictory)
+- Source: merge verification agent (QS-319 × QS-320 collision)
+
+**Description.** The QS-320 branch and QS-319 each wrote true statements that
+are false together, and the merge put them in the same tree:
+
+1. `load-base.md:133-135` claims `_ack_command` is "since QS-319 the **only**
+   caller" of `_clear_unresponsive(CONFIRMED)` — while `:171-181` of the same
+   file correctly lists our two disowned-slot CONFIRMED callers. The merged
+   tree has three: `load.py:690`, `:1190`, `:1260`.
+2. "An episode ends on exactly three things" (real ack / user remediation /
+   restart) is stated in four places — `load-base.md:120-124` (which itself
+   mandates every statement list all three), `notification-routing.md:78-87`,
+   the code comment at `load.py:1463-1466`, and the
+   `_notify_unresponsive` docstring at `:2010-2012`. The disowned-slot
+   CONFIRMED clear is a fourth ender (and after finding 1's fix it remains
+   one, cleanly).
+3. `load-base.md:414-421` still says the install convention has "no lint" —
+   stale since plan #01 F6 added
+   `test_every_running_command_write_site_is_sanctioned`. Qualify it: the
+   write-site half IS now test-enforced; only the never-reset-the-generation
+   half remains convention.
+
+**Proposed fix.** Update all five spots consistently: three CONFIRMED callers;
+four episode enders (add "proven contact on a slot that changed hands,
+QS-320"); lint sentence qualified. Bump `last_verified` on the two touched
+concept docs. Pure text — no behaviour change.
+
+## Invalid / refuted this round (do not touch)
+
+- Missing `@pytest.mark.asyncio` on the new tests — `pytest.ini:11` sets
+  `asyncio_mode = auto`.
+- `STATE_UNAVAILABLE` possibly unimported — imported at
+  `tests/test_qs307_override_expiry_unfreeze.py:50`.
+- Disowned-slot `res = timedelta(0)` sentinel — already pinned by plan #01 F9's
+  comment; both callers discard the value (re-verified round 2).
+
+## How to apply
+
+Run `/implement-task` against this fix plan. Finding 1 is behavioural and needs
+the two new race tests; finding 2 hardens the lint (re-verify red on an
+unsanctioned write); finding 3 is a doc note in plan #01; finding 9 is
+text-only doc reconciliation (coordinate with finding 1's fix — the episode-
+ender wording should describe the post-fix behaviour); 4-8 are polish (5/6/7
+land in the same lint test — one coordinated edit; 4 and 8 are
+docstring-only).
+
+Red lines carried over from plan #01, still test-pinned:
+- Do not touch `force_relaunch_command`'s disowned-slot bail (AC1, tests `:1073`).
+- Do not wrap `check_commands`' probe (QS-304 contract, adjudicated final this
+  round — see finding 3).
+- No bump-on-write property setter for `running_command`.
+
+When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-320.story_review_fix_#03.md
+++ b/docs/stories/QS-320.story_review_fix_#03.md
@@ -1,0 +1,146 @@
+# QS-320 — Review fix plan #03
+
+## Summary
+- Source PR: #326
+- Source story: `docs/stories/QS-320.story.md`
+- Previous plans: `#01` (applied `287ee00a`), `#02` (applied `d9fbd638`)
+- Findings to fix: 7 (1 should-fix, 6 nice-to-have)
+- Next implement phase: `/implement-task`
+- Triage decision: fix all (one-by-one, all confirmed)
+
+**This is a CONVERGENCE round — hard constraint: ZERO behaviour change.**
+Round 3 produced no must-fix from any of the four lenses; the acceptance
+auditor passed 9/9 on plan #02 with an independent red-check; CodeRabbit had
+no code findings. Everything below is lint-test hardening, comments,
+docstrings, and a two-character log cleanup. If implementing any item
+requires changing runtime control flow, STOP and report back instead —
+that means the finding was misjudged, not that the plan should stretch.
+No new race tests are required; the only test additions are the lint's own
+self-checks. All 43 tests in the touched file must stay green unmodified.
+
+## Findings to fix
+
+All refs against `d9fbd638`. The lint test is
+`test_every_running_command_write_site_is_sanctioned` in
+`tests/test_qs307_override_expiry_unfreeze.py` (walker `:1012-1054`).
+
+### [should-fix] 1. Lint: comprehension for-targets evade the walker
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py:1020` (`binding_targets`)
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (converged,
+  both with executed proof)
+
+`[0 for self.running_command in cmds]` parses AND binds the attribute at
+runtime (CPython-verified by both reviewers), but `ast.comprehension` nodes
+are absent from `binding_targets`, so the write is silently sanctioned —
+the exact failure mode plan #02/6 set out to close. Fix: one branch —
+`if isinstance(node, ast.comprehension): return [node.target]`
+(`iter_child_nodes` already reaches `comprehension` under
+`ListComp`/`SetComp`/`DictComp`/`GeneratorExp`). Also correct the walker
+docstring's "Every syntactic form that can bind" claim to match reality
+(see finding 3's residue). Verify red with a temporary local comprehension
+write, then remove it.
+
+### [nice-to-have] 2. Comment: re-entrant absorb-then-ack reads as "dropped" for one cycle
+
+- File: `custom_components/quiet_solar/home_model/load.py` (`check_commands`
+  disowned-slot branch)
+- Source: qs-review-blind-hunter
+
+If an equal-valued press lands mid-probe, absorbs (generation-neutral) and
+its own path acks (slot emptied), the resumer sees slot `None` + generation
+unchanged → "dropped" → returns `command_acked_or_good = False` for a
+dispatch that WAS acked by the press's path. Nothing is lost — the ack is
+already recorded; it self-heals next cycle, and the error direction is
+conservative (the opposite of the original QS-320 bug). **Comment only**:
+document the known one-cycle false negative at the branch so it is not
+rediscovered as a bug.
+
+### [nice-to-have] 3. Lint: setattr sibling forms — cover or scope the claim
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py:1029`
+  (`is_setattr_of_running_command`)
+- Source: qs-review-edge-case-hunter
+
+Only the bare-name `setattr(...)` form is matched; `builtins.setattr(...)`,
+aliased `s = setattr; s(...)`, `self.__dict__["running_command"] = x` and
+`object.__setattr__(...)` evade. Deliberate evasion is outside the lint's
+threat model — so EITHER add the cheap forms (`builtins.setattr` attribute
+form, `__dict__` subscript-store) OR explicitly scope the docstring to
+"accidental direct writes; deliberate evasion is out of scope", whichever
+is smaller. Coordinate the docstring wording with finding 1.
+
+### [nice-to-have] 4. Docstring: rung-reset premise is best-effort
+
+- File: `custom_components/quiet_solar/home_model/load.py:856-883`
+  (`_confirmed_contact_on_disowned_slot` docstring)
+- Source: qs-review-edge-case-hunter
+
+The reset's premise ("the successor has made zero relaunches of its own")
+can be wrong across a pathologically long probe await (> 300 s, e.g. a
+device probe with no client timeout): the successor's earned rungs are
+discarded and its backoff restarts at 50 s. Failure direction is benign —
+briefly faster retries against a device that just proved contact; never a
+re-announce (rung 0 moves the threshold away, latch already down).
+**Docstring sentence only.**
+
+### [nice-to-have] 5. Lint: key by package-relative path, not basename
+
+- File: `tests/test_qs307_override_expiry_unfreeze.py:997-1010`
+  (sanctioned keys)
+- Source: qs-review-blind-hunter
+
+Keys use `py_file.name`; a second `load.py` anywhere in the package would
+collide with the sanctioned entries. Key on the path relative to the
+package root (`py_file.relative_to(package_root)`), updating the five
+sanctioned entries accordingly.
+
+### [nice-to-have] 6. Stray unbalanced `)` in two log strings
+
+- File: `custom_components/quiet_solar/home_model/load.py`
+  (`check_commands` / `force_relaunch_command` log messages)
+- Source: qs-review-blind-hunter
+
+`"check command %s for this load %s) (#%s)"` and
+`"impossible to force command %s for this load %s)"` carry a stray `)`
+inherited from the original code. Remove the stray character; keep the
+lazy `%s` style. If any test pins these substrings, update the pin in the
+same edit.
+
+### [nice-to-have] 7. Comment: throttle save/restore only meaningful on the replaced arm
+
+- File: `custom_components/quiet_solar/home_model/load.py:856-883`
+  (`_confirmed_contact_on_disowned_slot`)
+- Source: qs-review-blind-hunter
+
+The `_last_supersede_time` snapshot/restore also runs on the *dropped*
+(emptied-slot) arm, where the preserved value is whatever the drop path
+left (today `None`, benign). **Comment only**: state that the restore is
+only meaningful on the replaced arm, so a future drop-path change cannot
+silently re-arm a stale throttle stamp.
+
+## Invalid / moot this round (do not touch)
+
+- Missing `@pytest.mark.asyncio` (blind-hunter, repeat) — re-refuted:
+  `pytest.ini:11` sets `asyncio_mode = auto`.
+- CodeRabbit 12:56Z "no lint" sentence — reviewed the merge commit only;
+  already fixed by plan #02/9.3 in `d9fbd638`.
+- CodeRabbit 14:03Z ×2 — wording nitpicks against plan #02's text ("five
+  spots" vs six; key-format phrasing). The implementation they concern is
+  done and audited (9/9); plan files are historical records.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. Findings 1/3/5 are one
+coordinated edit of the lint test (walker + keys + docstring — verify red
+locally with a temporary unsanctioned write in each new form, then remove
+it). Findings 2/4/7 are comments/docstrings in `load.py`. Finding 6 is a
+two-character log cleanup. Expected review outcome next round: zero
+findings → `/finish-task`.
+
+Red lines (all still test-pinned): no behaviour change anywhere; do not
+touch `_confirmed_contact_on_disowned_slot`'s logic, the guards, the
+anchor, or `force_relaunch_command`; the 43 existing tests pass unmodified.
+
+When done, return and run `/review-task` for what should be the closing
+verification.

--- a/tests/test_load_model.py
+++ b/tests/test_load_model.py
@@ -1503,9 +1503,17 @@ class TestCheckCommands:
         load.probe_if_command_set = probe_none
 
         time_now = datetime.now(tz=pytz.UTC)
-        await load.check_commands(time_now)
+        load.running_command_last_launch = time_now - timedelta(seconds=42)
+        res, command_acked_or_good = await load.check_commands(time_now)
 
         assert load.running_command_num_relaunch_after_invalid == 1
+        # QS-320: the invalid-probe block and the `is True: … elif …` block are TWO
+        # separate statements, so a `None` probe falls through to the staleness arm
+        # and still assigns `res`. Folding them into one `if/elif` chain — an easy
+        # accident when adding a guard — would silently return `timedelta(0)` here
+        # and the relaunch ladder would stop seeing how stale the command is.
+        assert res == timedelta(seconds=42)
+        assert command_acked_or_good is False
 
     @pytest.mark.asyncio
     async def test_check_commands_max_invalid_kills_command(self):

--- a/tests/test_qs307_override_expiry_unfreeze.py
+++ b/tests/test_qs307_override_expiry_unfreeze.py
@@ -27,12 +27,19 @@ Both death modes are covered, because they leave different command state behind:
   (`NUM_MAX_INVALID_PROBES_COMMANDS`) nulls `current_command` through
   `_ack_command(time, None)`, so `is_load_command_set` is `False` on its
   `current_command is None` arm instead.
+
+`_RacingPump` is *the* mid-await race harness, so this module hosts both stories'
+race cases: QS-307's **emptied** slot (AC25) and QS-320's **replaced** slot — one
+family, one view.
 """
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from datetime import time as dt_time
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -58,7 +65,7 @@ from custom_components.quiet_solar.ha_model.bistate_duration import (
     USER_OVERRIDE_STATE_BACK_DURATION_S,
     QSBiStateDuration,
 )
-from custom_components.quiet_solar.home_model.commands import CMD_IDLE, CMD_ON, LoadCommand, copy_command
+from custom_components.quiet_solar.home_model.commands import CMD_IDLE, CMD_OFF, CMD_ON, LoadCommand, copy_command
 from custom_components.quiet_solar.home_model.constraints import TimeBasedSimplePowerLoadConstraint
 from custom_components.quiet_solar.home_model.load import NUM_MAX_INVALID_PROBES_COMMANDS
 from tests.conftest import FakeHass
@@ -120,6 +127,14 @@ class _RacingPump(_StuckPump):
     touching the mode select, the on-duration number or the reset button while a
     service call is in flight really can empty the slot across the await. Setting
     `race_at` replays that deterministically, from inside the transport.
+
+    QS-320: `race_action` makes *which* user action lands pluggable, so the same
+    harness covers the slot being **replaced** (a button press that supersedes or
+    resets-then-reinstalls) as well as QS-307's **emptied** case. It must always go
+    through a real `launch_command` / `user_clean_and_reset` /
+    `_drop_running_command` — a race action that assigns `running_command` by hand
+    replaces the slot WITHOUT bumping the generation, so the guard under test would
+    never trip and the test would pass vacuously.
     """
 
     def __init__(self, **kwargs):
@@ -129,6 +144,9 @@ class _RacingPump(_StuckPump):
         # branch, `None` reaches the "impossible to force" log — both dereference
         # the command slot after the await
         self.race_result: bool | None = True
+        # QS-320: the user action that lands mid-await. QS-307's override-expiry
+        # drop is the default, so the two #316 tests keep their exact behaviour.
+        self.race_action: Callable[[datetime], Awaitable[Any]] = self.check_load_activity_and_constraints
 
     async def execute_command_system(self, time, command, state):
         """Let a user action land in the middle of the service call."""
@@ -137,8 +155,41 @@ class _RacingPump(_StuckPump):
 
         self.transport_calls.append((time, command.command, state))
         race_at, self.race_at = self.race_at, None
-        await self.check_load_activity_and_constraints(race_at)
+        await self.race_action(race_at)
         return self.race_result
+
+
+class _ProbeRacingPump(_RacingPump):
+    """A pump whose *probe* — not its service call — is interrupted mid-flight.
+
+    QS-320 needs this for `check_commands`, whose only await is
+    `probe_if_command_set`. Real subclasses do await I/O there:
+    `QSChargerGeneric.probe_if_command_set` awaits `_do_update_charger_state`, a
+    genuine `hass.services.async_call`, and `QSBattery`'s awaits
+    `is_charge_from_grid()`. Only the bistate probe this test file uses is
+    synchronous, hence the injection.
+
+    One-shot, like `race_at`: the injected press re-enters
+    `probe_if_command_set` through `launch_command`, so a re-arming hook would
+    recurse.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.probe_race_at: datetime | None = None
+        self.probe_race_action: Callable[[datetime], Awaitable[Any]] = self.check_load_activity_and_constraints
+        # what the interrupted probe reports back: `True` reaches the ack branch,
+        # `None` the invalid-probe branch, `False` the staleness arm
+        self.probe_race_result: bool | None = True
+
+    async def probe_if_command_set(self, time, command):
+        """Let a user action land in the middle of the probe."""
+        if self.probe_race_at is None:
+            return await super().probe_if_command_set(time, command)
+
+        probe_race_at, self.probe_race_at = self.probe_race_at, None
+        await self.probe_race_action(probe_race_at)
+        return self.probe_race_result
 
 
 def _next_daily_end(local_hours: dt_time, time_utc_now: datetime | None = None, output_in_utc=True):
@@ -792,6 +843,389 @@ async def test_a_user_action_during_the_first_launch_cannot_strand_the_command_s
     assert pump.external_user_initiated_state is None
     assert pump.current_command == confirmed
     assert pump.is_load_command_set(T_EXPIRED) is True
+
+
+# =============================================================================
+# QS-320 — the replaced slot
+#
+# #316 (above) guarded the slot being EMPTIED across an await. A slot that was
+# REPLACED passes an `is None` test just as well, so a button press that
+# supersedes — or resets and reinstalls — the in-flight command mid-await could
+# still write the previous command's answer onto the new occupant: a phantom ack
+# of a command no service call ever confirmed.
+#
+# Two distinct instants throughout, so a stamp written by the stale resumer is
+# always distinguishable from the press's own.
+# =============================================================================
+
+T_RELAUNCH = T_OVERRIDE + timedelta(hours=1)
+T_PRESS = T_RELAUNCH + timedelta(seconds=1)
+
+_LOAD_LOGGER = "custom_components.quiet_solar.home_model.load"
+
+
+def _spy_on_acks(pump: _StuckPump) -> list[LoadCommand | None]:
+    """Record every command `_ack_command` is called with from now on.
+
+    A phantom ack is the corruption this story is about, and its visible traces
+    (`current_command`, `num_on_off`, the counters) are all reachable by other
+    paths too. Recording the call itself is what makes "did not ack" an assertion
+    about the bug rather than about its footprint.
+    """
+    acked: list[LoadCommand | None] = []
+    real_ack = pump._ack_command
+
+    def _record(time, command):
+        acked.append(command)
+        return real_ack(time, command)
+
+    pump._ack_command = _record  # type: ignore[method-assign]
+    return acked
+
+
+def _sync_race(action: Callable[[], Any]) -> Callable[[datetime], Awaitable[None]]:
+    """Adapt a synchronous user action to the awaitable race-action hook."""
+
+    async def _run(_time: datetime) -> None:
+        action()
+
+    return _run
+
+
+def _race_log(caplog: pytest.LogCaptureFixture, site: str, verdict: str) -> bool:
+    """True when `site` reported the slot `dropped`/`replaced` across its await.
+
+    The dropped-vs-replaced axis IS the subject of this story, so both arms of the
+    guard's one message are pinned — an operator staring at a misbehaving load needs
+    to know which of the two happened.
+    """
+    needle = f"was {verdict} while a call to the device was in flight"
+    return any(needle in message and message.startswith(f"{site}:") for message in caplog.messages)
+
+
+def _arm_for_supersede(pump: _StuckPump, time: datetime = T_RELAUNCH) -> None:
+    """Put the pump in the exact state where a `CMD_IDLE` press SUPERSEDES (route A).
+
+    Every line is load-bearing, because the obvious setup reaches a *different*
+    branch and the test then passes even unfixed:
+
+    - no override armed — otherwise the press's `CMD_IDLE` is override-suppressed
+      and DROPPED instead of installed;
+    - `_ack_command` provides the confirmed `CMD_ON` of record. It nulls the slot as
+      a side effect, hence the direct slot write after it — setup only, never inside
+      a race action, where it would replace the slot without bumping the generation
+      and the test would pass vacuously;
+    - `unresponsive_since` set — otherwise `is_uncontrollable` is False and the
+      press STACKS;
+    - `_last_supersede_time` clear — otherwise the supersede is throttled and stacks;
+    - the confirmed command is `CMD_ON`, not `CMD_IDLE` — otherwise the press hits
+      the "already confirmed" early return and drops the stale command instead.
+
+    The entity reads `on` and the transport stops obeying, so the press's own
+    `CMD_IDLE` probe returns False and its service call leaves the replacement in
+    flight and *unacked* — which is precisely what makes a phantom ack of it visible.
+    """
+    pump.external_user_initiated_state = None
+    pump._ack_command(time, copy_command(CMD_ON))
+    pump.running_command = copy_command(CMD_ON)
+    pump.running_command_first_launch = time
+    pump.running_command_last_launch = time
+    pump.unresponsive_since = time
+    pump._last_supersede_time = None
+    pump.obeys = False
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=time)
+
+
+async def test_the_dispatch_generation_only_ever_moves_forward():
+    """AC13: the tag that makes "is the slot still MINE?" answerable.
+
+    The guard cannot compare the command value — route B reinstalls a
+    field-identical `CMD_IDLE`, so an equality test passes on the very race this
+    exists to catch — nor object identity, because absorb legitimately swaps in an
+    equal object for the SAME dispatch. Only a monotonic per-install tag
+    distinguishes them, and it is monotonic ONLY as long as nothing ever rewinds
+    it: a `reset()` that zeroed it would let a tag captured before the reset
+    compare equal to one issued after it, reopening QS-320 on exactly route B.
+    """
+    pump = _make_pump(pump_class=_RacingPump)
+    pump.hass.states.set(PUMP_ENTITY, "off", last_changed=T_RELAUNCH)
+    pump.obeys = False
+    start = pump._running_command_generation
+
+    await pump.launch_command(T_RELAUNCH, CMD_ON, ctxt="first install")
+    first = pump._running_command_generation
+    assert first > start
+
+    # absorb: the same command is already in flight, so this is not a new dispatch
+    # and the caller already awaiting still owns its paperwork
+    await pump.launch_command(T_RELAUNCH, CMD_ON, ctxt="absorbed")
+    assert pump.running_command == CMD_ON
+    assert pump._running_command_generation == first
+
+    # route B's `reset()` wipes the whole command state — it must NOT rewind the tag
+    pump.reset()
+    assert pump.running_command is None
+    assert pump._running_command_generation == first
+
+    await pump.launch_command(T_PRESS, CMD_ON, ctxt="reinstall after reset")
+    assert pump._running_command_generation > first
+
+
+async def test_a_press_that_supersedes_mid_relaunch_cannot_ack_the_command_it_replaced(caplog):
+    """AC1/AC8/AC9/AC10/AC12 — the headline bug, at `force_relaunch_command`.
+
+    The relaunch ladder's service call for `CMD_ON` is in flight when the user
+    presses "mark current constraint done". That press supersedes the slot with its
+    own `CMD_IDLE`, and on `main` the resumer then finishes `CMD_ON`'s paperwork
+    against the new occupant: it stamps `CMD_IDLE`'s launch time with the *relaunch*
+    instant and acks `CMD_IDLE` off `CMD_ON`'s result. QS records "the device
+    confirmed idle" though no `idle` service call ever completed, the load keeps
+    running, and nothing retries because the slot is empty and `current_command`
+    says idle.
+    """
+    pump = _make_pump(pump_class=_RacingPump)
+    _arm_for_supersede(pump)
+    assert pump.is_uncontrollable is True  # pre-race: the supersede branch is armed
+    rung_before = pump.running_command_num_relaunch
+    num_on_off_before = pump.num_on_off
+    acked = _spy_on_acks(pump)
+
+    pump.race_at = T_PRESS
+    pump.race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
+
+    with caplog.at_level(logging.INFO, logger=_LOAD_LOGGER):
+        await pump.force_relaunch_command(T_RELAUNCH)
+
+    # the supersede really ran: this is the REPLACED case, not #316's emptied one
+    assert pump.running_command == CMD_IDLE
+    assert pump.current_command == CMD_ON
+
+    # none of `CMD_ON`'s outcome was written onto the press's `CMD_IDLE`
+    assert acked == []
+    assert pump.running_command_last_launch == T_PRESS  # the press's stamp, not T_RELAUNCH
+    assert pump.num_on_off == num_on_off_before  # no phantom transition on the daily budget
+    assert pump.unresponsive_since == T_RELAUNCH  # the lost-control episode is not over
+
+    # AC8: the load is not stranded — the replacement is in flight and unacked, so
+    # the lifecycle still has something to drive
+    assert pump.is_load_command_set(T_PRESS) is False
+
+    # AC9 (D7): the ladder rung is deliberately INHERITED across a supersede — that
+    # is QS-304's saturated cadence, not a defect this story introduces
+    assert pump.running_command_num_relaunch == rung_before + 1
+
+    # AC10: a service call really landed, so the causality anchor must fire even
+    # though the slot changed hands
+    assert pump.last_command_execution_time == T_RELAUNCH
+
+    # AC12: the "replaced" arm of the guard's message
+    assert _race_log(caplog, "force_relaunch_command", "replaced")
+
+
+async def test_a_press_that_supersedes_the_first_dispatch_cannot_be_acked_by_it():
+    """AC2/AC8 — the same bug at `launch_command`, the first place a command reaches.
+
+    The entity is unavailable, so both probes return `None`: the outer dispatch falls
+    through to `execute_command` (where the press lands) instead of self-acking, and
+    the press's own dispatch executes and reports "dispatched, unconfirmed".
+    """
+    pump = _make_pump(pump_class=_RacingPump)
+    pump.external_user_initiated_state = None
+    pump._ack_command(T_RELAUNCH, copy_command(CMD_ON))  # the confirmed command of record
+    pump.unresponsive_since = T_RELAUNCH  # so the press supersedes rather than stacks
+    pump._last_supersede_time = None
+    pump.obeys = False
+    pump.hass.states.set(PUMP_ENTITY, STATE_UNAVAILABLE, last_changed=T_RELAUNCH)
+    acked = _spy_on_acks(pump)
+
+    pump.race_at = T_PRESS
+    pump.race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: clean and reset")
+
+    # `CMD_OFF`: the outer dispatch must differ from the confirmed `CMD_ON` (else it
+    # early-returns without ever installing) AND from the press's `CMD_IDLE` (else
+    # the press absorbs instead of superseding)
+    await pump.launch_command(T_RELAUNCH, CMD_OFF, ctxt="solver dispatch")
+
+    assert pump.running_command == CMD_IDLE  # the press's command, still in flight
+    assert pump.current_command == CMD_ON  # NOT the phantom `CMD_IDLE`
+    assert acked == []
+    assert pump.is_load_command_set(T_RELAUNCH) is False
+
+
+async def test_a_reset_that_reinstalls_an_identical_command_is_not_acked_by_the_old_one():
+    """AC3 — route B, the case a value-equality guard silently misses.
+
+    "Clean and reset" `reset()`s the whole command state and then installs a fresh
+    `CMD_IDLE`. When the in-flight command was already `CMD_IDLE`, that replacement
+    compares **equal on every field** to the one being awaited — so a guard that
+    compared commands instead of dispatches would wave the stale resumer through and
+    let it stamp and ack a dispatch whose service call is still in flight. This test
+    must FAIL under value equality and PASS under the generation tag.
+
+    No preconditions: `reset()` is unconditional, which is why route B is the
+    disproportionately dangerous one. Stamps are deliberately not asserted here —
+    `user_clean_and_reset` uses `datetime.now()`, not the test clock.
+    """
+    pump = _make_pump(pump_class=_RacingPump)
+    pump.external_user_initiated_state = None
+    pump.running_command = copy_command(CMD_IDLE)  # setup-only direct write
+    pump.running_command_first_launch = T_RELAUNCH
+    pump.running_command_last_launch = T_RELAUNCH
+    pump.obeys = False
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_RELAUNCH)
+    acked = _spy_on_acks(pump)
+
+    pump.race_at = T_PRESS
+    pump.race_action = lambda t: pump.user_clean_and_reset()
+
+    await pump.force_relaunch_command(T_RELAUNCH)
+
+    # a field-identical `CMD_IDLE` now occupies the slot, from a different dispatch
+    assert pump.running_command == CMD_IDLE
+    # the stale resumer must not ack it: `current_command is None` is the `reset()`'s
+    # own doing, and would read `CMD_IDLE` under the phantom ack
+    assert acked == []
+    assert pump.current_command is None
+
+
+@pytest.mark.parametrize("race_result", [True, None], ids=["service-call-lands", "service-call-impossible"])
+async def test_an_absorbed_command_still_belongs_to_the_caller_in_flight(race_result):
+    """AC4 — absorb must NOT trip the guard. The mirror of AC1.
+
+    The absorb branch fires when the incoming command equals the one in flight and
+    swaps in a **new object of equal value** for the SAME dispatch, leaving the
+    launch stamps and counters alone. Both buttons launch `CMD_IDLE`, so a press
+    against an in-flight `CMD_IDLE` takes absorb — and an identity-based guard would
+    read that as "replaced" and bail out *before* `running_command_last_launch =
+    time`. The stamp would stay stale, the backoff gate would then be permanently
+    open, and the load would make a service call every cycle while the rung climbed
+    to a false lost-control escalation.
+
+    Green both pre- and post-fix: it pins the design against the identity variant.
+    """
+    pump = _make_pump(pump_class=_RacingPump)
+    pump.external_user_initiated_state = None
+    pump.running_command = copy_command(CMD_IDLE)  # setup-only direct write
+    pump.running_command_first_launch = T_RELAUNCH
+    pump.running_command_last_launch = T_RELAUNCH
+    pump.obeys = False
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_RELAUNCH)
+    pump.race_result = race_result
+    slot_before = pump.running_command
+    generation_before = pump._running_command_generation
+    acked = _spy_on_acks(pump)
+
+    pump.race_at = T_PRESS
+    pump.race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
+
+    await pump.force_relaunch_command(T_RELAUNCH)
+
+    # absorb is the one non-`None` slot write that does NOT bump the generation
+    assert pump._running_command_generation == generation_before
+
+    if race_result is True:
+        # the caller in flight still owns its paperwork, so it still acks
+        assert acked == [CMD_IDLE]
+        assert pump.current_command == CMD_IDLE
+    else:
+        # the "impossible" arm: no ack, but the stamp is still ours to write, and
+        # the swapped-in object proves absorb really ran
+        assert acked == []
+        assert pump.running_command_last_launch == T_RELAUNCH
+        assert pump.running_command == CMD_IDLE
+        assert pump.running_command is not slot_before
+
+
+async def test_check_commands_cannot_ack_a_command_the_probe_never_saw():
+    """AC5 — the third site. `check_commands` had no post-await re-check at all.
+
+    Its await is the probe, and real subclasses do await I/O there —
+    `QSChargerGeneric.probe_if_command_set` awaits a genuine service call. A probe
+    that answers `True` about the command that WAS in the slot then acks whatever is
+    in the slot now.
+    """
+    pump = _make_pump(pump_class=_ProbeRacingPump)
+    _arm_for_supersede(pump)
+    acked = _spy_on_acks(pump)
+
+    pump.probe_race_at = T_PRESS
+    pump.probe_race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
+    pump.probe_race_result = True
+
+    res, command_acked_or_good = await pump.check_commands(T_RELAUNCH)
+
+    assert pump.running_command == CMD_IDLE  # the replacement, unacked
+    assert acked == []
+    assert pump.current_command == CMD_ON
+    # "not confirmed this cycle, re-check next cycle" — the safe answer for a probe
+    # that told us nothing about the current occupant
+    assert command_acked_or_good is False
+    assert res == timedelta(0)
+
+
+async def test_check_commands_hands_no_invalid_probe_strike_to_the_successor():
+    """AC6 — a deliberate behaviour change: the successor inherits no strike.
+
+    An invalid probe about the *previous* occupant says nothing about the new one, so
+    `running_command_num_relaunch_after_invalid` must not be charged. Pre-fix the
+    counter reads 1 — the supersede zeroed it and the stale resumer then incremented
+    it — and the successor starts life one strike closer to being killed off.
+    """
+    pump = _make_pump(pump_class=_ProbeRacingPump)
+    _arm_for_supersede(pump)
+
+    pump.probe_race_at = T_PRESS
+    pump.probe_race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
+    pump.probe_race_result = None
+
+    res, command_acked_or_good = await pump.check_commands(T_RELAUNCH)
+
+    assert pump.running_command == CMD_IDLE
+    assert pump.running_command_num_relaunch_after_invalid == 0
+    assert command_acked_or_good is False
+    # and no staleness computed from the previous dispatch's stamp (pre-fix: -1 s,
+    # because the press's stamp is LATER than the relaunch instant)
+    assert res == timedelta(0)
+
+
+async def test_check_commands_cannot_ack_none_onto_an_emptied_slot(caplog):
+    """AC7/AC12 — `check_commands` also carried an unguarded EMPTIED-slot hole.
+
+    With no post-await check, an emptied slot reached `_ack_command(time, None)`,
+    which nulls `current_command` — wiping the confirmed command of record and
+    dropping the load out of controlled-consumption accounting.
+
+    The bail-out is a flag rather than an early `return` precisely so the
+    stacked-promotion tail still runs in the same cycle; an early return would delay
+    an emptied-slot promotion by a whole cycle, a behaviour change on an unrelated
+    path.
+    """
+    pump = _make_pump(pump_class=_ProbeRacingPump)
+    pump.external_user_initiated_state = None
+    pump._ack_command(T_RELAUNCH, copy_command(CMD_ON))
+    pump.running_command = copy_command(CMD_ON)  # setup-only direct write
+    pump.running_command_first_launch = T_RELAUNCH
+    pump.running_command_last_launch = T_RELAUNCH
+    pump.obeys = False
+    # `off`: the promoted stacked command must not be able to self-ack and mask the
+    # corruption this test is looking for
+    pump.hass.states.set(PUMP_ENTITY, "off", last_changed=T_RELAUNCH)
+    # `abandon_running_command` leaves the stack alone, so the tail must still see it
+    pump._stacked_command = copy_command(CMD_ON)
+    acked = _spy_on_acks(pump)
+
+    pump.probe_race_at = T_PRESS
+    pump.probe_race_action = _sync_race(lambda: pump._drop_running_command("test: the user emptied the slot"))
+    pump.probe_race_result = True
+
+    with caplog.at_level(logging.INFO, logger=_LOAD_LOGGER):
+        _res, command_acked_or_good = await pump.check_commands(T_RELAUNCH)
+
+    assert acked == []  # pre-fix: `_ack_command(time, None)`
+    assert pump.current_command == CMD_ON  # the confirmed command of record survives
+    assert command_acked_or_good is False
+    assert pump._stacked_command is None  # the promotion tail still ran this cycle
+    assert _race_log(caplog, "check_commands", "dropped")
 
 
 # =============================================================================

--- a/tests/test_qs307_override_expiry_unfreeze.py
+++ b/tests/test_qs307_override_expiry_unfreeze.py
@@ -998,12 +998,14 @@ def test_every_running_command_write_site_is_sanctioned():
     # ambiguous — `constraint_reset_and_reset_commands_if_needed` exists on both
     # `AbstractDevice` and `AbstractLoad`, so a write added to an override of any
     # sanctioned name would have been silently sanctioned by name-match.
+    # Review fix #03/5: paths are PACKAGE-RELATIVE, so a second `load.py` anywhere
+    # in the package cannot collide with the sanctioned entries.
     sanctioned = {
-        ("load.py", "AbstractDevice.constraint_reset_and_reset_commands_if_needed"),
-        ("load.py", "AbstractDevice._ack_command"),
-        ("load.py", "AbstractDevice.abandon_running_command"),
-        ("load.py", "AbstractDevice._install_running_command"),
-        ("load.py", "AbstractDevice.launch_command"),
+        ("home_model/load.py", "AbstractDevice.constraint_reset_and_reset_commands_if_needed"),
+        ("home_model/load.py", "AbstractDevice._ack_command"),
+        ("home_model/load.py", "AbstractDevice.abandon_running_command"),
+        ("home_model/load.py", "AbstractDevice._install_running_command"),
+        ("home_model/load.py", "AbstractDevice.launch_command"),
     }
 
     def flattened(target: ast.expr):
@@ -1017,7 +1019,15 @@ def test_every_running_command_write_site_is_sanctioned():
             yield target
 
     def binding_targets(node: ast.AST) -> list[ast.expr]:
-        """Every syntactic form that can bind `self.running_command` (#02/6)."""
+        """The ACCIDENTAL syntactic forms that can bind `self.running_command`.
+
+        #02/6 + #03/1: assignment (plain, annotated, augmented), `for` loops,
+        `with ... as`, and comprehension for-targets (`[0 for self.running_command
+        in cmds]` parses AND binds at runtime; `iter_child_nodes` reaches the
+        `comprehension` node under all four comprehension kinds). Deliberate
+        evasion (aliased `setattr`, `object.__setattr__`, exec, C extensions) is
+        OUTSIDE this lint's threat model — see `is_sneaky_write_of_running_command`.
+        """
         if isinstance(node, ast.Assign):
             return node.targets
         if isinstance(node, ast.AnnAssign | ast.AugAssign):
@@ -1026,23 +1036,52 @@ def test_every_running_command_write_site_is_sanctioned():
             return [node.target]
         if isinstance(node, ast.withitem) and node.optional_vars is not None:
             return [node.optional_vars]
+        if isinstance(node, ast.comprehension):
+            return [node.target]
         return []
 
-    def is_setattr_of_running_command(node: ast.AST) -> bool:
-        """`setattr(obj, "running_command", ...)` evades target-based scanning (#02/6)."""
+    def is_sneaky_write_of_running_command(node: ast.AST) -> bool:
+        """Call/subscript forms a target-based scan misses (#02/6, #03/3).
+
+        Covers the cheap accidental spellings: bare `setattr(...)`,
+        `builtins.setattr(...)`. The `self.__dict__["running_command"] = x`
+        subscript-store is caught by the leaf matcher below. Deliberate evasion
+        (aliasing `setattr`, `object.__setattr__`, exec) is out of scope.
+        """
+        if not (isinstance(node, ast.Call) and len(node.args) >= 2):
+            return False
+        is_setattr = (isinstance(node.func, ast.Name) and node.func.id == "setattr") or (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "setattr"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "builtins"
+        )
+        return is_setattr and isinstance(node.args[1], ast.Constant) and node.args[1].value == "running_command"
+
+    def is_running_command_leaf(leaf: ast.expr) -> bool:
+        """`self.running_command` or `self.__dict__["running_command"]` (#03/3)."""
+        if (
+            isinstance(leaf, ast.Attribute)
+            and leaf.attr == "running_command"
+            and isinstance(leaf.value, ast.Name)
+            and leaf.value.id == "self"
+        ):
+            return True
         return (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "setattr"
-            and len(node.args) >= 2
-            and isinstance(node.args[1], ast.Constant)
-            and node.args[1].value == "running_command"
+            isinstance(leaf, ast.Subscript)
+            and isinstance(leaf.slice, ast.Constant)
+            and leaf.slice.value == "running_command"
+            and isinstance(leaf.value, ast.Attribute)
+            and leaf.value.attr == "__dict__"
+            and isinstance(leaf.value.value, ast.Name)
+            and leaf.value.value.id == "self"
         )
 
     found: set[tuple[str, str]] = set()
     for py_file in sorted(package.rglob("*.py")):
         # `filename=` so a syntax error names the file, not `<unknown>` (#02/5)
         tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        rel_path = py_file.relative_to(package).as_posix()
         # (node, dotted qualifier) worklist: ClassDef and function defs both extend
         # the qualifier, so each write is keyed by its class-qualified location
         stack: list[tuple[ast.AST, str]] = [(tree, "")]
@@ -1050,17 +1089,12 @@ def test_every_running_command_write_site_is_sanctioned():
             node, qual = stack.pop()
             if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
                 qual = f"{qual}.{node.name}" if qual else node.name
-            if is_setattr_of_running_command(node):
-                found.add((py_file.name, qual or "<module>"))
+            if is_sneaky_write_of_running_command(node):
+                found.add((rel_path, qual or "<module>"))
             for target in binding_targets(node):
                 for leaf in flattened(target):
-                    if (
-                        isinstance(leaf, ast.Attribute)
-                        and leaf.attr == "running_command"
-                        and isinstance(leaf.value, ast.Name)
-                        and leaf.value.id == "self"
-                    ):
-                        found.add((py_file.name, qual or "<module>"))
+                    if is_running_command_leaf(leaf):
+                        found.add((rel_path, qual or "<module>"))
             stack.extend((child, qual) for child in ast.iter_child_nodes(node))
 
     # Both directions reported (#02/7): an extra site is a QS-320 reopening; a

--- a/tests/test_qs307_override_expiry_unfreeze.py
+++ b/tests/test_qs307_override_expiry_unfreeze.py
@@ -35,10 +35,12 @@ family, one view.
 
 from __future__ import annotations
 
+import ast
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from datetime import time as dt_time
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -67,6 +69,7 @@ from custom_components.quiet_solar.ha_model.bistate_duration import (
 )
 from custom_components.quiet_solar.home_model.commands import CMD_IDLE, CMD_OFF, CMD_ON, LoadCommand, copy_command
 from custom_components.quiet_solar.home_model.constraints import TimeBasedSimplePowerLoadConstraint
+from custom_components.quiet_solar.home_model import load as load_module
 from custom_components.quiet_solar.home_model.load import NUM_MAX_INVALID_PROBES_COMMANDS
 from tests.conftest import FakeHass
 from tests.factories import create_minimal_home_model
@@ -864,13 +867,14 @@ T_PRESS = T_RELAUNCH + timedelta(seconds=1)
 _LOAD_LOGGER = "custom_components.quiet_solar.home_model.load"
 
 
-def _spy_on_acks(pump: _StuckPump) -> list[LoadCommand | None]:
+def _spy_on_acks(pump: _StuckPump, monkeypatch: pytest.MonkeyPatch) -> list[LoadCommand | None]:
     """Record every command `_ack_command` is called with from now on.
 
     A phantom ack is the corruption this story is about, and its visible traces
     (`current_command`, `num_on_off`, the counters) are all reachable by other
     paths too. Recording the call itself is what makes "did not ack" an assertion
-    about the bug rather than about its footprint.
+    about the bug rather than about its footprint. `monkeypatch` so the patch is
+    restored at teardown rather than leaking off the instance.
     """
     acked: list[LoadCommand | None] = []
     real_ack = pump._ack_command
@@ -879,7 +883,7 @@ def _spy_on_acks(pump: _StuckPump) -> list[LoadCommand | None]:
         acked.append(command)
         return real_ack(time, command)
 
-    pump._ack_command = _record  # type: ignore[method-assign]
+    monkeypatch.setattr(pump, "_ack_command", _record)
     return acked
 
 
@@ -971,7 +975,65 @@ async def test_the_dispatch_generation_only_ever_moves_forward():
     assert pump._running_command_generation > first
 
 
-async def test_a_press_that_supersedes_mid_relaunch_cannot_ack_the_command_it_replaced(caplog):
+def test_every_running_command_write_site_is_sanctioned():
+    """Review fix #01/6: the "one way in" install invariant, enforced.
+
+    The generation guard is sound only while every NEW-dispatch slot write bumps
+    the tag — i.e. goes through `_install_running_command`. That invariant was
+    held by a docstring alone, and QS-320 exists precisely because a future
+    install site can silently reopen it. This scans the whole package for direct
+    `self.running_command = ...` assignments and fails on any site outside the
+    sanctioned five, matched by enclosing function (not line number, so the test
+    does not rot on unrelated edits):
+
+    - `constraint_reset_and_reset_commands_if_needed` — the reset wipe (`None`)
+    - `_ack_command` — the ack clear (`None`)
+    - `abandon_running_command` — the abandon clear (`None`)
+    - `_install_running_command` — THE install, the only generation bump
+    - `launch_command` — absorb ONLY: an equal-valued object for the SAME
+      dispatch, deliberately generation-neutral
+    """
+    package = Path(load_module.__file__).resolve().parents[1]
+    sanctioned = {
+        ("load.py", "constraint_reset_and_reset_commands_if_needed"),
+        ("load.py", "_ack_command"),
+        ("load.py", "abandon_running_command"),
+        ("load.py", "_install_running_command"),
+        ("load.py", "launch_command"),
+    }
+
+    found: set[tuple[str, str]] = set()
+    for py_file in sorted(package.rglob("*.py")):
+        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        # (node, enclosing function name) worklist, so each write is keyed by its def
+        stack: list[tuple[ast.AST, str]] = [(tree, "<module>")]
+        while stack:
+            node, func = stack.pop()
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                func = node.name
+            targets: list[ast.expr] = []
+            if isinstance(node, ast.Assign):
+                targets = node.targets
+            elif isinstance(node, ast.AnnAssign | ast.AugAssign):
+                targets = [node.target]
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and target.attr == "running_command"
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                ):
+                    found.add((py_file.name, func))
+            stack.extend((child, func) for child in ast.iter_child_nodes(node))
+
+    assert found == sanctioned, (
+        f"unsanctioned `self.running_command =` write site(s): {sorted(found - sanctioned)} — "
+        "a new dispatch install MUST go through `_install_running_command` so the "
+        "generation tag is bumped, or QS-320 silently reopens"
+    )
+
+
+async def test_a_press_that_supersedes_mid_relaunch_cannot_ack_the_command_it_replaced(caplog, monkeypatch):
     """AC1/AC8/AC9/AC10/AC12 — the headline bug, at `force_relaunch_command`.
 
     The relaunch ladder's service call for `CMD_ON` is in flight when the user
@@ -988,7 +1050,7 @@ async def test_a_press_that_supersedes_mid_relaunch_cannot_ack_the_command_it_re
     assert pump.is_uncontrollable is True  # pre-race: the supersede branch is armed
     rung_before = pump.running_command_num_relaunch
     num_on_off_before = pump.num_on_off
-    acked = _spy_on_acks(pump)
+    acked = _spy_on_acks(pump, monkeypatch)
 
     pump.race_at = T_PRESS
     pump.race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
@@ -1022,7 +1084,37 @@ async def test_a_press_that_supersedes_mid_relaunch_cannot_ack_the_command_it_re
     assert _race_log(caplog, "force_relaunch_command", "replaced")
 
 
-async def test_a_press_that_supersedes_the_first_dispatch_cannot_be_acked_by_it():
+async def test_a_superseded_dispatch_cannot_rewind_the_causality_anchor():
+    """Review fix #01/1: the anchor is monotonic — it never moves backwards.
+
+    `_anchor_causality_guard_if_executed` sits ABOVE the ownership guard on
+    purpose (a service call physically landed, whoever owns the slot). But the
+    replacing dispatch may have already anchored a NEWER instant: here the press
+    obeys, so its `CMD_IDLE` really lands, anchors `T_PRESS` and acks. When the
+    superseded dispatch then resumes and anchors its older `T_RELAUNCH`, a plain
+    assignment rewinds the causality floor by one second — and the freshness test
+    in `check_load_activity_and_constraints` then classifies the entity state QS
+    itself just caused as an external user override, freezing the load for
+    `override_duration` hours on QS's own command.
+    """
+    pump = _make_pump(pump_class=_RacingPump)
+    _arm_for_supersede(pump)
+    # the press must really land: its execute moves the entity and anchors T_PRESS
+    pump.obeys = True
+
+    pump.race_at = T_PRESS
+    pump.race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
+
+    await pump.force_relaunch_command(T_RELAUNCH)
+
+    # the press's dispatch went the whole way: executed, anchored, acked
+    assert pump.current_command == CMD_IDLE
+    assert pump.running_command is None
+    # and the stale resumer did not drag the anchor one second into the past
+    assert pump.last_command_execution_time == T_PRESS
+
+
+async def test_a_press_that_supersedes_the_first_dispatch_cannot_be_acked_by_it(monkeypatch):
     """AC2/AC8 — the same bug at `launch_command`, the first place a command reaches.
 
     The entity is unavailable, so both probes return `None`: the outer dispatch falls
@@ -1036,7 +1128,7 @@ async def test_a_press_that_supersedes_the_first_dispatch_cannot_be_acked_by_it(
     pump._last_supersede_time = None
     pump.obeys = False
     pump.hass.states.set(PUMP_ENTITY, STATE_UNAVAILABLE, last_changed=T_RELAUNCH)
-    acked = _spy_on_acks(pump)
+    acked = _spy_on_acks(pump, monkeypatch)
 
     pump.race_at = T_PRESS
     pump.race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: clean and reset")
@@ -1050,9 +1142,12 @@ async def test_a_press_that_supersedes_the_first_dispatch_cannot_be_acked_by_it(
     assert pump.current_command == CMD_ON  # NOT the phantom `CMD_IDLE`
     assert acked == []
     assert pump.is_load_command_set(T_RELAUNCH) is False
+    # review fix #01/2: the execute returned True, so the device ANSWERED — proven
+    # contact must end the lost-control episode even though the ack is withheld
+    assert pump.unresponsive_since is None
 
 
-async def test_a_reset_that_reinstalls_an_identical_command_is_not_acked_by_the_old_one():
+async def test_a_reset_that_reinstalls_an_identical_command_is_not_acked_by_the_old_one(monkeypatch):
     """AC3 — route B, the case a value-equality guard silently misses.
 
     "Clean and reset" `reset()`s the whole command state and then installs a fresh
@@ -1073,7 +1168,7 @@ async def test_a_reset_that_reinstalls_an_identical_command_is_not_acked_by_the_
     pump.running_command_last_launch = T_RELAUNCH
     pump.obeys = False
     pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_RELAUNCH)
-    acked = _spy_on_acks(pump)
+    acked = _spy_on_acks(pump, monkeypatch)
 
     pump.race_at = T_PRESS
     pump.race_action = lambda t: pump.user_clean_and_reset()
@@ -1089,7 +1184,7 @@ async def test_a_reset_that_reinstalls_an_identical_command_is_not_acked_by_the_
 
 
 @pytest.mark.parametrize("race_result", [True, None], ids=["service-call-lands", "service-call-impossible"])
-async def test_an_absorbed_command_still_belongs_to_the_caller_in_flight(race_result):
+async def test_an_absorbed_command_still_belongs_to_the_caller_in_flight(race_result, monkeypatch):
     """AC4 — absorb must NOT trip the guard. The mirror of AC1.
 
     The absorb branch fires when the incoming command equals the one in flight and
@@ -1106,14 +1201,17 @@ async def test_an_absorbed_command_still_belongs_to_the_caller_in_flight(race_re
     pump = _make_pump(pump_class=_RacingPump)
     pump.external_user_initiated_state = None
     pump.running_command = copy_command(CMD_IDLE)  # setup-only direct write
-    pump.running_command_first_launch = T_RELAUNCH
-    pump.running_command_last_launch = T_RELAUNCH
+    pump.running_command_first_launch = T_RELAUNCH - timedelta(seconds=1)
+    # review fix #01/4: the setup stamp must DIFFER from the relaunch instant, or
+    # the "still stamped" assertion below holds whether or not the stamp was
+    # rewritten and the clause AC4 exists to prove is unobservable
+    pump.running_command_last_launch = T_RELAUNCH - timedelta(seconds=1)
     pump.obeys = False
     pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_RELAUNCH)
     pump.race_result = race_result
     slot_before = pump.running_command
     generation_before = pump._running_command_generation
-    acked = _spy_on_acks(pump)
+    acked = _spy_on_acks(pump, monkeypatch)
 
     pump.race_at = T_PRESS
     pump.race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
@@ -1136,7 +1234,7 @@ async def test_an_absorbed_command_still_belongs_to_the_caller_in_flight(race_re
         assert pump.running_command is not slot_before
 
 
-async def test_check_commands_cannot_ack_a_command_the_probe_never_saw():
+async def test_check_commands_cannot_ack_a_command_the_probe_never_saw(monkeypatch):
     """AC5 — the third site. `check_commands` had no post-await re-check at all.
 
     Its await is the probe, and real subclasses do await I/O there —
@@ -1146,7 +1244,7 @@ async def test_check_commands_cannot_ack_a_command_the_probe_never_saw():
     """
     pump = _make_pump(pump_class=_ProbeRacingPump)
     _arm_for_supersede(pump)
-    acked = _spy_on_acks(pump)
+    acked = _spy_on_acks(pump, monkeypatch)
 
     pump.probe_race_at = T_PRESS
     pump.probe_race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
@@ -1161,6 +1259,39 @@ async def test_check_commands_cannot_ack_a_command_the_probe_never_saw():
     # that told us nothing about the current occupant
     assert command_acked_or_good is False
     assert res == timedelta(0)
+
+
+async def test_a_confirming_probe_ends_the_lost_control_episode_even_when_the_slot_changed_hands(monkeypatch):
+    """Review fix #01/2: contact evidence must not ride on the ack.
+
+    A `True` probe proves the device ANSWERED — that is dispatch-independent
+    contact (`ContactEvidence.CONFIRMED` is documented as "an ack is contact
+    whether or not a clock was live"). On `main` the phantom ack cleared the
+    episode as a side effect; QS-320 correctly removed the ack, but the contact
+    signal must survive on its own, or a live lost-control episode outlasts
+    demonstrated contact and the next solver command supersedes (an extra service
+    call) instead of stacking.
+
+    The ack, the stamp and the counters stay withheld — only the episode ends.
+    """
+    pump = _make_pump(pump_class=_ProbeRacingPump)
+    _arm_for_supersede(pump)
+    assert pump.unresponsive_since == T_RELAUNCH
+    acked = _spy_on_acks(pump, monkeypatch)
+
+    pump.probe_race_at = T_PRESS
+    pump.probe_race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
+    pump.probe_race_result = True
+
+    _res, command_acked_or_good = await pump.check_commands(T_RELAUNCH)
+
+    # proven contact: the episode is over, the shout latch dropped with it
+    assert pump.unresponsive_since is None
+    assert pump._unresponsive_needs_ack is False
+    # but the ack is still withheld — the probe confirmed the PREVIOUS occupant
+    assert acked == []
+    assert pump.current_command == CMD_ON
+    assert command_acked_or_good is False
 
 
 async def test_check_commands_hands_no_invalid_probe_strike_to_the_successor():
@@ -1186,9 +1317,12 @@ async def test_check_commands_hands_no_invalid_probe_strike_to_the_successor():
     # and no staleness computed from the previous dispatch's stamp (pre-fix: -1 s,
     # because the press's stamp is LATER than the relaunch instant)
     assert res == timedelta(0)
+    # review fix #01/2: a `None` probe is NOT contact — the episode-ending clear is
+    # gated on `is True`, so the lost-control episode survives here
+    assert pump.unresponsive_since == T_RELAUNCH
 
 
-async def test_check_commands_cannot_ack_none_onto_an_emptied_slot(caplog):
+async def test_check_commands_cannot_ack_none_onto_an_emptied_slot(caplog, monkeypatch):
     """AC7/AC12 — `check_commands` also carried an unguarded EMPTIED-slot hole.
 
     With no post-await check, an emptied slot reached `_ack_command(time, None)`,
@@ -1212,7 +1346,7 @@ async def test_check_commands_cannot_ack_none_onto_an_emptied_slot(caplog):
     pump.hass.states.set(PUMP_ENTITY, "off", last_changed=T_RELAUNCH)
     # `abandon_running_command` leaves the stack alone, so the tail must still see it
     pump._stacked_command = copy_command(CMD_ON)
-    acked = _spy_on_acks(pump)
+    acked = _spy_on_acks(pump, monkeypatch)
 
     pump.probe_race_at = T_PRESS
     pump.probe_race_action = _sync_race(lambda: pump._drop_running_command("test: the user emptied the slot"))

--- a/tests/test_qs307_override_expiry_unfreeze.py
+++ b/tests/test_qs307_override_expiry_unfreeze.py
@@ -70,7 +70,7 @@ from custom_components.quiet_solar.ha_model.bistate_duration import (
 from custom_components.quiet_solar.home_model.commands import CMD_IDLE, CMD_OFF, CMD_ON, LoadCommand, copy_command
 from custom_components.quiet_solar.home_model.constraints import TimeBasedSimplePowerLoadConstraint
 from custom_components.quiet_solar.home_model import load as load_module
-from custom_components.quiet_solar.home_model.load import NUM_MAX_INVALID_PROBES_COMMANDS
+from custom_components.quiet_solar.home_model.load import NUM_MAX_COMMAND_RELAUNCH, NUM_MAX_INVALID_PROBES_COMMANDS
 from tests.conftest import FakeHass
 from tests.factories import create_minimal_home_model
 from tests.qs304_helpers import CYCLE_S, LADDER_WALL_S, drive
@@ -994,40 +994,81 @@ def test_every_running_command_write_site_is_sanctioned():
       dispatch, deliberately generation-neutral
     """
     package = Path(load_module.__file__).resolve().parents[1]
+    # Review fix #02/2: keys are CLASS-QUALIFIED. `(basename, bare-function)` was
+    # ambiguous — `constraint_reset_and_reset_commands_if_needed` exists on both
+    # `AbstractDevice` and `AbstractLoad`, so a write added to an override of any
+    # sanctioned name would have been silently sanctioned by name-match.
     sanctioned = {
-        ("load.py", "constraint_reset_and_reset_commands_if_needed"),
-        ("load.py", "_ack_command"),
-        ("load.py", "abandon_running_command"),
-        ("load.py", "_install_running_command"),
-        ("load.py", "launch_command"),
+        ("load.py", "AbstractDevice.constraint_reset_and_reset_commands_if_needed"),
+        ("load.py", "AbstractDevice._ack_command"),
+        ("load.py", "AbstractDevice.abandon_running_command"),
+        ("load.py", "AbstractDevice._install_running_command"),
+        ("load.py", "AbstractDevice.launch_command"),
     }
+
+    def flattened(target: ast.expr):
+        """Yield leaf targets through tuple/list/starred unpacking (#02/6)."""
+        if isinstance(target, ast.Tuple | ast.List):
+            for element in target.elts:
+                yield from flattened(element)
+        elif isinstance(target, ast.Starred):
+            yield from flattened(target.value)
+        else:
+            yield target
+
+    def binding_targets(node: ast.AST) -> list[ast.expr]:
+        """Every syntactic form that can bind `self.running_command` (#02/6)."""
+        if isinstance(node, ast.Assign):
+            return node.targets
+        if isinstance(node, ast.AnnAssign | ast.AugAssign):
+            return [node.target]
+        if isinstance(node, ast.For | ast.AsyncFor):
+            return [node.target]
+        if isinstance(node, ast.withitem) and node.optional_vars is not None:
+            return [node.optional_vars]
+        return []
+
+    def is_setattr_of_running_command(node: ast.AST) -> bool:
+        """`setattr(obj, "running_command", ...)` evades target-based scanning (#02/6)."""
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "setattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value == "running_command"
+        )
 
     found: set[tuple[str, str]] = set()
     for py_file in sorted(package.rglob("*.py")):
-        tree = ast.parse(py_file.read_text(encoding="utf-8"))
-        # (node, enclosing function name) worklist, so each write is keyed by its def
-        stack: list[tuple[ast.AST, str]] = [(tree, "<module>")]
+        # `filename=` so a syntax error names the file, not `<unknown>` (#02/5)
+        tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        # (node, dotted qualifier) worklist: ClassDef and function defs both extend
+        # the qualifier, so each write is keyed by its class-qualified location
+        stack: list[tuple[ast.AST, str]] = [(tree, "")]
         while stack:
-            node, func = stack.pop()
-            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-                func = node.name
-            targets: list[ast.expr] = []
-            if isinstance(node, ast.Assign):
-                targets = node.targets
-            elif isinstance(node, ast.AnnAssign | ast.AugAssign):
-                targets = [node.target]
-            for target in targets:
-                if (
-                    isinstance(target, ast.Attribute)
-                    and target.attr == "running_command"
-                    and isinstance(target.value, ast.Name)
-                    and target.value.id == "self"
-                ):
-                    found.add((py_file.name, func))
-            stack.extend((child, func) for child in ast.iter_child_nodes(node))
+            node, qual = stack.pop()
+            if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                qual = f"{qual}.{node.name}" if qual else node.name
+            if is_setattr_of_running_command(node):
+                found.add((py_file.name, qual or "<module>"))
+            for target in binding_targets(node):
+                for leaf in flattened(target):
+                    if (
+                        isinstance(leaf, ast.Attribute)
+                        and leaf.attr == "running_command"
+                        and isinstance(leaf.value, ast.Name)
+                        and leaf.value.id == "self"
+                    ):
+                        found.add((py_file.name, qual or "<module>"))
+            stack.extend((child, qual) for child in ast.iter_child_nodes(node))
 
+    # Both directions reported (#02/7): an extra site is a QS-320 reopening; a
+    # missing one means a sanctioned function was renamed/moved and the sanction
+    # list must follow it.
     assert found == sanctioned, (
-        f"unsanctioned `self.running_command =` write site(s): {sorted(found - sanctioned)} — "
+        f"unsanctioned `self.running_command` write site(s): {sorted(found - sanctioned)}; "
+        f"sanctioned site(s) no longer found (renamed/moved?): {sorted(sanctioned - found)} — "
         "a new dispatch install MUST go through `_install_running_command` so the "
         "generation tag is bumped, or QS-320 silently reopens"
     )
@@ -1292,6 +1333,120 @@ async def test_a_confirming_probe_ends_the_lost_control_episode_even_when_the_sl
     assert acked == []
     assert pump.current_command == CMD_ON
     assert command_acked_or_good is False
+
+
+# The instant of the "following cycle" in the two re-announce tests below: past
+# `T_PRESS` so the successor's launch stamp is in the past, and well inside even
+# the rung-0 backoff (50 s) so the cycle relaunches nothing.
+T_NEXT = T_PRESS + timedelta(seconds=5)
+
+
+def _arm_announced_episode(pump: _StuckPump) -> None:
+    """Saturate the ladder and mark the episode as already announced (QS-319).
+
+    `unresponsive_since` is only ever set once the rung reaches
+    `NUM_MAX_COMMAND_RELAUNCH`, and announcing sets the latch — so this is the
+    ONLY state in which the disowned-slot CONFIRMED clear can fire on a replaced
+    slot in production (a press can only supersede while `is_uncontrollable`).
+    """
+    pump.running_command_num_relaunch = NUM_MAX_COMMAND_RELAUNCH
+    pump._unresponsive_needs_ack = True
+
+
+async def test_proven_contact_on_a_replaced_slot_does_not_reannounce_the_episode(caplog, monkeypatch):
+    """Review fix #02/1, `check_commands` site: contact must END the episode, not restart it.
+
+    The #01/2 CONFIRMED clear drops both the clock and the QS-319 announce latch
+    — but the successor installed by the racing press inherits a saturated rung
+    it never earned. Unfixed, the very next `_escalate_or_recover` pass re-marks
+    the clock and, with the latch down, takes the ANNOUNCE branch: a fresh
+    "Lost control of load" ERROR with an inherited relaunch count, a second push,
+    and an on→off→on flap of the `qs_load_lost_control` PROBLEM sensor —
+    milliseconds after the device demonstrably answered. The ladder's premise is
+    "device not answering"; a confirming probe disproves it, so the successor
+    starts at rung 0. The clear also wiped `_last_supersede_time` — here the
+    stamp the successor's OWN supersede wrote a second earlier, so the
+    one-per-window throttle invariant lost its anchor; it is preserved.
+    """
+    pump = _make_pump(pump_class=_ProbeRacingPump)
+    _arm_for_supersede(pump)
+    _arm_announced_episode(pump)
+    pushes: list[LoadCommand] = []
+
+    async def _spy_push(time, command):
+        pushes.append(command)
+
+    monkeypatch.setattr(pump, "_notify_unresponsive", _spy_push)
+
+    pump.probe_race_at = T_PRESS
+    pump.probe_race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
+    pump.probe_race_result = True
+
+    with caplog.at_level(logging.INFO, logger=_LOAD_LOGGER):
+        await pump.check_commands(T_RELAUNCH)
+
+        # the successor performed zero relaunches of its own: rung reset, episode
+        # over, and its own supersede stamp survives the clear
+        assert pump.running_command_num_relaunch == 0
+        assert pump._last_supersede_time == T_PRESS
+        assert pump.unresponsive_since is None
+        assert pump.has_unacknowledged_lost_control is False
+
+        # the following driver cycle must not re-mark, re-announce or re-push
+        await pump.check_and_relaunch_command(T_NEXT)
+
+    assert not any("Lost control of load" in message for message in caplog.messages)
+    assert pushes == []
+    # the QS-319 pin: no PROBLEM-sensor re-flap — False, and it STAYS False
+    assert pump.has_unacknowledged_lost_control is False
+    assert pump.unresponsive_since is None
+    assert pump.running_command == CMD_IDLE  # the successor is intact and in flight
+
+
+async def test_proven_contact_on_a_replaced_first_dispatch_does_not_reannounce_the_episode(caplog, monkeypatch):
+    """Review fix #02/1, `launch_command` site: same scenario, one cycle later.
+
+    Identical mechanics, but the disowned-slot clear fires in `launch_command`,
+    so the spurious re-announce would land on the NEXT `check_and_relaunch_command`
+    cycle — with the PROBLEM sensor reading "resolved" across a full cycle
+    boundary in between, a real off→on edge for any automation on it.
+    """
+    pump = _make_pump(pump_class=_RacingPump)
+    pump.external_user_initiated_state = None
+    pump._ack_command(T_RELAUNCH, copy_command(CMD_ON))  # confirmed of record, slot -> None
+    pump.unresponsive_since = T_RELAUNCH
+    _arm_announced_episode(pump)
+    pump._last_supersede_time = None
+    pump.obeys = False
+    pump.hass.states.set(PUMP_ENTITY, "on", last_changed=T_RELAUNCH)
+    pushes: list[LoadCommand] = []
+
+    async def _spy_push(time, command):
+        pushes.append(command)
+
+    monkeypatch.setattr(pump, "_notify_unresponsive", _spy_push)
+
+    pump.race_at = T_PRESS
+    pump.race_action = lambda t: pump.launch_command(t, CMD_IDLE, ctxt="button: mark constraint done")
+
+    with caplog.at_level(logging.INFO, logger=_LOAD_LOGGER):
+        # `CMD_OFF`: differs from the confirmed `CMD_ON` (no early return) and from
+        # the press's `CMD_IDLE` (no absorb), and the entity reads `on` so the probe
+        # returns False and the dispatch reaches the execute where the race lands
+        await pump.launch_command(T_RELAUNCH, CMD_OFF, ctxt="solver dispatch")
+
+        assert pump.running_command_num_relaunch == 0
+        assert pump._last_supersede_time == T_PRESS
+        assert pump.unresponsive_since is None
+        assert pump.has_unacknowledged_lost_control is False
+
+        await pump.check_and_relaunch_command(T_NEXT)
+
+    assert not any("Lost control of load" in message for message in caplog.messages)
+    assert pushes == []
+    assert pump.has_unacknowledged_lost_control is False
+    assert pump.unresponsive_since is None
+    assert pump.running_command == CMD_IDLE
 
 
 async def test_check_commands_hands_no_invalid_probe_strike_to_the_successor():


### PR DESCRIPTION
## Summary
- Tag each dispatch with a monotonic `_running_command_generation` (issued by the single installer `_install_running_command`) and gate all completion paperwork on `_slot_still_holds` at all three sites — `launch_command`, `check_commands` and `force_relaunch_command`. #316 guarded the slot being *emptied*; a *replaced* slot passed an `is None` test, so a button press landing mid-await got acked off the previous command's result — the load kept running while QS believed it was idle, with nothing to retry it.
- Comparing the command value cannot work in either direction: absorb swaps in an equal-valued object for the *same* dispatch (identity over-triggers, breaking the backoff stamp), and the reset-then-reinstall route installs a field-identical `CMD_IDLE` from a *different* dispatch (equality under-triggers, leaving the bug open). The generation compares dispatches.
- `check_commands` had no post-await re-check at all, so it also carried an unguarded emptied-slot hole reaching `_ack_command(time, None)`, which nulled the confirmed command of record. Its bail-out is a flag, not an early return, so the stacked-promotion tail still runs in the same cycle.
- 8 new tests covering AC1-AC13 via a pluggable `race_action` on `_RacingPump` plus a new `_ProbeRacingPump`; AC1/AC2/AC3/AC5/AC6/AC7 were verified to fail pre-fix behaviourally (**6/6 red** against pre-fix `load.py` at `494b53d6` — 1/1 per AC), and AC11's non-vacuity was verified by temporarily reverting #316's guards (3 of 4 cases fail).
- Deliberately unchanged: the causality anchor still fires above the guard, and route A still inherits the ladder rung (QS-304's saturated cadence). Deliberately changed: a superseding successor no longer inherits an invalid-probe strike.

Fixes #320

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [x] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

## Review fix #01 (rev2) — all 6 should-fix + 5 of 6 nice-to-have

- **#1 (should-fix)** — `_anchor_causality_guard_if_executed` is now **monotonic**: a superseded dispatch resuming after its replacement anchored a newer instant can no longer rewind the causality floor and get QS's own state change classified as a user override. New race test with an obeying press (`test_a_superseded_dispatch_cannot_rewind_the_causality_anchor`), red pre-fix.
- **#2 (should-fix)** — proven contact no longer rides on the ack: a `True` result reaching a disowned-slot bail-out in `launch_command` or `check_commands` now calls `_clear_unresponsive(CONFIRMED)` while the ack/stamp/counters stay withheld. **Deliberate asymmetry:** `force_relaunch_command`'s bail-out does NOT clear — AC1 pins `unresponsive_since` surviving it — recorded in-code at that guard. AC6 now also pins that a `None` probe is *not* contact.
- **#3 (should-fix)** — `check_and_relaunch_command`'s docstring no longer over-claims "counting": only `running_command_num_relaunch_after_invalid` is guard-gated; the ladder rung is inherited by design (AC9, QS-304).
- **#4 (should-fix)** — AC4's setup stamp moved to `T_RELAUNCH − 1s`, making the "still stamped" assertion observable.
- **#5 (should-fix)** — quantified red-first evidence: the six "must fail pre-fix" tests were re-run against pre-fix `load.py` (`494b53d6`): **6/6 fail** — AC1 1/1, AC2 1/1, AC3 1/1, AC5 1/1, AC6 1/1, AC7 1/1 (complements the AC11 revert check minuted in `e764fbb6`: 3 of 4 parametrized #316 cases fail with the guards removed).
- **#6 (should-fix)** — the "one way in" install invariant is now enforced by an AST lint test that scans the package for `self.running_command =` writes and fails on any site outside the sanctioned five (matched by enclosing function, not line number). No property setter — per the plan's red line.
- **#7/#10/#12 (nice-to-have, one edit)** — `_slot_still_holds` takes the command **name** (plain `str`) and a **required** `ctxt` (`check_commands` passes the invalid-probe count, `force_relaunch_command` the relaunch count); the three f-string log calls converted to lazy `%s`.
- **#9 (nice-to-have)** — comment pinning `res`'s dead-value assumption on a disowned slot.
- **#11 (nice-to-have)** — `_spy_on_acks` now patches via `monkeypatch.setattr` (restored at teardown, `type: ignore` removed).

### Finding #8 deliberately NOT implemented (user-approved skip)

The proposed probe wrap in `check_commands` (catch → `is_command_set = None` → fall through) inverts a **test-pinned QS-304 design decision**: three tests assert with `pytest.raises` that a raising probe propagates out of `check_commands` (`tests/test_bug_304_command_deadlock.py:1004`, `:1023`, `:1271`), and `check_and_relaunch_command`'s docstring pins the contract — "The device exception is deliberately not swallowed — `QSHome.check_loads_commands` owns the per-load try/except." Implementing it means renegotiating that contract and rewriting those tests, which exceeds a nice-to-have's blast radius. Left for the next review round to adjudicate (or split into its own issue).

## Doc maintenance (review fix #01)

`load-base.md` (seven releasers, monotonic anchor, `_slot_still_holds` signature ×2) and `external-control-detection.md` (monotonic causality floor) updated with content; `user-override.md` and `piloted-device-and-heat-pump.md` verified content-unaffected, `last_verified` bumped. Drift checker exit 0.

## Review fix #02 — all 9 findings (post-merge, QS-319 interaction)

- **#1 (should-fix)** — the #01/2 CONFIRMED clear no longer restarts the episode it just ended: `_confirmed_contact_on_disowned_slot` (both sanctioned sites) resets the successor's inherited saturated rung to 0 — so `_escalate_or_recover` cannot re-mark and re-announce with an inherited count — and preserves the successor's own `_last_supersede_time` across the clear. Two new red-first race tests pin: rung 0, no `Lost control` ERROR, no second push, **no `qs_load_lost_control` PROBLEM-sensor re-flap** across the following cycle, and the stamp intact. `force_relaunch_command` and AC9's supersede-inheritance untouched (both test-pinned).
- **#2 (should-fix)** — the install-site lint is now class-qualified (`AbstractDevice.launch_command`, …); verified red on a write injected into `AbstractLoad.constraint_reset_and_reset_commands_if_needed` — the exact name-collision the bare keys would have silently sanctioned.
- **#3 (adjudication record)** — plan #01's F8 skip recorded as final in a "Disposition (round 2)" note; the bare probe in `check_commands` is deliberate.
- **#9 (should-fix)** — QS-319 × QS-320 doc contradictions reconciled at all five spots: the episode-ender rule now lists **four** enders everywhere (real ack / proven contact on a disowned slot / user remediation / restart); CONFIRMED has three callers on the merged tree; the "no lint" claim qualified (write-site half is now test-enforced).
- **#4/#5/#6/#7/#8 (nice-to-have)** — best-effort log-label caveat documented; `ast.parse` gets `filename=`; the lint walker covers tuple/starred unpacking, `For`, `withitem` and `setattr(_, "running_command", …)`; the lint failure message reports both set differences; the monotonic anchor's NTP step-back limitation documented (no clock-step detection, on purpose).

## Doc maintenance

`load-base.md` and `notification-routing.md` updated with content (episode enders, CONFIRMED callers, lint claim) and bumped. Three further docs surfaced by the drift checker are **content-unaffected by this round's diff** and deliberately not padded: `user-override.md` (describes the ownership check and causality guard — neither changed this round), `external-control-detection.md` (its causality bullet already carries the monotonic note from #01; #02/8 only documented an in-code limitation), `piloted-device-and-heat-pump.md` (covers the QS-306 reset-logging hook only).

## Review fix #03 — convergence round, all 7 findings, ZERO behaviour change

Validated on the diff: `load.py` changes are one docstring, two comment blocks and two log string literals losing a stray `)` — no executable statement added, removed or reordered. All 43 tests in the touched file green with the race tests unmodified.

- **#1 (should-fix)** — the lint walker now catches comprehension for-targets, the one accidental binding form #02/6 missed; **#3/#5** — cheap `setattr` siblings (`builtins.setattr`, `self.__dict__["running_command"]` store) covered, docstrings scoped to accidental writes (deliberate evasion out of the threat model), sanction keys package-relative. Each new form verified red with a temporary injected write, then removed.
- **#2/#4/#7** — three known-benign corners documented in place (absorb-then-ack one-cycle "dropped" false negative; best-effort zero-relaunches premise; throttle restore meaningful on the replaced arm only).
- **#6** — stray `)` removed from the two named log strings.

## Doc maintenance (review fix #03)

The drift checker flags five concept docs because `load.py` is in the diff — this round's `load.py` changes are comments, docstrings and log-string literals only, so no concept-doc content is affected; deliberately not padded.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated command results from affecting replacement commands, acknowledgements, counters, or timestamps.
  * Improved reliability when commands are replaced, cleared, relaunched, or completed asynchronously.
  * Preserved override expiry handling and recovery for unresponsive loads.
  * Ensured command timing remains monotonic and contact evidence is handled correctly.

* **Documentation**
  * Clarified command ownership, replacement behavior, and asynchronous processing.
  * Added guidance for race-condition handling and acceptance criteria.

* **Tests**
  * Expanded coverage for command replacement, probe races, stale acknowledgements, and stacked commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


