### PR TITLE
DO NOT MERGE: AC-2 probe

### DIFF
--- a/.claude/commands/implement-task.md
+++ b/.claude/commands/implement-task.md
@@ -21,8 +21,7 @@ Expected outcome:
 - TDD-implemented code under `custom_components/quiet_solar/` and tests.
 - `python scripts/qs/quality_gate.py --impacted` passes (changed lines
   100% covered; the whole-suite gate — pytest 100% cov + ruff + mypy +
-  translations — runs authoritatively in CI on every PR; translations
-  value-check is local-full-gate only until #292 lands).
+  translations — runs authoritatively in CI on every PR).
 - For change sets touching any `tests/qs`-pinned non-Python file
   (agent files, commands, workflow docs, `.claude/settings.json`) —
   even when Python files changed too —

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -59,12 +59,20 @@ jobs:
     name: Tests shard ${{ matrix.shard }}/4
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Least privilege: this job `pip install`s third-party packages, so
+    # it must not hold a writable token.
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Don't leave the token in the git credential store while
+          # third-party package code runs.
+          persist-credentials: false
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
@@ -86,11 +94,31 @@ jobs:
           TZ: Europe/Paris
         run: |
           set -euo pipefail
-          pytest tests/ --collect-only -q \
-            | grep -oE '^[0-9]+ tests? collected' \
-            | grep -oE '^[0-9]+' > total-collected.txt
+          if ! pytest tests/ --collect-only -q > collect-output.txt 2>&1; then
+            echo "::error::pytest collection failed — output below"
+            cat collect-output.txt
+            exit 1
+          fi
+          # Accept both `N tests collected` and the deselected form
+          # `N/M tests collected (K deselected)`, taking N — the number
+          # actually selected. `|| true` keeps a no-match from dying
+          # under `set -e` with no diagnostic.
+          total="$(grep -oE '^[0-9]+(/[0-9]+)? tests? collected' collect-output.txt \
+            | head -1 | grep -oE '^[0-9]+' || true)"
+          if [ -z "${total}" ]; then
+            echo "::error::could not parse the pytest collect summary — tail below"
+            tail -20 collect-output.txt
+            exit 1
+          fi
+          echo "${total}" > total-collected.txt
           cat total-collected.txt
 
+      # Each shard's terminal coverage report shows only what THAT shard
+      # exercised — roughly 58-70% of the package, which is expected and
+      # is not a regression. Only the aggregation job's combined report
+      # is a verdict. (`--cov-report=` cannot silence these: pytest-cov
+      # clears the report list only when '' is its SOLE member, and
+      # pytest.ini's addopts already contributes `term-missing`.)
       - name: Run shard ${{ matrix.shard }}
         env:
           TZ: Europe/Paris
@@ -117,7 +145,10 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
           overwrite: true
-          retention-days: 1
+          # Long enough that a "Re-run failed jobs" days later still
+          # finds the shard data. At 1 day the aggregation job could go
+          # permanently un-clearable by re-running it alone.
+          retention-days: 5
 
   # The job `name:` below is the LITERAL required status check on `main`
   # (verified: `gh api repos/:owner/:repo/branches/main/protection`
@@ -126,13 +157,19 @@ jobs:
   test:
     name: Tests (100% Coverage)
     needs: test-shard
