### PR TITLE
QS-332: create the 6 workflow lanes, declared at setup

### DIFF
--- a/.claude/agents/qs-create-plan.md
+++ b/.claude/agents/qs-create-plan.md
@@ -29,6 +29,15 @@ python scripts/qs/context.py
 Parse the JSON. You'll get: `issue`, `title`, `branch`, `story_file`,
 `worktree`, `harness`. From here on, refer to these values.
 
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
 if you haven't this session.

--- a/.claude/agents/qs-implement-setup-task.md
+++ b/.claude/agents/qs-implement-setup-task.md
@@ -27,7 +27,6 @@ python scripts/qs/context.py
 Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
 `latest_review_fix`.
 
-
 **Lane (QS-332).** Also capture `lane` from the context JSON, then read
 `docs/workflow/lanes/<lane>.md` — that file is this task's phase
 protocol. If `lane` is empty (a pre-existing worktree / legacy
@@ -38,6 +37,7 @@ labels (`gh issue edit <N> --add-label ...`). In this implement
 phase the labels must be resolved **before the first commit** — the
 first `--impacted` run fails otherwise (the gate is the backstop, not
 a parallel path).
+
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 if you haven't this session.
 
@@ -139,9 +139,11 @@ Pass on a green gate; fix on red.
 
 **Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
 with `lane check FAILED` (the task's issue has a missing/incomplete
-lane declaration), ask the user which lane the task belongs to, run the
-exact `gh issue edit <N> --add-label ...` command the gate printed,
-then re-run the gate. Do this before the first commit — the gate fails
+lane declaration), ask the user which lane the task belongs to, then
+apply the remediation the gate printed — its `gh issue edit <N>
+--remove-label`/`--add-label` commands run verbatim, plus the additions
+where the message says to substitute the user's chosen value — then
+re-run the gate. Do this before the first commit — the gate fails
 until the declaration exists.
 
 **Changes to `tests/qs`-pinned non-Python files.** For change sets

--- a/.claude/agents/qs-implement-setup-task.md
+++ b/.claude/agents/qs-implement-setup-task.md
@@ -27,6 +27,17 @@ python scripts/qs/context.py
 Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
 `latest_review_fix`.
 
+
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). In this implement
+phase the labels must be resolved **before the first commit** — the
+first `--impacted` run fails otherwise (the gate is the backstop, not
+a parallel path).
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 if you haven't this session.
 
@@ -125,6 +136,13 @@ python scripts/qs/quality_gate.py        # full gate, on EXPLICIT request only
 ```
 
 Pass on a green gate; fix on red.
+
+**Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
+with `lane check FAILED` (the task's issue has a missing/incomplete
+lane declaration), ask the user which lane the task belongs to, run the
+exact `gh issue edit <N> --add-label ...` command the gate printed,
+then re-run the gate. Do this before the first commit — the gate fails
+until the declaration exists.
 
 **Changes to `tests/qs`-pinned non-Python files.** For change sets
 touching any `tests/qs`-pinned non-Python file (agent files, commands,

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -125,9 +125,11 @@ python scripts/qs/quality_gate.py        # full gate, on EXPLICIT request only
 
 **Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
 with `lane check FAILED` (the task's issue has a missing/incomplete
-lane declaration), ask the user which lane the task belongs to, run the
-exact `gh issue edit <N> --add-label ...` command the gate printed,
-then re-run the gate. Do this before the first commit — the gate fails
+lane declaration), ask the user which lane the task belongs to, then
+apply the remediation the gate printed — its `gh issue edit <N>
+--remove-label`/`--add-label` commands run verbatim, plus the additions
+where the message says to substitute the user's chosen value — then
+re-run the gate. Do this before the first commit — the gate fails
 until the declaration exists.
 
 If `--impacted` fails, fix the **code/tests** — never switch to the

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -26,6 +26,17 @@ python scripts/qs/context.py
 Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
 `latest_review_fix`. The story file is your spec (unless a review fix plan is active — see step 1b).
 
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). In this implement
+phase the labels must be resolved **before the first commit** — the
+first `--impacted` run fails otherwise (the gate is the backstop, not
+a parallel path).
+
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
 if you haven't this session.
@@ -111,6 +122,13 @@ user request:
 ```bash
 python scripts/qs/quality_gate.py        # full gate, on EXPLICIT request only
 ```
+
+**Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
+with `lane check FAILED` (the task's issue has a missing/incomplete
+lane declaration), ask the user which lane the task belongs to, run the
+exact `gh issue edit <N> --add-label ...` command the gate printed,
+then re-run the gate. Do this before the first commit — the gate fails
+until the declaration exists.
 
 If `--impacted` fails, fix the **code/tests** — never switch to the
 full gate to diagnose. `--impacted` self-heals; a manual

--- a/.claude/agents/qs-review-task.md
+++ b/.claude/agents/qs-review-task.md
@@ -29,6 +29,15 @@ Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
 review (run `/implement-task` or `/implement-setup-task` first,
 whichever the story scope requires).
 
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
 ## Phase protocol
 
 ### 1. Fetch the PR diff

--- a/.claude/agents/qs-setup-task.md
+++ b/.claude/agents/qs-setup-task.md
@@ -15,9 +15,10 @@ You are Phase 1 of the Quiet Solar pipeline. Your job is to create the
 GitHub issue + branch + worktree and hand off to a fresh session on the
 worktree where the user will invoke `/create-plan`.
 
-**Be fast and automatic. Do NOT analyze the input.** Don't read log
-files, don't research the codebase, don't propose designs. Pass the
-text through to the GitHub issue verbatim. Deep analysis is
+**Be fast and automatic, *except* the single lane/epic question when
+the declaration is missing (step 1b). Do NOT analyze the input.** Don't
+read log files, don't research the codebase, don't propose designs.
+Pass the text through to the GitHub issue verbatim. Deep analysis is
 `/create-plan`'s job.
 
 ## Input
@@ -39,7 +40,9 @@ Optional: `--no-worktree` (create branch only, skip worktree).
 python scripts/qs/fetch_issue.py --issue {{N}}
 ```
 
-Capture `issue_number`, `title`, `body`, `labels` from the JSON.
+Capture `issue_number`, `title`, `body`, `labels`, plus the lane axes
+`kind` / `target` / `scale` / `lane`, `parent_epic`, and
+`declaration_complete` from the JSON. Lane handling is step 1b.
 
 **Otherwise** (new issue):
 - **Plan file** — read it; use its title as issue title; body is the full
@@ -47,11 +50,50 @@ Capture `issue_number`, `title`, `body`, `labels` from the JSON.
 - **Free text** — extract a short title (first sentence or ~80 chars);
   body is the full text verbatim.
 
+First resolve the lane (step 1b), then create the issue with its
+labels — every task is born fully declared:
+
 ```bash
-python scripts/qs/create_issue.py --title "{{title}}" --body "{{body}}"
+python scripts/qs/create_issue.py --title "{{title}}" --body "{{body}}" --labels "{{labels}}"
 ```
 
+e.g. `--labels "kind:bug,target:product,scale:task"`. If a parent epic
+was declared, include a `Refs #{{epic}}` line in the issue body.
+
 Capture `issue_number` from the JSON output.
+
+### 1b. Lane declaration (QS-332 — the one permitted question)
+
+Every issue carries exactly one lane: `kind:*` + `target:*` +
+`scale:task` for tasks, `target:*` + `scale:epic` (and **no kind**) for
+epics. `scale:task` is the implicit default — never ask "task or
+epic?" separately — but it is always applied explicitly as a label.
+
+**Existing issue (`--issue N`):** if `declaration_complete` is `true`,
+use the declaration as-is and ask nothing (epic linkage included:
+whatever the body says, or nothing). If it is `false`, ask the user for
+exactly the missing axes in ONE question, and — since a question is
+being asked anyway — include the optional "part of an epic? (#N /
+none)" iff the body carries no parent-epic declaration. Then backfill
+the full label set onto the issue before proceeding:
+
+```bash
+gh issue edit {{N}} --add-label "{{missing labels}}"
+```
+
+(plus a `Refs #{{epic}}` body line via `gh issue edit {{N}} --body ...`
+if an epic was given). The issue on GitHub always ends up fully
+declared — `setup_task.py` refuses to proceed otherwise.
+
+**New issue (free text / plan file):** ask ONE question for the lane —
+the 6 options: `bug` / `feature` (product), `harness bug` /
+`harness feature` (factory), `epic product` / `epic factory` — plus the
+optional "part of an epic? (#N / none)". Skip the question **only when
+the user's request contains an explicit lane name or explicit axis
+values** ("bug", "harness feature", "kind:bug target:factory",
+"epic product", ...); anything else — however suggestive the text —
+means ask. This is a bright line, not text analysis, so the "do NOT
+analyze the input" rule stands.
 
 ### 2. Set up branch and worktree + emit launcher
 
@@ -125,7 +167,11 @@ flow is one session per phase.
 
 ## Hard rules
 
-- Do NOT analyze the input. The launcher must come within a few seconds.
+- Do NOT analyze the input. The launcher must come fast and
+  automatically, *except* the single lane/epic question when the
+  declaration is missing (step 1b). Only an explicit lane name or
+  explicit axis values in the user's request count as an answer —
+  never inferred ones.
 - Do NOT commit or push — setup-task only creates branches/worktrees.
 - Do NOT touch `legacy/**` — that's the retired per-task-rendering
   OpenCode pipeline (frozen historical code).

--- a/.claude/agents/qs-setup-task.md
+++ b/.claude/agents/qs-setup-task.md
@@ -95,7 +95,22 @@ values** ("bug", "harness feature", "kind:bug target:factory",
 means ask. This is a bright line, not text analysis, so the "do NOT
 analyze the input" rule stands.
 
-### 2. Set up branch and worktree + emit launcher
+### 1c. Epic lanes stop here (no branch, no worktree)
+
+If the resolved lane is `epic-product` or `epic-factory`, the issue is
+the deliverable: an epic has **no implement phase and no branch,
+worktree, or PR** (see
+[docs/epics/QS-321.md](../../docs/epics/QS-321.md)). Its output is a
+rationale document on `main` plus **child issues**.
+
+So for an epic: create/label the issue as above, then **skip step 2
+entirely** — do NOT run `setup_task.py`. Report the epic issue number
+and tell the user the next move is to decompose it into child tasks
+(each child is its own task lane, carrying `Refs #<epic>`; run
+setup-task on those). `setup_task.py` refuses an epic outright, so a
+slip here fails loudly rather than silently cutting a worktree.
+
+### 2. Set up branch and worktree + emit launcher (tasks only)
 
 One command does it all:
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,8 @@
       "Bash(python **/scripts/qs/create_issue.py:*)",
       "Bash(python scripts/qs/context.py:*)",
       "Bash(python **/scripts/qs/context.py:*)",
+      "Bash(python scripts/qs/targets.py:*)",
+      "Bash(python **/scripts/qs/targets.py:*)",
       "Bash(python scripts/qs/next_step.py:*)",
       "Bash(python **/scripts/qs/next_step.py:*)",
       "Bash(python scripts/qs/cleanup_worktree.py:*)",

--- a/.cursor/agents/qs-create-plan.md
+++ b/.cursor/agents/qs-create-plan.md
@@ -30,6 +30,15 @@ python scripts/qs/context.py
 Parse the JSON. You'll get: `issue`, `title`, `branch`, `story_file`,
 `worktree`, `harness`. From here on, refer to these values.
 
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
 if you haven't this session.

--- a/.cursor/agents/qs-implement-setup-task.md
+++ b/.cursor/agents/qs-implement-setup-task.md
@@ -28,6 +28,17 @@ python scripts/qs/context.py
 Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
 `latest_review_fix`.
 
+
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). In this implement
+phase the labels must be resolved **before the first commit** — the
+first `--impacted` run fails otherwise (the gate is the backstop, not
+a parallel path).
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 if you haven't this session.
 
@@ -126,6 +137,13 @@ python scripts/qs/quality_gate.py        # full gate, on EXPLICIT request only
 ```
 
 Pass on a green gate; fix on red.
+
+**Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
+with `lane check FAILED` (the task's issue has a missing/incomplete
+lane declaration), ask the user which lane the task belongs to, run the
+exact `gh issue edit <N> --add-label ...` command the gate printed,
+then re-run the gate. Do this before the first commit — the gate fails
+until the declaration exists.
 
 **Changes to `tests/qs`-pinned non-Python files.** For change sets
 touching any `tests/qs`-pinned non-Python file (agent files, commands,

--- a/.cursor/agents/qs-implement-setup-task.md
+++ b/.cursor/agents/qs-implement-setup-task.md
@@ -28,7 +28,6 @@ python scripts/qs/context.py
 Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
 `latest_review_fix`.
 
-
 **Lane (QS-332).** Also capture `lane` from the context JSON, then read
 `docs/workflow/lanes/<lane>.md` — that file is this task's phase
 protocol. If `lane` is empty (a pre-existing worktree / legacy
@@ -39,6 +38,7 @@ labels (`gh issue edit <N> --add-label ...`). In this implement
 phase the labels must be resolved **before the first commit** — the
 first `--impacted` run fails otherwise (the gate is the backstop, not
 a parallel path).
+
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 if you haven't this session.
 
@@ -140,9 +140,11 @@ Pass on a green gate; fix on red.
 
 **Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
 with `lane check FAILED` (the task's issue has a missing/incomplete
-lane declaration), ask the user which lane the task belongs to, run the
-exact `gh issue edit <N> --add-label ...` command the gate printed,
-then re-run the gate. Do this before the first commit — the gate fails
+lane declaration), ask the user which lane the task belongs to, then
+apply the remediation the gate printed — its `gh issue edit <N>
+--remove-label`/`--add-label` commands run verbatim, plus the additions
+where the message says to substitute the user's chosen value — then
+re-run the gate. Do this before the first commit — the gate fails
 until the declaration exists.
 
 **Changes to `tests/qs`-pinned non-Python files.** For change sets

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -126,9 +126,11 @@ python scripts/qs/quality_gate.py        # full gate, on EXPLICIT request only
 
 **Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
 with `lane check FAILED` (the task's issue has a missing/incomplete
-lane declaration), ask the user which lane the task belongs to, run the
-exact `gh issue edit <N> --add-label ...` command the gate printed,
-then re-run the gate. Do this before the first commit — the gate fails
+lane declaration), ask the user which lane the task belongs to, then
+apply the remediation the gate printed — its `gh issue edit <N>
+--remove-label`/`--add-label` commands run verbatim, plus the additions
+where the message says to substitute the user's chosen value — then
+re-run the gate. Do this before the first commit — the gate fails
 until the declaration exists.
 
 If `--impacted` fails, fix the **code/tests** — never switch to the

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -27,6 +27,17 @@ python scripts/qs/context.py
 Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
 `latest_review_fix`. The story file is your spec (unless a review fix plan is active — see step 1b).
 
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). In this implement
+phase the labels must be resolved **before the first commit** — the
+first `--impacted` run fails otherwise (the gate is the backstop, not
+a parallel path).
+
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
 if you haven't this session.
@@ -112,6 +123,13 @@ user request:
 ```bash
 python scripts/qs/quality_gate.py        # full gate, on EXPLICIT request only
 ```
+
+**Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
+with `lane check FAILED` (the task's issue has a missing/incomplete
+lane declaration), ask the user which lane the task belongs to, run the
+exact `gh issue edit <N> --add-label ...` command the gate printed,
+then re-run the gate. Do this before the first commit — the gate fails
+until the declaration exists.
 
 If `--impacted` fails, fix the **code/tests** — never switch to the
 full gate to diagnose. `--impacted` self-heals; a manual

--- a/.cursor/agents/qs-review-task.md
+++ b/.cursor/agents/qs-review-task.md
@@ -29,6 +29,15 @@ Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
 review (run `/implement-task` or `/implement-setup-task` first,
 whichever the story scope requires).
 
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
 ## Phase protocol
 
 ### 1. Fetch the PR diff

--- a/.cursor/agents/qs-setup-task.md
+++ b/.cursor/agents/qs-setup-task.md
@@ -15,9 +15,10 @@ You are Phase 1 of the Quiet Solar pipeline. Your job is to create the
 GitHub issue + branch + worktree and hand off to a fresh session on the
 worktree where the user will invoke `/create-plan`.
 
-**Be fast and automatic. Do NOT analyze the input.** Don't read log
-files, don't research the codebase, don't propose designs. Pass the
-text through to the GitHub issue verbatim. Deep analysis is
+**Be fast and automatic, *except* the single lane/epic question when
+the declaration is missing (step 1b). Do NOT analyze the input.** Don't
+read log files, don't research the codebase, don't propose designs.
+Pass the text through to the GitHub issue verbatim. Deep analysis is
 `/create-plan`'s job.
 
 ## Input
@@ -39,7 +40,9 @@ Optional: `--no-worktree` (create branch only, skip worktree).
 python scripts/qs/fetch_issue.py --issue {{N}}
 ```
 
-Capture `issue_number`, `title`, `body`, `labels` from the JSON.
+Capture `issue_number`, `title`, `body`, `labels`, plus the lane axes
+`kind` / `target` / `scale` / `lane`, `parent_epic`, and
+`declaration_complete` from the JSON. Lane handling is step 1b.
 
 **Otherwise** (new issue):
 - **Plan file** — read it; use its title as issue title; body is the full
@@ -47,11 +50,50 @@ Capture `issue_number`, `title`, `body`, `labels` from the JSON.
 - **Free text** — extract a short title (first sentence or ~80 chars);
   body is the full text verbatim.
 
+First resolve the lane (step 1b), then create the issue with its
+labels — every task is born fully declared:
+
 ```bash
-python scripts/qs/create_issue.py --title "{{title}}" --body "{{body}}"
+python scripts/qs/create_issue.py --title "{{title}}" --body "{{body}}" --labels "{{labels}}"
 ```
 
+e.g. `--labels "kind:bug,target:product,scale:task"`. If a parent epic
+was declared, include a `Refs #{{epic}}` line in the issue body.
+
 Capture `issue_number` from the JSON output.
+
+### 1b. Lane declaration (QS-332 — the one permitted question)
+
+Every issue carries exactly one lane: `kind:*` + `target:*` +
+`scale:task` for tasks, `target:*` + `scale:epic` (and **no kind**) for
+epics. `scale:task` is the implicit default — never ask "task or
+epic?" separately — but it is always applied explicitly as a label.
+
+**Existing issue (`--issue N`):** if `declaration_complete` is `true`,
+use the declaration as-is and ask nothing (epic linkage included:
+whatever the body says, or nothing). If it is `false`, ask the user for
+exactly the missing axes in ONE question, and — since a question is
+being asked anyway — include the optional "part of an epic? (#N /
+none)" iff the body carries no parent-epic declaration. Then backfill
+the full label set onto the issue before proceeding:
+
+```bash
+gh issue edit {{N}} --add-label "{{missing labels}}"
+```
+
+(plus a `Refs #{{epic}}` body line via `gh issue edit {{N}} --body ...`
+if an epic was given). The issue on GitHub always ends up fully
+declared — `setup_task.py` refuses to proceed otherwise.
+
+**New issue (free text / plan file):** ask ONE question for the lane —
+the 6 options: `bug` / `feature` (product), `harness bug` /
+`harness feature` (factory), `epic product` / `epic factory` — plus the
+optional "part of an epic? (#N / none)". Skip the question **only when
+the user's request contains an explicit lane name or explicit axis
+values** ("bug", "harness feature", "kind:bug target:factory",
+"epic product", ...); anything else — however suggestive the text —
+means ask. This is a bright line, not text analysis, so the "do NOT
+analyze the input" rule stands.
 
 ### 2. Set up branch and worktree + emit launcher
 
@@ -108,7 +150,11 @@ no `tools:` change is needed here. See
 
 ## Hard rules
 
-- Do NOT analyze the input. The launcher must come within a few seconds.
+- Do NOT analyze the input. The launcher must come fast and
+  automatically, *except* the single lane/epic question when the
+  declaration is missing (step 1b). Only an explicit lane name or
+  explicit axis values in the user's request count as an answer —
+  never inferred ones.
 - Do NOT commit or push — setup-task only creates branches/worktrees.
 - Do NOT touch `legacy/**` — that's the retired per-task-rendering
   OpenCode pipeline (frozen historical code).

--- a/.cursor/agents/qs-setup-task.md
+++ b/.cursor/agents/qs-setup-task.md
@@ -95,7 +95,22 @@ values** ("bug", "harness feature", "kind:bug target:factory",
 means ask. This is a bright line, not text analysis, so the "do NOT
 analyze the input" rule stands.
 
-### 2. Set up branch and worktree + emit launcher
+### 1c. Epic lanes stop here (no branch, no worktree)
+
+If the resolved lane is `epic-product` or `epic-factory`, the issue is
+the deliverable: an epic has **no implement phase and no branch,
+worktree, or PR** (see
+[docs/epics/QS-321.md](../../docs/epics/QS-321.md)). Its output is a
+rationale document on `main` plus **child issues**.
+
+So for an epic: create/label the issue as above, then **skip step 2
+entirely** — do NOT run `setup_task.py`. Report the epic issue number
+and tell the user the next move is to decompose it into child tasks
+(each child is its own task lane, carrying `Refs #<epic>`; run
+setup-task on those). `setup_task.py` refuses an epic outright, so a
+slip here fails loudly rather than silently cutting a worktree.
+
+### 2. Set up branch and worktree + emit launcher (tasks only)
 
 One command does it all:
 

--- a/.github/ISSUE_TEMPLATE/bug-factory.yml
+++ b/.github/ISSUE_TEMPLATE/bug-factory.yml
@@ -1,0 +1,39 @@
+name: Bug (factory / dev pipeline)
+description: Report a bug in the development pipeline, agents, scripts, or quality gate
+labels: ["bug", "kind:bug", "target:factory", "scale:task", "area:dev-pipeline"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? How can we reproduce the issue? What was expected to happen?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Pipeline Surface
+      description: Which part of the factory is affected?
+      options:
+        - Quality gate (quality_gate.py)
+        - Agents / phase protocols
+        - Scripts (scripts/qs/)
+        - CI workflows (.github/)
+        - Docs (docs/workflow/, docs/agents/)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Output
+      description: Paste any relevant command output or logs
+      render: text
+
+  - type: input
+    id: parent_epic
+    attributes:
+      label: Parent epic
+      description: issue number of the epic this belongs to, e.g. 321 — leave empty if none

--- a/.github/ISSUE_TEMPLATE/bug-factory.yml
+++ b/.github/ISSUE_TEMPLATE/bug-factory.yml
@@ -1,6 +1,6 @@
 name: Bug (factory / dev pipeline)
 description: Report a bug in the development pipeline, agents, scripts, or quality gate
-labels: ["bug", "kind:bug", "target:factory", "scale:task", "area:dev-pipeline"]
+labels: ["kind:bug", "target:factory", "scale:task", "area:dev-pipeline"]
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/bug-product.yml
+++ b/.github/ISSUE_TEMPLATE/bug-product.yml
@@ -1,6 +1,6 @@
-name: Bug Report
-description: Report a bug or unexpected behavior
-labels: ["bug"]
+name: Bug (product)
+description: Report a bug or unexpected behavior in the Quiet Solar integration
+labels: ["bug", "kind:bug", "target:product", "scale:task"]
 body:
   - type: textarea
     id: description
@@ -28,10 +28,15 @@ body:
     validations:
       required: true
 
-
   - type: textarea
     id: logs
     attributes:
       label: Relevant Log Output
       description: Paste any relevant log output (debug level preferred)
       render: text
+
+  - type: input
+    id: parent_epic
+    attributes:
+      label: Parent epic
+      description: issue number of the epic this belongs to, e.g. 321 — leave empty if none

--- a/.github/ISSUE_TEMPLATE/bug-product.yml
+++ b/.github/ISSUE_TEMPLATE/bug-product.yml
@@ -1,6 +1,6 @@
 name: Bug (product)
 description: Report a bug or unexpected behavior in the Quiet Solar integration
-labels: ["bug", "kind:bug", "target:product", "scale:task"]
+labels: ["kind:bug", "target:product", "scale:task"]
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+# QS-332: blank web issues are disabled so every issue born through the
+# GitHub web UI carries its lane labels by construction. Known leak,
+# accepted (story D3): `gh issue create`, the REST/GraphQL API, bots and
+# transferred issues can still produce unlabelled issues; setup-task's
+# ask+backfill and the quality gate's declaration check are the safety
+# net there.
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/epic-factory.yml
+++ b/.github/ISSUE_TEMPLATE/epic-factory.yml
@@ -1,0 +1,23 @@
+name: Epic (factory / dev pipeline)
+description: A large dev-pipeline initiative decomposed into child tasks (no branch/worktree of its own)
+labels: ["scale:epic", "target:factory", "area:dev-pipeline"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What does the development pipeline gain when this epic is done?
+    validations:
+      required: true
+
+  - type: textarea
+    id: decomposition
+    attributes:
+      label: Decomposition sketch
+      description: Rough list of the child tasks you foresee (each becomes its own issue)
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context or references

--- a/.github/ISSUE_TEMPLATE/epic-product.yml
+++ b/.github/ISSUE_TEMPLATE/epic-product.yml
@@ -1,0 +1,23 @@
+name: Epic (product)
+description: A large product initiative decomposed into child tasks (no branch/worktree of its own)
+labels: ["scale:epic", "target:product"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What does the product gain when this epic is done?
+    validations:
+      required: true
+
+  - type: textarea
+    id: decomposition
+    attributes:
+      label: Decomposition sketch
+      description: Rough list of the child tasks you foresee (each becomes its own issue)
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or references

--- a/.github/ISSUE_TEMPLATE/feature-factory.yml
+++ b/.github/ISSUE_TEMPLATE/feature-factory.yml
@@ -1,0 +1,29 @@
+name: Feature (factory / dev pipeline)
+description: Suggest an enhancement to the development pipeline, agents, scripts, or quality gate
+labels: ["enhancement", "kind:feature", "target:factory", "scale:task", "area:dev-pipeline"]
+body:
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+      description: Describe the problem or need this enhancement addresses
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How do you envision this working?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context or references
+
+  - type: input
+    id: parent_epic
+    attributes:
+      label: Parent epic
+      description: issue number of the epic this belongs to, e.g. 321 — leave empty if none

--- a/.github/ISSUE_TEMPLATE/feature-factory.yml
+++ b/.github/ISSUE_TEMPLATE/feature-factory.yml
@@ -1,6 +1,6 @@
 name: Feature (factory / dev pipeline)
 description: Suggest an enhancement to the development pipeline, agents, scripts, or quality gate
-labels: ["enhancement", "kind:feature", "target:factory", "scale:task", "area:dev-pipeline"]
+labels: ["kind:feature", "target:factory", "scale:task", "area:dev-pipeline"]
 body:
   - type: textarea
     id: use_case

--- a/.github/ISSUE_TEMPLATE/feature-product.yml
+++ b/.github/ISSUE_TEMPLATE/feature-product.yml
@@ -1,6 +1,6 @@
 name: Feature (product)
 description: Suggest a new feature or enhancement for the Quiet Solar integration
-labels: ["enhancement", "kind:feature", "target:product", "scale:task"]
+labels: ["kind:feature", "target:product", "scale:task"]
 body:
   - type: textarea
     id: use_case

--- a/.github/ISSUE_TEMPLATE/feature-product.yml
+++ b/.github/ISSUE_TEMPLATE/feature-product.yml
@@ -1,6 +1,6 @@
-name: Feature Request
-description: Suggest a new feature or enhancement
-labels: ["enhancement"]
+name: Feature (product)
+description: Suggest a new feature or enhancement for the Quiet Solar integration
+labels: ["enhancement", "kind:feature", "target:product", "scale:task"]
 body:
   - type: textarea
     id: use_case
@@ -33,3 +33,9 @@ body:
     attributes:
       label: Additional Context
       description: Any other context, screenshots, or references
+
+  - type: input
+    id: parent_epic
+    attributes:
+      label: Parent epic
+      description: issue number of the epic this belongs to, e.g. 321 — leave empty if none

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -37,7 +37,7 @@ jobs:
               labels.push('area:person');
             if (/\bdashboards?\b/.test(text) || /\bui\b/.test(text))
               labels.push('area:ui');
-            if (/\bconfig[ _-]?flow\b/.test(text) || /\bconfig entr(y|ies)\b/.test(text))
+            if (/\bconfig[ _-]?flow\b/.test(text) || /\bconfig[ _-]?entr(y|ies)\b/.test(text))
               labels.push('area:config');
             if (/\b(harness|pipeline|agents?|workflow|worktree|quality gate|lanes?|launcher|testmon)\b/.test(text))
               labels.push('area:dev-pipeline');

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -13,26 +13,34 @@ jobs:
       - name: Label by keywords
         uses: actions/github-script@v7
         with:
+          # QS-332 (#293): word-boundary regexes instead of naive
+          # substring matching — 'ev' no longer fires on "dev",
+          # 'ui' no longer fires on "quiet", and bare 'config'/'setup'
+          # (which matched every factory issue) are narrowed to
+          # config-flow/config-entry phrases. New: area:dev-pipeline
+          # for harness/pipeline keywords.
           script: |
             const title = context.payload.issue.title.toLowerCase();
             const body = (context.payload.issue.body || '').toLowerCase();
             const text = title + ' ' + body;
             const labels = [];
 
-            if (text.includes('solver') || text.includes('constraint'))
+            if (/\bsolver\b/.test(text) || /\bconstraints?\b/.test(text))
               labels.push('area:solver');
-            if (text.includes('charger') || text.includes('ocpp') || text.includes('wallbox'))
+            if (/\bchargers?\b/.test(text) || /\bocpp\b/.test(text) || /\bwallbox\b/.test(text))
               labels.push('area:charger');
-            if (text.includes('car') || text.includes('vehicle') || text.includes('ev'))
+            if (/\bcars?\b/.test(text) || /\bvehicles?\b/.test(text) || /\bev\b/.test(text))
               labels.push('area:car');
-            if (text.includes('battery') || text.includes('storage'))
+            if (/\bbatter(y|ies)\b/.test(text) || /\bstorage\b/.test(text))
               labels.push('area:battery');
-            if (text.includes('person') || text.includes('presence'))
+            if (/\bpersons?\b/.test(text) || /\bpresence\b/.test(text))
               labels.push('area:person');
-            if (text.includes('dashboard') || text.includes('ui'))
+            if (/\bdashboards?\b/.test(text) || /\bui\b/.test(text))
               labels.push('area:ui');
-            if (text.includes('config') || text.includes('setup'))
+            if (/\bconfig[ _-]?flow\b/.test(text) || /\bconfig entr(y|ies)\b/.test(text))
               labels.push('area:config');
+            if (/\b(harness|pipeline|agents?|workflow|worktree|quality gate|lanes?|launcher|testmon)\b/.test(text))
+              labels.push('area:dev-pipeline');
 
             if (labels.length > 0) {
               await github.rest.issues.addLabels({

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -232,6 +232,35 @@ jobs:
           coverage combine shard-data
           coverage report --show-missing --fail-under=100
 
+  # QS-332 (B1): the lane check as its own job — NOT a step in the
+  # existing jobs, whose tokens are deliberately `contents: read`-only.
+  # It needs `issues: read` to fetch the task issue's lane labels.
+  # `--branch "${{ github.head_ref }}"` is load-bearing: a pull_request
+  # checkout is a detached merge ref where `git branch --show-current`
+  # is empty, which would silently no-op the check (review N-1).
+  # Declaration-missing or a `gh` failure exits non-zero (CI fails
+  # closed); a cross-target diff warns into GITHUB_STEP_SUMMARY and
+  # never fails.
+  lane-check:
+    name: Lane Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # The change set is origin/main...HEAD — the fetch must reach
+          # the merge base.
+          fetch-depth: 0
+
+      - name: Lane check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python scripts/qs/quality_gate.py --lane-check
+          --branch "${{ github.head_ref }}"
+
   hacs-validate:
     name: HACS Validation
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -254,12 +254,26 @@ jobs:
           # the merge base.
           fetch-depth: 0
 
+      # Same interpreter as every other job (review-fix #01 must-fix:
+      # the system Python is 3.12 and quality_gate.py uses 3.14-only
+      # syntax — without this pin the fail-closed job blocks every PR).
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      # HEAD_REF goes through an env var, never direct `${{ }}`
+      # interpolation into `run:` (review-fix #01 must-fix): branch
+      # names may contain `"`/`$`/backtick and `head_ref` is
+      # attacker-controlled on fork PRs — direct expansion is script
+      # injection with GH_TOKEN in env.
       - name: Lane check
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.head_ref }}
         run: >-
           python scripts/qs/quality_gate.py --lane-check
-          --branch "${{ github.head_ref }}"
+          --branch "$HEAD_REF"
 
   hacs-validate:
     name: HACS Validation

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,9 @@ jobs:
             recent activity. It will be closed in 30 days if no further activity occurs.
           days-before-stale: 30
           days-before-close: 30
-          exempt-issue-labels: pinned,security,critical
+          # QS-332: epics live as long as their children — never staled.
+          # PR exemptions unchanged (epics have no PRs).
+          exempt-issue-labels: pinned,security,critical,scale:epic
           exempt-pr-labels: pinned,security,critical
           stale-issue-label: stale
           stale-pr-label: stale

--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,4 @@ custom_components/volkswagencarnet
 # a SIGKILL or OOM kill can leave behind, and any `.json.bak` an older
 # revision of the writer may have left in an existing worktree.
 .claude/settings.local.json*
+.lane_check_cache

--- a/.opencode/agents/qs-create-plan.md
+++ b/.opencode/agents/qs-create-plan.md
@@ -66,6 +66,15 @@ python scripts/qs/context.py
 Parse the JSON. You'll get: `issue`, `title`, `branch`, `story_file`,
 `worktree`, `harness`. From here on, refer to these values.
 
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
 if you haven't this session.

--- a/.opencode/agents/qs-implement-setup-task.md
+++ b/.opencode/agents/qs-implement-setup-task.md
@@ -82,6 +82,17 @@ python scripts/qs/context.py
 Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
 `latest_review_fix`.
 
+
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). In this implement
+phase the labels must be resolved **before the first commit** — the
+first `--impacted` run fails otherwise (the gate is the backstop, not
+a parallel path).
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 if you haven't this session.
 
@@ -180,6 +191,13 @@ python scripts/qs/quality_gate.py        # full gate, on EXPLICIT request only
 ```
 
 Pass on a green gate; fix on red.
+
+**Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
+with `lane check FAILED` (the task's issue has a missing/incomplete
+lane declaration), ask the user which lane the task belongs to, run the
+exact `gh issue edit <N> --add-label ...` command the gate printed,
+then re-run the gate. Do this before the first commit — the gate fails
+until the declaration exists.
 
 **Changes to `tests/qs`-pinned non-Python files.** For change sets
 touching any `tests/qs`-pinned non-Python file (agent files, commands,

--- a/.opencode/agents/qs-implement-setup-task.md
+++ b/.opencode/agents/qs-implement-setup-task.md
@@ -82,7 +82,6 @@ python scripts/qs/context.py
 Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
 `latest_review_fix`.
 
-
 **Lane (QS-332).** Also capture `lane` from the context JSON, then read
 `docs/workflow/lanes/<lane>.md` — that file is this task's phase
 protocol. If `lane` is empty (a pre-existing worktree / legacy
@@ -93,6 +92,7 @@ labels (`gh issue edit <N> --add-label ...`). In this implement
 phase the labels must be resolved **before the first commit** — the
 first `--impacted` run fails otherwise (the gate is the backstop, not
 a parallel path).
+
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 if you haven't this session.
 
@@ -194,9 +194,11 @@ Pass on a green gate; fix on red.
 
 **Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
 with `lane check FAILED` (the task's issue has a missing/incomplete
-lane declaration), ask the user which lane the task belongs to, run the
-exact `gh issue edit <N> --add-label ...` command the gate printed,
-then re-run the gate. Do this before the first commit — the gate fails
+lane declaration), ask the user which lane the task belongs to, then
+apply the remediation the gate printed — its `gh issue edit <N>
+--remove-label`/`--add-label` commands run verbatim, plus the additions
+where the message says to substitute the user's chosen value — then
+re-run the gate. Do this before the first commit — the gate fails
 until the declaration exists.
 
 **Changes to `tests/qs`-pinned non-Python files.** For change sets

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -65,6 +65,17 @@ python scripts/qs/context.py
 Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
 `latest_review_fix`. The story file is your spec (unless a review fix plan is active — see step 1b).
 
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). In this implement
+phase the labels must be resolved **before the first commit** — the
+first `--impacted` run fails otherwise (the gate is the backstop, not
+a parallel path).
+
 Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
 if you haven't this session.
@@ -150,6 +161,13 @@ user request:
 ```bash
 python scripts/qs/quality_gate.py        # full gate, on EXPLICIT request only
 ```
+
+**Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
+with `lane check FAILED` (the task's issue has a missing/incomplete
+lane declaration), ask the user which lane the task belongs to, run the
+exact `gh issue edit <N> --add-label ...` command the gate printed,
+then re-run the gate. Do this before the first commit — the gate fails
+until the declaration exists.
 
 If `--impacted` fails, fix the **code/tests** — never switch to the
 full gate to diagnose. `--impacted` self-heals; a manual

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -164,9 +164,11 @@ python scripts/qs/quality_gate.py        # full gate, on EXPLICIT request only
 
 **Lane-declaration FAIL (QS-332 ask-and-backfill).** If the gate fails
 with `lane check FAILED` (the task's issue has a missing/incomplete
-lane declaration), ask the user which lane the task belongs to, run the
-exact `gh issue edit <N> --add-label ...` command the gate printed,
-then re-run the gate. Do this before the first commit — the gate fails
+lane declaration), ask the user which lane the task belongs to, then
+apply the remediation the gate printed — its `gh issue edit <N>
+--remove-label`/`--add-label` commands run verbatim, plus the additions
+where the message says to substitute the user's chosen value — then
+re-run the gate. Do this before the first commit — the gate fails
 until the declaration exists.
 
 If `--impacted` fails, fix the **code/tests** — never switch to the

--- a/.opencode/agents/qs-review-task.md
+++ b/.opencode/agents/qs-review-task.md
@@ -61,7 +61,6 @@ Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
 review (run `implement-task` or `implement-setup-task` first,
 whichever the story scope requires).
 
-
 **Lane (QS-332).** Also capture `lane` from the context JSON, then read
 `docs/workflow/lanes/<lane>.md` — that file is this task's phase
 protocol. If `lane` is empty (a pre-existing worktree / legacy
@@ -70,6 +69,7 @@ in-flight task — every new task is labelled at birth), fall back to
 and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
 with respect to the gate, so it may proceed on the fallback.
+
 ## Phase protocol
 
 ### 1. Fetch the PR diff

--- a/.opencode/agents/qs-review-task.md
+++ b/.opencode/agents/qs-review-task.md
@@ -61,6 +61,15 @@ Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
 review (run `implement-task` or `implement-setup-task` first,
 whichever the story scope requires).
 
+
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
 ## Phase protocol
 
 ### 1. Fetch the PR diff

--- a/.opencode/agents/qs-setup-task.md
+++ b/.opencode/agents/qs-setup-task.md
@@ -50,9 +50,10 @@ You are Phase 1 of the Quiet Solar pipeline. Your job is to create the
 GitHub issue + branch + worktree and hand off to a fresh session on the
 worktree where the user will activate `qs-create-plan`.
 
-**Be fast and automatic. Do NOT analyze the input.** Don't read log
-files, don't research the codebase, don't propose designs. Pass the
-text through to the GitHub issue verbatim. Deep analysis is
+**Be fast and automatic, *except* the single lane/epic question when
+the declaration is missing (step 1b). Do NOT analyze the input.** Don't
+read log files, don't research the codebase, don't propose designs.
+Pass the text through to the GitHub issue verbatim. Deep analysis is
 `qs-create-plan`'s job.
 
 ## Input
@@ -74,7 +75,9 @@ Optional: `--no-worktree` (create branch only, skip worktree).
 python scripts/qs/fetch_issue.py --issue {{N}}
 ```
 
-Capture `issue_number`, `title`, `body`, `labels` from the JSON.
+Capture `issue_number`, `title`, `body`, `labels`, plus the lane axes
+`kind` / `target` / `scale` / `lane`, `parent_epic`, and
+`declaration_complete` from the JSON. Lane handling is step 1b.
 
 **Otherwise** (new issue):
 - **Plan file** — read it; use its title as issue title; body is the full
@@ -82,11 +85,50 @@ Capture `issue_number`, `title`, `body`, `labels` from the JSON.
 - **Free text** — extract a short title (first sentence or ~80 chars);
   body is the full text verbatim.
 
+First resolve the lane (step 1b), then create the issue with its
+labels — every task is born fully declared:
+
 ```bash
-python scripts/qs/create_issue.py --title "{{title}}" --body "{{body}}"
+python scripts/qs/create_issue.py --title "{{title}}" --body "{{body}}" --labels "{{labels}}"
 ```
 
+e.g. `--labels "kind:bug,target:product,scale:task"`. If a parent epic
+was declared, include a `Refs #{{epic}}` line in the issue body.
+
 Capture `issue_number` from the JSON output.
+
+### 1b. Lane declaration (QS-332 — the one permitted question)
+
+Every issue carries exactly one lane: `kind:*` + `target:*` +
+`scale:task` for tasks, `target:*` + `scale:epic` (and **no kind**) for
+epics. `scale:task` is the implicit default — never ask "task or
+epic?" separately — but it is always applied explicitly as a label.
+
+**Existing issue (`--issue N`):** if `declaration_complete` is `true`,
+use the declaration as-is and ask nothing (epic linkage included:
+whatever the body says, or nothing). If it is `false`, ask the user for
+exactly the missing axes in ONE question, and — since a question is
+being asked anyway — include the optional "part of an epic? (#N /
+none)" iff the body carries no parent-epic declaration. Then backfill
+the full label set onto the issue before proceeding:
+
+```bash
+gh issue edit {{N}} --add-label "{{missing labels}}"
+```
+
+(plus a `Refs #{{epic}}` body line via `gh issue edit {{N}} --body ...`
+if an epic was given). The issue on GitHub always ends up fully
+declared — `setup_task.py` refuses to proceed otherwise.
+
+**New issue (free text / plan file):** ask ONE question for the lane —
+the 6 options: `bug` / `feature` (product), `harness bug` /
+`harness feature` (factory), `epic product` / `epic factory` — plus the
+optional "part of an epic? (#N / none)". Skip the question **only when
+the user's request contains an explicit lane name or explicit axis
+values** ("bug", "harness feature", "kind:bug target:factory",
+"epic product", ...); anything else — however suggestive the text —
+means ask. This is a bright line, not text analysis, so the "do NOT
+analyze the input" rule stands.
 
 ### 2. Set up branch and worktree + emit launcher
 
@@ -163,7 +205,11 @@ explicit `LSP` tool (diagnostics + navigation). See
 
 ## Hard rules
 
-- Do NOT analyze the input. The launcher must come within a few seconds.
+- Do NOT analyze the input. The launcher must come fast and
+  automatically, *except* the single lane/epic question when the
+  declaration is missing (step 1b). Only an explicit lane name or
+  explicit axis values in the user's request count as an answer —
+  never inferred ones.
 - Do NOT edit any repository files. Setup-task creates the GitHub
   issue, branch, and worktree only — no source-file commits.
   (`scripts/worktree-setup.sh` performs the initial `git push -u` to

--- a/.opencode/agents/qs-setup-task.md
+++ b/.opencode/agents/qs-setup-task.md
@@ -130,7 +130,22 @@ values** ("bug", "harness feature", "kind:bug target:factory",
 means ask. This is a bright line, not text analysis, so the "do NOT
 analyze the input" rule stands.
 
-### 2. Set up branch and worktree + emit launcher
+### 1c. Epic lanes stop here (no branch, no worktree)
+
+If the resolved lane is `epic-product` or `epic-factory`, the issue is
+the deliverable: an epic has **no implement phase and no branch,
+worktree, or PR** (see
+[docs/epics/QS-321.md](../../docs/epics/QS-321.md)). Its output is a
+rationale document on `main` plus **child issues**.
+
+So for an epic: create/label the issue as above, then **skip step 2
+entirely** — do NOT run `setup_task.py`. Report the epic issue number
+and tell the user the next move is to decompose it into child tasks
+(each child is its own task lane, carrying `Refs #<epic>`; run
+setup-task on those). `setup_task.py` refuses an epic outright, so a
+slip here fails loudly rather than silently cutting a worktree.
+
+### 2. Set up branch and worktree + emit launcher (tasks only)
 
 One command does it all:
 

--- a/docs/epics/QS-321.md
+++ b/docs/epics/QS-321.md
@@ -194,13 +194,22 @@ itself agent-body text.)
 
 ## The two targets (axis 1)
 
-### The rule: a task is never both
+### The rule: exactly one declared target (amended by QS-332)
 
-**A single task has exactly one target.** A change that needs both is two
-tasks, and must be split. This is a **hard boundary**; the remedy is
-`split the issue`, never an override flag.
+**A single task has exactly one target** — declared at creation,
+immutable. *Amended in child A / QS-332 (user ruling 2026-08-03,
+recorded verbatim): purpose, not path, is the classifier; a
+product-declared fix that must also enhance a test tool stays a product
+task.* The original hard-stop enforcement is superseded by a
+**visibility rule**: the quality gate FAILS a missing declaration, and
+a cross-target diff produces a **loud warning** — every crossing file
+listed, the split recommendation always printed — that never fails the
+gate. Splitting remains the *recommended* remedy for a substantial mix
+("substantial" is human judgment, not a computed threshold), at human
+discretion, never an override flag.
 
-This is not tidiness. It is forced by self-reference:
+The tension that motivated the original hard boundary still stands and
+is why the tripwire exists at all:
 
 > A factory change takes effect **one session later** — you are editing the
 > thing that is currently running, so the new behaviour does not exist until
@@ -212,7 +221,7 @@ tweak riding in a product PR is waved through by a coverage gate that says
 nothing about it; a product fix riding in a factory PR skips the gate that
 actually matters.
 
-**Scope of the hard boundary: `scale:task` only.** An epic never has a
+**Scope of the visibility rule: `scale:task` only.** An epic never has a
 diff, so there is nothing to stop; and epic rationale documents
 (`docs/epics/`) are **target-neutral by rule** — they are the *output of
 classifying*, not a classified surface. Without this rule a
@@ -281,16 +290,21 @@ Two further factory-prompt properties: **changes land one session late**
 tail), and **prompt-context cost** — every line added to an agent body is
 paid on every invocation, forever; additions must justify their rent.
 
-### Consequences of the hard boundary
+### Consequences of the declared target (amended by QS-332)
 
 - `target` is **declared at task creation** and immutable for the task's
-  life. It is never inferred from paths.
-- Touching paths outside the declared target is a **hard stop** whose
-  message names the remedy and prints the split procedure.
+  life. It is never inferred from paths. (Unchanged by the amendment.)
+- Touching paths outside the declared target **warns loudly and
+  surfaces** (gate stderr, CI step summary, a machine-injected `## Lane
+  note` in the PR body) — it never fails the gate. Verify the crossing
+  files serve the declared purpose; a path that *keeps* warning wrongly
+  earns a `targets.py` carve-out PR.
 - **`split the issue` is a documented manual procedure, not a tool**: the
-  hard-stop message prints the `gh issue create` incantation (title,
-  target label, back-link); tooling is built only if real friction is
-  observed. The requirement is the boundary; a split script is speculative.
+  warning prints the split recommendation, and the manual incantation
+  stays alive — `gh issue create` with the title, the other target's
+  labels, and a back-link to the original issue; then move those files'
+  changes to the new task's branch. Tooling is built only if real
+  friction is observed; a split script is speculative.
 - **Misdeclared ≠ mixed.** A task declared `target:product` that turns out
   to be pure factory work has nothing to split — the remedy is
   **close-and-refile** (or a sanctioned re-label while no commit exists
@@ -387,10 +401,11 @@ consequences, stated so nobody trips on them:
 
 - `kind:*` / `target:*` labels on wave-1 children are retro-applied by A
   (aspirational until then).
-- `Refs #321` in each child's PR body is added **by hand** (`gh pr edit`)
-  until child A's link mode merges — `create_pr.py` cannot emit it before
-  then (defect 1). The `Fixes #<child>` line for the child's *own* issue
-  is correct and stands.
+- `Refs #321` in each child's PR body **was** added by hand (`gh pr
+  edit`) until child A's link mode merged — since QS-332, `create_pr.py`
+  auto-appends `Refs #<epic>` toward the parent epic declared in the
+  child issue's body (defect 1 resolved). The `Fixes #<child>` line for
+  the child's *own* issue is correct and stands.
 
 ### Wave 1 — RESTRUCTURED AT FILING TIME (2026-08-02) — the lane model
 
@@ -455,7 +470,8 @@ Implementation notes for whoever opens a child:
   `.claude/settings.json` — which is `tests/qs`-pinned, so run
   `--quick tests/qs`.
 - Every child's PR body must link this document and carry `Refs #321`
-  (by hand until A lands — see bootstrap above).
+  (auto-appended by `create_pr.py` since A landed — see bootstrap
+  above).
 - Agent-body edits go to all three harness dirs (co-modification is
   enforced).
 

--- a/docs/stories/QS-332.story.md
+++ b/docs/stories/QS-332.story.md
@@ -209,16 +209,23 @@ exact lane labels by construction require **one form per lane**:
 
 | form | replaces / origin | fixed labels |
 |---|---|---|
-| `bug-product.yml` | reworked `bug_report.yml` (keeps its body fields) | `bug, kind:bug, target:product, scale:task` |
-| `feature-product.yml` | reworked `feature_request.yml` (keeps its body fields) | `enhancement, kind:feature, target:product, scale:task` |
-| `bug-factory.yml` | new (harness bug) | `bug, kind:bug, target:factory, scale:task, area:dev-pipeline` |
-| `feature-factory.yml` | new (harness feature) | `enhancement, kind:feature, target:factory, scale:task, area:dev-pipeline` |
+| `bug-product.yml` | reworked `bug_report.yml` (keeps its body fields) | `kind:bug, target:product, scale:task` |
+| `feature-product.yml` | reworked `feature_request.yml` (keeps its body fields) | `kind:feature, target:product, scale:task` |
+| `bug-factory.yml` | new (harness bug) | `kind:bug, target:factory, scale:task, area:dev-pipeline` |
+| `feature-factory.yml` | new (harness feature) | `kind:feature, target:factory, scale:task, area:dev-pipeline` |
 | `epic-product.yml` | new | `scale:epic, target:product` |
 | `epic-factory.yml` | new | `scale:epic, target:factory, area:dev-pipeline` |
 
-The legacy `bug`/`enhancement` labels are kept on the task forms
-(harmless, and existing tooling/filters keep working) even though their
-only code consumer, `story_type`, is deleted. Every **task** form gains
+**Amended by review fix #03 (user decision).** The v5 plan kept the
+legacy `bug`/`enhancement` labels on the task forms as harmless. Review
+round 3 showed they are not: the web path emitted them while the agent
+path (`--labels "kind:bug,target:product,scale:task"`) did not, so the
+same lane produced **two different label sets** depending on the door it
+came through, skewing any filter keyed on the plain labels. They are now
+dropped from all four task forms — both birth paths produce the axis-only
+set. Their only code consumer, `story_type`, is deleted by this task
+anyway. Pinned as *gone* (not merely absent) in
+`tests/qs/test_issue_templates.py`. Every **task** form gains
 an optional input `Parent epic` (description: "issue number of the epic
 this belongs to, e.g. 321 — leave empty if none"); the parent-epic
 parser (D4) prefers this structured section. Epic forms have no

--- a/docs/stories/QS-332.story.md
+++ b/docs/stories/QS-332.story.md
@@ -1,0 +1,874 @@
+# QS-332 — Create the 6 workflow lanes: identical copies, declared at setup, separated by construction
+
+- **Issue**: [#332](https://github.com/tmenguy/quiet-solar/issues/332)
+- **Epic**: [#321](https://github.com/tmenguy/quiet-solar/issues/321) — child A.
+  `Refs #321` reaches this PR's body via the task's own auto-`Refs`
+  (task 6 lands before the PR is opened and `create_pr.py` runs from
+  the worktree, so the unmerged code already applies); task 1 verifies
+  #332's issue body carries the parent-epic declaration it needs. Manual
+  `gh pr edit` remains the fallback only if the PR is somehow opened
+  before task 6.
+- **Also closes**: [#293](https://github.com/tmenguy/quiet-solar/issues/293)
+  (issue-triage keyword fixes — implemented here, `Fixes #293` in the PR
+  summary; GitHub closing keywords work anywhere in the body, so no
+  `create_pr.py` change is needed for the extra close)
+- **Branch**: `QS_332` · **Next phase**: `implement-setup-task` (every
+  touched path is factory/dev-env; `tests/test_quality_gate.py` is
+  factory by the purpose rule — see D5)
+- **Status**: draft v5 — review round 2 folded in (4 reviewers +
+  delta-auditor, 28 deduped findings; see Adversarial Review Notes)
+
+## Problem
+
+Today there is exactly one pipeline shape and the only branch point is
+path-based, inferred late at plan time (`implement-task` vs
+`implement-setup-task`). Epic #321 established three axes — `target`
+(product/factory), `kind` (bug/feature), `scale` (task/epic) — and a lane
+model: 6 lanes = {bug, feature, epic} × {product, factory}. None of it
+exists in the repo yet:
+
+1. No lane files; agents carry their protocol inline and read no
+   per-lane document.
+2. No declaration at setup: `qs-setup-task` creates issues with **zero
+   labels** (`create_issue.py` is invoked without `--labels`); the two
+   GitHub issue forms emit only legacy `bug`/`enhancement`;
+   `context.py` fetches only `title` and drops labels entirely.
+3. No visibility: nothing surfaces a factory-lane task touching
+   product files or vice versa (the epic doc's "The two targets"
+   originally framed this as a hard boundary — that stance is amended
+   by this task's B6; the *visibility* need stands).
+4. Safety defects: `create_pr.py` hardcodes `Fixes #{issue}`
+   ([create_pr.py:73](../../scripts/qs/create_pr.py)) so a child PR
+   toward an epic would auto-close it; the stale bot's exemptions lack
+   `scale:epic` ([stale.yml:24](../../.github/workflows/stale.yml)); the
+   issue-triage workflow labels by naive substring (`'ev'` matches
+   "dev" → `area:car`, `'ui'` matches "quiet", `'config'`/`'setup'`
+   matches every factory issue) — pre-existing issue #293.
+5. Dead code: `fetch_issue.py` derives `story_type` that nothing
+   consumes, and its `enhancement/feature` branch is a no-op (both arms
+   yield `"feature"`).
+
+## Goal
+
+Create the lane **structure**. The lane *content* is
+behaviour-preserving by construction (byte-identical copies of today's
+flow; divergence happens later, one PR per lane, #335–#340). The task
+ships **six enumerated behaviour changes** — nothing else changes
+behaviour:
+
+- **B1** — the quality gate gains the lane check (`--impacted`, full
+  gate, and a new CI job): a **missing declaration fails**; a
+  **cross-target diff warns loudly but never fails** — user ruling
+  2026-08-03: purpose, not path, is the classifier; a product-declared
+  fix that must also enhance a test tool stays a product task. The
+  warning lists the crossing files and always prints the
+  split-recommendation text ("substantial" is human judgment, not a
+  computed threshold — review R2-09).
+- **B2** — `setup_task.py` refuses an undeclared/inconsistent issue;
+  the setup agent asks for (and backfills) missing declarations.
+- **B3** — `.github/ISSUE_TEMPLATE/` becomes 6 lane forms (+
+  `config.yml` disabling blank web issues).
+- **B4** — workflow-bot fixes: `issue-triage.yml` labels by
+  word-boundary regex and gains the `area:dev-pipeline` mapping
+  (#293); `stale.yml` exempts `scale:epic` (folded here — review
+  delta I-1: the enumeration must be exhaustive).
+- **B5** — `create_pr.py` auto-appends `Refs #<epic>` toward a declared
+  parent epic (`Fixes` toward the PR's own issue unchanged) **and
+  machine-injects the "Lane note"** section into the PR body when the
+  diff crosses the declared target (review N-4 — no prompt-obeyed
+  relay).
+- **B6** — `docs/epics/QS-321.md` is amended (normal-PR path; the doc
+  is target-neutral): the "hard boundary / split the issue" enforcement
+  becomes the visibility rule of B1. `target` remains declared,
+  immutable, exactly one per task; what changes is the tripwire's
+  action — warn-and-surface instead of fail. Splitting remains the
+  *recommended* remedy for substantial mixes, at human discretion. The
+  prompt-specific caveat stands unweakened: factory *prompt* changes
+  still take effect one session later and still carry their own
+  verification protocol (a later lane PR's concern).
+
+Plus behaviour-neutral structure: 6 lane files + agents read their
+lane; axes labels always present on every new issue (implicit
+`scale:task` at the CLI, explicit as a label); `context.py` exposes all
+axes; retro-labels; `story_type` deleted.
+
+Out of scope (later lane PRs / epic waves): any per-lane divergence
+(reproduce-first bug flow, factory gate profiles, epic decompose
+orchestrator), dedicated per-lane agents, `split_issue.py` tooling,
+renaming `implement-setup-task`, consolidation of the *other* divergent
+path-list consumers onto `targets.py` (this task creates the mapping
+and wires the gate; #338 and later lane PRs migrate the rest).
+
+## Design
+
+### D1 — The six labels and the lane vocabulary
+
+Six GitHub labels (created once via `gh label create --force` —
+idempotent on re-run — recorded in the task breakdown): `kind:bug`,
+`kind:feature`, `target:product`, `target:factory`, `scale:task`,
+`scale:epic`.
+
+Invariants (from the epic, decisions confirmed in planning):
+
+- A **task** carries exactly one `kind:*`, one `target:*`, and
+  `scale:task`. An **epic** carries one `target:*` and `scale:epic`,
+  and **no kind** (an epic has no kind of its own).
+- `scale:task` is the **implicit CLI default** (you never have to say
+  "task") but is **always applied explicitly as a label** — user
+  decision: kind, target and scale are always properly set on the
+  GitHub issue.
+- Lane name = `{kind}-{target}` for tasks, `epic-{target}` for epics —
+  exactly the 6 lane file basenames.
+- The declaration-validity rule is implemented **exactly once**:
+  `targets.py::validate_declaration(labels)` (D5), consumed by
+  `fetch_issue.py`, `setup_task.py`, and the quality gate — three
+  touchpoints, one truth table (review SG-R1).
+- Note: the `kind:` GitHub label namespace does not collide with the
+  `kind:` frontmatter taxonomy of `docs/agents/` (concept/principle/…)
+  — different systems; called out so nobody "fixes" it.
+
+### D2 — Lane files: `docs/workflow/lanes/`
+
+Six files: `bug-product.md`, `bug-factory.md`, `feature-product.md`,
+`feature-factory.md`, `epic-product.md`, `epic-factory.md`. Each is a
+**byte-for-byte copy of [phase-protocols.md](../workflow/phase-protocols.md)**.
+Interpretation recorded once so #335–#340 don't relitigate it (review
+SG-C2): "today's flow" = the per-phase contract document
+`phase-protocols.md` and only it; `overview.md` /
+`adversarial-review.md` are cross-cutting architecture, lane-invariant
+by default — a lane PR that needs to diverge review behaviour writes
+that divergence into its lane file. `phase-protocols.md` itself stays
+in place and stays authoritative until lanes diverge (removing it would
+break the [test_quality_gate.py](../../tests/test_quality_gate.py)
+step-5 string pin and the qs-review-task reference).
+
+**Identity is enforced, divergence is an allowlist** (review PC-01 +
+PC-03): `tests/qs/docs/test_lanes.py` asserts each lane file
+byte-identical to `phase-protocols.md` **unless** its basename is in a
+`DIVERGED` set (empty at merge). Each lane PR's first act is adding
+itself to `DIVERGED`. This makes AC-1 machine-verified and closes the
+7-copy silent-drift window between this PR and the last lane PR.
+Byte-identity has a known cosmetic cost, accepted and pre-authorized
+(review DP2-06): relative links inside the copies resolve wrong one
+directory deeper; no repo test validates relative links under
+`docs/workflow/` (verified — the only doc-shape tests are the H2/glob
+pins named here), and each lane PR may fix its own file's links when it
+diverges. Do **not** "fix" the links in this task — that breaks
+identity.
+
+**"Agents stay shared and read their lane"**: each **orchestrator**
+body (qs-create-plan, qs-implement-task, qs-implement-setup-task,
+qs-review-task — ×3 harness dirs) gains one early step, written as
+prose (no template notation — static agents, no per-task rendering):
+read `docs/workflow/lanes/<lane>.md` where `<lane>` is the `lane` field
+from `context.py`. If `lane` is empty, fall back to
+`phase-protocols.md` and surface the backfill guidance (the D5 step-3
+message). **qs-finish-task is deliberately excluded** (review SG2-03):
+it has no lane-sensitive behaviour while lanes are identical (it
+verifies CI, merges, cleans up), and wiring it now would be a step with
+no reader; the exclusion is recorded here so a lane PR that diverges
+finish behaviour knows to add the wiring then. Empty-lane population is
+**pre-existing worktrees / legacy in-flight tasks only** — every new
+task is labelled at birth (D3). Interplay with the gate (review Q2):
+read-only phases (create-plan, review) may proceed on the fallback;
+implement phases must resolve the labels **before their first commit**,
+because the first `--impacted` run fails otherwise — the gate is the
+backstop, not a parallel path. qs-setup-task runs on main *before* a
+lane exists, so it gets the declaration step (D3) instead of a
+lane-read.
+
+`docs/workflow/overview.md` gains a short "Lanes" note inside the
+existing **Phase routing** H2. (Not load-bearing:
+[test_overview_structure.py](../../tests/qs/docs/test_overview_structure.py)
+pins only one H2 adjacency pair — "Adversarial review" immediately
+followed by the QS-175 section — so a new H2 elsewhere would pass; we
+keep the note in-section anyway because routing prose belongs in the
+routing section.)
+
+Known test hole to fix while here:
+[test_workflow_no_desktop_fallback_by_necessity.py](../../tests/qs/docs/test_workflow_no_desktop_fallback_by_necessity.py)
+globs `docs/workflow/*.md` non-recursively (line 50) and would silently
+skip lane files → extend to a recursive glob.
+
+The slash-command fallbacks (`.claude/commands/{create-plan,
+implement-task, implement-setup-task, review-task}.md`) are thin
+delegating wrappers — they inherit the agents' new lane-read step and
+need no edit; `.claude/commands/setup-task.md` is touched only if its
+wording contradicts the declaration step (review dev-proxy R1).
+
+### D3 — Declare at every entry point
+
+An issue is born in exactly one lane, whichever door it comes through.
+Three entry paths:
+
+**Path 1 — GitHub web: 6 lane issue forms.** Rework
+`.github/ISSUE_TEMPLATE/` so each of the 6 artifacts is one click away.
+Mechanical constraint that forces the shape: GitHub issue forms attach
+**fixed** labels per template — a dropdown cannot change labels — so
+exact lane labels by construction require **one form per lane**:
+
+| form | replaces / origin | fixed labels |
+|---|---|---|
+| `bug-product.yml` | reworked `bug_report.yml` (keeps its body fields) | `bug, kind:bug, target:product, scale:task` |
+| `feature-product.yml` | reworked `feature_request.yml` (keeps its body fields) | `enhancement, kind:feature, target:product, scale:task` |
+| `bug-factory.yml` | new (harness bug) | `bug, kind:bug, target:factory, scale:task, area:dev-pipeline` |
+| `feature-factory.yml` | new (harness feature) | `enhancement, kind:feature, target:factory, scale:task, area:dev-pipeline` |
+| `epic-product.yml` | new | `scale:epic, target:product` |
+| `epic-factory.yml` | new | `scale:epic, target:factory, area:dev-pipeline` |
+
+The legacy `bug`/`enhancement` labels are kept on the task forms
+(harmless, and existing tooling/filters keep working) even though their
+only code consumer, `story_type`, is deleted. Every **task** form gains
+an optional input `Parent epic` (description: "issue number of the epic
+this belongs to, e.g. 321 — leave empty if none"); the parent-epic
+parser (D4) prefers this structured section. Epic forms have no
+parent-epic field (no epic nesting) and no kind. A `config.yml` with
+`blank_issues_enabled: false` closes the label-less **web** door —
+kept by user ruling, with the leak stated honestly (review PC-04):
+`gh issue create`, the REST/GraphQL API, bots, and transferred issues
+can still produce unlabelled issues; for those, path 2's ask+backfill
+and the gate's declaration check (D5 step 3) are the safety net, and
+that residual friction (a CI-red PR fixed by one `gh issue edit`) is
+accepted.
+
+**Path 2 — `setup-task --issue N` (existing issue).**
+`fetch_issue.py` now reports the parsed axes and a
+`declaration_complete` boolean (computed by
+`targets.py::validate_declaration` — D1):
+- declaration **complete and consistent** → use it directly, ask
+  nothing (epic linkage included: whatever the body says, or nothing);
+- **missing or partial** → ask the user for exactly the missing axes
+  (one question), and since a question is being asked anyway, include
+  the optional "part of an epic? (#N / none)" **iff** the body carries
+  no parent-epic declaration (review SG-C3, user ruling). Then backfill
+  the full label set onto the issue via `gh issue edit N --add-label …`
+  (and the `Refs #<epic>` body line if an epic was given) before
+  proceeding. The issue on GitHub always ends up fully declared.
+
+**Path 3 — `setup-task` from a textual description (new issue).** Ask
+one question for the lane — the 6 options: `bug` / `feature` (product),
+`harness bug` / `harness feature` (factory), `epic product` /
+`epic factory` — plus the optional "part of an epic? (#N / none)".
+Precise trigger for skipping the question (review PC-08): **only an
+explicit lane name or explicit axis values in the user's request count
+as an answer** ("bug", "harness feature", "kind:bug target:factory",
+"epic product", …); anything else — however suggestive the text — means
+ask. This is a bright line, not text analysis, so the agent's "do NOT
+analyze the input" hard rule stands. The agent's companion speed rule
+("the launcher must come within a few seconds") is **reworded in the
+same edit** — "fast and automatic, *except* the single lane/epic
+question when the declaration is missing" — so the parity test doesn't
+pin a contradiction (review planner R2, task 11). Then pass the labels
+through the existing `create_issue.py --labels` passthrough (no script
+change needed, but the passthrough gains its first test — review
+R2-06), e.g. `--labels "kind:bug,target:product,scale:task"`; if a
+parent epic was declared, include a `Refs #<epic>` line in the issue
+body.
+
+**Script (setup_task.py) — enforcement by construction.** Before
+creating the branch/worktree, `setup_task.py` fetches the issue's
+labels (one `gh issue view --json labels` call — its first `gh` call,
+`check=False` with an explicit JSON-error path, like its peers) and
+**refuses to proceed** unless `validate_declaration` passes (exactly
+one `target:*`; `scale:epic` ⇒ no `kind:*`; `scale:task` ⇒ exactly one
+`kind:*`). The error message prints the exact
+`gh issue edit --add-label` command, shape-aware (task vs epic — review
+PC-11). This is the epic's resolved "setup-task refuses to proceed
+without a declaration", machine-checked rather than prompt-obeyed.
+(Epics don't reach `setup_task.py` — no branch/worktree — so in
+practice this validates tasks; if an epic issue is ever passed, the
+epic-shaped declaration validates as itself, it is not asked to grow a
+`kind`.)
+
+**`fetch_issue.py`.** Delete `story_type` (user decision: delete, not
+subsume — it has zero consumers and a no-op branch). Add to the JSON:
+`kind`, `target`, `scale`, `lane` (empty strings when unlabelled),
+`parent_epic` (D4 parser; `null` if none), `declaration_complete`
+(bool).
+
+### D4 — `context.py` exposes the axes
+
+Replace `_issue_title(issue) -> str` with
+`_issue_fields(issue) -> dict` (review I1): one `gh issue view --json
+title,labels,body` call (drop the `-q .title` extraction, JSON-parse
+the output), returning `{"title": "", "labels": [], "body": ""}` on any
+failure — that dict is also the new `_settle` default at **both**
+settle call sites (review planner: context.py:149 and :152); keeps
+`check=False` + `stdin=subprocess.DEVNULL`; the single-future submit at
+context.py:129 and the two-call `ThreadPoolExecutor` drain protocol
+stay **untouched** — still no new `gh` call, no concurrency change. New
+context keys, **appended after the existing keys in this order** (the
+emission contract the byte-identity pin is rewritten against — review
+dev-proxy R1):
+
+- `labels`: raw label-name list (`[]` when unavailable)
+- `kind`, `target`, `scale`: parsed axis values (empty string when
+  absent)
+- `lane`: `{kind}-{target}` / `epic-{target}` / `""` when undeclared
+- `parent_epic`: int or JSON `null`. Parser (shared with
+  `fetch_issue.py` and `create_pr.py`, lives in `targets.py`): **first**
+  the structured issue-form section — a `### Parent epic` heading whose
+  following non-empty line is `#?(\d+)` — **then** fallback to the
+  first `Refs #(\d+)` in the body (review PC-05: the structured field
+  wins over free-text cross-references). Set at creation per D3;
+  explicit, never guessed.
+
+`tests/qs/test_context.py::test_stdout_is_byte_identical` pins exact
+stdout bytes — it breaks **deliberately** and is rewritten against the
+key order above.
+
+### D5 — The lane check (the gate that makes lanes real)
+
+**New `scripts/qs/targets.py`** — the single machine-readable lane
+domain module (the epic doc suggests the name — "(e.g.
+`scripts/qs/targets.py`)", [QS-321.md](../epics/QS-321.md) — and the
+operative reason it is a module rather than a gate-internal helper is
+that it has **three consumers** in this PR: the gate, `fetch_issue.py`,
+`setup_task.py`; review SG-C4 rejected on that basis, citation softened
+per review planner). API:
+
+- `classify(path) -> "product" | "factory" | "neutral" | "unknown"` —
+  four values (review N-5): `"neutral"` is *enumerated* neutrality
+  (silent); `"unknown"` is fallthrough (nothing matched), which the
+  gate prints as an FYI line so the fail-open set stays visible
+  (review PC-09) — without a fourth value the gate would have to
+  re-derive the rules `targets.py` owns.
+- `parse_axes(labels) -> {kind, target, scale, lane}`
+- `validate_declaration(labels) -> (ok, missing, message)` — the one
+  truth table (D1)
+- `parse_parent_epic(body) -> int | None` (D4)
+
+Classification, fully enumerated (review PC-09):
+
+- **factory** (prefixes): `scripts/`, `tests/qs/`, `.claude/`,
+  `.cursor/`, `.opencode/`, `.github/`, `legacy/`, `docs/workflow/`
+  (lanes included). **Factory carve-outs by the purpose rule**:
+  `tests/test_quality_gate.py` — it pins factory code; without this the
+  task's own diff would warn on its own gate (review CR-1 — originally
+  self-*blocking* when the check hard-failed; the fail→warn ruling
+  makes it non-blocking, but the carve-out stays because it is simply
+  the correct classification and keeps the warning signal noise-free).
+  **Factory basenames** (top-level): `CLAUDE.md`, `AGENTS.md`,
+  `.cursorrules`, `.gitignore`, `pyproject.toml`, `setup.cfg`,
+  `requirements.txt`, `requirements_test.txt` (the `_is_dev_only`
+  basename list, copied — not referenced — so `targets.py` stays
+  import-independent of the gate).
+- **product** (prefixes): `custom_components/`, `tests/` (everything
+  not under `tests/qs/` and not a factory carve-out), `docs/agents/`
+  (product **by epic ruling** — the drift checker ties it to product
+  source), `docs/product/`.
+- **neutral** (enumerated, silent): `docs/stories/` (every task
+  commits its story), `docs/epics/` (target-neutral by epic rule),
+  `README.md`.
+- **unknown** (fallthrough, FYI-printed): any path matching nothing
+  above. Fail-open by design; the permanent remedy for a recurring
+  known path is a one-line `targets.py` classification PR.
+
+`targets.py` is **not** `_is_dev_only`'s complement and does not
+replace it here: `_is_dev_only` drives scope *detection* (which suite
+to run), `targets.py` drives lane *enforcement*. They coexist;
+consolidation is deferred (Goal / out of scope).
+
+**Import mechanism** (review RD-2): `quality_gate.py` is deliberately
+stdlib-only today; it gains its first sibling import
+(`import targets`), resolved the same way every `scripts/qs` module
+already resolves siblings (`context.py` does `from utils import …` via
+the script-dir on `sys.path`). Verified (review planner):
+`tests/test_quality_gate.py` already puts `scripts/qs` on `sys.path`
+(lines 22–26), so the sibling import resolves under pytest with **no**
+conftest change.
+
+**The helper and its result** (review R2-12): 
+`_check_lane_targets(changed_files) -> LaneCheckResult` — a small
+result object carrying `declaration_missing` (+ the shape-aware
+backfill message), `warning` (the cross-target text, or None), and
+`fyi` (unknown-path lines, or None). The helper never exits and never
+prints; **each call site** maps the result: declaration-missing →
+gate failure (exit non-zero via the site's normal mechanism), warning/
+fyi → printed to **stderr** (never stdout — `--json` mode must stay
+parseable; review DP2-03, pinned in test 6).
+
+**Two call sites** (review CR-2, seam corrected per review planner N-3
+— the non-`.py` early exit runs *before* diff-base resolution, so the
+v4 wording "after diff-base resolution" was impossible):
+
+1. inside `check_impacted()`: after `_ensure_testmon_db_safe()`
+   (quality_gate.py:2135) and **before** the warm-baseline early-exit
+   block (:2159). The change set is computed **unconditionally** via
+   `_impacted_early_exit_paths()` (today it is only computed inside the
+   warm-baseline guard). The hook must still run on a pure-docs change
+   set — a missing declaration fails and a cross-target diff warns
+   there too (review N-2/C-1: nothing about a crossing ever *fails*;
+   the FAIL in this sentence's v4 ancestor referred to a doctrine this
+   plan no longer holds). `_impacted_early_exit_paths()` returning
+   `None` (git failure) is treated exactly like a `gh` failure: local
+   warn + skip, CI fail closed.
+2. `main()`, between `_get_changed_files()` and `_detect_scope(...)`,
+   for the full gate. **Known skip, recorded** (review planner): the
+   `--cache` short-circuit sits before this seam, so a valid cached
+   pass returns without the lane check — acceptable because `--cache`
+   requires a previously green run on a clean tree and the mandated
+   pre-commit form is `--impacted`.
+
+Skipped in `--quick` / `--seed-testmon` / when no `QS_<N>` issue is
+resolvable (see CI resolution below for what "resolvable" means on a
+detached HEAD). Sequence — step 0 first (review R2-10/I-3):
+
+0. Classify every changed file; print `unknown` fallthrough paths as an
+   FYI line on stderr. (Included in `--lane-check` output too.)
+1. Resolve the declared target: **branch → issue → labels**. Branch
+   resolution (review N-1, found independently by three reviewers — a
+   `pull_request` checkout is a detached merge ref where
+   `git branch --show-current` is empty, which would silently no-op the
+   check in CI, reproducing CR-3): `get_issue_from_branch()` first;
+   when it yields nothing **and** `_is_ci()`, fall back to the
+   `--branch` value passed by the workflow step
+   (`--branch "${{ github.head_ref }}"` — `GITHUB_HEAD_REF` equals the
+   PR's source branch on every `pull_request` event). Only if both
+   yield nothing is the check skipped (locally: not a task branch;
+   in CI on a `QS_*` head ref this cannot happen). Then
+   `gh issue view N --json labels`. **Label cache**: a JSON marker file
+   keyed on `(issue, branch)`, 10-minute TTL, `_is_ci()` bypass, and
+   **only complete declarations are cached** (a backfill-then-re-run
+   can never be re-failed by a stale cache). Kept over review SG2-02's
+   drop suggestion — rejected with precedent: a network call in the
+   pre-commit hot loop is exactly what QS-290 spent a task TTL-caching.
+2. `gh` unavailable/failing → **local: warn + skip** (offline must not
+   brick the gate); **CI: fail closed** — CI has a guaranteed token and
+   network, a `gh` failure there is a real error, and a silent skip
+   would disable the one enforcement this task adds (review PC-02).
+3. Labels readable but declaration missing/incomplete
+   (`validate_declaration`) → **FAIL** with the exact, shape-aware
+   backfill commands. Locally the orchestrator asks the user which
+   lane, applies the labels to the issue, re-runs (this ask-and-backfill
+   flow lives in the implement agents' bodies — task 11 — and is
+   parity-pinned; review DP2-05/SG2-05). In CI this fails the PR;
+   acceptable because setup guarantees labels on all new issues, this
+   task retro-labels the epic's open ones, and the residual
+   unlabelled-issue leak is accepted (D3 path 1).
+4. Declared target present → any file of the **opposite** target ⇒
+   **LOUD WARNING** on stderr (never a failure — user ruling: purpose,
+   not path, is the classifier) listing *all* crossing files (no
+   truncation), stating "verify these serve the declared <target>
+   purpose", and always printing the split-procedure recommendation
+   (human judgment decides substantiality — review R2-09). Surfacing is
+   **machine-owned, not prompt-obeyed** (review N-4): `create_pr.py`
+   injects the "Lane note" into the PR body (D6), and the CI
+   `--lane-check` step writes the warning to `GITHUB_STEP_SUMMARY`.
+   Warnings **repeat by design** on every gate run (review R2-05):
+   there is no waiver and no acknowledgment state; a crossing that is
+   reviewed-and-accepted simply ships with its Lane note, and a path
+   that *keeps* warning wrongly earns a `targets.py` carve-out PR.
+   A `scale:epic` declaration is **valid** — no kind expected — and the
+   classification runs against its target (review PC-11).
+
+**`--lane-check` subcommand + CI job** (review CR-3 + N-1): a new cheap
+subcommand running steps 0–4 only (no pytest, no coverage). It joins
+the execution-mode mutex ladder (incompatible with `--impacted`,
+`--quick`, `--cache`, `--no-cache`, `--full`, `--fix`, and the seed
+trio) and short-circuits before scope detection, like `--impacted`
+(review planner). CI wiring is a **new job** in
+`.github/workflows/pr-quality.yml` (not a step in the existing jobs,
+whose tokens are deliberately `contents: read`-only — review planner):
+`permissions: { contents: read, issues: read }`,
+`env: GH_TOKEN: ${{ github.token }}` on the step (`gh` reads
+`GH_TOKEN`; it is preinstalled on `ubuntu-latest` — no install step),
+checkout with a fetch that reaches the merge base
+(`fetch-depth: 0`), change set = `origin/main...HEAD`, invocation
+`python scripts/qs/quality_gate.py --lane-check
+--branch "${{ github.head_ref }}"`. On a warning it appends the Lane
+note to `GITHUB_STEP_SUMMARY`; on declaration-missing or `gh` failure
+it exits non-zero (fail closed).
+
+**Existing-test hardening** (review dev-proxy R1): the hook sits on
+paths existing `tests/test_quality_gate.py` tests drive. Task 7
+includes an audit: existing tests must not become network-dependent —
+the check short-circuits when no issue is resolvable (most test
+fixtures) and the label fetch is stubbed in the remainder.
+
+This is behaviour change B1; the full enumerated behaviour-change list
+is in the Goal.
+
+### D6 — Safety fixes
+
+- **`create_pr.py` — epic linkage and Lane note, both machine-owned**
+  (reviews PC-06 + N-4, user rulings): `Fixes #{issue}` stays the
+  default for the PR's own issue. `create_pr.py` makes **one** new call
+  — `gh issue view N --json body,labels` — and:
+  - **auto-`Refs`**: resolves the parent epic from the body
+    (`targets.parse_parent_epic` — the declaration setup wrote at D3;
+    still explicit, never guessed) and appends it inside the existing
+    fixes-line slot: `fixes_line` becomes `"\nFixes #{issue}\nRefs
+    #{epic}\n"` when an epic resolves (placement pinned by test 3 —
+    review planner). **No CLI override flags** — the round-2 draft's
+    `--refs`/`--no-refs` are dropped as unrequested surface (review
+    SG2-01 accepted): the escape hatch for a wrong `Refs` is editing
+    the issue body, the declared source of truth.
+  - **Lane note** (B5): classifies its changed files
+    (`get_changed_files()` — already used for risk detection) against
+    the declared target from the labels, and when a crossing exists
+    injects a `## Lane note` section into the PR body listing the
+    crossing files verbatim. No agent involvement, no sentinel-string
+    parsing of gate output (review DP2-02's ambiguity dissolves — the
+    classification is recomputed from `targets.py`, the single source).
+- **`stale.yml`** (B4): `exempt-issue-labels:
+  pinned,security,critical,scale:epic` (PR exemptions unchanged —
+  epics have no PRs).
+- **`issue-triage.yml`** (B4, closes #293; the `area:dev-pipeline`
+  mapping is not scope creep — #293's own body proposes it verbatim,
+  review SG-C1). Per-keyword decisions, written here so test 8 pins a
+  decision rather than an improvisation (review dev-proxy R1):
+
+  | label | new match (word-boundary regex on title+body) | change |
+  |---|---|---|
+  | `area:solver` | `/\bsolver\b/`, `/\bconstraints?\b/` | boundary only |
+  | `area:charger` | `/\bchargers?\b/`, `/\bocpp\b/`, `/\bwallbox\b/` | boundary only |
+  | `area:car` | `/\bcars?\b/`, `/\bvehicles?\b/`, `/\bev\b/` | boundary (kills "dev"→car) |
+  | `area:battery` | `/\bbatter(y|ies)\b/`, `/\bstorage\b/` | boundary only |
+  | `area:person` | `/\bpersons?\b/`, `/\bpresence\b/` | boundary only |
+  | `area:ui` | `/\bdashboards?\b/`, `/\bui\b/` | boundary (kills "quiet"→ui) |
+  | `area:config` | `/\bconfig[ _-]?flow\b/`, `/\bconfig entr(y|ies)\b/` | **narrowed** (review R2-07: `\bconfiguration\b` still matched "harness configuration"); bare `config` and `setup` dropped |
+  | `area:dev-pipeline` | `/\b(harness|pipeline|agents?|workflow|worktree|quality gate|lanes?|launcher|testmon)\b/` | **new** (#293) |
+
+### D7 — Retro-labeling and housekeeping (one-time, recorded here)
+
+`gh` commands run during implementation, recorded in the PR:
+
+- **#332 → labelled in task 1** (`kind:feature`, `target:factory`,
+  `scale:task`), immediately after `gh label create` — **before** the
+  gate hook exists, otherwise every `--impacted` run mid-implementation
+  fails on this very branch (review RD-1, found independently by two
+  reviewers). Task 1 also **verifies #332's body carries the
+  parent-epic declaration** (`Refs #321` — it does by filing
+  convention; add it if absent) so the auto-`Refs` of task 6 finds it
+  (review R2-11).
+- #321 → `scale:epic`, `target:factory` (keeps `pinned`,
+  `area:dev-pipeline`).
+- #335–#340 → `kind:feature`, `target:factory`, `scale:task` (all
+  lane-divergence work is factory feature work); verify each body
+  carries `Refs #321` (true by filing convention).
+- #293 is **not** retro-labelled — it closes via this PR and labeling a
+  closed issue serves no consumer (review SG-I3).
+
+### Test plan (all under `tests/qs/` unless noted)
+
+Greenfield warning: `create_pr.py`, `create_issue.py`, `fetch_issue.py`
+have **zero existing tests**; `stale.yml` / `issue-triage.yml` /
+`ISSUE_TEMPLATE/` are pinned by nothing. New tests:
+
+1. `tests/qs/test_targets.py` — `classify()` truth table (every D5
+   rule: `tests/qs/` vs `tests/`, the `tests/test_quality_gate.py`
+   factory carve-out, `docs/agents/` product, `docs/stories/` +
+   `docs/epics/` + `README.md` **enumerated-neutral**, factory
+   basenames, unmatched → **`"unknown"`** — review N-5);
+   `validate_declaration` truth table (the **single** shared one —
+   per-caller tests only cover wiring, review SG-R1); `parse_axes`;
+   `parse_parent_epic` (structured section beats free-text `Refs`,
+   review PC-05).
+2. `tests/qs/test_fetch_issue.py` — axes + `declaration_complete` +
+   `parent_epic` wiring, `story_type` **absent** from output.
+3. `tests/qs/test_create_pr.py` — auto-`Refs` from a body with a
+   declared parent (`fixes_line` placement:
+   `"\nFixes #N\nRefs #E\n"`); no `Refs` when none declared; **Lane
+   note** injected when the diff crosses the declared target, absent
+   otherwise; body byte-identical to today's when no epic and no
+   crossing.
+4. `tests/qs/test_create_issue.py` (review R2-06) — the `--labels`
+   passthrough: comma-joined labels reach the `gh issue create`
+   invocation; no labels → no `--label` flag.
+5. `tests/qs/test_setup_task.py` (new — none exists) — declaration
+   validation wiring: complete passes, missing/conflicting refuses
+   with the shape-aware backfill command; epic-shaped declaration
+   validates as itself.
+6. `tests/qs/test_context.py` — extend: new keys in the contracted
+   order, lane derivation, unlabelled → empty values without failure;
+   rewrite the byte-identity pin.
+7. `tests/test_quality_gate.py` — lane-check tests pinning **both call
+   sites** (inside `check_impacted()` at the corrected seam — incl. the
+   pure-docs-crossing case that must run before the warm-baseline early
+   exit and **warn** with exit code unaffected — and `main()`), plus:
+   `LaneCheckResult` mapping (declaration-missing → non-zero, warning/
+   FYI → stderr, stdout untouched in `--json` mode — review DP2-03),
+   missing declaration **fails** with shape-aware backfill, local
+   gh-failure warns+skips vs **CI fail-closed**,
+   `_impacted_early_exit_paths() is None` handled like a `gh` failure,
+   CI branch resolution via `--branch` when `git branch
+   --show-current` is empty (review N-1), cache stores only complete
+   declarations, `--quick` skips, `--cache` known skip documented,
+   enumerated-neutral silent vs unknown-FYI printed, non-resolvable
+   issue skips locally, `scale:epic` declaration valid, `--lane-check`
+   mutex membership + step-summary output. Includes the existing-test
+   audit (no legacy gate test becomes network-dependent).
+8. `tests/qs/docs/test_lanes.py` — the 6 lane files exist **and** each
+   is byte-identical to `phase-protocols.md` unless in the `DIVERGED`
+   allowlist (empty now; lane PRs add themselves — review PC-01/PC-03).
+9. `tests/qs/test_github_workflows.py` — pin `stale.yml` exemption list
+   contains `scale:epic`; pin `issue-triage.yml` implements the D6
+   per-keyword table (word-boundary, dropped keywords absent,
+   `area:dev-pipeline` present); pin the new `pr-quality.yml` lane-check
+   job (own permissions block with `issues: read`, `GH_TOKEN` env,
+   `--branch "${{ github.head_ref }}"` in the invocation).
+10. `tests/qs/test_issue_templates.py` — the 6 lane forms exist, each
+    carries exactly its D3 label set; every task form has the
+    `Parent epic` field and epic forms don't; `config.yml` disables
+    blank issues; the legacy two template filenames are gone.
+11. `tests/qs/agents/test_lane_steps_parity.py` (named — review I2;
+    pattern: `test_doc_maintenance_parity.py`) — pins **three step
+    kinds** (list kept consistent across task 11 and AC-5 — review
+    I-2/R2-08): (a) the declaration step incl. the amended speed-rule
+    wording in qs-setup-task ×3, (b) the lane-read step in the 4
+    orchestrators ×3, (c) the ask-and-backfill-on-declaration-FAIL step
+    in the implement variants ×2 ×3. (The former Lane-note agent step
+    is gone — machine-owned by `create_pr.py`, pinned in test 3.)
+12. Extend `test_workflow_no_desktop_fallback_by_necessity.py` glob →
+    recursive.
+
+Gates: `--impacted` pre-commit + `--quick tests/qs` (agent files,
+workflows, workflow docs and `.claude/settings.json` are
+`tests/qs`-pinned non-Python surfaces).
+
+## Acceptance criteria
+
+1. `docs/workflow/lanes/` contains the 6 lane files;
+   `tests/qs/docs/test_lanes.py` proves each byte-identical to
+   `phase-protocols.md` (empty `DIVERGED` allowlist);
+   `phase-protocols.md` unchanged. [machine-verified]
+2. The 6 axis labels exist on GitHub; `setup_task.py` refuses an
+   undeclared/inconsistent issue with a shape-aware, actionable message
+   [machine-verified, test 5]; a task created through `qs-setup-task`
+   always ends up with `kind:*` + `target:*` + `scale:task` on its
+   issue — new-issue and `--issue N` paths both [pin-verified, test 11;
+   the label *delivery* mechanics are machine-verified via tests 4
+   and 5] (review CL-3).
+3. Entry-path behaviour — split by verification kind (review PC-12):
+   **machine-verified** (tests 2, 4, 5, 10): the 6 lane forms carry
+   exactly their label sets (task forms with `Parent epic` field, epic
+   forms without), `fetch_issue.py` emits the axes +
+   `declaration_complete`, `create_issue.py` forwards `--labels`,
+   `setup_task.py` refuses incomplete declarations;
+   **pin-verified** (test 11): the setup agent's instruction text for
+   use-if-complete / ask-only-missing (+ piggybacked optional epic
+   question) / ask-on-text with the explicit-words-only trigger and the
+   amended speed rule.
+4. Lane-read routing (review SG-I2): the 4 orchestrators ×3 harnesses
+   carry the read-`docs/workflow/lanes/<lane>.md` step with the
+   `phase-protocols.md` fallback for empty lane, and the implement
+   variants carry the ask-and-backfill-on-FAIL step (pin-verified,
+   test 11; qs-finish-task exclusion recorded in D2);
+   `python scripts/qs/context.py` on a labelled task emits `labels`,
+   `kind`, `target`, `scale`, `lane`, `parent_epic` in the contracted
+   order; on an unlabelled legacy task emits empty values without
+   failing (machine-verified, test 6).
+5. The lane check, from **both** call sites (`--impacted` at the
+   corrected seam — including a pure-docs change set — and the full
+   gate): a cross-target diff produces the **loud stderr warning** —
+   all crossing files listed, split recommendation always printed, exit
+   code unaffected, stdout `--json` unpolluted; a
+   labels-readable-but-undeclared task **fails** with the shape-aware
+   backfill command; local `gh` failure warns+skips, **CI fails
+   closed**; never runs in `--quick`/`--seed-testmon`; `--cache`'s
+   short-circuit skip is documented; unknown paths print as FYI,
+   enumerated-neutral stays silent; the `pr-quality.yml` **job** runs
+   `--lane-check --branch "${{ github.head_ref }}"` with `GH_TOKEN` and
+   `issues: read`, writes warnings to `GITHUB_STEP_SUMMARY`, and cannot
+   be no-oped by the detached-HEAD checkout [machine-verified, tests 7
+   and 9].
+6. `create_pr.py`: on an issue whose body declares a parent epic, the
+   PR body carries `Fixes #N` + `Refs #<epic>` in the specified
+   placement with no agent involvement and **no override flags**; when
+   the diff crosses the declared target the body carries the `## Lane
+   note` section listing the crossing files; with no epic and no
+   crossing the body is byte-identical to today's [machine-verified,
+   test 3].
+7. `stale.yml` exempts `scale:epic`; `issue-triage.yml` implements the
+   D6 table — no `area:car` from "dev"/"review", no `area:ui` from
+   "Quiet Solar", no `area:config` from "harness configuration",
+   `area:dev-pipeline` fires on harness/pipeline keywords (#293 closes
+   via this PR). [machine-verified, test 9]
+8. `fetch_issue.py` output carries the axes and **no** `story_type`.
+   [machine-verified, test 2]
+9. #332 labelled and its body carrying `Refs #321` verified in task 1;
+   #321 and #335–#340 retro-labelled per D7.
+10. All new/changed lines covered; `--quick tests/qs` green;
+    `scripts/qs/targets.py` allowlisted in `.claude/settings.json` in
+    both existing forms (mirror the paired entries for `context.py`:
+    the bare `scripts/qs/…` and the `**/`-prefixed variant) — the
+    entries permit agents to run ad-hoc classification queries
+    (`python scripts/qs/targets.py <path>`), which requires a small
+    `__main__` block in `targets.py` (review DP2-08).
+
+## Task breakdown
+
+1. Create the 6 GitHub labels (`gh label create --force` ×6, colors +
+   descriptions), **label #332 itself** (kind:feature, target:factory,
+   scale:task) — must precede task 7 (review RD-1) — and verify/add
+   `Refs #321` in #332's body (review R2-11).
+2. `scripts/qs/targets.py` (`classify` incl. `"unknown"`, `parse_axes`,
+   `validate_declaration`, `parse_parent_epic`, `__main__`
+   classification query) + `tests/qs/test_targets.py` (TDD).
+3. `scripts/qs/fetch_issue.py`: delete `story_type`, add axes +
+   `declaration_complete` + `parent_epic` (consume `targets.py`) +
+   `tests/qs/test_fetch_issue.py`; add
+   `tests/qs/test_create_issue.py` for the untouched `--labels`
+   passthrough (review R2-06).
+4. `scripts/qs/context.py`: `_issue_title` → `_issue_fields`
+   (`title,labels,body`, dict default at both settle sites, drain
+   protocol untouched) + new keys + update `tests/qs/test_context.py`.
+5. `scripts/qs/setup_task.py`: declaration validation via
+   `validate_declaration` + `tests/qs/test_setup_task.py`.
+6. `scripts/qs/create_pr.py`: one `gh issue view --json body,labels`
+   call → auto-`Refs` (fixes-line placement) + `## Lane note` injection
+   via `targets.classify`; no override flags +
+   `tests/qs/test_create_pr.py`.
+7. `scripts/qs/quality_gate.py`: `_check_lane_targets` →
+   `LaneCheckResult` (no printing/exiting in the helper), both call
+   sites at the **corrected** seams (D5), stderr-only warning/FYI,
+   label marker-file cache (complete-only, 10-min TTL, `_is_ci()`
+   bypass), local-warn/CI-fail-closed, `--lane-check` subcommand
+   (mutex-ladder membership, `--branch` flag, `GITHUB_STEP_SUMMARY`
+   output), existing-test audit + `tests/test_quality_gate.py`
+   additions.
+8. Lane files ×6 (`cp` from `phase-protocols.md`; relative links left
+   broken by design — D2) + `tests/qs/docs/test_lanes.py`
+   (DIVERGED-allowlist identity); overview.md "Lanes" note inside the
+   Phase-routing H2; recursive-glob fix in
+   `test_workflow_no_desktop_fallback_by_necessity.py`.
+9. Workflows: `stale.yml` exemption + `issue-triage.yml` rewrite per
+   the D6 table (#293) + the **new lane-check job** in
+   `pr-quality.yml` (own `permissions` with `issues: read`, `GH_TOKEN`
+   env, `fetch-depth: 0`, `--branch "${{ github.head_ref }}"`) +
+   `tests/qs/test_github_workflows.py`.
+10. Issue templates: rework `.github/ISSUE_TEMPLATE/` into the 6 lane
+    forms per D3 (rename/extend the 2 existing, add 4, add
+    `config.yml`) + `tests/qs/test_issue_templates.py`.
+11. Agent bodies ×3 harness dirs: qs-setup-task declaration step per
+    D3 paths 2–3 **including the amended speed rule** ("fast and
+    automatic except the single lane/epic question"); lane-read step
+    (prose, with fallback) in qs-create-plan, qs-implement-task,
+    qs-implement-setup-task, qs-review-task; implement variants ×2:
+    the ask-and-backfill-on-declaration-FAIL step (ask the user the
+    lane, run the printed `gh issue edit`, re-run the gate); +
+    `tests/qs/agents/test_lane_steps_parity.py` (pins exactly these
+    three step kinds). `.claude/commands/setup-task.md` touched only if
+    its wording contradicts the new step; the other command fallbacks
+    delegate and need no edit (D2).
+12. `.claude/settings.json`: allowlist `targets.py` (both forms, mirror
+    the `context.py` pair).
+13. Retro-label #321, #335–#340 (D7 — #332 done in task 1, #293 not
+    labelled).
+14. Docs: `docs/workflow/project-rules.md` — short "Lanes & axes"
+    subsection under Workflow routing (declaration, labels, lane
+    check as warn-not-fail); CLAUDE.md untouched.
+15. Epic amendment (B6): edit `docs/epics/QS-321.md` "The two
+    targets" — the hard-stop enforcement paragraph is superseded by
+    the visibility rule (user ruling 2026-08-03, recorded verbatim:
+    purpose, not path, is the classifier; a product fix that must
+    enhance a test tool stays product); splitting demoted from
+    machine-enforced remedy to recommended practice **with the manual
+    split incantation kept alive** (D5 step 4 points at it — review
+    CL-1); `target` declaration semantics (declared, immutable,
+    exactly one) unchanged; the factory-prompt one-session-late caveat
+    unchanged; the now-satisfied bootstrap note ("`Refs #321` by hand
+    until child A's link mode merges") reworded to past tense (review
+    DP2-04); update any `tests/qs` pin on the amended paragraphs —
+    such an edit is in scope for B6 (review DP2-07; none is known
+    today). Rides this PR — normal-PR amendment path, `docs/epics/` is
+    target-neutral.
+16. Gates + PR: `--impacted`, `--quick tests/qs`; PR body `Fixes #332`,
+    `Fixes #293` (in summary), `Refs #321` via the task-6 auto-`Refs`
+    (header note; manual `gh pr edit` only as fallback).
+
+## Doc maintenance
+
+`Doc-OK` (verified 2026-08-02): `check_doc_drift.py --paths <full
+planned set>` surfaces nothing — every touched path is factory-side and
+the drift checker tracks `custom_components/quiet_solar/` only (by
+QS-185 design); no `docs/agents/` doc `covers:` any planned file. The
+workflow-doc updates the lane model requires are themselves in scope
+(tasks 8 and 14). Harness-sync co-modification (×3 agent dirs) is in
+scope by construction (task 11). `pr-quality.yml` added to the planned
+set (task 9) — same result, factory-side.
+
+## Adversarial Review Notes
+
+**Round 1** (2026-08-03, reviewers: critic, concrete-planner,
+dev-proxy, scope-guardian — CodeRabbit not part of the plan fan-out).
+33 deduped findings against v2. 31 accepted & resolved in v3; 2
+rejected: **SG-I1** ("drop `config.yml`") — rejected by user ruling,
+kept with the leak documented (PC-04's substance accepted); **SG-C4**
+("start `classify()` gate-internal") — rejected: three consumers in
+this PR void the single-consumer premise (citation softened in v5 per
+round 2: the epic doc *suggests* the `targets.py` name, "e.g.", it does
+not mandate it). Full per-finding resolution map: see the v3 ledger in
+git history of this file; every resolution was re-verified by the
+round-2 delta-auditor (below).
+
+**Post-round-1 user ruling (2026-08-03, v4)**: "purpose, not path, is
+the classifier" — cross-target check became **warn-loud-never-fail**
+(was FAIL); missing-declaration FAIL, CI fail-closed, both call sites,
+the mapping, the CR-1 carve-out and RD-1 ordering all unchanged; the
+`target:mixed` waiver idea considered and dropped; epic doc amended in
+this PR (B6).
+
+**Round 2** (2026-08-03, same 4 reviewers + delta-auditor on the v2→v4
+in-context diff). Delta verdict: 30/31 round-1 resolutions intact, 1
+partial (PC-07 — fixed in v5 by folding `stale.yml` into B4), both
+rejections preserved. 28 new deduped findings, all resolved in v5
+except the two rejections below:
+
+- **N-1** CI dead-on-arrival (detached HEAD no-ops the check; token/
+  fetch unspecified) — found independently by critic R2-02, planner,
+  dev-proxy DP2-01 → D5 step 1 `--branch "${{ github.head_ref }}"`
+  fallback, new-job spec (permissions `issues: read`, `GH_TOKEN`,
+  `fetch-depth: 0`), tests 7 + 9.
+- **N-2/C-1** leftover "pure-docs lane violation must still fail" →
+  rewritten in D5 call site 1 (declaration fails, crossing warns).
+- **N-3** impossible `check_impacted()` seam wording → corrected seam
+  (after `_ensure_testmon_db_safe()`, before the warm-baseline block;
+  unconditional change-set computation; `None` → gh-failure semantics).
+- **N-4** prompt-obeyed Lane note (critic R2-03 + DP2-02 + SG2-04) →
+  machine-owned: `create_pr.py` injects it (B5/D6, test 3); CI writes
+  `GITHUB_STEP_SUMMARY`; the agent relay step deleted.
+- **N-5/R2-04** classify API vs FYI → fourth value `"unknown"`.
+- **R2-12** helper failure mechanism → `LaneCheckResult`, call sites
+  map. **DP2-03** `--json` pollution → stderr-only, pinned.
+- **SG2-01** `--refs`/`--no-refs` unrequested → **accepted, flags
+  dropped** (pure auto-consume).
+- **SG2-03** qs-finish-task exclusion → recorded rationale in D2 (not
+  wired).
+- **DP2-05/SG2-05** ask-and-backfill homeless → task 11 step (c) +
+  parity pin. **R2-05** warning fatigue → repeat-by-design rationale +
+  carve-out-PR remedy (D5 step 4). **R2-06** untested `--labels`
+  passthrough → test 4. **R2-07** `\bconfiguration\b` overbroad → D6
+  narrowed to `config[ _-]?flow` / `config entr(y|ies)`. **R2-08/I-2**
+  test-pin list drift → test 11 canonical list. **R2-09** "substantial"
+  → always-print + human judgment. **R2-10/I-3** step 0 → real step 0,
+  included in `--lane-check`. **R2-11** header/task-15 `Refs #321`
+  discrepancy → reconciled (auto-`Refs` applies; task 1 verifies the
+  body). **planner**: `--lane-check` mutex ladder → D5; `--cache` skip
+  recorded → D5/test 7; setup-agent speed-rule collision → D3/task 11;
+  `Refs` placement → D6; SG-C4 citation softened → notes above; both
+  `_settle` sites → D4. **DP2-04** bootstrap note → task 15. **DP2-06**
+  lane-copy relative links → D2 pre-authorized. **DP2-07** epic-doc
+  pins → task 15. **DP2-08** settings.json purpose → AC-10 `__main__`
+  query. **CL-2** Problem §3 supersession note → Problem. **CL-3**
+  AC-2 verification kinds → AC 2. **CL-4** canonical IDs (RD-2) → D5.
+
+**Rejected in round 2** (recorded so re-runs don't resurface them):
+
+- **SG2-02** "drop the label cache" — rejected with precedent: a
+  network call in the `--impacted` pre-commit hot loop is exactly the
+  class of cost QS-290 spent an entire task TTL-caching; the cache
+  keeps its one-paragraph spec (complete-only, 10-min TTL, CI bypass).
+- **SG2-04**'s remedy variant "gate output alone satisfies 'loudly'" —
+  superseded rather than adopted: the Lane note stays, but machine-owned
+  in `create_pr.py` (N-4), which removes the agent-body cost SG2-04
+  worried about.
+
+Finding states: round 1 — 31 resolved, 2 rejected; round 2 — 26
+resolved, 2 rejected; 0 open.
+
+**FINALIZE record** (2026-08-03): shipped at v5 with 0 open findings.
+Advisory surfaced and accepted by the user: the v5 fold-in of round 2's
+findings was itself not re-reviewed (no round 3) — round 2 produced no
+structural redesigns, only spec tightening with convergent fixes.

--- a/docs/stories/QS-332.story.md
+++ b/docs/stories/QS-332.story.md
@@ -282,10 +282,24 @@ one `target:*`; `scale:epic` ⇒ no `kind:*`; `scale:task` ⇒ exactly one
 `gh issue edit --add-label` command, shape-aware (task vs epic — review
 PC-11). This is the epic's resolved "setup-task refuses to proceed
 without a declaration", machine-checked rather than prompt-obeyed.
-(Epics don't reach `setup_task.py` — no branch/worktree — so in
-practice this validates tasks; if an epic issue is ever passed, the
-epic-shaped declaration validates as itself, it is not asked to grow a
-`kind`.)
+(If an epic issue is ever passed, the epic-shaped declaration validates
+as itself — it is not asked to grow a `kind`.)
+
+**Amended by review fix #04 (must-fix).** "Epics don't reach
+`setup_task.py` — no branch/worktree" was *aspirational*: nothing
+enforced it, and step 2 of the setup agent ran `setup_task.py`
+unconditionally, so picking an epic lane (or passing an existing epic
+via `--issue N`) cut a branch and a worktree — contradicting the epic
+model this task establishes (QS-321: "No implement phase; no branch,
+worktree, or PR"; output = a rationale doc on `main` + child issues).
+Now enforced on both sides: `setup_task.py::refuse_if_epic` refuses a
+`scale:epic` issue outright — including under `--no-worktree`, which
+still cuts a *branch* — reusing `check_declaration`'s labels (no extra
+`gh` call); and the setup agent gains step 1c (×3 harnesses,
+parity-pinned), which stops after issue creation for an epic lane and
+routes the user to decomposition into child tasks. Epic *issues* stay
+createable through setup-task — they are two of D3's six lane options —
+what an epic never gets is a branch/worktree/PR.
 
 **`fetch_issue.py`.** Delete `story_type` (user decision: delete, not
 subsume — it has zero consumers and a no-op branch). Add to the JSON:

--- a/docs/stories/QS-332.story_review_fix_#01.md
+++ b/docs/stories/QS-332.story_review_fix_#01.md
@@ -1,0 +1,233 @@
+# QS-332 — Review fix plan #01
+
+## Summary
+- Source PR: #343
+- Source story: docs/stories/QS-332.story.md
+- Findings to fix: 14 (2 must-fix, 8 should-fix, 4 nice-to-have — "fix all")
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user decision —
+  not relevant for harness-only file sets)
+
+## Findings to fix
+
+### [must-fix] Lane-check CI job is dead on arrival — missing setup-python
+- File: `.github/workflows/pr-quality.yml` (job `lane-check`, ~line 703)
+- Severity: must-fix
+- Source: qs-review-acceptance-auditor (+ qs-review-blind-hunter)
+- Description: The `lane-check` job has no `actions/setup-python` step,
+  unlike every other job in the file (all pin `python-version: '3.14'`
+  via `setup-python@v6`). It runs ubuntu-latest's system Python (3.12),
+  and `scripts/qs/quality_gate.py:527` uses PEP-758 syntax
+  (`except json.JSONDecodeError, OSError:`, valid only on 3.14+) →
+  `SyntaxError`, exit 1. Observed live: PR #343's required "Lane Check"
+  check is red (job 92331476888) while all other checks pass. The
+  fail-closed design means it currently blocks every PR.
+- Proposed fix: Add the `setup-python@v6` / `python-version: '3.14'`
+  step to the `lane-check` job. Extend
+  `tests/qs/test_github_workflows.py::test_lane_check_job_spec` to pin
+  the setup-python step (the current test pins permissions/token/
+  `--branch` but not the interpreter, which is how this slipped past).
+
+### [must-fix] Script injection via `github.head_ref` in lane-check job
+- File: `.github/workflows/pr-quality.yml:262` (`lane-check` job `run:`)
+- Severity: must-fix
+- Source: qs-review-edge-case-hunter
+- Description: `"${{ github.head_ref }}"` is expanded by Actions
+  *before* the shell sees the line; `"`, `$`, and backtick are all
+  legal in git branch names, and `head_ref` is attacker-controlled on
+  fork PRs of this public repo. A branch named e.g.
+  `QS_1"$(curl attacker)"` yields arbitrary command execution on the
+  runner with `GH_TOKEN` in env.
+- Proposed fix: Pass it through an env var per GitHub's hardening
+  guidance: `env: HEAD_REF: ${{ github.head_ref }}` on the step, then
+  `--branch "$HEAD_REF"` in `run:`. Pin the pattern in
+  `tests/qs/test_github_workflows.py::test_lane_check_job_spec`
+  (assert no direct `${{ github.head_ref }}` interpolation inside
+  `run:`).
+
+### [should-fix] `validate_declaration` remediation is not executable
+- File: `scripts/qs/targets.py:155-176`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (merged:
+  3 findings)
+- Description: (a) The printed backfill suggestion contains unresolved
+  alternatives (`"target:product|target:factory,scale:task,kind:bug|kind:feature"`),
+  while the implement agents are instructed to "run the exact
+  `gh issue edit <N> --add-label ...` command the gate printed" —
+  running it verbatim creates literal junk labels. (b) Duplicate-axis
+  declarations (two `target:*`, two `kind:*`, `scale:task`+`scale:epic`)
+  and the epic-with-kind arm fail correctly but the needed remedy is
+  `--remove-label`, which is never printed (for epic-with-kind,
+  `suggestions` stays empty so no command is emitted at all) — an agent
+  obeying the printed command enters a fail loop.
+- Proposed fix: In `validate_declaration`, detect the ambiguous (2+)
+  case per axis and the epic-with-kind case and print a
+  `gh issue edit <N> --remove-label ...` line for them; only print
+  `--add-label` for genuinely absent axes, and make every printed
+  command placeholder-free (no `|` alternatives — when the value is
+  unknown, say "with the user's chosen value substituted" in the
+  message instead). Align the wording of the "Lane-declaration FAIL"
+  block in the 6 implement agent files if needed. Tests in
+  `tests/qs/test_targets.py`.
+
+### [should-fix] `QS_<N>` branch parse accepts underscore grouping → wrong issue
+- File: `scripts/qs/quality_gate.py:1723` (`_resolve_lane_issue`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Python `int()` accepts underscore digit-grouping, so a
+  branch named `QS_332_2` (plausible "second attempt" variant) parses
+  as `int("332_2") == 3322` and the gate fetches and enforces issue
+  #3322's declaration.
+- Proposed fix: Guard with `re.fullmatch(r"QS_(\d+)", branch)` (or
+  `branch[3:].isdigit()`). Test in `tests/test_quality_gate.py`.
+
+### [should-fix] `_fetch_lane_labels`: no timeout on the pre-commit hot path
+- File: `scripts/qs/quality_gate.py:1758` (`_fetch_lane_labels`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The `gh issue view` subprocess has no `timeout`, on the
+  `--impacted` pre-commit hot path. With a half-dead network (VPN drop,
+  dead DNS — the QS-276 S1 scenario `_run`'s `timeout` param was added
+  for) and a cold/expired lane cache, the sub-15s gate hangs
+  indefinitely.
+- Proposed fix: Pass a bounded `timeout` to the call; rc 124 maps to
+  the existing `returncode != 0 → None → local warn+skip` path. Test in
+  `tests/test_quality_gate.py`.
+
+### [should-fix] `parse_parent_epic` rejects the repo's own `QS-321` convention; `_REFS_RE` case-sensitive
+- File: `scripts/qs/targets.py:213` (`parse_parent_epic`, `_REFS_RE`)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter + qs-review-blind-hunter (merged)
+- Description: The issue forms' "Parent epic" hint says "e.g. 321", but
+  every doc/branch in this project spells issues `QS-321`;
+  `re.fullmatch(r"#?(\d+)", "QS-321")` fails, the loop breaks, and the
+  declared parent is silently dropped (or a stray `Refs #N` elsewhere
+  in the body wins). Additionally `_REFS_RE` (`\bRefs #(\d+)`) is
+  case-sensitive while `_PARENT_EPIC_SECTION` is `re.IGNORECASE` and
+  GitHub's own keyword matching is case-insensitive — `refs #321` is
+  silently ignored.
+- Proposed fix: Accept `(?:QS-)?#?(\d+)` in the parent-epic field parse
+  and add `re.IGNORECASE` to `_REFS_RE`. Tests in
+  `tests/qs/test_targets.py`.
+
+### [should-fix] "CI fails closed" arm of `_check_lane_targets` is unreachable
+- File: `scripts/qs/quality_gate.py:1886` (`run_lane_check`) and the
+  full-gate call site (~line 3477)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Both CI-facing call sites feed `_get_changed_files()`,
+  which maps any git failure to `[]` (its docstring warns about this),
+  so the `changed_files is None` → "CI fails closed" arm documented in
+  `_check_lane_targets` can never trigger where CI actually runs — a
+  git failure in the `lane-check` job silently degrades to
+  declaration-only (no cross-target classification, no unknown-path
+  FYI) instead of failing closed. Reproduces if `origin/main` becomes
+  unresolvable in the CI checkout (e.g. a fetch-depth regression).
+- Proposed fix: Give `run_lane_check` and the full-gate call site a
+  fail-closed change-set helper (returncode-checked, returning `None`
+  on failure — the pattern `_impacted_early_exit_paths` already uses),
+  so `None` reaches `_check_lane_targets` and the fail-closed arm
+  works. Tests in `tests/test_quality_gate.py`.
+
+### [should-fix] Untracked files leak into the `--impacted` lane classification
+- File: `scripts/qs/quality_gate.py:2399` (`check_impacted` lane call site)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Call site 1 reuses `_impacted_early_exit_paths()`, whose
+  rung 3 (`git ls-files --others`) includes untracked files; call
+  site 2 and CI classify tracked diffs only. A factory-lane task with
+  an untracked local scratch file under a product prefix (e.g. an
+  experimental `custom_components/quiet_solar/scratch.py` never
+  intended for the PR) gets the LOUD 66-char cross-target banner on
+  every `--impacted` run, disagreeing with CI on the same tree.
+- Proposed fix: Filter the lane-check input to tracked paths (or
+  intersect with `_get_changed_files()`), keeping the untracked union
+  for the early-exit decision only. Test in
+  `tests/test_quality_gate.py`.
+
+### [should-fix] `--seed-testmon` lane-check skip has no test pin
+- File: `tests/test_quality_gate.py`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: AC-5 says the lane check "never runs in `--quick` /
+  `--seed-testmon`". The `--quick` half has a dedicated skip pin
+  (`TestLaneCheckMainCallSite::test_quick_mode_never_runs_the_lane_check`)
+  but no test runs `--seed-testmon` alone and asserts
+  `_check_lane_targets` is not called (the seed trio appears only in
+  the `--lane-check` mutex parametrization). Implementation is correct
+  by construction (seed subcommands short-circuit before the main-gate
+  lane seam) but the clause is unpinned.
+- Proposed fix: Add a seed-mode twin of the `--quick` skip test.
+
+### [should-fix] Whitespace drift in the mirrored lane blocks
+- Files: `.claude/agents/qs-implement-setup-task.md`,
+  `.cursor/agents/qs-implement-setup-task.md`,
+  `.opencode/agents/qs-implement-setup-task.md`,
+  `.opencode/agents/qs-review-task.md`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-acceptance-auditor (merged)
+- Description: The inserted "Lane (QS-332)" block in the three
+  `qs-implement-setup-task.md` copies has a doubled blank line above it
+  and **no blank line after it** — `...a parallel path).` runs directly
+  into `Read [docs/workflow/project-rules.md]...`, merging two rendered
+  paragraphs (the sibling `qs-implement-task.md` files are correct).
+  `.opencode/agents/qs-review-task.md` likewise abuts the block against
+  `## Phase protocol` with no separating blank line, unlike its
+  `.claude`/`.cursor` twins. Cosmetic, but these files are pinned
+  mirrors — this is exactly the drift class the parity tests exist to
+  prevent (the substring-based pins don't see whitespace).
+- Proposed fix: Normalize to one blank line before and after the block
+  in all copies; keep the three-harness mirrors byte-consistent for the
+  block and its surroundings.
+
+### [nice-to-have] `body: null` from the API raises `TypeError` in `build_context`
+- File: `scripts/qs/context.py:215` (`_issue_fields` / `build_context`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `data.get("body", "")` returns `None` when the key is
+  present-but-null, and `targets.parse_parent_epic(None)` raises
+  `TypeError`. `create_pr.py:63` already defends with `or ""`.
+- Proposed fix: Mirror the `or ""` guard in `_issue_fields`. Test in
+  `tests/qs/test_context.py`.
+
+### [nice-to-have] Non-ASCII paths are C-quoted by git and classify `unknown` forever
+- File: `scripts/qs/quality_gate.py:400` (`_get_changed_files` feeding
+  lane classification)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: With `core.quotePath` default, a path like
+  `docs/workflow/données.md` arrives C-quoted
+  (`"docs/workflow/donn\303\251es.md"`, literal quotes included) and
+  classifies `unknown` (verified). Fail-open only (FYI noise, and a
+  factory path escapes cross-target classification), unlike the
+  fail-closed `-z` treatment QS-290 gave `_impacted_early_exit_paths`.
+- Proposed fix: Use `-z` output for the diff feeding the lane check (or
+  `-c core.quotePath=false`), matching the QS-290 pattern. Test in
+  `tests/test_quality_gate.py`.
+
+### [nice-to-have] Known repo-root files classify `unknown` → perpetual FYI
+- File: `scripts/qs/targets.py:78` (`classify`)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `hacs.json`, `LICENSE`, `pytest.ini`, `opencode.json`,
+  `setenv.sh` all classify `unknown` today (verified), so any diff
+  touching them earns a perpetual FYI line. Fail-open by design per the
+  docstring, but `hacs.json` (product-defining) and `pytest.ini`
+  (factory) are enumerable now.
+- Proposed fix: Add the known top-level files to the appropriate
+  classification lists in `targets.py`. Tests in
+  `tests/qs/test_targets.py`.
+
+### [nice-to-have] Inaccurate comment: "mtime" vs stored `time` field
+- File: `scripts/qs/quality_gate.py` (`_read_lane_label_cache`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Comment says "A future **mtime** (clock skew)" but the
+  code checks the stored `time` JSON field, not the file's mtime.
+- Proposed fix: Reword the comment to match the implementation.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-332.story_review_fix_#02.md
+++ b/docs/stories/QS-332.story_review_fix_#02.md
@@ -1,0 +1,81 @@
+# QS-332 — Review fix plan #02
+
+## Summary
+- Source PR: #343
+- Source story: docs/stories/QS-332.story.md
+- Findings to fix: 2 (1 must-fix, 1 should-fix; 6 nice-to-have skipped
+  by user decision)
+- Next implement phase: `/implement-setup-task`
+- Review round: 2 (after fix commit f95e3c19 applied fix plan #01).
+  Round-2 status otherwise: acceptance-auditor fully clean (all 14
+  round-1 findings verified fixed + tested, all 10 story ACs trace,
+  all 11 CI checks green live including Lane Check); reviewers:
+  qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user decision).
+
+## Findings to fix
+
+### [must-fix] Missing null body/labels guard in `fetch_issue.py`
+- File: `scripts/qs/fetch_issue.py:44-59`
+- Severity: must-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (found
+  independently; merged)
+- Description: Fix plan #01 added `or ""` / `or []` null guards to
+  `context.py` (`_issue_fields`) and `create_pr.py` with the rationale
+  "the API can return a present-but-null field (`"body": null`)" — but
+  the **third** `parse_parent_epic` consumer was missed.
+  In `fetch_issue.py`, `data.get("labels", [])` iterates `None`
+  (uncaught `TypeError` at ~line 44) and `data.get("body", "")` passes
+  `None` into `targets.parse_parent_epic` (~line 59, uncaught
+  `TypeError` from `re.search(None)`), producing a raw traceback
+  instead of the script's structured error JSON. This is a round-1
+  accepted finding applied incompletely.
+- Proposed fix: `data.get("labels") or []` and
+  `data.get("body") or ""` — the exact pattern the sibling scripts now
+  use. Test: a null-body/null-labels twin of
+  `tests/qs/test_context.py::test_null_body_from_the_api_degrades_to_no_parent_epic`
+  in `tests/qs/test_fetch_issue.py`.
+
+### [should-fix] Non-canonical axis value → non-converging remediation
+- File: `scripts/qs/targets.py:186-196` (`validate_declaration`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (found
+  independently: `target:banana` / `kind:chore`; merged)
+- Description: A single axis label with a non-canonical value (e.g.
+  `kind:chore`, `target:prod`, `target:banana`) makes
+  `_axis_labels(axis)` count one present label (len==1, so the
+  duplicate-axis branch is skipped) while `parse_axes` yields `""` (so
+  the missing-axis branch fires) — but the stray label is never added
+  to `remove`. The printed remediation ("add exactly one of kind:bug /
+  kind:feature") is claimed executable verbatim (the fix-plan-#01
+  headline property), yet obeying it produces two `kind:*` labels and
+  the next gate run fails with the duplicate-axis error — a guaranteed
+  second round-trip. Verified live:
+  `validate_declaration(['kind:chore','target:product','scale:task'])`
+  emits no `--remove-label "kind:chore"`.
+- Proposed fix: In the `elif not axes[axis]` arm,
+  `remove.extend(present)` when `present` is non-empty, so the
+  remediation removes the unrecognized label(s) and adds the canonical
+  one in a single executable command set. Tests in
+  `tests/qs/test_targets.py`: non-canonical single value per axis →
+  remediation contains both the `--remove-label` of the stray label
+  and the `--add-label` prompt, and remains pipe-free/executable.
+
+## Findings skipped (user decision — recorded for traceability)
+
+- nice-to-have: `_resolve_lane_issue` `isdigit()` vs `isdecimal()`
+  (`QS_²` → uncaught `ValueError`).
+- nice-to-have: `_REFS_RE` single-space / `#`-only grammar
+  (`Refs  #321`, `Refs QS-321` silently ignored).
+- nice-to-have: `create_pr.py` lane-note classification not
+  `-z`-safe for non-ASCII paths (4th classification site).
+- nice-to-have: `parse_parent_epic` accepts `0` and self-references.
+- nice-to-have: hoisted `_impacted_early_exit_paths()` runs outside
+  the warm-baseline guard (cold-path git cost).
+- nice-to-have: no test pins `_run`'s `TimeoutExpired` → rc 124
+  conversion (verified manually by the edge-case-hunter).
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-332.story_review_fix_#03.md
+++ b/docs/stories/QS-332.story_review_fix_#03.md
@@ -1,0 +1,98 @@
+# QS-332 — Review fix plan #03
+
+## Summary
+- Source PR: #343
+- Source story: docs/stories/QS-332.story.md
+- Findings to fix: 3 (2 should-fix, 1 nice-to-have promoted by user
+  decision; 2 nice-to-have skipped)
+- Next implement phase: `/implement-setup-task`
+- Review round: 3 (after fix commit c6e040b3 applied fix plan #02).
+  Round-3 status otherwise: zero must-fix across all three reviewers;
+  acceptance-auditor fully clean (fix-plan-#02 matrix traced, no
+  story-AC regression, all 11 CI checks green live); reviewers:
+  qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user decision).
+
+## Findings to fix
+
+### [should-fix] Malformed `labels` entries still crash `fetch_issue.py`
+- File: `scripts/qs/fetch_issue.py:51`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The fix-plan-#02 guard covers a null `labels` *field*
+  (`data.get("labels") or []`), but the `lb["name"]` comprehension
+  sits **outside** the `try` at lines 38-42, and that `except` tuple
+  has no `KeyError`. A `"labels": [null]` or an entry missing `"name"`
+  (e.g. `{"id": 1}`) raises a raw `TypeError`/`KeyError` traceback
+  instead of the script's structured error JSON — the exact failure
+  mode round 2 was closing. All three peer consumers put the
+  comprehension inside a `try ... except (json.JSONDecodeError,
+  TypeError, KeyError)` (context.py:78-90, create_pr.py:58-63,
+  setup_task.py:57-61); fetch_issue.py is one level shallower than its
+  peers.
+- Proposed fix: Move the comprehension (lines 51-52) inside the
+  existing `try` block and extend the `except` to
+  `(json.JSONDecodeError, TypeError, KeyError)`. Tests in
+  `tests/qs/test_fetch_issue.py`: `"labels": [null]` and
+  `"labels": [{"id": 1}]` both degrade to the structured error JSON
+  (no traceback).
+
+### [should-fix] Canonical `or []` null-labels guard missing at 3 sibling sites
+- Files: `scripts/qs/create_pr.py:61`, `scripts/qs/setup_task.py:57`,
+  `scripts/qs/quality_gate.py:~1770` (`_fetch_lane_labels`)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The null-labels guard the PR declares canonical
+  (`data.get("labels") or []`, applied to fetch_issue.py/context.py
+  with the rationale "the API can return `"labels": null`") is still
+  missing at three sibling sites that use bare
+  `data.get("labels", [])`. The broad `except TypeError` keeps them
+  from crashing, but with degraded semantics: `create_pr.py` silently
+  drops a readable parent-epic `Refs` (and the Lane note) on a
+  null-labels response, and `setup_task.py` reports the misleading
+  `"Invalid JSON from gh CLI"` for a valid-JSON/null-labels response.
+- Proposed fix: Apply the same `data.get("labels") or []` at all three
+  sites. Tests: null-labels cases in `tests/qs/test_create_pr.py`,
+  `tests/qs/test_setup_task.py`, and `tests/test_quality_gate.py`
+  asserting the non-degraded behavior (Refs/Lane note still emitted,
+  correct error wording, labels resolve).
+
+### [nice-to-have → fix] Web forms attach legacy `bug`/`enhancement` labels — drop them
+- Files: `.github/ISSUE_TEMPLATE/bug-product.yml`,
+  `.github/ISSUE_TEMPLATE/bug-factory.yml`,
+  `.github/ISSUE_TEMPLATE/feature-product.yml`,
+  `.github/ISSUE_TEMPLATE/feature-factory.yml` (and any epic form
+  carrying a legacy label)
+- Severity: nice-to-have (user-promoted to fix)
+- Source: qs-review-blind-hunter
+- Description: Label-set asymmetry between birth paths: the web forms
+  attach the legacy `bug`/`enhancement` labels alongside the axis
+  labels, while the agent path (`--labels
+  "kind:bug,target:product,scale:task"`) omits them — same lane, two
+  different label sets, skewing any filter keyed on the plain
+  `bug`/`enhancement` labels.
+- Resolution direction (user decision): the web forms should no longer
+  attach the legacy labels — remove `bug`/`enhancement` from the
+  forms' `labels:` lists so both birth paths produce the axis-only
+  label set. Update `tests/qs/test_issue_templates.py`'s exact label
+  sets accordingly (the pins must assert the legacy labels are GONE
+  from every form).
+
+## Findings skipped (user decision — recorded for traceability)
+
+- nice-to-have: `validate_declaration` comma-joins raw label names in
+  one quoted `--remove-label` argument — a label containing `,` or `"`
+  breaks verbatim executability (widening of a pre-existing pattern).
+- nice-to-have: `tests/qs/agents/test_lane_steps_parity.py` sentinel
+  `next(...)` without default → raw `StopIteration` on a future
+  reword instead of a readable assertion.
+- (from plan #02, still skipped): `isdigit()` vs `isdecimal()`;
+  `_impacted_early_exit_paths()` hoist outside the warm-baseline
+  guard; `_REFS_RE` grammar; `create_pr.py` lane-note `-z` safety;
+  `parse_parent_epic` accepts `0`/self-reference; `_run`
+  `TimeoutExpired`→rc-124 test pin.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-332.story_review_fix_#04.md
+++ b/docs/stories/QS-332.story_review_fix_#04.md
@@ -1,0 +1,122 @@
+# QS-332 — Review fix plan #04
+
+## Summary
+- Source PR: #343
+- Source story: docs/stories/QS-332.story.md
+- Findings to fix: 4 (1 must-fix [user-promoted from should-fix],
+  1 should-fix, 2 nice-to-have) — "fix all"
+- Next implement phase: `/implement-setup-task`
+- Review round: 4 (after fix commit 1992e2ba applied fix plan #03).
+  Round-4 status otherwise: acceptance-auditor fully clean (fix-plan-#03
+  matrix traced, the story.md edit judged a legitimate consistency
+  amendment, all 11 CI checks green live); reviewers:
+  qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user decision).
+
+## Findings to fix
+
+### [must-fix] Epic lane creates a branch + worktree, violating the epic model
+- Files: `.claude/agents/qs-setup-task.md` (+ `.cursor/` and
+  `.opencode/` mirrors), `scripts/qs/setup_task.py`
+- Severity: must-fix (blind-hunter rated should-fix; user promoted to
+  must-fix — "creating a branch and worktree for an epic is a must-fix")
+- Source: qs-review-blind-hunter (orchestrator-verified valid)
+- Description: setup-task step 1b offers `epic product` / `epic factory`
+  as pickable lane options for a NEW issue, and step 2 runs
+  `setup_task.py {{issue}} ...` **unconditionally**, creating a branch
+  `QS_<N>` and a worktree. This directly contradicts the epic model the
+  PR itself establishes: story line 285 states "Epics don't reach
+  `setup_task.py` — no branch/worktree", and the epic issue templates
+  say an epic has "no branch/worktree of its own". Two entry paths hit
+  this: (1) a user picking an epic lane for a new issue at step 1b;
+  (2) an existing epic passed via `--issue N` (the story's "if an epic
+  issue is ever passed" case, L285-288) — `check_declaration` accepts
+  the epic-shaped declaration, then step 2 still cuts a worktree. The
+  round-1 "explicit story decision (L278)" note covered only
+  `setup_task.py`'s declaration refusal/validation, NOT the
+  worktree-for-epic path — this is a distinct, unreconciled gap.
+- Proposed fix (machine-enforced, matching the story's "machine-checked
+  rather than prompt-obeyed" philosophy): `setup_task.py` already
+  fetches the issue's labels for `check_declaration`; use that to
+  detect `scale:epic` and **refuse to create a branch/worktree** for an
+  epic (fail fast with a clear message, or force the no-worktree path
+  with an epic-appropriate next step) rather than relying on the agent
+  prompt. Then reconcile the setup-task agent (×3 harnesses): step 2
+  must not create a worktree for an epic lane, and step 1b's epic
+  options must be consistent with whatever epic-birth path the story
+  actually sanctions. Decide during implement whether epics are
+  createable via setup-task at all (web-template-only birth) or via a
+  distinct no-worktree path — but the machine invariant "epic ⇒ no
+  worktree" must hold regardless of prompt. Tests: `scripts/qs/setup_task.py`
+  epic path in `tests/qs/test_setup_task.py` (epic labels ⇒ no
+  worktree / refusal, both `--issue` and new-issue paths); parity pins
+  in `tests/qs/agents/test_lane_steps_parity.py` if the agent step
+  wording changes across the three mirrors.
+
+### [should-fix] `data["number"]` sits outside the guarded try in `fetch_issue.py`
+- File: `scripts/qs/fetch_issue.py:61` (also line 72)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Fix plan #03 moved the `labels`/`body` reads inside the
+  `try ... except (json.JSONDecodeError, TypeError, KeyError)` guard,
+  but `data["number"]` (used at both the `issue_number` and `branch`
+  lines) is still a bare subscript OUTSIDE the guard, with no default.
+  A valid-but-incomplete JSON object (`gh` exits 0, stdout `{}` or any
+  object lacking `"number"`) degrades cleanly on the labels/body path,
+  then crashes with a raw `KeyError` traceback — a hole in the
+  "everything degrades to structured JSON" contract the last two rounds
+  were closing. Unique to `fetch_issue.py` (the peer consumers never
+  read `number`, so their parity doesn't cover it).
+- Proposed fix: Read `number` inside the `try` block (`KeyError` is
+  already in the except tuple), or `data.get("number")` with an
+  explicit missing-number error branch. Test: `{}` / number-less object
+  ⇒ structured error JSON (no traceback) in `tests/qs/test_fetch_issue.py`.
+
+### [nice-to-have] `config entr(y|ies)` triage regex rejects `-`/`_` separators
+- File: `.github/workflows/issue-triage.yml`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Separator handling is asymmetric — `\bconfig[ _-]?flow\b`
+  matches `config flow` / `config-flow` / `config_flow` / `configflow`,
+  but `\bconfig entr(y|ies)\b` requires a literal space, so
+  `config-entry` / `config_entry` won't label.
+- Proposed fix: `\bconfig[ _-]?entr(y|ies)\b` for parity. Update the
+  corresponding pin in `tests/qs/test_github_workflows.py`.
+
+### [nice-to-have] Non-dict top-level JSON escapes the except tuples as `AttributeError`
+- Files: `scripts/qs/fetch_issue.py`, `scripts/qs/create_pr.py`,
+  `scripts/qs/quality_gate.py`, `scripts/qs/setup_task.py`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: When `json.loads` returns a non-dict top-level value
+  (`null`, `[]`, `42`), `data.get(...)` raises `AttributeError`, which
+  is not in the `(JSONDecodeError, TypeError, KeyError)` except tuples,
+  so it escapes as a raw traceback instead of the structured / `None`
+  degrade path. Pre-existing (not introduced this round) and
+  near-impossible from `gh issue view --json` on success; flagged only
+  because uniform defensive degradation is the stated goal of these
+  four guards.
+- Proposed fix: Add `AttributeError` to the except tuples (or guard
+  with `isinstance(data, dict)`) at the four sites. Tests alongside the
+  existing malformed-JSON cases in each consumer's test file.
+
+## Findings not carried (recorded for traceability)
+
+- invalid: blind-hunter re-raised "`_fetch_lane_labels` catches
+  `OSError` but a timeout raises `TimeoutExpired`" — already verified in
+  round 2 that `_run` converts `TimeoutExpired` → rc 124 (→ warn+skip
+  path). The only residue is the missing test pin, already a
+  user-skipped nice-to-have from fix plan #02.
+- already-skipped: blind-hunter re-raised the
+  `_impacted_early_exit_paths()` hoist (cold-path git cost) — recorded
+  as a user-skipped nice-to-have in fix plans #02/#03; no new action.
+- (still skipped from earlier rounds): `validate_declaration` comma-join
+  of label names with `,`/`"`; `test_lane_steps_parity.py` sentinel
+  `next(...)` without default; `isdigit()` vs `isdecimal()`; `_REFS_RE`
+  grammar; `create_pr.py` lane-note `-z` safety; `parse_parent_epic`
+  accepts `0`/self-reference.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/workflow/lanes/bug-factory.md
+++ b/docs/workflow/lanes/bug-factory.md
@@ -1,0 +1,262 @@
+# Phase protocols
+
+Each phase has a static agent under `.claude/agents/` (mirrored in
+`.cursor/agents/` and `.opencode/agents/`). Agents discover task
+context at runtime via
+`python scripts/qs/context.py`. This document captures the contract for
+each phase — inputs, outputs, hand-off, hard rules.
+
+Each phase is invoked **as an interactive session** via
+`claude --agent qs-<phase>` (the launcher form — preferred). The
+slash-command form (`/<phase>`) is kept as a **degraded fallback** for
+Claude Desktop and any chat without a CLI launcher. See
+[overview.md](overview.md) section "Orchestrators are interactive
+sessions; sub-agents are parallel fan-out" for the full rationale —
+this document does not duplicate it.
+
+---
+
+## `setup-task` (agent: `qs-setup-task`)
+
+**Runs on**: main checkout.
+**Inputs**: free text describing a feature, OR `--issue N` to use an
+existing GitHub issue, OR `--plan /path/to/plan.md`.
+**Side effects**: creates GitHub issue, creates branch `QS_<N>`, creates
+worktree at `<repo>-worktrees/QS_<N>/`.
+**Output**: launcher command (`scripts/qs/launchers/<harness>.py`-generated)
+the user runs to open a new session on the worktree.
+**Next phase**: `claude --agent qs-create-plan` in the worktree
+(preferred — fresh interactive session), or `/create-plan` as fallback.
+
+**Hard rules**:
+- Do NOT analyze, diagnose, or interpret user input. Pass the text
+  through to the GitHub issue verbatim. Deep analysis is `/create-plan`'s
+  job.
+- Do NOT switch the main checkout's branch.
+- Do NOT commit or push manually — setup only creates the branch and
+  worktree (`scripts/worktree-setup.sh` itself publishes the branch
+  via `git push -u`; that script-driven push is expected).
+
+---
+
+## `create-plan` (agent: `qs-create-plan`)
+
+**Runs on**: worktree.
+**Inputs**: branch `QS_<N>` (issue resolves from there).
+**Side effects**: writes story file to
+`docs/stories/QS-<N>.story.md` (written as soon as the first discussion
+round converges, **committed only at FINALIZE**).
+**Output**: story file with acceptance criteria + task breakdown +
+adversarial review notes appended.
+**Next phase**: `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` in the worktree (preferred —
+fresh interactive session), or `/implement-task` /
+`/implement-setup-task` as fallback. The agent decides which based on
+the file paths in its task breakdown.
+
+**Phase protocol** — a **user-driven mode loop** (DISCUSS / REVIEW /
+TRIAGE / FINALIZE), not a linear pipeline. DISCUSS is the durable
+default; REVIEW is invoked on demand and repeatable; the story file is
+the living document:
+
+- **DISCUSS (default)**: read the issue (`gh issue view`), read
+  `project-rules.md` / `project-context.md`, glob the relevant code,
+  and discuss scope/risks/acceptance with the user — iterate
+  indefinitely. As soon as the first round **converges** (the plan has
+  all required headings, or the user says "write it"), write the story
+  file and overwrite it on every later change; announce it is readable.
+  Run the doc-maintenance sub-step (`check_doc_drift.py --paths`). Print
+  the status banner and offer REVIEW once per stable version. The story
+  stays uncommitted.
+- **REVIEW (invoked)**: spawn the plan reviewers in parallel (one
+  message). Round 1 = the **4 global reviewers**; round 2+ = the same 4
+  **plus `qs-plan-delta-auditor`** fed an in-context diff + the prior
+  round's accepted findings. See [adversarial-review.md](adversarial-review.md).
+- **TRIAGE**: dedupe via the finding-state model
+  (`open`/`resolved`/`rejected`), present deltas first, drive
+  interactive triage, fold accepted findings into the story, then return
+  to DISCUSS.
+- **FINALIZE (on confirmed intent)**: an **advisory** gate (never
+  hard-blocks) — if the plan changed since the last review, or open
+  criticals remain, the agent asks but the user decides. Determine
+  `NEXT_PHASE` (`implement-setup-task` if all touched files are in
+  `scripts/`, `.claude/`, `.cursor/`, `.opencode/`, `legacy/`,
+  `docs/`, `.github/`, or top-level config; otherwise `implement-task`),
+  commit + push, then emit the launcher payload (preferred,
+  `claude --agent qs-implement-task` / `qs-implement-setup-task`) plus
+  the slash-command fallback.
+
+**Hard rules**:
+- Do not write code in this phase.
+- Edit scope is the story file — written during DISCUSS/TRIAGE,
+  committed only at FINALIZE.
+- Never skip the adversarial review for a plan you intend to ship.
+
+---
+
+## `implement-task` / `implement-setup-task` (agents: `qs-implement-task`, `qs-implement-setup-task`)
+
+**Runs on**: worktree.
+**Inputs**: story file from `create-plan`.
+**Side effects**: writes code under `custom_components/quiet_solar/` and
+`tests/` (or `scripts/`, `.claude/`, etc. for `implement-setup-task`);
+auto-commits, pushes, opens PR after green quality gate.
+**Output**: PR opened with quality checklist and risk assessment.
+**Next phase**: `claude --agent qs-review-task` in the worktree
+(preferred — fresh interactive session), or `/review-task` as fallback.
+
+**Phase protocol**:
+1. Read story file. Confirm branch state.
+2. TDD: write failing tests → implement minimum code → refactor.
+3. Present implementation summary (files modified, design decisions,
+   risks). Ask "Ready to run the quality gate?".
+4. **ALWAYS** run the impacted inner-loop gate
+   (`python scripts/qs/quality_gate.py --impacted`) before commit/PR —
+   it proves the *changed lines* are 100% covered in seconds and
+   self-heals a drifted testmon baseline automatically (no manual file
+   deletion ever). Do **not** run, or substitute, the full gate
+   locally: the whole-repo 100% gate runs authoritatively in **CI** on
+   every PR, and detecting coverage lost in *unchanged* code is **CI's
+   exclusive job**. The only local full-gate run is an explicit user
+   request. On an `--impacted` failure, fix the **code/tests** — never
+   reach for the full gate to diagnose; escalate only after 2–3
+   attempts. For change sets touching any `tests/qs`-pinned non-Python
+   file (agent files, commands, workflow docs,
+   `.claude/settings.json`) — even when Python files changed too —
+   also run `python scripts/qs/quality_gate.py --quick tests/qs`
+   before commit (testmon cannot see non-Python files).
+5. Auto-commit, push, open PR. No confirmation prompt — authorized by
+   the workflow.
+
+**Edit scope**:
+- `qs-implement-task`: `custom_components/quiet_solar/**`, `tests/**`,
+  plus the story file (for progress notes).
+- `qs-implement-setup-task`: `scripts/qs/**`, `.claude/**`, `.cursor/**`,
+  `.opencode/**`, `legacy/**` (frozen — `git mv` INTO only),
+  `docs/**`, `.github/**`,
+  top-level config files, plus the story file.
+
+**Hard rules**:
+- No code without a failing test first.
+- No commit without a green quality gate.
+- Coverage below 100% is a hard block. No `# pragma: no cover` without
+  explicit user authorization.
+
+---
+
+## `review-task` (agent: `qs-review-task`)
+
+**Runs on**: worktree.
+**Inputs**: PR number (resolved from branch).
+**Side effects**: writes fix-plan files under
+`docs/stories/QS-<N>.story_review_fix_#NN.md` (if fixes
+are needed).
+**Output**: triaged findings; either "ready for finish-task" or a fix
+plan + instructions for the user to apply fixes.
+**Next phase**: `claude --agent qs-finish-task` in the worktree
+(preferred — fresh interactive session), or `/finish-task` as fallback.
+When fixes are needed, re-run `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` (chosen by file scope of the
+findings, same rule as `/create-plan`) — with `/implement-task` or
+`/implement-setup-task` as the slash-command fallback — then re-run
+`claude --agent qs-review-task` (or `/review-task`).
+
+**Phase protocol**:
+1. Fetch PR diff.
+2. **Spawn 4 reviewer subagents in parallel** (one message, 4
+   invocations):
+   - `qs-review-blind-hunter` — diff only, no repo context
+   - `qs-review-edge-case-hunter` — diff + repo read-only
+   - `qs-review-acceptance-auditor` — diff + story file
+   - `qs-review-coderabbit` — wraps CodeRabbit's review
+3. Consolidate into must-fix / should-fix / nice-to-have / invalid.
+4. **Zero-findings fast path**: if no must-fix or should-fix findings,
+   emit the launcher payload (preferred, `claude --agent
+   qs-finish-task`) plus the slash-command fallback (`/finish-task`).
+5. Interactive triage: present table → ask "fix all / skip all / one by
+   one?" → collect decisions → confirm.
+6. If fixes needed, write fix-plan file (auto-incremented suffix
+   `#01`, `#02`, …) and emit the launcher payload (`claude --agent
+   qs-implement-task` or `claude --agent qs-implement-setup-task`,
+   chosen by file scope of the findings — same rule as `/create-plan`)
+   plus the matching slash-command fallback (`/implement-task` or
+   `/implement-setup-task`) for the user to apply the fix plan.
+7. When fixes pushed, the user re-runs `claude --agent qs-review-task`
+   (or `/review-task` as fallback) — loop back to step 1 until clean.
+
+**Hard rules**:
+- This agent is an orchestrator — do not review code yourself. Always
+  delegate to the 4 subagents.
+- Edit scope is the fix-plan files only.
+- Sub-agent spawning must be parallel, not serial.
+
+---
+
+## `finish-task` (agent: `qs-finish-task`)
+
+**Runs on**: worktree (until cleanup, then transitions out).
+**Inputs**: PR number if one exists — `pr_number` may be null (the
+no-PR abandon/cleanup path, Case A in the agent), in which case merge
+logic is skipped entirely.
+**Side effects**: merges PR, deletes branch on origin, removes worktree.
+**Output**: confirmation; user is directed to `/release` if appropriate.
+**Next phase**: `/release` from the main checkout (independent), or
+`claude --agent qs-release` if the user prefers the interactive form.
+Note that `qs-finish-task` does **not** call
+`scripts/qs/next_step.py --next-cmd release` to build a launcher
+payload — release lives on the main checkout, which is a different
+workspace, and the user invokes it manually. The agent body still
+mentions both `/release` and `claude --agent qs-release` in plain prose
+as alternatives (see QS-175 OUT OF SCOPE).
+
+**Phase protocol**:
+1. Show PR summary.
+2. Verify CI status: `gh pr checks <PR>`. If pending, advise wait. If
+   failed, STOP.
+3. Ask user for explicit merge authorization.
+4. Merge PR: `gh pr merge --merge`.
+5. Refresh the `--impacted` baseline (QS-276): capture `MAIN_DIR` (via
+   `git worktree list --porcelain | head -1`) **before** cleanup,
+   update the main checkout (`fetch` + `checkout main` + `pull
+   --ff-only`), then refresh the testmon DB via
+   `quality_gate.py --seed-testmon` — detached/best-effort, never
+   blocking cleanup. A failure or stale baseline is safe (new worktrees
+   just run more tests). QS-286: the detached run now emits a completion
+   signal — it redirects to `.testmondata.seed.log` and writes a
+   `.testmondata.seed-status` marker when done; poll it from the main
+   checkout with `quality_gate.py --seed-testmon-status` (0 = safe to
+   close, 4 = still running, 1 = rerun, 3 = no readable status).
+6. Delete remote branch (safety check: refuse if branch is
+   `main` / `master`).
+7. Run `python scripts/qs/cleanup_worktree.py --work-dir <wd>
+   --issue <N> --force` (force because code is safely on main).
+8. Report. If merged and production code touched, tell the user to run
+   `/release` from main.
+
+**Hard rules**:
+- No merge without explicit user authorization.
+- Never auto-chain to `/release` — it's a separate decision.
+
+---
+
+## `release` (agent: `qs-release`)
+
+**Runs on**: main checkout. Independent of any task.
+**Inputs**: none (uses current date for tag derivation).
+**Side effects**: bumps `manifest.json` version, commits, tags, pushes
+tag.
+**Output**: tag `vYYYY.MM.DD.N`; GitHub Actions runs the release
+pipeline.
+**Next phase**: terminal.
+
+**Phase protocol**:
+1. Confirm clean main: `git checkout main`, `git pull`, `git status`.
+2. Dry run: `python scripts/qs/release.py --dry-run` → show proposed
+   tag → ask for confirmation.
+3. Run real: `python scripts/qs/release.py` → bumps manifest, commits,
+   pushes, tags.
+4. Report tag and version; note that GitHub Actions handles the rest.
+
+**Hard rules**:
+- Always dry-run first. Get user confirmation before the real run.
+- Refuse to run if `git status` is not clean.

--- a/docs/workflow/lanes/bug-product.md
+++ b/docs/workflow/lanes/bug-product.md
@@ -1,0 +1,262 @@
+# Phase protocols
+
+Each phase has a static agent under `.claude/agents/` (mirrored in
+`.cursor/agents/` and `.opencode/agents/`). Agents discover task
+context at runtime via
+`python scripts/qs/context.py`. This document captures the contract for
+each phase — inputs, outputs, hand-off, hard rules.
+
+Each phase is invoked **as an interactive session** via
+`claude --agent qs-<phase>` (the launcher form — preferred). The
+slash-command form (`/<phase>`) is kept as a **degraded fallback** for
+Claude Desktop and any chat without a CLI launcher. See
+[overview.md](overview.md) section "Orchestrators are interactive
+sessions; sub-agents are parallel fan-out" for the full rationale —
+this document does not duplicate it.
+
+---
+
+## `setup-task` (agent: `qs-setup-task`)
+
+**Runs on**: main checkout.
+**Inputs**: free text describing a feature, OR `--issue N` to use an
+existing GitHub issue, OR `--plan /path/to/plan.md`.
+**Side effects**: creates GitHub issue, creates branch `QS_<N>`, creates
+worktree at `<repo>-worktrees/QS_<N>/`.
+**Output**: launcher command (`scripts/qs/launchers/<harness>.py`-generated)
+the user runs to open a new session on the worktree.
+**Next phase**: `claude --agent qs-create-plan` in the worktree
+(preferred — fresh interactive session), or `/create-plan` as fallback.
+
+**Hard rules**:
+- Do NOT analyze, diagnose, or interpret user input. Pass the text
+  through to the GitHub issue verbatim. Deep analysis is `/create-plan`'s
+  job.
+- Do NOT switch the main checkout's branch.
+- Do NOT commit or push manually — setup only creates the branch and
+  worktree (`scripts/worktree-setup.sh` itself publishes the branch
+  via `git push -u`; that script-driven push is expected).
+
+---
+
+## `create-plan` (agent: `qs-create-plan`)
+
+**Runs on**: worktree.
+**Inputs**: branch `QS_<N>` (issue resolves from there).
+**Side effects**: writes story file to
+`docs/stories/QS-<N>.story.md` (written as soon as the first discussion
+round converges, **committed only at FINALIZE**).
+**Output**: story file with acceptance criteria + task breakdown +
+adversarial review notes appended.
+**Next phase**: `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` in the worktree (preferred —
+fresh interactive session), or `/implement-task` /
+`/implement-setup-task` as fallback. The agent decides which based on
+the file paths in its task breakdown.
+
+**Phase protocol** — a **user-driven mode loop** (DISCUSS / REVIEW /
+TRIAGE / FINALIZE), not a linear pipeline. DISCUSS is the durable
+default; REVIEW is invoked on demand and repeatable; the story file is
+the living document:
+
+- **DISCUSS (default)**: read the issue (`gh issue view`), read
+  `project-rules.md` / `project-context.md`, glob the relevant code,
+  and discuss scope/risks/acceptance with the user — iterate
+  indefinitely. As soon as the first round **converges** (the plan has
+  all required headings, or the user says "write it"), write the story
+  file and overwrite it on every later change; announce it is readable.
+  Run the doc-maintenance sub-step (`check_doc_drift.py --paths`). Print
+  the status banner and offer REVIEW once per stable version. The story
+  stays uncommitted.
+- **REVIEW (invoked)**: spawn the plan reviewers in parallel (one
+  message). Round 1 = the **4 global reviewers**; round 2+ = the same 4
+  **plus `qs-plan-delta-auditor`** fed an in-context diff + the prior
+  round's accepted findings. See [adversarial-review.md](adversarial-review.md).
+- **TRIAGE**: dedupe via the finding-state model
+  (`open`/`resolved`/`rejected`), present deltas first, drive
+  interactive triage, fold accepted findings into the story, then return
+  to DISCUSS.
+- **FINALIZE (on confirmed intent)**: an **advisory** gate (never
+  hard-blocks) — if the plan changed since the last review, or open
+  criticals remain, the agent asks but the user decides. Determine
+  `NEXT_PHASE` (`implement-setup-task` if all touched files are in
+  `scripts/`, `.claude/`, `.cursor/`, `.opencode/`, `legacy/`,
+  `docs/`, `.github/`, or top-level config; otherwise `implement-task`),
+  commit + push, then emit the launcher payload (preferred,
+  `claude --agent qs-implement-task` / `qs-implement-setup-task`) plus
+  the slash-command fallback.
+
+**Hard rules**:
+- Do not write code in this phase.
+- Edit scope is the story file — written during DISCUSS/TRIAGE,
+  committed only at FINALIZE.
+- Never skip the adversarial review for a plan you intend to ship.
+
+---
+
+## `implement-task` / `implement-setup-task` (agents: `qs-implement-task`, `qs-implement-setup-task`)
+
+**Runs on**: worktree.
+**Inputs**: story file from `create-plan`.
+**Side effects**: writes code under `custom_components/quiet_solar/` and
+`tests/` (or `scripts/`, `.claude/`, etc. for `implement-setup-task`);
+auto-commits, pushes, opens PR after green quality gate.
+**Output**: PR opened with quality checklist and risk assessment.
+**Next phase**: `claude --agent qs-review-task` in the worktree
+(preferred — fresh interactive session), or `/review-task` as fallback.
+
+**Phase protocol**:
+1. Read story file. Confirm branch state.
+2. TDD: write failing tests → implement minimum code → refactor.
+3. Present implementation summary (files modified, design decisions,
+   risks). Ask "Ready to run the quality gate?".
+4. **ALWAYS** run the impacted inner-loop gate
+   (`python scripts/qs/quality_gate.py --impacted`) before commit/PR —
+   it proves the *changed lines* are 100% covered in seconds and
+   self-heals a drifted testmon baseline automatically (no manual file
+   deletion ever). Do **not** run, or substitute, the full gate
+   locally: the whole-repo 100% gate runs authoritatively in **CI** on
+   every PR, and detecting coverage lost in *unchanged* code is **CI's
+   exclusive job**. The only local full-gate run is an explicit user
+   request. On an `--impacted` failure, fix the **code/tests** — never
+   reach for the full gate to diagnose; escalate only after 2–3
+   attempts. For change sets touching any `tests/qs`-pinned non-Python
+   file (agent files, commands, workflow docs,
+   `.claude/settings.json`) — even when Python files changed too —
+   also run `python scripts/qs/quality_gate.py --quick tests/qs`
+   before commit (testmon cannot see non-Python files).
+5. Auto-commit, push, open PR. No confirmation prompt — authorized by
+   the workflow.
+
+**Edit scope**:
+- `qs-implement-task`: `custom_components/quiet_solar/**`, `tests/**`,
+  plus the story file (for progress notes).
+- `qs-implement-setup-task`: `scripts/qs/**`, `.claude/**`, `.cursor/**`,
+  `.opencode/**`, `legacy/**` (frozen — `git mv` INTO only),
+  `docs/**`, `.github/**`,
+  top-level config files, plus the story file.
+
+**Hard rules**:
+- No code without a failing test first.
+- No commit without a green quality gate.
+- Coverage below 100% is a hard block. No `# pragma: no cover` without
+  explicit user authorization.
+
+---
+
+## `review-task` (agent: `qs-review-task`)
+
+**Runs on**: worktree.
+**Inputs**: PR number (resolved from branch).
+**Side effects**: writes fix-plan files under
+`docs/stories/QS-<N>.story_review_fix_#NN.md` (if fixes
+are needed).
+**Output**: triaged findings; either "ready for finish-task" or a fix
+plan + instructions for the user to apply fixes.
+**Next phase**: `claude --agent qs-finish-task` in the worktree
+(preferred — fresh interactive session), or `/finish-task` as fallback.
+When fixes are needed, re-run `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` (chosen by file scope of the
+findings, same rule as `/create-plan`) — with `/implement-task` or
+`/implement-setup-task` as the slash-command fallback — then re-run
+`claude --agent qs-review-task` (or `/review-task`).
+
+**Phase protocol**:
+1. Fetch PR diff.
+2. **Spawn 4 reviewer subagents in parallel** (one message, 4
+   invocations):
+   - `qs-review-blind-hunter` — diff only, no repo context
+   - `qs-review-edge-case-hunter` — diff + repo read-only
+   - `qs-review-acceptance-auditor` — diff + story file
+   - `qs-review-coderabbit` — wraps CodeRabbit's review
+3. Consolidate into must-fix / should-fix / nice-to-have / invalid.
+4. **Zero-findings fast path**: if no must-fix or should-fix findings,
+   emit the launcher payload (preferred, `claude --agent
+   qs-finish-task`) plus the slash-command fallback (`/finish-task`).
+5. Interactive triage: present table → ask "fix all / skip all / one by
+   one?" → collect decisions → confirm.
+6. If fixes needed, write fix-plan file (auto-incremented suffix
+   `#01`, `#02`, …) and emit the launcher payload (`claude --agent
+   qs-implement-task` or `claude --agent qs-implement-setup-task`,
+   chosen by file scope of the findings — same rule as `/create-plan`)
+   plus the matching slash-command fallback (`/implement-task` or
+   `/implement-setup-task`) for the user to apply the fix plan.
+7. When fixes pushed, the user re-runs `claude --agent qs-review-task`
+   (or `/review-task` as fallback) — loop back to step 1 until clean.
+
+**Hard rules**:
+- This agent is an orchestrator — do not review code yourself. Always
+  delegate to the 4 subagents.
+- Edit scope is the fix-plan files only.
+- Sub-agent spawning must be parallel, not serial.
+
+---
+
+## `finish-task` (agent: `qs-finish-task`)
+
+**Runs on**: worktree (until cleanup, then transitions out).
+**Inputs**: PR number if one exists — `pr_number` may be null (the
+no-PR abandon/cleanup path, Case A in the agent), in which case merge
+logic is skipped entirely.
+**Side effects**: merges PR, deletes branch on origin, removes worktree.
+**Output**: confirmation; user is directed to `/release` if appropriate.
+**Next phase**: `/release` from the main checkout (independent), or
+`claude --agent qs-release` if the user prefers the interactive form.
+Note that `qs-finish-task` does **not** call
+`scripts/qs/next_step.py --next-cmd release` to build a launcher
+payload — release lives on the main checkout, which is a different
+workspace, and the user invokes it manually. The agent body still
+mentions both `/release` and `claude --agent qs-release` in plain prose
+as alternatives (see QS-175 OUT OF SCOPE).
+
+**Phase protocol**:
+1. Show PR summary.
+2. Verify CI status: `gh pr checks <PR>`. If pending, advise wait. If
+   failed, STOP.
+3. Ask user for explicit merge authorization.
+4. Merge PR: `gh pr merge --merge`.
+5. Refresh the `--impacted` baseline (QS-276): capture `MAIN_DIR` (via
+   `git worktree list --porcelain | head -1`) **before** cleanup,
+   update the main checkout (`fetch` + `checkout main` + `pull
+   --ff-only`), then refresh the testmon DB via
+   `quality_gate.py --seed-testmon` — detached/best-effort, never
+   blocking cleanup. A failure or stale baseline is safe (new worktrees
+   just run more tests). QS-286: the detached run now emits a completion
+   signal — it redirects to `.testmondata.seed.log` and writes a
+   `.testmondata.seed-status` marker when done; poll it from the main
+   checkout with `quality_gate.py --seed-testmon-status` (0 = safe to
+   close, 4 = still running, 1 = rerun, 3 = no readable status).
+6. Delete remote branch (safety check: refuse if branch is
+   `main` / `master`).
+7. Run `python scripts/qs/cleanup_worktree.py --work-dir <wd>
+   --issue <N> --force` (force because code is safely on main).
+8. Report. If merged and production code touched, tell the user to run
+   `/release` from main.
+
+**Hard rules**:
+- No merge without explicit user authorization.
+- Never auto-chain to `/release` — it's a separate decision.
+
+---
+
+## `release` (agent: `qs-release`)
+
+**Runs on**: main checkout. Independent of any task.
+**Inputs**: none (uses current date for tag derivation).
+**Side effects**: bumps `manifest.json` version, commits, tags, pushes
+tag.
+**Output**: tag `vYYYY.MM.DD.N`; GitHub Actions runs the release
+pipeline.
+**Next phase**: terminal.
+
+**Phase protocol**:
+1. Confirm clean main: `git checkout main`, `git pull`, `git status`.
+2. Dry run: `python scripts/qs/release.py --dry-run` → show proposed
+   tag → ask for confirmation.
+3. Run real: `python scripts/qs/release.py` → bumps manifest, commits,
+   pushes, tags.
+4. Report tag and version; note that GitHub Actions handles the rest.
+
+**Hard rules**:
+- Always dry-run first. Get user confirmation before the real run.
+- Refuse to run if `git status` is not clean.

--- a/docs/workflow/lanes/epic-factory.md
+++ b/docs/workflow/lanes/epic-factory.md
@@ -1,0 +1,262 @@
+# Phase protocols
+
+Each phase has a static agent under `.claude/agents/` (mirrored in
+`.cursor/agents/` and `.opencode/agents/`). Agents discover task
+context at runtime via
+`python scripts/qs/context.py`. This document captures the contract for
+each phase — inputs, outputs, hand-off, hard rules.
+
+Each phase is invoked **as an interactive session** via
+`claude --agent qs-<phase>` (the launcher form — preferred). The
+slash-command form (`/<phase>`) is kept as a **degraded fallback** for
+Claude Desktop and any chat without a CLI launcher. See
+[overview.md](overview.md) section "Orchestrators are interactive
+sessions; sub-agents are parallel fan-out" for the full rationale —
+this document does not duplicate it.
+
+---
+
+## `setup-task` (agent: `qs-setup-task`)
+
+**Runs on**: main checkout.
+**Inputs**: free text describing a feature, OR `--issue N` to use an
+existing GitHub issue, OR `--plan /path/to/plan.md`.
+**Side effects**: creates GitHub issue, creates branch `QS_<N>`, creates
+worktree at `<repo>-worktrees/QS_<N>/`.
+**Output**: launcher command (`scripts/qs/launchers/<harness>.py`-generated)
+the user runs to open a new session on the worktree.
+**Next phase**: `claude --agent qs-create-plan` in the worktree
+(preferred — fresh interactive session), or `/create-plan` as fallback.
+
+**Hard rules**:
+- Do NOT analyze, diagnose, or interpret user input. Pass the text
+  through to the GitHub issue verbatim. Deep analysis is `/create-plan`'s
+  job.
+- Do NOT switch the main checkout's branch.
+- Do NOT commit or push manually — setup only creates the branch and
+  worktree (`scripts/worktree-setup.sh` itself publishes the branch
+  via `git push -u`; that script-driven push is expected).
+
+---
+
+## `create-plan` (agent: `qs-create-plan`)
+
+**Runs on**: worktree.
+**Inputs**: branch `QS_<N>` (issue resolves from there).
+**Side effects**: writes story file to
+`docs/stories/QS-<N>.story.md` (written as soon as the first discussion
+round converges, **committed only at FINALIZE**).
+**Output**: story file with acceptance criteria + task breakdown +
+adversarial review notes appended.
+**Next phase**: `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` in the worktree (preferred —
+fresh interactive session), or `/implement-task` /
+`/implement-setup-task` as fallback. The agent decides which based on
+the file paths in its task breakdown.
+
+**Phase protocol** — a **user-driven mode loop** (DISCUSS / REVIEW /
+TRIAGE / FINALIZE), not a linear pipeline. DISCUSS is the durable
+default; REVIEW is invoked on demand and repeatable; the story file is
+the living document:
+
+- **DISCUSS (default)**: read the issue (`gh issue view`), read
+  `project-rules.md` / `project-context.md`, glob the relevant code,
+  and discuss scope/risks/acceptance with the user — iterate
+  indefinitely. As soon as the first round **converges** (the plan has
+  all required headings, or the user says "write it"), write the story
+  file and overwrite it on every later change; announce it is readable.
+  Run the doc-maintenance sub-step (`check_doc_drift.py --paths`). Print
+  the status banner and offer REVIEW once per stable version. The story
+  stays uncommitted.
+- **REVIEW (invoked)**: spawn the plan reviewers in parallel (one
+  message). Round 1 = the **4 global reviewers**; round 2+ = the same 4
+  **plus `qs-plan-delta-auditor`** fed an in-context diff + the prior
+  round's accepted findings. See [adversarial-review.md](adversarial-review.md).
+- **TRIAGE**: dedupe via the finding-state model
+  (`open`/`resolved`/`rejected`), present deltas first, drive
+  interactive triage, fold accepted findings into the story, then return
+  to DISCUSS.
+- **FINALIZE (on confirmed intent)**: an **advisory** gate (never
+  hard-blocks) — if the plan changed since the last review, or open
+  criticals remain, the agent asks but the user decides. Determine
+  `NEXT_PHASE` (`implement-setup-task` if all touched files are in
+  `scripts/`, `.claude/`, `.cursor/`, `.opencode/`, `legacy/`,
+  `docs/`, `.github/`, or top-level config; otherwise `implement-task`),
+  commit + push, then emit the launcher payload (preferred,
+  `claude --agent qs-implement-task` / `qs-implement-setup-task`) plus
+  the slash-command fallback.
+
+**Hard rules**:
+- Do not write code in this phase.
+- Edit scope is the story file — written during DISCUSS/TRIAGE,
+  committed only at FINALIZE.
+- Never skip the adversarial review for a plan you intend to ship.
+
+---
+
+## `implement-task` / `implement-setup-task` (agents: `qs-implement-task`, `qs-implement-setup-task`)
+
+**Runs on**: worktree.
+**Inputs**: story file from `create-plan`.
+**Side effects**: writes code under `custom_components/quiet_solar/` and
+`tests/` (or `scripts/`, `.claude/`, etc. for `implement-setup-task`);
+auto-commits, pushes, opens PR after green quality gate.
+**Output**: PR opened with quality checklist and risk assessment.
+**Next phase**: `claude --agent qs-review-task` in the worktree
+(preferred — fresh interactive session), or `/review-task` as fallback.
+
+**Phase protocol**:
+1. Read story file. Confirm branch state.
+2. TDD: write failing tests → implement minimum code → refactor.
+3. Present implementation summary (files modified, design decisions,
+   risks). Ask "Ready to run the quality gate?".
+4. **ALWAYS** run the impacted inner-loop gate
+   (`python scripts/qs/quality_gate.py --impacted`) before commit/PR —
+   it proves the *changed lines* are 100% covered in seconds and
+   self-heals a drifted testmon baseline automatically (no manual file
+   deletion ever). Do **not** run, or substitute, the full gate
+   locally: the whole-repo 100% gate runs authoritatively in **CI** on
+   every PR, and detecting coverage lost in *unchanged* code is **CI's
+   exclusive job**. The only local full-gate run is an explicit user
+   request. On an `--impacted` failure, fix the **code/tests** — never
+   reach for the full gate to diagnose; escalate only after 2–3
+   attempts. For change sets touching any `tests/qs`-pinned non-Python
+   file (agent files, commands, workflow docs,
+   `.claude/settings.json`) — even when Python files changed too —
+   also run `python scripts/qs/quality_gate.py --quick tests/qs`
+   before commit (testmon cannot see non-Python files).
+5. Auto-commit, push, open PR. No confirmation prompt — authorized by
+   the workflow.
+
+**Edit scope**:
+- `qs-implement-task`: `custom_components/quiet_solar/**`, `tests/**`,
+  plus the story file (for progress notes).
+- `qs-implement-setup-task`: `scripts/qs/**`, `.claude/**`, `.cursor/**`,
+  `.opencode/**`, `legacy/**` (frozen — `git mv` INTO only),
+  `docs/**`, `.github/**`,
+  top-level config files, plus the story file.
+
+**Hard rules**:
+- No code without a failing test first.
+- No commit without a green quality gate.
+- Coverage below 100% is a hard block. No `# pragma: no cover` without
+  explicit user authorization.
+
+---
+
+## `review-task` (agent: `qs-review-task`)
+
+**Runs on**: worktree.
+**Inputs**: PR number (resolved from branch).
+**Side effects**: writes fix-plan files under
+`docs/stories/QS-<N>.story_review_fix_#NN.md` (if fixes
+are needed).
+**Output**: triaged findings; either "ready for finish-task" or a fix
+plan + instructions for the user to apply fixes.
+**Next phase**: `claude --agent qs-finish-task` in the worktree
+(preferred — fresh interactive session), or `/finish-task` as fallback.
+When fixes are needed, re-run `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` (chosen by file scope of the
+findings, same rule as `/create-plan`) — with `/implement-task` or
+`/implement-setup-task` as the slash-command fallback — then re-run
+`claude --agent qs-review-task` (or `/review-task`).
+
+**Phase protocol**:
+1. Fetch PR diff.
+2. **Spawn 4 reviewer subagents in parallel** (one message, 4
+   invocations):
+   - `qs-review-blind-hunter` — diff only, no repo context
+   - `qs-review-edge-case-hunter` — diff + repo read-only
+   - `qs-review-acceptance-auditor` — diff + story file
+   - `qs-review-coderabbit` — wraps CodeRabbit's review
+3. Consolidate into must-fix / should-fix / nice-to-have / invalid.
+4. **Zero-findings fast path**: if no must-fix or should-fix findings,
+   emit the launcher payload (preferred, `claude --agent
+   qs-finish-task`) plus the slash-command fallback (`/finish-task`).
+5. Interactive triage: present table → ask "fix all / skip all / one by
+   one?" → collect decisions → confirm.
+6. If fixes needed, write fix-plan file (auto-incremented suffix
+   `#01`, `#02`, …) and emit the launcher payload (`claude --agent
+   qs-implement-task` or `claude --agent qs-implement-setup-task`,
+   chosen by file scope of the findings — same rule as `/create-plan`)
+   plus the matching slash-command fallback (`/implement-task` or
+   `/implement-setup-task`) for the user to apply the fix plan.
+7. When fixes pushed, the user re-runs `claude --agent qs-review-task`
+   (or `/review-task` as fallback) — loop back to step 1 until clean.
+
+**Hard rules**:
+- This agent is an orchestrator — do not review code yourself. Always
+  delegate to the 4 subagents.
+- Edit scope is the fix-plan files only.
+- Sub-agent spawning must be parallel, not serial.
+
+---
+
+## `finish-task` (agent: `qs-finish-task`)
+
+**Runs on**: worktree (until cleanup, then transitions out).
+**Inputs**: PR number if one exists — `pr_number` may be null (the
+no-PR abandon/cleanup path, Case A in the agent), in which case merge
+logic is skipped entirely.
+**Side effects**: merges PR, deletes branch on origin, removes worktree.
+**Output**: confirmation; user is directed to `/release` if appropriate.
+**Next phase**: `/release` from the main checkout (independent), or
+`claude --agent qs-release` if the user prefers the interactive form.
+Note that `qs-finish-task` does **not** call
+`scripts/qs/next_step.py --next-cmd release` to build a launcher
+payload — release lives on the main checkout, which is a different
+workspace, and the user invokes it manually. The agent body still
+mentions both `/release` and `claude --agent qs-release` in plain prose
+as alternatives (see QS-175 OUT OF SCOPE).
+
+**Phase protocol**:
+1. Show PR summary.
+2. Verify CI status: `gh pr checks <PR>`. If pending, advise wait. If
+   failed, STOP.
+3. Ask user for explicit merge authorization.
+4. Merge PR: `gh pr merge --merge`.
+5. Refresh the `--impacted` baseline (QS-276): capture `MAIN_DIR` (via
+   `git worktree list --porcelain | head -1`) **before** cleanup,
+   update the main checkout (`fetch` + `checkout main` + `pull
+   --ff-only`), then refresh the testmon DB via
+   `quality_gate.py --seed-testmon` — detached/best-effort, never
+   blocking cleanup. A failure or stale baseline is safe (new worktrees
+   just run more tests). QS-286: the detached run now emits a completion
+   signal — it redirects to `.testmondata.seed.log` and writes a
+   `.testmondata.seed-status` marker when done; poll it from the main
+   checkout with `quality_gate.py --seed-testmon-status` (0 = safe to
+   close, 4 = still running, 1 = rerun, 3 = no readable status).
+6. Delete remote branch (safety check: refuse if branch is
+   `main` / `master`).
+7. Run `python scripts/qs/cleanup_worktree.py --work-dir <wd>
+   --issue <N> --force` (force because code is safely on main).
+8. Report. If merged and production code touched, tell the user to run
+   `/release` from main.
+
+**Hard rules**:
+- No merge without explicit user authorization.
+- Never auto-chain to `/release` — it's a separate decision.
+
+---
+
+## `release` (agent: `qs-release`)
+
+**Runs on**: main checkout. Independent of any task.
+**Inputs**: none (uses current date for tag derivation).
+**Side effects**: bumps `manifest.json` version, commits, tags, pushes
+tag.
+**Output**: tag `vYYYY.MM.DD.N`; GitHub Actions runs the release
+pipeline.
+**Next phase**: terminal.
+
+**Phase protocol**:
+1. Confirm clean main: `git checkout main`, `git pull`, `git status`.
+2. Dry run: `python scripts/qs/release.py --dry-run` → show proposed
+   tag → ask for confirmation.
+3. Run real: `python scripts/qs/release.py` → bumps manifest, commits,
+   pushes, tags.
+4. Report tag and version; note that GitHub Actions handles the rest.
+
+**Hard rules**:
+- Always dry-run first. Get user confirmation before the real run.
+- Refuse to run if `git status` is not clean.

--- a/docs/workflow/lanes/epic-product.md
+++ b/docs/workflow/lanes/epic-product.md
@@ -1,0 +1,262 @@
+# Phase protocols
+
+Each phase has a static agent under `.claude/agents/` (mirrored in
+`.cursor/agents/` and `.opencode/agents/`). Agents discover task
+context at runtime via
+`python scripts/qs/context.py`. This document captures the contract for
+each phase — inputs, outputs, hand-off, hard rules.
+
+Each phase is invoked **as an interactive session** via
+`claude --agent qs-<phase>` (the launcher form — preferred). The
+slash-command form (`/<phase>`) is kept as a **degraded fallback** for
+Claude Desktop and any chat without a CLI launcher. See
+[overview.md](overview.md) section "Orchestrators are interactive
+sessions; sub-agents are parallel fan-out" for the full rationale —
+this document does not duplicate it.
+
+---
+
+## `setup-task` (agent: `qs-setup-task`)
+
+**Runs on**: main checkout.
+**Inputs**: free text describing a feature, OR `--issue N` to use an
+existing GitHub issue, OR `--plan /path/to/plan.md`.
+**Side effects**: creates GitHub issue, creates branch `QS_<N>`, creates
+worktree at `<repo>-worktrees/QS_<N>/`.
+**Output**: launcher command (`scripts/qs/launchers/<harness>.py`-generated)
+the user runs to open a new session on the worktree.
+**Next phase**: `claude --agent qs-create-plan` in the worktree
+(preferred — fresh interactive session), or `/create-plan` as fallback.
+
+**Hard rules**:
+- Do NOT analyze, diagnose, or interpret user input. Pass the text
+  through to the GitHub issue verbatim. Deep analysis is `/create-plan`'s
+  job.
+- Do NOT switch the main checkout's branch.
+- Do NOT commit or push manually — setup only creates the branch and
+  worktree (`scripts/worktree-setup.sh` itself publishes the branch
+  via `git push -u`; that script-driven push is expected).
+
+---
+
+## `create-plan` (agent: `qs-create-plan`)
+
+**Runs on**: worktree.
+**Inputs**: branch `QS_<N>` (issue resolves from there).
+**Side effects**: writes story file to
+`docs/stories/QS-<N>.story.md` (written as soon as the first discussion
+round converges, **committed only at FINALIZE**).
+**Output**: story file with acceptance criteria + task breakdown +
+adversarial review notes appended.
+**Next phase**: `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` in the worktree (preferred —
+fresh interactive session), or `/implement-task` /
+`/implement-setup-task` as fallback. The agent decides which based on
+the file paths in its task breakdown.
+
+**Phase protocol** — a **user-driven mode loop** (DISCUSS / REVIEW /
+TRIAGE / FINALIZE), not a linear pipeline. DISCUSS is the durable
+default; REVIEW is invoked on demand and repeatable; the story file is
+the living document:
+
+- **DISCUSS (default)**: read the issue (`gh issue view`), read
+  `project-rules.md` / `project-context.md`, glob the relevant code,
+  and discuss scope/risks/acceptance with the user — iterate
+  indefinitely. As soon as the first round **converges** (the plan has
+  all required headings, or the user says "write it"), write the story
+  file and overwrite it on every later change; announce it is readable.
+  Run the doc-maintenance sub-step (`check_doc_drift.py --paths`). Print
+  the status banner and offer REVIEW once per stable version. The story
+  stays uncommitted.
+- **REVIEW (invoked)**: spawn the plan reviewers in parallel (one
+  message). Round 1 = the **4 global reviewers**; round 2+ = the same 4
+  **plus `qs-plan-delta-auditor`** fed an in-context diff + the prior
+  round's accepted findings. See [adversarial-review.md](adversarial-review.md).
+- **TRIAGE**: dedupe via the finding-state model
+  (`open`/`resolved`/`rejected`), present deltas first, drive
+  interactive triage, fold accepted findings into the story, then return
+  to DISCUSS.
+- **FINALIZE (on confirmed intent)**: an **advisory** gate (never
+  hard-blocks) — if the plan changed since the last review, or open
+  criticals remain, the agent asks but the user decides. Determine
+  `NEXT_PHASE` (`implement-setup-task` if all touched files are in
+  `scripts/`, `.claude/`, `.cursor/`, `.opencode/`, `legacy/`,
+  `docs/`, `.github/`, or top-level config; otherwise `implement-task`),
+  commit + push, then emit the launcher payload (preferred,
+  `claude --agent qs-implement-task` / `qs-implement-setup-task`) plus
+  the slash-command fallback.
+
+**Hard rules**:
+- Do not write code in this phase.
+- Edit scope is the story file — written during DISCUSS/TRIAGE,
+  committed only at FINALIZE.
+- Never skip the adversarial review for a plan you intend to ship.
+
+---
+
+## `implement-task` / `implement-setup-task` (agents: `qs-implement-task`, `qs-implement-setup-task`)
+
+**Runs on**: worktree.
+**Inputs**: story file from `create-plan`.
+**Side effects**: writes code under `custom_components/quiet_solar/` and
+`tests/` (or `scripts/`, `.claude/`, etc. for `implement-setup-task`);
+auto-commits, pushes, opens PR after green quality gate.
+**Output**: PR opened with quality checklist and risk assessment.
+**Next phase**: `claude --agent qs-review-task` in the worktree
+(preferred — fresh interactive session), or `/review-task` as fallback.
+
+**Phase protocol**:
+1. Read story file. Confirm branch state.
+2. TDD: write failing tests → implement minimum code → refactor.
+3. Present implementation summary (files modified, design decisions,
+   risks). Ask "Ready to run the quality gate?".
+4. **ALWAYS** run the impacted inner-loop gate
+   (`python scripts/qs/quality_gate.py --impacted`) before commit/PR —
+   it proves the *changed lines* are 100% covered in seconds and
+   self-heals a drifted testmon baseline automatically (no manual file
+   deletion ever). Do **not** run, or substitute, the full gate
+   locally: the whole-repo 100% gate runs authoritatively in **CI** on
+   every PR, and detecting coverage lost in *unchanged* code is **CI's
+   exclusive job**. The only local full-gate run is an explicit user
+   request. On an `--impacted` failure, fix the **code/tests** — never
+   reach for the full gate to diagnose; escalate only after 2–3
+   attempts. For change sets touching any `tests/qs`-pinned non-Python
+   file (agent files, commands, workflow docs,
+   `.claude/settings.json`) — even when Python files changed too —
+   also run `python scripts/qs/quality_gate.py --quick tests/qs`
+   before commit (testmon cannot see non-Python files).
+5. Auto-commit, push, open PR. No confirmation prompt — authorized by
+   the workflow.
+
+**Edit scope**:
+- `qs-implement-task`: `custom_components/quiet_solar/**`, `tests/**`,
+  plus the story file (for progress notes).
+- `qs-implement-setup-task`: `scripts/qs/**`, `.claude/**`, `.cursor/**`,
+  `.opencode/**`, `legacy/**` (frozen — `git mv` INTO only),
+  `docs/**`, `.github/**`,
+  top-level config files, plus the story file.
+
+**Hard rules**:
+- No code without a failing test first.
+- No commit without a green quality gate.
+- Coverage below 100% is a hard block. No `# pragma: no cover` without
+  explicit user authorization.
+
+---
+
+## `review-task` (agent: `qs-review-task`)
+
+**Runs on**: worktree.
+**Inputs**: PR number (resolved from branch).
+**Side effects**: writes fix-plan files under
+`docs/stories/QS-<N>.story_review_fix_#NN.md` (if fixes
+are needed).
+**Output**: triaged findings; either "ready for finish-task" or a fix
+plan + instructions for the user to apply fixes.
+**Next phase**: `claude --agent qs-finish-task` in the worktree
+(preferred — fresh interactive session), or `/finish-task` as fallback.
+When fixes are needed, re-run `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` (chosen by file scope of the
+findings, same rule as `/create-plan`) — with `/implement-task` or
+`/implement-setup-task` as the slash-command fallback — then re-run
+`claude --agent qs-review-task` (or `/review-task`).
+
+**Phase protocol**:
+1. Fetch PR diff.
+2. **Spawn 4 reviewer subagents in parallel** (one message, 4
+   invocations):
+   - `qs-review-blind-hunter` — diff only, no repo context
+   - `qs-review-edge-case-hunter` — diff + repo read-only
+   - `qs-review-acceptance-auditor` — diff + story file
+   - `qs-review-coderabbit` — wraps CodeRabbit's review
+3. Consolidate into must-fix / should-fix / nice-to-have / invalid.
+4. **Zero-findings fast path**: if no must-fix or should-fix findings,
+   emit the launcher payload (preferred, `claude --agent
+   qs-finish-task`) plus the slash-command fallback (`/finish-task`).
+5. Interactive triage: present table → ask "fix all / skip all / one by
+   one?" → collect decisions → confirm.
+6. If fixes needed, write fix-plan file (auto-incremented suffix
+   `#01`, `#02`, …) and emit the launcher payload (`claude --agent
+   qs-implement-task` or `claude --agent qs-implement-setup-task`,
+   chosen by file scope of the findings — same rule as `/create-plan`)
+   plus the matching slash-command fallback (`/implement-task` or
+   `/implement-setup-task`) for the user to apply the fix plan.
+7. When fixes pushed, the user re-runs `claude --agent qs-review-task`
+   (or `/review-task` as fallback) — loop back to step 1 until clean.
+
+**Hard rules**:
+- This agent is an orchestrator — do not review code yourself. Always
+  delegate to the 4 subagents.
+- Edit scope is the fix-plan files only.
+- Sub-agent spawning must be parallel, not serial.
+
+---
+
+## `finish-task` (agent: `qs-finish-task`)
+
+**Runs on**: worktree (until cleanup, then transitions out).
+**Inputs**: PR number if one exists — `pr_number` may be null (the
+no-PR abandon/cleanup path, Case A in the agent), in which case merge
+logic is skipped entirely.
+**Side effects**: merges PR, deletes branch on origin, removes worktree.
+**Output**: confirmation; user is directed to `/release` if appropriate.
+**Next phase**: `/release` from the main checkout (independent), or
+`claude --agent qs-release` if the user prefers the interactive form.
+Note that `qs-finish-task` does **not** call
+`scripts/qs/next_step.py --next-cmd release` to build a launcher
+payload — release lives on the main checkout, which is a different
+workspace, and the user invokes it manually. The agent body still
+mentions both `/release` and `claude --agent qs-release` in plain prose
+as alternatives (see QS-175 OUT OF SCOPE).
+
+**Phase protocol**:
+1. Show PR summary.
+2. Verify CI status: `gh pr checks <PR>`. If pending, advise wait. If
+   failed, STOP.
+3. Ask user for explicit merge authorization.
+4. Merge PR: `gh pr merge --merge`.
+5. Refresh the `--impacted` baseline (QS-276): capture `MAIN_DIR` (via
+   `git worktree list --porcelain | head -1`) **before** cleanup,
+   update the main checkout (`fetch` + `checkout main` + `pull
+   --ff-only`), then refresh the testmon DB via
+   `quality_gate.py --seed-testmon` — detached/best-effort, never
+   blocking cleanup. A failure or stale baseline is safe (new worktrees
+   just run more tests). QS-286: the detached run now emits a completion
+   signal — it redirects to `.testmondata.seed.log` and writes a
+   `.testmondata.seed-status` marker when done; poll it from the main
+   checkout with `quality_gate.py --seed-testmon-status` (0 = safe to
+   close, 4 = still running, 1 = rerun, 3 = no readable status).
+6. Delete remote branch (safety check: refuse if branch is
+   `main` / `master`).
+7. Run `python scripts/qs/cleanup_worktree.py --work-dir <wd>
+   --issue <N> --force` (force because code is safely on main).
+8. Report. If merged and production code touched, tell the user to run
+   `/release` from main.
+
+**Hard rules**:
+- No merge without explicit user authorization.
+- Never auto-chain to `/release` — it's a separate decision.
+
+---
+
+## `release` (agent: `qs-release`)
+
+**Runs on**: main checkout. Independent of any task.
+**Inputs**: none (uses current date for tag derivation).
+**Side effects**: bumps `manifest.json` version, commits, tags, pushes
+tag.
+**Output**: tag `vYYYY.MM.DD.N`; GitHub Actions runs the release
+pipeline.
+**Next phase**: terminal.
+
+**Phase protocol**:
+1. Confirm clean main: `git checkout main`, `git pull`, `git status`.
+2. Dry run: `python scripts/qs/release.py --dry-run` → show proposed
+   tag → ask for confirmation.
+3. Run real: `python scripts/qs/release.py` → bumps manifest, commits,
+   pushes, tags.
+4. Report tag and version; note that GitHub Actions handles the rest.
+
+**Hard rules**:
+- Always dry-run first. Get user confirmation before the real run.
+- Refuse to run if `git status` is not clean.

--- a/docs/workflow/lanes/feature-factory.md
+++ b/docs/workflow/lanes/feature-factory.md
@@ -1,0 +1,262 @@
+# Phase protocols
+
+Each phase has a static agent under `.claude/agents/` (mirrored in
+`.cursor/agents/` and `.opencode/agents/`). Agents discover task
+context at runtime via
+`python scripts/qs/context.py`. This document captures the contract for
+each phase — inputs, outputs, hand-off, hard rules.
+
+Each phase is invoked **as an interactive session** via
+`claude --agent qs-<phase>` (the launcher form — preferred). The
+slash-command form (`/<phase>`) is kept as a **degraded fallback** for
+Claude Desktop and any chat without a CLI launcher. See
+[overview.md](overview.md) section "Orchestrators are interactive
+sessions; sub-agents are parallel fan-out" for the full rationale —
+this document does not duplicate it.
+
+---
+
+## `setup-task` (agent: `qs-setup-task`)
+
+**Runs on**: main checkout.
+**Inputs**: free text describing a feature, OR `--issue N` to use an
+existing GitHub issue, OR `--plan /path/to/plan.md`.
+**Side effects**: creates GitHub issue, creates branch `QS_<N>`, creates
+worktree at `<repo>-worktrees/QS_<N>/`.
+**Output**: launcher command (`scripts/qs/launchers/<harness>.py`-generated)
+the user runs to open a new session on the worktree.
+**Next phase**: `claude --agent qs-create-plan` in the worktree
+(preferred — fresh interactive session), or `/create-plan` as fallback.
+
+**Hard rules**:
+- Do NOT analyze, diagnose, or interpret user input. Pass the text
+  through to the GitHub issue verbatim. Deep analysis is `/create-plan`'s
+  job.
+- Do NOT switch the main checkout's branch.
+- Do NOT commit or push manually — setup only creates the branch and
+  worktree (`scripts/worktree-setup.sh` itself publishes the branch
+  via `git push -u`; that script-driven push is expected).
+
+---
+
+## `create-plan` (agent: `qs-create-plan`)
+
+**Runs on**: worktree.
+**Inputs**: branch `QS_<N>` (issue resolves from there).
+**Side effects**: writes story file to
+`docs/stories/QS-<N>.story.md` (written as soon as the first discussion
+round converges, **committed only at FINALIZE**).
+**Output**: story file with acceptance criteria + task breakdown +
+adversarial review notes appended.
+**Next phase**: `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` in the worktree (preferred —
+fresh interactive session), or `/implement-task` /
+`/implement-setup-task` as fallback. The agent decides which based on
+the file paths in its task breakdown.
+
+**Phase protocol** — a **user-driven mode loop** (DISCUSS / REVIEW /
+TRIAGE / FINALIZE), not a linear pipeline. DISCUSS is the durable
+default; REVIEW is invoked on demand and repeatable; the story file is
+the living document:
+
+- **DISCUSS (default)**: read the issue (`gh issue view`), read
+  `project-rules.md` / `project-context.md`, glob the relevant code,
+  and discuss scope/risks/acceptance with the user — iterate
+  indefinitely. As soon as the first round **converges** (the plan has
+  all required headings, or the user says "write it"), write the story
+  file and overwrite it on every later change; announce it is readable.
+  Run the doc-maintenance sub-step (`check_doc_drift.py --paths`). Print
+  the status banner and offer REVIEW once per stable version. The story
+  stays uncommitted.
+- **REVIEW (invoked)**: spawn the plan reviewers in parallel (one
+  message). Round 1 = the **4 global reviewers**; round 2+ = the same 4
+  **plus `qs-plan-delta-auditor`** fed an in-context diff + the prior
+  round's accepted findings. See [adversarial-review.md](adversarial-review.md).
+- **TRIAGE**: dedupe via the finding-state model
+  (`open`/`resolved`/`rejected`), present deltas first, drive
+  interactive triage, fold accepted findings into the story, then return
+  to DISCUSS.
+- **FINALIZE (on confirmed intent)**: an **advisory** gate (never
+  hard-blocks) — if the plan changed since the last review, or open
+  criticals remain, the agent asks but the user decides. Determine
+  `NEXT_PHASE` (`implement-setup-task` if all touched files are in
+  `scripts/`, `.claude/`, `.cursor/`, `.opencode/`, `legacy/`,
+  `docs/`, `.github/`, or top-level config; otherwise `implement-task`),
+  commit + push, then emit the launcher payload (preferred,
+  `claude --agent qs-implement-task` / `qs-implement-setup-task`) plus
+  the slash-command fallback.
+
+**Hard rules**:
+- Do not write code in this phase.
+- Edit scope is the story file — written during DISCUSS/TRIAGE,
+  committed only at FINALIZE.
+- Never skip the adversarial review for a plan you intend to ship.
+
+---
+
+## `implement-task` / `implement-setup-task` (agents: `qs-implement-task`, `qs-implement-setup-task`)
+
+**Runs on**: worktree.
+**Inputs**: story file from `create-plan`.
+**Side effects**: writes code under `custom_components/quiet_solar/` and
+`tests/` (or `scripts/`, `.claude/`, etc. for `implement-setup-task`);
+auto-commits, pushes, opens PR after green quality gate.
+**Output**: PR opened with quality checklist and risk assessment.
+**Next phase**: `claude --agent qs-review-task` in the worktree
+(preferred — fresh interactive session), or `/review-task` as fallback.
+
+**Phase protocol**:
+1. Read story file. Confirm branch state.
+2. TDD: write failing tests → implement minimum code → refactor.
+3. Present implementation summary (files modified, design decisions,
+   risks). Ask "Ready to run the quality gate?".
+4. **ALWAYS** run the impacted inner-loop gate
+   (`python scripts/qs/quality_gate.py --impacted`) before commit/PR —
+   it proves the *changed lines* are 100% covered in seconds and
+   self-heals a drifted testmon baseline automatically (no manual file
+   deletion ever). Do **not** run, or substitute, the full gate
+   locally: the whole-repo 100% gate runs authoritatively in **CI** on
+   every PR, and detecting coverage lost in *unchanged* code is **CI's
+   exclusive job**. The only local full-gate run is an explicit user
+   request. On an `--impacted` failure, fix the **code/tests** — never
+   reach for the full gate to diagnose; escalate only after 2–3
+   attempts. For change sets touching any `tests/qs`-pinned non-Python
+   file (agent files, commands, workflow docs,
+   `.claude/settings.json`) — even when Python files changed too —
+   also run `python scripts/qs/quality_gate.py --quick tests/qs`
+   before commit (testmon cannot see non-Python files).
+5. Auto-commit, push, open PR. No confirmation prompt — authorized by
+   the workflow.
+
+**Edit scope**:
+- `qs-implement-task`: `custom_components/quiet_solar/**`, `tests/**`,
+  plus the story file (for progress notes).
+- `qs-implement-setup-task`: `scripts/qs/**`, `.claude/**`, `.cursor/**`,
+  `.opencode/**`, `legacy/**` (frozen — `git mv` INTO only),
+  `docs/**`, `.github/**`,
+  top-level config files, plus the story file.
+
+**Hard rules**:
+- No code without a failing test first.
+- No commit without a green quality gate.
+- Coverage below 100% is a hard block. No `# pragma: no cover` without
+  explicit user authorization.
+
+---
+
+## `review-task` (agent: `qs-review-task`)
+
+**Runs on**: worktree.
+**Inputs**: PR number (resolved from branch).
+**Side effects**: writes fix-plan files under
+`docs/stories/QS-<N>.story_review_fix_#NN.md` (if fixes
+are needed).
+**Output**: triaged findings; either "ready for finish-task" or a fix
+plan + instructions for the user to apply fixes.
+**Next phase**: `claude --agent qs-finish-task` in the worktree
+(preferred — fresh interactive session), or `/finish-task` as fallback.
+When fixes are needed, re-run `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` (chosen by file scope of the
+findings, same rule as `/create-plan`) — with `/implement-task` or
+`/implement-setup-task` as the slash-command fallback — then re-run
+`claude --agent qs-review-task` (or `/review-task`).
+
+**Phase protocol**:
+1. Fetch PR diff.
+2. **Spawn 4 reviewer subagents in parallel** (one message, 4
+   invocations):
+   - `qs-review-blind-hunter` — diff only, no repo context
+   - `qs-review-edge-case-hunter` — diff + repo read-only
+   - `qs-review-acceptance-auditor` — diff + story file
+   - `qs-review-coderabbit` — wraps CodeRabbit's review
+3. Consolidate into must-fix / should-fix / nice-to-have / invalid.
+4. **Zero-findings fast path**: if no must-fix or should-fix findings,
+   emit the launcher payload (preferred, `claude --agent
+   qs-finish-task`) plus the slash-command fallback (`/finish-task`).
+5. Interactive triage: present table → ask "fix all / skip all / one by
+   one?" → collect decisions → confirm.
+6. If fixes needed, write fix-plan file (auto-incremented suffix
+   `#01`, `#02`, …) and emit the launcher payload (`claude --agent
+   qs-implement-task` or `claude --agent qs-implement-setup-task`,
+   chosen by file scope of the findings — same rule as `/create-plan`)
+   plus the matching slash-command fallback (`/implement-task` or
+   `/implement-setup-task`) for the user to apply the fix plan.
+7. When fixes pushed, the user re-runs `claude --agent qs-review-task`
+   (or `/review-task` as fallback) — loop back to step 1 until clean.
+
+**Hard rules**:
+- This agent is an orchestrator — do not review code yourself. Always
+  delegate to the 4 subagents.
+- Edit scope is the fix-plan files only.
+- Sub-agent spawning must be parallel, not serial.
+
+---
+
+## `finish-task` (agent: `qs-finish-task`)
+
+**Runs on**: worktree (until cleanup, then transitions out).
+**Inputs**: PR number if one exists — `pr_number` may be null (the
+no-PR abandon/cleanup path, Case A in the agent), in which case merge
+logic is skipped entirely.
+**Side effects**: merges PR, deletes branch on origin, removes worktree.
+**Output**: confirmation; user is directed to `/release` if appropriate.
+**Next phase**: `/release` from the main checkout (independent), or
+`claude --agent qs-release` if the user prefers the interactive form.
+Note that `qs-finish-task` does **not** call
+`scripts/qs/next_step.py --next-cmd release` to build a launcher
+payload — release lives on the main checkout, which is a different
+workspace, and the user invokes it manually. The agent body still
+mentions both `/release` and `claude --agent qs-release` in plain prose
+as alternatives (see QS-175 OUT OF SCOPE).
+
+**Phase protocol**:
+1. Show PR summary.
+2. Verify CI status: `gh pr checks <PR>`. If pending, advise wait. If
+   failed, STOP.
+3. Ask user for explicit merge authorization.
+4. Merge PR: `gh pr merge --merge`.
+5. Refresh the `--impacted` baseline (QS-276): capture `MAIN_DIR` (via
+   `git worktree list --porcelain | head -1`) **before** cleanup,
+   update the main checkout (`fetch` + `checkout main` + `pull
+   --ff-only`), then refresh the testmon DB via
+   `quality_gate.py --seed-testmon` — detached/best-effort, never
+   blocking cleanup. A failure or stale baseline is safe (new worktrees
+   just run more tests). QS-286: the detached run now emits a completion
+   signal — it redirects to `.testmondata.seed.log` and writes a
+   `.testmondata.seed-status` marker when done; poll it from the main
+   checkout with `quality_gate.py --seed-testmon-status` (0 = safe to
+   close, 4 = still running, 1 = rerun, 3 = no readable status).
+6. Delete remote branch (safety check: refuse if branch is
+   `main` / `master`).
+7. Run `python scripts/qs/cleanup_worktree.py --work-dir <wd>
+   --issue <N> --force` (force because code is safely on main).
+8. Report. If merged and production code touched, tell the user to run
+   `/release` from main.
+
+**Hard rules**:
+- No merge without explicit user authorization.
+- Never auto-chain to `/release` — it's a separate decision.
+
+---
+
+## `release` (agent: `qs-release`)
+
+**Runs on**: main checkout. Independent of any task.
+**Inputs**: none (uses current date for tag derivation).
+**Side effects**: bumps `manifest.json` version, commits, tags, pushes
+tag.
+**Output**: tag `vYYYY.MM.DD.N`; GitHub Actions runs the release
+pipeline.
+**Next phase**: terminal.
+
+**Phase protocol**:
+1. Confirm clean main: `git checkout main`, `git pull`, `git status`.
+2. Dry run: `python scripts/qs/release.py --dry-run` → show proposed
+   tag → ask for confirmation.
+3. Run real: `python scripts/qs/release.py` → bumps manifest, commits,
+   pushes, tags.
+4. Report tag and version; note that GitHub Actions handles the rest.
+
+**Hard rules**:
+- Always dry-run first. Get user confirmation before the real run.
+- Refuse to run if `git status` is not clean.

--- a/docs/workflow/lanes/feature-product.md
+++ b/docs/workflow/lanes/feature-product.md
@@ -1,0 +1,262 @@
+# Phase protocols
+
+Each phase has a static agent under `.claude/agents/` (mirrored in
+`.cursor/agents/` and `.opencode/agents/`). Agents discover task
+context at runtime via
+`python scripts/qs/context.py`. This document captures the contract for
+each phase — inputs, outputs, hand-off, hard rules.
+
+Each phase is invoked **as an interactive session** via
+`claude --agent qs-<phase>` (the launcher form — preferred). The
+slash-command form (`/<phase>`) is kept as a **degraded fallback** for
+Claude Desktop and any chat without a CLI launcher. See
+[overview.md](overview.md) section "Orchestrators are interactive
+sessions; sub-agents are parallel fan-out" for the full rationale —
+this document does not duplicate it.
+
+---
+
+## `setup-task` (agent: `qs-setup-task`)
+
+**Runs on**: main checkout.
+**Inputs**: free text describing a feature, OR `--issue N` to use an
+existing GitHub issue, OR `--plan /path/to/plan.md`.
+**Side effects**: creates GitHub issue, creates branch `QS_<N>`, creates
+worktree at `<repo>-worktrees/QS_<N>/`.
+**Output**: launcher command (`scripts/qs/launchers/<harness>.py`-generated)
+the user runs to open a new session on the worktree.
+**Next phase**: `claude --agent qs-create-plan` in the worktree
+(preferred — fresh interactive session), or `/create-plan` as fallback.
+
+**Hard rules**:
+- Do NOT analyze, diagnose, or interpret user input. Pass the text
+  through to the GitHub issue verbatim. Deep analysis is `/create-plan`'s
+  job.
+- Do NOT switch the main checkout's branch.
+- Do NOT commit or push manually — setup only creates the branch and
+  worktree (`scripts/worktree-setup.sh` itself publishes the branch
+  via `git push -u`; that script-driven push is expected).
+
+---
+
+## `create-plan` (agent: `qs-create-plan`)
+
+**Runs on**: worktree.
+**Inputs**: branch `QS_<N>` (issue resolves from there).
+**Side effects**: writes story file to
+`docs/stories/QS-<N>.story.md` (written as soon as the first discussion
+round converges, **committed only at FINALIZE**).
+**Output**: story file with acceptance criteria + task breakdown +
+adversarial review notes appended.
+**Next phase**: `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` in the worktree (preferred —
+fresh interactive session), or `/implement-task` /
+`/implement-setup-task` as fallback. The agent decides which based on
+the file paths in its task breakdown.
+
+**Phase protocol** — a **user-driven mode loop** (DISCUSS / REVIEW /
+TRIAGE / FINALIZE), not a linear pipeline. DISCUSS is the durable
+default; REVIEW is invoked on demand and repeatable; the story file is
+the living document:
+
+- **DISCUSS (default)**: read the issue (`gh issue view`), read
+  `project-rules.md` / `project-context.md`, glob the relevant code,
+  and discuss scope/risks/acceptance with the user — iterate
+  indefinitely. As soon as the first round **converges** (the plan has
+  all required headings, or the user says "write it"), write the story
+  file and overwrite it on every later change; announce it is readable.
+  Run the doc-maintenance sub-step (`check_doc_drift.py --paths`). Print
+  the status banner and offer REVIEW once per stable version. The story
+  stays uncommitted.
+- **REVIEW (invoked)**: spawn the plan reviewers in parallel (one
+  message). Round 1 = the **4 global reviewers**; round 2+ = the same 4
+  **plus `qs-plan-delta-auditor`** fed an in-context diff + the prior
+  round's accepted findings. See [adversarial-review.md](adversarial-review.md).
+- **TRIAGE**: dedupe via the finding-state model
+  (`open`/`resolved`/`rejected`), present deltas first, drive
+  interactive triage, fold accepted findings into the story, then return
+  to DISCUSS.
+- **FINALIZE (on confirmed intent)**: an **advisory** gate (never
+  hard-blocks) — if the plan changed since the last review, or open
+  criticals remain, the agent asks but the user decides. Determine
+  `NEXT_PHASE` (`implement-setup-task` if all touched files are in
+  `scripts/`, `.claude/`, `.cursor/`, `.opencode/`, `legacy/`,
+  `docs/`, `.github/`, or top-level config; otherwise `implement-task`),
+  commit + push, then emit the launcher payload (preferred,
+  `claude --agent qs-implement-task` / `qs-implement-setup-task`) plus
+  the slash-command fallback.
+
+**Hard rules**:
+- Do not write code in this phase.
+- Edit scope is the story file — written during DISCUSS/TRIAGE,
+  committed only at FINALIZE.
+- Never skip the adversarial review for a plan you intend to ship.
+
+---
+
+## `implement-task` / `implement-setup-task` (agents: `qs-implement-task`, `qs-implement-setup-task`)
+
+**Runs on**: worktree.
+**Inputs**: story file from `create-plan`.
+**Side effects**: writes code under `custom_components/quiet_solar/` and
+`tests/` (or `scripts/`, `.claude/`, etc. for `implement-setup-task`);
+auto-commits, pushes, opens PR after green quality gate.
+**Output**: PR opened with quality checklist and risk assessment.
+**Next phase**: `claude --agent qs-review-task` in the worktree
+(preferred — fresh interactive session), or `/review-task` as fallback.
+
+**Phase protocol**:
+1. Read story file. Confirm branch state.
+2. TDD: write failing tests → implement minimum code → refactor.
+3. Present implementation summary (files modified, design decisions,
+   risks). Ask "Ready to run the quality gate?".
+4. **ALWAYS** run the impacted inner-loop gate
+   (`python scripts/qs/quality_gate.py --impacted`) before commit/PR —
+   it proves the *changed lines* are 100% covered in seconds and
+   self-heals a drifted testmon baseline automatically (no manual file
+   deletion ever). Do **not** run, or substitute, the full gate
+   locally: the whole-repo 100% gate runs authoritatively in **CI** on
+   every PR, and detecting coverage lost in *unchanged* code is **CI's
+   exclusive job**. The only local full-gate run is an explicit user
+   request. On an `--impacted` failure, fix the **code/tests** — never
+   reach for the full gate to diagnose; escalate only after 2–3
+   attempts. For change sets touching any `tests/qs`-pinned non-Python
+   file (agent files, commands, workflow docs,
+   `.claude/settings.json`) — even when Python files changed too —
+   also run `python scripts/qs/quality_gate.py --quick tests/qs`
+   before commit (testmon cannot see non-Python files).
+5. Auto-commit, push, open PR. No confirmation prompt — authorized by
+   the workflow.
+
+**Edit scope**:
+- `qs-implement-task`: `custom_components/quiet_solar/**`, `tests/**`,
+  plus the story file (for progress notes).
+- `qs-implement-setup-task`: `scripts/qs/**`, `.claude/**`, `.cursor/**`,
+  `.opencode/**`, `legacy/**` (frozen — `git mv` INTO only),
+  `docs/**`, `.github/**`,
+  top-level config files, plus the story file.
+
+**Hard rules**:
+- No code without a failing test first.
+- No commit without a green quality gate.
+- Coverage below 100% is a hard block. No `# pragma: no cover` without
+  explicit user authorization.
+
+---
+
+## `review-task` (agent: `qs-review-task`)
+
+**Runs on**: worktree.
+**Inputs**: PR number (resolved from branch).
+**Side effects**: writes fix-plan files under
+`docs/stories/QS-<N>.story_review_fix_#NN.md` (if fixes
+are needed).
+**Output**: triaged findings; either "ready for finish-task" or a fix
+plan + instructions for the user to apply fixes.
+**Next phase**: `claude --agent qs-finish-task` in the worktree
+(preferred — fresh interactive session), or `/finish-task` as fallback.
+When fixes are needed, re-run `claude --agent qs-implement-task` or
+`claude --agent qs-implement-setup-task` (chosen by file scope of the
+findings, same rule as `/create-plan`) — with `/implement-task` or
+`/implement-setup-task` as the slash-command fallback — then re-run
+`claude --agent qs-review-task` (or `/review-task`).
+
+**Phase protocol**:
+1. Fetch PR diff.
+2. **Spawn 4 reviewer subagents in parallel** (one message, 4
+   invocations):
+   - `qs-review-blind-hunter` — diff only, no repo context
+   - `qs-review-edge-case-hunter` — diff + repo read-only
+   - `qs-review-acceptance-auditor` — diff + story file
+   - `qs-review-coderabbit` — wraps CodeRabbit's review
+3. Consolidate into must-fix / should-fix / nice-to-have / invalid.
+4. **Zero-findings fast path**: if no must-fix or should-fix findings,
+   emit the launcher payload (preferred, `claude --agent
+   qs-finish-task`) plus the slash-command fallback (`/finish-task`).
+5. Interactive triage: present table → ask "fix all / skip all / one by
+   one?" → collect decisions → confirm.
+6. If fixes needed, write fix-plan file (auto-incremented suffix
+   `#01`, `#02`, …) and emit the launcher payload (`claude --agent
+   qs-implement-task` or `claude --agent qs-implement-setup-task`,
+   chosen by file scope of the findings — same rule as `/create-plan`)
+   plus the matching slash-command fallback (`/implement-task` or
+   `/implement-setup-task`) for the user to apply the fix plan.
+7. When fixes pushed, the user re-runs `claude --agent qs-review-task`
+   (or `/review-task` as fallback) — loop back to step 1 until clean.
+
+**Hard rules**:
+- This agent is an orchestrator — do not review code yourself. Always
+  delegate to the 4 subagents.
+- Edit scope is the fix-plan files only.
+- Sub-agent spawning must be parallel, not serial.
+
+---
+
+## `finish-task` (agent: `qs-finish-task`)
+
+**Runs on**: worktree (until cleanup, then transitions out).
+**Inputs**: PR number if one exists — `pr_number` may be null (the
+no-PR abandon/cleanup path, Case A in the agent), in which case merge
+logic is skipped entirely.
+**Side effects**: merges PR, deletes branch on origin, removes worktree.
+**Output**: confirmation; user is directed to `/release` if appropriate.
+**Next phase**: `/release` from the main checkout (independent), or
+`claude --agent qs-release` if the user prefers the interactive form.
+Note that `qs-finish-task` does **not** call
+`scripts/qs/next_step.py --next-cmd release` to build a launcher
+payload — release lives on the main checkout, which is a different
+workspace, and the user invokes it manually. The agent body still
+mentions both `/release` and `claude --agent qs-release` in plain prose
+as alternatives (see QS-175 OUT OF SCOPE).
+
+**Phase protocol**:
+1. Show PR summary.
+2. Verify CI status: `gh pr checks <PR>`. If pending, advise wait. If
+   failed, STOP.
+3. Ask user for explicit merge authorization.
+4. Merge PR: `gh pr merge --merge`.
+5. Refresh the `--impacted` baseline (QS-276): capture `MAIN_DIR` (via
+   `git worktree list --porcelain | head -1`) **before** cleanup,
+   update the main checkout (`fetch` + `checkout main` + `pull
+   --ff-only`), then refresh the testmon DB via
+   `quality_gate.py --seed-testmon` — detached/best-effort, never
+   blocking cleanup. A failure or stale baseline is safe (new worktrees
+   just run more tests). QS-286: the detached run now emits a completion
+   signal — it redirects to `.testmondata.seed.log` and writes a
+   `.testmondata.seed-status` marker when done; poll it from the main
+   checkout with `quality_gate.py --seed-testmon-status` (0 = safe to
+   close, 4 = still running, 1 = rerun, 3 = no readable status).
+6. Delete remote branch (safety check: refuse if branch is
+   `main` / `master`).
+7. Run `python scripts/qs/cleanup_worktree.py --work-dir <wd>
+   --issue <N> --force` (force because code is safely on main).
+8. Report. If merged and production code touched, tell the user to run
+   `/release` from main.
+
+**Hard rules**:
+- No merge without explicit user authorization.
+- Never auto-chain to `/release` — it's a separate decision.
+
+---
+
+## `release` (agent: `qs-release`)
+
+**Runs on**: main checkout. Independent of any task.
+**Inputs**: none (uses current date for tag derivation).
+**Side effects**: bumps `manifest.json` version, commits, tags, pushes
+tag.
+**Output**: tag `vYYYY.MM.DD.N`; GitHub Actions runs the release
+pipeline.
+**Next phase**: terminal.
+
+**Phase protocol**:
+1. Confirm clean main: `git checkout main`, `git pull`, `git status`.
+2. Dry run: `python scripts/qs/release.py --dry-run` → show proposed
+   tag → ask for confirmation.
+3. Run real: `python scripts/qs/release.py` → bumps manifest, commits,
+   pushes, tags.
+4. Report tag and version; note that GitHub Actions handles the rest.
+
+**Hard rules**:
+- Always dry-run first. Get user confirmation before the real run.
+- Refuse to run if `git status` is not clean.

--- a/docs/workflow/overview.md
+++ b/docs/workflow/overview.md
@@ -147,6 +147,20 @@ files it expects to touch:
   `custom_components/quiet_solar/` is touched. Full quality gate
   (pytest 100% + ruff + mypy + translations).
 
+**Lanes (QS-332).** Every task is born in exactly one of 6 lanes —
+{bug, feature, epic} × {product, factory} — declared at setup as GitHub
+labels (`kind:*`, `target:*`, `scale:*`) and exposed by
+`python scripts/qs/context.py` as the `lane` field. Each lane has a
+protocol file `docs/workflow/lanes/<lane>.md`; orchestrator agents read
+their lane file early in the session (falling back to
+[phase-protocols.md](phase-protocols.md) when the lane is undeclared —
+pre-existing worktrees only). The lane files start as byte-identical
+copies of `phase-protocols.md` (enforced by
+`tests/qs/docs/test_lanes.py`); they diverge one PR per lane (#335–#340).
+The quality gate enforces the declaration (missing declaration fails)
+and surfaces cross-target diffs as a loud warning — purpose, not path,
+is the classifier, so a crossing never fails the gate.
+
 ## Harness abstraction
 
 Everything harness-specific lives in `scripts/qs/launchers/*.py` and is

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -281,6 +281,30 @@ Each command delegates to a static agent under `.claude/agents/` (or
 `.cursor/agents/`). Agents discover task context at runtime from
 `git branch --show-current` — there is no per-task agent rendering.
 
+### Lanes & axes (QS-332)
+
+Every task is born in exactly one of **6 lanes** — {bug, feature, epic}
+× {product, factory} — declared at setup as GitHub labels: exactly one
+`target:*` (`product`/`factory`), plus `scale:task` with exactly one
+`kind:*` (`bug`/`feature`) for tasks, or `scale:epic` with **no kind**
+for epics. `scale:task` is the implicit CLI default but is always
+applied explicitly as a label. The lane protocol files live in
+`docs/workflow/lanes/<lane>.md`; `python scripts/qs/context.py` exposes
+`labels`, `kind`, `target`, `scale`, `lane`, `parent_epic`. The domain
+module is `scripts/qs/targets.py` (path classification, declaration
+truth table, parent-epic parsing) — one machine-readable definition,
+consumed by `fetch_issue.py`, `setup_task.py`, and the quality gate.
+
+The **lane check** runs in `--impacted`, the full gate, and the CI
+`--lane-check` job: a **missing declaration fails**; a **cross-target
+diff warns loudly but never fails** — purpose, not path, is the
+classifier (a product-declared fix that must also enhance a test tool
+stays a product task). The warning lists the crossing files and always
+prints the split recommendation; splitting is at human discretion.
+`create_pr.py` auto-appends `Refs #<epic>` toward a declared parent
+epic and machine-injects a `## Lane note` when the diff crosses the
+declared target.
+
 **Commit authorization**: agents are authorized to commit and push as
 part of their defined workflow steps (e.g., the implement-task agent
 auto-commits and opens a PR after the quality gate passes). Outside of

--- a/scripts/qs/context.py
+++ b/scripts/qs/context.py
@@ -77,10 +77,14 @@ def _issue_fields(issue: int) -> dict:
         return _empty_issue_fields()
     try:
         data = json.loads(result.stdout)
+        # `or ""` / `or []` (QS-332 review-fix #01): the API can return a
+        # present-but-null field (`"body": null`), and a bare `.get`
+        # default doesn't catch that — `parse_parent_epic(None)` raises.
+        # Mirrors `create_pr.py`'s guard.
         return {
-            "title": data.get("title", ""),
-            "labels": [lb["name"] for lb in data.get("labels", [])],
-            "body": data.get("body", ""),
+            "title": data.get("title") or "",
+            "labels": [lb["name"] for lb in data.get("labels") or []],
+            "body": data.get("body") or "",
         }
     except (json.JSONDecodeError, TypeError, KeyError):
         return _empty_issue_fields()

--- a/scripts/qs/context.py
+++ b/scripts/qs/context.py
@@ -86,7 +86,10 @@ def _issue_fields(issue: int) -> dict:
             "labels": [lb["name"] for lb in data.get("labels") or []],
             "body": data.get("body") or "",
         }
-    except (json.JSONDecodeError, TypeError, KeyError):
+    except (json.JSONDecodeError, TypeError, KeyError, AttributeError):
+        # `AttributeError` (QS-332 review-fix #04): a non-dict top-level
+        # value (`null`, `[]`, `42`) makes `.get` raise. Kept uniform with
+        # the sibling consumers even though this one degrades silently.
         return _empty_issue_fields()
 
 

--- a/scripts/qs/context.py
+++ b/scripts/qs/context.py
@@ -13,25 +13,30 @@ Usage::
 Source of truth:
 
 - ``issue``: parsed from ``git branch --show-current`` (``QS_<N>``)
-- ``title``: from ``gh issue view <N>``
+- ``title``, ``labels``, ``kind``/``target``/``scale``/``lane``,
+  ``parent_epic``: from one ``gh issue view <N>`` call (QS-332 — the
+  axis parsing lives in :mod:`targets`)
 - ``story_file``: ``docs/stories/QS-<N>.story.md`` (if it exists)
 - ``pr_number``: from ``gh pr list --head <branch>`` (if open)
 - ``worktree``: current working directory
 - ``harness``: from :mod:`scripts.qs.harness`
 
-The two ``gh`` calls behind ``title`` and ``pr_number`` are the only
-network work here and dominate startup latency, so they are fetched
+The two ``gh`` calls behind the issue fields and ``pr_number`` are the
+only network work here and dominate startup latency, so they are fetched
 **concurrently** — do not re-serialize them.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
+
+import targets  # type: ignore[import-not-found]
 
 from harness import detect as detect_harness  # type: ignore[import-not-found]
 
@@ -47,16 +52,38 @@ from utils import (  # type: ignore[import-not-found]
 )
 
 
-def _issue_title(issue: int) -> str:
+def _empty_issue_fields() -> dict:
+    """The degraded issue-fields shape — also the ``_settle`` default at
+    both settle call sites (QS-332 review I1). A fresh dict every call so
+    no caller can mutate a shared default.
+    """
+    return {"title": "", "labels": [], "body": ""}
+
+
+def _issue_fields(issue: int) -> dict:
+    """Fetch ``title``, ``labels`` (names) and ``body`` in ONE ``gh`` call.
+
+    Returns :func:`_empty_issue_fields` on any failure (non-zero exit,
+    unparseable JSON) — degraded fields, never an exception, matching the
+    old ``_issue_title`` contract.
+    """
     result = run_gh(
-        ["issue", "view", str(issue), "--json", "title", "-q", ".title"],
+        ["issue", "view", str(issue), "--json", "title,labels,body"],
         check=False,
         # Concurrent with the PR lookup — see ``utils.run``'s ``stdin``.
         stdin=subprocess.DEVNULL,
     )
     if result.returncode != 0:
-        return ""
-    return result.stdout.strip()
+        return _empty_issue_fields()
+    try:
+        data = json.loads(result.stdout)
+        return {
+            "title": data.get("title", ""),
+            "labels": [lb["name"] for lb in data.get("labels", [])],
+            "body": data.get("body", ""),
+        }
+    except (json.JSONDecodeError, TypeError, KeyError):
+        return _empty_issue_fields()
 
 
 def _settle(future: Future | None, default: Any) -> tuple[Any, BaseException | None]:
@@ -126,7 +153,7 @@ def build_context(issue_override: int | None = None) -> dict:
     # start that raises, so an "inline fallback" cannot un-queue it and
     # double-executes the call (review fix #02 M1). Do not add one.
     with ThreadPoolExecutor(max_workers=2) as pool:
-        title_future = pool.submit(_issue_title, issue) if has_issue else None
+        title_future = pool.submit(_issue_fields, issue) if has_issue else None
         pr_future: Future | None = None
         try:
             # Inside the ``try`` so the drain below covers it: if this
@@ -146,10 +173,13 @@ def build_context(issue_override: int | None = None) -> dict:
             # The local work failed with both children still running: drain
             # them so neither exception is discarded, then let the local
             # error propagate as the primary one (review fix #01 S1).
-            for _value, exc in (_settle(title_future, ""), _settle(pr_future, None)):
+            for _value, exc in (
+                _settle(title_future, _empty_issue_fields()),
+                _settle(pr_future, None),
+            ):
                 _note_sibling(local_exc, exc)
             raise
-        title, title_exc = _settle(title_future, "")
+        fields, title_exc = _settle(title_future, _empty_issue_fields())
         pr_info, pr_exc = _settle(pr_future, None)
 
     # Raised outside the ``with`` so the pool has already joined both
@@ -161,17 +191,28 @@ def build_context(issue_override: int | None = None) -> dict:
     if pr_exc is not None:
         raise pr_exc
 
+    # QS-332: the lane axes are APPENDED after the existing keys, in this
+    # order — labels, kind, target, scale, lane, parent_epic. That order is
+    # the emission contract `tests/qs/test_context.py`'s byte-identity pin
+    # is written against; do not reorder.
+    axes = targets.parse_axes(fields["labels"])
     return {
         "harness": detect_harness(),
         "branch": branch,
         "issue": issue,
-        "title": title,
+        "title": fields["title"],
         "story_file": str(story_path) if story_path else "",
         "story_exists": bool(story_path),
         "latest_review_fix": str(review_fix_path) if review_fix_path else "",
         "pr_number": pr_info["pr_number"] if pr_info else None,
         "pr_url": pr_info["url"] if pr_info else "",
         "worktree": str(get_repo_root()),
+        "labels": fields["labels"],
+        "kind": axes["kind"],
+        "target": axes["target"],
+        "scale": axes["scale"],
+        "lane": axes["lane"],
+        "parent_epic": targets.parse_parent_epic(fields["body"]),
     }
 
 

--- a/scripts/qs/create_pr.py
+++ b/scripts/qs/create_pr.py
@@ -57,8 +57,13 @@ def _epic_and_lane_note(issue: int, changed: list[str]) -> tuple[int | None, str
         return None, ""
     try:
         data = json.loads(result.stdout)
-        issue_body = data.get("body", "") or ""
-        labels = [lb["name"] for lb in data.get("labels", [])]
+        issue_body = data.get("body") or ""
+        # `or []` (QS-332 review-fix #03): a `"labels": null` response is
+        # valid JSON and its BODY is perfectly readable — the bare
+        # `.get(..., [])` raised `TypeError` into the broad `except`
+        # below and silently dropped the parent-epic `Refs` (and any
+        # Lane note) for no good reason.
+        labels = [lb["name"] for lb in data.get("labels") or []]
     except (json.JSONDecodeError, TypeError, KeyError):
         return None, ""
 

--- a/scripts/qs/create_pr.py
+++ b/scripts/qs/create_pr.py
@@ -5,12 +5,33 @@ Usage:
     python scripts/qs/create_pr.py --title "..." --summary "..." [--issue N] [--risk CRITICAL]
 
 Output: JSON with PR number and URL.
+
+QS-332 (B5) — two machine-owned additions, both fed by ONE
+``gh issue view N --json body,labels`` call:
+
+- **auto-``Refs``**: a parent epic declared in the issue body
+  (``targets.parse_parent_epic`` — explicit, never guessed) is appended
+  inside the fixes-line slot (``Fixes #N`` then ``Refs #E``) so a child
+  PR never auto-closes its epic. No CLI override flags by design
+  (review SG2-01): the escape hatch for a wrong ``Refs`` is editing the
+  issue body, the declared source of truth.
+- **Lane note**: the changed files are classified against the issue's
+  declared ``target:*`` label; when the diff crosses targets, a
+  ``## Lane note`` section listing the crossing files verbatim is
+  injected into the PR body. Recomputed from ``targets.classify`` — no
+  sentinel-string parsing of gate output (review N-4/DP2-02).
+
+A failing/unparseable issue lookup degrades to today's body (no Refs,
+no note) rather than blocking the PR.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
+
+import targets
 
 from utils import (
     detect_risk_level,
@@ -22,6 +43,45 @@ from utils import (
     run_gh,
     run_git,
 )
+
+
+def _epic_and_lane_note(issue: int, changed: list[str]) -> tuple[int | None, str]:
+    """Return ``(parent_epic, lane_note_section)`` for the PR body.
+
+    One ``gh issue view --json body,labels`` call feeds both. Any failure
+    (non-zero exit, bad JSON) degrades to ``(None, "")`` — the PR body
+    stays byte-identical to today's.
+    """
+    result = run_gh(["issue", "view", str(issue), "--json", "body,labels"], check=False)
+    if result.returncode != 0:
+        return None, ""
+    try:
+        data = json.loads(result.stdout)
+        issue_body = data.get("body", "") or ""
+        labels = [lb["name"] for lb in data.get("labels", [])]
+    except (json.JSONDecodeError, TypeError, KeyError):
+        return None, ""
+
+    epic = targets.parse_parent_epic(issue_body)
+
+    declared = targets.parse_axes(labels)["target"]
+    lane_section = ""
+    if declared:
+        opposite = "product" if declared == "factory" else "factory"
+        crossing = [f for f in changed if targets.classify(f) == opposite]
+        if crossing:
+            file_list = "".join(f"- `{f}`\n" for f in crossing)
+            lane_section = (
+                "\n## Lane note\n"
+                f"This task declares `target:{declared}` but the diff touches "
+                f"{opposite}-classified files:\n\n"
+                f"{file_list}\n"
+                f"Verify these serve the declared {declared} purpose "
+                "(purpose, not path, is the classifier). If the "
+                f"{opposite}-side portion is substantial, consider splitting "
+                "the issue.\n"
+            )
+    return epic, lane_section
 
 
 def main() -> None:
@@ -71,6 +131,11 @@ def main() -> None:
 
     # Build PR body
     fixes_line = f"\nFixes #{issue}\n" if issue else ""
+    lane_section = ""
+    if issue:
+        epic, lane_section = _epic_and_lane_note(issue, changed)
+        if epic is not None:
+            fixes_line = f"\nFixes #{issue}\nRefs #{epic}\n"
     body = f"""## Summary
 {args.summary}
 {fixes_line}
@@ -86,7 +151,7 @@ def main() -> None:
 
 ## Risk assessment
 {chr(10).join(risk_lines)}
-
+{lane_section}
 ---
 Generated with [Claude Code](https://claude.com/claude-code)"""
 

--- a/scripts/qs/create_pr.py
+++ b/scripts/qs/create_pr.py
@@ -64,7 +64,10 @@ def _epic_and_lane_note(issue: int, changed: list[str]) -> tuple[int | None, str
         # below and silently dropped the parent-epic `Refs` (and any
         # Lane note) for no good reason.
         labels = [lb["name"] for lb in data.get("labels") or []]
-    except (json.JSONDecodeError, TypeError, KeyError):
+    except (json.JSONDecodeError, TypeError, KeyError, AttributeError):
+        # `AttributeError` (QS-332 review-fix #04): a non-dict top-level
+        # value (`null`, `[]`, `42`) makes `.get` raise, which used to
+        # escape this guard as a raw traceback.
         return None, ""
 
     epic = targets.parse_parent_epic(issue_body)

--- a/scripts/qs/fetch_issue.py
+++ b/scripts/qs/fetch_issue.py
@@ -41,8 +41,15 @@ def main() -> None:
         output_json({"error": "Invalid JSON from gh CLI", "detail": result.stdout.strip()})
         sys.exit(1)
 
-    label_names = [lb["name"] for lb in data.get("labels", [])]
-    body = data.get("body", "")
+    # `or []` / `or ""` (QS-332 review-fix #02): the API can return a
+    # present-but-null field (`"labels": null`, `"body": null`) — a bare
+    # `.get` default doesn't catch that, and iterating `None` /
+    # `parse_parent_epic(None)` raised a raw traceback instead of this
+    # script's structured error JSON. Same guard as `context.py` and
+    # `create_pr.py` (the fix-plan-#01 pattern, applied to the third
+    # consumer it missed).
+    label_names = [lb["name"] for lb in data.get("labels") or []]
+    body = data.get("body") or ""
     axes = targets.parse_axes(label_names)
     declaration_ok, _missing, _message = targets.validate_declaration(label_names)
 

--- a/scripts/qs/fetch_issue.py
+++ b/scripts/qs/fetch_issue.py
@@ -35,21 +35,25 @@ def main() -> None:
         output_json({"error": f"Failed to fetch issue #{args.issue}", "detail": result.stderr.strip()})
         sys.exit(1)
 
+    # The label comprehension belongs INSIDE this guard, and the `except`
+    # tuple needs `KeyError` (QS-332 review-fix #03): a malformed entry
+    # (`"labels": [null]`, or one missing `"name"`) otherwise raised a raw
+    # traceback instead of the structured error JSON below — one level
+    # shallower than all three peer consumers (`context.py`,
+    # `create_pr.py`, `setup_task.py`).
+    #
+    # `or []` / `or ""` (review-fix #02): the API can also return a
+    # present-but-NULL field (`"labels": null`, `"body": null`), which a
+    # bare `.get` default does not catch. A null field is readable and
+    # degrades to empty; a malformed ENTRY is not, and errors out.
     try:
         data = json.loads(result.stdout)
-    except (json.JSONDecodeError, TypeError):
+        label_names = [lb["name"] for lb in data.get("labels") or []]
+        body = data.get("body") or ""
+    except (json.JSONDecodeError, TypeError, KeyError):
         output_json({"error": "Invalid JSON from gh CLI", "detail": result.stdout.strip()})
         sys.exit(1)
 
-    # `or []` / `or ""` (QS-332 review-fix #02): the API can return a
-    # present-but-null field (`"labels": null`, `"body": null`) — a bare
-    # `.get` default doesn't catch that, and iterating `None` /
-    # `parse_parent_epic(None)` raised a raw traceback instead of this
-    # script's structured error JSON. Same guard as `context.py` and
-    # `create_pr.py` (the fix-plan-#01 pattern, applied to the third
-    # consumer it missed).
-    label_names = [lb["name"] for lb in data.get("labels") or []]
-    body = data.get("body") or ""
     axes = targets.parse_axes(label_names)
     declaration_ok, _missing, _message = targets.validate_declaration(label_names)
 

--- a/scripts/qs/fetch_issue.py
+++ b/scripts/qs/fetch_issue.py
@@ -4,7 +4,11 @@
 Usage:
     python scripts/qs/fetch_issue.py --issue 42
 
-Output: JSON with issue number, title, body, labels, and derived type.
+Output: JSON with issue number, title, body, labels, the parsed lane
+axes (``kind``/``target``/``scale``/``lane``), ``parent_epic`` and
+``declaration_complete`` (QS-332). The axis parsing and the
+declaration truth table live in :mod:`targets` — one table, three
+consumers.
 """
 
 from __future__ import annotations
@@ -12,6 +16,8 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+
+import targets
 
 from utils import output_json, run_gh
 
@@ -36,22 +42,22 @@ def main() -> None:
         sys.exit(1)
 
     label_names = [lb["name"] for lb in data.get("labels", [])]
-
-    # Derive story type from labels: bug > enhancement/feature > default (feature)
-    if "bug" in label_names:
-        story_type = "bug"
-    elif any(lb in label_names for lb in ("enhancement", "feature")):
-        story_type = "feature"
-    else:
-        story_type = "feature"
+    body = data.get("body", "")
+    axes = targets.parse_axes(label_names)
+    declaration_ok, _missing, _message = targets.validate_declaration(label_names)
 
     output_json({
         "issue_number": data["number"],
         "title": data.get("title", ""),
-        "body": data.get("body", ""),
+        "body": body,
         "labels": label_names,
         "state": data.get("state", ""),
-        "story_type": story_type,
+        "kind": axes["kind"],
+        "target": axes["target"],
+        "scale": axes["scale"],
+        "lane": axes["lane"],
+        "parent_epic": targets.parse_parent_epic(body),
+        "declaration_complete": declaration_ok,
         "branch": f"QS_{data['number']}",
     })
 

--- a/scripts/qs/fetch_issue.py
+++ b/scripts/qs/fetch_issue.py
@@ -48,9 +48,20 @@ def main() -> None:
     # degrades to empty; a malformed ENTRY is not, and errors out.
     try:
         data = json.loads(result.stdout)
+        # `number` belongs inside the guard too (review-fix #04): it was a
+        # bare subscript with no default, so a valid-but-incomplete object
+        # (`{}`, or any object lacking `"number"`) degraded cleanly on the
+        # labels/body path and then crashed with a raw `KeyError`. Unique
+        # to this script — the peer consumers never read `number`.
+        number = data["number"]
         label_names = [lb["name"] for lb in data.get("labels") or []]
         body = data.get("body") or ""
-    except (json.JSONDecodeError, TypeError, KeyError):
+        title = data.get("title") or ""
+        state = data.get("state") or ""
+    except (json.JSONDecodeError, TypeError, KeyError, AttributeError):
+        # `AttributeError` (review-fix #04): a non-dict top-level value
+        # (`null`, `[]`, `42`) makes `.get` raise, which used to escape
+        # this guard as a raw traceback.
         output_json({"error": "Invalid JSON from gh CLI", "detail": result.stdout.strip()})
         sys.exit(1)
 
@@ -58,18 +69,18 @@ def main() -> None:
     declaration_ok, _missing, _message = targets.validate_declaration(label_names)
 
     output_json({
-        "issue_number": data["number"],
-        "title": data.get("title", ""),
+        "issue_number": number,
+        "title": title,
         "body": body,
         "labels": label_names,
-        "state": data.get("state", ""),
+        "state": state,
         "kind": axes["kind"],
         "target": axes["target"],
         "scale": axes["scale"],
         "lane": axes["lane"],
         "parent_epic": targets.parse_parent_epic(body),
         "declaration_complete": declaration_ok,
-        "branch": f"QS_{data['number']}",
+        "branch": f"QS_{number}",
     })
 
 

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -1779,7 +1779,10 @@ def _fetch_lane_labels(issue: int, branch: str) -> list[str] | None:
         # the `TypeError` arm to `None` claimed `gh` was UNAVAILABLE and
         # degraded to warn+skip locally / fail-closed in CI instead.
         labels = [lb["name"] for lb in json.loads(result.stdout).get("labels") or []]
-    except (json.JSONDecodeError, TypeError, KeyError):
+    except (json.JSONDecodeError, TypeError, KeyError, AttributeError):
+        # `AttributeError` (QS-332 review-fix #04): a non-dict top-level
+        # value (`null`, `[]`, `42`) makes `.get` raise, which used to
+        # escape this guard as a raw traceback.
         return None
     ok, _missing, _message = targets.validate_declaration(labels)
     if ok and not _is_ci():

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -1680,6 +1680,13 @@ _IMPACTED_NON_PY_LINES = (
 LANE_CACHE_FILE = REPO_ROOT / ".lane_check_cache"
 _LANE_CACHE_TTL_S = 600.0
 
+# Bound on the `gh issue view` label fetch (review-fix #01): it sits on
+# the `--impacted` pre-commit hot path, and with a half-dead network
+# (VPN drop, dead DNS — the QS-276 S1 scenario) and a cold/expired cache
+# an unbounded call hangs the sub-15s gate indefinitely. A timeout
+# surfaces as rc 124 → the normal `!= 0 → None → local warn+skip` path.
+_LANE_GH_TIMEOUT_S = 10.0
+
 
 class LaneCheckResult(NamedTuple):
     """`_check_lane_targets`'s verdict (review R2-12). The helper never
@@ -1715,12 +1722,13 @@ def _resolve_lane_issue(branch_override: str | None = None) -> tuple[int, str] |
     branch = result.stdout.strip() if result.returncode == 0 else ""
     if not branch and _is_ci() and branch_override:
         branch = branch_override.strip()
-    if not branch.startswith("QS_"):
+    # Pure digits only (review-fix #01): `int()` accepts underscore
+    # digit-grouping, so `QS_332_2` (a plausible "second attempt" branch)
+    # parsed as issue #3322 and the gate enforced the WRONG issue's
+    # declaration. `isdigit()` also rejects the empty suffix.
+    if not branch.startswith("QS_") or not branch[3:].isdigit():
         return None
-    try:
-        return int(branch[3:]), branch
-    except ValueError:
-        return None
+    return int(branch[3:]), branch
 
 
 def _read_lane_label_cache(issue: int, branch: str) -> list[str] | None:
@@ -1736,7 +1744,8 @@ def _read_lane_label_cache(issue: int, branch: str) -> list[str] | None:
         return None
     ts = data.get("time")
     now = time.time()
-    # A future mtime (clock skew) or an expired TTL both mean "fetch".
+    # A future stored `time` field (clock skew) or an expired TTL both
+    # mean "fetch". (The check reads the JSON field, not the file mtime.)
     if not isinstance(ts, (int, float)) or ts > now or now - ts > _LANE_CACHE_TTL_S:
         return None
     labels = data.get("labels")
@@ -1755,7 +1764,10 @@ def _fetch_lane_labels(issue: int, branch: str) -> list[str] | None:
     if cached is not None:
         return cached
     try:
-        result = _run(["gh", "issue", "view", str(issue), "--json", "labels"])
+        result = _run(
+            ["gh", "issue", "view", str(issue), "--json", "labels"],
+            timeout=_LANE_GH_TIMEOUT_S,
+        )
     except OSError:
         return None
     if result.returncode != 0:
@@ -1778,6 +1790,39 @@ def _fetch_lane_labels(issue: int, branch: str) -> list[str] | None:
     return labels
 
 
+def _lane_changed_files() -> list[str] | None:
+    """The lane check's own change set, or ``None`` when git failed.
+
+    Review-fix #01 — three properties `_get_changed_files` lacks, each
+    load-bearing here:
+
+    - **Fail-closed**: any non-zero git exit yields ``None`` (reaching
+      `_check_lane_targets`'s gh-failure semantics: local warn + skip,
+      CI fail closed). `_get_changed_files` silently drops failed calls,
+      which made the documented CI fail-closed arm unreachable where CI
+      actually runs.
+    - **NUL-delimited** (`-z`): `core.quotePath` C-quotes non-ASCII
+      paths, which would classify `unknown` forever — the same treatment
+      QS-290 gave `_impacted_early_exit_paths`.
+    - **Tracked paths only** (no `ls-files --others` rung): an untracked
+      local scratch file must not earn the loud cross-target banner that
+      CI — which classifies tracked diffs only — would not print for the
+      same tree. The untracked union stays in
+      `_impacted_early_exit_paths`, for the early-exit decision alone.
+    """
+    paths: set[str] = set()
+    for cmd in (
+        ["git", "diff", "--name-only", "-z", "origin/main...HEAD"],
+        ["git", "diff", "--name-only", "-z", "HEAD"],
+        ["git", "diff", "--name-only", "-z", "--cached"],
+    ):
+        listing = _run(cmd)
+        if listing.returncode != 0:
+            return None
+        paths.update(field for field in listing.stdout.split("\0") if field)
+    return sorted(paths)
+
+
 def _lane_unavailable(reason: str, fyi: str | None) -> LaneCheckResult:
     """Map an unreadable input (gh failure / git failure): local warn +
     skip (offline must not brick the gate); CI fail closed — CI has a
@@ -1792,20 +1837,22 @@ def _lane_unavailable(reason: str, fyi: str | None) -> LaneCheckResult:
     return LaneCheckResult(warning=f"lane check: {reason} — skipping (local)", fyi=fyi)
 
 
-def _check_lane_targets(
-    changed_files: list[str] | None, branch_override: str | None = None
-) -> LaneCheckResult:
+def _check_lane_targets(branch_override: str | None = None) -> LaneCheckResult:
     """Steps 0-4 of the QS-332 lane check. Never exits, never prints.
 
-    Skipped (all-None result) when no `QS_<N>` issue is resolvable.
-    `changed_files is None` (a git failure upstream) has exactly the
-    `gh`-failure semantics: local warn + skip, CI fail closed.
+    Skipped (all-None result) when no `QS_<N>` issue is resolvable —
+    checked FIRST, so a non-task branch pays no git calls. The change
+    set is the helper's own fail-closed `_lane_changed_files()`
+    (review-fix #01: identical semantics at all three call sites, and a
+    git failure — `None` — gets exactly the `gh`-failure treatment:
+    local warn + skip, CI fail closed).
     """
     resolved = _resolve_lane_issue(branch_override)
     if resolved is None:
         return LaneCheckResult()
     issue, branch = resolved
 
+    changed_files = _lane_changed_files()
     if changed_files is None:
         return _lane_unavailable("the change set could not be computed (git failure)", None)
 
@@ -1883,7 +1930,7 @@ def run_lane_check(branch_override: str | None) -> int:
     """The `--lane-check` subcommand (reviews CR-3 + N-1): lane steps 0-4
     only — no pytest, no coverage. In CI the warning is additionally
     surfaced machine-owned via `GITHUB_STEP_SUMMARY` (review N-4)."""
-    result = _check_lane_targets(_get_changed_files(), branch_override)
+    result = _check_lane_targets(branch_override)
     rc = _emit_lane_check(result)
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if result.warning and summary_path:
@@ -2390,16 +2437,18 @@ def check_impacted() -> int:
     # been purged, after which testmon select-alls too. Cold falls through to
     # the full pass, exactly as before this feature existed.
     # QS-332 (B1), call site 1: after `_ensure_testmon_db_safe()` and
-    # BEFORE the warm-baseline early-exit block, with the change set
-    # computed UNCONDITIONALLY — the hook must run on a pure-docs change
-    # set too (a missing declaration fails and a cross-target diff warns
-    # there as well). `None` (git failure) is handled inside
-    # `_check_lane_targets` with gh-failure semantics: local warn + skip,
-    # CI fail closed.
-    early_exit_paths = _impacted_early_exit_paths()
-    if _emit_lane_check(_check_lane_targets(early_exit_paths)):
+    # BEFORE the warm-baseline early-exit block — the hook must run on a
+    # pure-docs change set too (a missing declaration fails and a
+    # cross-target diff warns there as well). The check computes its own
+    # tracked-only, fail-closed change set (review-fix #01) —
+    # `_impacted_early_exit_paths`'s union stays the early-exit input
+    # ONLY, because its untracked rung would banner local scratch files
+    # CI never sees; a git failure inside the check gets gh-failure
+    # semantics (local warn + skip, CI fail closed).
+    if _emit_lane_check(_check_lane_targets()):
         return 1
 
+    early_exit_paths = _impacted_early_exit_paths()
     if _testmon_baseline_warm():
         if early_exit_paths is not None and not any(p.endswith(".py") for p in early_exit_paths):
             for line in _IMPACTED_NON_PY_LINES:
@@ -3473,10 +3522,13 @@ def main() -> None:
     # Detect scope
     changed_files = _get_changed_files()
 
-    # QS-332 (B1), call site 2: the full gate. Between the change-set
-    # computation and scope detection; a missing declaration fails the
-    # gate, a cross-target diff warns on stderr and never fails.
-    if _emit_lane_check(_check_lane_targets(changed_files)):
+    # QS-332 (B1), call site 2: the full gate, before scope detection.
+    # A missing declaration fails the gate, a cross-target diff warns on
+    # stderr and never fails. The check computes its own fail-closed
+    # change set (review-fix #01) — `_get_changed_files` above maps git
+    # failures to `[]`, which would silently degrade the check to
+    # declaration-only.
+    if _emit_lane_check(_check_lane_targets()):
         sys.exit(1)
 
     scope_info = _detect_scope(changed_files)

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -77,7 +77,14 @@ from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
+
+# QS-332: the gate's first sibling import, resolved the same way every
+# `scripts/qs` module already resolves siblings — the script dir sits on
+# `sys.path` when run as a script, and `tests/test_quality_gate.py`
+# inserts it under pytest. `targets` owns the lane domain (path
+# classification + the declaration truth table); the gate only wires it.
+import targets
 
 # Resolve paths relative to repo root
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -1662,6 +1669,232 @@ _IMPACTED_NON_PY_LINES = (
 )
 
 
+# ---------------------------------------------------------------------------
+# QS-332 (B1): the lane check
+# ---------------------------------------------------------------------------
+
+# Label marker-file cache: keyed on (issue, branch), 10-minute TTL,
+# `_is_ci()` bypass. Kept over review SG2-02's drop suggestion — a network
+# call in the `--impacted` pre-commit hot loop is exactly the class of
+# cost QS-290 spent a task TTL-caching.
+LANE_CACHE_FILE = REPO_ROOT / ".lane_check_cache"
+_LANE_CACHE_TTL_S = 600.0
+
+
+class LaneCheckResult(NamedTuple):
+    """`_check_lane_targets`'s verdict (review R2-12). The helper never
+    exits and never prints; each call site maps the result via
+    `_emit_lane_check`: `declaration_missing` → gate failure (exit
+    non-zero through the site's normal mechanism), `warning`/`fyi` →
+    printed to STDERR (never stdout — `--json` must stay parseable,
+    review DP2-03).
+
+    `declaration_missing` carries anything that must FAIL the gate: a
+    missing/inconsistent declaration, or the CI fail-closed arm of a
+    `gh`/git failure. `warning` carries the cross-target text — or the
+    local warn-and-skip notice. `fyi` carries the unknown-path lines.
+    """
+
+    declaration_missing: str | None = None
+    warning: str | None = None
+    fyi: str | None = None
+
+
+def _resolve_lane_issue(branch_override: str | None = None) -> tuple[int, str] | None:
+    """Resolve `(issue, branch)` from `QS_<N>`, or None (→ check skipped).
+
+    CI fallback (review N-1, found independently by three reviewers): a
+    `pull_request` checkout is a detached merge ref where
+    `git branch --show-current` is empty, which would silently no-op the
+    check in CI. When it yields nothing AND `_is_ci()`, fall back to the
+    `--branch` value the workflow step passes (`${{ github.head_ref }}` —
+    the PR's source branch on every `pull_request` event). Locally the
+    override is ignored: not a task branch means nothing to enforce.
+    """
+    result = _run(["git", "branch", "--show-current"])
+    branch = result.stdout.strip() if result.returncode == 0 else ""
+    if not branch and _is_ci() and branch_override:
+        branch = branch_override.strip()
+    if not branch.startswith("QS_"):
+        return None
+    try:
+        return int(branch[3:]), branch
+    except ValueError:
+        return None
+
+
+def _read_lane_label_cache(issue: int, branch: str) -> list[str] | None:
+    if _is_ci():
+        return None
+    try:
+        data = json.loads(LANE_CACHE_FILE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("issue") != issue or data.get("branch") != branch:
+        return None
+    ts = data.get("time")
+    now = time.time()
+    # A future mtime (clock skew) or an expired TTL both mean "fetch".
+    if not isinstance(ts, (int, float)) or ts > now or now - ts > _LANE_CACHE_TTL_S:
+        return None
+    labels = data.get("labels")
+    if not isinstance(labels, list) or not all(isinstance(lb, str) for lb in labels):
+        return None
+    return labels
+
+
+def _fetch_lane_labels(issue: int, branch: str) -> list[str] | None:
+    """The issue's label names, TTL-cached; None = `gh` unavailable/failed.
+
+    ONLY complete declarations are cached, so a backfill-then-re-run can
+    never be re-failed by a stale cache.
+    """
+    cached = _read_lane_label_cache(issue, branch)
+    if cached is not None:
+        return cached
+    try:
+        result = _run(["gh", "issue", "view", str(issue), "--json", "labels"])
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        labels = [lb["name"] for lb in json.loads(result.stdout).get("labels", [])]
+    except (json.JSONDecodeError, TypeError, KeyError):
+        return None
+    ok, _missing, _message = targets.validate_declaration(labels)
+    if ok and not _is_ci():
+        try:
+            LANE_CACHE_FILE.write_text(
+                json.dumps(
+                    {"issue": issue, "branch": branch, "labels": labels, "time": time.time()}
+                ),
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+    return labels
+
+
+def _lane_unavailable(reason: str, fyi: str | None) -> LaneCheckResult:
+    """Map an unreadable input (gh failure / git failure): local warn +
+    skip (offline must not brick the gate); CI fail closed — CI has a
+    guaranteed token and network, so a failure there is a real error and
+    a silent skip would disable the one enforcement QS-332 adds
+    (review PC-02)."""
+    if _is_ci():
+        return LaneCheckResult(
+            declaration_missing=f"lane check: {reason} — failing closed in CI",
+            fyi=fyi,
+        )
+    return LaneCheckResult(warning=f"lane check: {reason} — skipping (local)", fyi=fyi)
+
+
+def _check_lane_targets(
+    changed_files: list[str] | None, branch_override: str | None = None
+) -> LaneCheckResult:
+    """Steps 0-4 of the QS-332 lane check. Never exits, never prints.
+
+    Skipped (all-None result) when no `QS_<N>` issue is resolvable.
+    `changed_files is None` (a git failure upstream) has exactly the
+    `gh`-failure semantics: local warn + skip, CI fail closed.
+    """
+    resolved = _resolve_lane_issue(branch_override)
+    if resolved is None:
+        return LaneCheckResult()
+    issue, branch = resolved
+
+    if changed_files is None:
+        return _lane_unavailable("the change set could not be computed (git failure)", None)
+
+    # Step 0 — classify every changed file; `unknown` fallthrough paths
+    # print as an FYI so the fail-open set stays visible (review PC-09).
+    classified = [(path, targets.classify(path)) for path in changed_files]
+    unknown = [path for path, cls in classified if cls == "unknown"]
+    fyi = None
+    if unknown:
+        fyi = (
+            "lane check FYI: unclassified path(s) — fail-open by design; a "
+            "recurring path deserves a one-line targets.py classification PR:\n"
+            + "\n".join(f"  - {path}" for path in unknown)
+        )
+
+    # Step 1 — the declared target: branch → issue → labels.
+    labels = _fetch_lane_labels(issue, branch)
+    if labels is None:
+        # Step 2 — gh unavailable/failing.
+        return _lane_unavailable(f"could not fetch labels for issue #{issue}", fyi)
+
+    # Step 3 — labels readable but declaration missing/incomplete → FAIL
+    # with the exact, shape-aware backfill command.
+    ok, _missing, message = targets.validate_declaration(labels)
+    if not ok:
+        text = (
+            f"lane check FAILED: issue #{issue} has no complete lane declaration "
+            f"(QS-332: every task is born in exactly one lane).\n"
+            + message.replace("<N>", str(issue))
+        )
+        return LaneCheckResult(declaration_missing=text, fyi=fyi)
+
+    # Step 4 — a `scale:epic` declaration is valid (no kind expected) and
+    # classifies against its target like any other (review PC-11).
+    declared = targets.parse_axes(labels)["target"]
+    opposite = "product" if declared == "factory" else "factory"
+    crossing = [path for path, cls in classified if cls == opposite]
+    warning = None
+    if crossing:
+        # LOUD, repeats by design on every run (review R2-05): no waiver,
+        # no acknowledgment state. Never a failure — user ruling: purpose,
+        # not path, is the classifier.
+        warning = (
+            "=" * 66
+            + "\nLANE WARNING: this task declares target:"
+            + declared
+            + f" but the diff\ntouches {opposite}-classified files:\n"
+            + "\n".join(f"  - {path}" for path in crossing)
+            + f"\nVerify these serve the declared {declared} purpose (purpose, not"
+            "\npath, is the classifier). If the "
+            + opposite
+            + "-side portion is substantial,"
+            "\nthe recommended remedy is to split the issue: file a separate "
+            + opposite
+            + "\ntask and move those changes there (see docs/epics/QS-321.md)."
+            "\nThis warning never fails the gate; a path that KEEPS warning"
+            "\nwrongly earns a targets.py carve-out PR.\n" + "=" * 66
+        )
+    return LaneCheckResult(warning=warning, fyi=fyi)
+
+
+def _emit_lane_check(result: LaneCheckResult) -> int:
+    """Map a `LaneCheckResult` at a call site: `fyi`/`warning` to stderr
+    (never stdout), `declaration_missing` to stderr + rc 1."""
+    for text in (result.fyi, result.warning):
+        if text:
+            print(text, file=sys.stderr)
+    if result.declaration_missing:
+        print(result.declaration_missing, file=sys.stderr)
+        return 1
+    return 0
+
+
+def run_lane_check(branch_override: str | None) -> int:
+    """The `--lane-check` subcommand (reviews CR-3 + N-1): lane steps 0-4
+    only — no pytest, no coverage. In CI the warning is additionally
+    surfaced machine-owned via `GITHUB_STEP_SUMMARY` (review N-4)."""
+    result = _check_lane_targets(_get_changed_files(), branch_override)
+    rc = _emit_lane_check(result)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if result.warning and summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write("## Lane note\n\n```\n" + result.warning + "\n```\n")
+        except OSError:
+            pass
+    return rc
+
+
 def _testmon_schema_version() -> int | None:
     """The DB schema version (`PRAGMA user_version`) the installed testmon
     expects, probed in VENV_PYTHON — the interpreter pytest actually runs
@@ -2156,8 +2389,18 @@ def check_impacted() -> int:
     # probe must be the POST-hygiene one — a corrupt DB looks warm but has just
     # been purged, after which testmon select-alls too. Cold falls through to
     # the full pass, exactly as before this feature existed.
+    # QS-332 (B1), call site 1: after `_ensure_testmon_db_safe()` and
+    # BEFORE the warm-baseline early-exit block, with the change set
+    # computed UNCONDITIONALLY — the hook must run on a pure-docs change
+    # set too (a missing declaration fails and a cross-target diff warns
+    # there as well). `None` (git failure) is handled inside
+    # `_check_lane_targets` with gh-failure semantics: local warn + skip,
+    # CI fail closed.
+    early_exit_paths = _impacted_early_exit_paths()
+    if _emit_lane_check(_check_lane_targets(early_exit_paths)):
+        return 1
+
     if _testmon_baseline_warm():
-        early_exit_paths = _impacted_early_exit_paths()
         if early_exit_paths is not None and not any(p.endswith(".py") for p in early_exit_paths):
             for line in _IMPACTED_NON_PY_LINES:
                 _emit("impacted", line)
@@ -2965,6 +3208,25 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--lane-check",
+        action="store_true",
+        help=(
+            "QS-332: run only the lane check (declaration + cross-target "
+            "classification) — no pytest, no coverage. Mutex with every "
+            "other execution mode. CI passes --branch alongside it."
+        ),
+    )
+    parser.add_argument(
+        "--branch",
+        default=None,
+        metavar="BRANCH",
+        help=(
+            "QS-332: branch-name fallback for --lane-check in CI, where a "
+            "pull_request checkout is a detached merge ref (pass "
+            '"${{ github.head_ref }}"). Only valid with --lane-check.'
+        ),
+    )
+    parser.add_argument(
         "--seed-testmon",
         action="store_true",
         help=(
@@ -3031,6 +3293,28 @@ def main() -> None:
         parser.error(
             "you cannot combine --impacted with --quick, --cache, --no-cache, --full, or --fix"
         )
+
+    # QS-332: --lane-check joins the execution-mode mutex ladder — it is a
+    # self-contained read-only subcommand, incompatible with every other
+    # execution mode (including the seed trio below).
+    if args.lane_check and (
+        args.impacted or args.quick or args.cache or args.no_cache or args.full or args.fix
+    ):
+        parser.error(
+            "you cannot combine --lane-check with --impacted, --quick, --cache, "
+            "--no-cache, --full, or --fix"
+        )
+    if args.lane_check and (
+        args.seed_testmon or args.seed_testmon_status or args.seed_testmon_follow
+    ):
+        parser.error(
+            "you cannot combine --lane-check with --seed-testmon, "
+            "--seed-testmon-status, or --seed-testmon-follow"
+        )
+    # --branch exists solely as the CI detached-HEAD fallback for
+    # --lane-check; anywhere else it is a usage error.
+    if args.branch is not None and not args.lane_check:
+        parser.error("--branch is only valid with --lane-check")
 
     # QS-299 review-fix #02 (finding #2): the three seed subcommands are pairwise
     # mutually exclusive. ONE centralized, symmetric check (order-independent)
@@ -3145,6 +3429,11 @@ def main() -> None:
         )
         sys.exit(0 if result["passed"] else 1)
 
+    # QS-332: --lane-check short-circuits before scope detection, like
+    # --impacted — lane steps 0-4 only, no pytest, no coverage.
+    if args.lane_check:
+        sys.exit(run_lane_check(args.branch))
+
     # --impacted short-circuits before scope detection / caching, exactly
     # like --quick: it is its own gate with a bespoke exit-code table.
     if args.impacted:
@@ -3183,6 +3472,13 @@ def main() -> None:
 
     # Detect scope
     changed_files = _get_changed_files()
+
+    # QS-332 (B1), call site 2: the full gate. Between the change-set
+    # computation and scope detection; a missing declaration fails the
+    # gate, a cross-target diff warns on stderr and never fails.
+    if _emit_lane_check(_check_lane_targets(changed_files)):
+        sys.exit(1)
+
     scope_info = _detect_scope(changed_files)
     scope = scope_info["scope"]
     if args.full:

--- a/scripts/qs/quality_gate.py
+++ b/scripts/qs/quality_gate.py
@@ -1773,7 +1773,12 @@ def _fetch_lane_labels(issue: int, branch: str) -> list[str] | None:
     if result.returncode != 0:
         return None
     try:
-        labels = [lb["name"] for lb in json.loads(result.stdout).get("labels", [])]
+        # `or []` (QS-332 review-fix #03): a `"labels": null` response is
+        # readable — it means "no labels", which the declaration check
+        # then fails on its own merits (actionable). Routing it through
+        # the `TypeError` arm to `None` claimed `gh` was UNAVAILABLE and
+        # degraded to warn+skip locally / fail-closed in CI instead.
+        labels = [lb["name"] for lb in json.loads(result.stdout).get("labels") or []]
     except (json.JSONDecodeError, TypeError, KeyError):
         return None
     ok, _missing, _message = targets.validate_declaration(labels)

--- a/scripts/qs/setup_task.py
+++ b/scripts/qs/setup_task.py
@@ -55,7 +55,11 @@ def check_declaration(issue: int) -> None:
         })
         sys.exit(1)
     try:
-        labels = [lb["name"] for lb in json.loads(result.stdout).get("labels", [])]
+        # `or []` (QS-332 review-fix #03): `"labels": null` IS valid JSON,
+        # so reporting "Invalid JSON from gh CLI" for it was misleading —
+        # the honest verdict is the ordinary missing-declaration refusal
+        # below, which prints an actionable backfill command.
+        labels = [lb["name"] for lb in json.loads(result.stdout).get("labels") or []]
     except (json.JSONDecodeError, TypeError, KeyError):
         output_json({"error": "Invalid JSON from gh CLI", "detail": result.stdout.strip()})
         sys.exit(1)

--- a/scripts/qs/setup_task.py
+++ b/scripts/qs/setup_task.py
@@ -37,8 +37,12 @@ from utils import (  # type: ignore[import-not-found]
 )
 
 
-def check_declaration(issue: int) -> None:
+def check_declaration(issue: int) -> list[str]:
     """Refuse to proceed unless ``issue`` carries a complete lane declaration.
+
+    Returns the issue's label names so the caller can enforce
+    scale-specific invariants without a second ``gh`` call
+    (:func:`refuse_if_epic`).
 
     QS-332 B2 — enforcement by construction: this runs BEFORE any
     branch/worktree work. One ``gh issue view --json labels`` call
@@ -60,7 +64,10 @@ def check_declaration(issue: int) -> None:
         # the honest verdict is the ordinary missing-declaration refusal
         # below, which prints an actionable backfill command.
         labels = [lb["name"] for lb in json.loads(result.stdout).get("labels") or []]
-    except (json.JSONDecodeError, TypeError, KeyError):
+    except (json.JSONDecodeError, TypeError, KeyError, AttributeError):
+        # `AttributeError` (QS-332 review-fix #04): a non-dict top-level
+        # value (`null`, `[]`, `42`) makes `.get` raise, which used to
+        # escape this guard as a raw traceback.
         output_json({"error": "Invalid JSON from gh CLI", "detail": result.stdout.strip()})
         sys.exit(1)
 
@@ -72,6 +79,40 @@ def check_declaration(issue: int) -> None:
             "detail": message.replace("<N>", str(issue)),
         })
         sys.exit(1)
+    return labels
+
+
+def refuse_if_epic(issue: int, labels: list[str]) -> None:
+    """Refuse to cut a branch/worktree for a ``scale:epic`` issue.
+
+    QS-332 review-fix #04 (must-fix). The epic model
+    (:doc:`docs/epics/QS-321`) is explicit: an epic has **no implement
+    phase; no branch, worktree, or PR** — its output is a rationale
+    document on ``main`` plus child issues. Step 2 of the setup agent used
+    to run this script unconditionally, so picking an epic lane (or
+    passing an existing epic via ``--issue N``) cut a worktree anyway.
+
+    Machine-enforced here rather than prompt-obeyed, matching the story's
+    "machine-checked rather than prompt-obeyed" philosophy, and enforced
+    for ``--no-worktree`` too: that flag still creates a **branch**, which
+    the model forbids as well. Consumes ``check_declaration``'s labels —
+    no extra ``gh`` call.
+    """
+    if targets.parse_axes(labels)["scale"] != "epic":
+        return
+    output_json({
+        "error": (
+            f"issue #{issue} is scale:epic — refusing to create a branch or worktree"
+        ),
+        "scale": "epic",
+        "detail": (
+            "An epic has no implement phase and no branch, worktree, or PR. "
+            "Its output is a rationale document on `main` plus child issues: "
+            "decompose it into child tasks (each child is its own task lane, "
+            "carrying `Refs #<epic>`) and run setup-task on those instead."
+        ),
+    })
+    sys.exit(1)
 
 # Public mapping (review-fix #04 SF1) — promoted to match the
 # round-3 SF1 rename of next_step.LAUNCHERS. The two dispatch tables
@@ -119,8 +160,11 @@ def main() -> None:
     branch = f"QS_{issue}"
 
     # QS-332 B2: an issue must be born in exactly one lane; refuse an
-    # undeclared/inconsistent one before touching git.
-    check_declaration(issue)
+    # undeclared/inconsistent one before touching git. Review-fix #04:
+    # and refuse an EPIC outright — no branch, no worktree (the labels
+    # come from the same fetch, so this costs no extra `gh` call).
+    labels = check_declaration(issue)
+    refuse_if_epic(issue, labels)
 
     main_dir = get_main_worktree()
 

--- a/scripts/qs/setup_task.py
+++ b/scripts/qs/setup_task.py
@@ -14,8 +14,11 @@ the agent should surface to the user).
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
+
+import targets  # type: ignore[import-not-found]
 
 from harness import canonicalize as canonicalize_harness  # type: ignore[import-not-found]
 from harness import detect as detect_harness
@@ -29,8 +32,42 @@ from utils import (  # type: ignore[import-not-found]
     get_main_worktree,
     get_worktree_dir,
     output_json,
+    run_gh,
     run_git,
 )
+
+
+def check_declaration(issue: int) -> None:
+    """Refuse to proceed unless ``issue`` carries a complete lane declaration.
+
+    QS-332 B2 — enforcement by construction: this runs BEFORE any
+    branch/worktree work. One ``gh issue view --json labels`` call
+    (``check=False`` with an explicit JSON-error path, like its peers);
+    the validity rule itself lives in :func:`targets.validate_declaration`
+    (one truth table, three consumers). The refusal message carries the
+    exact shape-aware ``gh issue edit --add-label`` backfill command.
+    """
+    result = run_gh(["issue", "view", str(issue), "--json", "labels"], check=False)
+    if result.returncode != 0:
+        output_json({
+            "error": f"Failed to fetch labels for issue #{issue}",
+            "detail": result.stderr.strip(),
+        })
+        sys.exit(1)
+    try:
+        labels = [lb["name"] for lb in json.loads(result.stdout).get("labels", [])]
+    except (json.JSONDecodeError, TypeError, KeyError):
+        output_json({"error": "Invalid JSON from gh CLI", "detail": result.stdout.strip()})
+        sys.exit(1)
+
+    ok, missing, message = targets.validate_declaration(labels)
+    if not ok:
+        output_json({
+            "error": f"issue #{issue} has no complete lane declaration — refusing to proceed",
+            "missing": missing,
+            "detail": message.replace("<N>", str(issue)),
+        })
+        sys.exit(1)
 
 # Public mapping (review-fix #04 SF1) — promoted to match the
 # round-3 SF1 rename of next_step.LAUNCHERS. The two dispatch tables
@@ -76,6 +113,11 @@ def main() -> None:
 
     issue = args.issue_number
     branch = f"QS_{issue}"
+
+    # QS-332 B2: an issue must be born in exactly one lane; refuse an
+    # undeclared/inconsistent one before touching git.
+    check_declaration(issue)
+
     main_dir = get_main_worktree()
 
     run_git(["fetch", "origin"], cwd=str(main_dir))

--- a/scripts/qs/targets.py
+++ b/scripts/qs/targets.py
@@ -188,6 +188,12 @@ def validate_declaration(labels: list[str]) -> tuple[bool, list[str], str]:
         elif not axes[axis]:
             missing.append(axis)
             problems.append(f"exactly one {axis}:* label is required")
+            # Review-fix #02: a single NON-CANONICAL value (`kind:chore`,
+            # `target:banana`) lands here — len==1 but `parse_axes`
+            # yields "". Without removing the stray label, obeying the
+            # printed remediation produced a duplicate-axis failure on
+            # the next run (a guaranteed second round-trip).
+            remove.extend(present)
             if axis == "scale" and not is_epic_shape:
                 # The implicit CLI default (D1) — deterministic, so it
                 # may appear in a verbatim-runnable command.

--- a/scripts/qs/targets.py
+++ b/scripts/qs/targets.py
@@ -46,7 +46,10 @@ _FACTORY_PREFIXES = (
 )
 
 # Copied from ``quality_gate._is_dev_only``'s basename list — see the
-# module docstring for why this is a copy, not an import.
+# module docstring for why this is a copy, not an import — plus the
+# review-fix #01 additions: known repo-root factory files that would
+# otherwise earn a perpetual unknown-FYI (`pytest.ini`, the OpenCode
+# harness config, the dev-env shell setup).
 _FACTORY_BASENAMES = frozenset(
     {
         "CLAUDE.md",
@@ -57,8 +60,15 @@ _FACTORY_BASENAMES = frozenset(
         "setup.cfg",
         "requirements.txt",
         "requirements_test.txt",
+        "pytest.ini",
+        "opencode.json",
+        "setenv.sh",
     }
 )
+
+# Review-fix #01: `hacs.json` is product-defining (it describes the
+# shipped integration to HACS).
+_PRODUCT_BASENAMES = frozenset({"hacs.json"})
 
 # ``docs/agents/`` is product BY EPIC RULING — the drift checker ties it
 # to product source.
@@ -70,9 +80,10 @@ _PRODUCT_PREFIXES = (
 )
 
 # Enumerated neutrality (silent): every task commits its story;
-# ``docs/epics/`` is target-neutral by epic rule.
+# ``docs/epics/`` is target-neutral by epic rule; `LICENSE` belongs to
+# the repo, not a target (review-fix #01).
 _NEUTRAL_PREFIXES = ("docs/stories/", "docs/epics/")
-_NEUTRAL_BASENAMES = frozenset({"README.md"})
+_NEUTRAL_BASENAMES = frozenset({"README.md", "LICENSE"})
 
 
 def classify(path: str) -> str:
@@ -93,6 +104,8 @@ def classify(path: str) -> str:
     if "/" not in path:
         if path in _FACTORY_BASENAMES:
             return "factory"
+        if path in _PRODUCT_BASENAMES:
+            return "product"
         if path in _NEUTRAL_BASENAMES:
             return "neutral"
     return "unknown"
@@ -140,52 +153,78 @@ def validate_declaration(labels: list[str]) -> tuple[bool, list[str], str]:
       assumed when ``scale`` is missing/ambiguous).
 
     ``missing`` lists the invalid-or-missing axis names. ``message`` is
-    shape-aware (task vs epic) and carries the exact backfill command
-    with an ``<N>`` placeholder for the issue number — callers substitute
-    it (``message.replace("<N>", str(issue))``).
+    shape-aware (task vs epic) and its remediation is **executable
+    verbatim** (review-fix #01): every printed ``gh issue edit`` command
+    contains only concrete labels — ``--remove-label`` for duplicate-axis
+    labels (remove all, then re-add the chosen one) and for an epic's
+    stray ``kind:*``; ``--add-label`` only for the deterministic
+    ``scale:task`` default. Axes whose value is the user's choice are
+    prose (``kind:bug / kind:feature``), never ``a|b`` alternatives baked
+    into a command. The one placeholder is ``<N>`` — callers substitute
+    the issue number (``message.replace("<N>", str(issue))``).
     """
-    kind_labels = [lb for lb in labels if lb.startswith("kind:")]
     axes = parse_axes(labels)
     is_epic_shape = "scale:epic" in labels and "scale:task" not in labels
 
+    def _axis_labels(axis: str) -> list[str]:
+        return sorted(lb for lb in labels if lb.startswith(f"{axis}:"))
+
     missing: list[str] = []
     problems: list[str] = []
-    suggestions: list[str] = []
+    remove: list[str] = []  # concrete labels to remove (executable)
+    add: list[str] = []  # concrete, deterministic labels to add
+    choose: list[str] = []  # user-chosen additions, described in prose
 
-    if not axes["target"]:
-        missing.append("target")
-        problems.append("exactly one target:* label is required")
-        suggestions.append("target:product|target:factory")
+    def _check_axis(axis: str, choices: str) -> None:
+        present = _axis_labels(axis)
+        if len(present) > 1:
+            missing.append(axis)
+            problems.append(
+                f"exactly one {axis}:* label is required "
+                f"({len(present)} present: {', '.join(present)})"
+            )
+            remove.extend(present)
+            choose.append(f"exactly one of {choices}")
+        elif not axes[axis]:
+            missing.append(axis)
+            problems.append(f"exactly one {axis}:* label is required")
+            if axis == "scale" and not is_epic_shape:
+                # The implicit CLI default (D1) — deterministic, so it
+                # may appear in a verbatim-runnable command.
+                add.append("scale:task")
+            else:
+                choose.append(f"exactly one of {choices}")
 
-    if not axes["scale"]:
-        missing.append("scale")
-        problems.append("exactly one scale:* label is required")
-        if not is_epic_shape:
-            suggestions.append("scale:task")
+    _check_axis("target", "target:product / target:factory")
+    _check_axis("scale", "scale:task / scale:epic")
 
     if is_epic_shape:
+        kind_labels = _axis_labels("kind")
         if kind_labels:
             missing.append("kind")
-            problems.append(
-                "an epic carries no kind:* label — remove "
-                + ", ".join(sorted(kind_labels))
-            )
-    elif not axes["kind"]:
-        missing.append("kind")
-        problems.append("exactly one kind:* label is required")
-        suggestions.append("kind:bug|kind:feature")
+            problems.append("an epic carries no kind:* label")
+            remove.extend(kind_labels)
+    else:
+        _check_axis("kind", "kind:bug / kind:feature")
 
     if not missing:
         return True, [], ""
 
     shape = "epic" if is_epic_shape else "task"
-    message = f"incomplete lane declaration ({shape}): " + "; ".join(problems)
-    if suggestions:
-        message += (
-            "\nbackfill with: gh issue edit <N> --add-label "
-            f'"{",".join(suggestions)}"'
+    lines = [f"incomplete lane declaration ({shape}): " + "; ".join(problems)]
+    if remove or add:
+        lines.append("fix with (run exactly as printed):")
+        if remove:
+            lines.append(f'  gh issue edit <N> --remove-label "{",".join(remove)}"')
+        if add:
+            lines.append(f'  gh issue edit <N> --add-label "{",".join(add)}"')
+    if choose:
+        lines.append(
+            "then add, via gh issue edit <N> --add-label, with the user's "
+            "chosen value substituted:"
         )
-    return False, missing, message
+        lines.extend(f"  {item}" for item in choose)
+    return False, missing, "\n".join(lines)
 
 
 # --- parse_parent_epic() (story D4) ----------------------------------------
@@ -193,14 +232,19 @@ def validate_declaration(labels: list[str]) -> tuple[bool, list[str], str]:
 _PARENT_EPIC_SECTION = re.compile(
     r"^###\s+Parent epic\s*$", re.IGNORECASE | re.MULTILINE
 )
-_REFS_RE = re.compile(r"\bRefs #(\d+)")
+# Case-insensitive (review-fix #01): GitHub's own keyword matching is,
+# and `_PARENT_EPIC_SECTION` above already is — `refs #321` must count.
+_REFS_RE = re.compile(r"\bRefs #(\d+)", re.IGNORECASE)
+# The structured field accepts the repo's own issue convention too
+# (review-fix #01): `321`, `#321`, `QS-321`, `qs-321`, `QS-#321`.
+_PARENT_EPIC_VALUE = re.compile(r"(?:QS-)?#?(\d+)", re.IGNORECASE)
 
 
 def parse_parent_epic(body: str) -> int | None:
     """Resolve the declared parent epic from an issue body, or ``None``.
 
     The structured issue-form section (a ``### Parent epic`` heading whose
-    following non-empty line is ``#?(\\d+)``) wins over free-text
+    following non-empty line is ``(?:QS-)?#?(\\d+)``) wins over free-text
     cross-references (review PC-05); fallback is the first ``Refs #N``.
     Explicit, never guessed.
     """
@@ -210,7 +254,7 @@ def parse_parent_epic(body: str) -> int | None:
             stripped = line.strip()
             if not stripped:
                 continue
-            match = re.fullmatch(r"#?(\d+)", stripped)
+            match = _PARENT_EPIC_VALUE.fullmatch(stripped)
             if match:
                 return int(match.group(1))
             break  # first non-empty line is not a number — fall back

--- a/scripts/qs/targets.py
+++ b/scripts/qs/targets.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Lane domain module (QS-332): axes, declaration validity, path targets.
+
+Single machine-readable source of truth for the 6-lane model of epic
+QS-321 — 6 lanes = {bug, feature, epic} x {product, factory}. Three
+consumers in-repo: the quality gate (lane check), ``fetch_issue.py``
+and ``setup_task.py`` (declaration validation). The declaration-validity
+rule lives HERE and only here (one truth table).
+
+Deliberately NOT ``quality_gate._is_dev_only``'s complement and not a
+replacement for it: ``_is_dev_only`` drives scope *detection* (which
+suite to run), this module drives lane *enforcement*. The factory
+basename list below is a copy, not a reference, so this module stays
+import-independent of the gate.
+
+Ad-hoc classification query (AC-10)::
+
+    python scripts/qs/targets.py <path> [<path> ...]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+KINDS = ("bug", "feature")
+TARGETS = ("product", "factory")
+SCALES = ("task", "epic")
+
+# --- classify(): fully enumerated classification (story D5) ---------------
+
+# Factory carve-outs by the PURPOSE rule: these pin factory code even
+# though their path prefix says otherwise (review CR-1).
+_FACTORY_CARVE_OUTS = frozenset({"tests/test_quality_gate.py"})
+
+# ``tests/qs/`` must be checked before the product ``tests/`` prefix.
+_FACTORY_PREFIXES = (
+    "scripts/",
+    "tests/qs/",
+    ".claude/",
+    ".cursor/",
+    ".opencode/",
+    ".github/",
+    "legacy/",
+    "docs/workflow/",
+)
+
+# Copied from ``quality_gate._is_dev_only``'s basename list — see the
+# module docstring for why this is a copy, not an import.
+_FACTORY_BASENAMES = frozenset(
+    {
+        "CLAUDE.md",
+        "AGENTS.md",
+        ".cursorrules",
+        ".gitignore",
+        "pyproject.toml",
+        "setup.cfg",
+        "requirements.txt",
+        "requirements_test.txt",
+    }
+)
+
+# ``docs/agents/`` is product BY EPIC RULING — the drift checker ties it
+# to product source.
+_PRODUCT_PREFIXES = (
+    "custom_components/",
+    "docs/agents/",
+    "docs/product/",
+    "tests/",
+)
+
+# Enumerated neutrality (silent): every task commits its story;
+# ``docs/epics/`` is target-neutral by epic rule.
+_NEUTRAL_PREFIXES = ("docs/stories/", "docs/epics/")
+_NEUTRAL_BASENAMES = frozenset({"README.md"})
+
+
+def classify(path: str) -> str:
+    """Classify a repo-relative path: product | factory | neutral | unknown.
+
+    ``"neutral"`` is *enumerated* neutrality (silent); ``"unknown"`` is
+    fallthrough (nothing matched), which the gate prints as an FYI line
+    so the fail-open set stays visible (review N-5/PC-09).
+    """
+    if path in _FACTORY_CARVE_OUTS:
+        return "factory"
+    if path.startswith(_FACTORY_PREFIXES):
+        return "factory"
+    if path.startswith(_NEUTRAL_PREFIXES):
+        return "neutral"
+    if path.startswith(_PRODUCT_PREFIXES):
+        return "product"
+    if "/" not in path:
+        if path in _FACTORY_BASENAMES:
+            return "factory"
+        if path in _NEUTRAL_BASENAMES:
+            return "neutral"
+    return "unknown"
+
+
+# --- parse_axes() ----------------------------------------------------------
+
+
+def _single_axis_value(labels: list[str], axis: str, values: tuple[str, ...]) -> str:
+    """Return the axis value iff exactly one label of that axis is present."""
+    found = [v for v in values if f"{axis}:{v}" in labels]
+    return found[0] if len(found) == 1 else ""
+
+
+def parse_axes(labels: list[str]) -> dict[str, str]:
+    """Parse the three axes (+ derived ``lane``) out of raw label names.
+
+    Best-effort and never-raising: an absent or ambiguous (multi-label)
+    axis yields ``""``. ``lane`` is ``{kind}-{target}`` for tasks,
+    ``epic-{target}`` for epics, ``""`` when undeclared/incomplete.
+    """
+    kind = _single_axis_value(labels, "kind", KINDS)
+    target = _single_axis_value(labels, "target", TARGETS)
+    scale = _single_axis_value(labels, "scale", SCALES)
+    if scale == "epic" and target:
+        lane = f"epic-{target}"
+    elif scale == "task" and kind and target:
+        lane = f"{kind}-{target}"
+    else:
+        lane = ""
+    return {"kind": kind, "target": target, "scale": scale, "lane": lane}
+
+
+# --- validate_declaration(): THE truth table (story D1) --------------------
+
+
+def validate_declaration(labels: list[str]) -> tuple[bool, list[str], str]:
+    """Validate an issue's lane declaration; return ``(ok, missing, message)``.
+
+    Rules (exactly one place — three consumers):
+
+    - exactly one ``target:*``;
+    - ``scale:epic``  ⇒ no ``kind:*`` at all;
+    - ``scale:task``  ⇒ exactly one ``kind:*`` (task is also the shape
+      assumed when ``scale`` is missing/ambiguous).
+
+    ``missing`` lists the invalid-or-missing axis names. ``message`` is
+    shape-aware (task vs epic) and carries the exact backfill command
+    with an ``<N>`` placeholder for the issue number — callers substitute
+    it (``message.replace("<N>", str(issue))``).
+    """
+    kind_labels = [lb for lb in labels if lb.startswith("kind:")]
+    axes = parse_axes(labels)
+    is_epic_shape = "scale:epic" in labels and "scale:task" not in labels
+
+    missing: list[str] = []
+    problems: list[str] = []
+    suggestions: list[str] = []
+
+    if not axes["target"]:
+        missing.append("target")
+        problems.append("exactly one target:* label is required")
+        suggestions.append("target:product|target:factory")
+
+    if not axes["scale"]:
+        missing.append("scale")
+        problems.append("exactly one scale:* label is required")
+        if not is_epic_shape:
+            suggestions.append("scale:task")
+
+    if is_epic_shape:
+        if kind_labels:
+            missing.append("kind")
+            problems.append(
+                "an epic carries no kind:* label — remove "
+                + ", ".join(sorted(kind_labels))
+            )
+    elif not axes["kind"]:
+        missing.append("kind")
+        problems.append("exactly one kind:* label is required")
+        suggestions.append("kind:bug|kind:feature")
+
+    if not missing:
+        return True, [], ""
+
+    shape = "epic" if is_epic_shape else "task"
+    message = f"incomplete lane declaration ({shape}): " + "; ".join(problems)
+    if suggestions:
+        message += (
+            "\nbackfill with: gh issue edit <N> --add-label "
+            f'"{",".join(suggestions)}"'
+        )
+    return False, missing, message
+
+
+# --- parse_parent_epic() (story D4) ----------------------------------------
+
+_PARENT_EPIC_SECTION = re.compile(
+    r"^###\s+Parent epic\s*$", re.IGNORECASE | re.MULTILINE
+)
+_REFS_RE = re.compile(r"\bRefs #(\d+)")
+
+
+def parse_parent_epic(body: str) -> int | None:
+    """Resolve the declared parent epic from an issue body, or ``None``.
+
+    The structured issue-form section (a ``### Parent epic`` heading whose
+    following non-empty line is ``#?(\\d+)``) wins over free-text
+    cross-references (review PC-05); fallback is the first ``Refs #N``.
+    Explicit, never guessed.
+    """
+    section = _PARENT_EPIC_SECTION.search(body)
+    if section:
+        for line in body[section.end() :].splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            match = re.fullmatch(r"#?(\d+)", stripped)
+            if match:
+                return int(match.group(1))
+            break  # first non-empty line is not a number — fall back
+    refs = _REFS_RE.search(body)
+    return int(refs.group(1)) if refs else None
+
+
+# --- ad-hoc classification query (AC-10) -----------------------------------
+
+
+def main(argv: list[str]) -> None:
+    """Print ``<classification>\\t<path>`` for each path argument."""
+    if not argv:
+        sys.stderr.write("usage: targets.py <path> [<path> ...]\n")
+        raise SystemExit(2)
+    for path in argv:
+        print(f"{classify(path)}\t{path}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tests/qs/agents/test_lane_steps_parity.py
+++ b/tests/qs/agents/test_lane_steps_parity.py
@@ -77,6 +77,28 @@ def test_setup_task_carries_the_declaration_step(harness_dir: Path) -> None:
 
 
 @pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_setup_task_epic_lane_creates_no_worktree(harness_dir: Path) -> None:
+    """Review-fix #04 (must-fix): step 2 used to run `setup_task.py`
+    unconditionally, cutting a branch + worktree even for an epic lane —
+    contradicting the epic model this very PR establishes ("No implement
+    phase; no branch, worktree, or PR"; output = a rationale doc on
+    `main` + child issues). The prompt must stop before step 2 for an
+    epic; `setup_task.py` enforces the same invariant machine-side."""
+    # Whitespace-normalised: the prose wraps mid-clause, so a naive
+    # substring scan would pass vacuously (the trap
+    # `test_workflow_no_desktop_fallback_by_necessity.py` documents).
+    body = " ".join(_body(harness_dir, "qs-setup-task").split())
+    assert "no branch, worktree, or PR" in body, (
+        f"{harness_dir / 'qs-setup-task.md'}: the epic lane must not reach "
+        "the branch/worktree step"
+    )
+    # The terminal state is named, so the agent doesn't improvise one.
+    assert "child issues" in body
+    # And the step-2 header states the precondition it now carries.
+    assert "Set up branch and worktree + emit launcher (tasks only)" in body
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
 def test_setup_task_speed_rule_is_amended(harness_dir: Path) -> None:
     """The old absolute speed rule would contradict the one permitted
     lane/epic question (review planner R2, story task 11)."""

--- a/tests/qs/agents/test_lane_steps_parity.py
+++ b/tests/qs/agents/test_lane_steps_parity.py
@@ -101,6 +101,32 @@ def test_orchestrators_read_their_lane_file(harness_dir: Path, agent_name: str) 
 
 
 @pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+@pytest.mark.parametrize("agent_name", LANE_READ_AGENT_NAMES)
+def test_lane_block_is_a_clean_mirrored_paragraph(
+    harness_dir: Path, agent_name: str
+) -> None:
+    """Review-fix #01: the lane-read block must sit between exactly one
+    blank line on each side in every copy — some copies had a doubled
+    blank above and NO blank below (two rendered paragraphs merged).
+    These files are pinned mirrors; whitespace drift is exactly the
+    class the parity tests exist to prevent, and the substring pins
+    above don't see it."""
+    body = _body(harness_dir, agent_name)
+    start = body.index("**Lane (QS-332).**")
+    assert body[start - 2 : start] == "\n\n", "one blank line before the block"
+    assert body[start - 3 : start] != "\n\n\n", "no doubled blank line before"
+    tail = body[start:]
+    sentinel = next(
+        marker
+        for marker in ("a parallel path).\n", "on the fallback.\n")
+        if marker in tail
+    )
+    end = tail.index(sentinel) + len(sentinel)
+    assert tail[end] == "\n", "one blank line after the block"
+    assert tail[end : end + 2] != "\n\n", "no doubled blank line after"
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
 def test_finish_task_is_deliberately_not_wired(harness_dir: Path) -> None:
     """qs-finish-task has no lane-sensitive behaviour while lanes are
     identical — wiring it now would be a step with no reader (SG2-03).
@@ -124,3 +150,9 @@ def test_implement_variants_carry_ask_and_backfill(
     )
     assert "gh issue edit" in body
     assert "re-run the gate" in body
+    # Review-fix #01: the gate's remediation may include `--remove-label`
+    # lines and user-chosen substitutions — the step must say "apply the
+    # remediation", not "run the exact --add-label command" (which is no
+    # longer always the printed shape).
+    assert "apply the remediation the gate printed" in body
+    assert "run the exact `gh issue edit <N> --add-label ...` command" not in body

--- a/tests/qs/agents/test_lane_steps_parity.py
+++ b/tests/qs/agents/test_lane_steps_parity.py
@@ -1,0 +1,126 @@
+"""QS-332: pin the three lane step kinds across the three harnesses.
+
+Canonical list (review I-2/R2-08 — kept consistent with story task 11
+and AC-5):
+
+(a) the **declaration step** — including the amended speed-rule wording —
+    in ``qs-setup-task`` ×3;
+(b) the **lane-read step** in the 4 orchestrators
+    (qs-create-plan, qs-implement-task, qs-implement-setup-task,
+    qs-review-task) ×3;
+(c) the **ask-and-backfill-on-declaration-FAIL step** in the implement
+    variants ×2 ×3.
+
+There is deliberately NO Lane-note relay step — surfacing the crossing
+in the PR body is machine-owned by ``create_pr.py`` (review N-4), pinned
+in ``tests/qs/test_create_pr.py``. ``qs-finish-task`` is deliberately
+excluded from (b): it has no lane-sensitive behaviour while lanes are
+identical (story D2, review SG2-03).
+
+Pattern follows ``test_doc_maintenance_parity.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+HARNESS_DIRS: tuple[Path, ...] = (
+    REPO_ROOT / ".claude" / "agents",
+    REPO_ROOT / ".cursor" / "agents",
+    REPO_ROOT / ".opencode" / "agents",
+)
+
+LANE_READ_AGENT_NAMES: tuple[str, ...] = (
+    "qs-create-plan",
+    "qs-implement-task",
+    "qs-implement-setup-task",
+    "qs-review-task",
+)
+
+IMPLEMENT_AGENT_NAMES: tuple[str, ...] = (
+    "qs-implement-task",
+    "qs-implement-setup-task",
+)
+
+
+def _harness_id(p: Path) -> str:
+    return p.parent.name.lstrip(".")
+
+
+def _body(harness_dir: Path, agent_name: str) -> str:
+    path = harness_dir / f"{agent_name}.md"
+    assert path.is_file(), f"Missing agent file: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+# --- (a) the declaration step in qs-setup-task ------------------------------
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_setup_task_carries_the_declaration_step(harness_dir: Path) -> None:
+    body = _body(harness_dir, "qs-setup-task")
+    assert "Lane declaration" in body
+    # Existing-issue path: use-if-complete / ask-only-missing.
+    assert "declaration_complete" in body
+    assert "exactly the missing axes" in body
+    # New-issue path: the labels passthrough and the six options.
+    assert "--labels" in body
+    assert "harness feature" in body
+    # The optional piggybacked epic question (review SG-C3).
+    assert "part of an epic?" in body
+    # The bright-line trigger (review PC-08): explicit words only.
+    assert "explicit lane name" in body
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_setup_task_speed_rule_is_amended(harness_dir: Path) -> None:
+    """The old absolute speed rule would contradict the one permitted
+    lane/epic question (review planner R2, story task 11)."""
+    body = _body(harness_dir, "qs-setup-task")
+    assert "except" in body and "the single lane/epic question" in body
+    assert "The launcher must come within a few seconds" not in body
+
+
+# --- (b) the lane-read step in the 4 orchestrators --------------------------
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+@pytest.mark.parametrize("agent_name", LANE_READ_AGENT_NAMES)
+def test_orchestrators_read_their_lane_file(harness_dir: Path, agent_name: str) -> None:
+    body = _body(harness_dir, agent_name)
+    assert "docs/workflow/lanes/<lane>.md" in body, (
+        f"{harness_dir / f'{agent_name}.md'}: missing the lane-read step "
+        "(read docs/workflow/lanes/<lane>.md, <lane> from context.py)"
+    )
+    # Empty-lane fallback for pre-existing worktrees / legacy tasks.
+    assert "phase-protocols.md" in body
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+def test_finish_task_is_deliberately_not_wired(harness_dir: Path) -> None:
+    """qs-finish-task has no lane-sensitive behaviour while lanes are
+    identical — wiring it now would be a step with no reader (SG2-03).
+    A lane PR that diverges finish behaviour adds the wiring then."""
+    body = _body(harness_dir, "qs-finish-task")
+    assert "docs/workflow/lanes/<lane>.md" not in body
+
+
+# --- (c) ask-and-backfill in the implement variants -------------------------
+
+
+@pytest.mark.parametrize("harness_dir", HARNESS_DIRS, ids=_harness_id)
+@pytest.mark.parametrize("agent_name", IMPLEMENT_AGENT_NAMES)
+def test_implement_variants_carry_ask_and_backfill(
+    harness_dir: Path, agent_name: str
+) -> None:
+    body = _body(harness_dir, agent_name)
+    assert "lane check FAILED" in body, (
+        f"{harness_dir / f'{agent_name}.md'}: missing the "
+        "ask-and-backfill-on-declaration-FAIL step"
+    )
+    assert "gh issue edit" in body
+    assert "re-run the gate" in body

--- a/tests/qs/docs/test_lanes.py
+++ b/tests/qs/docs/test_lanes.py
@@ -1,0 +1,71 @@
+"""QS-332: the 6 workflow lanes exist and are identical by construction.
+
+Identity is ENFORCED, divergence is an allowlist (review PC-01/PC-03):
+each lane file must be byte-identical to ``phase-protocols.md`` unless
+its basename is in ``DIVERGED``. The set is empty at QS-332 merge; each
+lane PR's (#335-#340) first act is adding its own file here. This makes
+AC-1 machine-verified and closes the 7-copy silent-drift window between
+this PR and the last lane PR.
+
+Known, pre-authorized cosmetic cost (review DP2-06): relative links
+inside the copies resolve wrong one directory deeper. Do NOT "fix" them
+while a lane is in this identity set — that breaks identity; a lane PR
+may fix its own file's links when it diverges.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LANES_DIR = REPO_ROOT / "docs" / "workflow" / "lanes"
+PHASE_PROTOCOLS = REPO_ROOT / "docs" / "workflow" / "phase-protocols.md"
+
+# Lane name = {kind}-{target} for tasks, epic-{target} for epics — the
+# 6 lanes of epic #321.
+LANES = (
+    "bug-product",
+    "bug-factory",
+    "feature-product",
+    "feature-factory",
+    "epic-product",
+    "epic-factory",
+)
+
+# Lane files allowed to diverge from phase-protocols.md. EMPTY at QS-332
+# merge; a lane PR adds its own basename (e.g. "bug-product.md") as its
+# first act, then writes its divergence.
+DIVERGED: frozenset[str] = frozenset()
+
+
+def test_exactly_the_six_lane_files_exist() -> None:
+    assert sorted(p.name for p in LANES_DIR.glob("*.md")) == sorted(
+        f"{lane}.md" for lane in LANES
+    )
+
+
+def test_phase_protocols_still_exists() -> None:
+    """The source stays in place and stays authoritative until lanes
+    diverge (its removal would break the step-5 string pin in
+    ``tests/test_quality_gate.py`` and the qs-review-task reference)."""
+    assert PHASE_PROTOCOLS.is_file()
+
+
+@pytest.mark.parametrize("lane", LANES)
+def test_lane_file_is_byte_identical_unless_diverged(lane: str) -> None:
+    lane_file = LANES_DIR / f"{lane}.md"
+    if lane_file.name in DIVERGED:
+        pytest.skip(f"{lane_file.name} has diverged (allowlisted)")
+    assert lane_file.read_bytes() == PHASE_PROTOCOLS.read_bytes(), (
+        f"docs/workflow/lanes/{lane}.md is not byte-identical to "
+        f"phase-protocols.md. Until a lane PR adds it to DIVERGED, every "
+        f"lane file is an exact copy — divergence happens one PR per lane "
+        f"(#335-#340), whose first act is the allowlist entry."
+    )
+
+
+def test_diverged_entries_are_real_lane_files() -> None:
+    """A typo'd allowlist entry would silently skip nothing."""
+    assert DIVERGED <= {f"{lane}.md" for lane in LANES}

--- a/tests/qs/docs/test_workflow_no_desktop_fallback_by_necessity.py
+++ b/tests/qs/docs/test_workflow_no_desktop_fallback_by_necessity.py
@@ -46,8 +46,13 @@ RETRACTED_INFERENCE = "fallback path by necessity"
 
 
 def _scanned_files() -> list[Path]:
-    """Return the workflow docs plus `CLAUDE.md` — the surface-routing prose."""
-    files = sorted((REPO_ROOT / "docs" / "workflow").glob("*.md"))
+    """Return the workflow docs plus `CLAUDE.md` — the surface-routing prose.
+
+    Recursive glob (QS-332): `docs/workflow/lanes/*.md` are full copies
+    of `phase-protocols.md` and future divergent lane protocols — a
+    non-recursive glob would silently skip them.
+    """
+    files = sorted((REPO_ROOT / "docs" / "workflow").rglob("*.md"))
     files.append(REPO_ROOT / "CLAUDE.md")
     return files
 

--- a/tests/qs/test_context.py
+++ b/tests/qs/test_context.py
@@ -297,6 +297,33 @@ def test_stdout_is_byte_identical_labelled_task(
     assert capsys.readouterr().out == json.dumps(expected, indent=2) + "\n"
 
 
+def test_null_body_from_the_api_degrades_to_no_parent_epic(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Review-fix #01: `gh` can return `"body": null` (present-but-null),
+    and `data.get("body", "")` passes the `None` straight to
+    `targets.parse_parent_epic` → `TypeError`. Mirror `create_pr.py`'s
+    `or ""` guard: the context degrades to `parent_epic: null` instead
+    of crashing."""
+    import utils  # type: ignore[import-not-found]
+
+    fake_run, _recorder = _make_fake_run(
+        branch="QS_42",
+        repo_root=tmp_path,
+        labels=["kind:feature", "target:factory", "scale:task"],
+        body=None,  # type: ignore[arg-type]  # deliberate: JSON null
+    )
+    monkeypatch.setattr(utils, "run", fake_run)
+
+    _run_main(monkeypatch, [])
+    ctx = json.loads(capsys.readouterr().out)
+
+    assert ctx["parent_epic"] is None
+    assert ctx["lane"] == "feature-factory"
+
+
 def test_epic_lane_derivation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/qs/test_context.py
+++ b/tests/qs/test_context.py
@@ -83,6 +83,8 @@ def _make_fake_run(
     branch: str,
     repo_root: Path,
     title: str = "Fake title",
+    labels: Sequence[str] = (),
+    body: str = "",
     gh_rc: dict[str, int] | None = None,
     barrier: threading.Barrier | None = None,
     raise_on: Sequence[RaiseTarget] = (),
@@ -143,7 +145,16 @@ def _make_fake_run(
         if head == GH_ISSUE:
             if "issue" in raise_on:
                 raise raise_cls(GH_ISSUE_BOOM)
-            return _completed(cmd, f"{title}\n", returncode=codes.get("issue", 0))
+            # QS-332: `_issue_fields` fetches `--json title,labels,body`
+            # in one call; the fake answers with that JSON shape.
+            issue_json = json.dumps(
+                {
+                    "title": title,
+                    "labels": [{"name": name} for name in labels],
+                    "body": body,
+                }
+            )
+            return _completed(cmd, f"{issue_json}\n", returncode=codes.get("issue", 0))
         if head == GH_PR:
             if "pr" in raise_on:
                 raise raise_cls(GH_PR_BOOM)
@@ -231,8 +242,83 @@ def test_stdout_is_byte_identical(
         "pr_number": 7,
         "pr_url": PR_URL,
         "worktree": str(tmp_path),
+        "labels": [],
+        "kind": "",
+        "target": "",
+        "scale": "",
+        "lane": "",
+        "parent_epic": None,
     }
     assert capsys.readouterr().out == json.dumps(expected, indent=2) + "\n"
+
+
+def test_stdout_is_byte_identical_labelled_task(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The labelled-task twin of the byte pin (QS-332).
+
+    Pins the appended-key emission contract — ``labels``, ``kind``,
+    ``target``, ``scale``, ``lane``, ``parent_epic``, in that order after
+    the pre-existing keys — with every axis populated and the parent epic
+    resolved from the body's ``Refs`` line.
+    """
+    import utils  # type: ignore[import-not-found]
+
+    fake_run, _recorder = _make_fake_run(
+        branch="QS_42",
+        repo_root=tmp_path,
+        labels=["enhancement", "kind:feature", "target:factory", "scale:task"],
+        body="intro\n\nRefs #321\n",
+    )
+    monkeypatch.setattr(utils, "run", fake_run)
+
+    _run_main(monkeypatch, [])
+
+    expected = {
+        "harness": "claude-code",
+        "branch": "QS_42",
+        "issue": 42,
+        "title": "Fake title",
+        "story_file": "",
+        "story_exists": False,
+        "latest_review_fix": "",
+        "pr_number": 7,
+        "pr_url": PR_URL,
+        "worktree": str(tmp_path),
+        "labels": ["enhancement", "kind:feature", "target:factory", "scale:task"],
+        "kind": "feature",
+        "target": "factory",
+        "scale": "task",
+        "lane": "feature-factory",
+        "parent_epic": 321,
+    }
+    assert capsys.readouterr().out == json.dumps(expected, indent=2) + "\n"
+
+
+def test_epic_lane_derivation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An epic-shaped declaration derives ``epic-<target>`` with no kind."""
+    import utils  # type: ignore[import-not-found]
+
+    fake_run, _recorder = _make_fake_run(
+        branch="QS_42",
+        repo_root=tmp_path,
+        labels=["pinned", "scale:epic", "target:factory"],
+    )
+    monkeypatch.setattr(utils, "run", fake_run)
+
+    _run_main(monkeypatch, [])
+    ctx = json.loads(capsys.readouterr().out)
+
+    assert ctx["lane"] == "epic-factory"
+    assert ctx["kind"] == ""
+    assert ctx["scale"] == "epic"
+    assert ctx["parent_epic"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/qs/test_create_issue.py
+++ b/tests/qs/test_create_issue.py
@@ -1,0 +1,58 @@
+"""Tests for ``scripts/qs/create_issue.py`` — the ``--labels`` passthrough.
+
+QS-332 (review R2-06): the passthrough existed untested; the setup
+agent's declare-at-birth path (D3 path 3) now depends on it, so it gets
+its first pin. No script change was needed — these are characterization
+tests.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+import pytest
+
+_URL = "https://github.com/tmenguy/quiet-solar/issues/42\n"
+
+
+def _run_main(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    argv: list[str],
+) -> tuple[list[str], dict[str, Any]]:
+    import create_issue
+    import utils
+
+    seen: list[str] = []
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        seen.extend(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=_URL, stderr="")
+
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["create_issue.py", *argv])
+    create_issue.main()
+    return seen, json.loads(capsys.readouterr().out)
+
+
+def test_labels_passthrough_reaches_gh(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cmd, out = _run_main(
+        monkeypatch,
+        capsys,
+        ["--title", "t", "--body", "b", "--labels", "kind:bug,target:product,scale:task"],
+    )
+    label_idx = cmd.index("--label")
+    assert cmd[label_idx + 1] == "kind:bug,target:product,scale:task"
+    assert out["issue_number"] == 42
+    assert out["branch"] == "QS_42"
+
+
+def test_no_labels_means_no_label_flag(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cmd, _out = _run_main(monkeypatch, capsys, ["--title", "t"])
+    assert "--label" not in cmd

--- a/tests/qs/test_create_pr.py
+++ b/tests/qs/test_create_pr.py
@@ -201,6 +201,43 @@ def test_null_labels_still_emits_the_parent_epic_refs(
     assert "## Lane note" not in body
 
 
+@pytest.mark.parametrize("raw", ["null", "[]", "42"])
+def test_non_dict_issue_json_degrades_to_todays_body(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], raw: str
+) -> None:
+    """Review-fix #04: a non-dict top-level value makes `data.get(...)`
+    raise `AttributeError`, which was not in the except tuple — it
+    escaped as a raw traceback instead of the degrade path."""
+    import create_pr
+    import utils
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        head = cmd[:3]
+        if head == GIT_BRANCH:
+            return subprocess.CompletedProcess(cmd, 0, stdout="QS_42\n", stderr="")
+        if head == GH_PR_LIST:
+            return subprocess.CompletedProcess(cmd, 0, stdout="[]", stderr="")
+        if head == GIT_PUSH:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if head == GIT_DIFF:
+            return subprocess.CompletedProcess(cmd, 0, stdout="scripts/qs/x.py\n", stderr="")
+        if head == GH_ISSUE_VIEW:
+            return subprocess.CompletedProcess(cmd, 0, stdout=raw, stderr="")
+        if head == GH_PR_CREATE:
+            return subprocess.CompletedProcess(cmd, 0, stdout=PR_URL, stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    seen: list[list[str]] = []
+    orig = fake_run
+
+    def recording(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        seen.append(list(cmd))
+        return orig(cmd, **kwargs)
+
+    _run_main(monkeypatch, recording)
+    assert _created_body(seen) == _expected_plain_body()
+
+
 def test_issue_view_failure_degrades_to_todays_body(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/qs/test_create_pr.py
+++ b/tests/qs/test_create_pr.py
@@ -1,0 +1,184 @@
+"""Tests for ``scripts/qs/create_pr.py`` — epic linkage + Lane note (QS-332 B5).
+
+Machine-owned, no agent involvement: the parent epic is resolved from
+the issue body (``targets.parse_parent_epic``) and appended as ``Refs``
+inside the fixes-line slot; a cross-target diff injects a ``## Lane
+note`` section recomputed from ``targets.classify`` — never relayed
+from gate output.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+import pytest
+
+PR_URL = "https://github.com/tmenguy/quiet-solar/pull/99\n"
+
+GIT_BRANCH = ["git", "branch", "--show-current"]
+GIT_PUSH = ["git", "push", "-u"]
+GIT_DIFF = ["git", "diff", "--name-only"]
+GH_PR_LIST = ["gh", "pr", "list"]
+GH_PR_CREATE = ["gh", "pr", "create"]
+GH_ISSUE_VIEW = ["gh", "issue", "view"]
+
+
+def _make_fake_run(
+    *,
+    issue_body: str = "",
+    issue_labels: list[str] | None = None,
+    changed_files: list[str] | None = None,
+    issue_view_rc: int = 0,
+):
+    """Return ``(fake_run, seen)``; ``seen`` records every command."""
+    seen: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        seen.append(list(cmd))
+        head = cmd[:3]
+        if head == GIT_BRANCH:
+            return subprocess.CompletedProcess(cmd, 0, stdout="QS_42\n", stderr="")
+        if head == GH_PR_LIST:
+            return subprocess.CompletedProcess(cmd, 0, stdout="[]", stderr="")
+        if head == GIT_PUSH:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if head == GIT_DIFF:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="\n".join(changed_files or []) + "\n", stderr=""
+            )
+        if head == GH_ISSUE_VIEW:
+            payload = json.dumps(
+                {
+                    "body": issue_body,
+                    "labels": [{"name": name} for name in (issue_labels or [])],
+                }
+            )
+            return subprocess.CompletedProcess(
+                cmd, issue_view_rc, stdout=payload, stderr=""
+            )
+        if head == GH_PR_CREATE:
+            return subprocess.CompletedProcess(cmd, 0, stdout=PR_URL, stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    return fake_run, seen
+
+
+def _created_body(seen: list[list[str]]) -> str:
+    create = next(cmd for cmd in seen if cmd[:3] == GH_PR_CREATE)
+    return create[create.index("--body") + 1]
+
+
+def _run_main(monkeypatch: pytest.MonkeyPatch, fake_run, argv: list[str] | None = None) -> None:
+    import create_pr
+    import utils
+
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["create_pr.py", "--title", "t", "--summary", "- s", "--risk", "LOW", *(argv or [])],
+    )
+    create_pr.main()
+
+
+def _expected_plain_body() -> str:
+    """Today's body, byte-for-byte, for issue 42 / summary '- s' / risk LOW."""
+    risk_lines = [
+        "- [ ] CRITICAL (solver, constraints, charger budgeting)",
+        "- [ ] HIGH (load base, constants, orchestration)",
+        "- [ ] MEDIUM (device-specific: car, person, battery, solar)",
+        "- [x] LOW (platforms, UI, docs)",
+    ]
+    return f"""## Summary
+- s
+
+Fixes #42
+
+## Testing
+- [x] Tests added/updated for new behavior
+- [x] 100% coverage verified
+- [x] No flaky tests introduced
+
+## Code quality
+- [x] Ruff passes (lint + format)
+- [x] MyPy passes
+- [x] No new `# type: ignore` or `noqa` without justification
+
+## Risk assessment
+{chr(10).join(risk_lines)}
+
+---
+Generated with [Claude Code](https://claude.com/claude-code)"""
+
+
+def test_no_epic_no_crossing_body_is_byte_identical_to_today(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_run, seen = _make_fake_run(
+        issue_body="no epic here",
+        issue_labels=["kind:feature", "target:factory", "scale:task"],
+        changed_files=["scripts/qs/targets.py", "docs/workflow/lanes/bug-product.md"],
+    )
+    _run_main(monkeypatch, fake_run)
+    assert _created_body(seen) == _expected_plain_body()
+    assert json.loads(capsys.readouterr().out)["pr_number"] == 99
+
+
+def test_declared_parent_epic_appends_refs_in_fixes_slot(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_run, seen = _make_fake_run(
+        issue_body="intro\n\nRefs #321\n",
+        issue_labels=["kind:feature", "target:factory", "scale:task"],
+        changed_files=["scripts/qs/targets.py"],
+    )
+    _run_main(monkeypatch, fake_run)
+    body = _created_body(seen)
+    # Pinned placement (review planner): inside the existing fixes-line slot.
+    assert "\nFixes #42\nRefs #321\n" in body
+
+
+def test_crossing_diff_injects_lane_note(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_run, seen = _make_fake_run(
+        issue_body="",
+        issue_labels=["kind:feature", "target:factory", "scale:task"],
+        changed_files=[
+            "scripts/qs/targets.py",
+            "custom_components/quiet_solar/solver.py",
+            "tests/test_solver.py",
+            "docs/stories/QS-42.story.md",  # neutral — never listed
+        ],
+    )
+    _run_main(monkeypatch, fake_run)
+    body = _created_body(seen)
+    assert "## Lane note" in body
+    assert "custom_components/quiet_solar/solver.py" in body
+    assert "tests/test_solver.py" in body
+    assert "docs/stories/QS-42.story.md" not in body
+
+
+def test_no_crossing_means_no_lane_note(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_run, seen = _make_fake_run(
+        issue_body="",
+        issue_labels=["kind:bug", "target:product", "scale:task"],
+        changed_files=["custom_components/quiet_solar/solver.py", "tests/test_solver.py"],
+    )
+    _run_main(monkeypatch, fake_run)
+    assert "## Lane note" not in _created_body(seen)
+
+
+def test_issue_view_failure_degrades_to_todays_body(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A failing ``gh issue view`` must not block the PR — no Refs, no note."""
+    fake_run, seen = _make_fake_run(
+        issue_view_rc=1,
+        changed_files=["custom_components/quiet_solar/solver.py"],
+    )
+    _run_main(monkeypatch, fake_run)
+    assert _created_body(seen) == _expected_plain_body()

--- a/tests/qs/test_create_pr.py
+++ b/tests/qs/test_create_pr.py
@@ -31,8 +31,14 @@ def _make_fake_run(
     issue_labels: list[str] | None = None,
     changed_files: list[str] | None = None,
     issue_view_rc: int = 0,
+    null_labels: bool = False,
 ):
-    """Return ``(fake_run, seen)``; ``seen`` records every command."""
+    """Return ``(fake_run, seen)``; ``seen`` records every command.
+
+    ``null_labels`` emits a literal JSON ``"labels": null`` (what the API
+    can actually return), which is NOT the same as an empty list — see
+    the review-fix #03 test below.
+    """
     seen: list[list[str]] = []
 
     def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
@@ -52,7 +58,9 @@ def _make_fake_run(
             payload = json.dumps(
                 {
                     "body": issue_body,
-                    "labels": [{"name": name} for name in (issue_labels or [])],
+                    "labels": None
+                    if null_labels
+                    else [{"name": name} for name in (issue_labels or [])],
                 }
             )
             return subprocess.CompletedProcess(
@@ -170,6 +178,27 @@ def test_no_crossing_means_no_lane_note(
     )
     _run_main(monkeypatch, fake_run)
     assert "## Lane note" not in _created_body(seen)
+
+
+def test_null_labels_still_emits_the_parent_epic_refs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Review-fix #03: with a bare ``.get("labels", [])`` a
+    ``"labels": null`` response was caught by the broad ``except
+    TypeError`` and silently dropped a perfectly readable parent-epic
+    ``Refs`` (and any Lane note). The epic comes from the BODY — a null
+    labels field must not cost it."""
+    fake_run, seen = _make_fake_run(
+        issue_body="intro\n\nRefs #321\n",
+        null_labels=True,
+        changed_files=["scripts/qs/targets.py"],
+    )
+    _run_main(monkeypatch, fake_run)
+    body = _created_body(seen)
+    assert "\nFixes #42\nRefs #321\n" in body
+    # No declared target is resolvable, so no Lane note — but the PR is
+    # otherwise intact.
+    assert "## Lane note" not in body
 
 
 def test_issue_view_failure_degrades_to_todays_body(

--- a/tests/qs/test_fetch_issue.py
+++ b/tests/qs/test_fetch_issue.py
@@ -1,0 +1,114 @@
+"""Tests for ``scripts/qs/fetch_issue.py`` — axes wiring (QS-332).
+
+The declaration truth table itself is pinned in ``test_targets.py``;
+these cover only the wiring: axes + ``declaration_complete`` +
+``parent_epic`` in the JSON, and ``story_type`` deleted.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+import pytest
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+def _run_main(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    issue_payload: dict[str, Any],
+) -> dict[str, Any]:
+    import fetch_issue
+    import utils
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert cmd[:3] == ["gh", "issue", "view"]
+        return _completed(stdout=json.dumps(issue_payload))
+
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["fetch_issue.py", "--issue", str(issue_payload["number"])])
+    fetch_issue.main()
+    return json.loads(capsys.readouterr().out)
+
+
+def test_labelled_issue_reports_axes_and_parent_epic(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    out = _run_main(
+        monkeypatch,
+        capsys,
+        {
+            "number": 332,
+            "title": "lanes",
+            "body": "intro\n\nRefs #321\n",
+            "labels": [
+                {"name": "enhancement"},
+                {"name": "kind:feature"},
+                {"name": "target:factory"},
+                {"name": "scale:task"},
+            ],
+            "state": "OPEN",
+        },
+    )
+    assert out["kind"] == "feature"
+    assert out["target"] == "factory"
+    assert out["scale"] == "task"
+    assert out["lane"] == "feature-factory"
+    assert out["parent_epic"] == 321
+    assert out["declaration_complete"] is True
+    assert out["branch"] == "QS_332"
+
+
+def test_unlabelled_issue_reports_empty_axes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    out = _run_main(
+        monkeypatch,
+        capsys,
+        {
+            "number": 7,
+            "title": "legacy",
+            "body": "no declarations here",
+            "labels": [{"name": "bug"}],
+            "state": "OPEN",
+        },
+    )
+    assert out["kind"] == ""
+    assert out["target"] == ""
+    assert out["scale"] == ""
+    assert out["lane"] == ""
+    assert out["parent_epic"] is None
+    assert out["declaration_complete"] is False
+
+
+def test_story_type_is_gone(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``story_type`` had zero consumers and a no-op branch — deleted."""
+    out = _run_main(
+        monkeypatch,
+        capsys,
+        {"number": 1, "title": "t", "body": "", "labels": [], "state": "OPEN"},
+    )
+    assert "story_type" not in out
+
+
+def test_gh_failure_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import fetch_issue
+    import utils
+
+    monkeypatch.setattr(
+        utils, "run", lambda cmd, **kw: _completed(returncode=1)
+    )
+    monkeypatch.setattr("sys.argv", ["fetch_issue.py", "--issue", "1"])
+    with pytest.raises(SystemExit) as exc:
+        fetch_issue.main()
+    assert exc.value.code == 1
+    assert "error" in json.loads(capsys.readouterr().out)

--- a/tests/qs/test_fetch_issue.py
+++ b/tests/qs/test_fetch_issue.py
@@ -127,6 +127,43 @@ def test_story_type_is_gone(
     assert "story_type" not in out
 
 
+@pytest.mark.parametrize(
+    ("labels", "case"),
+    [
+        ([None], "null-entry"),
+        ([{"id": 1}], "entry-without-name"),
+        (["kind:bug"], "entry-is-a-bare-string"),
+    ],
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+def test_malformed_label_entries_degrade_to_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    labels: list,
+    case: str,
+) -> None:
+    """Review-fix #03: the fix-#02 guard covered a null labels *field*,
+    but the `lb["name"]` comprehension sat OUTSIDE the `try` whose
+    `except` also lacked `KeyError` — a malformed entry raised a raw
+    traceback instead of this script's structured error JSON, the exact
+    failure mode round 2 was closing. All three peer consumers keep the
+    comprehension inside the guarded block; this one was a level
+    shallower."""
+    import fetch_issue
+    import utils
+
+    payload = json.dumps(
+        {"number": 5, "title": "t", "body": "", "labels": labels, "state": "OPEN"}
+    )
+    monkeypatch.setattr(utils, "run", lambda cmd, **kw: _completed(stdout=payload))
+    monkeypatch.setattr("sys.argv", ["fetch_issue.py", "--issue", "5"])
+
+    with pytest.raises(SystemExit) as exc:
+        fetch_issue.main()
+    assert exc.value.code == 1
+    assert "error" in json.loads(capsys.readouterr().out)
+
+
 def test_gh_failure_exits_nonzero(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/qs/test_fetch_issue.py
+++ b/tests/qs/test_fetch_issue.py
@@ -164,6 +164,46 @@ def test_malformed_label_entries_degrade_to_structured_error(
     assert "error" in json.loads(capsys.readouterr().out)
 
 
+@pytest.mark.parametrize(
+    ("stdout", "case"),
+    [
+        ("{}", "empty-object"),
+        ('{"title": "t", "body": "", "labels": []}', "object-without-number"),
+        ("null", "top-level-null"),
+        ("[]", "top-level-list"),
+        ("42", "top-level-int"),
+    ],
+    ids=lambda v: v if isinstance(v, str) and not v.startswith(("{", "[", "n", "4")) else "",
+)
+def test_incomplete_or_non_dict_json_degrades_to_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    stdout: str,
+    case: str,
+) -> None:
+    """Review-fix #04: two remaining holes in the "everything degrades to
+    structured JSON" contract.
+
+    - `data["number"]` was a bare subscript OUTSIDE the guard (finding 2):
+      a valid-but-incomplete object (`{}`) degraded cleanly on the
+      labels/body path and then crashed with a raw `KeyError`. Unique to
+      this script — the peer consumers never read `number`.
+    - A non-dict top-level value (`null`/`[]`/`42`) made `data.get(...)`
+      raise `AttributeError`, which was not in the except tuple
+      (finding 4).
+    """
+    import fetch_issue
+    import utils
+
+    monkeypatch.setattr(utils, "run", lambda cmd, **kw: _completed(stdout=stdout))
+    monkeypatch.setattr("sys.argv", ["fetch_issue.py", "--issue", "5"])
+
+    with pytest.raises(SystemExit) as exc:
+        fetch_issue.main()
+    assert exc.value.code == 1
+    assert "error" in json.loads(capsys.readouterr().out)
+
+
 def test_gh_failure_exits_nonzero(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/qs/test_fetch_issue.py
+++ b/tests/qs/test_fetch_issue.py
@@ -86,6 +86,35 @@ def test_unlabelled_issue_reports_empty_axes(
     assert out["declaration_complete"] is False
 
 
+def test_null_body_and_labels_degrade_instead_of_crashing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Review-fix #02 (must-fix): the API can return present-but-null
+    fields (`"body": null`, `"labels": null`). Fix plan #01 guarded the
+    other two `parse_parent_epic` consumers (`context.py`,
+    `create_pr.py`) but missed this one — iterating `None` and
+    `re.search(None)` raised a raw traceback instead of the script's
+    structured JSON. Twin of
+    `test_context.py::test_null_body_from_the_api_degrades_to_no_parent_epic`.
+    """
+    out = _run_main(
+        monkeypatch,
+        capsys,
+        {
+            "number": 9,
+            "title": "null fields",
+            "body": None,
+            "labels": None,
+            "state": "OPEN",
+        },
+    )
+    assert out["labels"] == []
+    assert out["body"] == ""
+    assert out["parent_epic"] is None
+    assert out["declaration_complete"] is False
+    assert out["lane"] == ""
+
+
 def test_story_type_is_gone(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/qs/test_github_workflows.py
+++ b/tests/qs/test_github_workflows.py
@@ -105,14 +105,28 @@ def test_lane_check_job_spec() -> None:
     # The change set is origin/main...HEAD — must reach the merge base.
     assert checkout["with"]["fetch-depth"] == 0
 
+    # Review-fix #01 must-fix: the job must pin the SAME interpreter as
+    # every other job — ubuntu-latest's system Python is 3.12 and
+    # quality_gate.py uses 3.14-only syntax, so without this step the
+    # fail-closed job blocks every PR with a SyntaxError.
+    setup_python = next(
+        s for s in job["steps"] if "setup-python" in s.get("uses", "")
+    )
+    assert setup_python["with"]["python-version"] == "3.14"
+
     run_step = next(s for s in job["steps"] if "run" in s)
     # `gh` reads GH_TOKEN; preinstalled on ubuntu-latest, no install step.
     assert run_step["env"]["GH_TOKEN"] == "${{ github.token }}"
     assert "quality_gate.py --lane-check" in run_step["run"]
     # Detached-HEAD fallback (review N-1): a pull_request checkout has an
     # empty `git branch --show-current`; GITHUB_HEAD_REF is the PR's
-    # source branch on every pull_request event.
-    assert '--branch "${{ github.head_ref }}"' in run_step["run"]
+    # source branch on every pull_request event. Review-fix #01 must-fix:
+    # `head_ref` is attacker-controlled on fork PRs and Actions expands
+    # `${{ }}` BEFORE the shell sees the line — script injection. It must
+    # reach the shell through an env var, never direct interpolation.
+    assert run_step["env"]["HEAD_REF"] == "${{ github.head_ref }}"
+    assert '--branch "$HEAD_REF"' in run_step["run"]
+    assert "${{" not in run_step["run"]
 
 
 def test_other_pr_quality_jobs_keep_read_only_tokens() -> None:

--- a/tests/qs/test_github_workflows.py
+++ b/tests/qs/test_github_workflows.py
@@ -1,0 +1,127 @@
+"""QS-332: pins on the workflow-bot fixes (B4) and the lane-check CI job (B1).
+
+``stale.yml`` / ``issue-triage.yml`` were previously pinned by nothing;
+these tests pin the D6 decisions so a later edit is a deliberate act.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def _load(name: str) -> dict:
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# stale.yml — scale:epic exemption (B4)
+# ---------------------------------------------------------------------------
+
+
+def test_stale_exempts_epics() -> None:
+    doc = _load("stale.yml")
+    step = doc["jobs"]["stale"]["steps"][0]
+    issue_exemptions = step["with"]["exempt-issue-labels"].split(",")
+    assert "scale:epic" in issue_exemptions
+    # The pre-existing exemptions survive.
+    assert {"pinned", "security", "critical"} <= set(issue_exemptions)
+    # PR exemptions unchanged — epics have no PRs.
+    assert step["with"]["exempt-pr-labels"] == "pinned,security,critical"
+
+
+# ---------------------------------------------------------------------------
+# issue-triage.yml — the D6 per-keyword table (#293)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="triage_script")
+def triage_script_fixture() -> str:
+    doc = _load("issue-triage.yml")
+    return doc["jobs"]["triage"]["steps"][0]["with"]["script"]
+
+
+@pytest.mark.parametrize(
+    ("label", "patterns"),
+    [
+        ("area:solver", [r"/\bsolver\b/", r"/\bconstraints?\b/"]),
+        ("area:charger", [r"/\bchargers?\b/", r"/\bocpp\b/", r"/\bwallbox\b/"]),
+        ("area:car", [r"/\bcars?\b/", r"/\bvehicles?\b/", r"/\bev\b/"]),
+        ("area:battery", [r"/\bbatter(y|ies)\b/", r"/\bstorage\b/"]),
+        ("area:person", [r"/\bpersons?\b/", r"/\bpresence\b/"]),
+        ("area:ui", [r"/\bdashboards?\b/", r"/\bui\b/"]),
+        ("area:config", [r"/\bconfig[ _-]?flow\b/", r"/\bconfig entr(y|ies)\b/"]),
+        (
+            "area:dev-pipeline",
+            [
+                r"/\b(harness|pipeline|agents?|workflow|worktree|quality gate|lanes?|launcher|testmon)\b/"
+            ],
+        ),
+    ],
+)
+def test_triage_implements_the_d6_table(
+    triage_script: str, label: str, patterns: list[str]
+) -> None:
+    assert f"'{label}'" in triage_script
+    for pattern in patterns:
+        assert pattern in triage_script, f"{label} must match via {pattern}"
+
+
+def test_triage_has_no_naive_substring_matching(triage_script: str) -> None:
+    """The #293 bug class: `includes('ev')` fired on "dev", `includes('ui')`
+    on "quiet", `includes('config')`/`includes('setup')` on every factory
+    issue. Substring matching is banned wholesale."""
+    assert ".includes(" not in triage_script
+
+
+def test_triage_dropped_keywords_are_gone(triage_script: str) -> None:
+    # Bare 'config' and 'setup' dropped; 'configuration' (R2-07: still
+    # matched "harness configuration") never reintroduced.
+    assert not re.search(r"/\\bconfig\\b/", triage_script)
+    assert "setup" not in triage_script
+    assert "configuration" not in triage_script
+
+
+# ---------------------------------------------------------------------------
+# pr-quality.yml — the lane-check job (B1, reviews CR-3 + N-1)
+# ---------------------------------------------------------------------------
+
+
+def test_lane_check_job_spec() -> None:
+    doc = _load("pr-quality.yml")
+    job = doc["jobs"]["lane-check"]
+    # Own least-privilege permissions block; the OTHER jobs stay
+    # `contents: read`-only — this one needs the labels.
+    assert job["permissions"] == {"contents": "read", "issues": "read"}
+
+    checkout = job["steps"][0]
+    assert "actions/checkout" in checkout["uses"]
+    # The change set is origin/main...HEAD — must reach the merge base.
+    assert checkout["with"]["fetch-depth"] == 0
+
+    run_step = next(s for s in job["steps"] if "run" in s)
+    # `gh` reads GH_TOKEN; preinstalled on ubuntu-latest, no install step.
+    assert run_step["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert "quality_gate.py --lane-check" in run_step["run"]
+    # Detached-HEAD fallback (review N-1): a pull_request checkout has an
+    # empty `git branch --show-current`; GITHUB_HEAD_REF is the PR's
+    # source branch on every pull_request event.
+    assert '--branch "${{ github.head_ref }}"' in run_step["run"]
+
+
+def test_other_pr_quality_jobs_keep_read_only_tokens() -> None:
+    """The lane check must not have been grafted onto an existing job."""
+    doc = _load("pr-quality.yml")
+    for name, job in doc["jobs"].items():
+        if name == "lane-check":
+            continue
+        assert "issues" not in job.get("permissions", {}), (
+            f"job {name} must not hold an issues-scoped token"
+        )
+        assert "--lane-check" not in str(job)

--- a/tests/qs/test_github_workflows.py
+++ b/tests/qs/test_github_workflows.py
@@ -56,7 +56,9 @@ def triage_script_fixture() -> str:
         ("area:battery", [r"/\bbatter(y|ies)\b/", r"/\bstorage\b/"]),
         ("area:person", [r"/\bpersons?\b/", r"/\bpresence\b/"]),
         ("area:ui", [r"/\bdashboards?\b/", r"/\bui\b/"]),
-        ("area:config", [r"/\bconfig[ _-]?flow\b/", r"/\bconfig entr(y|ies)\b/"]),
+        # Review-fix #04: separator handling must be symmetric across both
+        # config phrases — `config-entry` / `config_entry` used to miss.
+        ("area:config", [r"/\bconfig[ _-]?flow\b/", r"/\bconfig[ _-]?entr(y|ies)\b/"]),
         (
             "area:dev-pipeline",
             [

--- a/tests/qs/test_issue_templates.py
+++ b/tests/qs/test_issue_templates.py
@@ -1,0 +1,86 @@
+"""QS-332 (B3): the 6 lane issue forms, one per lane, exact labels.
+
+GitHub issue forms attach FIXED labels per template — a dropdown cannot
+change labels — so exact lane labels by construction require one form
+per lane (story D3, path 1).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_DIR = REPO_ROOT / ".github" / "ISSUE_TEMPLATE"
+
+# The D3 table: form basename → exact fixed label set.
+EXPECTED_LABELS = {
+    "bug-product": ["bug", "kind:bug", "target:product", "scale:task"],
+    "feature-product": ["enhancement", "kind:feature", "target:product", "scale:task"],
+    "bug-factory": ["bug", "kind:bug", "target:factory", "scale:task", "area:dev-pipeline"],
+    "feature-factory": [
+        "enhancement",
+        "kind:feature",
+        "target:factory",
+        "scale:task",
+        "area:dev-pipeline",
+    ],
+    "epic-product": ["scale:epic", "target:product"],
+    "epic-factory": ["scale:epic", "target:factory", "area:dev-pipeline"],
+}
+
+TASK_FORMS = ("bug-product", "feature-product", "bug-factory", "feature-factory")
+EPIC_FORMS = ("epic-product", "epic-factory")
+
+
+def _load(form: str) -> dict:
+    return yaml.safe_load((TEMPLATE_DIR / f"{form}.yml").read_text(encoding="utf-8"))
+
+
+def _field_labels(form: str) -> list[str]:
+    return [
+        item["attributes"].get("label", "")
+        for item in _load(form)["body"]
+    ]
+
+
+def test_exactly_the_six_lane_forms_plus_config_exist() -> None:
+    names = sorted(p.name for p in TEMPLATE_DIR.iterdir() if p.suffix == ".yml")
+    assert names == sorted([*(f"{f}.yml" for f in EXPECTED_LABELS), "config.yml"])
+
+
+def test_legacy_templates_are_gone() -> None:
+    assert not (TEMPLATE_DIR / "bug_report.yml").exists()
+    assert not (TEMPLATE_DIR / "feature_request.yml").exists()
+
+
+@pytest.mark.parametrize("form", sorted(EXPECTED_LABELS))
+def test_form_carries_exactly_its_lane_labels(form: str) -> None:
+    assert _load(form)["labels"] == EXPECTED_LABELS[form]
+
+
+@pytest.mark.parametrize("form", TASK_FORMS)
+def test_task_forms_have_the_parent_epic_field(form: str) -> None:
+    """The field label must be exactly "Parent epic": it renders as the
+    `### Parent epic` heading `targets.parse_parent_epic` keys on."""
+    assert "Parent epic" in _field_labels(form)
+    # Optional by design — "leave empty if none".
+    field = next(
+        item
+        for item in _load(form)["body"]
+        if item["attributes"].get("label") == "Parent epic"
+    )
+    assert field.get("validations", {}).get("required") is not True
+
+
+@pytest.mark.parametrize("form", EPIC_FORMS)
+def test_epic_forms_have_no_parent_epic_field(form: str) -> None:
+    """No epic nesting — and no kind label either (checked via the table)."""
+    assert "Parent epic" not in _field_labels(form)
+
+
+def test_blank_issues_are_disabled() -> None:
+    config = yaml.safe_load((TEMPLATE_DIR / "config.yml").read_text(encoding="utf-8"))
+    assert config["blank_issues_enabled"] is False

--- a/tests/qs/test_issue_templates.py
+++ b/tests/qs/test_issue_templates.py
@@ -16,12 +16,20 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 TEMPLATE_DIR = REPO_ROOT / ".github" / "ISSUE_TEMPLATE"
 
 # The D3 table: form basename → exact fixed label set.
+#
+# Review-fix #03 (user decision) amends D3: the legacy `bug` /
+# `enhancement` labels are NO LONGER attached. They created a label-set
+# asymmetry between the two birth paths — the web forms emitted them
+# while the agent path (`--labels "kind:bug,target:product,scale:task"`)
+# did not, so the same lane produced two different label sets and skewed
+# any filter keyed on the plain labels. Both paths now produce the
+# axis-only set. Their only code consumer (`story_type`) was deleted by
+# this same task.
 EXPECTED_LABELS = {
-    "bug-product": ["bug", "kind:bug", "target:product", "scale:task"],
-    "feature-product": ["enhancement", "kind:feature", "target:product", "scale:task"],
-    "bug-factory": ["bug", "kind:bug", "target:factory", "scale:task", "area:dev-pipeline"],
+    "bug-product": ["kind:bug", "target:product", "scale:task"],
+    "feature-product": ["kind:feature", "target:product", "scale:task"],
+    "bug-factory": ["kind:bug", "target:factory", "scale:task", "area:dev-pipeline"],
     "feature-factory": [
-        "enhancement",
         "kind:feature",
         "target:factory",
         "scale:task",
@@ -30,6 +38,10 @@ EXPECTED_LABELS = {
     "epic-product": ["scale:epic", "target:product"],
     "epic-factory": ["scale:epic", "target:factory", "area:dev-pipeline"],
 }
+
+# Review-fix #03: pinned as GONE from every form, not merely absent from
+# the table above — a future edit re-adding one must fail loudly.
+LEGACY_LABELS = ("bug", "enhancement")
 
 TASK_FORMS = ("bug-product", "feature-product", "bug-factory", "feature-factory")
 EPIC_FORMS = ("epic-product", "epic-factory")
@@ -59,6 +71,18 @@ def test_legacy_templates_are_gone() -> None:
 @pytest.mark.parametrize("form", sorted(EXPECTED_LABELS))
 def test_form_carries_exactly_its_lane_labels(form: str) -> None:
     assert _load(form)["labels"] == EXPECTED_LABELS[form]
+
+
+@pytest.mark.parametrize("form", sorted(EXPECTED_LABELS))
+def test_no_form_attaches_a_legacy_label(form: str) -> None:
+    """Review-fix #03: both birth paths must produce the SAME label set
+    for a lane — the web forms no longer attach `bug`/`enhancement`."""
+    attached = _load(form)["labels"]
+    assert not set(LEGACY_LABELS) & set(attached), (
+        f"{form}.yml still attaches a legacy label: "
+        f"{sorted(set(LEGACY_LABELS) & set(attached))}. The agent birth "
+        f"path emits axis labels only; the two paths must not disagree."
+    )
 
 
 @pytest.mark.parametrize("form", TASK_FORMS)

--- a/tests/qs/test_setup_task.py
+++ b/tests/qs/test_setup_task.py
@@ -91,6 +91,33 @@ def test_conflicting_declaration_refuses(
     assert "target" in json.loads(capsys.readouterr().out)["missing"]
 
 
+def test_null_labels_reports_the_declaration_error_not_invalid_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Review-fix #03: a valid-JSON response with ``"labels": null`` hit
+    the broad ``except TypeError`` and reported the misleading "Invalid
+    JSON from gh CLI". It is valid JSON — the honest verdict is the
+    ordinary missing-declaration refusal, with its actionable backfill
+    command."""
+    import setup_task
+    import utils
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert cmd[:3] == ["gh", "issue", "view"]
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout=json.dumps({"labels": None}), stderr=""
+        )
+
+    monkeypatch.setattr(utils, "run", fake_run)
+    with pytest.raises(SystemExit) as exc:
+        setup_task.check_declaration(42)
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert "Invalid JSON" not in out["error"]
+    assert "no complete lane declaration" in out["error"]
+    assert "gh issue edit 42 --add-label" in out["detail"]
+
+
 def test_gh_failure_refuses(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/qs/test_setup_task.py
+++ b/tests/qs/test_setup_task.py
@@ -1,0 +1,125 @@
+"""Tests for ``scripts/qs/setup_task.py`` — declaration validation (QS-332 B2).
+
+The truth table lives in ``test_targets.py``; these pin only the wiring:
+``setup_task`` refuses an undeclared/inconsistent issue BEFORE any
+branch/worktree work, with the shape-aware backfill command carrying the
+real issue number.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+import pytest
+
+
+def _gh_labels_response(labels: list[str]) -> str:
+    return json.dumps({"labels": [{"name": name} for name in labels]})
+
+
+def _make_fake_run(labels: list[str] | None, *, gh_rc: int = 0):
+    """Return ``(fake_run, seen_cmds)``; ``labels=None`` + ``gh_rc`` fakes a gh failure."""
+    seen: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        seen.append(list(cmd))
+        if cmd[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=gh_rc,
+                stdout=_gh_labels_response(labels or []),
+                stderr="" if gh_rc == 0 else "boom",
+            )
+        raise AssertionError(f"unexpected command after refusal: {cmd}")
+
+    return fake_run, seen
+
+
+def test_complete_task_declaration_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    import setup_task
+    import utils
+
+    fake_run, _seen = _make_fake_run(["kind:feature", "target:factory", "scale:task"])
+    monkeypatch.setattr(utils, "run", fake_run)
+    setup_task.check_declaration(332)  # returns without exiting
+
+
+def test_epic_declaration_validates_as_itself(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An epic-shaped declaration is not asked to grow a kind (story D3)."""
+    import setup_task
+    import utils
+
+    fake_run, _seen = _make_fake_run(["scale:epic", "target:product", "pinned"])
+    monkeypatch.setattr(utils, "run", fake_run)
+    setup_task.check_declaration(321)
+
+
+def test_undeclared_issue_refuses_with_backfill_command(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import setup_task
+    import utils
+
+    fake_run, _seen = _make_fake_run(["bug"])
+    monkeypatch.setattr(utils, "run", fake_run)
+    with pytest.raises(SystemExit) as exc:
+        setup_task.check_declaration(42)
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert "error" in out
+    assert set(out["missing"]) == {"kind", "target", "scale"}
+    # Shape-aware, actionable, with the REAL issue number substituted.
+    assert "gh issue edit 42 --add-label" in out["detail"]
+    assert "<N>" not in out["detail"]
+
+
+def test_conflicting_declaration_refuses(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import setup_task
+    import utils
+
+    fake_run, _seen = _make_fake_run(
+        ["kind:bug", "target:product", "target:factory", "scale:task"]
+    )
+    monkeypatch.setattr(utils, "run", fake_run)
+    with pytest.raises(SystemExit) as exc:
+        setup_task.check_declaration(42)
+    assert exc.value.code == 1
+    assert "target" in json.loads(capsys.readouterr().out)["missing"]
+
+
+def test_gh_failure_refuses(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import setup_task
+    import utils
+
+    fake_run, _seen = _make_fake_run(None, gh_rc=1)
+    monkeypatch.setattr(utils, "run", fake_run)
+    with pytest.raises(SystemExit) as exc:
+        setup_task.check_declaration(42)
+    assert exc.value.code == 1
+    assert "error" in json.loads(capsys.readouterr().out)
+
+
+def test_main_refuses_before_any_git_work(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The declaration check is enforcement BY CONSTRUCTION: it runs before
+    the fetch/branch/worktree machinery, so a refused issue never touches
+    git (the fake raises on any non-``gh issue view`` command).
+    """
+    import setup_task
+    import utils
+
+    fake_run, seen = _make_fake_run([])
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["setup_task.py", "42", "--no-worktree"])
+    with pytest.raises(SystemExit) as exc:
+        setup_task.main()
+    assert exc.value.code == 1
+    assert all(cmd[0] == "gh" for cmd in seen)
+    assert "gh issue edit 42 --add-label" in json.loads(capsys.readouterr().out)["detail"]

--- a/tests/qs/test_setup_task.py
+++ b/tests/qs/test_setup_task.py
@@ -47,13 +47,82 @@ def test_complete_task_declaration_passes(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_epic_declaration_validates_as_itself(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An epic-shaped declaration is not asked to grow a kind (story D3)."""
+    """An epic-shaped declaration is not asked to grow a kind (story D3).
+
+    Declaration validity and the epic *worktree* refusal are deliberately
+    separate steps: the declaration IS valid — what an epic must not get
+    is a branch/worktree (see the epic-refusal tests below).
+    """
     import setup_task
     import utils
 
     fake_run, _seen = _make_fake_run(["scale:epic", "target:product", "pinned"])
     monkeypatch.setattr(utils, "run", fake_run)
     setup_task.check_declaration(321)
+
+
+# ---------------------------------------------------------------------------
+# Review-fix #04 (must-fix): epic ⇒ NO branch, NO worktree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argv_extra", [[], ["--no-worktree"]], ids=["worktree", "no-worktree"]
+)
+def test_epic_issue_is_refused_before_any_git_work(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    argv_extra: list[str],
+) -> None:
+    """The epic model (QS-321): "No implement phase; no branch, worktree,
+    or PR" — an epic's output is a rationale doc on `main` + child issues.
+
+    Machine-enforced here rather than prompt-obeyed, and enforced for
+    `--no-worktree` too: that flag still cuts a BRANCH, which the model
+    also forbids. The fake raises on any non-`gh` command, so this also
+    proves nothing git-side ran.
+    """
+    import setup_task
+    import utils
+
+    fake_run, seen = _make_fake_run(["scale:epic", "target:factory"])
+    monkeypatch.setattr(utils, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["setup_task.py", "321", *argv_extra])
+
+    with pytest.raises(SystemExit) as exc:
+        setup_task.main()
+    assert exc.value.code == 1
+    assert all(cmd[0] == "gh" for cmd in seen)
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["scale"] == "epic"
+    assert "worktree" in out["error"]
+    # Actionable: says what an epic DOES produce instead.
+    assert "child" in out["detail"]
+
+
+def test_task_issue_is_not_refused_as_an_epic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The guard is scale-specific — a task passes it untouched."""
+    import setup_task
+    import utils
+
+    fake_run, _seen = _make_fake_run(["kind:bug", "target:product", "scale:task"])
+    monkeypatch.setattr(utils, "run", fake_run)
+    labels = setup_task.check_declaration(42)
+    setup_task.refuse_if_epic(42, labels)  # returns without exiting
+
+
+def test_check_declaration_returns_the_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The epic guard reuses `check_declaration`'s already-fetched labels
+    — no second `gh` call on the setup path."""
+    import setup_task
+    import utils
+
+    fake_run, seen = _make_fake_run(["kind:feature", "target:factory", "scale:task"])
+    monkeypatch.setattr(utils, "run", fake_run)
+    labels = setup_task.check_declaration(332)
+    assert labels == ["kind:feature", "target:factory", "scale:task"]
+    assert len([c for c in seen if c[:3] == ["gh", "issue", "view"]]) == 1
 
 
 def test_undeclared_issue_refuses_with_backfill_command(
@@ -116,6 +185,25 @@ def test_null_labels_reports_the_declaration_error_not_invalid_json(
     assert "Invalid JSON" not in out["error"]
     assert "no complete lane declaration" in out["error"]
     assert "gh issue edit 42 --add-label" in out["detail"]
+
+
+@pytest.mark.parametrize("raw", ["null", "[]", "42"])
+def test_non_dict_json_refuses_with_the_structured_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], raw: str
+) -> None:
+    """Review-fix #04: a non-dict top-level value raised `AttributeError`
+    out of the except tuple as a raw traceback."""
+    import setup_task
+    import utils
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=raw, stderr="")
+
+    monkeypatch.setattr(utils, "run", fake_run)
+    with pytest.raises(SystemExit) as exc:
+        setup_task.check_declaration(42)
+    assert exc.value.code == 1
+    assert "error" in json.loads(capsys.readouterr().out)
 
 
 def test_gh_failure_refuses(

--- a/tests/qs/test_targets.py
+++ b/tests/qs/test_targets.py
@@ -230,6 +230,50 @@ def test_validate_declaration_two_scales_is_invalid(targets) -> None:
     assert "scale:task / scale:epic" in message
 
 
+@pytest.mark.parametrize(
+    ("labels", "stray", "choices"),
+    [
+        (
+            ["kind:chore", "target:product", "scale:task"],
+            "kind:chore",
+            "kind:bug / kind:feature",
+        ),
+        (
+            ["kind:bug", "target:banana", "scale:task"],
+            "target:banana",
+            "target:product / target:factory",
+        ),
+    ],
+)
+def test_validate_declaration_non_canonical_value_remediation_converges(
+    targets, labels: list[str], stray: str, choices: str
+) -> None:
+    """Review-fix #02 (should-fix): a single non-canonical axis value
+    (`kind:chore`, `target:banana`) fired the missing-axis branch but
+    never removed the stray label — obeying the printed remediation
+    produced a duplicate-axis failure on the next run (a guaranteed
+    second round-trip). The remediation must remove the unrecognized
+    label AND prompt the canonical addition, in one executable set."""
+    ok, missing, message = targets.validate_declaration(labels)
+    assert not ok
+    assert f'gh issue edit <N> --remove-label "{stray}"' in message
+    assert choices in message
+    # Still executable verbatim: no pipe alternatives anywhere.
+    assert "|" not in message
+
+
+def test_validate_declaration_non_canonical_scale_still_adds_task_default(
+    targets,
+) -> None:
+    """`scale:sprint` is removed AND the deterministic `scale:task`
+    default is still offered as a runnable command."""
+    _ok, _missing, message = targets.validate_declaration(
+        ["kind:bug", "target:product", "scale:sprint"]
+    )
+    assert 'gh issue edit <N> --remove-label "scale:sprint"' in message
+    assert 'gh issue edit <N> --add-label "scale:task"' in message
+
+
 def test_validate_declaration_epic_shape_message_has_no_kind(targets) -> None:
     """Shape-aware: an epic missing its target is not asked to grow a kind."""
     ok, missing, message = targets.validate_declaration(["scale:epic"])

--- a/tests/qs/test_targets.py
+++ b/tests/qs/test_targets.py
@@ -59,12 +59,18 @@ def targets_fixture():
         ("tests/ha_tests/test_home.py", "product"),
         ("docs/agents/concepts/solver.md", "product"),
         ("docs/product/roadmap.md", "product"),
+        # --- known top-level files (review-fix #01: enumerable now,
+        # instead of a perpetual unknown-FYI) ---
+        ("hacs.json", "product"),
+        ("pytest.ini", "factory"),
+        ("opencode.json", "factory"),
+        ("setenv.sh", "factory"),
+        ("LICENSE", "neutral"),
         # --- enumerated neutral (silent) ---
         ("docs/stories/QS-332.story.md", "neutral"),
         ("docs/epics/QS-321.md", "neutral"),
         ("README.md", "neutral"),
         # --- unknown fallthrough (FYI-printed by the gate) ---
-        ("hacs.json", "unknown"),
         ("some/random/path.txt", "unknown"),
         ("info.md", "unknown"),
         # a nested file matching a factory BASENAME is not top-level
@@ -151,21 +157,31 @@ def test_validate_declaration_complete_epic(targets) -> None:
 
 
 def test_validate_declaration_epic_with_kind_is_invalid(targets) -> None:
+    """Review-fix #01: the remedy for an epic carrying a kind is an
+    EXECUTABLE `--remove-label` command (previously nothing was printed
+    at all — an agent obeying the output entered a fail loop)."""
     ok, _missing, message = targets.validate_declaration(
         ["scale:epic", "target:product", "kind:bug"]
     )
     assert not ok
-    assert "kind" in message
+    assert 'gh issue edit <N> --remove-label "kind:bug"' in message
 
 
 def test_validate_declaration_empty_labels(targets) -> None:
     ok, missing, message = targets.validate_declaration(["bug"])
     assert not ok
     assert set(missing) == {"kind", "target", "scale"}
-    # The message carries the shape-aware backfill command with an <N>
-    # placeholder callers substitute with the issue number.
-    assert "gh issue edit <N> --add-label" in message
-    assert "scale:task" in message
+    # Review-fix #01: every printed command is placeholder-free (apart
+    # from <N>, which callers substitute) and runnable verbatim — only
+    # the DETERMINISTIC label (scale:task) appears in a command; the
+    # user-chosen axes are prose, never `a|b` alternatives baked into
+    # the command.
+    assert 'gh issue edit <N> --add-label "scale:task"' in message
+    assert "kind:bug|kind:feature" not in message
+    assert "target:product|target:factory" not in message
+    assert "kind:bug / kind:feature" in message
+    assert "target:product / target:factory" in message
+    assert "user's chosen value" in message
 
 
 def test_validate_declaration_partial_reports_only_missing_axes(targets) -> None:
@@ -174,32 +190,44 @@ def test_validate_declaration_partial_reports_only_missing_axes(targets) -> None
     )
     assert not ok
     assert missing == ["target"]
-    assert "target:product" in message
-    assert "kind:" not in message.split("--add-label")[-1]
+    # Nothing deterministic to add and nothing to remove → NO verbatim
+    # command is printed (running one would create junk labels); the
+    # choice is prose.
+    assert "run exactly as printed" not in message
+    assert 'gh issue edit <N> --add-label "' not in message
+    assert 'gh issue edit <N> --remove-label "' not in message
+    assert "target:product / target:factory" in message
+    assert "kind:bug" not in message
 
 
 def test_validate_declaration_two_targets_is_invalid(targets) -> None:
-    ok, missing, _message = targets.validate_declaration(
+    ok, missing, message = targets.validate_declaration(
         ["kind:bug", "target:product", "target:factory", "scale:task"]
     )
     assert not ok
     assert "target" in missing
+    # Executable remedy: remove BOTH, then re-add the chosen one.
+    assert 'gh issue edit <N> --remove-label "target:factory,target:product"' in message
+    assert "target:product / target:factory" in message
 
 
 def test_validate_declaration_two_kinds_is_invalid(targets) -> None:
-    ok, missing, _message = targets.validate_declaration(
+    ok, missing, message = targets.validate_declaration(
         ["kind:bug", "kind:feature", "target:product", "scale:task"]
     )
     assert not ok
     assert "kind" in missing
+    assert 'gh issue edit <N> --remove-label "kind:bug,kind:feature"' in message
 
 
 def test_validate_declaration_two_scales_is_invalid(targets) -> None:
-    ok, missing, _message = targets.validate_declaration(
+    ok, missing, message = targets.validate_declaration(
         ["kind:bug", "target:product", "scale:task", "scale:epic"]
     )
     assert not ok
     assert "scale" in missing
+    assert 'gh issue edit <N> --remove-label "scale:epic,scale:task"' in message
+    assert "scale:task / scale:epic" in message
 
 
 def test_validate_declaration_epic_shape_message_has_no_kind(targets) -> None:
@@ -241,6 +269,23 @@ def test_parse_parent_epic_no_response_falls_back_to_refs(targets) -> None:
     assert targets.parse_parent_epic(body) == 321
 
 
+@pytest.mark.parametrize("value", ["QS-321", "qs-321", "QS-#321"])
+def test_parse_parent_epic_accepts_the_repo_issue_convention(
+    targets, value: str
+) -> None:
+    """Review-fix #01: the forms hint "e.g. 321" but the repo's own
+    convention spells issues `QS-321` — the structured field must not
+    silently drop it (letting a stray `Refs` elsewhere win)."""
+    body = f"Refs #999\n\n### Parent epic\n\n{value}\n"
+    assert targets.parse_parent_epic(body) == 321
+
+
+def test_parse_parent_epic_refs_is_case_insensitive(targets) -> None:
+    """Review-fix #01: GitHub's own keyword matching is case-insensitive,
+    and `_PARENT_EPIC_SECTION` already is — `refs #321` must count."""
+    assert targets.parse_parent_epic("some text\n\nrefs #321\n") == 321
+
+
 def test_parse_parent_epic_none(targets) -> None:
     assert targets.parse_parent_epic("plain body, no epic") is None
     assert targets.parse_parent_epic("") is None
@@ -252,12 +297,12 @@ def test_parse_parent_epic_none(targets) -> None:
 
 
 def test_main_classifies_paths(targets, capsys: pytest.CaptureFixture[str]) -> None:
-    targets.main(["scripts/qs/targets.py", "custom_components/x.py", "hacs.json"])
+    targets.main(["scripts/qs/targets.py", "custom_components/x.py", "mystery.bin"])
     out = capsys.readouterr().out.splitlines()
     assert out == [
         "factory\tscripts/qs/targets.py",
         "product\tcustom_components/x.py",
-        "unknown\thacs.json",
+        "unknown\tmystery.bin",
     ]
 
 

--- a/tests/qs/test_targets.py
+++ b/tests/qs/test_targets.py
@@ -1,0 +1,266 @@
+"""Tests for ``scripts/qs/targets.py`` — the lane domain module (QS-332).
+
+One truth table, three consumers (``fetch_issue.py``, ``setup_task.py``,
+the quality gate). These tests pin the shared table itself; per-caller
+tests only cover wiring (review SG-R1).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(name="targets")
+def targets_fixture():
+    """Import inside the fixture: ``tests/qs/conftest.py``'s autouse
+    fixture inserts ``scripts/qs/`` on ``sys.path`` at fixture time and
+    purges the module on teardown (same pattern as ``test_context.py``).
+    """
+    import targets as mod
+
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# classify() — the D5 classification, fully enumerated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        # --- factory prefixes ---
+        ("scripts/qs/quality_gate.py", "factory"),
+        ("scripts/worktree-setup.sh", "factory"),
+        ("tests/qs/test_context.py", "factory"),
+        ("tests/qs/agents/test_lane_steps_parity.py", "factory"),
+        (".claude/agents/qs-setup-task.md", "factory"),
+        (".cursor/agents/qs-setup-task.md", "factory"),
+        (".opencode/agents/qs-setup-task.md", "factory"),
+        (".github/workflows/pr-quality.yml", "factory"),
+        ("legacy/old_pipeline.py", "factory"),
+        ("docs/workflow/project-rules.md", "factory"),
+        ("docs/workflow/lanes/bug-product.md", "factory"),
+        # --- factory carve-out by the purpose rule (review CR-1) ---
+        ("tests/test_quality_gate.py", "factory"),
+        # --- factory basenames (top-level only) ---
+        ("CLAUDE.md", "factory"),
+        ("AGENTS.md", "factory"),
+        (".cursorrules", "factory"),
+        (".gitignore", "factory"),
+        ("pyproject.toml", "factory"),
+        ("setup.cfg", "factory"),
+        ("requirements.txt", "factory"),
+        ("requirements_test.txt", "factory"),
+        # --- product prefixes ---
+        ("custom_components/quiet_solar/solver.py", "product"),
+        ("custom_components/quiet_solar/ui/dashboard.py", "product"),
+        ("tests/test_solver.py", "product"),
+        ("tests/ha_tests/test_home.py", "product"),
+        ("docs/agents/concepts/solver.md", "product"),
+        ("docs/product/roadmap.md", "product"),
+        # --- enumerated neutral (silent) ---
+        ("docs/stories/QS-332.story.md", "neutral"),
+        ("docs/epics/QS-321.md", "neutral"),
+        ("README.md", "neutral"),
+        # --- unknown fallthrough (FYI-printed by the gate) ---
+        ("hacs.json", "unknown"),
+        ("some/random/path.txt", "unknown"),
+        ("info.md", "unknown"),
+        # a nested file matching a factory BASENAME is not top-level
+        ("somewhere/pyproject.toml", "unknown"),
+        ("somewhere/README.md", "unknown"),
+    ],
+)
+def test_classify(targets, path: str, expected: str) -> None:
+    assert targets.classify(path) == expected
+
+
+def test_classify_tests_qs_beats_product_tests(targets) -> None:
+    """``tests/qs/`` is factory even though ``tests/`` is product."""
+    assert targets.classify("tests/qs/test_targets.py") == "factory"
+    assert targets.classify("tests/test_constraints.py") == "product"
+
+
+# ---------------------------------------------------------------------------
+# parse_axes()
+# ---------------------------------------------------------------------------
+
+
+def test_parse_axes_task_lane(targets) -> None:
+    axes = targets.parse_axes(["kind:bug", "target:product", "scale:task"])
+    assert axes == {
+        "kind": "bug",
+        "target": "product",
+        "scale": "task",
+        "lane": "bug-product",
+    }
+
+
+def test_parse_axes_epic_lane(targets) -> None:
+    axes = targets.parse_axes(["scale:epic", "target:factory", "pinned"])
+    assert axes == {
+        "kind": "",
+        "target": "factory",
+        "scale": "epic",
+        "lane": "epic-factory",
+    }
+
+
+def test_parse_axes_unlabelled_is_empty(targets) -> None:
+    axes = targets.parse_axes(["bug", "area:solver"])
+    assert axes == {"kind": "", "target": "", "scale": "", "lane": ""}
+
+
+def test_parse_axes_conflicting_axis_is_empty(targets) -> None:
+    """Two labels on the same axis → that axis is ambiguous → empty."""
+    axes = targets.parse_axes(
+        ["target:product", "target:factory", "kind:bug", "scale:task"]
+    )
+    assert axes["target"] == ""
+    assert axes["lane"] == ""
+
+
+def test_parse_axes_incomplete_has_no_lane(targets) -> None:
+    axes = targets.parse_axes(["kind:feature", "target:factory"])
+    assert axes["lane"] == ""
+
+
+# ---------------------------------------------------------------------------
+# validate_declaration() — THE truth table (D1)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_declaration_complete_task(targets) -> None:
+    ok, missing, message = targets.validate_declaration(
+        ["kind:feature", "target:factory", "scale:task", "enhancement"]
+    )
+    assert ok
+    assert missing == []
+    assert message == ""
+
+
+def test_validate_declaration_complete_epic(targets) -> None:
+    """An epic-shaped declaration validates as itself — no kind expected."""
+    ok, missing, message = targets.validate_declaration(
+        ["scale:epic", "target:product"]
+    )
+    assert ok
+    assert missing == []
+    assert message == ""
+
+
+def test_validate_declaration_epic_with_kind_is_invalid(targets) -> None:
+    ok, _missing, message = targets.validate_declaration(
+        ["scale:epic", "target:product", "kind:bug"]
+    )
+    assert not ok
+    assert "kind" in message
+
+
+def test_validate_declaration_empty_labels(targets) -> None:
+    ok, missing, message = targets.validate_declaration(["bug"])
+    assert not ok
+    assert set(missing) == {"kind", "target", "scale"}
+    # The message carries the shape-aware backfill command with an <N>
+    # placeholder callers substitute with the issue number.
+    assert "gh issue edit <N> --add-label" in message
+    assert "scale:task" in message
+
+
+def test_validate_declaration_partial_reports_only_missing_axes(targets) -> None:
+    ok, missing, message = targets.validate_declaration(
+        ["kind:bug", "scale:task"]
+    )
+    assert not ok
+    assert missing == ["target"]
+    assert "target:product" in message
+    assert "kind:" not in message.split("--add-label")[-1]
+
+
+def test_validate_declaration_two_targets_is_invalid(targets) -> None:
+    ok, missing, _message = targets.validate_declaration(
+        ["kind:bug", "target:product", "target:factory", "scale:task"]
+    )
+    assert not ok
+    assert "target" in missing
+
+
+def test_validate_declaration_two_kinds_is_invalid(targets) -> None:
+    ok, missing, _message = targets.validate_declaration(
+        ["kind:bug", "kind:feature", "target:product", "scale:task"]
+    )
+    assert not ok
+    assert "kind" in missing
+
+
+def test_validate_declaration_two_scales_is_invalid(targets) -> None:
+    ok, missing, _message = targets.validate_declaration(
+        ["kind:bug", "target:product", "scale:task", "scale:epic"]
+    )
+    assert not ok
+    assert "scale" in missing
+
+
+def test_validate_declaration_epic_shape_message_has_no_kind(targets) -> None:
+    """Shape-aware: an epic missing its target is not asked to grow a kind."""
+    ok, missing, message = targets.validate_declaration(["scale:epic"])
+    assert not ok
+    assert missing == ["target"]
+    assert "kind:" not in message
+
+
+# ---------------------------------------------------------------------------
+# parse_parent_epic()
+# ---------------------------------------------------------------------------
+
+
+def test_parse_parent_epic_structured_section(targets) -> None:
+    body = "intro\n\n### Parent epic\n\n321\n\nmore text\n"
+    assert targets.parse_parent_epic(body) == 321
+
+
+def test_parse_parent_epic_structured_with_hash(targets) -> None:
+    body = "### Parent epic\n#321\n"
+    assert targets.parse_parent_epic(body) == 321
+
+
+def test_parse_parent_epic_structured_beats_refs(targets) -> None:
+    """The structured field wins over free-text cross-refs (review PC-05)."""
+    body = "Refs #999\n\n### Parent epic\n\n321\n"
+    assert targets.parse_parent_epic(body) == 321
+
+
+def test_parse_parent_epic_refs_fallback(targets) -> None:
+    body = "some description\n\nRefs #321\n"
+    assert targets.parse_parent_epic(body) == 321
+
+
+def test_parse_parent_epic_no_response_falls_back_to_refs(targets) -> None:
+    body = "### Parent epic\n\n_No response_\n\nRefs #321\n"
+    assert targets.parse_parent_epic(body) == 321
+
+
+def test_parse_parent_epic_none(targets) -> None:
+    assert targets.parse_parent_epic("plain body, no epic") is None
+    assert targets.parse_parent_epic("") is None
+
+
+# ---------------------------------------------------------------------------
+# __main__ classification query (AC-10 / review DP2-08)
+# ---------------------------------------------------------------------------
+
+
+def test_main_classifies_paths(targets, capsys: pytest.CaptureFixture[str]) -> None:
+    targets.main(["scripts/qs/targets.py", "custom_components/x.py", "hacs.json"])
+    out = capsys.readouterr().out.splitlines()
+    assert out == [
+        "factory\tscripts/qs/targets.py",
+        "product\tcustom_components/x.py",
+        "unknown\thacs.json",
+    ]
+
+
+def test_main_no_args_errors(targets) -> None:
+    with pytest.raises(SystemExit):
+        targets.main([])

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -7510,19 +7510,36 @@ def _patch_lane_labels(labels: list[str] | None):
     return patch.object(quality_gate, "_fetch_lane_labels", return_value=labels)
 
 
+def _patch_lane_files(paths: list[str] | None):
+    """Patch the fail-closed lane change-set seam (review-fix #01: the
+    lane check computes its own tracked-only, NUL-delimited change set —
+    `None` means a git failure and must reach the fail-closed arm)."""
+    return patch.object(quality_gate, "_lane_changed_files", return_value=paths)
+
+
 class TestLaneCheckHelper:
     """`_check_lane_targets` — never exits, never prints (review R2-12);
     the result object carries `declaration_missing` / `warning` / `fyi`
     and each call site maps it."""
 
     def test_skips_silently_when_no_issue_resolvable(self) -> None:
-        with patch.object(quality_gate, "_resolve_lane_issue", return_value=None):
-            res = quality_gate._check_lane_targets(["custom_components/quiet_solar/a.py"])
+        with (
+            patch.object(quality_gate, "_resolve_lane_issue", return_value=None),
+            patch.object(quality_gate, "_lane_changed_files") as files_mock,
+        ):
+            res = quality_gate._check_lane_targets()
         assert res == quality_gate.LaneCheckResult(None, None, None)
+        # Review-fix #01: the change-set git calls only run once an issue
+        # resolves — a non-task branch pays nothing.
+        files_mock.assert_not_called()
 
     def test_missing_declaration_fails_with_shape_aware_backfill(self) -> None:
-        with _patch_lane_issue(), _patch_lane_labels(["bug"]):
-            res = quality_gate._check_lane_targets(["docs/workflow/x.md"])
+        with (
+            _patch_lane_issue(),
+            _patch_lane_labels(["bug"]),
+            _patch_lane_files(["docs/workflow/x.md"]),
+        ):
+            res = quality_gate._check_lane_targets()
         assert res.declaration_missing is not None
         assert "gh issue edit 332 --add-label" in res.declaration_missing
         assert "<N>" not in res.declaration_missing
@@ -7535,8 +7552,12 @@ class TestLaneCheckHelper:
             "tests/test_a.py",
             "docs/stories/QS-332.story.md",  # neutral — never listed
         ]
-        with _patch_lane_issue(), _patch_lane_labels(_LANE_FACTORY_TASK):
-            res = quality_gate._check_lane_targets(files)
+        with (
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+            _patch_lane_files(files),
+        ):
+            res = quality_gate._check_lane_targets()
         assert res.declaration_missing is None
         assert res.warning is not None
         assert "custom_components/quiet_solar/a.py" in res.warning
@@ -7549,16 +7570,24 @@ class TestLaneCheckHelper:
 
     def test_no_crossing_means_no_warning(self) -> None:
         files = ["scripts/qs/x.py", "docs/workflow/lanes/bug-product.md", "README.md"]
-        with _patch_lane_issue(), _patch_lane_labels(_LANE_FACTORY_TASK):
-            res = quality_gate._check_lane_targets(files)
+        with (
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+            _patch_lane_files(files),
+        ):
+            res = quality_gate._check_lane_targets()
         assert res == quality_gate.LaneCheckResult(None, None, None)
 
     def test_unknown_paths_are_fyi_and_neutral_stays_silent(self) -> None:
-        files = ["hacs.json", "docs/stories/QS-332.story.md", "scripts/x.sh"]
-        with _patch_lane_issue(), _patch_lane_labels(_LANE_FACTORY_TASK):
-            res = quality_gate._check_lane_targets(files)
+        files = ["mystery.bin", "docs/stories/QS-332.story.md", "scripts/x.sh"]
+        with (
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+            _patch_lane_files(files),
+        ):
+            res = quality_gate._check_lane_targets()
         assert res.fyi is not None
-        assert "hacs.json" in res.fyi
+        assert "mystery.bin" in res.fyi
         assert "docs/stories/QS-332.story.md" not in res.fyi
         assert res.warning is None
         assert res.declaration_missing is None
@@ -7566,8 +7595,12 @@ class TestLaneCheckHelper:
     def test_epic_declaration_is_valid_and_classified_against_its_target(self) -> None:
         """A `scale:epic` declaration has no kind and is NOT asked to grow
         one (review PC-11); the crossing check runs against its target."""
-        with _patch_lane_issue(), _patch_lane_labels(["scale:epic", "target:factory"]):
-            res = quality_gate._check_lane_targets(["custom_components/quiet_solar/a.py"])
+        with (
+            _patch_lane_issue(),
+            _patch_lane_labels(["scale:epic", "target:factory"]),
+            _patch_lane_files(["custom_components/quiet_solar/a.py"]),
+        ):
+            res = quality_gate._check_lane_targets()
         assert res.declaration_missing is None
         assert res.warning is not None
 
@@ -7575,9 +7608,10 @@ class TestLaneCheckHelper:
         with (
             _patch_lane_issue(),
             _patch_lane_labels(None),
+            _patch_lane_files(["scripts/qs/x.py"]),
             patch.object(quality_gate, "_is_ci", return_value=False),
         ):
-            res = quality_gate._check_lane_targets(["scripts/qs/x.py"])
+            res = quality_gate._check_lane_targets()
         assert res.declaration_missing is None
         assert res.warning is not None  # the skip notice rides the warning channel
 
@@ -7585,9 +7619,10 @@ class TestLaneCheckHelper:
         with (
             _patch_lane_issue(),
             _patch_lane_labels(None),
+            _patch_lane_files(["scripts/qs/x.py"]),
             patch.object(quality_gate, "_is_ci", return_value=True),
         ):
-            res = quality_gate._check_lane_targets(["scripts/qs/x.py"])
+            res = quality_gate._check_lane_targets()
         assert res.declaration_missing is not None
 
     @pytest.mark.parametrize("is_ci", [False, True], ids=["local", "ci"])
@@ -7597,9 +7632,10 @@ class TestLaneCheckHelper:
         with (
             _patch_lane_issue(),
             _patch_lane_labels(_LANE_FACTORY_TASK),
+            _patch_lane_files(None),
             patch.object(quality_gate, "_is_ci", return_value=is_ci),
         ):
-            res = quality_gate._check_lane_targets(None)
+            res = quality_gate._check_lane_targets()
         if is_ci:
             assert res.declaration_missing is not None
         else:
@@ -7803,7 +7839,8 @@ class TestLaneCheckImpactedCallSite:
         before the warm-baseline block."""
         with (
             self._base_patches(),
-            _patch_early_exit(["docs/agents/concepts/solver.md"]),  # product-classified
+            _patch_early_exit(["docs/agents/concepts/solver.md"]),
+            _patch_lane_files(["docs/agents/concepts/solver.md"]),  # product-classified
             _patch_lane_issue(),
             _patch_lane_labels(_LANE_FACTORY_TASK),
         ):
@@ -7812,11 +7849,35 @@ class TestLaneCheckImpactedCallSite:
         assert "docs/agents/concepts/solver.md" in err
         assert "no Python files changed" in err  # the early exit still fired
 
+    def test_untracked_scratch_file_never_warns(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Review-fix #01: the lane classification runs on the TRACKED
+        change set only — an untracked local scratch file under a product
+        prefix (present in `_impacted_early_exit_paths`'s union, which
+        keeps it for the early-exit decision) must not earn the loud
+        cross-target banner that CI would not print for the same tree."""
+        with (
+            self._base_patches(),
+            _patch_early_exit(
+                ["docs/workflow/x.md", "custom_components/quiet_solar/scratch.py"]
+            ),
+            _patch_lane_files(["docs/workflow/x.md"]),  # tracked only
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+            patch.object(quality_gate, "_resolve_diff_base", return_value=None),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+        ):
+            assert quality_gate.check_impacted() == 0
+        err = capsys.readouterr().err
+        assert "LANE WARNING" not in err
+
     def test_pure_docs_missing_declaration_fails(self) -> None:
         """A missing declaration FAILS even on a pure-docs change set."""
         with (
             self._base_patches(),
             _patch_early_exit(["docs/workflow/x.md"]),
+            _patch_lane_files(["docs/workflow/x.md"]),
             _patch_lane_issue(),
             _patch_lane_labels([]),
         ):
@@ -7828,6 +7889,7 @@ class TestLaneCheckImpactedCallSite:
         with (
             self._base_patches(),
             _patch_early_exit(None),
+            _patch_lane_files(None),
             _patch_lane_issue(),
             _patch_lane_labels(_LANE_FACTORY_TASK),
             patch.object(quality_gate, "_resolve_diff_base", return_value=None),
@@ -7840,6 +7902,7 @@ class TestLaneCheckImpactedCallSite:
         with (
             self._base_patches(),
             _patch_early_exit(None),
+            _patch_lane_files(None),
             _patch_lane_issue(),
             _patch_lane_labels(_LANE_FACTORY_TASK),
             patch.object(quality_gate, "_is_ci", return_value=True),
@@ -7864,6 +7927,7 @@ class TestLaneCheckMainCallSite:
         with (
             patch("sys.argv", ["quality_gate.py", "--json"]),
             patch.object(quality_gate, "_get_changed_files", return_value=["scripts/qs/x.py"]),
+            _patch_lane_files(["scripts/qs/x.py"]),
             _patch_lane_issue(),
             _patch_lane_labels([]),
             _patch_all_gates() as mocks,
@@ -7884,8 +7948,9 @@ class TestLaneCheckMainCallSite:
             patch.object(
                 quality_gate,
                 "_get_changed_files",
-                return_value=["custom_components/quiet_solar/a.py", "hacs.json"],
+                return_value=["custom_components/quiet_solar/a.py", "mystery.bin"],
             ),
+            _patch_lane_files(["custom_components/quiet_solar/a.py", "mystery.bin"]),
             _patch_lane_issue(),
             _patch_lane_labels(_LANE_FACTORY_TASK),
             _patch_full_scope(),
@@ -7898,7 +7963,7 @@ class TestLaneCheckMainCallSite:
         output = json.loads(captured.out)  # must not raise
         assert output["all_passed"] is True
         assert "custom_components/quiet_solar/a.py" in captured.err
-        assert "hacs.json" in captured.err  # the unknown-path FYI
+        assert "mystery.bin" in captured.err  # the unknown-path FYI
 
     def test_quick_mode_never_runs_the_lane_check(self) -> None:
         with (
@@ -7973,7 +8038,6 @@ class TestLaneCheckSubcommand:
     def test_forwards_branch_override_and_runs_no_gates(self) -> None:
         with (
             patch("sys.argv", ["quality_gate.py", "--lane-check", "--branch", "QS_45"]),
-            patch.object(quality_gate, "_get_changed_files", return_value=["scripts/x.sh"]),
             patch.object(
                 quality_gate,
                 "_check_lane_targets",
@@ -7984,9 +8048,25 @@ class TestLaneCheckSubcommand:
         ):
             quality_gate.main()
         assert exc_info.value.code == 0
-        lane_mock.assert_called_once_with(["scripts/x.sh"], "QS_45")
+        lane_mock.assert_called_once_with("QS_45")
         for m in mocks:
             m.assert_not_called()
+
+    def test_git_failure_in_ci_fails_closed_end_to_end(self) -> None:
+        """Review-fix #01: `_get_changed_files` maps git failures to `[]`,
+        which silently degraded the CI job to declaration-only. The lane
+        check now computes its own FAIL-CLOSED change set: a git failure
+        (`None`) in CI exits non-zero from the subcommand."""
+        with (
+            patch("sys.argv", ["quality_gate.py", "--lane-check"]),
+            _patch_lane_files(None),
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 1
 
     def test_warning_lands_in_github_step_summary(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -7995,11 +8075,7 @@ class TestLaneCheckSubcommand:
         monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
         with (
             patch("sys.argv", ["quality_gate.py", "--lane-check"]),
-            patch.object(
-                quality_gate,
-                "_get_changed_files",
-                return_value=["custom_components/quiet_solar/a.py"],
-            ),
+            _patch_lane_files(["custom_components/quiet_solar/a.py"]),
             _patch_lane_issue(),
             _patch_lane_labels(_LANE_FACTORY_TASK),
             pytest.raises(SystemExit) as exc_info,
@@ -8014,10 +8090,154 @@ class TestLaneCheckSubcommand:
         monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
         with (
             patch("sys.argv", ["quality_gate.py", "--lane-check"]),
-            patch.object(quality_gate, "_get_changed_files", return_value=["scripts/x.sh"]),
+            _patch_lane_files(["scripts/x.sh"]),
             _patch_lane_issue(),
             _patch_lane_labels([]),
             pytest.raises(SystemExit) as exc_info,
         ):
             quality_gate.main()
         assert exc_info.value.code == 1
+
+
+class TestResolveLaneIssueUnderscore:
+    """Review-fix #01: `int()` accepts underscore digit-grouping, so a
+    branch `QS_332_2` parsed as issue #3322 and the gate enforced the
+    wrong issue's declaration."""
+
+    def _patch_branch(self, branch: str):
+        def fake_run(cmd, **kwargs):
+            assert cmd == ["git", "branch", "--show-current"]
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{branch}\n", stderr="")
+
+        return patch.object(quality_gate, "_run", side_effect=fake_run)
+
+    @pytest.mark.parametrize("branch", ["QS_332_2", "QS_1_000", "QS_", "QS_x2"])
+    def test_non_pure_digit_suffix_resolves_to_none(self, branch: str) -> None:
+        with self._patch_branch(branch):
+            assert _REAL_RESOLVE_LANE_ISSUE(None) is None
+
+    def test_ci_override_with_underscore_grouping_is_rejected_too(self) -> None:
+        with self._patch_branch(""), patch.object(quality_gate, "_is_ci", return_value=True):
+            assert _REAL_RESOLVE_LANE_ISSUE("QS_332_2") is None
+
+
+class TestFetchLaneLabelsTimeout:
+    """Review-fix #01: the `gh issue view` call sits on the `--impacted`
+    pre-commit hot path — it must carry a bounded timeout (a half-dead
+    network with a cold cache must not hang the sub-15s gate). rc 124
+    maps to the existing `!= 0 → None → local warn+skip` path."""
+
+    def test_gh_call_carries_a_bounded_timeout(self, tmp_path: Path) -> None:
+        seen_timeouts: list[float | None] = []
+
+        def fake_run(cmd, timeout=None, **kwargs):
+            seen_timeouts.append(timeout)
+            payload = json.dumps({"labels": [{"name": n} for n in _LANE_FACTORY_TASK]})
+            return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
+
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", tmp_path / "c"),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            patch.object(quality_gate, "_run", side_effect=fake_run),
+        ):
+            quality_gate._fetch_lane_labels(332, "QS_332")
+        assert len(seen_timeouts) == 1
+        assert seen_timeouts[0] is not None and seen_timeouts[0] > 0
+
+    def test_timeout_rc_124_degrades_to_none(self, tmp_path: Path) -> None:
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 124, stdout="", stderr="timed out")
+
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", tmp_path / "c"),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            patch.object(quality_gate, "_run", side_effect=fake_run),
+        ):
+            assert quality_gate._fetch_lane_labels(332, "QS_332") is None
+
+
+class TestLaneChangedFiles:
+    """Review-fix #01: the lane check's own change-set helper — tracked
+    paths only, NUL-delimited (`-z`, the QS-290 non-ASCII treatment),
+    returncode-checked and FAIL-CLOSED (`None` on any git failure, so the
+    CI fail-closed arm of `_check_lane_targets` is reachable where CI
+    actually runs)."""
+
+    def _fake_run(self, outputs: dict[str, tuple[int, str]]):
+        def fake_run(cmd, **kwargs):
+            key = " ".join(cmd)
+            for fragment, (rc, out) in outputs.items():
+                if fragment in key:
+                    return subprocess.CompletedProcess(cmd, rc, stdout=out, stderr="")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        return patch.object(quality_gate, "_run", side_effect=fake_run)
+
+    def test_union_of_the_three_tracked_diffs_sorted(self) -> None:
+        with self._fake_run(
+            {
+                "origin/main...HEAD": (0, "b.md\0a.py\0"),
+                "--cached": (0, "c.md\0"),
+                "diff --name-only -z HEAD": (0, "a.py\0d.md\0"),
+            }
+        ):
+            assert quality_gate._lane_changed_files() == ["a.py", "b.md", "c.md", "d.md"]
+
+    @pytest.mark.parametrize(
+        "failing", ["origin/main...HEAD", "--cached", "diff --name-only -z HEAD"]
+    )
+    def test_any_git_failure_returns_none(self, failing: str) -> None:
+        outputs = {
+            "origin/main...HEAD": (0, "a.py\0"),
+            "--cached": (0, ""),
+            "diff --name-only -z HEAD": (0, ""),
+        }
+        outputs[failing] = (128, "")
+        with self._fake_run(outputs):
+            assert quality_gate._lane_changed_files() is None
+
+    def test_non_ascii_paths_arrive_unquoted(self) -> None:
+        """`-z` emits raw bytes — no `core.quotePath` C-quoting, so
+        `docs/workflow/données.md` classifies factory, not unknown."""
+        with self._fake_run(
+            {
+                "origin/main...HEAD": (0, "docs/workflow/données.md\0"),
+                "--cached": (0, ""),
+                "diff --name-only -z HEAD": (0, ""),
+            }
+        ):
+            files = quality_gate._lane_changed_files()
+        assert files == ["docs/workflow/données.md"]
+        import targets as targets_mod
+
+        assert targets_mod.classify(files[0]) == "factory"
+
+    def test_untracked_files_are_not_listed(self) -> None:
+        """No `git ls-files --others` rung — tracked diffs only (the
+        untracked union stays in `_impacted_early_exit_paths`, for the
+        early-exit decision alone)."""
+        commands: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch.object(quality_gate, "_run", side_effect=fake_run):
+            assert quality_gate._lane_changed_files() == []
+        assert all("ls-files" not in " ".join(cmd) for cmd in commands)
+
+
+class TestSeedModeSkipsLaneCheck:
+    """Review-fix #01: AC-5's "never runs in --seed-testmon" clause was
+    unpinned (only the `--quick` half had a dedicated skip test)."""
+
+    def test_seed_testmon_never_runs_the_lane_check(self) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--seed-testmon"]),
+            patch.object(quality_gate, "_check_lane_targets") as lane_mock,
+            patch.object(quality_gate, "seed_testmon", return_value=0),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 0
+        lane_mock.assert_not_called()

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -8241,3 +8241,62 @@ class TestSeedModeSkipsLaneCheck:
             quality_gate.main()
         assert exc_info.value.code == 0
         lane_mock.assert_not_called()
+
+
+class TestFetchLaneLabelsNullLabels:
+    """Review-fix #03: `"labels": null` is a valid-JSON response the API
+    can return. With a bare `.get("labels", [])` the comprehension raised
+    `TypeError`, was swallowed by the broad `except`, and degraded to
+    `None` — i.e. the gh-FAILURE path (local warn+skip / CI fail closed)
+    for a response that was perfectly readable. The honest answer is an
+    empty label list, which then fails the declaration check on its own
+    merits."""
+
+    def test_null_labels_resolve_to_an_empty_list(self, tmp_path: Path) -> None:
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps({"labels": None}), stderr=""
+            )
+
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", tmp_path / "c"),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            patch.object(quality_gate, "_run", side_effect=fake_run),
+        ):
+            assert quality_gate._fetch_lane_labels(332, "QS_332") == []
+
+    def test_null_labels_fail_the_declaration_rather_than_the_fetch(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end: the result is a declaration FAILURE (actionable),
+        not a `gh`-unavailable warn+skip (silent locally)."""
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps({"labels": None}), stderr=""
+            )
+
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", tmp_path / "c"),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            patch.object(quality_gate, "_run", side_effect=fake_run),
+            _patch_lane_issue(),
+            _patch_lane_files(["scripts/qs/x.py"]),
+        ):
+            res = quality_gate._check_lane_targets()
+        assert res.declaration_missing is not None
+        assert "gh issue edit 332" in res.declaration_missing
+
+    def test_malformed_label_entries_degrade_to_none(self, tmp_path: Path) -> None:
+        """A malformed ENTRY (null / no `name`) is genuinely unreadable —
+        it keeps the existing unavailable semantics, unlike a null field."""
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps({"labels": [{"id": 1}]}), stderr=""
+            )
+
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", tmp_path / "c"),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            patch.object(quality_gate, "_run", side_effect=fake_run),
+        ):
+            assert quality_gate._fetch_lane_labels(332, "QS_332") is None

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import io
 import json
 import os
@@ -57,6 +58,31 @@ def _patch_full_scope():
 
 
 _DEFAULT_EARLY_EXIT_PATHS = ["custom_components/quiet_solar/home_model/load.py"]
+
+# QS-332: the REAL issue resolver, captured at import time — the autouse
+# `_lane_check_isolated` fixture below patches the module attribute for
+# every test, so `TestResolveLaneIssue` calls this reference instead.
+_REAL_RESOLVE_LANE_ISSUE = quality_gate._resolve_lane_issue
+
+
+@pytest.fixture(autouse=True)
+def _lane_check_isolated(tmp_path_factory: pytest.TempPathFactory):
+    """QS-332 existing-test audit: keep every test in this module
+    network-free. The lane check `check_impacted()` and `main()` now run
+    would otherwise resolve THIS repo's real `QS_<N>` branch and issue a
+    real `gh issue view` (or write the real label cache). Stub the issue
+    resolution to "not a task branch" (silent skip) by default; lane
+    tests re-patch `_resolve_lane_issue` inside their own bodies (a
+    nested `patch.object` cleanly overrides this one). The cache file is
+    pointed at a tmp dir so no test touches the repo's real
+    `.lane_check_cache`.
+    """
+    root = tmp_path_factory.mktemp("lane")
+    with (
+        patch.object(quality_gate, "_resolve_lane_issue", return_value=None),
+        patch.object(quality_gate, "LANE_CACHE_FILE", root / ".lane_check_cache"),
+    ):
+        yield
 
 # A real sentinel object, so the default is not a
 # `str` masquerading as a `list[str] | None` behind a blanket `type: ignore`.
@@ -7467,3 +7493,531 @@ class TestTestmonRelocationInvariant:
             "relocated .testmondata under-selected a changed-content test "
             f"(got {selected}); the 'never fewer' invariant is violated"
         )
+
+
+# --- QS-332 (B1): the lane check ---
+
+
+_LANE_FACTORY_TASK = ["kind:feature", "target:factory", "scale:task"]
+_LANE_PRODUCT_TASK = ["kind:bug", "target:product", "scale:task"]
+
+
+def _patch_lane_issue(issue: int = 332, branch: str = "QS_332"):
+    return patch.object(quality_gate, "_resolve_lane_issue", return_value=(issue, branch))
+
+
+def _patch_lane_labels(labels: list[str] | None):
+    return patch.object(quality_gate, "_fetch_lane_labels", return_value=labels)
+
+
+class TestLaneCheckHelper:
+    """`_check_lane_targets` — never exits, never prints (review R2-12);
+    the result object carries `declaration_missing` / `warning` / `fyi`
+    and each call site maps it."""
+
+    def test_skips_silently_when_no_issue_resolvable(self) -> None:
+        with patch.object(quality_gate, "_resolve_lane_issue", return_value=None):
+            res = quality_gate._check_lane_targets(["custom_components/quiet_solar/a.py"])
+        assert res == quality_gate.LaneCheckResult(None, None, None)
+
+    def test_missing_declaration_fails_with_shape_aware_backfill(self) -> None:
+        with _patch_lane_issue(), _patch_lane_labels(["bug"]):
+            res = quality_gate._check_lane_targets(["docs/workflow/x.md"])
+        assert res.declaration_missing is not None
+        assert "gh issue edit 332 --add-label" in res.declaration_missing
+        assert "<N>" not in res.declaration_missing
+        assert res.warning is None
+
+    def test_cross_target_diff_warns_and_lists_all_crossing_files(self) -> None:
+        files = [
+            "scripts/qs/x.py",
+            "custom_components/quiet_solar/a.py",
+            "tests/test_a.py",
+            "docs/stories/QS-332.story.md",  # neutral — never listed
+        ]
+        with _patch_lane_issue(), _patch_lane_labels(_LANE_FACTORY_TASK):
+            res = quality_gate._check_lane_targets(files)
+        assert res.declaration_missing is None
+        assert res.warning is not None
+        assert "custom_components/quiet_solar/a.py" in res.warning
+        assert "tests/test_a.py" in res.warning
+        assert "docs/stories/QS-332.story.md" not in res.warning
+        # The split recommendation ALWAYS prints — "substantial" is human
+        # judgment, not a computed threshold (review R2-09).
+        assert "split" in res.warning.lower()
+        assert "verify these serve the declared factory purpose" in res.warning.lower()
+
+    def test_no_crossing_means_no_warning(self) -> None:
+        files = ["scripts/qs/x.py", "docs/workflow/lanes/bug-product.md", "README.md"]
+        with _patch_lane_issue(), _patch_lane_labels(_LANE_FACTORY_TASK):
+            res = quality_gate._check_lane_targets(files)
+        assert res == quality_gate.LaneCheckResult(None, None, None)
+
+    def test_unknown_paths_are_fyi_and_neutral_stays_silent(self) -> None:
+        files = ["hacs.json", "docs/stories/QS-332.story.md", "scripts/x.sh"]
+        with _patch_lane_issue(), _patch_lane_labels(_LANE_FACTORY_TASK):
+            res = quality_gate._check_lane_targets(files)
+        assert res.fyi is not None
+        assert "hacs.json" in res.fyi
+        assert "docs/stories/QS-332.story.md" not in res.fyi
+        assert res.warning is None
+        assert res.declaration_missing is None
+
+    def test_epic_declaration_is_valid_and_classified_against_its_target(self) -> None:
+        """A `scale:epic` declaration has no kind and is NOT asked to grow
+        one (review PC-11); the crossing check runs against its target."""
+        with _patch_lane_issue(), _patch_lane_labels(["scale:epic", "target:factory"]):
+            res = quality_gate._check_lane_targets(["custom_components/quiet_solar/a.py"])
+        assert res.declaration_missing is None
+        assert res.warning is not None
+
+    def test_gh_failure_local_warns_and_skips(self) -> None:
+        with (
+            _patch_lane_issue(),
+            _patch_lane_labels(None),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+        ):
+            res = quality_gate._check_lane_targets(["scripts/qs/x.py"])
+        assert res.declaration_missing is None
+        assert res.warning is not None  # the skip notice rides the warning channel
+
+    def test_gh_failure_in_ci_fails_closed(self) -> None:
+        with (
+            _patch_lane_issue(),
+            _patch_lane_labels(None),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+        ):
+            res = quality_gate._check_lane_targets(["scripts/qs/x.py"])
+        assert res.declaration_missing is not None
+
+    @pytest.mark.parametrize("is_ci", [False, True], ids=["local", "ci"])
+    def test_unknown_change_set_has_gh_failure_semantics(self, is_ci: bool) -> None:
+        """`_impacted_early_exit_paths() is None` (git failure) is treated
+        exactly like a `gh` failure: local warn+skip, CI fail closed."""
+        with (
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+            patch.object(quality_gate, "_is_ci", return_value=is_ci),
+        ):
+            res = quality_gate._check_lane_targets(None)
+        if is_ci:
+            assert res.declaration_missing is not None
+        else:
+            assert res.declaration_missing is None
+            assert res.warning is not None
+
+
+class TestEmitLaneCheck:
+    """The call-site mapping: fyi/warning → stderr (NEVER stdout — `--json`
+    must stay parseable, review DP2-03); declaration_missing → rc 1."""
+
+    def test_warning_and_fyi_go_to_stderr_only(self, capsys: pytest.CaptureFixture[str]) -> None:
+        res = quality_gate.LaneCheckResult(None, "WARN-TEXT", "FYI-TEXT")
+        assert quality_gate._emit_lane_check(res) == 0
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "WARN-TEXT" in captured.err
+        assert "FYI-TEXT" in captured.err
+
+    def test_declaration_missing_maps_to_failure(self, capsys: pytest.CaptureFixture[str]) -> None:
+        res = quality_gate.LaneCheckResult("MISSING-TEXT", None, None)
+        assert quality_gate._emit_lane_check(res) == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "MISSING-TEXT" in captured.err
+
+    def test_skip_result_is_silent(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert quality_gate._emit_lane_check(quality_gate.LaneCheckResult(None, None, None)) == 0
+        captured = capsys.readouterr()
+        assert captured.out == "" and captured.err == ""
+
+
+class TestResolveLaneIssue:
+    """Branch → issue resolution, incl. the CI detached-HEAD fallback
+    (review N-1: `git branch --show-current` is empty on a pull_request
+    merge-ref checkout; `--branch "${{ github.head_ref }}"` fills in)."""
+
+    def _patch_branch(self, branch: str):
+        def fake_run(cmd, **kwargs):
+            assert cmd == ["git", "branch", "--show-current"]
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{branch}\n", stderr="")
+
+        return patch.object(quality_gate, "_run", side_effect=fake_run)
+
+    def test_qs_branch_resolves(self) -> None:
+        with self._patch_branch("QS_45"):
+            assert _REAL_RESOLVE_LANE_ISSUE(None) == (45, "QS_45")
+
+    def test_non_task_branch_resolves_to_none(self) -> None:
+        with self._patch_branch("main"):
+            assert _REAL_RESOLVE_LANE_ISSUE(None) is None
+
+    def test_detached_head_in_ci_falls_back_to_branch_override(self) -> None:
+        with self._patch_branch(""), patch.object(quality_gate, "_is_ci", return_value=True):
+            assert _REAL_RESOLVE_LANE_ISSUE("QS_45") == (45, "QS_45")
+
+    def test_detached_head_locally_ignores_override(self) -> None:
+        with self._patch_branch(""), patch.object(quality_gate, "_is_ci", return_value=False):
+            assert _REAL_RESOLVE_LANE_ISSUE("QS_45") is None
+
+    def test_detached_head_in_ci_without_override_is_none(self) -> None:
+        with self._patch_branch(""), patch.object(quality_gate, "_is_ci", return_value=True):
+            assert _REAL_RESOLVE_LANE_ISSUE(None) is None
+
+
+class TestLaneLabelCache:
+    """The label marker-file cache: keyed on (issue, branch), 10-minute
+    TTL, `_is_ci()` bypass, and ONLY complete declarations are cached (a
+    backfill-then-re-run can never be re-failed by a stale cache)."""
+
+    def _gh_run(self, labels: list[str], calls: list[list[str]]):
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            payload = json.dumps({"labels": [{"name": n} for n in labels]})
+            return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
+
+        return patch.object(quality_gate, "_run", side_effect=fake_run)
+
+    def test_complete_declaration_is_cached_and_reused(self, tmp_path: Path) -> None:
+        calls: list[list[str]] = []
+        cache = tmp_path / ".lane_check_cache"
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", cache),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            self._gh_run(_LANE_FACTORY_TASK, calls),
+        ):
+            assert quality_gate._fetch_lane_labels(332, "QS_332") == _LANE_FACTORY_TASK
+            assert quality_gate._fetch_lane_labels(332, "QS_332") == _LANE_FACTORY_TASK
+        assert len(calls) == 1  # second hit served from the cache
+        assert cache.exists()
+
+    def test_incomplete_declaration_is_never_cached(self, tmp_path: Path) -> None:
+        calls: list[list[str]] = []
+        cache = tmp_path / ".lane_check_cache"
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", cache),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            self._gh_run(["bug"], calls),
+        ):
+            assert quality_gate._fetch_lane_labels(332, "QS_332") == ["bug"]
+            assert quality_gate._fetch_lane_labels(332, "QS_332") == ["bug"]
+        assert len(calls) == 2  # no cache write, no cache hit
+        assert not cache.exists()
+
+    def test_cache_is_keyed_on_issue_and_branch(self, tmp_path: Path) -> None:
+        calls: list[list[str]] = []
+        cache = tmp_path / ".lane_check_cache"
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", cache),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            self._gh_run(_LANE_FACTORY_TASK, calls),
+        ):
+            quality_gate._fetch_lane_labels(332, "QS_332")
+            quality_gate._fetch_lane_labels(45, "QS_45")
+        assert len(calls) == 2
+
+    def test_expired_cache_refetches(self, tmp_path: Path) -> None:
+        calls: list[list[str]] = []
+        cache = tmp_path / ".lane_check_cache"
+        cache.write_text(
+            json.dumps(
+                {
+                    "issue": 332,
+                    "branch": "QS_332",
+                    "labels": _LANE_FACTORY_TASK,
+                    "time": time.time() - quality_gate._LANE_CACHE_TTL_S - 1,
+                }
+            )
+        )
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", cache),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            self._gh_run(_LANE_FACTORY_TASK, calls),
+        ):
+            quality_gate._fetch_lane_labels(332, "QS_332")
+        assert len(calls) == 1
+
+    def test_ci_bypasses_the_cache(self, tmp_path: Path) -> None:
+        calls: list[list[str]] = []
+        cache = tmp_path / ".lane_check_cache"
+        cache.write_text(
+            json.dumps(
+                {
+                    "issue": 332,
+                    "branch": "QS_332",
+                    "labels": _LANE_PRODUCT_TASK,
+                    "time": time.time(),
+                }
+            )
+        )
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", cache),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+            self._gh_run(_LANE_FACTORY_TASK, calls),
+        ):
+            assert quality_gate._fetch_lane_labels(332, "QS_332") == _LANE_FACTORY_TASK
+        assert len(calls) == 1
+
+    def test_gh_failure_returns_none(self, tmp_path: Path) -> None:
+        def failing_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="boom")
+
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", tmp_path / "c"),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            patch.object(quality_gate, "_run", side_effect=failing_run),
+        ):
+            assert quality_gate._fetch_lane_labels(332, "QS_332") is None
+
+
+class TestLaneCheckImpactedCallSite:
+    """Call site 1 (review CR-2 / planner N-3): inside `check_impacted()`,
+    after `_ensure_testmon_db_safe()` and BEFORE the warm-baseline
+    early-exit block — the hook must run on a pure-docs change set."""
+
+    @pytest.fixture(autouse=True)
+    def _testmon_db_present(self, tmp_path_factory: pytest.TempPathFactory):
+        root = tmp_path_factory.mktemp("tmdb-lane")
+        db = root / ".testmondata"
+        db.write_bytes(b"x")
+        with (
+            patch.object(quality_gate, "TESTMON_DATA", db),
+            patch.object(quality_gate, "COVERAGE_DATA", root / ".coverage"),
+        ):
+            yield
+
+    def _base_patches(self) -> contextlib.ExitStack:
+        stack = contextlib.ExitStack()
+        stack.enter_context(
+            patch.object(quality_gate, "_impacted_tooling_available", return_value=True)
+        )
+        stack.enter_context(patch.object(quality_gate, "_clean_orphan_cov_shards"))
+        stack.enter_context(patch.object(quality_gate, "_ensure_testmon_db_safe"))
+        return stack
+
+    def test_pure_docs_crossing_warns_but_early_exit_still_passes(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A cross-target pure-docs diff WARNS (exit code unaffected) even
+        though the non-`.py` early exit then fires — the lane check runs
+        before the warm-baseline block."""
+        with (
+            self._base_patches(),
+            _patch_early_exit(["docs/agents/concepts/solver.md"]),  # product-classified
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+        ):
+            assert quality_gate.check_impacted() == 0
+        err = capsys.readouterr().err
+        assert "docs/agents/concepts/solver.md" in err
+        assert "no Python files changed" in err  # the early exit still fired
+
+    def test_pure_docs_missing_declaration_fails(self) -> None:
+        """A missing declaration FAILS even on a pure-docs change set."""
+        with (
+            self._base_patches(),
+            _patch_early_exit(["docs/workflow/x.md"]),
+            _patch_lane_issue(),
+            _patch_lane_labels([]),
+        ):
+            assert quality_gate.check_impacted() == 1
+
+    def test_git_failure_locally_warns_and_pipeline_continues(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            self._base_patches(),
+            _patch_early_exit(None),
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+            patch.object(quality_gate, "_resolve_diff_base", return_value=None),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+        ):
+            assert quality_gate.check_impacted() == 0
+        assert "lane check" in capsys.readouterr().err
+
+    def test_git_failure_in_ci_fails_closed(self) -> None:
+        with (
+            self._base_patches(),
+            _patch_early_exit(None),
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+            patch.object(quality_gate, "_is_ci", return_value=True),
+        ):
+            assert quality_gate.check_impacted() == 1
+
+    def test_no_issue_resolvable_skips_and_pipeline_runs(self) -> None:
+        """Not a task branch → the check silently skips (most fixtures)."""
+        with (
+            self._base_patches(),
+            _patch_early_exit(["docs/x.md"]),
+        ):
+            # autouse fixture already stubs _resolve_lane_issue → None
+            assert quality_gate.check_impacted() == 0
+
+
+class TestLaneCheckMainCallSite:
+    """Call site 2: `main()`, between `_get_changed_files()` and
+    `_detect_scope(...)`, for the full gate."""
+
+    def test_missing_declaration_fails_before_any_gate_runs(self) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--json"]),
+            patch.object(quality_gate, "_get_changed_files", return_value=["scripts/qs/x.py"]),
+            _patch_lane_issue(),
+            _patch_lane_labels([]),
+            _patch_all_gates() as mocks,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 1
+        for m in mocks:
+            m.assert_not_called()
+
+    def test_warning_keeps_json_stdout_parseable(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Warning/FYI go to stderr; `--json` stdout stays machine-readable
+        (review DP2-03)."""
+        with (
+            patch("sys.argv", ["quality_gate.py", "--json"]),
+            patch.object(
+                quality_gate,
+                "_get_changed_files",
+                return_value=["custom_components/quiet_solar/a.py", "hacs.json"],
+            ),
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+            _patch_full_scope(),
+            _patch_all_gates(),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)  # must not raise
+        assert output["all_passed"] is True
+        assert "custom_components/quiet_solar/a.py" in captured.err
+        assert "hacs.json" in captured.err  # the unknown-path FYI
+
+    def test_quick_mode_never_runs_the_lane_check(self) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--quick", "tests/qs"]),
+            patch.object(quality_gate, "_check_lane_targets") as lane_mock,
+            patch.object(
+                quality_gate,
+                "check_pytest_files",
+                return_value={"name": "pytest", "passed": True, "detail": ""},
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 0
+        lane_mock.assert_not_called()
+
+    def test_cache_hit_skips_the_lane_check_by_design(self, tmp_path: Path) -> None:
+        """KNOWN skip, recorded (review planner): the `--cache`
+        short-circuit sits before the lane seam. Acceptable because
+        `--cache` requires a previously green run on a clean tree and the
+        mandated pre-commit form is `--impacted`."""
+        cache_path = tmp_path / ".quality_gate_cache"
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "branch": "QS_76",
+                    "commit": "abc123",
+                    "all_passed": True,
+                    "results": _make_all_pass_results(),
+                    "timestamp": "",
+                }
+            )
+        )
+        with (
+            patch("sys.argv", ["quality_gate.py", "--cache", "--json"]),
+            _patch_git_state("QS_76", "abc123", True),
+            patch.object(quality_gate, "CACHE_FILE", cache_path),
+            patch.object(quality_gate, "_check_lane_targets") as lane_mock,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 0
+        lane_mock.assert_not_called()
+
+
+class TestLaneCheckSubcommand:
+    """`--lane-check` (reviews CR-3 + N-1): a cheap subcommand running the
+    lane steps only — no pytest, no coverage — in the execution-mode
+    mutex ladder, short-circuiting before scope detection."""
+
+    @pytest.mark.parametrize(
+        "conflict",
+        ["--impacted", "--quick", "--cache", "--no-cache", "--full", "--fix",
+         "--seed-testmon", "--seed-testmon-status", "--seed-testmon-follow"],
+    )
+    def test_mutex_ladder_membership(self, conflict: str) -> None:
+        argv = ["quality_gate.py", "--lane-check", conflict]
+        if conflict == "--quick":
+            argv.append("tests/qs")
+        with patch("sys.argv", argv), pytest.raises(SystemExit) as exc_info:
+            quality_gate.main()
+        assert exc_info.value.code == 2
+
+    def test_branch_flag_requires_lane_check(self) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--branch", "QS_45"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 2
+
+    def test_forwards_branch_override_and_runs_no_gates(self) -> None:
+        with (
+            patch("sys.argv", ["quality_gate.py", "--lane-check", "--branch", "QS_45"]),
+            patch.object(quality_gate, "_get_changed_files", return_value=["scripts/x.sh"]),
+            patch.object(
+                quality_gate,
+                "_check_lane_targets",
+                return_value=quality_gate.LaneCheckResult(None, None, None),
+            ) as lane_mock,
+            _patch_all_gates() as mocks,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 0
+        lane_mock.assert_called_once_with(["scripts/x.sh"], "QS_45")
+        for m in mocks:
+            m.assert_not_called()
+
+    def test_warning_lands_in_github_step_summary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        summary = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        with (
+            patch("sys.argv", ["quality_gate.py", "--lane-check"]),
+            patch.object(
+                quality_gate,
+                "_get_changed_files",
+                return_value=["custom_components/quiet_solar/a.py"],
+            ),
+            _patch_lane_issue(),
+            _patch_lane_labels(_LANE_FACTORY_TASK),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 0  # a crossing never fails
+        assert "custom_components/quiet_solar/a.py" in summary.read_text(encoding="utf-8")
+
+    def test_missing_declaration_exits_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        with (
+            patch("sys.argv", ["quality_gate.py", "--lane-check"]),
+            patch.object(quality_gate, "_get_changed_files", return_value=["scripts/x.sh"]),
+            _patch_lane_issue(),
+            _patch_lane_labels([]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            quality_gate.main()
+        assert exc_info.value.code == 1

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -8300,3 +8300,22 @@ class TestFetchLaneLabelsNullLabels:
             patch.object(quality_gate, "_run", side_effect=fake_run),
         ):
             assert quality_gate._fetch_lane_labels(332, "QS_332") is None
+
+
+class TestFetchLaneLabelsNonDictJson:
+    """Review-fix #04: a non-dict top-level JSON value (`null`, `[]`, `42`)
+    made `data.get(...)` raise `AttributeError`, which was not in the
+    except tuple — it escaped as a raw traceback instead of the `None`
+    (gh-unavailable) degrade path."""
+
+    @pytest.mark.parametrize("raw", ["null", "[]", "42"])
+    def test_non_dict_json_degrades_to_none(self, tmp_path: Path, raw: str) -> None:
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout=raw, stderr="")
+
+        with (
+            patch.object(quality_gate, "LANE_CACHE_FILE", tmp_path / "c"),
+            patch.object(quality_gate, "_is_ci", return_value=False),
+            patch.object(quality_gate, "_run", side_effect=fake_run),
+        ):
+            assert quality_gate._fetch_lane_labels(332, "QS_332") is None


### PR DESCRIPTION
## Summary
- 6 lanes = {bug, feature, epic} x {product, factory}: byte-identical lane files (identity machine-enforced via a DIVERGED allowlist), 6 axis labels declared at every entry point (6 issue forms, setup-task ask+backfill, setup_task.py refusal), context.py/fetch_issue.py expose the axes via the new scripts/qs/targets.py domain module
- Lane check in --impacted, the full gate and a new CI job: missing declaration FAILS; a cross-target diff WARNS loudly but never fails (purpose, not path, is the classifier); create_pr.py auto-appends Refs #<epic> and machine-injects the Lane note
- Workflow-bot fixes: issue-triage word-boundary regexes + area:dev-pipeline (Fixes #293), stale-bot exempts scale:epic; epic doc amended (hard boundary -> visibility rule). Epic: docs/epics/QS-321.md
- Doc maintenance: Doc-OK — check_doc_drift.py exit 0 on the staged diff; every touched path is factory-side (drift checker tracks custom_components/quiet_solar/ only); workflow-doc updates and the x3 harness co-modification are in scope by construction

Fixes #332
Refs #321

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added six workflow lanes for product and factory bugs, features, and epics.
  * Added lane-specific issue templates with standardized labels and optional parent-epic references.
  * Added pull-request lane validation, parent-epic references, and cross-target change notes.
  * Added lane-aware workflow protocols and issue metadata.

* **Bug Fixes**
  * Improved issue triage keyword matching to prevent unintended labels.
  * Epic issues are now exempt from stale-issue handling.
  * Disabled blank issue creation in the web interface.

* **Documentation**
  * Added comprehensive lane workflow protocols and project guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Doc maintenance
Review fix #01 modifies `.opencode/agents/qs-review-task.md` without its
`.claude`/`.cursor` twins, which trips the harness-sync co-modification
check. Justified single-file edit: the change is whitespace-only —
review finding "Whitespace drift in the mirrored lane blocks" — and the
defect (lane block abutting `## Phase protocol` with no blank line)
existed **only** in the OpenCode copy; the other two copies were already
correct, so "fixing" them would be a no-op commit. The mirrored shape is
now machine-pinned in all three harnesses by
`tests/qs/agents/test_lane_steps_parity.py::test_lane_block_is_a_clean_mirrored_paragraph`,
so this drift class cannot recur silently.
