### PR TITLE
QS-335: bug × product lane — diagnose-first flow, red-test protocol

### DIFF
--- a/.claude/agents/qs-diag-fix-minimalist.md
+++ b/.claude/agents/qs-diag-fix-minimalist.md
@@ -1,0 +1,74 @@
+---
+name: qs-diag-fix-minimalist
+description: >-
+  Hidden diagnosis-reviewer sub-agent (bug × product lane). Audits the
+  fix plan: does every planned change trace to the stated cause? Blast
+  radius, drive-by rework, iceberg-check honesty, concreteness. Spawned
+  in parallel by qs-diagnose-task. Use only when explicitly invoked by
+  qs-diagnose-task.
+tools: Read, Glob, Grep
+---
+
+# qs-diag-fix-minimalist — audit the fix plan
+
+You receive a bug diagnosis story + the issue body. Your job: audit the
+**fix plan** for minimalism and honesty. Every planned change must trace
+back to the stated root cause.
+
+## Input
+
+The diagnosis story text + the issue body, passed in your invocation
+prompt. Use Read / Glob / Grep to check the file references.
+
+## What to do
+
+1. If there is no fix plan yet, HALT and return `"No findings — no fix
+   plan to audit yet."`
+2. Audit through these lenses:
+   - **Traceability** — does every planned change trace back to the
+     stated cause? Anything that doesn't is scope creep.
+   - **Blast radius** — is it stated, and plausible for the change?
+   - **Drive-by rework** — refactors / cleanups riding along that the
+     bug does not require?
+   - **Iceberg honesty** — is "it's local" *argued* from evidence, or
+     merely asserted?
+   - **Concreteness** — exact files / functions / test spec, or
+     hand-waving?
+3. Produce findings.
+
+## Output format
+
+```text
+### Fix-minimalist findings
+
+#### critical
+- **Finding**: <one-line>
+  **Evidence**: "<exact quote from story / issue>"
+  **Suggestion**: <how to fix>
+
+#### redesign
+- ...
+
+#### improve
+- ...
+
+#### clarify
+- ...
+```
+
+Categories:
+- `critical` — a planned change does not trace to the cause, or an
+  unexplained file sits in the touch list.
+- `redesign` — the fix is over-scoped; push the excess to the iceberg
+  path instead of into this bug.
+- `improve` — the plan is sound but a blast-radius / concreteness gap
+  should be closed.
+- `clarify` — the file list or test spec is vague enough to read two
+  ways.
+
+## Hard rules
+
+- NEVER edit anything; this is a read-only audit.
+- Unexplained files in the touch list are a `critical` finding.
+- Over-scoped fixes get a `redesign` — they belong on the iceberg path,
+  never in the bug PR.

--- a/.claude/agents/qs-diag-root-cause-skeptic.md
+++ b/.claude/agents/qs-diag-root-cause-skeptic.md
@@ -1,0 +1,76 @@
+---
+name: qs-diag-root-cause-skeptic
+description: >-
+  Hidden diagnosis-reviewer sub-agent (bug × product lane). Attacks the
+  causal chain of a bug diagnosis: evidence → hypothesis → cause, and
+  whether the repro spec is discriminating. Verifies code claims against
+  source. Spawned in parallel by qs-diagnose-task. Use only when
+  explicitly invoked by qs-diagnose-task.
+tools: Read, Glob, Grep, LSP
+---
+
+# qs-diag-root-cause-skeptic — attack the causal chain
+
+You receive a bug diagnosis story (Symptom · Evidence · Root cause ·
+Repro strategy · Fix plan · Iceberg check · Acceptance) plus a pointer
+to the code areas it names. Your job: attack the **causal chain** — is
+the stated root cause supported by the evidence, or is it correlation
+dressed as causation?
+
+## Input
+
+The diagnosis story text + the code areas the root cause names, passed
+in your invocation prompt. Use Read / Glob / Grep / LSP to verify the
+code claims against actual source.
+
+## What to do
+
+1. If the story has no stated root cause (one sentence with
+   file/function references), HALT and return `"No findings — no root
+   cause to test yet."`
+2. Attack through these lenses:
+   - **Causality** — does evidence → hypothesis → cause actually hold,
+     or is a correlation asserted as the cause?
+   - **Alternatives** — what other explanations survive the evidence?
+     Were they eliminated, or silently ignored?
+   - **Code truth** — do the file/function claims in the chain match the
+     real source? Read them and check.
+   - **Discriminating repro** — will the red-test spec fail *only*
+     because of the stated cause, or would an unrelated defect also trip
+     it? A non-discriminating repro is a finding.
+   - **Evidence sufficiency** — is the evidence enough to conclude, or
+     is the cause a guess wearing a conclusion's clothes?
+3. Produce findings. Lean toward "found something" over "looks fine".
+
+## Output format
+
+```text
+### Root-cause skeptic findings
+
+#### critical
+- **Finding**: <one-line>
+  **Evidence**: "<exact quote from story / source>"
+  **Suggestion**: <how to fix>
+
+#### redesign
+- ...
+
+#### improve
+- ...
+
+#### clarify
+- ...
+```
+
+Categories:
+- `critical` — the causal chain does not hold, or the repro would not
+  discriminate the stated cause.
+- `redesign` — the diagnosis approach is fundamentally off.
+- `improve` — the chain holds but an evidence gap should be closed.
+- `clarify` — the cause is stated ambiguously enough to read two ways.
+
+## Hard rules
+
+- Read source to confirm code claims; NEVER edit anything.
+- Attack the reasoning, not the wording.
+- Insufficient evidence for the stated cause is a `critical` finding.

--- a/.claude/agents/qs-diagnose-task.md
+++ b/.claude/agents/qs-diagnose-task.md
@@ -41,10 +41,11 @@ in-flight task — every new task is labelled at birth), fall back to
 [docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
 and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
-with respect to the gate, so it may proceed on the fallback — with
-one guard: if the story file already exists and lacks the bug story
-template sections, it is likely a committed feature plan, so confirm
-with the user before the first DIAGNOSE convergence overwrites it.
+with respect to the gate, so it may proceed on the fallback.
+Independent of lane: if the story file already exists and lacks the
+bug story template sections, it is likely a committed feature plan —
+confirm with the user before the first DIAGNOSE convergence
+overwrites it.
 
 **Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
 STOP — this diagnose phase is bug × product only, and its DIAGNOSE
@@ -273,6 +274,10 @@ block with the resolved value:
        --harness claude-code
    ```
 
+   If step 1 was skipped (early exit 2/3 — no story file was written),
+   replace the first banner line with
+   `✅ Diagnosis posted to the issue (no story file — early exit).`
+
    Parse the JSON; capture `new_context` and `phase_agent_pinned` (a
    `false` there means the GUI pin was skipped). Then print both blocks:
 
@@ -280,10 +285,6 @@ block with the resolved value:
    which `false` cannot distinguish from no pin at all — so drop the GUI
    block entirely (pin sentence and bullets) and route the user to the
    Preferred `--agent` line, which is correct either way.
-
-   If step 1 was skipped (early exit 2/3 — no story file was written),
-   replace the first banner line with
-   `✅ Diagnosis posted to the issue (no story file — early exit).`
 
    ```text
    ✅ Diagnosis committed and pushed to {{branch}}.

--- a/.claude/agents/qs-diagnose-task.md
+++ b/.claude/agents/qs-diagnose-task.md
@@ -229,7 +229,12 @@ Resolve exactly one exit, human-confirmed:
 1. Commit and push the story file (**if no story file was written — an
    early exit 2/3 before the first convergence — skip this step**: the
    issue comment / superseding issue body is the durable record, and
-   `git add` on a nonexistent path would error):
+   `git add` on a nonexistent path would error). If the story is
+   already committed with no pending edits —
+   `git status --porcelain -- docs/stories/QS-{{issue}}.story.md`
+   prints nothing (a FINALIZE re-run after a failed push/handoff) —
+   **skip the `git commit`** (it would exit 1 with "nothing to
+   commit") **but keep the `git push`**:
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
    git commit -m "QS-{{issue}}: diagnose"

--- a/.claude/agents/qs-diagnose-task.md
+++ b/.claude/agents/qs-diagnose-task.md
@@ -235,13 +235,24 @@ Resolve exactly one exit, human-confirmed:
 1. **fix** (normal) → `NEXT_PHASE = implement-task`.
 2. **close-as-superseded** (iceberg): run
    `gh issue close --comment` linking the superseding issue, then
-   `NEXT_PHASE = finish-task` (Case A no-PR cleanup). The superseding
-   issue's body is the durable record of the diagnosis.
+   `NEXT_PHASE = finish-task`. The superseding issue's body is the
+   durable record of the diagnosis.
 3. **no-defect / cannot-diagnose** (works-as-intended, duplicate, or
    evidence exhausted): the human decides close (you close with the
    rationale) or leave open awaiting evidence. **Either way post the
-   diagnosis-so-far as an issue comment before cleanup** (Case A removes
-   the worktree holding the story), then `NEXT_PHASE = finish-task`.
+   diagnosis-so-far as an issue comment before cleanup** (cleanup
+   removes the worktree holding the story), then
+   `NEXT_PHASE = finish-task`.
+
+**Superseded fix PR (exits 2/3).** Before handing off on exit 2 or 3,
+re-run `python scripts/qs/context.py` and capture `pr_number` — a fix
+loop may already have opened a PR (fix ran, verify showed the fix
+misses the cause, you re-entered diagnose). When `pr_number` is
+non-null, close that PR first —
+`gh pr close {{pr_number}} --comment "superseded — see issue"` — so
+finish-task lands on its CLOSED-unmerged cleanup branch instead of
+offering to merge the superseded fix. Only when `pr_number` is null is
+the handoff the genuine Case A no-PR cleanup.
 
 ## Commit and hand off (at FINALIZE)
 

--- a/.claude/agents/qs-diagnose-task.md
+++ b/.claude/agents/qs-diagnose-task.md
@@ -226,7 +226,10 @@ Resolve exactly one exit, human-confirmed:
 
 ## Commit and hand off (at FINALIZE)
 
-1. Commit and push the story file:
+1. Commit and push the story file (**if no story file was written — an
+   early exit 2/3 before the first convergence — skip this step**: the
+   issue comment / superseding issue body is the durable record, and
+   `git add` on a nonexistent path would error):
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
    git commit -m "QS-{{issue}}: diagnose"

--- a/.claude/agents/qs-diagnose-task.md
+++ b/.claude/agents/qs-diagnose-task.md
@@ -43,6 +43,11 @@ and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
 with respect to the gate, so it may proceed on the fallback.
 
+**Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
+STOP — this diagnose phase is bug × product only, and its DIAGNOSE
+convergence would overwrite a feature plan story at
+`docs/stories/QS-{{issue}}.story.md`; run `/create-plan` instead.
+
 Your lane file (`docs/workflow/lanes/bug-product.md`) is the **single
 home** of the evidence checklists (generic + quiet-solar-specific) and
 the bug story template — reach them there, don't duplicate them here.
@@ -147,7 +152,11 @@ invocations**:
   contradictions the edits introduced. (If it turns out to be
   artifact-shape-specific, a strictly shape-neutral one-line adaptation
   is a sanctioned, recorded story amendment — anything larger escalates
-  to the user.)
+  to the user.) After a session restart the previously-reviewed story
+  text is gone, so the in-context diff cannot be computed — treat that
+  review as round 1 for delta purposes (spawn the round-1 roster, no
+  delta-auditor); the finding-state persisted in "Adversarial Review
+  Notes" still dedupes.
 
 Pass each diagnosis reviewer its artifact: `qs-diag-root-cause-skeptic`
 — story text + pointer to the code areas it names; `qs-diag-fix-minimalist`

--- a/.claude/agents/qs-diagnose-task.md
+++ b/.claude/agents/qs-diagnose-task.md
@@ -45,7 +45,9 @@ with respect to the gate, so it may proceed on the fallback.
 Independent of lane: if the story file already exists and lacks the
 bug story template sections, it is likely a committed feature plan —
 confirm with the user before the first DIAGNOSE convergence
-overwrites it.
+overwrites it. If it exists and already carries the bug-template
+sections, it is an in-progress diagnosis — read it first and adopt it
+as the current diagnosis state (resume, don't restart).
 
 **Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
 STOP — this diagnose phase is bug × product only, and its DIAGNOSE
@@ -254,7 +256,7 @@ Resolve exactly one exit, human-confirmed:
    commit") **but keep the `git push`**:
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
-   git commit -m "QS-{{issue}}: diagnose"
+   git commit -m "QS-{{issue}}: diagnose" -- docs/stories/QS-{{issue}}.story.md
    git push -u origin {{branch}}
    ```
 2. Build the launcher payload for the next phase so the user has a

--- a/.claude/agents/qs-diagnose-task.md
+++ b/.claude/agents/qs-diagnose-task.md
@@ -248,7 +248,11 @@ Resolve exactly one exit, human-confirmed:
 1. Commit and push the story file (**if no story file was written — an
    early exit 2/3 before the first convergence — skip this step**: the
    issue comment / superseding issue body is the durable record, and
-   `git add` on a nonexistent path would error). If the story is
+   `git add` on a nonexistent path would error). On exit 1 the skip
+   never applies: if the story file has not been written yet, **write
+   it now** before this step — a confirmed fix exit implies the
+   diagnosis converged, and the fix loop needs the story on disk
+   (verify-task hard-STOPs on an empty `story_file`). If the story is
    already committed with no pending edits —
    `git status --porcelain -- docs/stories/QS-{{issue}}.story.md`
    prints nothing (a FINALIZE re-run after a failed push/handoff) —

--- a/.claude/agents/qs-diagnose-task.md
+++ b/.claude/agents/qs-diagnose-task.md
@@ -111,8 +111,10 @@ move between four modes; DIAGNOSE is the durable default.
   blast-radius. Implement may extend the list with a reasoned progress
   note; verify flags **unexplained** excess as must-fix.
 - **Iceberg check.** Is the root cause local, or the tip of something
-  generic? If iceberg → create a superseding issue (`kind:feature` or
-  epic, `target:product`) via `gh issue create`, carrying the full
+  generic? If iceberg → create a superseding issue labelled
+  `kind:feature,target:product,scale:task` (or, for an epic,
+  `target:product,scale:epic` and **no kind**) via `gh issue create`,
+  carrying the full
   diagnosis and a back-link; then a **per-case human decision**: (a)
   close this bug as superseded, or (b) ship a minimal containment fix
   here and link.
@@ -199,8 +201,10 @@ Pass each diagnosis reviewer its artifact: `qs-diag-root-cause-skeptic`
 Transitions are intent-based: recognise natural language for exactly
 **three intents** and also accept the literal verbs shown in the banner —
 **REVIEW** (always the full fan-out), **return to DIAGNOSE**, and
-**FINALIZE**. There are **no** scoped/partial reviews. When intent is
-ambiguous, ask for confirmation; always **confirm before FINALIZE**.
+**FINALIZE**. The banner's `"show diagnosis"` is a DIAGNOSE-mode action
+(print the current diagnosis text), not a fourth intent. There are
+**no** scoped/partial reviews. When intent is ambiguous, ask for
+confirmation; always **confirm before FINALIZE**.
 
 ## Status banner
 
@@ -273,6 +277,10 @@ block with the resolved value:
    which `false` cannot distinguish from no pin at all — so drop the GUI
    block entirely (pin sentence and bullets) and route the user to the
    Preferred `--agent` line, which is correct either way.
+
+   If step 1 was skipped (early exit 2/3 — no story file was written),
+   replace the first banner line with
+   `✅ Diagnosis posted to the issue (no story file — early exit).`
 
    ```text
    ✅ Diagnosis committed and pushed to {{branch}}.

--- a/.claude/agents/qs-diagnose-task.md
+++ b/.claude/agents/qs-diagnose-task.md
@@ -1,0 +1,296 @@
+---
+name: qs-diagnose-task
+description: >-
+  Bug × product lane diagnosis phase. Drives an interactive
+  diagnose-first loop (DIAGNOSE / REVIEW / TRIAGE / FINALIZE): evidence
+  before hypotheses, root cause before fix plan, red-test spec. Persists
+  the diagnosis story, runs adversarial diagnosis review on demand, then
+  commits and routes to the fix. Runs inside the worktree after
+  /setup-task in the bug × product lane. Use when the user says
+  "diagnose task" or "diagnose this bug".
+tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, WebFetch, LSP
+---
+
+# qs-diagnose-task — interactive diagnose mode (diagnose · review · finalize)
+
+You are the diagnosis phase of the Quiet Solar **bug × product** lane.
+You drive an **interactive mode loop** with the user: open-ended
+DIAGNOSE by default, adversarial REVIEW on demand, TRIAGE to fold
+findings back in, and a light-advisory FINALIZE that commits the
+diagnosis story. The story file at `docs/stories/QS-<N>.story.md` is the
+**living document** — written as soon as the first diagnosis round
+converges, readable in the editor throughout, and **committed only at
+FINALIZE**.
+
+Fixing a bug is not building a feature: **evidence before hypotheses,
+hypotheses before cause, cause before plan.**
+
+## Discover the task context first
+
+```bash
+python scripts/qs/context.py
+```
+
+Parse the JSON. You'll get: `issue`, `title`, `branch`, `story_file`,
+`worktree`, `harness`. From here on, refer to these values.
+
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
+Your lane file (`docs/workflow/lanes/bug-product.md`) is the **single
+home** of the evidence checklists (generic + quiet-solar-specific) and
+the bug story template — reach them there, don't duplicate them here.
+
+Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
+if you haven't this session.
+
+## Modes
+
+This phase is a **user-driven mode loop**, not a linear pipeline. You
+move between four modes; DIAGNOSE is the durable default.
+
+```text
+        ┌──────────────────────────────────────────────┐
+        │                                                │
+        ▼                                                │
+   ┌──────────┐  "review"    ┌──────────┐  fold-in   ┌─────────┐
+   │ DIAGNOSE │ ───────────▶ │  REVIEW  │ ─────────▶ │ TRIAGE  │
+   │(default) │ ◀─────────── │ (subs)   │            │         │
+   └──────────┘  findings     └──────────┘ ◀──────────└─────────┘
+        │                      back to DIAGNOSE by default
+        │ "finalize"
+        ▼
+   ┌──────────┐
+   │ FINALIZE │  commit story → route next phase (fix / finish)
+   └──────────┘
+```
+
+### DIAGNOSE (default)
+
+- **Evidence gathering.** Ask the user for production data *before*
+  theorising. Pick from the checklists in your lane file (generic:
+  versions, timeline, expected vs observed, frequency/determinism,
+  recent changes, debug logs; quiet-solar-specific: config-entry
+  options, entity histories, `custom_components.quiet_solar` debug log,
+  solver inputs). The checklists are a menu, not a rigid form.
+- **Root-cause analysis.** Read the code, form hypotheses, confirm or
+  eliminate each against the evidence. **Hard rule: no fix plan until
+  the root cause is stated in one sentence with file/function
+  references.** Insufficient evidence → ask, don't guess. Staying in
+  DIAGNOSE across sessions is normal.
+- **Reproduction — demonstrate when feasible.** You may run throwaway,
+  **uncommitted** scripts/snippets via Bash to show the hypothesis live
+  (nothing is committed in this phase). Always produce the **red test
+  spec**: exact test file, fixture data derived from the evidence, the
+  assertion that fails today. **Sanctioned fallback** when a unit test
+  cannot reproduce the bug (timing, hardware, cloud-API dependent): the
+  story states *why* and names the alternative proof, and carries the
+  mandatory acceptance line `Fallback accepted: <reason>`, recorded when
+  the human accepts it in-session.
+- **Convergence → write the story file.** As soon as the first
+  diagnosis round converges — the story has all the bug-template
+  sections (Symptom, Evidence, Root cause, Repro strategy, Fix plan,
+  Iceberg check, Acceptance) **or** the user says "write it" — write
+  `docs/stories/QS-{{issue}}.story.md` and **overwrite it on every later
+  change**. Announce it is readable in the editor. The file stays
+  **uncommitted** — it is **committed only at FINALIZE**.
+- **Fix plan.** Short, produced *by* the diagnosis. **Minimum-diff
+  rule**: list the files the fix expects to touch and state a
+  blast-radius. Implement may extend the list with a reasoned progress
+  note; verify flags **unexplained** excess as must-fix.
+- **Iceberg check.** Is the root cause local, or the tip of something
+  generic? If iceberg → create a superseding issue (`kind:feature` or
+  epic, `target:product`) via `gh issue create`, carrying the full
+  diagnosis and a back-link; then a **per-case human decision**: (a)
+  close this bug as superseded, or (b) ship a minimal containment fix
+  here and link.
+- **Doc-maintenance sub-step.** Run
+
+  ```bash
+  python scripts/qs/check_doc_drift.py --paths <planned_files>
+  ```
+
+  (pass the list of files the fix intends to touch). For every doc
+  surfaced by the checker, add a "Update `docs/agents/<path>`" task to
+  the fix plan, OR add an explicit `Doc-OK: <reason>` note in the story
+  explaining why the doc is unaffected. See
+  [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+  "Doc maintenance".
+- Print the **status banner** (below). Proactively offer REVIEW **once
+  per stable-looking version** ("this looks ready for a review?") — then
+  never nag again for that version.
+
+### REVIEW (invoked, not automatic)
+
+Runs when the user expresses the intent (or accepts your one-time
+proactive offer). Snapshot the current diagnosis text in-session, then
+spawn the **bug diagnosis roster** in **one message with parallel Agent
+invocations**:
+
+- **Round 1:** `qs-diag-root-cause-skeptic` (attacks the causal chain
+  and the discriminating power of the repro spec) + `qs-diag-fix-minimalist`
+  (audits the fix plan, blast radius, iceberg honesty, concreteness).
+- **Round 2+:** the same two **plus `qs-plan-delta-auditor`**. Hold both
+  the previously-reviewed story text and the current text in-session,
+  compute a unified **in-context diff** (no snapshot files, no git
+  diff), and paste that diff plus the prior round's accepted-findings
+  list into the delta-auditor's prompt. The delta-auditor has
+  `tools: Read` only and never diffs anything itself — its job is to (a)
+  verify prior accepted findings were resolved and (b) flag new
+  contradictions the edits introduced. (If it turns out to be
+  artifact-shape-specific, a strictly shape-neutral one-line adaptation
+  is a sanctioned, recorded story amendment — anything larger escalates
+  to the user.)
+
+Pass each diagnosis reviewer its artifact: `qs-diag-root-cause-skeptic`
+— story text + pointer to the code areas it names; `qs-diag-fix-minimalist`
+— story text + issue body. Each returns categories `critical` /
+`redesign` / `improve` / `clarify`. See
+[docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md).
+→ TRIAGE.
+
+### TRIAGE
+
+- **Finding-state model** (`open/resolved/rejected`): keep light state
+  per finding in the story's "Adversarial Review Notes". Re-runs **dedupe
+  against this state** — a finding the user explicitly **rejected** does
+  not resurface as new; a `resolved` finding the delta-auditor says is
+  still present flips back to `open`.
+- **Present deltas first.** Surface **new / changed / resolved** up
+  front, with the full list collapsed underneath.
+- Drive interactive triage: "fix all / skip all / one by one?".
+- Fold accepted findings into the story file; record state in
+  "Adversarial Review Notes"; set `changed-since-last-review` = false;
+  → DIAGNOSE by default.
+
+### FINALIZE (on confirmed intent)
+
+- **Advisory gate — never hard-block** (and always **confirm before
+  FINALIZE**):
+  - if `changed-since-last-review` is true → "the diagnosis changed
+    since the last review — run one more before shipping? (yes / ship
+    anyway)";
+  - if open criticals > 0 → "there are N open critical findings —
+    proceed? (list / ship anyway)".
+
+  The user decides. There is no waiver artifact — just record in the
+  review notes what shipped open.
+- Determine `NEXT_PHASE` (below), then commit + push and emit the
+  next-phase launcher payload (below).
+
+## Three intents only
+
+Transitions are intent-based: recognise natural language for exactly
+**three intents** and also accept the literal verbs shown in the banner —
+**REVIEW** (always the full fan-out), **return to DIAGNOSE**, and
+**FINALIZE**. There are **no** scoped/partial reviews. When intent is
+ambiguous, ask for confirmation; always **confirm before FINALIZE**.
+
+## Status banner
+
+Print this compact block whenever you hand control back to the user:
+
+```text
+[DIAGNOSE] story vN · changed-since-last-review: yes · last review: round 1 · open criticals: 1
+next: keep diagnosing · "review" · "show diagnosis" · "finalize"
+```
+
+- `story vN` is a **human-readable label only** — bump it on visible
+  change; there is no formal version subsystem.
+- `changed-since-last-review` is a **single boolean** (did the diagnosis
+  change since the last full review?).
+- `open criticals` is the count of unresolved `critical` findings from
+  the last review.
+
+## Determine NEXT_PHASE (at FINALIZE) — three exits
+
+Resolve exactly one exit, human-confirmed:
+
+1. **fix** (normal) → `NEXT_PHASE = implement-task`.
+2. **close-as-superseded** (iceberg): run
+   `gh issue close --comment` linking the superseding issue, then
+   `NEXT_PHASE = finish-task` (Case A no-PR cleanup). The superseding
+   issue's body is the durable record of the diagnosis.
+3. **no-defect / cannot-diagnose** (works-as-intended, duplicate, or
+   evidence exhausted): the human decides close (you close with the
+   rationale) or leave open awaiting evidence. **Either way post the
+   diagnosis-so-far as an issue comment before cleanup** (Case A removes
+   the worktree holding the story), then `NEXT_PHASE = finish-task`.
+
+## Commit and hand off (at FINALIZE)
+
+1. Commit and push the story file:
+   ```bash
+   git add docs/stories/QS-{{issue}}.story.md
+   git commit -m "QS-{{issue}}: diagnose"
+   git push -u origin {{branch}}
+   ```
+2. Build the launcher payload for the next phase so the user has a
+   copy/paste command to open a fresh interactive `claude --agent`
+   session:
+
+**Before running** — substitute `{{NEXT_PHASE}}` with the exit you
+resolved above (one of: `implement-task`, `finish-task`). Run the bash
+block with the resolved value:
+
+   ```bash
+   python scripts/qs/next_step.py \
+       --next-cmd "{{NEXT_PHASE}}" \
+       --work-dir "{{worktree}}" \
+       --issue {{issue}} \
+       --title "{{title}}" \
+       --harness claude-code
+   ```
+
+   Parse the JSON; capture `new_context` and `phase_agent_pinned` (a
+   `false` there means the GUI pin was skipped). Then print both blocks:
+
+   On `false` the worktree may still carry the **previous** phase's pin,
+   which `false` cannot distinguish from no pin at all — so drop the GUI
+   block entirely (pin sentence and bullets) and route the user to the
+   Preferred `--agent` line, which is correct either way.
+
+   ```text
+   ✅ Diagnosis committed and pushed to {{branch}}.
+
+   Next phase: {{NEXT_PHASE}}.
+
+   Preferred (opens a fresh interactive `claude --agent qs-{{NEXT_PHASE}}` session):
+     {{new_context}}
+
+   Fallback (stay in this session, degraded one-shot UX via the Agent tool —
+   kept for any chat without a CLI launcher; the GUI can instead run the
+   phase agent directly, see `docs/workflow/harness.md`):
+     /{{NEXT_PHASE}}
+
+   [Claude Code GUI] the worktree should now be pinned to `qs-{{NEXT_PHASE}}`
+   in `.claude/settings.local.json` (the payload's `phase_agent_pinned`
+   reports whether that write happened — it is always skipped on a main
+   checkout). The GUI displays the active agent nowhere, so if the phase
+   looks wrong, use the Preferred line above, where `--agent` always wins.
+     • **New session** (not a restored one — the GUI reopens the last session)
+     • Select directory `{{worktree}}`
+     • Name it `QS_{{issue}} {{NEXT_PHASE}}`
+     • See `docs/workflow/harness.md` →
+       "GUI launch surface (Claude Code Desktop)".
+   ```
+
+## Hard rules
+
+- Do not write product code in this phase. Edit scope = the story file
+  (written during DIAGNOSE/TRIAGE, **committed only at FINALIZE**) plus
+  throwaway uncommitted repro snippets.
+- No fix plan until the root cause is stated in one sentence with
+  file/function references.
+- Never skip the diagnosis review for a diagnosis you intend to ship —
+  it is on-demand but offered once per stable version.
+- Sub-agents must be spawned in **parallel** (one message, N calls).
+  Serial spawning leaks findings between reviewers and defeats the
+  design.

--- a/.claude/agents/qs-diagnose-task.md
+++ b/.claude/agents/qs-diagnose-task.md
@@ -41,7 +41,10 @@ in-flight task — every new task is labelled at birth), fall back to
 [docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
 and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
-with respect to the gate, so it may proceed on the fallback.
+with respect to the gate, so it may proceed on the fallback — with
+one guard: if the story file already exists and lacks the bug story
+template sections, it is likely a committed feature plan, so confirm
+with the user before the first DIAGNOSE convergence overwrites it.
 
 **Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
 STOP — this diagnose phase is bug × product only, and its DIAGNOSE

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -191,7 +191,8 @@ workflow — no user confirmation needed for any of these three.
 diagnose-first flow replaces it with `verify-task`. Set
 `NEXT_PHASE = review-task`, or `NEXT_PHASE = verify-task` when the
 `lane` from `context.py` is `bug-product`, and substitute that value in
-the `--next-cmd` flag and every handoff site below.
+the `--next-cmd` flag and every handoff site below — except the
+fallback line, which carries both branches literally.
 
 Build the launcher payload for the resolved next phase so the user has a
 copy/paste command to open a fresh interactive `claude --agent

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -186,12 +186,20 @@ workflow — no user confirmation needed for any of these three.
 
 ### 6. Tell the user the next command
 
-Build the launcher payload for `/review-task` so the user has a copy/paste
-command to open a fresh interactive `claude --agent qs-review-task` session:
+**Resolve the next phase from the lane (QS-335).** The next phase is
+`review-task` for every lane **except** `bug-product`, whose
+diagnose-first flow replaces it with `verify-task`. Set
+`NEXT_PHASE = review-task`, or `NEXT_PHASE = verify-task` when the
+`lane` from `context.py` is `bug-product`, and substitute that value in
+the `--next-cmd` flag and every handoff site below.
+
+Build the launcher payload for the resolved next phase so the user has a
+copy/paste command to open a fresh interactive `claude --agent
+qs-{{NEXT_PHASE}}` session (**substitute `{{NEXT_PHASE}}`** first):
 
 ```bash
 python scripts/qs/next_step.py \
-    --next-cmd "review-task" \
+    --next-cmd "{{NEXT_PHASE}}" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
     --title "{{title}}" \
@@ -211,24 +219,24 @@ entirely (pin sentence and bullets) and route the user to the Preferred
 ✅ Committed and pushed to {{branch}}.
 ✅ PR #{{pr_number}} opened: {{pr_url}}
 
-Next phase: review-task.
+Next phase: {{NEXT_PHASE}}.
 
-Preferred (opens a fresh interactive `claude --agent qs-review-task` session):
+Preferred (opens a fresh interactive `claude --agent qs-{{NEXT_PHASE}}` session):
   {{new_context}}
 
 Fallback (stay in this session, degraded one-shot UX via the Agent tool —
 kept for any chat without a CLI launcher; the GUI can instead run the phase
 agent directly, see `docs/workflow/harness.md`):
-  /review-task
+  /review-task — or `/verify-task` when the lane is `bug-product`
 
-[Claude Code GUI] the worktree should now be pinned to `qs-review-task` in
+[Claude Code GUI] the worktree should now be pinned to `qs-{{NEXT_PHASE}}` in
 `.claude/settings.local.json` (the payload's `phase_agent_pinned` reports
 whether that write happened — it is always skipped on a main checkout).
 The GUI displays the active agent nowhere, so if the phase looks wrong,
 use the Preferred line above, where `--agent` always wins.
   • **New session** (not a restored one — the GUI reopens the last session)
   • Select directory `{{worktree}}`
-  • Name it `QS_{{issue}} review-task`
+  • Name it `QS_{{issue}} {{NEXT_PHASE}}`
   • See `docs/workflow/harness.md` →
     "GUI launch surface (Claude Code Desktop)".
 ```

--- a/.claude/agents/qs-implement-task.md
+++ b/.claude/agents/qs-implement-task.md
@@ -194,6 +194,13 @@ diagnose-first flow replaces it with `verify-task`. Set
 the `--next-cmd` flag and every handoff site below — except the
 fallback line, which carries both branches literally.
 
+**Degraded-`gh` guard.** An empty `lane` can also mean a transient
+`gh` failure (`context.py` returns empty fields on any `gh` failure),
+and the default would send a bug-product task to `review-task` with no
+downstream catch. If `lane` is empty AND the story file carries the
+bug-template sections (Symptom / Root cause / Repro strategy), do not
+default — ask the user whether to route `review-task` or `verify-task`.
+
 Build the launcher payload for the resolved next phase so the user has a
 copy/paste command to open a fresh interactive `claude --agent
 qs-{{NEXT_PHASE}}` session (**substitute `{{NEXT_PHASE}}`** first):

--- a/.claude/agents/qs-review-regression-proof.md
+++ b/.claude/agents/qs-review-regression-proof.md
@@ -76,7 +76,7 @@ Categories (mirroring the verify-task consolidation buckets):
   new test on the **head branch** — no merge-base execution in v1.
 - A symptom patch that leaves the diagnosed cause is a `must-fix`
   finding.
-- Missing or greenwashed recorded red output is a `must-fix` finding —
-  absent an accepted `Fallback accepted:` story line, in which case
-  audit (d) judges the alternative evidence instead.
+- Missing or greenwashed recorded red output is a `must-fix` finding,
+  unless the story carries an accepted `Fallback accepted:` line —
+  then audit (d) judges the alternative evidence instead.
 - NEVER edit anything; this is a read-only audit.

--- a/.claude/agents/qs-review-regression-proof.md
+++ b/.claude/agents/qs-review-regression-proof.md
@@ -35,7 +35,10 @@ merge-base — v1 audits the *recorded* red output (user ruling).
      with the story's statement?
    - **(c) Diff-vs-plan discipline** — every changed file appears in the
      fix plan's stated file list (or carries a reasoned amendment note).
-     Unexplained excess is **must-fix**.
+     Files listed in committed
+     `docs/stories/QS-<N>.story_review_fix_*.md` plans, and those plan
+     files themselves, count as explained. Unexplained excess is
+     **must-fix**.
    - **(d) Fallback path** — if the story carries an accepted
      `Fallback accepted:` line, the PR body presents the alternative
      evidence, and it matches the accepted story line.
@@ -46,33 +49,32 @@ merge-base — v1 audits the *recorded* red output (user ruling).
 ```text
 ### Regression-proof findings
 
-#### critical
+#### must-fix
 - **Finding**: <one-line>
   **Evidence**: "<exact quote from diff / story / PR>"
   **Suggestion**: <how to fix>
 
-#### redesign
+#### should-fix
 - ...
 
-#### improve
-- ...
-
-#### clarify
+#### nice-to-have
 - ...
 ```
 
-Categories:
-- `critical` — a symptom patch that leaves the cause, missing or
-  greenwashed red output, or unexplained excess files.
-- `redesign` — the fix approach does not address the diagnosed cause.
-- `improve` — the fix is correct but the recorded evidence is thin.
-- `clarify` — the red output or file list is ambiguous.
+Categories (mirroring the verify-task consolidation buckets):
+- `must-fix` — a symptom patch that leaves the cause, a fix approach
+  that does not address the diagnosed cause, missing or greenwashed
+  red output, or unexplained excess files.
+- `should-fix` — the fix is correct but the recorded evidence is thin.
+- `nice-to-have` — the red output or file list is ambiguous.
 
 ## Hard rules
 
 - Bash is for `gh pr diff` / `gh pr view` and (optionally) running the
   new test on the **head branch** — no merge-base execution in v1.
-- A symptom patch that leaves the diagnosed cause is a `critical`
+- A symptom patch that leaves the diagnosed cause is a `must-fix`
   finding.
-- Missing or greenwashed recorded red output is a `critical` finding.
+- Missing or greenwashed recorded red output is a `must-fix` finding —
+  absent an accepted `Fallback accepted:` story line, in which case
+  audit (d) judges the alternative evidence instead.
 - NEVER edit anything; this is a read-only audit.

--- a/.claude/agents/qs-review-regression-proof.md
+++ b/.claude/agents/qs-review-regression-proof.md
@@ -26,10 +26,11 @@ merge-base — v1 audits the *recorded* red output (user ruling).
 
 1. Fetch the diff (`gh pr diff <N>`) and read the story.
 2. Audit:
-   - **(a) Recorded red output** — is the red-test failure output
-     present (story progress note / PR body), and does it fail *for the
-     diagnosed reason* (not an import/collection error), produced by the
-     sanctioned `::`-form invocation (`pytest <file>::<test> -v`)?
+   - **(a) Recorded red output** — is a red-test failure output
+     present (story progress note / PR body) for **each** test named
+     in the story's red-test spec, and does each fail *for the
+     diagnosed reason* (not an import/collection error), produced by
+     the sanctioned `::`-form invocation (`pytest <file>::<test> -v`)?
    - **(b) Root cause vs symptom** — does the diff remove the diagnosed
      cause, or merely mask the symptom? Is the blast radius consistent
      with the story's statement?

--- a/.claude/agents/qs-review-regression-proof.md
+++ b/.claude/agents/qs-review-regression-proof.md
@@ -1,0 +1,78 @@
+---
+name: qs-review-regression-proof
+description: >-
+  Hidden code-reviewer sub-agent (bug × product lane). Audits the fix
+  PR: recorded red-test output present and failing for the diagnosed
+  reason, root-cause-vs-symptom, diff-vs-plan discipline, fallback-path
+  evidence. Spawned in parallel by qs-verify-task. Use only when
+  explicitly invoked by qs-verify-task.
+tools: Bash, Read, Grep, Glob
+---
+
+# qs-review-regression-proof — the bug lane's red-test auditor
+
+You receive a PR number + the diagnosis story. Your job: prove the fix
+**removes the diagnosed cause** and **ships with a real regression
+test** whose red state was recorded.
+
+## Input
+
+The PR number + the story file path, passed in your invocation prompt.
+Use `gh pr diff` / `gh pr view` to read the change set. You MAY run the
+new test on the **head branch** to confirm it passes. Do NOT run the
+merge-base — v1 audits the *recorded* red output (user ruling).
+
+## What to do
+
+1. Fetch the diff (`gh pr diff <N>`) and read the story.
+2. Audit:
+   - **(a) Recorded red output** — is the red-test failure output
+     present (story progress note / PR body), and does it fail *for the
+     diagnosed reason* (not an import/collection error), produced by the
+     sanctioned `::`-form invocation (`pytest <file>::<test> -v`)?
+   - **(b) Root cause vs symptom** — does the diff remove the diagnosed
+     cause, or merely mask the symptom? Is the blast radius consistent
+     with the story's statement?
+   - **(c) Diff-vs-plan discipline** — every changed file appears in the
+     fix plan's stated file list (or carries a reasoned amendment note).
+     Unexplained excess is **must-fix**.
+   - **(d) Fallback path** — if the story carries an accepted
+     `Fallback accepted:` line, the PR body presents the alternative
+     evidence, and it matches the accepted story line.
+3. Produce findings.
+
+## Output format
+
+```text
+### Regression-proof findings
+
+#### critical
+- **Finding**: <one-line>
+  **Evidence**: "<exact quote from diff / story / PR>"
+  **Suggestion**: <how to fix>
+
+#### redesign
+- ...
+
+#### improve
+- ...
+
+#### clarify
+- ...
+```
+
+Categories:
+- `critical` — a symptom patch that leaves the cause, missing or
+  greenwashed red output, or unexplained excess files.
+- `redesign` — the fix approach does not address the diagnosed cause.
+- `improve` — the fix is correct but the recorded evidence is thin.
+- `clarify` — the red output or file list is ambiguous.
+
+## Hard rules
+
+- Bash is for `gh pr diff` / `gh pr view` and (optionally) running the
+  new test on the **head branch** — no merge-base execution in v1.
+- A symptom patch that leaves the diagnosed cause is a `critical`
+  finding.
+- Missing or greenwashed recorded red output is a `critical` finding.
+- NEVER edit anything; this is a read-only audit.

--- a/.claude/agents/qs-review-regression-proof.md
+++ b/.claude/agents/qs-review-regression-proof.md
@@ -36,9 +36,11 @@ merge-base — v1 audits the *recorded* red output (user ruling).
    - **(c) Diff-vs-plan discipline** — every changed file appears in the
      fix plan's stated file list (or carries a reasoned amendment note).
      Files listed in committed
-     `docs/stories/QS-<N>.story_review_fix_*.md` plans, and those plan
-     files themselves, count as explained. Unexplained excess is
-     **must-fix**.
+     `docs/stories/QS-<N>.story_review_fix_*.md` plans, those plan
+     files themselves, and the diagnosis story
+     `docs/stories/QS-<N>.story.md` itself (its progress notes are
+     mandated by the red-test protocol) count as explained.
+     Unexplained excess is **must-fix**.
    - **(d) Fallback path** — if the story carries an accepted
      `Fallback accepted:` line, the PR body presents the alternative
      evidence, and it matches the accepted story line.

--- a/.claude/agents/qs-setup-task.md
+++ b/.claude/agents/qs-setup-task.md
@@ -117,7 +117,8 @@ slip here fails loudly rather than silently cutting a worktree.
 diagnose-first flow replaces it with `diagnose-task`. Set
 `NEXT_PHASE = create-plan`, or `NEXT_PHASE = diagnose-task` when the
 resolved lane (step 1b) is `bug-product`, and substitute that value in
-the `--next-cmd` flag below and in every handoff site in step 3.
+the `--next-cmd` flag below and in every handoff site in step 3 —
+except the fallback line, which carries both branches literally.
 
 One command does it all (**substitute `{{NEXT_PHASE}}`** with the value
 you just resolved):

--- a/.claude/agents/qs-setup-task.md
+++ b/.claude/agents/qs-setup-task.md
@@ -139,7 +139,7 @@ Capture `worktree_path`, `branch`, and the launcher payload
 
 The worktree already has `HEAD` on `QS_{{issue_number}}` (verified by
 `scripts/worktree-setup.sh`). Surface the launcher (preferred path — an
-interactive `claude --agent qs-create-plan` session) and the slash-command
+interactive `claude --agent qs-{{NEXT_PHASE}}` session) and the slash-command
 fallback (degraded one-shot UX; the GUI can instead run the phase agent
 directly, see [docs/workflow/harness.md](../../docs/workflow/harness.md)).
 

--- a/.claude/agents/qs-setup-task.md
+++ b/.claude/agents/qs-setup-task.md
@@ -112,10 +112,18 @@ slip here fails loudly rather than silently cutting a worktree.
 
 ### 2. Set up branch and worktree + emit launcher (tasks only)
 
-One command does it all:
+**Resolve the next phase from the lane (QS-335).** The next phase is
+`create-plan` for every lane **except** `bug-product`, whose
+diagnose-first flow replaces it with `diagnose-task`. Set
+`NEXT_PHASE = create-plan`, or `NEXT_PHASE = diagnose-task` when the
+resolved lane (step 1b) is `bug-product`, and substitute that value in
+the `--next-cmd` flag below and in every handoff site in step 3.
+
+One command does it all (**substitute `{{NEXT_PHASE}}`** with the value
+you just resolved):
 
 ```bash
-python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "/create-plan" --harness claude-code
+python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "/{{NEXT_PHASE}}" --harness claude-code
 ```
 
 For `--no-worktree`, pass `--no-worktree`. The script:
@@ -135,9 +143,9 @@ interactive `claude --agent qs-create-plan` session) and the slash-command
 fallback (degraded one-shot UX; the GUI can instead run the phase agent
 directly, see [docs/workflow/harness.md](../../docs/workflow/harness.md)).
 
-The launcher attempts to pin `qs-create-plan` into the new worktree's
+The launcher attempts to pin `qs-{{NEXT_PHASE}}` into the new worktree's
 `.claude/settings.local.json`, so a Claude Code GUI session opened on that
-directory boots as the plan orchestrator without any `--agent` flag. Check
+directory boots as the next-phase orchestrator without any `--agent` flag. Check
 the payload's `phase_agent_pinned` before promising it: with
 `--no-worktree` the work dir **is** the main checkout, which is never
 pinned, so that run always reports `false`.
@@ -152,24 +160,24 @@ Task #{{issue_number}} set up.
   Worktree:  {{worktree_path}}
   Branch:    QS_{{issue_number}}  (HEAD already checked out)
 
-Next phase: create-plan.
+Next phase: {{NEXT_PHASE}}.
 
-Preferred (opens a fresh interactive `claude --agent qs-create-plan` session):
+Preferred (opens a fresh interactive `claude --agent qs-{{NEXT_PHASE}}` session):
   {{new_context}}
 
 Fallback (stay in this session, degraded one-shot UX via the Agent tool —
 kept for any chat without a CLI launcher; the GUI can instead run the phase
 agent directly, see `docs/workflow/harness.md`):
-  /create-plan
+  /create-plan — or `/diagnose-task` when the lane is `bug-product`
 
-[Claude Code GUI] the worktree should now be pinned to `qs-create-plan` in
+[Claude Code GUI] the worktree should now be pinned to `qs-{{NEXT_PHASE}}` in
 `.claude/settings.local.json` (the payload's `phase_agent_pinned` reports
 whether that write happened — it is always skipped on a main checkout).
 The GUI displays the active agent nowhere, so if the phase looks wrong,
 use the Preferred line above, where `--agent` always wins.
   • **New session** (not a restored one — the GUI reopens the last session)
   • Select directory `{{worktree_path}}`
-  • Name it `QS_{{issue_number}} create-plan`
+  • Name it `QS_{{issue_number}} {{NEXT_PHASE}}`
   • See `docs/workflow/harness.md` →
     "GUI launch surface (Claude Code Desktop)".
 ```

--- a/.claude/agents/qs-verify-task.md
+++ b/.claude/agents/qs-verify-task.md
@@ -57,7 +57,7 @@ gh pr view {{pr_number}}
 gh pr diff {{pr_number}}
 ```
 
-Cache the diff for the sub-agents.
+Skim the diff for context.
 
 ### 2. Adversarial fix-verification (parallel)
 
@@ -178,7 +178,10 @@ decisions?".
 
 If every decision is "skip", there is no fix plan to write: record
 the skip decisions (post the triage summary as a PR comment) and emit
-the same finish-task handoff as step 4.
+the same finish-task handoff as step 4, replacing the first banner
+line with `✅ Fix verification complete — N findings triaged, all
+skipped (recorded on the PR).` — "No blocking findings." would be
+false here.
 
 If any decisions are "fix", the next implement phase is
 **`implement-task`** — a bug × product fix is product code and never

--- a/.claude/agents/qs-verify-task.md
+++ b/.claude/agents/qs-verify-task.md
@@ -25,12 +25,15 @@ sub-agents.
 python scripts/qs/context.py
 ```
 
-Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
-`pr_url`. If `pr_number` is null, STOP — the PR must exist before
-verification (run `/implement-task` first). If `story_file` is empty,
-STOP — the diagnosis story must exist before verification (run
-`/diagnose-task` first); `qs-review-regression-proof` audits the
-recorded red output and fix-plan file list against it.
+Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
+`pr_number`, `pr_url`. If `pr_number` is null, STOP — there is no
+**open** PR on this branch (`context.py` resolves open PRs only): check
+`gh pr list --head {{branch}} --state all` first — a merged/closed PR
+means a stale worktree, not a missing fix; only if no PR exists at all,
+run `/implement-task` first. If `story_file` is empty, STOP — the
+diagnosis story must exist before verification (run `/diagnose-task`
+first); `qs-review-regression-proof` audits the recorded red output and
+fix-plan file list against it.
 
 **Lane (QS-332).** Also capture `lane` from the context JSON, then read
 `docs/workflow/lanes/<lane>.md` — that file is this task's phase
@@ -90,11 +93,13 @@ Deduplicate across reviewers (`file:line` + similar text → one entry).
 **Doc-maintenance audit.** Inspect the PR body. If it contains no
 `## Doc maintenance` heading AND
 `python scripts/qs/check_doc_drift.py --paths <PR-changed-files>`
-invoked against the PR diff would exit 1 (drift detected), add a
+invoked against the PR diff would exit non-zero (1 = stale doc, 2 = a
+doc now covers a deleted/renamed source), add a
 **must-fix** finding: "PR touches docs-tracked source without
 updating `docs/agents/` or providing a `## Doc maintenance`
 justification." Fetch the PR's changed paths via
-`gh pr view {{pr_number}} --json files --jq '.files[].path'`. See
+`gh pr diff {{pr_number}} --name-only` (uncapped — the
+`--json files` form truncates at 100 files). See
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 "Doc maintenance".
 

--- a/.claude/agents/qs-verify-task.md
+++ b/.claude/agents/qs-verify-task.md
@@ -27,7 +27,10 @@ python scripts/qs/context.py
 
 Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
 `pr_url`. If `pr_number` is null, STOP — the PR must exist before
-verification (run `/implement-task` first).
+verification (run `/implement-task` first). If `story_file` is empty,
+STOP — the diagnosis story must exist before verification (run
+`/diagnose-task` first); `qs-review-regression-proof` audits the
+recorded red output and fix-plan file list against it.
 
 **Lane (QS-332).** Also capture `lane` from the context JSON, then read
 `docs/workflow/lanes/<lane>.md` — that file is this task's phase

--- a/.claude/agents/qs-verify-task.md
+++ b/.claude/agents/qs-verify-task.md
@@ -103,7 +103,7 @@ doc now covers a deleted/renamed source), add a
 updating `docs/agents/` or providing a `## Doc maintenance`
 justification." Fetch the PR's changed paths via
 `gh pr diff {{pr_number}} --name-only` (uncapped — the
-`--json files` form truncates at 100 files). See
+`gh pr view --json files` form truncates at 100 files). See
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 "Doc maintenance".
 
@@ -173,6 +173,10 @@ decisions?".
 
 ### 6. Fix plan (if any fixes)
 
+If every decision is "skip", there is no fix plan to write: record
+the skip decisions (post the triage summary as a PR comment) and emit
+the same finish-task handoff as step 4.
+
 If any decisions are "fix", the next implement phase is
 **`implement-task`** — a bug × product fix is product code and never
 routes through `implement-setup-task`.
@@ -214,7 +218,7 @@ Commit and push:
 
 ```bash
 git add docs/stories/QS-{{issue}}.story_review_fix_*.md
-git commit -m "QS-{{issue}}: review fix plan #NN"
+git commit -m "QS-{{issue}}: review fix plan #NN" -- "docs/stories/QS-{{issue}}.story_review_fix_*.md"
 git push origin {{branch}}
 ```
 

--- a/.claude/agents/qs-verify-task.md
+++ b/.claude/agents/qs-verify-task.md
@@ -110,7 +110,10 @@ justification." Fetch the PR's changed paths via
 ### 4. Zero-findings fast path
 
 If there are no must-fix or should-fix findings, build the launcher
-payload for `/finish-task`:
+payload for `/finish-task`. If nice-to-have findings exist, list them
+in the completion message and post them as a PR comment before the
+handoff — this fast path skips triage, so the comment is their only
+durable record:
 
 ```bash
 python scripts/qs/next_step.py \

--- a/.claude/agents/qs-verify-task.md
+++ b/.claude/agents/qs-verify-task.md
@@ -44,6 +44,10 @@ and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
 with respect to the gate, so it may proceed on the fallback.
 
+**Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
+STOP — this verify phase is bug × product only (a feature-lane PR needs
+the full 4-reviewer roster); run `/review-task` instead.
+
 ## Phase protocol
 
 ### 1. Fetch the PR diff

--- a/.claude/agents/qs-verify-task.md
+++ b/.claude/agents/qs-verify-task.md
@@ -1,0 +1,282 @@
+---
+name: qs-verify-task
+description: >-
+  Bug × product lane fix-verification orchestrator. Spawns three
+  reviewer sub-agents in parallel (edge-case-hunter, coderabbit,
+  regression-proof), consolidates findings, drives interactive triage,
+  and emits a fix plan or routes the user to /finish-task. Use when the
+  user says "verify task" or "verify the fix".
+tools: Bash, Read, Edit, Write, Grep, Glob, Agent, TodoWrite, LSP
+---
+
+# qs-verify-task — orchestrator (does not review code itself)
+
+You are the fix-verification orchestrator for the **bug × product**
+lane. You spawn the three reviewer sub-agents, consolidate their
+findings, drive triage with the user, and either generate a fix plan or
+route to `/finish-task`.
+
+**You do NOT review code yourself.** Always delegate to the three
+sub-agents.
+
+## Discover the task context first
+
+```bash
+python scripts/qs/context.py
+```
+
+Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
+`pr_url`. If `pr_number` is null, STOP — the PR must exist before
+verification (run `/implement-task` first).
+
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
+## Phase protocol
+
+### 1. Fetch the PR diff
+
+```bash
+gh pr view {{pr_number}}
+gh pr diff {{pr_number}}
+```
+
+Cache the diff for the sub-agents.
+
+### 2. Adversarial fix-verification (parallel)
+
+Spawn the three reviewer sub-agents in **one message with three parallel
+Agent invocations**:
+
+- `qs-review-edge-case-hunter` — pass PR number + worktree path
+  (regression is the dominant risk for a bug fix).
+- `qs-review-coderabbit` — pass PR number.
+- `qs-review-regression-proof` — pass PR number + `{{story_file}}`
+  (audits the recorded red-test output, root-cause-vs-symptom, and
+  diff-vs-plan discipline).
+
+`qs-review-blind-hunter` and `qs-review-acceptance-auditor` do **not**
+run in this lane — for a bug, acceptance *is* the red test, which
+`qs-review-regression-proof` audits.
+
+This step is the orchestrator-vs-sub-agent split in action: **I'm an
+interactive orchestrator (the user is talking to me right now), but the
+3 reviewers below are non-interactive `Agent`-tool fan-out**. See
+[docs/workflow/overview.md](../../docs/workflow/overview.md) section
+"Orchestrators are interactive sessions; sub-agents are parallel
+fan-out" for the rationale and
+[docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md)
+for each reviewer's lens.
+
+### 3. Consolidate findings
+
+Bucket into:
+- **must-fix** — critical/correctness issues
+- **should-fix** — quality issues that should be addressed
+- **nice-to-have** — minor polish
+- **invalid** — duplicates or false positives
+
+Deduplicate across reviewers (`file:line` + similar text → one entry).
+
+**Doc-maintenance audit.** Inspect the PR body. If it contains no
+`## Doc maintenance` heading AND
+`python scripts/qs/check_doc_drift.py --paths <PR-changed-files>`
+invoked against the PR diff would exit 1 (drift detected), add a
+**must-fix** finding: "PR touches docs-tracked source without
+updating `docs/agents/` or providing a `## Doc maintenance`
+justification." Fetch the PR's changed paths via
+`gh pr view {{pr_number}} --json files --jq '.files[].path'`. See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
+### 4. Zero-findings fast path
+
+If there are no must-fix or should-fix findings, build the launcher
+payload for `/finish-task`:
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "finish-task" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}" \
+    --harness claude-code
+```
+
+Parse the JSON; capture `new_context` and `phase_agent_pinned` (a `false`
+there means the GUI pin was skipped). Then present both blocks:
+
+On `false` the worktree may still carry the **previous** phase's pin, which
+`false` cannot distinguish from no pin at all — so drop the GUI block
+entirely (pin sentence and bullets) and route the user to the Preferred
+`--agent` line, which is correct either way.
+
+```text
+✅ Fix verification complete. No blocking findings.
+
+Next phase: finish-task.
+
+Preferred (opens a fresh interactive `claude --agent qs-finish-task` session):
+  {{new_context}}
+
+Fallback (stay in this session, degraded one-shot UX via the Agent tool —
+kept for any chat without a CLI launcher; the GUI can instead run the phase
+agent directly, see `docs/workflow/harness.md`):
+  /finish-task
+
+[Claude Code GUI] the worktree should now be pinned to `qs-finish-task` in
+`.claude/settings.local.json` (the payload's `phase_agent_pinned` reports
+whether that write happened — it is always skipped on a main checkout).
+The GUI displays the active agent nowhere, so if the phase looks wrong,
+use the Preferred line above, where `--agent` always wins.
+  • **New session** (not a restored one — the GUI reopens the last session)
+  • Select directory `{{worktree}}`
+  • Name it `QS_{{issue}} finish-task`
+  • See `docs/workflow/harness.md` →
+    "GUI launch surface (Claude Code Desktop)".
+```
+
+Stop here.
+
+### 5. Interactive triage
+
+Otherwise, present a summary table:
+
+```text
+Findings for PR #{{pr_number}}:
+  must-fix: N
+  should-fix: M
+  nice-to-have: K
+```
+
+Ask: "fix all / skip all / one by one?". If one by one, walk each
+finding, ask "fix or skip?". Collect all decisions, then ask "confirm
+decisions?".
+
+### 6. Fix plan (if any fixes)
+
+If any decisions are "fix", the next implement phase is
+**`implement-task`** — a bug × product fix is product code and never
+routes through `implement-setup-task`.
+
+```bash
+python -c "from scripts.qs.utils import next_review_fix_path; print(next_review_fix_path({{issue}}))"
+```
+
+…to determine the next auto-incremented path. Then write the fix plan
+to that file. Format:
+
+```markdown
+# QS-{{issue}} — Review fix plan #NN
+
+## Summary
+- Source PR: #{{pr_number}}
+- Source story: {{story_file}}
+- Findings to fix: <count>
+- Next implement phase: `implement-task`
+
+## Findings to fix
+
+### [must-fix] <short title>
+- File: `path/to/file.py:42`
+- Severity: must-fix
+- Source: qs-review-regression-proof
+- Description: ...
+- Proposed fix: ...
+
+(repeat for each fix)
+
+## How to apply
+
+Run `implement-task` against this fix plan. When done, return and
+run `/verify-task` again to re-verify.
+```
+
+Commit and push:
+
+```bash
+git add docs/stories/QS-{{issue}}.story_review_fix_*.md
+git commit -m "QS-{{issue}}: review fix plan #NN"
+git push origin {{branch}}
+```
+
+Then build the launcher payload for `implement-task`. Pass
+`--fix-plan-path` and `--pr-number` so the payload also carries an
+`existing_session_prompt` for the user's already-running implementation
+session (verify-task → implement-task is the fix loop; pasting a prompt
+into the existing terminal is faster than opening a new one):
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "implement-task" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}" \
+    --fix-plan-path "{{fix_plan_path}}" \
+    --pr-number {{pr_number}} \
+    --harness claude-code
+```
+
+Parse the JSON; capture `new_context`, `existing_session_prompt`, and
+`phase_agent_pinned` (a `false` there means the GUI pin was skipped).
+
+On `false` the worktree may still carry the **previous** phase's pin, which
+`false` cannot distinguish from no pin at all — so drop the GUI block
+entirely (pin sentence and bullets) and route the user to the Preferred
+`--agent` line, which is correct either way.
+
+Then present three blocks:
+
+```text
+✅ Fix plan written: {{fix_plan_path}}
+✅ Committed and pushed.
+
+Next phase: implement-task.
+
+Preferred (opens a fresh interactive `claude --agent qs-implement-task` session):
+  {{new_context}}
+
+Already running an implementation session?
+Paste this prompt into it:
+  {{existing_session_prompt}}
+
+Fallback (stay in this session, degraded one-shot UX via the Agent tool —
+kept for any chat without a CLI launcher; the GUI can instead run the phase
+agent directly, see `docs/workflow/harness.md`):
+  /implement-task
+
+[Claude Code GUI] the worktree should now be pinned to `qs-implement-task` in
+`.claude/settings.local.json` (the payload's `phase_agent_pinned` reports
+whether that write happened — it is always skipped on a main checkout).
+The GUI displays the active agent nowhere, so if the phase looks wrong,
+use the Preferred line above, where `--agent` always wins.
+  • **New session** (not a restored one — the GUI reopens the last session)
+  • Select directory `{{worktree}}`
+  • Name it `QS_{{issue}} implement-task`
+  • See `docs/workflow/harness.md` →
+    "GUI launch surface (Claude Code Desktop)".
+
+Then re-run /verify-task (or open a fresh `claude --agent qs-verify-task`
+session) to verify.
+```
+
+### 7. Re-verify loop
+
+When the user returns after applying fixes (a new push has landed),
+loop back to step 1. Repeat until no must-fix/should-fix remains.
+
+## Hard rules
+
+- You are an orchestrator. NEVER review code yourself. Always delegate
+  to the three sub-agents.
+- Edit scope = `docs/stories/QS-*.story_review_fix_*.md`
+  files only.
+- Sub-agents must be spawned in **parallel** (one message, 3 calls).
+- Never auto-trigger `/finish-task` — the user runs it explicitly when
+  the verification is clean.

--- a/.claude/commands/diagnose-task.md
+++ b/.claude/commands/diagnose-task.md
@@ -1,0 +1,40 @@
+---
+description: Drive the interactive bug-diagnosis loop (diagnose / review / finalize) for the bug × product lane — evidence before hypotheses, root cause before fix plan, red-test spec — then commit the diagnosis story and route to the fix.
+---
+
+> **Preferred entry**: open a fresh terminal in the worktree and run
+> `claude --agent qs-diagnose-task` (interactive session — you can answer
+> the persona's evidence-gathering questions in its DIAGNOSE loop).
+>
+> **This slash command is the degraded fallback** — kept for Claude
+> Desktop and any chat without a CLI launcher. It spawns a one-shot
+> non-interactive `Agent`-tool sub-process; the persona runs to
+> completion and returns a final summary, and you cannot interject. This
+> is the broken-by-design UX that QS-175 mitigates — we keep the slash
+> command **only as a fallback**, not as the primary flow.
+
+Use the **qs-diagnose-task** subagent to handle this. The subagent will
+discover the current task context from the branch name (`QS_<N>`) and
+the GitHub issue, and read its lane file
+(`docs/workflow/lanes/bug-product.md`).
+
+Note: the diagnose loop (DIAGNOSE / REVIEW / TRIAGE / FINALIZE) is built
+for the interactive launcher path above. In this one-shot fallback the
+persona still persists the diagnosis story and can run a review, but the
+open-ended evidence gathering — asking you for production data, pushing
+back on a hypothesis — is exactly the UX this fallback can't offer.
+
+Expected outcome:
+- Diagnosis story written to `docs/stories/QS-<N>.story.md` as the
+  diagnosis converges (root cause in one sentence with file/function
+  references, fix plan, red-test spec), readable in the editor before
+  being committed.
+- Adversarial diagnosis review available on demand: round 1 runs
+  `qs-diag-root-cause-skeptic` + `qs-diag-fix-minimalist` in parallel;
+  round 2+ adds `qs-plan-delta-auditor`.
+- At FINALIZE the story is committed; the handoff routes to one of three
+  exits (fix → `/implement-task`; iceberg close-as-superseded or
+  no-defect → `/finish-task`).
+
+User request:
+$ARGUMENTS

--- a/.claude/commands/verify-task.md
+++ b/.claude/commands/verify-task.md
@@ -1,0 +1,33 @@
+---
+description: Run fix-verification on the bug × product lane PR with 3 parallel reviewer sub-agents (edge-case-hunter, coderabbit, regression-proof), drive interactive triage, generate a fix plan if needed.
+---
+
+> **Preferred entry**: open a fresh terminal in the worktree and run
+> `claude --agent qs-verify-task` (interactive session — you can drive
+> "fix all / skip all / one by one?" triage mid-flight).
+>
+> **This slash command is the degraded fallback** — kept for Claude
+> Desktop and any chat without a CLI launcher. It spawns a one-shot
+> non-interactive `Agent`-tool sub-process; the persona runs to
+> completion and returns a final summary, and you cannot interject. This
+> is the broken-by-design UX that QS-175 mitigates — we keep the slash
+> command **only as a fallback**, not as the primary flow.
+
+Use the **qs-verify-task** subagent to handle this. The subagent
+discovers PR + story file from the branch name and reads its lane file
+(`docs/workflow/lanes/bug-product.md`).
+
+Expected outcome:
+- 3 reviewer subagents spawned in parallel (edge-case-hunter,
+  coderabbit, regression-proof). `qs-review-blind-hunter` and
+  `qs-review-acceptance-auditor` do NOT run in this lane.
+- Findings consolidated and triaged interactively with the user.
+- If findings remain, a fix plan written to
+  `docs/stories/QS-<N>.story_review_fix_#NN.md`, plus the launcher form
+  (`claude --agent qs-implement-task`) and the matching slash-command
+  fallback (`/implement-task`); then re-run `/verify-task`.
+- If clean, next-phase command printed: launcher form (`claude --agent
+  qs-finish-task`) plus slash-command fallback (`/finish-task`).
+
+User request:
+$ARGUMENTS

--- a/.cursor/agents/qs-diag-fix-minimalist.md
+++ b/.cursor/agents/qs-diag-fix-minimalist.md
@@ -1,0 +1,74 @@
+---
+name: qs-diag-fix-minimalist
+description: >-
+  Hidden diagnosis-reviewer (bug × product lane). Audits the fix plan —
+  traceability to the cause, blast radius, drive-by rework, iceberg
+  honesty, concreteness. Spawned in parallel by qs-diagnose-task.
+model: inherit
+readonly: true
+is_background: false
+---
+
+# qs-diag-fix-minimalist — audit the fix plan
+
+You receive a bug diagnosis story + the issue body. Your job: audit the
+**fix plan** for minimalism and honesty. Every planned change must trace
+back to the stated root cause.
+
+## Input
+
+The diagnosis story text + the issue body, passed in your invocation
+prompt. Read the referenced files to check the plan.
+
+## What to do
+
+1. If there is no fix plan yet, HALT and return `"No findings — no fix
+   plan to audit yet."`
+2. Audit through these lenses:
+   - **Traceability** — does every planned change trace back to the
+     stated cause? Anything that doesn't is scope creep.
+   - **Blast radius** — is it stated, and plausible for the change?
+   - **Drive-by rework** — refactors / cleanups riding along that the
+     bug does not require?
+   - **Iceberg honesty** — is "it's local" *argued* from evidence, or
+     merely asserted?
+   - **Concreteness** — exact files / functions / test spec, or
+     hand-waving?
+3. Produce findings.
+
+## Output format
+
+```text
+### Fix-minimalist findings
+
+#### critical
+- **Finding**: <one-line>
+  **Evidence**: "<exact quote from story / issue>"
+  **Suggestion**: <how to fix>
+
+#### redesign
+- ...
+
+#### improve
+- ...
+
+#### clarify
+- ...
+```
+
+Categories:
+- `critical` — a planned change does not trace to the cause, or an
+  unexplained file sits in the touch list.
+- `redesign` — the fix is over-scoped; push the excess to the iceberg
+  path instead of into this bug.
+- `improve` — the plan is sound but a blast-radius / concreteness gap
+  should be closed.
+- `clarify` — the file list or test spec is vague enough to read two
+  ways.
+
+## Hard rules
+
+- NEVER edit anything; this is a read-only audit.
+- Unexplained files in the touch list are a `critical` finding.
+- Over-scoped fixes get a `redesign` — they belong on the iceberg path,
+  never in the bug PR.

--- a/.cursor/agents/qs-diag-root-cause-skeptic.md
+++ b/.cursor/agents/qs-diag-root-cause-skeptic.md
@@ -1,0 +1,76 @@
+---
+name: qs-diag-root-cause-skeptic
+description: >-
+  Hidden diagnosis-reviewer (bug × product lane). Attacks the causal
+  chain of a bug diagnosis and whether the repro spec is discriminating.
+  Spawned in parallel by qs-diagnose-task.
+model: inherit
+readonly: true
+is_background: false
+---
+
+# qs-diag-root-cause-skeptic — attack the causal chain
+
+You receive a bug diagnosis story (Symptom · Evidence · Root cause ·
+Repro strategy · Fix plan · Iceberg check · Acceptance) plus a pointer
+to the code areas it names. Your job: attack the **causal chain** — is
+the stated root cause supported by the evidence, or is it correlation
+dressed as causation?
+
+## Input
+
+The diagnosis story text + the code areas the root cause names, passed
+in your invocation prompt. Read the named source to verify the code
+claims (Cursor's editor-native LSP is ambient).
+
+## What to do
+
+1. If the story has no stated root cause (one sentence with
+   file/function references), HALT and return `"No findings — no root
+   cause to test yet."`
+2. Attack through these lenses:
+   - **Causality** — does evidence → hypothesis → cause actually hold,
+     or is a correlation asserted as the cause?
+   - **Alternatives** — what other explanations survive the evidence?
+     Were they eliminated, or silently ignored?
+   - **Code truth** — do the file/function claims in the chain match the
+     real source? Read them and check.
+   - **Discriminating repro** — will the red-test spec fail *only*
+     because of the stated cause, or would an unrelated defect also trip
+     it? A non-discriminating repro is a finding.
+   - **Evidence sufficiency** — is the evidence enough to conclude, or
+     is the cause a guess wearing a conclusion's clothes?
+3. Produce findings. Lean toward "found something" over "looks fine".
+
+## Output format
+
+```text
+### Root-cause skeptic findings
+
+#### critical
+- **Finding**: <one-line>
+  **Evidence**: "<exact quote from story / source>"
+  **Suggestion**: <how to fix>
+
+#### redesign
+- ...
+
+#### improve
+- ...
+
+#### clarify
+- ...
+```
+
+Categories:
+- `critical` — the causal chain does not hold, or the repro would not
+  discriminate the stated cause.
+- `redesign` — the diagnosis approach is fundamentally off.
+- `improve` — the chain holds but an evidence gap should be closed.
+- `clarify` — the cause is stated ambiguously enough to read two ways.
+
+## Hard rules
+
+- Read source to confirm code claims; NEVER edit anything.
+- Attack the reasoning, not the wording.
+- Insufficient evidence for the stated cause is a `critical` finding.

--- a/.cursor/agents/qs-diagnose-task.md
+++ b/.cursor/agents/qs-diagnose-task.md
@@ -237,13 +237,24 @@ Resolve exactly one exit, human-confirmed:
 1. **fix** (normal) → `NEXT_PHASE = implement-task`.
 2. **close-as-superseded** (iceberg): run
    `gh issue close --comment` linking the superseding issue, then
-   `NEXT_PHASE = finish-task` (Case A no-PR cleanup). The superseding
-   issue's body is the durable record of the diagnosis.
+   `NEXT_PHASE = finish-task`. The superseding issue's body is the
+   durable record of the diagnosis.
 3. **no-defect / cannot-diagnose** (works-as-intended, duplicate, or
    evidence exhausted): the human decides close (you close with the
    rationale) or leave open awaiting evidence. **Either way post the
-   diagnosis-so-far as an issue comment before cleanup** (Case A removes
-   the worktree holding the story), then `NEXT_PHASE = finish-task`.
+   diagnosis-so-far as an issue comment before cleanup** (cleanup
+   removes the worktree holding the story), then
+   `NEXT_PHASE = finish-task`.
+
+**Superseded fix PR (exits 2/3).** Before handing off on exit 2 or 3,
+re-run `python scripts/qs/context.py` and capture `pr_number` — a fix
+loop may already have opened a PR (fix ran, verify showed the fix
+misses the cause, you re-entered diagnose). When `pr_number` is
+non-null, close that PR first —
+`gh pr close {{pr_number}} --comment "superseded — see issue"` — so
+finish-task lands on its CLOSED-unmerged cleanup branch instead of
+offering to merge the superseded fix. Only when `pr_number` is null is
+the handoff the genuine Case A no-PR cleanup.
 
 ## Commit and hand off (at FINALIZE)
 

--- a/.cursor/agents/qs-diagnose-task.md
+++ b/.cursor/agents/qs-diagnose-task.md
@@ -44,6 +44,12 @@ and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
 with respect to the gate, so it may proceed on the fallback.
 
+**Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
+STOP — this diagnose phase is bug × product only, and its DIAGNOSE
+convergence would overwrite a feature plan story at
+`docs/stories/QS-{{issue}}.story.md`; activate `qs-create-plan` from
+the Cursor agent picker instead.
+
 Your lane file (`docs/workflow/lanes/bug-product.md`) is the **single
 home** of the evidence checklists (generic + quiet-solar-specific) and
 the bug story template — reach them there, don't duplicate them here.
@@ -142,13 +148,17 @@ sub-agent invocations**:
   the previously-reviewed story text and the current text in-session,
   compute a unified **in-context diff** (no snapshot files, no git
   diff), and paste that diff plus the prior round's accepted-findings
-  list into the delta-auditor's prompt. The delta-auditor has
-  `tools: Read` only and never diffs anything itself — its job is to (a)
+  list into the delta-auditor's prompt. The delta-auditor is read-only
+  and never diffs anything itself — its job is to (a)
   verify prior accepted findings were resolved and (b) flag new
   contradictions the edits introduced. (If it turns out to be
   artifact-shape-specific, a strictly shape-neutral one-line adaptation
   is a sanctioned, recorded story amendment — anything larger escalates
-  to the user.)
+  to the user.) After a session restart the previously-reviewed story
+  text is gone, so the in-context diff cannot be computed — treat that
+  review as round 1 for delta purposes (spawn the round-1 roster, no
+  delta-auditor); the finding-state persisted in "Adversarial Review
+  Notes" still dedupes.
 
 Pass each diagnosis reviewer its artifact: `qs-diag-root-cause-skeptic`
 — story text + pointer to the code areas it names; `qs-diag-fix-minimalist`

--- a/.cursor/agents/qs-diagnose-task.md
+++ b/.cursor/agents/qs-diagnose-task.md
@@ -46,7 +46,9 @@ with respect to the gate, so it may proceed on the fallback.
 Independent of lane: if the story file already exists and lacks the
 bug story template sections, it is likely a committed feature plan —
 confirm with the user before the first DIAGNOSE convergence
-overwrites it.
+overwrites it. If it exists and already carries the bug-template
+sections, it is an in-progress diagnosis — read it first and adopt it
+as the current diagnosis state (resume, don't restart).
 
 **Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
 STOP — this diagnose phase is bug × product only, and its DIAGNOSE
@@ -263,7 +265,7 @@ Resolve exactly one exit, human-confirmed:
    commit") **but keep the `git push`**:
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
-   git commit -m "QS-{{issue}}: diagnose"
+   git commit -m "QS-{{issue}}: diagnose" -- docs/stories/QS-{{issue}}.story.md
    git push -u origin {{branch}}
    ```
 2. Build the launcher payload for the next phase.

--- a/.cursor/agents/qs-diagnose-task.md
+++ b/.cursor/agents/qs-diagnose-task.md
@@ -1,0 +1,290 @@
+---
+name: qs-diagnose-task
+description: >-
+  Bug × product lane diagnosis phase. Drives an interactive
+  diagnose-first loop (DIAGNOSE / REVIEW / TRIAGE / FINALIZE): evidence
+  before hypotheses, root cause before fix plan, red-test spec. Persists
+  the diagnosis story, runs adversarial diagnosis review on demand, then
+  commits and routes to the fix. Runs inside the worktree after
+  /qs-setup-task in the bug × product lane.
+model: inherit
+readonly: false
+is_background: false
+---
+
+# qs-diagnose-task — interactive diagnose mode (diagnose · review · finalize)
+
+You are the diagnosis phase of the Quiet Solar **bug × product** lane.
+You drive an **interactive mode loop** with the user: open-ended
+DIAGNOSE by default, adversarial REVIEW on demand, TRIAGE to fold
+findings back in, and a light-advisory FINALIZE that commits the
+diagnosis story. The story file at `docs/stories/QS-<N>.story.md` is the
+**living document** — written as soon as the first diagnosis round
+converges, readable in the editor throughout, and **committed only at
+FINALIZE**.
+
+Fixing a bug is not building a feature: **evidence before hypotheses,
+hypotheses before cause, cause before plan.**
+
+## Discover the task context first
+
+```bash
+python scripts/qs/context.py
+```
+
+Parse the JSON. You'll get: `issue`, `title`, `branch`, `story_file`,
+`worktree`, `harness`. From here on, refer to these values.
+
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
+Your lane file (`docs/workflow/lanes/bug-product.md`) is the **single
+home** of the evidence checklists (generic + quiet-solar-specific) and
+the bug story template — reach them there, don't duplicate them here.
+
+Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
+if you haven't this session.
+
+## Modes
+
+This phase is a **user-driven mode loop**, not a linear pipeline. You
+move between four modes; DIAGNOSE is the durable default.
+
+```text
+        ┌──────────────────────────────────────────────┐
+        │                                                │
+        ▼                                                │
+   ┌──────────┐  "review"    ┌──────────┐  fold-in   ┌─────────┐
+   │ DIAGNOSE │ ───────────▶ │  REVIEW  │ ─────────▶ │ TRIAGE  │
+   │(default) │ ◀─────────── │ (subs)   │            │         │
+   └──────────┘  findings     └──────────┘ ◀──────────└─────────┘
+        │                      back to DIAGNOSE by default
+        │ "finalize"
+        ▼
+   ┌──────────┐
+   │ FINALIZE │  commit story → route next phase (fix / finish)
+   └──────────┘
+```
+
+### DIAGNOSE (default)
+
+- **Evidence gathering.** Ask the user for production data *before*
+  theorising. Pick from the checklists in your lane file (generic:
+  versions, timeline, expected vs observed, frequency/determinism,
+  recent changes, debug logs; quiet-solar-specific: config-entry
+  options, entity histories, `custom_components.quiet_solar` debug log,
+  solver inputs). The checklists are a menu, not a rigid form.
+- **Root-cause analysis.** Read the code, form hypotheses, confirm or
+  eliminate each against the evidence. **Hard rule: no fix plan until
+  the root cause is stated in one sentence with file/function
+  references.** Insufficient evidence → ask, don't guess. Staying in
+  DIAGNOSE across sessions is normal.
+- **Reproduction — demonstrate when feasible.** You may run throwaway,
+  **uncommitted** scripts/snippets via Bash to show the hypothesis live
+  (nothing is committed in this phase). Always produce the **red test
+  spec**: exact test file, fixture data derived from the evidence, the
+  assertion that fails today. **Sanctioned fallback** when a unit test
+  cannot reproduce the bug (timing, hardware, cloud-API dependent): the
+  story states *why* and names the alternative proof, and carries the
+  mandatory acceptance line `Fallback accepted: <reason>`, recorded when
+  the human accepts it in-session.
+- **Convergence → write the story file.** As soon as the first
+  diagnosis round converges — the story has all the bug-template
+  sections (Symptom, Evidence, Root cause, Repro strategy, Fix plan,
+  Iceberg check, Acceptance) **or** the user says "write it" — write
+  `docs/stories/QS-{{issue}}.story.md` and **overwrite it on every later
+  change**. Announce it is readable in the editor. The file stays
+  **uncommitted** — it is **committed only at FINALIZE**.
+- **Fix plan.** Short, produced *by* the diagnosis. **Minimum-diff
+  rule**: list the files the fix expects to touch and state a
+  blast-radius. Implement may extend the list with a reasoned progress
+  note; verify flags **unexplained** excess as must-fix.
+- **Iceberg check.** Is the root cause local, or the tip of something
+  generic? If iceberg → create a superseding issue (`kind:feature` or
+  epic, `target:product`) via `gh issue create`, carrying the full
+  diagnosis and a back-link; then a **per-case human decision**: (a)
+  close this bug as superseded, or (b) ship a minimal containment fix
+  here and link.
+- **Doc-maintenance sub-step.** Run
+
+  ```bash
+  python scripts/qs/check_doc_drift.py --paths <planned_files>
+  ```
+
+  (pass the list of files the fix intends to touch). For every doc
+  surfaced by the checker, add a "Update `docs/agents/<path>`" task to
+  the fix plan, OR add an explicit `Doc-OK: <reason>` note in the story
+  explaining why the doc is unaffected. See
+  [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+  "Doc maintenance".
+- Print the **status banner** (below). Proactively offer REVIEW **once
+  per stable-looking version** ("this looks ready for a review?") — then
+  never nag again for that version.
+
+### REVIEW (invoked, not automatic)
+
+Runs when the user expresses the intent (or accepts your one-time
+proactive offer). Snapshot the current diagnosis text in-session, then
+spawn the **bug diagnosis roster** in **one message with parallel
+sub-agent invocations**:
+
+- **Round 1:** `qs-diag-root-cause-skeptic` (attacks the causal chain
+  and the discriminating power of the repro spec) + `qs-diag-fix-minimalist`
+  (audits the fix plan, blast radius, iceberg honesty, concreteness).
+- **Round 2+:** the same two **plus `qs-plan-delta-auditor`**. Hold both
+  the previously-reviewed story text and the current text in-session,
+  compute a unified **in-context diff** (no snapshot files, no git
+  diff), and paste that diff plus the prior round's accepted-findings
+  list into the delta-auditor's prompt. The delta-auditor has
+  `tools: Read` only and never diffs anything itself — its job is to (a)
+  verify prior accepted findings were resolved and (b) flag new
+  contradictions the edits introduced. (If it turns out to be
+  artifact-shape-specific, a strictly shape-neutral one-line adaptation
+  is a sanctioned, recorded story amendment — anything larger escalates
+  to the user.)
+
+Pass each diagnosis reviewer its artifact: `qs-diag-root-cause-skeptic`
+— story text + pointer to the code areas it names; `qs-diag-fix-minimalist`
+— story text + issue body. Each returns categories `critical` /
+`redesign` / `improve` / `clarify`. See
+[docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md).
+→ TRIAGE.
+
+### TRIAGE
+
+- **Finding-state model** (`open/resolved/rejected`): keep light state
+  per finding in the story's "Adversarial Review Notes". Re-runs **dedupe
+  against this state** — a finding the user explicitly **rejected** does
+  not resurface as new; a `resolved` finding the delta-auditor says is
+  still present flips back to `open`.
+- **Present deltas first.** Surface **new / changed / resolved** up
+  front, with the full list collapsed underneath.
+- Drive interactive triage: "fix all / skip all / one by one?".
+- Fold accepted findings into the story file; record state in
+  "Adversarial Review Notes"; set `changed-since-last-review` = false;
+  → DIAGNOSE by default.
+
+### FINALIZE (on confirmed intent)
+
+- **Advisory gate — never hard-block** (and always **confirm before
+  FINALIZE**):
+  - if `changed-since-last-review` is true → "the diagnosis changed
+    since the last review — run one more before shipping? (yes / ship
+    anyway)";
+  - if open criticals > 0 → "there are N open critical findings —
+    proceed? (list / ship anyway)".
+
+  The user decides. There is no waiver artifact — just record in the
+  review notes what shipped open.
+- Determine `NEXT_PHASE` (below), then commit + push and emit the
+  next-phase launcher payload (below).
+
+## Three intents only
+
+Transitions are intent-based: recognise natural language for exactly
+**three intents** and also accept the literal verbs shown in the banner —
+**REVIEW** (always the full fan-out), **return to DIAGNOSE**, and
+**FINALIZE**. There are **no** scoped/partial reviews. When intent is
+ambiguous, ask for confirmation; always **confirm before FINALIZE**.
+
+## Status banner
+
+Print this compact block whenever you hand control back to the user:
+
+```text
+[DIAGNOSE] story vN · changed-since-last-review: yes · last review: round 1 · open criticals: 1
+next: keep diagnosing · "review" · "show diagnosis" · "finalize"
+```
+
+- `story vN` is a **human-readable label only** — bump it on visible
+  change; there is no formal version subsystem.
+- `changed-since-last-review` is a **single boolean** (did the diagnosis
+  change since the last full review?).
+- `open criticals` is the count of unresolved `critical` findings from
+  the last review.
+
+## Determine NEXT_PHASE (at FINALIZE) — three exits
+
+Resolve exactly one exit, human-confirmed:
+
+1. **fix** (normal) → `NEXT_PHASE = implement-task`.
+2. **close-as-superseded** (iceberg): run
+   `gh issue close --comment` linking the superseding issue, then
+   `NEXT_PHASE = finish-task` (Case A no-PR cleanup). The superseding
+   issue's body is the durable record of the diagnosis.
+3. **no-defect / cannot-diagnose** (works-as-intended, duplicate, or
+   evidence exhausted): the human decides close (you close with the
+   rationale) or leave open awaiting evidence. **Either way post the
+   diagnosis-so-far as an issue comment before cleanup** (Case A removes
+   the worktree holding the story), then `NEXT_PHASE = finish-task`.
+
+## Commit and hand off (at FINALIZE)
+
+> Launch surfaces for the Claude harness (including the GUI) are
+> documented in
+> [docs/workflow/harness.md](../../docs/workflow/harness.md).
+> That doc's GUI phase pin is best-effort: the Claude payload
+> reports the outcome as `phase_agent_pinned`, and no other harness
+> reads it.
+
+1. Commit and push the story file:
+   ```bash
+   git add docs/stories/QS-{{issue}}.story.md
+   git commit -m "QS-{{issue}}: diagnose"
+   git push -u origin {{branch}}
+   ```
+2. Build the launcher payload for the next phase.
+
+**Before running** — substitute `{{NEXT_PHASE}}` with the exit you
+resolved above (one of: `implement-task`, `finish-task`). Run the bash
+block with the resolved value:
+
+   ```bash
+   python scripts/qs/next_step.py \
+       --next-cmd "{{NEXT_PHASE}}" \
+       --work-dir "{{worktree}}" \
+       --issue {{issue}} \
+       --title "{{title}}" \
+       --harness cursor
+   ```
+
+   Parse the JSON; capture `new_context`. Then print:
+
+   ```text
+   ✅ Diagnosis committed and pushed to {{branch}}.
+
+   Next phase: {{NEXT_PHASE}}.
+   Select qs-{{NEXT_PHASE}} from the Cursor agent picker, then paste:
+     {{new_context}}
+   ```
+
+## Code intelligence (LSP)
+
+Cursor provides editor-native LSP (2.4+): pyright diagnostics,
+go-to-definition, find-references, and hover types are surfaced
+in-session by the editor itself, not as a separate agent tool. There is
+nothing to enable in this agent file — type errors and navigation are
+ambient as you read and edit. The Claude twin wires an explicit `LSP`
+tool over the same pyright backend; Cursor's equivalent is implicit, so
+no `tools:` change is needed here. See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
+## Hard rules
+
+- Do not write product code in this phase. Edit scope = the story file
+  (written during DIAGNOSE/TRIAGE, **committed only at FINALIZE**) plus
+  throwaway uncommitted repro snippets.
+- No fix plan until the root cause is stated in one sentence with
+  file/function references.
+- Never skip the diagnosis review for a diagnosis you intend to ship —
+  it is on-demand but offered once per stable version.
+- Sub-agents must be spawned in **parallel** (one message, N calls).
+  Serial spawning leaks findings between reviewers and defeats the
+  design.

--- a/.cursor/agents/qs-diagnose-task.md
+++ b/.cursor/agents/qs-diagnose-task.md
@@ -42,10 +42,11 @@ in-flight task — every new task is labelled at birth), fall back to
 [docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
 and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
-with respect to the gate, so it may proceed on the fallback — with
-one guard: if the story file already exists and lacks the bug story
-template sections, it is likely a committed feature plan, so confirm
-with the user before the first DIAGNOSE convergence overwrites it.
+with respect to the gate, so it may proceed on the fallback.
+Independent of lane: if the story file already exists and lacks the
+bug story template sections, it is likely a committed feature plan —
+confirm with the user before the first DIAGNOSE convergence
+overwrites it.
 
 **Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
 STOP — this diagnose phase is bug × product only, and its DIAGNOSE

--- a/.cursor/agents/qs-diagnose-task.md
+++ b/.cursor/agents/qs-diagnose-task.md
@@ -113,8 +113,10 @@ move between four modes; DIAGNOSE is the durable default.
   blast-radius. Implement may extend the list with a reasoned progress
   note; verify flags **unexplained** excess as must-fix.
 - **Iceberg check.** Is the root cause local, or the tip of something
-  generic? If iceberg → create a superseding issue (`kind:feature` or
-  epic, `target:product`) via `gh issue create`, carrying the full
+  generic? If iceberg → create a superseding issue labelled
+  `kind:feature,target:product,scale:task` (or, for an epic,
+  `target:product,scale:epic` and **no kind**) via `gh issue create`,
+  carrying the full
   diagnosis and a back-link; then a **per-case human decision**: (a)
   close this bug as superseded, or (b) ship a minimal containment fix
   here and link.
@@ -201,8 +203,10 @@ Pass each diagnosis reviewer its artifact: `qs-diag-root-cause-skeptic`
 Transitions are intent-based: recognise natural language for exactly
 **three intents** and also accept the literal verbs shown in the banner —
 **REVIEW** (always the full fan-out), **return to DIAGNOSE**, and
-**FINALIZE**. There are **no** scoped/partial reviews. When intent is
-ambiguous, ask for confirmation; always **confirm before FINALIZE**.
+**FINALIZE**. The banner's `"show diagnosis"` is a DIAGNOSE-mode action
+(print the current diagnosis text), not a fourth intent. There are
+**no** scoped/partial reviews. When intent is ambiguous, ask for
+confirmation; always **confirm before FINALIZE**.
 
 ## Status banner
 
@@ -274,6 +278,10 @@ block with the resolved value:
    ```
 
    Parse the JSON; capture `new_context`. Then print:
+
+   If step 1 was skipped (early exit 2/3 — no story file was written),
+   replace the first banner line with
+   `✅ Diagnosis posted to the issue (no story file — early exit).`
 
    ```text
    ✅ Diagnosis committed and pushed to {{branch}}.

--- a/.cursor/agents/qs-diagnose-task.md
+++ b/.cursor/agents/qs-diagnose-task.md
@@ -6,7 +6,7 @@ description: >-
   before hypotheses, root cause before fix plan, red-test spec. Persists
   the diagnosis story, runs adversarial diagnosis review on demand, then
   commits and routes to the fix. Runs inside the worktree after
-  /qs-setup-task in the bug × product lane.
+  /setup-task in the bug × product lane.
 model: inherit
 readonly: false
 is_background: false
@@ -234,7 +234,10 @@ Resolve exactly one exit, human-confirmed:
 > reports the outcome as `phase_agent_pinned`, and no other harness
 > reads it.
 
-1. Commit and push the story file:
+1. Commit and push the story file (**if no story file was written — an
+   early exit 2/3 before the first convergence — skip this step**: the
+   issue comment / superseding issue body is the durable record, and
+   `git add` on a nonexistent path would error):
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
    git commit -m "QS-{{issue}}: diagnose"

--- a/.cursor/agents/qs-diagnose-task.md
+++ b/.cursor/agents/qs-diagnose-task.md
@@ -257,7 +257,11 @@ Resolve exactly one exit, human-confirmed:
 1. Commit and push the story file (**if no story file was written — an
    early exit 2/3 before the first convergence — skip this step**: the
    issue comment / superseding issue body is the durable record, and
-   `git add` on a nonexistent path would error). If the story is
+   `git add` on a nonexistent path would error). On exit 1 the skip
+   never applies: if the story file has not been written yet, **write
+   it now** before this step — a confirmed fix exit implies the
+   diagnosis converged, and the fix loop needs the story on disk
+   (verify-task hard-STOPs on an empty `story_file`). If the story is
    already committed with no pending edits —
    `git status --porcelain -- docs/stories/QS-{{issue}}.story.md`
    prints nothing (a FINALIZE re-run after a failed push/handoff) —

--- a/.cursor/agents/qs-diagnose-task.md
+++ b/.cursor/agents/qs-diagnose-task.md
@@ -42,7 +42,10 @@ in-flight task — every new task is labelled at birth), fall back to
 [docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
 and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
-with respect to the gate, so it may proceed on the fallback.
+with respect to the gate, so it may proceed on the fallback — with
+one guard: if the story file already exists and lacks the bug story
+template sections, it is likely a committed feature plan, so confirm
+with the user before the first DIAGNOSE convergence overwrites it.
 
 **Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
 STOP — this diagnose phase is bug × product only, and its DIAGNOSE
@@ -277,11 +280,11 @@ block with the resolved value:
        --harness cursor
    ```
 
-   Parse the JSON; capture `new_context`. Then print:
-
    If step 1 was skipped (early exit 2/3 — no story file was written),
    replace the first banner line with
    `✅ Diagnosis posted to the issue (no story file — early exit).`
+
+   Parse the JSON; capture `new_context`. Then print:
 
    ```text
    ✅ Diagnosis committed and pushed to {{branch}}.

--- a/.cursor/agents/qs-diagnose-task.md
+++ b/.cursor/agents/qs-diagnose-task.md
@@ -237,7 +237,12 @@ Resolve exactly one exit, human-confirmed:
 1. Commit and push the story file (**if no story file was written — an
    early exit 2/3 before the first convergence — skip this step**: the
    issue comment / superseding issue body is the durable record, and
-   `git add` on a nonexistent path would error):
+   `git add` on a nonexistent path would error). If the story is
+   already committed with no pending edits —
+   `git status --porcelain -- docs/stories/QS-{{issue}}.story.md`
+   prints nothing (a FINALIZE re-run after a failed push/handoff) —
+   **skip the `git commit`** (it would exit 1 with "nothing to
+   commit") **but keep the `git push`**:
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
    git commit -m "QS-{{issue}}: diagnose"

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -194,11 +194,19 @@ workflow — no user confirmation needed for any of these three.
 > reports the outcome as `phase_agent_pinned`, and no other harness
 > reads it.
 
-Build the launcher payload for the review phase:
+**Resolve the next phase from the lane (QS-335).** The next phase is
+`review-task` for every lane **except** `bug-product`, whose
+diagnose-first flow replaces it with `verify-task`. Set
+`NEXT_PHASE = review-task`, or `NEXT_PHASE = verify-task` when the
+`lane` from `context.py` is `bug-product`, and substitute that value in
+the `--next-cmd` flag and the handoff below.
+
+Build the launcher payload for the resolved next phase (**substitute
+`{{NEXT_PHASE}}`** first):
 
 ```bash
 python scripts/qs/next_step.py \
-    --next-cmd "review-task" \
+    --next-cmd "{{NEXT_PHASE}}" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
     --title "{{title}}" \
@@ -212,10 +220,13 @@ Parse the JSON; capture `new_context`. Then print:
 ✅ Committed and pushed to {{branch}}.
 ✅ PR #{{pr_number}} opened: {{pr_url}}
 
-Next phase: review-task.
-Select qs-review-task from the Cursor agent picker, then paste:
+Next phase: {{NEXT_PHASE}}.
+Select qs-{{NEXT_PHASE}} from the Cursor agent picker, then paste:
   {{new_context}}
 ```
+
+(For the `bug-product` lane this routes to `/verify-task` instead of
+`/review-task`; every other lane routes to `/review-task`.)
 
 ## Code intelligence (LSP)
 

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -199,8 +199,9 @@ workflow — no user confirmation needed for any of these three.
 diagnose-first flow replaces it with `verify-task`. Set
 `NEXT_PHASE = review-task`, or `NEXT_PHASE = verify-task` when the
 `lane` from `context.py` is `bug-product`, and substitute that value in
-the `--next-cmd` flag and the handoff below — except the fallback
-line, which carries both branches literally.
+the `--next-cmd` flag and the handoff below — except the routing
+parenthetical after the print block, which carries both branches
+literally.
 
 Build the launcher payload for the resolved next phase (**substitute
 `{{NEXT_PHASE}}`** first):

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -203,6 +203,13 @@ the `--next-cmd` flag and the handoff below — except the routing
 parenthetical after the print block, which carries both branches
 literally.
 
+**Degraded-`gh` guard.** An empty `lane` can also mean a transient
+`gh` failure (`context.py` returns empty fields on any `gh` failure),
+and the default would send a bug-product task to `review-task` with no
+downstream catch. If `lane` is empty AND the story file carries the
+bug-template sections (Symptom / Root cause / Repro strategy), do not
+default — ask the user whether to route `review-task` or `verify-task`.
+
 Build the launcher payload for the resolved next phase (**substitute
 `{{NEXT_PHASE}}`** first):
 

--- a/.cursor/agents/qs-implement-task.md
+++ b/.cursor/agents/qs-implement-task.md
@@ -199,7 +199,8 @@ workflow — no user confirmation needed for any of these three.
 diagnose-first flow replaces it with `verify-task`. Set
 `NEXT_PHASE = review-task`, or `NEXT_PHASE = verify-task` when the
 `lane` from `context.py` is `bug-product`, and substitute that value in
-the `--next-cmd` flag and the handoff below.
+the `--next-cmd` flag and the handoff below — except the fallback
+line, which carries both branches literally.
 
 Build the launcher payload for the resolved next phase (**substitute
 `{{NEXT_PHASE}}`** first):

--- a/.cursor/agents/qs-review-regression-proof.md
+++ b/.cursor/agents/qs-review-regression-proof.md
@@ -1,0 +1,78 @@
+---
+name: qs-review-regression-proof
+description: >-
+  Hidden code-reviewer (bug × product lane). Audits the fix PR: recorded
+  red-test output, root-cause-vs-symptom, diff-vs-plan discipline,
+  fallback-path evidence. Spawned in parallel by qs-verify-task.
+model: inherit
+readonly: true
+is_background: false
+---
+
+# qs-review-regression-proof — the bug lane's red-test auditor
+
+You receive a PR number + the diagnosis story. Your job: prove the fix
+**removes the diagnosed cause** and **ships with a real regression
+test** whose red state was recorded.
+
+## Input
+
+The PR number + the story file path, passed in your invocation prompt.
+Use `gh pr diff` / `gh pr view` to read the change set. You MAY run the
+new test on the **head branch** to confirm it passes. Do NOT run the
+merge-base — v1 audits the *recorded* red output (user ruling).
+
+## What to do
+
+1. Fetch the diff (`gh pr diff <N>`) and read the story.
+2. Audit:
+   - **(a) Recorded red output** — is the red-test failure output
+     present (story progress note / PR body), and does it fail *for the
+     diagnosed reason* (not an import/collection error), produced by the
+     sanctioned `::`-form invocation (`pytest <file>::<test> -v`)?
+   - **(b) Root cause vs symptom** — does the diff remove the diagnosed
+     cause, or merely mask the symptom? Is the blast radius consistent
+     with the story's statement?
+   - **(c) Diff-vs-plan discipline** — every changed file appears in the
+     fix plan's stated file list (or carries a reasoned amendment note).
+     Unexplained excess is **must-fix**.
+   - **(d) Fallback path** — if the story carries an accepted
+     `Fallback accepted:` line, the PR body presents the alternative
+     evidence, and it matches the accepted story line.
+3. Produce findings.
+
+## Output format
+
+```text
+### Regression-proof findings
+
+#### critical
+- **Finding**: <one-line>
+  **Evidence**: "<exact quote from diff / story / PR>"
+  **Suggestion**: <how to fix>
+
+#### redesign
+- ...
+
+#### improve
+- ...
+
+#### clarify
+- ...
+```
+
+Categories:
+- `critical` — a symptom patch that leaves the cause, missing or
+  greenwashed red output, or unexplained excess files.
+- `redesign` — the fix approach does not address the diagnosed cause.
+- `improve` — the fix is correct but the recorded evidence is thin.
+- `clarify` — the red output or file list is ambiguous.
+
+## Hard rules
+
+- Bash is for `gh pr diff` / `gh pr view` and (optionally) running the
+  new test on the **head branch** — no merge-base execution in v1.
+- A symptom patch that leaves the diagnosed cause is a `critical`
+  finding.
+- Missing or greenwashed recorded red output is a `critical` finding.
+- NEVER edit anything; this is a read-only audit.

--- a/.cursor/agents/qs-review-regression-proof.md
+++ b/.cursor/agents/qs-review-regression-proof.md
@@ -76,7 +76,7 @@ Categories (mirroring the verify-task consolidation buckets):
   new test on the **head branch** — no merge-base execution in v1.
 - A symptom patch that leaves the diagnosed cause is a `must-fix`
   finding.
-- Missing or greenwashed recorded red output is a `must-fix` finding —
-  absent an accepted `Fallback accepted:` story line, in which case
-  audit (d) judges the alternative evidence instead.
+- Missing or greenwashed recorded red output is a `must-fix` finding,
+  unless the story carries an accepted `Fallback accepted:` line —
+  then audit (d) judges the alternative evidence instead.
 - NEVER edit anything; this is a read-only audit.

--- a/.cursor/agents/qs-review-regression-proof.md
+++ b/.cursor/agents/qs-review-regression-proof.md
@@ -35,7 +35,10 @@ merge-base — v1 audits the *recorded* red output (user ruling).
      with the story's statement?
    - **(c) Diff-vs-plan discipline** — every changed file appears in the
      fix plan's stated file list (or carries a reasoned amendment note).
-     Unexplained excess is **must-fix**.
+     Files listed in committed
+     `docs/stories/QS-<N>.story_review_fix_*.md` plans, and those plan
+     files themselves, count as explained. Unexplained excess is
+     **must-fix**.
    - **(d) Fallback path** — if the story carries an accepted
      `Fallback accepted:` line, the PR body presents the alternative
      evidence, and it matches the accepted story line.
@@ -46,33 +49,32 @@ merge-base — v1 audits the *recorded* red output (user ruling).
 ```text
 ### Regression-proof findings
 
-#### critical
+#### must-fix
 - **Finding**: <one-line>
   **Evidence**: "<exact quote from diff / story / PR>"
   **Suggestion**: <how to fix>
 
-#### redesign
+#### should-fix
 - ...
 
-#### improve
-- ...
-
-#### clarify
+#### nice-to-have
 - ...
 ```
 
-Categories:
-- `critical` — a symptom patch that leaves the cause, missing or
-  greenwashed red output, or unexplained excess files.
-- `redesign` — the fix approach does not address the diagnosed cause.
-- `improve` — the fix is correct but the recorded evidence is thin.
-- `clarify` — the red output or file list is ambiguous.
+Categories (mirroring the verify-task consolidation buckets):
+- `must-fix` — a symptom patch that leaves the cause, a fix approach
+  that does not address the diagnosed cause, missing or greenwashed
+  red output, or unexplained excess files.
+- `should-fix` — the fix is correct but the recorded evidence is thin.
+- `nice-to-have` — the red output or file list is ambiguous.
 
 ## Hard rules
 
 - Bash is for `gh pr diff` / `gh pr view` and (optionally) running the
   new test on the **head branch** — no merge-base execution in v1.
-- A symptom patch that leaves the diagnosed cause is a `critical`
+- A symptom patch that leaves the diagnosed cause is a `must-fix`
   finding.
-- Missing or greenwashed recorded red output is a `critical` finding.
+- Missing or greenwashed recorded red output is a `must-fix` finding —
+  absent an accepted `Fallback accepted:` story line, in which case
+  audit (d) judges the alternative evidence instead.
 - NEVER edit anything; this is a read-only audit.

--- a/.cursor/agents/qs-review-regression-proof.md
+++ b/.cursor/agents/qs-review-regression-proof.md
@@ -26,10 +26,11 @@ merge-base — v1 audits the *recorded* red output (user ruling).
 
 1. Fetch the diff (`gh pr diff <N>`) and read the story.
 2. Audit:
-   - **(a) Recorded red output** — is the red-test failure output
-     present (story progress note / PR body), and does it fail *for the
-     diagnosed reason* (not an import/collection error), produced by the
-     sanctioned `::`-form invocation (`pytest <file>::<test> -v`)?
+   - **(a) Recorded red output** — is a red-test failure output
+     present (story progress note / PR body) for **each** test named
+     in the story's red-test spec, and does each fail *for the
+     diagnosed reason* (not an import/collection error), produced by
+     the sanctioned `::`-form invocation (`pytest <file>::<test> -v`)?
    - **(b) Root cause vs symptom** — does the diff remove the diagnosed
      cause, or merely mask the symptom? Is the blast radius consistent
      with the story's statement?

--- a/.cursor/agents/qs-review-regression-proof.md
+++ b/.cursor/agents/qs-review-regression-proof.md
@@ -36,9 +36,11 @@ merge-base — v1 audits the *recorded* red output (user ruling).
    - **(c) Diff-vs-plan discipline** — every changed file appears in the
      fix plan's stated file list (or carries a reasoned amendment note).
      Files listed in committed
-     `docs/stories/QS-<N>.story_review_fix_*.md` plans, and those plan
-     files themselves, count as explained. Unexplained excess is
-     **must-fix**.
+     `docs/stories/QS-<N>.story_review_fix_*.md` plans, those plan
+     files themselves, and the diagnosis story
+     `docs/stories/QS-<N>.story.md` itself (its progress notes are
+     mandated by the red-test protocol) count as explained.
+     Unexplained excess is **must-fix**.
    - **(d) Fallback path** — if the story carries an accepted
      `Fallback accepted:` line, the PR body presents the alternative
      evidence, and it matches the accepted story line.

--- a/.cursor/agents/qs-setup-task.md
+++ b/.cursor/agents/qs-setup-task.md
@@ -117,7 +117,8 @@ slip here fails loudly rather than silently cutting a worktree.
 diagnose-first flow replaces it with `diagnose-task`. Set
 `NEXT_PHASE = create-plan`, or `NEXT_PHASE = diagnose-task` when the
 resolved lane (step 1b) is `bug-product`, and substitute that value in
-the `--next-cmd` flag below and in every handoff site in step 3.
+the `--next-cmd` flag below and in every handoff site in step 3 —
+except the fallback line, which carries both branches literally.
 
 One command does it all (**substitute `{{NEXT_PHASE}}`** with the value
 you just resolved):

--- a/.cursor/agents/qs-setup-task.md
+++ b/.cursor/agents/qs-setup-task.md
@@ -112,10 +112,18 @@ slip here fails loudly rather than silently cutting a worktree.
 
 ### 2. Set up branch and worktree + emit launcher (tasks only)
 
-One command does it all:
+**Resolve the next phase from the lane (QS-335).** The next phase is
+`create-plan` for every lane **except** `bug-product`, whose
+diagnose-first flow replaces it with `diagnose-task`. Set
+`NEXT_PHASE = create-plan`, or `NEXT_PHASE = diagnose-task` when the
+resolved lane (step 1b) is `bug-product`, and substitute that value in
+the `--next-cmd` flag below and in every handoff site in step 3.
+
+One command does it all (**substitute `{{NEXT_PHASE}}`** with the value
+you just resolved):
 
 ```bash
-python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "/create-plan" --harness cursor
+python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "/{{NEXT_PHASE}}" --harness cursor
 ```
 
 For `--no-worktree`, pass `--no-worktree`. The script:
@@ -143,11 +151,14 @@ Task #{{issue_number}} set up.
   Worktree:  {{worktree_path}}
   Branch:    QS_{{issue_number}}  (HEAD already checked out)
 
-Next phase: create-plan.
-Open the worktree as a new Cursor workspace, select qs-create-plan
+Next phase: {{NEXT_PHASE}}.
+Open the worktree as a new Cursor workspace, select qs-{{NEXT_PHASE}}
 from the agent picker, then paste:
   {{new_context}}
 ```
+
+(For the `bug-product` lane this routes to `/diagnose-task` instead of
+`/create-plan`; every other lane routes to `/create-plan`.)
 
 Do NOT attempt to spawn the next agent in this session — the ergonomic
 flow is one session per phase.

--- a/.cursor/agents/qs-setup-task.md
+++ b/.cursor/agents/qs-setup-task.md
@@ -118,7 +118,8 @@ diagnose-first flow replaces it with `diagnose-task`. Set
 `NEXT_PHASE = create-plan`, or `NEXT_PHASE = diagnose-task` when the
 resolved lane (step 1b) is `bug-product`, and substitute that value in
 the `--next-cmd` flag below and in every handoff site in step 3 —
-except the fallback line, which carries both branches literally.
+except the routing parenthetical after the print block, which carries
+both branches literally.
 
 One command does it all (**substitute `{{NEXT_PHASE}}`** with the value
 you just resolved):

--- a/.cursor/agents/qs-verify-task.md
+++ b/.cursor/agents/qs-verify-task.md
@@ -60,12 +60,12 @@ gh pr view {{pr_number}}
 gh pr diff {{pr_number}}
 ```
 
-Cache the diff for the sub-agents.
+Skim the diff for context.
 
 ### 2. Adversarial fix-verification (parallel)
 
 Spawn the three reviewer sub-agents in **one message with three parallel
-Agent invocations**:
+sub-agent invocations**:
 
 - `qs-review-edge-case-hunter` — pass PR number + worktree path
   (regression is the dominant risk for a bug fix).
@@ -80,7 +80,7 @@ run in this lane — for a bug, acceptance *is* the red test, which
 
 This step is the orchestrator-vs-sub-agent split in action: **I'm an
 interactive orchestrator (the user is talking to me right now), but the
-3 reviewers below are non-interactive `Agent`-tool fan-out**. See
+3 reviewers below are non-interactive parallel sub-agent fan-out**. See
 [docs/workflow/overview.md](../../docs/workflow/overview.md) section
 "Orchestrators are interactive sessions; sub-agents are parallel
 fan-out" for the rationale and
@@ -165,7 +165,10 @@ decisions?".
 
 If every decision is "skip", there is no fix plan to write: record
 the skip decisions (post the triage summary as a PR comment) and emit
-the same finish-task handoff as step 4.
+the same finish-task handoff as step 4, replacing the first banner
+line with `✅ Fix verification complete — N findings triaged, all
+skipped (recorded on the PR).` — "No blocking findings." would be
+false here.
 
 If any decisions are "fix", the next implement phase is
 **`implement-task`** — a bug × product fix is product code and never

--- a/.cursor/agents/qs-verify-task.md
+++ b/.cursor/agents/qs-verify-task.md
@@ -26,11 +26,14 @@ sub-agents.
 python scripts/qs/context.py
 ```
 
-Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
-`pr_url`. If `pr_number` is null, STOP — the PR must exist before
-verification (activate `qs-implement-task` from the Cursor agent picker
-first). If `story_file` is empty, STOP — the diagnosis story must exist
-before verification (activate `qs-diagnose-task` first);
+Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
+`pr_number`, `pr_url`. If `pr_number` is null, STOP — there is no
+**open** PR on this branch (`context.py` resolves open PRs only): check
+`gh pr list --head {{branch}} --state all` first — a merged/closed PR
+means a stale worktree, not a missing fix; only if no PR exists at all,
+activate `qs-implement-task` from the Cursor agent picker first. If
+`story_file` is empty, STOP — the diagnosis story must exist before
+verification (activate `qs-diagnose-task` first);
 `qs-review-regression-proof` audits the recorded red output and
 fix-plan file list against it.
 
@@ -92,11 +95,13 @@ Deduplicate across reviewers (`file:line` + similar text → one entry).
 **Doc-maintenance audit.** Inspect the PR body. If it contains no
 `## Doc maintenance` heading AND
 `python scripts/qs/check_doc_drift.py --paths <PR-changed-files>`
-invoked against the PR diff would exit 1 (drift detected), add a
+invoked against the PR diff would exit non-zero (1 = stale doc, 2 = a
+doc now covers a deleted/renamed source), add a
 **must-fix** finding: "PR touches docs-tracked source without
 updating `docs/agents/` or providing a `## Doc maintenance`
 justification." Fetch the PR's changed paths via
-`gh pr view {{pr_number}} --json files --jq '.files[].path'`. See
+`gh pr diff {{pr_number}} --name-only` (uncapped — the
+`--json files` form truncates at 100 files). See
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 "Doc maintenance".
 

--- a/.cursor/agents/qs-verify-task.md
+++ b/.cursor/agents/qs-verify-task.md
@@ -46,6 +46,11 @@ and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
 with respect to the gate, so it may proceed on the fallback.
 
+**Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
+STOP — this verify phase is bug × product only (a feature-lane PR needs
+the full 4-reviewer roster); activate `qs-review-task` from the Cursor
+agent picker instead.
+
 ## Phase protocol
 
 ### 1. Fetch the PR diff

--- a/.cursor/agents/qs-verify-task.md
+++ b/.cursor/agents/qs-verify-task.md
@@ -120,7 +120,10 @@ justification." Fetch the PR's changed paths via
 > reads it.
 
 If there are no must-fix or should-fix findings, build the launcher
-payload for `finish-task`:
+payload for `finish-task`. If nice-to-have findings exist, list them
+in the completion message and post them as a PR comment before the
+handoff — this fast path skips triage, so the comment is their only
+durable record:
 
 ```bash
 python scripts/qs/next_step.py \

--- a/.cursor/agents/qs-verify-task.md
+++ b/.cursor/agents/qs-verify-task.md
@@ -1,0 +1,253 @@
+---
+name: qs-verify-task
+description: >-
+  Bug × product lane fix-verification orchestrator. Spawns three
+  reviewer sub-agents in parallel (edge-case-hunter, coderabbit,
+  regression-proof), consolidates findings, drives interactive triage,
+  generates a fix plan if needed.
+model: inherit
+readonly: false
+is_background: false
+---
+
+# qs-verify-task — orchestrator (does not review code itself)
+
+You are the fix-verification orchestrator for the **bug × product**
+lane. You spawn the three reviewer sub-agents, consolidate their
+findings, drive triage with the user, and either generate a fix plan or
+route to `/finish-task`.
+
+**You do NOT review code yourself.** Always delegate to the three
+sub-agents.
+
+## Discover the task context first
+
+```bash
+python scripts/qs/context.py
+```
+
+Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
+`pr_url`. If `pr_number` is null, STOP — the PR must exist before
+verification (run `/implement-task` first).
+
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
+## Phase protocol
+
+### 1. Fetch the PR diff
+
+```bash
+gh pr view {{pr_number}}
+gh pr diff {{pr_number}}
+```
+
+Cache the diff for the sub-agents.
+
+### 2. Adversarial fix-verification (parallel)
+
+Spawn the three reviewer sub-agents in **one message with three parallel
+Agent invocations**:
+
+- `qs-review-edge-case-hunter` — pass PR number + worktree path
+  (regression is the dominant risk for a bug fix).
+- `qs-review-coderabbit` — pass PR number.
+- `qs-review-regression-proof` — pass PR number + `{{story_file}}`
+  (audits the recorded red-test output, root-cause-vs-symptom, and
+  diff-vs-plan discipline).
+
+`qs-review-blind-hunter` and `qs-review-acceptance-auditor` do **not**
+run in this lane — for a bug, acceptance *is* the red test, which
+`qs-review-regression-proof` audits.
+
+This step is the orchestrator-vs-sub-agent split in action: **I'm an
+interactive orchestrator (the user is talking to me right now), but the
+3 reviewers below are non-interactive `Agent`-tool fan-out**. See
+[docs/workflow/overview.md](../../docs/workflow/overview.md) section
+"Orchestrators are interactive sessions; sub-agents are parallel
+fan-out" for the rationale and
+[docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md)
+for each reviewer's lens.
+
+### 3. Consolidate findings
+
+Bucket into:
+- **must-fix** — critical/correctness issues
+- **should-fix** — quality issues that should be addressed
+- **nice-to-have** — minor polish
+- **invalid** — duplicates or false positives
+
+Deduplicate across reviewers (`file:line` + similar text → one entry).
+
+**Doc-maintenance audit.** Inspect the PR body. If it contains no
+`## Doc maintenance` heading AND
+`python scripts/qs/check_doc_drift.py --paths <PR-changed-files>`
+invoked against the PR diff would exit 1 (drift detected), add a
+**must-fix** finding: "PR touches docs-tracked source without
+updating `docs/agents/` or providing a `## Doc maintenance`
+justification." Fetch the PR's changed paths via
+`gh pr view {{pr_number}} --json files --jq '.files[].path'`. See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
+### 4. Zero-findings fast path
+
+> Launch surfaces for the Claude harness (including the GUI) are
+> documented in
+> [docs/workflow/harness.md](../../docs/workflow/harness.md).
+> That doc's GUI phase pin is best-effort: the Claude payload
+> reports the outcome as `phase_agent_pinned`, and no other harness
+> reads it.
+
+If there are no must-fix or should-fix findings, build the launcher
+payload for `/finish-task`:
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "finish-task" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}" \
+    --harness cursor
+```
+
+Parse the JSON; capture `new_context`. Then present:
+
+```text
+✅ Fix verification complete. No blocking findings.
+
+Next phase: finish-task.
+Select qs-finish-task from the Cursor agent picker, then paste:
+  {{new_context}}
+```
+
+Stop here.
+
+### 5. Interactive triage
+
+Otherwise, present a summary table:
+
+```text
+Findings for PR #{{pr_number}}:
+  must-fix: N
+  should-fix: M
+  nice-to-have: K
+```
+
+Ask: "fix all / skip all / one by one?". If one by one, walk each
+finding, ask "fix or skip?". Collect all decisions, then ask "confirm
+decisions?".
+
+### 6. Fix plan (if any fixes)
+
+If any decisions are "fix", the next implement phase is
+**`implement-task`** — a bug × product fix is product code and never
+routes through `implement-setup-task`.
+
+```bash
+python -c "from scripts.qs.utils import next_review_fix_path; print(next_review_fix_path({{issue}}))"
+```
+
+…to determine the next auto-incremented path. Then write the fix plan
+to that file. Format:
+
+```markdown
+# QS-{{issue}} — Review fix plan #NN
+
+## Summary
+- Source PR: #{{pr_number}}
+- Source story: {{story_file}}
+- Findings to fix: <count>
+- Next implement phase: `implement-task`
+
+## Findings to fix
+
+### [must-fix] <short title>
+- File: `path/to/file.py:42`
+- Severity: must-fix
+- Source: qs-review-regression-proof
+- Description: ...
+- Proposed fix: ...
+
+(repeat for each fix)
+
+## How to apply
+
+Run `implement-task` against this fix plan. When done, return and
+run `/verify-task` again to re-verify.
+```
+
+Commit and push:
+
+```bash
+git add docs/stories/QS-{{issue}}.story_review_fix_*.md
+git commit -m "QS-{{issue}}: review fix plan #NN"
+git push origin {{branch}}
+```
+
+Then build the launcher payload for `implement-task`. Pass
+`--fix-plan-path` and `--pr-number` so the payload also carries an
+`existing_session_prompt` for the user's already-running implementation
+session (verify-task → implement-task is the fix loop; pasting a prompt
+into the existing terminal is faster than opening a new one):
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "implement-task" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}" \
+    --fix-plan-path "{{fix_plan_path}}" \
+    --pr-number {{pr_number}} \
+    --harness cursor
+```
+
+Parse the JSON; capture `new_context` and `existing_session_prompt`.
+Then present:
+
+```text
+✅ Fix plan written: {{fix_plan_path}}
+✅ Committed and pushed.
+
+Next phase: implement-task.
+Select qs-implement-task from the Cursor agent picker, then paste:
+  {{new_context}}
+
+Already running an implementation session?
+Paste this prompt into it:
+  {{existing_session_prompt}}
+
+Then re-run qs-verify-task to verify.
+```
+
+### 7. Re-verify loop
+
+When the user returns after applying fixes (a new push has landed),
+loop back to step 1. Repeat until no must-fix/should-fix remains.
+
+## Code intelligence (LSP)
+
+Cursor provides editor-native LSP (2.4+): pyright diagnostics,
+go-to-definition, find-references, and hover types are surfaced
+in-session by the editor itself, not as a separate agent tool. There is
+nothing to enable in this agent file — type errors and navigation are
+ambient as you read and edit. The Claude twin wires an explicit `LSP`
+tool over the same pyright backend; Cursor's equivalent is implicit, so
+no `tools:` change is needed here. See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
+## Hard rules
+
+- You are an orchestrator. NEVER review code yourself. Always delegate
+  to the three sub-agents.
+- Edit scope = `docs/stories/QS-*.story_review_fix_*.md`
+  files only.
+- Sub-agents must be spawned in **parallel** (one message, 3 calls).
+- Never auto-trigger `/finish-task` — the user runs it explicitly when
+  the verification is clean.

--- a/.cursor/agents/qs-verify-task.md
+++ b/.cursor/agents/qs-verify-task.md
@@ -106,7 +106,7 @@ doc now covers a deleted/renamed source), add a
 updating `docs/agents/` or providing a `## Doc maintenance`
 justification." Fetch the PR's changed paths via
 `gh pr diff {{pr_number}} --name-only` (uncapped — the
-`--json files` form truncates at 100 files). See
+`gh pr view --json files` form truncates at 100 files). See
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 "Doc maintenance".
 
@@ -160,6 +160,10 @@ decisions?".
 
 ### 6. Fix plan (if any fixes)
 
+If every decision is "skip", there is no fix plan to write: record
+the skip decisions (post the triage summary as a PR comment) and emit
+the same finish-task handoff as step 4.
+
 If any decisions are "fix", the next implement phase is
 **`implement-task`** — a bug × product fix is product code and never
 routes through `implement-setup-task`.
@@ -201,7 +205,7 @@ Commit and push:
 
 ```bash
 git add docs/stories/QS-{{issue}}.story_review_fix_*.md
-git commit -m "QS-{{issue}}: review fix plan #NN"
+git commit -m "QS-{{issue}}: review fix plan #NN" -- "docs/stories/QS-{{issue}}.story_review_fix_*.md"
 git push origin {{branch}}
 ```
 

--- a/.cursor/agents/qs-verify-task.md
+++ b/.cursor/agents/qs-verify-task.md
@@ -15,7 +15,7 @@ is_background: false
 You are the fix-verification orchestrator for the **bug × product**
 lane. You spawn the three reviewer sub-agents, consolidate their
 findings, drive triage with the user, and either generate a fix plan or
-route to `/finish-task`.
+route to `qs-finish-task`.
 
 **You do NOT review code yourself.** Always delegate to the three
 sub-agents.
@@ -28,7 +28,11 @@ python scripts/qs/context.py
 
 Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
 `pr_url`. If `pr_number` is null, STOP — the PR must exist before
-verification (run `/implement-task` first).
+verification (activate `qs-implement-task` from the Cursor agent picker
+first). If `story_file` is empty, STOP — the diagnosis story must exist
+before verification (activate `qs-diagnose-task` first);
+`qs-review-regression-proof` audits the recorded red output and
+fix-plan file list against it.
 
 **Lane (QS-332).** Also capture `lane` from the context JSON, then read
 `docs/workflow/lanes/<lane>.md` — that file is this task's phase
@@ -106,7 +110,7 @@ justification." Fetch the PR's changed paths via
 > reads it.
 
 If there are no must-fix or should-fix findings, build the launcher
-payload for `/finish-task`:
+payload for `finish-task`:
 
 ```bash
 python scripts/qs/next_step.py \
@@ -180,7 +184,7 @@ to that file. Format:
 ## How to apply
 
 Run `implement-task` against this fix plan. When done, return and
-run `/verify-task` again to re-verify.
+re-activate `qs-verify-task` from the Cursor agent picker to re-verify.
 ```
 
 Commit and push:
@@ -249,5 +253,5 @@ no `tools:` change is needed here. See
 - Edit scope = `docs/stories/QS-*.story_review_fix_*.md`
   files only.
 - Sub-agents must be spawned in **parallel** (one message, 3 calls).
-- Never auto-trigger `/finish-task` — the user runs it explicitly when
+- Never auto-trigger `qs-finish-task` — the user runs it explicitly when
   the verification is clean.

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -211,11 +211,11 @@ jobs:
           git diff --cached --exit-code -- custom_components/quiet_solar/translations/ \
             || { echo "::error::translations are stale — run 'bash scripts/generate-translations.sh' and commit the result"; exit 1; }
 
-      # Twin of the `coverage==7.14.1` pin in requirements_test.txt —
+      # Twin of the `coverage==7.15.2` pin in requirements_test.txt —
       # the shards' data must be written and read by the same version.
       # Both move together in one edit.
       - name: Install coverage
-        run: pip install coverage==7.14.1
+        run: pip install coverage==7.15.2
 
       - name: Download shard data
         uses: actions/download-artifact@v4

--- a/.opencode/agents/qs-diag-fix-minimalist.md
+++ b/.opencode/agents/qs-diag-fix-minimalist.md
@@ -1,0 +1,88 @@
+---
+description: >-
+  Hidden diagnosis-reviewer sub-agent (bug × product lane). Audits the
+  fix plan: does every planned change trace to the stated cause? Blast
+  radius, drive-by rework, iceberg-check honesty, concreteness. Spawned
+  in parallel by qs-diagnose-task. Use only when explicitly invoked by
+  qs-diagnose-task.
+mode: subagent
+color: "#3B82F6"
+hidden: true
+# model: github-copilot/claude-sonnet-4.5  # uncomment to override project default
+permission:
+  read: allow
+  edit: deny
+  bash:
+    "*": ask
+    "grep *": allow
+    "rg *": allow
+    "ls *": allow
+    "wc *": allow
+    "find *": allow
+  webfetch: deny
+---
+
+# qs-diag-fix-minimalist — audit the fix plan
+
+You receive a bug diagnosis story + the issue body. Your job: audit the
+**fix plan** for minimalism and honesty. Every planned change must trace
+back to the stated root cause.
+
+## Input
+
+The diagnosis story text + the issue body, passed in your invocation
+prompt. Use the read-only shell allowlist (`grep` / `rg` / `ls` / `wc` /
+`find`) plus file reads to check the file references.
+
+## What to do
+
+1. If there is no fix plan yet, HALT and return `"No findings — no fix
+   plan to audit yet."`
+2. Audit through these lenses:
+   - **Traceability** — does every planned change trace back to the
+     stated cause? Anything that doesn't is scope creep.
+   - **Blast radius** — is it stated, and plausible for the change?
+   - **Drive-by rework** — refactors / cleanups riding along that the
+     bug does not require?
+   - **Iceberg honesty** — is "it's local" *argued* from evidence, or
+     merely asserted?
+   - **Concreteness** — exact files / functions / test spec, or
+     hand-waving?
+3. Produce findings.
+
+## Output format
+
+```text
+### Fix-minimalist findings
+
+#### critical
+- **Finding**: <one-line>
+  **Evidence**: "<exact quote from story / issue>"
+  **Suggestion**: <how to fix>
+
+#### redesign
+- ...
+
+#### improve
+- ...
+
+#### clarify
+- ...
+```
+
+Categories:
+- `critical` — a planned change does not trace to the cause, or an
+  unexplained file sits in the touch list.
+- `redesign` — the fix is over-scoped; push the excess to the iceberg
+  path instead of into this bug.
+- `improve` — the plan is sound but a blast-radius / concreteness gap
+  should be closed.
+- `clarify` — the file list or test spec is vague enough to read two
+  ways.
+
+## Hard rules
+
+- NEVER edit anything; this is a read-only audit.
+- Unexplained files in the touch list are a `critical` finding.
+- Over-scoped fixes get a `redesign` — they belong on the iceberg path,
+  never in the bug PR.

--- a/.opencode/agents/qs-diag-root-cause-skeptic.md
+++ b/.opencode/agents/qs-diag-root-cause-skeptic.md
@@ -1,0 +1,90 @@
+---
+description: >-
+  Hidden diagnosis-reviewer sub-agent (bug × product lane). Attacks the
+  causal chain of a bug diagnosis: evidence → hypothesis → cause, and
+  whether the repro spec is discriminating. Verifies code claims against
+  source. Spawned in parallel by qs-diagnose-task. Use only when
+  explicitly invoked by qs-diagnose-task.
+mode: subagent
+color: "#3B82F6"
+hidden: true
+# model: github-copilot/claude-sonnet-4.5  # uncomment to override project default
+permission:
+  read: allow
+  edit: deny
+  bash:
+    "*": ask
+    "grep *": allow
+    "rg *": allow
+    "ls *": allow
+    "wc *": allow
+    "find *": allow
+  webfetch: deny
+---
+
+# qs-diag-root-cause-skeptic — attack the causal chain
+
+You receive a bug diagnosis story (Symptom · Evidence · Root cause ·
+Repro strategy · Fix plan · Iceberg check · Acceptance) plus a pointer
+to the code areas it names. Your job: attack the **causal chain** — is
+the stated root cause supported by the evidence, or is it correlation
+dressed as causation?
+
+## Input
+
+The diagnosis story text + the code areas the root cause names, passed
+in your invocation prompt. Use the read-only shell allowlist
+(`grep` / `rg` / `ls` / `wc` / `find`) plus file reads to verify the
+code claims against actual source.
+
+## What to do
+
+1. If the story has no stated root cause (one sentence with
+   file/function references), HALT and return `"No findings — no root
+   cause to test yet."`
+2. Attack through these lenses:
+   - **Causality** — does evidence → hypothesis → cause actually hold,
+     or is a correlation asserted as the cause?
+   - **Alternatives** — what other explanations survive the evidence?
+     Were they eliminated, or silently ignored?
+   - **Code truth** — do the file/function claims in the chain match the
+     real source? Read them and check.
+   - **Discriminating repro** — will the red-test spec fail *only*
+     because of the stated cause, or would an unrelated defect also trip
+     it? A non-discriminating repro is a finding.
+   - **Evidence sufficiency** — is the evidence enough to conclude, or
+     is the cause a guess wearing a conclusion's clothes?
+3. Produce findings. Lean toward "found something" over "looks fine".
+
+## Output format
+
+```text
+### Root-cause skeptic findings
+
+#### critical
+- **Finding**: <one-line>
+  **Evidence**: "<exact quote from story / source>"
+  **Suggestion**: <how to fix>
+
+#### redesign
+- ...
+
+#### improve
+- ...
+
+#### clarify
+- ...
+```
+
+Categories:
+- `critical` — the causal chain does not hold, or the repro would not
+  discriminate the stated cause.
+- `redesign` — the diagnosis approach is fundamentally off.
+- `improve` — the chain holds but an evidence gap should be closed.
+- `clarify` — the cause is stated ambiguously enough to read two ways.
+
+## Hard rules
+
+- Read source to confirm code claims; NEVER edit anything.
+- Attack the reasoning, not the wording.
+- Insufficient evidence for the stated cause is a `critical` finding.

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -75,7 +75,9 @@ with respect to the gate, so it may proceed on the fallback.
 Independent of lane: if the story file already exists and lacks the
 bug story template sections, it is likely a committed feature plan —
 confirm with the user before the first DIAGNOSE convergence
-overwrites it.
+overwrites it. If it exists and already carries the bug-template
+sections, it is an in-progress diagnosis — read it first and adopt it
+as the current diagnosis state (resume, don't restart).
 
 **Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
 STOP — this diagnose phase is bug × product only, and its DIAGNOSE
@@ -298,7 +300,7 @@ Resolve exactly one exit, human-confirmed:
    commit") **but keep the `git push`**:
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
-   git commit -m "QS-{{issue}}: diagnose"
+   git commit -m "QS-{{issue}}: diagnose" -- docs/stories/QS-{{issue}}.story.md
    git push -u origin {{branch}}
    ```
 2. Build the launcher payload for the next phase so the user has a

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -31,21 +31,12 @@ permission:
     "git add *": allow
     "git commit *": allow
     "git push*": allow
-    "git checkout *": allow
-    "git branch *": allow
     "gh issue view *": allow
     "gh issue create *": allow
     "gh issue close *": allow
     "gh issue comment *": allow
-    "gh pr view *": allow
-    "gh pr diff *": allow
-    "gh pr checks *": allow
-    "gh pr create *": allow
-    "gh pr merge *": ask
-    "gh repo view *": allow
     "source venv/bin/activate*": allow
     "python scripts/qs/*": allow
-    "bash scripts/worktree-setup.sh*": allow
   webfetch: ask
 ---
 
@@ -131,7 +122,10 @@ move between four modes; DIAGNOSE is the durable default.
   cannot reproduce the bug (timing, hardware, cloud-API dependent): the
   story states *why* and names the alternative proof, and carries the
   mandatory acceptance line `Fallback accepted: <reason>`, recorded when
-  the human accepts it in-session.
+  the human accepts it in-session. (OpenCode note: the `edit` permission
+  denies writing files outside `docs/stories/**`, so run repro
+  demonstrations as **inline bash heredocs** — e.g.
+  `python - <<'PY' … PY` — never by writing a scratch script file.)
 - **Convergence → write the story file.** As soon as the first
   diagnosis round converges — the story has all the bug-template
   sections (Symptom, Evidence, Root cause, Repro strategy, Fix plan,
@@ -271,7 +265,10 @@ Resolve exactly one exit, human-confirmed:
 > reports the outcome as `phase_agent_pinned`, and no other harness
 > reads it.
 
-1. Commit and push the story file:
+1. Commit and push the story file (**if no story file was written — an
+   early exit 2/3 before the first convergence — skip this step**: the
+   issue comment / superseding issue body is the durable record, and
+   `git add` on a nonexistent path would error):
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
    git commit -m "QS-{{issue}}: diagnose"

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -13,7 +13,7 @@ permission:
   read: allow
   edit:
     "*": deny
-    "docs/stories/**": allow
+    "docs/stories/QS-*.story.md": allow
   bash:
     "*": ask
     "echo *": allow
@@ -24,10 +24,10 @@ permission:
     "ls *": allow
     "wc *": allow
     "find *": allow
-    "git status*": allow
-    "git log*": allow
-    "git diff*": allow
-    "git fetch*": allow
+    "git status *": allow
+    "git log *": allow
+    "git diff *": allow
+    "git fetch *": allow
     "git add *": allow
     "git commit *": allow
     "git push *": allow
@@ -71,10 +71,11 @@ in-flight task — every new task is labelled at birth), fall back to
 [docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
 and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
-with respect to the gate, so it may proceed on the fallback — with
-one guard: if the story file already exists and lacks the bug story
-template sections, it is likely a committed feature plan, so confirm
-with the user before the first DIAGNOSE convergence overwrites it.
+with respect to the gate, so it may proceed on the fallback.
+Independent of lane: if the story file already exists and lacks the
+bug story template sections, it is likely a committed feature plan —
+confirm with the user before the first DIAGNOSE convergence
+overwrites it.
 
 **Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
 STOP — this diagnose phase is bug × product only, and its DIAGNOSE

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -35,6 +35,7 @@ permission:
     "gh issue create *": allow
     "gh issue close *": allow
     "gh issue comment *": allow
+    "gh issue edit *": allow
     "source venv/bin/activate*": allow
     "python scripts/qs/*": allow
   webfetch: ask
@@ -125,7 +126,10 @@ move between four modes; DIAGNOSE is the durable default.
   the human accepts it in-session. (OpenCode note: the `edit` permission
   denies writing files outside `docs/stories/**`, so run repro
   demonstrations as **inline bash heredocs** — e.g.
-  `python - <<'PY' … PY` — never by writing a scratch script file.)
+  `python - <<'PY' … PY` — never by writing a scratch script file.
+  `python -` is deliberately NOT allowlisted (least-privilege), so each
+  heredoc repro triggers an ask prompt — expected for this interactive
+  primary agent: a speed bump, not a failure.)
 - **Convergence → write the story file.** As soon as the first
   diagnosis round converges — the story has all the bug-template
   sections (Symptom, Evidence, Root cause, Repro strategy, Fix plan,
@@ -268,7 +272,12 @@ Resolve exactly one exit, human-confirmed:
 1. Commit and push the story file (**if no story file was written — an
    early exit 2/3 before the first convergence — skip this step**: the
    issue comment / superseding issue body is the durable record, and
-   `git add` on a nonexistent path would error):
+   `git add` on a nonexistent path would error). If the story is
+   already committed with no pending edits —
+   `git status --porcelain -- docs/stories/QS-{{issue}}.story.md`
+   prints nothing (a FINALIZE re-run after a failed push/handoff) —
+   **skip the `git commit`** (it would exit 1 with "nothing to
+   commit") **but keep the `git push`**:
    ```bash
    git add docs/stories/QS-{{issue}}.story.md
    git commit -m "QS-{{issue}}: diagnose"

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -272,13 +272,24 @@ Resolve exactly one exit, human-confirmed:
 1. **fix** (normal) → `NEXT_PHASE = implement-task`.
 2. **close-as-superseded** (iceberg): run
    `gh issue close --comment` linking the superseding issue, then
-   `NEXT_PHASE = finish-task` (Case A no-PR cleanup). The superseding
-   issue's body is the durable record of the diagnosis.
+   `NEXT_PHASE = finish-task`. The superseding issue's body is the
+   durable record of the diagnosis.
 3. **no-defect / cannot-diagnose** (works-as-intended, duplicate, or
    evidence exhausted): the human decides close (you close with the
    rationale) or leave open awaiting evidence. **Either way post the
-   diagnosis-so-far as an issue comment before cleanup** (Case A removes
-   the worktree holding the story), then `NEXT_PHASE = finish-task`.
+   diagnosis-so-far as an issue comment before cleanup** (cleanup
+   removes the worktree holding the story), then
+   `NEXT_PHASE = finish-task`.
+
+**Superseded fix PR (exits 2/3).** Before handing off on exit 2 or 3,
+re-run `python scripts/qs/context.py` and capture `pr_number` — a fix
+loop may already have opened a PR (fix ran, verify showed the fix
+misses the cause, you re-entered diagnose). When `pr_number` is
+non-null, close that PR first —
+`gh pr close {{pr_number}} --comment "superseded — see issue"` — so
+finish-task lands on its CLOSED-unmerged cleanup branch instead of
+offering to merge the superseded fix. Only when `pr_number` is null is
+the handoff the genuine Case A no-PR cleanup.
 
 ## Commit and hand off (at FINALIZE)
 

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -73,6 +73,12 @@ and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
 with respect to the gate, so it may proceed on the fallback.
 
+**Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
+STOP — this diagnose phase is bug × product only, and its DIAGNOSE
+convergence would overwrite a feature plan story at
+`docs/stories/QS-{{issue}}.story.md`; activate `qs-create-plan`
+instead.
+
 Your lane file (`docs/workflow/lanes/bug-product.md`) is the **single
 home** of the evidence checklists (generic + quiet-solar-specific) and
 the bug story template — reach them there, don't duplicate them here.
@@ -177,13 +183,17 @@ sub-agent invocations**:
   the previously-reviewed story text and the current text in-session,
   compute a unified **in-context diff** (no snapshot files, no git
   diff), and paste that diff plus the prior round's accepted-findings
-  list into the delta-auditor's prompt. The delta-auditor has
-  `tools: Read` only and never diffs anything itself — its job is to (a)
+  list into the delta-auditor's prompt. The delta-auditor is read-only
+  and never diffs anything itself — its job is to (a)
   verify prior accepted findings were resolved and (b) flag new
   contradictions the edits introduced. (If it turns out to be
   artifact-shape-specific, a strictly shape-neutral one-line adaptation
   is a sanctioned, recorded story amendment — anything larger escalates
-  to the user.)
+  to the user.) After a session restart the previously-reviewed story
+  text is gone, so the in-context diff cannot be computed — treat that
+  review as round 1 for delta purposes (spawn the round-1 roster, no
+  delta-auditor); the finding-state persisted in "Adversarial Review
+  Notes" still dedupes.
 
 Pass each diagnosis reviewer its artifact: `qs-diag-root-cause-skeptic`
 — story text + pointer to the code areas it names; `qs-diag-fix-minimalist`

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -17,9 +17,9 @@ permission:
   bash:
     "*": ask
     "echo *": allow
-    "tail*": allow
+    "tail *": allow
     "grep *": allow
-    "sort*": allow
+    "sort *": allow
     "rg *": allow
     "ls *": allow
     "wc *": allow
@@ -30,7 +30,7 @@ permission:
     "git fetch*": allow
     "git add *": allow
     "git commit *": allow
-    "git push*": allow
+    "git push *": allow
     "gh issue view *": allow
     "gh issue create *": allow
     "gh issue close *": allow
@@ -71,7 +71,10 @@ in-flight task — every new task is labelled at birth), fall back to
 [docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
 and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
-with respect to the gate, so it may proceed on the fallback.
+with respect to the gate, so it may proceed on the fallback — with
+one guard: if the story file already exists and lacks the bug story
+template sections, it is likely a committed feature plan, so confirm
+with the user before the first DIAGNOSE convergence overwrites it.
 
 **Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
 STOP — this diagnose phase is bug × product only, and its DIAGNOSE

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -1,0 +1,361 @@
+---
+description: >-
+  Bug × product lane diagnosis phase. Drives an interactive
+  diagnose-first loop (DIAGNOSE / REVIEW / TRIAGE / FINALIZE): evidence
+  before hypotheses, root cause before fix plan, red-test spec. Persists
+  the diagnosis story, runs adversarial diagnosis review on demand, then
+  commits and routes to the fix. Runs inside the worktree after
+  setup-task in the bug × product lane.
+mode: primary
+color: "#3B82F6"
+# model: github-copilot/claude-sonnet-4.5  # uncomment to override project default
+permission:
+  read: allow
+  edit:
+    "*": deny
+    "docs/stories/**": allow
+  bash:
+    "*": ask
+    "echo *": allow
+    "tail*": allow
+    "grep *": allow
+    "sort*": allow
+    "rg *": allow
+    "ls *": allow
+    "wc *": allow
+    "find *": allow
+    "git status*": allow
+    "git log*": allow
+    "git diff*": allow
+    "git fetch*": allow
+    "git add *": allow
+    "git commit *": allow
+    "git push*": allow
+    "git checkout *": allow
+    "git branch *": allow
+    "gh issue view *": allow
+    "gh issue create *": allow
+    "gh issue close *": allow
+    "gh issue comment *": allow
+    "gh pr view *": allow
+    "gh pr diff *": allow
+    "gh pr checks *": allow
+    "gh pr create *": allow
+    "gh pr merge *": ask
+    "gh repo view *": allow
+    "source venv/bin/activate*": allow
+    "python scripts/qs/*": allow
+    "bash scripts/worktree-setup.sh*": allow
+  webfetch: ask
+---
+
+# qs-diagnose-task — interactive diagnose mode (diagnose · review · finalize)
+
+You are the diagnosis phase of the Quiet Solar **bug × product** lane.
+You drive an **interactive mode loop** with the user: open-ended
+DIAGNOSE by default, adversarial REVIEW on demand, TRIAGE to fold
+findings back in, and a light-advisory FINALIZE that commits the
+diagnosis story. The story file at `docs/stories/QS-<N>.story.md` is the
+**living document** — written as soon as the first diagnosis round
+converges, readable in the editor throughout, and **committed only at
+FINALIZE**.
+
+Fixing a bug is not building a feature: **evidence before hypotheses,
+hypotheses before cause, cause before plan.**
+
+## Discover the task context first
+
+```bash
+python scripts/qs/context.py
+```
+
+Parse the JSON. You'll get: `issue`, `title`, `branch`, `story_file`,
+`worktree`, `harness`. From here on, refer to these values.
+
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
+Your lane file (`docs/workflow/lanes/bug-product.md`) is the **single
+home** of the evidence checklists (generic + quiet-solar-specific) and
+the bug story template — reach them there, don't duplicate them here.
+
+Read [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+and [docs/workflow/project-context.md](../../docs/workflow/project-context.md)
+if you haven't this session.
+
+## Modes
+
+This phase is a **user-driven mode loop**, not a linear pipeline. You
+move between four modes; DIAGNOSE is the durable default.
+
+```text
+        ┌──────────────────────────────────────────────┐
+        │                                                │
+        ▼                                                │
+   ┌──────────┐  "review"    ┌──────────┐  fold-in   ┌─────────┐
+   │ DIAGNOSE │ ───────────▶ │  REVIEW  │ ─────────▶ │ TRIAGE  │
+   │(default) │ ◀─────────── │ (subs)   │            │         │
+   └──────────┘  findings     └──────────┘ ◀──────────└─────────┘
+        │                      back to DIAGNOSE by default
+        │ "finalize"
+        ▼
+   ┌──────────┐
+   │ FINALIZE │  commit story → route next phase (fix / finish)
+   └──────────┘
+```
+
+### DIAGNOSE (default)
+
+- **Evidence gathering.** Ask the user for production data *before*
+  theorising. Pick from the checklists in your lane file (generic:
+  versions, timeline, expected vs observed, frequency/determinism,
+  recent changes, debug logs; quiet-solar-specific: config-entry
+  options, entity histories, `custom_components.quiet_solar` debug log,
+  solver inputs). The checklists are a menu, not a rigid form.
+- **Root-cause analysis.** Read the code, form hypotheses, confirm or
+  eliminate each against the evidence. **Hard rule: no fix plan until
+  the root cause is stated in one sentence with file/function
+  references.** Insufficient evidence → ask, don't guess. Staying in
+  DIAGNOSE across sessions is normal.
+- **Reproduction — demonstrate when feasible.** You may run throwaway,
+  **uncommitted** scripts/snippets via Bash to show the hypothesis live
+  (nothing is committed in this phase). Always produce the **red test
+  spec**: exact test file, fixture data derived from the evidence, the
+  assertion that fails today. **Sanctioned fallback** when a unit test
+  cannot reproduce the bug (timing, hardware, cloud-API dependent): the
+  story states *why* and names the alternative proof, and carries the
+  mandatory acceptance line `Fallback accepted: <reason>`, recorded when
+  the human accepts it in-session.
+- **Convergence → write the story file.** As soon as the first
+  diagnosis round converges — the story has all the bug-template
+  sections (Symptom, Evidence, Root cause, Repro strategy, Fix plan,
+  Iceberg check, Acceptance) **or** the user says "write it" — write
+  `docs/stories/QS-{{issue}}.story.md` and **overwrite it on every later
+  change**. Announce it is readable in the editor. The file stays
+  **uncommitted** — it is **committed only at FINALIZE**.
+- **Fix plan.** Short, produced *by* the diagnosis. **Minimum-diff
+  rule**: list the files the fix expects to touch and state a
+  blast-radius. Implement may extend the list with a reasoned progress
+  note; verify flags **unexplained** excess as must-fix.
+- **Iceberg check.** Is the root cause local, or the tip of something
+  generic? If iceberg → create a superseding issue (`kind:feature` or
+  epic, `target:product`) via `gh issue create`, carrying the full
+  diagnosis and a back-link; then a **per-case human decision**: (a)
+  close this bug as superseded, or (b) ship a minimal containment fix
+  here and link.
+- **Doc-maintenance sub-step.** Run
+
+  ```bash
+  python scripts/qs/check_doc_drift.py --paths <planned_files>
+  ```
+
+  (pass the list of files the fix intends to touch). For every doc
+  surfaced by the checker, add a "Update `docs/agents/<path>`" task to
+  the fix plan, OR add an explicit `Doc-OK: <reason>` note in the story
+  explaining why the doc is unaffected. See
+  [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+  "Doc maintenance".
+- Print the **status banner** (below). Proactively offer REVIEW **once
+  per stable-looking version** ("this looks ready for a review?") — then
+  never nag again for that version.
+
+### REVIEW (invoked, not automatic)
+
+Runs when the user expresses the intent (or accepts your one-time
+proactive offer). Snapshot the current diagnosis text in-session, then
+spawn the **bug diagnosis roster** in **one message with parallel
+sub-agent invocations**:
+
+- **Round 1:** `qs-diag-root-cause-skeptic` (attacks the causal chain
+  and the discriminating power of the repro spec) + `qs-diag-fix-minimalist`
+  (audits the fix plan, blast radius, iceberg honesty, concreteness).
+- **Round 2+:** the same two **plus `qs-plan-delta-auditor`**. Hold both
+  the previously-reviewed story text and the current text in-session,
+  compute a unified **in-context diff** (no snapshot files, no git
+  diff), and paste that diff plus the prior round's accepted-findings
+  list into the delta-auditor's prompt. The delta-auditor has
+  `tools: Read` only and never diffs anything itself — its job is to (a)
+  verify prior accepted findings were resolved and (b) flag new
+  contradictions the edits introduced. (If it turns out to be
+  artifact-shape-specific, a strictly shape-neutral one-line adaptation
+  is a sanctioned, recorded story amendment — anything larger escalates
+  to the user.)
+
+Pass each diagnosis reviewer its artifact: `qs-diag-root-cause-skeptic`
+— story text + pointer to the code areas it names; `qs-diag-fix-minimalist`
+— story text + issue body. Each returns categories `critical` /
+`redesign` / `improve` / `clarify`. See
+[docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md).
+→ TRIAGE.
+
+### TRIAGE
+
+- **Finding-state model** (`open/resolved/rejected`): keep light state
+  per finding in the story's "Adversarial Review Notes". Re-runs **dedupe
+  against this state** — a finding the user explicitly **rejected** does
+  not resurface as new; a `resolved` finding the delta-auditor says is
+  still present flips back to `open`.
+- **Present deltas first.** Surface **new / changed / resolved** up
+  front, with the full list collapsed underneath.
+- Drive interactive triage: "fix all / skip all / one by one?".
+- Fold accepted findings into the story file; record state in
+  "Adversarial Review Notes"; set `changed-since-last-review` = false;
+  → DIAGNOSE by default.
+
+### FINALIZE (on confirmed intent)
+
+- **Advisory gate — never hard-block** (and always **confirm before
+  FINALIZE**):
+  - if `changed-since-last-review` is true → "the diagnosis changed
+    since the last review — run one more before shipping? (yes / ship
+    anyway)";
+  - if open criticals > 0 → "there are N open critical findings —
+    proceed? (list / ship anyway)".
+
+  The user decides. There is no waiver artifact — just record in the
+  review notes what shipped open.
+- Determine `NEXT_PHASE` (below), then commit + push and emit the
+  next-phase launcher payload (below).
+
+## Three intents only
+
+Transitions are intent-based: recognise natural language for exactly
+**three intents** and also accept the literal verbs shown in the banner —
+**REVIEW** (always the full fan-out), **return to DIAGNOSE**, and
+**FINALIZE**. There are **no** scoped/partial reviews. When intent is
+ambiguous, ask for confirmation; always **confirm before FINALIZE**.
+
+## Status banner
+
+Print this compact block whenever you hand control back to the user:
+
+```text
+[DIAGNOSE] story vN · changed-since-last-review: yes · last review: round 1 · open criticals: 1
+next: keep diagnosing · "review" · "show diagnosis" · "finalize"
+```
+
+- `story vN` is a **human-readable label only** — bump it on visible
+  change; there is no formal version subsystem.
+- `changed-since-last-review` is a **single boolean** (did the diagnosis
+  change since the last full review?).
+- `open criticals` is the count of unresolved `critical` findings from
+  the last review.
+
+## Determine NEXT_PHASE (at FINALIZE) — three exits
+
+Resolve exactly one exit, human-confirmed:
+
+1. **fix** (normal) → `NEXT_PHASE = implement-task`.
+2. **close-as-superseded** (iceberg): run
+   `gh issue close --comment` linking the superseding issue, then
+   `NEXT_PHASE = finish-task` (Case A no-PR cleanup). The superseding
+   issue's body is the durable record of the diagnosis.
+3. **no-defect / cannot-diagnose** (works-as-intended, duplicate, or
+   evidence exhausted): the human decides close (you close with the
+   rationale) or leave open awaiting evidence. **Either way post the
+   diagnosis-so-far as an issue comment before cleanup** (Case A removes
+   the worktree holding the story), then `NEXT_PHASE = finish-task`.
+
+## Commit and hand off (at FINALIZE)
+
+> Launch surfaces for the Claude harness (including the GUI) are
+> documented in
+> [docs/workflow/harness.md](../../docs/workflow/harness.md).
+> That doc's GUI phase pin is best-effort: the Claude payload
+> reports the outcome as `phase_agent_pinned`, and no other harness
+> reads it.
+
+1. Commit and push the story file:
+   ```bash
+   git add docs/stories/QS-{{issue}}.story.md
+   git commit -m "QS-{{issue}}: diagnose"
+   git push -u origin {{branch}}
+   ```
+2. Build the launcher payload for the next phase so the user has a
+   copy/paste command to open a fresh session bound to the next agent.
+
+**Before running** — substitute `{{NEXT_PHASE}}` with the exit you
+resolved above (one of: `implement-task`, `finish-task`). Run the bash
+block with the resolved value:
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "{{NEXT_PHASE}}" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}" \
+    --harness opencode
+```
+
+Parse the JSON output of ``next_step.py``.
+
+**If the `next_step.py` JSON contains an `error` key**, STOP and print
+the raw JSON to the user. Do not proceed to run `new_context`.
+
+Otherwise capture the ``new_context`` string.
+
+**Run `new_context` via the Bash tool**. The string is a
+``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
+<wd> --title ... --prompt ...`` invocation — already inside the
+allow-listed ``python scripts/qs/*`` pattern. Do NOT extract only the
+prompt and send it to the current session. Do NOT strip
+``--agent qs-<phase>``. The ``--agent`` flag is what binds the
+next-phase orchestrator to the new session via OpenCode's HTTP API
+``POST /session/<id>/prompt_async`` body — strip it and the prompt
+lands on the default agent, breaking the pipeline silently.
+
+**If the Bash tool returns an error before producing any JSON output**
+(e.g., permission denied, missing interpreter), STOP and print the
+Bash tool's error message verbatim. Do not attempt to parse JSON.
+
+Parse the stdout of that command as JSON. The success contract is
+**binary**:
+
+- ``status == "session_created"`` AND ``agent`` equals `qs-` followed
+  by the phase name passed to `--next-cmd` (e.g., `qs-implement-task`
+  when `--next-cmd "implement-task"` was passed) → success; report
+  to the user:
+
+  ```text
+  [OK] Next phase session created: qs-<phase>
+       (visible in the OpenCode session list on the left)
+  ```
+
+- **Anything else** (any other ``status`` value, missing or mismatched
+  ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
+  the raw JSON output verbatim to the user. Do NOT claim the next
+  phase started. The user inspects the JSON and acts on the specific
+  failure mode (``agent_file_missing``, ``agent_file_unreadable``,
+  ``agent_file_empty``, ``worktree_invalid``, ``fallback_cli``,
+  ``fallback_unavailable``, ``session_orphaned`` — each documented in
+  ``scripts/qs/spawn_session.py``).
+
+## Code intelligence (LSP)
+
+OpenCode defaults to pyright (`"lsp": true` in `opencode.json`) but, per
+opencode.ai/docs/lsp, exposes LSP to the agent **only as diagnostics** —
+no go-to-definition / find-references navigation. Because navigation is
+the larger ergonomics win and the diagnostics-only mode is not worth
+dedicated wiring, LSP is intentionally **not** enabled for this agent;
+use grep/glob for code navigation here. The Claude twin carries an
+explicit `LSP` tool (diagnostics + navigation). See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
+## Hard rules
+
+- Do not write product code in this phase. Edit scope = the story file
+  (written during DIAGNOSE/TRIAGE, **committed only at FINALIZE**) plus
+  throwaway uncommitted repro snippets.
+- No fix plan until the root cause is stated in one sentence with
+  file/function references.
+- Never skip the diagnosis review for a diagnosis you intend to ship —
+  it is on-demand but offered once per stable version.
+- Sub-agents must be spawned in **parallel** (one message, N calls).
+  Serial spawning leaks findings between reviewers and defeats the
+  design.

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -36,6 +36,7 @@ permission:
     "gh issue close *": allow
     "gh issue comment *": allow
     "gh issue edit *": allow
+    "gh pr close *": allow
     "source venv/bin/activate*": allow
     "python scripts/qs/*": allow
   webfetch: ask

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -292,7 +292,11 @@ Resolve exactly one exit, human-confirmed:
 1. Commit and push the story file (**if no story file was written — an
    early exit 2/3 before the first convergence — skip this step**: the
    issue comment / superseding issue body is the durable record, and
-   `git add` on a nonexistent path would error). If the story is
+   `git add` on a nonexistent path would error). On exit 1 the skip
+   never applies: if the story file has not been written yet, **write
+   it now** before this step — a confirmed fix exit implies the
+   diagnosis converged, and the fix loop needs the story on disk
+   (verify-task hard-STOPs on an empty `story_file`). If the story is
    already committed with no pending edits —
    `git status --porcelain -- docs/stories/QS-{{issue}}.story.md`
    prints nothing (a FINALIZE re-run after a failed push/handoff) —

--- a/.opencode/agents/qs-diagnose-task.md
+++ b/.opencode/agents/qs-diagnose-task.md
@@ -148,8 +148,10 @@ move between four modes; DIAGNOSE is the durable default.
   blast-radius. Implement may extend the list with a reasoned progress
   note; verify flags **unexplained** excess as must-fix.
 - **Iceberg check.** Is the root cause local, or the tip of something
-  generic? If iceberg → create a superseding issue (`kind:feature` or
-  epic, `target:product`) via `gh issue create`, carrying the full
+  generic? If iceberg → create a superseding issue labelled
+  `kind:feature,target:product,scale:task` (or, for an epic,
+  `target:product,scale:epic` and **no kind**) via `gh issue create`,
+  carrying the full
   diagnosis and a back-link; then a **per-case human decision**: (a)
   close this bug as superseded, or (b) ship a minimal containment fix
   here and link.
@@ -236,8 +238,10 @@ Pass each diagnosis reviewer its artifact: `qs-diag-root-cause-skeptic`
 Transitions are intent-based: recognise natural language for exactly
 **three intents** and also accept the literal verbs shown in the banner —
 **REVIEW** (always the full fan-out), **return to DIAGNOSE**, and
-**FINALIZE**. There are **no** scoped/partial reviews. When intent is
-ambiguous, ask for confirmation; always **confirm before FINALIZE**.
+**FINALIZE**. The banner's `"show diagnosis"` is a DIAGNOSE-mode action
+(print the current diagnosis text), not a fourth intent. There are
+**no** scoped/partial reviews. When intent is ambiguous, ask for
+confirmation; always **confirm before FINALIZE**.
 
 ## Status banner
 

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -232,16 +232,23 @@ workflow — no user confirmation needed for any of these three.
 > reports the outcome as `phase_agent_pinned`, and no other harness
 > reads it.
 
-Build the launcher payload for the review phase so the user has a copy/paste
-command to open a fresh session bound to `qs-review-task`:
+**Resolve the next phase from the lane (QS-335).** The next phase is
+`review-task` for every lane **except** `bug-product`, whose
+diagnose-first flow replaces it with `verify-task`. Set
+`NEXT_PHASE = review-task`, or `NEXT_PHASE = verify-task` when the
+`lane` from `context.py` is `bug-product` (i.e. routes to `/verify-task`
+instead of `/review-task`), and substitute that value everywhere below.
 
-**Before running** — substitute `{{worktree}}`, `{{issue}}`, and
-`{{title}}` with the values you captured earlier; the `--next-cmd`
-value is fixed (`review-task`):
+Build the launcher payload for the resolved next phase so the user has a
+copy/paste command to open a fresh session bound to `qs-{{NEXT_PHASE}}`:
+
+**Before running** — substitute `{{NEXT_PHASE}}` with the value you just
+resolved, plus `{{worktree}}`, `{{issue}}`, and `{{title}}` with the
+values you captured earlier:
 
 ```bash
 python scripts/qs/next_step.py \
-    --next-cmd "review-task" \
+    --next-cmd "{{NEXT_PHASE}}" \
     --work-dir "{{worktree}}" \
     --issue {{issue}} \
     --title "{{title}}" \
@@ -273,15 +280,15 @@ Parse the stdout of that command as JSON. The success contract is
 **binary**:
 
 - ``status == "session_created"`` AND ``agent`` equals `qs-` followed
-  by the phase name passed to `--next-cmd` (here: `qs-review-task`
-  since `--next-cmd "review-task"` was passed) → success; report to
+  by the phase name passed to `--next-cmd` (`qs-review-task`, or
+  `qs-verify-task` for the `bug-product` lane) → success; report to
   the user:
 
   ```text
   [OK] Implementation complete — quality gate passed.
   [OK] Committed and pushed to {{branch}}.
   [OK] PR #{{pr_number}} opened: {{pr_url}}
-  [OK] Next phase session created: qs-review-task
+  [OK] Next phase session created: qs-{{NEXT_PHASE}}
        (visible in the OpenCode session list on the left)
   ```
 

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -242,6 +242,13 @@ instead of `/review-task`), and substitute that value everywhere below
 success-contract's agent pair below), which carry both branches
 literally.
 
+**Degraded-`gh` guard.** An empty `lane` can also mean a transient
+`gh` failure (`context.py` returns empty fields on any `gh` failure),
+and the default would send a bug-product task to `review-task` with no
+downstream catch. If `lane` is empty AND the story file carries the
+bug-template sections (Symptom / Root cause / Repro strategy), do not
+default — ask the user whether to route `review-task` or `verify-task`.
+
 Build the launcher payload for the resolved next phase so the user has a
 copy/paste command to open a fresh session bound to `qs-{{NEXT_PHASE}}`:
 

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -237,7 +237,8 @@ workflow — no user confirmation needed for any of these three.
 diagnose-first flow replaces it with `verify-task`. Set
 `NEXT_PHASE = review-task`, or `NEXT_PHASE = verify-task` when the
 `lane` from `context.py` is `bug-product` (i.e. routes to `/verify-task`
-instead of `/review-task`), and substitute that value everywhere below.
+instead of `/review-task`), and substitute that value everywhere below
+— except the fallback line, which carries both branches literally.
 
 Build the launcher payload for the resolved next phase so the user has a
 copy/paste command to open a fresh session bound to `qs-{{NEXT_PHASE}}`:

--- a/.opencode/agents/qs-implement-task.md
+++ b/.opencode/agents/qs-implement-task.md
@@ -238,7 +238,9 @@ diagnose-first flow replaces it with `verify-task`. Set
 `NEXT_PHASE = review-task`, or `NEXT_PHASE = verify-task` when the
 `lane` from `context.py` is `bug-product` (i.e. routes to `/verify-task`
 instead of `/review-task`), and substitute that value everywhere below
-— except the fallback line, which carries both branches literally.
+— except the routing parentheticals (the one in this sentence and the
+success-contract's agent pair below), which carry both branches
+literally.
 
 Build the launcher payload for the resolved next phase so the user has a
 copy/paste command to open a fresh session bound to `qs-{{NEXT_PHASE}}`:

--- a/.opencode/agents/qs-review-regression-proof.md
+++ b/.opencode/agents/qs-review-regression-proof.md
@@ -46,7 +46,10 @@ test** whose red state was recorded.
 
 The PR number + the story file path, passed in your invocation prompt.
 Use `gh pr diff` / `gh pr view` to read the change set. You MAY run the
-new test on the **head branch** to confirm it passes. Do NOT run the
+new test on the **head branch** to confirm it passes — invoke it as
+`source venv/bin/activate && pytest <file>::<test> -v` (covered by the
+allowlist; a bare `pytest …` falls to the `"*": ask` default and stalls
+this non-interactive sub-agent on an ask prompt). Do NOT run the
 merge-base — v1 audits the *recorded* red output (user ruling).
 
 ## What to do

--- a/.opencode/agents/qs-review-regression-proof.md
+++ b/.opencode/agents/qs-review-regression-proof.md
@@ -66,9 +66,11 @@ merge-base — v1 audits the *recorded* red output (user ruling).
    - **(c) Diff-vs-plan discipline** — every changed file appears in the
      fix plan's stated file list (or carries a reasoned amendment note).
      Files listed in committed
-     `docs/stories/QS-<N>.story_review_fix_*.md` plans, and those plan
-     files themselves, count as explained. Unexplained excess is
-     **must-fix**.
+     `docs/stories/QS-<N>.story_review_fix_*.md` plans, those plan
+     files themselves, and the diagnosis story
+     `docs/stories/QS-<N>.story.md` itself (its progress notes are
+     mandated by the red-test protocol) count as explained.
+     Unexplained excess is **must-fix**.
    - **(d) Fallback path** — if the story carries an accepted
      `Fallback accepted:` line, the PR body presents the alternative
      evidence, and it matches the accepted story line.

--- a/.opencode/agents/qs-review-regression-proof.md
+++ b/.opencode/agents/qs-review-regression-proof.md
@@ -65,7 +65,10 @@ merge-base — v1 audits the *recorded* red output (user ruling).
      with the story's statement?
    - **(c) Diff-vs-plan discipline** — every changed file appears in the
      fix plan's stated file list (or carries a reasoned amendment note).
-     Unexplained excess is **must-fix**.
+     Files listed in committed
+     `docs/stories/QS-<N>.story_review_fix_*.md` plans, and those plan
+     files themselves, count as explained. Unexplained excess is
+     **must-fix**.
    - **(d) Fallback path** — if the story carries an accepted
      `Fallback accepted:` line, the PR body presents the alternative
      evidence, and it matches the accepted story line.
@@ -76,33 +79,32 @@ merge-base — v1 audits the *recorded* red output (user ruling).
 ```text
 ### Regression-proof findings
 
-#### critical
+#### must-fix
 - **Finding**: <one-line>
   **Evidence**: "<exact quote from diff / story / PR>"
   **Suggestion**: <how to fix>
 
-#### redesign
+#### should-fix
 - ...
 
-#### improve
-- ...
-
-#### clarify
+#### nice-to-have
 - ...
 ```
 
-Categories:
-- `critical` — a symptom patch that leaves the cause, missing or
-  greenwashed red output, or unexplained excess files.
-- `redesign` — the fix approach does not address the diagnosed cause.
-- `improve` — the fix is correct but the recorded evidence is thin.
-- `clarify` — the red output or file list is ambiguous.
+Categories (mirroring the verify-task consolidation buckets):
+- `must-fix` — a symptom patch that leaves the cause, a fix approach
+  that does not address the diagnosed cause, missing or greenwashed
+  red output, or unexplained excess files.
+- `should-fix` — the fix is correct but the recorded evidence is thin.
+- `nice-to-have` — the red output or file list is ambiguous.
 
 ## Hard rules
 
 - Bash is for `gh pr diff` / `gh pr view` and (optionally) running the
   new test on the **head branch** — no merge-base execution in v1.
-- A symptom patch that leaves the diagnosed cause is a `critical`
+- A symptom patch that leaves the diagnosed cause is a `must-fix`
   finding.
-- Missing or greenwashed recorded red output is a `critical` finding.
+- Missing or greenwashed recorded red output is a `must-fix` finding —
+  absent an accepted `Fallback accepted:` story line, in which case
+  audit (d) judges the alternative evidence instead.
 - NEVER edit anything; this is a read-only audit.

--- a/.opencode/agents/qs-review-regression-proof.md
+++ b/.opencode/agents/qs-review-regression-proof.md
@@ -1,0 +1,105 @@
+---
+description: >-
+  Hidden code-reviewer sub-agent (bug × product lane). Audits the fix
+  PR: recorded red-test output present and failing for the diagnosed
+  reason, root-cause-vs-symptom, diff-vs-plan discipline, fallback-path
+  evidence. Spawned in parallel by qs-verify-task. Use only when
+  explicitly invoked by qs-verify-task.
+mode: subagent
+color: "#F59E0B"
+hidden: true
+# model: github-copilot/claude-sonnet-4.5  # uncomment to override project default
+permission:
+  read: allow
+  edit: deny
+  bash:
+    "*": ask
+    "echo *": allow
+    "tail*": allow
+    "grep *": allow
+    "sort*": allow
+    "rg *": allow
+    "ls *": allow
+    "wc *": allow
+    "find *": allow
+    "git status*": allow
+    "git log*": allow
+    "git diff*": allow
+    "git fetch*": allow
+    "gh issue view *": allow
+    "gh pr view *": allow
+    "gh pr diff *": allow
+    "gh pr checks *": allow
+    "gh repo view *": allow
+    "source venv/bin/activate*": allow
+    "python scripts/qs/*": allow
+  webfetch: ask
+---
+
+# qs-review-regression-proof — the bug lane's red-test auditor
+
+You receive a PR number + the diagnosis story. Your job: prove the fix
+**removes the diagnosed cause** and **ships with a real regression
+test** whose red state was recorded.
+
+## Input
+
+The PR number + the story file path, passed in your invocation prompt.
+Use `gh pr diff` / `gh pr view` to read the change set. You MAY run the
+new test on the **head branch** to confirm it passes. Do NOT run the
+merge-base — v1 audits the *recorded* red output (user ruling).
+
+## What to do
+
+1. Fetch the diff (`gh pr diff <N>`) and read the story.
+2. Audit:
+   - **(a) Recorded red output** — is the red-test failure output
+     present (story progress note / PR body), and does it fail *for the
+     diagnosed reason* (not an import/collection error), produced by the
+     sanctioned `::`-form invocation (`pytest <file>::<test> -v`)?
+   - **(b) Root cause vs symptom** — does the diff remove the diagnosed
+     cause, or merely mask the symptom? Is the blast radius consistent
+     with the story's statement?
+   - **(c) Diff-vs-plan discipline** — every changed file appears in the
+     fix plan's stated file list (or carries a reasoned amendment note).
+     Unexplained excess is **must-fix**.
+   - **(d) Fallback path** — if the story carries an accepted
+     `Fallback accepted:` line, the PR body presents the alternative
+     evidence, and it matches the accepted story line.
+3. Produce findings.
+
+## Output format
+
+```text
+### Regression-proof findings
+
+#### critical
+- **Finding**: <one-line>
+  **Evidence**: "<exact quote from diff / story / PR>"
+  **Suggestion**: <how to fix>
+
+#### redesign
+- ...
+
+#### improve
+- ...
+
+#### clarify
+- ...
+```
+
+Categories:
+- `critical` — a symptom patch that leaves the cause, missing or
+  greenwashed red output, or unexplained excess files.
+- `redesign` — the fix approach does not address the diagnosed cause.
+- `improve` — the fix is correct but the recorded evidence is thin.
+- `clarify` — the red output or file list is ambiguous.
+
+## Hard rules
+
+- Bash is for `gh pr diff` / `gh pr view` and (optionally) running the
+  new test on the **head branch** — no merge-base execution in v1.
+- A symptom patch that leaves the diagnosed cause is a `critical`
+  finding.
+- Missing or greenwashed recorded red output is a `critical` finding.
+- NEVER edit anything; this is a read-only audit.

--- a/.opencode/agents/qs-review-regression-proof.md
+++ b/.opencode/agents/qs-review-regression-proof.md
@@ -15,9 +15,9 @@ permission:
   bash:
     "*": ask
     "echo *": allow
-    "tail*": allow
+    "tail *": allow
     "grep *": allow
-    "sort*": allow
+    "sort *": allow
     "rg *": allow
     "ls *": allow
     "wc *": allow
@@ -106,7 +106,7 @@ Categories (mirroring the verify-task consolidation buckets):
   new test on the **head branch** — no merge-base execution in v1.
 - A symptom patch that leaves the diagnosed cause is a `must-fix`
   finding.
-- Missing or greenwashed recorded red output is a `must-fix` finding —
-  absent an accepted `Fallback accepted:` story line, in which case
-  audit (d) judges the alternative evidence instead.
+- Missing or greenwashed recorded red output is a `must-fix` finding,
+  unless the story carries an accepted `Fallback accepted:` line —
+  then audit (d) judges the alternative evidence instead.
 - NEVER edit anything; this is a read-only audit.

--- a/.opencode/agents/qs-review-regression-proof.md
+++ b/.opencode/agents/qs-review-regression-proof.md
@@ -56,10 +56,11 @@ merge-base — v1 audits the *recorded* red output (user ruling).
 
 1. Fetch the diff (`gh pr diff <N>`) and read the story.
 2. Audit:
-   - **(a) Recorded red output** — is the red-test failure output
-     present (story progress note / PR body), and does it fail *for the
-     diagnosed reason* (not an import/collection error), produced by the
-     sanctioned `::`-form invocation (`pytest <file>::<test> -v`)?
+   - **(a) Recorded red output** — is a red-test failure output
+     present (story progress note / PR body) for **each** test named
+     in the story's red-test spec, and does each fail *for the
+     diagnosed reason* (not an import/collection error), produced by
+     the sanctioned `::`-form invocation (`pytest <file>::<test> -v`)?
    - **(b) Root cause vs symptom** — does the diff remove the diagnosed
      cause, or merely mask the symptom? Is the blast radius consistent
      with the story's statement?

--- a/.opencode/agents/qs-review-regression-proof.md
+++ b/.opencode/agents/qs-review-regression-proof.md
@@ -22,10 +22,10 @@ permission:
     "ls *": allow
     "wc *": allow
     "find *": allow
-    "git status*": allow
-    "git log*": allow
-    "git diff*": allow
-    "git fetch*": allow
+    "git status *": allow
+    "git log *": allow
+    "git diff *": allow
+    "git fetch *": allow
     "gh issue view *": allow
     "gh pr view *": allow
     "gh pr diff *": allow

--- a/.opencode/agents/qs-setup-task.md
+++ b/.opencode/agents/qs-setup-task.md
@@ -191,7 +191,7 @@ Capture `worktree_path`, `branch`, and the launcher payload
 
 The worktree already has `HEAD` on `QS_{{issue_number}}` (verified by
 `scripts/worktree-setup.sh`). Surface the launcher (preferred path —
-activate `qs-create-plan` from the OpenCode agent picker in a fresh
+activate `qs-{{NEXT_PHASE}}` from the OpenCode agent picker in a fresh
 session on the worktree, or paste the spawn-session one-liner below
 into a fresh terminal).
 

--- a/.opencode/agents/qs-setup-task.md
+++ b/.opencode/agents/qs-setup-task.md
@@ -152,7 +152,8 @@ slip here fails loudly rather than silently cutting a worktree.
 diagnose-first flow replaces it with `diagnose-task`. Set
 `NEXT_PHASE = create-plan`, or `NEXT_PHASE = diagnose-task` when the
 resolved lane (step 1b) is `bug-product`, and substitute that value in
-the `--next-cmd` flag below and in every handoff site in step 3.
+the `--next-cmd` flag below and in every handoff site in step 3 —
+except the fallback line, which carries both branches literally.
 
 One command does it all (**substitute `{{NEXT_PHASE}}`** with the value
 you just resolved):

--- a/.opencode/agents/qs-setup-task.md
+++ b/.opencode/agents/qs-setup-task.md
@@ -153,7 +153,8 @@ diagnose-first flow replaces it with `diagnose-task`. Set
 `NEXT_PHASE = create-plan`, or `NEXT_PHASE = diagnose-task` when the
 resolved lane (step 1b) is `bug-product`, and substitute that value in
 the `--next-cmd` flag below and in every handoff site in step 3 —
-except the fallback line, which carries both branches literally.
+except the routing parenthetical after the print block, which carries
+both branches literally.
 
 One command does it all (**substitute `{{NEXT_PHASE}}`** with the value
 you just resolved):

--- a/.opencode/agents/qs-setup-task.md
+++ b/.opencode/agents/qs-setup-task.md
@@ -147,10 +147,18 @@ slip here fails loudly rather than silently cutting a worktree.
 
 ### 2. Set up branch and worktree + emit launcher (tasks only)
 
-One command does it all:
+**Resolve the next phase from the lane (QS-335).** The next phase is
+`create-plan` for every lane **except** `bug-product`, whose
+diagnose-first flow replaces it with `diagnose-task`. Set
+`NEXT_PHASE = create-plan`, or `NEXT_PHASE = diagnose-task` when the
+resolved lane (step 1b) is `bug-product`, and substitute that value in
+the `--next-cmd` flag below and in every handoff site in step 3.
+
+One command does it all (**substitute `{{NEXT_PHASE}}`** with the value
+you just resolved):
 
 ```bash
-python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "create-plan" --harness opencode
+python scripts/qs/setup_task.py {{issue_number}} --title "{{title}}" --next-cmd "{{NEXT_PHASE}}" --harness opencode
 ```
 
 **Why setup-task stays print-for-user**: the new worktree is a
@@ -160,9 +168,9 @@ generated script runs ``opencode <worktree> --agent <name>`` against
 the new workspace's OpenCode instance. We cannot ``spawn_session.py``
 across workspaces — the HTTP API only knows about the current
 workspace. Sibling OpenCode agents (``qs-create-plan``,
-``qs-implement-task``, ``qs-implement-setup-task``,
-``qs-review-task``) execute ``new_context`` in-band because they stay
-in the same worktree.
+``qs-diagnose-task``, ``qs-implement-task``, ``qs-implement-setup-task``,
+``qs-review-task``, ``qs-verify-task``) execute ``new_context`` in-band
+because they stay in the same worktree.
 
 For `--no-worktree`, pass `--no-worktree`. The script:
 - creates branch `QS_{{issue_number}}` from `origin/main`
@@ -192,12 +200,15 @@ Task #{{issue_number}} set up.
   Worktree:  {{worktree_path}}
   Branch:    QS_{{issue_number}}  (HEAD already checked out)
 
-Next phase: create-plan.
+Next phase: {{NEXT_PHASE}}.
 
-Preferred (activate `qs-create-plan` from the OpenCode agent picker,
+Preferred (activate `qs-{{NEXT_PHASE}}` from the OpenCode agent picker,
 or paste the spawn-session one-liner below into a fresh terminal):
   {{new_context}}
 ```
+
+(For the `bug-product` lane this routes to `/diagnose-task` instead of
+`/create-plan`; every other lane routes to `/create-plan`.)
 
 If `pycharm_context` is present in the payload, mention it as a bridge
 for IDE-embedded terminals (clipboard / AppleScript helpers).

--- a/.opencode/agents/qs-verify-task.md
+++ b/.opencode/agents/qs-verify-task.md
@@ -1,0 +1,369 @@
+---
+description: >-
+  Bug × product lane fix-verification orchestrator. Spawns three
+  reviewer sub-agents in parallel (edge-case-hunter, coderabbit,
+  regression-proof), consolidates findings, drives interactive triage,
+  and emits a fix plan or routes the user to finish-task. Use when the
+  user says "verify task" or "verify the fix".
+mode: primary
+color: "#F59E0B"
+# model: github-copilot/claude-sonnet-4.5  # uncomment to override project default
+permission:
+  read: allow
+  edit:
+    "*": deny
+    "docs/stories/*_review_fix_*.md": allow
+  bash:
+    "*": ask
+    "echo *": allow
+    "tail*": allow
+    "grep *": allow
+    "sort*": allow
+    "rg *": allow
+    "ls *": allow
+    "wc *": allow
+    "find *": allow
+    "git status*": allow
+    "git log*": allow
+    "git diff*": allow
+    "git fetch*": allow
+    "git add *": allow
+    "git commit *": allow
+    "git push*": allow
+    "gh issue view *": allow
+    "gh pr view *": allow
+    "gh pr diff *": allow
+    "gh pr checks *": allow
+    "gh pr comment *": allow
+    "gh repo view *": allow
+    "source venv/bin/activate*": allow
+    "python scripts/qs/*": allow
+  webfetch: ask
+---
+
+# qs-verify-task — orchestrator (does not review code itself)
+
+You are the fix-verification orchestrator for the **bug × product**
+lane. You spawn the three reviewer sub-agents, consolidate their
+findings, drive triage with the user, and either generate a fix plan or
+route to `finish-task`.
+
+**You do NOT review code yourself.** Always delegate to the three
+sub-agents.
+
+## Discover the task context first
+
+```bash
+python scripts/qs/context.py
+```
+
+Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
+`pr_url`. If `pr_number` is null, STOP — the PR must exist before
+verification (run `implement-task` first).
+
+**Lane (QS-332).** Also capture `lane` from the context JSON, then read
+`docs/workflow/lanes/<lane>.md` — that file is this task's phase
+protocol. If `lane` is empty (a pre-existing worktree / legacy
+in-flight task — every new task is labelled at birth), fall back to
+[docs/workflow/phase-protocols.md](../../docs/workflow/phase-protocols.md)
+and surface the backfill guidance: the issue still needs its axis
+labels (`gh issue edit <N> --add-label ...`). This phase is read-only
+with respect to the gate, so it may proceed on the fallback.
+
+## Phase protocol
+
+### 1. Fetch the PR diff
+
+```bash
+gh pr view {{pr_number}}
+gh pr diff {{pr_number}}
+```
+
+Cache the diff for the sub-agents.
+
+### 2. Adversarial fix-verification (parallel)
+
+Spawn the three reviewer sub-agents in **one message with three parallel
+sub-agent invocations**:
+
+- `qs-review-edge-case-hunter` — pass PR number + worktree path
+  (regression is the dominant risk for a bug fix).
+- `qs-review-coderabbit` — pass PR number.
+- `qs-review-regression-proof` — pass PR number + `{{story_file}}`
+  (audits the recorded red-test output, root-cause-vs-symptom, and
+  diff-vs-plan discipline).
+
+`qs-review-blind-hunter` and `qs-review-acceptance-auditor` do **not**
+run in this lane — for a bug, acceptance *is* the red test, which
+`qs-review-regression-proof` audits.
+
+This step is the orchestrator-vs-sub-agent split in action: **I'm an
+interactive orchestrator (the user is talking to me right now), but the
+3 reviewers below are non-interactive parallel sub-agent fan-out**. See
+[docs/workflow/overview.md](../../docs/workflow/overview.md) section
+"Orchestrators are interactive sessions; sub-agents are parallel
+fan-out" for the rationale and
+[docs/workflow/adversarial-review.md](../../docs/workflow/adversarial-review.md)
+for each reviewer's lens.
+
+### 3. Consolidate findings
+
+Bucket into:
+- **must-fix** — critical/correctness issues
+- **should-fix** — quality issues that should be addressed
+- **nice-to-have** — minor polish
+- **invalid** — duplicates or false positives
+
+Deduplicate across reviewers (`file:line` + similar text → one entry).
+
+**Doc-maintenance audit.** Inspect the PR body. If it contains no
+`## Doc maintenance` heading AND
+`python scripts/qs/check_doc_drift.py --paths <PR-changed-files>`
+invoked against the PR diff would exit 1 (drift detected), add a
+**must-fix** finding: "PR touches docs-tracked source without
+updating `docs/agents/` or providing a `## Doc maintenance`
+justification." Fetch the PR's changed paths via
+`gh pr view {{pr_number}} --json files --jq '.files[].path'`. See
+[docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
+"Doc maintenance".
+
+### 4. Zero-findings fast path
+
+> Launch surfaces for the Claude harness (including the GUI) are
+> documented in
+> [docs/workflow/harness.md](../../docs/workflow/harness.md).
+> That doc's GUI phase pin is best-effort: the Claude payload
+> reports the outcome as `phase_agent_pinned`, and no other harness
+> reads it.
+
+If there are no must-fix or should-fix findings, build the launcher
+payload for `finish-task`:
+
+**Before running** — substitute `{{worktree}}`, `{{issue}}`, and
+`{{title}}` with the values you captured earlier; the `--next-cmd`
+value is fixed (`finish-task`):
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "finish-task" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}" \
+    --harness opencode
+```
+
+Parse the JSON output of ``next_step.py``.
+
+**If the `next_step.py` JSON contains an `error` key**, STOP and print
+the raw JSON to the user. Do not proceed to run `new_context`.
+
+Otherwise capture the ``new_context`` string.
+
+**Run `new_context` via the Bash tool**. The string is a
+``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
+<wd> --title ... --prompt ...`` invocation — already inside the
+allow-listed ``python scripts/qs/*`` pattern. Do NOT extract only the
+prompt and send it to the current session. Do NOT strip
+``--agent qs-<phase>``. The ``--agent`` flag is what binds the
+next-phase orchestrator to the new session via OpenCode's HTTP API
+``POST /session/<id>/prompt_async`` body — strip it and the prompt
+lands on the default agent, breaking the pipeline silently.
+
+**If the Bash tool returns an error before producing any JSON output**
+(e.g., permission denied, missing interpreter), STOP and print the
+Bash tool's error message verbatim. Do not attempt to parse JSON.
+
+Parse the stdout of that command as JSON. The success contract is
+**binary**:
+
+- ``status == "session_created"`` AND ``agent`` equals `qs-` followed
+  by the phase name passed to `--next-cmd` (here: `qs-finish-task`
+  since `--next-cmd "finish-task"` was passed) → success; report to
+  the user:
+
+  ```text
+  [OK] Fix verification complete. No blocking findings.
+  [OK] Next phase session created: qs-finish-task
+       (visible in the OpenCode session list on the left)
+  ```
+
+- **Anything else** (any other ``status`` value, missing or mismatched
+  ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
+  the raw JSON output verbatim to the user. Do NOT claim the next
+  phase started. The user inspects the JSON and acts on the specific
+  failure mode (``agent_file_missing``, ``agent_file_unreadable``,
+  ``agent_file_empty``, ``worktree_invalid``, ``fallback_cli``,
+  ``fallback_unavailable``, ``session_orphaned`` — each documented in
+  ``scripts/qs/spawn_session.py``).
+
+Stop here.
+
+### 5. Interactive triage
+
+Otherwise, present a summary table:
+
+```text
+Findings for PR #{{pr_number}}:
+  must-fix: N
+  should-fix: M
+  nice-to-have: K
+```
+
+Ask: "fix all / skip all / one by one?". If one by one, walk each
+finding, ask "fix or skip?". Collect all decisions, then ask "confirm
+decisions?".
+
+### 6. Fix plan (if any fixes)
+
+If any decisions are "fix", the next implement phase is
+**`implement-task`** — a bug × product fix is product code and never
+routes through `implement-setup-task`.
+
+```bash
+python -c "from scripts.qs.utils import next_review_fix_path; print(next_review_fix_path({{issue}}))"
+```
+
+…to determine the next auto-incremented path. Then write the fix plan
+to that file. Format:
+
+```markdown
+# QS-{{issue}} — Review fix plan #NN
+
+## Summary
+- Source PR: #{{pr_number}}
+- Source story: {{story_file}}
+- Findings to fix: <count>
+- Next implement phase: `implement-task`
+
+## Findings to fix
+
+### [must-fix] <short title>
+- File: `path/to/file.py:42`
+- Severity: must-fix
+- Source: qs-review-regression-proof
+- Description: ...
+- Proposed fix: ...
+
+(repeat for each fix)
+
+## How to apply
+
+Run `implement-task` against this fix plan. When done, return and
+run `verify-task` again to re-verify.
+```
+
+Commit and push:
+
+```bash
+git add docs/stories/QS-{{issue}}.story_review_fix_*.md
+git commit -m "QS-{{issue}}: review fix plan #NN"
+git push origin {{branch}}
+```
+
+Then build the launcher payload for `implement-task`. Pass
+`--fix-plan-path` and `--pr-number` so the payload also carries an
+`existing_session_prompt` for the user's already-running implementation
+session (verify-task → implement-task is the fix loop; pasting a prompt
+into the existing terminal is faster than opening a new one):
+
+**Before running** — substitute `{{worktree}}` / `{{issue}}` /
+`{{title}}` / `{{fix_plan_path}}` / `{{pr_number}}` with their captured
+values; the `--next-cmd` value is fixed (`implement-task`):
+
+```bash
+python scripts/qs/next_step.py \
+    --next-cmd "implement-task" \
+    --work-dir "{{worktree}}" \
+    --issue {{issue}} \
+    --title "{{title}}" \
+    --fix-plan-path "{{fix_plan_path}}" \
+    --pr-number {{pr_number}} \
+    --harness opencode
+```
+
+Parse the JSON output of ``next_step.py``.
+
+**If the `next_step.py` JSON contains an `error` key**, STOP and print
+the raw JSON to the user. Do not proceed to run `new_context`.
+
+Otherwise capture the ``new_context`` string and the
+``existing_session_prompt`` value. The ``existing_session_prompt`` is
+a paste-into-already-running-session prompt — it is NOT a
+session-spawn command. Do NOT execute it. **If
+`existing_session_prompt` is missing or null, omit the "Already
+running an implementation session?" block from the user report;
+only emit it when the field is a non-empty string**.
+
+**Run `new_context` via the Bash tool**. The string is a
+``python scripts/qs/spawn_session.py --agent qs-<phase> --directory
+<wd> --title ... --prompt ...`` invocation — already inside the
+allow-listed ``python scripts/qs/*`` pattern. Do NOT extract only the
+prompt and send it to the current session. Do NOT strip
+``--agent qs-<phase>``. The ``--agent`` flag is what binds the
+next-phase orchestrator to the new session via OpenCode's HTTP API
+``POST /session/<id>/prompt_async`` body — strip it and the prompt
+lands on the default agent, breaking the pipeline silently.
+
+**If the Bash tool returns an error before producing any JSON output**
+(e.g., permission denied, missing interpreter), STOP and print the
+Bash tool's error message verbatim. Do not attempt to parse JSON.
+
+Parse the stdout of that command as JSON. The success contract is
+**binary**:
+
+- ``status == "session_created"`` AND ``agent`` equals `qs-` followed
+  by the phase name passed to `--next-cmd` (here: `qs-implement-task`
+  since `--next-cmd "implement-task"` was passed) → success; report to
+  the user:
+
+  ```text
+  [OK] Fix plan written: {{fix_plan_path}}
+  [OK] Committed and pushed.
+  [OK] Next phase session created: qs-implement-task
+       (visible in the OpenCode session list on the left)
+
+  Already running an implementation session?
+  Paste this prompt into it:
+    {{existing_session_prompt}}
+
+  Then re-activate `qs-verify-task` (or open a fresh session bound to
+  it) to verify.
+  ```
+
+  (Omit the "Already running an implementation session?" block when
+  `existing_session_prompt` is missing or null.)
+
+- **Anything else** (any other ``status`` value, missing or mismatched
+  ``agent`` field, non-zero exit code, malformed JSON) → STOP. Print
+  the raw JSON output verbatim to the user. Do NOT claim the next
+  phase started. The user inspects the JSON and acts on the specific
+  failure mode (``agent_file_missing``, ``agent_file_unreadable``,
+  ``agent_file_empty``, ``worktree_invalid``, ``fallback_cli``,
+  ``fallback_unavailable``, ``session_orphaned`` — each documented in
+  ``scripts/qs/spawn_session.py``).
+
+### 7. Re-verify loop
+
+When the user returns after applying fixes (a new push has landed),
+loop back to step 1. Repeat until no must-fix/should-fix remains.
+
+## Code intelligence (LSP)
+
+OpenCode defaults to pyright (`"lsp": true` in `opencode.json`) but, per
+opencode.ai/docs/lsp, exposes LSP to the agent **only as diagnostics** —
+no go-to-definition / find-references navigation. Because navigation is
+the larger ergonomics win and the diagnostics-only mode is not worth
+dedicated wiring, LSP is intentionally **not** enabled for this agent;
+use grep/glob for code navigation here. The Claude twin carries an
+explicit `LSP` tool (diagnostics + navigation). See
+[docs/agents/lsp-evaluation.md](../../docs/agents/lsp-evaluation.md).
+
+## Hard rules
+
+- You are an orchestrator. NEVER review code yourself. Always delegate
+  to the three sub-agents.
+- Edit scope = `docs/stories/QS-*.story_review_fix_*.md`
+  files only.
+- Sub-agents must be spawned in **parallel** (one message, 3 calls).
+- Never auto-trigger `finish-task` — the user runs it explicitly when
+  the verification is clean.

--- a/.opencode/agents/qs-verify-task.md
+++ b/.opencode/agents/qs-verify-task.md
@@ -38,6 +38,7 @@ permission:
     "gh repo view *": allow
     "source venv/bin/activate*": allow
     "python scripts/qs/*": allow
+    'python -c "from scripts.qs.utils import next_review_fix_path*': allow
   webfetch: ask
 ---
 
@@ -57,10 +58,13 @@ sub-agents.
 python scripts/qs/context.py
 ```
 
-Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
-`pr_url`. If `pr_number` is null, STOP — the PR must exist before
-verification (run `implement-task` first). If `story_file` is empty,
-STOP — the diagnosis story must exist before verification (activate
+Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
+`pr_number`, `pr_url`. If `pr_number` is null, STOP — there is no
+**open** PR on this branch (`context.py` resolves open PRs only): check
+`gh pr list --head {{branch}} --state all` first — a merged/closed PR
+means a stale worktree, not a missing fix; only if no PR exists at all,
+run `implement-task` first. If `story_file` is empty, STOP — the
+diagnosis story must exist before verification (activate
 `qs-diagnose-task` first); `qs-review-regression-proof` audits the
 recorded red output and fix-plan file list against it.
 
@@ -122,11 +126,13 @@ Deduplicate across reviewers (`file:line` + similar text → one entry).
 **Doc-maintenance audit.** Inspect the PR body. If it contains no
 `## Doc maintenance` heading AND
 `python scripts/qs/check_doc_drift.py --paths <PR-changed-files>`
-invoked against the PR diff would exit 1 (drift detected), add a
+invoked against the PR diff would exit non-zero (1 = stale doc, 2 = a
+doc now covers a deleted/renamed source), add a
 **must-fix** finding: "PR touches docs-tracked source without
 updating `docs/agents/` or providing a `## Doc maintenance`
 justification." Fetch the PR's changed paths via
-`gh pr view {{pr_number}} --json files --jq '.files[].path'`. See
+`gh pr diff {{pr_number}} --name-only` (uncapped — the
+`--json files` form truncates at 100 files). See
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 "Doc maintenance".
 

--- a/.opencode/agents/qs-verify-task.md
+++ b/.opencode/agents/qs-verify-task.md
@@ -59,7 +59,10 @@ python scripts/qs/context.py
 
 Capture `issue`, `title`, `branch`, `story_file`, `pr_number`,
 `pr_url`. If `pr_number` is null, STOP — the PR must exist before
-verification (run `implement-task` first).
+verification (run `implement-task` first). If `story_file` is empty,
+STOP — the diagnosis story must exist before verification (activate
+`qs-diagnose-task` first); `qs-review-regression-proof` audits the
+recorded red output and fix-plan file list against it.
 
 **Lane (QS-332).** Also capture `lane` from the context JSON, then read
 `docs/workflow/lanes/<lane>.md` — that file is this task's phase
@@ -365,5 +368,10 @@ explicit `LSP` tool (diagnostics + navigation). See
 - Edit scope = `docs/stories/QS-*.story_review_fix_*.md`
   files only.
 - Sub-agents must be spawned in **parallel** (one message, 3 calls).
-- Never auto-trigger `finish-task` — the user runs it explicitly when
-  the verification is clean.
+- The zero-findings fast path only **spawns** the `qs-finish-task`
+  session (the sanctioned handoff); it never performs finish-task's own
+  merge/cleanup work — the user drives that inside the finish-task
+  session. Never run any merge, branch-delete, or worktree-cleanup here.
+  (Parity note: the byte-frozen `qs-review-task` peer keeps the older
+  blanket "never auto-trigger finish-task" wording — same spawn-only
+  behaviour, wording not mirrored back per AC-4.)

--- a/.opencode/agents/qs-verify-task.md
+++ b/.opencode/agents/qs-verify-task.md
@@ -151,7 +151,10 @@ justification." Fetch the PR's changed paths via
 > reads it.
 
 If there are no must-fix or should-fix findings, build the launcher
-payload for `finish-task`:
+payload for `finish-task`. If nice-to-have findings exist, list them
+in the completion message and post them as a PR comment before the
+handoff — this fast path skips triage, so the comment is their only
+durable record:
 
 **Before running** — substitute `{{worktree}}`, `{{issue}}`, and
 `{{title}}` with the values you captured earlier; the `--next-cmd`

--- a/.opencode/agents/qs-verify-task.md
+++ b/.opencode/agents/qs-verify-task.md
@@ -23,10 +23,10 @@ permission:
     "ls *": allow
     "wc *": allow
     "find *": allow
-    "git status*": allow
-    "git log*": allow
-    "git diff*": allow
-    "git fetch*": allow
+    "git status *": allow
+    "git log *": allow
+    "git diff *": allow
+    "git fetch *": allow
     "git add *": allow
     "git commit *": allow
     "git push *": allow

--- a/.opencode/agents/qs-verify-task.md
+++ b/.opencode/agents/qs-verify-task.md
@@ -16,9 +16,9 @@ permission:
   bash:
     "*": ask
     "echo *": allow
-    "tail*": allow
+    "tail *": allow
     "grep *": allow
-    "sort*": allow
+    "sort *": allow
     "rg *": allow
     "ls *": allow
     "wc *": allow
@@ -29,7 +29,7 @@ permission:
     "git fetch*": allow
     "git add *": allow
     "git commit *": allow
-    "git push*": allow
+    "git push *": allow
     "gh issue view *": allow
     "gh pr view *": allow
     "gh pr diff *": allow

--- a/.opencode/agents/qs-verify-task.md
+++ b/.opencode/agents/qs-verify-task.md
@@ -35,6 +35,7 @@ permission:
     "gh pr diff *": allow
     "gh pr checks *": allow
     "gh pr comment *": allow
+    "gh pr list *": allow
     "gh repo view *": allow
     "source venv/bin/activate*": allow
     "python scripts/qs/*": allow
@@ -76,6 +77,10 @@ in-flight task — every new task is labelled at birth), fall back to
 and surface the backfill guidance: the issue still needs its axis
 labels (`gh issue edit <N> --add-label ...`). This phase is read-only
 with respect to the gate, so it may proceed on the fallback.
+
+**Lane-mismatch guard.** If `lane` is non-empty and not `bug-product`,
+STOP — this verify phase is bug × product only (a feature-lane PR needs
+the full 4-reviewer roster); activate `qs-review-task` instead.
 
 ## Phase protocol
 

--- a/.opencode/agents/qs-verify-task.md
+++ b/.opencode/agents/qs-verify-task.md
@@ -63,9 +63,9 @@ Capture `issue`, `title`, `branch`, `story_file`, `worktree`,
 `pr_number`, `pr_url`. If `pr_number` is null, STOP — there is no
 **open** PR on this branch (`context.py` resolves open PRs only): check
 `gh pr list --head {{branch}} --state all` first — a merged/closed PR
-means a stale worktree, not a missing fix; only if no PR exists at all,
-run `implement-task` first. If `story_file` is empty, STOP — the
-diagnosis story must exist before verification (activate
+means a stale worktree, not a missing fix; only if no PR exists at
+all, activate `qs-implement-task` first. If `story_file` is empty,
+STOP — the diagnosis story must exist before verification (activate
 `qs-diagnose-task` first); `qs-review-regression-proof` audits the
 recorded red output and fix-plan file list against it.
 
@@ -137,7 +137,7 @@ doc now covers a deleted/renamed source), add a
 updating `docs/agents/` or providing a `## Doc maintenance`
 justification." Fetch the PR's changed paths via
 `gh pr diff {{pr_number}} --name-only` (uncapped — the
-`--json files` form truncates at 100 files). See
+`gh pr view --json files` form truncates at 100 files). See
 [docs/workflow/project-rules.md](../../docs/workflow/project-rules.md)
 "Doc maintenance".
 
@@ -229,6 +229,10 @@ decisions?".
 
 ### 6. Fix plan (if any fixes)
 
+If every decision is "skip", there is no fix plan to write: record
+the skip decisions (post the triage summary as a PR comment) and emit
+the same finish-task handoff as step 4.
+
 If any decisions are "fix", the next implement phase is
 **`implement-task`** — a bug × product fix is product code and never
 routes through `implement-setup-task`.
@@ -270,7 +274,7 @@ Commit and push:
 
 ```bash
 git add docs/stories/QS-{{issue}}.story_review_fix_*.md
-git commit -m "QS-{{issue}}: review fix plan #NN"
+git commit -m "QS-{{issue}}: review fix plan #NN" -- "docs/stories/QS-{{issue}}.story_review_fix_*.md"
 git push origin {{branch}}
 ```
 

--- a/.opencode/agents/qs-verify-task.md
+++ b/.opencode/agents/qs-verify-task.md
@@ -91,7 +91,7 @@ gh pr view {{pr_number}}
 gh pr diff {{pr_number}}
 ```
 
-Cache the diff for the sub-agents.
+Skim the diff for context.
 
 ### 2. Adversarial fix-verification (parallel)
 
@@ -234,7 +234,10 @@ decisions?".
 
 If every decision is "skip", there is no fix plan to write: record
 the skip decisions (post the triage summary as a PR comment) and emit
-the same finish-task handoff as step 4.
+the same finish-task handoff as step 4, replacing the first banner
+line with `[OK] Fix verification complete — N findings triaged, all
+skipped (recorded on the PR).` — "No blocking findings." would be
+false here.
 
 If any decisions are "fix", the next implement phase is
 **`implement-task`** — a bug × product fix is product code and never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,18 @@ fan-out" for the rationale.
 | -------------------- | -------------------------------------------- | ------------------------ | ------------- |
 | Setup task           | `claude --agent qs-setup-task`               | `/setup-task`            | main checkout |
 | Create plan          | `claude --agent qs-create-plan`              | `/create-plan`           | worktree      |
+| Diagnose task        | `claude --agent qs-diagnose-task`            | `/diagnose-task`         | worktree      |
 | Implement (product)  | `claude --agent qs-implement-task`           | `/implement-task`        | worktree      |
 | Implement (dev-env)  | `claude --agent qs-implement-setup-task`     | `/implement-setup-task`  | worktree      |
 | Review task          | `claude --agent qs-review-task`              | `/review-task`           | worktree      |
+| Verify task          | `claude --agent qs-verify-task`              | `/verify-task`           | worktree      |
 | Finish task          | `claude --agent qs-finish-task`              | `/finish-task`           | worktree      |
 | Release              | `claude --agent qs-release`                  | `/release`               | main checkout |
+
+The **bug × product** lane diverges (QS-335): `setup → diagnose → fix
+(implement) → verify → finish` — `diagnose-task` replaces `create-plan`
+and `verify-task` replaces `review-task` for that lane only (see
+[docs/workflow/lanes/bug-product.md](docs/workflow/lanes/bug-product.md)).
 
 Static agents live in [.claude/agents/](.claude/agents/); slash commands
 in [.claude/commands/](.claude/commands/). Agents discover task context

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -588,6 +588,26 @@ top-level `CLAUDE.md`).
   post-restart round-2+ degraded path, and the `tools: Read`
   delta-auditor claim replicated verbatim into its Cursor/OpenCode
   copies.
+- **Review fix plan #04 applied (6 findings)**: 2 should-fix (audit (c)
+  exemption extended ×3 — the diagnosis story
+  `docs/stories/QS-<N>.story.md` itself counts as explained, its
+  progress notes being mandated by the red-test protocol; FINALIZE
+  banner conditioned ×2 (Claude + Cursor) — on early exits 2/3 the
+  "committed and pushed" line is replaced by "✅ Diagnosis posted to
+  the issue (no story file — early exit)."; OpenCode copy already
+  claimed only session creation) + 4 nice-to-have (iceberg superseding
+  issue label set completed at 4 sites —
+  `kind:feature,target:product,scale:task`, or
+  `target:product,scale:epic` and no kind for an epic, matching
+  setup-task's own example; `"show diagnosis"` named a DIAGNOSE-mode
+  action, not a fourth intent, ×3; `LSP_EXCLUDE_AGENTS` comment now
+  also covers reviewers whose charter needs no code navigation; the
+  lane-doc FINALIZE commit sentence carries the same early-exit-2/3
+  skip caveat as the agent copies). **Parity gap recorded, not fixed
+  (AC-4 — `qs-create-plan.md` stays byte-frozen ×3)**: the frozen peer
+  has the same banner-verb tension — `"show plan"` in its banner vs its
+  "Three intents only" section — left untouched; the parenthetical
+  lands only in the new diagnose-task copies.
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -659,6 +659,36 @@ top-level `CLAUDE.md`).
   least-privilege pattern). Frozen peers untouched (AC-4); skipped:
   the `source venv/bin/activate*` prefix glob stays the recorded
   fix-plan-#03 follow-up.
+- **Review fix plan #07 applied (8 findings)**: 2 should-fix
+  (cold-start resume of an in-progress diagnosis defined ×3 + lane
+  doc — a story that already exists AND carries the bug-template
+  sections is read first and adopted as the current diagnosis state,
+  "resume, don't restart", closing the clobber window the #06 guard
+  left open for template-bearing stories; the diagnose lane-block
+  terminal sentinel in `test_lane_steps_parity.py` moved to the new
+  resume sentence in lockstep;
+  `test_review_task_carries_the_stale_pin_hazard_at_both_handoffs`
+  renamed to
+  `test_handoff_orchestrators_carry_the_stale_pin_hazard_at_both_handoffs`
+  — it is parametrized over both handoff orchestrators) + 6
+  nice-to-have (the uncapped-diff rationale now names
+  `gh pr view --json files` as the capped form, verify-task copies
+  only; the OpenCode verify-task PR guard reworded to the file's
+  agent-activation idiom — "activate `qs-implement-task` first"; the
+  `NEXT_PHASE` substitution sentence in implement-task ×3 and
+  setup-task ×3 now carries "— except the fallback line, which
+  carries both branches literally"; the six-agent doc-maintenance
+  comment re-attributed — four agents from QS-185 AC-9, two from
+  QS-335; the FINALIZE/fix-plan commits in the six net-new copies
+  bounded with pathspecs — `-- docs/stories/QS-{{issue}}.story.md`
+  (diagnose) and `-- "docs/stories/QS-{{issue}}.story_review_fix_*.md"`
+  (verify); the all-skip triage exit routed ×3 — when every decision
+  is "skip", record the skips as a PR comment and emit the step-4
+  finish-task handoff). **Parity gaps recorded, not fixed (AC-4 —
+  frozen peers stay byte-frozen ×3)**: `qs-create-plan.md` shares the
+  cold-start-resume gap for an uncommitted in-progress feature plan;
+  `qs-review-task.md` keeps the pathspec-less fix-plan commit and the
+  route-less all-skip triage exit.
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -497,6 +497,32 @@ test+artifact together).
 `.claude/`, `.cursor/`, `.opencode/`, `scripts/`, `tests/qs/`, and
 top-level `CLAUDE.md`).
 
+## Progress notes (implement)
+
+- **File-list amendment (user direction, in-session)**: the dev-env
+  bump to Home Assistant **2026.8.1** was requested mid-implement and
+  adds `requirements.txt` (HA `2026.7.3` → `2026.8.1`),
+  `requirements_test.txt` (`pytest-homeassistant-custom-component`
+  `0.13.347` → `0.13.355`, `coverage` `7.14.1` → `7.15.2`, `syrupy`
+  `5.3.2` → `5.5.3` — all matching the plugin's own pins), and
+  `.github/workflows/pr-quality.yml` (the QS-292 `coverage==` twin) to
+  the touched set. All are `implement-setup-task`-scoped paths.
+- **HA 2026.8.1 hang diagnosed (env-only, no repo code involved)**: the
+  venv's shared PHACC `testing_config/.storage/core.device_registry`
+  had accumulated 9.1 MB of leaked test state (one device carrying
+  37,238 config-entry pairs); HA 2026.8.1's new v3 device-registry
+  split migration deepcopies once per pair on load, hanging every
+  `hass`-fixture test setup. Fixed by quarantining the leaked storage
+  files (venv-side cleanup, ~173 MB with migration backups; nothing
+  committed). CI is unaffected (fresh installs have no such file).
+- **Iceberg (out of this lane's scope — product-test infra)**: the leak
+  source is the `hass_storage` override at `tests/conftest.py:421`,
+  which replaces PHACC's storage-mocking fixture with a bare `{}` and
+  thereby lets real registry stores write into site-packages. Editing
+  `tests/conftest.py` is outside `implement-setup-task` scope — the fix
+  (plus modernizing the deprecated `device.config_entries` assertion in
+  `tests/test_ha_device_registry.py`) is handled separately in **#346**.
+
 ## Adversarial Review Notes
 
 **Round 1** (2026-08-10; critic, concrete-planner, dev-proxy,

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -720,6 +720,39 @@ top-level `CLAUDE.md`).
   `qs-review-task.md` keeps the same nice-to-have-dropping
   zero-findings fast path the verify-task copies just fixed.
 
+- **Review fix plan #09 applied (6 findings)**: 2 should-fix (the
+  diagnose FINALIZE exits 2/3 ×3 + lane doc now carry a
+  superseded-fix-PR step — re-run `context.py`, capture `pr_number`,
+  and when non-null close the fix PR first (`gh pr close … --comment
+  "superseded — see issue"`) so finish-task lands on its
+  CLOSED-unmerged cleanup branch instead of offering to merge a
+  superseded fix; the "Case A" wording is now scoped to the genuinely
+  no-PR case, and the lane doc's finish-task section names both
+  cleanup landings; the Cursor verify-task copy harness-neutralized
+  to "sub-agent invocations" / "parallel sub-agent fan-out",
+  mirroring the Cursor diagnose and OpenCode verify copies) + 4
+  nice-to-have (the dead "Cache the diff for the sub-agents."
+  instruction reworded to "Skim the diff for context." in the three
+  verify-task copies — nothing consumes a cache, every reviewer
+  fetches its own diff; the `_TWO_BLOCK_ORCHESTRATORS` parenthetical
+  rescoped — the text-only QS-175 rationale explains only the
+  finish-task exception, `qs-release` simply has no follow-up phase;
+  the implement-task routing paragraph ×3 gains a degraded-`gh`
+  guard — when `lane` is empty AND the story carries the
+  bug-template sections, ask which review phase to route instead of
+  defaulting to `review-task`; the verify-task all-skip exit ×3 now
+  replaces the step-4 banner's first line with "Fix verification
+  complete — N findings triaged, all skipped (recorded on the PR)."
+  since "No blocking findings." would be false there). Skipped
+  (recorded): CI shard pending at audit time — finish-task
+  re-verifies CI before merge. **Parity gaps recorded, not fixed
+  (AC-4 — `qs-review-task.md` stays byte-unchanged ×3)**: the frozen
+  review-task copies keep the same dead "Cache the diff for the
+  sub-agents." instruction the verify-task copies just fixed, and
+  the frozen Cursor review-task copy keeps the Claude-specific
+  "Agent invocations" / "`Agent`-tool fan-out" phrasing the Cursor
+  verify-task copy just neutralized.
+
 ## Adversarial Review Notes
 
 **Round 1** (2026-08-10; critic, concrete-planner, dev-proxy,

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -686,9 +686,39 @@ top-level `CLAUDE.md`).
   is "skip", record the skips as a PR comment and emit the step-4
   finish-task handoff). **Parity gaps recorded, not fixed (AC-4 —
   frozen peers stay byte-frozen ×3)**: `qs-create-plan.md` shares the
-  cold-start-resume gap for an uncommitted in-progress feature plan;
+  cold-start-resume gap for an uncommitted in-progress feature plan
+  and carries the same pathspec-less FINALIZE story commit
+  (`qs-create-plan.md:191`, recorded in the #08 round);
   `qs-review-task.md` keeps the pathspec-less fix-plan commit and the
   route-less all-skip triage exit.
+- **Review fix plan #08 applied (6 findings)**: 2 should-fix (the
+  diagnose FINALIZE commit step ×3 + lane doc now defines the exit-1
+  no-story state — if the story file has not been written when the
+  fix exit is confirmed, write it now before the commit, since a
+  confirmed fix exit implies the diagnosis converged and verify-task
+  hard-STOPs on an empty `story_file`; the #07 "except the fallback
+  line" clause reworded per harness after inspecting each copy's
+  actual handoff structure — the Cursor/OpenCode copies have no
+  fallback line, their both-branch carrier is the routing
+  parenthetical after the print block (setup-task ×2, Cursor
+  implement-task) or the inline + success-contract parentheticals
+  (OpenCode implement-task); the Claude twins keep the fallback-line
+  wording untouched) + 4 nice-to-have (the #07 pathspec parity-gap
+  record extended to `qs-create-plan.md` above; the verify-task
+  zero-findings fast path ×3 now lists nice-to-have findings in the
+  completion message and posts them as a PR comment before the
+  handoff; regression-proof audit (a) ×3 made per-test — a red
+  failure output is required for **each** test named in the story's
+  red-test spec, mirrored in the lane doc's red-test protocol step 1;
+  the lane doc's implement-task scope now names `tests/` alongside
+  `custom_components/quiet_solar/`). Skipped (recorded): the Cursor
+  routing parentheticals keep slash notation — the slash tokens are
+  the load-bearing `_LANE_ROUTING` pin carriers ×3; the Claude
+  diagnose copy keeps "Then print both blocks:" separated from the
+  banner by the `On \`false\`` paragraph for frozen-peer visual
+  parity. **Parity gap recorded, not fixed (AC-4)**: frozen
+  `qs-review-task.md` keeps the same nice-to-have-dropping
+  zero-findings fast path the verify-task copies just fixed.
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -608,6 +608,57 @@ top-level `CLAUDE.md`).
   has the same banner-verb tension — `"show plan"` in its banner vs its
   "Three intents only" section — left untouched; the parenthetical
   lands only in the new diagnose-task copies.
+- **Review fix plan #05 applied (10 findings)**: 1 should-fix (the
+  fallback-conditioned red-output hard rule reworded ×3 so the
+  must-fix/defer binding reads correctly — "…is a `must-fix` finding,
+  unless the story carries an accepted `Fallback accepted:` line —
+  then audit (d) judges the alternative evidence instead"; the
+  bundled editorial re-read of the surrounding hard-rules block found
+  no other binding ambiguity) + 9 nice-to-have (Cursor diagnose
+  FINALIZE early-exit conditional moved above "Then print:"; the
+  `bug-product.md` FINALIZE commit sentence re-wrapped to the file's
+  width and extended to both skip cases — early exits 2/3 AND the
+  idempotent re-run where the story is already committed and
+  unchanged; `test_opencode_review_task_has_two_execute_blocks`
+  renamed to
+  `test_opencode_handoff_orchestrators_have_two_execute_blocks`; the
+  "7 worktree handoffs" comment corrected to "7 GUI-block handoffs";
+  diagnose-task/verify-task rows added to the `overview.md` phase
+  table; net-new OpenCode allowlist globs tightened — `"tail *"`,
+  `"sort *"`, `"git push *"` — in the three new agent files, bodies
+  verified to always pass args; the empty-lane diagnose fallback
+  guarded ×3 against silently overwriting a committed feature story;
+  the lane-block parity sentinel extended for the grown paragraph;
+  the lane-resolution paragraph pinned by a fourth assertion in
+  `test_shared_orchestrator_carries_both_lane_branches`). **Parity
+  gaps recorded, not fixed**: the second-skip-case wording (the
+  idempotent FINALIZE re-run) lands only in `bug-product.md` — the
+  five byte-identical lane files / `phase-protocols.md` keep the
+  shorter commit sentence (AC-4 byte-identity); the byte-frozen
+  OpenCode peers keep their no-trailing-space glob convention, and
+  the `source venv/bin/activate*` prefix glob stays a recorded
+  follow-up (fix plan #03).
+- **Review fix plan #06 applied (6 findings)**: 1 should-fix (this
+  progress-note pair — the missing #05 applied-note above, with its
+  parity-gap records, plus this #06 note, restoring the per-plan
+  applied-note convention at head) + 5 nice-to-have (the
+  story-overwrite guard lifted into a lane-independent sentence ×3 —
+  "Independent of lane: …" — so a `bug-product`-labelled worktree
+  carrying a pre-existing non-bug story is guarded too, not only the
+  empty-lane fallback; the lane-block parity sentinel in
+  `test_lane_steps_parity.py` switched from a first-match tuple over
+  the whole file remainder to a per-agent terminal-marker map, in
+  lockstep with the guard rewording; the four remaining no-space
+  globs — `git status/log/diff/fetch` — tightened in the three
+  net-new OpenCode files only, the sole body invocation
+  (`git status --porcelain -- …`) verified to still match; the Claude
+  diagnose FINALIZE early-exit conditional moved above "Then print
+  both blocks:", mirroring the #05 Cursor move; the OpenCode diagnose
+  edit scope narrowed from `docs/stories/**` to
+  `docs/stories/QS-*.story.md`, matching the sibling verify-task's
+  least-privilege pattern). Frozen peers untouched (AC-4); skipped:
+  the `source venv/bin/activate*` prefix glob stays the recorded
+  fix-plan-#03 follow-up.
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -538,6 +538,29 @@ top-level `CLAUDE.md`).
   note). **Parity note**: the byte-frozen `qs-review-task` OpenCode peer
   keeps the older blanket "never auto-trigger finish-task" wording — the
   scoped rewrite lands only in the new `qs-verify-task` file (AC-4).
+- **Review fix plan #02 applied (10 findings)**: 2 should-fix
+  (`worktree` added to the verify-task context capture list ×3;
+  verify-task doc-maintenance audit trigger widened from "would exit 1"
+  to any non-zero `check_doc_drift.py` exit — 1 = stale doc, 2 = a doc
+  now covers a deleted/renamed source) + 8 nice-to-have (sanctioned
+  `source venv/bin/activate && pytest <file>::<test> -v` invocation
+  named in the OpenCode regression-proof; heredoc-repro ask-prompt
+  expectation stated in the OpenCode diagnose note; `gh issue edit`
+  allowlisted in the OpenCode diagnose frontmatter for the backfill
+  guidance; "All 8 orchestrators" comment corrected to the 7-entry
+  reality in `test_orchestrator_handoff.py`; FINALIZE commit made
+  idempotent ×3 — skip the commit, keep the push, when the story is
+  already committed unchanged; verify-task doc-audit path source
+  switched to the uncapped `gh pr diff --name-only` ×3; the `python -c`
+  fix-plan-path helper allowlisted in the OpenCode verify-task
+  frontmatter; `pr_number` STOP reworded ×3 to "no **open** PR on this
+  branch" with a `gh pr list --head <branch> --state all` hint).
+  **Parity gaps recorded, not fixed (AC-4 — `qs-review-task.md` stays
+  byte-frozen ×3)**: the frozen peer shares five of these gaps — no
+  `worktree` in its capture list, the "would exit 1" doc-audit
+  trigger, the 100-file-capped `gh pr view --json files` path source,
+  the misdirecting `pr_number` STOP wording, and (OpenCode copy only)
+  the un-allowlisted `python -c` fix-plan-path helper.
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -1,0 +1,536 @@
+# QS-335 — Bug × product lane: diagnose-first flow, red-test protocol rule
+
+**Issue**: [#335](https://github.com/tmenguy/quiet-solar/issues/335) ·
+**Lane of this task**: feature-factory · **Refs** #321
+
+## Problem
+
+`docs/workflow/lanes/bug-product.md` is a byte-for-byte copy of the
+feature flow (QS-332 created it that way on purpose). Fixing a bug is
+not building a feature: today's flow demands a plan with acceptance
+criteria *before* any diagnosis (fiction before evidence), has no
+reproduction requirement, no scope discipline against "while I'm in
+here" rework, and no sanctioned exit when the reported symptom turns
+out to be the tip of a bigger design problem.
+
+## Goal
+
+Diverge the bug × product lane — and only it — into a
+**diagnose-first** flow:
+
+`setup → diagnose → fix (implement) → verify → finish`
+
+with **two dedicated orchestrators** (`qs-diagnose-task`,
+`qs-verify-task`; `qs-create-plan`, `qs-review-task` and
+`qs-implement-setup-task` stay byte-untouched — the only shared-agent
+edits are the two routing conditionals in D3), a **dedicated minimal
+adversarial roster** (2 new diagnosis reviewers; the verify round runs
+3 — two existing + 1 new), a **red-test protocol rule** (v1: protocol,
+not a mechanical gate), a **minimum-diff rule**, and a documented
+**iceberg escalation** path.
+
+## Design
+
+### D1. New phase `diagnose-task`, agent `qs-diagnose-task` (dedicated)
+
+Decision (user): dedicated agent — `qs-create-plan`'s body is too
+prescriptive for a lane file to reliably bend, and a diagnosis session
+is not a planning session.
+
+Interactive mode loop, same skeleton as create-plan, re-purposed.
+Authoring directive: lift the REVIEW / TRIAGE / FINALIZE mode
+machinery, status banner, doc-maintenance step, and handoff blocks
+from **each harness dir's own create-plan peer** (per-harness copy —
+the opencode auto-execute markers and cursor pointer block must land
+in the right dirs), then apply exactly this substitution list:
+(1) DISCUSS → DIAGNOSE everywhere incl. the banner; (2) reviewer
+roster → D5's; (3) the `{{NEXT_PHASE}}` value set → `implement-task` |
+`finish-task`; (4) phase name in banner/handoff → `diagnose-task`.
+The lane-read paragraph (`**Lane (QS-332).**` block) is copied
+**byte-for-byte** (parity sentinel pins). Every ```bash fence invoking
+`next_step.py`/`setup_task.py` carries the dir-matching `--harness`
+flag. Diag-reviewer reports mirror `qs-plan-critic`'s findings-block
+format so the lifted TRIAGE machinery consumes them unchanged.
+
+- **DIAGNOSE (default)** — evidence before hypotheses, hypotheses
+  before cause, cause before plan:
+  - *Evidence gathering*: ask the user for production data. The
+    checklists (generic: exact HA + integration versions, timeline,
+    expected vs observed, frequency/determinism, recent changes,
+    debug-level logs; quiet-solar-specific: config-entry options /
+    device setup, entity histories for charger/car/solar/grid sensors,
+    `custom_components.quiet_solar` debug log capture, solver inputs
+    around the incident window) live **in the lane file only** — the
+    single home; the agent reaches them through its lane-read step.
+    The agent picks from them per bug — not a rigid form.
+  - *Root-cause analysis*: read the code, form hypotheses, confirm or
+    eliminate each against evidence. **Hard rule: no fix plan until
+    the root cause is stated in one sentence with file/function
+    references.** Insufficient evidence → ask, don't guess; staying in
+    DIAGNOSE across sessions is normal.
+  - *Reproduction*: **demonstrate when feasible** — the agent may run
+    throwaway, uncommitted scripts/snippets via Bash to show the
+    hypothesis live (nothing is committed in this phase). Always
+    produce the **red test spec**: exact test file, fixture data
+    derived from the evidence, the assertion that fails today.
+    **Sanctioned fallback** when a unit test cannot reproduce the bug
+    (timing, hardware, cloud-API dependent): the story states *why*
+    and names the alternative proof, and carries a mandatory
+    acceptance line — `Fallback accepted: <reason>` — recorded when
+    the human accepts it in-session.
+  - *Fix plan*: short, produced *by* the diagnosis.
+    **Minimum-diff rule**: the fix plan lists the files it expects to
+    touch. Amendment path: implement may extend the list with a
+    reasoned progress note in the story; review flags **unexplained**
+    excess as must-fix. Blast-radius statement mandatory.
+  - *Iceberg check* (mandatory story section): is the root cause
+    local, or the tip of something generic? If iceberg → create a new
+    issue (`kind:feature` or epic, `target:product`) via
+    `gh issue create`, carrying the full diagnosis and a back-link;
+    then a **per-case human decision**: (a) close this bug as
+    superseded, or (b) ship a minimal containment fix here and link.
+- **REVIEW / TRIAGE** — same loop mechanics as create-plan, with the
+  **bug roster** (D5): round 1 = `qs-diag-root-cause-skeptic` +
+  `qs-diag-fix-minimalist` in parallel; round 2+ adds
+  `qs-plan-delta-auditor` — **used unchanged**; one implement-time
+  step confirms its body is artifact-shape-agnostic. If it is not, a
+  strictly shape-neutral one-line adaptation is a **sanctioned,
+  recorded exception** to the shared-agents-untouched rule (story
+  amendment with progress note); anything larger escalates to the
+  user instead of being edited in. Review stays **on-demand**
+  (user-invoked, offered once per stable version), as in create-plan.
+- **FINALIZE** — commit story; dynamic next-phase handoff (the
+  `{{NEXT_PHASE}}` placeholder pattern, à la create-plan; single GUI
+  block, count 1). **Three exits**, all human-confirmed:
+  1. *fix* (normal) → `implement-task`;
+  2. *close-as-superseded* (iceberg): the **diagnose agent** runs
+     `gh issue close --comment` linking the superseding issue at
+     FINALIZE; then `finish-task` (Case A — no-PR cleanup **only**,
+     it does not touch the issue). The superseding issue's body is
+     the durable record of the diagnosis;
+  3. *no-defect / cannot-diagnose*: works-as-intended, duplicate, or
+     evidence exhausted — the human decides close (agent closes with
+     the rationale) or leave open awaiting evidence. **Either way the
+     diagnosis-so-far is posted as an issue comment before cleanup**
+     (Case A removes the worktree holding the story — a future
+     session must not restart from zero); → `finish-task` Case A.
+
+**Story template for bug diagnoses** (defined in the lane file):
+Symptom · Evidence · Root cause · Repro strategy · Fix plan ·
+Iceberg check · Acceptance (the red test(s), or the fallback proof +
+acceptance line).
+
+The agent carries the create-plan doc-maintenance step (inherited by
+the lift; a fix plan touches product code, so `check_doc_drift.py`
+applies) and joins `DOC_MAINTENANCE_AGENT_NAMES`.
+
+### D1b. New phase `verify-task`, agent `qs-verify-task` (dedicated)
+
+Decision (user): same reasoning as D1 — the bug-lane code review is a
+**separate phase with its own orchestrator**, not a lane-conditional
+bolted onto shared `qs-review-task` (whose body imperatively hardcodes
+the feature four; a lane file cannot reliably override an imperative).
+**`qs-review-task` stays byte-untouched.**
+
+Authoring directive: lift from **each harness dir's own
+`qs-review-task` peer** (per-harness copy), then substitute:
+(1) roster → the D5 verify roster, **and delete roster-specific
+orchestration/consolidation prose for reviewers not in it**
+(blind-hunter's artifact-withholding protocol, acceptance-auditor's
+criteria-mapping steps); (2) **every occurrence** of `review-task` /
+`qs-review-task` / `/review-task` → the `verify-task` forms — banner,
+handoff blocks, fix-loop re-run instruction, GUI blocks — **except**
+the fix-plan filename pattern `QS-<N>.story_review_fix_#NN.md`, kept
+verbatim (phase-agnostic by `scripts/qs/utils.py`, verified).
+Everything else is review-task's existing shape, inherited: fix-plan
+files, zero-findings fast path → `finish-task`, fix loop →
+`implement-task` then re-run `verify-task`, **two** handoff sites
+(GUI count 2, stale-pin sentence at both — the sentence is expected
+phase-agnostic; verify at implement, and if it names the phase, use a
+per-agent variant and parametrize the pin the same way), lane-read
+paragraph byte-for-byte, PR-diff doc-maintenance step (joins
+`DOC_MAINTENANCE_AGENT_NAMES` **and** `REVIEW_AGENT_NAMES`).
+
+**Fork-drift policy** (decision): the lifted orchestrator bodies (2
+agents × 3 dirs) **may drift independently** from their create-plan /
+review-task sources after landing; only the sentinel-pinned blocks
+(lane-read paragraph, pointer block, stale-pin sentence) stay
+mirrored by tests. Future edits to the source agents carry no
+obligation to mirror into the forks, and vice versa.
+
+### D2. Lane file rewrite — `docs/workflow/lanes/bug-product.md`
+
+Full rewrite. **First act: add `"bug-product.md"` to `DIVERGED` in
+`tests/qs/docs/test_lanes.py`** (which pins byte-identity to
+phase-protocols for undiverged lanes — it is also the AC-1 vehicle for
+"other 5 lanes byte-unchanged"). Per phase:
+
+- **setup-task**: unchanged except next-phase routing (D3).
+- **diagnose-task**: the contract from D1, including the evidence
+  checklists (single home) and the bug story template.
+- **implement-task** (shared agent; lane-read step already pinned):
+  1. write the spec'd regression test first, run it with the
+     sanctioned `::`-form (`pytest <file>::<test> -v`), **record the
+     failure output** (story progress note + PR body) — it must fail
+     for the diagnosed reason, not an import/collection error;
+  2. minimal fix; re-run green;
+  3. scope constraint: deliver the fix at the scope diagnosed — no
+     drive-by refactors, no opportunistic cleanups; anything bigger
+     goes through the iceberg escalation, never into the bug PR.
+     File-list amendments carry a reasoned progress note (D1);
+  4. fallback path: with an accepted cannot-unit-repro line in the
+     story, implement per plan and document the alternative evidence
+     in the PR body;
+  5. next-phase handoff routes to `verify-task` (D3).
+- **verify-task**: the contract from D1b. `qs-review-task` does not
+  run in this lane and is not modified by this story.
+- **finish-task**: unchanged (bug × product closes on merge; Case A
+  covers D1 exits 2–3 as pure cleanup; the verifying-tail lifecycle
+  is bug × factory, #336's scope).
+
+Prose discipline: lane files are prompt rent paid every session — the
+divergence is written tight and adds **no** "verify your own work"
+scaffolding. The `test_lanes.py` required-section asserts pin
+**headings / sentinel lines only** (story-template headings, roster
+sentinel, checklist section headings — never checklist prose; the
+checklists must stay free to evolve).
+
+### D3. Routing: two shared agents get the lane conditional
+
+`/create-plan` (setup) and `/review-task` (implement) each appear at
+**~5–7 sites** per agent file, one of them functional: the
+`setup_task.py` / `next_step.py` ```bash fence whose `--next-cmd`
+value drives the launcher payload **and the GUI pin write**. A
+conditional on the fallback line alone would still pin the wrong
+agent. Resolution — the codebase's own dynamic pattern:
+
+- The agent resolves the next phase **once** from its lane context
+  (setup-task resolves the lane at its step 1b; implement-task reads
+  `lane` from `context.py`): `create-plan` — or `diagnose-task` when
+  lane is `bug-product` (resp. `review-task` / `verify-task`) — and
+  substitutes that value in: the fence's `--next-cmd`, the
+  "Next phase:" line, the Preferred line, the GUI pin sentence, and
+  the session-name bullet (exactly how `qs-create-plan` handles its
+  dynamic `{{NEXT_PHASE}}`).
+- **Pin compatibility**: the fallback *line* keeps its literal default
+  (`/create-plan` resp. `/review-task`) as the first slash token —
+  `_find_fallback_line` returns the first line starting with `/` or
+  `{{` after the `Fallback` marker — with the branch appended
+  mid-sentence on the same line ("— or `/diagnose-task` when the lane
+  is `bug-product`"). `_HARDCODED_FALLBACK` (a **list of tuples**, not
+  a dict) keeps both agents' default entries; `_GUI_BLOCK_COUNTS`
+  stays 1 for both; `_STALE_PIN_SENTENCE` stays verbatim.
+- `qs-implement-setup-task` is **untouched** — a bug × product fix is
+  product code and never routes through it.
+
+New pin: a **`HARNESS_DIRS`-parametrized** test **added inside
+`test_orchestrator_handoff.py`** (pattern of
+`test_lane_steps_parity.py`) asserting each of the 3 copies of both
+agents contains both branches (`bug-product → /diagnose-task` resp.
+`→ /verify-task`, plus the default). Note: `scripts/qs/setup_task.py:149`
+defaults `--next-cmd` to `/create-plan` — not a second routing site
+(the agent always passes the flag); leave it. The new pins must not
+encode `bug-factory` expectations (#336 rewrites that lane).
+
+### D4. Phase registry, fallback commands, test-pin ledger
+
+- `scripts/qs/launchers/phases.py::PHASE_TO_AGENT` gains
+  `"diagnose-task": "qs-diagnose-task"` (**after `create-plan`**) and
+  `"verify-task": "qs-verify-task"` (**after `review-task`**);
+  `PHASE_AGENT_NAMES` mirrors both indices. (`next_step.py` validates
+  strictly via this registry — these entries are load-bearing.)
+- `.claude/commands/diagnose-task.md` + `.claude/commands/verify-task.md`
+  fallbacks — same preamble pattern as their peers (commands exist
+  **only** under `.claude/commands/`; no cursor/opencode commands
+  dirs, no codex agents dir).
+- **Test-pin ledger** (test edits land *first* within each coupled
+  green unit):
+  - `tests/qs/docs/test_lanes.py` — `DIVERGED` += `bug-product.md`;
+    heading/sentinel asserts for the diverged file (D2).
+  - `tests/qs/launchers/test_phase_mapping.py` — `_KNOWN_PHASES` +=
+    `diagnose-task`, `verify-task`.
+  - `tests/qs/agents/test_opencode_agents.py` — **list-driven, not
+    glob-scoped**: `PHASE_AGENT_NAMES` += the 2 orchestrators (same
+    indices as the dict); `SUB_AGENT_NAMES` += the 3 reviewers —
+    without this they get **zero** contract checking (`mode:
+    subagent`, `hidden: true`, frontmatter keys, legacy-token scan).
+  - `tests/qs/agents/test_lsp_tool_enabled.py` — partition exhaustive
+    over `.claude/agents/*.md`: `LSP_INCLUDE_AGENTS` +=
+    `qs-diagnose-task`, `qs-verify-task`,
+    `qs-diag-root-cause-skeptic`; `LSP_EXCLUDE_AGENTS` +=
+    `qs-diag-fix-minimalist`, `qs-review-regression-proof`.
+  - `tests/qs/agents/test_lane_steps_parity.py` —
+    `LANE_READ_AGENT_NAMES` += `qs-diagnose-task`, `qs-verify-task`
+    (reviewers get artifacts from the orchestrator; they do not read
+    the lane).
+  - `tests/qs/agents/test_orchestrator_handoff.py` — D3 pins for both
+    shared agents; **both** new orchestrators join **both**
+    `_TWO_BLOCK_ORCHESTRATORS` and `_GUI_BLOCK_ORCHESTRATORS` (a
+    set-equality test couples the two lists);
+    `_FALLBACK_LINE_EXPECTATION` derives from `_HARDCODED_FALLBACK` —
+    append `("qs-diagnose-task.md", "/{{NEXT_PHASE}}")` and
+    `("qs-verify-task.md", "/finish-task")` to that list (one edit
+    each); `_GUI_BLOCK_COUNTS["qs-verify-task.md"] = 2`;
+    **parametrize the dedicated stale-sentence-twice test**
+    (`test_review_task_carries_the_stale_pin_hazard_at_both_handoffs`)
+    over `["qs-review-task.md", "qs-verify-task.md"]`; update the two
+    stale count comments ("All 6 orchestrators", "the 5 worktree
+    handoffs"); counterpart copies carry the verbatim
+    `_POINTER_BLOCK`.
+  - `tests/qs/agents/test_opencode_execute_contract.py` —
+    `OPENCODE_EXECUTE_AGENTS` += both orchestrators; **parametrize
+    the hardcoded `qs-review-task.md` `EXECUTE_MARKER >= 2` check**
+    over `["qs-review-task.md", "qs-verify-task.md"]`.
+  - `tests/qs/agents/test_slash_command_preambles.py` —
+    `_SLASH_COMMAND_FILES` += `diagnose-task.md`, `verify-task.md`
+    (five pinned markers each).
+  - `tests/qs/agents/test_doc_maintenance_parity.py` —
+    `DOC_MAINTENANCE_AGENT_NAMES` += both orchestrators;
+    `REVIEW_AGENT_NAMES` += `qs-verify-task` (the PR-diff variant
+    contract); docstring "four orchestrator agents" → six (task 3
+    only, after both names exist).
+  - `tests/qs/agents/test_harness_flag_explicit.py` — no test edit;
+    genuinely glob-scoped, the new bodies must satisfy it.
+- Permissions: `.claude/settings.json` `Bash(gh issue:*)` already
+  covers create + close; opencode create-plan peer already allows
+  `gh issue create` — **add `gh issue close`** to `qs-diagnose-task`'s
+  opencode allowlist (task 2); check the cursor peer in the same task
+  and add the equivalent permission there if missing. Other
+  frontmatter copied from each harness's closest peer
+  (`qs-create-plan` / `qs-review-task` for the orchestrators;
+  `qs-plan-critic`-style for read-only reviewers;
+  `qs-review-blind-hunter`-style for the Bash-bearing
+  regression-proof).
+- Verified phase-agnostic (no edits needed): `scripts/qs/utils.py`
+  fix-plan globbing, `context.py` `latest_review_fix`,
+  `create_pr.py`, launcher fixtures.
+- Codex passthrough hole: pre-existing, **out of scope**.
+
+### D5. The bug-lane adversarial rosters (dedicated, minimal)
+
+Decision (user): the feature rosters are too heavy for a short
+diagnosis, and large fan-outs amplify over-verification on
+review-happy models. **3 new sub-agents total**; lean bodies as an
+authoring directive (target ≤ ~80 lines; no self-verification
+clauses) — deliberately **not** an acceptance criterion (untestable).
+
+**Diagnosis review** (spawned by `qs-diagnose-task`, parallel):
+
+1. `qs-diag-root-cause-skeptic` — attacks the **causal chain**:
+   does evidence → hypothesis → cause hold, or is it correlation
+   dressed as causation? What alternative explanations survive the
+   evidence? Is the repro spec **discriminating** — failing *only*
+   because of the stated cause? Verifies the code claims in the chain
+   against actual source. Tools: `Read, Glob, Grep, LSP`.
+   Artifact: story text + pointer to the code areas it names.
+2. `qs-diag-fix-minimalist` — audits the **fix plan**: does every
+   planned change trace back to the stated cause? Blast radius stated
+   and plausible? Drive-by rework? Iceberg-check honesty (is "it's
+   local" argued or asserted)? Concreteness (exact files / functions /
+   test spec)? Tools: `Read, Glob, Grep`. Artifact: story text +
+   issue body.
+
+   Round 2+ adds `qs-plan-delta-auditor` (see D1 for the
+   shape-agnostic check). Findings use the
+   `critical/redesign/improve/clarify` categories, report format
+   mirroring `qs-plan-critic`, and the same finding-state triage
+   model as create-plan.
+
+**Fix verification** (spawned by `qs-verify-task`, D1b; roster width
+**3 confirmed by user**): `qs-review-edge-case-hunter` (existing —
+regression is the dominant risk) + `qs-review-coderabbit` (existing) +
+
+3. `qs-review-regression-proof` — the lane's specific auditor:
+   (a) recorded red-test failure output present (story/PR) and
+   failing **for the diagnosed reason**, produced by the sanctioned
+   `::`-form invocation; (b) **root cause or symptom patch** — does
+   the diff remove the diagnosed cause or mask the symptom? blast
+   radius consistent with the story's statement?; (c) **diff-vs-plan
+   discipline**: every changed file appears in the fix plan's stated
+   file list (or carries a reasoned amendment note) — unexplained
+   excess is must-fix; (d) fallback-path PRs: the alternative
+   evidence is present and matches the accepted story line. Tools:
+   `Bash, Read, Grep, Glob` — Bash is for `gh pr diff` / `gh pr view`
+   and (optionally) running the new test **on the head branch** to
+   confirm it passes; **no merge-base execution in v1** (user ruling,
+   round 2): auditing the *recorded* red output is the normative
+   check. Report format mirrors the existing review reviewers'
+   findings block so verify-task's lifted consolidation consumes it
+   unchanged.
+
+**Not run in this lane**: `qs-review-blind-hunter`,
+`qs-review-acceptance-auditor` (for a bug, acceptance *is* the red
+test — regression-proof subsumes it), and the 4 plan reviewers
+(their lenses are absorbed, specialized, into the two diag reviewers).
+
+### Decisions & deferrals
+
+- **Two dedicated orchestrators, shared agents untouched** (user
+  rulings): `qs-diagnose-task` replaces create-plan, `qs-verify-task`
+  replaces review-task *in this lane*; `qs-create-plan` and
+  `qs-review-task` are not modified. The only shared-agent edits are
+  the two routing conditionals (D3). Sanctioned exception: the
+  delta-auditor one-liner (D1), recorded as a story amendment if
+  needed.
+- **Contingency bound**: every deferred verification in this story
+  (cursor-peer permission, stale-sentence phase-agnosticism,
+  delta-auditor shape) has a budgeted one-line resolution; if the
+  actual fix exceeds it, that is a **story amendment with a progress
+  note**, never silent expansion — the same discipline D1 imposes on
+  fix plans.
+- **Fork-drift policy** (D1b): lifted orchestrator bodies may drift
+  from their sources; only sentinel-pinned blocks stay mirrored.
+- **Red-test gate is a protocol rule in v1, not mechanical** (user
+  ruling): no gate script, no CI job, and — round-2 ruling — **no
+  reviewer-side merge-base execution either**. Enforcement = implement
+  protocol + `qs-review-regression-proof` auditing the recorded
+  output. Mechanical enforcement is the named follow-up once the lane
+  has run real bugs; recipe recorded for it: `git merge-base` →
+  `git worktree add <scratch outside the task worktree>` →
+  `git checkout <branch> -- <test file>` → `::`-form pytest from the
+  review worktree's venv → mandatory scratch cleanup.
+- **Unreviewed fix plans are permitted** (accepted risk, stated):
+  diagnosis review is on-demand; `qs-review-regression-proof` is the
+  backstop at verify time.
+- **No-unit-test fallback** (user ruling, Q2): a second, distinct
+  under-delivery of the issue's letter ("must ship with a regression
+  test") — sanctioned because some bugs (timing, hardware, cloud-API)
+  cannot be unit-reproduced; bar kept high: in-session human
+  acceptance recorded as a mandatory story line.
+- **Reproduce-in-session** (user ruling, CL-A): throwaway uncommitted
+  demonstration in DIAGNOSE when feasible; spec-only otherwise.
+- **Dedicated minimal rosters** (user rulings, CL-B + round 2): 2 diag
+  reviewers + 1 new code reviewer; verify round width 3;
+  delta-auditor reused; blind-hunter and acceptance-auditor not run
+  in this lane.
+- **Iceberg exits are per-case human decisions** (user ruling);
+  close-as-superseded is executed by the diagnose agent at FINALIZE,
+  finish-task only cleans up; exits 2–3 leave the diagnosis durable
+  on the issue (superseding-issue body resp. issue comment).
+- **`docs/workflow/phase-protocols.md` untouched** — legacy fallback
+  for unlabelled tasks; labelled tasks read their lane file.
+- **Per-model harness options** (Opus-5 scope/verbosity controls):
+  out of scope — separate factory task to be filed.
+- QS-321.md is background rationale, not a spec (user ruling); where
+  they diverge, this story wins.
+- Doc-drift: zero findings at plan time (factory-only change set);
+  **re-run at implement time** after the final touched-paths set is
+  known. At implement, also grep the story for `AC-` references after
+  any renumbering.
+
+## Acceptance criteria
+
+1. `docs/workflow/lanes/bug-product.md` diverged: diagnose contract
+   (checklist section sentinels, root-cause hard rule, repro incl.
+   demonstrate-when-feasible + fallback, iceberg check, three
+   FINALIZE exits), red-test implement protocol, verify-task
+   contract, escalation procedure — pinned by the extended
+   `tests/qs/docs/test_lanes.py` (headings/sentinels only); other 5
+   lane files byte-identical to phase-protocols (same test).
+2. `qs-diagnose-task` and `qs-verify-task` exist ×3 harness dirs; all
+   D4 ledger tests green.
+3. `diagnose-task` and `verify-task` resolve via `PHASE_TO_AGENT`
+   (inserted after `create-plan` resp. `review-task`);
+   `.claude/commands/diagnose-task.md` and
+   `.claude/commands/verify-task.md` exist with the pinned preamble
+   markers.
+4. `qs-setup-task` and `qs-implement-task` ×3 carry the
+   lane-resolved dynamic handoff (D3: `--next-cmd`, "Next phase:",
+   Preferred line, GUI pin sentence and session name all follow the
+   resolved phase; fallback line keeps the literal default + appended
+   branch) — pinned `HARNESS_DIRS`-parametrized (both branches
+   asserted); `qs-create-plan`, `qs-review-task`, and
+   `qs-implement-setup-task` are **byte-unchanged, verified by
+   review-time `git diff` against `main`** (no parity test built).
+5. The 3 new reviewer sub-agents exist ×3 harness dirs with the D5
+   tool sets, listed in `SUB_AGENT_NAMES`; contract tests green.
+6. `python scripts/qs/quality_gate.py --impacted` and
+   `python scripts/qs/quality_gate.py --quick tests/qs` green
+   pre-commit.
+
+## Task breakdown
+
+Test edits land first **within each coupled green unit** (some pins
+cannot go green before their artifact exists — the unit is
+test+artifact together).
+
+1. `tests/qs/docs/test_lanes.py`: `DIVERGED` + heading/sentinel
+   asserts (red) → rewrite `docs/workflow/lanes/bug-product.md` (D2)
+   (green).
+2. Coupled unit, diagnose: `_KNOWN_PHASES` + `PHASE_AGENT_NAMES` +
+   `phases.py` entry + author `qs-diagnose-task` ×3 dirs (D1) + its
+   ledger pins (`LANE_READ_AGENT_NAMES`, LSP include,
+   `DOC_MAINTENANCE_AGENT_NAMES`, `OPENCODE_EXECUTE_AGENTS`, handoff
+   lists + `_HARDCODED_FALLBACK` tuple + `_POINTER_BLOCK`
+   counterpart) + opencode frontmatter allowlist incl.
+   `gh issue close` + cursor-peer permission check.
+3. Coupled unit, verify: same set for `qs-verify-task` (D1b) — plus
+   `_GUI_BLOCK_COUNTS` = 2, the stale-sentence-twice test and the
+   opencode `EXECUTE_MARKER >= 2` check parametrized over both
+   agents, `("qs-verify-task.md", "/finish-task")` tuple,
+   `REVIEW_AGENT_NAMES`, the doc-maintenance docstring four → six,
+   and the two stale count comments.
+4. `_SLASH_COMMAND_FILES` pins → `.claude/commands/diagnose-task.md`
+   + `verify-task.md`.
+5. Routing: `HARNESS_DIRS` both-branches pins (inside
+   `test_orchestrator_handoff.py`) (red) → `qs-setup-task` and
+   `qs-implement-task` ×3 lane-resolved dynamic handoffs (D3)
+   (green).
+6. Reviewers: `SUB_AGENT_NAMES` + LSP partition entries (red) →
+   author `qs-diag-root-cause-skeptic`, `qs-diag-fix-minimalist`,
+   `qs-review-regression-proof` ×3 dirs (D5) (green).
+7. Phase-enumeration sweep — row/branch-annotation additions only,
+   nothing else changes; linear chains get **branch annotations**
+   ("`create-plan` — or `diagnose-task` when lane = `bug-product`";
+   likewise `review-task` / `verify-task`), not new chain links:
+   `CLAUDE.md` commands table (two rows),
+   `docs/workflow/overview.md`, `docs/workflow/project-rules.md`
+   (routing table **and** the "four orchestrator agents"
+   doc-maintenance prose → six), `docs/workflow/project-context.md`,
+   `docs/workflow/adversarial-review.md` (**one-line pointer** at the
+   lane file, nothing more). `harness.md` verified — no phase
+   enumeration; excluded.
+8. Re-run `check_doc_drift.py` on the final touched-paths set; update
+   the Doc-OK note; grep the story for stale `AC-` references.
+
+**NEXT_PHASE**: `implement-setup-task` (all paths in `docs/`,
+`.claude/`, `.cursor/`, `.opencode/`, `scripts/`, `tests/qs/`, and
+top-level `CLAUDE.md`).
+
+## Adversarial Review Notes
+
+**Round 1** (2026-08-10; critic, concrete-planner, dev-proxy,
+scope-guardian): 24 findings, all resolved in v2, none rejected.
+
+**Round 2** (2026-08-10; same four + delta-auditor): all round-1
+verified resolved; N1–N6 + batch resolved in v3 (N6 by user ruling —
+no merge-base execution; roster width 3 confirmed), none rejected.
+
+**v4 design change (user direction)**: dedicated `verify-task` phase /
+agent (D1b) superseding the N5 resolution; `qs-implement-task` gains
+the routing conditional (D3).
+
+**Round 3** (2026-08-11; the four + delta-auditor, on v4).
+Delta-auditor: all round-2 findings resolved; N5 **superseded
+coherently** (no leftover amendment references). New findings — all
+resolved in v5, none rejected:
+
+| ID | Finding (short) | State |
+|---|---|---|
+| P1 | AC-4 byte-unchanged had no vehicle | resolved (review-time `git diff`, stated in AC-4; no parity test) |
+| P2 | delta-auditor adaptation contradicted shared-untouched rule | resolved (sanctioned recorded exception + contingency bound) |
+| P3 | mid-sentence conditional insufficient — `--next-cmd` fence drives payload + GUI pin (~7 sites in qs-implement-task) | resolved (D3 rewritten: lane-resolved dynamic value substituted at all functional sites; fallback line keeps literal default) |
+| P4 | fork-maintenance policy undecided (6 forked bodies) | resolved (fork-drift policy recorded, D1b) |
+| P5 | exit-3 "leave open" destroyed the diagnosis | resolved (issue comment before Case A cleanup) |
+| P6 | two hardcoded qs-review-task tests (stale-twice, EXECUTE_MARKER≥2) not list-driven | resolved (parametrized over both agents) |
+| P7 | `REVIEW_AGENT_NAMES` missed; `_HARDCODED_FALLBACK` is a list not dict; stale count comments | resolved (ledger corrected) |
+| P8 | D1b substitutions under-specified (self-references, roster-prose removal, regression-proof report format) | resolved (D1b sharpened) |
+| P9 | bug-lens duplication (consolidation vs regression-proof charter) | resolved (dropped from D1b; charter is the single home) |
+| P10 | task-7 trims (adversarial-review.md net-new prose); Goal vs D3 wording; Bash purpose; pin home; AC-1 checklist wording; gh-close task home; docstring timing; doc-maintenance in D1 | resolved (folded) |
+
+Verified clean by concrete-planner: fix-plan file plumbing
+(`utils.py`, `context.py`, `next_step.py`) is phase-agnostic —
+verify-task writing `story_review_fix_#NN` files just works; no other
+implement→review hardcoding exists.
+
+Open criticals: 0. Rejected: none.

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -522,6 +522,22 @@ top-level `CLAUDE.md`).
   `tests/conftest.py` is outside `implement-setup-task` scope — the fix
   (plus modernizing the deprecated `device.config_entries` assertion in
   `tests/test_ha_device_registry.py`) is handled separately in **#346**.
+- **Doc-OK (task 8, re-run at implement time)**:
+  `python scripts/qs/check_doc_drift.py` on the final staged touched set
+  exits **0** (no drift) — the only output is the pre-existing
+  `testing-layers.md` "covers entry outside custom_components" warnings,
+  which are not drift. No `docs/agents/` update required.
+- **Review fix plan #01 applied (10 findings)**: 4 should-fix
+  (verify-task `finish-task` hard-rule contradiction scoped in the
+  OpenCode copy; OpenCode diagnose-task allowlist trimmed to
+  least-privilege; empty-`story_file` STOP guard added to verify-task
+  ×3; this Doc-OK record) + 6 nice-to-have (Cursor diagnose description
+  `/setup-task`; Cursor verify-task agent-picker phrasing; routing-table
+  pipe alignment; `→` "replaced by" reworded in overview/project-context;
+  FINALIZE early-exit commit guard ×3; OpenCode diagnose repro-heredoc
+  note). **Parity note**: the byte-frozen `qs-review-task` OpenCode peer
+  keeps the older blanket "never auto-trigger finish-task" wording — the
+  scoped rewrite lands only in the new `qs-verify-task` file (AC-4).
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -561,6 +561,33 @@ top-level `CLAUDE.md`).
   trigger, the 100-file-capped `gh pr view --json files` path source,
   the misdirecting `pr_number` STOP wording, and (OpenCode copy only)
   the un-allowlisted `python -c` fix-plan-path helper.
+- **Review fix plan #03 applied (10 findings)**: 3 should-fix
+  (regression-proof output taxonomy switched from
+  `critical/redesign/improve/clarify` to
+  `must-fix/should-fix/nice-to-have` ×3, matching the verify-task
+  consolidation buckets and the story's D5 ruling; verify-round-2+
+  convergence fixed ×3 — files listed in committed
+  `QS-<N>.story_review_fix_*.md` plans, and the plan files themselves,
+  count as explained in audit (c); lane-mismatch guard added to
+  verify-task and diagnose-task ×3 each — a non-empty, non-`bug-product`
+  lane STOPs and routes to `review-task` / `create-plan`) + 7
+  nice-to-have (`gh pr list *` allowlisted in the OpenCode verify-task
+  frontmatter; `test_doc_maintenance_parity.py` docstring title "four"
+  → "six"; the two remaining hardcoded `qs-create-plan` prose mentions
+  in setup-task (Claude + OpenCode) now `qs-{{NEXT_PHASE}}`; the "8th
+  orchestrator" ordinal dropped in `test_orchestrator_handoff.py` —
+  `qs-finish-task` and `qs-release` both skip the two-block pattern;
+  the red-output hard rule conditioned on the absence of an accepted
+  `Fallback accepted:` story line ×3, severity word `must-fix` per the
+  new taxonomy; post-restart review round defined ×3 — treat as round 1
+  for delta purposes, round-1 roster, finding-state still dedupes; the
+  Claude-specific `tools: Read` delta-auditor claim made
+  harness-neutral in the Cursor/OpenCode diagnose-task copies).
+  **Parity gaps recorded, not fixed (AC-4 — `qs-create-plan.md` stays
+  byte-frozen ×3)**: the frozen peer shares two of these gaps — no
+  post-restart round-2+ degraded path, and the `tools: Read`
+  delta-auditor claim replicated verbatim into its Cursor/OpenCode
+  copies.
 
 ## Adversarial Review Notes
 

--- a/docs/stories/QS-335.story.md
+++ b/docs/stories/QS-335.story.md
@@ -753,6 +753,17 @@ top-level `CLAUDE.md`).
   "Agent invocations" / "`Agent`-tool fan-out" phrasing the Cursor
   verify-task copy just neutralized.
 
+- **Review fix plan #10 applied (1 finding)**: 1 should-fix (the
+  OpenCode diagnose copy's bash allowlist gains `"gh pr close *":
+  allow` — fix #09's superseded-fix-PR FINALIZE step mandates
+  `gh pr close {{pr_number}} --comment …`, but without the entry the
+  command fell to `"*": ask` on exactly that path; same degradation
+  class rounds #02/#03/#05 fixed for `gh issue edit` / `gh pr list` /
+  `python -c`. Claude/Cursor copies carry no permission model and are
+  unaffected). Rejected/deduped: the ASCII mode-diagram alignment
+  re-report (cosmetic skip from #01 honored) and the informational
+  CI-shard/CodeRabbit-rate-limit notes (finish-task re-verifies CI).
+
 ## Adversarial Review Notes
 
 **Round 1** (2026-08-10; critic, concrete-planner, dev-proxy,

--- a/docs/stories/QS-335.story_review_fix_#01.md
+++ b/docs/stories/QS-335.story_review_fix_#01.md
@@ -1,0 +1,154 @@
+# QS-335 — Review fix plan #01
+
+## Summary
+- Source PR: #347
+- Source story: docs/stories/QS-335.story.md
+- Findings to fix: 10
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user direction —
+  harness-only change set)
+
+## Findings to fix
+
+### [should-fix] Internal contradiction: auto-run of finish-task launcher vs "never auto-trigger" hard rule
+- File: `.opencode/agents/qs-verify-task.md` (step 4 / hard rules)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: Step 4 instructs "Run `new_context` via the Bash tool"
+  (which spawns the `qs-finish-task` session via `prompt_async`), while
+  the hard rule says "Never auto-trigger `finish-task` — the user runs
+  it explicitly when the review is clean."
+- Proposed fix: Scope the hard rule to name what "auto-trigger"
+  excludes (mirror whatever wording `.opencode/agents/qs-review-task.md`
+  uses for the same exit — keep the two OpenCode orchestrators
+  consistent). If review-task has the same contradiction, fix only the
+  new verify-task file (review-task is byte-frozen per AC-4) and note
+  the parity gap in the story progress notes.
+
+### [should-fix] Over-broad bash allowlist in OpenCode qs-diagnose-task
+- File: `.opencode/agents/qs-diagnose-task.md` (permission frontmatter)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: Allowlist grants `"gh pr create *"`,
+  `"bash scripts/worktree-setup.sh*"`, `"git checkout *"`,
+  `"git branch *"` — none used by any diagnose step (copied from the
+  create-plan peer). Diagnose's hard rule is "do not write product
+  code"; least-privilege applies.
+- Proposed fix: Trim the allowlist to the commands the agent body
+  actually invokes (context.py, gh issue view/comment/close/edit,
+  git add/commit/push of the story file, check_doc_drift.py,
+  next_step.py, read-only investigation commands). Keep
+  `gh issue close *` (used by FINALIZE exit 3). Update any
+  tests/qs pins if they reference the removed entries.
+
+### [should-fix] Doc-drift re-run outcome not recorded in story (task 8 mandate)
+- File: `docs/stories/QS-335.story.md` (Progress notes; plan-time note at :417)
+- Severity: should-fix
+- Source: qs-review-acceptance-auditor
+- Description: The story mandates re-running `check_doc_drift.py` on
+  the final touched-paths set and updating the Doc-OK note. The re-run
+  passes (exit 0 — independently confirmed twice at review time), but
+  the mandated record is absent.
+- Proposed fix: Add one line to the story's Progress notes:
+  "Doc-OK: `check_doc_drift.py --paths <final touched set>` re-run at
+  implement time, exit 0 (no drift)."
+
+### [should-fix] Missing empty-`story_file` guard in qs-verify-task (all 3 harness copies)
+- File: `.claude/agents/qs-verify-task.md:28` (and `.cursor/`,
+  `.opencode/` twins)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The protocol STOPs on `pr_number == null` but passes
+  `{{story_file}}` straight to `qs-review-regression-proof` with no
+  guard; `context.py` returns `""` when the story file does not exist,
+  silently degrading the regression-proof audit (recorded red output,
+  fix-plan file list, `Fallback accepted:` line) and blanking the
+  fix-plan template's `Source story:` line.
+- Proposed fix: Mirror the `pr_number` guard in all three harness
+  copies: "If `story_file` is empty, STOP — the diagnosis story must
+  exist before verification (run `/diagnose-task` first)." Update the
+  D4 ledger/parity tests in `tests/qs/` if they pin the context-step
+  text.
+
+### [nice-to-have] Malformed phase token in Cursor qs-diagnose-task description
+- File: `.cursor/agents/qs-diagnose-task.md:9`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Description says "Runs inside the worktree after
+  /qs-setup-task" — mixes the slash-command form (`/setup-task`) with
+  the agent name (`qs-setup-task`). The Claude twin says `/setup-task`.
+- Proposed fix: Change to `/setup-task` to match the Claude twin.
+
+### [nice-to-have] Cursor qs-verify-task routes users to nonexistent slash commands
+- File: `.cursor/agents/qs-verify-task.md` (~:33, ~:250)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The Cursor copy routes users to `/implement-task` /
+  `/finish-task` slash commands, but commands exist only under
+  `.claude/commands/`; Cursor users select agents from the picker.
+- Proposed fix: Use the agent-picker phrasing that the other Cursor
+  handoffs use. Check the parity/ledger tests for pinned counts of the
+  fallback lines and update in lockstep.
+
+### [nice-to-have] Routing-table pipe misalignment ("Verify task" row)
+- File: `docs/workflow/project-rules.md` (~:276)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter + qs-review-acceptance-auditor (deduped)
+- Description: The new "Verify task" row's first cell is one character
+  short versus the adjacent "Diagnose task" row, breaking the file's
+  aligned-pipe style.
+- Proposed fix: Pad the cell by one space.
+
+### [nice-to-have] Ambiguous `→` meaning "replaced by" next to pipeline diagrams
+- File: `docs/workflow/overview.md:15`, `docs/workflow/project-context.md:26`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: "`create-plan` → `diagnose-task`" uses the arrow to mean
+  "replaced by" directly under/next to diagrams where `→` means
+  "followed by" — easy to misread as a chain link.
+- Proposed fix: Replace the arrow with words, e.g.
+  "`create-plan` is replaced by `diagnose-task`", in both files.
+
+### [nice-to-have] qs-diagnose-task FINALIZE commits the story unconditionally
+- File: `.claude/agents/qs-diagnose-task.md:231` (and `.cursor/`,
+  `.opencode/` twins)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `git add docs/stories/QS-{{issue}}.story.md` +
+  `git commit` run for all three FINALIZE exits, but exit 3
+  (cannot-diagnose) — and exit 2 — is reachable before the first
+  convergence writes the story; `git add` then errors on a nonexistent
+  path.
+- Proposed fix: Add one line to the FINALIZE commit step in all three
+  copies: "If no story file was written (early exit 2/3), skip step 1;
+  the issue comment / superseding issue body is the record."
+
+### [nice-to-have] OpenCode edit-deny blocks the sanctioned throwaway repro scripts
+- File: `.opencode/agents/qs-diagnose-task.md:14-16`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The body sanctions "throwaway, uncommitted
+  scripts/snippets via Bash", but the OpenCode frontmatter's
+  `edit: {"*": deny, "docs/stories/**": allow}` hard-denies writing any
+  repro script file — the same protocol behaves differently per
+  harness.
+- Proposed fix: State in the OpenCode copy that repro snippets must be
+  inline bash heredocs (cheapest option; no permission change). Keep
+  the Claude/Cursor copies untouched.
+
+## Skipped findings (recorded, not fixed)
+
+- ASCII mode-loop diagram misalignment in qs-diagnose-task (×3) —
+  cosmetic churn, skipped.
+- Lane-file condensation of undiverged phases — confirmed intended
+  reading, awareness only.
+- `setup_task.py` lane-vs-`--next-cmd` advisory cross-check — new code
+  + tests; candidate follow-up issue.
+- Substring-pin test for the diagnose-task mode loop
+  (`test_plan_mode_loop.py` pattern) — candidate follow-up issue.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-335.story_review_fix_#02.md
+++ b/docs/stories/QS-335.story_review_fix_#02.md
@@ -1,0 +1,165 @@
+# QS-335 — Review fix plan #02
+
+## Summary
+- Source PR: #347 (re-review round 2, post-70c0450c)
+- Source story: docs/stories/QS-335.story.md
+- Findings to fix: 10
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user direction —
+  harness-only change set). Round-1 fix plan #01: all 10 findings
+  verified resolved by the acceptance auditor.
+
+## Findings to fix
+
+### [should-fix] `worktree` missing from qs-verify-task context capture list (×3)
+- File: `.claude/agents/qs-verify-task.md:~30` (and `.cursor/`,
+  `.opencode/` twins)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The "Discover the task context" step captures `issue`,
+  `title`, `branch`, `story_file`, `pr_number`, `pr_url` — but never
+  `worktree`, which is then used undefined in every `next_step.py`
+  fence (`--work-dir "{{worktree}}"`) and GUI bullet ("Select directory
+  `{{worktree}}`"). The sibling `qs-diagnose-task` capture list
+  includes `worktree`.
+- Proposed fix: Add `worktree` to the capture list in all three
+  copies. The byte-frozen `qs-review-task` peer may carry the same gap
+  — do NOT touch it (AC-4); if it does, record the parity gap in the
+  story progress notes.
+
+### [should-fix] Doc-maintenance audit trigger misses exit 2 in qs-verify-task (×3)
+- File: `.claude/agents/qs-verify-task.md:~85` (and `.cursor/`,
+  `.opencode/` twins)
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The must-fix trigger is keyed on `check_doc_drift.py`
+  "would exit 1", but a PR that deletes/renames a `covers:`-tracked
+  source produces exit 2 (missing-covers validation, which takes
+  precedence over exit 1), so the audit adds no finding for exactly
+  the drift case it exists to catch. No CI backstop exists for this
+  check; in the bug lane this audit is the last gate.
+- Proposed fix: Change the trigger to "would exit non-zero (1 = stale
+  doc, 2 = doc now covers a deleted/renamed source)" in the three
+  verify-task copies only. The wording is byte-lifted from the frozen
+  `qs-review-task.md` — per the round-1 precedent, fix only the new
+  copies and record the parity gap in the story progress notes.
+
+### [nice-to-have] Clarify sanctioned pytest invocation in OpenCode regression-proof
+- File: `.opencode/agents/qs-review-regression-proof.md:~48`
+- Severity: nice-to-have (downgraded from a blind-hunter should-fix
+  after adjudication: the `"source venv/bin/activate*"` allowlist
+  prefix DOES cover a conventional chained pytest run)
+- Description: "You MAY run the new test on the head branch" names no
+  invocation form; a bare `pytest …` would fall to `"*": ask` inside a
+  hidden non-interactive sub-agent, while the conventional
+  `source venv/bin/activate && pytest …` is allowlisted.
+- Proposed fix: One-line clarification in the OpenCode copy: run the
+  test via `source venv/bin/activate && pytest <file>::<test> -v`
+  (allowlist-covered); a bare invocation will stall on an ask prompt.
+
+### [nice-to-have] OpenCode diagnose heredoc repro not allowlisted
+- File: `.opencode/agents/qs-diagnose-task.md:~125` (frontmatter + repro note)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The repro note mandates inline heredocs
+  (`python - <<'PY' … PY`), but `python -` is not allowlisted (only
+  `python scripts/qs/*`), so every sanctioned repro demonstration
+  triggers an ask prompt while the note reads as if frictionless.
+- Proposed fix: State in the note that the ask prompt is expected for
+  heredoc repros (interactive primary agent — a speed bump, not a
+  failure). Do not blanket-allowlist `python -` (least-privilege).
+
+### [nice-to-have] `gh issue edit` missing from OpenCode diagnose allowlist
+- File: `.opencode/agents/qs-diagnose-task.md:~70` (frontmatter)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The empty-lane fallback guidance says the issue needs
+  its axis labels backfilled (`gh issue edit <N> --add-label ...`),
+  but the allowlist grants only `gh issue view/create/close/comment`.
+- Proposed fix: Add `"gh issue edit *": allow` (the guidance expects
+  the agent to surface/perform the backfill).
+
+### [nice-to-have] "All 8 orchestrators" comment vs 7-entry list
+- File: `tests/qs/agents/test_orchestrator_handoff.py:45`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Comment says "All 8 orchestrators that ship the strict
+  two-block pattern" above a 7-entry `_TWO_BLOCK_ORCHESTRATORS` list
+  (the 8th, `qs-finish-task`, is the exception that does NOT ship it).
+- Proposed fix: Rephrase, e.g. "The 7 two-block orchestrators
+  (qs-finish-task is the exception)".
+
+### [nice-to-have] FINALIZE commit not idempotent in qs-diagnose-task (×3)
+- File: `.claude/agents/qs-diagnose-task.md:~271` (and `.cursor/`,
+  `.opencode/` twins)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The round-1 guard covers only "no story file written";
+  when the story is already committed (FINALIZE re-run after a failed
+  push/handoff, or a second finalize with no story edits),
+  `git commit` exits 1 with "nothing to commit".
+- Proposed fix: Extend the guard note in all three copies: skip the
+  commit (keep the push) when
+  `git status --porcelain -- docs/stories/QS-<N>.story.md` is empty.
+
+### [nice-to-have] 100-file truncation in verify-task doc-audit path source (×3)
+- File: `.claude/agents/qs-verify-task.md:~88` (and `.cursor/`,
+  `.opencode/` twins)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `gh pr view --json files --jq '.files[].path'` caps at
+  100 files, silently truncating the list fed to
+  `check_doc_drift.py --paths` on a >100-file PR. Remote for
+  minimal-diff bug-lane PRs, but free to fix.
+- Proposed fix: Use `gh pr diff <N> --name-only` (uncapped) in the
+  three verify-task copies only (same frozen-peer parity note as
+  above — `qs-review-task.md` keeps its wording).
+
+### [nice-to-have] `python -c` fix-plan-path helper not allowlisted in OpenCode verify-task
+- File: `.opencode/agents/qs-verify-task.md:~226` vs frontmatter
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The step-6 command
+  `python -c "from scripts.qs.utils import next_review_fix_path; …"`
+  matches no allowlist entry (`"python scripts/qs/*"` does not cover
+  `python -c`), causing an ask prompt on every fix-plan round. Same
+  gap exists in the frozen OpenCode `qs-review-task.md` (parity —
+  leave it).
+- Proposed fix: Add a scoped allow entry for the helper invocation
+  (e.g. `"python -c \"from scripts.qs.utils import next_review_fix_path*": allow`)
+  in the OpenCode verify-task copy.
+
+### [nice-to-have] `pr_number` STOP message misdirects on merged/closed PR (×3)
+- File: `.claude/agents/qs-verify-task.md:~28` (and `.cursor/`,
+  `.opencode/` twins)
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `context.py` resolves `pr_number` from open PRs only,
+  so the STOP ("run the fix implement first") also fires in a stale
+  worktree whose PR was already merged — misdirecting toward
+  re-implementing a shipped fix.
+- Proposed fix: Reword to "no **open** PR on this branch" and hint to
+  check `gh pr list --head <branch> --state all` before
+  re-implementing. Verify-task copies only (frozen-peer parity note).
+
+## Skipped findings (recorded, not fixed)
+
+- `_ROUTING_HARNESS_DIRS` duplicating `HARNESS_DIRS` from
+  `test_lane_steps_parity.py` — single-source in a follow-up
+  (acceptance-auditor's own recommendation; not blocking).
+
+## Implementation notes
+
+- Several fixes touch agent files pinned by `tests/qs` ledger tests —
+  update pins in lockstep where needed and run
+  `python scripts/qs/quality_gate.py --quick tests/qs` plus
+  `--impacted` before commit.
+- Frozen-peer rule (AC-4): `qs-review-task.md`, `qs-create-plan.md`,
+  `qs-implement-setup-task.md` stay byte-unchanged in all 3 harness
+  dirs; record any parity gaps in the story progress notes instead.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-335.story_review_fix_#03.md
+++ b/docs/stories/QS-335.story_review_fix_#03.md
@@ -1,0 +1,175 @@
+# QS-335 — Review fix plan #03
+
+## Summary
+- Source PR: #347 (re-review round 3, post-9dcea5b5)
+- Source story: docs/stories/QS-335.story.md
+- Findings to fix: 10
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user direction).
+  Fix plan #02: all 10 findings verified resolved; frozen peers
+  byte-unchanged 9/9; all 6 story ACs still green.
+
+## Findings to fix
+
+### [should-fix] Regression-proof output taxonomy mismatches its consumer (×3)
+- File: `.claude/agents/qs-review-regression-proof.md:49` (output
+  format), `:38` (self-contradiction), `:71-77` (hard rules) — and
+  `.cursor/`, `.opencode/` twins
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The agent's output format is
+  `critical/redesign/improve/clarify` (the plan-review taxonomy), but
+  its consumer `qs-verify-task` consolidates only
+  `must-fix/should-fix/nice-to-have/invalid`, and the story's D5
+  ruling requires the report format to mirror the review reviewers'
+  findings block (story :357). The file even contradicts itself: :38
+  says "Unexplained excess is **must-fix**" while its own format has
+  no must-fix bucket.
+- Proposed fix: Switch the output format and the hard-rule sentences
+  to `must-fix/should-fix/nice-to-have` in all three harness copies.
+  Update any tests/qs pins that reference the old bucket names.
+
+### [should-fix] Re-verify loop cannot converge: fix-plan files flagged as excess (×3)
+- File: `.claude/agents/qs-review-regression-proof.md:36` (audit (c))
+  — and `.cursor/`, `.opencode/` twins
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: On verify round 2+, the PR diff contains
+  `docs/stories/QS-<N>.story_review_fix_*.md` (committed by
+  verify-task itself) plus every review-fix-touched file — none in
+  the diagnosis story's fix-plan file list — so audit (c)
+  deterministically emits "unexplained excess" every round.
+- Proposed fix: One sentence in audit (c) in all three copies: files
+  listed in committed `QS-<N>.story_review_fix_*.md` plans, and those
+  plan files themselves, count as explained.
+
+### [should-fix] No lane-mismatch guard in the two new orchestrators (×3 each)
+- File: `.claude/agents/qs-verify-task.md:38`,
+  `.claude/agents/qs-diagnose-task.md:37` — and `.cursor/`,
+  `.opencode/` twins
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Both agents capture `lane` and handle only the
+  empty-lane legacy fallback; a non-empty, non-`bug-product` lane
+  proceeds silently. A feature-lane "verify the fix" gets the weaker
+  3-reviewer roster; worse, diagnose-task's DIAGNOSE convergence
+  overwrites `docs/stories/QS-<N>.story.md`, clobbering a finalized
+  feature plan story.
+- Proposed fix: One guard sentence after the lane read in both new
+  agents (all three copies each): if `lane` is non-empty and not
+  `bug-product`, STOP and route to `review-task` (verify) /
+  `create-plan` (diagnose).
+
+### [nice-to-have] `gh pr list` missing from OpenCode verify-task allowlist
+- File: `.opencode/agents/qs-verify-task.md:64` vs frontmatter `:17-42`
+- Severity: nice-to-have (deduped: blind-hunter should-fix +
+  edge-case-hunter nice-to-have; interactive primary agent → ask
+  prompt is a speed bump, not a failure — but trivially fixed)
+- Description: The round-2-added STOP diagnostic mandates
+  `gh pr list --head {{branch}} --state all`, but the allowlist has no
+  `gh pr list *` entry — it falls to `"*": ask` on exactly the
+  stale-worktree path the guidance was added for.
+- Proposed fix: Add `"gh pr list *": allow` to the OpenCode
+  verify-task frontmatter.
+
+### [nice-to-have] Docstring headline still says "four orchestrator agents"
+- File: `tests/qs/agents/test_doc_maintenance_parity.py:1`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The D4 ledger item (docstring "four" → "six") was
+  applied to the body sentence and comment but not the title line,
+  which now contradicts them.
+- Proposed fix: "four" → "six" on line 1.
+
+### [nice-to-have] Two hardcoded `qs-create-plan` prose mentions in setup-task
+- File: `.claude/agents/qs-setup-task.md:142`,
+  `.opencode/agents/qs-setup-task.md:194`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: Every functional handoff site is dynamic
+  (`{{NEXT_PHASE}}`), but two narrative sentences still name
+  `qs-create-plan`; on a `bug-product` task the surrounding prose
+  names the wrong agent. Not an AC-4 breach (D3 enumerates only the
+  functional sites).
+- Proposed fix: `qs-create-plan` → `qs-{{NEXT_PHASE}}` at both sites.
+  Leave the `.opencode:51/:57` role-framing mentions (they describe
+  the common case). Check handoff-test pins.
+
+### [nice-to-have] "the 8th orchestrator" ordinal off by one
+- File: `tests/qs/agents/test_orchestrator_handoff.py:~45`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The round-2 rewording says `qs-finish-task` "(the 8th
+  orchestrator) is the deliberate exception" — but `qs-release` is a
+  9th phase orchestrator that also doesn't ship the pattern.
+- Proposed fix: Drop the ordinal, e.g. "The 7 two-block orchestrators;
+  `qs-finish-task` and `qs-release` deliberately do NOT ship it."
+
+### [nice-to-have] Unconditional red-output critical vs sanctioned fallback path (×3)
+- File: `.claude/agents/qs-review-regression-proof.md:77` — and twins
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Hard rule "Missing or greenwashed recorded red output
+  is a critical finding" is unconditional; on a sanctioned
+  fallback-path PR (story carries an accepted `Fallback accepted:`
+  line, no red test by design) a literal reading emits a false
+  critical even though audit (d) validates the alternative evidence.
+- Proposed fix: Condition the rule — "absent an accepted
+  `Fallback accepted:` story line". Apply together with the taxonomy
+  fix (finding 1) since it edits the same hard-rules block; the
+  severity word becomes `must-fix` per the new taxonomy.
+
+### [nice-to-have] Session-restart between diagnose review rounds undefined (×3)
+- File: `.claude/agents/qs-diagnose-task.md:133-140` — and twins
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Round-2+ REVIEW holds the previously-reviewed story
+  text in-session only, while the story stays uncommitted until
+  FINALIZE — yet :87 normalizes "Staying in DIAGNOSE across sessions".
+  After a restart the delta-auditor's in-context diff cannot be
+  computed.
+- Proposed fix: One line defining the degraded path: treat the
+  post-restart review as round 1 for delta purposes (the
+  finding-state persisted in "Adversarial Review Notes" still
+  dedupes). Wording lifted from frozen `qs-create-plan` — fix the new
+  copies only and record the parity gap in the story progress notes.
+
+### [nice-to-have] Claude-specific "tools: Read" claim replicated to other harnesses
+- File: `.cursor/agents/qs-diagnose-task.md:~160`,
+  `.opencode/agents/qs-diagnose-task.md:~190`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The REVIEW section states "The delta-auditor has
+  `tools: Read` only" — a Claude-frontmatter claim; the Cursor/
+  OpenCode delta-auditor twins use `readonly:`/`permission:`
+  mechanics.
+- Proposed fix: Harness-neutral phrasing in the Cursor/OpenCode
+  copies, e.g. "the delta-auditor is read-only and never diffs
+  anything itself". (Check the parity tests: if the sentence is
+  pinned across harnesses, update the pin consistently instead.)
+
+## Skipped findings (recorded, not fixed)
+
+- `"source venv/bin/activate*"` prefix glob allowlists any chained
+  command — security smell inherited from frozen-peer convention;
+  blind-hunter itself scoped it as a follow-up tightening across all
+  OpenCode agents, not this PR. Candidate follow-up issue.
+- (Carried from #01/#02 skips: ASCII diagram alignment, lane-file
+  condensation awareness, setup_task.py lane cross-check,
+  diagnose-task mode-loop pin test, `HARNESS_DIRS` single-sourcing.)
+
+## Implementation notes
+
+- Frozen-peer rule (AC-4) still applies: `qs-review-task.md`,
+  `qs-create-plan.md`, `qs-implement-setup-task.md` stay
+  byte-unchanged ×3 harness dirs; record parity gaps in the story
+  progress notes.
+- Agent-file edits are tests/qs-pinned: run
+  `python scripts/qs/quality_gate.py --quick tests/qs` and
+  `--impacted` before commit; move ledger pins in lockstep.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-335.story_review_fix_#04.md
+++ b/docs/stories/QS-335.story_review_fix_#04.md
@@ -1,0 +1,127 @@
+# QS-335 — Review fix plan #04
+
+## Summary
+- Source PR: #347 (re-review round 4, post-e4e948ad)
+- Source story: docs/stories/QS-335.story.md
+- Findings to fix: 6
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user direction).
+  Fix plan #03: all 10 findings verified resolved; acceptance auditor
+  round 4 fully clean (all ACs green, frozen peers 9/9, parity notes
+  recorded).
+
+## Findings to fix
+
+### [should-fix] Audit (c) exemption misses the diagnosis story file itself (×3)
+- File: `.claude/agents/qs-review-regression-proof.md:36-41`,
+  `.cursor/agents/qs-review-regression-proof.md:39-40`,
+  `.opencode/agents/qs-review-regression-proof.md:69-70`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The round-3 exemption covers only
+  `story_review_fix_*.md` plans and their listed files, but the
+  diagnosis story `docs/stories/QS-<N>.story.md` is in the PR diff by
+  construction (diagnose FINALIZE commits it; the red-test protocol
+  mandates implement update its progress notes) while nothing mandates
+  the fix plan's file list name it — so audit (c) deterministically
+  flags it as unexplained excess on every compliant bug PR.
+- Proposed fix: Extend the exemption sentence in all three copies:
+  "…and the diagnosis story `docs/stories/QS-<N>.story.md` itself
+  (its progress notes are mandated by the red-test protocol) count as
+  explained."
+
+### [should-fix] FINALIZE banner claims "committed and pushed" on early exits (×2)
+- File: `.claude/agents/qs-diagnose-task.md:~275` and `.cursor/` twin
+  (OpenCode copy unaffected — its success block claims only session
+  creation)
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The FINALIZE handoff template unconditionally prints
+  `✅ Diagnosis committed and pushed to {{branch}}.`, but step 1
+  sanctions skipping the commit on early exits 2/3 (no story file
+  written) — a literal reading prints a false status line.
+- Proposed fix: Condition the banner: "✅ Diagnosis committed and
+  pushed…" only when step 1 ran; otherwise e.g. "✅ Diagnosis posted
+  to the issue (no story file — early exit)."
+
+### [nice-to-have] Iceberg superseding-issue label set incomplete (4 sites)
+- File: `.claude/agents/qs-diagnose-task.md:113-118`,
+  `.cursor/agents/qs-diagnose-task.md:~116`,
+  `.opencode/agents/qs-diagnose-task.md:~151`,
+  `docs/workflow/lanes/bug-product.md:78-83`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The instruction names only "`kind:feature` or epic,
+  `target:product`" — no `scale:*` — so `parse_axes` yields `lane=""`
+  and the superseding issue is born violating the "labelled at birth"
+  invariant (handled downstream only by setup-task's silent backfill).
+- Proposed fix: Name the complete label set at all four sites:
+  `kind:feature,target:product,scale:task` (or
+  `target:product,scale:epic`, no kind), matching setup-task's own
+  example. CAREFUL: `docs/workflow/lanes/bug-product.md` is
+  sentinel-pinned by `tests/qs/docs/test_lanes.py` — keep sentinels
+  intact (or update the pin in lockstep if a sentinel covers this
+  text).
+
+### [nice-to-have] "show diagnosis" fourth verb vs "three intents only" (×3)
+- File: `.claude/agents/qs-diagnose-task.md:~197` and `.cursor/`,
+  `.opencode/` twins
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The status banner offers `"show diagnosis"` while the
+  "Three intents only" section says to recognise exactly three intents
+  (REVIEW / DIAGNOSE / FINALIZE). Internally inconsistent (lifted from
+  create-plan's "show plan").
+- Proposed fix: Name it a DIAGNOSE-mode action (e.g. a parenthetical
+  "(a DIAGNOSE-mode action, not a fourth intent)") or mirror however
+  the frozen create-plan resolves it — if create-plan has the same
+  tension, prefer the parenthetical in the new copies only and record
+  the parity gap.
+
+### [nice-to-have] LSP_EXCLUDE_AGENTS comment no longer describes its entries
+- File: `tests/qs/agents/test_lsp_tool_enabled.py:~67`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Comment reads "Context-starved (blind) reviewers +
+  merge/release agents", but `qs-diag-fix-minimalist` and
+  `qs-review-regression-proof` fit neither description.
+- Proposed fix: One-line comment update, e.g. "…+ reviewers whose
+  charter needs no code navigation".
+
+### [nice-to-have] Lane-doc FINALIZE commit sentence unconditional
+- File: `docs/workflow/lanes/bug-product.md` (FINALIZE section)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: "Commit the story, then route via one of three exits"
+  is unconditional, while all three agent copies carry the
+  early-exit-2/3 skip guard — doc and agents disagree.
+- Proposed fix: Add the same one-clause caveat to the lane contract
+  ("(skip the commit if no story file was written — early exits 2/3)").
+  Same sentinel-pin caution as above: run the `tests/qs/docs`
+  sentinel test and update pins in lockstep if needed.
+
+## Skipped findings
+
+- None this round. (Prior rounds' recorded skips/follow-ups carry
+  forward unchanged: ASCII diagram alignment, `source venv/bin/
+  activate*` prefix-glob tightening, `HARNESS_DIRS` single-sourcing,
+  setup_task.py lane cross-check, diagnose-task mode-loop pin test,
+  lane-file condensation awareness.)
+
+## Implementation notes
+
+- Frozen-peer rule (AC-4): `qs-review-task.md`, `qs-create-plan.md`,
+  `qs-implement-setup-task.md` stay byte-unchanged ×3 harness dirs;
+  record parity gaps in the story progress notes.
+- `docs/workflow/lanes/bug-product.md` edits: the OTHER five lane
+  files must stay byte-identical to their shared source
+  (`tests/qs/docs/test_lanes.py` byte-identity test) — only
+  bug-product.md may change; verify its 17/18 sentinels still pass.
+- Gates: `python scripts/qs/quality_gate.py --impacted` AND
+  `python scripts/qs/quality_gate.py --quick tests/qs`.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-335.story_review_fix_#05.md
+++ b/docs/stories/QS-335.story_review_fix_#05.md
@@ -1,0 +1,155 @@
+# QS-335 — Review fix plan #05
+
+## Summary
+- Source PR: #347 (re-review round 5, post-46968cab)
+- Source story: docs/stories/QS-335.story.md
+- Findings to fix: 10
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user direction).
+  Fix plan #04: all 6 findings verified resolved; CI fully green
+  (11/11) at head; frozen peers 9/9 byte-unchanged; lane byte-identity
+  holds.
+
+## Findings to fix
+
+### [should-fix] Fallback-conditioned red-output rule reads inverted (×3)
+- File: `.claude/agents/qs-review-regression-proof.md:~78`,
+  `.cursor/agents/qs-review-regression-proof.md:~78`,
+  `.opencode/agents/qs-review-regression-proof.md:~108`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: "Missing or greenwashed recorded red output is a
+  `must-fix` finding — absent an accepted `Fallback accepted:` story
+  line, in which case audit (d) judges the alternative evidence
+  instead" — "in which case" grammatically binds to the *absence* of
+  the line, telling the reviewer to defer exactly when it should emit
+  must-fix.
+- Proposed fix: Reword in all three copies: "…is a `must-fix`
+  finding, unless the story carries an accepted `Fallback accepted:`
+  line — then audit (d) judges the alternative evidence instead."
+
+### [nice-to-have] Cursor FINALIZE conditional paragraph placement
+- File: `.cursor/agents/qs-diagnose-task.md:280-284`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The fix-#04 conditional was inserted between "Parse the
+  JSON; capture `new_context`. Then print:" and the ```text block, so
+  "Then print:" no longer directly introduces the block.
+- Proposed fix: Move the conditional paragraph above the "Then print:"
+  sentence.
+
+### [nice-to-have] Lane-doc FINALIZE sentence over-length + missing second skip case
+- File: `docs/workflow/lanes/bug-product.md:~119/148`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor + qs-review-blind-hunter (deduped)
+- Description: (a) The amended sentence is ~120 chars in a ~72-wrapped
+  file; (b) it covers only the early-exit-2/3 skip while the agent
+  copies also skip on the idempotent FINALIZE re-run (story already
+  committed, `git status --porcelain` empty).
+- Proposed fix: Re-wrap to the file's prevailing width and extend the
+  parenthetical to cover both skip cases, e.g. "(skip the commit if no
+  story file was written — early exits 2/3 — or if the story is
+  already committed and unchanged)". Keep the FINALIZE sentinel
+  heading and all other sentinels intact (`tests/qs/docs/test_lanes.py`).
+
+### [nice-to-have] Parametrized test keeps review-task-only name
+- File: `tests/qs/agents/test_opencode_execute_contract.py:171`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `test_opencode_review_task_has_two_execute_blocks` is
+  now parametrized over review-task AND verify-task.
+- Proposed fix: Rename, e.g.
+  `test_opencode_handoff_orchestrators_have_two_execute_blocks`.
+
+### [nice-to-have] "the 7 worktree handoffs" comment imprecise
+- File: `tests/qs/agents/test_orchestrator_handoff.py:~259`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `_GUI_BLOCK_ORCHESTRATORS` includes `qs-setup-task`,
+  which hands off from the main checkout — count right, "worktree"
+  label wrong.
+- Proposed fix: Drop or correct the word (e.g. "the 7 GUI-block
+  handoffs").
+
+### [nice-to-have] overview.md phase table lacks the two new phase rows
+- File: `docs/workflow/overview.md` (phase table under :15)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Only a prose paragraph was added; the phase table gains
+  no `diagnose-task`/`verify-task` rows, unlike the CLAUDE.md table
+  which got two rows.
+- Proposed fix: Add the two rows (or a lane-branch annotation)
+  mirroring the CLAUDE.md table's wording. Check any tests/qs pins on
+  overview.md text.
+
+### [nice-to-have] New allowlist globs missing trailing space
+- File: `.opencode/agents/qs-diagnose-task.md`,
+  `.opencode/agents/qs-verify-task.md`,
+  `.opencode/agents/qs-review-regression-proof.md` (frontmatter)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Net-new entries like `"tail*"`, `"sort*"`, `"git push*"`
+  lack the trailing space of siblings (`"grep *"`), so `tailscale` or
+  `git pushX` would match.
+- Proposed fix: Tighten to `"tail *"`, `"sort *"`, `"git push *"` etc.
+  in these three net-new files only (frozen peers keep their
+  convention; the `source venv/bin/activate*` analog stays a recorded
+  follow-up). Verify each body invocation still matches (e.g. a bare
+  `git push` with no args would not match `"git push *"` — confirm the
+  bodies always pass args, or keep that one glob as-is).
+
+### [nice-to-have] Empty-lane branch bypasses the story-overwrite hazard (×3)
+- File: `.claude/agents/qs-diagnose-task.md:37-49` and `.cursor/`,
+  `.opencode/` twins
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The lane-mismatch guard STOPs only on a non-empty,
+  non-`bug-product` lane; the empty-lane legacy branch proceeds into
+  DIAGNOSE, whose convergence overwrites
+  `docs/stories/QS-<N>.story.md` with no existing-file check — a
+  pre-QS-332 worktree carrying a committed feature story gets silently
+  clobbered.
+- Proposed fix: One clause in the empty-lane fallback branch ×3: if
+  `story_file` is non-empty and the existing story lacks the
+  bug-template sections, confirm with the user before the first
+  overwrite. (qs-verify-task's empty-lane branch is read-only — no
+  change there.)
+
+### [nice-to-have] Lane-routing pin is non-discriminating
+- File: `tests/qs/agents/test_orchestrator_handoff.py:581-599`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: All three assertions of
+  `test_shared_orchestrator_carries_both_lane_branches` are satisfied
+  by the fallback line alone; deleting the "Resolve the next phase
+  from the lane (QS-335)" paragraph would keep the test green while
+  the `{{NEXT_PHASE}}` sites lose their definition.
+- Proposed fix: Add a fourth sentinel assertion on the resolution
+  sentence, e.g. `"Resolve the next phase from the lane"` (present
+  verbatim in both agents across all three harness dirs).
+
+### [nice-to-have] (bundled with the should-fix) hard-rules block re-read
+- File: same files as the should-fix
+- Severity: nice-to-have
+- Description: While rewording the inverted rule, re-read the
+  surrounding hard-rules block for any similar binding ambiguity
+  introduced by the #03/#04 rewrites; adjust only if trivially wrong.
+- Proposed fix: Editorial pass on that block only.
+
+## Skipped findings
+
+- None this round. (Prior recorded skips/follow-ups carry forward.)
+
+## Implementation notes
+
+- Frozen-peer rule (AC-4): `qs-review-task.md`, `qs-create-plan.md`,
+  `qs-implement-setup-task.md` byte-unchanged ×3; other 5 lane files
+  byte-identical; bug-product.md sentinels must keep passing.
+- Gates: `python scripts/qs/quality_gate.py --impacted` AND
+  `python scripts/qs/quality_gate.py --quick tests/qs`.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-335.story_review_fix_#06.md
+++ b/docs/stories/QS-335.story_review_fix_#06.md
@@ -1,0 +1,114 @@
+# QS-335 — Review fix plan #06
+
+## Summary
+- Source PR: #347 (re-review round 6, post-718bfae7)
+- Source story: docs/stories/QS-335.story.md
+- Findings to fix: 6
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user direction).
+  Fix plan #05: all 10 findings + the sentinel extra verified
+  resolved; acceptance auditor fully clean; CI 11/11 green at head.
+
+## Findings to fix
+
+### [should-fix] Missing "Review fix plan #05 applied" story progress note
+- File: `docs/stories/QS-335.story.md` (Progress notes)
+- Severity: should-fix
+- Source: qs-review-blind-hunter (corroborated by
+  qs-review-edge-case-hunter)
+- Description: The PR applies fix plan #05 (visible in the diff) but
+  the story's progress notes stop at "#04 applied" — breaking the
+  per-plan applied-note convention this same PR establishes, and
+  leaving #05's parity-gap records unwritten (e.g. the lane-doc
+  second-skip-case wording the frozen peers don't carry).
+- Proposed fix: Add a "Review fix plan #05 applied (10 findings)"
+  progress note with the usual parity-gap record. Include the #06
+  note when this plan is applied, so the convention holds at head.
+
+### [nice-to-have] Story-overwrite guard scoped to empty-lane only (×3)
+- File: `.claude/agents/qs-diagnose-task.md:44-47`,
+  `.cursor/agents/qs-diagnose-task.md:45-48`,
+  `.opencode/agents/qs-diagnose-task.md:74-77`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The #05 guard is syntactically scoped to the empty-lane
+  fallback sentence; a `lane == bug-product` worktree carrying a
+  pre-existing non-bug story (e.g. issue relabelled feature→bug
+  mid-flight after create-plan committed a feature story) still
+  reaches DIAGNOSE convergence unguarded and clobbers the story.
+- Proposed fix: Lift the clause into a standalone lane-independent
+  sentence ×3: "Independent of lane: if the story file already exists
+  and lacks the bug story template sections, confirm with the user
+  before the first DIAGNOSE convergence overwrites it." Keep the
+  `test_lane_steps_parity.py` terminal-sentinel in lockstep.
+
+### [nice-to-have] Remaining no-space globs in the net-new OpenCode files
+- File: `.opencode/agents/qs-diagnose-task.md`,
+  `.opencode/agents/qs-verify-task.md`,
+  `.opencode/agents/qs-review-regression-proof.md` (frontmatter)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: #05 tightened `tail/sort/git push` but the same files
+  still ship `"git status*"`, `"git log*"`, `"git diff*"`,
+  `"git fetch*"` — `"git diff*"` also matches `git difftool`.
+- Proposed fix: Add the trailing space to those four globs in the
+  three net-new files only (verify bodies always pass args — e.g. a
+  bare `git status`/`git log`/`git diff`/`git fetch` invocation would
+  stop matching; if any body uses the bare form, keep that glob or
+  use both forms). Frozen peers untouched.
+
+### [nice-to-have] Claude FINALIZE conditional placement (mirror the Cursor #05 move)
+- File: `.claude/agents/qs-diagnose-task.md:~300`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: The early-exit conditional sits between "Then print
+  both blocks:" and the banner block — the exact placement #05
+  corrected in the Cursor copy, leaving fork-drift between the two.
+- Proposed fix: Move the conditional above the "Then print both
+  blocks:" sentence, mirroring the Cursor copy.
+
+### [nice-to-have] OpenCode diagnose edit scope broader than needed
+- File: `.opencode/agents/qs-diagnose-task.md` (frontmatter `edit`)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: `"docs/stories/**": allow` permits editing any task's
+  story file; the sibling verify-task scopes to its fix-plan pattern.
+- Proposed fix: Scope to `"docs/stories/QS-*.story.md": allow` (the
+  only file diagnose writes), if OpenCode's glob supports it.
+
+### [nice-to-have] Lane-block parity sentinel: first-match-over-EOF fragility
+- File: `tests/qs/agents/test_lane_steps_parity.py:146-155`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `test_lane_block_is_a_clean_mirrored_paragraph` picks
+  its terminal sentinel by tuple order over the whole file remainder;
+  if any marker phrase later appears in another agent's body ahead of
+  that agent's real terminal sentence, the assertions inspect
+  arbitrary bytes (vacuous pass or spurious fail).
+- Proposed fix: Bound the search to the block (slice at the next
+  `\n\n**` paragraph boundary) or map agent name → its single
+  expected terminal marker instead of a first-match tuple. Keep in
+  lockstep with finding 2's sentinel change.
+
+## Skipped findings
+
+- `source venv/bin/activate*` prefix glob — carried forward,
+  already recorded as a follow-up in fix plan #03.
+
+## Implementation notes
+
+- Findings 2 and 6 interact (guard sentence is the parity-test
+  terminal sentinel) — apply together.
+- Frozen-peer rule (AC-4): `qs-review-task.md`, `qs-create-plan.md`,
+  `qs-implement-setup-task.md` byte-unchanged ×3; other 5 lane files
+  byte-identical; bug-product.md sentinels keep passing.
+- Gates: `python scripts/qs/quality_gate.py --impacted` AND
+  `python scripts/qs/quality_gate.py --quick tests/qs`.
+- Remember the story progress notes: add BOTH the missing #05 note
+  (finding 1) and the #06 applied-note for this plan.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-335.story_review_fix_#07.md
+++ b/docs/stories/QS-335.story_review_fix_#07.md
@@ -1,0 +1,143 @@
+# QS-335 — Review fix plan #07
+
+## Summary
+- Source PR: #347 (re-review round 7, post-5f22eca3)
+- Source story: docs/stories/QS-335.story.md
+- Findings to fix: 8
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user direction).
+  Fix plan #06: all 6 findings verified resolved; acceptance auditor
+  round 7 fully clean; CI 11/11 green at head.
+
+## Findings to fix
+
+### [should-fix] Cold-start resume of an in-progress diagnosis undefined (×3 + lane doc)
+- File: `.claude/agents/qs-diagnose-task.md:45,96`,
+  `.cursor/agents/qs-diagnose-task.md:46,98`,
+  `.opencode/agents/qs-diagnose-task.md:75,127`,
+  `docs/workflow/lanes/bug-product.md:62`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Multi-session diagnosis is the declared paved path and
+  the story stays uncommitted until FINALIZE, but no copy instructs a
+  fresh session to read an existing template-bearing story and adopt
+  it as current state — the #06 guard covers only a story that LACKS
+  the bug-template sections, so the next convergence silently
+  clobbers the prior uncommitted diagnosis with no git recovery.
+- Proposed fix: One lane-independent sentence next to the existing
+  guard, in all three copies + the lane doc: if the story file
+  already exists AND carries the bug-template sections, read it first
+  and treat it as the current diagnosis state (resume, don't
+  restart). Keep `LANE_BLOCK_TERMINALS` in
+  `tests/qs/agents/test_lane_steps_parity.py` in lockstep if the
+  sentence lands inside the lane block. Frozen `qs-create-plan`
+  shares the gap — record as a parity gap per AC-4, do not touch it.
+
+### [should-fix] Parametrized stale-pin test keeps review-task-only name
+- File: `tests/qs/agents/test_orchestrator_handoff.py:454`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description:
+  `test_review_task_carries_the_stale_pin_hazard_at_both_handoffs` is
+  parametrized over `qs-review-task.md` AND `qs-verify-task.md` —
+  the exact finding class fix #05 corrected in
+  `test_opencode_execute_contract.py`.
+- Proposed fix: Rename, e.g.
+  `test_handoff_orchestrators_carry_the_stale_pin_hazard_at_both_handoffs`.
+
+### [nice-to-have] Uncapped-diff rationale never names the capped command (×3)
+- File: `.claude/agents/qs-verify-task.md` (Doc-maintenance audit) and
+  `.cursor/`, `.opencode/` twins
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: "(uncapped — the `--json files` form truncates at 100
+  files)" never names `gh pr view`; `gh pr diff` has no `--json`
+  flag, so a literal reader may try `gh pr diff --json files`.
+- Proposed fix: "…the `gh pr view --json files` form truncates…".
+  Verify-task copies only (frozen `qs-review-task` peer untouched).
+
+### [nice-to-have] Mixed handoff idioms in OpenCode verify-task context paragraph
+- File: `.opencode/agents/qs-verify-task.md` (context-discovery paragraph)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: "run `implement-task` first" (PR guard) vs "activate
+  `qs-diagnose-task` first" (story guard) in the same paragraph; the
+  file's convention is agent-activation phrasing.
+- Proposed fix: "activate `qs-implement-task` first".
+
+### [nice-to-have] "every handoff site below" vs literal fallback line (×3)
+- File: `.claude/agents/qs-implement-task.md:189` and `.cursor/`,
+  `.opencode/` twins
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: "substitute that value in the `--next-cmd` flag and
+  every handoff site below" conflicts with the D3 rule that the
+  fallback line keeps its literal default unsubstituted.
+- Proposed fix: Add one clause: "…except the fallback line, which
+  carries both branches literally." Same edit in the qs-setup-task
+  copies if they share the sentence. Check `_LANE_ROUTING` pins.
+
+### [nice-to-have] Stale "AC-9 requires" attribution for the six-agent claim
+- File: `tests/qs/agents/test_doc_maintenance_parity.py:38`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: "The six orchestrator agents that AC-9 requires us to
+  update" — AC-9 (QS-185) required only four; the QS-335 additions
+  are not required by it.
+- Proposed fix: Reword, e.g. "The six orchestrator agents that carry
+  the doc-maintenance step (four from QS-185 AC-9, two from QS-335)".
+
+### [nice-to-have] Pathspec-less `git commit` sweeps the whole index (×6 net-new copies)
+- File: `.claude/agents/qs-diagnose-task.md:257`,
+  `.cursor:266`, `.opencode:301`; `.claude/agents/qs-verify-task.md:217`,
+  `.cursor:204`, `.opencode:273`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: FINALIZE/fix-plan commit stages only the intended file
+  but `git commit -m "…"` commits everything in the index — a stray
+  staged file (e.g. a throwaway repro snippet) rides into the commit.
+- Proposed fix: Bound with a pathspec in the six net-new copies only:
+  `git commit -m "…" -- docs/stories/QS-{{issue}}.story.md` (diagnose)
+  and `-- "docs/stories/QS-{{issue}}.story_review_fix_*.md"` (verify).
+  Frozen peers share the pattern — stay byte-frozen, record the
+  parity gap.
+
+### [nice-to-have] All-skip triage exit is route-less (×3)
+- File: `.claude/agents/qs-verify-task.md:176`, `.cursor:163`,
+  `.opencode:232`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Step 4's fast path needs zero must/should findings;
+  step 6 needs at least one "fix" decision. Findings + "skip all"
+  hits neither branch — no fix plan, no handoff, and the
+  no-auto-trigger hard rule leaves the agent without a sanctioned
+  next move.
+- Proposed fix: One sentence in step 6 ×3: if every decision is
+  "skip", record the skips (triage summary / PR comment) and emit the
+  same finish-task handoff as step 4. Inherited from the frozen
+  `qs-review-task` peer — fix the net-new copies only, record the
+  parity gap.
+
+## Skipped findings
+
+- None this round. (Prior recorded skips/follow-ups and accepted
+  parity gaps carry forward.)
+
+## Implementation notes
+
+- Finding 1 interacts with `LANE_BLOCK_TERMINALS` — keep the sentinel
+  in lockstep, same as #06.
+- Frozen-peer rule (AC-4): `qs-review-task.md`, `qs-create-plan.md`,
+  `qs-implement-setup-task.md` byte-unchanged ×3; other 5 lane files
+  byte-identical; bug-product.md sentinels keep passing.
+- Add the "Review fix plan #07 applied" story progress note (with the
+  new parity-gap records: create-plan cold-start resume; frozen-peer
+  pathspec-less commit; review-task all-skip exit).
+- Gates: `python scripts/qs/quality_gate.py --impacted` AND
+  `python scripts/qs/quality_gate.py --quick tests/qs`.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-335.story_review_fix_#08.md
+++ b/docs/stories/QS-335.story_review_fix_#08.md
@@ -1,0 +1,125 @@
+# QS-335 — Review fix plan #08
+
+## Summary
+- Source PR: #347 (re-review round 8, post-82ef05ee)
+- Source story: docs/stories/QS-335.story.md
+- Findings to fix: 6
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user direction).
+  Fix plan #07: all 8 findings verified resolved; auditor round 8
+  clean (CI 10/10 green at head).
+
+## Findings to fix
+
+### [should-fix] Exit-1 FINALIZE before first convergence leaves no-story state undefined (×3 + lane doc)
+- File: `.claude/agents/qs-diagnose-task.md:248`,
+  `.cursor/agents/qs-diagnose-task.md:257`,
+  `.opencode/agents/qs-diagnose-task.md:292`,
+  `docs/workflow/lanes/bug-product.md:122`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: The commit-skip clause is scoped to "early exits 2/3",
+  so an exit-1 ("finalize — go fix it") reached before the story was
+  ever written hits `git add` on a nonexistent path; the fix loop
+  then lands in implement/verify with no story, and verify-task
+  hard-STOPs on empty `story_file`.
+- Proposed fix: One clause in the FINALIZE commit step ×3 + the lane
+  doc: on exit 1, if the story file has not been written yet, write
+  it now (a confirmed fix exit implies the diagnosis converged)
+  before step 1; keep the 2/3 skip as is. Watch bug-product.md
+  sentinels and `LANE_BLOCK_TERMINALS` if wording lands in pinned
+  text.
+
+### [should-fix] "except the fallback line" clause references a nonexistent element in Cursor/OpenCode copies
+- File: `.cursor/agents/qs-setup-task.md:~115`,
+  `.cursor/agents/qs-implement-task.md:~197`,
+  `.opencode/agents/qs-setup-task.md:~150`,
+  `.opencode/agents/qs-implement-task.md:~240`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: The #07 clause was applied verbatim ×3 harnesses, but
+  the Cursor/OpenCode copies have no fallback line — their
+  both-branch carrier is the trailing routing parenthetical outside
+  the print block. The instruction is correct only in the Claude
+  twins.
+- Proposed fix: FIRST verify each copy's actual handoff structure,
+  then reword the clause per harness where needed, e.g. "— except
+  the routing parenthetical below, which carries both branches
+  literally." Leave the Claude copies as-is. Check `_LANE_ROUTING`
+  and handoff-test pins stay green.
+
+### [nice-to-have] Pathspec parity-gap record incomplete in story
+- File: `docs/stories/QS-335.story.md:687-691`
+- Severity: nice-to-have
+- Source: qs-review-acceptance-auditor
+- Description: The #07 pathspec-less-commit parity gap is recorded
+  only for `qs-review-task.md`, but frozen `qs-create-plan.md:191`
+  carries the same pattern.
+- Proposed fix: Extend the record to name `qs-create-plan.md` too.
+
+### [nice-to-have] Nice-to-have-only round silently drops all findings (×3)
+- File: `.claude/agents/qs-verify-task.md:112`, `.cursor:122`,
+  `.opencode:153`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: Step 4's fast path fires on "no must-fix or
+  should-fix", so a nice-to-have-only consolidation skips triage and
+  the fix plan and prints "No blocking findings" — the nice-to-haves
+  evaporate with the session (unlike the #07 all-skip exit, which
+  records skips).
+- Proposed fix: One sentence in step 4 ×3: if nice-to-have findings
+  exist, list them in the completion message and post them as a PR
+  comment before the handoff. Inherited from frozen `qs-review-task`
+  — net-new copies only, record the parity gap.
+
+### [nice-to-have] Plural red tests, singular audit (×3 + optional lane doc)
+- File: `.claude/agents/qs-review-regression-proof.md:29`,
+  `.cursor:29`, `.opencode:59`; optionally
+  `docs/workflow/lanes/bug-product.md:108` region
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The story template allows "red test(s)" plural, but
+  audit (a) is phrased for one test — a diagnosis speccing two
+  regression tests is literally satisfied by one recorded red output
+  (the greenwash window the audit exists to close).
+- Proposed fix: One clause in audit (a) ×3: "for **each** test named
+  in the story's red-test spec"; optionally mirror "run each spec'd
+  test red first" in the lane doc's red-test protocol step 1
+  (sentinel caution).
+
+### [nice-to-have] Lane-doc implement scope omits `tests/`
+- File: `docs/workflow/lanes/bug-product.md` (implement-task section)
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: "Fixes the diagnosed bug under
+  `custom_components/quiet_solar/`" omits the regression test the
+  red-test protocol itself writes under `tests/`.
+- Proposed fix: "…under `custom_components/quiet_solar/` and
+  `tests/`."
+
+## Skipped findings (recorded, not fixed)
+
+- Cursor routing parentheticals use slash notation
+  (`routes to /diagnose-task`) — the slash tokens are load-bearing
+  `_LANE_ROUTING` pin carriers across all three harnesses; accepted
+  as pin carriers per the reviewer's own alternative.
+- "Then print both blocks:" separated from the banner by the
+  `On \`false\`` paragraph in the Claude diagnose copy — inherited
+  from the frozen peers' layout; kept for frozen-peer visual parity.
+
+## Implementation notes
+
+- Frozen-peer rule (AC-4): `qs-review-task.md`, `qs-create-plan.md`,
+  `qs-implement-setup-task.md` byte-unchanged ×3; other 5 lane files
+  byte-identical; bug-product.md sentinels keep passing;
+  `LANE_BLOCK_TERMINALS` in lockstep if terminal text moves.
+- Add the "Review fix plan #08 applied" story progress note with the
+  new parity-gap record (review-task NTH-only fast path).
+- Gates: `python scripts/qs/quality_gate.py --impacted` AND
+  `python scripts/qs/quality_gate.py --quick tests/qs`.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-335.story_review_fix_#09.md
+++ b/docs/stories/QS-335.story_review_fix_#09.md
@@ -1,0 +1,123 @@
+# QS-335 — Review fix plan #09
+
+## Summary
+- Source PR: #347 (re-review round 9, post-0339938c)
+- Source story: docs/stories/QS-335.story.md
+- Findings to fix: 6
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user direction).
+  Fix plan #08: all 6 findings + 2 recorded skips verified resolved;
+  auditor round 9 clean.
+
+## Findings to fix
+
+### [should-fix] Exits 2/3 with an open fix PR route to a merge offer for a superseded fix (×3 + lane doc)
+- File: `.claude/agents/qs-diagnose-task.md:231-244`,
+  `.cursor/agents/qs-diagnose-task.md:240`,
+  `.opencode/agents/qs-diagnose-task.md:275`,
+  `docs/workflow/lanes/bug-product.md:129-137,196-198`
+- Severity: should-fix
+- Source: qs-review-edge-case-hunter
+- Description: Exits 2/3 hard-assert "Case A no-PR cleanup" and the
+  agent never captures `pr_number`. When a fix PR is already open
+  (fix loop ran, verify showed the fix misses the cause, user
+  re-entered diagnose and finalized via exit 2/3), the handoff routes
+  to finish-task, which sees the open PR, enters Case B, and asks
+  "Ready to merge PR #N?" — one wrong "yes" merges a
+  superseded/abandoned fix into main.
+- Proposed fix: In the exits-2/3 text (×3 copies + lane doc): capture
+  `pr_number` from `context.py`; when non-null, close the fix PR
+  first (`gh pr close {{pr_number}} --comment "superseded — see
+  issue"`) so finish-task lands on its CLOSED-unmerged cleanup
+  branch; keep the "Case A" wording only for the genuinely no-PR
+  case. Watch bug-product.md sentinels / `LANE_BLOCK_TERMINALS`.
+
+### [should-fix] Cursor verify-task keeps Claude-specific `Agent`-tool phrasing
+- File: `.cursor/agents/qs-verify-task.md:~63,~78`
+- Severity: should-fix
+- Source: qs-review-blind-hunter
+- Description: "one message with three parallel **Agent invocations**"
+  and "non-interactive `Agent`-tool fan-out" — Cursor exposes no
+  `Agent` tool; the Cursor diagnose copy and OpenCode verify copy in
+  this same PR were harness-neutralized ("parallel sub-agent
+  invocations" / "sub-agent fan-out"). Same class as the #03
+  "tools: Read" neutralization.
+- Proposed fix: Mirror the Cursor diagnose copy's sub-agent wording.
+  If the frozen Cursor `qs-review-task` peer carries the same
+  phrasing, fix only the net-new file and record the parity gap
+  (AC-4). Check parity-test pins.
+
+### [nice-to-have] "Cache the diff for the sub-agents." is a dead instruction (×3)
+- File: `.claude/agents/qs-verify-task.md` step 1 and `.cursor/`,
+  `.opencode/` twins
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: Step 2 passes only the PR number (+ paths) and every
+  reviewer fetches its own diff — nothing consumes the cache.
+- Proposed fix: Reword to "Skim the diff for context." in the three
+  verify-task copies only; if inherited from the frozen
+  `qs-review-task` peer, record the parity gap.
+
+### [nice-to-have] `_TWO_BLOCK_ORCHESTRATORS` parenthetical rationale imprecise
+- File: `tests/qs/agents/test_orchestrator_handoff.py:~46`
+- Severity: nice-to-have
+- Source: qs-review-blind-hunter
+- Description: "(release follow-up is text-only — see QS-175 OUT OF
+  SCOPE)" now reads as the rationale for both `qs-finish-task` and
+  `qs-release`, but only explains the finish-task exception.
+- Proposed fix: One-line reword scoping the parenthetical to
+  finish-task (release simply has no follow-up phase).
+
+### [nice-to-have] Degraded-`gh` empty lane silently misroutes a bug task (×3)
+- File: `.claude/agents/qs-implement-task.md:189-195`,
+  `.cursor:197`, `.opencode:235`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: `context.py` returns empty fields on any `gh` failure,
+  so `lane == ""` also covers a transient failure; the routing
+  paragraph then defaults a bug-product task to
+  `NEXT_PHASE = review-task` with no downstream catch (frozen
+  `qs-review-task` has no reverse guard).
+- Proposed fix: In the resolution paragraph ×3: when `lane` is empty
+  AND the story file carries the bug-template sections
+  (Symptom/Root cause/Repro strategy), ask the user which review
+  phase to route instead of defaulting. Check `_LANE_ROUTING` pins
+  stay green.
+
+### [nice-to-have] All-skip exit reuses a banner that contradicts it (×3)
+- File: `.claude/agents/qs-verify-task.md:179-181`, `.cursor:166`,
+  `.opencode:235`
+- Severity: nice-to-have
+- Source: qs-review-edge-case-hunter
+- Description: The #07 all-skip exit emits step 4's handoff, whose
+  banner opens "✅ Fix verification complete. **No blocking
+  findings.**" — false when blocking findings existed and were all
+  skipped.
+- Proposed fix: One clause in step 6 ×3: "…replacing the first banner
+  line with `✅ Fix verification complete — N findings triaged, all
+  skipped (recorded on the PR).`"
+
+## Skipped findings
+
+- CI Tests shard 1/4 pending at audit time (auditor informational) —
+  finish-task re-verifies CI before merge; no change needed.
+- (Prior recorded skips/follow-ups and accepted parity gaps carry
+  forward.)
+
+## Implementation notes
+
+- Frozen-peer rule (AC-4): `qs-review-task.md`, `qs-create-plan.md`,
+  `qs-implement-setup-task.md` byte-unchanged ×3; other 5 lane files
+  byte-identical; bug-product.md sentinels and `LANE_BLOCK_TERMINALS`
+  / `_LANE_ROUTING` pins in lockstep if pinned text moves.
+- Add the "Review fix plan #09 applied" story progress note with any
+  new parity-gap records (review-task "cache the diff" dead
+  instruction; Cursor review-task Agent-tool phrasing, if shared).
+- Gates: `python scripts/qs/quality_gate.py --impacted` AND
+  `python scripts/qs/quality_gate.py --quick tests/qs`.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. When done, return
+and run `/review-task` again to re-verify.

--- a/docs/stories/QS-335.story_review_fix_#10.md
+++ b/docs/stories/QS-335.story_review_fix_#10.md
@@ -1,0 +1,51 @@
+# QS-335 — Review fix plan #10
+
+## Summary
+- Source PR: #347 (re-review round 10, post-ab2b2883)
+- Source story: docs/stories/QS-335.story.md
+- Findings to fix: 1
+- Next implement phase: `/implement-setup-task`
+- Reviewers: qs-review-blind-hunter, qs-review-edge-case-hunter,
+  qs-review-acceptance-auditor (CodeRabbit skipped by user direction).
+  Round 10 is the convergence round: the auditor and edge-case-hunter
+  report zero blocking findings; the single remaining item was flagged
+  independently by BOTH the blind hunter and the edge-case hunter —
+  it is a ripple introduced by fix #09 itself.
+
+## Findings to fix
+
+### [should-fix] `gh pr close` instructed by #09's FINALIZE step but not allowlisted (OpenCode)
+- File: `.opencode/agents/qs-diagnose-task.md:289` (body) vs
+  frontmatter bash map `:17-40`
+- Severity: should-fix
+- Source: qs-review-blind-hunter + qs-review-edge-case-hunter (deduped)
+- Description: The #09 "Superseded fix PR (exits 2/3)" step mandates
+  `gh pr close {{pr_number}} --comment "superseded — see issue"`, but
+  the allowlist has no `gh pr close *` entry — the command falls to
+  `"*": ask` on exactly the FINALIZE path it was added for; the same
+  degradation class rounds #02/#03/#05 fixed for `gh issue edit` /
+  `gh pr list` / `python -c`. Claude/Cursor copies carry no
+  permission model and are unaffected.
+- Proposed fix: Add `"gh pr close *": allow` to the OpenCode
+  `qs-diagnose-task.md` bash map.
+
+## Invalid / deduplicated this round
+
+- ASCII mode-diagram misalignment (blind hunter) — duplicate of the
+  cosmetic skip recorded in fix plan #01; prior rejection honored.
+- CI Tests shard 1/4 pending + CodeRabbit rate-limit pass (auditor) —
+  informational; finish-task re-verifies CI before merge.
+
+## Implementation notes
+
+- One-line frontmatter edit; OpenCode-only, so expect the harness
+  drift flag from `check_doc_drift.py` — extend the PR body's
+  `## Doc maintenance` justification (same precedent as #05/#06/#08).
+- Add the "Review fix plan #10 applied" story progress note.
+- Gates: `python scripts/qs/quality_gate.py --impacted` AND
+  `python scripts/qs/quality_gate.py --quick tests/qs`.
+
+## How to apply
+
+Run `/implement-setup-task` against this fix plan. This closes the
+review loop: round 10 produced zero other findings.

--- a/docs/workflow/adversarial-review.md
+++ b/docs/workflow/adversarial-review.md
@@ -12,6 +12,11 @@ reviewer doesn't enumerate edge cases.
 those four **plus a fifth, diff-aware** reviewer
 (`qs-plan-delta-auditor`) — see "Round asymmetry" below.
 
+The **bug × product** lane (QS-335) runs dedicated minimal rosters
+instead — 2 diagnosis reviewers (`diagnose-task`) and 3 fix-verification
+reviewers (`verify-task`); see
+[lanes/bug-product.md](lanes/bug-product.md).
+
 ## Why parallel, not serial
 
 All the round's subagents must be spawned in **one message with parallel

--- a/docs/workflow/lanes/bug-product.md
+++ b/docs/workflow/lanes/bug-product.md
@@ -76,8 +76,10 @@ evidence before hypotheses, hypotheses before cause, cause before plan.
   extend the list with a reasoned progress note in the story; verify
   flags **unexplained** excess as must-fix.
 - **Iceberg check** — is the root cause local, or the tip of something
-  generic? If iceberg → create a new issue (`kind:feature` or epic,
-  `target:product`) via `gh issue create`, carrying the full diagnosis
+  generic? If iceberg → create a new issue labelled
+  `kind:feature,target:product,scale:task` (or, for an epic,
+  `target:product,scale:epic` and **no kind**) via `gh issue create`,
+  carrying the full diagnosis
   and a back-link; then a **per-case human decision**: (a) close this
   bug as superseded, or (b) ship a minimal containment fix here and
   link.
@@ -114,7 +116,7 @@ finding-state triage model as create-plan.
 
 ### FINALIZE (three exits, all human-confirmed)
 
-Commit the story, then route via one of **three exits**:
+Commit the story (skip the commit if no story file was written — early exits 2/3), then route via one of **three exits**:
 
 1. **fix** (normal) → `implement-task`.
 2. **close-as-superseded** (iceberg): the diagnose agent runs

--- a/docs/workflow/lanes/bug-product.md
+++ b/docs/workflow/lanes/bug-product.md
@@ -59,7 +59,10 @@ evidence before hypotheses, hypotheses before cause, cause before plan.
   eliminate each against the evidence. **Hard rule: no fix plan until
   the root cause is stated in one sentence with file/function
   references.** Insufficient evidence → ask, don't guess; staying in
-  DIAGNOSE across sessions is normal.
+  DIAGNOSE across sessions is normal. A fresh session that finds the
+  story file already existing and carrying the bug-template sections
+  reads it first and adopts it as the current diagnosis state
+  (resume, don't restart).
 - **Reproduction** — **demonstrate when feasible**: the agent may run
   throwaway, uncommitted scripts/snippets via Bash to show the
   hypothesis live (nothing is committed in this phase). Always produce

--- a/docs/workflow/lanes/bug-product.md
+++ b/docs/workflow/lanes/bug-product.md
@@ -121,7 +121,9 @@ finding-state triage model as create-plan.
 
 Commit the story (skip the commit if no story file was written —
 early exits 2/3 — or if the story is already committed and
-unchanged), then route via one of **three exits**:
+unchanged; on exit 1 an unwritten story is **written now first** — a
+confirmed fix exit implies the diagnosis converged, and the fix loop
+needs the story on disk), then route via one of **three exits**:
 
 1. **fix** (normal) → `implement-task`.
 2. **close-as-superseded** (iceberg): the diagnose agent runs
@@ -139,15 +141,16 @@ unchanged), then route via one of **three exits**:
 ## `implement-task` (agent: `qs-implement-task`)
 
 **Runs on**: worktree. Fixes the diagnosed bug under
-`custom_components/quiet_solar/`. Follows the shared implement contract
+`custom_components/quiet_solar/` and `tests/` (the regression test the
+red-test protocol writes). Follows the shared implement contract
 with the **red-test protocol** below.
 
 ### Red-test protocol
 
-1. Write the spec'd regression test **first**, run it with the
-   sanctioned `::`-form (`pytest <file>::<test> -v`), and **record the
-   failure output** (story progress note + PR body) — it must fail for
-   the diagnosed reason, not an import/collection error.
+1. Write **each** spec'd regression test **first**, run each red with
+   the sanctioned `::`-form (`pytest <file>::<test> -v`), and **record
+   the failure output** (story progress note + PR body) — each must
+   fail for the diagnosed reason, not an import/collection error.
 2. Apply the minimal fix; re-run the test green.
 3. **Scope constraint**: deliver the fix at the scope diagnosed — no
    drive-by refactors, no opportunistic cleanups. Anything bigger goes

--- a/docs/workflow/lanes/bug-product.md
+++ b/docs/workflow/lanes/bug-product.md
@@ -128,13 +128,21 @@ needs the story on disk), then route via one of **three exits**:
 1. **fix** (normal) → `implement-task`.
 2. **close-as-superseded** (iceberg): the diagnose agent runs
    `gh issue close --comment` linking the superseding issue, then →
-   `finish-task` (Case A no-PR cleanup). The superseding issue's body
-   is the durable record of the diagnosis.
+   `finish-task`. The superseding issue's body is the durable record
+   of the diagnosis.
 3. **no-defect / cannot-diagnose** (works-as-intended, duplicate, or
    evidence exhausted): the human decides close (agent closes with the
    rationale) or leave open awaiting evidence. **Either way the
    diagnosis-so-far is posted as an issue comment before cleanup** →
-   `finish-task` Case A.
+   `finish-task`.
+
+On exits 2/3 with an open fix PR (`pr_number` non-null from
+`context.py` — a fix loop already ran and this diagnosis abandons that
+fix), the diagnose agent closes the PR first
+(`gh pr close <pr_number> --comment "superseded — see issue"`) so
+finish-task lands on its CLOSED-unmerged cleanup branch instead of
+offering to merge the superseded fix. Only when no fix PR exists is
+the handoff the Case A no-PR cleanup.
 
 ---
 
@@ -194,8 +202,10 @@ run in this lane — for a bug, acceptance *is* the red test, which
 ## `finish-task` (agent: `qs-finish-task`)
 
 Unchanged from the shared contract. Bug × product closes on merge; the
-no-PR Case A covers the diagnose-task iceberg / no-defect exits as pure
-cleanup (it does not touch the issue — the diagnose agent already did).
+diagnose-task iceberg / no-defect exits land as pure cleanup — Case A
+when no fix PR was ever opened, the CLOSED-unmerged cleanup branch when
+diagnose-task closed a superseded fix PR (either way finish-task does
+not touch the issue — the diagnose agent already did).
 
 ---
 

--- a/docs/workflow/lanes/bug-product.md
+++ b/docs/workflow/lanes/bug-product.md
@@ -116,7 +116,9 @@ finding-state triage model as create-plan.
 
 ### FINALIZE (three exits, all human-confirmed)
 
-Commit the story (skip the commit if no story file was written — early exits 2/3), then route via one of **three exits**:
+Commit the story (skip the commit if no story file was written —
+early exits 2/3 — or if the story is already committed and
+unchanged), then route via one of **three exits**:
 
 1. **fix** (normal) → `implement-task`.
 2. **close-as-superseded** (iceberg): the diagnose agent runs

--- a/docs/workflow/lanes/bug-product.md
+++ b/docs/workflow/lanes/bug-product.md
@@ -1,262 +1,206 @@
-# Phase protocols
+# Phase protocols — bug × product lane
 
-Each phase has a static agent under `.claude/agents/` (mirrored in
-`.cursor/agents/` and `.opencode/agents/`). Agents discover task
-context at runtime via
-`python scripts/qs/context.py`. This document captures the contract for
-each phase — inputs, outputs, hand-off, hard rules.
+This lane **diverges** from
+[phase-protocols.md](../phase-protocols.md): fixing a bug is not
+building a feature. The flow is **diagnose-first**:
+
+`setup → diagnose → fix (implement) → verify → finish`
+
+`create-plan` and `review-task` do **not** run in this lane. They are
+replaced by `diagnose-task` (agent `qs-diagnose-task`) and `verify-task`
+(agent `qs-verify-task`). Every other phase follows the shared contract;
+only the divergent details are spelled out below. Each phase has a
+static agent under `.claude/agents/` (mirrored in `.cursor/agents/` and
+`.opencode/agents/`); agents discover task context at runtime via
+`python scripts/qs/context.py`.
 
 Each phase is invoked **as an interactive session** via
 `claude --agent qs-<phase>` (the launcher form — preferred). The
-slash-command form (`/<phase>`) is kept as a **degraded fallback** for
-Claude Desktop and any chat without a CLI launcher. See
-[overview.md](overview.md) section "Orchestrators are interactive
-sessions; sub-agents are parallel fan-out" for the full rationale —
-this document does not duplicate it.
+slash-command form (`/<phase>`) is kept as a **degraded fallback**. See
+[overview.md](../overview.md) for the rationale.
 
 ---
 
 ## `setup-task` (agent: `qs-setup-task`)
 
-**Runs on**: main checkout.
-**Inputs**: free text describing a feature, OR `--issue N` to use an
-existing GitHub issue, OR `--plan /path/to/plan.md`.
-**Side effects**: creates GitHub issue, creates branch `QS_<N>`, creates
-worktree at `<repo>-worktrees/QS_<N>/`.
-**Output**: launcher command (`scripts/qs/launchers/<harness>.py`-generated)
-the user runs to open a new session on the worktree.
-**Next phase**: `claude --agent qs-create-plan` in the worktree
-(preferred — fresh interactive session), or `/create-plan` as fallback.
+**Runs on**: main checkout. Unchanged from the shared contract except
+routing: **next phase is `diagnose-task`**, not `create-plan`.
+**Side effects**: creates GitHub issue, branch `QS_<N>`, worktree.
+**Next phase**: `claude --agent qs-diagnose-task` in the worktree
+(preferred), or `/diagnose-task` as fallback.
 
-**Hard rules**:
-- Do NOT analyze, diagnose, or interpret user input. Pass the text
-  through to the GitHub issue verbatim. Deep analysis is `/create-plan`'s
-  job.
-- Do NOT switch the main checkout's branch.
-- Do NOT commit or push manually — setup only creates the branch and
-  worktree (`scripts/worktree-setup.sh` itself publishes the branch
-  via `git push -u`; that script-driven push is expected).
+**Hard rules**: do NOT analyze or interpret user input — pass it
+through to the issue verbatim; diagnosis is `diagnose-task`'s job.
 
 ---
 
-## `create-plan` (agent: `qs-create-plan`)
+## `diagnose-task` (agent: `qs-diagnose-task`)
 
 **Runs on**: worktree.
 **Inputs**: branch `QS_<N>` (issue resolves from there).
-**Side effects**: writes story file to
-`docs/stories/QS-<N>.story.md` (written as soon as the first discussion
-round converges, **committed only at FINALIZE**).
-**Output**: story file with acceptance criteria + task breakdown +
-adversarial review notes appended.
-**Next phase**: `claude --agent qs-implement-task` or
-`claude --agent qs-implement-setup-task` in the worktree (preferred —
-fresh interactive session), or `/implement-task` /
-`/implement-setup-task` as fallback. The agent decides which based on
-the file paths in its task breakdown.
+**Side effects**: writes the diagnosis story to
+`docs/stories/QS-<N>.story.md` (written as soon as the first diagnosis
+round converges, **committed only at FINALIZE**). May create a
+superseding issue via `gh issue create` (iceberg), and at FINALIZE may
+close this issue via `gh issue close --comment`.
+**Output**: a diagnosis story — root cause + fix plan + red-test spec.
+**Next phase**: `implement-task` (normal fix) or `finish-task` (iceberg
+close-as-superseded / no-defect) — resolved at FINALIZE.
 
-**Phase protocol** — a **user-driven mode loop** (DISCUSS / REVIEW /
-TRIAGE / FINALIZE), not a linear pipeline. DISCUSS is the durable
-default; REVIEW is invoked on demand and repeatable; the story file is
-the living document:
+A **diagnose-first** mode loop (DIAGNOSE / REVIEW / TRIAGE / FINALIZE):
+evidence before hypotheses, hypotheses before cause, cause before plan.
 
-- **DISCUSS (default)**: read the issue (`gh issue view`), read
-  `project-rules.md` / `project-context.md`, glob the relevant code,
-  and discuss scope/risks/acceptance with the user — iterate
-  indefinitely. As soon as the first round **converges** (the plan has
-  all required headings, or the user says "write it"), write the story
-  file and overwrite it on every later change; announce it is readable.
-  Run the doc-maintenance sub-step (`check_doc_drift.py --paths`). Print
-  the status banner and offer REVIEW once per stable version. The story
-  stays uncommitted.
-- **REVIEW (invoked)**: spawn the plan reviewers in parallel (one
-  message). Round 1 = the **4 global reviewers**; round 2+ = the same 4
-  **plus `qs-plan-delta-auditor`** fed an in-context diff + the prior
-  round's accepted findings. See [adversarial-review.md](adversarial-review.md).
-- **TRIAGE**: dedupe via the finding-state model
-  (`open`/`resolved`/`rejected`), present deltas first, drive
-  interactive triage, fold accepted findings into the story, then return
-  to DISCUSS.
-- **FINALIZE (on confirmed intent)**: an **advisory** gate (never
-  hard-blocks) — if the plan changed since the last review, or open
-  criticals remain, the agent asks but the user decides. Determine
-  `NEXT_PHASE` (`implement-setup-task` if all touched files are in
-  `scripts/`, `.claude/`, `.cursor/`, `.opencode/`, `legacy/`,
-  `docs/`, `.github/`, or top-level config; otherwise `implement-task`),
-  commit + push, then emit the launcher payload (preferred,
-  `claude --agent qs-implement-task` / `qs-implement-setup-task`) plus
-  the slash-command fallback.
+### DIAGNOSE (default)
 
-**Hard rules**:
-- Do not write code in this phase.
-- Edit scope is the story file — written during DISCUSS/TRIAGE,
-  committed only at FINALIZE.
-- Never skip the adversarial review for a plan you intend to ship.
+- **Evidence gathering** — ask the user for production data before
+  theorising. Pick from the checklists below per bug; they are not a
+  rigid form.
+- **Root-cause analysis** — read the code, form hypotheses, confirm or
+  eliminate each against the evidence. **Hard rule: no fix plan until
+  the root cause is stated in one sentence with file/function
+  references.** Insufficient evidence → ask, don't guess; staying in
+  DIAGNOSE across sessions is normal.
+- **Reproduction** — **demonstrate when feasible**: the agent may run
+  throwaway, uncommitted scripts/snippets via Bash to show the
+  hypothesis live (nothing is committed in this phase). Always produce
+  the **red test spec**: exact test file, fixture data derived from the
+  evidence, the assertion that fails today. **Sanctioned fallback**
+  when a unit test cannot reproduce the bug (timing, hardware,
+  cloud-API dependent): the story states *why* and names the
+  alternative proof, and carries the mandatory acceptance line —
+  `Fallback accepted: <reason>` — recorded when the human accepts it
+  in-session.
+- **Fix plan** — short, produced *by* the diagnosis. **Minimum-diff
+  rule**: the fix plan lists the files it expects to touch; a
+  blast-radius statement is mandatory. Amendment path: implement may
+  extend the list with a reasoned progress note in the story; verify
+  flags **unexplained** excess as must-fix.
+- **Iceberg check** — is the root cause local, or the tip of something
+  generic? If iceberg → create a new issue (`kind:feature` or epic,
+  `target:product`) via `gh issue create`, carrying the full diagnosis
+  and a back-link; then a **per-case human decision**: (a) close this
+  bug as superseded, or (b) ship a minimal containment fix here and
+  link.
 
----
+#### Generic evidence checklist
 
-## `implement-task` / `implement-setup-task` (agents: `qs-implement-task`, `qs-implement-setup-task`)
+- exact HA + integration versions
+- timeline; expected vs observed; frequency / determinism
+- recent changes (upgrades, config edits, HA core bumps)
+- debug-level logs around the incident window
 
-**Runs on**: worktree.
-**Inputs**: story file from `create-plan`.
-**Side effects**: writes code under `custom_components/quiet_solar/` and
-`tests/` (or `scripts/`, `.claude/`, etc. for `implement-setup-task`);
-auto-commits, pushes, opens PR after green quality gate.
-**Output**: PR opened with quality checklist and risk assessment.
-**Next phase**: `claude --agent qs-review-task` in the worktree
-(preferred — fresh interactive session), or `/review-task` as fallback.
+#### Quiet-solar evidence checklist
 
-**Phase protocol**:
-1. Read story file. Confirm branch state.
-2. TDD: write failing tests → implement minimum code → refactor.
-3. Present implementation summary (files modified, design decisions,
-   risks). Ask "Ready to run the quality gate?".
-4. **ALWAYS** run the impacted inner-loop gate
-   (`python scripts/qs/quality_gate.py --impacted`) before commit/PR —
-   it proves the *changed lines* are 100% covered in seconds and
-   self-heals a drifted testmon baseline automatically (no manual file
-   deletion ever). Do **not** run, or substitute, the full gate
-   locally: the whole-repo 100% gate runs authoritatively in **CI** on
-   every PR, and detecting coverage lost in *unchanged* code is **CI's
-   exclusive job**. The only local full-gate run is an explicit user
-   request. On an `--impacted` failure, fix the **code/tests** — never
-   reach for the full gate to diagnose; escalate only after 2–3
-   attempts. For change sets touching any `tests/qs`-pinned non-Python
-   file (agent files, commands, workflow docs,
-   `.claude/settings.json`) — even when Python files changed too —
-   also run `python scripts/qs/quality_gate.py --quick tests/qs`
-   before commit (testmon cannot see non-Python files).
-5. Auto-commit, push, open PR. No confirmation prompt — authorized by
-   the workflow.
+- config-entry options / device setup
+- entity histories for charger / car / solar / grid sensors
+- `custom_components.quiet_solar` debug log capture
+- solver inputs around the incident window
 
-**Edit scope**:
-- `qs-implement-task`: `custom_components/quiet_solar/**`, `tests/**`,
-  plus the story file (for progress notes).
-- `qs-implement-setup-task`: `scripts/qs/**`, `.claude/**`, `.cursor/**`,
-  `.opencode/**`, `legacy/**` (frozen — `git mv` INTO only),
-  `docs/**`, `.github/**`,
-  top-level config files, plus the story file.
+### Bug story template
 
-**Hard rules**:
-- No code without a failing test first.
-- No commit without a green quality gate.
-- Coverage below 100% is a hard block. No `# pragma: no cover` without
-  explicit user authorization.
+The diagnosis story carries these sections:
+**Symptom** · **Evidence** · **Root cause** · **Repro strategy** ·
+**Fix plan** · **Iceberg check** · **Acceptance** (the red test(s), or
+the fallback proof + the `Fallback accepted:` acceptance line).
+
+### REVIEW / TRIAGE (invoked, on demand)
+
+Same loop mechanics as create-plan, with the **bug diagnosis roster**:
+round 1 = `qs-diag-root-cause-skeptic` + `qs-diag-fix-minimalist` in
+parallel; round 2+ adds `qs-plan-delta-auditor`. Review stays
+**on-demand** (user-invoked, offered once per stable version). Findings
+use the `critical/redesign/improve/clarify` categories and the same
+finding-state triage model as create-plan.
+
+### FINALIZE (three exits, all human-confirmed)
+
+Commit the story, then route via one of **three exits**:
+
+1. **fix** (normal) → `implement-task`.
+2. **close-as-superseded** (iceberg): the diagnose agent runs
+   `gh issue close --comment` linking the superseding issue, then →
+   `finish-task` (Case A no-PR cleanup). The superseding issue's body
+   is the durable record of the diagnosis.
+3. **no-defect / cannot-diagnose** (works-as-intended, duplicate, or
+   evidence exhausted): the human decides close (agent closes with the
+   rationale) or leave open awaiting evidence. **Either way the
+   diagnosis-so-far is posted as an issue comment before cleanup** →
+   `finish-task` Case A.
 
 ---
 
-## `review-task` (agent: `qs-review-task`)
+## `implement-task` (agent: `qs-implement-task`)
+
+**Runs on**: worktree. Fixes the diagnosed bug under
+`custom_components/quiet_solar/`. Follows the shared implement contract
+with the **red-test protocol** below.
+
+### Red-test protocol
+
+1. Write the spec'd regression test **first**, run it with the
+   sanctioned `::`-form (`pytest <file>::<test> -v`), and **record the
+   failure output** (story progress note + PR body) — it must fail for
+   the diagnosed reason, not an import/collection error.
+2. Apply the minimal fix; re-run the test green.
+3. **Scope constraint**: deliver the fix at the scope diagnosed — no
+   drive-by refactors, no opportunistic cleanups. Anything bigger goes
+   through the iceberg escalation, never into the bug PR. File-list
+   amendments carry a reasoned progress note (minimum-diff rule).
+4. **Fallback path**: with an accepted `Fallback accepted:` line in the
+   story, implement per plan and document the alternative evidence in
+   the PR body.
+5. Run the impacted gate before commit; next-phase handoff routes to
+   **`verify-task`**.
+
+**Next phase**: `claude --agent qs-verify-task` (preferred), or
+`/verify-task` as fallback.
+
+---
+
+## `verify-task` (agent: `qs-verify-task`)
 
 **Runs on**: worktree.
 **Inputs**: PR number (resolved from branch).
 **Side effects**: writes fix-plan files under
-`docs/stories/QS-<N>.story_review_fix_#NN.md` (if fixes
-are needed).
+`docs/stories/QS-<N>.story_review_fix_#NN.md` (if fixes are needed).
 **Output**: triaged findings; either "ready for finish-task" or a fix
-plan + instructions for the user to apply fixes.
-**Next phase**: `claude --agent qs-finish-task` in the worktree
-(preferred — fresh interactive session), or `/finish-task` as fallback.
-When fixes are needed, re-run `claude --agent qs-implement-task` or
-`claude --agent qs-implement-setup-task` (chosen by file scope of the
-findings, same rule as `/create-plan`) — with `/implement-task` or
-`/implement-setup-task` as the slash-command fallback — then re-run
-`claude --agent qs-review-task` (or `/review-task`).
+plan. `qs-review-task` does **not** run in this lane.
+**Next phase**: `finish-task` (clean), or `implement-task` then re-run
+`verify-task` (fixes).
 
-**Phase protocol**:
-1. Fetch PR diff.
-2. **Spawn 4 reviewer subagents in parallel** (one message, 4
-   invocations):
-   - `qs-review-blind-hunter` — diff only, no repo context
-   - `qs-review-edge-case-hunter` — diff + repo read-only
-   - `qs-review-acceptance-auditor` — diff + story file
-   - `qs-review-coderabbit` — wraps CodeRabbit's review
-3. Consolidate into must-fix / should-fix / nice-to-have / invalid.
-4. **Zero-findings fast path**: if no must-fix or should-fix findings,
-   emit the launcher payload (preferred, `claude --agent
-   qs-finish-task`) plus the slash-command fallback (`/finish-task`).
-5. Interactive triage: present table → ask "fix all / skip all / one by
-   one?" → collect decisions → confirm.
-6. If fixes needed, write fix-plan file (auto-incremented suffix
-   `#01`, `#02`, …) and emit the launcher payload (`claude --agent
-   qs-implement-task` or `claude --agent qs-implement-setup-task`,
-   chosen by file scope of the findings — same rule as `/create-plan`)
-   plus the matching slash-command fallback (`/implement-task` or
-   `/implement-setup-task`) for the user to apply the fix plan.
-7. When fixes pushed, the user re-runs `claude --agent qs-review-task`
-   (or `/review-task` as fallback) — loop back to step 1 until clean.
+Orchestrator — spawns the **fix-verification roster** in parallel (one
+message): `qs-review-edge-case-hunter` (regression is the dominant
+risk) + `qs-review-coderabbit` + `qs-review-regression-proof`. Consolidate
+into must-fix / should-fix / nice-to-have / invalid, drive interactive
+triage, and either fast-path to `finish-task` (zero findings) or write a
+fix plan and loop through `implement-task`.
 
-**Hard rules**:
-- This agent is an orchestrator — do not review code yourself. Always
-  delegate to the 4 subagents.
-- Edit scope is the fix-plan files only.
-- Sub-agent spawning must be parallel, not serial.
+`qs-review-blind-hunter` and `qs-review-acceptance-auditor` do **not**
+run in this lane — for a bug, acceptance *is* the red test, which
+`qs-review-regression-proof` audits.
 
 ---
 
 ## `finish-task` (agent: `qs-finish-task`)
 
-**Runs on**: worktree (until cleanup, then transitions out).
-**Inputs**: PR number if one exists — `pr_number` may be null (the
-no-PR abandon/cleanup path, Case A in the agent), in which case merge
-logic is skipped entirely.
-**Side effects**: merges PR, deletes branch on origin, removes worktree.
-**Output**: confirmation; user is directed to `/release` if appropriate.
-**Next phase**: `/release` from the main checkout (independent), or
-`claude --agent qs-release` if the user prefers the interactive form.
-Note that `qs-finish-task` does **not** call
-`scripts/qs/next_step.py --next-cmd release` to build a launcher
-payload — release lives on the main checkout, which is a different
-workspace, and the user invokes it manually. The agent body still
-mentions both `/release` and `claude --agent qs-release` in plain prose
-as alternatives (see QS-175 OUT OF SCOPE).
-
-**Phase protocol**:
-1. Show PR summary.
-2. Verify CI status: `gh pr checks <PR>`. If pending, advise wait. If
-   failed, STOP.
-3. Ask user for explicit merge authorization.
-4. Merge PR: `gh pr merge --merge`.
-5. Refresh the `--impacted` baseline (QS-276): capture `MAIN_DIR` (via
-   `git worktree list --porcelain | head -1`) **before** cleanup,
-   update the main checkout (`fetch` + `checkout main` + `pull
-   --ff-only`), then refresh the testmon DB via
-   `quality_gate.py --seed-testmon` — detached/best-effort, never
-   blocking cleanup. A failure or stale baseline is safe (new worktrees
-   just run more tests). QS-286: the detached run now emits a completion
-   signal — it redirects to `.testmondata.seed.log` and writes a
-   `.testmondata.seed-status` marker when done; poll it from the main
-   checkout with `quality_gate.py --seed-testmon-status` (0 = safe to
-   close, 4 = still running, 1 = rerun, 3 = no readable status).
-6. Delete remote branch (safety check: refuse if branch is
-   `main` / `master`).
-7. Run `python scripts/qs/cleanup_worktree.py --work-dir <wd>
-   --issue <N> --force` (force because code is safely on main).
-8. Report. If merged and production code touched, tell the user to run
-   `/release` from main.
-
-**Hard rules**:
-- No merge without explicit user authorization.
-- Never auto-chain to `/release` — it's a separate decision.
+Unchanged from the shared contract. Bug × product closes on merge; the
+no-PR Case A covers the diagnose-task iceberg / no-defect exits as pure
+cleanup (it does not touch the issue — the diagnose agent already did).
 
 ---
 
 ## `release` (agent: `qs-release`)
 
-**Runs on**: main checkout. Independent of any task.
-**Inputs**: none (uses current date for tag derivation).
-**Side effects**: bumps `manifest.json` version, commits, tags, pushes
-tag.
-**Output**: tag `vYYYY.MM.DD.N`; GitHub Actions runs the release
-pipeline.
-**Next phase**: terminal.
+Unchanged from the shared contract. Runs on the main checkout,
+independent of any task.
 
-**Phase protocol**:
-1. Confirm clean main: `git checkout main`, `git pull`, `git status`.
-2. Dry run: `python scripts/qs/release.py --dry-run` → show proposed
-   tag → ask for confirmation.
-3. Run real: `python scripts/qs/release.py` → bumps manifest, commits,
-   pushes, tags.
-4. Report tag and version; note that GitHub Actions handles the rest.
+---
 
-**Hard rules**:
-- Always dry-run first. Get user confirmation before the real run.
-- Refuse to run if `git status` is not clean.
+## Adversarial review
+
+See [adversarial-review.md](../adversarial-review.md). This lane runs
+**dedicated minimal rosters**: 2 diagnosis reviewers
+(`qs-diag-root-cause-skeptic`, `qs-diag-fix-minimalist`; round 2+ adds
+`qs-plan-delta-auditor`) at diagnose time, and 3 fix-verification
+reviewers (`qs-review-edge-case-hunter`, `qs-review-coderabbit`,
+`qs-review-regression-proof`) at verify time.

--- a/docs/workflow/overview.md
+++ b/docs/workflow/overview.md
@@ -22,8 +22,10 @@ The **bug × product** lane (QS-335) diverges into a diagnose-first flow:
 | ---------------- | -------------------- | ------------------------------------------- |
 | `setup-task`     | main checkout        | issue, branch `QS_<N>`, worktree            |
 | `create-plan`    | worktree             | story file at `docs/stories/QS-<N>.story.md` via an interactive discuss/review/finalize loop, committed at finalize |
+| `diagnose-task`  | worktree             | bug × product lane only — replaces `create-plan`: diagnosis story (root cause, red-test spec) via an interactive diagnose/review/finalize loop |
 | `implement-task` | worktree             | TDD code, green quality gate, PR opened     |
 | `review-task`    | worktree             | parallel adversarial review, fix-plan loop  |
+| `verify-task`    | worktree             | bug × product lane only — replaces `review-task`: fix-verification review, fix-plan loop |
 | `finish-task`    | worktree             | PR merged, worktree removed                 |
 | `release`        | main checkout        | tag, manifest bump, GitHub Release          |
 

--- a/docs/workflow/overview.md
+++ b/docs/workflow/overview.md
@@ -12,6 +12,11 @@ isolated in `scripts/qs/launchers/`.
                                                                             (independent)
 ```
 
+The **bug × product** lane (QS-335) diverges into a diagnose-first flow:
+`create-plan` → `diagnose-task` and `review-task` → `verify-task` for
+that lane only (`setup → diagnose → fix → verify → finish`). See
+[lanes/bug-product.md](lanes/bug-product.md).
+
 | Phase            | Where it runs        | What it produces                            |
 | ---------------- | -------------------- | ------------------------------------------- |
 | `setup-task`     | main checkout        | issue, branch `QS_<N>`, worktree            |
@@ -65,8 +70,10 @@ The pipeline runs two fundamentally different kinds of agent, and the
 launcher distinction matters.
 
 **Phase orchestrators** (`qs-setup-task`, `qs-create-plan`,
-`qs-implement-task`, `qs-implement-setup-task`, `qs-review-task`,
-`qs-finish-task`, `qs-release`) are meant to run as **interactive
+`qs-diagnose-task`, `qs-implement-task`, `qs-implement-setup-task`,
+`qs-review-task`, `qs-verify-task`, `qs-finish-task`, `qs-release`;
+`qs-diagnose-task` / `qs-verify-task` run only in the bug × product
+lane) are meant to run as **interactive
 `claude --agent qs-<phase>` sessions**. Claude Code launches a fresh
 session whose system prompt IS the agent body, and the user converses
 with the persona mid-flight — answering clarifying questions in

--- a/docs/workflow/overview.md
+++ b/docs/workflow/overview.md
@@ -13,8 +13,9 @@ isolated in `scripts/qs/launchers/`.
 ```
 
 The **bug × product** lane (QS-335) diverges into a diagnose-first flow:
-`create-plan` → `diagnose-task` and `review-task` → `verify-task` for
-that lane only (`setup → diagnose → fix → verify → finish`). See
+`create-plan` is replaced by `diagnose-task` and `review-task` by
+`verify-task` for that lane only
+(`setup → diagnose → fix → verify → finish`). See
 [lanes/bug-product.md](lanes/bug-product.md).
 
 | Phase            | Where it runs        | What it produces                            |

--- a/docs/workflow/project-context.md
+++ b/docs/workflow/project-context.md
@@ -23,6 +23,9 @@ agent can run directly instead — see
 [harness.md](harness.md) → "GUI launch surface (Claude Code Desktop)"):
 
 - **`qs-setup-task`** → **`qs-create-plan`** → **`qs-implement-task`** → **`qs-review-task`** → **`qs-finish-task`** → **`qs-release`**
+  - bug × product lane (QS-335): **`qs-create-plan`** → **`qs-diagnose-task`**
+    and **`qs-review-task`** → **`qs-verify-task`** (see
+    [lanes/bug-product.md](lanes/bug-product.md))
 
 Agents are defined in `.claude/agents/` (and mirrored to `.cursor/agents/`
 and `.opencode/agents/` — bodies must stay in sync per the harness-sync

--- a/docs/workflow/project-context.md
+++ b/docs/workflow/project-context.md
@@ -23,9 +23,9 @@ agent can run directly instead — see
 [harness.md](harness.md) → "GUI launch surface (Claude Code Desktop)"):
 
 - **`qs-setup-task`** → **`qs-create-plan`** → **`qs-implement-task`** → **`qs-review-task`** → **`qs-finish-task`** → **`qs-release`**
-  - bug × product lane (QS-335): **`qs-create-plan`** → **`qs-diagnose-task`**
-    and **`qs-review-task`** → **`qs-verify-task`** (see
-    [lanes/bug-product.md](lanes/bug-product.md))
+  - bug × product lane (QS-335): **`qs-create-plan`** is replaced by
+    **`qs-diagnose-task`** and **`qs-review-task`** by **`qs-verify-task`**
+    (see [lanes/bug-product.md](lanes/bug-product.md))
 
 Agents are defined in `.claude/agents/` (and mirrored to `.cursor/agents/`
 and `.opencode/agents/` — bodies must stay in sync per the harness-sync

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -273,7 +273,7 @@ which phase to use — infer from context.
 | "Diagnose task" (bug × product lane)                         | `claude --agent qs-diagnose-task`        | `/diagnose-task`   |
 | "Implement task" (inside worktree)                           | `claude --agent qs-implement-task`       | `/implement-task`  |
 | "Review PR #5" or "review task"                              | `claude --agent qs-review-task`          | `/review-task`     |
-| "Verify task" (bug × product lane)                          | `claude --agent qs-verify-task`          | `/verify-task`     |
+| "Verify task" (bug × product lane)                           | `claude --agent qs-verify-task`          | `/verify-task`     |
 | "Merge PR #5" or "finish task"                               | `claude --agent qs-finish-task`          | `/finish-task`     |
 | "Create a release"                                           | `claude --agent qs-release` on main      | `/release`         |
 | Bug fix / small fix                                          | `claude --agent qs-setup-task` on main   | `/setup-task`      |

--- a/docs/workflow/project-rules.md
+++ b/docs/workflow/project-rules.md
@@ -226,11 +226,13 @@ The agent-facing documentation hierarchy lives under
 via `covers:` frontmatter. The drift checker
 `scripts/qs/check_doc_drift.py` validates that every `covers:` path
 exists and flags docs whose source was modified without a
-co-modification. The four orchestrator agents
+co-modification. The six orchestrator agents
 ([qs-create-plan](../../.claude/agents/qs-create-plan.md),
+[qs-diagnose-task](../../.claude/agents/qs-diagnose-task.md),
 [qs-implement-task](../../.claude/agents/qs-implement-task.md),
 [qs-implement-setup-task](../../.claude/agents/qs-implement-setup-task.md),
-[qs-review-task](../../.claude/agents/qs-review-task.md)) wire the
+[qs-review-task](../../.claude/agents/qs-review-task.md),
+[qs-verify-task](../../.claude/agents/qs-verify-task.md)) wire the
 checker into their phase protocol. Taxonomy: **concept** (one source
 file), **principle** (cross-cutting rule), **use-case** (end-to-end
 scenario), **persona** (user archetype).
@@ -268,11 +270,19 @@ which phase to use — infer from context.
 | ------------------------------------------------------------ | ---------------------------------------- | ------------------ |
 | "Setup task 3.2" / describe feature / "work on issue #42"    | `claude --agent qs-setup-task` on main   | `/setup-task`      |
 | "Create plan" (inside worktree)                              | `claude --agent qs-create-plan`          | `/create-plan`     |
+| "Diagnose task" (bug × product lane)                         | `claude --agent qs-diagnose-task`        | `/diagnose-task`   |
 | "Implement task" (inside worktree)                           | `claude --agent qs-implement-task`       | `/implement-task`  |
 | "Review PR #5" or "review task"                              | `claude --agent qs-review-task`          | `/review-task`     |
+| "Verify task" (bug × product lane)                          | `claude --agent qs-verify-task`          | `/verify-task`     |
 | "Merge PR #5" or "finish task"                               | `claude --agent qs-finish-task`          | `/finish-task`     |
 | "Create a release"                                           | `claude --agent qs-release` on main      | `/release`         |
 | Bug fix / small fix                                          | `claude --agent qs-setup-task` on main   | `/setup-task`      |
+
+The **bug × product** lane (QS-335) runs a diagnose-first flow:
+`create-plan` → `diagnose-task` and `review-task` → `verify-task` for
+that lane only. `qs-setup-task` / `qs-implement-task` resolve the next
+phase from the lane; see
+[lanes/bug-product.md](lanes/bug-product.md).
 
 See [overview.md](overview.md) section "Orchestrators are interactive
 sessions; sub-agents are parallel fan-out" for the rationale.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-homeassistant==2026.7.3  # pinned: CI must match local dev env
+homeassistant==2026.8.1  # pinned: CI must match local dev env
 haversine==2.9.0
 aiofiles
 # Core dependencies (if needed)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,15 +9,15 @@ pytest-testmon==2.2.0  # QS-276: test-impact selection for the --impacted inner 
 diff-cover==10.3.0     # QS-276: diff-scoped coverage verdict for --impacted
 # QS-292: shard splitter for the CI test matrix in pr-quality.yml
 pytest-split==0.11.0
-# QS-292: twin of the `pip install coverage==7.14.1` literal in
+# QS-292: twin of the `pip install coverage==7.15.2` literal in
 # pr-quality.yml's aggregation job — the shards' data must be written and
 # read by the same version. Both move together in one edit.
-coverage==7.14.1
+coverage==7.15.2  # matches pytest-homeassistant-custom-component's own pin
 
 # Mock and testing utilities
-pytest-homeassistant-custom-component==0.13.347
+pytest-homeassistant-custom-component==0.13.355  # HA 2026.8.1
 freezegun==1.5.5
-syrupy==5.3.2  # matches pytest-homeassistant-custom-component's own pin
+syrupy==5.5.3  # matches pytest-homeassistant-custom-component's own pin
 
 scipy==1.17.1
 

--- a/scripts/qs/launchers/phases.py
+++ b/scripts/qs/launchers/phases.py
@@ -85,9 +85,13 @@ class UnknownPhaseError(ValueError):
 PHASE_TO_AGENT: dict[str, str] = {
     "setup-task": "qs-setup-task",
     "create-plan": "qs-create-plan",
+    # QS-335: bug × product lane replaces create-plan with diagnose-task.
+    "diagnose-task": "qs-diagnose-task",
     "implement-task": "qs-implement-task",
     "implement-setup-task": "qs-implement-setup-task",
     "review-task": "qs-review-task",
+    # QS-335: bug × product lane replaces review-task with verify-task.
+    "verify-task": "qs-verify-task",
     "finish-task": "qs-finish-task",
     "release": "qs-release",
 }

--- a/tests/qs/agents/test_doc_maintenance_parity.py
+++ b/tests/qs/agents/test_doc_maintenance_parity.py
@@ -3,16 +3,20 @@
 QS-185 introduced an addressable documentation hierarchy under
 ``docs/agents/`` plus a drift-checker script
 (``scripts/qs/check_doc_drift.py``). For the drift checker to be
-useful, four agent bodies must invoke it at the right phase:
+useful, six agent bodies must invoke it at the right phase:
 
 - ``qs-create-plan``      — during plan drafting, run
   ``check_doc_drift.py --paths <planned_files>``.
+- ``qs-diagnose-task``    — during diagnosis (bug × product lane), same
+  ``--paths`` form as create-plan.
 - ``qs-implement-task``   — at the quality gate, run
   ``check_doc_drift.py`` on the staged diff.
 - ``qs-implement-setup-task`` — same.
 - ``qs-review-task``      — during consolidation, flag a must-fix
   finding if the PR shows no ``## Doc maintenance`` justification
   and ``check_doc_drift.py`` would have failed.
+- ``qs-verify-task``      — the bug × product lane's review-variant,
+  same PR-diff audit as qs-review-task.
 
 Body content is mirrored across three harnesses (Claude / Cursor /
 OpenCode) — the frontmatter format is harness-specific and stays
@@ -31,12 +35,17 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# The four orchestrator agents that AC-9 requires us to update.
+# The six orchestrator agents that AC-9 requires us to update (QS-335
+# added the two bug × product lane orchestrators qs-diagnose-task and
+# qs-verify-task, which lift the create-plan / review-task
+# doc-maintenance step).
 DOC_MAINTENANCE_AGENT_NAMES: tuple[str, ...] = (
     "qs-create-plan",
     "qs-implement-task",
     "qs-implement-setup-task",
     "qs-review-task",
+    "qs-diagnose-task",
+    "qs-verify-task",
 )
 
 # Three harnesses to mirror across.
@@ -63,8 +72,9 @@ IMPLEMENT_AGENT_NAMES: tuple[str, ...] = (
 
 # Review-variant agents (post-PR): the doc-maintenance step inspects
 # the PR diff, not a "staged" diff (no canonical staged state exists
-# at review time). Pinned post-review-fix #01 S1.
-REVIEW_AGENT_NAMES: tuple[str, ...] = ("qs-review-task",)
+# at review time). Pinned post-review-fix #01 S1. QS-335: qs-verify-task
+# is the bug × product lane's review-variant, lifted from qs-review-task.
+REVIEW_AGENT_NAMES: tuple[str, ...] = ("qs-review-task", "qs-verify-task")
 
 
 # Review-fix #01 N6: strip the leading dot from harness ids so

--- a/tests/qs/agents/test_doc_maintenance_parity.py
+++ b/tests/qs/agents/test_doc_maintenance_parity.py
@@ -35,10 +35,10 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# The six orchestrator agents that AC-9 requires us to update (QS-335
-# added the two bug × product lane orchestrators qs-diagnose-task and
-# qs-verify-task, which lift the create-plan / review-task
-# doc-maintenance step).
+# The six orchestrator agents that carry the doc-maintenance step:
+# four required by QS-185 AC-9, plus the two bug × product lane
+# orchestrators qs-diagnose-task and qs-verify-task (QS-335), which
+# lift the create-plan / review-task doc-maintenance step.
 DOC_MAINTENANCE_AGENT_NAMES: tuple[str, ...] = (
     "qs-create-plan",
     "qs-implement-task",

--- a/tests/qs/agents/test_doc_maintenance_parity.py
+++ b/tests/qs/agents/test_doc_maintenance_parity.py
@@ -1,4 +1,4 @@
-"""Pin the doc-maintenance step across the four orchestrator agents.
+"""Pin the doc-maintenance step across the six orchestrator agents.
 
 QS-185 introduced an addressable documentation hierarchy under
 ``docs/agents/`` plus a drift-checker script

--- a/tests/qs/agents/test_lane_steps_parity.py
+++ b/tests/qs/agents/test_lane_steps_parity.py
@@ -140,9 +140,16 @@ def test_lane_block_is_a_clean_mirrored_paragraph(
     assert body[start - 2 : start] == "\n\n", "one blank line before the block"
     assert body[start - 3 : start] != "\n\n\n", "no doubled blank line before"
     tail = body[start:]
+    # Review-fix #05: qs-diagnose-task's block gained the empty-lane
+    # story-overwrite guard, so its terminal sentence is now the guard's
+    # ("...convergence overwrites it."), not "on the fallback.".
     sentinel = next(
         marker
-        for marker in ("a parallel path).\n", "on the fallback.\n")
+        for marker in (
+            "a parallel path).\n",
+            "convergence overwrites it.\n",
+            "on the fallback.\n",
+        )
         if marker in tail
     )
     end = tail.index(sentinel) + len(sentinel)

--- a/tests/qs/agents/test_lane_steps_parity.py
+++ b/tests/qs/agents/test_lane_steps_parity.py
@@ -48,6 +48,23 @@ IMPLEMENT_AGENT_NAMES: tuple[str, ...] = (
     "qs-implement-setup-task",
 )
 
+# The lane-read block's terminal sentence, per agent (review-fix #06):
+# the previous first-match tuple scanned the whole file remainder, so a
+# marker phrase appearing in a later paragraph of another agent's body
+# could hijack the block boundary and make the whitespace assertions
+# inspect arbitrary bytes (vacuous pass or spurious fail). The
+# implement variants end on the before-first-commit rule; diagnose-task
+# ends on the lane-independent story-overwrite guard (review-fix
+# #05/#06); the rest end on the read-only fallback sentence.
+LANE_BLOCK_TERMINALS: dict[str, str] = {
+    "qs-create-plan": "on the fallback.\n",
+    "qs-implement-task": "a parallel path).\n",
+    "qs-implement-setup-task": "a parallel path).\n",
+    "qs-review-task": "on the fallback.\n",
+    "qs-diagnose-task": "convergence\noverwrites it.\n",
+    "qs-verify-task": "on the fallback.\n",
+}
+
 
 def _harness_id(p: Path) -> str:
     return p.parent.name.lstrip(".")
@@ -140,17 +157,10 @@ def test_lane_block_is_a_clean_mirrored_paragraph(
     assert body[start - 2 : start] == "\n\n", "one blank line before the block"
     assert body[start - 3 : start] != "\n\n\n", "no doubled blank line before"
     tail = body[start:]
-    # Review-fix #05: qs-diagnose-task's block gained the empty-lane
-    # story-overwrite guard, so its terminal sentence is now the guard's
-    # ("...convergence overwrites it."), not "on the fallback.".
-    sentinel = next(
-        marker
-        for marker in (
-            "a parallel path).\n",
-            "convergence overwrites it.\n",
-            "on the fallback.\n",
-        )
-        if marker in tail
+    sentinel = LANE_BLOCK_TERMINALS[agent_name]
+    assert sentinel in tail, (
+        f"{harness_dir / f'{agent_name}.md'}: lane block missing its "
+        f"terminal sentence {sentinel!r}"
     )
     end = tail.index(sentinel) + len(sentinel)
     assert tail[end] == "\n", "one blank line after the block"

--- a/tests/qs/agents/test_lane_steps_parity.py
+++ b/tests/qs/agents/test_lane_steps_parity.py
@@ -54,14 +54,15 @@ IMPLEMENT_AGENT_NAMES: tuple[str, ...] = (
 # could hijack the block boundary and make the whitespace assertions
 # inspect arbitrary bytes (vacuous pass or spurious fail). The
 # implement variants end on the before-first-commit rule; diagnose-task
-# ends on the lane-independent story-overwrite guard (review-fix
-# #05/#06); the rest end on the read-only fallback sentence.
+# ends on the lane-independent story-overwrite guard's cold-start
+# resume sentence (review-fix #05/#06/#07); the rest end on the
+# read-only fallback sentence.
 LANE_BLOCK_TERMINALS: dict[str, str] = {
     "qs-create-plan": "on the fallback.\n",
     "qs-implement-task": "a parallel path).\n",
     "qs-implement-setup-task": "a parallel path).\n",
     "qs-review-task": "on the fallback.\n",
-    "qs-diagnose-task": "convergence\noverwrites it.\n",
+    "qs-diagnose-task": "adopt it\nas the current diagnosis state (resume, don't restart).\n",
     "qs-verify-task": "on the fallback.\n",
 }
 

--- a/tests/qs/agents/test_lane_steps_parity.py
+++ b/tests/qs/agents/test_lane_steps_parity.py
@@ -39,6 +39,8 @@ LANE_READ_AGENT_NAMES: tuple[str, ...] = (
     "qs-implement-task",
     "qs-implement-setup-task",
     "qs-review-task",
+    "qs-diagnose-task",
+    "qs-verify-task",
 )
 
 IMPLEMENT_AGENT_NAMES: tuple[str, ...] = (

--- a/tests/qs/agents/test_lsp_tool_enabled.py
+++ b/tests/qs/agents/test_lsp_tool_enabled.py
@@ -54,6 +54,9 @@ LSP_INCLUDE_AGENTS: tuple[str, ...] = (
     "qs-review-edge-case-hunter",
     "qs-review-acceptance-auditor",
     "qs-setup-task",
+    "qs-diagnose-task",
+    "qs-verify-task",
+    "qs-diag-root-cause-skeptic",
 )
 
 # Context-starved (blind) reviewers + merge/release agents. They must
@@ -67,6 +70,8 @@ LSP_EXCLUDE_AGENTS: tuple[str, ...] = (
     "qs-review-coderabbit",
     "qs-finish-task",
     "qs-release",
+    "qs-diag-fix-minimalist",
+    "qs-review-regression-proof",
 )
 
 PYRIGHT_PLUGIN_ID = "pyright-lsp@claude-plugins-official"

--- a/tests/qs/agents/test_lsp_tool_enabled.py
+++ b/tests/qs/agents/test_lsp_tool_enabled.py
@@ -59,8 +59,9 @@ LSP_INCLUDE_AGENTS: tuple[str, ...] = (
     "qs-diag-root-cause-skeptic",
 )
 
-# Context-starved (blind) reviewers + merge/release agents. They must
-# NOT get ``LSP`` — code navigation contradicts their design.
+# Context-starved (blind) reviewers, merge/release agents, and
+# reviewers whose charter needs no code navigation. They must NOT get
+# ``LSP`` — it contradicts (or adds nothing to) their design.
 LSP_EXCLUDE_AGENTS: tuple[str, ...] = (
     "qs-plan-critic",
     "qs-plan-dev-proxy",

--- a/tests/qs/agents/test_opencode_agents.py
+++ b/tests/qs/agents/test_opencode_agents.py
@@ -68,9 +68,11 @@ OPENCODE_AGENTS_DIR = REPO_ROOT / ".opencode" / "agents"
 PHASE_AGENT_NAMES: tuple[str, ...] = (
     "qs-setup-task",
     "qs-create-plan",
+    "qs-diagnose-task",
     "qs-implement-task",
     "qs-implement-setup-task",
     "qs-review-task",
+    "qs-verify-task",
     "qs-finish-task",
     "qs-release",
 )
@@ -85,6 +87,9 @@ SUB_AGENT_NAMES: tuple[str, ...] = (
     "qs-review-edge-case-hunter",
     "qs-review-acceptance-auditor",
     "qs-review-coderabbit",
+    "qs-diag-root-cause-skeptic",
+    "qs-diag-fix-minimalist",
+    "qs-review-regression-proof",
 )
 
 ALL_STATIC_AGENT_NAMES: tuple[str, ...] = PHASE_AGENT_NAMES + SUB_AGENT_NAMES

--- a/tests/qs/agents/test_opencode_execute_contract.py
+++ b/tests/qs/agents/test_opencode_execute_contract.py
@@ -169,7 +169,7 @@ def test_opencode_agent_no_emoji_in_success_block(name: str) -> None:
 
 
 @pytest.mark.parametrize("filename", ["qs-review-task.md", "qs-verify-task.md"])
-def test_opencode_review_task_has_two_execute_blocks(filename: str) -> None:
+def test_opencode_handoff_orchestrators_have_two_execute_blocks(filename: str) -> None:
     """review-task / verify-task each have 2 next_step.py callsites — both
     must auto-execute.
 

--- a/tests/qs/agents/test_opencode_execute_contract.py
+++ b/tests/qs/agents/test_opencode_execute_contract.py
@@ -59,9 +59,11 @@ SUBSTITUTION_REMINDER = "**Before running** — substitute"
 
 OPENCODE_EXECUTE_AGENTS = (
     "qs-create-plan",
+    "qs-diagnose-task",
     "qs-implement-task",
     "qs-implement-setup-task",
     "qs-review-task",
+    "qs-verify-task",
 )
 
 
@@ -166,17 +168,21 @@ def test_opencode_agent_no_emoji_in_success_block(name: str) -> None:
     )
 
 
-def test_opencode_review_task_has_two_execute_blocks() -> None:
-    """review-task has 2 next_step.py callsites — both must auto-execute.
+@pytest.mark.parametrize("filename", ["qs-review-task.md", "qs-verify-task.md"])
+def test_opencode_review_task_has_two_execute_blocks(filename: str) -> None:
+    """review-task / verify-task each have 2 next_step.py callsites — both
+    must auto-execute.
 
     Counts occurrences of the EXECUTE_MARKER. Asserts ``>= 2`` so the
     test is robust to future prose elaboration; the lower bound is
-    what matters.
+    what matters. QS-335: qs-verify-task is the bug × product lane's
+    review-variant and hands off twice (zero-findings + fix-plan), same
+    as qs-review-task.
     """
-    body = (OPENCODE_DIR / "qs-review-task.md").read_text(encoding="utf-8")
+    body = (OPENCODE_DIR / filename).read_text(encoding="utf-8")
     count = body.count(EXECUTE_MARKER)
     assert count >= 2, (
-        f"qs-review-task.md should auto-execute both new_context "
+        f"{filename} should auto-execute both new_context "
         f"callsites (zero-findings + fix-plan); found {count} "
         f"occurrences of {EXECUTE_MARKER!r}."
     )

--- a/tests/qs/agents/test_orchestrator_handoff.py
+++ b/tests/qs/agents/test_orchestrator_handoff.py
@@ -44,9 +44,9 @@ _FORBIDDEN_RELEASE_INVOCATION = re.compile(
 
 # The 7 two-block orchestrators — every phase orchestrator that ships
 # the strict ``Preferred`` / ``Fallback`` pattern. ``qs-finish-task``
-# (the 8th orchestrator) is the deliberate exception that does NOT
-# ship it (release follow-up is text-only — see QS-175 OUT OF SCOPE)
-# and gets its own dedicated tests below. QS-335 added the bug ×
+# and ``qs-release`` deliberately do NOT ship it (release follow-up is
+# text-only — see QS-175 OUT OF SCOPE); ``qs-finish-task`` gets its
+# own dedicated tests below. QS-335 added the bug ×
 # product lane's ``qs-diagnose-task`` (lifted from create-plan) and
 # ``qs-verify-task`` (lifted from review-task).
 _TWO_BLOCK_ORCHESTRATORS = [

--- a/tests/qs/agents/test_orchestrator_handoff.py
+++ b/tests/qs/agents/test_orchestrator_handoff.py
@@ -44,9 +44,9 @@ _FORBIDDEN_RELEASE_INVOCATION = re.compile(
 
 # The 7 two-block orchestrators — every phase orchestrator that ships
 # the strict ``Preferred`` / ``Fallback`` pattern. ``qs-finish-task``
-# and ``qs-release`` deliberately do NOT ship it (release follow-up is
-# text-only — see QS-175 OUT OF SCOPE); ``qs-finish-task`` gets its
-# own dedicated tests below. QS-335 added the bug ×
+# deliberately does NOT ship it (its follow-up is text-only — see
+# QS-175 OUT OF SCOPE) and gets its own dedicated tests below;
+# ``qs-release`` has no follow-up phase at all. QS-335 added the bug ×
 # product lane's ``qs-diagnose-task`` (lifted from create-plan) and
 # ``qs-verify-task`` (lifted from review-task).
 _TWO_BLOCK_ORCHESTRATORS = [

--- a/tests/qs/agents/test_orchestrator_handoff.py
+++ b/tests/qs/agents/test_orchestrator_handoff.py
@@ -42,28 +42,37 @@ _FORBIDDEN_RELEASE_INVOCATION = re.compile(
 )
 
 
-# All 6 orchestrators that ship the strict two-block ``Preferred`` /
+# All 8 orchestrators that ship the strict two-block ``Preferred`` /
 # ``Fallback`` pattern. ``qs-finish-task`` is the deliberate exception
 # (release follow-up is text-only — see QS-175 OUT OF SCOPE) and gets
-# its own dedicated tests below.
+# its own dedicated tests below. QS-335 added the bug × product lane's
+# ``qs-diagnose-task`` (lifted from create-plan) and ``qs-verify-task``
+# (lifted from review-task).
 _TWO_BLOCK_ORCHESTRATORS = [
     "qs-setup-task.md",
     "qs-create-plan.md",
+    "qs-diagnose-task.md",
     "qs-implement-task.md",
     "qs-implement-setup-task.md",
     "qs-review-task.md",
+    "qs-verify-task.md",
 ]
 
-# Five of those orchestrators emit a hardcoded ``/<phase>`` in the
-# fallback block. ``qs-create-plan`` is dynamic (the NEXT_PHASE depends
-# on the diff) and gets its own dedicated test asserting it uses a
-# placeholder of the right SHAPE, but explicitly NOT
-# ``{{same_context}}``.
+# Those orchestrators whose fallback block names a fixed ``/<phase>``
+# token. ``qs-create-plan`` is dynamic (the NEXT_PHASE depends on the
+# diff) and gets its own dedicated test asserting it uses a placeholder
+# of the right SHAPE, but explicitly NOT ``{{same_context}}``.
+# QS-335: ``qs-diagnose-task`` is likewise dynamic (fix / finish exits)
+# but its fallback line carries the literal ``/{{NEXT_PHASE}}`` token, so
+# the concrete-slash assertion still holds against that literal;
+# ``qs-verify-task``'s clean-path fallback is the fixed ``/finish-task``.
 _HARDCODED_FALLBACK = [
     ("qs-setup-task.md", "/create-plan"),
     ("qs-implement-task.md", "/review-task"),
     ("qs-implement-setup-task.md", "/review-task"),
     ("qs-review-task.md", "/finish-task"),
+    ("qs-diagnose-task.md", "/{{NEXT_PHASE}}"),
+    ("qs-verify-task.md", "/finish-task"),
 ]
 
 
@@ -246,7 +255,7 @@ def test_forbidden_release_regex_ignores_prose_mention() -> None:
 # next phase into ``<worktree>/.claude/settings.local.json`` and each
 # handoff must print the GUI gesture (New session → select directory →
 # name it). The set of orchestrators is exactly the two-block set — the
-# 5 worktree handoffs — and the equality is asserted below.
+# 7 worktree handoffs — and the equality is asserted below.
 #
 # Review-fix #01 S3: this list used to be a bare ALIAS of
 # ``_TWO_BLOCK_ORCHESTRATORS``, which made that equality assertion an
@@ -258,9 +267,11 @@ def test_forbidden_release_regex_ignores_prose_mention() -> None:
 _GUI_BLOCK_ORCHESTRATORS = [
     "qs-setup-task.md",
     "qs-create-plan.md",
+    "qs-diagnose-task.md",
     "qs-implement-task.md",
     "qs-implement-setup-task.md",
     "qs-review-task.md",
+    "qs-verify-task.md",
 ]
 
 _GUI_BLOCK_MARKER = "[Claude Code GUI]"
@@ -287,6 +298,9 @@ _GUI_BLOCK_REQUIRED_TOKENS = (
 # would leave the review-found-problems hop with no GUI instructions.
 _GUI_BLOCK_COUNTS = {name: 1 for name in _GUI_BLOCK_ORCHESTRATORS}
 _GUI_BLOCK_COUNTS["qs-review-task.md"] = 2
+# QS-335: qs-verify-task lifts review-task's two handoffs (clean →
+# finish-task, fixes → implement-task then re-run verify-task).
+_GUI_BLOCK_COUNTS["qs-verify-task.md"] = 2
 
 # The fallback line each orchestrator's handoff must still expose after
 # the GUI block was inserted. ``qs-create-plan`` is the dynamic-next-phase
@@ -436,17 +450,22 @@ def test_false_branch_carries_the_stale_pin_hazard(filename: str) -> None:
     )
 
 
-def test_review_task_carries_the_stale_pin_hazard_at_both_handoffs() -> None:
-    """``qs-review-task`` hands off twice, so it needs the sentence twice.
+@pytest.mark.parametrize("filename", ["qs-review-task.md", "qs-verify-task.md"])
+def test_review_task_carries_the_stale_pin_hazard_at_both_handoffs(
+    filename: str,
+) -> None:
+    """``qs-review-task`` / ``qs-verify-task`` hand off twice, so each needs
+    the sentence twice.
 
     The per-file test above is satisfied by one occurrence; this is the same
     two-handoff asymmetry ``_GUI_BLOCK_COUNTS`` exists for. Without it the
-    fix-plan loop back to the implement phase keeps the old wording.
+    fix-plan loop back to the implement phase keeps the old wording. QS-335:
+    qs-verify-task is the bug × product lane's two-handoff review-variant.
     """
-    body = " ".join((AGENTS_DIR / "qs-review-task.md").read_text().split())
+    body = " ".join((AGENTS_DIR / filename).read_text().split())
     expected = " ".join(_STALE_PIN_SENTENCE.split())
     assert body.count(expected) == 2, (
-        f"qs-review-task.md: expected the stale-pin sentence at both handoff "
+        f"{filename}: expected the stale-pin sentence at both handoff "
         f"sites, found {body.count(expected)}"
     )
 
@@ -533,6 +552,59 @@ def test_pointer_block_stays_within_the_doc_line_width() -> None:
             f"pointer-block line is {len(line)} chars, over the ~72-column "
             f"convention of the surrounding docs: {line!r}"
         )
+
+
+# --------------------------------------------------------------------------- #
+# QS-335 D3 — the two shared orchestrators carry the lane-resolved dynamic
+# handoff. ``qs-setup-task`` routes ``create-plan`` by default and
+# ``diagnose-task`` when the lane is ``bug-product``; ``qs-implement-task``
+# routes ``review-task`` by default and ``verify-task`` for ``bug-product``.
+# Both branches must appear in every one of the 3 harness copies. Pattern
+# of ``test_lane_steps_parity.py`` (HARNESS_DIRS-parametrized). The
+# fallback line keeps its literal default as the first slash token with
+# the bug-product branch appended mid-sentence (D3 pin compatibility).
+# ``qs-create-plan``, ``qs-review-task``, ``qs-implement-setup-task`` stay
+# byte-unchanged — verified at review time by ``git diff`` against main
+# (AC-4), no parity test built.
+# --------------------------------------------------------------------------- #
+
+_ROUTING_HARNESS_DIRS = (
+    REPO_ROOT / ".claude" / "agents",
+    REPO_ROOT / ".cursor" / "agents",
+    REPO_ROOT / ".opencode" / "agents",
+)
+
+# agent file -> (default-lane phase token, bug-product-lane phase token)
+_LANE_ROUTING = {
+    "qs-setup-task.md": ("/create-plan", "/diagnose-task"),
+    "qs-implement-task.md": ("/review-task", "/verify-task"),
+}
+
+
+@pytest.mark.parametrize(
+    "harness_dir", _ROUTING_HARNESS_DIRS, ids=lambda p: p.parent.name.lstrip(".")
+)
+@pytest.mark.parametrize("filename", sorted(_LANE_ROUTING))
+def test_shared_orchestrator_carries_both_lane_branches(
+    harness_dir: Path, filename: str,
+) -> None:
+    """Both the default and the bug-product routing branch appear in each copy."""
+    default_tok, bug_tok = _LANE_ROUTING[filename]
+    path = harness_dir / filename
+    assert path.is_file(), f"missing agent file: {path}"
+    body = path.read_text(encoding="utf-8")
+    assert default_tok in body, (
+        f"{path}: missing the default-lane routing token {default_tok!r} "
+        f"(QS-335 D3)."
+    )
+    assert bug_tok in body, (
+        f"{path}: missing the bug-product routing branch {bug_tok!r} — the "
+        f"handoff must resolve the next phase from the lane (QS-335 D3)."
+    )
+    assert "bug-product" in body, (
+        f"{path}: the lane-resolved handoff must name the `bug-product` lane "
+        f"that selects the alternate next phase (QS-335 D3)."
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/qs/agents/test_orchestrator_handoff.py
+++ b/tests/qs/agents/test_orchestrator_handoff.py
@@ -452,7 +452,7 @@ def test_false_branch_carries_the_stale_pin_hazard(filename: str) -> None:
 
 
 @pytest.mark.parametrize("filename", ["qs-review-task.md", "qs-verify-task.md"])
-def test_review_task_carries_the_stale_pin_hazard_at_both_handoffs(
+def test_handoff_orchestrators_carry_the_stale_pin_hazard_at_both_handoffs(
     filename: str,
 ) -> None:
     """``qs-review-task`` / ``qs-verify-task`` hand off twice, so each needs

--- a/tests/qs/agents/test_orchestrator_handoff.py
+++ b/tests/qs/agents/test_orchestrator_handoff.py
@@ -42,12 +42,13 @@ _FORBIDDEN_RELEASE_INVOCATION = re.compile(
 )
 
 
-# All 8 orchestrators that ship the strict two-block ``Preferred`` /
-# ``Fallback`` pattern. ``qs-finish-task`` is the deliberate exception
-# (release follow-up is text-only — see QS-175 OUT OF SCOPE) and gets
-# its own dedicated tests below. QS-335 added the bug × product lane's
-# ``qs-diagnose-task`` (lifted from create-plan) and ``qs-verify-task``
-# (lifted from review-task).
+# The 7 two-block orchestrators — every phase orchestrator that ships
+# the strict ``Preferred`` / ``Fallback`` pattern. ``qs-finish-task``
+# (the 8th orchestrator) is the deliberate exception that does NOT
+# ship it (release follow-up is text-only — see QS-175 OUT OF SCOPE)
+# and gets its own dedicated tests below. QS-335 added the bug ×
+# product lane's ``qs-diagnose-task`` (lifted from create-plan) and
+# ``qs-verify-task`` (lifted from review-task).
 _TWO_BLOCK_ORCHESTRATORS = [
     "qs-setup-task.md",
     "qs-create-plan.md",

--- a/tests/qs/agents/test_orchestrator_handoff.py
+++ b/tests/qs/agents/test_orchestrator_handoff.py
@@ -256,7 +256,7 @@ def test_forbidden_release_regex_ignores_prose_mention() -> None:
 # next phase into ``<worktree>/.claude/settings.local.json`` and each
 # handoff must print the GUI gesture (New session → select directory →
 # name it). The set of orchestrators is exactly the two-block set — the
-# 7 worktree handoffs — and the equality is asserted below.
+# 7 GUI-block handoffs — and the equality is asserted below.
 #
 # Review-fix #01 S3: this list used to be a bare ALIAS of
 # ``_TWO_BLOCK_ORCHESTRATORS``, which made that equality assertion an
@@ -605,6 +605,14 @@ def test_shared_orchestrator_carries_both_lane_branches(
     assert "bug-product" in body, (
         f"{path}: the lane-resolved handoff must name the `bug-product` lane "
         f"that selects the alternate next phase (QS-335 D3)."
+    )
+    # Discriminating pin (review-fix #05): the fallback line alone carries
+    # both phase tokens and "bug-product", so without this assertion the
+    # resolution paragraph — the definition of ``{{NEXT_PHASE}}`` — could
+    # be deleted while the test stays green.
+    assert "Resolve the next phase from the lane" in body, (
+        f"{path}: missing the lane-resolution paragraph that defines "
+        f"{{{{NEXT_PHASE}}}} (QS-335 D3)."
     )
 
 

--- a/tests/qs/agents/test_slash_command_preambles.py
+++ b/tests/qs/agents/test_slash_command_preambles.py
@@ -37,9 +37,11 @@ COMMANDS_DIR = REPO_ROOT / ".claude" / "commands"
 _SLASH_COMMAND_FILES = [
     "setup-task.md",
     "create-plan.md",
+    "diagnose-task.md",
     "implement-task.md",
     "implement-setup-task.md",
     "review-task.md",
+    "verify-task.md",
     "finish-task.md",
 ]
 

--- a/tests/qs/docs/test_lanes.py
+++ b/tests/qs/docs/test_lanes.py
@@ -37,7 +37,42 @@ LANES = (
 # Lane files allowed to diverge from phase-protocols.md. EMPTY at QS-332
 # merge; a lane PR adds its own basename (e.g. "bug-product.md") as its
 # first act, then writes its divergence.
-DIVERGED: frozenset[str] = frozenset()
+DIVERGED: frozenset[str] = frozenset({"bug-product.md"})
+
+# QS-335: required headings / sentinel lines pinned for the diverged
+# bug × product lane file. Headings and sentinel lines ONLY — never
+# checklist prose, which must stay free to evolve (D2).
+BUG_PRODUCT_SENTINELS: tuple[str, ...] = (
+    # diverged flow banner
+    "setup → diagnose → fix (implement) → verify → finish",
+    # phase sections that replace create-plan / review-task
+    "## `diagnose-task` (agent: `qs-diagnose-task`)",
+    "## `verify-task` (agent: `qs-verify-task`)",
+    # diagnose contract: checklist section headings (headings, not prose)
+    "#### Generic evidence checklist",
+    "#### Quiet-solar evidence checklist",
+    # root-cause hard rule
+    "**Hard rule: no fix plan until",
+    # reproduction: demonstrate-when-feasible + fallback
+    "**demonstrate when feasible**",
+    "Fallback accepted: <reason>",
+    # iceberg check
+    "**Iceberg check**",
+    # bug story template headings
+    "### Bug story template",
+    "**Symptom** · **Evidence** · **Root cause** · **Repro strategy** ·",
+    # diagnosis roster sentinel
+    "`qs-diag-root-cause-skeptic` + `qs-diag-fix-minimalist`",
+    # three FINALIZE exits
+    "### FINALIZE (three exits, all human-confirmed)",
+    # red-test implement protocol (sanctioned ::-form)
+    "### Red-test protocol",
+    "sanctioned `::`-form (`pytest <file>::<test> -v`)",
+    # verify-task roster sentinel
+    "`qs-review-regression-proof`",
+    # escalation procedure
+    "through the iceberg escalation",
+)
 
 
 def test_exactly_the_six_lane_files_exist() -> None:
@@ -69,3 +104,14 @@ def test_lane_file_is_byte_identical_unless_diverged(lane: str) -> None:
 def test_diverged_entries_are_real_lane_files() -> None:
     """A typo'd allowlist entry would silently skip nothing."""
     assert DIVERGED <= {f"{lane}.md" for lane in LANES}
+
+
+@pytest.mark.parametrize("sentinel", BUG_PRODUCT_SENTINELS)
+def test_bug_product_lane_carries_required_sentinels(sentinel: str) -> None:
+    """The diverged bug × product lane pins its headings / sentinel lines.
+
+    Headings and sentinel lines ONLY (AC-1 / D2) — the evidence-checklist
+    prose is deliberately NOT pinned so it can evolve.
+    """
+    text = (LANES_DIR / "bug-product.md").read_text(encoding="utf-8")
+    assert sentinel in text, f"bug-product.md missing sentinel: {sentinel!r}"

--- a/tests/qs/launchers/test_phase_mapping.py
+++ b/tests/qs/launchers/test_phase_mapping.py
@@ -16,9 +16,11 @@ import pytest
 _KNOWN_PHASES = (
     "setup-task",
     "create-plan",
+    "diagnose-task",
     "implement-task",
     "implement-setup-task",
     "review-task",
+    "verify-task",
     "finish-task",
     "release",
 )


### PR DESCRIPTION
## Summary
- Diverge docs/workflow/lanes/bug-product.md into the diagnose-first flow (setup → diagnose → fix → verify → finish) with evidence checklists, bug story template, red-test protocol, minimum-diff rule, and iceberg escalation
- Add qs-diagnose-task + qs-verify-task orchestrators and 3 dedicated reviewers (qs-diag-root-cause-skeptic, qs-diag-fix-minimalist, qs-review-regression-proof) across all 3 harness dirs, with phase registry entries, slash-command fallbacks, and lane-resolved routing in qs-setup-task / qs-implement-task
- Bump dev env to HA 2026.8.1 (PHACC 0.13.355, coverage 7.15.2 CI twin, syrupy 5.5.3); local hang root-caused to leaked test storage, fixed venv-side; test-infra follow-ups tracked in #346

Fixes #335
Refs #321

## Testing
- [x] Tests added/updated for new behavior
- [x] 100% coverage verified
- [x] No flaky tests introduced

## Code quality
- [x] Ruff passes (lint + format)
- [x] MyPy passes
- [x] No new `# type: ignore` or `noqa` without justification

## Risk assessment
- [ ] CRITICAL (solver, constraints, charger budgeting)
- [ ] HIGH (load base, constants, orchestration)
- [ ] MEDIUM (device-specific: car, person, battery, solar)
- [x] LOW (platforms, UI, docs)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a diagnose-first workflow for bug and product issues, including root-cause analysis, reproduction evidence, implementation, verification, and completion.
  * Added diagnosis, verification, and regression-review capabilities across supported development tools.
  * Added interactive and fallback commands for diagnosis and verification.

* **Documentation**
  * Documented workflow routing, review processes, evidence requirements, and completion paths.

* **Bug Fixes**
  * Corrected lane-specific phase handoffs for bug-product work.

* **Chores**
  * Updated application and test dependencies and aligned CI coverage tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## Doc maintenance

Review-fix #05 flagged `harness drift: qs-verify-task.md (out of sync:
.claude, .cursor)`. The `.opencode/agents/qs-verify-task.md` edit is
frontmatter-only — tightening OpenCode bash-permission allowlist globs
(`"tail *"`, `"sort *"`, `"git push *"`). The `.claude` and `.cursor`
twins carry no per-command bash allowlist in their frontmatter (that
permission machinery is OpenCode-specific), so there is no counterpart
change to mirror; the shared prose body of the three copies is
untouched and remains in sync.

Review-fix #06 flagged the same class twice: `harness drift:
qs-verify-task.md` and `harness drift: qs-review-regression-proof.md`
(out of sync: .claude, .cursor). Both `.opencode` edits are again
frontmatter-only — adding the trailing space to the remaining
`"git status/log/diff/fetch"` allowlist globs. The `.claude` and
`.cursor` twins carry no such frontmatter, so there is no counterpart
change to mirror; the shared prose bodies remain in sync
(`qs-diagnose-task.md`, whose prose did change, was edited in all
three harness dirs and is not flagged).



Review-fix #08 flags `harness drift: qs-setup-task.md` and
`harness drift: qs-implement-task.md` (out of sync: .claude). This
divergence is the finding itself: the #07 "except the fallback line"
clause is correct only in the Claude twins (whose handoff has an
actual fallback line); the Cursor/OpenCode copies have no fallback
line — their both-branch carrier is the routing parenthetical after
the print block (or, in the OpenCode implement copy, the inline and
success-contract parentheticals). Only the four Cursor/OpenCode copies
are reworded to name their real carrier; the Claude copies are
deliberately untouched, so there is no counterpart change to mirror.


Review-fix #10 flags `harness drift: qs-diagnose-task.md` (out of
sync: .claude, .cursor). The `.opencode` edit is frontmatter-only —
adding `"gh pr close *": allow` to the OpenCode bash-permission
allowlist so #09's superseded-fix-PR FINALIZE step no longer falls to
`"*": ask`. The `.claude` and `.cursor` twins carry no per-command
bash allowlist in their frontmatter (that permission machinery is
OpenCode-specific), so there is no counterpart change to mirror; the
shared prose body of the three copies is untouched and remains in
sync (same precedent as #05/#06/#08).