-    if: always()
+    # `!cancelled()` — NOT `always()`. Both keep this required check
+    # from being SKIPPED when a shard fails (branch protection counts a
+    # skipped required check as passing), but `always()` also fires on
+    # cancellation and would turn a cancelled run into a hard red.
+    if: ${{ !cancelled() }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      # With a plain `needs:`, a failing shard would SKIP this job, and
-      # branch protection treats a skipped required check as passing.
-      # `if: always()` plus this guard makes that a hard red.
+      # A failing shard must surface here as a hard red, since test
+      # failures now live in a `Tests shard N/4` job that is NOT the
+      # required context.
       - name: Fail if any shard failed
         if: needs.test-shard.result != 'success'
         run: |
@@ -141,6 +178,8 @@ jobs:
           exit 1
 
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
@@ -148,12 +187,28 @@ jobs:
           python-version: '3.14'
 
       # D-14: value-level translations check. Invokes the SAME entry
-      # point as the local gate's `check_translations`, so the two can
-      # never disagree.
+      # point as the local gate's `check_translations`
+      # (`bash scripts/generate-translations.sh`), so the two cannot
+      # disagree on the STALENESS verdict — the whole point of D-14.
+      #
+      # One deliberate asymmetry: the local gate ignores the generator's
+      # exit code ("may fail for unrelated integrations"), whereas a
+      # hard generator failure — absent strings.json, unresolvable
+      # `[%key:…%]` — is red here. CI is intentionally the stricter of
+      # the two, and says so instead of dying on a bare traceback.
+      #
+      # `git add -A` before diffing: `git diff` alone cannot see
+      # UNTRACKED files, so a PR that DELETES en.json would have the
+      # generator recreate it and pass vacuously.
       - name: Check translations/en.json is freshly generated
         run: |
-          bash scripts/generate-translations.sh
-          git diff --exit-code -- custom_components/quiet_solar/translations/ \
+          set -euo pipefail
+          if ! bash scripts/generate-translations.sh; then
+            echo "::error::scripts/generate-translations.sh failed — check strings.json for an absent file or an unresolvable [%key:...%] reference"
+            exit 1
+          fi
+          git add -A -- custom_components/quiet_solar/translations/
+          git diff --cached --exit-code -- custom_components/quiet_solar/translations/ \
             || { echo "::error::translations are stale — run 'bash scripts/generate-translations.sh' and commit the result"; exit 1; }
 
       # Twin of the `coverage==7.14.1` pin in requirements_test.txt —

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements_test.txt
 
       - name: Install dependencies
         run: |
@@ -38,6 +42,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements_test.txt
 
       - name: Install dependencies
         run: |
@@ -47,9 +55,14 @@ jobs:
       - name: MyPy type check
         run: mypy custom_components/quiet_solar/
 
-  test:
-    name: Tests (100% Coverage)
+  test-shard:
+    name: Tests shard ${{ matrix.shard }}/4
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v5
 
@@ -57,17 +70,112 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements_test.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements_test.txt
 
-      - name: Run tests with 100% coverage
+      - name: Record total collected test count
+        if: matrix.shard == 1
+        env:
+          TZ: Europe/Paris
+        run: |
+          set -euo pipefail
+          pytest tests/ --collect-only -q \
+            | grep -oE '^[0-9]+ tests? collected' \
+            | grep -oE '^[0-9]+' > total-collected.txt
+          cat total-collected.txt
+
+      - name: Run shard ${{ matrix.shard }}
         env:
           TZ: Europe/Paris
           COVERAGE_CORE: sysmon
-        run: pytest tests/ -n auto --cov=custom_components/quiet_solar --cov-report=term-missing --cov-fail-under=100
+          COVERAGE_FILE: .coverage.shard-${{ matrix.shard }}
+        run: >-
+          pytest tests/ -n auto
+          --splits 4 --group ${{ matrix.shard }}
+          --cov=custom_components/quiet_solar
+          --junitxml=junit-shard-${{ matrix.shard }}.xml
+
+      - name: Upload shard data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shard-data-${{ matrix.shard }}
+          # `total-collected.txt` exists only on shard 1;
+          # `if-no-files-found` is evaluated on the aggregate match set,
+          # so shards 2-4 still satisfy it via the other two entries.
+          path: |
+            .coverage.shard-${{ matrix.shard }}*
+            junit-shard-${{ matrix.shard }}.xml
+            total-collected.txt
+          include-hidden-files: true
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  # The job `name:` below is the LITERAL required status check on `main`
+  # (verified: `gh api repos/:owner/:repo/branches/main/protection`
+  # returns required_status_checks.contexts == ["Tests (100% Coverage)"]).
+  # Renaming it blocks every PR forever. Do not touch.
+  test:
+    name: Tests (100% Coverage)
+    needs: test-shard
+    if: always()
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      # With a plain `needs:`, a failing shard would SKIP this job, and
+      # branch protection treats a skipped required check as passing.
+      # `if: always()` plus this guard makes that a hard red.
+      - name: Fail if any shard failed
+        if: needs.test-shard.result != 'success'
+        run: |
+          echo "::error::test-shard result was '${{ needs.test-shard.result }}'"
+          echo "::error::See the 'Tests shard N/4' jobs for the failing tests."
+          exit 1
+
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      # D-14: value-level translations check. Invokes the SAME entry
+      # point as the local gate's `check_translations`, so the two can
+      # never disagree.
+      - name: Check translations/en.json is freshly generated
+        run: |
+          bash scripts/generate-translations.sh
+          git diff --exit-code -- custom_components/quiet_solar/translations/ \
+            || { echo "::error::translations are stale — run 'bash scripts/generate-translations.sh' and commit the result"; exit 1; }
+
+      # Twin of the `coverage==7.14.1` pin in requirements_test.txt —
+      # the shards' data must be written and read by the same version.
+      # Both move together in one edit.
+      - name: Install coverage
+        run: pip install coverage==7.14.1
+
+      - name: Download shard data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: shard-data-*
+          path: shard-data
+          merge-multiple: true
+
+      - name: Reconcile test counts
+        run: python3 scripts/qs/ci_reconcile_shards.py shard-data --splits 4
+
+      - name: Combine coverage and enforce 100%
+        run: |
+          coverage combine shard-data
+          coverage report --show-missing --fail-under=100
 
   hacs-validate:
     name: HACS Validation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements_test.txt
 
       - name: Install dependencies
         run: |
@@ -34,7 +38,8 @@ jobs:
       - name: Run tests with 100% coverage
         env:
           TZ: Europe/Paris
-        run: pytest tests/ --cov=custom_components/quiet_solar --cov-report=term-missing --cov-fail-under=100
+          COVERAGE_CORE: sysmon
+        run: pytest tests/ -n auto --cov=custom_components/quiet_solar --cov-report=term-missing --cov-fail-under=100
 
   hacs-validate:
     name: HACS Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ ad-hoc single-node debugging (positional must contain `::`).
 python scripts/qs/quality_gate.py --impacted  # MANDATORY pre-commit gate (QS-276): testmon-selected tests + changed-line 100% cov, self-healing
 python scripts/qs/quality_gate.py --quick tests/qs  # REQUIRED supplement when the change set touches tests/qs-pinned non-Python files: agent files, commands, workflow docs, .claude/settings.json (testmon cannot see non-Python files)
 python scripts/qs/quality_gate.py --quick tests/test_solver.py  # fast TDD inner loop on an explicit path
-python scripts/qs/quality_gate.py          # full gate (cov + ruff + mypy + translations) — EXPLICIT user request only; CI owns it except the translations value-check (#292)
+python scripts/qs/quality_gate.py          # full gate (cov + ruff + mypy + translations) — EXPLICIT user request only; CI owns it
 python scripts/qs/quality_gate.py --full   # force the full suite regardless of scope detection (a bare run scope-skips on dev-only / ui-only trees)
 python scripts/qs/quality_gate.py --cache  # skip repeated FULL-gate runs if git state matches last pass
 python scripts/qs/quality_gate.py --fix    # auto-fix ruff format / lint
@@ -85,8 +85,8 @@ pre-commit gate (for change sets touching `tests/qs`-pinned non-Python
 files — agent files, commands, workflow docs, `.claude/settings.json` —
 `--quick tests/qs` is a required supplement even when Python files
 changed too; testmon cannot see non-Python files); `--quick PATH` is the fast TDD inner loop; the
-bare full gate runs authoritatively in CI (translations value-check
-excepted until #292 lands; local runs only on explicit user request) —
+bare full gate runs authoritatively in CI (local runs only on
+explicit user request) —
 see the Commands section above for the full grammar.
 
 ## Legacy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,8 @@ translations. Smart scope detection skips the full suite when only
 dev-infrastructure files changed. The mandatory pre-commit form is
 `python scripts/qs/quality_gate.py --impacted` (testmon-selected tests
 plus changed-line 100% coverage, self-healing); the whole-suite gate
-runs authoritatively in CI on every PR (translations value-check is
-local-full-gate only until #292 lands). For change sets touching
+runs authoritatively in CI on every PR (including the translations
+value-check since QS-292). For change sets touching
 `tests/qs`-pinned non-Python files (agent files, commands, workflow
 docs, `.claude/settings.json`),
 `python scripts/qs/quality_gate.py --quick tests/qs` is a required

--- a/docs/agents/concepts/testing-layers.md
+++ b/docs/agents/concepts/testing-layers.md
@@ -119,11 +119,13 @@ would let a production line covered *only* by a domain integration test
 report 0% and FAIL `--impacted` with no local remedy (review-fix MF1).
 The self-tests never cover `custom_components/quiet_solar`, so ignoring
 that one file cannot change the diff-cover verdict; it just keeps the
-loop fast. CI's whole-repo gate (`pr-quality.yml`: four parallel
-`pytest tests/ -n auto --splits 4 --group N` shards whose data is
-combined into one `coverage report --fail-under=100`) ignores no test,
-so it runs every test — domain integration and self-tests alike — for
-the authoritative 100%.
+loop fast. CI's whole-repo gate (`pr-quality.yml`: N parallel
+`pytest tests/ -n auto --cov=custom_components/quiet_solar --splits N
+--group <i>` shards whose data is combined into one
+`coverage report --fail-under=100`) ignores no test, so it runs every
+test — domain integration and self-tests alike — for the authoritative
+100%. The shard count lives only in the workflow;
+`tests/test_quality_gate.py` pins its four copies to each other.
 
 ## Key types / structures
 

--- a/docs/agents/concepts/testing-layers.md
+++ b/docs/agents/concepts/testing-layers.md
@@ -119,9 +119,11 @@ would let a production line covered *only* by a domain integration test
 report 0% and FAIL `--impacted` with no local remedy (review-fix MF1).
 The self-tests never cover `custom_components/quiet_solar`, so ignoring
 that one file cannot change the diff-cover verdict; it just keeps the
-loop fast. CI's whole-repo gate (`pr-quality.yml`, `pytest tests/ -n auto
---cov-fail-under=100`) ignores nothing, so it runs every test — domain
-integration and self-tests alike — for the authoritative 100%.
+loop fast. CI's whole-repo gate (`pr-quality.yml`: four parallel
+`pytest tests/ -n auto --splits 4 --group N` shards whose data is
+combined into one `coverage report --fail-under=100`) ignores no test,
+so it runs every test — domain integration and self-tests alike — for
+the authoritative 100%.
 
 ## Key types / structures
 

--- a/docs/stories/QS-292.story.md
+++ b/docs/stories/QS-292.story.md
@@ -799,29 +799,37 @@ _To be filled at tasks 10-12._
 | Per-shard job durations | cold-cache run [30718305154](https://github.com/tmenguy/quiet-solar/actions/runs/30718305154): shard 1 **193s**, 2 **127s**, 3 **135s**, 4 **143s**, aggregation **22s**. Warm-cache [30745439928](https://github.com/tmenguy/quiet-solar/actions/runs/30745439928): shard 1 **177s**, 2 **123s**, 3 **119s**, 4 **120s**, aggregation **17s**. Shard 1 is the pace-setter as designed — but by a **~55s** margin over its siblings, materially worse than the ~15s the projection assumed (see AC-3) |
 | Combined `TOTAL` statements (AC-4) | **PASS on substance.** Run 30741000157 (pre-QS-319 tree): `TOTAL 16314 0 100%` — byte-identical to the recorded baseline, which is the exact comparison AC-4 specifies. Run 30745439928 then reported `16339 0 100%`: **QS-319 merged into `main` at 11:16:56 UTC**, 1 minute before that run, and a `pull_request` build measures the *merge* commit, so +25 statements arrived from `ha_model/device.py` + `home_model/load.py`. Not a sharding artifact — every shard reported the same 16339 denominator, and combining still yielded 0 missing. AC-4's literal number is only meaningful against a fixed tree |
 | `executed=N collected=N` (AC-5) | **PASS** — `executed=6921 collected=6921` (run 30741000157), then `executed=6949 collected=6949` (run 30745439928). Every count reconciles exactly: the layer-1 proof's 6912 predates tasks 3/5, which added 9 tests (6912+9 = 6921); review fix #01 added 9 more and QS-319's merge brought 19 (6921+9+19 = 6949); the local pre-commit collect agreed at 6930 = 6921+9, without the merge |
-| Critical path samples + median (AC-3, bar 200s) | **2 of ≥3 samples, both marginal.** Warm: **195s** (30741000157), **197s** (30745439928). Excluded cold: 223s (30718305154). Against the 277s baseline this is a **~29% cut, not the ~44% projected** — the design predicted ~155s typical / ~180s stacked worst case, and the *typical* case is already worse than the projected worst case. Cause: shard-1 imbalance (177s vs 119-123s), i.e. the no-`.test_durations` decision (D2) costs more than priced. It clears the 200s bar by ~2%, which is inside runner variance — see the note below the table |
+| Critical path samples + median (AC-3, bar 200s) | **PASS, by 3s.** Three warm-cache samples: **195s** (30741000157), **197s** (30745439928), **197s** (30749311286) → **median 197s** ≤ 200s. Excluded cold-cache run: 223s (30718305154). Remarkably tight spread (195/197/197), so the median is trustworthy — but it is a **~29% cut, not the ~44% projected**: the design predicted ~155s typical / ~180s stacked worst case, and the *typical* measured case is worse than the projected *worst* case. Cause: shard-1 imbalance (177-178s vs 118-126s). See the note below |
 | AC-2 probe run URL + conclusion | **OPEN** — maintainer-run, see "Probe procedure" |
 
-### AC-3 is passing on a ~2% margin — a maintainer decision, not a green tick
+### AC-3 passes by 3s — read this before treating it as settled
 
-Both warm samples (195s, 197s) sit just under the 200s bar that AC-3
-names as the **rollback trigger** for §A. Two honest readings:
+The median (197s) clears the 200s rollback trigger by **1.5%**. The
+sample spread is tight (195/197/197), so this is a real measurement
+rather than a lucky draw — but the *headroom* is not comfortable:
 
-- *Ship it.* The bar is met, the change is a real ~29% cut (277s → ~196s)
-  on ~100 runs/month, and every soundness guard (AC-1, AC-4, AC-5) is
-  green.
-- *The margin is inside the noise.* The baseline itself spanned 269-282s,
-  so a ~2% margin is not a robust pass. Any test-suite growth lands
-  disproportionately on shard 1 and pushes the median over 200s, at
-  which point the documented response is to revert §A entirely.
+- *In favour of shipping.* The bar is met on three samples, the change
+  is a genuine ~29% cut (277s → 197s) across ~100 runs/month, and every
+  soundness criterion (AC-1, AC-4, AC-5) is green.
+- *Against treating it as done.* 3s of headroom means ordinary suite
+  growth flips it. Growth is not evenly distributed: with no durations
+  file, `pytest-split` slices *collection order* into contiguous chunks,
+  and shard 1 already carries **177-178s against 118-126s** for its
+  siblings. New tests landing in shard 1's range push the median over
+  200s, whose documented consequence is reverting §A wholesale.
 
-The cheap fix for the margin — a committed `.test_durations` file — was
-declined as **D2**. That decision was priced against an assumed ~15s
-shard-1 penalty; the measured penalty is **~55s**, which is the single
-largest term keeping the critical path near the bar. Revisiting D2 (or
-raising the shard count) would likely reach the projected ~155s, and is
-worth doing before concluding §A underdelivers. Recorded here rather
-than acted on: changing it now would exceed this fix plan's scope.
+**The projection's error is now measurable.** §A budgeted shard 1 a
+~15s penalty (the collect-only step); the observed gap to the other
+shards is **~55s**. Shard 1 is not slow because of the collect step —
+it is slow because its contiguous chunk is heavier. That is exactly the
+cost **D2** accepted when it declined a committed `.test_durations`
+file, priced there as "bounded, worst case ~40% of variable time".
+
+So the honest status is: AC-3 is met, and D2's cost estimate was
+optimistic. Before concluding §A underdelivers, revisit D2 or raise the
+shard count — either should approach the projected ~155s. Not acted on
+here: it is outside this fix plan's scope and would change the
+performance characteristics the three samples above just measured.
 
 ### Round 1 — critic, concrete-planner, dev-proxy, scope-guardian (4 parallel)
 

--- a/docs/stories/QS-292.story.md
+++ b/docs/stories/QS-292.story.md
@@ -796,15 +796,32 @@ _To be filled at tasks 10-12._
 | Layer-1 partition proof: four group sizes | **PASS** — 6912 collected; **1728 / 1728 / 1728 / 1728**; union == full collected set; all six pairwise intersections empty |
 | AC-6 local probe | **PASS** — tweaked one `strings.json` value → regen → `git diff --exit-code -- translations/` exited **1**; clean regen is byte-identical (no false positive) |
 | AC-9 pre-commit gates | **PASS** — `--impacted` (baseline rebuilt, 6921 tests, 0 failures; changed lines carry no `custom_components/` delta); `--quick tests/qs` 688/688; `--quick tests/test_quality_gate.py` 483/483 |
-| Per-shard job durations | run [30718305154](https://github.com/tmenguy/quiet-solar/actions/runs/30718305154) (**cold cache**): shard 1 **193s**, shard 2 **127s**, shard 3 **135s**, shard 4 **143s**; aggregation **22s**. Shard 1 is the pace-setter as designed (it carries the collect-only step) |
-| Combined `TOTAL` statements (AC-4) | **PASS** — `TOTAL 16314 0 100%`, byte-identical to the pre-change baseline. Per-shard partial reports were 58% / 70% / 62% / 59%, i.e. each shard alone sees well under the whole (expected; only the combined report is a verdict) |
-| `executed=N collected=N` (AC-5) | **PASS** — `executed=6921 collected=6921`. The layer-1 proof's 6912 is **not** a discrepancy: it ran at task 2, before tasks 3 and 5 added exactly 9 tests (6 in `test_ci_reconcile_shards.py`, +3 from splitting `TestCiWorkflowConfig`'s single test into four). 6912 + 9 = 6921 |
-| Critical path samples + median (AC-3, bar 200s) | **OPEN** — the only run so far (30718305154) is the excluded cold-cache one; its path was **223s** (21:03:15 → 21:06:58). Needs ≥3 warm-cache samples |
+| Per-shard job durations | cold-cache run [30718305154](https://github.com/tmenguy/quiet-solar/actions/runs/30718305154): shard 1 **193s**, 2 **127s**, 3 **135s**, 4 **143s**, aggregation **22s**. Warm-cache [30745439928](https://github.com/tmenguy/quiet-solar/actions/runs/30745439928): shard 1 **177s**, 2 **123s**, 3 **119s**, 4 **120s**, aggregation **17s**. Shard 1 is the pace-setter as designed — but by a **~55s** margin over its siblings, materially worse than the ~15s the projection assumed (see AC-3) |
+| Combined `TOTAL` statements (AC-4) | **PASS on substance.** Run 30741000157 (pre-QS-319 tree): `TOTAL 16314 0 100%` — byte-identical to the recorded baseline, which is the exact comparison AC-4 specifies. Run 30745439928 then reported `16339 0 100%`: **QS-319 merged into `main` at 11:16:56 UTC**, 1 minute before that run, and a `pull_request` build measures the *merge* commit, so +25 statements arrived from `ha_model/device.py` + `home_model/load.py`. Not a sharding artifact — every shard reported the same 16339 denominator, and combining still yielded 0 missing. AC-4's literal number is only meaningful against a fixed tree |
+| `executed=N collected=N` (AC-5) | **PASS** — `executed=6921 collected=6921` (run 30741000157), then `executed=6949 collected=6949` (run 30745439928). Every count reconciles exactly: the layer-1 proof's 6912 predates tasks 3/5, which added 9 tests (6912+9 = 6921); review fix #01 added 9 more and QS-319's merge brought 19 (6921+9+19 = 6949); the local pre-commit collect agreed at 6930 = 6921+9, without the merge |
+| Critical path samples + median (AC-3, bar 200s) | **2 of ≥3 samples, both marginal.** Warm: **195s** (30741000157), **197s** (30745439928). Excluded cold: 223s (30718305154). Against the 277s baseline this is a **~29% cut, not the ~44% projected** — the design predicted ~155s typical / ~180s stacked worst case, and the *typical* case is already worse than the projected worst case. Cause: shard-1 imbalance (177s vs 119-123s), i.e. the no-`.test_durations` decision (D2) costs more than priced. It clears the 200s bar by ~2%, which is inside runner variance — see the note below the table |
 | AC-2 probe run URL + conclusion | **OPEN** — maintainer-run, see "Probe procedure" |
 
----
+### AC-3 is passing on a ~2% margin — a maintainer decision, not a green tick
 
-## Adversarial Review Notes
+Both warm samples (195s, 197s) sit just under the 200s bar that AC-3
+names as the **rollback trigger** for §A. Two honest readings:
+
+- *Ship it.* The bar is met, the change is a real ~29% cut (277s → ~196s)
+  on ~100 runs/month, and every soundness guard (AC-1, AC-4, AC-5) is
+  green.
+- *The margin is inside the noise.* The baseline itself spanned 269-282s,
+  so a ~2% margin is not a robust pass. Any test-suite growth lands
+  disproportionately on shard 1 and pushes the median over 200s, at
+  which point the documented response is to revert §A entirely.
+
+The cheap fix for the margin — a committed `.test_durations` file — was
+declined as **D2**. That decision was priced against an assumed ~15s
+shard-1 penalty; the measured penalty is **~55s**, which is the single
+largest term keeping the critical path near the bar. Revisiting D2 (or
+raising the shard count) would likely reach the projected ~155s, and is
+worth doing before concluding §A underdelivers. Recorded here rather
+than acted on: changing it now would exceed this fix plan's scope.
 
 ### Round 1 — critic, concrete-planner, dev-proxy, scope-guardian (4 parallel)
 

--- a/docs/stories/QS-292.story.md
+++ b/docs/stories/QS-292.story.md
@@ -107,6 +107,21 @@ carries ~40% of the variable time, priced into the projection below.
 
 #### Job topology (`.github/workflows/pr-quality.yml`)
 
+> **Amended by review fix #01 — the block below is the original design,
+> not the shipped file.** The workflow now additionally carries:
+> `if: ${{ !cancelled() }}` on the aggregation job instead of
+> `always()` (S3 — `always()` also fires on cancellation, turning a
+> cancelled run into a hard red); `permissions: contents: read` plus
+> `persist-credentials: false` on both new jobs (S4); the translations
+> step staging with `git add -A` before `git diff --cached` (M1 — plain
+> `git diff` cannot see an untracked file, so a PR *deleting* `en.json`
+> passed vacuously) and honouring the generator's exit code (S1);
+> `retention-days: 5` (S5); a collect-count parser that accepts
+> pytest's `N/M tests collected (K deselected)` form and fails with an
+> explicit `::error::` rather than opaquely (N1); and a comment
+> explaining the expected 58-70% per-shard coverage reports (N2 — note
+> `--cov-report=` cannot suppress them, per trap 5).
+
 ```yaml
   test-shard:
     name: Tests shard ${{ matrix.shard }}/4
@@ -271,13 +286,21 @@ by count:
   collection hook misbehaves fails silently, and no count check would
   catch it. **Failure here is Plan B's trigger** (below), not an install
   error.
-- **Layer 2 — permanent CI count guard.** Shard 1 records the collected
+- **Layer 2 — permanent CI guard.** Shard 1 records the collected
   total; every shard emits JUnit XML; `ci_reconcile_shards.py` asserts
   exactly 4 shard artifacts arrived and that the executed sum equals the
   collected total. Cheap, and catches a later regression (a shard
   silently not running, a `--splits`/matrix-length mismatch). There are
   no `allow_module_level` skips and no `collect_ignore` under `tests/`
   (verified), so the equality is exact.
+  **Strengthened by review fix #01 S2**, because a count-only check is
+  weaker than this bullet implied: it now also asserts the shard
+  **indices** are exactly `1..N` (a missing shard 3 plus a stray shard
+  99 balances the count) and that no `(classname, name)` case appears
+  in two shards (an *offsetting* duplicate-plus-drop — test A twice,
+  test B never — also balances the count). The layer-1 identity proof
+  therefore has a permanent, cheap counterpart in CI rather than only a
+  one-off local run.
 
 *Plan B* if layer 1 fails, or `pytest-split` refuses `pytest==9.0.3` at
 install: do **not** substitute `pytest-shard` (unmaintained since 2020).
@@ -316,9 +339,14 @@ but `coverage`.
 
 - Signature: `ci_reconcile_shards.py <dir> --splits N`
 - Success: prints `executed=<n> collected=<n>` to stdout, exit 0.
-- Failures, each printing one `::error::` line and exiting 1: wrong
-  number of JUnit files; missing `total-collected.txt`; unparseable XML;
-  count mismatch.
+- Failures, each printing exactly one `::error::` line and exiting 1:
+  wrong number of JUnit files (the message names the remedy — "re-run
+  ALL jobs", per S5, since expired artifacts are not clearable by
+  re-running the aggregation job alone); an unexpected artifact name; a
+  shard-index set that isn't `1..N` (S2a); missing
+  `total-collected.txt`; an unreadable collected count (`ValueError`
+  *or* `OSError`, per N7); unparseable XML; a `(classname, name)` case
+  executed in more than one shard (S2b); count mismatch.
 - House style per `project-context.md:104-106`: `from __future__ import
   annotations`, module docstring, full type hints,
   `main(argv: list[str] | None = None) -> int` with a
@@ -350,11 +378,15 @@ must not be used as the measurement.
 *Excluded*: runner queue time. The change takes the workflow from 4 jobs
 to 8 and adds a second serialized runner acquisition.
 
-**Runner consumption goes up ~35%** — ~501 job-seconds today
-(269+95+89+48) versus ~677 after (4×102 + 15 + 38 + 232), mostly four
-duplicated dependency installs. On a public repo with standard runners
-these minutes are free; the trade is wall-clock for throughput, and it
-is deliberate.
+**Runner consumption goes up ~38%** — ~501 job-seconds today
+(269+95+89+48) versus ~693 after (3×102 for shards 2-4 + 117 for
+shard 1, which carries the collect-only step + 38 aggregation + 232 for
+the unchanged lint/mypy/HACS jobs), mostly four duplicated dependency
+installs. On a public repo with standard runners these minutes are
+free; the trade is wall-clock for throughput, and it is deliberate.
+(Review fix #01 N5: an earlier revision wrote `4×102 + 15 + 38 + 232`
+and called it ~677 / ~35% — that sum is 693, and it double-counted the
+collect-only step as both a separate term and part of shard 1.)
 
 ### B. Translations value-check as a workflow step (D-14)
 
@@ -422,21 +454,36 @@ edits shift later ones.
 | `AGENTS.md` (prose) | `(translations value-check excepted until #292 lands; local runs only on explicit user request)` → `(local runs only on explicit user request)` |
 | `docs/workflow/project-rules.md` | `# Full quality gate (pytest 100% cov + ruff + mypy + translations;` / `# the translations value-check is local-full-gate only until #292 lands).` → `# Full quality gate (pytest 100% cov + ruff + mypy + translations).` |
 | `.claude/commands/implement-task.md` | `translations — runs authoritatively in CI on every PR; translations value-check is local-full-gate only until #292 lands).` → `translations — runs authoritatively in CI on every PR).` |
-| `docs/agents/concepts/testing-layers.md` | ``CI's whole-repo gate (`pr-quality.yml`, `pytest tests/ -n auto --cov-fail-under=100`) ignores nothing`` → ``CI's whole-repo gate (`pr-quality.yml`: four parallel `pytest tests/ -n auto --splits 4 --group N` shards whose data is combined into one `coverage report --fail-under=100`) ignores no test`` — "ignores no test" rather than "ignores nothing", since the verdict is scoped to `custom_components/quiet_solar/` |
-| `docs/workflow/project-context.md` | `enforced authoritatively in **CI** on every PR (`pr-quality.yml`, whole-repo `--cov-fail-under=100`)` → the sharded description, mirroring the `testing-layers.md` row. **This file is the 42-rule document every implementing agent reads first — it silently becomes false after §A, and AC-8's `#292` grep cannot catch it.** |
+| `docs/agents/concepts/testing-layers.md` | the old single-job description → ``CI's whole-repo gate (`pr-quality.yml`: N parallel `pytest tests/ -n auto --cov=custom_components/quiet_solar --splits N --group <i>` shards whose data is combined into one `coverage report --fail-under=100`) ignores no test`` — "ignores no test" rather than "ignores nothing", since the verdict is scoped to `custom_components/quiet_solar/` |
+| `docs/workflow/project-context.md` | the old whole-repo phrasing → the sharded description, mirroring the `testing-layers.md` row. **This file is the 42-rule document every implementing agent reads first — it silently becomes false after §A, and AC-8's `#292` grep cannot catch it.** |
+
+*Review fix #01 N4*: both replacement sentences say "N parallel shards"
+rather than hardcoding "four", and both carry the
+`--cov=custom_components/quiet_solar` flag the workflow actually passes
+(without it a copied command collects no package coverage). This row's
+"before" strings are described rather than quoted, so AC-8's second
+grep is satisfiable — see S9.
 | `docs/workflow/project-rules.md` | **add** the CI carve-out below, after the `--seed-testmon` paragraph and before `**UI-only fast path.**` |
 
 **New carve-out** — a plain bold-lead paragraph matching the two
 existing carve-outs' formatting (no blockquote, issue-tagged):
 
-> **Carve-out — CI workflows (QS-292).** `.github/workflows/*.yml`
-> invoke `pytest` and `coverage` directly, by design. The raw-`pytest`
-> grammar rule and the "`quality_gate.py` is the single test entry
-> point" rule govern *interactive and agent* commands, not CI. Where
-> the PR suite is sharded, the job providing the required status check
-> on `main` ends in a single authoritative fail-under-100 coverage
-> verdict over the whole of `custom_components/quiet_solar/` — spelled
+> **Carve-out — CI test workflows (QS-292).**
+> `.github/workflows/pr-quality.yml` and
+> `.github/workflows/release.yml` invoke `pytest` and `coverage`
+> directly, by design. The raw-`pytest` grammar rule and the
+> "`quality_gate.py` is the single test entry point" rule govern
+> *interactive and agent* commands, not CI. Where the PR suite is
+> sharded, the job providing the required status check on `main` ends in
+> a single authoritative fail-under-100 coverage verdict over the whole
+> of `custom_components/quiet_solar/` — spelled
 > `pytest --cov-fail-under=100` or `coverage report --fail-under=100`.
+
+*Review fix #01 N6*: the glob `.github/workflows/*.yml` was narrowed to
+the two named test workflows, since the carve-out should not license
+raw `pytest` in an arbitrary future workflow. (The same review flagged
+`.github` as needing a capital H — declined: it is a literal directory
+name inside backticks, and capitalizing it would make the path wrong.)
 
 Deliberately **descriptive, not legislative**: it records existing
 practice (`pr-quality.yml` already ran raw `pytest` before this issue)
@@ -525,6 +572,13 @@ Changes:
   `requirements_test.txt` — the pip cache key — so that run is excluded
   from the measurement. All samples recorded, not just the median. If
   the bar is missed, §A is reverted rather than kept (see Rollback).
+  *Sampling note (review fix #01 N8)*: the six jobs in one run share a
+  single pip cache key, so on the first run after any
+  `requirements*.txt` change five of them log `Unable to reserve
+  cache … another job may be creating this cache` and install **cold**
+  concurrently. Harmless, but it is why that entire run — not merely its
+  shard 1 — is excluded, and why a run is "warm-cache" only if no
+  `requirements*.txt` changed in the commit it builds.
 - **AC-4** The combined verdict is a genuine whole-package 100% check:
   the aggregation job's `coverage report` reports **16314 total
   statements** — identical to the pre-change baseline recorded above —
@@ -546,9 +600,15 @@ Changes:
 - **AC-8** No stale caveat remains. Two greps, both empty:
   `grep -rnE "until #292 lands|value-check \(#292\)" CLAUDE.md AGENTS.md docs/workflow docs/agents .claude .cursor .opencode legacy`
   and
-  `grep -rnE "whole-repo .--cov-fail-under=100|pytest tests/ -n auto --cov-fail-under=100" docs/ CLAUDE.md AGENTS.md`.
+  `grep -rnE "whole-repo .--cov-fail-under=100|pytest tests/ -n auto --cov-fail-under=100" docs/workflow docs/agents CLAUDE.md AGENTS.md`.
   (`-E` is required: BSD `grep` on macOS has no `\|` alternation in BRE,
   so the BRE form would match nothing and pass vacuously.)
+  **Review fix #01 S9**: the second grep originally scoped over all of
+  `docs/`, which is unsatisfiable by construction — `docs/stories/**`
+  holds this story's own §E edit table quoting the *old* string, AC-8
+  quoting *its own pattern*, and a historical review record in
+  `QS-311.story.md`. Both greps now scope to the live agent-facing docs
+  (`docs/workflow docs/agents`), which is the substantive intent.
 - **AC-9** Pre-commit gates pass: `--impacted`; `--quick tests/qs` (a
   `.claude/commands/` file and workflow docs changed);
   `--quick tests/test_quality_gate.py` (§F — **not** reachable by either
@@ -736,11 +796,11 @@ _To be filled at tasks 10-12._
 | Layer-1 partition proof: four group sizes | **PASS** — 6912 collected; **1728 / 1728 / 1728 / 1728**; union == full collected set; all six pairwise intersections empty |
 | AC-6 local probe | **PASS** — tweaked one `strings.json` value → regen → `git diff --exit-code -- translations/` exited **1**; clean regen is byte-identical (no false positive) |
 | AC-9 pre-commit gates | **PASS** — `--impacted` (baseline rebuilt, 6921 tests, 0 failures; changed lines carry no `custom_components/` delta); `--quick tests/qs` 688/688; `--quick tests/test_quality_gate.py` 483/483 |
-| Per-shard job durations | |
-| Critical path samples + median (AC-3, bar 200s) | |
-| Combined `TOTAL` statements (AC-4) | |
-| `executed=N collected=N` (AC-5) | |
-| AC-2 probe run URL + conclusion | |
+| Per-shard job durations | run [30718305154](https://github.com/tmenguy/quiet-solar/actions/runs/30718305154) (**cold cache**): shard 1 **193s**, shard 2 **127s**, shard 3 **135s**, shard 4 **143s**; aggregation **22s**. Shard 1 is the pace-setter as designed (it carries the collect-only step) |
+| Combined `TOTAL` statements (AC-4) | **PASS** — `TOTAL 16314 0 100%`, byte-identical to the pre-change baseline. Per-shard partial reports were 58% / 70% / 62% / 59%, i.e. each shard alone sees well under the whole (expected; only the combined report is a verdict) |
+| `executed=N collected=N` (AC-5) | **PASS** — `executed=6921 collected=6921`. The layer-1 proof's 6912 is **not** a discrepancy: it ran at task 2, before tasks 3 and 5 added exactly 9 tests (6 in `test_ci_reconcile_shards.py`, +3 from splitting `TestCiWorkflowConfig`'s single test into four). 6912 + 9 = 6921 |
+| Critical path samples + median (AC-3, bar 200s) | **OPEN** — the only run so far (30718305154) is the excluded cold-cache one; its path was **223s** (21:03:15 → 21:06:58). Needs ≥3 warm-cache samples |
+| AC-2 probe run URL + conclusion | **OPEN** — maintainer-run, see "Probe procedure" |
 
 ---
 

--- a/docs/stories/QS-292.story.md
+++ b/docs/stories/QS-292.story.md
@@ -733,7 +733,9 @@ _To be filled at tasks 10-12._
 | --- | --- |
 | Baseline critical path (median of 3) | **277s** (282 / 269 / 277) |
 | Baseline `TOTAL` statements | **16314**, 0 missing, 100% |
-| Layer-1 partition proof: four group sizes | |
+| Layer-1 partition proof: four group sizes | **PASS** — 6912 collected; **1728 / 1728 / 1728 / 1728**; union == full collected set; all six pairwise intersections empty |
+| AC-6 local probe | **PASS** — tweaked one `strings.json` value → regen → `git diff --exit-code -- translations/` exited **1**; clean regen is byte-identical (no false positive) |
+| AC-9 pre-commit gates | **PASS** — `--impacted` (baseline rebuilt, 6921 tests, 0 failures; changed lines carry no `custom_components/` delta); `--quick tests/qs` 688/688; `--quick tests/test_quality_gate.py` 483/483 |
 | Per-shard job durations | |
 | Critical path samples + median (AC-3, bar 200s) | |
 | Combined `TOTAL` statements (AC-4) | |

--- a/docs/stories/QS-292.story.md
+++ b/docs/stories/QS-292.story.md
@@ -1,0 +1,843 @@
+# QS-292 — CI: shard pytest; add translations value-check; align release.yml
+
+- **Issue**: [#292](https://github.com/tmenguy/quiet-solar/issues/292)
+- **Branch**: `QS_292`
+- **Origin**: QS-288 audit findings S-2, D-14, D-15 (`docs/stories/QS-288.audit-report.md` §3/§4)
+- **Next phase**: `implement-setup-task` (all touched paths are dev-infrastructure)
+
+---
+
+## Problem
+
+Three independent CI defects from the QS-288 audit.
+
+**S-2 — the PR test job is the critical path.** Measured from the run
+log of `pr-quality.yml`, the `Tests (100% Coverage)` job takes **269s**:
+
+| segment | time |
+| --- | --- |
+| runner provisioning | 3s |
+| checkout + `setup-python` | 4s |
+| `pip install -r requirements.txt -r requirements_test.txt` | 77s |
+| `pytest tests/ -n auto --cov …` | 182s |
+| post-job cleanup | 3s |
+| **total** | **269s** |
+
+Across the three most recent runs the job measures 282s / 269s / 277s —
+**median 277s** (the n=3 baseline AC-3 compares against). The other
+jobs are shorter (mypy 95s, lint 89s, HACS 48s), so this job alone sets
+the merge-blocking wait.
+
+The audit's original premise — "plausibly 20-30 min on 4-core CI
+runners" — was wrong, and the issue's correction comment records the
+measured reality (228-307s), demoting the finding from ~200 to ~40.
+Proceeding anyway (D1): `gh run list --workflow pr-quality.yml -L 100`
+shows **96 runs in July 2026**, so ~100 blocking waits/month.
+
+**D-14 — a value-stale `en.json` merges green.** The local full gate
+regenerates `translations/en.json` and byte-compares it
+(`scripts/qs/quality_gate.py:796-825`, `check_translations`: capture
+`en_before`, run `bash scripts/generate-translations.sh`, compare with
+`en_after`). CI only runs `tests/test_translations.py`, which asserts
+*key structure* and states in its own docstring that "values may
+differ". So an `en.json` whose **values** drifted from `strings.json`
+(developer edited `strings.json`, forgot to regenerate) passes CI and
+fails only on the next local full gate — which `project-rules.md:42-45`
+reserves for explicit user request, so in practice it may go unnoticed
+for a long time. This is a correctness hole, not a latency issue.
+
+**D-15 — `release.yml` is unaligned.** `release.yml:34-37` runs
+`pytest tests/ --cov …` with neither `-n auto` nor
+`COVERAGE_CORE: sysmon`, unlike `pr-quality.yml:66-70`.
+
+## Goal
+
+Cut the merge-blocking job from a **277s median to ~155s**, close the
+translations value hole **inside the required status check**, and align
+`release.yml` — without weakening the 100%-coverage verdict and without
+touching branch protection.
+
+## Non-goals
+
+- Routing CI through `scripts/qs/quality_gate.py`.
+- Sharding `release.yml`.
+- Committing a `.test_durations` file (D2).
+- Rewriting `docs/product/architecture.md` (see Doc-OK below).
+- Changing branch protection through the API.
+- A `concurrency: cancel-in-progress` group on `pr-quality.yml`. A real
+  win at ~100 runs/month, genuinely outside this issue — filed as a
+  follow-up instead.
+
+---
+
+## Design
+
+### A. Shard the `pr-quality` test job 4 ways
+
+**Splitter**: `pytest-split==0.11.0` (released 2026-02-03; declares
+`pytest>=5,<10`, Python 3.10-3.14 — compatible with the pinned
+`pytest==9.0.3` on Python 3.14). It goes in `requirements_test.txt`
+rather than being installed ad hoc, per that file's stated convention
+("Pinned to exact versions so CI is reproducible against the local dev
+env").
+
+**Baseline facts** (verified, so the shard command lines are auditable):
+
+- `pytest.ini:14-17` — `addopts = --strict-markers -ra
+  --cov-report=term-missing`. **No `--cov`, no `--cov-fail-under`.**
+- The current `test` job's full command is
+  `pytest tests/ -n auto --cov=custom_components/quiet_solar
+  --cov-report=term-missing --cov-fail-under=100`
+  (`pr-quality.yml:70`). The shard command differs from it **only** by
+  `--splits/--group`, `--junitxml`, and the omitted `--cov-fail-under`.
+  This matters for AC-4: the `--cov` scope must stay byte-identical for
+  the statement-count comparison to be valid.
+- There is **no coverage config anywhere** — no `.coveragerc`, and
+  `pyproject.toml` carries only `[tool.ruff*]` and `[tool.mypy]`. The
+  aggregation job's `coverage combine` / `coverage report` therefore run
+  on pure defaults.
+- Baseline for AC-4, read from the latest run log:
+  `TOTAL 16314 statements, 0 missing, 100%`.
+
+**No durations file.** `pytest-split` falls back to equal weight per
+test. Accepted with eyes open: that fallback slices *collection order*
+into contiguous chunks, so a slow module cluster lands wholly in one
+shard rather than being averaged out. Bounded — worst case one shard
+carries ~40% of the variable time, priced into the projection below.
+
+#### Job topology (`.github/workflows/pr-quality.yml`)
+
+```yaml
+  test-shard:
+    name: Tests shard ${{ matrix.shard }}/4
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements_test.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements_test.txt
+      - name: Record total collected test count
+        if: matrix.shard == 1
+        env:
+          TZ: Europe/Paris
+        run: |
+          set -euo pipefail
+          pytest tests/ --collect-only -q \
+            | grep -oE '^[0-9]+ tests? collected' \
+            | grep -oE '^[0-9]+' > total-collected.txt
+          cat total-collected.txt
+      - name: Run shard ${{ matrix.shard }}
+        env:
+          TZ: Europe/Paris
+          COVERAGE_CORE: sysmon
+          COVERAGE_FILE: .coverage.shard-${{ matrix.shard }}
+        run: >-
+          pytest tests/ -n auto
+          --splits 4 --group ${{ matrix.shard }}
+          --cov=custom_components/quiet_solar
+          --junitxml=junit-shard-${{ matrix.shard }}.xml
+      - name: Upload shard data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shard-data-${{ matrix.shard }}
+          # `total-collected.txt` exists only on shard 1;
+          # `if-no-files-found` is evaluated on the aggregate match set,
+          # so shards 2-4 still satisfy it via the other two entries.
+          path: |
+            .coverage.shard-${{ matrix.shard }}*
+            junit-shard-${{ matrix.shard }}.xml
+            total-collected.txt
+          include-hidden-files: true
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  # The job `name:` below is the LITERAL required status check on `main`
+  # (verified: `gh api repos/:owner/:repo/branches/main/protection`
+  # returns required_status_checks.contexts == ["Tests (100% Coverage)"]).
+  # Renaming it blocks every PR forever. Do not touch.
+  test:
+    name: Tests (100% Coverage)
+    needs: test-shard
+    if: always()
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any shard failed
+        if: needs.test-shard.result != 'success'
+        run: |
+          echo "::error::test-shard result was '${{ needs.test-shard.result }}'"
+          echo "::error::See the 'Tests shard N/4' jobs for the failing tests."
+          exit 1
+      - uses: actions/checkout@v5
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+      # D-14: value-level translations check. Invokes the SAME entry
+      # point as the local gate's `check_translations`, so the two can
+      # never disagree.
+      - name: Check translations/en.json is freshly generated
+        run: |
+          bash scripts/generate-translations.sh
+          git diff --exit-code -- custom_components/quiet_solar/translations/ \
+            || { echo "::error::translations are stale — run 'bash scripts/generate-translations.sh' and commit the result"; exit 1; }
+      # Twin of the `coverage==7.14.1` pin in requirements_test.txt —
+      # the shards' data must be written and read by the same version.
+      # Both move together in one edit.
+      - name: Install coverage
+        run: pip install coverage==7.14.1
+      - name: Download shard data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: shard-data-*
+          path: shard-data
+          merge-multiple: true
+      - name: Reconcile test counts
+        run: python3 scripts/qs/ci_reconcile_shards.py shard-data --splits 4
+      - name: Combine coverage and enforce 100%
+        run: |
+          coverage combine shard-data
+          coverage report --show-missing --fail-under=100
+```
+
+#### The six traps this shape avoids
+
+Each was verified against the repo or GitHub's docs, not assumed.
+
+1. **Required-check rename.** Branch protection on `main` requires
+   exactly one context, the string `Tests (100% Coverage)`. A naive
+   matrix renames it to `Tests (100% Coverage) (1)` … and no PR can ever
+   merge again. The *aggregation* job keeps the name verbatim; shards
+   get an explicit `name:` with the matrix variable interpolated, which
+   also suppresses GitHub's automatic `(1)`-style suffix.
+2. **Skipped-required-check merge hole.** With a plain `needs:`, a
+   failing shard *skips* the aggregation job, and branch protection
+   treats a **skipped** required check as **passing** — a PR with red
+   tests would be mergeable. `if: always()` plus the
+   `needs.test-shard.result != 'success'` guard (first step, so it fires
+   before any download) makes that a hard red. Because test failures now
+   surface in a `Tests shard N/4` job that is *not* the required
+   context, the guard's message points there.
+3. **Dotfile artifacts silently dropped.** `.coverage.shard-N` is a
+   hidden file; `upload-artifact@v4` excludes hidden files unless
+   `include-hidden-files: true`. The `*` glob also captures a stray
+   un-combined xdist worker file; `if-no-files-found: error` catches the
+   zero-file case.
+4. **"Re-run failed jobs" bricks the gate.** `upload-artifact@v4`
+   artifacts are immutable and scoped to the *run*, not the attempt. Re-
+   running one failed shard would hit a 409 on an artifact name that
+   already exists, so the shard could never go green and the required
+   check would be permanently red. `overwrite: true` fixes it. This is
+   the most likely developer reaction to any flake, so it must work.
+5. **`--cov-report=` cannot disable reporting here.**
+   `pytest_cov/plugin.py:242` only clears the report list when `''` is
+   its *sole* member, and `addopts` already contributes `term-missing`.
+   Shards keep `term-missing` and simply omit `--cov-fail-under`, which
+   is safe precisely because `addopts` supplies none.
+6. **Silently dropped tests.** A sharded suite is *green by
+   construction* for this, so a green run proves nothing. Addressed in
+   two layers — see below.
+
+#### Proving the split is a true partition
+
+Counting alone is insufficient: if two shards both ran test X while
+nobody ran test Y, the executed total still equals the collected total.
+So the property is proved once, by identity, and then guarded cheaply
+by count:
+
+- **Layer 1 — one-off local proof (task 2, before any workflow edit).**
+  Run `pytest tests/ --collect-only -q` plus the four
+  `--splits 4 --group N` variants (≈4.1s each locally), and assert the
+  union of the four group node-ID sets equals the full collected set and
+  the four sets are pairwise disjoint. This proves `pytest-split`'s
+  partition behaviour against *this* pytest/xdist/cov combination, which
+  is the real risk — a plugin whose metadata accepts pytest 9 but whose
+  collection hook misbehaves fails silently, and no count check would
+  catch it. **Failure here is Plan B's trigger** (below), not an install
+  error.
+- **Layer 2 — permanent CI count guard.** Shard 1 records the collected
+  total; every shard emits JUnit XML; `ci_reconcile_shards.py` asserts
+  exactly 4 shard artifacts arrived and that the executed sum equals the
+  collected total. Cheap, and catches a later regression (a shard
+  silently not running, a `--splits`/matrix-length mismatch). There are
+  no `allow_module_level` skips and no `collect_ignore` under `tests/`
+  (verified), so the equality is exact.
+
+*Plan B* if layer 1 fails, or `pytest-split` refuses `pytest==9.0.3` at
+install: do **not** substitute `pytest-shard` (unmaintained since 2020).
+Drop §A, ship §B/§C/§D — independently valuable — and re-file the shard.
+
+#### Why the combined coverage verdict is not weakened
+
+`pytest-cov` translates `--cov=custom_components/quiet_solar` into
+coverage's `source` setting, so each shard's data records
+**zero-executed entries for every file in the package**, not only the
+ones that shard imported. The union after `coverage combine` therefore
+spans the whole package, and a module no shard ever imports still
+reports 0% and fails `--fail-under=100`. AC-4 cross-checks this once
+against the recorded 16314-statement baseline.
+
+#### Mechanics worth stating
+
+- **`COVERAGE_FILE` + xdist**: under `-n auto`, pytest-cov's workers
+  write suffixed data files and the controller combines them into
+  `$COVERAGE_FILE` at session end — which is why one
+  `.coverage.shard-N` exists to upload (the `*` glob is belt-and-braces).
+- **Path assumption**: coverage data stores absolute paths. All jobs run
+  on `ubuntu-latest` at `/home/runner/work/quiet-solar/quiet-solar`, so
+  `combine` matches. `relative_files = true` was rejected — it would
+  also change the local `coverage xml` that `--impacted` feeds to
+  `diff-cover`. Failure mode is loud (`No source for code:`).
+- **Behavioural delta**: coverage-shortfall failures now surface in the
+  aggregation job's log, not a pytest tail.
+
+#### New helper: `scripts/qs/ci_reconcile_shards.py`
+
+A small testable script rather than an inline YAML heredoc (untestable,
+unlintable). **Stdlib only** — `argparse`, `pathlib`,
+`xml.etree.ElementTree` — because the aggregation job installs nothing
+but `coverage`.
+
+- Signature: `ci_reconcile_shards.py <dir> --splits N`
+- Success: prints `executed=<n> collected=<n>` to stdout, exit 0.
+- Failures, each printing one `::error::` line and exiting 1: wrong
+  number of JUnit files; missing `total-collected.txt`; unparseable XML;
+  count mismatch.
+- House style per `project-context.md:104-106`: `from __future__ import
+  annotations`, module docstring, full type hints,
+  `main(argv: list[str] | None = None) -> int` with a
+  `if __name__ == "__main__":` guard.
+- Tests in `tests/qs/test_ci_reconcile_shards.py` as **plain functions**
+  (`project-context.md:193` — no test classes), driving synthetic
+  `tmp_path` fixtures. `tests/qs/conftest.py`'s autouse
+  `_add_scripts_qs_to_syspath` fixture puts `scripts/qs/` on `sys.path`,
+  so the module imports in-process.
+
+#### Projection
+
+Per shard 2-4: 7s provisioning+checkout+setup, ~30s warm-cache install,
+~57s pytest (a ~15s fixed cost — collection on each of 4 xdist workers,
+HA imports, worker startup — plus ~42s of the 167s variable work), ~5s
+upload, 3s post ≈ **~102s**. Shard 1 adds the ~15s collect-only step ≈
+**~117s**, so shard 1 sets the pace by construction. Aggregation: 7 + 5
++ 8 (pip) + 3 (translations) + 5 (download) + 2 (reconcile) + 5
+(combine) + 3 ≈ **~38s**. Critical path ≈ **155s** vs a 277s median.
+
+**Stacked worst case**: if the heavy contiguous chunk also lands in
+shard 1 (7 + 30 + 15 + 82 + 5 + 3 = 142) plus aggregation ≈ **180s**.
+AC-3's bar is **200s**, leaving headroom only for the second runner
+acquisition — which is why AC-3 must be measured on a **warm-cache**
+push. The first push on this branch edits `requirements_test.txt`, which
+*is* the cache key, so its install runs uncached at ~77s and that run
+must not be used as the measurement.
+
+*Excluded*: runner queue time. The change takes the workflow from 4 jobs
+to 8 and adds a second serialized runner acquisition.
+
+**Runner consumption goes up ~35%** — ~501 job-seconds today
+(269+95+89+48) versus ~677 after (4×102 + 15 + 38 + 232), mostly four
+duplicated dependency installs. On a public repo with standard runners
+these minutes are free; the trade is wall-clock for throughput, and it
+is deliberate.
+
+### B. Translations value-check as a workflow step (D-14)
+
+Two steps in the aggregation job (above): run
+`bash scripts/generate-translations.sh`, then `git diff --exit-code` on
+`custom_components/quiet_solar/translations/`.
+
+This is the **same entry point** `quality_gate.check_translations` uses,
+so the local and CI verdicts cannot disagree — that identity is the
+whole point, and it is why the step shells out to the `.sh` wrapper
+rather than calling `generate_translations.py` directly. The diff is
+scoped to the `translations/` directory rather than `en.json` alone, in
+case the generator ever emits more than one file.
+
+It lives in the aggregation job because `Tests (100% Coverage)` is the
+*only* required status check on `main`, so nothing outside that context
+can block a merge.
+
+An earlier draft implemented this as a pytest test plus a
+`render_en_json()` extraction; reversed in review round 1 (R1-07) because
+it created a **second implementation** of the invariant — able to drift
+from the local gate and thereby reintroduce, in narrower form, exactly
+the divergence D-14 exists to close — and because it dragged in
+`importlib`, mypy `| None` guards, and encoding questions for what is a
+two-line shell check.
+
+### C. Align `release.yml` (D-15)
+
+At `release.yml:34-37`: add `COVERAGE_CORE: sysmon` to the step's `env:`
+(currently only `TZ: Europe/Paris`) and `-n auto` after `pytest tests/`.
+Add `cache: 'pip'` + `cache-dependency-path` to the `setup-python` at
+`release.yml:15-18`. Left deliberately **unsharded**.
+
+The translations steps are **not** added here (dropped in review round
+2, scope): D-14 names `pr-quality.yml`, and a value-stale `en.json`
+cannot reach a release tag without first passing the required
+`Tests (100% Coverage)` context.
+
+### D. pip caching
+
+All four `setup-python` steps in `pr-quality.yml` after the change, and
+the one in `release.yml`:
+
+| job | cached? | why |
+| --- | --- | --- |
+| `lint` | yes | consistency / runner minutes |
+| `typecheck` | yes | consistency / runner minutes |
+| `test-shard` | yes | the only one on the critical path (~47s) |
+| `test` (aggregation) | no | installs only `coverage` |
+| `hacs-validate` | n/a | has no `setup-python` step (verified) |
+| `release.yml` quality-gate | yes | consistency |
+
+Only `test-shard`'s cache affects wall time; lint (89s) and mypy (95s)
+already finish well inside the test job.
+
+### E. Documentation
+
+Edits are specified as exact strings, not line numbers, because earlier
+edits shift later ones.
+
+| file | remove / change |
+| --- | --- |
+| `CLAUDE.md` | `(translations value-check is local-full-gate only until #292 lands)` → `(including the translations value-check since QS-292)` |
+| `AGENTS.md` (commands block) | `; CI owns it except the translations value-check (#292)` → `; CI owns it` |
+| `AGENTS.md` (prose) | `(translations value-check excepted until #292 lands; local runs only on explicit user request)` → `(local runs only on explicit user request)` |
+| `docs/workflow/project-rules.md` | `# Full quality gate (pytest 100% cov + ruff + mypy + translations;` / `# the translations value-check is local-full-gate only until #292 lands).` → `# Full quality gate (pytest 100% cov + ruff + mypy + translations).` |
+| `.claude/commands/implement-task.md` | `translations — runs authoritatively in CI on every PR; translations value-check is local-full-gate only until #292 lands).` → `translations — runs authoritatively in CI on every PR).` |
+| `docs/agents/concepts/testing-layers.md` | ``CI's whole-repo gate (`pr-quality.yml`, `pytest tests/ -n auto --cov-fail-under=100`) ignores nothing`` → ``CI's whole-repo gate (`pr-quality.yml`: four parallel `pytest tests/ -n auto --splits 4 --group N` shards whose data is combined into one `coverage report --fail-under=100`) ignores no test`` — "ignores no test" rather than "ignores nothing", since the verdict is scoped to `custom_components/quiet_solar/` |
+| `docs/workflow/project-context.md` | `enforced authoritatively in **CI** on every PR (`pr-quality.yml`, whole-repo `--cov-fail-under=100`)` → the sharded description, mirroring the `testing-layers.md` row. **This file is the 42-rule document every implementing agent reads first — it silently becomes false after §A, and AC-8's `#292` grep cannot catch it.** |
+| `docs/workflow/project-rules.md` | **add** the CI carve-out below, after the `--seed-testmon` paragraph and before `**UI-only fast path.**` |
+
+**New carve-out** — a plain bold-lead paragraph matching the two
+existing carve-outs' formatting (no blockquote, issue-tagged):
+
+> **Carve-out — CI workflows (QS-292).** `.github/workflows/*.yml`
+> invoke `pytest` and `coverage` directly, by design. The raw-`pytest`
+> grammar rule and the "`quality_gate.py` is the single test entry
+> point" rule govern *interactive and agent* commands, not CI. Where
+> the PR suite is sharded, the job providing the required status check
+> on `main` ends in a single authoritative fail-under-100 coverage
+> verdict over the whole of `custom_components/quiet_solar/` — spelled
+> `pytest --cov-fail-under=100` or `coverage report --fail-under=100`.
+
+Deliberately **descriptive, not legislative**: it records existing
+practice (`pr-quality.yml` already ran raw `pytest` before this issue)
+and is scoped to the required-check job. An earlier draft bound *every*
+workflow file to producing a coverage verdict — unsatisfiable for the
+HACS and lint jobs — and named only pytest-cov's `--cov-fail-under`
+spelling, which is not the flag §A actually runs.
+
+**Dropped in review** (scope): a proposed standing obligation "after
+editing `strings.json`, run `--quick tests/test_translations.py`".
+
+**Harness sync does not apply.** The rule covers
+`.<harness>/agents/*.md`. The only harness file touched is
+`.claude/commands/implement-task.md`; `.cursor/` and `.opencode/` have
+no `commands/` directory, and a repo-wide `#292` search outside
+`docs/stories/**` returns exactly five hits, none in any `agents/`
+directory. *Contingency*: if AC-8's widened grep does hit an
+`agents/*.md` file, the co-modification rule
+(`project-rules.md:181-189`) applies and all three harness copies must
+be edited in the same commit.
+
+**Doc-OK — `docs/product/architecture.md`.** Not updated. A historical
+BMAD product brief that opens with "**Current state**: No CI/CD exists"
+and documents a `pr-merge.yml` that never shipped. Not part of the
+agent-facing `docs/agents/` hierarchy; patching one line inside an
+already-superseded snapshot would make it more misleading.
+
+**Drift-checker result** (verification, not an exemption):
+`check_doc_drift.py --paths` over the **full** changed file set exits 0,
+with only four pre-existing warnings about `testing-layers.md`
+`covers:` entries pointing outside `custom_components/quiet_solar/`.
+
+### F. Update the CI-workflow regression test
+
+`tests/test_quality_gate.py:873-897` (`TestCiWorkflowConfig`) reads
+`data["jobs"]["test"]`, requires a step whose `run` contains `pytest`,
+and asserts `-n auto` and `COVERAGE_CORE: sysmon`. After §A,
+`jobs.test` has no pytest step and this **fails**.
+
+It is a trap: `--impacted` cannot select it (testmon cannot see YAML,
+and `quality_gate.py` is unchanged) and `--quick tests/qs` does not
+reach `tests/test_quality_gate.py` — so it would go red *only in CI*, on
+the very check being rewritten.
+
+Changes:
+
+- Retarget to `data["jobs"]["test-shard"]`, and select the step **by
+  name** (`Run shard …`), not by "first step whose `run` contains
+  pytest" — `test-shard` now has *two* pytest steps and the collect-only
+  one comes first and carries neither flag.
+- Add three assertions pinning traps 1, 2 and 4:
+  `data["jobs"]["test"]["name"] == "Tests (100% Coverage)"`;
+  `data["jobs"]["test"]["if"] == "always()"`; and some step in
+  `jobs.test` references `needs.test-shard.result`.
+  (`if` is a safe YAML key — unlike `on`, it is not a YAML 1.1 boolean.)
+- Assert the three hard-coded `4`s agree: `len(matrix.shard)`, the
+  `--splits N` in the shard command, and the `--splits N` passed to
+  `ci_reconcile_shards.py`.
+
+`tests/test_quality_gate.py::TestRequirementsTestDeps` only asserts
+`"pytest-xdist" in reqs`, so adding two pins does not disturb it
+(verified).
+
+---
+
+## Acceptance criteria
+
+- **AC-1** `pr-quality.yml` runs four parallel jobs named
+  `Tests shard N/4` and exactly one aggregation job whose `name:` is the
+  literal `Tests (100% Coverage)`.
+  *Verify*: `gh pr checks <PR>` lists a `Tests (100% Coverage)` context
+  on the story PR. (Branch protection was read successfully during
+  planning — `required_status_checks.contexts == ["Tests (100%
+  Coverage)"]` — so the target string is not in doubt; the criterion is
+  that the context still appears and protection was never edited.)
+- **AC-2** A failing shard turns the required check **red**, never
+  skipped. Executed as a **manual step by the maintainer** (see
+  "Probe procedure"), because a deliberately-red throwaway PR is not a
+  defined step of `implement-setup-task` and `project-rules.md:216-219`
+  limits agent commits to defined workflow steps. Evidence: the run URL
+  and the literal conclusion string, pasted into "Measured outcome".
+- **AC-3** Performance is real and falsifiable: the **median of ≥3
+  warm-cache runs** of the critical path (first shard job start → final
+  aggregation job end) is **≤ 200s**, against the recorded 277s median
+  baseline. The first push on this branch changes
+  `requirements_test.txt` — the pip cache key — so that run is excluded
+  from the measurement. All samples recorded, not just the median. If
+  the bar is missed, §A is reverted rather than kept (see Rollback).
+- **AC-4** The combined verdict is a genuine whole-package 100% check:
+  the aggregation job's `coverage report` reports **16314 total
+  statements** — identical to the pre-change baseline recorded above —
+  at 100%.
+- **AC-5** No test is lost by the split. Layer 1: the one-off local
+  partition proof (task 2) shows union == full collected set and
+  pairwise-disjoint groups; the four group sizes are recorded. Layer 2:
+  the CI reconcile step passes and its `executed=N collected=N` line is
+  recorded.
+- **AC-6** A value-stale `en.json` is caught. *Verified locally, no PR
+  needed* — the step under test has no CI-specific behaviour: edit one
+  **value in `strings.json`** (never `en.json` — `project-rules.md:152`
+  forbids editing it), run `bash scripts/generate-translations.sh`,
+  confirm `git diff --exit-code -- custom_components/quiet_solar/translations/`
+  exits non-zero, then `git restore` both files. That the story PR's own
+  CI runs this step green proves it is wired and does not false-positive.
+- **AC-7** `release.yml`'s pytest step runs with `-n auto` and
+  `COVERAGE_CORE: sysmon`, and its `setup-python` is pip-cached.
+- **AC-8** No stale caveat remains. Two greps, both empty:
+  `grep -rnE "until #292 lands|value-check \(#292\)" CLAUDE.md AGENTS.md docs/workflow docs/agents .claude .cursor .opencode legacy`
+  and
+  `grep -rnE "whole-repo .--cov-fail-under=100|pytest tests/ -n auto --cov-fail-under=100" docs/ CLAUDE.md AGENTS.md`.
+  (`-E` is required: BSD `grep` on macOS has no `\|` alternation in BRE,
+  so the BRE form would match nothing and pass vacuously.)
+- **AC-9** Pre-commit gates pass: `--impacted`; `--quick tests/qs` (a
+  `.claude/commands/` file and workflow docs changed);
+  `--quick tests/test_quality_gate.py` (§F — **not** reachable by either
+  of the other two).
+- **AC-10** `tests/qs/test_ci_reconcile_shards.py` exercises every
+  branch of `ci_reconcile_shards.py` by enumeration — happy path, wrong
+  JUnit-file count, missing `total-collected.txt`, unparseable XML,
+  count mismatch — checkable by inspection. (Stated as enumeration
+  rather than a coverage percentage because no gate measures `scripts/`:
+  CI's `--cov` is scoped to `custom_components/quiet_solar`, and
+  `--quick` skips coverage entirely.)
+
+---
+
+## Probe procedure (AC-2, maintainer-run)
+
+Not agent-executable — see AC-2. Commands, to be run after the story PR
+is open and green:
+
+```bash
+git switch -c QS_292-probe QS_292
+# make one test fail
+printf '\ndef test_ac2_probe():\n    assert False, "AC-2 probe"\n' >> tests/test_translations.py
+git commit -am "AC-2 probe: deliberately failing test (do not merge)" --no-verify
+git push -u origin QS_292-probe
+gh pr create --base main --head QS_292-probe --title "DO NOT MERGE: AC-2 probe" --body "Probes that a failing shard turns the required check red rather than skipped. Close without merging."
+gh pr checks --watch   # expect: Tests (100% Coverage) = fail, NOT skipped
+```
+
+Then paste the run URL and conclusion into "Measured outcome" and clean
+up:
+
+```bash
+gh pr close QS_292-probe --delete-branch
+```
+
+The branch is cut from `QS_292`, **not `main`** — a `pull_request` run
+executes the workflow from the *head* ref, so a branch off `main` would
+run the old single-job workflow and prove nothing. `--no-verify` and the
+skipped `--impacted` gate are deliberate and confined to a never-merged
+branch.
+
+---
+
+## Task breakdown
+
+0. Record the AC-3 and AC-4 baselines before touching anything (already
+   captured during planning: median 277s over 3 runs; `TOTAL 16314`).
+1. `requirements_test.txt`: add `pytest-split==0.11.0` and
+   `coverage==7.14.1`, each with a `# QS-292:` comment on its **own
+   preceding line**; the `coverage` comment names the workflow literal
+   as its twin. `pip install -r requirements_test.txt` in `venv`.
+   Confirm the resolved version with `pip show coverage` and use *that*
+   literal in the workflow rather than trusting this document. Expect
+   the next `--impacted` to rebuild the testmon baseline (a new pytest
+   plugin changes testmon's environment fingerprint) — minutes, not
+   seconds; this is the documented self-heal path
+   (`project-rules.md:33-37`), not a failure. Never delete files
+   manually.
+2. **Layer-1 partition proof** (gates everything else): run the five
+   collect-only invocations locally, assert union == full and pairwise
+   disjoint, record the four group sizes. If this fails, stop and
+   execute Plan B.
+3. TDD `scripts/qs/ci_reconcile_shards.py` +
+   `tests/qs/test_ci_reconcile_shards.py` (AC-10) against synthetic
+   `tmp_path` fixtures, to the stdout/exit contract in §A.
+4. `.github/workflows/pr-quality.yml`: write it as a **diff against the
+   existing `test` job**, not a from-scratch paste — the §A YAML block
+   is authoritative for the *new* structure, but every step and `env:`
+   key of the current job must appear in `test-shard` unless named here
+   as removed. The current job's full pytest line is quoted in §A; the
+   only deltas are `--splits/--group`, `--junitxml`, `COVERAGE_FILE`,
+   the collect-count step, and the artifact upload.
+5. §F: retarget and extend `TestCiWorkflowConfig`; run
+   `--quick tests/test_quality_gate.py`.
+6. `.github/workflows/release.yml`: `-n auto`, `COVERAGE_CORE: sysmon`,
+   pip cache.
+7. Docs: the eight edits in §E plus the carve-out. Run both AC-8 greps.
+   If either hits an `agents/*.md` file, apply the harness-sync
+   contingency.
+8. `python scripts/qs/check_doc_drift.py --paths <full changed set>`;
+   confirm exit 0. Run `python scripts/qs/quality_gate.py --fix` (ruff
+   is not run by `--impacted` or `--quick`, so the two new Python files
+   get their first lint here, not in CI). Note `--fix` is mutually
+   exclusive with `--impacted`, so it is a separate invocation.
+9. Pre-commit gates (AC-9); re-run both AC-8 greps; commit; open PR.
+10. On the story PR: verify AC-1, AC-4, AC-5 layer 2. Push a trivial
+    no-op commit (no `requirements_test.txt` change) to get warm-cache
+    runs, and collect ≥3 samples for AC-3.
+11. Verify AC-6 locally. Hand the AC-2 probe procedure to the
+    maintainer.
+12. Fill in "Measured outcome". A docs-only follow-up commit that still
+    needs **`--impacted` and** `--quick tests/qs` (story files fall
+    under the `tests/qs`-pinned non-Python umbrella; `--quick` is an
+    additional requirement, never a substitute for `--impacted`).
+
+---
+
+## Rollback
+
+§A reverts cleanly on its own, but it has more dependents than the
+first draft claimed. A full revert is:
+
+1. `pr-quality.yml` — back to the single `test` job.
+2. §F — restore the original `TestCiWorkflowConfig`.
+3. `requirements_test.txt` — drop `pytest-split` (leaving it is dead
+   weight plus another testmon-fingerprint rebuild). Keep the
+   `coverage` pin; it is harmless and correct either way.
+4. `scripts/qs/ci_reconcile_shards.py` and its test — delete.
+5. `docs/agents/concepts/testing-layers.md` and
+   `docs/workflow/project-context.md` — the replacement sentences
+   describe four shards and become false.
+6. The §E carve-out — its "where the PR suite is sharded" clause is
+   already conditional, so it can stay as-is.
+
+§B/§C/§D survive a §A revert untouched, except that §B's two
+translations steps move into the restored `test` job.
+
+**Rollback trigger**: AC-3 fails (median > 200s). A second trigger —
+"≥2 spurious infrastructure reds in the first 20 runs" — is recorded in
+the PR description rather than here, since nobody is assigned to watch
+20 runs after the story closes.
+
+---
+
+## Risks
+
+| risk | mitigation |
+| --- | --- |
+| Required check renamed → all PRs blocked | name pinned verbatim + inline YAML comment + §F assertion |
+| Failing shard → skipped required check → unsound merge gate | `if: always()` + result guard; §F assertion; AC-2 probes it live |
+| "Re-run failed jobs" → 409 → permanently red merge gate | `overwrite: true` (trap 4) |
+| Tests silently dropped or double-run by the split | layer-1 identity proof + layer-2 count guard |
+| Dotfile / stray worker artifact dropped → under-counted coverage still reporting 100% | `include-hidden-files: true`, `*` glob, `if-no-files-found: error` |
+| Contiguous-chunk imbalance erodes the win | priced at ~180s stacked worst case; AC-3 gates at 200s |
+| `pytest-split` misbehaves silently against pytest 9 + xdist + cov | layer-1 proof is the gate; Plan B if it fails |
+| Hung shard holds the required check for the 6h runner default | `timeout-minutes` on both new jobs |
+| `coverage` version skew between shards and aggregator | pinned in `requirements_test.txt` and the workflow as twins |
+| `tests/test_quality_gate.py` red only in CI | §F + AC-9's explicit `--quick tests/test_quality_gate.py` |
+
+---
+
+## Decisions log
+
+- **D1 — shard despite the demotion.** The issue comment demoted S-2
+  (~200 → ~40) on corrected timing. Proceeding: at ~100 runs/month the
+  blocking wait drops from ~4.6min to ~2.6min typical (~3.0min at the
+  stacked worst case), against a ~35% rise in runner consumption and a
+  new flake surface on the merge gate. Stated at the worst case, not the
+  happy path, so the trade is judgable.
+- **D2 — no `.test_durations`.** Committing and maintaining a durations
+  file was declined; the consequence (contiguous-chunk imbalance) is
+  priced in §A and bounded by AC-3. Note: an earlier revision "corrected"
+  this rationale by claiming §E's carve-out made the grammar-rule
+  argument moot — that correction was itself wrong, since regenerating
+  durations means running `pytest tests/ --store-durations` **locally**
+  and the carve-out is scoped to CI. Both the original rationale and the
+  maintenance-cost rationale stand.
+- **D3 — pip caching included** although outside the issue's letter: a
+  few lines, ~47s on the critical path. (Not justified on runner-minute
+  cost — §A's own accounting shows consumption going *up*.)
+- **D4 — D-14 as a workflow step, not a pytest test.** Reversed in round
+  1; §B carries the reasoning. The step shells out to
+  `scripts/generate-translations.sh`, the same entry point as the local
+  gate, after round 2 caught that calling the `.py` directly would have
+  recreated the divergence in miniature.
+- **D5 — `coverage` pinned in both `requirements_test.txt` and the
+  workflow**, as cross-referenced twins. An earlier draft grepped the
+  pin out of the requirements file; that broke on the repo's
+  inline-comment house style. Pinning only the workflow was also
+  rejected: the shards' `coverage` arrives transitively via
+  `pytest-cov`, so an unpinned float would eventually have shards
+  writing a schema the pinned aggregator refuses — blocking every PR.
+
+---
+
+## Measured outcome
+
+_To be filled at tasks 10-12._
+
+| item | value |
+| --- | --- |
+| Baseline critical path (median of 3) | **277s** (282 / 269 / 277) |
+| Baseline `TOTAL` statements | **16314**, 0 missing, 100% |
+| Layer-1 partition proof: four group sizes | |
+| Per-shard job durations | |
+| Critical path samples + median (AC-3, bar 200s) | |
+| Combined `TOTAL` statements (AC-4) | |
+| `executed=N collected=N` (AC-5) | |
+| AC-2 probe run URL + conclusion | |
+
+---
+
+## Adversarial Review Notes
+
+### Round 1 — critic, concrete-planner, dev-proxy, scope-guardian (4 parallel)
+
+36 findings: 30 accepted, 6 rejected. All 30 verified `resolved` or
+`partially-resolved` by the round-2 delta-auditor; the six partials were
+carried into round 2 and are now closed. Rejected in round 1 and **not
+to be resurfaced**: `--cov-fail-under` in `addopts` (false —
+`addopts` is `--strict-markers -ra --cov-report=term-missing`);
+combined `coverage report` missing never-imported modules (false —
+`--cov=pkg` sets coverage's `source`); split §A into a second PR (user
+chose otherwise); "cannot confirm `coverage==7.14.1`" (read from the
+venv); measure the duration long tail first (declined); teach
+`--impacted` about `strings.json` (out of scope).
+
+### Round 2 — critic, dev-proxy, scope-guardian, delta-auditor (+ concrete-planner, aborted)
+
+The concrete-planner sub-agent terminated on an API error in both
+attempts. Its round-2 checklist was verified directly instead:
+`generate-translations.sh` body (a 9-line `exec python3` wrapper),
+`if` as a safe YAML key, `upload-artifact` `if-no-files-found`
+semantics on an aggregate match set, `tests/qs/conftest.py`'s autouse
+sys.path fixture, the `setup-python` count, and the current `test`
+job's full pytest line. Round 1's concrete-planner pass did complete
+and found the `TestCiWorkflowConfig` trap.
+
+**Accepted — `resolved` in this revision**
+
+| # | source | finding | resolution |
+| --- | --- | --- | --- |
+| R2-01 | critic, dev-proxy, delta N1 | `critical` "same generator by the same entry point" is false — CI ran the `.py`, the local gate runs the `.sh` | §B now invokes `bash scripts/generate-translations.sh`; claim is now literally true |
+| R2-02 | critic | `critical` count-only reconciliation cannot catch a duplicate+drop swap | two layers: one-off local identity proof (task 2) + CI count guard |
+| R2-03 | critic | `redesign` "Re-run failed jobs" → 409 → permanently red required check | `overwrite: true`, trap 4, risk row |
+| R2-04 | dev-proxy, delta N3 | `critical` AC-2 and AC-6 mutually unobservable — the guard fires before the translations step | AC-6 is now local-only; AC-2 alone uses the PR |
+| R2-05 | dev-proxy, delta N2 | `critical` AC-6 still hand-edited `translations/en.json` | probe now edits `strings.json`; §B reason 2 dropped |
+| R2-06 | dev-proxy | `critical` `project-context.md:152` becomes false; AC-8's grep can't catch it | new §E row + a second AC-8 grep |
+| R2-07 | dev-proxy, delta N9, scope-guardian | `critical` carve-out over-broad and named the wrong flag | rewritten descriptive, scoped to the required-check job, both spellings |
+| R2-08 | critic | `critical` AC-3's budget ignores the cold cache and the collect-only step | warm-cache mandate, step budgeted, bar 200s, stacked worst case stated |
+| R2-09 | critic | `critical` AC-3 was n=1 against a 228-307s distribution | median of ≥3 both sides; baseline captured (277s) |
+| R2-10 | dev-proxy | `redesign` scratch PR exceeds agent commit authorization | AC-2 is now a maintainer-run manual step with a written procedure |
+| R2-11 | dev-proxy | `redesign` unpinned `coverage` on the shards is a merge-gate time bomb | D5 — pinned in both places as twins |
+| R2-12 | critic, delta N5 | `improve` collect-only step unbudgeted; shard 1 becomes the pace-setter | projection corrected to ~117s / ~155s / ~180s |
+| R2-13 | critic | `improve` §F would match the wrong pytest step | select by step name; plus a `--splits`-consistency assertion |
+| R2-14 | critic, delta N4 | `improve` Rollback under-scoped | six-item enumeration |
+| R2-15 | critic | `improve` D2's self-correction was itself wrong | D2 rewritten; carve-out is CI-scoped, `--store-durations` is local |
+| R2-16 | critic | `improve` no `timeout-minutes` | added to both new jobs |
+| R2-17 | scope-guardian | `improve` translations steps in `release.yml` exceed D-15 | dropped from §C and AC-7 |
+| R2-18 | dev-proxy, delta N8 | `improve` script stdout/exit contract unspecified | full contract in §A |
+| R2-19 | delta N6 | `improve` helper's dependency surface unstated | stdlib-only, stated and testable |
+| R2-20 | dev-proxy | `improve` no style/lint obligations for the new files | house style spelled out; `--fix` pass added as task 8 |
+| R2-21 | dev-proxy | `improve` AC-8 assigned to no task | task 7, re-run in task 9 |
+| R2-22 | dev-proxy | `improve` AC-4 baseline captured after the change | task 0; values recorded |
+| R2-23 | dev-proxy | `critical` AC-10 unfalsifiable — no gate measures `scripts/` | restated as branch enumeration, with the reason |
+| R2-24 | dev-proxy | `critical` task 11 omitted `--impacted` | task 12 names both |
+| R2-25 | critic, dev-proxy | `clarify` scratch branch base unstated → probe would be vacuous off `main` | procedure branches from `QS_292`, with the reason |
+| R2-26 | critic, scope-guardian | `clarify` AC-1's 403 clause was a can't-fail escape | removed; protection read recorded as planning provenance |
+| R2-27 | delta N7 | `clarify` "three of four" no longer identified the fourth | §D enumerates all five, including HACS |
+| R2-28 | delta N10 | `clarify` current pytest line never quoted, but AC-4 depends on it | quoted in §A "Baseline facts" |
+| R2-29 | delta N11 | `clarify` "ignores nothing" vs a package-scoped verdict | "ignores no test" |
+| R2-30 | critic | `clarify` YAML block vs "diff against the existing job" ambiguity | task 4 states which artifact wins |
+| R2-31 | dev-proxy | `clarify` `if-no-files-found` with a shard-1-only file | inline YAML comment |
+| R2-32 | dev-proxy | `clarify` `requirements_test.txt` pin-parity test | verified: `TestRequirementsTestDeps` only asserts `pytest-xdist` |
+| R2-33 | dev-proxy | `clarify` harness contingency if AC-8 hits an agent file | one-line contingency in §E + task 7 |
+| R2-34 | dev-proxy | `clarify` Problem section paraphrased `project-rules.md:42-45` | reworded |
+| R2-35 | scope-guardian | `clarify` §B duplicated the review table's history | compressed to one paragraph |
+| R2-36 | critic | `improve` runner-consumption increase unstated while D3 cited minute cost | ~35% figure stated; D3's cost claim withdrawn |
+
+**Rejected — will not resurface**
+
+| # | source | finding | reason |
+| --- | --- | --- | --- |
+| R2-37 | scope-guardian | `redesign` delete the reconciliation apparatus entirely | partially accepted instead: the expensive identity proof moved off the critical path to a one-off local run, the cheap count guard stays. Sharding newly makes silent test loss possible; AC-4 only proves the coverage *domain*, not that every test ran |
+| R2-38 | scope-guardian | `clarify` drop §F's `if: always()` and `needs.test-shard.result` assertions | these pin the two invisible-and-catastrophic traps permanently; AC-2 is a one-time probe. Keeping both |
+| R2-39 | critic | `improve` add a `concurrency: cancel-in-progress` group | real win, genuinely outside this issue — recorded as a follow-up in Non-goals |
+| R2-40 | scope-guardian | `clarify` plan-document inflation (10 ACs, 12 tasks) | the AC/task count tracks the *verification* burden of changing the sole merge-gating check, not the size of the diff. Compressed where possible (R2-35) |
+
+**Open criticals: 0.**
+
+### Finalize record
+
+Shipped at **v3** with `changed-since-last-review = true`: the 36
+round-2 fixes above were folded in *after* round 2 ran and were not
+re-reviewed by a round 3. Accepted knowingly by the maintainer on the
+advisory prompt. Nothing shipped `open` — no critical, redesign,
+improve or clarify finding from either round is unresolved; the residual
+risk is only that the round-2 *fixes themselves* carry no adversarial
+pass.
+
+Two items deliberately left for the implement phase to confirm rather
+than assume:
+
+1. **AC-2 is maintainer-run**, not agent-run (R2-10). If you would
+   rather authorize the implement agent to create and delete the
+   throwaway PR itself, that is a one-line change to AC-2 and the probe
+   procedure.
+2. **The concrete-planner reviewer never completed a round-2 pass**
+   (API error, twice). Its checklist was verified by hand — see the
+   round-2 header — but that is self-verification, not an independent
+   lens.

--- a/docs/stories/QS-292.story_review_fix_#01.md
+++ b/docs/stories/QS-292.story_review_fix_#01.md
@@ -1,0 +1,329 @@
+# QS-292 — Review fix plan #01
+
+## Summary
+- Source PR: #328
+- Source story: `docs/stories/QS-292.story.md`
+- Findings to fix: 21 (3 must-fix, 10 should-fix, 8 nice-to-have)
+- Next implement phase: `/implement-setup-task`
+
+Triage decision: **fix all**.
+
+Scope note: every touched path is `.github/`, `scripts/qs/`, `docs/`, or a
+dev-tooling test (`tests/test_quality_gate.py`,
+`tests/qs/test_ci_reconcile_shards.py`) — no `custom_components/` changes,
+hence `implement-setup-task`.
+
+Two must-fix items (M2, M3) are **not code changes** — they are verification
+gaps. See "Non-code must-fix items" at the end for how to discharge them.
+
+---
+
+## Findings to fix
+
+### [must-fix] M1 — Translations check is vacuously green for untracked files
+- File: `.github/workflows/pr-quality.yml:153-157`
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter (must-fix), qs-review-blind-hunter (should-fix)
+- Description: `git diff --exit-code -- custom_components/quiet_solar/translations/`
+  never sees **untracked** files. If a PR deletes `en.json`, the generator
+  recreates it, but the file is untracked so `git diff --exit-code` exits 0
+  and the required check passes. Reproduced in a scratch repo:
+  `git diff --exit-code -- tr/` returned 0 while `git status --porcelain -- tr/`
+  returned `?? tr/en.json`. The local gate catches this
+  (`scripts/qs/quality_gate.py:809-816` compares content, `en_before` is `""`
+  when the file is missing), so CI is **strictly weaker than local** for exactly
+  the delete case — the opposite of D-14's intent. Same vacuous pass if the
+  translations directory is ever moved (`git diff -- <path-matching-nothing>`
+  is silently 0).
+- Proposed fix: stage before diffing so untracked files are visible:
+  ```bash
+  bash scripts/generate-translations.sh
+  git add -A -- custom_components/quiet_solar/translations/
+  git diff --cached --exit-code -- custom_components/quiet_solar/translations/ \
+    || { echo "::error::translations are stale — run 'bash scripts/generate-translations.sh' and commit the result"; exit 1; }
+  ```
+  (`git status --porcelain -- <dir>` is an equivalent alternative.)
+
+### [should-fix] S1 — Generator non-zero exit makes CI and local disagree
+- File: `.github/workflows/pr-quality.yml:153-155`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `scripts/generate_translations.py` exits 1 on a missing
+  `strings.json` (lines 92-94) and on an unresolvable `[%key:…%]` reference
+  (lines 60-64). GitHub's default `bash -e` kills the step with no `::error::`
+  annotation, while `check_translations` at `scripts/qs/quality_gate.py:811-812`
+  **deliberately ignores** the exit code (`# Run generation — ignore exit code`)
+  and reports PASS because `en.json` is unchanged. Add
+  `"x": "[%key:component::quiet_solar::nope%]"` to `strings.json` and local
+  says PASS while CI goes red with a bare traceback. The step comment claims the
+  two "can never disagree"; for these two inputs they do.
+- Proposed fix: capture the generator's exit code and emit an explicit
+  `::error::` annotation naming the failure, so the CI red is self-describing.
+  Either make the local gate honour the exit code too, or soften the
+  "can never disagree" comment to state the exact carve-out.
+
+### [should-fix] S2 — Reconcile guard is count-only and index-blind
+- File: `scripts/qs/ci_reconcile_shards.py:47-50, 63-77`
+- Severity: should-fix
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter
+- Description: two related weaknesses in the layer-2 guard.
+  (a) `len(sorted(shard_dir.glob("junit-shard-*.xml"))) != splits` never checks
+  the shard **indices** are `1..N` distinct — four files all named
+  `junit-shard-1.xml`, or a missing shard 3 plus a stray file, both pass.
+  (b) Counting `.//testcase` cannot distinguish "all 6921 ran once" from
+  "test A ran in two shards, test B in none" — the totals balance and the script
+  exits 0, yet the error string on the failing branch claims to catch
+  "double-ran tests". Latent today (every `glob()`-derived parametrization is
+  wrapped in `sorted()`, e.g. `tests/qs/agents/test_harness_flag_explicit.py:83`),
+  but one unsorted `Path.glob()` in a future `@pytest.mark.parametrize` re-arms it.
+- Proposed fix: parse the index out of each filename and assert the set equals
+  `{1..splits}`; accumulate `(classname, name)` pairs into a set and assert
+  `len(set) == executed == collected`. Extend
+  `tests/qs/test_ci_reconcile_shards.py` with cases for duplicate index, missing
+  index, and the offsetting duplicate+drop.
+
+### [should-fix] S3 — `if: always()` turns cancelled runs into hard reds
+- File: `.github/workflows/pr-quality.yml:129`
+- Severity: should-fix
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter (nice-to-have)
+- Description: `always()` also fires on run **cancellation**, so the guard step
+  sees `needs.test-shard.result == 'cancelled'` and turns a cancelled run into a
+  hard-red required check rather than a cancelled one.
+- Proposed fix: use `if: ${{ !cancelled() }}` — identical anti-skip protection
+  (a skipped required check still counts as passing under branch protection)
+  without the false red. Update the adjacent comment and the
+  `test_aggregation_runs_even_when_a_shard_fails` assertion in
+  `tests/test_quality_gate.py`.
+
+### [should-fix] S4 — Checkout credentials and job permissions unhardened
+- File: `.github/workflows/pr-quality.yml:58-76, 126-149`
+- Severity: should-fix
+- Source: qs-review-coderabbit (zizmor 1.28.0 — `artipacked`, `excessive-permissions`)
+- Description: neither `actions/checkout@v5` step (lines 67 and 143) sets
+  `persist-credentials: false`, and neither `test-shard` nor `test` declares a
+  `permissions:` block. Both jobs then run `pip install` from third-party
+  packages with the git credential store still populated, so a compromised
+  dependency could exfiltrate the token.
+- Proposed fix: add `permissions:\n  contents: read` to both jobs and
+  `with:\n  persist-credentials: false` to both checkout steps.
+
+### [should-fix] S5 — `retention-days: 1` makes a delayed re-run unclearable
+- File: `.github/workflows/pr-quality.yml:120, 165-170`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: if the `Tests (100% Coverage)` job is red, the PR sits >24h, and
+  a maintainer clicks "Re-run failed jobs", only the `test` job re-runs.
+  `needs.test-shard.result` is the carried-over `success` so the guard passes,
+  but the shard artifacts have expired → `pattern: shard-data-*` downloads
+  nothing → `expected 4 JUnit shard files in shard-data, found 0`. It fails
+  safe, but is **unclearable by re-running that job** — the user must re-run all
+  jobs, and nothing says so. This is precisely the "spurious infrastructure red"
+  class named in the PR's own rollback trigger.
+- Proposed fix: raise `retention-days` to ~5, **and** have the reconcile error
+  name the remedy ("shard artifacts missing or expired — re-run *all* jobs, not
+  just this one").
+
+### [should-fix] S6 — AC-4 / AC-5 evidence not recorded in the story
+- File: `docs/stories/QS-292.story.md` ("Measured outcome" table)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: both criteria are satisfied in CI but neither is written into the
+  story's "Measured outcome" table, which AC-5 explicitly requires ("its
+  `executed=N collected=N` line is recorded").
+- Proposed fix: fill the table from run `30718305154`: `TOTAL 16314 0 100%`,
+  `Combined 4 files`, `executed=6921 collected=6921`, per-shard durations
+  3m13s / 2m7s / 2m15s / 2m23s + 22s aggregation. Add a one-line note that the
+  L1 proof's 6912 vs CI's 6921 is **not** a discrepancy — the proof ran at
+  task 2, before tasks 3 and 5 added exactly 9 tests.
+
+### [should-fix] S7 — No regression guard pins the translations step inside `jobs.test`
+- File: `tests/test_quality_gate.py` (`TestCiWorkflowConfig`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: `TestCiWorkflowConfig` now pins the job name, `if: always()`, the
+  result guard, `-n auto`, `COVERAGE_CORE`, and `--splits` agreement — but not
+  that `jobs.test` contains a step running `generate-translations.sh`. D-14's
+  entire value is that the check lives *inside* the required context; a future
+  workflow edit could delete it and every gate stays green.
+- Proposed fix: one assertion mirroring the existing three.
+
+### [should-fix] S8 — Nothing pins `release.yml` alignment
+- File: `.github/workflows/release.yml`, `tests/test_quality_gate.py`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC-7 is implemented correctly (`-n auto`, `COVERAGE_CORE: sysmon`,
+  pip caching all present), but no test references `release.yml` anywhere in
+  `tests/`. §F extended `TestCiWorkflowConfig` for `pr-quality.yml` only, so the
+  exact drift **D-15** documents can silently recur.
+- Proposed fix: extend `TestCiWorkflowConfig` with a `release.yml` case
+  asserting `-n auto`, `COVERAGE_CORE: sysmon`, and `cache: 'pip'`.
+
+### [should-fix] S9 — AC-8's second grep is unsatisfiable as written
+- File: `docs/stories/QS-292.story.md` (AC-8)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: `grep -rnE "whole-repo .--cov-fail-under=100|pytest tests/ -n auto --cov-fail-under=100" docs/ CLAUDE.md AGENTS.md`
+  scopes over all of `docs/`, which includes `docs/stories/**`. Three of the four
+  hits are inside `QS-292.story.md` itself (§E's edit table quoting the *old*
+  string, and AC-8 quoting *its own pattern*), so the criterion **can never pass
+  by construction**; the fourth is a historical review record at
+  `QS-311.story.md:932`. Grep 1 correctly scoped itself to
+  `docs/workflow docs/agents`. The substantive intent — no stale caveat in live
+  agent-facing docs — is met.
+- Proposed fix: amend AC-8's second grep to use the same directory list as the
+  first (`docs/workflow docs/agents CLAUDE.md AGENTS.md`) or add
+  `--exclude-dir=stories`, then record it as passing.
+
+### [should-fix] S10 — Unpinned split-count and coverage-version literals
+- File: `.github/workflows/pr-quality.yml:~60`, `requirements_test.txt:12-15`,
+  `tests/test_quality_gate.py` (`test_split_counts_agree`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter, qs-review-edge-case-hunter (nice-to-have)
+- Description: (a) `name: Tests shard ${{ matrix.shard }}/4` hardcodes a
+  **fourth** copy of the split count that `test_split_counts_agree` does not
+  check (it pins matrix length, `--splits` in pytest, and `--splits` in
+  reconcile). Moving to 6 shards silently leaves job names reading `/4`.
+  (b) The `coverage==7.14.1` pin exists twice — `requirements_test.txt` and the
+  aggregation job's `pip install` — with no guard, unlike the `--splits` triple.
+  Bump one side only and the "same version reads and writes" invariant is
+  silently gone.
+- Proposed fix: extend `test_split_counts_agree` to also parse the shard job
+  `name:` suffix; add a four-line twin test pinning the two `coverage==` literals
+  to each other.
+
+### [nice-to-have] N1 — Collect-count regex misses pytest's deselected form
+- File: `.github/workflows/pr-quality.yml:88-91`
+- Source: qs-review-edge-case-hunter
+- Description: the anchor `^[0-9]+ tests? collected` does not match
+  `172/688 tests collected (516 deselected) in 0.12s` (verified locally on
+  pytest 9.0.3), so `set -euo pipefail` turns it into an opaque shard-1 failure
+  with no diagnostic. Triggers the moment `addopts` grows an `-m`/`--deselect`,
+  or a conftest gains a `pytest_collection_modifyitems` deselect hook. The
+  warnings/errors variants do match, so this is the only gap.
+- Proposed fix: broaden the regex to accept the `N/M tests collected` form (use
+  the executed count `N`), or fail with an explicit "could not parse collect
+  summary" `::error::`.
+
+### [nice-to-have] N2 — Shard logs print a misleading ~25% coverage report
+- File: `.github/workflows/pr-quality.yml` (shard pytest step)
+- Source: qs-review-blind-hunter
+- Description: shards inherit `--cov-report=term-missing` from `addopts`, so each
+  of the four logs prints a full ~16k-statement "missing" report at ~25%
+  coverage — noisy and easy to misread as a regression.
+- Proposed fix: add `--cov-report=` to the shard step to silence the per-shard
+  terminal report, or a one-line comment explaining the expected ~25%.
+
+### [nice-to-have] N3 — Dead `# type: ignore[type-arg]`
+- File: `tests/test_quality_gate.py:~875`
+- Source: qs-review-blind-hunter
+- Description: `-> dict:  # type: ignore[type-arg]` — CI runs mypy only against
+  `custom_components/quiet_solar/`, so the ignore is dead weight and would itself
+  be flagged under `warn_unused_ignores` if tests entered the mypy scope.
+- Proposed fix: annotate properly (`-> dict[str, Any]`) and drop the ignore.
+
+### [nice-to-have] N4 — Doc shard commands hardcode "four" and omit `--cov=`
+- File: `docs/workflow/project-context.md:152`,
+  `docs/agents/concepts/testing-layers.md:122-126`,
+  `docs/stories/QS-292.story.md:425-426`
+- Source: qs-review-blind-hunter, qs-review-coderabbit
+- Description: two overlapping nits. (a) All three sites hardcode "four
+  parallel … `--splits 4`"; nothing enforces this against the workflow, so it is
+  fresh doc drift the moment the shard count changes. (b) The actual workflow
+  passes `--cov=custom_components/quiet_solar`, which all three documented
+  commands omit — a copied command would not collect the package coverage the
+  final 100% report requires.
+- Proposed fix: phrase as "N parallel shards", and either add the `--cov=` flag
+  or explicitly mark the command as abbreviated.
+
+### [nice-to-have] N5 — Runner-consumption arithmetic is wrong
+- File: `docs/stories/QS-292.story.md:353-355`
+- Source: qs-review-coderabbit
+- Description: `4×102 + 15 + 38 + 232` equals **693**, not `~677`. That is ~38%
+  above `501`, not 35%.
+- Proposed fix: if the 15s collect-only cost is additive, write
+  `3×102 + 117 + 38 + 232 = 693`; otherwise drop the extra `+15`. Make the
+  percentage consistent with whichever formula stands.
+
+### [nice-to-have] N6 — CI carve-out glob is broader than intended
+- File: `docs/workflow/project-rules.md:137-144`,
+  `docs/stories/QS-292.story.md:432-439`
+- Source: qs-review-coderabbit
+- Description: the `.github/workflows/*.yml` glob states a broader exception than
+  the required sharded PR test check warrants. Also a LanguageTool nit at ~L137:
+  "GitHub" should be spelled with a capital "H".
+- Proposed fix: replace the glob with `.github/workflows/pr-quality.yml` (or
+  "test workflows"), apply the same wording in the story so policy and design
+  record stay consistent, and fix the capitalization.
+
+### [nice-to-have] N7 — Reconcile leaves an `OSError` path uncaught
+- File: `scripts/qs/ci_reconcile_shards.py:56-60`
+- Source: qs-review-blind-hunter
+- Description: only `ValueError` is caught around
+  `total_file.read_text()`/`int()`. The missing-file case is already handled by
+  the `is_file()` guard above, so this is a narrow residual (unreadable file,
+  undecodable bytes) — but an `OSError`/`UnicodeDecodeError` would escape as a
+  raw traceback instead of the single `::error::` line + exit 1 the module
+  docstring promises.
+- Proposed fix: widen to `except (ValueError, OSError)` and add a case to
+  `tests/qs/test_ci_reconcile_shards.py`.
+
+### [nice-to-have] N8 — Document the cold-cache concurrency effect for AC-3
+- File: `docs/stories/QS-292.story.md` (AC-3 sampling procedure)
+- Source: qs-review-edge-case-hunter
+- Description: six jobs in one run share a single pip cache key, so on the first
+  run after any `requirements*.txt` change, five log `Unable to reserve cache …
+  another job may be creating this cache`. Harmless, but it means the first
+  post-requirements-change run has six concurrent **cold** installs — directly
+  relevant when sampling AC-3's warm-cache median.
+- Proposed fix: note this in the AC-3 sampling procedure so the exclusion rule is
+  unambiguous.
+
+---
+
+## Non-code must-fix items
+
+These two cannot be discharged by editing files; they need CI runs.
+
+### [must-fix] M2 — AC-2 live probe not run
+- Severity: must-fix
+- Source: qs-review-acceptance-auditor
+- Description: the "a failing shard turns the required check red, never skipped"
+  mechanism is implemented (`if: always()` + guard step) and statically asserted
+  by `test_aggregation_runs_even_when_a_shard_fails`, but that test only proves
+  the YAML keys are present — not that GitHub behaves as assumed. The evidence
+  row (`AC-2 probe run URL + conclusion`) is empty. This is the highest-
+  consequence claim in the story: a skipped-required-check hole makes the merge
+  gate unsound.
+- How to discharge: **maintainer-run** — the story's "Probe procedure" requires a
+  deliberately-red throwaway PR, which exceeds agent commit authorization. Run
+  it, then paste the run URL + conclusion into the story's Measured-outcome table.
+
+### [must-fix] M3 — AC-3 has zero valid warm-cache samples
+- Severity: must-fix
+- Source: qs-review-acceptance-auditor
+- Description: `gh run list --branch QS_292` returns exactly one `PR Quality Gate`
+  run (30718305154), on the commit that edits `requirements_test.txt` — the pip
+  cache key — which AC-3 explicitly **excludes**. That cold run's critical path
+  was **223s** (shard 1 start 21:03:15 → aggregation end 21:06:58; shard 1 alone
+  193s). Warm-cache should shave ~47s to ~176s, but that is a projection, not a
+  measurement. AC-3 is also the documented rollback trigger, so it cannot ship
+  unmeasured.
+- How to discharge: this fix plan's own commit does **not** touch
+  `requirements_test.txt`, so its CI run is the first valid warm-cache sample.
+  Collect ≥3 (task 10's "push a trivial no-op commit ×3"), compute the median,
+  and record it. Median >200s fires the rollback.
+
+---
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. Note that S2, S3, S7, S8,
+S10, N7 all touch `tests/test_quality_gate.py` or
+`tests/qs/test_ci_reconcile_shards.py` — both `tests/qs`-pinned, so the
+pre-commit gate needs `python scripts/qs/quality_gate.py --impacted` **plus**
+`python scripts/qs/quality_gate.py --quick tests/qs`.
+
+Avoid touching `requirements_test.txt` in the fix commit so the resulting CI run
+counts as M3's first warm-cache sample.
+
+When done, return and run `/review-task` again to re-verify.

--- a/docs/workflow/project-context.md
+++ b/docs/workflow/project-context.md
@@ -149,7 +149,7 @@ When adding a new device type, agents must touch:
 
 ### Coverage
 
-- **100% test coverage is MANDATORY and NON-NEGOTIABLE.** Every PR must maintain 100% coverage — enforced authoritatively in **CI** on every PR (`pr-quality.yml`, whole-repo `--cov-fail-under=100`).
+- **100% test coverage is MANDATORY and NON-NEGOTIABLE.** Every PR must maintain 100% coverage — enforced authoritatively in **CI** on every PR (`pr-quality.yml`: four parallel `pytest tests/ -n auto --splits 4 --group N` shards whose data is combined into one `coverage report --fail-under=100`).
 - **Local-vs-CI split (QS-276).** Local commits run the `--impacted` inner loop (the lines *you changed* are 100% covered, in ~seconds); the whole-repo 100% guarantee lives in CI. `--impacted` deliberately cannot detect coverage lost in *unchanged* code — only CI's whole-repo gate catches that.
 - `scripts/qs/quality_gate.py` is the single test entry point (owns cache, xdist, sysmon, scope detection, `--impacted`/`--seed-testmon`). Raw `pytest` bypasses all of it.
 - Impacted inner-loop gate — the implement phase ALWAYS runs it before commit/PR and never substitutes the full gate locally (the only local full-gate run is an explicit user request): `python scripts/qs/quality_gate.py --impacted`. It self-heals a drifted testmon baseline automatically (QS-283) — no manual file deletion ever.

--- a/docs/workflow/project-context.md
+++ b/docs/workflow/project-context.md
@@ -149,7 +149,7 @@ When adding a new device type, agents must touch:
 
 ### Coverage
 
-- **100% test coverage is MANDATORY and NON-NEGOTIABLE.** Every PR must maintain 100% coverage — enforced authoritatively in **CI** on every PR (`pr-quality.yml`: four parallel `pytest tests/ -n auto --splits 4 --group N` shards whose data is combined into one `coverage report --fail-under=100`).
+- **100% test coverage is MANDATORY and NON-NEGOTIABLE.** Every PR must maintain 100% coverage — enforced authoritatively in **CI** on every PR (`pr-quality.yml`: N parallel `pytest tests/ -n auto --cov=custom_components/quiet_solar --splits N --group <i>` shards whose data is combined into one `coverage report --fail-under=100`).
 - **Local-vs-CI split (QS-276).** Local commits run the `--impacted` inner loop (the lines *you changed* are 100% covered, in ~seconds); the whole-repo 100% guarantee lives in CI. `--impacted` deliberately cannot detect coverage lost in *unchanged* code — only CI's whole-repo gate catches that.
 - `scripts/qs/quality_gate.py` is the single test entry point (owns cache, xdist, sysmon, scope detection, `--impacted`/`--seed-testmon`). Raw `pytest` bypasses all of it.
 - Impacted inner-loop gate — the implement phase ALWAYS runs it before commit/PR and never substitutes the full gate locally (the only local full-gate run is an explicit user request): `python scripts/qs/quality_gate.py --impacted`. It self-heals a drifted testmon baseline automatically (QS-283) — no manual file deletion ever.

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -37,8 +37,7 @@ all four; use it only for ad-hoc single-node debugging.
 # left by a killed run with NO manual file deletion ever required.
 python scripts/qs/quality_gate.py --impacted
 
-# Full quality gate (pytest 100% cov + ruff + mypy + translations;
-# the translations value-check is local-full-gate only until #292 lands).
+# Full quality gate (pytest 100% cov + ruff + mypy + translations).
 # Authoritative full-suite gate — enforced in CI on every PR; the only
 # local run is an EXPLICIT user request. Detecting coverage lost in
 # UNCHANGED code is CI's exclusive job (--impacted cannot see it); never
@@ -134,6 +133,15 @@ The detached seed accepts `--detached` (own process group) and
 `--seed-token <T>` (per-run identity); a newer seed automatically preempts
 an earlier still-running one (last-wins), and a stale baseline is always
 safe (new worktrees just over-select tests).
+
+**Carve-out — CI workflows (QS-292).** `.github/workflows/*.yml`
+invoke `pytest` and `coverage` directly, by design. The raw-`pytest`
+grammar rule and the "`quality_gate.py` is the single test entry
+point" rule govern *interactive and agent* commands, not CI. Where
+the PR suite is sharded, the job providing the required status check
+on `main` ends in a single authoritative fail-under-100 coverage
+verdict over the whole of `custom_components/quiet_solar/` — spelled
+`pytest --cov-fail-under=100` or `coverage report --fail-under=100`.
 
 **UI-only fast path.** When only `custom_components/quiet_solar/ui/*.j2`
 templates and `custom_components/quiet_solar/ui/resources/**` assets

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -134,13 +134,15 @@ The detached seed accepts `--detached` (own process group) and
 an earlier still-running one (last-wins), and a stale baseline is always
 safe (new worktrees just over-select tests).
 
-**Carve-out — CI workflows (QS-292).** `.github/workflows/*.yml`
-invoke `pytest` and `coverage` directly, by design. The raw-`pytest`
-grammar rule and the "`quality_gate.py` is the single test entry
-point" rule govern *interactive and agent* commands, not CI. Where
-the PR suite is sharded, the job providing the required status check
-on `main` ends in a single authoritative fail-under-100 coverage
-verdict over the whole of `custom_components/quiet_solar/` — spelled
+**Carve-out — CI test workflows (QS-292).**
+`.github/workflows/pr-quality.yml` and
+`.github/workflows/release.yml` invoke `pytest` and `coverage`
+directly, by design. The raw-`pytest` grammar rule and the
+"`quality_gate.py` is the single test entry point" rule govern
+*interactive and agent* commands, not CI. Where the PR suite is
+sharded, the job providing the required status check on `main` ends in
+a single authoritative fail-under-100 coverage verdict over the whole
+of `custom_components/quiet_solar/` — spelled
 `pytest --cov-fail-under=100` or `coverage report --fail-under=100`.
 
 **UI-only fast path.** When only `custom_components/quiet_solar/ui/*.j2`

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,6 +7,12 @@ pytest-timeout==2.4.0
 pytest-xdist==3.8.0
 pytest-testmon==2.2.0  # QS-276: test-impact selection for the --impacted inner loop
 diff-cover==10.3.0     # QS-276: diff-scoped coverage verdict for --impacted
+# QS-292: shard splitter for the CI test matrix in pr-quality.yml
+pytest-split==0.11.0
+# QS-292: twin of the `pip install coverage==7.14.1` literal in
+# pr-quality.yml's aggregation job — the shards' data must be written and
+# read by the same version. Both move together in one edit.
+coverage==7.14.1
 
 # Mock and testing utilities
 pytest-homeassistant-custom-component==0.13.347

--- a/scripts/qs/ci_reconcile_shards.py
+++ b/scripts/qs/ci_reconcile_shards.py
@@ -1,0 +1,84 @@
+"""Reconcile sharded CI test counts against the collected total (QS-292).
+
+Layer-2 guard of the sharded ``pr-quality.yml`` test matrix: asserts that
+exactly ``--splits`` JUnit shard reports arrived and that the number of
+executed test cases across them equals the total recorded by shard 1's
+collect-only step. Catches a shard silently not running or a
+``--splits``/matrix-length mismatch. (The one-off partition-identity
+proof — union == collected, pairwise disjoint — is a local planning
+step, not this script's job.)
+
+Stdlib only by design: the aggregation job installs nothing but
+``coverage``.
+
+Usage::
+
+    python3 scripts/qs/ci_reconcile_shards.py <dir> --splits N
+
+Success prints ``executed=<n> collected=<n>`` and exits 0. Each failure
+mode prints one ``::error::`` line (GitHub Actions annotation) and
+exits 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns the process exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "shard_dir",
+        type=Path,
+        help="directory holding junit-shard-*.xml and total-collected.txt",
+    )
+    parser.add_argument(
+        "--splits",
+        type=int,
+        required=True,
+        help="expected number of JUnit shard files",
+    )
+    args = parser.parse_args(argv)
+    shard_dir: Path = args.shard_dir
+    splits: int = args.splits
+
+    junit_files = sorted(shard_dir.glob("junit-shard-*.xml"))
+    if len(junit_files) != splits:
+        print(f"::error::expected {splits} JUnit shard files in {shard_dir}, found {len(junit_files)}")
+        return 1
+
+    total_file = shard_dir / "total-collected.txt"
+    if not total_file.is_file():
+        print(f"::error::missing {total_file} (shard 1's collect-only step)")
+        return 1
+    try:
+        collected = int(total_file.read_text(encoding="utf-8").strip())
+    except ValueError:
+        print(f"::error::unparseable collected count in {total_file}")
+        return 1
+
+    executed = 0
+    for junit_file in junit_files:
+        try:
+            root = ElementTree.parse(junit_file).getroot()
+        except ElementTree.ParseError:
+            print(f"::error::unparseable JUnit XML: {junit_file}")
+            return 1
+        executed += len(root.findall(".//testcase"))
+
+    if executed != collected:
+        print(
+            f"::error::executed test count {executed} != collected "
+            f"{collected} — a shard silently dropped or double-ran tests"
+        )
+        return 1
+
+    print(f"executed={executed} collected={collected}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qs/ci_reconcile_shards.py
+++ b/scripts/qs/ci_reconcile_shards.py
@@ -1,12 +1,21 @@
 """Reconcile sharded CI test counts against the collected total (QS-292).
 
-Layer-2 guard of the sharded ``pr-quality.yml`` test matrix: asserts that
-exactly ``--splits`` JUnit shard reports arrived and that the number of
-executed test cases across them equals the total recorded by shard 1's
-collect-only step. Catches a shard silently not running or a
-``--splits``/matrix-length mismatch. (The one-off partition-identity
-proof — union == collected, pairwise disjoint — is a local planning
-step, not this script's job.)
+Layer-2 guard of the sharded ``pr-quality.yml`` test matrix. Given the
+downloaded shard artifacts it asserts that:
+
+1. exactly ``--splits`` JUnit shard reports arrived, and their shard
+   indices are precisely ``1..splits`` (a right-count/wrong-index set,
+   e.g. a missing shard 3 plus a stray shard 99, is caught here);
+2. no ``(classname, name)`` test case appears in more than one shard —
+   identity, not arithmetic, so an *offsetting* duplicate-plus-drop
+   (test A run twice, test B never) cannot balance the books; and
+3. the number of executed test cases equals the total recorded by
+   shard 1's collect-only step.
+
+Together these catch a shard silently not running, a
+``--splits``/matrix-length mismatch, and a split that is not a true
+partition. (The one-off partition-identity proof over *collected node
+IDs* is a local planning step, not this script's job.)
 
 Stdlib only by design: the aggregation job installs nothing but
 ``coverage``.
@@ -15,16 +24,19 @@ Usage::
 
     python3 scripts/qs/ci_reconcile_shards.py <dir> --splits N
 
-Success prints ``executed=<n> collected=<n>`` and exits 0. Each failure
-mode prints one ``::error::`` line (GitHub Actions annotation) and
-exits 1.
+Success prints ``executed=<n> collected=<n>`` and exits 0. Every
+failure mode prints exactly one ``::error::`` line (a GitHub Actions
+annotation) and exits 1.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 from pathlib import Path
 from xml.etree import ElementTree
+
+SHARD_FILE_RE = re.compile(r"junit-shard-(\d+)\.xml")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -47,7 +59,29 @@ def main(argv: list[str] | None = None) -> int:
 
     junit_files = sorted(shard_dir.glob("junit-shard-*.xml"))
     if len(junit_files) != splits:
-        print(f"::error::expected {splits} JUnit shard files in {shard_dir}, found {len(junit_files)}")
+        # Fails safe, but is NOT clearable by re-running this job alone
+        # once the shard artifacts have expired, so name the remedy.
+        print(
+            f"::error::expected {splits} JUnit shard files in {shard_dir}, "
+            f"found {len(junit_files)} — shard artifacts missing or expired; "
+            f"re-run ALL jobs, not just this one"
+        )
+        return 1
+
+    indices: set[int] = set()
+    for junit_file in junit_files:
+        match = SHARD_FILE_RE.fullmatch(junit_file.name)
+        if match is None:
+            print(f"::error::unexpected shard artifact name: {junit_file.name}")
+            return 1
+        indices.add(int(match.group(1)))
+
+    expected_indices = set(range(1, splits + 1))
+    if indices != expected_indices:
+        print(
+            f"::error::shard indices {sorted(indices)} != expected "
+            f"{sorted(expected_indices)} — a shard is missing or misnamed"
+        )
         return 1
 
     total_file = shard_dir / "total-collected.txt"
@@ -56,24 +90,31 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     try:
         collected = int(total_file.read_text(encoding="utf-8").strip())
-    except ValueError:
-        print(f"::error::unparseable collected count in {total_file}")
+    except (ValueError, OSError) as err:
+        print(f"::error::unreadable collected count in {total_file}: {err}")
         return 1
 
     executed = 0
+    seen: set[tuple[str, str]] = set()
     for junit_file in junit_files:
         try:
             root = ElementTree.parse(junit_file).getroot()
         except ElementTree.ParseError:
             print(f"::error::unparseable JUnit XML: {junit_file}")
             return 1
-        executed += len(root.findall(".//testcase"))
+        for case in root.findall(".//testcase"):
+            executed += 1
+            seen.add((case.get("classname", ""), case.get("name", "")))
+
+    if len(seen) != executed:
+        print(
+            f"::error::{executed - len(seen)} duplicate test case(s) ran in more "
+            f"than one shard — the split is not a partition"
+        )
+        return 1
 
     if executed != collected:
-        print(
-            f"::error::executed test count {executed} != collected "
-            f"{collected} — a shard silently dropped or double-ran tests"
-        )
+        print(f"::error::executed test count {executed} != collected {collected} — a shard silently dropped tests")
         return 1
 
     print(f"executed={executed} collected={collected}")

--- a/tests/qs/test_ci_reconcile_shards.py
+++ b/tests/qs/test_ci_reconcile_shards.py
@@ -1,0 +1,113 @@
+"""Tests for ``scripts/qs/ci_reconcile_shards.py`` (QS-292, AC-10).
+
+Exercises every branch of the reconcile script by enumeration against
+synthetic ``tmp_path`` fixtures: happy path, wrong JUnit-file count,
+missing ``total-collected.txt``, unparseable collected count,
+unparseable XML, and executed-vs-collected count mismatch.
+
+The module import relies on ``tests/qs/conftest.py``'s autouse
+``_add_scripts_qs_to_syspath`` fixture, so it must happen inside each
+test function (the fixture is not active at collection time).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_junit(path: Path, n_tests: int) -> None:
+    """Write a minimal pytest-shaped JUnit XML file with ``n_tests`` cases."""
+    cases = "".join(f'<testcase classname="tests.test_x" name="test_{i}" time="0.01"/>' for i in range(n_tests))
+    path.write_text(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        f'<testsuites><testsuite name="pytest" tests="{n_tests}">'
+        f"{cases}</testsuite></testsuites>",
+        encoding="utf-8",
+    )
+
+
+def _make_shard_dir(tmp_path: Path, shard_sizes: list[int], collected: int | str | None) -> Path:
+    """Populate ``tmp_path`` with JUnit shard files and a collected count."""
+    for i, size in enumerate(shard_sizes, start=1):
+        _write_junit(tmp_path / f"junit-shard-{i}.xml", size)
+    if collected is not None:
+        (tmp_path / "total-collected.txt").write_text(f"{collected}\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_happy_path_prints_counts_and_exits_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Four shards whose executed sum equals the collected total → exit 0."""
+    import ci_reconcile_shards
+
+    _make_shard_dir(tmp_path, [3, 2, 4, 1], collected=10)
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "executed=10 collected=10" in out
+    assert "::error::" not in out
+
+
+def test_wrong_junit_file_count_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Three JUnit files against ``--splits 4`` → one ::error:: line, exit 1."""
+    import ci_reconcile_shards
+
+    _make_shard_dir(tmp_path, [3, 3, 4], collected=10)
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert out.count("::error::") == 1
+    assert "expected 4 JUnit shard files" in out
+    assert "found 3" in out
+
+
+def test_missing_total_collected_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """No ``total-collected.txt`` → one ::error:: line, exit 1."""
+    import ci_reconcile_shards
+
+    _make_shard_dir(tmp_path, [3, 2, 4, 1], collected=None)
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert out.count("::error::") == 1
+    assert "total-collected.txt" in out
+
+
+def test_unparseable_collected_count_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Garbage in ``total-collected.txt`` → one ::error:: line, exit 1."""
+    import ci_reconcile_shards
+
+    _make_shard_dir(tmp_path, [3, 2, 4, 1], collected="not-a-number")
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert out.count("::error::") == 1
+    assert "unparseable collected count" in out
+
+
+def test_unparseable_junit_xml_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A truncated JUnit file → one ::error:: line naming it, exit 1."""
+    import ci_reconcile_shards
+
+    _make_shard_dir(tmp_path, [3, 2, 4], collected=10)
+    (tmp_path / "junit-shard-4.xml").write_text("<testsuites><testsuite", encoding="utf-8")
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert out.count("::error::") == 1
+    assert "unparseable JUnit XML" in out
+    assert "junit-shard-4.xml" in out
+
+
+def test_count_mismatch_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Executed sum != collected total → one ::error:: line, exit 1."""
+    import ci_reconcile_shards
+
+    _make_shard_dir(tmp_path, [3, 2, 4, 1], collected=11)
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert out.count("::error::") == 1
+    assert "executed test count 10" in out
+    assert "collected 11" in out

--- a/tests/qs/test_ci_reconcile_shards.py
+++ b/tests/qs/test_ci_reconcile_shards.py
@@ -2,8 +2,10 @@
 
 Exercises every branch of the reconcile script by enumeration against
 synthetic ``tmp_path`` fixtures: happy path, wrong JUnit-file count,
-missing ``total-collected.txt``, unparseable collected count,
-unparseable XML, and executed-vs-collected count mismatch.
+unexpected artifact name, bad shard-index set, missing
+``total-collected.txt``, unparseable/unreadable collected count,
+unparseable XML, duplicate test cases across shards, and an
+executed-vs-collected count mismatch.
 
 The module import relies on ``tests/qs/conftest.py``'s autouse
 ``_add_scripts_qs_to_syspath`` fixture, so it must happen inside each
@@ -17,21 +19,37 @@ from pathlib import Path
 import pytest
 
 
-def _write_junit(path: Path, n_tests: int) -> None:
-    """Write a minimal pytest-shaped JUnit XML file with ``n_tests`` cases."""
-    cases = "".join(f'<testcase classname="tests.test_x" name="test_{i}" time="0.01"/>' for i in range(n_tests))
+def _write_junit(path: Path, cases: list[tuple[str, str]]) -> None:
+    """Write a minimal pytest-shaped JUnit XML file for ``cases``.
+
+    ``cases`` is a list of ``(classname, name)`` pairs, so a test can
+    control cross-shard uniqueness explicitly.
+    """
+    body = "".join(f'<testcase classname="{classname}" name="{name}" time="0.01"/>' for classname, name in cases)
     path.write_text(
         '<?xml version="1.0" encoding="utf-8"?>'
-        f'<testsuites><testsuite name="pytest" tests="{n_tests}">'
-        f"{cases}</testsuite></testsuites>",
+        f'<testsuites><testsuite name="pytest" tests="{len(cases)}">'
+        f"{body}</testsuite></testsuites>",
         encoding="utf-8",
     )
 
 
-def _make_shard_dir(tmp_path: Path, shard_sizes: list[int], collected: int | str | None) -> Path:
-    """Populate ``tmp_path`` with JUnit shard files and a collected count."""
-    for i, size in enumerate(shard_sizes, start=1):
-        _write_junit(tmp_path / f"junit-shard-{i}.xml", size)
+def _make_shard_dir(
+    tmp_path: Path,
+    shard_sizes: list[int],
+    collected: int | str | None,
+    indices: list[int] | None = None,
+) -> Path:
+    """Populate ``tmp_path`` with JUnit shard files and a collected count.
+
+    Each shard gets its own ``classname``, so the synthetic
+    ``(classname, name)`` pairs are unique across shards unless a test
+    deliberately arranges a collision.
+    """
+    shard_indices = indices if indices is not None else list(range(1, len(shard_sizes) + 1))
+    for idx, size in zip(shard_indices, shard_sizes, strict=True):
+        cases = [(f"tests.test_shard{idx}", f"test_{i}") for i in range(size)]
+        _write_junit(tmp_path / f"junit-shard-{idx}.xml", cases)
     if collected is not None:
         (tmp_path / "total-collected.txt").write_text(f"{collected}\n", encoding="utf-8")
     return tmp_path
@@ -62,6 +80,55 @@ def test_wrong_junit_file_count_fails(tmp_path: Path, capsys: pytest.CaptureFixt
     assert "found 3" in out
 
 
+def test_missing_artifacts_error_names_the_remedy(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Zero artifacts (expired) → the error tells the user to re-run ALL jobs.
+
+    Review fix #01 S5: a delayed "Re-run failed jobs" on the aggregation
+    job alone downloads nothing once the shard artifacts have expired.
+    It fails safe, but the message must say how to clear it.
+    """
+    import ci_reconcile_shards
+
+    (tmp_path / "total-collected.txt").write_text("10\n", encoding="utf-8")
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "found 0" in out
+    assert "expired" in out
+    assert "re-run ALL jobs" in out
+
+
+def test_unexpected_artifact_name_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A non-numeric shard suffix → one ::error:: line naming it, exit 1."""
+    import ci_reconcile_shards
+
+    _make_shard_dir(tmp_path, [3, 2, 4], collected=10)
+    _write_junit(tmp_path / "junit-shard-oops.xml", [("tests.x", "test_a")])
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert out.count("::error::") == 1
+    assert "junit-shard-oops.xml" in out
+
+
+def test_shard_indices_must_be_one_through_n(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Right file COUNT but wrong index set → exit 1.
+
+    Review fix #01 S2(a): a missing shard 3 plus a stray shard 99 passes
+    a count-only check. (Two files with the SAME index cannot coexist in
+    one directory, so the index-set equality is what covers that class.)
+    """
+    import ci_reconcile_shards
+
+    _make_shard_dir(tmp_path, [3, 2, 4, 1], collected=10, indices=[1, 2, 4, 99])
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert out.count("::error::") == 1
+    assert "shard indices" in out
+    assert "99" in out
+
+
 def test_missing_total_collected_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """No ``total-collected.txt`` → one ::error:: line, exit 1."""
     import ci_reconcile_shards
@@ -83,7 +150,25 @@ def test_unparseable_collected_count_fails(tmp_path: Path, capsys: pytest.Captur
     out = capsys.readouterr().out
     assert rc == 1
     assert out.count("::error::") == 1
-    assert "unparseable collected count" in out
+    assert "unreadable collected count" in out
+
+
+def test_undecodable_collected_count_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Undecodable bytes → the same single ::error:: line, not a traceback.
+
+    Review fix #01 N7: ``read_text`` can raise ``OSError`` /
+    ``UnicodeDecodeError`` as well as ``ValueError`` from ``int()``; the
+    module docstring promises one ``::error::`` line for every failure.
+    """
+    import ci_reconcile_shards
+
+    _make_shard_dir(tmp_path, [3, 2, 4, 1], collected=None)
+    (tmp_path / "total-collected.txt").write_bytes(b"\xff\xfe\x00garbage")
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert out.count("::error::") == 1
+    assert "unreadable collected count" in out
 
 
 def test_unparseable_junit_xml_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -98,6 +183,31 @@ def test_unparseable_junit_xml_fails(tmp_path: Path, capsys: pytest.CaptureFixtu
     assert out.count("::error::") == 1
     assert "unparseable JUnit XML" in out
     assert "junit-shard-4.xml" in out
+
+
+def test_offsetting_duplicate_and_drop_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A test run twice while another never runs → exit 1.
+
+    Review fix #01 S2(b): the counts still BALANCE here (executed ==
+    collected == 10), so a count-only guard exits 0 while the split is
+    not a partition. Identity, not arithmetic, is what catches it.
+    """
+    import ci_reconcile_shards
+
+    _make_shard_dir(tmp_path, [3, 2, 4, 1], collected=10)
+    # Shard 2 re-runs one of shard 1's cases instead of its own second
+    # case: the total is unchanged, but one pair is now duplicated and
+    # another was never executed anywhere.
+    _write_junit(
+        tmp_path / "junit-shard-2.xml",
+        [("tests.test_shard1", "test_0"), ("tests.test_shard2", "test_0")],
+    )
+    rc = ci_reconcile_shards.main([str(tmp_path), "--splits", "4"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert out.count("::error::") == 1
+    assert "duplicate" in out
+    assert "not a partition" in out
 
 
 def test_count_mismatch_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -14,6 +14,7 @@ import sys
 import threading
 import time
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -874,17 +875,18 @@ class TestCiWorkflowConfig:
     """Regression guard for .github/workflows/pr-quality.yml (QS-292 shape)."""
 
     @staticmethod
-    def _load_workflow() -> dict:  # type: ignore[type-arg]
+    def _load_workflow(filename: str = "pr-quality.yml") -> dict[str, Any]:
         try:
             import yaml
         except ImportError:
             pytest.skip("PyYAML not installed")
 
         repo_root = Path(__file__).resolve().parent.parent
-        wf_path = repo_root / ".github" / "workflows" / "pr-quality.yml"
+        wf_path = repo_root / ".github" / "workflows" / filename
         if not wf_path.exists():
             pytest.skip("workflow file missing")
-        return yaml.safe_load(wf_path.read_text())  # type: ignore[no-any-return]
+        loaded: dict[str, Any] = yaml.safe_load(wf_path.read_text())
+        return loaded
 
     def test_shard_job_uses_xdist_sysmon(self) -> None:
         """The shard job's pytest step uses -n auto and COVERAGE_CORE=sysmon.
@@ -895,9 +897,7 @@ class TestCiWorkflowConfig:
         """
         data = self._load_workflow()
         shard_job = data["jobs"]["test-shard"]
-        run_steps = [
-            s for s in shard_job["steps"] if s.get("name", "").startswith("Run shard")
-        ]
+        run_steps = [s for s in shard_job["steps"] if s.get("name", "").startswith("Run shard")]
         assert run_steps, "no 'Run shard …' step found in test-shard job"
         pytest_step = run_steps[0]
         assert "-n auto" in pytest_step["run"] or "--numprocesses auto" in pytest_step["run"]
@@ -914,50 +914,138 @@ class TestCiWorkflowConfig:
         assert data["jobs"]["test"]["name"] == "Tests (100% Coverage)"
 
     def test_aggregation_runs_even_when_a_shard_fails(self) -> None:
-        """`if: always()` + a needs.test-shard.result guard step.
+        """`if: !cancelled()` + a needs.test-shard.result guard step.
 
         Without them a failing shard SKIPS the aggregation job, and
         branch protection treats a skipped required check as passing.
-        (`if` is a safe YAML key — unlike `on`, it is not a YAML 1.1
-        boolean.)
+        `!cancelled()` gives identical anti-skip protection to
+        `always()` WITHOUT turning a cancelled run into a hard red
+        (review fix #01 S3). (`if` is a safe YAML key — unlike `on`, it
+        is not a YAML 1.1 boolean.)
         """
         data = self._load_workflow()
         test_job = data["jobs"]["test"]
-        assert test_job["if"] == "always()"
-        assert any(
-            "needs.test-shard.result" in str(s.get("if", "")) for s in test_job["steps"]
-        ), "no step in jobs.test guards on needs.test-shard.result"
+        condition = str(test_job["if"])
+        assert "cancelled()" in condition and "!" in condition, (
+            f"jobs.test `if` must be a !cancelled() guard, got {condition!r}"
+        )
+        assert "always()" not in condition, (
+            "always() also fires on cancellation, turning a cancelled run into a hard red"
+        )
+        assert any("needs.test-shard.result" in str(s.get("if", "")) for s in test_job["steps"]), (
+            "no step in jobs.test guards on needs.test-shard.result"
+        )
+
+    def test_translations_value_check_lives_in_required_job(self) -> None:
+        """D-14: the translations check must sit INSIDE the required context.
+
+        `Tests (100% Coverage)` is the only required status check on
+        `main`, so a value-stale en.json is blocked only if the check
+        runs in that job. A future edit could delete the step and every
+        other gate would stay green (review fix #01 S7).
+        """
+        data = self._load_workflow()
+        steps = data["jobs"]["test"]["steps"]
+        gen_steps = [s for s in steps if "generate-translations.sh" in s.get("run", "")]
+        assert gen_steps, "no generate-translations.sh step in the required `test` job"
+        # The check is only meaningful if the regenerated output is then
+        # compared — a bare generator call always exits 0.
+        assert any("git diff" in s.get("run", "") for s in gen_steps), (
+            "generate-translations.sh runs but its output is never diffed"
+        )
 
     def test_split_counts_agree(self) -> None:
-        """The three hard-coded shard counts agree.
+        """All four hard-coded shard counts agree.
 
         len(matrix.shard), the `--splits N` in the shard pytest command,
-        and the `--splits N` passed to ci_reconcile_shards.py must all
-        name the same number.
+        the `--splits N` passed to ci_reconcile_shards.py, and the `/N`
+        suffix in the shard job's display name (review fix #01 S10a —
+        moving to 6 shards would otherwise leave job names reading `/4`).
         """
         data = self._load_workflow()
         shard_job = data["jobs"]["test-shard"]
         matrix_len = len(shard_job["strategy"]["matrix"]["shard"])
 
-        run_steps = [
-            s for s in shard_job["steps"] if s.get("name", "").startswith("Run shard")
-        ]
+        run_steps = [s for s in shard_job["steps"] if s.get("name", "").startswith("Run shard")]
         assert run_steps
         match = re.search(r"--splits (\d+)", run_steps[0]["run"])
         assert match, "no --splits flag in the shard pytest command"
         pytest_splits = int(match.group(1))
 
-        reconcile_steps = [
-            s
-            for s in data["jobs"]["test"]["steps"]
-            if "ci_reconcile_shards.py" in s.get("run", "")
-        ]
+        reconcile_steps = [s for s in data["jobs"]["test"]["steps"] if "ci_reconcile_shards.py" in s.get("run", "")]
         assert reconcile_steps, "no ci_reconcile_shards.py step in jobs.test"
         match = re.search(r"--splits (\d+)", reconcile_steps[0]["run"])
         assert match, "no --splits flag in the reconcile command"
         reconcile_splits = int(match.group(1))
 
-        assert matrix_len == pytest_splits == reconcile_splits
+        match = re.search(r"/(\d+)\s*$", shard_job["name"])
+        assert match, f"shard job name has no /N suffix: {shard_job['name']!r}"
+        name_splits = int(match.group(1))
+
+        assert matrix_len == pytest_splits == reconcile_splits == name_splits
+
+    def test_coverage_pin_matches_requirements(self) -> None:
+        """The aggregation job's `coverage==` pin twins requirements_test.txt.
+
+        The shards' data must be written and read by the same coverage
+        version; bumping one side only silently breaks that invariant
+        (review fix #01 S10b).
+        """
+        data = self._load_workflow()
+        wf_pins = {
+            m.group(1)
+            for s in data["jobs"]["test"]["steps"]
+            if (m := re.search(r"coverage==([\d.]+)", s.get("run", "")))
+        }
+        assert len(wf_pins) == 1, f"expected exactly one coverage== pin, got {wf_pins}"
+
+        repo_root = Path(__file__).resolve().parent.parent
+        reqs = (repo_root / "requirements_test.txt").read_text()
+        match = re.search(r"^coverage==([\d.]+)", reqs, re.MULTILINE)
+        assert match, "no top-level coverage== pin in requirements_test.txt"
+        assert wf_pins == {match.group(1)}, (
+            f"workflow pins coverage {wf_pins}, requirements_test.txt pins {match.group(1)}"
+        )
+
+    def test_shard_and_aggregation_jobs_are_hardened(self) -> None:
+        """Both new jobs drop credentials and declare least-privilege perms.
+
+        Each runs `pip install` from third-party packages; leaving the
+        git credential store populated hands a compromised dependency a
+        usable token (review fix #01 S4, zizmor `artipacked` /
+        `excessive-permissions`).
+        """
+        data = self._load_workflow()
+        for job_name in ("test-shard", "test"):
+            job = data["jobs"][job_name]
+            assert job.get("permissions") == {"contents": "read"}, (
+                f"jobs.{job_name} lacks `permissions: contents: read`"
+            )
+            checkouts = [s for s in job["steps"] if "actions/checkout" in str(s.get("uses", ""))]
+            assert checkouts, f"jobs.{job_name} has no checkout step"
+            for step in checkouts:
+                assert step.get("with", {}).get("persist-credentials") is False, (
+                    f"jobs.{job_name} checkout must set persist-credentials: false"
+                )
+
+    def test_release_workflow_is_aligned(self) -> None:
+        """AC-7 / D-15: release.yml matches pr-quality's pytest invocation.
+
+        Nothing else in `tests/` references release.yml, so the exact
+        drift D-15 documents could silently recur (review fix #01 S8).
+        """
+        data = self._load_workflow("release.yml")
+        steps = data["jobs"]["quality-gate"]["steps"]
+
+        pytest_steps = [s for s in steps if "pytest" in s.get("run", "")]
+        assert pytest_steps, "no pytest step in release.yml quality-gate job"
+        step = pytest_steps[0]
+        assert "-n auto" in step["run"] or "--numprocesses auto" in step["run"]
+        assert step.get("env", {}).get("COVERAGE_CORE") == "sysmon"
+
+        setup_steps = [s for s in steps if "actions/setup-python" in str(s.get("uses", ""))]
+        assert setup_steps, "no setup-python step in release.yml"
+        assert setup_steps[0].get("with", {}).get("cache") == "pip"
 
 
 # --- B1: requirements_test.txt includes pytest-xdist ---
@@ -2377,9 +2465,7 @@ class TestRunTimeout:
         with patch.object(
             quality_gate.subprocess,
             "run",
-            side_effect=subprocess.TimeoutExpired(
-                cmd=["x"], timeout=5.0, output="partial out", stderr="partial err"
-            ),
+            side_effect=subprocess.TimeoutExpired(cmd=["x"], timeout=5.0, output="partial out", stderr="partial err"),
         ):
             result = quality_gate._run(["x"], timeout=5.0)
         assert result.returncode == 124
@@ -2655,9 +2741,7 @@ class TestCheckImpacted:
             assert quality_gate.check_impacted() == 1
         mock_run.assert_not_called()  # diff-cover never runs if tests failed
 
-    def test_diff_coverage_below_100_returns_1(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_diff_coverage_below_100_returns_1(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         xml = tmp_path / "coverage.xml"
         absent_db = tmp_path / ".testmondata"  # never created → select-all, no self-heal
 
@@ -2840,9 +2924,7 @@ class TestTestmonSchemaVersion:
 class TestResetCoverageData:
     """QS-278: `_reset_coverage_data` clears the persistent coverage data."""
 
-    def test_removes_primary_data_and_xdist_shards(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_removes_primary_data_and_xdist_shards(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # #01-5: shards are globbed from COVERAGE_DATA's own dir — patching it
         # alone must clear both the primary file and the shards.
         data = tmp_path / ".coverage"
@@ -2856,9 +2938,7 @@ class TestResetCoverageData:
         assert not data.exists()
         assert not shard.exists()
 
-    def test_is_noop_when_no_data_present(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_is_noop_when_no_data_present(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Absent data must not raise (first-ever run)."""
         monkeypatch.setattr(quality_gate, "COVERAGE_DATA", tmp_path / ".coverage")
         quality_gate._reset_coverage_data()  # must not raise
@@ -2868,9 +2948,7 @@ class TestCleanOrphanCovShards:
     """QS-283 A1 (AC#1): `_clean_orphan_cov_shards` reaps only `.coverage.*`
     shards; the combined `.coverage` survives."""
 
-    def test_removes_shard_but_keeps_combined_coverage(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_removes_shard_but_keeps_combined_coverage(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         combined = tmp_path / ".coverage"
         combined.write_text("combined")
         shard = tmp_path / ".coverage.host.4242.XYZ"
@@ -2882,18 +2960,14 @@ class TestCleanOrphanCovShards:
         assert combined.exists(), "the combined .coverage must survive (warm baseline)"
         assert not shard.exists(), "a pre-existing orphan shard must be removed"
 
-    def test_is_noop_when_no_shards_present(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_is_noop_when_no_shards_present(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         combined = tmp_path / ".coverage"
         combined.write_text("combined")
         monkeypatch.setattr(quality_gate, "COVERAGE_DATA", combined)
         quality_gate._clean_orphan_cov_shards()  # must not raise
         assert combined.exists()
 
-    def test_uses_same_glob_as_reset_coverage_data(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_uses_same_glob_as_reset_coverage_data(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """The two helpers must share the shard-matching rule (they differ
         ONLY in whether the primary `.coverage` is also unlinked)."""
         combined = tmp_path / ".coverage"
@@ -2966,14 +3040,10 @@ class TestCheckImpactedSelfHeal:
         db.write_bytes(b"warm-baseline")  # present + non-empty → was_incremental True
         return db
 
-    def test_incremental_false_fail_recovers_to_pass(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_incremental_false_fail_recovers_to_pass(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """An incremental changed-line FAIL that is a desync recovers to PASS
         after exactly one rebuild + retry; the self-heal notice is emitted."""
-        rc, mock_rebuild, mock_pass = self._run(
-            db=self._incremental_db(tmp_path), verdicts=[self.CHANGED, self.PASS]
-        )
+        rc, mock_rebuild, mock_pass = self._run(db=self._incremental_db(tmp_path), verdicts=[self.CHANGED, self.PASS])
         assert rc == 0
         mock_rebuild.assert_called_once()
         assert mock_pass.call_count == 2, "exactly one rebuild + one retry"
@@ -3007,9 +3077,7 @@ class TestCheckImpactedSelfHeal:
         mock_rebuild.assert_not_called()
         assert mock_pass.call_count == 1
 
-    def test_testmondata_vanishing_before_stat_is_non_incremental(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_testmondata_vanishing_before_stat_is_non_incremental(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Review fix #02: if `.testmondata` is unlinked (concurrent run / other
         worktree / mid-purge) so `TESTMON_DATA.stat()` raises `FileNotFoundError`,
         `check_impacted` must NOT crash — it treats the run as non-incremental
@@ -3036,9 +3104,7 @@ class TestCheckImpactedSelfHeal:
     ) -> None:
         """A never-failed PASS is distinguishable from a recovered PASS: no
         rebuild, no self-heal notice."""
-        rc, mock_rebuild, mock_pass = self._run(
-            db=self._incremental_db(tmp_path), verdicts=[self.PASS]
-        )
+        rc, mock_rebuild, mock_pass = self._run(db=self._incremental_db(tmp_path), verdicts=[self.PASS])
         assert rc == 0
         mock_rebuild.assert_not_called()
         assert mock_pass.call_count == 1
@@ -3047,9 +3113,7 @@ class TestCheckImpactedSelfHeal:
     def test_non_retriable_verdict_exits_1_without_retry(self, tmp_path: Path) -> None:
         """A non-changed-line failure (e.g. selected tests failed) is genuine
         even on an incremental run — it must not trigger the self-heal."""
-        rc, mock_rebuild, mock_pass = self._run(
-            db=self._incremental_db(tmp_path), verdicts=[self.TESTS_FAILED]
-        )
+        rc, mock_rebuild, mock_pass = self._run(db=self._incremental_db(tmp_path), verdicts=[self.TESTS_FAILED])
         assert rc == 1
         mock_rebuild.assert_not_called()
         assert mock_pass.call_count == 1
@@ -3353,9 +3417,7 @@ class TestWriteSeedStatus:
             quality_gate._write_seed_status("ok", returncode=0)
         mock_replace.assert_called_once()
 
-    def test_best_effort_swallows_and_cleans_up_on_failure(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_best_effort_swallows_and_cleans_up_on_failure(self, capsys: pytest.CaptureFixture[str]) -> None:
         """A write failure must NOT raise (never abort the detached rebuild),
         the temp file must still be unlinked by the `finally`, AND a single
         diagnostic line is emitted (review-fix #02)."""
@@ -3392,9 +3454,7 @@ class TestPidAlive:
     # review-fix #04: `_pid_alive` is total — an untrusted pid that makes
     # os.kill raise anything other than PermissionError is treated as dead,
     # never propagating out of the read-only status query.
-    @pytest.mark.parametrize(
-        "exc", [OverflowError, ValueError, TypeError], ids=["overflow", "value", "type"]
-    )
+    @pytest.mark.parametrize("exc", [OverflowError, ValueError, TypeError], ids=["overflow", "value", "type"])
     def test_dead_on_other_os_kill_errors(self, exc: type[Exception]) -> None:
         with patch.object(quality_gate.os, "kill", side_effect=exc):
             assert quality_gate._pid_alive(10**19) is False
@@ -3501,9 +3561,7 @@ class TestSeedTestmonStatus:
         [5, "x", None, [1], 3.14],
         ids=["int", "str", "null", "array", "float"],
     )
-    def test_non_dict_payload_exits_3(
-        self, payload: object, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_non_dict_payload_exits_3(self, payload: object, capsys: pytest.CaptureFixture[str]) -> None:
         self._write(payload)
         assert quality_gate.seed_testmon_status() == 3  # no AttributeError
         assert "unreadable" in capsys.readouterr().out.lower()
@@ -3526,9 +3584,7 @@ class TestSeedTestmonStatus:
         ],
         ids=["no-pid", "pid-null", "pid-str", "pid-float", "pid-zero", "pid-neg", "pid-bool"],
     )
-    def test_running_with_bad_pid_exits_3(
-        self, marker: dict, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_running_with_bad_pid_exits_3(self, marker: dict, capsys: pytest.CaptureFixture[str]) -> None:
         """A `running` marker without a positive, non-bool int pid is
         unreadable — never reaches `_pid_alive`/`os.kill`."""
         self._write(marker)
@@ -3541,9 +3597,7 @@ class TestSeedTestmonStatus:
         mock_kill.assert_not_called()
         assert "unreadable" in capsys.readouterr().out.lower()
 
-    def test_running_out_of_range_pid_interrupted_no_crash(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_running_out_of_range_pid_interrupted_no_crash(self, capsys: pytest.CaptureFixture[str]) -> None:
         """review-fix #04 must-fix: a positive pid beyond pid_t (10**19) passes
         the positivity guard, reaches the real os.kill (→ OverflowError), and is
         treated as dead → interrupted (exit 1), never crashing the query."""
@@ -3593,9 +3647,7 @@ class TestSeedTestmonStatus:
         assert "still running" in out.lower()
         assert "an unknown time" in out
 
-    def test_incomplete_missing_returncode_prints_placeholder(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_incomplete_missing_returncode_prints_placeholder(self, capsys: pytest.CaptureFixture[str]) -> None:
         self._write({"state": "incomplete"})
         assert quality_gate.seed_testmon_status() == 1
         out = capsys.readouterr().out
@@ -4008,9 +4060,7 @@ class TestSeedTestmonTokenPreemption:
                 "_stream_pytest",
                 # a fresher seed claims the marker while we run.
                 side_effect=lambda *a, **k: (
-                    quality_gate.SEED_STATUS.write_text(
-                        json.dumps({"state": "running", "token": "winner"})
-                    ),
+                    quality_gate.SEED_STATUS.write_text(json.dumps({"state": "running", "token": "winner"})),
                     {"returncode": 0},
                 )[1],
             ),
@@ -4067,7 +4117,9 @@ class TestMarkerElapsed:
             assert quality_gate._marker_elapsed({"started": 40.0}) == 60.0
 
     @pytest.mark.parametrize(
-        "started", [None, "x", True, float("inf"), float("nan"), 10**400], ids=["none", "str", "bool", "inf", "nan", "huge"]
+        "started",
+        [None, "x", True, float("inf"), float("nan"), 10**400],
+        ids=["none", "str", "bool", "inf", "nan", "huge"],
     )
     def test_bad_started_is_zero(self, started: object) -> None:
         with patch.object(quality_gate.time, "time", return_value=100.0):
@@ -4186,9 +4238,7 @@ class TestSeedTestmonFollow:
         assert "safe to close" in out
         assert out.isascii()
 
-    def test_stale_foreign_marker_then_own_claim_streams_progress(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_stale_foreign_marker_then_own_claim_streams_progress(self, capsys: pytest.CaptureFixture[str]) -> None:
         """review-fix #01 (finding #1) MUST-FIX: a stale foreign marker present at
         startup must NOT trigger a spurious exit 5 — once our own seed claims the
         marker within the grace window we stream our own progress to completion."""
@@ -4545,9 +4595,7 @@ class TestSeedFollowCli:
         ],
         ids=["seed+status", "seed+follow", "status+follow", "status+seed", "follow+seed", "follow+status"],
     )
-    def test_seed_modes_pairwise_mutex_exits_2(
-        self, pair: list[str], capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_seed_modes_pairwise_mutex_exits_2(self, pair: list[str], capsys: pytest.CaptureFixture[str]) -> None:
         """review-fix #02 (finding #2): the three seed subcommands are pairwise
         mutually exclusive via ONE centralized, order-independent check — neither
         the seed side nor the follow side silently wins."""
@@ -4624,9 +4672,7 @@ class TestImpactedCli:
         ],
         ids=["impacted", "cache", "no-cache", "full", "fix", "quick"],
     )
-    def test_seed_testmon_mutex_exits_2(
-        self, conflict: list[str], capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_seed_testmon_mutex_exits_2(self, conflict: list[str], capsys: pytest.CaptureFixture[str]) -> None:
         """review-fix M1: --seed-testmon combined with any execution mode is a usage error."""
         with (
             patch("sys.argv", ["quality_gate.py", "--seed-testmon", *conflict]),
@@ -4667,9 +4713,7 @@ class TestImpactedCli:
         ],
         ids=["impacted", "cache", "no-cache", "full", "fix", "quick"],
     )
-    def test_seed_testmon_status_mutex_exits_2(
-        self, conflict: list[str], capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_seed_testmon_status_mutex_exits_2(self, conflict: list[str], capsys: pytest.CaptureFixture[str]) -> None:
         """AC#5: --seed-testmon-status combined with an execution mode is a usage
         error (seed-mode pairs → test_seed_modes_pairwise_mutex_exits_2)."""
         with (
@@ -4734,9 +4778,7 @@ class TestProjectRulesDocGuards:
     """review-fix N2: content guard for the AC#12 doc edits (not just drift-checker)."""
 
     def _rules(self) -> str:
-        return (
-            Path(__file__).resolve().parent.parent / "docs" / "workflow" / "project-rules.md"
-        ).read_text()
+        return (Path(__file__).resolve().parent.parent / "docs" / "workflow" / "project-rules.md").read_text()
 
     def test_seed_testmon_carveout_heading_present(self) -> None:
         rules = self._rules()
@@ -4759,9 +4801,7 @@ class TestProjectRulesDocGuards:
         """review-fix #04 (AC#9): pin the phase-protocols.md step-5 completion
         -signal note, symmetric to the project-rules guard above so a drift /
         revert of the step-5 line is caught."""
-        proto = (
-            Path(__file__).resolve().parent.parent / "docs" / "workflow" / "phase-protocols.md"
-        ).read_text()
+        proto = (Path(__file__).resolve().parent.parent / "docs" / "workflow" / "phase-protocols.md").read_text()
         assert "quality_gate.py --seed-testmon-status" in proto
         assert ".testmondata.seed.log" in proto
 
@@ -4805,7 +4845,7 @@ class TestFinishTaskFollowerAgents:
     @pytest.mark.parametrize("rel", _AGENTS)
     def test_no_rm_f_marker(self, rel: str) -> None:
         """The new seed must READ the predecessor marker to preempt it — never rm."""
-        assert "rm -f \"$MAIN_DIR/.testmondata.seed-status\"" not in self._text(rel)
+        assert 'rm -f "$MAIN_DIR/.testmondata.seed-status"' not in self._text(rel)
 
     @pytest.mark.parametrize("rel", _AGENTS)
     def test_streams_follower_inline(self, rel: str) -> None:
@@ -4929,9 +4969,7 @@ class TestFinishTaskRefreshesBaseline:
         background+monitor prose is allowed to differ)."""
         blocks = []
         for harness in (".claude", ".cursor", ".opencode"):
-            body = (
-                Path(__file__).resolve().parent.parent / harness / "agents" / "qs-finish-task.md"
-            ).read_text()
+            body = (Path(__file__).resolve().parent.parent / harness / "agents" / "qs-finish-task.md").read_text()
             # Anchor on the token generation and the exact detached-launch
             # redirect line — both code-adjacent, so per-harness follower prose
             # after the fence can't truncate the slice inconsistently.
@@ -5115,7 +5153,13 @@ class TestImpactedIntegrationRealTestmon:
 
         def _dc(*extra: str) -> subprocess.CompletedProcess[str]:
             return subprocess.run(
-                [quality_gate._venv_tool("diff-cover"), str(xml), f"--compare-branch={base}", *extra, "--fail-under=100"],
+                [
+                    quality_gate._venv_tool("diff-cover"),
+                    str(xml),
+                    f"--compare-branch={base}",
+                    *extra,
+                    "--fail-under=100",
+                ],
                 cwd=str(repo),
                 capture_output=True,
                 text=True,

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -871,10 +871,10 @@ class TestPytestIniRegression:
 
 
 class TestCiWorkflowConfig:
-    """Regression guard for .github/workflows/pr-quality.yml."""
+    """Regression guard for .github/workflows/pr-quality.yml (QS-292 shape)."""
 
-    def test_workflow_yaml_is_valid_and_uses_xdist_sysmon(self) -> None:
-        """Workflow parses as YAML, test job uses -n auto and COVERAGE_CORE=sysmon."""
+    @staticmethod
+    def _load_workflow() -> dict:  # type: ignore[type-arg]
         try:
             import yaml
         except ImportError:
@@ -884,17 +884,80 @@ class TestCiWorkflowConfig:
         wf_path = repo_root / ".github" / "workflows" / "pr-quality.yml"
         if not wf_path.exists():
             pytest.skip("workflow file missing")
+        return yaml.safe_load(wf_path.read_text())  # type: ignore[no-any-return]
 
-        data = yaml.safe_load(wf_path.read_text())
-        # Find the `test` job
-        test_job = data["jobs"]["test"]
-        steps = test_job["steps"]
-        run_steps = [s for s in steps if "run" in s and "pytest" in s.get("run", "")]
-        assert run_steps, "no pytest step found in test job"
+    def test_shard_job_uses_xdist_sysmon(self) -> None:
+        """The shard job's pytest step uses -n auto and COVERAGE_CORE=sysmon.
+
+        The step is selected BY NAME (`Run shard …`), not by "first step
+        whose run contains pytest" — test-shard has two pytest steps and
+        the collect-only one comes first and carries neither flag.
+        """
+        data = self._load_workflow()
+        shard_job = data["jobs"]["test-shard"]
+        run_steps = [
+            s for s in shard_job["steps"] if s.get("name", "").startswith("Run shard")
+        ]
+        assert run_steps, "no 'Run shard …' step found in test-shard job"
         pytest_step = run_steps[0]
         assert "-n auto" in pytest_step["run"] or "--numprocesses auto" in pytest_step["run"]
         env = pytest_step.get("env", {})
         assert env.get("COVERAGE_CORE") == "sysmon"
+
+    def test_required_check_name_is_pinned(self) -> None:
+        """The aggregation job's name is the LITERAL required status check.
+
+        Branch protection on `main` requires exactly the string
+        `Tests (100% Coverage)`; renaming it blocks every PR forever.
+        """
+        data = self._load_workflow()
+        assert data["jobs"]["test"]["name"] == "Tests (100% Coverage)"
+
+    def test_aggregation_runs_even_when_a_shard_fails(self) -> None:
+        """`if: always()` + a needs.test-shard.result guard step.
+
+        Without them a failing shard SKIPS the aggregation job, and
+        branch protection treats a skipped required check as passing.
+        (`if` is a safe YAML key — unlike `on`, it is not a YAML 1.1
+        boolean.)
+        """
+        data = self._load_workflow()
+        test_job = data["jobs"]["test"]
+        assert test_job["if"] == "always()"
+        assert any(
+            "needs.test-shard.result" in str(s.get("if", "")) for s in test_job["steps"]
+        ), "no step in jobs.test guards on needs.test-shard.result"
+
+    def test_split_counts_agree(self) -> None:
+        """The three hard-coded shard counts agree.
+
+        len(matrix.shard), the `--splits N` in the shard pytest command,
+        and the `--splits N` passed to ci_reconcile_shards.py must all
+        name the same number.
+        """
+        data = self._load_workflow()
+        shard_job = data["jobs"]["test-shard"]
+        matrix_len = len(shard_job["strategy"]["matrix"]["shard"])
+
+        run_steps = [
+            s for s in shard_job["steps"] if s.get("name", "").startswith("Run shard")
+        ]
+        assert run_steps
+        match = re.search(r"--splits (\d+)", run_steps[0]["run"])
+        assert match, "no --splits flag in the shard pytest command"
+        pytest_splits = int(match.group(1))
+
+        reconcile_steps = [
+            s
+            for s in data["jobs"]["test"]["steps"]
+            if "ci_reconcile_shards.py" in s.get("run", "")
+        ]
+        assert reconcile_steps, "no ci_reconcile_shards.py step in jobs.test"
+        match = re.search(r"--splits (\d+)", reconcile_steps[0]["run"])
+        assert match, "no --splits flag in the reconcile command"
+        reconcile_splits = int(match.group(1))
+
+        assert matrix_len == pytest_splits == reconcile_splits
 
 
 # --- B1: requirements_test.txt includes pytest-xdist ---

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -123,8 +123,3 @@ def test_translations_en_matches_strings_structure() -> None:
     strings = _load_strings()
     en = _load_translations_en()
     _assert_same_key_structure(strings, en)
-
-
-def test_ac2_probe():
-    """AC-2 probe: deliberately failing. Do not merge."""
-    assert False, "AC-2 probe"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -123,3 +123,8 @@ def test_translations_en_matches_strings_structure() -> None:
     strings = _load_strings()
     en = _load_translations_en()
     _assert_same_key_structure(strings, en)
+
+
+def test_ac2_probe():
+    """AC-2 probe: deliberately failing. Do not merge."""
+    assert False, "AC-2 probe"


### PR DESCRIPTION
Probes that a failing shard turns the required check `Tests (100% Coverage)` **red** rather than **skipped**.

Deliberately contains one failing test. Close without merging.

Part of QS-292 AC-2 verification. Run under explicit maintainer authorization.