### PR TITLE
QS-342: Suspected regression: OCPP charger no longer detects IDBuzz plug-in (manual car association required)

### DIFF
--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -3325,15 +3325,16 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                     if other is charger or other in assigned_chargers:
                         continue
                     for other_score, other_car in chargers_scores[other]:
-                        # Identity, not name equality (review #03 / D10): the charger
-                        # exclusion just above already uses `is`, and mixing the two
-                        # would let a distinct car object sharing a name contribute a
-                        # phantom alternative and perturb regret. Every score list is
-                        # built from the SAME `home._cars` iteration, so under the
-                        # documented unique-name invariant `is` and `.name ==` select
-                        # the identical set — this is a no-op by construction, and it
-                        # stops depending on that invariant here.
-                        if other_car is car and other_score > best_alternative:
+                        # Match by NAME, like the rest of the cascade. This is not an
+                        # oversight and must not be "tidied" to identity (review #04 /
+                        # B1 reverts exactly that): removal after assignment consumes a
+                        # whole NAME from every list, and stickiness compares names, so
+                        # regret must use the same relation or the rules stop describing
+                        # the same set. Car names are NOT enforced unique anywhere, and
+                        # under duplicates an identity scan under-counts alternatives,
+                        # inflates regret for the duplicated name and orphans the other
+                        # charger — the original #342 symptom.
+                        if other_car.name == car.name and other_score > best_alternative:
                             best_alternative = other_score
                 regret = best_cur_score - best_alternative
 

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -236,11 +236,22 @@ _POWER_LOG_DEADBAND_W = 100.0  # ignore sub-100W jitter on the available-power l
 # (GPS creeping 0.55 m per cycle) is a new value every cycle, so it satisfies "not the
 # same stuff over and over" literally while leaving volume unbounded. The budget is
 # what makes the bound provable and DATA-INDEPENDENT: <= budget + 1 lines per key per
-# window, whatever the value pattern. Overflow is disclosed as a count, never silent.
+# window, whatever the value pattern. Overflow is disclosed as a count on the next
+# call for that key.
 _LOG_VALUES_PER_WINDOW = 4
+# QS-342 (review fix #04 / B12+B13): a LARGER budget for the two genuine-telemetry
+# sites — `dyn_handle`'s available-power line and the SoC callback. The default
+# assumes "many distinct values per window == churn, and the churn is itself the
+# signal", which is true for allocation keys but FALSE here: these values advance
+# monotonically during perfectly normal operation (a charging battery's Wh/%, a
+# home's import/export crossing zero), so the default budget put them in permanent
+# overflow and dropped real operational events. 12 per 900 s is one line per 75 s
+# worst case — still bounded, and enough to keep a genuine transition visible.
+_LOG_TELEMETRY_VALUES_PER_WINDOW = 12
 # Strictly greater than the budget, so the BUDGET binds first and eviction never
 # silently re-inflates volume by forgetting a value that is still being repeated.
 _LOG_MAX_REMEMBERED_VALUES = 8
+_LOG_MAX_REMEMBERED_TELEMETRY_VALUES = _LOG_TELEMETRY_VALUES_PER_WINDOW * 2
 
 
 class QSChargerStates(StrEnum):
@@ -653,22 +664,33 @@ def _is_unchanged(prev: object, current: object, deadband: float | None) -> bool
 
 @dataclass
 class _LogOnChangeRecord:
-    """Recently-emitted values for one key, plus this window's budget accounting.
+    """Recently-OBSERVED values for one key, plus this window's accounting.
 
-    `seen` is a bounded LIST of `(value, last_emitted_time)` scanned linearly with
-    `_is_unchanged` — deliberately NOT a `dict[value, time]`. Two load-bearing
-    reasons: `float('nan')` values would never hit a dict lookup (every read builds
-    a fresh NaN and `NaN != NaN`), silently re-inflating a stuck sensor to the full
-    cycle rate — exactly what `_element_unchanged` guards against; and the deadband
-    comparison is not an equality relation at all, so it cannot be a hash key. A
-    linear scan over at most `_LOG_MAX_REMEMBERED_VALUES` entries keeps both guards
-    and dodges hashability (the soc site's value nests a tuple).
+    `seen` is a bounded LIST of `(value, stamp, was_emitted)` scanned linearly with
+    `_is_unchanged` — deliberately NOT a `dict[value, ...]`, because the deadband
+    comparison is not an equality relation and cannot be a hash key, and the soc
+    site's value nests a tuple (unhashable). A linear scan over at most
+    `_LOG_MAX_REMEMBERED_VALUES` entries dodges hashability entirely and keeps the
+    NaN guard in `_element_unchanged` reachable.
+
+    `was_emitted` is load-bearing (review #04 / B4). Values are recorded whether or
+    not they were shown — recording only on emit would turn `dropped` from a count
+    of distinct values into a count of CALLS — but a value the budget dropped must
+    not carry an emission-grade TTL, or it stays suppressed after the window rolls
+    and is never counted again either. The flag separates "shown, hold it for the
+    TTL" from "seen but dropped, show it as soon as budget allows".
+
+    `suppressed` counts dedup hits (review #04 / B7). Without it a 2-hour ping-pong
+    at the 7 s cycle is byte-identical in the log to a home whose winner genuinely
+    alternates every 7.5 minutes — and the original #342 diagnosis rested entirely
+    on the volume being visibly absurd.
     """
 
-    seen: list[tuple[object, datetime]]
+    seen: list[tuple[object, datetime, bool]]
     window_start: datetime
     emitted: int = 0
     dropped: int = 0
+    suppressed: int = 0
 
 
 class LogOnChangeMixin:
@@ -723,6 +745,20 @@ class LogOnChangeMixin:
         and disclosed as a single overflow line when the window rolls. Per key the
         bound is therefore `budget + 1` lines per window, INDEPENDENT of the data.
 
+        The disclosure also carries the number of dedup-suppressed REPEATS (review
+        #04 / B7), which is the only remaining signal of the incident's defining
+        symptom: a key pinned at the cycle rate and one changing every few minutes
+        otherwise produce identical logs, and #342 was diagnosed from the volume.
+
+        KNOWN RESIDUAL (review #04 / B5): the disclosure is flushed by the next call
+        on the same key, so if a key goes quiet for good — charger unplugged, device
+        disabled, car removed, HA restart — the final window's counts are lost. This
+        is reachable on the incident path itself (`get_best_car` stops being called
+        the instant the charger unplugs). It is accepted rather than fixed: a flush
+        hook would put logging concerns back into charger lifecycle control flow,
+        and cross-session banking is what rounds #01-#03 proved unworkable. So the
+        guarantee is "disclosed on the next call for that key", NOT "never silent".
+
         `time` may be naive: it is normalised to UTC rather than branched on, so
         alternating naive/aware callers can no longer defeat the bound (the old
         non-comparable-clock branch emitted unconditionally). `|elapsed|` is used so
@@ -747,35 +783,57 @@ class LogOnChangeMixin:
             st = state[key] = _LogOnChangeRecord([], time)
 
         if abs((time - st.window_start).total_seconds()) >= _RELOG_UNCHANGED_AFTER_S:
-            if st.dropped:
-                # Concatenated OUTSIDE the logging call (ruff G003) and only ever with
-                # static format text: the values stay lazy %-args.
-                disclosure = msg + " [+%s further change(s) not shown in the last %ss]"
-                _LOGGER.info(disclosure, *args, st.dropped, int(_RELOG_UNCHANGED_AFTER_S))
+            if st.dropped or st.suppressed:
+                # STATIC text, keyed by `key`, with none of the caller's `*args`
+                # (review #04 / B6). Stapling this onto the current call's message
+                # attributed the count to a value that had nothing to do with the
+                # dropped ones, and the same line was then logged again immediately.
+                _LOGGER.info(
+                    "log throttle [%s]: %s distinct change(s) not shown, %s repeat(s) suppressed in the last %ss",
+                    key,
+                    st.dropped,
+                    st.suppressed,
+                    int(_RELOG_UNCHANGED_AFTER_S),
+                )
             st.window_start = time
             st.emitted = 0
             st.dropped = 0
+            st.suppressed = 0
 
         hit = next(
-            (index for index, (seen_value, _t) in enumerate(st.seen) if _is_unchanged(seen_value, value, deadband)),
+            (index for index, (seen_value, _t, _e) in enumerate(st.seen) if _is_unchanged(seen_value, value, deadband)),
             None,
         )
-        if hit is not None and abs((time - st.seen[hit][1]).total_seconds()) < _RELOG_UNCHANGED_AFTER_S:
-            # Still remembered: suppress WITHOUT restamping, so the TTL bounds the gap
-            # between emissions of one value rather than being pushed forward forever
-            # by a value that never changes (that is the 900 s heartbeat).
-            return
-
         if hit is not None:
-            st.seen[hit] = (value, time)
+            _seen_value, seen_time, was_emitted = st.seen[hit]
+            if was_emitted and abs((time - seen_time).total_seconds()) < _RELOG_UNCHANGED_AFTER_S:
+                # Still remembered: suppress WITHOUT restamping, so the TTL bounds the
+                # gap between emissions of one value rather than being pushed forward
+                # forever by a value that never changes (the 900 s heartbeat).
+                st.suppressed += 1
+                return
+            if not was_emitted and st.emitted >= budget:
+                # Already counted once this window as a dropped DISTINCT value.
+                # Counting it again per call is what would turn `dropped` into a call
+                # counter (review #04 / B4).
+                st.suppressed += 1
+                return
+
+        will_emit = st.emitted < budget
+        entry = (value, time, will_emit)
+        if hit is not None:
+            st.seen[hit] = entry
         else:
-            st.seen.append((value, time))
+            st.seen.append(entry)
             if len(st.seen) > max_values:
+                # Insertion-ordered, NOT recency-ordered (review #04 / C5): a refreshed
+                # entry is rewritten in place, so this can evict a value seen more
+                # recently than the one it keeps. Harmless — `max_values` exceeds the
+                # budget, so the budget always binds first and eviction can never
+                # re-inflate volume — but it is not an LRU and should not be called one.
                 del st.seen[0]
 
-        # Recorded above whether or not we emit, so an overflowing key counts once per
-        # DISTINCT value rather than once per call.
-        if st.emitted >= budget:
+        if not will_emit:
             st.dropped += 1
             return
 
@@ -986,6 +1044,10 @@ class QSChargerGroup(LogOnChangeMixin):
                     grid_available_home_power,
                     battery_asked_charge,
                     deadband=_POWER_LOG_DEADBAND_W,
+                    # Telemetry, not churn (review #04 / B13): a home crossing between
+                    # import and export is a real operational event, and the default
+                    # budget was dropping them. See _LOG_TELEMETRY_VALUES_PER_WINDOW.
+                    budget=_LOG_TELEMETRY_VALUES_PER_WINDOW,
                     # Single-`prev` semantics: with a deadband, a value SET would
                     # suppress transitive drift (0 -> 99 -> 198, each step inside the
                     # deadband of some remembered neighbour) forever.
@@ -2881,7 +2943,14 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         self._boot_last_completed_constraint = None
 
     def reset(self, keep_commands=False):
-        _LOGGER.info("Charger reset %s", self.name)
+        # DEBUG, not INFO (review #04): `reset()` is idempotent and is called on every
+        # cycle in the "no car connected" state, so an unconditional INFO here was
+        # ~74 000 lines/day from one charger. The single INFO marker for "a reset
+        # actually destroyed something" is `Constraint Reset device` in
+        # `constraint_reset_and_reset_commands_if_needed`, which is gated on
+        # `_has_state_to_reset` — a predicate that only ever picks a LOG LEVEL, so a
+        # wrong answer costs a log line rather than charger state.
+        _LOGGER.debug("Charger reset %s", self.name)
         super().reset(keep_commands=keep_commands)
         self.detach_car()
         self._reset_state_machine()
@@ -2891,7 +2960,7 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         self.possible_charge_error_start_time = None
 
     def _reset_state_machine(self):
-        _LOGGER.info("_reset_state_machine: %s", self.name)
+        _LOGGER.debug("_reset_state_machine: %s", self.name)
         self._verified_correct_state_time = None
         self._inner_expected_charge_state = None
         self._inner_amperage = None
@@ -3198,7 +3267,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                                 # Stays at ERROR and stays unthrottled: it CLEARS the
                                 # conflicting flag, so it self-heals and cannot repeat.
                                 _LOGGER.error(
-                                    f"get_best_car: {car.name} manually attached to multiple chargers: {self.name} and {charger.name}, detaching from {charger.name}"
+                                    "get_best_car: %s manually attached to multiple chargers: %s and %s, detaching from %s",
+                                    car.name,
+                                    self.name,
+                                    charger.name,
+                                    charger.name,
                                 )
                                 charger.clear_user_originated(USER_ORIGINATED_CAR_NAME)
                             else:
@@ -3237,8 +3310,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         # chargers must pass `is_plugged(for_duration=CHARGER_CHECK_STATE_WINDOW_S)`,
         # so for ≤ that window after a second charger plugs in, different callers
         # can see different charger sets — self-healing once the window elapses.
-        # `str(...)`: D12 — a non-comparable `name` would raise TypeError here, and a
-        # sort key must never be able to break the allocation.
+        # `str(...)`: D12, defensive only. It does NOT make the allocation immune to a
+        # non-comparable `name` (review #04 / B10 corrected the original claim): the
+        # `ranked` tuples further down still carry raw `charger.name` / `car.name`, so
+        # such a name would raise TypeError inside `min(ranked, …)` regardless. Both
+        # are unreachable while `name: str` holds; this one is simply free.
         active_chargers.sort(key=lambda c: str(c.name))
 
         cache = {}
@@ -3256,7 +3332,8 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                     # D5: DEBUG, not INFO. This reports a STATIC user setting from
                     # inside a charger x car double loop that itself runs once per
                     # charger per cycle — N^2*M lines/cycle (measured ~62k/day). An
-                    # INFO anchor for the setting belongs in its setter, not here.
+                    # An INFO anchor for the setting would belong in its setter; none
+                    # has been added, so the setting is currently only visible at DEBUG.
                     _LOGGER.debug("get_best_car: FORCE_CAR_NO_CHARGER_CONNECTED car: %s", car.name)
                     continue
 
@@ -3395,6 +3472,9 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                 # the best is not as good as the boot one ... we will use the boot one for now, whatever the score
                 best_car = self._boot_car
                 reason = "boot_over_computed"
+                # The score reported alongside this reason belongs to the DISCARDED
+                # computed car, not to the boot car that actually won — the boot car
+                # was never scored on this charger, so there is no score to report.
             else:
                 reason = "computed"
 
@@ -3567,49 +3647,6 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             self.car.do_force_next_charge = False
             self.car.do_next_charge_time = None
 
-    def _reset_would_change_state(self, keep_commands: bool = True) -> bool:
-        """Return True when `reset(keep_commands)` would destroy any state.
-
-        QS-342 review #03 / D6. `reset()` is otherwise a per-cycle no-op that still
-        emits six INFO lines, which measured ~74 000 lines/day from a single charger
-        — four times the original incident — while the user has "no car connected"
-        selected. Gating on this predicate makes that state idempotent.
-
-        This must enumerate EVERYTHING the reset chain clears, or the gate would skip
-        real work: `_has_state_to_reset` covers the constraint/command half (including
-        the charger override's user-initiated flags), and the rest mirrors
-        `QSChargerGeneric.reset` field by field — `detach_car`, `_reset_state_machine`,
-        `reset_boot_data`, the two reboot/priority flags, `reset_daily_load_datas` and
-        `_dampen_start_transition`. A new field cleared by `reset()` must be added here.
-        """
-        return (
-            self._has_state_to_reset(keep_commands)
-            # detach_car
-            or self.car is not None
-            or bool(self._power_steps)
-            or self.car_attach_time is not None
-            # _reset_state_machine
-            or self._verified_correct_state_time is not None
-            or self._inner_expected_charge_state is not None
-            or self._inner_amperage is not None
-            or self._inner_num_active_phases is not None
-            or self._last_amp_change_time is not None
-            # QSChargerGeneric.reset's own flags
-            or self._asked_for_reboot_at_time is not None
-            or bool(self.qs_bump_solar_priority)
-            or self.possible_charge_error_start_time is not None
-            # reset_boot_data
-            or self._boot_time is not None
-            or self._boot_car is not None
-            or self._boot_time_adjusted is not None
-            or bool(self._boot_constraints)
-            or self._boot_last_completed_constraint is not None
-            # AbstractDevice.reset
-            or bool(self.num_on_off)
-            or self.last_state_change_time is not None
-            or self._dampen_start_transition is not None
-        )
-
     async def check_load_activity_and_constraints(self, time: datetime) -> bool:
         # check that we have a connected car, and which one, or that it is completely disconnected
         #  if there is no more car ... just reset
@@ -3701,15 +3738,22 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
 
             # user forced a "deconnection"
             if best_car is None:
-                # D6: the reset here runs EVERY cycle while "no car connected" is
-                # selected, and each run emits six INFO lines. Skip it once there is
-                # nothing left to reset — the state is then genuinely unchanged, so
-                # this only ever skips work that is already a no-op.
-                if self._reset_would_change_state(keep_commands=True):
-                    _LOGGER.info(
-                        "check_load_activity_and_constraints: plugged car with CHARGER_NO_CAR_CONNECTED selected option"
-                    )
-                    self.reset(keep_commands=True)
+                # UNCONDITIONAL, exactly as before QS-342 review #03 / D6. That round
+                # gated this on a predicate enumerating every field `reset()` clears;
+                # review #04 / B2 then found the enumeration already incomplete. Any
+                # such mirror silently rots the moment `reset()` learns a new field,
+                # and the failure mode is stale charger state — so the gate is gone.
+                # `reset()` is idempotent, so running it every cycle is free; the
+                # ~74 000 lines/day it used to produce were a LOGGING defect, and are
+                # fixed where they belong: the reset chain's own lines are DEBUG
+                # unless the reset did real work, and the line below is throttled.
+                self.log_info_on_change(
+                    "no_car_connected",
+                    self.car is not None,
+                    time,
+                    "check_load_activity_and_constraints: plugged car with CHARGER_NO_CAR_CONNECTED selected option",
+                )
+                self.reset(keep_commands=True)
                 return True
 
             elif self.car:
@@ -5342,9 +5386,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
 
         # The key includes `is_target_percent`: the percent and energy callbacks are two
         # delegating entry points, and one shared key would let them thrash. It also
-        # includes the car name as defence in depth — `detach_car()` clears the memo,
-        # but a future path could swap a car without routing through it. The literal
-        # `%` must be `%%` or `record.getMessage()` raises ValueError.
+        # includes the car name because that is what makes the key safe across a car
+        # swap: `detach_car()` no longer clears the log state at all (see the D2
+        # rationale block on `detach_car`), so key qualification is the ONLY guarantee
+        # that a key cannot name a stale car — not defence in depth.
+        # The literal `%` must be `%%` or `record.getMessage()` raises ValueError.
         # The memo covers everything the message PRINTS, so no printed field can go
         # stale for up to 900 s — including `power_consign`, which `LoadCommand.__eq__`
         # compares but the command NAME alone hides. The continuous values are
@@ -5374,6 +5420,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             result_calculus,
             is_car_charged,
             self.current_command,
+            # Telemetry, not churn (review #04 / B12): the Wh/% figures in the value
+            # advance every cycle during a perfectly normal charge, so the default
+            # budget put this key in PERMANENT overflow whenever a car was charging.
+            budget=_LOG_TELEMETRY_VALUES_PER_WINDOW,
+            max_values=_LOG_MAX_REMEMBERED_TELEMETRY_VALUES,
         )
 
         return (result, do_continue_constraint)

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -227,6 +227,13 @@ CHARGER_START_STOP_RETRY_S = 90
 # sourced from SOLVER_STEP_S despite the numeric coincidence.
 _RELOG_UNCHANGED_AFTER_S = 900  # max gap between two emissions for one key
 _POWER_LOG_DEADBAND_W = 100.0  # ignore sub-100W jitter on the available-power line
+# QS-342 (review fix #01): rate limit for CHANGED-value re-emissions of a key —
+# distinct from the 900 s unchanged-value heartbeat above. A value oscillating on
+# every ~7 s allocation cycle (e.g. a car GPS-jittering across a 0.5 m distance
+# bucket edge) must not track the cycle rate: with this floor a key emits at most
+# ~1 changed line per minute, while a genuine change after a quiet period still
+# logs immediately (the last emission is then typically older than the floor).
+_CHANGED_RELOG_MIN_INTERVAL_S = 60
 
 
 class QSChargerStates(StrEnum):
@@ -660,6 +667,7 @@ class LogOnChangeMixin:
         msg: str,
         *args: object,
         deadband: float | None = None,
+        min_interval_s: float | None = None,
     ) -> None:
         """Log `msg` at INFO if `value` changed for `key`, or if 900 s elapsed.
 
@@ -667,6 +675,13 @@ class LogOnChangeMixin:
         receives. `|elapsed|` is used so a backwards clock jump cannot silence a
         key. The timer is re-stamped on every emission, so the constant bounds the
         gap between emissions rather than imposing a fixed cadence.
+
+        `min_interval_s` (QS-342) additionally rate-limits CHANGED-value
+        emissions: after an emission for `key`, a different value is suppressed
+        until the floor elapses. The memo is deliberately NOT updated on
+        suppression, so the next post-floor call still compares against the last
+        *emitted* value — a value flapping between two states cannot silence
+        itself by landing back on the previous one at floor expiry.
         """
         state = self._log_on_change_state
         if state is None:
@@ -678,12 +693,13 @@ class LogOnChangeMixin:
             # the subtraction. A logging helper must never be load-bearing, so bail to
             # logging instead of propagating out of the caller's control cycle.
             comparable = (prev_time.tzinfo is None) == (time.tzinfo is None)
-            if (
-                comparable
-                and abs((time - prev_time).total_seconds()) < _RELOG_UNCHANGED_AFTER_S
-                and _is_unchanged(prev_value, value, deadband)
-            ):
-                return
+            if comparable:
+                elapsed = abs((time - prev_time).total_seconds())
+                unchanged = _is_unchanged(prev_value, value, deadband)
+                if unchanged and elapsed < _RELOG_UNCHANGED_AFTER_S:
+                    return
+                if not unchanged and min_interval_s is not None and elapsed < min_interval_s:
+                    return
         state[key] = (value, time)
         _LOGGER.info(msg, *args)
 
@@ -3009,9 +3025,12 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             # incident diagnosable only via a recorder-DB forensic session, so it is
             # a DELIBERATE INFO exception to the "debug for non-user-facing" rule.
             # Change key = the quantised tuple ONLY: raw distance and the attach
-            # delta are payload, so GPS jitter inside a 0.5 m bucket emits nothing;
-            # the 900 s heartbeat bounds steady-state volume to ~1 line per
-            # (charger, car) per window.
+            # delta are payload, so GPS jitter inside a 0.5 m bucket emits nothing.
+            # Volume bound (review fix #01): changed values are rate-limited to
+            # ~1 line per key per _CHANGED_RELOG_MIN_INTERVAL_S (a tuple flapping
+            # across a quantisation edge every cycle cannot track the cycle rate),
+            # and unchanged values re-emit on the 900 s heartbeat — so a key emits
+            # at most ~1 line per minute worst-case, ~1 per 900 s steady-state.
             self.log_info_on_change(
                 f"get_car_score:{car.name}",
                 (score_plug_bump, score_plug_time_bump, score_dist_bump),
@@ -3025,6 +3044,7 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                 score_plug_bump,
                 score_plug_time_bump,
                 connected_time_delta,
+                min_interval_s=_CHANGED_RELOG_MIN_INTERVAL_S,
             )
 
         if score is None:
@@ -3092,6 +3112,10 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         # QS-342: deterministic charger order. Defensive only — the tie-break
         # cascade below scans ALL tied pairs so it is already caller-independent;
         # sorting just removes the historical `[self, others…]` positional bias.
+        # Known bounded transient: `self` joins unconditionally while OTHER
+        # chargers must pass `is_plugged(for_duration=CHARGER_CHECK_STATE_WINDOW_S)`,
+        # so for ≤ that window after a second charger plugs in, different callers
+        # can see different charger sets — self-healing once the window elapses.
         active_chargers.sort(key=lambda c: c.name)
 
         cache = {}
@@ -3153,6 +3177,10 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                     continue
 
                 for score, car in chargers_scores[charger]:
+                    # Exact float `==` tie detection is safe: every score component
+                    # is integer-valued by construction (quantised bumps), so tied
+                    # pairs carry the identical float. A future fractional component
+                    # would silently kill the tie-break — keep the bumps quantised.
                     if score != best_cur_score:
                         continue
 
@@ -3181,6 +3209,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                     # HA config-entry titles).
                     ranked.append(((-regret, -sticky, charger.name, car.name), charger, car))
 
+            # `ranked` is never empty here: `best_cur_score` was found by scanning
+            # exactly the same (unassigned charger × score list) pair set the tied-
+            # pair scan iterates. Assert the coupling rather than adding a dead
+            # `if not ranked: break` branch the 100% coverage gate could never see.
+            assert ranked, "QS-342: tied-pair scan found no pair at the max score"
             _, best_cur_charger, best_cur_car = min(ranked, key=lambda item: item[0])
 
             assigned_chargers[best_cur_charger] = best_cur_car
@@ -4154,7 +4187,14 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         # them would suppress the first line of the NEXT charge session whenever the
         # new car reports the same value inside the 900 s window — and the last
         # emitted record would name the wrong car.
-        self._log_on_change_state = None
+        # QS-342 (review fix #01): EXCEPT the `get_car_score:{car}` keys — those are
+        # car-qualified and describe every candidate car on this charger, not the
+        # departed session; wiping them would re-emit one decomposition line per car
+        # after every detach, defeating the on-change suppression under churn.
+        # Collapse to None when nothing survives (the QS-306 fresh-session shape).
+        if self._log_on_change_state is not None:
+            kept = {k: v for k, v in self._log_on_change_state.items() if k.startswith("get_car_score:")}
+            self._log_on_change_state = kept or None
 
     # update in place the power steps
     def update_power_steps(self):

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -223,33 +223,19 @@ TIME_OK_BETWEEN_CHANGING_CHARGER_PHASES = 60 * 30
 CHARGER_START_STOP_RETRY_S = 90
 
 
-# QS-306 log-tuning values. Module-private: they are not operator configuration,
-# so they stay here rather than in const.py, and they are deliberately NOT
-# sourced from SOLVER_STEP_S despite the numeric coincidence.
-# Doubles as the per-VALUE dedup TTL and the length of the per-key budget window
-# (QS-342 review #03 / D1): a value is suppressed while it is still remembered, and
-# a key may emit at most `_LOG_VALUES_PER_WINDOW` lines per window.
+# Log-tuning values. Module-private: not operator configuration, and deliberately
+# NOT sourced from SOLVER_STEP_S despite the numeric coincidence.
+# Per-value dedup TTL, and the length of the per-key budget window.
 _RELOG_UNCHANGED_AFTER_S = 900
 _POWER_LOG_DEADBAND_W = 100.0  # ignore sub-100W jitter on the available-power line
-# QS-342 (review fix #03): per-key emission budget per window. Dedup-by-value alone
-# kills oscillation perfectly and DRIFT not at all — a monotonically drifting value
-# (GPS creeping 0.55 m per cycle) is a new value every cycle, so it satisfies "not the
-# same stuff over and over" literally while leaving volume unbounded. The budget is
-# what makes the bound provable and DATA-INDEPENDENT: <= budget + 1 lines per key per
-# window, whatever the value pattern. Overflow is disclosed as a count on the next
-# call for that key.
+# Per-key emissions per window. Dedup alone bounds oscillation but not drift (a value
+# creeping one quantum per cycle is a new value every cycle), so the budget is what
+# makes the bound data-independent: <= budget + 1 lines per key per window.
 _LOG_VALUES_PER_WINDOW = 4
-# QS-342 (review fix #04 / B12+B13): a LARGER budget for the two genuine-telemetry
-# sites — `dyn_handle`'s available-power line and the SoC callback. The default
-# assumes "many distinct values per window == churn, and the churn is itself the
-# signal", which is true for allocation keys but FALSE here: these values advance
-# monotonically during perfectly normal operation (a charging battery's Wh/%, a
-# home's import/export crossing zero), so the default budget put them in permanent
-# overflow and dropped real operational events. 12 per 900 s is one line per 75 s
-# worst case — still bounded, and enough to keep a genuine transition visible.
+# Telemetry sites (available power, SoC) advance monotonically in normal operation,
+# so the default budget would keep them permanently in overflow.
 _LOG_TELEMETRY_VALUES_PER_WINDOW = 12
-# Strictly greater than the budget, so the BUDGET binds first and eviction never
-# silently re-inflates volume by forgetting a value that is still being repeated.
+# Strictly greater than the budget, so the budget binds first.
 _LOG_MAX_REMEMBERED_VALUES = 8
 _LOG_MAX_REMEMBERED_TELEMETRY_VALUES = _LOG_TELEMETRY_VALUES_PER_WINDOW * 2
 
@@ -664,26 +650,15 @@ def _is_unchanged(prev: object, current: object, deadband: float | None) -> bool
 
 @dataclass
 class _LogOnChangeRecord:
-    """Recently-OBSERVED values for one key, plus this window's accounting.
+    """Recently-observed values for one key, plus this window's accounting.
 
-    `seen` is a bounded LIST of `(value, stamp, was_emitted)` scanned linearly with
-    `_is_unchanged` — deliberately NOT a `dict[value, ...]`, because the deadband
-    comparison is not an equality relation and cannot be a hash key, and the soc
-    site's value nests a tuple (unhashable). A linear scan over at most
-    `_LOG_MAX_REMEMBERED_VALUES` entries dodges hashability entirely and keeps the
-    NaN guard in `_element_unchanged` reachable.
+    `seen` is a bounded list scanned linearly with `_is_unchanged` rather than a
+    dict: the deadband comparison is not an equality relation and cannot be a hash
+    key, and the soc site's value nests a tuple.
 
-    `was_emitted` is load-bearing (review #04 / B4). Values are recorded whether or
-    not they were shown — recording only on emit would turn `dropped` from a count
-    of distinct values into a count of CALLS — but a value the budget dropped must
-    not carry an emission-grade TTL, or it stays suppressed after the window rolls
-    and is never counted again either. The flag separates "shown, hold it for the
-    TTL" from "seen but dropped, show it as soon as budget allows".
-
-    `suppressed` counts dedup hits (review #04 / B7). Without it a 2-hour ping-pong
-    at the 7 s cycle is byte-identical in the log to a home whose winner genuinely
-    alternates every 7.5 minutes — and the original #342 diagnosis rested entirely
-    on the volume being visibly absurd.
+    `was_emitted` distinguishes "shown, hold it for the TTL" from "seen but dropped,
+    show it as soon as budget allows". Values are recorded either way, so `dropped`
+    counts distinct values rather than calls.
     """
 
     seen: list[tuple[object, datetime, bool]]
@@ -695,10 +670,6 @@ class _LogOnChangeRecord:
 
 class LogOnChangeMixin:
     """Emit INFO once per distinct value per window, within a per-key budget.
-
-    QS-306 introduced this as "log only on change"; QS-342 review #03 generalised it
-    to de-duplication by VALUE plus a per-key emission budget — see
-    `log_info_on_change` for the mechanism and the bound it guarantees.
 
     NOTE: this deliberately closes over THIS module's `_LOGGER`, so every host emits
     on the `ha_model.charger` logger. Both current hosts live here, and the tests pin
@@ -725,53 +696,24 @@ class LogOnChangeMixin:
     ) -> None:
         """Log `msg` at INFO the first time `value` is seen for `key` in a window.
 
-        QS-342 review #03 replaced a *time floor on changed values* with
-        de-duplication *by value* plus a per-key emission budget. The incident was
-        never "changes happened too fast" — it was the SAME value repeated 17 791
-        times — and a time floor is structurally unable to satisfy completeness:
-        any state whose whole lifetime fits inside the window is unobservable.
+        Per key: remember observed values, emit each distinct one once, suppress it
+        while still remembered (`_RELOG_UNCHANGED_AFTER_S`, which doubles as the TTL),
+        and cap emissions at `budget` per window. Overflow and dedup-suppressed
+        repeats are reported by one static disclosure line when the window rolls, so
+        a key pinned at the cycle rate stays distinguishable from a calm one.
 
-        The rule: remember the recently-emitted values for a key; emit a value the
-        first time it is seen and suppress it while it is still remembered
-        (`_RELOG_UNCHANGED_AFTER_S`, which doubles as the per-value TTL). An
-        A->B->A oscillation therefore emits A once and B once per window and then
-        goes quiet — volume becomes O(distinct states per window) rather than
-        O(transitions), and nothing is banked, stranded or misattributed.
+        `time` may be naive; it is normalised to UTC. `|elapsed|` is used so a
+        backwards clock jump cannot silence a key.
 
-        Dedup alone is not enough: it is exactly complementary to a time floor,
-        killing oscillation perfectly and DRIFT not at all (a value creeping by one
-        quantum per cycle is a new value every cycle). So each key also gets a
-        budget of `budget` emissions per window; further distinct values are counted
-        and disclosed as a single overflow line when the window rolls. Per key the
-        bound is therefore `budget + 1` lines per window, INDEPENDENT of the data.
+        `max_values=1` restores single-`prev` semantics, which the deadband site
+        needs: with a value set, transitive drift (0 -> 99 -> 198, each step inside
+        the deadband of a remembered neighbour) would be suppressed forever.
 
-        The disclosure also carries the number of dedup-suppressed REPEATS (review
-        #04 / B7), which is the only remaining signal of the incident's defining
-        symptom: a key pinned at the cycle rate and one changing every few minutes
-        otherwise produce identical logs, and #342 was diagnosed from the volume.
-
-        KNOWN RESIDUAL (review #04 / B5): the disclosure is flushed by the next call
-        on the same key, so if a key goes quiet for good — charger unplugged, device
-        disabled, car removed, HA restart — the final window's counts are lost. This
-        is reachable on the incident path itself (`get_best_car` stops being called
-        the instant the charger unplugs). It is accepted rather than fixed: a flush
-        hook would put logging concerns back into charger lifecycle control flow,
-        and cross-session banking is what rounds #01-#03 proved unworkable. So the
-        guarantee is "disclosed on the next call for that key", NOT "never silent".
-
-        `time` may be naive: it is normalised to UTC rather than branched on, so
-        alternating naive/aware callers can no longer defeat the bound (the old
-        non-comparable-clock branch emitted unconditionally). `|elapsed|` is used so
-        a backwards clock jump cannot silence a key.
-
-        `max_values=1` restores single-`prev` semantics, which is what the deadband
-        site needs: with a value *set*, transitive drift (0 -> 99 -> 198, each step
-        inside the deadband of a remembered neighbour) would be suppressed forever.
+        The disclosure is flushed by the next call on the same key, so a key that
+        goes quiet for good loses its final window's counts.
         """
-        # Normalise BEFORE any arithmetic: mixing naive and aware datetimes under one
-        # key would raise TypeError on the subtraction, and a logging helper must
-        # never be load-bearing. Branching on it instead (the old behaviour) let an
-        # alternating-clock caller escape the bound entirely.
+        # Before any arithmetic: mixing naive and aware datetimes would raise, and a
+        # logging helper must never be load-bearing.
         if time.tzinfo is None:
             time = time.replace(tzinfo=pytz.UTC)
 
@@ -784,10 +726,8 @@ class LogOnChangeMixin:
 
         if abs((time - st.window_start).total_seconds()) >= _RELOG_UNCHANGED_AFTER_S:
             if st.dropped or st.suppressed:
-                # STATIC text, keyed by `key`, with none of the caller's `*args`
-                # (review #04 / B6). Stapling this onto the current call's message
-                # attributed the count to a value that had nothing to do with the
-                # dropped ones, and the same line was then logged again immediately.
+                # Static text keyed by `key`: the caller's `*args` describe the
+                # current value, not the dropped ones.
                 _LOGGER.info(
                     "log throttle [%s]: %s distinct change(s) not shown, %s repeat(s) suppressed in the last %ss",
                     key,
@@ -807,15 +747,13 @@ class LogOnChangeMixin:
         if hit is not None:
             _seen_value, seen_time, was_emitted = st.seen[hit]
             if was_emitted and abs((time - seen_time).total_seconds()) < _RELOG_UNCHANGED_AFTER_S:
-                # Still remembered: suppress WITHOUT restamping, so the TTL bounds the
-                # gap between emissions of one value rather than being pushed forward
-                # forever by a value that never changes (the 900 s heartbeat).
+                # Suppress WITHOUT restamping, so the TTL bounds the gap between
+                # emissions rather than being pushed forward by an unchanging value.
                 st.suppressed += 1
                 return
             if not was_emitted and st.emitted >= budget:
-                # Already counted once this window as a dropped DISTINCT value.
-                # Counting it again per call is what would turn `dropped` into a call
-                # counter (review #04 / B4).
+                # Already counted this window; counting again would make `dropped` a
+                # call counter.
                 st.suppressed += 1
                 return
 
@@ -826,11 +764,9 @@ class LogOnChangeMixin:
         else:
             st.seen.append(entry)
             if len(st.seen) > max_values:
-                # Insertion-ordered, NOT recency-ordered (review #04 / C5): a refreshed
-                # entry is rewritten in place, so this can evict a value seen more
-                # recently than the one it keeps. Harmless — `max_values` exceeds the
-                # budget, so the budget always binds first and eviction can never
-                # re-inflate volume — but it is not an LRU and should not be called one.
+                # Insertion-ordered, not LRU: a refreshed entry is rewritten in place,
+                # so this can evict a more recently seen value. Harmless because the
+                # budget binds before eviction does.
                 del st.seen[0]
 
         if not will_emit:
@@ -1044,9 +980,7 @@ class QSChargerGroup(LogOnChangeMixin):
                     grid_available_home_power,
                     battery_asked_charge,
                     deadband=_POWER_LOG_DEADBAND_W,
-                    # Telemetry, not churn (review #04 / B13): a home crossing between
-                    # import and export is a real operational event, and the default
-                    # budget was dropping them. See _LOG_TELEMETRY_VALUES_PER_WINDOW.
+                    # Telemetry, not churn: import/export crossings are real events.
                     budget=_LOG_TELEMETRY_VALUES_PER_WINDOW,
                     # Single-`prev` semantics: with a deadband, a value SET would
                     # suppress transitive drift (0 -> 99 -> 198, each step inside the
@@ -2943,13 +2877,8 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         self._boot_last_completed_constraint = None
 
     def reset(self, keep_commands=False):
-        # DEBUG, not INFO (review #04): `reset()` is idempotent and is called on every
-        # cycle in the "no car connected" state, so an unconditional INFO here was
-        # ~74 000 lines/day from one charger. The single INFO marker for "a reset
-        # actually destroyed something" is `Constraint Reset device` in
-        # `constraint_reset_and_reset_commands_if_needed`, which is gated on
-        # `_has_state_to_reset` — a predicate that only ever picks a LOG LEVEL, so a
-        # wrong answer costs a log line rather than charger state.
+        # DEBUG: this runs every cycle in some states. `Constraint Reset device` is
+        # the INFO marker for a reset that actually destroyed something.
         _LOGGER.debug("Charger reset %s", self.name)
         super().reset(keep_commands=keep_commands)
         self.detach_car()
@@ -3173,18 +3102,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                     score_plug_time_bump,
                 )
 
-            # QS-342: the score decomposition is the single data point that made the
-            # incident diagnosable only via a recorder-DB forensic session, so it is
-            # a DELIBERATE INFO exception to the "debug for non-user-facing" rule.
-            # Change key = the quantised tuple ONLY: raw distance and the attach
-            # delta are payload, so GPS jitter inside a 0.5 m bucket emits nothing.
-            # Volume bound (review #03): the helper de-duplicates by VALUE over a
-            # 900 s window and caps each key at `_LOG_VALUES_PER_WINDOW` emissions
-            # plus one overflow-disclosure line. So this key emits ≤ 5 lines per
-            # 900 s REGARDLESS of the value pattern — oscillation across a
-            # quantisation edge, monotone GPS drift, or a value held constant all
-            # behave the same. Keys are per (charger, car), so the aggregate for this
-            # site is ≤ 5·N·M per window.
+            # Deliberate INFO exception to the "debug for non-user-facing" rule: this
+            # decomposition is what makes allocation incidents diagnosable without a
+            # recorder-DB session. Change key = the quantised tuple ONLY, so GPS jitter
+            # inside a 0.5 m bucket emits nothing; raw distance and the attach delta
+            # ride along as payload.
             self.log_info_on_change(
                 f"get_car_score:{car.name}",
                 (score_plug_bump, score_plug_time_bump, score_dist_bump),
@@ -3211,12 +3133,8 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
     def get_best_car(self, time: datetime) -> QSCar | None:
         """Pick this charger's car, announcing the outcome through ONE throttled key.
 
-        QS-342 review #03 / D4: the winner used to be announced from six separate
-        raw `_LOGGER.info` branches, only one of which was throttled — so the volume
-        bound was a property of one call site rather than of the mechanism, and five
-        branches ran at the full cycle rate. The decision itself lives in
-        `_compute_best_car`; this wrapper is the single exit point, so every branch
-        shares one key (`get_best_car`), one line shape, and one budget.
+        The decision lives in `_compute_best_car`; this wrapper is the single exit
+        point, so every branch shares one key, one line shape and one budget.
         """
         best_car, reason, score = self._compute_best_car(time)
         # The change key is `(reason, car_name)` ONLY: the score is a per-cycle float,
@@ -3234,11 +3152,7 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         return best_car
 
     def _compute_best_car(self, time: datetime) -> tuple[QSCar | None, str, float | None]:
-        """Return `(car, reason, score)`; `reason` names the branch that decided.
-
-        Split out of `get_best_car` for D4 only — the allocation semantics below are
-        unchanged and must stay that way (see the story's frozen-cascade note).
-        """
+        """Return `(car, reason, score)`; `reason` names the branch that decided."""
         # find the best car ...
 
         # cleanly handle the case where it has been user forced to a car
@@ -3264,8 +3178,7 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                                 charger.get_user_originated(USER_ORIGINATED_CAR_NAME) is not None
                                 and charger.get_user_originated(USER_ORIGINATED_CAR_NAME) == car.name
                             ):
-                                # Stays at ERROR and stays unthrottled: it CLEARS the
-                                # conflicting flag, so it self-heals and cannot repeat.
+                                # Unthrottled: it clears the flag, so it cannot repeat.
                                 _LOGGER.error(
                                     "get_best_car: %s manually attached to multiple chargers: %s and %s, detaching from %s",
                                     car.name,
@@ -3303,18 +3216,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             if charger.is_plugged(time, for_duration=CHARGER_CHECK_STATE_WINDOW_S):
                 active_chargers.append(charger)
 
-        # QS-342: deterministic charger order. Defensive only — the tie-break
-        # cascade below scans ALL tied pairs so it is already caller-independent;
-        # sorting just removes the historical `[self, others…]` positional bias.
-        # Known bounded transient: `self` joins unconditionally while OTHER
-        # chargers must pass `is_plugged(for_duration=CHARGER_CHECK_STATE_WINDOW_S)`,
-        # so for ≤ that window after a second charger plugs in, different callers
-        # can see different charger sets — self-healing once the window elapses.
-        # `str(...)`: D12, defensive only. It does NOT make the allocation immune to a
-        # non-comparable `name` (review #04 / B10 corrected the original claim): the
-        # `ranked` tuples further down still carry raw `charger.name` / `car.name`, so
-        # such a name would raise TypeError inside `min(ranked, …)` regardless. Both
-        # are unreachable while `name: str` holds; this one is simply free.
+        # Defensive only: the cascade below scans all tied pairs, so it is already
+        # caller-independent. Bounded transient: `self` joins unconditionally while
+        # others must pass `is_plugged(for_duration=...)`, so callers can briefly see
+        # different charger sets. `str(...)` is free insurance; `ranked` below still
+        # carries raw names anyway.
         active_chargers.sort(key=lambda c: str(c.name))
 
         cache = {}
@@ -3329,11 +3235,8 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
 
             for car in self.home._cars:
                 if car.get_user_originated(USER_ORIGINATED_CHARGER_NAME) == FORCE_CAR_NO_CHARGER_CONNECTED:
-                    # D5: DEBUG, not INFO. This reports a STATIC user setting from
-                    # inside a charger x car double loop that itself runs once per
-                    # charger per cycle — N^2*M lines/cycle (measured ~62k/day). An
-                    # An INFO anchor for the setting would belong in its setter; none
-                    # has been added, so the setting is currently only visible at DEBUG.
+                    # DEBUG: a static user setting reported from inside a charger x car
+                    # double loop, i.e. N^2*M lines per cycle at INFO.
                     _LOGGER.debug("get_best_car: FORCE_CAR_NO_CHARGER_CONNECTED car: %s", car.name)
                     continue
 
@@ -3350,20 +3253,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         while True:
             # assign the biggest score of the bunch
 
-            # QS-342: exact score ties are a NORMAL operating case (0.5 m distance
-            # buckets — cars sleeping in their usual spots tie every night). The old
-            # head-of-list strict `>` scan made the calling charger win every tie,
-            # which caused an attach/detach ping-pong between chargers and orphaned
-            # the car whose row was discarded. Deterministic cascade instead:
-            # max score → regret → stickiness → stable (charger name, car name).
-
-            # Every remaining (charger, car) pair of the unassigned chargers — not
-            # just each list's head: a tied car buried behind another tied car in one
-            # charger's list must still be able to win elsewhere. Collected ONCE, so
-            # the max and the tied set are derived from the same list and cannot
-            # drift apart (review #02 / S6: this replaces an `assert` that both
-            # `python -O` would strip and put an AssertionError on the live
-            # allocation path — there is now no invariant left to guard).
+            # Exact score ties are NORMAL (0.5 m distance buckets), so they get a
+            # deterministic cascade: max score -> regret -> stickiness -> stable
+            # (charger name, car name). Every remaining pair, not just each list's
+            # head — a tied car buried behind another must still win elsewhere — and
+            # collected once so the max and the tied set cannot drift apart.
             candidates = [
                 (score, charger, car)
                 for charger in active_chargers
@@ -3380,14 +3274,9 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
 
             ranked = []
             for score, charger, car in candidates:
-                # Exact float `==` tie detection is safe, and it always matches at
-                # least the candidate `max` just returned: every score component is
-                # an exactly-representable dyadic value (the quantised bumps, plus
-                # the 0.5 home-instant-fallback `dist_bump`, which scales to exactly
-                # 50000.0 — so "integer-valued" is NOT the invariant), and both
-                # sides are the identical expression, so tied pairs carry
-                # bit-identical floats. A future non-dyadic component, or a per-pair
-                # re-derivation of the score, would silently kill the tie-break.
+                # Exact float `==` is safe: every score component is dyadic and both
+                # sides are the identical expression, so tied pairs are bit-identical.
+                # A non-dyadic component would silently kill the tie-break.
                 if score != best_cur_score:
                     continue
 
@@ -3402,15 +3291,9 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                     if other is charger or other in assigned_chargers:
                         continue
                     for other_score, other_car in chargers_scores[other]:
-                        # Match by NAME, like the rest of the cascade. This is not an
-                        # oversight and must not be "tidied" to identity (review #04 /
-                        # B1 reverts exactly that): removal after assignment consumes a
-                        # whole NAME from every list, and stickiness compares names, so
-                        # regret must use the same relation or the rules stop describing
-                        # the same set. Car names are NOT enforced unique anywhere, and
-                        # under duplicates an identity scan under-counts alternatives,
-                        # inflates regret for the duplicated name and orphans the other
-                        # charger — the original #342 symptom.
+                        # By NAME, like removal and stickiness below. Do not "tidy"
+                        # this to identity: names are not enforced unique, and under
+                        # duplicates the comparators diverge and orphan a charger.
                         if other_car.name == car.name and other_score > best_alternative:
                             best_alternative = other_score
                 regret = best_cur_score - best_alternative
@@ -3471,10 +3354,9 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             ):
                 # the best is not as good as the boot one ... we will use the boot one for now, whatever the score
                 best_car = self._boot_car
+                # NB: the logged score belongs to the discarded computed car — the boot
+                # car was never scored on this charger.
                 reason = "boot_over_computed"
-                # The score reported alongside this reason belongs to the DISCARDED
-                # computed car, not to the boot car that actually won — the boot car
-                # was never scored on this charger, so there is no score to report.
             else:
                 reason = "computed"
 
@@ -3738,15 +3620,9 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
 
             # user forced a "deconnection"
             if best_car is None:
-                # UNCONDITIONAL, exactly as before QS-342 review #03 / D6. That round
-                # gated this on a predicate enumerating every field `reset()` clears;
-                # review #04 / B2 then found the enumeration already incomplete. Any
-                # such mirror silently rots the moment `reset()` learns a new field,
-                # and the failure mode is stale charger state — so the gate is gone.
-                # `reset()` is idempotent, so running it every cycle is free; the
-                # ~74 000 lines/day it used to produce were a LOGGING defect, and are
-                # fixed where they belong: the reset chain's own lines are DEBUG
-                # unless the reset did real work, and the line below is throttled.
+                # Unconditional: `reset()` is idempotent, so do NOT gate it on a
+                # predicate enumerating what it clears — such a mirror rots and the
+                # failure mode is stale charger state. Volume is handled by logging.
                 self.log_info_on_change(
                     "no_car_connected",
                     self.car is not None,
@@ -4409,28 +4285,13 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         self.car = None
         self._power_steps = []
         self.car_attach_time = None
-        # QS-342 review #03 / D2: there is deliberately NO log-state wipe here.
-        #
-        # The wipe (QS-306, narrowed in review #01) is what made every throttle on
-        # this path a no-op in production: `detach_car()` is on the churn path itself
-        # — every change of the `get_best_car` value routes through it — so the key
-        # was dropped, the next call saw no previous value, and it emitted
-        # unconditionally. Rounds #01-#03 each tuned a throttle that this line then
-        # discarded.
-        #
-        # It is also redundant, which is why deleting it is the minimal fix rather
-        # than a trade-off: no key can ever name a stale car. Every key is either
-        # car-qualified (`get_car_score:{car}`, `update_value_callback_soc:{car}:…`)
-        # or carries the car name as its VALUE (`get_best_car`), so a swapped car
-        # yields a different key or a changed value and emits either way. The
-        # remaining keys live on `QSChargerGroup`, which has no car at all.
-        #
-        # Do NOT reintroduce a "session boundary" wipe here or in `reset()`:
-        # `detach_car()` cannot distinguish churn from a boundary (it is reached from
-        # the unplug edge, the disable setter, the user reset AND from the per-cycle
-        # allocation path), and `reset()` is not a boundary either. The session
-        # anchors already exist: `update_power_steps` emits an INFO per attach and
-        # the unplug WARNING anchors the other end.
+        # NO log-state wipe here, deliberately. `detach_car()` is on the churn path
+        # itself, so wiping dropped the key on every allocation change and made the
+        # throttle a no-op. It is also redundant: every key is car-qualified or carries
+        # the car name as its value, so none can name a stale car. Do not reintroduce a
+        # "session boundary" wipe here or in `reset()` — neither can distinguish churn
+        # from a boundary, and the attach INFO plus the unplug WARNING already anchor
+        # sessions.
 
     # update in place the power steps
     def update_power_steps(self):
@@ -5387,9 +5248,8 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         # The key includes `is_target_percent`: the percent and energy callbacks are two
         # delegating entry points, and one shared key would let them thrash. It also
         # includes the car name because that is what makes the key safe across a car
-        # swap: `detach_car()` no longer clears the log state at all (see the D2
-        # rationale block on `detach_car`), so key qualification is the ONLY guarantee
-        # that a key cannot name a stale car — not defence in depth.
+        # swap: nothing clears the log state on detach, so key qualification is the
+        # only guarantee that a key cannot name a stale car.
         # The literal `%` must be `%%` or `record.getMessage()` raises ValueError.
         # The memo covers everything the message PRINTS, so no printed field can go
         # stale for up to 900 s — including `power_consign`, which `LoadCommand.__eq__`
@@ -5420,9 +5280,7 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             result_calculus,
             is_car_charged,
             self.current_command,
-            # Telemetry, not churn (review #04 / B12): the Wh/% figures in the value
-            # advance every cycle during a perfectly normal charge, so the default
-            # budget put this key in PERMANENT overflow whenever a car was charging.
+            # Telemetry, not churn: the Wh/% figures advance every cycle while charging.
             budget=_LOG_TELEMETRY_VALUES_PER_WINDOW,
             max_values=_LOG_MAX_REMEMBERED_TELEMETRY_VALUES,
         )

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from enum import StrEnum
-from typing import Any, TypeIs
+from typing import Any, NamedTuple, TypeIs
 
 import pytz
 from haversine import Unit, haversine
@@ -644,6 +644,19 @@ def _is_unchanged(prev: object, current: object, deadband: float | None) -> bool
     return all(_element_unchanged(p, c, deadband) for p, c in zip(prev, current, strict=True))
 
 
+class _LogOnChangeRecord(NamedTuple):
+    """Last EMITTED value for a key, plus churn hidden by the rate floor.
+
+    `suppressed_changes` counts value changes dropped by `min_interval_s` since
+    that emission. It exists so an excursion that reverts inside the floor window
+    still gets disclosed (QS-342 review #02 / S1) instead of vanishing.
+    """
+
+    value: object
+    time: datetime
+    suppressed_changes: int = 0
+
+
 class LogOnChangeMixin:
     """Emit INFO only when a reported value changes, or after 900 s (QS-306).
 
@@ -657,7 +670,7 @@ class LogOnChangeMixin:
     # Annotation WITH an immutable default. Never give this a `{}` default: a mutable
     # class attribute is shared across instances, and the per-charger sites use keys
     # that are not instance-qualified, so every charger would silence the others.
-    _log_on_change_state: dict[str, tuple[object, datetime]] | None = None
+    _log_on_change_state: dict[str, _LogOnChangeRecord] | None = None
 
     def log_info_on_change(
         self,
@@ -669,26 +682,38 @@ class LogOnChangeMixin:
         deadband: float | None = None,
         min_interval_s: float | None = None,
     ) -> None:
-        """Log `msg` at INFO if `value` changed for `key`, or if 900 s elapsed.
+        """Log `msg` at INFO if `value` changed for `key`, after 900 s unchanged, or
+        to disclose churn hidden by the optional `min_interval_s` rate floor.
 
         `time` must be timezone-aware UTC — the same value the caller already
         receives. `|elapsed|` is used so a backwards clock jump cannot silence a
         key. The timer is re-stamped on every emission, so the constant bounds the
         gap between emissions rather than imposing a fixed cadence.
 
-        `min_interval_s` (QS-342) additionally rate-limits CHANGED-value
-        emissions: after an emission for `key`, a different value is suppressed
-        until the floor elapses. The memo is deliberately NOT updated on
-        suppression, so the next post-floor call still compares against the last
-        *emitted* value — a value flapping between two states cannot silence
-        itself by landing back on the previous one at floor expiry.
+        `min_interval_s` (QS-342) rate-limits CHANGED-value emissions: within the
+        floor of the last emission nothing is logged, but each dropped change is
+        BANKED on the key, and the first call at/after floor expiry emits — even
+        if the value has meanwhile reverted to the last emitted one — appending
+        the suppressed count. So a genuine change is delayed by at most the floor
+        and an excursion that both starts and ends inside the window is still
+        reported (it would otherwise be lost entirely: the memo holds the last
+        *emitted* value, so a revert looks unchanged). Per key the floor therefore
+        bounds emissions to ~1 per window; the caller owns the aggregate (one key
+        per charger×car at the `get_car_score` site).
+
+        Non-comparable clocks (naive vs aware under one key) cannot yield an
+        `elapsed`, so that path emits unconditionally rather than raising — a
+        logging helper must never be load-bearing. It is self-limiting: the
+        emission re-stamps the key with `time`, so the very next call on the same
+        clock kind is comparable and floored again.
         """
         state = self._log_on_change_state
         if state is None:
             state = self._log_on_change_state = {}
+        suppressed_changes = 0
         prev = state.get(key)
         if prev is not None:
-            prev_value, prev_time = prev
+            prev_value, prev_time, banked_changes = prev
             # Mixing naive and aware datetimes under one key would raise TypeError on
             # the subtraction. A logging helper must never be load-bearing, so bail to
             # logging instead of propagating out of the caller's control cycle.
@@ -696,12 +721,24 @@ class LogOnChangeMixin:
             if comparable:
                 elapsed = abs((time - prev_time).total_seconds())
                 unchanged = _is_unchanged(prev_value, value, deadband)
-                if unchanged and elapsed < _RELOG_UNCHANGED_AFTER_S:
+                if min_interval_s is not None and elapsed < min_interval_s:
+                    # Under the floor nothing is emitted. Bank a changed value so the
+                    # excursion survives a revert; leave value/time untouched so the
+                    # comparison stays against the last EMITTED state.
+                    if not unchanged:
+                        state[key] = _LogOnChangeRecord(prev_value, prev_time, banked_changes + 1)
                     return
-                if not unchanged and min_interval_s is not None and elapsed < min_interval_s:
+                if unchanged and banked_changes == 0 and elapsed < _RELOG_UNCHANGED_AFTER_S:
                     return
-        state[key] = (value, time)
-        _LOGGER.info(msg, *args)
+                suppressed_changes = banked_changes
+        state[key] = _LogOnChangeRecord(value, time)
+        if suppressed_changes:
+            # Concatenated OUTSIDE the logging call (ruff G003) and only ever with
+            # static format text: the values stay lazy %-args.
+            disclosure = msg + " [+%s change(s) suppressed by the rate floor]"
+            _LOGGER.info(disclosure, *args, suppressed_changes)
+        else:
+            _LOGGER.info(msg, *args)
 
 
 class QSChargerGroup(LogOnChangeMixin):
@@ -3026,11 +3063,15 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             # a DELIBERATE INFO exception to the "debug for non-user-facing" rule.
             # Change key = the quantised tuple ONLY: raw distance and the attach
             # delta are payload, so GPS jitter inside a 0.5 m bucket emits nothing.
-            # Volume bound (review fix #01): changed values are rate-limited to
-            # ~1 line per key per _CHANGED_RELOG_MIN_INTERVAL_S (a tuple flapping
-            # across a quantisation edge every cycle cannot track the cycle rate),
-            # and unchanged values re-emit on the 900 s heartbeat — so a key emits
-            # at most ~1 line per minute worst-case, ~1 per 900 s steady-state.
+            # Volume bound (review #01, tightened in #02): changed values are
+            # rate-limited to ~1 line per key per _CHANGED_RELOG_MIN_INTERVAL_S (a
+            # tuple flapping across a quantisation edge every cycle cannot track the
+            # cycle rate; churn hidden by the floor is disclosed as a suppressed
+            # count, so nothing is lost), and unchanged values re-emit on the 900 s
+            # heartbeat. Per key: ≤ ~1 line/min worst case, ~1 per 900 s steady
+            # state. Keys are per (charger, car), so the AGGREGATE worst case is
+            # N chargers × M cars per minute — plus one floored key per charger for
+            # the `get_best_car` winner line below.
             self.log_info_on_change(
                 f"get_car_score:{car.name}",
                 (score_plug_bump, score_plug_time_bump, score_dist_bump),
@@ -3153,67 +3194,65 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             # the car whose row was discarded. Deterministic cascade instead:
             # max score → regret → stickiness → stable (charger name, car name).
 
-            # Find the maximum remaining score over ALL (charger, car) pairs of all
-            # unassigned chargers — not just each list's head: a tied car buried
-            # behind another tied car in one charger's list must still be able to
-            # win elsewhere.
-            best_cur_score = None
-            for charger in active_chargers:
-                if charger in assigned_chargers:
-                    continue
-
+            # Every remaining (charger, car) pair of the unassigned chargers — not
+            # just each list's head: a tied car buried behind another tied car in one
+            # charger's list must still be able to win elsewhere. Collected ONCE, so
+            # the max and the tied set are derived from the same list and cannot
+            # drift apart (review #02 / S6: this replaces an `assert` that both
+            # `python -O` would strip and put an AssertionError on the live
+            # allocation path — there is now no invariant left to guard).
+            candidates = [
+                (score, charger, car)
+                for charger in active_chargers
+                if charger not in assigned_chargers
                 # score > 0 by construction (see the get_car_score loop above)
-                for score, _car in chargers_scores[charger]:
-                    if best_cur_score is None or score > best_cur_score:
-                        best_cur_score = score
+                for score, car in chargers_scores[charger]
+            ]
 
-            if best_cur_score is None:
+            if not candidates:
                 # no more changes to do
                 break
 
+            best_cur_score = max(score for score, _charger, _car in candidates)
+
             ranked = []
-            for charger in active_chargers:
-                if charger in assigned_chargers:
+            for score, charger, car in candidates:
+                # Exact float `==` tie detection is safe, and it always matches at
+                # least the candidate `max` just returned: every score component is
+                # an exactly-representable dyadic value (the quantised bumps, plus
+                # the 0.5 home-instant-fallback `dist_bump`, which scales to exactly
+                # 50000.0 — so "integer-valued" is NOT the invariant), and both
+                # sides are the identical expression, so tied pairs carry
+                # bit-identical floats. A future non-dyadic component, or a per-pair
+                # re-derivation of the score, would silently kill the tie-break.
+                if score != best_cur_score:
                     continue
 
-                for score, car in chargers_scores[charger]:
-                    # Exact float `==` tie detection is safe: every score component
-                    # is integer-valued by construction (quantised bumps), so tied
-                    # pairs carry the identical float. A future fractional component
-                    # would silently kill the tie-break — keep the bumps quantised.
-                    if score != best_cur_score:
+                # Regret: how much this car loses if not assigned here — its tied
+                # score minus its best score on any OTHER unassigned charger (no
+                # other positive-score option → alternative 0, regret = own score).
+                # Chargers already in assigned_chargers MUST be skipped: their
+                # score lists are stale by design (only cars are removed on
+                # assignment, never chargers).
+                best_alternative = 0.0
+                for other in active_chargers:
+                    if other is charger or other in assigned_chargers:
                         continue
+                    for other_score, other_car in chargers_scores[other]:
+                        if other_car.name == car.name and other_score > best_alternative:
+                            best_alternative = other_score
+                regret = best_cur_score - best_alternative
 
-                    # Regret: how much this car loses if not assigned here — its tied
-                    # score minus its best score on any OTHER unassigned charger (no
-                    # other positive-score option → alternative 0, regret = own score).
-                    # Chargers already in assigned_chargers MUST be skipped: their
-                    # score lists are stale by design (only cars are removed on
-                    # assignment, never chargers).
-                    best_alternative = 0.0
-                    for other in active_chargers:
-                        if other is charger or other in assigned_chargers:
-                            continue
-                        for other_score, other_car in chargers_scores[other]:
-                            if other_car.name == car.name and other_score > best_alternative:
-                                best_alternative = other_score
-                    regret = best_cur_score - best_alternative
+                # Stickiness: among equal-regret tied pairs, prefer the charger
+                # this car is currently attached to (keeps symmetric steady
+                # states stable — no swap flapping).
+                sticky = 1 if (charger.car is not None and charger.car.name == car.name) else 0
 
-                    # Stickiness: among equal-regret tied pairs, prefer the charger
-                    # this car is currently attached to (keeps symmetric steady
-                    # states stable — no swap flapping).
-                    sticky = 1 if (charger.car is not None and charger.car.name == car.name) else 0
+                # Stable order: charger name then car name — arbitrary but
+                # identical for every caller (device names are unique de facto:
+                # HA config-entry titles).
+                ranked.append(((-regret, -sticky, charger.name, car.name), charger, car))
 
-                    # Stable order: charger name then car name — arbitrary but
-                    # identical for every caller (device names are unique de facto:
-                    # HA config-entry titles).
-                    ranked.append(((-regret, -sticky, charger.name, car.name), charger, car))
-
-            # `ranked` is never empty here: `best_cur_score` was found by scanning
-            # exactly the same (unassigned charger × score list) pair set the tied-
-            # pair scan iterates. Assert the coupling rather than adding a dead
-            # `if not ranked: break` branch the 100% coverage gate could never see.
-            assert ranked, "QS-342: tied-pair scan found no pair at the max score"
             _, best_cur_charger, best_cur_car = min(ranked, key=lambda item: item[0])
 
             assigned_chargers[best_cur_charger] = best_cur_car
@@ -3262,6 +3301,10 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             else:
                 # Keyed on the car name only: the score is a per-cycle float, so
                 # keying on it would preserve every line.
+                # QS-342 review #02 / S2: floored like the `get_car_score` site. The
+                # residual failure mode this PR documents (a car GPS-jittering across
+                # a 0.5 m bucket edge flips the STRICT-score winner, which no
+                # tie-break sees) drives this key at the full cycle rate otherwise.
                 self.log_info_on_change(
                     "get_best_car",
                     best_car.name,
@@ -3270,6 +3313,7 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                     best_car.name,
                     assigned_chargers_score.get(self),
                     self.name,
+                    min_interval_s=_CHANGED_RELOG_MIN_INTERVAL_S,
                 )
 
         if best_car.charger is not None and best_car.charger != self:
@@ -4192,6 +4236,13 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         # departed session; wiping them would re-emit one decomposition line per car
         # after every detach, defeating the on-change suppression under churn.
         # Collapse to None when nothing survives (the QS-306 fresh-session shape).
+        # Accepted consequence (review #02 / N3): these keys also survive `reset()`,
+        # i.e. the physical-unplug and `qs_enable_device` disable paths. A new
+        # session started within 900 s with the car parked in the same spot gets no
+        # session-start decomposition line — the score is genuinely unchanged, and
+        # re-emitting per detach is what would break the volume bound (a wiped key
+        # has no `prev`, so it escapes the rate floor entirely). The `get_best_car`
+        # winner line, which IS wiped here, remains the per-session anchor.
         if self._log_on_change_state is not None:
             kept = {k: v for k, v in self._log_on_change_state.items() if k.startswith("get_car_score:")}
             self._log_on_change_state = kept or None

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -3005,8 +3005,26 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                     score_plug_time_bump,
                 )
 
-            _LOGGER.debug(
-                f"get_car_score: {car.name} for {self.name} score: {score} dist_bump: {score_dist_bump} dist: {int(dist * 100) / 100.0}m plug_bump: {score_plug_bump} plug_time_bump {score_plug_time_bump} connected {connected_time_delta}"
+            # QS-342: the score decomposition is the single data point that made the
+            # incident diagnosable only via a recorder-DB forensic session, so it is
+            # a DELIBERATE INFO exception to the "debug for non-user-facing" rule.
+            # Change key = the quantised tuple ONLY: raw distance and the attach
+            # delta are payload, so GPS jitter inside a 0.5 m bucket emits nothing;
+            # the 900 s heartbeat bounds steady-state volume to ~1 line per
+            # (charger, car) per window.
+            self.log_info_on_change(
+                f"get_car_score:{car.name}",
+                (score_plug_bump, score_plug_time_bump, score_dist_bump),
+                time,
+                "get_car_score: %s for %s score: %s dist_bump: %s dist: %.2fm plug_bump: %s plug_time_bump: %s connected: %s",
+                car.name,
+                self.name,
+                score,
+                score_dist_bump,
+                dist,
+                score_plug_bump,
+                score_plug_time_bump,
+                connected_time_delta,
             )
 
         if score is None:
@@ -3071,6 +3089,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             if charger.is_plugged(time, for_duration=CHARGER_CHECK_STATE_WINDOW_S):
                 active_chargers.append(charger)
 
+        # QS-342: deterministic charger order. Defensive only — the tie-break
+        # cascade below scans ALL tied pairs so it is already caller-independent;
+        # sorting just removes the historical `[self, others…]` positional bias.
+        active_chargers.sort(key=lambda c: c.name)
+
         cache = {}
 
         chargers_scores = {}
@@ -3099,27 +3122,66 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         while True:
             # assign the biggest score of the bunch
 
-            best_cur_score = None
-            best_cur_charger = None
-            best_cur_car = None
+            # QS-342: exact score ties are a NORMAL operating case (0.5 m distance
+            # buckets — cars sleeping in their usual spots tie every night). The old
+            # head-of-list strict `>` scan made the calling charger win every tie,
+            # which caused an attach/detach ping-pong between chargers and orphaned
+            # the car whose row was discarded. Deterministic cascade instead:
+            # max score → regret → stickiness → stable (charger name, car name).
 
+            # Find the maximum remaining score over ALL (charger, car) pairs of all
+            # unassigned chargers — not just each list's head: a tied car buried
+            # behind another tied car in one charger's list must still be able to
+            # win elsewhere.
+            best_cur_score = None
             for charger in active_chargers:
                 if charger in assigned_chargers:
                     continue
 
-                if len(chargers_scores[charger]) == 0:
-                    continue
-
-                score, car = chargers_scores[charger][0]
                 # score > 0 by construction (see the get_car_score loop above)
-                if best_cur_score is None or score > best_cur_score:
-                    best_cur_score = score
-                    best_cur_car = car
-                    best_cur_charger = charger
+                for score, _car in chargers_scores[charger]:
+                    if best_cur_score is None or score > best_cur_score:
+                        best_cur_score = score
 
-            if best_cur_car is None:
+            if best_cur_score is None:
                 # no more changes to do
                 break
+
+            ranked = []
+            for charger in active_chargers:
+                if charger in assigned_chargers:
+                    continue
+
+                for score, car in chargers_scores[charger]:
+                    if score != best_cur_score:
+                        continue
+
+                    # Regret: how much this car loses if not assigned here — its tied
+                    # score minus its best score on any OTHER unassigned charger (no
+                    # other positive-score option → alternative 0, regret = own score).
+                    # Chargers already in assigned_chargers MUST be skipped: their
+                    # score lists are stale by design (only cars are removed on
+                    # assignment, never chargers).
+                    best_alternative = 0.0
+                    for other in active_chargers:
+                        if other is charger or other in assigned_chargers:
+                            continue
+                        for other_score, other_car in chargers_scores[other]:
+                            if other_car.name == car.name and other_score > best_alternative:
+                                best_alternative = other_score
+                    regret = best_cur_score - best_alternative
+
+                    # Stickiness: among equal-regret tied pairs, prefer the charger
+                    # this car is currently attached to (keeps symmetric steady
+                    # states stable — no swap flapping).
+                    sticky = 1 if (charger.car is not None and charger.car.name == car.name) else 0
+
+                    # Stable order: charger name then car name — arbitrary but
+                    # identical for every caller (device names are unique de facto:
+                    # HA config-entry titles).
+                    ranked.append(((-regret, -sticky, charger.name, car.name), charger, car))
+
+            _, best_cur_charger, best_cur_car = min(ranked, key=lambda item: item[0])
 
             assigned_chargers[best_cur_charger] = best_cur_car
             assigned_chargers_score[best_cur_charger] = best_cur_score

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -3239,7 +3239,15 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                     if other is charger or other in assigned_chargers:
                         continue
                     for other_score, other_car in chargers_scores[other]:
-                        if other_car.name == car.name and other_score > best_alternative:
+                        # Identity, not name equality (review #03 / D10): the charger
+                        # exclusion just above already uses `is`, and mixing the two
+                        # would let a distinct car object sharing a name contribute a
+                        # phantom alternative and perturb regret. Every score list is
+                        # built from the SAME `home._cars` iteration, so under the
+                        # documented unique-name invariant `is` and `.name ==` select
+                        # the identical set — this is a no-op by construction, and it
+                        # stops depending on that invariant here.
+                        if other_car is car and other_score > best_alternative:
                             best_alternative = other_score
                 regret = best_cur_score - best_alternative
 

--- a/custom_components/quiet_solar/ha_model/charger.py
+++ b/custom_components/quiet_solar/ha_model/charger.py
@@ -3,10 +3,11 @@ import copy
 import logging
 import math
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from enum import StrEnum
-from typing import Any, NamedTuple, TypeIs
+from typing import Any, TypeIs
 
 import pytz
 from haversine import Unit, haversine
@@ -225,15 +226,21 @@ CHARGER_START_STOP_RETRY_S = 90
 # QS-306 log-tuning values. Module-private: they are not operator configuration,
 # so they stay here rather than in const.py, and they are deliberately NOT
 # sourced from SOLVER_STEP_S despite the numeric coincidence.
-_RELOG_UNCHANGED_AFTER_S = 900  # max gap between two emissions for one key
+# Doubles as the per-VALUE dedup TTL and the length of the per-key budget window
+# (QS-342 review #03 / D1): a value is suppressed while it is still remembered, and
+# a key may emit at most `_LOG_VALUES_PER_WINDOW` lines per window.
+_RELOG_UNCHANGED_AFTER_S = 900
 _POWER_LOG_DEADBAND_W = 100.0  # ignore sub-100W jitter on the available-power line
-# QS-342 (review fix #01): rate limit for CHANGED-value re-emissions of a key —
-# distinct from the 900 s unchanged-value heartbeat above. A value oscillating on
-# every ~7 s allocation cycle (e.g. a car GPS-jittering across a 0.5 m distance
-# bucket edge) must not track the cycle rate: with this floor a key emits at most
-# ~1 changed line per minute, while a genuine change after a quiet period still
-# logs immediately (the last emission is then typically older than the floor).
-_CHANGED_RELOG_MIN_INTERVAL_S = 60
+# QS-342 (review fix #03): per-key emission budget per window. Dedup-by-value alone
+# kills oscillation perfectly and DRIFT not at all — a monotonically drifting value
+# (GPS creeping 0.55 m per cycle) is a new value every cycle, so it satisfies "not the
+# same stuff over and over" literally while leaving volume unbounded. The budget is
+# what makes the bound provable and DATA-INDEPENDENT: <= budget + 1 lines per key per
+# window, whatever the value pattern. Overflow is disclosed as a count, never silent.
+_LOG_VALUES_PER_WINDOW = 4
+# Strictly greater than the budget, so the BUDGET binds first and eviction never
+# silently re-inflates volume by forgetting a value that is still being repeated.
+_LOG_MAX_REMEMBERED_VALUES = 8
 
 
 class QSChargerStates(StrEnum):
@@ -644,21 +651,32 @@ def _is_unchanged(prev: object, current: object, deadband: float | None) -> bool
     return all(_element_unchanged(p, c, deadband) for p, c in zip(prev, current, strict=True))
 
 
-class _LogOnChangeRecord(NamedTuple):
-    """Last EMITTED value for a key, plus churn hidden by the rate floor.
+@dataclass
+class _LogOnChangeRecord:
+    """Recently-emitted values for one key, plus this window's budget accounting.
 
-    `suppressed_changes` counts value changes dropped by `min_interval_s` since
-    that emission. It exists so an excursion that reverts inside the floor window
-    still gets disclosed (QS-342 review #02 / S1) instead of vanishing.
+    `seen` is a bounded LIST of `(value, last_emitted_time)` scanned linearly with
+    `_is_unchanged` — deliberately NOT a `dict[value, time]`. Two load-bearing
+    reasons: `float('nan')` values would never hit a dict lookup (every read builds
+    a fresh NaN and `NaN != NaN`), silently re-inflating a stuck sensor to the full
+    cycle rate — exactly what `_element_unchanged` guards against; and the deadband
+    comparison is not an equality relation at all, so it cannot be a hash key. A
+    linear scan over at most `_LOG_MAX_REMEMBERED_VALUES` entries keeps both guards
+    and dodges hashability (the soc site's value nests a tuple).
     """
 
-    value: object
-    time: datetime
-    suppressed_changes: int = 0
+    seen: list[tuple[object, datetime]]
+    window_start: datetime
+    emitted: int = 0
+    dropped: int = 0
 
 
 class LogOnChangeMixin:
-    """Emit INFO only when a reported value changes, or after 900 s (QS-306).
+    """Emit INFO once per distinct value per window, within a per-key budget.
+
+    QS-306 introduced this as "log only on change"; QS-342 review #03 generalised it
+    to de-duplication by VALUE plus a per-key emission budget — see
+    `log_info_on_change` for the mechanism and the bound it guarantees.
 
     NOTE: this deliberately closes over THIS module's `_LOGGER`, so every host emits
     on the `ha_model.charger` logger. Both current hosts live here, and the tests pin
@@ -680,65 +698,89 @@ class LogOnChangeMixin:
         msg: str,
         *args: object,
         deadband: float | None = None,
-        min_interval_s: float | None = None,
+        budget: int = _LOG_VALUES_PER_WINDOW,
+        max_values: int = _LOG_MAX_REMEMBERED_VALUES,
     ) -> None:
-        """Log `msg` at INFO if `value` changed for `key`, after 900 s unchanged, or
-        to disclose churn hidden by the optional `min_interval_s` rate floor.
+        """Log `msg` at INFO the first time `value` is seen for `key` in a window.
 
-        `time` must be timezone-aware UTC — the same value the caller already
-        receives. `|elapsed|` is used so a backwards clock jump cannot silence a
-        key. The timer is re-stamped on every emission, so the constant bounds the
-        gap between emissions rather than imposing a fixed cadence.
+        QS-342 review #03 replaced a *time floor on changed values* with
+        de-duplication *by value* plus a per-key emission budget. The incident was
+        never "changes happened too fast" — it was the SAME value repeated 17 791
+        times — and a time floor is structurally unable to satisfy completeness:
+        any state whose whole lifetime fits inside the window is unobservable.
 
-        `min_interval_s` (QS-342) rate-limits CHANGED-value emissions: within the
-        floor of the last emission nothing is logged, but each dropped change is
-        BANKED on the key, and the first call at/after floor expiry emits — even
-        if the value has meanwhile reverted to the last emitted one — appending
-        the suppressed count. So a genuine change is delayed by at most the floor
-        and an excursion that both starts and ends inside the window is still
-        reported (it would otherwise be lost entirely: the memo holds the last
-        *emitted* value, so a revert looks unchanged). Per key the floor therefore
-        bounds emissions to ~1 per window; the caller owns the aggregate (one key
-        per charger×car at the `get_car_score` site).
+        The rule: remember the recently-emitted values for a key; emit a value the
+        first time it is seen and suppress it while it is still remembered
+        (`_RELOG_UNCHANGED_AFTER_S`, which doubles as the per-value TTL). An
+        A->B->A oscillation therefore emits A once and B once per window and then
+        goes quiet — volume becomes O(distinct states per window) rather than
+        O(transitions), and nothing is banked, stranded or misattributed.
 
-        Non-comparable clocks (naive vs aware under one key) cannot yield an
-        `elapsed`, so that path emits unconditionally rather than raising — a
-        logging helper must never be load-bearing. It is self-limiting: the
-        emission re-stamps the key with `time`, so the very next call on the same
-        clock kind is comparable and floored again.
+        Dedup alone is not enough: it is exactly complementary to a time floor,
+        killing oscillation perfectly and DRIFT not at all (a value creeping by one
+        quantum per cycle is a new value every cycle). So each key also gets a
+        budget of `budget` emissions per window; further distinct values are counted
+        and disclosed as a single overflow line when the window rolls. Per key the
+        bound is therefore `budget + 1` lines per window, INDEPENDENT of the data.
+
+        `time` may be naive: it is normalised to UTC rather than branched on, so
+        alternating naive/aware callers can no longer defeat the bound (the old
+        non-comparable-clock branch emitted unconditionally). `|elapsed|` is used so
+        a backwards clock jump cannot silence a key.
+
+        `max_values=1` restores single-`prev` semantics, which is what the deadband
+        site needs: with a value *set*, transitive drift (0 -> 99 -> 198, each step
+        inside the deadband of a remembered neighbour) would be suppressed forever.
         """
+        # Normalise BEFORE any arithmetic: mixing naive and aware datetimes under one
+        # key would raise TypeError on the subtraction, and a logging helper must
+        # never be load-bearing. Branching on it instead (the old behaviour) let an
+        # alternating-clock caller escape the bound entirely.
+        if time.tzinfo is None:
+            time = time.replace(tzinfo=pytz.UTC)
+
         state = self._log_on_change_state
         if state is None:
             state = self._log_on_change_state = {}
-        suppressed_changes = 0
-        prev = state.get(key)
-        if prev is not None:
-            prev_value, prev_time, banked_changes = prev
-            # Mixing naive and aware datetimes under one key would raise TypeError on
-            # the subtraction. A logging helper must never be load-bearing, so bail to
-            # logging instead of propagating out of the caller's control cycle.
-            comparable = (prev_time.tzinfo is None) == (time.tzinfo is None)
-            if comparable:
-                elapsed = abs((time - prev_time).total_seconds())
-                unchanged = _is_unchanged(prev_value, value, deadband)
-                if min_interval_s is not None and elapsed < min_interval_s:
-                    # Under the floor nothing is emitted. Bank a changed value so the
-                    # excursion survives a revert; leave value/time untouched so the
-                    # comparison stays against the last EMITTED state.
-                    if not unchanged:
-                        state[key] = _LogOnChangeRecord(prev_value, prev_time, banked_changes + 1)
-                    return
-                if unchanged and banked_changes == 0 and elapsed < _RELOG_UNCHANGED_AFTER_S:
-                    return
-                suppressed_changes = banked_changes
-        state[key] = _LogOnChangeRecord(value, time)
-        if suppressed_changes:
-            # Concatenated OUTSIDE the logging call (ruff G003) and only ever with
-            # static format text: the values stay lazy %-args.
-            disclosure = msg + " [+%s change(s) suppressed by the rate floor]"
-            _LOGGER.info(disclosure, *args, suppressed_changes)
+        st = state.get(key)
+        if st is None:
+            st = state[key] = _LogOnChangeRecord([], time)
+
+        if abs((time - st.window_start).total_seconds()) >= _RELOG_UNCHANGED_AFTER_S:
+            if st.dropped:
+                # Concatenated OUTSIDE the logging call (ruff G003) and only ever with
+                # static format text: the values stay lazy %-args.
+                disclosure = msg + " [+%s further change(s) not shown in the last %ss]"
+                _LOGGER.info(disclosure, *args, st.dropped, int(_RELOG_UNCHANGED_AFTER_S))
+            st.window_start = time
+            st.emitted = 0
+            st.dropped = 0
+
+        hit = next(
+            (index for index, (seen_value, _t) in enumerate(st.seen) if _is_unchanged(seen_value, value, deadband)),
+            None,
+        )
+        if hit is not None and abs((time - st.seen[hit][1]).total_seconds()) < _RELOG_UNCHANGED_AFTER_S:
+            # Still remembered: suppress WITHOUT restamping, so the TTL bounds the gap
+            # between emissions of one value rather than being pushed forward forever
+            # by a value that never changes (that is the 900 s heartbeat).
+            return
+
+        if hit is not None:
+            st.seen[hit] = (value, time)
         else:
-            _LOGGER.info(msg, *args)
+            st.seen.append((value, time))
+            if len(st.seen) > max_values:
+                del st.seen[0]
+
+        # Recorded above whether or not we emit, so an overflowing key counts once per
+        # DISTINCT value rather than once per call.
+        if st.emitted >= budget:
+            st.dropped += 1
+            return
+
+        st.emitted += 1
+        _LOGGER.info(msg, *args)
 
 
 class QSChargerGroup(LogOnChangeMixin):
@@ -944,6 +986,10 @@ class QSChargerGroup(LogOnChangeMixin):
                     grid_available_home_power,
                     battery_asked_charge,
                     deadband=_POWER_LOG_DEADBAND_W,
+                    # Single-`prev` semantics: with a deadband, a value SET would
+                    # suppress transitive drift (0 -> 99 -> 198, each step inside the
+                    # deadband of some remembered neighbour) forever.
+                    max_values=1,
                 )
 
                 dampened_chargers = {}
@@ -3063,15 +3109,13 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             # a DELIBERATE INFO exception to the "debug for non-user-facing" rule.
             # Change key = the quantised tuple ONLY: raw distance and the attach
             # delta are payload, so GPS jitter inside a 0.5 m bucket emits nothing.
-            # Volume bound (review #01, tightened in #02): changed values are
-            # rate-limited to ~1 line per key per _CHANGED_RELOG_MIN_INTERVAL_S (a
-            # tuple flapping across a quantisation edge every cycle cannot track the
-            # cycle rate; churn hidden by the floor is disclosed as a suppressed
-            # count, so nothing is lost), and unchanged values re-emit on the 900 s
-            # heartbeat. Per key: ≤ ~1 line/min worst case, ~1 per 900 s steady
-            # state. Keys are per (charger, car), so the AGGREGATE worst case is
-            # N chargers × M cars per minute — plus one floored key per charger for
-            # the `get_best_car` winner line below.
+            # Volume bound (review #03): the helper de-duplicates by VALUE over a
+            # 900 s window and caps each key at `_LOG_VALUES_PER_WINDOW` emissions
+            # plus one overflow-disclosure line. So this key emits ≤ 5 lines per
+            # 900 s REGARDLESS of the value pattern — oscillation across a
+            # quantisation edge, monotone GPS drift, or a value held constant all
+            # behave the same. Keys are per (charger, car), so the aggregate for this
+            # site is ≤ 5·N·M per window.
             self.log_info_on_change(
                 f"get_car_score:{car.name}",
                 (score_plug_bump, score_plug_time_bump, score_dist_bump),
@@ -3085,7 +3129,6 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                 score_plug_bump,
                 score_plug_time_bump,
                 connected_time_delta,
-                min_interval_s=_CHANGED_RELOG_MIN_INTERVAL_S,
             )
 
         if score is None:
@@ -3097,6 +3140,36 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         return score
 
     def get_best_car(self, time: datetime) -> QSCar | None:
+        """Pick this charger's car, announcing the outcome through ONE throttled key.
+
+        QS-342 review #03 / D4: the winner used to be announced from six separate
+        raw `_LOGGER.info` branches, only one of which was throttled — so the volume
+        bound was a property of one call site rather than of the mechanism, and five
+        branches ran at the full cycle rate. The decision itself lives in
+        `_compute_best_car`; this wrapper is the single exit point, so every branch
+        shares one key (`get_best_car`), one line shape, and one budget.
+        """
+        best_car, reason, score = self._compute_best_car(time)
+        # The change key is `(reason, car_name)` ONLY: the score is a per-cycle float,
+        # so keying on it would preserve every line. It rides along as lazy payload.
+        self.log_info_on_change(
+            "get_best_car",
+            (reason, None if best_car is None else best_car.name),
+            time,
+            "get_best_car: %s selected %s with score %s for charger %s",
+            reason,
+            None if best_car is None else best_car.name,
+            score,
+            self.name,
+        )
+        return best_car
+
+    def _compute_best_car(self, time: datetime) -> tuple[QSCar | None, str, float | None]:
+        """Return `(car, reason, score)`; `reason` names the branch that decided.
+
+        Split out of `get_best_car` for D4 only — the allocation semantics below are
+        unchanged and must stay that way (see the story's frozen-cascade note).
+        """
         # find the best car ...
 
         # cleanly handle the case where it has been user forced to a car
@@ -3113,8 +3186,6 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                     car = None
 
                 if car is not None:
-                    _LOGGER.info("get_best_car: Best Car from user selection: %s for charger %s", car.name, self.name)
-
                     for charger in self.home._chargers:
                         if charger.qs_enable_device is False:
                             continue
@@ -3124,20 +3195,29 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                                 charger.get_user_originated(USER_ORIGINATED_CAR_NAME) is not None
                                 and charger.get_user_originated(USER_ORIGINATED_CAR_NAME) == car.name
                             ):
+                                # Stays at ERROR and stays unthrottled: it CLEARS the
+                                # conflicting flag, so it self-heals and cannot repeat.
                                 _LOGGER.error(
                                     f"get_best_car: {car.name} manually attached to multiple chargers: {self.name} and {charger.name}, detaching from {charger.name}"
                                 )
                                 charger.clear_user_originated(USER_ORIGINATED_CAR_NAME)
                             else:
-                                _LOGGER.info(
-                                    f"get_best_car: {car.name} manually attached to charger {self.name}, detaching from {charger.name}"
+                                # D7: repeatable every cycle while the sibling holds the
+                                # car, so it needs the same throttle as the rest.
+                                self.log_info_on_change(
+                                    "manual_attach_conflict",
+                                    (car.name, charger.name),
+                                    time,
+                                    "get_best_car: %s manually attached to charger %s, detaching from %s",
+                                    car.name,
+                                    self.name,
+                                    charger.name,
                                 )
                             charger.detach_car()
 
-                    return car
+                    return car, "user_selection", None
             else:
-                _LOGGER.info("get_best_car: NO GOOD CAR BECAUSE:CHARGER_NO_CAR_CONNECTED")
-                return None
+                return None, "user_no_car", None
 
         active_chargers = [self]
         for charger in self.home._chargers:
@@ -3157,7 +3237,9 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         # chargers must pass `is_plugged(for_duration=CHARGER_CHECK_STATE_WINDOW_S)`,
         # so for ≤ that window after a second charger plugs in, different callers
         # can see different charger sets — self-healing once the window elapses.
-        active_chargers.sort(key=lambda c: c.name)
+        # `str(...)`: D12 — a non-comparable `name` would raise TypeError here, and a
+        # sort key must never be able to break the allocation.
+        active_chargers.sort(key=lambda c: str(c.name))
 
         cache = {}
 
@@ -3171,7 +3253,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
 
             for car in self.home._cars:
                 if car.get_user_originated(USER_ORIGINATED_CHARGER_NAME) == FORCE_CAR_NO_CHARGER_CONNECTED:
-                    _LOGGER.info("get_best_car: FORCE_CAR_NO_CHARGER_CONNECTED car: %s", car.name)
+                    # D5: DEBUG, not INFO. This reports a STATIC user setting from
+                    # inside a charger x car double loop that itself runs once per
+                    # charger per cycle — N^2*M lines/cycle (measured ~62k/day). An
+                    # INFO anchor for the setting belongs in its setter, not here.
+                    _LOGGER.debug("get_best_car: FORCE_CAR_NO_CHARGER_CONNECTED car: %s", car.name)
                     continue
 
                 score = charger.get_car_score(car, time, cache)
@@ -3254,6 +3340,10 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                 # Stickiness: among equal-regret tied pairs, prefer the charger
                 # this car is currently attached to (keeps symmetric steady
                 # states stable — no swap flapping).
+                # CAVEAT (D13): `charger.car` is LIVE state on other chargers, not a
+                # snapshot — it mutates as those chargers apply their own rows during
+                # the round. See the story's mid-round mutation note; the cascade is
+                # caller-independent regardless, because it scans all tied pairs.
                 sticky = 1 if (charger.car is not None and charger.car.name == car.name) else 0
 
                 # Stable order: charger name then car name — arbitrary but
@@ -3284,11 +3374,11 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                 and self._boot_car.get_user_originated(USER_ORIGINATED_CHARGER_NAME) != FORCE_CAR_NO_CHARGER_CONNECTED
             ):
                 best_car = self._boot_car
-                _LOGGER.info("get_best_car: Best Car from boot data: %s for charger %s", best_car.name, self.name)
+                reason = "boot"
             else:
                 # there is no good car for this charger: get teh charger invited one
                 best_car = self._default_generic_car
-                _LOGGER.info("get_best_car: Default car used: %s", best_car.name)
+                reason = "generic_fallback"
                 if self.home and self.home._cars:
                     _LOGGER.debug(
                         "get_best_car: generic car fallback despite %s real cars existing for charger %s",
@@ -3302,37 +3392,28 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
                 and self._boot_car.get_user_originated(USER_ORIGINATED_CHARGER_NAME) != FORCE_CAR_NO_CHARGER_CONNECTED
             ):
                 # the best is not as good as the boot one ... we will use the boot one for now, whatever the score
-                _LOGGER.info(
-                    f"get_best_car: Use Best Car from boot data: {self._boot_car.name} instead of computed one {best_car.name} for charger {self.name}"
-                )
                 best_car = self._boot_car
+                reason = "boot_over_computed"
             else:
-                # Keyed on the car name only: the score is a per-cycle float, so
-                # keying on it would preserve every line.
-                # QS-342 review #02 / S2: floored like the `get_car_score` site. The
-                # residual failure mode this PR documents (a car GPS-jittering across
-                # a 0.5 m bucket edge flips the STRICT-score winner, which no
-                # tie-break sees) drives this key at the full cycle rate otherwise.
-                self.log_info_on_change(
-                    "get_best_car",
-                    best_car.name,
-                    time,
-                    "get_best_car: %s with score %s for charger %s",
-                    best_car.name,
-                    assigned_chargers_score.get(self),
-                    self.name,
-                    min_interval_s=_CHANGED_RELOG_MIN_INTERVAL_S,
-                )
+                reason = "computed"
 
         if best_car.charger is not None and best_car.charger != self:
-            # will force a reset of everything
-            _LOGGER.info(
-                f"get_best_car: for charger {self.name}: removed from another charger {best_car.charger.name} and select for charger {self.name}"
+            # D3: THIS is the incident message — "removed from another charger", the
+            # literal line that appeared 17 791 times. It sits inside the ping-pong
+            # condition itself, and until now it was a raw unthrottled f-string.
+            self.log_info_on_change(
+                "detach_from_other_charger",
+                (best_car.name, best_car.charger.name),
+                time,
+                "get_best_car: for charger %s: removed from another charger %s and select for charger %s",
+                self.name,
+                best_car.charger.name,
+                self.name,
             )
             best_car.charger.detach_car()
             # hoping we won't have back and forth between chargers
 
-        return best_car
+        return best_car, reason, assigned_chargers_score.get(self)
 
     def get_car_options(self) -> list[str]:
 
@@ -3485,6 +3566,49 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
             self.car.do_force_next_charge = False
             self.car.do_next_charge_time = None
 
+    def _reset_would_change_state(self, keep_commands: bool = True) -> bool:
+        """Return True when `reset(keep_commands)` would destroy any state.
+
+        QS-342 review #03 / D6. `reset()` is otherwise a per-cycle no-op that still
+        emits six INFO lines, which measured ~74 000 lines/day from a single charger
+        — four times the original incident — while the user has "no car connected"
+        selected. Gating on this predicate makes that state idempotent.
+
+        This must enumerate EVERYTHING the reset chain clears, or the gate would skip
+        real work: `_has_state_to_reset` covers the constraint/command half (including
+        the charger override's user-initiated flags), and the rest mirrors
+        `QSChargerGeneric.reset` field by field — `detach_car`, `_reset_state_machine`,
+        `reset_boot_data`, the two reboot/priority flags, `reset_daily_load_datas` and
+        `_dampen_start_transition`. A new field cleared by `reset()` must be added here.
+        """
+        return (
+            self._has_state_to_reset(keep_commands)
+            # detach_car
+            or self.car is not None
+            or bool(self._power_steps)
+            or self.car_attach_time is not None
+            # _reset_state_machine
+            or self._verified_correct_state_time is not None
+            or self._inner_expected_charge_state is not None
+            or self._inner_amperage is not None
+            or self._inner_num_active_phases is not None
+            or self._last_amp_change_time is not None
+            # QSChargerGeneric.reset's own flags
+            or self._asked_for_reboot_at_time is not None
+            or bool(self.qs_bump_solar_priority)
+            or self.possible_charge_error_start_time is not None
+            # reset_boot_data
+            or self._boot_time is not None
+            or self._boot_car is not None
+            or self._boot_time_adjusted is not None
+            or bool(self._boot_constraints)
+            or self._boot_last_completed_constraint is not None
+            # AbstractDevice.reset
+            or bool(self.num_on_off)
+            or self.last_state_change_time is not None
+            or self._dampen_start_transition is not None
+        )
+
     async def check_load_activity_and_constraints(self, time: datetime) -> bool:
         # check that we have a connected car, and which one, or that it is completely disconnected
         #  if there is no more car ... just reset
@@ -3576,10 +3700,15 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
 
             # user forced a "deconnection"
             if best_car is None:
-                _LOGGER.info(
-                    "check_load_activity_and_constraints: plugged car with CHARGER_NO_CAR_CONNECTED selected option"
-                )
-                self.reset(keep_commands=True)
+                # D6: the reset here runs EVERY cycle while "no car connected" is
+                # selected, and each run emits six INFO lines. Skip it once there is
+                # nothing left to reset — the state is then genuinely unchanged, so
+                # this only ever skips work that is already a no-op.
+                if self._reset_would_change_state(keep_commands=True):
+                    _LOGGER.info(
+                        "check_load_activity_and_constraints: plugged car with CHARGER_NO_CAR_CONNECTED selected option"
+                    )
+                    self.reset(keep_commands=True)
                 return True
 
             elif self.car:
@@ -4235,25 +4364,28 @@ class QSChargerGeneric(LogOnChangeMixin, HADeviceMixin, AbstractLoad):
         self.car = None
         self._power_steps = []
         self.car_attach_time = None
-        # QS-306: the log-on-change memos describe the car that just left. Keeping
-        # them would suppress the first line of the NEXT charge session whenever the
-        # new car reports the same value inside the 900 s window — and the last
-        # emitted record would name the wrong car.
-        # QS-342 (review fix #01): EXCEPT the `get_car_score:{car}` keys — those are
-        # car-qualified and describe every candidate car on this charger, not the
-        # departed session; wiping them would re-emit one decomposition line per car
-        # after every detach, defeating the on-change suppression under churn.
-        # Collapse to None when nothing survives (the QS-306 fresh-session shape).
-        # Accepted consequence (review #02 / N3): these keys also survive `reset()`,
-        # i.e. the physical-unplug and `qs_enable_device` disable paths. A new
-        # session started within 900 s with the car parked in the same spot gets no
-        # session-start decomposition line — the score is genuinely unchanged, and
-        # re-emitting per detach is what would break the volume bound (a wiped key
-        # has no `prev`, so it escapes the rate floor entirely). The `get_best_car`
-        # winner line, which IS wiped here, remains the per-session anchor.
-        if self._log_on_change_state is not None:
-            kept = {k: v for k, v in self._log_on_change_state.items() if k.startswith("get_car_score:")}
-            self._log_on_change_state = kept or None
+        # QS-342 review #03 / D2: there is deliberately NO log-state wipe here.
+        #
+        # The wipe (QS-306, narrowed in review #01) is what made every throttle on
+        # this path a no-op in production: `detach_car()` is on the churn path itself
+        # — every change of the `get_best_car` value routes through it — so the key
+        # was dropped, the next call saw no previous value, and it emitted
+        # unconditionally. Rounds #01-#03 each tuned a throttle that this line then
+        # discarded.
+        #
+        # It is also redundant, which is why deleting it is the minimal fix rather
+        # than a trade-off: no key can ever name a stale car. Every key is either
+        # car-qualified (`get_car_score:{car}`, `update_value_callback_soc:{car}:…`)
+        # or carries the car name as its VALUE (`get_best_car`), so a swapped car
+        # yields a different key or a changed value and emits either way. The
+        # remaining keys live on `QSChargerGroup`, which has no car at all.
+        #
+        # Do NOT reintroduce a "session boundary" wipe here or in `reset()`:
+        # `detach_car()` cannot distinguish churn from a boundary (it is reached from
+        # the unplug edge, the disable setter, the user reset AND from the per-cycle
+        # allocation path), and `reset()` is not a boundary either. The session
+        # anchors already exist: `update_power_steps` emits an INFO per attach and
+        # the unplug WARNING anchors the other end.
 
     # update in place the power steps
     def update_power_steps(self):

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -446,8 +446,7 @@ class AbstractDevice:
 
     # for class overcharging reset
     def reset(self, keep_commands=False):
-        # DEBUG: see `QSChargerGeneric.reset`. `Constraint Reset device` below is the
-        # INFO marker for a reset that actually destroyed state.
+        # DEBUG: `Constraint Reset device` is the INFO marker for a real reset.
         _LOGGER.debug("Reset device %s", self.name)
         self.constraint_reset_and_reset_commands_if_needed(keep_commands=keep_commands)
         self.reset_daily_load_datas()
@@ -1778,9 +1777,7 @@ class AbstractLoad(AbstractDevice):
 
         self.is_load_time_sensitive = False
 
-    # The derived constraint-progress fields this class's reset clears. Named once
-    # and consumed by BOTH the predicate and the reset below, so the two cannot
-    # drift apart — the duplication is what let QS-342 review #04 / B2 happen.
+    # Consumed by BOTH the predicate and the reset below, so the two cannot drift.
     _DERIVED_CONSTRAINT_FIELDS = (
         "current_constraint_current_value",
         "current_constraint_current_energy",
@@ -1791,14 +1788,6 @@ class AbstractLoad(AbstractDevice):
 
     def _has_state_to_reset(self, keep_commands: bool) -> bool:
         """Extend the base predicate with the derived fields this class clears.
-
-        QS-342 review #04 / B2. The base rule ("subclasses that clear EXTRA state
-        must extend this predicate") was violated here for five fields. That was
-        harmless while the predicate only chose a log level, but QS-342 review #03 /
-        D6 promoted it to control flow gating a real `reset()`, so a `False` verdict
-        now skips work. Verified strandable: with `_constraints` empty and
-        `_last_completed_constraint` None the predicate returned False while
-        `reset()` cleared all five.
 
         `getattr` for the same `__init__`-ordering reason the base documents.
         """

--- a/custom_components/quiet_solar/home_model/load.py
+++ b/custom_components/quiet_solar/home_model/load.py
@@ -446,7 +446,9 @@ class AbstractDevice:
 
     # for class overcharging reset
     def reset(self, keep_commands=False):
-        _LOGGER.info("Reset device %s", self.name)
+        # DEBUG: see `QSChargerGeneric.reset`. `Constraint Reset device` below is the
+        # INFO marker for a reset that actually destroyed state.
+        _LOGGER.debug("Reset device %s", self.name)
         self.constraint_reset_and_reset_commands_if_needed(keep_commands=keep_commands)
         self.reset_daily_load_datas()
         self._dampen_start_transition = None
@@ -1776,14 +1778,39 @@ class AbstractLoad(AbstractDevice):
 
         self.is_load_time_sensitive = False
 
+    # The derived constraint-progress fields this class's reset clears. Named once
+    # and consumed by BOTH the predicate and the reset below, so the two cannot
+    # drift apart — the duplication is what let QS-342 review #04 / B2 happen.
+    _DERIVED_CONSTRAINT_FIELDS = (
+        "current_constraint_current_value",
+        "current_constraint_current_energy",
+        "current_constraint_current_percent_completion",
+        "next_or_current_constraint_start_time",
+        "next_or_current_constraint_end_time",
+    )
+
+    def _has_state_to_reset(self, keep_commands: bool) -> bool:
+        """Extend the base predicate with the derived fields this class clears.
+
+        QS-342 review #04 / B2. The base rule ("subclasses that clear EXTRA state
+        must extend this predicate") was violated here for five fields. That was
+        harmless while the predicate only chose a log level, but QS-342 review #03 /
+        D6 promoted it to control flow gating a real `reset()`, so a `False` verdict
+        now skips work. Verified strandable: with `_constraints` empty and
+        `_last_completed_constraint` None the predicate returned False while
+        `reset()` cleared all five.
+
+        `getattr` for the same `__init__`-ordering reason the base documents.
+        """
+        return super()._has_state_to_reset(keep_commands) or any(
+            getattr(self, field, None) is not None for field in self._DERIVED_CONSTRAINT_FIELDS
+        )
+
     def constraint_reset_and_reset_commands_if_needed(self, keep_commands=True):
         super().constraint_reset_and_reset_commands_if_needed(keep_commands=keep_commands)
 
-        self.current_constraint_current_value = None
-        self.current_constraint_current_energy = None
-        self.current_constraint_current_percent_completion = None
-        self.next_or_current_constraint_start_time = None
-        self.next_or_current_constraint_end_time = None
+        for field in self._DERIVED_CONSTRAINT_FIELDS:
+            setattr(self, field, None)
         self._last_completed_constraint = None
 
     def update_to_be_saved_extra_device_info(self, data_to_update: dict):
@@ -2165,7 +2192,7 @@ class AbstractLoad(AbstractDevice):
         return True
 
     def reset(self, keep_commands=False):
-        _LOGGER.info("Reset load %s", self.name)
+        _LOGGER.debug("Reset load %s", self.name)
         super().reset(keep_commands=keep_commands)
 
     async def ack_completed_constraint(self, time: datetime, constraint: LoadConstraint | None):

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -4,7 +4,7 @@ slug: charger-budgeting
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/charger.py
-last_verified: 2026-08-06
+last_verified: 2026-08-07
 ---
 
 # Charger Dynamic Budgeting — the tactical layer
@@ -32,12 +32,12 @@ deliberate exceptions: a sign flip (export ↔ import) logs **when either side
 is at least the deadband** — the floor matters, because an unbounded flip term
 makes near-zero dither log every cycle — and a stuck-at-`NaN` or
 stuck-at-`inf` sensor counts as *unchanged*, so a broken sensor cannot
-re-inflate the log to the full cycle rate. `detach_car()` clears the memos, so
-each charge session gets a fresh first line — **except** the car-qualified
-`get_car_score:*` keys (QS-342), which describe every candidate car rather
-than the departed session and survive the detach so churn cannot re-emit a
-per-car decomposition burst. A disabled charger's key is
-evicted so a re-enable is always announced. `QSChargerGeneric` extends
+re-inflate the log to the full cycle rate. `detach_car()` does **not** touch the
+log-on-change state (QS-342 review #03 / D2): it sits on the churn path itself, so
+wiping there dropped the key on every allocation change and made the throttle a
+no-op in production — and it is redundant, because every key is either
+car-qualified or carries the car name as its value. A disabled charger's
+group-level key is still evicted so a re-enable is always announced. `QSChargerGeneric` extends
 `_has_state_to_reset()` (see [load-base.md](load-base.md)) because its reset
 override destroys the user-initiated `do_force_next_charge` /
 `do_next_charge_time` flags.
@@ -149,9 +149,9 @@ what makes allocation incidents diagnosable without a recorder-DB
 forensic session.
 
 **How the throttle works** (`LogOnChangeMixin.log_info_on_change`).
-Per key the helper remembers the recently-emitted *values* and emits a
-value the first time it is seen, suppressing it while it is still
-remembered (`_RELOG_UNCHANGED_AFTER_S`, 900 s, which doubles as the
+Per key the helper remembers the recently-*observed* values (each flagged
+with whether it was actually shown) and emits a value the first time it is
+seen, suppressing it while it is still remembered (`_RELOG_UNCHANGED_AFTER_S`, 900 s, which doubles as the
 per-value TTL). On top of that each key carries a budget of
 `_LOG_VALUES_PER_WINDOW` (4) emissions per window; further distinct values
 are counted and disclosed as a single
@@ -168,17 +168,47 @@ rolls. Both halves are load-bearing:
   stuff over and over" literally while leaving volume effectively
   unbounded. Capping the remembered-value map bounds memory, not volume.
 
-**Volume bound.** Per key: **≤ budget + 1 = 5 lines per 900 s**
-(≈ 0.33/min), and this is *data-independent* — oscillation, monotone
-drift and a held-constant value all behave the same. Keys are `N·M`
+**Volume bound.** Per key: **≤ budget + 1 lines per 900 s**, and this is
+*data-independent* — oscillation, monotone drift and a held-constant value
+all behave the same. Allocation keys use the default budget of 4 (so 5
+lines per 900 s, ≈ 0.33/min); the two **telemetry** sites —
+`dyn_handle`'s available-power line and the SoC callback — use
+`_LOG_TELEMETRY_VALUES_PER_WINDOW` (12) instead. That exception is
+deliberate (review #04 / B12+B13): the default budget assumes many distinct
+values per window means churn, which is true for allocation keys and false
+for telemetry, whose values advance during entirely normal operation (a
+charging battery's Wh/%, a home crossing between import and export). With
+the default those sites sat in permanent overflow during a normal charge
+and dropped real operational events. Keys are `N·M`
 (`get_car_score`) + `N` (the merged `get_best_car` winner line) + `N`
 (`detach_from_other_charger`) + `2N` (`update_value_callback_soc`) +
 `N + 1` (group), so the **aggregate** is ≤ `5·(N·M + 5N + 1)` per 900 s.
 For N=3, M=4 that is ≤ 140 lines per 900 s ≈ 13 400/day worst case and
-~2 400/day in steady state. Completeness holds for distinct states: only
-budget *overflow* loses detail, it is disclosed as a count, and it occurs
-only above 4 distinct values per window — the pathological regime, which
-is itself the signal.
+~2 400/day in steady state. The `2N` SoC term uses the telemetry budget, so the aggregate is
+`5·(N·M + 3N + 1) + 13·2N`. Completeness holds for distinct states: only
+budget *overflow* loses detail, and it is disclosed as a count.
+
+The disclosure line is static text keyed by the throttle key — never the
+caller's own message and arguments — and carries **both** the number of
+distinct changes dropped and the number of dedup-suppressed repeats. That
+repeat count preserves the incident's defining signal: without it a key
+pinned at the 7 s cycle rate and one genuinely changing every few minutes
+produce identical logs, and #342 was diagnosed from the volume being
+visibly absurd.
+
+Two caveats on "never silent":
+
+- The disclosure is flushed by the **next call on the same key**. If a key
+  goes quiet for good — charger unplugged, device disabled, car removed, HA
+  restart — the final window's counts are lost. This is reachable on the
+  incident path itself. Accepted rather than fixed: a flush hook would put
+  logging concerns back into charger lifecycle control flow, and
+  cross-session banking is what rounds #01–#03 proved unworkable.
+- The window roll uses `abs()` on the elapsed time, so a caller alternating
+  between two timestamps 900 s apart would roll the window every call and
+  defeat the budget. Not reachable at any current call site (all pass a
+  monotonically advancing `event_time`), but the "data-independent" claim
+  assumes a sane clock.
 
 `time` is normalised to UTC on entry, so a caller mixing naive and aware
 datetimes under one key can neither raise nor escape the bound.
@@ -191,6 +221,11 @@ no-op in production. It is also redundant — every key is either
 car-qualified (`get_car_score:{car}`) or carries the car name as its
 *value* (`get_best_car`), so no key can name a stale car. The per-session
 anchors are `update_power_steps`' attach line and the unplug WARNING.
+
+A consequence (review #04 / C7): `_log_on_change_state` keys are now never
+pruned, so renaming a car or charger orphans its old keys for the lifetime
+of the process. Bounded by config churn — a handful of small tuples — so it
+is recorded rather than fixed.
 
 **Historical note (do not re-invent).** Review rounds #01–#03 of QS-342
 each tried a *time floor* on changed values (`_CHANGED_RELOG_MIN_INTERVAL_S`,

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -4,7 +4,7 @@ slug: charger-budgeting
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/charger.py
-last_verified: 2026-08-05
+last_verified: 2026-08-06
 ---
 
 # Charger Dynamic Budgeting — the tactical layer
@@ -131,20 +131,36 @@ state matching a regret-consistent allocation is a fixed point.
   that starts *after* the restart has both clocks aligned and is
   unaffected. Follow-up:
   <https://github.com/tmenguy/quiet-solar/issues/344>.
-- *Residual failure mode*: a car GPS-jittering across a 0.5 m bucket edge
-  produces alternating strict-score winners that no tie-break sees.
-  Steal-margin hysteresis stays out of scope until observed in the field.
+- *Residual failure mode — two unhysteresised quantisation edges.* (1) The
+  0.5 m `dist_bump` bucket edge: a car GPS-jittering across it produces
+  alternating **strict-score** winners that no tie-break sees. (2) The
+  `dist <= 3.0` threshold that adds +1 to `plug_bump`: because `plug_bump`
+  is the lowest-order term, a ±1 flip converts an **exact tie** — where
+  stickiness protects the incumbent — into a strict win, which steals with
+  no margin at all. The second edge therefore *bypasses* the cascade rather
+  than being resolved by it, and it is reachable in the incident's own
+  geometry (3.58 / 3.69 / 3.97 m). Steal-margin hysteresis stays out of
+  scope until observed in the field.
 
 `get_car_score` logs its decomposition at INFO-on-change keyed on the
 quantised tuple `(plug_bump, plug_time_bump, dist_bump)` only — a
 deliberate INFO exception to the QS-306 volume rules, because this line is
 what makes allocation incidents diagnosable without a recorder-DB
-forensic session. Volume bound: changed values are rate-limited to ~1 line
-per (charger, car) per `_CHANGED_RELOG_MIN_INTERVAL_S` (60 s) — so a tuple
-flapping across a quantisation edge every ~7 s cycle cannot track the
-cycle rate — and unchanged values re-emit on the 900 s heartbeat; these
-memo keys survive `detach_car()` (see above), so attach/detach churn
-cannot defeat the suppression either.
+forensic session. **Volume bound** (both this site and the sibling
+`get_best_car` winner line are floored): changed values are rate-limited to
+~1 line per key per `_CHANGED_RELOG_MIN_INTERVAL_S` (60 s) — so a value
+flapping across a quantisation edge every ~7 s cycle cannot track the cycle
+rate — and unchanged values re-emit on the 900 s heartbeat. Keys are per
+(charger, car) for the decomposition and per charger for the winner line,
+so the **aggregate** worst case is (N chargers × M cars + N) lines/minute,
+settling to one per key per 900 s. Churn hidden by the floor is not lost:
+suppressed changes are banked and the first emission after the floor
+appends `[+n change(s) suppressed…]`, so an excursion that starts *and*
+ends inside the window is still visible. The decomposition memo keys
+survive `detach_car()` (see above) — and hence `reset()`, i.e. physical
+unplug and device disable — so a new session within 900 s with the car in
+the same spot has no session-start decomposition line; the `get_best_car`
+winner line, which *is* wiped, is the per-session anchor.
 
 ### Charge-origin tagging & `get_charge_type()` (QS-274)
 

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -33,7 +33,10 @@ is at least the deadband** — the floor matters, because an unbounded flip term
 makes near-zero dither log every cycle — and a stuck-at-`NaN` or
 stuck-at-`inf` sensor counts as *unchanged*, so a broken sensor cannot
 re-inflate the log to the full cycle rate. `detach_car()` clears the memos, so
-each charge session gets a fresh first line, and a disabled charger's key is
+each charge session gets a fresh first line — **except** the car-qualified
+`get_car_score:*` keys (QS-342), which describe every candidate car rather
+than the departed session and survive the detach so churn cannot re-emit a
+per-car decomposition burst. A disabled charger's key is
 evicted so a re-enable is always announced. `QSChargerGeneric` extends
 `_has_state_to_reset()` (see [load-base.md](load-base.md)) because its reset
 override destroys the user-initiated `do_force_next_charge` /
@@ -119,10 +122,14 @@ state matching a regret-consistent allocation is a fixed point.
 
 **Known limitations:**
 
-- *Plug-time correlation is dead after an HA restart*: car plug probes are
+- *Plug-time correlation is dead after an HA restart for plug sessions
+  already active before the restart*: car plug probes are
   recorder-bootstrapped (3 days) but the charger's synthetic
-  `is_there_a_car_plugged` probe is in-memory-only since restart, so
-  `plug_time_bump` is structurally 0 exactly when it is needed. Follow-up:
+  `is_there_a_car_plugged` probe is in-memory-only since restart, so for a
+  pre-restart session the compared durations never realign and
+  `plug_time_bump` is structurally 0 exactly when it is needed. A session
+  that starts *after* the restart has both clocks aligned and is
+  unaffected. Follow-up:
   <https://github.com/tmenguy/quiet-solar/issues/344>.
 - *Residual failure mode*: a car GPS-jittering across a 0.5 m bucket edge
   produces alternating strict-score winners that no tie-break sees.
@@ -132,7 +139,12 @@ state matching a regret-consistent allocation is a fixed point.
 quantised tuple `(plug_bump, plug_time_bump, dist_bump)` only — a
 deliberate INFO exception to the QS-306 volume rules, because this line is
 what makes allocation incidents diagnosable without a recorder-DB
-forensic session.
+forensic session. Volume bound: changed values are rate-limited to ~1 line
+per (charger, car) per `_CHANGED_RELOG_MIN_INTERVAL_S` (60 s) — so a tuple
+flapping across a quantisation edge every ~7 s cycle cannot track the
+cycle rate — and unchanged values re-emit on the 900 s heartbeat; these
+memo keys survive `detach_car()` (see above), so attach/detach churn
+cannot defeat the suppression either.
 
 ### Charge-origin tagging & `get_charge_type()` (QS-274)
 

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -4,7 +4,7 @@ slug: charger-budgeting
 kind: concept
 covers:
   - custom_components/quiet_solar/ha_model/charger.py
-last_verified: 2026-08-01
+last_verified: 2026-08-05
 ---
 
 # Charger Dynamic Budgeting — the tactical layer
@@ -86,6 +86,53 @@ Then `apply_budget_strategy()`:
 - `CHARGER_ADAPTATION_WINDOW_S = 45` — stability requirement before
   rebalancing.
 - `CHARGER_STATE_REFRESH_INTERVAL_S = 14` — state-polling cadence.
+
+### Car↔charger allocation tie-break (QS-342)
+
+`QSChargerGeneric.get_best_car` runs a greedy per-charger allocation over
+all plugged chargers: each charger scores every car (`get_car_score`) and
+the loop repeatedly assigns the best remaining (charger, car) pair. Two
+QS-342 facts to internalise:
+
+- **Exact score ties are a NORMAL operating case.** The dominant score
+  component is the distance bump, quantised in **0.5 m buckets** over 50 m
+  (deliberate — car GPS jitters by metres; finer resolution would make the
+  allocation flap with noise). Cars sleeping in their usual spots between
+  two wallboxes tie *every night*. Never "fix" a tie by sharpening the
+  distance resolution.
+- **Ties are resolved by a deterministic cascade**, evaluated over ALL
+  (charger, car) pairs at the max remaining score (not just each charger's
+  list head): **regret → stickiness → stable (charger name, car name)
+  order**. Regret = the pair's score minus the car's best score on any
+  *other unassigned* charger (no alternative → 0, i.e. regret = own score);
+  it is recomputed at every greedy iteration, skipping already-assigned
+  chargers (their score lists are stale by design). Stickiness prefers the
+  charger the car is currently attached to, so symmetric steady states
+  don't swap-flap. The stable order assumes **unique device names**
+  (enforced de facto by HA config-entry titles).
+
+**Steal semantics:** an attached car is displaced *only* by a strictly
+higher score, or by an **equal score with strictly higher regret** — the
+latter is required so a crossed pairing (leftover of the pre-fix
+ping-pong) recovers to the regret-consistent allocation. Any attachment
+state matching a regret-consistent allocation is a fixed point.
+
+**Known limitations:**
+
+- *Plug-time correlation is dead after an HA restart*: car plug probes are
+  recorder-bootstrapped (3 days) but the charger's synthetic
+  `is_there_a_car_plugged` probe is in-memory-only since restart, so
+  `plug_time_bump` is structurally 0 exactly when it is needed. Follow-up:
+  <https://github.com/tmenguy/quiet-solar/issues/344>.
+- *Residual failure mode*: a car GPS-jittering across a 0.5 m bucket edge
+  produces alternating strict-score winners that no tie-break sees.
+  Steal-margin hysteresis stays out of scope until observed in the field.
+
+`get_car_score` logs its decomposition at INFO-on-change keyed on the
+quantised tuple `(plug_bump, plug_time_bump, dist_bump)` only — a
+deliberate INFO exception to the QS-306 volume rules, because this line is
+what makes allocation incidents diagnosable without a recorder-DB
+forensic session.
 
 ### Charge-origin tagging & `get_charge_type()` (QS-274)
 

--- a/docs/agents/concepts/charger-budgeting.md
+++ b/docs/agents/concepts/charger-budgeting.md
@@ -146,21 +146,63 @@ state matching a regret-consistent allocation is a fixed point.
 quantised tuple `(plug_bump, plug_time_bump, dist_bump)` only — a
 deliberate INFO exception to the QS-306 volume rules, because this line is
 what makes allocation incidents diagnosable without a recorder-DB
-forensic session. **Volume bound** (both this site and the sibling
-`get_best_car` winner line are floored): changed values are rate-limited to
-~1 line per key per `_CHANGED_RELOG_MIN_INTERVAL_S` (60 s) — so a value
-flapping across a quantisation edge every ~7 s cycle cannot track the cycle
-rate — and unchanged values re-emit on the 900 s heartbeat. Keys are per
-(charger, car) for the decomposition and per charger for the winner line,
-so the **aggregate** worst case is (N chargers × M cars + N) lines/minute,
-settling to one per key per 900 s. Churn hidden by the floor is not lost:
-suppressed changes are banked and the first emission after the floor
-appends `[+n change(s) suppressed…]`, so an excursion that starts *and*
-ends inside the window is still visible. The decomposition memo keys
-survive `detach_car()` (see above) — and hence `reset()`, i.e. physical
-unplug and device disable — so a new session within 900 s with the car in
-the same spot has no session-start decomposition line; the `get_best_car`
-winner line, which *is* wiped, is the per-session anchor.
+forensic session.
+
+**How the throttle works** (`LogOnChangeMixin.log_info_on_change`).
+Per key the helper remembers the recently-emitted *values* and emits a
+value the first time it is seen, suppressing it while it is still
+remembered (`_RELOG_UNCHANGED_AFTER_S`, 900 s, which doubles as the
+per-value TTL). On top of that each key carries a budget of
+`_LOG_VALUES_PER_WINDOW` (4) emissions per window; further distinct values
+are counted and disclosed as a single
+`[+n further change(s) not shown in the last 900s]` line when the window
+rolls. Both halves are load-bearing:
+
+- **Dedup by value** kills oscillation. An A→B→A flap across a
+  quantisation edge emits A once and B once per window and then goes
+  quiet, so volume is `O(distinct states per window)` rather than
+  `O(transitions)`.
+- **The per-key budget** kills drift, which dedup cannot touch: a value
+  creeping by one quantum per cycle (GPS drifting 0.55 m per ~7 s cycle)
+  is a *new* value every cycle, so dedup alone satisfies "not the same
+  stuff over and over" literally while leaving volume effectively
+  unbounded. Capping the remembered-value map bounds memory, not volume.
+
+**Volume bound.** Per key: **≤ budget + 1 = 5 lines per 900 s**
+(≈ 0.33/min), and this is *data-independent* — oscillation, monotone
+drift and a held-constant value all behave the same. Keys are `N·M`
+(`get_car_score`) + `N` (the merged `get_best_car` winner line) + `N`
+(`detach_from_other_charger`) + `2N` (`update_value_callback_soc`) +
+`N + 1` (group), so the **aggregate** is ≤ `5·(N·M + 5N + 1)` per 900 s.
+For N=3, M=4 that is ≤ 140 lines per 900 s ≈ 13 400/day worst case and
+~2 400/day in steady state. Completeness holds for distinct states: only
+budget *overflow* loses detail, it is disclosed as a count, and it occurs
+only above 4 distinct values per window — the pathological regime, which
+is itself the signal.
+
+`time` is normalised to UTC on entry, so a caller mixing naive and aware
+datetimes under one key can neither raise nor escape the bound.
+
+The log-on-change state deliberately **survives `detach_car()`**. There is
+no session-boundary wipe, and none should be reintroduced: `detach_car()`
+sits on the churn path itself (every change of the `get_best_car` value
+routes through it), so wiping there dropped the key and made the throttle a
+no-op in production. It is also redundant — every key is either
+car-qualified (`get_car_score:{car}`) or carries the car name as its
+*value* (`get_best_car`), so no key can name a stale car. The per-session
+anchors are `update_power_steps`' attach line and the unplug WARNING.
+
+**Historical note (do not re-invent).** Review rounds #01–#03 of QS-342
+each tried a *time floor* on changed values (`_CHANGED_RELOG_MIN_INTERVAL_S`,
+60 s) plus a "banked suppressed-change" counter, and each round fixed the
+previous round's defect while introducing the next. A time floor is
+structurally incapable of completeness — any state whose whole lifetime
+fits inside the window is unobservable — and the bank counted *calls*
+rather than *states*, so it over-reported a held change, under-reported an
+oscillation, and was destroyed outright by the `detach_car()` wipe. The
+incident was never "changes happened too fast"; it was **the same value
+repeated 17 791 times**, which is why the correct primitive is
+de-duplication by value.
 
 ### Charge-origin tagging & `get_charge_type()` (QS-274)
 

--- a/docs/agents/concepts/load-base.md
+++ b/docs/agents/concepts/load-base.md
@@ -4,7 +4,7 @@ slug: load-base
 kind: concept
 covers:
   - custom_components/quiet_solar/home_model/load.py
-last_verified: 2026-08-02
+last_verified: 2026-08-07
 ---
 
 # AbstractDevice & AbstractLoad
@@ -21,9 +21,16 @@ solver's entry point), plus green-only mode, user override state, and
 external-control detection. **Both live in `home_model/load.py` —
 strict zero-HA-import boundary.**
 
-**Log levels (QS-306).** `constraint_reset_and_reset_commands_if_needed()`
-now logs INFO only when there was something to reset, and the
-"no bad constraint found" line is DEBUG. No behavior change.
+**Log levels (QS-306, extended by QS-342).**
+`constraint_reset_and_reset_commands_if_needed()` logs INFO only when there
+was something to reset, and the "no bad constraint found" line is DEBUG.
+`AbstractDevice.reset()` / `AbstractLoad.reset()` (and
+`QSChargerGeneric.reset()` / `_reset_state_machine()`) are DEBUG
+unconditionally: `reset()` is idempotent and runs on every cycle in some
+states, which measured ~74 000 INFO lines/day from a single charger. The
+single INFO marker for "a reset actually destroyed something" is
+`Constraint Reset device`, gated on `_has_state_to_reset`. No behavior
+change.
 
 The "was there anything to reset?" test lives in the overridable
 `_has_state_to_reset(keep_commands)` hook. **Any subclass whose reset
@@ -34,11 +41,26 @@ while the base reports "nothing to reset" at DEBUG. The base term covers
 a queued `_stacked_command`. Every access uses `getattr` with a default: the
 hook runs during `AbstractDevice.__init__`, before those attributes exist.
 
+`AbstractLoad` itself extends the hook for the five derived
+constraint-progress fields its own override nulls
+(`current_constraint_current_*`, `next_or_current_constraint_*`). Those are
+named once in `_DERIVED_CONSTRAINT_FIELDS` and consumed by *both* the
+predicate and the reset, so the two cannot drift — the duplication is what
+let them go uncovered for a whole release (QS-342 review #04 / B2).
+
 `QSChargerGeneric` is the worked example: its override clears the
 user-initiated `do_force_next_charge` / `do_next_charge_time`, so it ORs them
 into the hook. Without that, a user pressing "force next charge" on a charger
 holding no constraints would have the flag destroyed while the log said
 "nothing to reset".
+
+**This hook picks a LOG LEVEL only — never control flow.** QS-342 review #03
+briefly gated a real `reset()` on a charger-side predicate enumerating every
+field the reset clears; review #04 found that enumeration already incomplete.
+Any such mirror rots the moment `reset()` learns a new field, and the failure
+mode there is stale device state rather than a missing log line. If you find
+yourself writing "would this reset do anything?" to decide whether to *call*
+it, don't — `reset()` is idempotent, so just call it.
 
 ## When you need this concept
 

--- a/docs/stories/QS-342.story.md
+++ b/docs/stories/QS-342.story.md
@@ -431,9 +431,19 @@ gate hints otherwise, follow the gate's hint as the source of truth.
    `test_naive_time_is_normalised`, `test_log_state_survives_detach_car`;
    `caplog` pinned to `custom_components.quiet_solar.ha_model.charger`).
    Aggregate volume over a full 900 s window is asserted on the real
-   `check_load_activity_and_constraints` path, not on `get_best_car` in
-   isolation (`test_allocation_churn_total_log_volume_over_a_full_window`
-   and the per-site throttle tests beside it).
+   `check_load_activity_and_constraints` path with REAL scoring, not on
+   `get_best_car` in isolation and not with `get_car_score` stubbed
+   (`test_allocation_churn_total_log_volume_over_a_full_window` and the
+   per-site throttle tests beside it, all with lower bounds as well as
+   ceilings). Review fix #04 additionally pins: the overflow-disclosure
+   branch itself (`test_b3_budget_overflow_is_disclosed_when_the_window_rolls`),
+   that a budget-dropped value is shown once budget allows rather than
+   being stamped as if emitted (`test_b4_...`), that the disclosure is
+   static text carrying no caller arguments (`test_b6_...`), and that it
+   reports dedup-suppressed repeats so the incident's *rate* signal
+   survives (`test_b7_...`). The two telemetry sites (`dyn_handle`
+   available power, the SoC callback) carry a larger explicit budget —
+   the default put them in permanent overflow during normal operation.
 6. The follow-up issue "restore plug-time correlation" exists and its
    URL is recorded in the story header's **Follow-up issue** line.
 7. `docs/agents/concepts/charger-budgeting.md` updated (tie-break

--- a/docs/stories/QS-342.story.md
+++ b/docs/stories/QS-342.story.md
@@ -2,7 +2,7 @@
 
 - **Issue**: [#342](https://github.com/tmenguy/quiet_solar/issues/342) — "Suspected regression: OCPP charger no longer detects IDBuzz plug-in (manual car association required)"
 - **Branch**: `QS_342`
-- **Follow-up issue** (task C2): _URL to be recorded here when filed._
+- **Follow-up issue** (task C2): https://github.com/tmenguy/quiet-solar/issues/344
 
 ## Problem
 

--- a/docs/stories/QS-342.story.md
+++ b/docs/stories/QS-342.story.md
@@ -1,6 +1,6 @@
 # QS-342 — Deterministic car↔charger allocation: fix the self-biased tie-break that orphans a plugged car
 
-- **Issue**: [#342](https://github.com/tmenguy/quiet_solar/issues/342) — "Suspected regression: OCPP charger no longer detects IDBuzz plug-in (manual car association required)"
+- **Issue**: [#342](https://github.com/tmenguy/quiet-solar/issues/342) — "Suspected regression: OCPP charger no longer detects IDBuzz plug-in (manual car association required)"
 - **Branch**: `QS_342`
 - **Follow-up issue** (task C2): https://github.com/tmenguy/quiet-solar/issues/344
 
@@ -98,8 +98,10 @@ same clock:
    HA entity). One minute after the Aug 4 16:26 restart the Zoe
    reported ≈ 14 h 52 plugged vs ≈ 17 s for the charger →
    `|Δ| ≫ CHARGER_LONG_CONNECTION_S (20 min)` → bump 0, permanently.
-   After any restart the plug-time disambiguator is structurally dead —
-   exactly in the scenario it was designed for.
+   For any plug session already active before an HA restart the
+   plug-time disambiguator is structurally dead — exactly in the
+   scenario it was designed for. (A session that starts *after* the
+   restart has both clocks aligned and is unaffected.)
 2. **Aggravating factor: hole tolerance.** The Zoe's integration
    reloads twice a day, leaving `unavailable` holes of 39 s (midnight)
    and 7 min (01:28) on `binary_sensor.gd054rl_plug`;
@@ -254,8 +256,8 @@ consecutive full rounds; **oscillation observable** = calls to
   the exact tie matrix, no prior attachments. Assert ID.buzz→wallbox 2
   and Zoe→wallbox 3 (via regret), convergence within one full round,
   zero `detach_car` calls after convergence over ≥3 further rounds.
-  **Expected red on current code** (self-biased tie-break gives the
-  caller the Zoe).
+  **Historical TDD note: was red on pre-A1 code as required** (the
+  self-biased tie-break gave the caller the Zoe); green since A1.
 - **Start-state × order sweep**
   (`test_convergence_from_all_attachment_states`, parametrised): all
   attachment states of the 2×2 fixture (each charger's car ∈ {None,
@@ -265,7 +267,8 @@ consecutive full rounds; **oscillation observable** = calls to
   3) within one full round, independent of order. This is the oracle
   for the Goal's "every attachment state" claim and covers the
   crossed-pairing recovery case (Zoe pre-attached to wallbox 2 — the
-  pre-fix ping-pong leftover; **expected red on current code**).
+  pre-fix ping-pong leftover; **historical TDD note: was red on
+  pre-A1 code as required**, green since A1).
 - **Regret tie-break** (`test_regret_prefers_charger_specific_car`):
   tie where one car has a strictly worse alternative → it wins the
   contested charger; plus the no-alternative case (car absent from
@@ -329,17 +332,12 @@ preserved becomes a named replacement test.
    need updating — same PR-description documentation rule as B2
    (`--impacted`/testmon will select them).
 2. **Root-cause `plug_time_bump = 0`** — DONE during planning (see
-   defect P2). Remaining action: file the follow-up issue (task C2)
-   with this exact, pre-authorized command:
-
-   ```bash
-   gh issue create --title "Restore charger↔car plug-time correlation (dead after HA restart)" --body "Split from QS-342 (see docs/stories/QS-342.story.md, defect P2). plug_time_bump is structurally 0 after an HA restart: car plug probes are recorder-bootstrapped (3 days) while the charger's synthetic is_there_a_car_plugged probe is in-memory-only since restart, so the compared durations never match within CHARGER_LONG_CONNECTION_S. Aggravated by allowed_max_holes_s=30s vs real integration-reload unavailable holes (39s–7min). Proposed: (a) bootstrap the charger synthetic plug probe from the status sensor's recorder history at startup; (b) per-entity/larger hole tolerance for periodically-reloading integrations. Verified against production recorder DB on 2026-08-05."
-   ```
-
-   Creating this issue from the implement phase is **explicitly
-   authorized by this story** (it is not a generic implement-phase
-   power). Record the resulting URL in the **Follow-up issue** line of
-   the story header (single canonical location — AC6 checks there).
+   defect P2). **Task C2 COMPLETE**: the follow-up issue was filed from
+   the implement phase (explicitly authorized by this story) with the
+   pre-authorized `gh issue create` command; the command is not
+   reproduced here to avoid accidental duplicate filing. The resulting
+   URL is recorded in the **Follow-up issue** line of the story header
+   (single canonical location — AC6 checks there).
 3. **Document** in `docs/agents/concepts/charger-budgeting.md`: the
    allocation tie-break cascade (A) including the steal semantics, the
    fact that exact score ties are a normal operating case (0.5 m
@@ -389,7 +387,7 @@ gate hints otherwise, follow the gate's hint as the source of truth.
    attachment state of the 2×2 incident fixture (parametrised sweep,
    both execution-order permutations)** the allocation converges to
    the same fixed point within one full round, with zero `detach_car`
-   calls afterwards (tested over ≥3 further rounds).
+   calls afterward (tested over ≥3 further rounds).
 2. In the incident replay **and** across the start-state sweep
    (including the crossed pairing), ID.buzz ends attached to wallbox 2
    and Zoe to wallbox 3 without any user selection.

--- a/docs/stories/QS-342.story.md
+++ b/docs/stories/QS-342.story.md
@@ -325,9 +325,17 @@ preserved becomes a named replacement test.
    non-user-facing" rule and the QS-306 log-volume tightening),
    recorded here and ratified by review round 2: this is the single
    data point that made QS-342 diagnosable only via a recorder-DB
-   forensic session. Volume bound: on change, plus a steady-state
-   floor of ~1 line per (charger, car) per 900 s from the helper's
-   re-log heartbeat. Note: existing caplog-based tests counting INFO
+   forensic session. Volume bound (as-planned: on change, plus a
+   steady-state floor of ~1 line per (charger, car) per 900 s from the
+   helper's re-log heartbeat). **Amended by review fix #01/#02** — the
+   as-planned bound did not hold when the change key flaps across a
+   quantisation edge, so changed values are additionally rate-limited
+   to ~1 line per key per `_CHANGED_RELOG_MIN_INTERVAL_S` (60 s), with
+   suppressed changes banked and disclosed (`[+n change(s)
+   suppressed…]`) on the first emission after the floor so a
+   revert-within-the-window excursion is never lost; the sibling
+   `get_best_car` winner line is floored the same way. Aggregate worst
+   case: (N chargers × M cars + N) lines/min. Note: existing caplog-based tests counting INFO
    lines from `custom_components.quiet_solar.ha_model.charger` may
    need updating — same PR-description documentation rule as B2
    (`--impacted`/testmon will select them).
@@ -399,12 +407,22 @@ gate hints otherwise, follow the gate's hint as the source of truth.
    generic car — it never ends the allocation round with
    `car is None` — and the generic attachment survives the following
    round.
-5. `get_car_score` decomposition is visible at INFO on change, keyed
-   on the quantised tuple only; within a single 900 s re-log window
-   (time controlled by the test), GPS jitter inside a distance bucket
-   produces zero new log lines; the 900 s unchanged-value re-emit is
-   asserted once (pins the bounded-volume claim)
+5. `get_car_score` decomposition is visible at INFO on change — subject
+   to the 60 s changed-value rate floor added by review fix #01/#02, so
+   "on change" means "within one floor window of the change, or banked
+   and disclosed as a suppressed count" — keyed on the quantised tuple
+   only; GPS jitter inside a distance bucket produces zero new log
+   lines **including when the last emission is older than the floor**
+   (the key-composition oracle: the floor must not be what explains the
+   silence), as must a changed `connected_time_delta`; the 900 s
+   unchanged-value re-emit is asserted once, an excursion that reverts
+   inside the floor is asserted to be disclosed rather than lost, and
+   sustained flapping is asserted to emit no more than once per floor
    (`test_get_car_score_decomposition_logs_once_then_on_change`,
+   `test_get_car_score_change_key_ignores_the_attach_delta`,
+   `test_get_car_score_excursion_reverting_inside_the_floor_is_disclosed`,
+   `test_get_car_score_decomposition_rate_limited_when_tuple_oscillates`,
+   `test_get_best_car_log_is_rate_limited_when_the_winner_flips`;
    `caplog` pinned to `custom_components.quiet_solar.ha_model.charger`).
 6. The follow-up issue "restore plug-time correlation" exists and its
    URL is recorded in the story header's **Follow-up issue** line.

--- a/docs/stories/QS-342.story.md
+++ b/docs/stories/QS-342.story.md
@@ -327,16 +327,22 @@ preserved becomes a named replacement test.
    data point that made QS-342 diagnosable only via a recorder-DB
    forensic session. Volume bound (as-planned: on change, plus a
    steady-state floor of ~1 line per (charger, car) per 900 s from the
-   helper's re-log heartbeat). **Amended by review fix #01/#02** — the
-   as-planned bound did not hold when the change key flaps across a
-   quantisation edge, so changed values are additionally rate-limited
-   to ~1 line per key per `_CHANGED_RELOG_MIN_INTERVAL_S` (60 s), with
-   suppressed changes banked and disclosed (`[+n change(s)
-   suppressed…]`) on the first emission after the floor so a
-   revert-within-the-window excursion is never lost; the sibling
-   `get_best_car` winner line is floored the same way. Aggregate worst
-   case: (N chargers × M cars + N) lines/min. Note: existing caplog-based tests counting INFO
-   lines from `custom_components.quiet_solar.ha_model.charger` may
+   helper's re-log heartbeat). **Superseded by review fix #03** — review
+   fixes #01/#02 added a 60 s changed-value time *floor* plus a banked
+   suppressed-change count; both are now deleted. A time floor cannot
+   satisfy completeness (a state whose whole lifetime fits inside the
+   window is unobservable) and the bank counted calls rather than
+   states. The helper now de-duplicates **by value** over a 900 s TTL
+   and caps each key at `_LOG_VALUES_PER_WINDOW` (4) emissions per
+   window, disclosing overflow as
+   `[+n further change(s) not shown in the last 900s]`. Dedup removes
+   the oscillation class; the budget makes the bound provable and
+   data-independent. Per key: **≤ 5 lines per 900 s**; aggregate:
+   **≤ 5·(N·M + 5N + 1)** per 900 s. All six `get_best_car`
+   winner-announcement branches are merged into one key, so the bound
+   is a property of the helper rather than of one call site. Note:
+   existing caplog-based tests counting INFO lines from
+   `custom_components.quiet_solar.ha_model.charger` may
    need updating — same PR-description documentation rule as B2
    (`--impacted`/testmon will select them).
 2. **Root-cause `plug_time_bump = 0`** — DONE during planning (see
@@ -407,23 +413,27 @@ gate hints otherwise, follow the gate's hint as the source of truth.
    generic car — it never ends the allocation round with
    `car is None` — and the generic attachment survives the following
    round.
-5. `get_car_score` decomposition is visible at INFO on change — subject
-   to the 60 s changed-value rate floor added by review fix #01/#02, so
-   "on change" means "within one floor window of the change, or banked
-   and disclosed as a suppressed count" — keyed on the quantised tuple
-   only; GPS jitter inside a distance bucket produces zero new log
-   lines **including when the last emission is older than the floor**
-   (the key-composition oracle: the floor must not be what explains the
-   silence), as must a changed `connected_time_delta`; the 900 s
-   unchanged-value re-emit is asserted once, an excursion that reverts
-   inside the floor is asserted to be disclosed rather than lost, and
-   sustained flapping is asserted to emit no more than once per floor
-   (`test_get_car_score_decomposition_logs_once_then_on_change`,
+5. `get_car_score` decomposition is visible at INFO the first time each
+   distinct value is seen in a window (review fix #03: dedup by value
+   over a 900 s TTL plus a per-key budget of 4 emissions per window,
+   overflow disclosed as a count) — keyed on the quantised tuple only;
+   GPS jitter inside a distance bucket produces zero new log lines
+   **including long after the previous emission** (the key-composition
+   oracle: no rate limit may be what explains the silence), as must a
+   changed `connected_time_delta`; the 900 s TTL re-emit is asserted
+   once, an A→B→A oscillation is asserted to cost one line per distinct
+   value rather than one per transition, and monotone drift is asserted
+   to be capped by the budget
+   (`test_get_car_score_decomposition_dedups_by_value`,
    `test_get_car_score_change_key_ignores_the_attach_delta`,
-   `test_get_car_score_excursion_reverting_inside_the_floor_is_disclosed`,
-   `test_get_car_score_decomposition_rate_limited_when_tuple_oscillates`,
-   `test_get_best_car_log_is_rate_limited_when_the_winner_flips`;
+   `test_get_car_score_decomposition_bounded_when_tuple_oscillates`,
+   `test_monotone_value_drift_is_budget_capped`,
+   `test_naive_time_is_normalised`, `test_log_state_survives_detach_car`;
    `caplog` pinned to `custom_components.quiet_solar.ha_model.charger`).
+   Aggregate volume over a full 900 s window is asserted on the real
+   `check_load_activity_and_constraints` path, not on `get_best_car` in
+   isolation (`test_allocation_churn_total_log_volume_over_a_full_window`
+   and the per-site throttle tests beside it).
 6. The follow-up issue "restore plug-time correlation" exists and its
    URL is recorded in the story header's **Follow-up issue** line.
 7. `docs/agents/concepts/charger-budgeting.md` updated (tie-break

--- a/docs/stories/QS-342.story.md
+++ b/docs/stories/QS-342.story.md
@@ -1,0 +1,496 @@
+# QS-342 — Deterministic car↔charger allocation: fix the self-biased tie-break that orphans a plugged car
+
+- **Issue**: [#342](https://github.com/tmenguy/quiet_solar/issues/342) — "Suspected regression: OCPP charger no longer detects IDBuzz plug-in (manual car association required)"
+- **Branch**: `QS_342`
+- **Follow-up issue** (task C2): _URL to be recorded here when filed._
+
+## Problem
+
+Field incident (2026-08-04 → 2026-08-05, user log `home-assistant.log`):
+ID.buzz physically plugged into wallbox 2 "parking" (OCPP) and Zoe
+plugged into wallbox 3 "portail", both continuously since Aug 3. In the
+QS UI the ID.buzz showed **no charger** and wallbox 2 showed **no car —
+not even its generic car** — until the user manually associated the
+ID.buzz at ~09:46. All sensors were correct the whole time (OCPP plug
+state, VW plug sensor `on`, tracker `home` with GPS).
+
+Root cause — **verified against the production recorder DB**
+(`home-assistant_v2.db`, tracker attribute history Aug 3–5). QS's Zoe
+tracker is `device_tracker.gd054rl_location`; during the incident it
+reported a stable position 3.97 m from charger 2 and 3.69 m from
+charger 3 (the Zoe was physically parked between the two wallboxes,
+which are 7.54 m apart). ID.buzz
+(`device_tracker.volkswagen_id_buzz_2023_lwb_pro_location`) sat 3.58 m
+/ 9.18 m from them. Verified positions (usable directly in tests;
+distances re-derived independently in review round 2):
+
+- wallbox 2 "parking" (QS config): `43.635211, 6.989175`
+- wallbox 3 "portail" (QS config): `43.635238, 6.989261`
+- Zoe tracker during incident: `43.6352197222222, 6.98922277777778`
+- ID.buzz tracker during incident: `43.635236, 6.989147`
+
+| `get_car_score` (incident, verified) | wallbox 2 (parking) | wallbox 3 (portail) |
+|---|---|---|
+| Zoe (3.97 m / 3.69 m) | **9 300 005** | **9 300 005** |
+| ID.buzz (3.58 m / 9.18 m) | **9 300 005** | 8 200 005 |
+
+The logged score (`9300005.0`) matches the computed one to the digit.
+The distance component (`dist_bump = 1 + int(100·(50−d)/50)`, i.e.
+0.5 m buckets over 50 m) dominates the score and produces an **exact
+3-way tie**: 3.69 m, 3.97 m and 3.58 m all land in the same
+`[3.5 m, 4.0 m)` bucket → bump 93, even though the Zoe is physically
+closer to charger 3. This quantisation is deliberate-looking and
+sensible (car GPS jitters by metres; finer resolution would make the
+allocation flap with GPS noise), so **exact ties are a normal operating
+case that recurs every time the cars sleep in their usual spots** —
+the fix must be a deterministic tie-break, *not* finer distance
+resolution. In
+`QSChargerGeneric.get_best_car` (`custom_components/quiet_solar/ha_model/charger.py`),
+the greedy assignment loop:
+
+1. builds `active_chargers = [self, <other plugged chargers>]` and uses
+   a strict `>` when picking the best (score, car) pair — **on a tie,
+   the charger running the computation wins the car**;
+2. only keeps its own row of the computed allocation
+   (`assigned_chargers.get(self)`), discarding the (correct)
+   assignments computed for the other chargers.
+
+Consequences observed in the log (17 791 × `removed from another
+charger` since the HA restart at Aug 4 16:26, every ~7 s):
+
+- wallbox 2's own call assigns Zoe to itself; 30 ms later wallbox 3's
+  call steals Zoe back → **infinite attach/detach ping-pong**, the
+  charger constraint is pushed and reset every cycle;
+- wallbox 3's call correctly computes ID.buzz→wallbox 2 but that row is
+  discarded → **ID.buzz is never attached anywhere**;
+- because wallbox 2's own call always "wins" a car, `best_car` is never
+  `None` for it, so the existing generic-car fallback
+  (`get_best_car`, `self._default_generic_car` branch) **never
+  triggers** → "plugged but no car" in the UI.
+
+Not a sensor / OCPP / VW regression. The greedy allocation dates from
+2025-03; the trigger is situational (two chargers plugged
+simultaneously, cars parked within metres of both chargers → exact
+score tie). QS-306/319 (log changes) verified behaviour-neutral here.
+
+Why no existing mechanism broke the tie: `plug_time_bump` is dead (see
+P2 below), and the *attach-duration* bumps (`connected_time_delta`,
+`CHARGER_LONG_CONNECTION_S`/`CAR_CHARGER_LONG_RELATIONSHIP_S` — a
+**different** component from plug-time correlation) never accrued
+because the 7 s ping-pong reset `car_attach_time` on every cycle — the
+oscillation starves the very mechanism that would have damped it.
+
+### Secondary defect P2 — plug-time correlation is dead
+
+(Stable label "P2", distinct from the design section letters.)
+**Root-caused and verified in the recorder DB**: `plug_time_bump = 0`
+on both chargers because the two compared durations do not live on the
+same clock:
+
+1. **Asymmetric duration sources.** The *car* side
+   (`car.get_continuous_plug_duration`) is backed by a probe that is
+   bootstrapped with up to **3 days of recorder history** at startup
+   (`attach_ha_state_to_probe(self.car_plugged, …,
+   reload_from_history=True)`, `car.py`, introduced 2025-12-01
+   `615241e1`). The *charger* side uses the synthetic
+   `is_there_a_car_plugged` probe, which is **in-memory only and born
+   at HA restart** (no recorder bootstrap possible — it is not a real
+   HA entity). One minute after the Aug 4 16:26 restart the Zoe
+   reported ≈ 14 h 52 plugged vs ≈ 17 s for the charger →
+   `|Δ| ≫ CHARGER_LONG_CONNECTION_S (20 min)` → bump 0, permanently.
+   After any restart the plug-time disambiguator is structurally dead —
+   exactly in the scenario it was designed for.
+2. **Aggravating factor: hole tolerance.** The Zoe's integration
+   reloads twice a day, leaving `unavailable` holes of 39 s (midnight)
+   and 7 min (01:28) on `binary_sensor.gd054rl_plug`;
+   `get_last_state_value_duration`'s default
+   `allowed_max_holes_s = 30 s` (`num_seconds_before=None` path,
+   `device.py`) truncates the duration at each such hole (9 h 29
+   instead of ~35 h on the morning of Aug 5).
+3. Also observed: charger 2 had a 59 s `Available` blip at 21:19,
+   restarting its own plugged duration.
+
+Restoring plug-time correlation (charger-side bootstrap derived from
+the status sensor's recorder history + per-entity hole tolerance) is a
+**follow-up issue**, not this story: fix A below resolves the user
+incident without it.
+
+## Goal
+
+A plugged charger must always end up with a stable, deterministic car:
+the same allocation whichever charger computes it (given identical
+attachment state), convergence to a fixed point within one full
+allocation round from **every attachment state of the 2×2 incident
+fixture (parametrised sweep)** — including the crossed pairing
+inherited from the pre-fix ping-pong — no attach/detach oscillation,
+and the generic car as a working safety net.
+In the incident scenario: Zoe ends on wallbox 3, **ID.buzz gets
+wallbox 2 automatically** (no manual association needed).
+
+## Design
+
+### A — Deterministic allocation (caller-independent given identical attachment state)
+
+In `get_best_car` (`custom_components/quiet_solar/ha_model/charger.py`,
+greedy loop ~3099–3134), keep the greedy structure (no global/
+home-level refactor — explicitly ruled out with the user as too risky)
+but make its result independent of the caller. Verified implementable
+in place (review round 2): selection is a full-list max scan + tied-
+pair collection + cascade replacing lines ~3106–3118; assignment and
+car-removal (~3124–3133) unchanged; scores precomputed in
+`chargers_scores`, so regret needs no re-scoring.
+
+1. **Stable charger iteration order**: build `active_chargers` in
+   deterministic order (sort by charger name) instead of `[self,
+   others…]`. **Defensive only** — A.2 alone guarantees caller
+   independence (it scans all pairs); the stable order just removes
+   the positional bias as belt-and-braces.
+2. **Deterministic tie-break cascade in the selection loop.** Each
+   greedy iteration first finds the maximum remaining score, then
+   considers **all (charger, car) pairs at that score across all
+   unassigned chargers** (not only each charger's list head — a tied
+   car buried behind another tied car in one charger's list must still
+   be able to win elsewhere). Among the tied pairs, prefer in order:
+   a. **Regret** (user-approved 2026-08-05; ordering and steal
+      semantics user-approved after review rounds 1–2) — the pair
+      whose car loses most if not assigned here:
+      `regret(car, charger) = score(car, charger) − best score of that
+      car on any other unassigned active charger`, where a car with no
+      other positive-score **unassigned** charger has alternative `0`
+      (regret = its own score). Implementation trap (review round 2):
+      the alternative-scan **must skip chargers already in
+      `assigned_chargers`** — their `chargers_scores` lists are stale
+      by design (only cars are removed on assignment, not chargers).
+      Regret is **recomputed at every greedy iteration** over the
+      remaining unassigned chargers. Incident walk-through: round 1
+      tied set = {(c2, Zoe), (c3, Zoe), (c2, ID.buzz)} at 9 300 005;
+      regret(ID.buzz, c2) = 1 100 000 > regret(Zoe, ·) = 0 →
+      ID.buzz→wallbox 2; round 2 → Zoe→wallbox 3.
+   b. **Stickiness** — among equal-regret tied pairs, prefer the
+      charger this car is currently attached to (defined as
+      `charger.car is not None and charger.car.name == car.name`,
+      charger = the pair's charger). Keeps symmetric steady states
+      stable (no swap flapping).
+   c. **Stable order** — charger name, then car name; arbitrary but
+      identical for every caller. Assumes device names are unique
+      (enforced de facto by HA config-entry titles; documented
+      assumption, not re-verified per cycle — runtime duplicate-name
+      guard reviewed and **rejected** as YAGNI, see review notes).
+   Across *different* scores nothing changes: a strictly higher score
+   wins, as today.
+
+   **Steal semantics (deliberate change vs the round-1 draft):** an
+   attached car can be displaced at *equal* score by a
+   *strictly-higher-regret* pair — this is required for crossed-
+   pairing recovery (round-1 finding C2). The defensible invariant is:
+   the allocation produced by regret is attachment-independent up to
+   equal-regret ties, so **any attachment state matching a
+   regret-consistent allocation is a fixed point**; an incumbent is
+   only evicted when the clean-slate allocation would not have given
+   it that charger. (The earlier claim "regret never evicts an
+   incumbent" was wrong and is withdrawn.)
+3. **Per-charger score list**: unchanged. The round-1 idea of a
+   deterministic sort key was dropped in round 2 — selection
+   correctness does not depend on list order (A.2 scans all tied
+   pairs), and changing the sort would only inflate existing-test
+   churn for zero AC value.
+
+**Mid-round mutation caveat** (review round 2): each charger applies
+its own row immediately, so attachment state — which stickiness (2b)
+reads — mutates *during* a round, and production execution order is
+scheduler-dependent. The regret step is attachment-independent, so
+this only matters for equal-regret ties; section B therefore tests
+**both execution-order permutations** and sweeps **all attachment
+states of the 2×2 fixture** to pin convergence empirically.
+
+**Explicitly retained**: the "each caller keeps only its own row"
+behaviour (`assigned_chargers.get(self)`) — convergence relies on
+every plugged charger running its own `get_best_car` within one update
+cycle (~7 s in the field); a latency assumption, not a correctness
+one. Also retained: scoring formula (`get_car_score`), user-selection
+override path (it early-returns before the greedy loop and forces
+competing chargers to score 0 for other cars, so a user-pinned pair is
+effectively excluded from the contested pool — behaviour unchanged),
+boot-car path, generic-car fallback. The per-charger
+`_default_generic_car` is **not** in `home._cars`, hence never a
+candidate in `chargers_scores` — it cannot be stolen and never
+competes; it is only the local fallback. It exists unconditionally by
+construction (`QSChargerGeneric.__init__`).
+
+### B — Scenario tests (regression net)
+
+New test module `tests/test_charger_allocation_tiebreak.py`. Fixture
+source: `tests/test_charger_coverage_deep.py` helpers (`_make_hass`,
+`_make_home`, `_create_charger` — forwards `CONF_CHARGER_LATITUDE`/
+`CONF_CHARGER_LONGITUDE` via `config.update(extra)` —, `_make_real_car`,
+`_plug_car`, `_init_charger_states`); **import them** (copy only if
+import proves impossible, and say so in the PR description).
+
+Fixture recipe (pins the exact incident matrix — review round 2):
+patch `QSCar.get_car_coordinates` per car with the fixed tuples from
+the Problem section; patch `car.is_car_plugged` → `True` (it is called
+both with and without `for_duration` — cover both) so
+`plug_bump == 5`; patch `charger.is_plugged` → `True` on **both**
+chargers (otherwise the other charger never enters `active_chargers`);
+leave `get_continuous_plug_duration` unmocked (returns `None` → −1 →
+`plug_time_bump == 0`, as in the field). Preconditions:
+`charger._boot_car is None` (the boot-car branch preempts the generic
+fallback) and no user-originated car selection.
+
+Round driver: a `_run_allocation_round(chargers, time)` helper — for
+each charger in the given order: `car = charger.get_best_car(time)`
+then `charger.attach_car(car, time)` if it changed; advance simulated
+time ~7 s per round; keep total simulated span **< 20 min** (so the
+`connected_time_delta` bumps never dissolve the tie mid-test) and
+**< 900 s** where log assertions are involved (see C1).
+
+Definitions used by the assertions: **convergence** = the allocation
+(mapping charger→car over all active chargers) is identical on two
+consecutive full rounds; **oscillation observable** = calls to
+`detach_car` (spy/wrap) after convergence.
+
+- **Incident replay** (`test_incident_replay_idbuzz_gets_parking`):
+  two plugged chargers at the verified coordinates, Zoe + ID.buzz with
+  the exact tie matrix, no prior attachments. Assert ID.buzz→wallbox 2
+  and Zoe→wallbox 3 (via regret), convergence within one full round,
+  zero `detach_car` calls after convergence over ≥3 further rounds.
+  **Expected red on current code** (self-biased tie-break gives the
+  caller the Zoe).
+- **Start-state × order sweep**
+  (`test_convergence_from_all_attachment_states`, parametrised): all
+  attachment states of the 2×2 fixture (each charger's car ∈ {None,
+  Zoe, ID.buzz}, minus double-attachment of the same car) × both
+  execution-order permutations of `_run_allocation_round`. Assert:
+  convergence to the same fixed point (ID.buzz→wallbox 2, Zoe→wallbox
+  3) within one full round, independent of order. This is the oracle
+  for the Goal's "every attachment state" claim and covers the
+  crossed-pairing recovery case (Zoe pre-attached to wallbox 2 — the
+  pre-fix ping-pong leftover; **expected red on current code**).
+- **Regret tie-break** (`test_regret_prefers_charger_specific_car`):
+  tie where one car has a strictly worse alternative → it wins the
+  contested charger; plus the no-alternative case (car absent from
+  other chargers' lists → alternative 0); plus, as a **single
+  assertion** (not a new scenario family), the all-equal case falling
+  through to stable name order.
+- **Stickiness** (`test_equal_score_does_not_steal_attached_car`):
+  symmetric tie (equal regrets), car attached to one charger with
+  `car_attach_time` **within the last 20 min** (beyond
+  `CHARGER_LONG_CONNECTION_S` the existing attach-duration score bumps
+  take over and the tie disappears — the test must exercise the new
+  tie-break, not the old bumps). Assert the incumbent keeps the car;
+  a strictly higher score, or an equal score with strictly higher
+  regret, does steal it (matching AC3).
+- **Generic fallback / no orphan**
+  (`test_losing_charger_falls_back_to_generic_car`): incident matrix
+  but the second car scores 0 → the losing plugged charger's
+  `get_best_car` returns its `_default_generic_car`; run one more
+  round and assert the generic attachment is stable (the generic car
+  is not in `home._cars`, so it never becomes a steal candidate); in
+  the tested scenarios a plugged charger never ends an allocation
+  round with `car is None`. (Scope: `get_best_car`-level; driving the
+  full async `check_load_activity_and_constraints` is not required.)
+- **Caller independence** (`test_allocation_is_caller_independent`):
+  for each scenario above, `get_best_car` computed from every charger
+  yields the same global allocation given identical attachment state.
+
+**Existing suites** (task B2): the tie-break change alters allocation
+outcomes wherever old tests encoded caller-wins-ties semantics. After
+A1, run
+`python scripts/qs/quality_gate.py --quick tests/test_charger_rebalancing_scenarios.py tests/test_bug_48_charger_oscillation.py tests/test_charger_coverage_deep.py tests/test_chargers_advanced.py`
+and update any assertion that relied on the self-biased tie-break,
+documenting each change in the PR description. **Intent preservation
+rule**: assertion updates must keep each test's original failure mode
+detectable — change expected *allocations*, never delete
+oscillation/detach-count checks (especially in
+`test_bug_48_charger_oscillation.py`); anything that cannot be
+preserved becomes a named replacement test.
+
+### C — Diagnosis & observability
+
+1. **Score decomposition logging** in `get_car_score`: promote the
+   existing DEBUG decomposition to INFO-on-change via the existing
+   `log_info_on_change` helper (`LogOnChangeMixin`,
+   `charger.py` ~655–688: per-instance memo, `deadband=None` = exact
+   `==`, unchanged-value re-log after `_RELOG_UNCHANGED_AFTER_S =
+   900 s`; `QSChargerGeneric` inherits it). **Change key = the
+   quantised tuple only** `(score_plug_bump, score_plug_time_bump,
+   score_dist_bump)`, memo key `f"get_car_score:{car.name}"` (memo
+   lives on the scored charger instance, so cross-caller dedup is
+   automatic). Raw distance and `connected_time_delta` may appear in
+   the message payload (%-style lazy args) but **must not** be part of
+   the change key. *Deliberate INFO exception* (vs the "debug for
+   non-user-facing" rule and the QS-306 log-volume tightening),
+   recorded here and ratified by review round 2: this is the single
+   data point that made QS-342 diagnosable only via a recorder-DB
+   forensic session. Volume bound: on change, plus a steady-state
+   floor of ~1 line per (charger, car) per 900 s from the helper's
+   re-log heartbeat. Note: existing caplog-based tests counting INFO
+   lines from `custom_components.quiet_solar.ha_model.charger` may
+   need updating — same PR-description documentation rule as B2
+   (`--impacted`/testmon will select them).
+2. **Root-cause `plug_time_bump = 0`** — DONE during planning (see
+   defect P2). Remaining action: file the follow-up issue (task C2)
+   with this exact, pre-authorized command:
+
+   ```bash
+   gh issue create --title "Restore charger↔car plug-time correlation (dead after HA restart)" --body "Split from QS-342 (see docs/stories/QS-342.story.md, defect P2). plug_time_bump is structurally 0 after an HA restart: car plug probes are recorder-bootstrapped (3 days) while the charger's synthetic is_there_a_car_plugged probe is in-memory-only since restart, so the compared durations never match within CHARGER_LONG_CONNECTION_S. Aggravated by allowed_max_holes_s=30s vs real integration-reload unavailable holes (39s–7min). Proposed: (a) bootstrap the charger synthetic plug probe from the status sensor's recorder history at startup; (b) per-entity/larger hole tolerance for periodically-reloading integrations. Verified against production recorder DB on 2026-08-05."
+   ```
+
+   Creating this issue from the implement phase is **explicitly
+   authorized by this story** (it is not a generic implement-phase
+   power). Record the resulting URL in the **Follow-up issue** line of
+   the story header (single canonical location — AC6 checks there).
+3. **Document** in `docs/agents/concepts/charger-budgeting.md`: the
+   allocation tie-break cascade (A) including the steal semantics, the
+   fact that exact score ties are a normal operating case (0.5 m
+   distance buckets), the name-uniqueness assumption, the "plug-time
+   correlation is dead after HA restart (asymmetric history sources)"
+   limitation with a pointer to the follow-up issue, and the **known
+   residual failure mode**: a car GPS-jittering across a 0.5 m bucket
+   edge produces alternating strict-score winners that no tie-break
+   sees (steal-margin hysteresis stays out of scope until observed in
+   the field).
+
+### Out of scope (agreed with user)
+
+- Global/home-level single allocation pass (risk; the deterministic
+  greedy achieves the same observable result).
+- Configurable steal-margin hysteresis (YAGNI — regret + stickiness on
+  equal score suffices for the observed failure; bucket-edge flapping
+  recorded as a known residual in the doc update).
+- Persisting state history across restarts.
+- Fixing plug-time correlation itself (follow-up issue, task C2).
+- Runtime duplicate-name guard (rejected in round-2 triage, YAGNI).
+
+## Doc maintenance
+
+`scripts/qs/check_doc_drift.py --paths ha_model/charger.py ha_model/device.py`:
+
+- `docs/agents/concepts/charger-budgeting.md` — **stale + affected**:
+  task Doc below updates it (tie-break cascade + steal semantics +
+  residual bucket-edge note + restart limitation), bumps
+  `last_verified`.
+- `docs/agents/concepts/ha-device-mixin.md` — Doc-OK: `device.py` is
+  only *read* for diagnosis (P2); no change to mixin behaviour in this
+  story (the hole-tolerance change belongs to the follow-up issue).
+- `docs/agents/concepts/external-control-detection.md`,
+  `docs/agents/concepts/notification-routing.md` — Doc-OK: flagged only
+  because they list `device.py` as source; lost-control/notification
+  surfaces untouched by this story.
+
+Gate note: the change set is Python + `docs/` only, so the
+`--quick tests/qs` supplement is **not expected** to apply; if the
+gate hints otherwise, follow the gate's hint as the source of truth.
+
+## Acceptance criteria
+
+1. Given identical attachment state, `get_best_car` computes the same
+   global allocation whichever charger calls it; and from **every
+   attachment state of the 2×2 incident fixture (parametrised sweep,
+   both execution-order permutations)** the allocation converges to
+   the same fixed point within one full round, with zero `detach_car`
+   calls afterwards (tested over ≥3 further rounds).
+2. In the incident replay **and** across the start-state sweep
+   (including the crossed pairing), ID.buzz ends attached to wallbox 2
+   and Zoe to wallbox 3 without any user selection.
+3. A car attached to a charger is stolen **only** by a strictly higher
+   score, or by an equal score with strictly higher regret; an
+   equal-score, equal-regret competitor never steals.
+4. In the incident-replay and score-0 scenarios (with
+   `_boot_car is None`), the losing plugged charger attaches its
+   generic car — it never ends the allocation round with
+   `car is None` — and the generic attachment survives the following
+   round.
+5. `get_car_score` decomposition is visible at INFO on change, keyed
+   on the quantised tuple only; within a single 900 s re-log window
+   (time controlled by the test), GPS jitter inside a distance bucket
+   produces zero new log lines; the 900 s unchanged-value re-emit is
+   asserted once (pins the bounded-volume claim)
+   (`test_get_car_score_decomposition_logs_once_then_on_change`,
+   `caplog` pinned to `custom_components.quiet_solar.ha_model.charger`).
+6. The follow-up issue "restore plug-time correlation" exists and its
+   URL is recorded in the story header's **Follow-up issue** line.
+7. `docs/agents/concepts/charger-budgeting.md` updated (tie-break
+   cascade + steal semantics + exact-tie normality + name-uniqueness
+   assumption + bucket-edge residual + restart/asymmetric-history
+   limitation), `last_verified` bumped.
+8. `python scripts/qs/quality_gate.py --impacted` green (plus the
+   `--quick` runs listed in section B for the existing suites; the
+   `tests/qs` supplement is not expected for this change set).
+
+## Task breakdown
+
+1. **B1** — write `tests/test_charger_allocation_tiebreak.py` (all six
+   scenario families from section B, fixture recipe and round driver
+   per section B) — TDD: the incident-replay and start-state-sweep
+   tests are **confirmed red** on current code before A1 starts (the
+   other tests may accidentally pass under the old caller-bias
+   depending on the computing charger — red confirmation is required
+   only for those two).
+2. **A1** — `get_best_car`: deterministic `active_chargers` ordering
+   (defensive) + full tie-break cascade **regret → stickiness → stable
+   name order** over all tied max-score pairs (per Design A.2,
+   including the no-alternative regret definition and the
+   skip-assigned-chargers alternative-scan). Per-charger list sort
+   unchanged. (`custom_components/quiet_solar/ha_model/charger.py`)
+3. **B2** — re-run the existing charger suites listed in section B;
+   update assertions that encoded caller-wins-ties semantics under the
+   intent-preservation rule; document each change in the PR
+   description.
+4. **C1** — score-decomposition INFO-on-change logging in
+   `get_car_score` (quantised-tuple key, %-style lazy args) +
+   `test_get_car_score_decomposition_logs_once_then_on_change`
+   (time-controlled, < 900 s window + one re-emit assertion).
+5. **C2** — file the follow-up issue with the pre-authorized
+   `gh issue create` command from Design C.2; record the URL in the
+   story header.
+6. **Doc** — update `docs/agents/concepts/charger-budgeting.md`
+   (tie-break cascade, steal semantics, exact-tie normality,
+   name-uniqueness assumption, bucket-edge residual, restart
+   limitation), bump `last_verified`.
+7. **Gate** — `python scripts/qs/quality_gate.py --impacted` green +
+   section-B `--quick` runs (`tests/qs` supplement not expected, see
+   Doc maintenance).
+
+## Adversarial Review Notes
+
+**Round 1 — 2026-08-05, story v4 reviewed** (4 reviewers: critic,
+concrete-planner, dev-proxy, scope-guardian). 19 deduped findings, all
+accepted and folded into v5; verified **19/19 resolved** by the
+delta-auditor in round 2. Highlights: C1 task A1 had dropped the
+regret step (all 4 reviewers); C2 stickiness-first could freeze the
+crossed pairing → cascade reordered regret-first (**user-approved**).
+Full round-1 table available in the v5 revision (git history).
+
+**Round 2 — 2026-08-05, story v5 reviewed** (4 global reviewers +
+delta-auditor). Dev-proxy verdict: READY. Delta-auditor: 19/19 round-1
+findings resolved, no criticals in the delta; coordinates re-derived
+and confirmed.
+
+| # | Finding (deduped) | Reviewers | State |
+|---|---|---|---|
+| N-C1 | AC3 "strictly higher score to steal" contradicted the regret-based crossed-pairing recovery (equal-score steal); A.2b justification "higher-regret challenger targets a different charger by construction" false (counterexample verified) | critic, concrete-planner, delta-auditor | **resolved** — AC3 rewritten (steal = strictly higher score OR equal score + strictly higher regret, **user-approved**); false invariant withdrawn, replaced by the fixed-point statement in A.2 "Steal semantics" |
+| N-R1 | Mid-round attachment mutation: stickiness reads `charger.car` which mutates as chargers apply their rows; intra-round order scheduler-dependent | critic | **resolved** — caveat stated in Design A; B sweeps all 2×2 attachment states × both execution orders (**user-approved**) |
+| N-I1 | A.3 sort-key change was hygiene-only and inflated B2 churn | scope-guardian | **resolved** — dropped; per-charger list sort unchanged |
+| N-I2 | A.1 stable ordering defensive vs load-bearing unstated | scope-guardian | **resolved** — marked defensive-only |
+| N-I3 | AC1/Goal "any starting attachment state" lacked an oracle | scope-guardian, dev-proxy, critic, delta-auditor | **resolved** — parametrised start-state × order sweep; claims scoped to the swept fixture |
+| N-I4 | B2 could weaken bug-48 regression net | dev-proxy | **resolved** — intent-preservation rule added |
+| N-I5 | "import or copy" fixtures ambiguous | dev-proxy | **resolved** — import by default, copy only if impossible (documented in PR) |
+| N-I6 | AC5 ignored the 900 s re-log heartbeat | dev-proxy, critic, concrete-planner | **resolved** — AC5/C1 time-bounded; re-emit asserted; volume floor recorded in the INFO justification |
+| N-I7 | Regret alternative-scan trap: assigned chargers' lists stay populated | concrete-planner | **resolved** — skip-assigned-chargers rule in A.2a |
+| N-I8 | Fixture spec didn't pin `plug_bump=5` / `plug_time_bump=0` / other charger's `is_plugged` | concrete-planner | **resolved** — fixture recipe added to section B |
+| N-I9 | Round driver under-specified (attach after get_best_car, time steps) | concrete-planner | **resolved** — `_run_allocation_round` spec in section B |
+| N-I10 | Bucket-edge flapping is a residual failure mode | critic | **resolved** — recorded in the charger-budgeting doc task |
+| N-CL1 | P2 "permanently dead" vs "<20 min bumps" apparent contradiction | critic | **resolved** — distinct components explained (plug-time vs attach-duration; ping-pong starved the attach bumps) |
+| N-CL2 | User-pinned/boot-car pool interaction unstated | critic | **resolved** — early-return/exclusion behaviour stated (unchanged) in Design A |
+| N-CL3 | Generic car's role in later rounds unstated | critic | **resolved** — not in `home._cars`, never a candidate; post-attach round assertion added |
+| N-CL4 | D2 command seemed title-only | critic | **closed, no change** — artifact of the abbreviated review prompt; the story contains the full command |
+| N-CL5 | Design sections A/B/D with no C; P2 note referenced the gap | critic | **resolved** — Design D renamed C; P2 note reworded |
+| N-CL6 | B1 "confirmed red" dubious for some tests | critic | **resolved** — red confirmation required only for incident-replay + sweep |
+| N-CL7 | Section A heading lacked the attachment-state qualifier | delta-auditor | **resolved** — heading amended |
+| N-CL8 | Task-7 gate clause vs `tests/qs` supplement ambiguity | delta-auditor | **resolved** — "not expected for this change set" clause |
+| N-CL9 | Existing caplog INFO-count tests may break under C1 | concrete-planner | **resolved** — note + PR-documentation rule in C.1 |
+| N-CL10 | Follow-up-issue URL had three destinations | dev-proxy | **resolved** — single canonical location: story header line |
+| N-X1 | Runtime duplicate-name guard suggested | critic | **rejected** (user decision, round-2 triage) — doc-only treatment kept (round-1 I4); YAGNI, HA config-entry titles make duplicates unlikely |
+
+Open criticals: 0. Rejected: N-X1 (will not resurface).

--- a/docs/stories/QS-342.story_review_fix_#01.md
+++ b/docs/stories/QS-342.story_review_fix_#01.md
@@ -1,0 +1,202 @@
+# QS-342 — Review fix plan #01
+
+## Summary
+- Source PR: #345
+- Source story: docs/stories/QS-342.story.md
+- Findings to fix: 14 (8 should-fix + 6 nice-to-have; triaged with the user 2026-08-05, "fix" confirmed)
+- Next implement phase: `/implement-task`
+
+## Findings to fix
+
+### [should-fix] Unbounded INFO volume when the change key oscillates across a quantisation edge
+- File: `custom_components/quiet_solar/ha_model/charger.py:3015` (the `log_info_on_change` call in `get_car_score`; the `LogOnChangeMixin` helper lives at ~640–688)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The memo compares only against the immediately-previous tuple, with no
+  hysteresis or minimum-interval floor. A car GPS-jittering across a 0.5 m
+  `dist_bump` bucket edge (charger.py ~2963) alternates the change key on every
+  ~7 s allocation cycle → ~12k INFO lines/day per (charger, car). Also triggered
+  by `score_plug_time_bump`'s fine quantisation (~2937–2943: a step every 3.6 s
+  of Δ) whenever plug-time correlation is alive and probe durations jitter
+  (recorder holes / sensor blips — the story's P2 aggravators). The in-code
+  comment's volume claim ("900 s heartbeat bounds steady-state volume") does not
+  hold in exactly the churn conditions this incident produced — the same
+  INFO-spam class QS-306 removed. The story ratified the INFO exception on a
+  volume bound that must actually hold.
+- Proposed fix: Add a per-key minimum-interval floor to the on-change emission
+  (e.g. after emitting for key K, suppress further *changed-value* emissions for
+  K for a floor window — a rate limit, distinct from the existing 900 s
+  unchanged-value re-log), or equivalent hysteresis (e.g. only re-emit when the
+  value differs from the last *emitted* value AND the floor has elapsed).
+  Whichever mechanism is chosen: update the in-code QS-342 comment and the
+  `docs/agents/concepts/charger-budgeting.md` paragraph so the documented volume
+  bound matches the implementation, and extend
+  `tests/test_charger_allocation_tiebreak.py::test_get_car_score_decomposition_logs_once_then_on_change`
+  (or add a sibling test) with an oscillating-tuple case asserting the bounded
+  rate. Coordinate with the next finding — they interact on the same memo.
+
+### [should-fix] `detach_car` wipes the whole log-on-change memo, defeating the new suppression
+- File: `custom_components/quiet_solar/ha_model/charger.py:4157` (`detach_car`'s `_log_on_change_state` wipe)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: `detach_car` clears the charger's entire `_log_on_change_state` —
+  a QS-306 behaviour written for keys describing the attached car — but the new
+  `get_car_score:{car.name}` keys are car-qualified and cover *every* car, not
+  just the departing one. After any detach, the next `get_best_car` cycle
+  re-emits one INFO decomposition line per car on that charger even though every
+  tuple is unchanged; under attach/detach churn the on-change suppression is
+  permanently defeated and compounds with the previous finding.
+- Proposed fix: Scope the wipe: preserve `get_car_score:*` keys (or, minimally,
+  wipe only the departing car's `get_car_score:{car.name}` key alongside the
+  attached-car keys the wipe was written for). Add a test: attach → score (1
+  line) → detach → score again with unchanged tuples → assert no re-emission
+  burst. If instead the burst is deliberately accepted, document that in the
+  in-code comment and in `charger-budgeting.md` — but the preferred resolution
+  is scoping the wipe.
+
+### [should-fix] Detach spy swallows real failures as `TypeError`
+- File: `tests/test_charger_allocation_tiebreak.py:124` (`_spy_detach` wrapper, ~124–133)
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-acceptance-auditor
+- Description: The wrapper is defined with no parameters; `detach_car` takes
+  arguments, so a real post-convergence oscillation would surface as a
+  `TypeError` inside the wrapper instead of the intended `detach_calls` count
+  assertion — a noisy, misleading failure mode for the regression net's core
+  observable.
+- Proposed fix: Give the spy `*args, **kwargs` and forward them to the wrapped
+  `detach_car`.
+
+### [should-fix] Caller-independence test does not cover all scenario families
+- File: `tests/test_charger_allocation_tiebreak.py:338` (`test_allocation_is_caller_independent`)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The story's section B specifies caller independence "for each
+  scenario above". The test sweeps only the real-score incident matrix; the
+  patched-score regret scenario (~:237), the stickiness scenario (~:267) and the
+  generic-fallback scenario (~:302) exercise both chargers only sequentially in
+  one fixed order, with attachment state mutating between calls — never
+  `get_best_car` from every charger against identical attachment state.
+- Proposed fix: Extend the parametrisation (or add per-scenario assertions) so
+  that for the regret, stickiness and generic-fallback score maps, `get_best_car`
+  computed from each charger under identical attachment state yields the same
+  global allocation.
+
+### [should-fix] Story issue link uses the wrong repo slug (dead link)
+- File: `docs/stories/QS-342.story.md:3`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-acceptance-auditor
+- Description: The issue #342 link is `https://github.com/tmenguy/quiet_solar/issues/342`
+  (underscore) while the repo is `tmenguy/quiet-solar` (hyphen — as the
+  follow-up link on line 5 correctly uses).
+- Proposed fix: Change `quiet_solar` → `quiet-solar` in the header link.
+
+### [should-fix] Restart limitation documented as universal; scope it to pre-restart plug sessions
+- File: `docs/agents/concepts/charger-budgeting.md:122-126` and `docs/stories/QS-342.story.md` (P2 diagnosis, ~lines 101–102)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: Both documents describe the plug-time-correlation restart
+  limitation as universal, but the documented mechanism only breaks when the
+  car-side plug duration includes pre-restart recorder history while the
+  synthetic charger probe was born at restart. A plug session that starts
+  *after* the restart has both clocks aligned.
+- Proposed fix: Reword both passages to scope the limitation to plug sessions
+  already active before the HA restart.
+
+### [should-fix] Stale "expected red on current code" statements in the story
+- File: `docs/stories/QS-342.story.md:252-268` (~lines 257–258 and 267–268)
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The story still says the incident-replay and convergence-sweep
+  tests are "expected red on current code"; the PR implements the fix, so these
+  are now historical pre-A1 statements presented as current status.
+- Proposed fix: Mark them explicitly as historical pre-A1 results (e.g.
+  "was red before A1, now green"), keeping the TDD evidence.
+
+### [should-fix] Stale task C2 section — follow-up issue already filed
+- File: `docs/stories/QS-342.story.md:331-342`
+- Severity: should-fix
+- Source: qs-review-coderabbit
+- Description: The section still presents filing the follow-up issue as a
+  remaining action with a ready-to-run `gh issue create` command, but line 5
+  already records https://github.com/tmenguy/quiet-solar/issues/344 and the ACs
+  require the issue to exist (it does, OPEN).
+- Proposed fix: Mark C2 as complete, remove (or neutralise) the duplicate
+  creation command, keep the header line as the canonical URL.
+
+### [nice-to-have] Pin the exact-float-equality tie invariant with a comment
+- File: `custom_components/quiet_solar/ha_model/charger.py` (~3155, the `score != best_cur_score` filter in the tied-pair scan)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Tie detection relies on exact float equality — safe today because
+  every score component is integer-valued (quantised bumps), but a future
+  fractional component would silently kill the tie-break.
+- Proposed fix: One-line comment stating the invariant ("all score components
+  are integer-valued by construction; exact `==` tie detection depends on it").
+
+### [nice-to-have] Defensive guard before `min(ranked, …)`
+- File: `custom_components/quiet_solar/ha_model/charger.py` (~3185)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `ranked` non-emptiness is guaranteed only by the coupling between
+  the max-scan and the tied-pair scan iterating the identical pair set; a future
+  edit to either loop could break the invariant and crash with a bare
+  `ValueError`.
+- Proposed fix: `if not ranked: break` (or an assert with a message) making the
+  invariant explicit. Note for coverage: if a plain `if not ranked: break` is
+  unreachable by construction, prefer an assert or a `# pragma: no cover`-free
+  construction that keeps the 100 % gate green — implementer's choice, but do
+  not weaken the gate.
+
+### [nice-to-have] Round driver deviates from the story recipe (attach-if-changed)
+- File: `tests/test_charger_allocation_tiebreak.py:109-114` (`_run_allocation_round`)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The driver calls `attach_car` unconditionally when a car is
+  returned; the story recipe says "attach if it changed". Assertions still catch
+  oscillation, but the deviation invites a "is this meaningful?" question.
+- Proposed fix: Only call `attach_car` when the returned car differs from
+  `charger.car` (matching the story recipe).
+
+### [nice-to-have] PR-body note evidencing the TDD red step
+- File: PR #345 description (no repo file)
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The story's "confirmed red before A1" step is a process claim not
+  evidenced anywhere.
+- Proposed fix: When updating the PR body for this fix round, add a one-line
+  note that the incident-replay and sweep tests were confirmed red on pre-A1
+  code (e.g. name the commit or describe the check).
+
+### [nice-to-have] Comment the ≤15 s caller-dependence transient at the plug boundary
+- File: `custom_components/quiet_solar/ha_model/charger.py:3081-3094` (`active_chargers` construction and the caller-independence comment)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `self` is always in `active_chargers` regardless of its own plug
+  state, while other chargers must pass `is_plugged(for_duration=15 s)`; during
+  the first ≤15 s after a second charger plugs in, different callers see
+  different charger sets, so the caller-independence guarantee has a bounded,
+  self-healing exception the adjacent comment currently overstates.
+- Proposed fix: Extend the QS-342 comment at ~3092–3094 to note the bounded
+  ≤ `CHARGER_CHECK_STATE_WINDOW_S` transient. Comment only — no behaviour change.
+
+### [nice-to-have] Locale: "afterwards" → "afterward"
+- File: `docs/stories/QS-342.story.md:392`
+- Severity: nice-to-have
+- Source: qs-review-coderabbit
+- Description: LanguageTool locale rule (American English).
+- Proposed fix: Replace the word.
+
+## Explicitly skipped (triage decision, do not implement)
+- O(pairs) max-scan → sorted-head-read optimisation (blind-hunter): perf churn
+  in risk-critical code for unmeasurable benefit.
+- `%.2f` rounding vs historical truncation of `dist` in the log payload
+  (blind-hunter): cosmetic 0.01 m drift.
+- Stale `get_car_score:*` memo keys on car rename/removal across config reloads
+  (edge-case-hunter): bounded and cosmetic; revisit only if it survives the
+  S1/S2 memo rework.
+
+## How to apply
+
+Run `/implement-task` against this fix plan. The two log-volume findings
+(memo floor + detach wipe scope) interact — design them together before
+coding. When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-342.story_review_fix_#01.md
+++ b/docs/stories/QS-342.story_review_fix_#01.md
@@ -1,5 +1,10 @@
 # QS-342 — Review fix plan #01
 
+> **STATUS: FULLY IMPLEMENTED** (commit `fe0cbfe2`) — all 14 findings applied and
+> verified resolved by both round-2 re-review passes. The findings below are kept
+> verbatim as the historical record; do **not** re-run them. The successor plan is
+> [QS-342.story_review_fix_#02.md](QS-342.story_review_fix_#02.md).
+
 ## Summary
 - Source PR: #345
 - Source story: docs/stories/QS-342.story.md
@@ -194,9 +199,17 @@
 - Stale `get_car_score:*` memo keys on car rename/removal across config reloads
   (edge-case-hunter): bounded and cosmetic; revisit only if it survives the
   S1/S2 memo rework.
+  **Amended (round-2 N11):** this deferral was justified partly by the periodic
+  whole-memo wipe evicting stale keys, and the scoped wipe implemented here
+  removed that mitigation — `get_car_score:{oldname}` entries now live for the
+  whole charger-object lifetime. The decision to defer **stands on boundedness
+  alone** (bounded by the number of distinct car names seen in one process, and
+  purely cosmetic); the original justification no longer applies.
 
 ## How to apply
 
-Run `/implement-task` against this fix plan. The two log-volume findings
-(memo floor + detach wipe scope) interact — design them together before
-coding. When done, return and run `/review-task` again to re-verify.
+~~Run `/implement-task` against this fix plan.~~ **Done** — see the STATUS
+banner at the top. The two log-volume findings (memo floor + detach wipe scope)
+interacted and were designed together, as advised. Re-review produced
+[QS-342.story_review_fix_#02.md](QS-342.story_review_fix_#02.md), which is the
+plan to apply next.

--- a/docs/stories/QS-342.story_review_fix_#02.md
+++ b/docs/stories/QS-342.story_review_fix_#02.md
@@ -1,0 +1,343 @@
+# QS-342 — Review fix plan #02
+
+## Summary
+- Source PR: #345 (head at review time: `fe0cbfe2`)
+- Source story: docs/stories/QS-342.story.md
+- Predecessor: docs/stories/QS-342.story_review_fix_#01.md (14/14 findings resolved — verified by both re-review passes)
+- Findings to fix: 18 (6 should-fix + 12 nice-to-have)
+- Next implement phase: `/implement-task`
+
+### Provenance of this round
+
+Round 2 was reviewed **twice** with two model generations, and the results
+were confronted. The union is fixed here (user decision: "fix all the opus 5
+findings plus the opus 4.8 that are not part of that").
+
+Where the two passes disagreed, the orchestrator traced the mechanism by
+hand and recorded the verdict inline — see S1 in particular, where the two
+passes reached **opposite** conclusions and the "safe" verdict was shown to
+be wrong. Do not re-litigate S1 on the basis of the opus-4.8 clearance.
+
+Also note what round 2 *cleared*: the tie-break cascade itself survived
+adversarial probing (300 randomised score matrices × 2–3 chargers × random
+execution orders → zero non-convergent trials, zero caller conflicts;
+3-charger topologies caller-independent for all 6 execution orders). No
+finding in this plan touches the allocation semantics — they are all about
+the **observability** mechanism added by fix round #01, its tests, and doc
+accuracy. Keep the cascade as-is.
+
+## Findings to fix
+
+### [should-fix] S1 — A tuple excursion that begins AND ends inside the floor window is silenced completely, not merely delayed
+- File: `custom_components/quiet_solar/ha_model/charger.py:701` (the `min_interval_s` suppression branch in `log_info_on_change`); call site `:3034` in `get_car_score`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter (opus-5), with an empirical repro; **contradicted** by the opus-4.8 pass, which cleared this path as "a genuine change is delayed by at most `min_interval_s`, never lost"
+- Description: The memo is deliberately not restamped on suppression, and the
+  suppression check compares against the last *emitted* value. So a change
+  that reverts before the floor expires leaves **no trace at all**, and the
+  900 s heartbeat then re-emits the *pre-excursion* tuple, showing the
+  operator a flat trace. Traced by hand:
+  - `T0` → emit `A`, memo = `(A, T0)`
+  - `T0+7 / +14 / +21` → tuple `B`, changed vs `A`, `elapsed < 60` → suppress, memo untouched
+  - `T0+28` → tuple back to `A`, now *unchanged* vs last-emitted `A` → suppress
+  - `T0+900` → heartbeat re-emits `A`
+  The `B` excursion is emitted **never**. The opus-4.8 "never lost" clearance
+  holds only for a change that *persists* past the floor; it is wrong for one
+  that reverts within it. Verified empirically by the opus-5 reviewer: a 21 s
+  excursion produced **1 line total** over the following 400 s of calls.
+  Aggravator specific to this call path: `ha_model/home.py:2219` passes one
+  identical `time` to all loads, so within a single HA cycle the first
+  computation claims the memo and every later one has `elapsed == 0` and is
+  unconditionally suppressed — **including the recomputation that follows a
+  mid-cycle `attach_car`/`detach_car`**, which is exactly the ping-pong signal
+  this INFO exception was ratified to capture. Sub-60 s ping-pong is therefore
+  invisible: the diagnostic is diluted precisely in the incident class that
+  motivated it.
+- Proposed fix: Make suppressed churn impossible to lose entirely, while
+  keeping the volume bound. Preferred shape: count suppressed changes per key
+  and **force one emission when the floor expires** if any change was
+  suppressed (even if the value has since reverted), and/or append the
+  suppressed-change count to the payload (e.g. `… (+3 suppressed changes)`).
+  Whichever shape is chosen, the emitted line must make the excursion
+  visible. Add a regression test for the revert-within-floor scenario
+  asserting the excursion is not silently lost. Update the docstring, the
+  in-code QS-342 comment, and the `charger-budgeting.md` volume paragraph so
+  the documented semantics match — the current docstring claim that a
+  flap-back "cannot silence a key" is what misled a reviewer.
+
+### [should-fix] S2 — Sibling INFO-on-change site in the same function has no rate floor
+- File: `custom_components/quiet_solar/ha_model/charger.py:3263` (`log_info_on_change("get_best_car", …)`, change key = `best_car.name`)
+- Severity: should-fix (opus-5 rated should-fix; opus-4.8 rated nice-to-have — taking the higher severity, both agree the issue is real)
+- Source: qs-review-edge-case-hunter (both passes, independently)
+- Description: The fix round added the floor to the `get_car_score` line but
+  not to this adjacent site inside the very function this PR rewrites. Keyed
+  on `best_car.name` with no floor, it re-emits at the full allocation-cycle
+  rate under exactly the churn class fix round #01 set out to bound — the
+  residual failure mode this PR itself documents (a car GPS-jittering across a
+  0.5 m `dist_bump` bucket edge produces alternating strict-score winners that
+  no tie-break sees). Verified: 20 cycles over 133 s → **20 INFO lines**
+  (~12k lines/day/charger) while the new `get_car_score` site stayed at 8 over
+  the same run. The log site predates this PR, but the tie-break change is
+  what makes the flip reach it, and `charger-budgeting.md` now ratifies a
+  volume argument that silently does not cover it.
+- Proposed fix: Pass `min_interval_s=_CHANGED_RELOG_MIN_INTERVAL_S` here too
+  (one argument). Alternative worth considering per the opus-4.8 reviewer: key
+  on the quantised max score rather than the car name. Extend the
+  `charger-budgeting.md` volume paragraph to state that both sites are floored.
+
+### [should-fix] S3 — AC5's "keyed on the quantised tuple only" is no longer pinned by any test
+- File: `tests/test_charger_allocation_tiebreak.py:426-433`, `:435-438`, `:474-477`
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor (opus-5); **missed** by the opus-4.8 pass, which rated AC5 a clean ✅
+- Description: After fix round #01 all three "no new line" assertions fall
+  *within* `_CHANGED_RELOG_MIN_INTERVAL_S` of the previous emission —
+  in-bucket jitter at `T0+10` (previous emission `T0`), the within-floor
+  change at `T0+77` (emission at `T0+70`), and the post-detach call at `T0+14`
+  (emission at `T0+7`). The rate limiter alone therefore explains every
+  expected suppression, and the final 900 s heartbeat step re-uses identical
+  coordinates so it is unchanged under either key. Consequence: a mutation
+  that puts the **raw distance** (or `connected_time_delta`) into the change
+  key instead of the quantised tuple **still passes all three** of
+  `test_get_car_score_decomposition_logs_once_then_on_change`,
+  `test_get_car_score_decomposition_rate_limited_when_tuple_oscillates` and
+  `test_detach_car_preserves_get_car_score_memo`. Before `fe0cbfe2` the
+  `+10 s` jitter step did pin this — the story's AC5 wording "GPS jitter
+  inside a distance bucket produces zero new log lines" was a key-composition
+  oracle, and the floor masked it.
+- Proposed fix: Add an assertion where the last emission is **older than 60 s**
+  and the raw distance changed *inside the same bucket* (e.g. in-bucket coords
+  at `T0 + 65 s` → still 1 line). Under a raw-distance key that call would
+  emit (changed + floor elapsed) and the test would fail. Optionally do the
+  same for `connected_time_delta` (score ≥60 s after an emission with a
+  changed attach delta → no new line). Note the interaction with S1: if S1
+  introduces a forced post-floor emission, design these assertions together so
+  the key-composition oracle survives whatever S1 lands.
+
+### [should-fix] S4 — Rate floor is bypassed on the tzinfo-mismatch fallback path
+- File: `custom_components/quiet_solar/ha_model/charger.py:696-702`
+- Severity: should-fix
+- Source: qs-review-blind-hunter (opus-5); missed by the opus-4.8 pass
+- Description: `min_interval_s` is nested inside `if comparable:`, so on a
+  naive/aware mismatch between the memoised time and `time` every call still
+  emits. The documented bound ("a key emits at most ~1 changed line per
+  minute") silently does not hold on the one path that logs unconditionally.
+- Proposed fix: Apply the floor (or an explicit, documented decision to emit)
+  on the non-comparable path too. If emitting unconditionally is deliberate —
+  it is a one-shot situation, since the emission restamps the key — say so in
+  the docstring and the volume paragraph rather than leaving the bound
+  overstated.
+
+### [should-fix] S5 — Vacuous detach-memo assertion cannot detect the regression it guards
+- File: `tests/test_charger_allocation_tiebreak.py:484`
+- Severity: should-fix
+- Source: qs-review-blind-hunter (opus-5) + qs-review-coderabbit (both rounds); the opus-4.8 blind pass marked the scoped wipe "verified clean"
+- Description: `assert all(key.startswith("get_car_score:") for key in
+  fx.parking._log_on_change_state)` passes when no non-`get_car_score` key
+  ever existed, so it cannot detect a regression where the scoped wipe stops
+  clearing the QS-306 session keys.
+- Proposed fix: Seed a non-score memo before the detach — e.g.
+  `fx.parking._log_on_change_state["session"] = object()` — then assert both
+  `"session" not in fx.parking._log_on_change_state` and the existing
+  prefix-only invariant.
+
+### [should-fix] S6 — `assert ranked` is load-bearing control flow, stripped under `python -O`
+- File: `custom_components/quiet_solar/ha_model/charger.py:3212-3216` (approx. `:3178`/`:3189` in other reviewers' numbering)
+- Severity: should-fix (elevated from nice-to-have in plan #01 on the opus-4.8 `-O` argument)
+- Source: qs-review-blind-hunter (both passes; the `-O` framing is the opus-4.8 pass's one net-new contribution). Note the opus-5 edge-case-hunter deliberately did **not** re-raise it, citing the plan #01 triage decision — this plan overrides that.
+- Description: Fix round #01 implemented the plan #01 guard as
+  `assert ranked, "QS-342: …"`, immediately guarding `min(ranked, …)`. Under
+  `python -O` asserts are stripped, so a future coupling break between the
+  max-scan and the tied-pair scan surfaces as a bare `ValueError` on `min([])`
+  rather than the intended message — and the assertion also puts an
+  `AssertionError` on the live allocation control path, against the adjacent
+  QS-306 comment that a logging helper "must never be load-bearing… bail
+  instead of propagating".
+- Proposed fix: Replace with a real guard that survives `-O`: log an error and
+  `break` (treating it as "no more assignments to make", the same as the
+  existing `best_cur_score is None` exit), keeping the QS-342 rationale
+  comment. Coverage note: if the branch is unreachable by construction, keep
+  the 100 % gate green without weakening it — do not reach for a blanket
+  pragma; prefer a construction the gate can see, or exercise it via a
+  targeted test that breaks the coupling deliberately.
+
+### [nice-to-have] N1 — The exact-`==` tie invariant comment states a reason that is false
+- File: `custom_components/quiet_solar/ha_model/charger.py:3180-3183`; counter-example at `:2999`
+- Source: qs-review-edge-case-hunter (opus-5)
+- Description: The comment added by fix round #01 says "every score component
+  is integer-valued by construction (quantised bumps)", but `:2999` sets
+  `score_dist_bump = 0.5 if home_instant_fallback else 1.0`. The *conclusion*
+  is still sound (`0.5 × plug_span × plug_time_span == 50000.0` exactly, and
+  0.5 is dyadic, so tied pairs still carry bit-identical floats — the opus-4.8
+  pass independently confirmed the invariant holds), but a maintainer checking
+  the guard rail will find the stated reason false and cannot tell which
+  property actually matters. Reachable when `is_car_home(for_duration=…)`
+  returns `None`/`False` while the instant check returns `True` and the car has
+  no usable coordinates.
+- Proposed fix: Restate the load-bearing invariant: "every component is an
+  exactly-representable dyadic value and both sides are computed by the
+  identical expression." Mention the 0.5 case explicitly as the reason
+  "integer-valued" is not the right framing.
+
+### [nice-to-have] N2 — Second unhysteresised quantisation edge is undocumented, and it bypasses the cascade
+- File: `custom_components/quiet_solar/ha_model/charger.py:2981` (`if dist <= 3.0: score_plug_bump += 1`); doc at `docs/agents/concepts/charger-budgeting.md` residual-failure-mode bullet
+- Source: qs-review-edge-case-hunter (opus-5)
+- Description: The documented residual mode enumerates only the 0.5 m
+  `dist_bump` bucket edge. The `dist <= 3.0` threshold is a second
+  unhysteresised edge, and because `plug_bump` is the lowest-order term a ±1
+  flip converts an **exact tie** (where stickiness protects the incumbent)
+  into a **strict win** (which steals with no margin at all) — it bypasses the
+  whole cascade rather than being resolved by it. Reachable in the incident's
+  own measured geometry (3.58 / 3.69 / 3.97 m) when a car's GPS jitters across
+  3.0 m from one charger while both chargers stay inside the same 0.5 m bucket.
+- Proposed fix: Documentation only (no behaviour change — hysteresis stays out
+  of scope as already decided). Add this second edge to the residual-failure-mode
+  bullet in `charger-budgeting.md`, noting the qualitative difference: it
+  converts a tie into a strict win, so the cascade never sees it.
+
+### [nice-to-have] N3 — Preserved memo keys survive `reset()`, so unplug/disable loses the session-start decomposition line
+- File: `custom_components/quiet_solar/ha_model/charger.py:4196` (`detach_car` scoped wipe); `reset()` at `:2803`, physical-unplug path `:3488`, disable path `home_model/load.py:487`
+- Source: qs-review-edge-case-hunter (opus-5)
+- Description: The preserved `get_car_score:*` keys survive not just detaches
+  but every `reset()` — including the physical-unplug and `qs_enable_device`
+  disable paths. A new charge session started within 900 s with the car parked
+  in the same spot therefore gets **no session-start decomposition line at
+  all** — the diagnostic anchor for "which car did this charger pick this
+  session, and why", which is the property QS-306's original comment cites as
+  the reason for the wipe. In tension with the volume bound: wiping the
+  departing car's key (plan #01's narrower option) would re-emit one *unfloored*
+  line per detach, because a wiped key has no `prev` and so escapes the floor.
+- Proposed fix: Documentation rather than behaviour, per the reviewer's own
+  recommendation: state the consequence in the in-code comment at the scoped
+  wipe and in `charger-budgeting.md`. If S1's suppressed-change mechanism
+  happens to make a cheap session-anchor emission possible, prefer that — but
+  do not trade the volume bound for it.
+
+### [nice-to-have] N4 — Documented volume bound is per-key; state the aggregate
+- File: `custom_components/quiet_solar/ha_model/charger.py:3034` (in-code comment); `docs/agents/concepts/charger-budgeting.md:~289`
+- Source: qs-review-blind-hunter (opus-5)
+- Description: The bound is documented *per memo key*, and keys are
+  `get_car_score:{car}` per charger — so a site with N chargers × M cars can
+  still sustain ~N·M INFO lines/minute worst case. Worth stating explicitly,
+  since the INFO exception was ratified on a volume claim.
+- Proposed fix: State the aggregate bound (N chargers × M cars × 1/min worst
+  case, plus the 900 s heartbeat floor) alongside the per-key bound, in both
+  places. Fold in S2's second site once floored.
+
+### [nice-to-have] N5 — Rate-limit test bound is ~2× looser than the real expectation
+- File: `tests/test_charger_allocation_tiebreak.py:~460`
+- Source: qs-review-blind-hunter (opus-5)
+- Description: `bound = 1 + span_s // 60 + 1` with `assert 2 <= len(lines) <= bound`
+  is about twice as loose as the actual expectation, so it would not catch a
+  floor that is half as effective as intended.
+- Proposed fix: Tighten the bound, or assert the observed emission **gaps** are
+  ≥ the floor — the latter pins the mechanism directly rather than a count.
+
+### [nice-to-have] N6 — Story Design C.1 and AC5 still describe the pre-floor volume bound
+- File: `docs/stories/QS-342.story.md:~636-638` (Design C.1) and AC5 (~line 390 area)
+- Source: qs-review-blind-hunter (opus-5) + qs-review-acceptance-auditor (opus-5)
+- Description: The story still states the bound as "on change, plus a
+  steady-state floor of ~1 line per (charger, car) per 900 s", and AC5 still
+  says "visible at INFO **on change**" — both now contradicted by the 60 s
+  changed-value floor documented in `charger-budgeting.md` and in the code. The
+  implementation defers a genuine change by up to 60 s (and, pending S1, can
+  currently drop a reverting excursion entirely). Fix plan #01 only mandated
+  the in-code + concept-doc updates, so this is not a defect in that fix — but
+  the story is the artifact future review rounds audit against.
+- Proposed fix: Update Design C.1 and AC5 to describe the floor (and whatever
+  S1 lands). Keep the historical reasoning intact; add the current semantics.
+
+### [nice-to-have] N7 — Stale "expected red" wording survives in the test module
+- File: `tests/test_charger_allocation_tiebreak.py:172`, `:201`
+- Source: qs-review-acceptance-auditor (opus-5)
+- Description: Section banners read "(expected red on pre-fix code)" —
+  present-tense status, the exact wording fix #01 replaced in the story with
+  "Historical TDD note … green since A1". (The story task-breakdown line ~424
+  is task-instruction voice and is defensible as-is.)
+- Proposed fix: Reword both banners to the historical form used in the story.
+
+### [nice-to-have] N8 — `last_verified` not re-bumped when `fe0cbfe2` edited the same doc
+- File: `docs/agents/concepts/charger-budgeting.md:7`
+- Source: qs-review-acceptance-auditor (opus-5)
+- Description: Still `2026-08-05` although `fe0cbfe2` (2026-08-06) edited the
+  doc. AC7 only requires *a* bump, so it passes — but re-bumping keeps the
+  drift checker honest.
+- Proposed fix: Bump to the date of the fix commit landing this plan.
+
+### [nice-to-have] N9 — `_pin_car` docstring is stale
+- File: `tests/test_charger_allocation_tiebreak.py:53`
+- Source: qs-review-blind-hunter (opus-5)
+- Description: Says "plugged (both call forms)" but only `is_car_plugged` is
+  mocked — leftover wording from an earlier revision.
+- Proposed fix: Correct the docstring to match what is actually patched.
+
+### [nice-to-have] N10 — Fix plan #01 still reads as pending implementation
+- File: `docs/stories/QS-342.story_review_fix_#01.md:3-7` (and the per-finding sections, `:198-202`)
+- Source: qs-review-coderabbit
+- Description: All 14 findings are implemented, but the document still lists
+  them as pending and instructs `/implement-task`.
+- Proposed fix: Mark plan #01 as fully implemented (a status line at the top is
+  enough — no need to annotate all 14 sections individually) and point its
+  "How to apply" section at this plan as the successor. Do **not** rewrite its
+  findings; they are the historical record.
+
+### [nice-to-have] N11 — Update the stale-memo-key deferral justification
+- File: `docs/stories/QS-342.story_review_fix_#01.md` ("Explicitly skipped" section, third bullet)
+- Source: qs-review-edge-case-hunter (both passes)
+- Description: That triage decision was justified partly by the periodic
+  whole-memo wipe evicting stale keys; the scoped wipe from fix #01 removed
+  that mitigation, so `get_car_score:{oldname}` entries for renamed/removed
+  cars now live for the whole charger-object lifetime. Severity is unchanged
+  (still bounded by the count of distinct car names ever seen in one process,
+  still cosmetic) — only the stated justification is now inaccurate.
+- Proposed fix: Amend the deferral note to record that the scoped wipe widened
+  the window, and that the decision to defer stands on boundedness alone.
+
+### [nice-to-have] N12 — `log_info_on_change` docstring summary omits the new floor
+- File: `custom_components/quiet_solar/ha_model/charger.py:693-702`
+- Source: qs-review-blind-hunter (opus-4.8) — one of that pass's two net-new findings
+- Description: The docstring's opening line still reads "Log `msg` at INFO if
+  `value` changed for `key`, or if 900 s elapsed", without mentioning the
+  changed-value `min_interval_s` floor; the floor is only covered in a later
+  paragraph. Readers skimming the signature get the pre-fix contract.
+- Proposed fix: Mention the floor in the summary line. Fold in the S1 semantics
+  once decided, so the summary is accurate in one pass.
+
+## Explicitly skipped (carried forward from plan #01 — do not implement)
+- O(pairs) max-scan → sorted-head-read optimisation (raised again by both
+  round-2 blind passes, both noting it was already triaged out): perf churn in
+  risk-critical code for unmeasurable benefit at household scale.
+- `%.2f` rounding vs the historical truncation of `dist` in the log payload:
+  cosmetic 0.01 m drift.
+- Stale `get_car_score:*` memo keys on car rename/removal — *behaviour*
+  unchanged; only the justification note is updated, see N11.
+
+## Not findings (recorded so future rounds don't re-raise them)
+- **The tie-break cascade is validated.** Randomised adversarial probing (300
+  score matrices × {2,3} chargers × {1,2,3} cars × random execution order;
+  300 identical-state caller-conflict trials; all 6 execution orders on
+  3-charger topologies) found zero non-convergent trials and zero conflicting
+  claims. Both round-2 passes independently cleared it.
+- `tests/utils/charger_harness.py` exists on `origin/main` (a round-2 blind
+  pass flagged a possible collection error as an explicit assumption;
+  orchestrator verified the module is present).
+- Fix #01's F3 premise was inaccurate — `detach_car` takes no arguments
+  (`def detach_car(self)`, 9 zero-arg call sites). The `*args, **kwargs`
+  forwarding that was applied is harmless and defensive; leave it.
+- `active_chargers`' `self`-inclusion asymmetry: the only caller
+  (`charger.py:3503`) is guarded by the same
+  `is_plugged(for_duration=CHARGER_CHECK_STATE_WINDOW_S)` predicate other
+  chargers must pass, and `ha_model/home.py:2216` guards disabled devices, so
+  the comment added by fix #01 is conservative rather than wrong.
+
+## How to apply
+
+Run `/implement-task` against this fix plan.
+
+Sequencing advice: **S1 first, and design S1 + S3 + N12 together** — S1
+changes the emission semantics, S3 must pin key composition *around* whatever
+S1 lands, and N12 documents the result. S2, S4, S5, S6 are independent and
+small (S2 is close to a one-argument change). The nice-to-haves are mostly
+doc/test wording and can follow in one pass, except N4/N6, which should be
+written after S1 and S2 settle so the documented bound is the final one.
+
+When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-342.story_review_fix_#02.md
+++ b/docs/stories/QS-342.story_review_fix_#02.md
@@ -1,5 +1,12 @@
 # QS-342 — Review fix plan #02
 
+> **STATUS: FULLY IMPLEMENTED** (commit `45634973`) — all 18 findings applied and
+> verified resolved by the round-3 review. The findings below are kept verbatim as
+> the historical record; do **not** re-run them. The successor plan is
+> [QS-342.story_review_fix_#03.md](QS-342.story_review_fix_#03.md), which
+> **replaces** this round's log-throttling mechanism outright (the changed-value
+> time floor and the suppressed-change bank are deleted, not tuned).
+
 ## Summary
 - Source PR: #345 (head at review time: `fe0cbfe2`)
 - Source story: docs/stories/QS-342.story.md
@@ -21,10 +28,14 @@ be wrong. Do not re-litigate S1 on the basis of the opus-4.8 clearance.
 Also note what round 2 *cleared*: the tie-break cascade itself survived
 adversarial probing (300 randomised score matrices × 2–3 chargers × random
 execution orders → zero non-convergent trials, zero caller conflicts;
-3-charger topologies caller-independent for all 6 execution orders). No
-finding in this plan touches the allocation semantics — they are all about
-the **observability** mechanism added by fix round #01, its tests, and doc
-accuracy. Keep the cascade as-is.
+3-charger topologies caller-independent for all 6 execution orders). The
+normal tie-break ordering is unchanged by this plan — the findings are
+about the **observability** mechanism added by fix round #01, its tests,
+and doc accuracy. (Narrowed by review #03 / D11: the original claim said
+"no finding touches the allocation semantics", which was too broad — S6
+replaces an `assert` on the `get_best_car` control path with a `break`,
+which does change behaviour when the invariant fails.) Keep the cascade
+as-is.
 
 ## Findings to fix
 

--- a/docs/stories/QS-342.story_review_fix_#03.md
+++ b/docs/stories/QS-342.story_review_fix_#03.md
@@ -1,0 +1,553 @@
+# QS-342 — Review fix plan #03 (log-throttling redesign)
+
+## Summary
+- Source PR: #345 (head at review time: `45634973`)
+- Source story: docs/stories/QS-342.story.md
+- Predecessors: review fix plans #01 (14/14 applied) and #02 (18/18 applied) — both verified fully implemented; **do not re-run them**
+- Findings to fix: 1 redesign (D1–D8) + 4 independent items + 6 nice-to-have
+- Next implement phase: `/implement-task`
+
+> **This plan replaces a mechanism rather than patching it.** Rounds #01–#03
+> each fixed the previous round's log-throttling defect and introduced the
+> next one. The primitive is wrong, not the tuning. Read the analysis below
+> before touching code — do **not** start from the existing floor/bank code
+> and adjust it.
+
+---
+
+## Part 0 — Problem analysis
+
+### The requirement
+
+> "Be sure to log any changes, but not log too much the same stuff over and
+> over."
+
+Two obligations, and every round so far has traded one against the other:
+
+- **Completeness** — a state the system genuinely entered must appear in the
+  log.
+- **Boundedness** — a state the system is *still* in must not be repeated.
+
+### Why the current primitive is wrong
+
+The mechanism rate-limits by **time**: after emitting for key K, suppress
+*changed-value* emissions for K for 60 s (`_CHANGED_RELOG_MIN_INTERVAL_S`).
+A time floor is structurally incapable of satisfying completeness: any state
+whose whole lifetime fits inside the window is unobservable. Round #03's
+"banked suppressed-change count" was an attempt to paper over that, and it
+inherited the floor's frame — counting *calls* rather than *states* — which
+is why it over-reports a held change, under-reports an oscillation, gets
+destroyed by the memo wipe, and can strand or misattribute a bank across
+sessions.
+
+### The corrected diagnosis
+
+The incident was never "changes happened too fast". It was **the same value
+repeated 17 791 times**. The correct primitive is therefore
+**de-duplication by value**, not by time:
+
+> Per key, remember the recently-emitted *values*. Emit a value the first
+> time it is seen; suppress it while it is still remembered.
+
+Under this rule an A→B→A oscillation emits A once and B once per window and
+then goes quiet: volume becomes `O(distinct states per window)` instead of
+`O(transitions)`, and nothing is invisible, banked, stranded or
+misattributed.
+
+### Where dedup-alone fails, and the required correction
+
+**Verified against the real fixture:** dedup-by-value is exactly
+complementary to a time floor — it kills oscillation perfectly and **drift
+not at all**.
+
+| value pattern over one 900 s window (128 cycles @ 7 s) | distinct values |
+| ------------------------------------------------------ | --------------- |
+| bucket-edge oscillation                                 | 2               |
+| ±3 m GPS jitter                                         | 4               |
+| **monotone drift, 0.55 m per cycle**                    | **87 of 128**   |
+
+So a dedup-only design satisfies "not the same stuff over and over"
+*literally* while leaving volume effectively unbounded, and capping the
+remembered-value map bounds **memory, not volume** — a drifting key just
+churns the map and emits every cycle.
+
+**Therefore: hybrid.** Value-TTL dedup **plus a per-key emission budget per
+window**, with a single overflow-count line. Dedup removes the oscillation
+and same-cycle-duplicate classes; the budget makes the bound provable and
+**data-independent**. Neither half is optional: D8's drift test fails a
+dedup-only implementation with 87 lines.
+
+### Premise corrections (do not repeat these mistakes)
+
+1. **`plug_time_bump` does not step every 3.6 s of elapsed time.** It is
+   `1.0 + int((CHARGER_LONG_CONNECTION_S - |Δ|)/3.6)` where
+   `Δ = charger_plugged_duration − car_plugged_duration` (`charger.py:2991-2998`).
+   Both durations walk back a 3-day buffer from a fixed anchor, so **Δ is
+   constant while both stay plugged** — it moves only on a re-plug or a
+   history hole > `allowed_max_holes_s = 30.0` (`device.py:1080`). Measured
+   cardinality contribution ≈ 1. Earlier plans' worry about its fine
+   quantisation was wrong, and "coarsen or exclude `plug_time_bump` from the
+   key" would fix nothing. The real cardinality driver is
+   `score_dist_bump` (`charger.py:3013`, 0.5 m buckets, 101 values,
+   GPS-driven).
+2. **`detach_car` cannot distinguish churn from a session boundary, and
+   `reset()` is not a boundary either** — see D2.
+3. **The identical-`time`-per-cycle property does not break value dedup.**
+   `time` is HA's `event_time`, one aware-UTC value for all loads
+   (`data_handler.py:84` → `home.py:2190` → `2219`). Each
+   `get_car_score:{car}` key is hit **N times per cycle** (once per active
+   charger's `get_best_car`, `charger.py:3175`). That is what inflated the
+   bank by a factor of N. Under dedup the N same-time calls carry the same
+   value: the first emits and stamps, the rest hit the TTL. Idempotent,
+   because the predicate is `elapsed >= TTL` on an *unchanged* value rather
+   than `elapsed >= floor` on a *changed* one.
+
+### Two defects larger than anything triaged in rounds #01–#03
+
+Three rounds have been tuning the lines *adjacent* to the incident:
+
+- **`charger.py:3321-3323` is the incident message itself** — "removed from
+  another charger", the literal line that appeared 17 791 times — and it is
+  **still a raw `_LOGGER.info` f-string with no throttling at all**. It sits
+  inside `if best_car.charger is not None and best_car.charger != self:`,
+  i.e. exactly the ping-pong condition. Measured 20 lines / 20 cycles.
+- **`reset()` is itself a per-cycle churn path.**
+  `check_load_activity_and_constraints` calls `self.reset(keep_commands=True)`
+  at `charger.py:3565` **every cycle** while the user has "no car connected"
+  selected, producing **6 unthrottled INFO lines per cycle** (`charger.py:2838`
+  `Charger reset`, `:2848` `_reset_state_machine`, `load.py:2168` `Reset load`,
+  `load.py:449` `Reset device`, `charger.py:3139` `NO GOOD CAR BECAUSE`,
+  `:3563` `plugged car with CHARGER_NO_CAR_CONNECTED`). Measured **120 INFO
+  lines over 20 cycles = ~74 000/day — four times the original incident**,
+  from a single charger. `_has_state_to_reset` already exists
+  (`load.py:2014`) and is not consulted.
+
+### Measured baseline (all reproduced on `45634973`, 7 s cycle)
+
+| probe | result |
+| ----- | ------ |
+| `get_best_car` key, winner flips, **real apply path** | gaps `[14,7,7,7,…]` — full cycle rate, floor never engages |
+| same flip, `get_best_car` **in isolation** (what the current test does) | offsets `[0,63,126]` — floor engages |
+| `"Default car used"` (`:3283`) | 20 / 20 cycles |
+| `"removed from another charger"` (`:3321`) | 20 / 20 cycles |
+| `"Best Car from user selection"` (`:3116`) | 20 / 20 cycles |
+| `FORCE_CAR_NO_CHARGER_CONNECTED` (`:3174`, inside charger×car loop) | 101 lines / 20 cycles × 2 chargers (~62k/day) |
+| `CHARGER_NO_CAR_CONNECTED` via `check_load_activity_and_constraints` | 120 / 20 cycles = 6/cycle (~74k/day) |
+
+---
+
+## Part 1 — The redesign (must-fix)
+
+### [must-fix] D1 — Replace the time floor + bank with value-TTL dedup + per-key window budget
+
+- File: `custom_components/quiet_solar/ha_model/charger.py:640-745` (`LogOnChangeMixin`, `_LogOnChangeRecord`)
+- Source: consolidated round-3 findings (edge-case-hunter must-fix + blind-hunter + coderabbit) plus the design analysis above
+
+**Constants**
+
+```python
+_RELOG_UNCHANGED_AFTER_S    = 900   # kept: now the PER-VALUE TTL *and* the window
+_LOG_VALUES_PER_WINDOW      = 4     # per-key emission budget
+_LOG_MAX_REMEMBERED_VALUES  = 8     # >= budget, so the budget binds, not eviction
+```
+
+**Record shape** (per key)
+
+```python
+class _LogOnChangeRecord:
+    seen: list[tuple[object, datetime]]  # value -> last emitted time; bounded, FIFO evict
+    window_start: datetime
+    emitted: int
+    dropped: int
+```
+
+**Use a bounded `list` scanned with the existing `_is_unchanged` — NOT a
+`dict[value, datetime]`.** Two reasons, both load-bearing: `float('nan')`
+values would never hit a dict lookup (fresh NaN objects, `NaN != NaN`),
+silently re-inflating to full rate — precisely what `_element_unchanged`
+guards at `charger.py:614-618`; and the soc call site's value contains a
+nested tuple. A linear scan over ≤ `max_values` preserves the NaN and
+deadband guards and dodges hashability entirely.
+
+**Emission predicate** for
+`log_info_on_change(key, value, time, msg, *args, deadband=None, budget=None, max_values=...)`:
+
+1. Normalise: `time = time.replace(tzinfo=UTC) if time.tzinfo is None else time`.
+2. `st = state.setdefault(key, _LogOnChangeRecord([], time, 0, 0))`.
+3. Roll the window: if `(time - st.window_start).total_seconds() >= _RELOG_UNCHANGED_AFTER_S`:
+   if `st.dropped`, emit one line
+   `"<msg> [+%s further change(s) not shown in the last %ss]"`;
+   then reset `window_start=time, emitted=0, dropped=0`.
+4. `hit = first (v, t) in st.seen where _is_unchanged(v, value, deadband)`.
+5. `if hit and (time - hit.t).total_seconds() < _RELOG_UNCHANGED_AFTER_S: return`.
+6. Record `(value, time)` into `st.seen` (FIFO-evict past `max_values`)
+   **whether or not we emit**, so overflow counts once per distinct value,
+   not once per call.
+7. `if budget is not None and st.emitted >= budget: st.dropped += 1; return`.
+8. `st.emitted += 1; _LOGGER.info(msg, *args)`.
+
+Pass `max_values = 1` for the deadband site
+(`dyn_handle_available_power`, `charger.py:938`): with a deadband, a
+value-*set* suppresses transitive drift (0→99→198→… each within 100 of a
+remembered neighbour) forever. Deadband keeps single-`prev` semantics.
+
+**Why an excursion is visible without any banking:** A→B→A emits B
+immediately (B is a new value), then A is TTL-suppressed. Nothing is banked,
+stranded, or misattributed. Only *budget overflow* loses detail, it is
+disclosed as a count, and it occurs only above `budget` distinct values per
+window — the pathological regime, which is itself the signal.
+
+**Delete outright** (do not adapt):
+- `_CHANGED_RELOG_MIN_INTERVAL_S` (`charger.py:236`) and every
+  `min_interval_s=` argument at every call site.
+- `_LogOnChangeRecord.suppressed_changes` and the entire banking mechanism
+  (`charger.py:650-657`, `:723-732`, `:735-741`).
+- The `comparable` / non-comparable-clock branch (`charger.py:711-716`) —
+  superseded by step 1's normalisation. It was a test artifact that, under
+  alternating naive/aware callers, disabled the bound entirely.
+- The `min_interval_s` docstring block (`charger.py:694-707`).
+
+### [must-fix] D2 — Delete the `_log_on_change_state` wipe from `detach_car`
+
+- File: `custom_components/quiet_solar/ha_model/charger.py:4231-4249`
+- Source: edge-case-hunter (round-3 must-fix M1), corrected by the design analysis
+
+This is the defect that made round #02's S2 floor a **no-op in production**:
+`detach_car` drops every key not prefixed `get_car_score:`, and every change
+of the `get_best_car` value routes through `detach_car()` → key gone →
+`prev is None` → unconditional emission, bank destroyed with it.
+
+Plan #02 assumed the remedy was to distinguish churn from session boundary.
+**That assumption is wrong** — enumerating every caller:
+
+| site | classification |
+| ---- | -------------- |
+| `charger.py:2840` (`reset()`) | **ambiguous** — `reset()` is reached from the unplug boundary (`:3520`), the disable setter (`load.py:481`), `user_clean_and_reset` (`load.py:453`) **and from `charger.py:3565` every cycle** |
+| `charger.py:3135` (user-pinned car held by a sibling) | churn (repeatable per cycle) |
+| `charger.py:3322` (losing charger in the ping-pong) | **churn — the incident** |
+| `charger.py:3356` (`user_set_selected_car_by_name`) | user action, rare |
+| `charger.py:3592` (`best_car is not self.car`) | **churn — the incident's other half** |
+| `charger.py:4204` (inside `attach_car`, replacing) | indistinguishable |
+| `home.py:2037` / `:2048` (device removed) | boundary |
+| `car.py:1466` (`detach_charger`) | caller-dependent |
+
+`detach_car()` cannot tell them apart, and `reset()` is not a boundary
+either. Threading a `reason=` flag through 9 sites is the same ad-hoc
+patching that produced three failed rounds.
+
+**Minimal correct change: delete the wipe entirely — it is redundant.**
+Every key is already car-qualified or carries the car name as its *value*,
+so no key can ever name a stale car:
+
+- `get_car_score:{car.name}` — car in key (`:3076`)
+- `get_best_car` — the car name **is** the value (`:3309-3310`)
+- `update_value_callback_soc:{car.name}:{is_target_percent}` — car in key (`:5214`)
+- `ensure_correct_state:{charger.name}`, `dyn_handle_available_power` — on
+  `QSChargerGroup`, no car, untouched by detach either way
+
+The wipe buys nothing and destroys the throttle. The comment at
+`charger.py:5203-5205` already states that key qualification is the real
+guarantee and the wipe is only "defence in depth".
+`test_sf1_car_swap_is_not_silenced_by_the_memo`
+(`tests/test_qs306_log_volume.py:808`) still passes without it — a swapped
+car yields a *different key*, so `prev is None` and it emits.
+
+Do **not** add a session-anchor drop in `reset()` or `detach_car()`. If one
+is ever wanted, the only genuine edge is the edge-triggered unplug branch at
+`charger.py:3510-3524` (inside `if self.car:`). In practice no anchor work is
+needed: `update_power_steps` already emits an INFO per attach (`:4270`) and
+the unplug WARNING at `:3511` anchors the other end.
+
+### [must-fix] D3 — Route the incident message itself through the helper
+
+- File: `custom_components/quiet_solar/ha_model/charger.py:3321-3323`
+
+"removed from another charger" — the message from the original incident —
+is still an unthrottled raw `_LOGGER.info` f-string firing every cycle
+(measured 20/20). Route it through `log_info_on_change` with key
+`"detach_from_other_charger"`, value `(best_car.name, best_car.charger.name)`,
+and convert the f-string to lazy `%`-args.
+
+### [must-fix] D4 — Collapse the six winner-announcement sites into one
+
+- File: `custom_components/quiet_solar/ha_model/charger.py:3116, 3139, 3279, 3283, 3297, 3308`
+- Source: edge-case-hunter (round-3 R6); round #02's S2 floored **one of six** branches
+
+One call at a single exit point, key `"get_best_car"`, value
+`(reason, car_name_or_None)`, score as lazy payload:
+
+| line | current message | `reason` |
+| ---- | --------------- | -------- |
+| 3116 | Best Car from user selection | `user_selection` |
+| 3139 | NO GOOD CAR BECAUSE:CHARGER_NO_CAR_CONNECTED | `user_no_car` (car `None`) |
+| 3279 | Best Car from boot data | `boot` |
+| 3283 | Default car used | `generic_fallback` |
+| 3297 | Use Best Car from boot data instead of computed | `boot_over_computed` |
+| 3308 | (the existing floored site) | `computed` |
+
+One key, one line shape, ≤ budget lines per window regardless of which
+branch wins — the bound becomes a property of the helper rather than of one
+call site. Realistic cardinality 1–2.
+
+### [must-fix] D5 — Demote the `FORCE_CAR_NO_CHARGER_CONNECTED` line out of the inner loop
+
+- File: `custom_components/quiet_solar/ha_model/charger.py:3174`
+
+It reports a **static user setting** from inside a `charger × car` double
+loop that itself runs once per charger per cycle → N²·M lines/cycle
+(measured 101 over 20 cycles × 2 chargers, ~62k/day). Drop it to
+`_LOGGER.debug`. If an INFO anchor is wanted, log it once in the setter, not
+in the allocation loop.
+
+### [must-fix] D6 — Make the "no car connected" reset idempotent
+
+- File: `custom_components/quiet_solar/ha_model/charger.py:3563-3565`; `home_model/load.py:2014` (`_has_state_to_reset`), `:2168`, `:449`; `charger.py:2838`, `:2848`, `:3139`
+
+The single largest volume source (~74k/day, 4× the original incident): a
+per-cycle `reset(keep_commands=True)` while "no car connected" is selected,
+emitting 6 INFO lines each time. Gate the reset on the existing
+`_has_state_to_reset` (`load.py:2014`) so the no-car state is idempotent.
+Same bug class, same user-visible symptom as the incident.
+
+### [must-fix] D7 — Route the remaining allocation-path INFO lines through the helper
+
+- File: `custom_components/quiet_solar/ha_model/charger.py:3132`
+
+"manually attached to charger X, detaching from Y" → key
+`"manual_attach_conflict"`, value `(car.name, charger.name)`.
+
+Leave `charger.py:3127` (`_LOGGER.error`, "attached to multiple chargers")
+at ERROR — it clears the flag, so it self-heals.
+
+### [must-fix] D8 — Tests must drive the production entry point and assert aggregate volume
+
+- File: `tests/test_charger_allocation_tiebreak.py`, `tests/test_qs306_log_volume.py`
+
+**Why round #02's S2 shipped green:**
+`test_get_best_car_log_is_rate_limited_when_the_winner_flips`
+(`tests/test_charger_allocation_tiebreak.py:559-597`) calls
+`fx.parking.get_best_car(time)` and **never applies the result**, so
+`detach_car()` never runs. Isolated: `[0, 63, 126]`. Real path:
+`[0, 14, 21, 28, …]`. The test verified a configuration production never
+runs. Two structural rules follow:
+
+- **Drive `await charger.check_load_activity_and_constraints(time)`**, not
+  `get_best_car` / `get_car_score` in isolation. `_run_allocation_round`
+  (`:118-122`) is a step in the right direction but still bypasses the detach
+  at `charger.py:3592`.
+- **Assert aggregate logger volume over a full 900 s window**, not
+  per-prefix counts. Every escaped site (`:3116`, `:3139`, `:3174`, `:3279`,
+  `:3283`, `:3297`, `:3321`, the reset storm) is invisible to a
+  prefix-scoped assertion.
+
+Tests to add:
+
+1. `test_allocation_churn_total_log_volume_over_a_full_window` — both
+   chargers, 129 cycles at 7 s via `check_load_activity_and_constraints`,
+   bucket-edge winner flip; assert **total** INFO record count on
+   `ha_model.charger` + `home_model.load` ≤ `5·(N·M + 5N + 1)`. This single
+   test covers D2, D3, D4, D5 and D6.
+2. `test_log_state_survives_detach_car` — **replaces**
+   `test_sf1_detach_car_clears_the_memo`
+   (`tests/test_qs306_log_volume.py:840-853`), which pinned the *mechanism*
+   and is what locked the bug in. Keep
+   `test_sf1_car_swap_is_not_silenced_by_the_memo` (`:808`) as the property
+   test.
+3. `test_removed_from_another_charger_is_throttled` — `best_car.charger is
+   not self` for 129 cycles; ≤ budget+1 (currently 20/20).
+4. `test_generic_car_fallback_line_is_throttled` — charger with no scoring
+   car (currently 20/20).
+5. `test_user_pinned_car_line_is_throttled` and
+   `test_no_car_selected_state_is_idempotent` (currently 20/20 and 6/cycle).
+6. `test_force_car_no_charger_is_not_logged_from_the_inner_loop` — 0 INFO
+   over 20 cycles × N chargers (currently 101).
+7. `test_monotone_value_drift_is_budget_capped` — 128 cycles of 0.55 m/cycle
+   GPS drift; ≤ budget+1. **A dedup-only implementation fails this with 87
+   lines** — this is the test that makes the budget non-optional. Do not
+   weaken it.
+8. `test_same_cycle_duplicate_calls_emit_once` — one cycle, N chargers,
+   exactly one line per `get_car_score:{car}` key despite N calls at
+   identical `time`.
+9. `test_naive_time_is_normalised` — **replaces**
+   `test_log_info_on_change_floor_survives_a_tzinfo_mismatch` (`:510`) and
+   `test_log_info_on_change_survives_a_naive_datetime`
+   (`tests/test_qs306_log_volume.py:176`): a naive input does not raise
+   **and** stays throttled.
+
+Note: `tests/test_qs306_log_volume.py:798-801` needs its `swap_at`
+arithmetic reworked once the floor constant is gone.
+
+### Provable volume bound (to be documented, see D9)
+
+Per key: **≤ `budget + 1` = 5 lines per 900 s = 0.33/min**, *data-independent*
+— versus the current floor's ~15/900 s where it engages and **unbounded**
+where it does not.
+
+Keys: `N·M` (`get_car_score`) + `N` (merged `get_best_car`) + `N`
+(`detach_from_other_charger`) + `2N` (`update_value_callback_soc`) + `N + 1`
+(group). Aggregate **≤ 5·(N·M + 5N + 1) per 900 s**. For N=3, M=4:
+≤ 140/900 s ≈ **13 400/day worst case, ~2 400/day steady state**, against a
+measured current worst of ~74 000/day from a single charger.
+
+---
+
+## Part 2 — Independent findings (unrelated to the redesign)
+
+### [should-fix] D9 — Documentation must describe the new mechanism and bound
+- Files: `docs/agents/concepts/charger-budgeting.md` (the volume paragraph, `~:139-163`), `docs/stories/QS-342.story.md` (Design C.1 `~:329-338`, AC5 `~:410-426`), plus the in-code comment at `charger.py:3068-3074`
+- Description: Every doc currently describes the floor + bank semantics
+  (and the story still carries the round-#02 amendment notes). All of it is
+  superseded. Round-3 findings R4 (missing naive/aware caveat) and the
+  aggregate-bound nice-to-have are **subsumed** — the non-comparable branch
+  ceases to exist and the aggregate bound is now provable.
+- Proposed fix: Rewrite the volume paragraph around: dedup-by-value + TTL +
+  per-key window budget + one overflow-disclosure line; state the per-key
+  and aggregate bounds from the section above; state that completeness holds
+  for distinct states (only budget overflow degrades, and it is disclosed);
+  re-bump `last_verified`. Update Design C.1 and AC5 to match. Keep the
+  historical record of why the floor/bank existed — one paragraph, marked
+  historical, so round #04 does not re-invent it.
+
+### [should-fix] D10 — Regret scan mixes name equality with object identity
+- File: `custom_components/quiet_solar/ha_model/charger.py:3242`
+- Source: qs-review-blind-hunter (round 3) — **survives the redesign, unrelated to logging**
+- Description: The alternative-scan matches candidates with
+  `other_car.name == car.name` while charger exclusion uses identity
+  (`other is charger`). Mixing the two means a distinct car object sharing a
+  name contributes a phantom alternative, perturbing regret.
+- Proposed fix: Use `other_car is car` — exact and cheaper. Keep the
+  documented unique-name assumption as an assumption, but stop depending on
+  it here.
+
+### [should-fix] D11 — Plan #02 needs a status banner and one narrowed claim
+- File: `docs/stories/QS-342.story_review_fix_#02.md:3-8`, `:21-27`
+- Source: qs-review-coderabbit
+- Description: Plan #02 is fully implemented but still reads as pending and
+  still schedules `/implement-task`. Separately, its claim that "no finding
+  in this plan touches the allocation semantics" is too broad: S6 replaced an
+  assertion on the `get_best_car` control path with a `break`, which does
+  change behaviour when the invariant fails.
+- Proposed fix: Add a STATUS banner in the shape used by plan #01, pointing
+  at this plan as successor; narrow the claim to "normal tie-break ordering
+  is unchanged". Do not rewrite the findings — they are the historical record.
+
+### [nice-to-have] D12 — `sort(key=lambda c: c.name)` is not defensive
+- File: `custom_components/quiet_solar/ha_model/charger.py:3160`
+- Source: qs-review-blind-hunter
+- Description: Raises `TypeError` on any non-comparable `name` — the quirk
+  that already forced a change at `tests/test_chargers_advanced.py:345`.
+- Proposed fix: `key=lambda c: str(c.name)`.
+
+### [nice-to-have] D13 — Stickiness reads mutating state; comment implies a snapshot
+- File: `custom_components/quiet_solar/ha_model/charger.py:3249`
+- Source: qs-review-blind-hunter
+- Description: Stickiness reads `charger.car` on *other* chargers, which
+  mutates as chargers apply their rows mid-round; the in-code comment reads
+  as though the set were frozen. The mid-round mutation caveat is already
+  documented in the story, but not here.
+- Proposed fix: One caveat line cross-referencing the story's mid-round
+  mutation note.
+
+### [nice-to-have] D14 — Disclosure carries a count, not the values
+- File: `custom_components/quiet_solar/ha_model/charger.py` (the overflow line from D1)
+- Source: qs-review-edge-case-hunter
+- Description: For the `get_best_car` key (value = car name) an operator who
+  sees an overflow count cannot tell *which* car held the charger during the
+  window — the fact the original forensics needed. Much less severe under the
+  new design (overflow only in the pathological >budget regime, and each
+  distinct value gets its own line until the budget binds), but worth
+  considering.
+- Proposed fix: If cheap, name the distinct values in the overflow line
+  (they are already in `st.seen`). Optional.
+
+### [nice-to-have] D15 — Tied-matrix cost
+- File: `custom_components/quiet_solar/ha_model/charger.py:3204-3256`
+- Source: qs-review-edge-case-hunter + qs-review-blind-hunter (raised in every round)
+- Description: `candidates` is rebuilt per assignment and the regret scan is
+  O(N·M) per tied candidate → O(N·(N·M)²) per `get_best_car`, times N callers
+  per cycle, on the event loop. Fine at the real 2×2/3×3 scale; a fully-tied
+  10×10 would cost ~10⁶ inner comparisons per cycle.
+- Proposed fix: A memoised per-car best-alternative map would flatten it.
+  **Still explicitly deferred** unless the device count is unbounded —
+  recorded here only because it has now been raised in three consecutive
+  rounds; the deferral is deliberate, not an oversight.
+
+### [nice-to-have] D16 — Process observations from round 3
+- Description: (a) `python scripts/qs/quality_gate.py --impacted` reported
+  PASS with **0 tests selected** by testmon on this change set — the
+  changed-line coverage half was meaningful, the selection half vacuous. Run
+  the affected suites explicitly (`--quick`) in addition to `--impacted` for
+  this PR. (b) A whole-suite local run shows `tests/ha_tests/test_sensor.py::test_home_sensors`
+  failing on a syrupy snapshot entity-id prefix mismatch
+  (`tests/ha_tests/snapshots/test_sensor.ambr:542`); this PR touches no
+  sensor/home code and CI is green, so it is a pre-existing local-environment
+  mismatch — do not "fix" it in this PR, and do not claim "whole suite green
+  locally" from this worktree.
+
+---
+
+## Superseded round-3 findings (do NOT implement separately)
+
+These were real on `45634973` but cease to exist under D1/D2 — they are
+recorded so the next audit can see they were handled by deletion rather than
+missed:
+
+- Bank counts calls rather than distinct changes, and counts the change it is
+  reporting (round-3 R1) — banking deleted.
+- Bank silently discarded on the tzinfo path (R2) — branch deleted, time
+  normalised.
+- Alternating naive/aware clocks defeat the bound entirely (R3) — same.
+- Bank stranded when the call site stops being reached, or flushed onto the
+  next session's first line (R5) — banking deleted; no cross-session state
+  beyond the value TTL.
+- Vacuous `assert "3" in lines[1]` count oracle (round-3 M2, disputed
+  severity) — the banking test it guards is deleted; D8 replaces the suite.
+- Confounded 900 s heartbeat assertion (R8) — same; D8's TTL tests pin the
+  heartbeat cleanly.
+- Memo-key pruning / unbounded growth (raised in rounds 2 and 3) — solved
+  structurally: `st.seen` is FIFO-bounded at `_LOG_MAX_REMEMBERED_VALUES`.
+
+## Explicitly skipped (carried forward)
+- O(pairs) max-scan → sorted-head read: see D15 — deferred, not forgotten.
+- `%.2f` vs the historical `int(dist*100)/100.0` truncation in the payload:
+  cosmetic 5 mm shift in forensic lines; verified safe at every reachable
+  path (`dist` is initialised to `-1` and only ever reassigned from
+  `haversine`, never `None`).
+
+## Not findings (verified; do not re-raise)
+- The **tie-break cascade is validated** — randomised probing (300 score
+  matrices × {2,3} chargers × {1,2,3} cars × random execution order; 300
+  identical-state caller-conflict trials; all 6 orders on 3-charger
+  topologies) found zero non-convergent trials and zero conflicting claims,
+  across two independent model generations.
+- **S6's guardless `min(ranked, …)` is safe**: `charger.py:3179` admits a
+  score only when `score > 0`, which rejects NaN, so `best_cur_score` is
+  always one of the candidates' own float objects and the `score !=
+  best_cur_score` filter cannot drop it — `ranked` is non-empty by
+  construction. Even in an unreachable `inf`-score case, NaN regret makes
+  `min` never replace the incumbent, so the result stays deterministic.
+- `tests/utils/charger_harness.py` exists on `origin/main` (flagged as a
+  possible collection error in three separate rounds; verified present each
+  time).
+- Ruff `line-length = 120` (`pyproject.toml:3`) and CI Ruff is green — the
+  E501 concern raised in round 3 is invalid.
+- `detach_car` takes no arguments; the `*args, **kwargs` spy forwarding from
+  fix #01 is harmless and defensive. Leave it.
+
+## How to apply
+
+Run `/implement-task` against this plan.
+
+**Sequencing.** D1 and D2 are one unit — implement and land them together,
+because D2's deletion is what makes D1's bound hold in production, and D1's
+dedup is what makes D2's retained state safe. Then D3–D7 (independent call-site
+changes, each small). D8 last, but write test 1 and test 7 *first* as the
+red oracles: test 1 fails today on aggregate volume, and test 7 is what
+distinguishes the hybrid from a dedup-only implementation. D9 after the code
+settles. D10–D16 in any order.
+
+**Do not** reintroduce a changed-value time floor, a suppressed-change bank,
+or a `detach_car` log-state wipe. If a future round believes one is needed,
+re-read Part 0 first.
+
+When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-342.story_review_fix_#03.md
+++ b/docs/stories/QS-342.story_review_fix_#03.md
@@ -15,6 +15,71 @@
 
 ---
 
+## ⛔ NON-NEGOTIABLE GUARDRAIL — do not touch the QS-342 bug fix
+
+**This plan is about LOGGING. The actual user-facing bug fix is DONE,
+validated, and must come out of this round byte-for-byte unchanged in
+behaviour.**
+
+The bug QS-342 exists to fix is the self-biased tie-break that orphaned a
+plugged car (ID.buzz on wallbox 2 with no car attached, requiring manual
+association). It is fixed by the deterministic cascade in
+`QSChargerGeneric.get_best_car`: **max score → regret → stickiness → stable
+(charger name, car name)**, scanned over ALL tied pairs. That code is
+validated by randomised adversarial probing across two independent model
+generations (300 score matrices × {2,3} chargers × {1,2,3} cars × random
+execution orders; 300 identical-state caller-conflict trials; all 6 orders on
+3-charger topologies) — zero non-convergent trials, zero conflicting claims.
+
+**Frozen — do NOT modify:**
+
+- The scoring formula in `get_car_score` (`charger.py` ~2900–3060) — every
+  bump, threshold, and quantisation. The 0.5 m distance bucketing is
+  *deliberate*; sharpening it is explicitly forbidden (story Design A).
+- The change key `(score_plug_bump, score_plug_time_bump, score_dist_bump)`
+  is a *logging* concern and stays as-is; the underlying components are
+  scoring and are frozen.
+- The cascade ordering, the regret definition, the stickiness rule, the
+  stable name order, the steal semantics (strictly-higher score, or equal
+  score with strictly-higher regret).
+- The skip-already-assigned-chargers rule in the alternative scan.
+- The stable `active_chargers` sort, the `self`-inclusion behaviour, and the
+  "each caller keeps only its own row" contract.
+- The generic-car fallback, the boot-car path, and the user-selection
+  override path.
+
+**Frozen — do NOT weaken, delete, or relax any of these tests:**
+
+- `test_incident_replay_idbuzz_gets_parking`
+- `test_convergence_from_all_attachment_states` (7 states × 2 orders)
+- `test_allocation_is_caller_independent`,
+  `test_scenario_families_are_caller_independent`
+- `test_equal_score_does_not_steal_attached_car` (all three sub-cases)
+- `test_losing_charger_falls_back_to_generic_car`
+- `test_regret_prefers_charger_specific_car`
+- the `detach_car` spy / oscillation assertions anywhere in the suite,
+  especially in `tests/test_bug_48_charger_oscillation.py`
+
+If a logging change appears to require an allocation change, **stop and ask**
+— it does not. The one exception is D10, which is deliberately scoped and
+carries its own proof obligation; read it carefully.
+
+**Acceptance gate for this round:** story ACs 1–4 (the allocation ACs) must
+still pass **unmodified**, and the allocation outcome of every existing test
+must be identical to `45634973`. A diff that changes an expected allocation
+anywhere is a failed round, not a fix.
+
+**Two call-site changes in this plan touch allocation *files* but not
+allocation *behaviour*** — D5 demotes a log line to DEBUG, D6 gates a
+`reset()` on an existing predicate. D6 is the only one that changes runtime
+control flow: it must skip work that is *already a no-op*
+(`_has_state_to_reset` false ⇒ nothing to reset), so verify it cannot skip a
+reset that would have changed state. If in doubt, leave D6 out and file it
+separately — the log-volume win is not worth risking the charger state
+machine.
+
+---
+
 ## Part 0 — Problem analysis
 
 ### The requirement
@@ -410,14 +475,35 @@ measured current worst of ~74 000/day from a single charger.
 
 ### [should-fix] D10 — Regret scan mixes name equality with object identity
 - File: `custom_components/quiet_solar/ha_model/charger.py:3242`
-- Source: qs-review-blind-hunter (round 3) — **survives the redesign, unrelated to logging**
+- Source: qs-review-blind-hunter (round 3) — survives the redesign, unrelated to logging
+- ⚠️ **This is the ONE item in this plan that edits the validated allocation
+  code.** It is in scope only because it is provably behaviour-preserving
+  under the assumption the design already documents. Read the proof
+  obligation before touching it; if it cannot be met, **defer the item** — it
+  is a robustness nicety, not a bug affecting any user.
 - Description: The alternative-scan matches candidates with
   `other_car.name == car.name` while charger exclusion uses identity
   (`other is charger`). Mixing the two means a distinct car object sharing a
-  name contributes a phantom alternative, perturbing regret.
+  name would contribute a phantom alternative, perturbing regret.
 - Proposed fix: Use `other_car is car` — exact and cheaper. Keep the
   documented unique-name assumption as an assumption, but stop depending on
   it here.
+- **Proof obligation (mandatory, all three):**
+  1. Under the documented unique-name invariant (HA config-entry titles are
+     unique, and `home._cars` holds one object per car), `is` and
+     `.name ==` select the identical set, so the change is a **no-op by
+     construction**. State this in the commit message.
+  2. Every frozen allocation test listed in the guardrail passes
+     **unmodified** — in particular the full 7-state × 2-order convergence
+     sweep and both caller-independence tests. No expected allocation
+     anywhere in the suite may change.
+  3. Do **not** "fix" any test that fails because a fixture reuses car
+     objects or shares names across chargers. Such a failure means the
+     change is *not* behaviour-preserving in that configuration — in which
+     case revert D10 and record why. Changing a fixture to make D10 pass is
+     forbidden.
+- Sequencing: land D10 **alone, in its own commit**, separate from every
+  logging change, so a bisect can isolate it.
 
 ### [should-fix] D11 — Plan #02 needs a status banner and one narrowed claim
 - File: `docs/stories/QS-342.story_review_fix_#02.md:3-8`, `:21-27`
@@ -549,5 +635,12 @@ settles. D10–D16 in any order.
 **Do not** reintroduce a changed-value time floor, a suppressed-change bank,
 or a `detach_car` log-state wipe. If a future round believes one is needed,
 re-read Part 0 first.
+
+**Before pushing, re-read the guardrail section and confirm:** the allocation
+cascade is untouched, no frozen test was modified or weakened, and every
+expected allocation in the suite is identical to `45634973`. The user-facing
+bug (ID.buzz gets wallbox 2 automatically, no manual association) is already
+fixed and must stay fixed — this round only changes what gets written to the
+log.
 
 When done, return and run `/review-task` again to re-verify.

--- a/docs/stories/QS-342.story_review_fix_#04.md
+++ b/docs/stories/QS-342.story_review_fix_#04.md
@@ -1,0 +1,426 @@
+# QS-342 — Review fix plan #04
+
+## Summary
+- Source PR: #345 (head at review time: `bb4508fe`)
+- Source story: docs/stories/QS-342.story.md
+- Predecessors: plans #01 (14/14), #02 (18/18), #03 (18/18 — D14 optional/not done, D15 deferred). All verified implemented; **do not re-run them**.
+- Findings to fix: 3 must-fix + 12 should-fix + 8 nice-to-have
+- Next implement phase: `/implement-task`
+
+---
+
+## ⛔ NON-NEGOTIABLE GUARDRAIL — the business fix is the product; the logging is a diagnostic aid
+
+**Exactly ONE item in this plan changes allocation logic: B1, which REVERTS a
+change. Nothing else may touch the cascade.**
+
+The bug QS-342 exists to fix is the self-biased tie-break that left a plugged
+charger with no car (ID.buzz on wallbox 2, manual association required). It is
+fixed by the deterministic cascade in `_compute_best_car`: **max score →
+regret → stickiness → stable (charger name, car name)** over ALL tied pairs.
+Round 4 verified it byte-identical apart from two lines, with all seven frozen
+tests AST-identical and the whole suite green (7203 passed).
+
+**Frozen — do NOT modify** (unchanged from plan #03): the `get_car_score`
+scoring formula and every bump/threshold/quantisation (the 0.5 m bucketing is
+deliberate); the cascade ordering; the regret definition (beyond B1's revert);
+stickiness; the stable name order; steal semantics; the skip-assigned rule;
+the `active_chargers` sort and `self`-inclusion; the own-row contract; the
+generic-car, boot-car and user-selection paths.
+
+**Frozen — do NOT weaken, rename or delete:**
+`test_incident_replay_idbuzz_gets_parking`,
+`test_convergence_from_all_attachment_states`,
+`test_allocation_is_caller_independent`,
+`test_scenario_families_are_caller_independent`,
+`test_equal_score_does_not_steal_attached_car`,
+`test_losing_charger_falls_back_to_generic_car`,
+`test_regret_prefers_charger_specific_car`, and every detach/oscillation
+assertion including `tests/test_bug_48_charger_oscillation.py`.
+
+**Acceptance gate:** story ACs 1–4 pass unmodified, and **no expected
+allocation anywhere in the suite changes** — except where B1 restores the
+pre-D10 behaviour, which by definition restores the validated allocation.
+
+### The lesson from round 4 — read this before touching allocation code
+
+D10 was a *cleanup* to validated allocation code, justified by an invariant
+(car-name uniqueness) that the codebase **does not enforce**. The commit
+asserted the premise instead of testing it, and the divergence reproduces the
+original symptom. Plan #03's proof obligation said "if it cannot be met,
+defer the item"; that off-ramp was not taken.
+
+**Rule for this round and every future one:** an allocation change justified
+by an invariant is acceptable *only* if the invariant is enforced in code. If
+it is merely documented or assumed, **defer the change**. A tidier-looking
+comparison is never worth a path back to the reported bug.
+
+**B2 is business state, not logs.** D6 (plan #03) promoted a predicate that
+previously only chose a *log level* into runtime control flow gating a real
+`reset()`. Treat it with allocation-grade care: the failure mode is stale
+charger state, not a missing log line.
+
+---
+
+## Part A — must-fix
+
+### [must-fix] B1 — Revert D10: the regret scan must match cars by name, like the rest of the cascade
+
+- File: `custom_components/quiet_solar/ha_model/charger.py:3336`
+- Source: qs-review-edge-case-hunter (round 4, must-fix) + qs-review-acceptance-auditor (round 4 fast pass, CONFIRMED). The round-4 full acceptance pass rated D10 "proof obligations met" — its proof is explicitly conditioned on *"whenever `home._cars` holds one object per name"*, which is the premise that fails. **Do not re-litigate on the basis of that clearance.**
+
+**Change:**
+
+```python
+# revert to:
+if other_car.name == car.name and other_score > best_alternative:
+```
+
+…and **delete the "no-op by construction" comment block** introduced with
+D10. Replace it with a short note that the cascade is name-based throughout
+and that regret must use the same relation as removal.
+
+**Why.** The cascade is *effectively over names*:
+
+| line | step | relation |
+| ---- | ---- | -------- |
+| `:3336` | regret alternative scan | **identity** ← D10, the odd one out |
+| `:3347` | stickiness | name |
+| `:3365` | car removal after assignment | **name** — consumes a whole NAME from every list |
+
+Removal drops both twins of a duplicated name while regret credits only one,
+so the two rules no longer describe the same set. This is visible in-file
+without any external assumption (round-4 fast auditor), and it is reachable:
+`CONF_NAME` is a plain `cv.string` in the options flow with **no collision
+validation anywhere**, the options flow never re-checks `unique_id`, and
+`add_device` (`home.py:1985`) dedups by object identity only (`QSCar` defines
+no `__eq__`) — so two config entries named "Zoe" yield two `QSCar` objects
+named "Zoe".
+
+Under that state the comparators diverge, in the bug's own failure direction
+(replayed against the cascade as written):
+
+```
+cars: A#1("A"), A#2("A"), B("B")     chargers: C1, C2
+C1 -> [(100, A#1), (100, B)]         C2 -> [(100, A#2)]
+
+IDENTITY (D10)  -> { C1: A#1 }           chargers with NO car: ['C2']
+NAME (reverted) -> { C1: B, C2: A#2 }    chargers with NO car: []
+```
+
+Identity under-counts alternatives → regret for `(C1, A#1)` inflates 0 → 100
+→ it wins round 1 → name-based removal strips `A#2` off C2 → C2 exits with
+nothing → `best_car is None` → generic fallback. **That is the #342 symptom.**
+
+**Verification:** all seven frozen tests pass unmodified (they did before the
+revert too — they contain no duplicate-name fixture, which is why this
+shipped). Land B1 **alone, in its own commit**, mirroring how D10 landed, so
+the pair is trivially bisectable.
+
+**Do NOT "fix" the inconsistency the other way.** Making removal or
+stickiness identity-based is a far larger semantic change to validated code
+and is explicitly out of scope. Name-based everywhere is the validated
+state.
+
+### [must-fix] B2 — `_reset_would_change_state` can skip a reset that would clear real state
+
+- File: `custom_components/quiet_solar/ha_model/charger.py:3569-3616`, gate at `:3707`; `custom_components/quiet_solar/home_model/load.py:386-392` (`_has_state_to_reset`), `:1779-1786` (`constraint_reset_and_reset_commands_if_needed`)
+- Source: qs-review-acceptance-auditor (round-4 fast pass, NEW-1) — **disputed** by the round-4 full pass, which judged the same fields self-nulling at `load.py:2630-2641` and therefore unstrandable
+
+`AbstractLoad.constraint_reset_and_reset_commands_if_needed` clears six
+fields but only extends `_has_state_to_reset` for one
+(`_last_completed_constraint`). The five uncovered:
+`current_constraint_current_value`, `current_constraint_current_energy`,
+`current_constraint_current_percent_completion`,
+`next_or_current_constraint_start_time`,
+`next_or_current_constraint_end_time` — in direct violation of that
+predicate's own docstring rule (`load.py:390-392`).
+
+While the predicate only decided a **log level** (QS-306) this was harmless.
+D6 promoted it to **control flow**, so a `False` verdict now skips the reset
+itself.
+
+**Required work — resolve the dispute first, then fix:**
+
+1. **Settle it empirically.** Construct a state where at least one of the five
+   fields is non-default *and* the self-nulling path at `load.py:2630-2641`
+   does not apply (i.e. a constraint exists), then assert whether
+   `_reset_would_change_state()` returns `False` while `reset()` would have
+   cleared it. Record the answer in the commit message either way.
+2. **Fix in `_has_state_to_reset`, not in `_reset_would_change_state`** —
+   preferred because it also repairs the original QS-306 log-level decision
+   and removes the duplicated field list rather than extending it.
+3. If the dispute resolves as "unstrandable", still add the fields (or a
+   comment naming the self-nulling argument with its line reference), because
+   the docstring rule is currently violated and the next reader cannot tell.
+
+**Regression test (required either way, and the deeper fix for B4):** seed
+every field that `reset()` clears, assert `_reset_would_change_state()` is
+`True`; then assert that after `reset()` it is `False`. This mechanically
+couples the predicate to its subject.
+
+**Care:** this gate guards real charger state. If the work cannot be made
+safe with confidence, **revert D6 entirely** — its benefit is log volume, and
+plan #03 already said the log-volume win is not worth risking the charger
+state machine.
+
+### [must-fix] B3 — The overflow-disclosure branch is uncovered and will fail CI's 100 % gate
+
+- File: `custom_components/quiet_solar/ha_model/charger.py:753-754` (line numbers per the round-4 full pass; the disclosure emission inside the window roll)
+- Source: qs-review-acceptance-auditor (round 4, whole-suite coverage run)
+
+Whole-suite coverage of `charger.py`: **2994 stmts, 2 miss, 99 % — missing
+753-754**, and `.github/workflows/pr-quality.yml:233` runs
+`coverage report --show-missing --fail-under=100`. These are new lines from
+this round.
+
+Root cause: no test produces `st.dropped > 0` **and then** crosses the 900 s
+window — the longest existing runs are 128–129 cycles × 7 s = 896 s, just
+under it.
+
+Beyond the gate, this leaves the plan's, AC5's and `charger-budgeting.md`'s
+central completeness claim ("overflow is disclosed as a count, never silent")
+entirely unpinned, and the disclosure builds its format string by
+concatenation with two extra args — a mismatch would raise inside `logging`
+at runtime with no test to catch it.
+
+**Fix:** add a test emitting ≥ `_LOG_VALUES_PER_WINDOW + 1` distinct values
+inside one window, then one call past 900 s; assert the disclosure line
+appears **and** carries the correct count. Design it together with B5/B6,
+which change what that line should say.
+
+---
+
+## Part B — should-fix
+
+### [should-fix] B4 — Budget-dropped values are recorded in `seen` as if they had been emitted
+- File: `charger.py:775-784` (append/restamp precedes the `st.emitted >= budget` check)
+- Source: edge-case-hunter + blind-hunter + both acceptance passes (all four reviewers)
+- A value suppressed by the budget gets an emission-grade TTL stamp, so when
+  the window rolls it is *still* TTL-suppressed — and that suppression path
+  returns before `st.dropped += 1`, so it is not counted the second time
+  either. Reproduced: a value present from t=28 s was first shown at
+  t=928 s, uncounted after the first disclosure.
+- Fix: distinguish "recorded-and-emitted" from "recorded-but-dropped" in
+  `seen` (a third field). Note the trade the current code protects
+  (`charger.py:776-777`): counting on emit-only would inflate `dropped` from
+  per-distinct-value to per-call — so add a flag, do not simply move the
+  append below the budget check.
+
+### [should-fix] B5 — The overflow disclosure is stranded
+- File: `charger.py:749-757` / `:762-770`
+- `st.dropped` is flushed only by a *subsequent call on the same key*. If the
+  key goes quiet — charger unplugged, device disabled, car removed, HA
+  restart — the count is lost silently. This is reachable on the incident
+  path itself: `get_best_car` stops being called the instant the charger
+  unplugs. The in-code claim "overflow is disclosed as a count, never
+  silent" does not hold.
+- Fix: flush on the state transition that ends the key's life (or accept and
+  **document** it precisely). Do not reintroduce cross-session banking.
+
+### [should-fix] B6 — The overflow disclosure is misattributed and duplicated
+- File: `charger.py:749-757`
+- It reuses the **current** call's `msg`/`*args`, so "+N further change(s)"
+  is stapled onto a value that has nothing to do with the dropped ones, and
+  the same line is then usually logged again immediately. Verified:
+  `car=ZZZ state=99 [+4 further change(s)…]` followed by a duplicate plain
+  `car=ZZZ state=99`.
+- Fix: emit the disclosure with static text only (no `*args`), keyed to the
+  key name rather than the current message.
+
+### [should-fix] B7 — Dedup-suppressed repeats are counted nowhere, so the incident's *rate* is invisible
+- File: `charger.py:763-774` (returns before any accounting)
+- `dropped` covers budget overflow only. A 2-hour ping-pong at the 7 s cycle
+  emits 16 lines with `dropped == 0` — byte-identical to a benign home whose
+  winner genuinely alternates every 7.5 minutes. **The original #342
+  diagnosis rested on the volume (17 791 lines); that signal is now gone.**
+- Fix: a per-key `suppressed` counter folded into the same disclosure line —
+  zero extra volume, restores the rate signal.
+
+### [should-fix] B8 — Four new throttle tests have upper bounds only and cannot fail
+- File: `tests/test_charger_allocation_tiebreak.py:667, 687, 711, 725`
+- They assert only a ceiling, so they pass if the line disappears entirely.
+  Worse, two match on the **new** reason strings (`"generic_fallback"`,
+  `"user_selection"`) which do not exist pre-fix, so they would have passed
+  vacuously against `45634973` — they are not red oracles. Contrast
+  `test_monotone_value_drift_is_budget_capped:539`, which correctly adds
+  `assert len(lines) >= 2`.
+- Fix: add `>= 1` (or better) lower bounds to all four.
+
+### [should-fix] B9 — The aggregate-volume test stubs out the very site it budgets for
+- File: `tests/test_charger_allocation_tiebreak.py:610-617` (`_pin_scores`)
+- It replaces `charger.get_car_score` with a `MagicMock`, so the
+  `get_car_score:{car}` INFO site — **the one that produced the original
+  17 791 lines** — never fires in
+  `test_allocation_churn_total_log_volume_over_a_full_window`, nor in any
+  other production-path aggregate test. The `N·M` term of the ceiling is
+  unexercised, and plan #03 billed this test as covering D2–D6.
+- Fix: drive at least one aggregate test with real scoring (pin coordinates
+  instead of stubbing the method).
+
+### [should-fix] B10 — D12 breached the guardrail's process contract, and its stated goal is unmet
+- File: `charger.py:3242` (the change) and `:3352` (the gap)
+- Plan #03 froze "the stable `active_chargers` sort" and named D10 as the one
+  exception; D12 changed that exact line and landed **inside** the 400-line
+  logging commit, without isolation or proof. The change is provably a no-op
+  (`name: str`), so this is process, not behaviour — but the plan
+  contradicted itself (guardrail vs. nice-to-have D12) and the looser half
+  won silently.
+- Additionally the in-code claim *"a sort key must never be able to break the
+  allocation"* is **false**: `:3352` still builds `ranked` with raw
+  `charger.name` / `car.name`, so a non-comparable name still raises
+  `TypeError` inside `min(ranked, …)` a few lines later.
+- Fix: either apply `str()` at `:3352` too (a no-op under `name: str`, so
+  permissible — land it **alone**, like B1) **or** drop the overreaching
+  comment. Do not leave the claim without the guarantee.
+
+### [should-fix] B11 — `_reset_would_change_state` defaults opposite to `reset`
+- File: `charger.py:3569` (`keep_commands: bool = True`) vs `:2883` (`reset(keep_commands=False)`)
+- The gate calls the predicate with its default, testing the **narrower**
+  condition (constraints only) while performing the **wider** reset
+  (constraints + `current_command` / `running_command` / `_stacked_command` +
+  `_clear_unresponsive`).
+- Fix: make the parameter required, or default it to `False` to match its
+  subject. Part of B2's work.
+
+### [should-fix] B12 — The SoC site is in permanent budget overflow during a normal charge
+- File: `charger.py:5353`; doc claim at `docs/agents/concepts/charger-budgeting.md:~185`
+- Its value tuple carries `round(result)` / `round(sensor_result)` /
+  `round(result_calculus)` — Wh and % figures that genuinely advance every
+  cycle while charging, i.e. the *drift* class. So during any active charge
+  the key emits 4 lines then a bare `[+n further change(s)…]` count per
+  900 s. The doc asserts overflow "occurs only above 4 distinct values per
+  window — the pathological regime, which is itself the signal", which is
+  false for this site in the **normal** regime.
+- Fix: give it a larger `budget=`, or state the exception in the doc. Decide
+  deliberately — this is real telemetry, not churn.
+
+### [should-fix] B13 — The `dyn_handle` telemetry site lost genuine transitions
+- File: `charger.py:992` (`max_values=1`, no `budget=` → inherits 4); test `tests/test_qs306_log_volume.py:441-445`
+- Available-power/battery transitions are operational telemetry, not churn.
+  The test was relaxed from `== 10` to `2 <= n <= _PER_KEY_CEILING`, i.e. the
+  budget is now dropping real events.
+- Fix: same decision as B12 — larger `budget=` for this site, or an explicit
+  "accepted observability cost" note in the story. Same class as B12; decide
+  both together.
+
+### [should-fix] B14 — Stale comment contradicted by D2 in the same commit
+- File: `charger.py:5344`
+- *"includes the car name as defence in depth — `detach_car()` clears the
+  memo, but a future path could swap a car without routing through it."* The
+  wipe was deleted at `:4359-4387`.
+- Fix: cross-reference the D2 rationale block instead. This is exactly the
+  class of stale comment that fed rounds #01–#03.
+
+### [should-fix] B15 — The PR description still describes the deleted mechanism
+- File: PR #345 body
+- No "Review fix #03" section; the body still presents
+  `_CHANGED_RELOG_MIN_INTERVAL_S = 60 s`, "suppressed changes are banked",
+  and "`detach_car` preserves the car-qualified `get_car_score:*` memo keys
+  while still wiping the QS-306 session memos" as current. All three were
+  deleted. The story's B2 rule also requires documenting existing-test
+  changes there, and this round changed nine.
+- Fix: rewrite the relevant sections; add a round-#04 section when this plan
+  lands.
+
+---
+
+## Part C — nice-to-have
+
+- **C1** `docs/agents/concepts/charger-budgeting.md:7` — `last_verified` not
+  re-bumped after a ~60-line rewrite (D9 asked explicitly).
+- **C2** Docs describe `st.seen` as "recently-emitted values"; it holds
+  *observed* ones (recorded before the budget check). Wording — but it is the
+  wording that hides B4.
+- **C3** `charger.py:3352` — see B10; if B10 is resolved by dropping the
+  comment, note the residual `TypeError` risk here instead.
+- **C4** `charger.py:749` — `abs()` on the window roll re-opens the
+  alternating-clock escape D1 claims to have closed (12 values under two
+  timestamps 900 s apart emit 12 lines). Not reachable at today's call sites;
+  the doc's "provable and data-independent" claim needs the caveat.
+- **C5** `charger.py:781-783` — `st.seen` eviction is insertion-ordered, not
+  recency-ordered: a TTL-expired hit is rewritten in place, so `del
+  st.seen[0]` can evict a just-refreshed value. Cannot inflate volume (budget
+  binds first); the FIFO comment overstates the structure.
+- **C6** `charger.py:658-665` — the list-over-dict NaN justification only
+  applies to the one deadband site (with `deadband=None`, `_is_unchanged`
+  falls back to `prev == current`, where fresh NaNs compare unequal exactly
+  as a dict lookup would). The unhashability argument is the real one and is
+  sufficient.
+- **C7** `_log_on_change_state` keys are never pruned since D2 removed the
+  only pruning path; a rename orphans a key for the process lifetime.
+  Bounded by config churn — a one-line note, not code.
+- **C8** Assorted: f-string in the ERROR branch (`:3199`);
+  `boot_over_computed` logs the **discarded** computed car's score (`:3416`);
+  the `FORCE_CAR` comment promises a setter anchor that was never added
+  (`:3256-3260`); D14 (naming values in the overflow line) still not done —
+  plan-optional; an unused `caplog` parameter and a test name that now
+  describes disclaimed behaviour; log message texts changed
+  (`Default car used` → `generic_fallback`) which breaks existing
+  greps/dashboards — worth a changelog note.
+
+---
+
+## Not findings (verified round 4 — do not re-raise)
+
+- **NaN crash in `min(ranked, …)`** — INVALID. `charger.py:3265`'s
+  `if score > 0` rejects NaN (`NaN > 0` is `False`), so NaN never enters
+  `chargers_scores`, `max()` never returns NaN, and the filter never rejects
+  every candidate. Raised in rounds 3 and 4; verified twice.
+- **The D4 refactor is faithful.** `get_best_car` → thin wrapper +
+  `_compute_best_car` was AST-diffed: return topology 1:1, no branch merged
+  away, no early exit added or removed, all six announcement outcomes
+  reachable, `reason` provably bound on every path.
+- **`get_car_score`'s scoring formula is byte-identical** — only the log call
+  lost its `min_interval_s=` kwarg.
+- **The superseded mechanisms were genuinely deleted**, not patched: zero
+  repo-wide occurrences of `_CHANGED_RELOG_MIN_INTERVAL_S`,
+  `suppressed_changes`, `min_interval_s`, or the non-comparable clock branch.
+- **No fixture was changed** to make anything pass:
+  `tests/utils/charger_harness.py`, `tests/factories.py`, `tests/conftest.py`
+  are absent from the diff, and `_make_incident_fixture` is identical across
+  revisions.
+- **`tests/utils/charger_harness.py` exists on `origin/main`** (raised as a
+  possible collection error in four separate rounds).
+- **Ruff `line-length = 120`** and CI Ruff is green — the E501 concern is
+  invalid.
+- **Suite state at `bb4508fe`:** whole suite 7203 passed, ruff clean,
+  **0 mypy errors in `charger.py`**. The `test_home_sensors` snapshot failure
+  reported in round 3 did **not** reproduce.
+- **CI red on `bb4508fe` was pure infrastructure** — every failing job
+  reported "The job was not acquired by Runner of type hosted"; re-run
+  triggered.
+
+## Explicitly skipped (carried forward)
+- Tied-matrix cost / O(pairs) rescan (D15, raised in every round since #02) —
+  deliberately deferred at the real 2–3 charger scale.
+- `%.2f` vs the historical truncation of `dist` — cosmetic.
+
+---
+
+## How to apply
+
+Run `/implement-task` against this plan.
+
+**Sequencing.**
+1. **B1 first, alone, in its own commit** — it restores the validated
+   allocation. Nothing else in the commit.
+2. **B2 next** (settle the dispute, fix `_has_state_to_reset`, add the
+   coupling test) — business state, allocation-grade care. Consider reverting
+   D6 if it cannot be made safe.
+3. **B3 + B4 + B5 + B6 + B7 together** — they all reshape what the disclosure
+   line means and says; designing them separately is how rounds #01–#03 went
+   wrong. B3's test must pin whatever B5/B6/B7 decide.
+4. **B8 + B9** — make the throttle tests capable of failing; write them
+   red-first.
+5. B10–B15, then Part C.
+
+**Do not** reintroduce a changed-value time floor, a suppressed-change bank,
+or a `detach_car` log-state wipe.
+
+**Before pushing:** confirm the guardrail — the cascade is untouched apart
+from B1's revert, no frozen test was modified, and no expected allocation
+changed. Run the affected suites with `--quick` in addition to `--impacted`
+(testmon selected **0 tests** for a comparable change set in round 3).
+
+When done, return and run `/review-task` again.

--- a/tests/ha_tests/test_charger.py
+++ b/tests/ha_tests/test_charger.py
@@ -1270,11 +1270,10 @@ async def test_charger_check_load_activity_plugged_no_car(
 
     time = datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC)
 
-    # QS-342 review #03 / D6: the reset is gated on there being state to destroy, so
-    # the "no car connected" state stops re-running a no-op reset (and its six INFO
-    # lines) every cycle. Seed some state so the reset still runs here.
-    charger_device._last_amp_change_time = time
-    assert charger_device._reset_would_change_state(keep_commands=True) is True
+    # The reset runs on every cycle in this state and is NOT gated on a predicate
+    # enumerating what it clears (review #04 / B2: such a mirror was already
+    # incomplete, and its failure mode is stale charger state). `reset()` is
+    # idempotent; the log volume it used to cause is fixed in the logging.
     charger_device.reset = MagicMock()
 
     do_force = await charger_device.check_load_activity_and_constraints(time)
@@ -1282,15 +1281,12 @@ async def test_charger_check_load_activity_plugged_no_car(
     assert do_force is True
     charger_device.reset.assert_called_once()
 
-    # With nothing left to reset the same call does no work at all.
-    charger_device._last_amp_change_time = None
-    assert charger_device._reset_would_change_state(keep_commands=True) is False
     charger_device.reset = MagicMock()
 
     do_force = await charger_device.check_load_activity_and_constraints(time)
 
     assert do_force is True
-    charger_device.reset.assert_not_called()
+    charger_device.reset.assert_called_once()
 
 
 async def test_charger_check_load_activity_force_constraint(

--- a/tests/ha_tests/test_charger.py
+++ b/tests/ha_tests/test_charger.py
@@ -1267,13 +1267,30 @@ async def test_charger_check_load_activity_plugged_no_car(
     charger_device.is_not_plugged = MagicMock(return_value=False)
     charger_device.is_plugged = MagicMock(return_value=True)
     charger_device.get_best_car = MagicMock(return_value=None)
-    charger_device.reset = MagicMock()
 
     time = datetime(2026, 1, 15, 9, 0, tzinfo=pytz.UTC)
+
+    # QS-342 review #03 / D6: the reset is gated on there being state to destroy, so
+    # the "no car connected" state stops re-running a no-op reset (and its six INFO
+    # lines) every cycle. Seed some state so the reset still runs here.
+    charger_device._last_amp_change_time = time
+    assert charger_device._reset_would_change_state(keep_commands=True) is True
+    charger_device.reset = MagicMock()
+
     do_force = await charger_device.check_load_activity_and_constraints(time)
 
     assert do_force is True
     charger_device.reset.assert_called_once()
+
+    # With nothing left to reset the same call does no work at all.
+    charger_device._last_amp_change_time = None
+    assert charger_device._reset_would_change_state(keep_commands=True) is False
+    charger_device.reset = MagicMock()
+
+    do_force = await charger_device.check_load_activity_and_constraints(time)
+
+    assert do_force is True
+    charger_device.reset.assert_not_called()
 
 
 async def test_charger_check_load_activity_force_constraint(
@@ -3390,6 +3407,9 @@ async def test_charger_check_load_activity_plugged_best_car_none(
     charger_device.is_not_plugged = MagicMock(return_value=False)
     charger_device.is_plugged = MagicMock(return_value=True)
     charger_device.get_best_car = MagicMock(return_value=None)
+    # QS-342 review #03 / D6: the reset only runs when it would destroy something,
+    # so the no-car state stops re-running a no-op reset every cycle.
+    charger_device._last_amp_change_time = now
     charger_device.reset = MagicMock()
     assert await charger_device.check_load_activity_and_constraints(now) is True
     charger_device.reset.assert_called_once()

--- a/tests/test_charger_allocation_tiebreak.py
+++ b/tests/test_charger_allocation_tiebreak.py
@@ -50,7 +50,11 @@ FIXED_POINT = {"wallbox_parking": "IDBuzz", "wallbox_portail": "Zoe"}
 
 
 def _pin_car(car, coords) -> None:
-    """Pin a car to the incident matrix: plugged (both call forms) + fixed GPS."""
+    """Pin a car to the incident matrix: fixed GPS + `is_car_plugged` → True.
+
+    Patching `is_car_plugged` covers both call forms (`for_duration` set and
+    unset), so `plug_bump` is 5 rather than the instant-fallback 2.
+    """
     car.get_car_coordinates = MagicMock(return_value=coords)
     car.is_car_plugged = MagicMock(return_value=True)
 
@@ -169,7 +173,7 @@ def _apply_attachment_state(fx, parking_car, portail_car, time) -> None:
 
 
 # =============================================================================
-# Incident replay (expected red on pre-fix code)
+# Incident replay (historical TDD note: was red on pre-A1 code, green since A1)
 # =============================================================================
 
 
@@ -198,7 +202,7 @@ def test_incident_replay_idbuzz_gets_parking():
 
 
 # =============================================================================
-# Start-state × execution-order sweep (expected red on pre-fix code)
+# Start-state × execution-order sweep (historical TDD note: was red pre-A1)
 # =============================================================================
 
 
@@ -392,6 +396,14 @@ def test_scenario_families_are_caller_independent(scenario, caller_name):
 # =============================================================================
 
 
+def _messages(caplog, fragment: str) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == CHARGER_LOGGER and fragment in record.getMessage()
+    ]
+
+
 def _decomposition_lines(caplog) -> list[str]:
     return [
         record.getMessage()
@@ -419,10 +431,18 @@ def test_get_car_score_decomposition_logs_once_then_on_change(caplog):
     fx.parking.get_car_score(fx.zoe, time, {})
     assert len(_decomposition_lines(caplog)) == 1
 
+    # KEY-COMPOSITION ORACLE (do not fold into the step above): in-bucket jitter
+    # with the last emission OLDER than the rate floor. The floor can no longer
+    # explain the silence, so this fails if the change key ever grows a raw
+    # (unquantised) component — raw distance here.
+    fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0000005, ZOE_COORDS[1]))
+    time = T0 + timedelta(seconds=_CHANGED_RELOG_MIN_INTERVAL_S + 5)
+    fx.parking.get_car_score(fx.zoe, time, {})
+    assert len(_decomposition_lines(caplog)) == 1
+
     # Crossing a bucket edge (≈11 m shift) changes the quantised tuple → one
-    # new line, once past the changed-value rate-limit floor.
+    # new line (the floor has elapsed since the only emission, at T0).
     fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1]))
-    time = T0 + timedelta(seconds=_CHANGED_RELOG_MIN_INTERVAL_S + 10)
     fx.parking.get_car_score(fx.zoe, time, {})
     assert len(_decomposition_lines(caplog)) == 2
 
@@ -439,6 +459,93 @@ def test_get_car_score_decomposition_logs_once_then_on_change(caplog):
     assert len(_decomposition_lines(caplog)) == 3
 
 
+def test_get_car_score_change_key_ignores_the_attach_delta(caplog):
+    # Second key-composition oracle: `connected_time_delta` grows on every call
+    # while the car stays attached. It is payload, not part of the change key —
+    # scoring 65 s later (floor elapsed, quantised tuple identical) must stay
+    # silent. Fails if the attach delta ever enters the key.
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+
+    fx.parking.attach_car(fx.zoe, T0)
+    fx.parking.get_car_score(fx.zoe, T0, {})
+    assert len(_decomposition_lines(caplog)) == 1
+
+    later = T0 + timedelta(seconds=_CHANGED_RELOG_MIN_INTERVAL_S + 5)
+    fx.parking.get_car_score(fx.zoe, later, {})
+    assert len(_decomposition_lines(caplog)) == 1
+
+
+def test_get_car_score_excursion_reverting_inside_the_floor_is_disclosed(caplog):
+    # QS-342 review #02 / S1: a tuple excursion that begins AND ends inside the
+    # floor window must not vanish. The memo is not restamped on suppression, so
+    # a revert would otherwise leave the operator a flat trace while the 900 s
+    # heartbeat re-emits the pre-excursion tuple.
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+
+    fx.parking.get_car_score(fx.zoe, T0, {})
+    assert len(_decomposition_lines(caplog)) == 1
+
+    # Excursion to another bucket for three cycles, all inside the floor.
+    fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1]))
+    for offset in (7, 14, 21):
+        fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=offset), {})
+    assert len(_decomposition_lines(caplog)) == 1
+
+    # Reverts to the pre-excursion bucket, still inside the floor: nothing yet.
+    fx.zoe.get_car_coordinates = MagicMock(return_value=ZOE_COORDS)
+    fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=28), {})
+    assert len(_decomposition_lines(caplog)) == 1
+
+    # Once the floor expires the banked excursion is disclosed, even though the
+    # value now equals the last emitted one.
+    fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=_CHANGED_RELOG_MIN_INTERVAL_S + 5), {})
+    lines = _decomposition_lines(caplog)
+    assert len(lines) == 2
+    assert "suppressed" in lines[1]
+    assert "3" in lines[1]  # the three suppressed changes are counted
+
+
+def test_log_info_on_change_floor_survives_a_tzinfo_mismatch(caplog):
+    # S4: the naive/aware mismatch path cannot compute `elapsed`, so it emits
+    # (a logging helper must never raise). Pin that this is ONE-SHOT: the
+    # emission restamps the key, so the floor governs again immediately after.
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    charger = fx.parking
+    floor = {"min_interval_s": _CHANGED_RELOG_MIN_INTERVAL_S}
+
+    charger.log_info_on_change("k", "a", T0, "tz probe %s", "aware", **floor)
+    charger.log_info_on_change("k", "b", T0.replace(tzinfo=None), "tz probe %s", "naive", **floor)
+    assert len(_messages(caplog, "tz probe")) == 2
+
+    # Same (naive) clock kind again, changed value inside the floor: suppressed.
+    charger.log_info_on_change(
+        "k", "c", T0.replace(tzinfo=None) + timedelta(seconds=7), "tz probe %s", "naive again", **floor
+    )
+    assert len(_messages(caplog, "tz probe")) == 2
+
+
+def _gaps(offsets: list[int]) -> list[int]:
+    """Simulated-time distances between consecutive emissions."""
+    return [later - earlier for earlier, later in zip(offsets[:-1], offsets[1:], strict=True)]
+
+
+def _emission_offsets(caplog, lines_fn, cycles, step_s, run_cycle) -> list[int]:
+    """Simulated-time offsets (s) at which `lines_fn` gained a line."""
+    offsets: list[int] = []
+    seen = len(lines_fn(caplog))
+    for index in range(cycles):
+        offset = index * step_s
+        run_cycle(index, T0 + timedelta(seconds=offset))
+        current = len(lines_fn(caplog))
+        if current > seen:
+            offsets.append(offset)
+            seen = current
+    return offsets
+
+
 def test_get_car_score_decomposition_rate_limited_when_tuple_oscillates(caplog):
     # A car GPS-jittering ACROSS a 0.5 m bucket edge alternates the change key
     # on every ~7 s allocation cycle (the incident's churn class): emissions
@@ -449,17 +556,47 @@ def test_get_car_score_decomposition_rate_limited_when_tuple_oscillates(caplog):
     in_bucket = ZOE_COORDS
     other_bucket = (ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1])  # ≈11 m: different bucket
 
-    cycles = 40
-    step_s = 7
-    for i in range(cycles):
-        coords = other_bucket if i % 2 else in_bucket
-        fx.zoe.get_car_coordinates = MagicMock(return_value=coords)
-        fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=i * step_s), {})
+    def _cycle(index, time):
+        fx.zoe.get_car_coordinates = MagicMock(return_value=other_bucket if index % 2 else in_bucket)
+        fx.parking.get_car_score(fx.zoe, time, {})
 
-    span_s = (cycles - 1) * step_s  # 273 s of sustained flapping
-    bound = 1 + span_s // _CHANGED_RELOG_MIN_INTERVAL_S + 1  # first line + ≤1/floor
-    lines = _decomposition_lines(caplog)
-    assert 2 <= len(lines) <= bound  # bounded, yet still emitting on change
+    offsets = _emission_offsets(caplog, _decomposition_lines, cycles=40, step_s=7, run_cycle=_cycle)
+
+    # Pin the MECHANISM, not a loose count: consecutive emissions are at least a
+    # floor apart (a floor half as effective would fail), and churn still gets
+    # reported rather than silenced entirely.
+    assert len(offsets) >= 2
+    assert all(gap >= _CHANGED_RELOG_MIN_INTERVAL_S for gap in _gaps(offsets)), offsets
+
+
+def test_get_best_car_log_is_rate_limited_when_the_winner_flips(caplog):
+    # S2: the sibling INFO-on-change site in `get_best_car` is keyed on the
+    # winning car name. The documented residual mode (a car jittering across a
+    # 0.5 m bucket edge flips the strict-score winner) drives it at the full
+    # cycle rate unless it is floored too.
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    _patch_scores(fx.portail, {})  # never competes: keeps the flip on `parking`
+    scores = {"Zoe": 100.0, "IDBuzz": 90.0}
+    fx.parking.get_car_score = MagicMock(side_effect=lambda car, time, cache: scores.get(car.name, 0.0))
+
+    def _lines(cap):
+        return [
+            record.getMessage()
+            for record in cap.records
+            if record.name == CHARGER_LOGGER and record.getMessage().startswith("get_best_car: ")
+        ]
+
+    def _cycle(index, time):
+        # Strict-score winner flips every cycle — no tie, so the cascade never
+        # sees it (this is the documented bucket-edge residual).
+        scores["Zoe"], scores["IDBuzz"] = (90.0, 100.0) if index % 2 else (100.0, 90.0)
+        fx.parking.get_best_car(time)
+
+    offsets = _emission_offsets(caplog, _lines, cycles=20, step_s=7, run_cycle=_cycle)
+
+    assert len(offsets) >= 2
+    assert all(gap >= _CHANGED_RELOG_MIN_INTERVAL_S for gap in _gaps(offsets)), offsets
 
 
 def test_detach_car_preserves_get_car_score_memo(caplog):
@@ -474,11 +611,17 @@ def test_detach_car_preserves_get_car_score_memo(caplog):
     fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=7), {})
     assert len(_decomposition_lines(caplog)) == 1
 
+    # Seed a NON-score memo so the wipe assertion below is not vacuous: without
+    # it the prefix-only check passes even if the wipe stops clearing anything.
+    fx.parking.log_info_on_change("session", "seeded", T0, "session probe")
+    assert "session" in fx.parking._log_on_change_state
+
     fx.parking.detach_car()
 
     # Unchanged tuple right after the detach: no re-emission burst.
     fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=14), {})
     assert len(_decomposition_lines(caplog)) == 1
 
-    # The non-get_car_score memos are still cleared (QS-306 fresh-session rule).
+    # The non-get_car_score memos ARE still cleared (QS-306 fresh-session rule).
+    assert "session" not in fx.parking._log_on_change_state
     assert all(key.startswith("get_car_score:") for key in fx.parking._log_on_change_state)

--- a/tests/test_charger_allocation_tiebreak.py
+++ b/tests/test_charger_allocation_tiebreak.py
@@ -323,6 +323,44 @@ def test_equal_score_does_not_steal_attached_car():
 # =============================================================================
 
 
+def _patch_scores_by_object(charger, mapping) -> None:
+    """Score map keyed by object IDENTITY — the only way to tell twins apart."""
+    charger.get_car_score = MagicMock(side_effect=lambda car, time, cache: mapping.get(id(car), 0.0))
+
+
+def test_duplicate_car_names_do_not_orphan_a_charger():
+    """B1 (review #04): regret must use the same relation as removal — the NAME.
+
+    The cascade is effectively over names: removal consumes a whole NAME from every
+    charger's list, and stickiness compares names. A regret scan matching by object
+    identity is the odd one out, and the two rules then stop describing the same set.
+
+    Nothing enforces car-name uniqueness. `CONF_NAME` is a plain `cv.string` in the
+    options flow with no collision validation, the options flow never re-checks
+    `unique_id`, and `add_device` dedups by object identity only (`QSCar` defines no
+    `__eq__`) — so two config entries named "Zoe" yield two distinct `QSCar` objects
+    named "Zoe".
+
+    Under that state an identity scan under-counts alternatives, so regret for the
+    duplicated name inflates (0 -> 100) and it wins round 1; name-based removal then
+    strips its twin off the other charger, which exits the round with nothing and
+    falls back to its generic car. That is exactly the #342 symptom.
+    """
+    fx = _make_incident_fixture(pin_buzz=False)
+    twin = make_real_car(fx.hass, fx.home, name=fx.zoe.name)
+    assert twin is not fx.zoe and twin.name == fx.zoe.name
+    # Sorts after "Zoe", so the stable-order tie-break prefers a twin over it and the
+    # identity/name divergence is observable rather than masked by ordering.
+    spare = make_real_car(fx.hass, fx.home, name="Zzz")
+
+    _patch_scores_by_object(fx.parking, {id(fx.zoe): 100.0, id(spare): 100.0})
+    _patch_scores_by_object(fx.portail, {id(twin): 100.0})
+
+    # Neither plugged charger may end the round without a car (AC4).
+    assert fx.portail.get_best_car(T0) is twin
+    assert fx.parking.get_best_car(T0) is spare
+
+
 def test_losing_charger_falls_back_to_generic_car():
     # Incident matrix but the second car scores 0 (not plugged, no coords, not
     # home): the Zoe ties on both chargers, stable order gives it to parking,

--- a/tests/test_charger_allocation_tiebreak.py
+++ b/tests/test_charger_allocation_tiebreak.py
@@ -17,23 +17,35 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytz
 
 from custom_components.quiet_solar.const import (
+    CHARGER_NO_CAR_CONNECTED,
     CONF_CHARGER_LATITUDE,
     CONF_CHARGER_LONGITUDE,
+    FORCE_CAR_NO_CHARGER_CONNECTED,
     USER_ORIGINATED_CAR_NAME,
+    USER_ORIGINATED_CHARGER_NAME,
 )
-from custom_components.quiet_solar.ha_model.charger import _CHANGED_RELOG_MIN_INTERVAL_S
+from custom_components.quiet_solar.ha_model.charger import (
+    _LOG_VALUES_PER_WINDOW,
+    _RELOG_UNCHANGED_AFTER_S,
+)
 from tests.utils.charger_harness import (
     create_charger,
     make_hass,
     make_home,
     make_real_car,
 )
+
+LOAD_LOGGER = "custom_components.quiet_solar.home_model.load"
+
+# Per key the helper emits at most `budget` lines per window plus one overflow
+# disclosure — see `LogOnChangeMixin.log_info_on_change`.
+_PER_KEY_CEILING = _LOG_VALUES_PER_WINDOW + 1
 
 CHARGER_LOGGER = "custom_components.quiet_solar.ha_model.charger"
 
@@ -414,7 +426,7 @@ def _decomposition_lines(caplog) -> list[str]:
     ]
 
 
-def test_get_car_score_decomposition_logs_once_then_on_change(caplog):
+def test_get_car_score_decomposition_dedups_by_value(caplog):
     fx = _make_incident_fixture()
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     time = T0
@@ -424,37 +436,36 @@ def test_get_car_score_decomposition_logs_once_then_on_change(caplog):
     assert len(_decomposition_lines(caplog)) == 1
     assert "plug_bump" in _decomposition_lines(caplog)[0]
 
-    # GPS jitter INSIDE the same 0.5 m distance bucket, within the 900 s
-    # window: the quantised tuple is unchanged → zero new lines.
+    # GPS jitter INSIDE the same 0.5 m distance bucket: the quantised tuple is
+    # unchanged, so the value is still remembered → zero new lines.
     fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0000005, ZOE_COORDS[1]))
     time += timedelta(seconds=10)
     fx.parking.get_car_score(fx.zoe, time, {})
     assert len(_decomposition_lines(caplog)) == 1
 
-    # KEY-COMPOSITION ORACLE (do not fold into the step above): in-bucket jitter
-    # with the last emission OLDER than the rate floor. The floor can no longer
-    # explain the silence, so this fails if the change key ever grows a raw
-    # (unquantised) component — raw distance here.
-    fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0000005, ZOE_COORDS[1]))
-    time = T0 + timedelta(seconds=_CHANGED_RELOG_MIN_INTERVAL_S + 5)
+    # KEY-COMPOSITION ORACLE (do not fold into the step above): the same in-bucket
+    # jitter far later, still inside the 900 s TTL. Only the change key can explain
+    # the silence, so this fails if the key ever grows a raw (unquantised)
+    # component — raw distance here.
+    time = T0 + timedelta(seconds=600)
     fx.parking.get_car_score(fx.zoe, time, {})
     assert len(_decomposition_lines(caplog)) == 1
 
-    # Crossing a bucket edge (≈11 m shift) changes the quantised tuple → one
-    # new line (the floor has elapsed since the only emission, at T0).
+    # Crossing a bucket edge (≈11 m) is a value never seen before → one new line.
     fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1]))
     fx.parking.get_car_score(fx.zoe, time, {})
     assert len(_decomposition_lines(caplog)) == 2
 
-    # A change WITHIN the floor window is rate-limited: no new line.
+    # Reverting to the FIRST bucket stays silent — that value is still remembered.
+    # This is the whole point of dedup-by-value: the old changed-value time floor
+    # re-emitted here, so an A->B->A oscillation cost a line per TRANSITION. It now
+    # costs one line per DISTINCT VALUE per window.
     fx.zoe.get_car_coordinates = MagicMock(return_value=ZOE_COORDS)
     fx.parking.get_car_score(fx.zoe, time + timedelta(seconds=7), {})
     assert len(_decomposition_lines(caplog)) == 2
 
-    # Unchanged value re-emits once the 900 s heartbeat elapses (pins the
-    # bounded-volume claim).
-    fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1]))
-    time += timedelta(seconds=901)
+    # Once the per-value TTL lapses, the 900 s heartbeat re-emits it.
+    time = T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 7)
     fx.parking.get_car_score(fx.zoe, time, {})
     assert len(_decomposition_lines(caplog)) == 3
 
@@ -471,157 +482,312 @@ def test_get_car_score_change_key_ignores_the_attach_delta(caplog):
     fx.parking.get_car_score(fx.zoe, T0, {})
     assert len(_decomposition_lines(caplog)) == 1
 
-    later = T0 + timedelta(seconds=_CHANGED_RELOG_MIN_INTERVAL_S + 5)
+    later = T0 + timedelta(seconds=65)
     fx.parking.get_car_score(fx.zoe, later, {})
     assert len(_decomposition_lines(caplog)) == 1
 
 
-def test_get_car_score_excursion_reverting_inside_the_floor_is_disclosed(caplog):
-    # QS-342 review #02 / S1: a tuple excursion that begins AND ends inside the
-    # floor window must not vanish. The memo is not restamped on suppression, so
-    # a revert would otherwise leave the operator a flat trace while the 900 s
-    # heartbeat re-emits the pre-excursion tuple.
-    fx = _make_incident_fixture()
-    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
-
-    fx.parking.get_car_score(fx.zoe, T0, {})
-    assert len(_decomposition_lines(caplog)) == 1
-
-    # Excursion to another bucket for three cycles, all inside the floor.
-    fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1]))
-    for offset in (7, 14, 21):
-        fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=offset), {})
-    assert len(_decomposition_lines(caplog)) == 1
-
-    # Reverts to the pre-excursion bucket, still inside the floor: nothing yet.
-    fx.zoe.get_car_coordinates = MagicMock(return_value=ZOE_COORDS)
-    fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=28), {})
-    assert len(_decomposition_lines(caplog)) == 1
-
-    # Once the floor expires the banked excursion is disclosed, even though the
-    # value now equals the last emitted one.
-    fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=_CHANGED_RELOG_MIN_INTERVAL_S + 5), {})
-    lines = _decomposition_lines(caplog)
-    assert len(lines) == 2
-    assert "suppressed" in lines[1]
-    assert "3" in lines[1]  # the three suppressed changes are counted
-
-
-def test_log_info_on_change_floor_survives_a_tzinfo_mismatch(caplog):
-    # S4: the naive/aware mismatch path cannot compute `elapsed`, so it emits
-    # (a logging helper must never raise). Pin that this is ONE-SHOT: the
-    # emission restamps the key, so the floor governs again immediately after.
+def test_naive_time_is_normalised(caplog):
+    # Replaces the old naive/aware "non-comparable clock" tests. That branch used to
+    # emit unconditionally, so a caller alternating naive and aware datetimes under
+    # one key escaped the bound ENTIRELY. `time` is now normalised to UTC up front:
+    # a naive input must neither raise nor become an escape hatch.
     fx = _make_incident_fixture()
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     charger = fx.parking
-    floor = {"min_interval_s": _CHANGED_RELOG_MIN_INTERVAL_S}
 
-    charger.log_info_on_change("k", "a", T0, "tz probe %s", "aware", **floor)
-    charger.log_info_on_change("k", "b", T0.replace(tzinfo=None), "tz probe %s", "naive", **floor)
-    assert len(_messages(caplog, "tz probe")) == 2
+    charger.log_info_on_change("k", "a", T0, "tz probe %s", "aware")
+    assert len(_messages(caplog, "tz probe")) == 1
 
-    # Same (naive) clock kind again, changed value inside the floor: suppressed.
-    charger.log_info_on_change(
-        "k", "c", T0.replace(tzinfo=None) + timedelta(seconds=7), "tz probe %s", "naive again", **floor
-    )
-    assert len(_messages(caplog, "tz probe")) == 2
+    # Same instant, same value, expressed naively: still throttled, still no raise.
+    charger.log_info_on_change("k", "a", T0.replace(tzinfo=None), "tz probe %s", "naive")
+    assert len(_messages(caplog, "tz probe")) == 1
 
-
-def _gaps(offsets: list[int]) -> list[int]:
-    """Simulated-time distances between consecutive emissions."""
-    return [later - earlier for earlier, later in zip(offsets[:-1], offsets[1:], strict=True)]
-
-
-def _emission_offsets(caplog, lines_fn, cycles, step_s, run_cycle) -> list[int]:
-    """Simulated-time offsets (s) at which `lines_fn` gained a line."""
-    offsets: list[int] = []
-    seen = len(lines_fn(caplog))
-    for index in range(cycles):
-        offset = index * step_s
-        run_cycle(index, T0 + timedelta(seconds=offset))
-        current = len(lines_fn(caplog))
-        if current > seen:
-            offsets.append(offset)
-            seen = current
-    return offsets
+    # Alternating clock kinds cannot re-inflate the key either.
+    for offset in range(1, 20):
+        stamp = T0 + timedelta(seconds=7 * offset)
+        charger.log_info_on_change(
+            "k", "a", stamp if offset % 2 else stamp.replace(tzinfo=None), "tz probe %s", "mixed"
+        )
+    assert len(_messages(caplog, "tz probe")) == 1
 
 
-def test_get_car_score_decomposition_rate_limited_when_tuple_oscillates(caplog):
-    # A car GPS-jittering ACROSS a 0.5 m bucket edge alternates the change key
-    # on every ~7 s allocation cycle (the incident's churn class): emissions
-    # must stay bounded by the changed-value floor, not track the cycle rate.
+def test_get_car_score_decomposition_bounded_when_tuple_oscillates(caplog):
+    # A car GPS-jittering ACROSS a 0.5 m bucket edge alternates the change key on
+    # every ~7 s allocation cycle (the incident's churn class). Under dedup this
+    # collapses to ONE line per distinct bucket — two lines total, then silence for
+    # the rest of the window.
     fx = _make_incident_fixture()
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
 
     in_bucket = ZOE_COORDS
     other_bucket = (ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1])  # ≈11 m: different bucket
 
-    def _cycle(index, time):
+    for index in range(128):
         fx.zoe.get_car_coordinates = MagicMock(return_value=other_bucket if index % 2 else in_bucket)
-        fx.parking.get_car_score(fx.zoe, time, {})
+        fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=7 * index), {})
 
-    offsets = _emission_offsets(caplog, _decomposition_lines, cycles=40, step_s=7, run_cycle=_cycle)
-
-    # Pin the MECHANISM, not a loose count: consecutive emissions are at least a
-    # floor apart (a floor half as effective would fail), and churn still gets
-    # reported rather than silenced entirely.
-    assert len(offsets) >= 2
-    assert all(gap >= _CHANGED_RELOG_MIN_INTERVAL_S for gap in _gaps(offsets)), offsets
+    # Exactly the two distinct states, not one line per transition, and well under
+    # the per-key ceiling — so the budget never even engages for an oscillation.
+    assert len(_decomposition_lines(caplog)) == 2
 
 
-def test_get_best_car_log_is_rate_limited_when_the_winner_flips(caplog):
-    # S2: the sibling INFO-on-change site in `get_best_car` is keyed on the
-    # winning car name. The documented residual mode (a car jittering across a
-    # 0.5 m bucket edge flips the strict-score winner) drives it at the full
-    # cycle rate unless it is floored too.
+def test_monotone_value_drift_is_budget_capped(caplog):
+    """The test that makes the BUDGET non-optional. Do not weaken it.
+
+    Dedup-by-value kills oscillation perfectly and drift not at all: a car creeping
+    0.55 m per cycle lands in a new 0.5 m bucket almost every cycle, so every cycle
+    is a value never seen before. A dedup-only implementation emits ~87 lines here.
+    """
     fx = _make_incident_fixture()
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
-    _patch_scores(fx.portail, {})  # never competes: keeps the flip on `parking`
-    scores = {"Zoe": 100.0, "IDBuzz": 90.0}
-    fx.parking.get_car_score = MagicMock(side_effect=lambda car, time, cache: scores.get(car.name, 0.0))
 
-    def _lines(cap):
-        return [
-            record.getMessage()
-            for record in cap.records
-            if record.name == CHARGER_LOGGER and record.getMessage().startswith("get_best_car: ")
-        ]
+    # ~0.55 m per cycle, due north of the wallbox.
+    metres_per_degree_lat = 111_320.0
+    for index in range(128):
+        drift = index * 0.55 / metres_per_degree_lat
+        fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + drift, ZOE_COORDS[1]))
+        fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=7 * index), {})
 
-    def _cycle(index, time):
-        # Strict-score winner flips every cycle — no tie, so the cascade never
-        # sees it (this is the documented bucket-edge residual).
-        scores["Zoe"], scores["IDBuzz"] = (90.0, 100.0) if index % 2 else (100.0, 90.0)
-        fx.parking.get_best_car(time)
-
-    offsets = _emission_offsets(caplog, _lines, cycles=20, step_s=7, run_cycle=_cycle)
-
-    assert len(offsets) >= 2
-    assert all(gap >= _CHANGED_RELOG_MIN_INTERVAL_S for gap in _gaps(offsets)), offsets
+    lines = _decomposition_lines(caplog)
+    assert len(lines) <= _PER_KEY_CEILING, lines
+    # The drift is genuinely distinct-valued, so the budget (not dedup) is what
+    # bounded it — if this ever drops to 1 the fixture stopped drifting.
+    assert len(lines) >= 2, lines
 
 
-def test_detach_car_preserves_get_car_score_memo(caplog):
-    # `detach_car` wipes the QS-306 memos describing the departed session, but
-    # the `get_car_score:{car}` keys are car-qualified and cover EVERY candidate
-    # car: they must survive, or attach/detach churn re-emits one decomposition
-    # line per car per detach even with unchanged tuples.
+def test_log_state_survives_detach_car(caplog):
+    """Replaces `test_sf1_detach_car_clears_the_memo`, which pinned the defect.
+
+    `detach_car()` sits ON the churn path — every change of the `get_best_car` value
+    routes through it — so wiping the log state there dropped the key, left the next
+    call with nothing to compare against, and made every throttle on this path a
+    no-op in production. The state must now survive.
+    """
     fx = _make_incident_fixture()
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
 
     fx.parking.attach_car(fx.zoe, T0)
     fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=7), {})
-    assert len(_decomposition_lines(caplog)) == 1
-
-    # Seed a NON-score memo so the wipe assertion below is not vacuous: without
-    # it the prefix-only check passes even if the wipe stops clearing anything.
     fx.parking.log_info_on_change("session", "seeded", T0, "session probe")
-    assert "session" in fx.parking._log_on_change_state
+    assert len(_decomposition_lines(caplog)) == 1
+    assert len(_messages(caplog, "session probe")) == 1
 
     fx.parking.detach_car()
 
-    # Unchanged tuple right after the detach: no re-emission burst.
-    fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=14), {})
-    assert len(_decomposition_lines(caplog)) == 1
+    # Nothing was dropped, so neither key re-emits.
+    assert "session" in fx.parking._log_on_change_state
+    assert any(key.startswith("get_car_score:") for key in fx.parking._log_on_change_state)
 
-    # The non-get_car_score memos ARE still cleared (QS-306 fresh-session rule).
-    assert "session" not in fx.parking._log_on_change_state
-    assert all(key.startswith("get_car_score:") for key in fx.parking._log_on_change_state)
+    fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=14), {})
+    fx.parking.log_info_on_change("session", "seeded", T0 + timedelta(seconds=14), "session probe")
+    assert len(_decomposition_lines(caplog)) == 1
+    assert len(_messages(caplog, "session probe")) == 1
+
+
+# =============================================================================
+# Production-path volume (review #03 / D8)
+#
+# These drive `check_load_activity_and_constraints`, NOT `get_best_car` or
+# `get_car_score` in isolation. That distinction is the whole reason round #02's
+# throttle shipped green and did nothing: the isolated call never applies the
+# result, so `detach_car()` never runs — and `detach_car()` was wiping the very
+# state the throttle depended on. Isolated, emissions looked ~63 s apart; on the
+# real path they were at the full 7 s cycle rate.
+# =============================================================================
+
+
+def _drive_real_cycle_path(fx) -> None:
+    """Stub only HA I/O so `check_load_activity_and_constraints` runs end to end."""
+    for charger in (fx.parking, fx.portail):
+        charger.is_charger_unavailable = MagicMock(return_value=False)
+        charger.probe_for_possible_needed_reboot = MagicMock(return_value=False)
+        charger.is_not_plugged = MagicMock(return_value=False)
+        charger.set_charging_num_phases = AsyncMock(return_value=False)
+        charger.set_max_charging_current = AsyncMock(return_value=True)
+        charger.reboot = AsyncMock()
+        charger.is_car_stopped_asking_current = MagicMock(return_value=False)
+    for car in (fx.zoe, fx.buzz):
+        car.get_car_charge_percent = lambda time=None, *a, **kw: 40.0
+        car.get_best_person_next_need = AsyncMock(return_value=(False, None, None, None))
+        car.get_next_scheduled_event = AsyncMock(return_value=(None, None))
+        car.setup_car_charge_target_if_needed = AsyncMock(return_value=80.0)
+
+
+def _pin_scores(fx, per_charger: dict) -> None:
+    """Give each charger a fixed score for the Zoe (0 for anything else)."""
+    for charger in (fx.parking, fx.portail):
+        charger.get_car_score = MagicMock(
+            side_effect=lambda car, time, cache, _c=charger: (
+                per_charger[_c.name] if car.name == "Zoe" else 0.0
+            )
+        )
+
+
+def _info_volume(caplog) -> list:
+    return [
+        record
+        for record in caplog.records
+        if record.levelno == logging.INFO and record.name in (CHARGER_LOGGER, LOAD_LOGGER)
+    ]
+
+
+async def _run_cycles(fx, caplog, cycles: int = 129, step_s: int = 7) -> None:
+    for index in range(cycles):
+        time = T0 + timedelta(seconds=step_s * index)
+        for charger in (fx.parking, fx.portail):
+            await charger.check_load_activity_and_constraints(time)
+
+
+async def test_allocation_churn_total_log_volume_over_a_full_window(caplog):
+    """AGGREGATE volume over a full 900 s window, not a per-prefix count.
+
+    Every escaped site is invisible to a prefix-scoped assertion, which is how five
+    of the six winner-announcement branches ran unthrottled through three review
+    rounds. The scenario is a STABLE allocation — parking keeps the Zoe, portail
+    falls back to its generic car — so no session churn is involved and every line
+    above the floor is pure logging defect. Measured 149 lines before this round,
+    129 of them from the single unthrottled `Default car used` branch.
+    """
+    fx = _make_incident_fixture(pin_buzz=False)
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    caplog.set_level(logging.INFO, logger=LOAD_LOGGER)
+    fx.home._cars = [fx.zoe]
+    _drive_real_cycle_path(fx)
+    _pin_scores(fx, {"wallbox_parking": 100.0, "wallbox_portail": 90.0})
+
+    await _run_cycles(fx, caplog)
+
+    # N chargers, M real cars: get_car_score (N*M) + get_best_car (N) +
+    # detach_from_other_charger (N) + soc (2N) + group (N+1) keys, each bounded by
+    # `budget + 1` lines per window.
+    num_chargers, num_cars = 2, 1
+    ceiling = _PER_KEY_CEILING * (num_chargers * num_cars + 5 * num_chargers + 1)
+    volume = _info_volume(caplog)
+    assert len(volume) <= ceiling, f"{len(volume)} lines > {ceiling}:\n" + "\n".join(
+        sorted({record.getMessage()[:110] for record in volume})
+    )
+
+    # The allocation itself is untouched by any of this.
+    assert fx.parking.car is fx.zoe
+    assert fx.portail.car is fx.portail._default_generic_car
+
+
+async def test_generic_car_fallback_line_is_throttled(caplog):
+    # `Default car used` fired 129/129 cycles: a charger with no scoring car says so
+    # every single cycle, forever, while nothing whatsoever is changing.
+    fx = _make_incident_fixture(pin_buzz=False)
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    fx.home._cars = [fx.zoe]
+    _drive_real_cycle_path(fx)
+    _pin_scores(fx, {"wallbox_parking": 100.0, "wallbox_portail": 90.0})
+
+    await _run_cycles(fx, caplog)
+
+    fallback = [r for r in caplog.records if "generic_fallback" in r.getMessage()]
+    assert len(fallback) <= _PER_KEY_CEILING, fallback
+
+
+async def test_removed_from_another_charger_is_throttled(caplog):
+    # THE incident message — the literal line that appeared 17 791 times. It sits
+    # inside the ping-pong condition and was still a raw unthrottled f-string.
+    fx = _make_incident_fixture(pin_buzz=False)
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    fx.home._cars = [fx.zoe]
+    _drive_real_cycle_path(fx)
+
+    # The winner flips between the two chargers every cycle, so the loser's
+    # `best_car.charger is not self` branch is taken on every cycle.
+    per_charger = {"wallbox_parking": 100.0, "wallbox_portail": 90.0}
+    _pin_scores(fx, per_charger)
+    for index in range(129):
+        per_charger["wallbox_parking"], per_charger["wallbox_portail"] = (
+            (90.0, 100.0) if index % 2 else (100.0, 90.0)
+        )
+        time = T0 + timedelta(seconds=7 * index)
+        for charger in (fx.parking, fx.portail):
+            await charger.check_load_activity_and_constraints(time)
+
+    removed = [r for r in caplog.records if "removed from another charger" in r.getMessage()]
+    assert len(removed) <= _PER_KEY_CEILING, removed
+
+
+async def test_user_pinned_car_line_is_throttled(caplog):
+    # `Best Car from user selection` fired 20/20 cycles for a setting that never
+    # changes. It is now one branch of the single merged `get_best_car` key.
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    _drive_real_cycle_path(fx)
+    fx.parking.set_user_originated(USER_ORIGINATED_CAR_NAME, fx.zoe.name)
+
+    await _run_cycles(fx, caplog, cycles=20)
+
+    pinned = [r for r in caplog.records if "user_selection" in r.getMessage()]
+    assert len(pinned) <= _PER_KEY_CEILING, pinned
+
+
+async def test_no_car_selected_state_is_idempotent(caplog):
+    """The single largest volume source: ~74 000 lines/day from one charger.
+
+    Selecting "no car connected" ran a full `reset(keep_commands=True)` EVERY cycle,
+    emitting six INFO lines each time — four times the original incident. Once there
+    is nothing left to reset the state must go completely quiet.
+    """
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    caplog.set_level(logging.INFO, logger=LOAD_LOGGER)
+    _drive_real_cycle_path(fx)
+    for charger in (fx.parking, fx.portail):
+        charger.set_user_originated(USER_ORIGINATED_CAR_NAME, CHARGER_NO_CAR_CONNECTED)
+
+    await _run_cycles(fx, caplog, cycles=20)
+
+    # Two chargers x (one merged `get_best_car` key + at most one settling reset).
+    volume = _info_volume(caplog)
+    assert len(volume) <= 2 * (_PER_KEY_CEILING + 6), "\n".join(
+        record.getMessage()[:110] for record in volume
+    )
+
+    # And the reset genuinely stops running rather than merely logging less.
+    reset_lines = [r for r in caplog.records if "CHARGER_NO_CAR_CONNECTED selected option" in r.getMessage()]
+    assert len(reset_lines) <= 2, reset_lines
+    assert fx.parking.car is None
+
+
+async def test_force_car_no_charger_is_not_logged_from_the_inner_loop(caplog):
+    # This reports a STATIC user setting from inside a charger x car double loop
+    # that itself runs once per charger per cycle: N^2*M lines per cycle, measured
+    # 101 over 20 cycles (~62k/day). It belongs at DEBUG.
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    _drive_real_cycle_path(fx)
+    for car in (fx.zoe, fx.buzz):
+        car.set_user_originated(USER_ORIGINATED_CHARGER_NAME, FORCE_CAR_NO_CHARGER_CONNECTED)
+
+    await _run_cycles(fx, caplog, cycles=20)
+
+    assert [r for r in caplog.records if "FORCE_CAR_NO_CHARGER_CONNECTED" in r.getMessage()] == []
+
+
+def test_same_cycle_duplicate_calls_emit_once(caplog):
+    """One cycle, N chargers, ONE line per `get_car_score:{car}` key.
+
+    `time` is HA's single `event_time` for the whole cycle, and each key is hit once
+    per active charger's `get_best_car`. Under the old floor those N same-instant
+    calls inflated the suppressed-change bank by a factor of N; under dedup the
+    first emits and the rest are the same value at the same instant.
+    """
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+
+    for charger in (fx.parking, fx.portail):
+        charger.get_best_car(T0)
+
+    for car in (fx.zoe, fx.buzz):
+        for charger in (fx.parking, fx.portail):
+            per_key = [
+                record
+                for record in caplog.records
+                if record.getMessage().startswith(f"get_car_score: {car.name} for {charger.name} ")
+            ]
+            assert len(per_key) == 1, per_key

--- a/tests/test_charger_allocation_tiebreak.py
+++ b/tests/test_charger_allocation_tiebreak.py
@@ -27,6 +27,7 @@ from custom_components.quiet_solar.const import (
     CONF_CHARGER_LONGITUDE,
     USER_ORIGINATED_CAR_NAME,
 )
+from custom_components.quiet_solar.ha_model.charger import _CHANGED_RELOG_MIN_INTERVAL_S
 from tests.utils.charger_harness import (
     create_charger,
     make_hass,
@@ -107,10 +108,13 @@ def _make_incident_fixture(pin_buzz: bool = True) -> SimpleNamespace:
 
 
 def _run_allocation_round(chargers, time) -> None:
-    """One full allocation round: each charger picks then applies its own row."""
+    """One full allocation round: each charger picks then applies its own row.
+
+    Per the story recipe: attach only when the returned car actually changed.
+    """
     for charger in chargers:
         car = charger.get_best_car(time)
-        if car is not None:
+        if car is not None and charger.car is not car:
             charger.attach_car(car, time)
 
 
@@ -122,13 +126,17 @@ def _allocation(fx) -> dict:
 
 
 def _spy_detach(charger) -> list:
-    """Wrap `detach_car` so post-convergence oscillation is observable."""
+    """Wrap `detach_car` so post-convergence oscillation is observable.
+
+    Forwards any arguments: a real oscillation must surface as a non-empty
+    `calls` list, never as a `TypeError` inside the spy.
+    """
     original = charger.detach_car
     calls: list[str] = []
 
-    def spy():
+    def spy(*args, **kwargs):
         calls.append(charger.name)
-        original()
+        original(*args, **kwargs)
 
     charger.detach_car = spy
     return calls
@@ -344,6 +352,41 @@ def test_allocation_is_caller_independent(parking_car, portail_car, caller_name)
     assert caller.get_best_car(T0) is fx.cars[FIXED_POINT[caller_name]]
 
 
+def _setup_scenario(fx, scenario):
+    """Set up one scenario family; return the expected global allocation."""
+    if scenario == "regret_no_alternative":
+        _patch_scores(fx.parking, {"Zoe": 100.0, "IDBuzz": 100.0})
+        _patch_scores(fx.portail, {"Zoe": 100.0})  # IDBuzz has no alternative
+        return {"wallbox_parking": fx.buzz, "wallbox_portail": fx.zoe}
+    if scenario == "all_equal_stable_order":
+        _patch_scores(fx.parking, {"Zoe": 100.0, "IDBuzz": 100.0})
+        _patch_scores(fx.portail, {"Zoe": 100.0, "IDBuzz": 100.0})
+        return {"wallbox_parking": fx.buzz, "wallbox_portail": fx.zoe}
+    if scenario == "stickiness":
+        _patch_scores(fx.parking, {"Zoe": 100.0, "IDBuzz": 100.0})
+        _patch_scores(fx.portail, {"Zoe": 100.0, "IDBuzz": 100.0})
+        fx.portail.attach_car(fx.zoe, T0 - timedelta(seconds=60))
+        return {"wallbox_parking": fx.buzz, "wallbox_portail": fx.zoe}
+    assert scenario == "generic_fallback"  # real incident scores, Zoe only
+    return {"wallbox_parking": fx.zoe, "wallbox_portail": fx.portail._default_generic_car}
+
+
+@pytest.mark.parametrize("caller_name", ["wallbox_parking", "wallbox_portail"])
+@pytest.mark.parametrize(
+    "scenario",
+    ["regret_no_alternative", "all_equal_stable_order", "stickiness", "generic_fallback"],
+)
+def test_scenario_families_are_caller_independent(scenario, caller_name):
+    # Story section B: caller independence holds "for each scenario above" —
+    # a fresh fixture per caller gives every charger the IDENTICAL attachment
+    # state, and each caller's own row must agree with the same global
+    # allocation.
+    fx = _make_incident_fixture(pin_buzz=(scenario != "generic_fallback"))
+    expected = _setup_scenario(fx, scenario)
+    caller = fx.chargers[caller_name]
+    assert caller.get_best_car(T0) is expected[caller_name]
+
+
 # =============================================================================
 # C1 — score-decomposition INFO-on-change logging (AC5)
 # =============================================================================
@@ -377,14 +420,65 @@ def test_get_car_score_decomposition_logs_once_then_on_change(caplog):
     assert len(_decomposition_lines(caplog)) == 1
 
     # Crossing a bucket edge (≈11 m shift) changes the quantised tuple → one
-    # new line.
+    # new line, once past the changed-value rate-limit floor.
     fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1]))
-    time += timedelta(seconds=10)
+    time = T0 + timedelta(seconds=_CHANGED_RELOG_MIN_INTERVAL_S + 10)
     fx.parking.get_car_score(fx.zoe, time, {})
+    assert len(_decomposition_lines(caplog)) == 2
+
+    # A change WITHIN the floor window is rate-limited: no new line.
+    fx.zoe.get_car_coordinates = MagicMock(return_value=ZOE_COORDS)
+    fx.parking.get_car_score(fx.zoe, time + timedelta(seconds=7), {})
     assert len(_decomposition_lines(caplog)) == 2
 
     # Unchanged value re-emits once the 900 s heartbeat elapses (pins the
     # bounded-volume claim).
+    fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1]))
     time += timedelta(seconds=901)
     fx.parking.get_car_score(fx.zoe, time, {})
     assert len(_decomposition_lines(caplog)) == 3
+
+
+def test_get_car_score_decomposition_rate_limited_when_tuple_oscillates(caplog):
+    # A car GPS-jittering ACROSS a 0.5 m bucket edge alternates the change key
+    # on every ~7 s allocation cycle (the incident's churn class): emissions
+    # must stay bounded by the changed-value floor, not track the cycle rate.
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+
+    in_bucket = ZOE_COORDS
+    other_bucket = (ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1])  # ≈11 m: different bucket
+
+    cycles = 40
+    step_s = 7
+    for i in range(cycles):
+        coords = other_bucket if i % 2 else in_bucket
+        fx.zoe.get_car_coordinates = MagicMock(return_value=coords)
+        fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=i * step_s), {})
+
+    span_s = (cycles - 1) * step_s  # 273 s of sustained flapping
+    bound = 1 + span_s // _CHANGED_RELOG_MIN_INTERVAL_S + 1  # first line + ≤1/floor
+    lines = _decomposition_lines(caplog)
+    assert 2 <= len(lines) <= bound  # bounded, yet still emitting on change
+
+
+def test_detach_car_preserves_get_car_score_memo(caplog):
+    # `detach_car` wipes the QS-306 memos describing the departed session, but
+    # the `get_car_score:{car}` keys are car-qualified and cover EVERY candidate
+    # car: they must survive, or attach/detach churn re-emits one decomposition
+    # line per car per detach even with unchanged tuples.
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+
+    fx.parking.attach_car(fx.zoe, T0)
+    fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=7), {})
+    assert len(_decomposition_lines(caplog)) == 1
+
+    fx.parking.detach_car()
+
+    # Unchanged tuple right after the detach: no re-emission burst.
+    fx.parking.get_car_score(fx.zoe, T0 + timedelta(seconds=14), {})
+    assert len(_decomposition_lines(caplog)) == 1
+
+    # The non-get_car_score memos are still cleared (QS-306 fresh-session rule).
+    assert all(key.startswith("get_car_score:") for key in fx.parking._log_on_change_state)

--- a/tests/test_charger_allocation_tiebreak.py
+++ b/tests/test_charger_allocation_tiebreak.py
@@ -1,0 +1,390 @@
+"""QS-342 — deterministic car↔charger allocation tie-break (regression net).
+
+Replays the 2026-08-04/05 field incident: ID.buzz on wallbox 2 "parking" and
+Zoe on wallbox 3 "portail", with the Zoe physically parked between the two
+wallboxes. The verified tracker/charger coordinates produce an EXACT 3-way
+score tie (`dist_bump` 0.5 m buckets), which the pre-fix greedy loop resolved
+with a caller-wins bias: infinite attach/detach ping-pong on the Zoe and the
+ID.buzz never attached anywhere.
+
+Fixture helpers are imported from `tests.utils.charger_harness` (the shared
+copy of the `tests/test_charger_coverage_deep.py` module-level helpers the
+story points at).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import pytz
+
+from custom_components.quiet_solar.const import (
+    CONF_CHARGER_LATITUDE,
+    CONF_CHARGER_LONGITUDE,
+    USER_ORIGINATED_CAR_NAME,
+)
+from tests.utils.charger_harness import (
+    create_charger,
+    make_hass,
+    make_home,
+    make_real_car,
+)
+
+CHARGER_LOGGER = "custom_components.quiet_solar.ha_model.charger"
+
+T0 = datetime(2026, 8, 4, 17, 0, 0, tzinfo=pytz.UTC)
+
+# Verified against the production recorder DB (story, Problem section).
+WALLBOX_PARKING_COORDS = (43.635211, 6.989175)  # wallbox 2 "parking"
+WALLBOX_PORTAIL_COORDS = (43.635238, 6.989261)  # wallbox 3 "portail"
+ZOE_COORDS = (43.6352197222222, 6.98922277777778)  # 3.97 m / 3.69 m
+IDBUZZ_COORDS = (43.635236, 6.989147)  # 3.58 m / 9.18 m
+
+# The fixed point the incident matrix must converge to (via regret).
+FIXED_POINT = {"wallbox_parking": "IDBuzz", "wallbox_portail": "Zoe"}
+
+
+def _pin_car(car, coords) -> None:
+    """Pin a car to the incident matrix: plugged (both call forms) + fixed GPS."""
+    car.get_car_coordinates = MagicMock(return_value=coords)
+    car.is_car_plugged = MagicMock(return_value=True)
+
+
+def _make_incident_fixture(pin_buzz: bool = True) -> SimpleNamespace:
+    """Two plugged chargers + two cars at the verified incident coordinates.
+
+    `get_continuous_plug_duration` stays unmocked (returns None → -1 →
+    `plug_time_bump == 0`, as in the field after an HA restart).
+    """
+    hass = make_hass()
+    home = make_home()
+    parking = create_charger(
+        hass,
+        home,
+        name="wallbox_parking",
+        **{
+            CONF_CHARGER_LATITUDE: WALLBOX_PARKING_COORDS[0],
+            CONF_CHARGER_LONGITUDE: WALLBOX_PARKING_COORDS[1],
+        },
+    )
+    portail = create_charger(
+        hass,
+        home,
+        name="wallbox_portail",
+        **{
+            CONF_CHARGER_LATITUDE: WALLBOX_PORTAIL_COORDS[0],
+            CONF_CHARGER_LONGITUDE: WALLBOX_PORTAIL_COORDS[1],
+        },
+    )
+    zoe = make_real_car(hass, home, name="Zoe")
+    buzz = make_real_car(hass, home, name="IDBuzz")
+
+    _pin_car(zoe, ZOE_COORDS)
+    if pin_buzz:
+        _pin_car(buzz, IDBUZZ_COORDS)
+
+    for charger in (parking, portail):
+        charger.is_plugged = MagicMock(return_value=True)
+        # Preconditions from the story: no boot car (it would preempt the
+        # generic fallback) and no user-originated car selection.
+        assert charger._boot_car is None
+        assert charger.get_user_originated(USER_ORIGINATED_CAR_NAME) is None
+
+    return SimpleNamespace(
+        hass=hass,
+        home=home,
+        parking=parking,
+        portail=portail,
+        zoe=zoe,
+        buzz=buzz,
+        chargers={"wallbox_parking": parking, "wallbox_portail": portail},
+        cars={"Zoe": zoe, "IDBuzz": buzz},
+    )
+
+
+def _run_allocation_round(chargers, time) -> None:
+    """One full allocation round: each charger picks then applies its own row."""
+    for charger in chargers:
+        car = charger.get_best_car(time)
+        if car is not None:
+            charger.attach_car(car, time)
+
+
+def _allocation(fx) -> dict:
+    return {
+        name: (charger.car.name if charger.car is not None else None)
+        for name, charger in fx.chargers.items()
+    }
+
+
+def _spy_detach(charger) -> list:
+    """Wrap `detach_car` so post-convergence oscillation is observable."""
+    original = charger.detach_car
+    calls: list[str] = []
+
+    def spy():
+        calls.append(charger.name)
+        original()
+
+    charger.detach_car = spy
+    return calls
+
+
+# Attachment states of the 2×2 incident fixture: each charger's car in
+# {None, Zoe, IDBuzz}, minus double-attachment of the same car.
+_ATTACHMENT_STATES = [
+    (parking_car, portail_car)
+    for parking_car in (None, "Zoe", "IDBuzz")
+    for portail_car in (None, "Zoe", "IDBuzz")
+    if parking_car is None or parking_car != portail_car
+]
+
+_EXECUTION_ORDERS = [
+    ("wallbox_parking", "wallbox_portail"),
+    ("wallbox_portail", "wallbox_parking"),
+]
+
+
+def _apply_attachment_state(fx, parking_car, portail_car, time) -> None:
+    for charger_name, car_name in (
+        ("wallbox_parking", parking_car),
+        ("wallbox_portail", portail_car),
+    ):
+        if car_name is not None:
+            # Within the last 20 min: the attach-duration score bumps must NOT
+            # kick in — the tests exercise the new tie-break, not the old bumps.
+            fx.chargers[charger_name].attach_car(fx.cars[car_name], time - timedelta(seconds=60))
+
+
+# =============================================================================
+# Incident replay (expected red on pre-fix code)
+# =============================================================================
+
+
+def test_incident_replay_idbuzz_gets_parking():
+    fx = _make_incident_fixture()
+    order = [fx.parking, fx.portail]
+    time = T0
+
+    _run_allocation_round(order, time)
+
+    # The regret tie-break resolves the 3-way tie: ID.buzz→parking, Zoe→portail.
+    assert _allocation(fx) == FIXED_POINT
+
+    # Convergence: the next round changes nothing…
+    time += timedelta(seconds=7)
+    _run_allocation_round(order, time)
+    assert _allocation(fx) == FIXED_POINT
+
+    # …and zero detach_car calls over ≥3 further rounds (no ping-pong).
+    detach_calls = [_spy_detach(fx.parking), _spy_detach(fx.portail)]
+    for _ in range(3):
+        time += timedelta(seconds=7)
+        _run_allocation_round(order, time)
+        assert _allocation(fx) == FIXED_POINT
+    assert detach_calls == [[], []]
+
+
+# =============================================================================
+# Start-state × execution-order sweep (expected red on pre-fix code)
+# =============================================================================
+
+
+@pytest.mark.parametrize("order_names", _EXECUTION_ORDERS, ids=lambda o: "->".join(o))
+@pytest.mark.parametrize(
+    ("parking_car", "portail_car"),
+    _ATTACHMENT_STATES,
+    ids=lambda v: str(v),
+)
+def test_convergence_from_all_attachment_states(parking_car, portail_car, order_names):
+    fx = _make_incident_fixture()
+    _apply_attachment_state(fx, parking_car, portail_car, T0)
+    order = [fx.chargers[name] for name in order_names]
+    time = T0
+
+    # Converges to the same fixed point within ONE full round, whatever the
+    # starting attachment state (including the crossed pairing inherited from
+    # the pre-fix ping-pong) and whatever the execution order.
+    _run_allocation_round(order, time)
+    assert _allocation(fx) == FIXED_POINT
+
+    time += timedelta(seconds=7)
+    _run_allocation_round(order, time)
+    assert _allocation(fx) == FIXED_POINT
+
+    detach_calls = [_spy_detach(fx.parking), _spy_detach(fx.portail)]
+    for _ in range(3):
+        time += timedelta(seconds=7)
+        _run_allocation_round(order, time)
+        assert _allocation(fx) == FIXED_POINT
+    assert detach_calls == [[], []]
+
+
+# =============================================================================
+# Regret tie-break (selection-level, patched score maps)
+# =============================================================================
+
+
+def _patch_scores(charger, mapping) -> None:
+    """Replace `get_car_score` with a fixed map (0.0 = excluded from the pool)."""
+    charger.get_car_score = MagicMock(side_effect=lambda car, time, cache: mapping.get(car.name, 0.0))
+
+
+def test_regret_prefers_charger_specific_car():
+    # Incident matrix (real scores): ID.buzz's alternative on portail is
+    # strictly worse (8 200 005 < 9 300 005) → regret 1 100 000 beats the
+    # Zoe's regret 0 → ID.buzz wins the contested parking charger.
+    fx = _make_incident_fixture()
+    assert fx.parking.get_best_car(T0) is fx.buzz
+    assert fx.portail.get_best_car(T0) is fx.zoe
+
+    # No-alternative case: the car is absent from every other unassigned
+    # charger's list → its alternative is 0 → regret = its own score.
+    fx = _make_incident_fixture()
+    _patch_scores(fx.parking, {"Zoe": 100.0, "IDBuzz": 100.0})
+    _patch_scores(fx.portail, {"Zoe": 100.0})  # IDBuzz scores 0 on portail
+    assert fx.parking.get_best_car(T0) is fx.buzz
+    assert fx.portail.get_best_car(T0) is fx.zoe
+
+    # All-equal case (equal scores, equal regrets, no attachment): falls
+    # through to stable (charger name, car name) order — parking < portail,
+    # IDBuzz < Zoe → (parking, IDBuzz) first, then (portail, Zoe).
+    fx = _make_incident_fixture()
+    _patch_scores(fx.parking, {"Zoe": 100.0, "IDBuzz": 100.0})
+    _patch_scores(fx.portail, {"Zoe": 100.0, "IDBuzz": 100.0})
+    assert (fx.parking.get_best_car(T0), fx.portail.get_best_car(T0)) == (fx.buzz, fx.zoe)
+
+
+# =============================================================================
+# Stickiness and steal semantics (AC3)
+# =============================================================================
+
+
+def test_equal_score_does_not_steal_attached_car():
+    # Symmetric tie, equal regrets: the incumbent keeps the car.
+    fx = _make_incident_fixture()
+    _patch_scores(fx.parking, {"Zoe": 100.0, "IDBuzz": 100.0})
+    _patch_scores(fx.portail, {"Zoe": 100.0, "IDBuzz": 100.0})
+    fx.portail.attach_car(fx.zoe, T0 - timedelta(seconds=60))
+
+    assert fx.portail.get_best_car(T0) is fx.zoe
+    assert fx.parking.get_best_car(T0) is fx.buzz
+    # The equal-score, equal-regret competitor never stole the Zoe.
+    assert fx.portail.car is fx.zoe
+
+    # A strictly higher score DOES steal an attached car.
+    fx = _make_incident_fixture()
+    _patch_scores(fx.parking, {"Zoe": 100.0, "IDBuzz": 100.0})
+    _patch_scores(fx.portail, {"Zoe": 200.0})
+    fx.parking.attach_car(fx.zoe, T0 - timedelta(seconds=60))
+    assert fx.portail.get_best_car(T0) is fx.zoe  # stolen from parking
+    assert fx.parking.car is None  # get_best_car detached it from the incumbent
+
+    # An equal score with strictly higher regret DOES steal (crossed-pairing
+    # recovery, real incident scores): the Zoe sits on parking but ID.buzz's
+    # regret there is strictly higher → ID.buzz evicts it.
+    fx = _make_incident_fixture()
+    fx.parking.attach_car(fx.zoe, T0 - timedelta(seconds=60))
+    fx.portail.attach_car(fx.buzz, T0 - timedelta(seconds=60))
+    assert fx.parking.get_best_car(T0) is fx.buzz
+    assert fx.portail.get_best_car(T0) is fx.zoe
+
+
+# =============================================================================
+# Generic-car fallback: a losing plugged charger is never orphaned (AC4)
+# =============================================================================
+
+
+def test_losing_charger_falls_back_to_generic_car():
+    # Incident matrix but the second car scores 0 (not plugged, no coords, not
+    # home): the Zoe ties on both chargers, stable order gives it to parking,
+    # and the losing portail must fall back to its own generic car.
+    fx = _make_incident_fixture(pin_buzz=False)
+    order = [fx.parking, fx.portail]
+    time = T0
+
+    best = fx.portail.get_best_car(time)
+    assert best is fx.portail._default_generic_car
+
+    _run_allocation_round(order, time)
+    assert fx.parking.car is fx.zoe
+    assert fx.portail.car is fx.portail._default_generic_car
+
+    # One more round: the generic attachment is stable (the generic car is not
+    # in home._cars, so it can never become a steal candidate) and no plugged
+    # charger ends the round with car is None.
+    time += timedelta(seconds=7)
+    _run_allocation_round(order, time)
+    assert fx.parking.car is fx.zoe
+    assert fx.portail.car is fx.portail._default_generic_car
+    assert all(charger.car is not None for charger in order)
+
+
+# =============================================================================
+# Caller independence (AC1)
+# =============================================================================
+
+
+@pytest.mark.parametrize("caller_name", ["wallbox_parking", "wallbox_portail"])
+@pytest.mark.parametrize(
+    ("parking_car", "portail_car"),
+    _ATTACHMENT_STATES,
+    ids=lambda v: str(v),
+)
+def test_allocation_is_caller_independent(parking_car, portail_car, caller_name):
+    # Given identical attachment state, every charger's own computed row agrees
+    # with the same global allocation, whichever charger runs the computation.
+    fx = _make_incident_fixture()
+    _apply_attachment_state(fx, parking_car, portail_car, T0)
+    caller = fx.chargers[caller_name]
+    assert caller.get_best_car(T0) is fx.cars[FIXED_POINT[caller_name]]
+
+
+# =============================================================================
+# C1 — score-decomposition INFO-on-change logging (AC5)
+# =============================================================================
+
+
+def _decomposition_lines(caplog) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == CHARGER_LOGGER
+        and record.levelno == logging.INFO
+        and record.getMessage().startswith("get_car_score:")
+    ]
+
+
+def test_get_car_score_decomposition_logs_once_then_on_change(caplog):
+    fx = _make_incident_fixture()
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    time = T0
+
+    # First evaluation: exactly one INFO decomposition line.
+    fx.parking.get_car_score(fx.zoe, time, {})
+    assert len(_decomposition_lines(caplog)) == 1
+    assert "plug_bump" in _decomposition_lines(caplog)[0]
+
+    # GPS jitter INSIDE the same 0.5 m distance bucket, within the 900 s
+    # window: the quantised tuple is unchanged → zero new lines.
+    fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0000005, ZOE_COORDS[1]))
+    time += timedelta(seconds=10)
+    fx.parking.get_car_score(fx.zoe, time, {})
+    assert len(_decomposition_lines(caplog)) == 1
+
+    # Crossing a bucket edge (≈11 m shift) changes the quantised tuple → one
+    # new line.
+    fx.zoe.get_car_coordinates = MagicMock(return_value=(ZOE_COORDS[0] + 0.0001, ZOE_COORDS[1]))
+    time += timedelta(seconds=10)
+    fx.parking.get_car_score(fx.zoe, time, {})
+    assert len(_decomposition_lines(caplog)) == 2
+
+    # Unchanged value re-emits once the 900 s heartbeat elapses (pins the
+    # bounded-volume claim).
+    time += timedelta(seconds=901)
+    fx.parking.get_car_score(fx.zoe, time, {})
+    assert len(_decomposition_lines(caplog)) == 3

--- a/tests/test_charger_allocation_tiebreak.py
+++ b/tests/test_charger_allocation_tiebreak.py
@@ -135,10 +135,7 @@ def _run_allocation_round(chargers, time) -> None:
 
 
 def _allocation(fx) -> dict:
-    return {
-        name: (charger.car.name if charger.car is not None else None)
-        for name, charger in fx.chargers.items()
-    }
+    return {name: (charger.car.name if charger.car is not None else None) for name, charger in fx.chargers.items()}
 
 
 def _spy_detach(charger) -> list:
@@ -656,9 +653,7 @@ def _pin_scores(fx, per_charger: dict) -> None:
     """Give each charger a fixed score for the Zoe (0 for anything else)."""
     for charger in (fx.parking, fx.portail):
         charger.get_car_score = MagicMock(
-            side_effect=lambda car, time, cache, _c=charger: (
-                per_charger[_c.name] if car.name == "Zoe" else 0.0
-            )
+            side_effect=lambda car, time, cache, _c=charger: per_charger[_c.name] if car.name == "Zoe" else 0.0
         )
 
 
@@ -686,13 +681,17 @@ async def test_allocation_churn_total_log_volume_over_a_full_window(caplog):
     falls back to its generic car — so no session churn is involved and every line
     above the floor is pure logging defect. Measured 149 lines before this round,
     129 of them from the single unthrottled `Default car used` branch.
+
+    REAL scoring, not a stubbed `get_car_score` (review #04 / B9): stubbing it meant
+    the `get_car_score:{car}` site — the one that produced the original 17 791
+    lines — never fired here, leaving the `N*M` term of the ceiling unexercised.
+    Coordinates are pinned instead, so the whole production path runs.
     """
     fx = _make_incident_fixture(pin_buzz=False)
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     caplog.set_level(logging.INFO, logger=LOAD_LOGGER)
     fx.home._cars = [fx.zoe]
     _drive_real_cycle_path(fx)
-    _pin_scores(fx, {"wallbox_parking": 100.0, "wallbox_portail": 90.0})
 
     await _run_cycles(fx, caplog)
 
@@ -705,6 +704,10 @@ async def test_allocation_churn_total_log_volume_over_a_full_window(caplog):
     assert len(volume) <= ceiling, f"{len(volume)} lines > {ceiling}:\n" + "\n".join(
         sorted({record.getMessage()[:110] for record in volume})
     )
+
+    # The scoring site really did run — otherwise the N*M term is untested and this
+    # whole assertion is weaker than it looks.
+    assert [r for r in caplog.records if r.getMessage().startswith("get_car_score: ")]
 
     # The allocation itself is untouched by any of this.
     assert fx.parking.car is fx.zoe
@@ -722,8 +725,11 @@ async def test_generic_car_fallback_line_is_throttled(caplog):
 
     await _run_cycles(fx, caplog)
 
+    # LOWER bound too (review #04 / B8): a ceiling alone passes if the line vanishes
+    # entirely, and this matches on a reason string that did not exist pre-fix — so
+    # without it the test was vacuously green against the pre-fix revision.
     fallback = [r for r in caplog.records if "generic_fallback" in r.getMessage()]
-    assert len(fallback) <= _PER_KEY_CEILING, fallback
+    assert 1 <= len(fallback) <= _PER_KEY_CEILING, fallback
 
 
 async def test_removed_from_another_charger_is_throttled(caplog):
@@ -739,15 +745,13 @@ async def test_removed_from_another_charger_is_throttled(caplog):
     per_charger = {"wallbox_parking": 100.0, "wallbox_portail": 90.0}
     _pin_scores(fx, per_charger)
     for index in range(129):
-        per_charger["wallbox_parking"], per_charger["wallbox_portail"] = (
-            (90.0, 100.0) if index % 2 else (100.0, 90.0)
-        )
+        per_charger["wallbox_parking"], per_charger["wallbox_portail"] = (90.0, 100.0) if index % 2 else (100.0, 90.0)
         time = T0 + timedelta(seconds=7 * index)
         for charger in (fx.parking, fx.portail):
             await charger.check_load_activity_and_constraints(time)
 
     removed = [r for r in caplog.records if "removed from another charger" in r.getMessage()]
-    assert len(removed) <= _PER_KEY_CEILING, removed
+    assert 1 <= len(removed) <= _PER_KEY_CEILING, removed
 
 
 async def test_user_pinned_car_line_is_throttled(caplog):
@@ -761,15 +765,20 @@ async def test_user_pinned_car_line_is_throttled(caplog):
     await _run_cycles(fx, caplog, cycles=20)
 
     pinned = [r for r in caplog.records if "user_selection" in r.getMessage()]
-    assert len(pinned) <= _PER_KEY_CEILING, pinned
+    assert 1 <= len(pinned) <= _PER_KEY_CEILING, pinned
 
 
-async def test_no_car_selected_state_is_idempotent(caplog):
+async def test_no_car_selected_state_is_quiet(caplog):
     """The single largest volume source: ~74 000 lines/day from one charger.
 
-    Selecting "no car connected" ran a full `reset(keep_commands=True)` EVERY cycle,
-    emitting six INFO lines each time — four times the original incident. Once there
-    is nothing left to reset the state must go completely quiet.
+    Selecting "no car connected" runs a full `reset(keep_commands=True)` EVERY cycle
+    and used to emit six INFO lines each time — four times the original incident.
+
+    The reset itself is NOT skipped (review #04 / B2: gating it on a predicate that
+    mirrors what `reset()` clears is a rot hazard whose failure mode is stale charger
+    state). `reset()` is idempotent, so it keeps running; the volume is fixed where
+    it belongs — the reset chain logs at DEBUG unless it destroyed something, and the
+    announcement is throttled.
     """
     fx = _make_incident_fixture()
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
@@ -780,15 +789,13 @@ async def test_no_car_selected_state_is_idempotent(caplog):
 
     await _run_cycles(fx, caplog, cycles=20)
 
-    # Two chargers x (one merged `get_best_car` key + at most one settling reset).
+    # Two chargers x (one merged `get_best_car` key + the throttled announcement).
     volume = _info_volume(caplog)
-    assert len(volume) <= 2 * (_PER_KEY_CEILING + 6), "\n".join(
-        record.getMessage()[:110] for record in volume
-    )
+    assert len(volume) <= 2 * 2 * _PER_KEY_CEILING, "\n".join(record.getMessage()[:110] for record in volume)
 
-    # And the reset genuinely stops running rather than merely logging less.
+    # The announcement is throttled rather than repeated per cycle...
     reset_lines = [r for r in caplog.records if "CHARGER_NO_CAR_CONNECTED selected option" in r.getMessage()]
-    assert len(reset_lines) <= 2, reset_lines
+    assert 1 <= len(reset_lines) <= 2 * _PER_KEY_CEILING, reset_lines
     assert fx.parking.car is None
 
 
@@ -797,14 +804,18 @@ async def test_force_car_no_charger_is_not_logged_from_the_inner_loop(caplog):
     # that itself runs once per charger per cycle: N^2*M lines per cycle, measured
     # 101 over 20 cycles (~62k/day). It belongs at DEBUG.
     fx = _make_incident_fixture()
-    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    caplog.set_level(logging.DEBUG, logger=CHARGER_LOGGER)
     _drive_real_cycle_path(fx)
     for car in (fx.zoe, fx.buzz):
         car.set_user_originated(USER_ORIGINATED_CHARGER_NAME, FORCE_CAR_NO_CHARGER_CONNECTED)
 
     await _run_cycles(fx, caplog, cycles=20)
 
-    assert [r for r in caplog.records if "FORCE_CAR_NO_CHARGER_CONNECTED" in r.getMessage()] == []
+    forced = [r for r in caplog.records if "FORCE_CAR_NO_CHARGER_CONNECTED" in r.getMessage()]
+    assert [r for r in forced if r.levelno == logging.INFO] == []
+    # LOWER bound (review #04 / B8): the branch really is reached, so the INFO
+    # assertion above is about the LEVEL and not about a dead code path.
+    assert [r for r in forced if r.levelno == logging.DEBUG]
 
 
 def test_same_cycle_duplicate_calls_emit_once(caplog):

--- a/tests/test_charger_allocation_tiebreak.py
+++ b/tests/test_charger_allocation_tiebreak.py
@@ -326,22 +326,13 @@ def _patch_scores_by_object(charger, mapping) -> None:
 
 
 def test_duplicate_car_names_do_not_orphan_a_charger():
-    """B1 (review #04): regret must use the same relation as removal — the NAME.
+    """Regret must match cars by NAME, like removal and stickiness.
 
-    The cascade is effectively over names: removal consumes a whole NAME from every
-    charger's list, and stickiness compares names. A regret scan matching by object
-    identity is the odd one out, and the two rules then stop describing the same set.
-
-    Nothing enforces car-name uniqueness. `CONF_NAME` is a plain `cv.string` in the
-    options flow with no collision validation, the options flow never re-checks
-    `unique_id`, and `add_device` dedups by object identity only (`QSCar` defines no
-    `__eq__`) — so two config entries named "Zoe" yield two distinct `QSCar` objects
-    named "Zoe".
-
-    Under that state an identity scan under-counts alternatives, so regret for the
-    duplicated name inflates (0 -> 100) and it wins round 1; name-based removal then
-    strips its twin off the other charger, which exits the round with nothing and
-    falls back to its generic car. That is exactly the #342 symptom.
+    Car names are not enforced unique (`CONF_NAME` is a plain `cv.string` with no
+    collision validation), so two entries named "Zoe" give two distinct `QSCar`s.
+    An identity-based regret scan then under-counts alternatives, inflates regret
+    for the duplicated name, and lets name-based removal strip its twin off the
+    other charger — which exits with no car. That is the #342 symptom.
     """
     fx = _make_incident_fixture(pin_buzz=False)
     twin = make_real_car(fx.hass, fx.home, name=fx.zoe.name)
@@ -673,19 +664,12 @@ async def _run_cycles(fx, caplog, cycles: int = 129, step_s: int = 7) -> None:
 
 
 async def test_allocation_churn_total_log_volume_over_a_full_window(caplog):
-    """AGGREGATE volume over a full 900 s window, not a per-prefix count.
+    """AGGREGATE volume over a full window, not a per-prefix count.
 
-    Every escaped site is invisible to a prefix-scoped assertion, which is how five
-    of the six winner-announcement branches ran unthrottled through three review
-    rounds. The scenario is a STABLE allocation — parking keeps the Zoe, portail
-    falls back to its generic car — so no session churn is involved and every line
-    above the floor is pure logging defect. Measured 149 lines before this round,
-    129 of them from the single unthrottled `Default car used` branch.
-
-    REAL scoring, not a stubbed `get_car_score` (review #04 / B9): stubbing it meant
-    the `get_car_score:{car}` site — the one that produced the original 17 791
-    lines — never fired here, leaving the `N*M` term of the ceiling unexercised.
-    Coordinates are pinned instead, so the whole production path runs.
+    A prefix-scoped assertion cannot see an escaped site. The allocation is STABLE
+    here (parking keeps the Zoe, portail falls back to generic), so there is no
+    session churn and every line above the floor is a logging defect — 149 before
+    this work. Scoring is real, not stubbed, so the `N*M` term is exercised too.
     """
     fx = _make_incident_fixture(pin_buzz=False)
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
@@ -769,16 +753,10 @@ async def test_user_pinned_car_line_is_throttled(caplog):
 
 
 async def test_no_car_selected_state_is_quiet(caplog):
-    """The single largest volume source: ~74 000 lines/day from one charger.
+    """ "No car connected" ran a full reset every cycle, at six INFO lines each.
 
-    Selecting "no car connected" runs a full `reset(keep_commands=True)` EVERY cycle
-    and used to emit six INFO lines each time — four times the original incident.
-
-    The reset itself is NOT skipped (review #04 / B2: gating it on a predicate that
-    mirrors what `reset()` clears is a rot hazard whose failure mode is stale charger
-    state). `reset()` is idempotent, so it keeps running; the volume is fixed where
-    it belongs — the reset chain logs at DEBUG unless it destroyed something, and the
-    announcement is throttled.
+    The reset still runs (it is idempotent, and gating it on a mirror of what it
+    clears is a rot hazard). The volume is fixed in the logging instead.
     """
     fx = _make_incident_fixture()
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)

--- a/tests/test_charger_heavy_integration.py
+++ b/tests/test_charger_heavy_integration.py
@@ -337,8 +337,15 @@ class TestCheckLoadActivityAndConstraints:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_plugged_no_car_selected_is_idempotent(self, setup_charger):
-        """D6: with nothing left to reset the cycle does no work and logs nothing."""
+    async def test_plugged_no_car_selected_resets_unconditionally(self, setup_charger):
+        """The reset is NOT gated on a predicate mirroring what it clears.
+
+        Review #03 / D6 added such a gate; review #04 / B2 found the mirror already
+        incomplete. Any enumeration of "what reset clears" rots the moment `reset()`
+        learns a new field, and the failure mode is stale charger state. `reset()` is
+        idempotent, so it simply runs — the log volume it used to cause is fixed in
+        the logging, not by skipping the work.
+        """
         charger, home = setup_charger
         time = datetime.now(pytz.UTC)
 
@@ -348,12 +355,11 @@ class TestCheckLoadActivityAndConstraints:
             patch.object(charger, "is_not_plugged", return_value=False),
             patch.object(charger, "is_plugged", return_value=True),
             patch.object(charger, "get_best_car", return_value=None),
+            patch.object(charger, "reset") as mock_reset,
         ):
-            assert charger._reset_would_change_state(keep_commands=True) is False
-            with patch.object(charger, "reset") as mock_reset:
-                result = await charger.check_load_activity_and_constraints(time)
+            result = await charger.check_load_activity_and_constraints(time)
 
-        mock_reset.assert_not_called()
+        mock_reset.assert_called_once()
         assert result is True
 
     @pytest.mark.asyncio

--- a/tests/test_charger_heavy_integration.py
+++ b/tests/test_charger_heavy_integration.py
@@ -34,6 +34,7 @@ from custom_components.quiet_solar.ha_model.charger import (
     QSChargerGeneric,
     QSChargerGroup,
     QSChargerStatus,
+    QSStateCmd,
 )
 from custom_components.quiet_solar.home_model.commands import CMD_AUTO_GREEN_ONLY, copy_command
 from tests.factories import create_minimal_home_model
@@ -310,9 +311,17 @@ class TestCheckLoadActivityAndConstraints:
 
     @pytest.mark.asyncio
     async def test_plugged_no_car_selected_resets(self, setup_charger):
-        """Test that selecting no car resets the charger."""
+        """Selecting no car resets the charger — once, then the state is idempotent.
+
+        QS-342 review #03 / D6: this reset used to run on EVERY cycle while "no car
+        connected" was selected, emitting six INFO lines each time (~74 000/day from
+        one charger, four times the original incident). It is now gated on there
+        actually being something to reset.
+        """
         charger, home = setup_charger
         time = datetime.now(pytz.UTC)
+        # Something to reset: the state machine is populated.
+        charger._inner_amperage = QSStateCmd()
 
         with (
             patch.object(charger, "is_charger_unavailable", return_value=False),
@@ -325,6 +334,26 @@ class TestCheckLoadActivityAndConstraints:
             result = await charger.check_load_activity_and_constraints(time)
 
         mock_reset.assert_called_once()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_plugged_no_car_selected_is_idempotent(self, setup_charger):
+        """D6: with nothing left to reset the cycle does no work and logs nothing."""
+        charger, home = setup_charger
+        time = datetime.now(pytz.UTC)
+
+        with (
+            patch.object(charger, "is_charger_unavailable", return_value=False),
+            patch.object(charger, "probe_for_possible_needed_reboot", return_value=False),
+            patch.object(charger, "is_not_plugged", return_value=False),
+            patch.object(charger, "is_plugged", return_value=True),
+            patch.object(charger, "get_best_car", return_value=None),
+        ):
+            assert charger._reset_would_change_state(keep_commands=True) is False
+            with patch.object(charger, "reset") as mock_reset:
+                result = await charger.check_load_activity_and_constraints(time)
+
+        mock_reset.assert_not_called()
         assert result is True
 
     @pytest.mark.asyncio

--- a/tests/test_chargers_advanced.py
+++ b/tests/test_chargers_advanced.py
@@ -23,6 +23,7 @@ from custom_components.quiet_solar.const import (
 from custom_components.quiet_solar.ha_model.charger import (
     QSChargerGeneric,
     QSChargerStates,
+    QSStateCmd,
 )
 
 # Import the necessary classes
@@ -383,11 +384,17 @@ class TestQSChargerGenericAdvanced(unittest.IsolatedAsyncioTestCase):
 
     @pytest.mark.asyncio
     async def test_check_load_activity_and_constraints_plugged_no_car(self):
-        """Test check_load_activity_and_constraints when plugged but forced no car."""
+        """Test check_load_activity_and_constraints when plugged but forced no car.
+
+        QS-342 review #03 / D6: the reset is gated on there actually being state to
+        destroy, so the "no car connected" state stops re-running a no-op reset (and
+        its six INFO lines) on every cycle. Seed some state so the reset still runs.
+        """
         with patch("custom_components.quiet_solar.ha_model.charger.entity_registry"):
             charger = QSChargerGeneric(**self.charger_config)
 
         time = datetime.now(pytz.UTC)
+        charger._inner_amperage = QSStateCmd()
 
         with (
             patch.object(charger, "is_plugged", return_value=True),
@@ -400,6 +407,26 @@ class TestQSChargerGenericAdvanced(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(result)
         mock_reset.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_check_load_activity_and_constraints_plugged_no_car_is_idempotent(self):
+        """D6: with nothing left to reset the cycle does no work at all."""
+        with patch("custom_components.quiet_solar.ha_model.charger.entity_registry"):
+            charger = QSChargerGeneric(**self.charger_config)
+
+        time = datetime.now(pytz.UTC)
+        self.assertFalse(charger._reset_would_change_state(keep_commands=True))
+
+        with (
+            patch.object(charger, "is_plugged", return_value=True),
+            patch.object(charger, "get_best_car", return_value=None),
+            patch.object(charger, "get_and_adapt_existing_constraints", return_value=[], create=True),
+            patch.object(charger, "reset") as mock_reset,
+        ):
+            result = await charger.check_load_activity_and_constraints(time)
+
+        self.assertTrue(result)
+        mock_reset.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_check_load_activity_and_constraints_car_change(self):

--- a/tests/test_chargers_advanced.py
+++ b/tests/test_chargers_advanced.py
@@ -342,6 +342,9 @@ class TestQSChargerGenericAdvanced(unittest.IsolatedAsyncioTestCase):
 
         # Mock chargers
         mock_charger2 = MagicMock()
+        # QS-342: `name=` is reserved in the MagicMock constructor, so set it after
+        # creation — the deterministic allocation order sorts chargers by name.
+        mock_charger2.name = "Charger2"
         mock_charger2.qs_enable_device = True
         mock_charger2.car = mock_car2
         mock_charger2.get_user_originated = MagicMock(return_value=None)

--- a/tests/test_chargers_advanced.py
+++ b/tests/test_chargers_advanced.py
@@ -409,26 +409,6 @@ class TestQSChargerGenericAdvanced(unittest.IsolatedAsyncioTestCase):
         mock_reset.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_check_load_activity_and_constraints_plugged_no_car_is_idempotent(self):
-        """D6: with nothing left to reset the cycle does no work at all."""
-        with patch("custom_components.quiet_solar.ha_model.charger.entity_registry"):
-            charger = QSChargerGeneric(**self.charger_config)
-
-        time = datetime.now(pytz.UTC)
-        self.assertFalse(charger._reset_would_change_state(keep_commands=True))
-
-        with (
-            patch.object(charger, "is_plugged", return_value=True),
-            patch.object(charger, "get_best_car", return_value=None),
-            patch.object(charger, "get_and_adapt_existing_constraints", return_value=[], create=True),
-            patch.object(charger, "reset") as mock_reset,
-        ):
-            result = await charger.check_load_activity_and_constraints(time)
-
-        self.assertTrue(result)
-        mock_reset.assert_not_called()
-
-    @pytest.mark.asyncio
     async def test_check_load_activity_and_constraints_car_change(self):
         """Test check_load_activity_and_constraints when car changes."""
         with patch("custom_components.quiet_solar.ha_model.charger.entity_registry"):

--- a/tests/test_qs306_log_volume.py
+++ b/tests/test_qs306_log_volume.py
@@ -23,6 +23,7 @@ from custom_components.quiet_solar.const import (
     USER_ORIGINATED_CAR_NAME,
 )
 from custom_components.quiet_solar.ha_model.charger import (
+    _CHANGED_RELOG_MIN_INTERVAL_S,
     _POWER_LOG_DEADBAND_W,
     _RELOG_UNCHANGED_AFTER_S,
     CHARGER_ADAPTATION_WINDOW_S,
@@ -216,7 +217,8 @@ def test_log_info_on_change_only_mutates_its_own_state(caplog: pytest.LogCapture
     after = vars(host)
     assert set(after) - set(before) == {"_log_on_change_state"}
     assert set(before) - set(after) == set()
-    assert host._log_on_change_state == {"k": ("v", T0)}
+    # Third field: QS-342's suppressed-change counter (0 = no banked churn).
+    assert host._log_on_change_state == {"k": ("v", T0, 0)}
 
 
 def test_log_info_on_change_resets_the_timer_on_every_emission(caplog: pytest.LogCaptureFixture) -> None:
@@ -792,7 +794,12 @@ async def test_s11_best_car_logged_once_per_window(caplog: pytest.LogCaptureFixt
     assert len(_messages(caplog, "with score", logging.INFO, CHARGER_LOGGER)) == 2
 
     scores["CarB"] = 100.0
-    assert charger.get_best_car(T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 70)).name == car_b.name
+    # QS-342: this site now carries a changed-value rate floor, so the swap must sit
+    # at least `_CHANGED_RELOG_MIN_INTERVAL_S` after the previous emission (+63) for
+    # the winner change to be emitted rather than banked. The NH7 intent below —
+    # every record names the car that actually won — is unchanged.
+    swap_at = _RELOG_UNCHANGED_AFTER_S + 63 + _CHANGED_RELOG_MIN_INTERVAL_S + 7
+    assert charger.get_best_car(T0 + timedelta(seconds=swap_at)).name == car_b.name
     records = _messages(caplog, "with score", logging.INFO, CHARGER_LOGGER)
     assert len(records) == 3
     # NH7: the records must name the car that actually won each time.

--- a/tests/test_qs306_log_volume.py
+++ b/tests/test_qs306_log_volume.py
@@ -177,14 +177,11 @@ def test_log_info_on_change_emission_predicate(
 
 
 def test_log_info_on_change_normalises_a_naive_datetime(caplog: pytest.LogCaptureFixture) -> None:
-    """NH2, re-cut for QS-342 review #03: normalise rather than branch.
+    """A naive datetime must neither raise nor become an escape hatch.
 
-    Mixing naive and aware datetimes under one key raises `TypeError` on the
-    subtraction, and that exception would propagate out of `dyn_handle` and kill the
-    whole budgeting cycle — so the helper must not raise. The OLD remedy (detect the
-    mismatch and emit unconditionally) was itself a hole: a caller alternating clock
-    kinds escaped the throttle on every call. Normalising to UTC removes the branch
-    and the hole together.
+    Mixing naive and aware datetimes would raise on the subtraction and kill the
+    budgeting cycle. Emitting unconditionally on mismatch would instead let an
+    alternating-clock caller escape the throttle entirely; normalising does neither.
     """
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     host = _Host()
@@ -268,13 +265,7 @@ def _disclosures(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
 def test_b3_budget_overflow_is_disclosed_when_the_window_rolls(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """B3: the overflow branch had no test at all — CI's 100 % gate would have failed.
-
-    No existing run produced `dropped > 0` AND then crossed 900 s (the longest were
-    128-129 cycles x 7 s = 896 s, just under). That left the plan's, AC5's and the
-    doc's central completeness claim entirely unpinned, on a line that builds a
-    format string with extra args and would raise inside `logging` if mismatched.
-    """
+    """Overflow must be disclosed with the right count when the window rolls."""
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     host = _Host()
 
@@ -319,13 +310,10 @@ def test_b6_disclosure_is_not_misattributed_or_duplicated(caplog: pytest.LogCapt
 def test_b4_a_budget_dropped_value_is_shown_once_budget_allows(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """B4: dropped values got an emission-grade TTL and were then silent forever.
+    """A value the budget dropped must be shown once budget allows.
 
-    A value recorded but never shown was stamped as if emitted, so after the window
-    rolled it was STILL TTL-suppressed — and that suppression path returns before
-    the drop counter, so it was not counted the second time either. Reproduced
-    against the previous code: a value present from t=28 s first appeared at
-    t=928 s and was uncounted after the first disclosure.
+    Stamping it as if emitted left it TTL-suppressed after the window rolled, and
+    that path returns before the drop counter, so it was not counted either.
     """
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     host = _Host()
@@ -348,11 +336,10 @@ def test_b4_a_budget_dropped_value_is_shown_once_budget_allows(
 
 
 def test_b7_dedup_suppressed_repeats_are_counted(caplog: pytest.LogCaptureFixture) -> None:
-    """B7: without this, a pinned key and a calm one produce identical logs.
+    """Dedup-suppressed repeats must be counted, or the rate signal is lost.
 
-    `dropped` covers budget overflow only, so a 2-hour ping-pong at the 7 s cycle
-    emitted 16 lines with `dropped == 0` — indistinguishable from a home whose
-    winner genuinely alternates every 7.5 minutes. #342 was diagnosed from volume.
+    `dropped` covers budget overflow only, so a ping-pong at the cycle rate would
+    otherwise look identical to a winner alternating every few minutes.
     """
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     host = _Host()
@@ -541,15 +528,8 @@ async def test_mf1_near_zero_sign_dither_does_not_re_inflate_the_log(caplog: pyt
 async def test_mf1_real_export_import_transition_is_still_logged(caplog: pytest.LogCaptureFixture) -> None:
     """MF1: the throttle must not cost us a genuine export <-> import transition.
 
-    Every cycle here crosses zero with both sides outside the deadband, so every
-    cycle is a real operational event and every cycle is reported.
-
-    Review #04 / B13: this briefly regressed to `2 <= n <= 5` when the default
-    per-key budget was applied here. That budget assumes "many distinct values per
-    window means churn, and the churn is itself the signal" — true for allocation
-    keys, false for telemetry, where the values advance during normal operation.
-    This site now carries `_LOG_TELEMETRY_VALUES_PER_WINDOW`, so the exact count is
-    back and the volume is still bounded.
+    Every cycle crosses zero with both sides outside the deadband, so every cycle is
+    a real event. This site uses the telemetry budget for exactly this reason.
     """
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     group, _, home = _make_dyn_handle_group(num_chargers=2, battery=make_battery(0.0), available_power_w=1000.0)
@@ -972,13 +952,10 @@ async def test_sf1_car_swap_is_not_silenced_by_the_memo(caplog: pytest.LogCaptur
 
 
 def test_sf1_log_state_survives_detach_car() -> None:
-    """QS-342 review #03 / D2: the wipe is GONE — it was the defect, not the fix.
+    """`detach_car()` must NOT clear the log state — that wipe was the defect.
 
-    `detach_car()` is on the churn path itself, so wiping the log state there dropped
-    the key on every allocation change and made the throttle a no-op in production.
-    It is also redundant: every key is car-qualified or carries the car name as its
-    value, so no key can name a stale car. The property test that actually matters —
-    a car swap is still announced — is
+    It sits on the churn path, so wiping dropped the key on every allocation change.
+    The property that matters (a car swap is still announced) is covered by
     `test_sf1_car_swap_is_not_silenced_by_the_memo` above.
     """
     hass = make_hass()
@@ -1132,11 +1109,8 @@ async def test_sfg_soc_volume_ceiling_is_the_per_key_budget(
 ) -> None:
     """The documented CEILING of SF-G, so the cost is explicit rather than implied.
 
-    A consign alternating on every cycle is only TWO distinct values, so dedup alone
-    already collapses it — this used to emit one line per cycle. The per-key budget
-    then caps the pathological case regardless of how many distinct consigns appear.
-    If a future change adds smoothing, this test should fail and force a conscious
-    decision.
+    An alternating consign is only two distinct values, so dedup collapses it; the
+    budget caps the pathological case. Smoothing added later should fail this.
     """
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     charger, constraint = _make_soc_callback_charger()

--- a/tests/test_qs306_log_volume.py
+++ b/tests/test_qs306_log_volume.py
@@ -23,13 +23,16 @@ from custom_components.quiet_solar.const import (
     USER_ORIGINATED_CAR_NAME,
 )
 from custom_components.quiet_solar.ha_model.charger import (
-    _CHANGED_RELOG_MIN_INTERVAL_S,
+    _LOG_VALUES_PER_WINDOW,
     _POWER_LOG_DEADBAND_W,
     _RELOG_UNCHANGED_AFTER_S,
     CHARGER_ADAPTATION_WINDOW_S,
     LogOnChangeMixin,
     QSChargerStatus,
 )
+
+# Per key: `budget` emissions per window plus one overflow-disclosure line.
+_PER_KEY_CEILING = _LOG_VALUES_PER_WINDOW + 1
 from custom_components.quiet_solar.home_model.commands import (
     CMD_AUTO_FROM_CONSIGN,
     CMD_AUTO_GREEN_ONLY,
@@ -173,12 +176,15 @@ def test_log_info_on_change_emission_predicate(
     assert len(_messages(caplog, "probe", logging.INFO, CHARGER_LOGGER)) == expected
 
 
-def test_log_info_on_change_survives_a_naive_datetime(caplog: pytest.LogCaptureFixture) -> None:
-    """NH2: a logging helper must never be load-bearing.
+def test_log_info_on_change_normalises_a_naive_datetime(caplog: pytest.LogCaptureFixture) -> None:
+    """NH2, re-cut for QS-342 review #03: normalise rather than branch.
 
     Mixing naive and aware datetimes under one key raises `TypeError` on the
-    subtraction; that exception would propagate out of `dyn_handle` and kill the
-    whole budgeting cycle. Bail to logging instead.
+    subtraction, and that exception would propagate out of `dyn_handle` and kill the
+    whole budgeting cycle — so the helper must not raise. The OLD remedy (detect the
+    mismatch and emit unconditionally) was itself a hole: a caller alternating clock
+    kinds escaped the throttle on every call. Normalising to UTC removes the branch
+    and the hole together.
     """
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     host = _Host()
@@ -186,10 +192,12 @@ def test_log_info_on_change_survives_a_naive_datetime(caplog: pytest.LogCaptureF
     host.log_info_on_change("k", 1, T0, "naive %s", "aware")
     host.log_info_on_change("k", 1, T0.replace(tzinfo=None), "naive %s", "naive")
 
-    assert len(_messages(caplog, "naive", logging.INFO, CHARGER_LOGGER)) == 2
-    # The key is re-stamped with the naive value, so the reverse direction is safe too.
+    # Same instant, same value: the naive call is throttled, not treated as new.
+    assert len(_messages(caplog, "naive", logging.INFO, CHARGER_LOGGER)) == 1
+
+    # ... and it stays throttled in the reverse direction too.
     host.log_info_on_change("k", 1, T0, "naive %s", "aware again")
-    assert len(_messages(caplog, "naive", logging.INFO, CHARGER_LOGGER)) == 3
+    assert len(_messages(caplog, "naive", logging.INFO, CHARGER_LOGGER)) == 1
 
 
 def test_log_info_on_change_keeps_state_per_instance(caplog: pytest.LogCaptureFixture) -> None:
@@ -217,8 +225,11 @@ def test_log_info_on_change_only_mutates_its_own_state(caplog: pytest.LogCapture
     after = vars(host)
     assert set(after) - set(before) == {"_log_on_change_state"}
     assert set(before) - set(after) == set()
-    # Third field: QS-342's suppressed-change counter (0 = no banked churn).
-    assert host._log_on_change_state == {"k": ("v", T0, 0)}
+    # QS-342 review #03 record shape: the remembered values, the window anchor, and
+    # this window's budget accounting.
+    record = host._log_on_change_state["k"]
+    assert record.seen == [("v", T0)]
+    assert (record.window_start, record.emitted, record.dropped) == (T0, 1, 0)
 
 
 def test_log_info_on_change_resets_the_timer_on_every_emission(caplog: pytest.LogCaptureFixture) -> None:
@@ -416,15 +427,22 @@ async def test_mf1_near_zero_sign_dither_does_not_re_inflate_the_log(caplog: pyt
 
 
 async def test_mf1_real_export_import_transition_is_still_logged(caplog: pytest.LogCaptureFixture) -> None:
-    """MF1: the floor must not cost us a genuine export <-> import transition."""
+    """MF1: a genuine export <-> import transition is reported, within the budget.
+
+    Every cycle here crosses zero with both sides outside the deadband, so every
+    cycle is a real transition. QS-342 review #03 caps each key at `budget`
+    emissions per window: the transitions ARE reported (this is not silence), but a
+    site flipping on every cycle can no longer track the cycle rate. That trade is
+    deliberate and is what makes the volume bound data-independent — an unbounded
+    site is exactly how the original incident reached 17 791 lines.
+    """
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     group, _, home = _make_dyn_handle_group(num_chargers=2, battery=make_battery(0.0), available_power_w=1000.0)
 
     await _run_oscillating_power_cycles(group, home, watts=150.0)
 
-    # Every cycle crosses zero with both sides outside the deadband, so every cycle
-    # is a real transition and every cycle is reported.
-    assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 10
+    records = _messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)
+    assert 2 <= len(records) <= _PER_KEY_CEILING, records
 
 
 # =============================================================================
@@ -794,16 +812,17 @@ async def test_s11_best_car_logged_once_per_window(caplog: pytest.LogCaptureFixt
     assert len(_messages(caplog, "with score", logging.INFO, CHARGER_LOGGER)) == 2
 
     scores["CarB"] = 100.0
-    # QS-342: this site now carries a changed-value rate floor, so the swap must sit
-    # at least `_CHANGED_RELOG_MIN_INTERVAL_S` after the previous emission (+63) for
-    # the winner change to be emitted rather than banked. The NH7 intent below —
-    # every record names the car that actually won — is unchanged.
-    swap_at = _RELOG_UNCHANGED_AFTER_S + 63 + _CHANGED_RELOG_MIN_INTERVAL_S + 7
+    # QS-342 review #03: no changed-value floor any more, so a genuinely new winner
+    # emits immediately — a value never seen before is never suppressed. The NH7
+    # intent below (every record names the car that actually won) is unchanged.
+    swap_at = _RELOG_UNCHANGED_AFTER_S + 70
     assert charger.get_best_car(T0 + timedelta(seconds=swap_at)).name == car_b.name
     records = _messages(caplog, "with score", logging.INFO, CHARGER_LOGGER)
     assert len(records) == 3
-    # NH7: the records must name the car that actually won each time.
-    assert [car_a.name, car_a.name, car_b.name] == [r.args[0] for r in records]
+    # NH7: the records must name the car that actually won each time. `args[1]` is
+    # the car — `args[0]` is now the branch that decided (D4's merged key).
+    assert [car_a.name, car_a.name, car_b.name] == [r.args[1] for r in records]
+    assert {r.args[0] for r in records} == {"computed"}
 
 
 async def test_sf1_car_swap_is_not_silenced_by_the_memo(caplog: pytest.LogCaptureFixture) -> None:
@@ -838,8 +857,16 @@ async def test_sf1_car_swap_is_not_silenced_by_the_memo(caplog: pytest.LogCaptur
     assert car_b.name in records[1].getMessage()
 
 
-def test_sf1_detach_car_clears_the_memo() -> None:
-    """SF1: the clear is unconditional — it also marks a new session on replug."""
+def test_sf1_log_state_survives_detach_car() -> None:
+    """QS-342 review #03 / D2: the wipe is GONE — it was the defect, not the fix.
+
+    `detach_car()` is on the churn path itself, so wiping the log state there dropped
+    the key on every allocation change and made the throttle a no-op in production.
+    It is also redundant: every key is car-qualified or carries the car name as its
+    value, so no key can name a stale car. The property test that actually matters —
+    a car swap is still announced — is
+    `test_sf1_car_swap_is_not_silenced_by_the_memo` above.
+    """
     hass = make_hass()
     home = make_home()
     charger = create_charger(hass, home, name="DetachCh")
@@ -851,7 +878,7 @@ def test_sf1_detach_car_clears_the_memo() -> None:
 
     charger.detach_car()
 
-    assert charger._log_on_change_state is None
+    assert "get_best_car" in charger._log_on_change_state
 
 
 # =============================================================================
@@ -986,16 +1013,16 @@ async def test_sfg_soc_volume_scales_with_amp_changes_not_cycles(caplog: pytest.
     assert len(records) == len(set(consigns)) == 3, "one line per amp change, not one per cycle"
 
 
-async def test_sfg_soc_volume_ceiling_is_one_line_per_consign_change(
+async def test_sfg_soc_volume_ceiling_is_the_per_key_budget(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The documented CEILING of SF-G, so the cost is explicit rather than implied.
 
-    If the consign genuinely changed on every cycle, every cycle would log. In
-    production that is bounded by the 45 s amp-change cooldown (the S2 site), not by
-    this memo — so the worst realistic case is ~1 line per 45 s, still far below the
-    ~7 s cycle rate. If a future change adds smoothing, this test should fail and
-    force a conscious decision.
+    A consign alternating on every cycle is only TWO distinct values, so dedup alone
+    already collapses it — this used to emit one line per cycle. The per-key budget
+    then caps the pathological case regardless of how many distinct consigns appear.
+    If a future change adds smoothing, this test should fail and force a conscious
+    decision.
     """
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     charger, constraint = _make_soc_callback_charger()
@@ -1005,7 +1032,8 @@ async def test_sfg_soc_volume_ceiling_is_one_line_per_consign_change(
         charger.current_command = copy_command(CMD_AUTO_FROM_CONSIGN, power_consign=consign)
         await charger.constraint_update_value_callback_percent_soc(constraint, T0 + timedelta(seconds=7 * cycle))
 
-    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 10
+    # Two distinct consigns -> two lines, not ten.
+    assert len(_messages(caplog, _S12_FRAGMENT, logging.INFO, CHARGER_LOGGER)) == 2
 
 
 async def test_s12_literal_percent_is_escaped(caplog: pytest.LogCaptureFixture) -> None:
@@ -1155,7 +1183,7 @@ _B5_SITES = {
         "battery_asked_charge",
         "dyn_handle: full_available_home_power %sW, grid_available_home_power %sW battery_asked_charge %sW",
     ),
-    "S11": ("with score", "get_best_car: %s with score %s for charger %s"),
+    "S11": ("with score", "get_best_car: %s selected %s with score %s for charger %s"),
     "S12": (
         "is_car_charged",
         "update_value_callback (is %%:%s):%s %s  %s/%s (%s/%s) is_car_charged %s cmd %s",

--- a/tests/test_qs306_log_volume.py
+++ b/tests/test_qs306_log_volume.py
@@ -225,11 +225,11 @@ def test_log_info_on_change_only_mutates_its_own_state(caplog: pytest.LogCapture
     after = vars(host)
     assert set(after) - set(before) == {"_log_on_change_state"}
     assert set(before) - set(after) == set()
-    # QS-342 review #03 record shape: the remembered values, the window anchor, and
-    # this window's budget accounting.
+    # Record shape: observed values (each flagged with whether it was actually
+    # SHOWN — review #04 / B4), the window anchor, and this window's accounting.
     record = host._log_on_change_state["k"]
-    assert record.seen == [("v", T0)]
-    assert (record.window_start, record.emitted, record.dropped) == (T0, 1, 0)
+    assert record.seen == [("v", T0, True)]
+    assert (record.window_start, record.emitted, record.dropped, record.suppressed) == (T0, 1, 0, 0)
 
 
 def test_log_info_on_change_resets_the_timer_on_every_emission(caplog: pytest.LogCaptureFixture) -> None:
@@ -256,6 +256,118 @@ def test_log_info_on_change_keys_are_independent(caplog: pytest.LogCaptureFixtur
     host.log_info_on_change("a", 1, T0 + timedelta(seconds=7), "keyed %s", "a")
 
     assert len(_messages(caplog, "keyed", logging.INFO, CHARGER_LOGGER)) == 2
+
+
+_DISCLOSURE = "log throttle ["
+
+
+def _disclosures(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return _messages(caplog, _DISCLOSURE, logging.INFO, CHARGER_LOGGER)
+
+
+def test_b3_budget_overflow_is_disclosed_when_the_window_rolls(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """B3: the overflow branch had no test at all — CI's 100 % gate would have failed.
+
+    No existing run produced `dropped > 0` AND then crossed 900 s (the longest were
+    128-129 cycles x 7 s = 896 s, just under). That left the plan's, AC5's and the
+    doc's central completeness claim entirely unpinned, on a line that builds a
+    format string with extra args and would raise inside `logging` if mismatched.
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    host = _Host()
+
+    # budget + 3 distinct values inside one window: `budget` shown, 3 dropped.
+    overflow = 3
+    for index in range(_LOG_VALUES_PER_WINDOW + overflow):
+        host.log_info_on_change("k", index, T0 + timedelta(seconds=7 * index), "probe %s", index)
+    assert len(_messages(caplog, "probe", logging.INFO, CHARGER_LOGGER)) == _LOG_VALUES_PER_WINDOW
+    assert _disclosures(caplog) == []
+
+    # One call past the window: the disclosure appears, with the right count.
+    host.log_info_on_change("k", "next", T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 7), "probe %s", "next")
+
+    disclosures = _disclosures(caplog)
+    assert len(disclosures) == 1
+    message = disclosures[0].getMessage()
+    assert f"{overflow} distinct change(s) not shown" in message, message
+    assert "[k]" in message, message
+    # B6: static text keyed to the KEY — none of the caller's args are stapled on.
+    assert "probe" not in message
+
+
+def test_b6_disclosure_is_not_misattributed_or_duplicated(caplog: pytest.LogCaptureFixture) -> None:
+    """B6: it reused the CURRENT call's msg/args, then logged that same line again."""
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    host = _Host()
+
+    for index in range(_LOG_VALUES_PER_WINDOW + 2):
+        host.log_info_on_change("k", index, T0 + timedelta(seconds=7 * index), "car %s state %s", "ZZZ", index)
+    host.log_info_on_change(
+        "k", "fresh", T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 7), "car %s state %s", "ZZZ", "fresh"
+    )
+
+    # The disclosure names no car and no state...
+    disclosure = _disclosures(caplog)[0].getMessage()
+    assert "ZZZ" not in disclosure and "fresh" not in disclosure
+
+    # ...and the value line that triggered the roll is logged exactly once.
+    assert len([r for r in caplog.records if r.getMessage() == "car ZZZ state fresh"]) == 1
+
+
+def test_b4_a_budget_dropped_value_is_shown_once_budget_allows(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """B4: dropped values got an emission-grade TTL and were then silent forever.
+
+    A value recorded but never shown was stamped as if emitted, so after the window
+    rolled it was STILL TTL-suppressed — and that suppression path returns before
+    the drop counter, so it was not counted the second time either. Reproduced
+    against the previous code: a value present from t=28 s first appeared at
+    t=928 s and was uncounted after the first disclosure.
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    host = _Host()
+
+    for index in range(_LOG_VALUES_PER_WINDOW):
+        host.log_info_on_change("k", index, T0 + timedelta(seconds=7 * index), "probe %s", index)
+    # Budget is now exhausted; this value is observed but dropped.
+    dropped_at = T0 + timedelta(seconds=28)
+    host.log_info_on_change("k", "late", dropped_at, "probe %s", "late")
+    assert _messages(caplog, "probe late", logging.INFO, CHARGER_LOGGER) == []
+
+    # Repeating it inside the window must not inflate the drop count per call.
+    for index in range(5):
+        host.log_info_on_change("k", "late", dropped_at + timedelta(seconds=7 * index), "probe %s", "late")
+
+    # Past the window: disclosed as ONE distinct change, and now actually shown.
+    host.log_info_on_change("k", "late", T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 7), "probe %s", "late")
+    assert "1 distinct change(s) not shown" in _disclosures(caplog)[0].getMessage()
+    assert len(_messages(caplog, "probe late", logging.INFO, CHARGER_LOGGER)) == 1
+
+
+def test_b7_dedup_suppressed_repeats_are_counted(caplog: pytest.LogCaptureFixture) -> None:
+    """B7: without this, a pinned key and a calm one produce identical logs.
+
+    `dropped` covers budget overflow only, so a 2-hour ping-pong at the 7 s cycle
+    emitted 16 lines with `dropped == 0` — indistinguishable from a home whose
+    winner genuinely alternates every 7.5 minutes. #342 was diagnosed from volume.
+    """
+    caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
+    host = _Host()
+
+    # One value hammered at the cycle rate for a whole window.
+    repeats = 100
+    for index in range(repeats):
+        host.log_info_on_change("k", "steady", T0 + timedelta(seconds=7 * index), "probe %s", "steady")
+    assert len(_messages(caplog, "probe", logging.INFO, CHARGER_LOGGER)) == 1
+
+    host.log_info_on_change("k", "steady", T0 + timedelta(seconds=_RELOG_UNCHANGED_AFTER_S + 7), "probe %s", "steady")
+
+    disclosure = _disclosures(caplog)[0].getMessage()
+    assert f"{repeats - 1} repeat(s) suppressed" in disclosure, disclosure
+    assert "0 distinct change(s) not shown" in disclosure, disclosure
 
 
 # =============================================================================
@@ -427,22 +539,24 @@ async def test_mf1_near_zero_sign_dither_does_not_re_inflate_the_log(caplog: pyt
 
 
 async def test_mf1_real_export_import_transition_is_still_logged(caplog: pytest.LogCaptureFixture) -> None:
-    """MF1: a genuine export <-> import transition is reported, within the budget.
+    """MF1: the throttle must not cost us a genuine export <-> import transition.
 
     Every cycle here crosses zero with both sides outside the deadband, so every
-    cycle is a real transition. QS-342 review #03 caps each key at `budget`
-    emissions per window: the transitions ARE reported (this is not silence), but a
-    site flipping on every cycle can no longer track the cycle rate. That trade is
-    deliberate and is what makes the volume bound data-independent — an unbounded
-    site is exactly how the original incident reached 17 791 lines.
+    cycle is a real operational event and every cycle is reported.
+
+    Review #04 / B13: this briefly regressed to `2 <= n <= 5` when the default
+    per-key budget was applied here. That budget assumes "many distinct values per
+    window means churn, and the churn is itself the signal" — true for allocation
+    keys, false for telemetry, where the values advance during normal operation.
+    This site now carries `_LOG_TELEMETRY_VALUES_PER_WINDOW`, so the exact count is
+    back and the volume is still bounded.
     """
     caplog.set_level(logging.INFO, logger=CHARGER_LOGGER)
     group, _, home = _make_dyn_handle_group(num_chargers=2, battery=make_battery(0.0), available_power_w=1000.0)
 
     await _run_oscillating_power_cycles(group, home, watts=150.0)
 
-    records = _messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)
-    assert 2 <= len(records) <= _PER_KEY_CEILING, records
+    assert len(_messages(caplog, "battery_asked_charge", logging.INFO, CHARGER_LOGGER)) == 10
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fix the self-biased tie-break in get_best_car that orphaned a plugged car: exact score ties (normal with 0.5 m distance buckets) are now resolved by a deterministic cascade regret → stickiness → stable (charger, car) name order, scanned over ALL tied pairs, so the allocation is caller-independent and converges in one round from every attachment state (incident: ID.buzz→wallbox 2, Zoe→wallbox 3, no manual association).
- New regression net tests/test_charger_allocation_tiebreak.py (incident replay at the verified recorder-DB coordinates, 7-state × 2-order convergence sweep, regret/stickiness/steal semantics, generic-car fallback, caller independence, duplicate-name divergence) + get_car_score decomposition promoted to INFO-on-change keyed on the quantised bump tuple (deliberate INFO exception, story-ratified). **The throttle mechanism described in the round #01/#02 sections below is superseded — see review fix #03/#04 for what is actually in the tree.** B2 note: only one existing-test change was needed — tests/test_chargers_advanced.py test_get_best_car_automatic_selection got a string name on its mock charger (MagicMock constructor quirk surfaced by the deterministic name sort); intent preserved, no oscillation/detach assertion touched. Fixture helpers imported from tests/utils/charger_harness (the shared copy of the test_charger_coverage_deep helpers the story points at).
- Follow-up issue filed per story task C2 (plug-time correlation dead after HA restart): https://github.com/tmenguy/quiet-solar/issues/344 ; docs/agents/concepts/charger-budgeting.md documents the cascade, steal semantics, name-uniqueness assumption, bucket-edge residual and restart limitation.

Fixes #342

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [x] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [ ] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic car-to-charger assignment with deterministic pairing and smarter tie-breaking.
  * Preserves suitable existing connections and handles equal-score choices more consistently.
  * Added rate-limited score-change logging with suppressed-change reporting and bounded log volume.

* **Bug Fixes**
  * Prevented results from depending on evaluation order.
  * Reduced unnecessary detach-and-reattach behavior.
  * Made no-car resets consistent and idempotent.

* **Documentation**
  * Added allocation rules, limitations, acceptance criteria, and troubleshooting guidance.

* **Tests**
  * Expanded coverage for allocation stability, fallback behavior, tie-breaking, logging, and reset handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review fix #01 (2026-08-05/06)

All 14 triaged findings from `docs/stories/QS-342.story_review_fix_#01.md` applied (8 should-fix + 6 nice-to-have):

- **Log volume actually bounded**: changed-value emissions of the `get_car_score` decomposition are now rate-limited per key (`_CHANGED_RELOG_MIN_INTERVAL_S = 60 s`, memo compares against the last *emitted* value), and `detach_car` preserves the car-qualified `get_car_score:*` memo keys while still wiping the QS-306 session memos — bucket-edge flapping and attach/detach churn can no longer track the ~7 s cycle rate. New tests: oscillating-tuple rate bound, detach-preserves-memo; docs updated to state the bound that actually holds.
- **Test hardening**: detach spy forwards `*args/**kwargs`; caller-independence now also swept across the regret / all-equal / stickiness / generic-fallback scenario families; round driver matches the story recipe (attach only on change).
- **Docs/story hygiene**: issue link repo slug fixed, restart limitation scoped to pre-restart plug sessions, stale "expected red" and task-C2 sections marked historical/complete, locale fix.
- **Code comments**: integer-valued-score tie invariant, `assert ranked` coupling guard, ≤15 s caller-set transient at the plug boundary.

**TDD red evidence** (review finding): the incident-replay and start-state-sweep tests were confirmed red on pre-A1 code — 26 failures on the parent of 76e2b6eb, reproducing the field ping-pong (`get_best_car: … removed from another charger` alternating between the two wallboxes) before the tie-break cascade was written; same red-first protocol for this round's floor/detach tests (ImportError + behavioral red before the mixin change).


## Review fix #02 (2026-08-06)

All 18 findings from `docs/stories/QS-342.story_review_fix_#02.md` applied (6 should-fix + 12 nice-to-have). No change to the allocation semantics — round 2 cleared the cascade (300 randomised matrices, zero non-convergent trials), and every finding concerned the observability mechanism, its tests, or doc accuracy.

- **S1 — floor-suppressed churn is now disclosed, not lost.** The memo record became `_LogOnChangeRecord(value, time, suppressed_changes)`: a change dropped by the floor is *banked*, and the first call at/after floor expiry emits — even if the value reverted meanwhile — appending `[+n change(s) suppressed by the rate floor]`. An excursion that starts *and* ends inside the window can no longer leave a flat trace.
- **S2** — the sibling `get_best_car` winner line is floored too (it was driven at full cycle rate by the documented bucket-edge winner flip). **S4** — the tzinfo-mismatch path is documented as deliberate *and self-limiting* (the emission restamps the key) and pinned by a test.
- **S6 — invariant eliminated rather than asserted.** The selection now collects `candidates` once and derives both `max` and the tied set from that single list, so the coupling that could break no longer exists: no `assert` for `python -O` to strip, no `AssertionError` on the live allocation path, and no unreachable branch fighting the 100% gate. Selection is byte-identical.
- **S3/S5/N5 — tests that can actually fail.** Key-composition oracles moved *past* the floor (so the rate limiter can no longer explain the silence) for both raw distance and `connected_time_delta`; the detach assertion seeds a non-score memo key first; the oscillation tests now assert emission **gaps ≥ floor** instead of a loose count.
- **Docs**: second unhysteresised edge (`dist <= 3.0`, which converts a tie into a strict win and thus bypasses the cascade), aggregate volume bound `(N×M + N)/min`, `reset()` consequence for the preserved keys, dyadic-not-integer tie invariant, story Design C.1 + AC5 realigned, plan #01 marked implemented, stale-memo deferral justification amended.

**Existing-test updates** (intent preserved): the memo-shape assertion takes the 3-field form, and `test_s11_best_car_logged_once_per_window` moves its car-swap cycle past the new floor — its NH7 "each record names the car that actually won" check is untouched.



## Review fix #03 (2026-08-07)

18 findings from `docs/stories/QS-342.story_review_fix_#03.md`. This round **replaced the throttle primitive rather than tuning it** — rounds #01–#03 each fixed the previous round's log-throttling defect and introduced the next one.

- **D1 — value dedup + per-key budget replaces the time floor and the bank.** `_CHANGED_RELOG_MIN_INTERVAL_S`, `suppressed_changes`, `min_interval_s=` and the non-comparable-clock branch are **deleted**, not adapted. A time floor is structurally unable to satisfy completeness (a state whose whole lifetime fits inside the window is unobservable), and the incident was never "changes happened too fast" — it was *the same value repeated 17 791 times*. Per key the helper now remembers observed values over a 900 s TTL and emits each distinct value once, within a budget of 4 emissions per window. Dedup kills oscillation; the budget kills drift (which dedup cannot touch — a value creeping one quantum per cycle is a new value every cycle). `time` is normalised to UTC instead of branched on.
- **D2 — the `detach_car` log-state wipe is deleted.** It was the reason round #02's throttle was a **no-op in production**: `detach_car()` sits on the churn path itself, so every allocation change dropped the key and left the next call with nothing to compare against. It was also redundant — every key is car-qualified or carries the car name as its value.
- **D3–D7 — the escaped call sites.** The literal incident message (`removed from another charger`, still an unthrottled f-string at 20/20 cycles) is routed through the helper; all six `get_best_car` winner-announcement branches collapse into one key via a `_compute_best_car` extract-method, so the bound is a property of the helper rather than of one call site; `FORCE_CAR_NO_CHARGER_CONNECTED` drops to DEBUG (it reported a static setting from inside a charger×car double loop, ~62k lines/day).
- **D8 — tests drive the production entry point.** Round #02's throttle shipped green because its test called `get_best_car` and never applied the result, so `detach_car()` never ran: isolated it looked ~63 s apart, on the real path it was the full 7 s cycle rate. Volume is now asserted in aggregate over a full 900 s window through `check_load_activity_and_constraints`.
- **D10 — regret scan switched to identity.** *Reverted in round #04; see below.*

**Measured on the real path** (stable allocation, 129 cycles × 7 s, two chargers): **149 → 20 INFO lines**.

**Existing tests updated** (nine, intent preserved): the memo-shape assertion takes the new record shape; the naive/aware tests assert normalisation instead of the deleted escape branch; `test_sf1_detach_car_clears_the_memo` becomes `test_sf1_log_state_survives_detach_car` (it pinned the defect); the oscillation/winner-flip tests assert distinct-value counts instead of floor gaps; `test_s11_...` reads `args[1]` for the car (`args[0]` is now the deciding branch); the two "every cycle logs" volume ceilings were re-cut.

## Review fix #04 (2026-08-07)

3 must-fix + 12 should-fix + 8 nice-to-have from `docs/stories/QS-342.story_review_fix_#04.md`.

- **B1 (must-fix) — reverted D10, landed alone.** D10 had "tidied" the regret alternative scan from name equality to object identity, justified by a car-name uniqueness invariant **the codebase does not enforce** (`CONF_NAME` is a plain `cv.string` with no collision validation; `add_device` dedups by object identity only). The cascade is effectively over names — removal after assignment consumes a whole *name* from every list — so an identity scan under-counts alternatives, inflates regret for a duplicated name, and lets removal strip the twin off the other charger, which then exits with no car. **That is the #342 symptom itself.** `test_duplicate_car_names_do_not_orphan_a_charger` reproduces it.
- **B2 (must-fix) — the reset gate is deleted, not extended.** The dispute was settled empirically first: the predicate returned `False` while `reset()` cleared all five derived constraint-progress fields, so they *were* strandable. Rather than add the missing fields to a hand-maintained mirror of "everything `reset()` clears", `_reset_would_change_state` is gone and the reset runs unconditionally again — any such mirror rots the moment `reset()` learns a new field, and its failure mode is stale charger state. `reset()` is idempotent, so the log volume is fixed where it belongs: the reset chain is DEBUG unless it destroyed something. `AbstractLoad._has_state_to_reset` still gains its five missing fields (that hook only picks a log level), with predicate and reset now sharing one `_DERIVED_CONSTRAINT_FIELDS` tuple.
- **B3–B7 — the disclosure line, redesigned as one unit.** B3: the overflow branch had **no test at all** and would have failed CI's 100 % gate (no run produced `dropped > 0` *and* crossed 900 s — the longest were 896 s). B4: `seen` entries now carry `was_emitted`, so a budget-dropped value is no longer stamped as if emitted and then silently suppressed forever. B6: the disclosure is static text keyed by the throttle key, carrying none of the caller's args (it used to be stapled onto an unrelated value, then duplicated). B7: it also reports dedup-suppressed **repeats**, restoring the rate signal #342 was diagnosed from. B5: the "flushed only by the next call on the same key" residual is documented precisely rather than papered over with a lifecycle flush hook.
- **B12/B13 — telemetry is not churn.** The `dyn_handle` available-power and SoC sites take a larger explicit budget (12/window); the default had put them in permanent overflow during a normal charge. `test_mf1_real_export_import_transition_is_still_logged` is back to its original exact `== 10`.
- **B8/B9 — tests that can fail.** Lower bounds added to four throttle tests (they asserted only a ceiling, and two matched reason strings that did not exist pre-fix, so they were vacuously green against the pre-fix revision); the aggregate-volume test now uses **real scoring** instead of stubbing `get_car_score` — the very site that produced the original 17 791 lines.
- **B10/B14/C1–C8** — corrected the false "a `str()` sort key cannot break the allocation" claim (`ranked` still carries raw names), the stale comment about the deleted `detach_car` wipe, lazy `%`-args in the multiple-chargers ERROR branch, the `boot_over_computed` score caveat, and the doc (observed-not-emitted values, the telemetry exception, both "never silent" caveats, never-pruned keys, insertion-vs-recency eviction, `last_verified` bumps).

**Suite:** 7177 passed. The 5 failures (4 `tests/ha_tests/test_sensor.py` snapshots, 1 Hungarian internal-paths) reproduce identically on a clean stashed tree — pre-existing, untouched by this PR.

## Doc maintenance

`docs/agents/concepts/charger-budgeting.md` and `docs/agents/concepts/load-base.md` are updated and re-verified. `check_doc_drift.py` also flags four further docs that cover `home_model/load.py` — `external-control-detection.md`, `notification-routing.md`, `piloted-device-and-heat-pump.md`, `user-override.md`. None is affected: this PR's `load.py` changes are confined to `_has_state_to_reset` / `constraint_reset_and_reset_commands_if_needed` and two log-level demotions, which those four documents do not describe.
